### PR TITLE
fix(#2059 #2c): re-key record_verdict on reviewed_head + create-or-buffer

### DIFF
--- a/src/daemon/pr_state/mod.rs
+++ b/src/daemon/pr_state/mod.rs
@@ -51,6 +51,7 @@ pub mod auto_arm;
 pub mod gh_poll;
 mod remote_gc;
 mod scanner;
+pub(crate) mod verdict_buffer;
 // #986: the production per-tick handler drives the scanner with an explicit
 // (snapshot) poller via `scan_and_emit_with` — the old `scan_and_emit` wrapper
 // (hardcoded `CliGhPoller`, synchronous on the scanner thread) is gone.
@@ -822,6 +823,31 @@ pub fn record_ci_result(
                     observed_at: chrono::Utc::now().to_rfc3339(),
                 },
             );
+            // #2059 #2(c): the state's head_sha is now established at `head_sha`.
+            // Drain + replay any verdicts that were buffered for this SHA before
+            // the state existed (the #2058 verdict-before-CI ordering gap). They
+            // apply against the current head, so a VERIFIED here can flip the PR
+            // merge-ready on the next scan tick — closing the dead zone. The
+            // buffer drain touches a SEPARATE dir (verdict-buffer/), not this
+            // file's flock, so there is no self-deadlock.
+            for v in verdict_buffer::drain_for_head(home, head_sha) {
+                tracing::info!(
+                    repo = %repo,
+                    branch = %branch,
+                    head = %head_sha,
+                    reviewer = %v.reviewer,
+                    kind = %v.kind,
+                    "#2059 verdict_buffer: replaying buffered verdict onto newly-observed state"
+                );
+                apply(
+                    state,
+                    Event::VerdictObserved {
+                        reviewer: &v.reviewer,
+                        reviewed_head: head_sha,
+                        kind: v.verdict_kind(),
+                    },
+                );
+            }
         },
     ) {
         tracing::warn!(
@@ -834,17 +860,16 @@ pub fn record_ci_result(
 }
 
 /// Verdict ingestion entry point — called from
-/// `api::handlers::messaging::handle_send` after the existing
-/// `auto_release::enqueue_intent` hook. `task_id` is the verdict's
-/// correlation_id. We look up the task's branch on the task board
-/// and apply the verdict to the matching pr_state file.
+/// `api::handlers::messaging::handle_send`. `task_id` is the verdict's
+/// correlation_id, kept only for logging.
 ///
-/// Best-effort: if the task can't be found, or no pr_state file
-/// exists for the task's branch yet, the verdict is silently
-/// dropped (auto_release still handles it; pr_state will pick up
-/// the verdict on next CI tick when the file is created — TODO
-/// for v2: persist orphan verdicts in a sidecar so they apply on
-/// next file-create).
+/// #2059 #2(c): keyed on `reviewed_head` (the SHA the reviewer asserts they
+/// reviewed), not the task→branch chain. Applies the verdict to the pr-state
+/// whose `head_sha == reviewed_head`; if none exists yet (the verdict preceded
+/// the first CI/gh-poll observation — the #2058 dead zone), the verdict is
+/// BUFFERED keyed by the SHA and replayed by [`record_ci_result`] when it
+/// creates/observes a branch state at that head (see [`verdict_buffer`]).
+/// Best-effort throughout — a failure never propagates into the verdict path.
 pub fn record_verdict(
     home: &Path,
     task_id: &str,
@@ -868,45 +893,39 @@ pub fn record_verdict(
         );
         return;
     };
-    let Some(task) = crate::tasks::load_by_id(home, task_id) else {
-        tracing::info!(
-            task_id,
-            reviewer,
-            "#1002 record_verdict skipped (gate B) — task not found in task board; \
-             correlation_id likely mismatched (e.g. used review-task id instead of impl-task id)"
-        );
-        return;
+    // #2059 #2(c): key on `reviewed_head` (the SHA the reviewer asserts they
+    // reviewed), NOT the task→branch chain. Gates B (task lookup) and C
+    // (task.branch) are GONE: a review task usually carries no branch (the
+    // #2058 dead zone), and the SHA is self-describing + branch-independent
+    // (survives fork PRs, missing tasks, multi-reviewer). The owned kind
+    // metadata is extracted up front so it can both drive the live apply and
+    // be buffered verbatim if no pr-state exists at this SHA yet.
+    let (kind_str, kind_reason): (&str, Option<&str>) = match kind {
+        VerdictKind::Verified => ("verified", None),
+        VerdictKind::Rejected { reason } => ("rejected", reason),
+        VerdictKind::Unverified => ("unverified", None),
     };
-    let branch = match task.branch {
-        Some(b) if !b.is_empty() => b,
-        _ => {
-            tracing::info!(
-                task_id,
-                reviewer,
-                "#1002 record_verdict skipped (gate C) — task.branch field empty; \
-                 task was created without a branch hint"
-            );
-            return;
-        }
-    };
-    // We don't always know the repo from the task. Walk the pr-state
-    // directory and find the file whose branch matches. (Typically 1
-    // pr per branch; ambiguity unlikely.)
+    // Walk the pr-state directory and find the file whose head_sha matches the
+    // reviewed_head (typically 0 or 1; one PR per branch). A missing/unreadable
+    // dir (no pr-state has ever been created — the verdict-before-anything case)
+    // is NOT a hard error: it just means zero matches, so we fall through to the
+    // buffer below rather than dropping the verdict (the gate-D early-return was
+    // the second half of the #2058 dead zone — the dir often doesn't exist yet
+    // when an early reviewer verdicts).
     let dir = pr_state_dir(home);
-    let entries = match std::fs::read_dir(&dir) {
-        Ok(e) => e,
-        Err(e) => {
-            tracing::warn!(
+    let mut matched_any = false;
+    let read = std::fs::read_dir(&dir);
+    if let Err(ref e) = read {
+        if e.kind() != std::io::ErrorKind::NotFound {
+            tracing::debug!(
                 task_id,
                 dir = %dir.display(),
                 error = %e,
-                "#1002 record_verdict skipped (gate D) — pr-state dir read failed"
+                "#2059 record_verdict: pr-state dir read failed — treating as no match, buffering"
             );
-            return;
         }
-    };
-    let mut matched_any = false;
-    for entry in entries.flatten() {
+    }
+    for entry in read.into_iter().flatten().flatten() {
         let path = entry.path();
         if !is_pr_state_file(&path) {
             continue; // #2059: skip .emitted-terminal.json ledger + .lock sidecars
@@ -917,11 +936,12 @@ pub fn record_verdict(
         let Ok(state): Result<PrState, _> = serde_json::from_str(&content) else {
             continue;
         };
-        if state.branch != branch {
+        if state.head_sha != reviewed_head {
             continue;
         }
         matched_any = true;
         let repo = state.repo.clone();
+        let branch = state.branch.clone();
         let label = verdict_label(&kind);
         // #2 (t-verdict-to-author-routing): capture the verdict notification under
         // the flock, enqueue it AFTER `with_pr_state` returns (self-IPC safety —
@@ -974,13 +994,14 @@ pub fn record_verdict(
         }
     }
     if !matched_any {
-        tracing::info!(
-            task_id,
-            branch = %branch,
-            reviewer,
-            "#1002 record_verdict noop (gate E) — no pr-state file matched task branch; \
-             CI watch may not have created the file yet for this branch"
-        );
+        // #2059 #2(c): the verdict-before-CI ordering gap (gate E) — no pr-state
+        // exists at this SHA yet (the verdict preceded the first gh-poll
+        // observation, the #2058 case). Instead of dropping it, BUFFER it keyed
+        // by `reviewed_head`; `record_ci_result` drains + replays it the moment
+        // it creates/observes a branch state at this head. The #1888
+        // track-until-resolution pattern — a signal that precedes its consumer
+        // is persisted and replayed, never silently lost.
+        verdict_buffer::buffer(home, reviewed_head, reviewer, kind_str, kind_reason);
     }
 }
 
@@ -1727,6 +1748,205 @@ mod tests {
         );
         let s = load(&dir, "owner/repo", "feat/x").expect("reloaded");
         assert!(matches!(s.ci_state, CiState::Green { .. }));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // ── #2059 #2(c) §3.9 — SHA-key + create-or-buffer, the 5 edge cases ──
+    // All drive the REAL entry points (record_verdict + record_ci_result), no
+    // binding and no task board — proving the SHA key needs neither.
+
+    fn vbuf_home(tag: &str) -> std::path::PathBuf {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static C: AtomicU32 = AtomicU32::new(0);
+        let d = std::env::temp_dir().join(format!(
+            "agend-2059c-{}-{}-{}",
+            tag,
+            std::process::id(),
+            C.fetch_add(1, Ordering::Relaxed)
+        ));
+        let _ = std::fs::remove_dir_all(&d);
+        std::fs::create_dir_all(&d).unwrap();
+        d
+    }
+
+    /// EDGE 1 (review-before-impl — the #2058 dead zone) + EDGE 2 (no-binding):
+    /// a verdict that PRECEDES the pr-state is buffered, then replayed when
+    /// `record_ci_result` first observes that SHA, flipping the PR merge-ready.
+    /// No binding and no task board are involved — the SHA carries everything.
+    #[test]
+    fn buffered_verdict_replays_on_ci_observe_2059() {
+        let dir = vbuf_home("replay");
+        // Verdict arrives first — no pr-state exists yet (gate E / #2058).
+        record_verdict(
+            &dir,
+            "t-review-task",
+            "reviewer-1",
+            Some("sha-A"),
+            VerdictKind::Verified,
+        );
+        assert!(
+            load(&dir, "owner/repo", "feat/x").is_none(),
+            "a verdict must NOT itself create a pr-state — it buffers"
+        );
+        // CI observes sha-A green → creates the state + drains/replays the buffer.
+        record_ci_result(
+            &dir,
+            "owner/repo",
+            "feat/x",
+            "sha-A",
+            CiConclusion::Green,
+            vec!["dev".to_string()],
+            ReviewClass::Single,
+        );
+        let s = load(&dir, "owner/repo", "feat/x").expect("created");
+        assert!(
+            is_merge_ready(&s),
+            "buffered VERIFIED + CI green at the same SHA → merge-ready (#2058 closed)"
+        );
+        // The buffer entry was consumed.
+        assert!(
+            verdict_buffer::drain_for_head(&dir, "sha-A").is_empty(),
+            "the buffered verdict was drained on observe"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// EDGE 3 (fork PR — same branch NAME, different SHA): a verdict for sha-A
+    /// lands only on the sha-A state, never the same-named fork at sha-B.
+    #[test]
+    fn verdict_keys_by_sha_not_branch_name_fork_2059() {
+        let dir = vbuf_home("fork");
+        record_ci_result(
+            &dir,
+            "owner/repo",
+            "feat/x",
+            "sha-A",
+            CiConclusion::Green,
+            vec!["dev".into()],
+            ReviewClass::Single,
+        );
+        // A fork's PR: identical branch name, different repo + head SHA.
+        record_ci_result(
+            &dir,
+            "fork/repo",
+            "feat/x",
+            "sha-B",
+            CiConclusion::Green,
+            vec!["dev".into()],
+            ReviewClass::Single,
+        );
+        // Verdict for sha-A.
+        record_verdict(
+            &dir,
+            "t",
+            "reviewer-1",
+            Some("sha-A"),
+            VerdictKind::Verified,
+        );
+        assert!(
+            is_merge_ready(&load(&dir, "owner/repo", "feat/x").unwrap()),
+            "the sha-A PR is merge-ready"
+        );
+        assert!(
+            !is_merge_ready(&load(&dir, "fork/repo", "feat/x").unwrap()),
+            "the same-named fork at a DIFFERENT sha must be untouched (SHA-keyed, not branch-keyed)"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// EDGE 4 (multi-reviewer, dual class): two DISTINCT verdicts on the same SHA
+    /// accumulate; merge-ready only after the quorum (not collapsed to one row).
+    #[test]
+    fn multi_reviewer_dual_quorum_on_sha_2059() {
+        let dir = vbuf_home("multi");
+        record_ci_result(
+            &dir,
+            "owner/repo",
+            "feat/d",
+            "sha-A",
+            CiConclusion::Green,
+            vec!["dev".into()],
+            ReviewClass::Dual,
+        );
+        record_verdict(
+            &dir,
+            "t",
+            "reviewer-1",
+            Some("sha-A"),
+            VerdictKind::Verified,
+        );
+        assert!(
+            !is_merge_ready(&load(&dir, "owner/repo", "feat/d").unwrap()),
+            "1 of 2 verified — not yet merge-ready under dual class"
+        );
+        record_verdict(
+            &dir,
+            "t",
+            "reviewer-2",
+            Some("sha-A"),
+            VerdictKind::Verified,
+        );
+        assert!(
+            is_merge_ready(&load(&dir, "owner/repo", "feat/d").unwrap()),
+            "2 distinct reviewers on the SHA → dual quorum met"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// EDGE 5 (stale force-push): after the head advances, neither the cleared
+    /// old-SHA verdict nor a LATE verdict for the stale SHA flips the new head
+    /// merge-ready (the §4.2 staleness invariant + SHA-keyed buffer).
+    #[test]
+    fn stale_forcepush_verdict_does_not_flip_2059() {
+        let dir = vbuf_home("stale");
+        record_ci_result(
+            &dir,
+            "owner/repo",
+            "feat/x",
+            "sha-A",
+            CiConclusion::Green,
+            vec!["dev".into()],
+            ReviewClass::Single,
+        );
+        record_verdict(
+            &dir,
+            "t",
+            "reviewer-1",
+            Some("sha-A"),
+            VerdictKind::Verified,
+        );
+        assert!(
+            is_merge_ready(&load(&dir, "owner/repo", "feat/x").unwrap()),
+            "baseline: CI green + VERIFIED at sha-A → merge-ready"
+        );
+        // Force-push: CI now observes a NEW head sha-B. CiObserved clears the
+        // accumulated sha-A verdict.
+        record_ci_result(
+            &dir,
+            "owner/repo",
+            "feat/x",
+            "sha-B",
+            CiConclusion::Green,
+            vec![],
+            ReviewClass::Single,
+        );
+        assert!(
+            !is_merge_ready(&load(&dir, "owner/repo", "feat/x").unwrap()),
+            "head advanced to sha-B; the sha-A verdict no longer applies"
+        );
+        // A LATE verdict still asserting the stale sha-A: no state is at sha-A
+        // now → it buffers, and is never drained for sha-B → can't resurrect.
+        record_verdict(
+            &dir,
+            "t",
+            "reviewer-1",
+            Some("sha-A"),
+            VerdictKind::Verified,
+        );
+        assert!(
+            !is_merge_ready(&load(&dir, "owner/repo", "feat/x").unwrap()),
+            "a stale-SHA verdict must not flip the advanced head merge-ready"
+        );
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/src/daemon/pr_state/verdict_buffer.rs
+++ b/src/daemon/pr_state/verdict_buffer.rs
@@ -1,0 +1,267 @@
+//! #2059 #2(c): the verdict buffer — a TTL-bounded sidecar that holds a review
+//! verdict which arrived BEFORE its pr-state existed (the verdict-before-CI
+//! ordering gap that caused the #2058 dead zone).
+//!
+//! [`super::record_verdict`] now keys on the verdict's `reviewed_head` (the SHA
+//! the reviewer asserts they reviewed) instead of the task→branch chain. When no
+//! pr-state for that SHA exists yet, the verdict is buffered here keyed by the
+//! SHA; [`super::record_ci_result`] drains + replays matching buffered verdicts
+//! the moment it creates/observes a branch state at that head. This is the #1888
+//! *track-until-resolution* pattern: a signal that precedes its consumer is
+//! persisted and replayed on the resolving event, never dropped on the floor.
+//!
+//! Storage: file-per-entry under
+//! `<home>/pr-state/verdict-buffer/<sha>--<reviewer>.json`, atomic write
+//! (`tmp`+`rename`), 24 h TTL — a SHA that never becomes any branch's head
+//! self-expires so the buffer can't leak.
+
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+/// A SHA that never resolves to a branch head is dropped after this. 24 h
+/// matches the `ci_handoff_track` TTL (#1888) — the same orphan-signal horizon.
+const TTL_HOURS: i64 = 24;
+
+/// An owned snapshot of a verdict, parked until its pr-state appears. `kind` is
+/// the lowercased verdict word (`VerdictKind` carries a borrow, so it can't be
+/// stored directly); [`buffered_kind`] reconstructs the borrowed form on replay.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct BufferedVerdict {
+    pub reviewed_head: String,
+    pub reviewer: String,
+    /// `"verified" | "rejected" | "unverified"`.
+    pub kind: String,
+    #[serde(default)]
+    pub reason: Option<String>,
+    pub buffered_at: String,
+}
+
+impl BufferedVerdict {
+    /// Reconstruct the borrowed [`super::VerdictKind`] for replay. Unknown kind
+    /// strings map to `Unverified` (the evidence-exempt, never-merge-ready
+    /// verdict) — a corrupt buffer entry can never spuriously flip merge-ready.
+    pub(crate) fn verdict_kind(&self) -> super::VerdictKind<'_> {
+        match self.kind.as_str() {
+            "verified" => super::VerdictKind::Verified,
+            "rejected" => super::VerdictKind::Rejected {
+                reason: self.reason.as_deref(),
+            },
+            _ => super::VerdictKind::Unverified,
+        }
+    }
+}
+
+fn buffer_dir(home: &Path) -> PathBuf {
+    super::pr_state_dir(home).join("verdict-buffer")
+}
+
+/// Filename-safe token. Hex SHAs and agent names are already safe; this is a
+/// defensive guard against an unexpected character reaching the path.
+fn sanitize(s: &str) -> String {
+    s.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+/// Buffer a verdict keyed by (reviewed_head, reviewer). Idempotent per key (a
+/// re-buffer of the same reviewer+SHA overwrites). Best-effort: errors are
+/// logged, never propagated — the verdict path must stay non-fragile.
+pub(crate) fn buffer(
+    home: &Path,
+    reviewed_head: &str,
+    reviewer: &str,
+    kind: &str,
+    reason: Option<&str>,
+) {
+    let v = BufferedVerdict {
+        reviewed_head: reviewed_head.to_string(),
+        reviewer: reviewer.to_string(),
+        kind: kind.to_string(),
+        reason: reason.map(String::from),
+        buffered_at: chrono::Utc::now().to_rfc3339(),
+    };
+    match write_atomic(home, &v) {
+        Ok(()) => tracing::info!(
+            reviewed_head,
+            reviewer,
+            kind,
+            "#2059 verdict_buffer: buffered verdict (no pr-state at this SHA yet — replays on CI observe)"
+        ),
+        Err(e) => tracing::warn!(reviewed_head, reviewer, error = %e, "#2059 verdict_buffer: write failed"),
+    }
+}
+
+fn write_atomic(home: &Path, v: &BufferedVerdict) -> std::io::Result<()> {
+    let dir = buffer_dir(home);
+    std::fs::create_dir_all(&dir)?;
+    let name = format!(
+        "{}--{}.json",
+        sanitize(&v.reviewed_head),
+        sanitize(&v.reviewer)
+    );
+    let final_path = dir.join(&name);
+    let tmp = dir.join(format!(".{name}.tmp"));
+    std::fs::write(&tmp, serde_json::to_vec_pretty(v)?)?;
+    std::fs::rename(&tmp, &final_path)
+}
+
+/// Drain (read **and delete**) every buffered verdict whose `reviewed_head`
+/// matches `head`. Called by [`super::record_ci_result`] the moment a pr-state's
+/// head_sha is established at `head`, so the replayed verdicts land on the
+/// just-created/observed state. A SHA mismatch leaves the entry parked (a future
+/// CI observation at that SHA, or the TTL sweep, resolves it).
+pub(crate) fn drain_for_head(home: &Path, head: &str) -> Vec<BufferedVerdict> {
+    let dir = buffer_dir(home);
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !is_buffer_file(&path) {
+            continue;
+        }
+        let Ok(content) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let Ok(v) = serde_json::from_str::<BufferedVerdict>(&content) else {
+            continue;
+        };
+        if v.reviewed_head == head {
+            let _ = std::fs::remove_file(&path);
+            out.push(v);
+        }
+    }
+    out
+}
+
+/// Drop buffered verdicts older than [`TTL_HOURS`]. A verdict whose SHA never
+/// becomes any branch's head (abandoned PR, force-push past it) must not leak.
+/// Wired into the hourly retention sweep. Returns the count removed.
+pub(crate) fn sweep_expired(home: &Path, now: chrono::DateTime<chrono::Utc>) -> usize {
+    let dir = buffer_dir(home);
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return 0;
+    };
+    let mut removed = 0;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !is_buffer_file(&path) {
+            continue;
+        }
+        let expired = std::fs::read_to_string(&path)
+            .ok()
+            .and_then(|c| serde_json::from_str::<BufferedVerdict>(&c).ok())
+            .and_then(|v| chrono::DateTime::parse_from_rfc3339(&v.buffered_at).ok())
+            .map(|t| {
+                now.signed_duration_since(t.with_timezone(&chrono::Utc))
+                    > chrono::Duration::hours(TTL_HOURS)
+            })
+            // Unparseable / unreadable → a broken entry must not linger forever.
+            .unwrap_or(true);
+        if expired {
+            let _ = std::fs::remove_file(&path);
+            removed += 1;
+        }
+    }
+    removed
+}
+
+/// A buffer file is a `*.json` that is not a dotfile (`.tmp` write-staging).
+fn is_buffer_file(path: &Path) -> bool {
+    let is_dotfile = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .is_some_and(|n| n.starts_with('.'));
+    !is_dotfile && path.extension().and_then(|e| e.to_str()) == Some("json")
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn tmp_home(tag: &str) -> PathBuf {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static C: AtomicU32 = AtomicU32::new(0);
+        let d = std::env::temp_dir().join(format!(
+            "agend-vbuf-{}-{}-{}",
+            tag,
+            std::process::id(),
+            C.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::create_dir_all(&d).unwrap();
+        d
+    }
+
+    /// buffer → drain_for_head round-trip: the matching SHA is returned + removed;
+    /// a non-matching SHA leaves its entry parked.
+    #[test]
+    fn buffer_drains_matching_sha_only_2059() {
+        let home = tmp_home("drain");
+        buffer(&home, "sha-A", "reviewer-1", "verified", None);
+        buffer(&home, "sha-B", "reviewer-2", "rejected", Some("needs r1"));
+
+        let drained = drain_for_head(&home, "sha-A");
+        assert_eq!(drained.len(), 1);
+        assert_eq!(drained[0].reviewer, "reviewer-1");
+        assert!(matches!(
+            drained[0].verdict_kind(),
+            super::super::VerdictKind::Verified
+        ));
+        // sha-A removed; sha-B still parked.
+        assert!(drain_for_head(&home, "sha-A").is_empty());
+        let b = drain_for_head(&home, "sha-B");
+        assert_eq!(b.len(), 1);
+        assert_eq!(b[0].reason.as_deref(), Some("needs r1"));
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// TTL sweep removes a stale entry, keeps a fresh one.
+    #[test]
+    fn sweep_expired_drops_stale_keeps_fresh_2059() {
+        let home = tmp_home("sweep");
+        buffer(&home, "sha-fresh", "rv", "verified", None);
+        // Hand-write a stale entry (buffered_at 48h ago).
+        let stale = BufferedVerdict {
+            reviewed_head: "sha-stale".into(),
+            reviewer: "rv".into(),
+            kind: "verified".into(),
+            reason: None,
+            buffered_at: (chrono::Utc::now() - chrono::Duration::hours(48)).to_rfc3339(),
+        };
+        write_atomic(&home, &stale).unwrap();
+
+        let now = chrono::Utc::now();
+        assert_eq!(sweep_expired(&home, now), 1, "only the 48h-stale entry");
+        assert!(
+            !drain_for_head(&home, "sha-fresh").is_empty(),
+            "the fresh entry survives the sweep"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// A corrupt `kind` reconstructs as `Unverified` (never merge-ready) — a
+    /// broken buffer entry can't spuriously flip a PR to mergeable.
+    #[test]
+    fn corrupt_kind_maps_to_unverified_2059() {
+        let v = BufferedVerdict {
+            reviewed_head: "s".into(),
+            reviewer: "r".into(),
+            kind: "garbage".into(),
+            reason: None,
+            buffered_at: chrono::Utc::now().to_rfc3339(),
+        };
+        assert!(matches!(
+            v.verdict_kind(),
+            super::super::VerdictKind::Unverified
+        ));
+    }
+}

--- a/src/daemon/retention/mod.rs
+++ b/src/daemon/retention/mod.rs
@@ -56,6 +56,11 @@ impl RetentionSupervisor {
         // crash-leftover `.tmp` sidecars, by mtime + orphan check.
         let ci_handoff_swept =
             crate::daemon::ci_handoff_track::gc_orphan_sidecars(home, std::time::SystemTime::now());
+        // #2059 #2(c): drop verdict-buffer entries whose SHA never became a
+        // branch head within 24h (abandoned PR / force-push past it) so a
+        // never-resolving buffered verdict can't leak.
+        let verdict_buffer_swept =
+            crate::daemon::pr_state::verdict_buffer::sweep_expired(home, chrono::Utc::now());
 
         tracing::info!(
             decisions = decisions_swept,
@@ -63,6 +68,7 @@ impl RetentionSupervisor {
             tracking = tracking_swept,
             worktrees = worktrees_swept,
             ci_handoff = ci_handoff_swept,
+            verdict_buffer = verdict_buffer_swept,
             "retention sweep: cycle complete"
         );
         crate::event_log::log(


### PR DESCRIPTION
#2059 fix **#2(c)** — the dialectic-ruled chokepoint that closes the verdict-correlation + verdict-before-CI ordering gaps. Builds on #1 (prefix strip, merged #2062) and is independent of #3 (merge-authority routing, merged #2063).

## Problem (from the #2059 RCA)

After #1 made `record_verdict` actually *fire*, three task-correlation gates still blocked #2058-shaped flows:
- **gate B** — `load_by_id(correlation_id)` resolved the *review* task (codex correlates to it), not the impl task.
- **gate C** — that review task had `branch=None` (the lead's review dispatch carried no branch).
- **gate E** — even with a branch, no pr-state file existed yet (the verdict at 14:00 preceded gh-poll's first observation at 14:12).

All three are artifacts of keying on the task→branch chain. The verdict already carries a **self-describing, branch-independent** key it asserts it reviewed: `reviewed_head`.

## Fix (vote (c), unanimous in the dialectic)

- **Re-key on `reviewed_head` (SHA)**: apply the verdict to the pr-state whose `head_sha == reviewed_head`. Gates B + C dropped entirely; gate D (dir read) no longer hard-returns — a missing pr-state dir just means zero matches → fall through to buffer (the dir often doesn't exist when an early reviewer verdicts).
- **create-or-buffer**: when no pr-state matches the SHA, park the verdict in a new TTL-bounded sidecar (`pr-state/verdict-buffer/<sha>--<reviewer>.json`, 24 h, atomic write — the **#1888 track-until-resolution** pattern). `record_ci_result` **drains + replays** matching buffered verdicts the instant it creates/observes a branch state at that head, so a VERIFIED that preceded CI flips the PR merge-ready on the next scan. `sweep_expired` wired into the hourly retention cycle so a never-resolving SHA can't leak.

This collapses gates B/C/E into one SHA-keyed ingestion step, needing **no** dispatch discipline ((a) correlate-to-impl / (b) dispatch-carries-branch both re-grow the gap the day someone forgets — #1713).

## §3.9 — 5 edge cases (all through the real entry points, no binding/task board)

- **review-before-impl (#2058) + no-binding** — `buffered_verdict_replays_on_ci_observe`: a verdict parked before any pr-state replays on CI observe → merge-ready.
- **fork PR** — `verdict_keys_by_sha_not_branch_name_fork`: same branch NAME, different SHA → the verdict lands only on the matching SHA; the fork is untouched.
- **multi-reviewer (dual)** — `multi_reviewer_dual_quorum_on_sha`: two distinct verdicts accumulate on the SHA → quorum.
- **stale force-push** — `stale_forcepush_verdict_does_not_flip`: head advances → the cleared old verdict AND a late stale-SHA verdict both refuse to flip the new head (§4.2 staleness + SHA-keyed buffer parks-not-applies).
- Plus `verdict_buffer` unit tests (drain-by-SHA, TTL sweep, corrupt-kind→Unverified). **RED-verified**: removing the buffer fails the replay test.

## Verify

`cargo fmt --check` + `cargo clippy --all-targets --features tray -- -D warnings` ✅; pr_state suite 86 + retention/messaging/auto_release 114 green.

With #1 + #3 + this, the full pipeline lives: detect the verdict prefix-robustly (#1) → record it by the SHA it carries, buffer-and-replay the ordering gap (#2c) → route the ready signal to the merge authority (#3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)