### PR TITLE
refactor(#2050 W1.1): unify 12 supervisor trackers into PerTickHandler set

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -156,9 +156,11 @@ const APP_TICK_ALLOWLIST: &[&str] = &["snapshot_rotation", "thread_dump"];
 /// `stage2_dispatch_available = false` — `RecoveryDispatcherHandler` now RUNS
 /// (no longer allowlisted out) and its Stage2 path escalates to Stage3 rather
 /// than emit onto the consumerless channel.
-fn app_tick_handlers() -> Vec<Box<dyn crate::daemon::per_tick::PerTickHandler>> {
+fn app_tick_handlers(
+    daemon_binary_stale: crate::daemon::mcp_registry_watcher::DaemonBinaryStale,
+) -> Vec<Box<dyn crate::daemon::per_tick::PerTickHandler>> {
     let (crash_tx, _crash_rx) = crossbeam_channel::bounded(1);
-    let mut handlers = crate::daemon::build_default_handlers(crash_tx, false);
+    let mut handlers = crate::daemon::build_default_handlers(crash_tx, false, daemon_binary_stale);
     handlers.retain(|h| !APP_TICK_ALLOWLIST.contains(&h.name()));
     handlers
 }
@@ -212,11 +214,7 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
     // the daemon already runs its own supervisor against the real registry, so
     // the app must not also poll a disjoint (empty) registry.
     if !attached_mode {
-        crate::daemon::supervisor::spawn(
-            home.clone(),
-            Arc::clone(&registry),
-            Arc::clone(&daemon_binary_stale),
-        );
+        crate::daemon::supervisor::spawn(home.clone(), Arc::clone(&registry));
         crate::instance_monitor::spawn_monitor_tick(home.clone(), Arc::clone(&registry));
         // Attached mode stays unwired: that process never owns the registry,
         // and the Telegram bot (if any) runs under the other daemon which
@@ -397,7 +395,11 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
     // harmlessly unused.
     let app_externals: crate::agent::ExternalRegistry = Arc::new(Mutex::new(HashMap::new()));
     let app_configs: crate::api::ConfigRegistry = Arc::new(Mutex::new(HashMap::new()));
-    let app_handlers = app_tick_handlers();
+    // W1.1 (#2050): the `mcp_registry` tracker (now a handler) flips this same
+    // `daemon_binary_stale` flag the render loop reads (line ~186); hand it the
+    // shared `Arc` so the status-bar warning still surfaces after the tracker
+    // moved off the supervisor thread.
+    let app_handlers = app_tick_handlers(Arc::clone(&daemon_binary_stale));
 
     // #2057: read the size-probe env gate ONCE (it can't change mid-run) — keep
     // the per-frame draw loop's hot path at zero env-lookup cost (codex #2060).
@@ -1518,11 +1520,17 @@ mod tests {
     fn app_tick_handlers_cover_every_non_allowlisted_daemon_handler() {
         use std::collections::HashSet;
         let (crash_tx, _rx) = crossbeam_channel::bounded(1);
-        let all: HashSet<&str> = crate::daemon::build_default_handlers(crash_tx, true)
+        let stale: crate::daemon::mcp_registry_watcher::DaemonBinaryStale =
+            Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let all: HashSet<&str> = crate::daemon::build_default_handlers(crash_tx, true, stale)
             .iter()
             .map(|h| h.name())
             .collect();
-        let app: HashSet<&str> = app_tick_handlers().iter().map(|h| h.name()).collect();
+        let app: HashSet<&str> =
+            app_tick_handlers(Arc::new(std::sync::atomic::AtomicBool::new(false)))
+                .iter()
+                .map(|h| h.name())
+                .collect();
 
         // Positive: every non-allowlisted daemon handler must run in app.
         let missing: Vec<&str> = all
@@ -1555,7 +1563,11 @@ mod tests {
     /// (the #1720 / #1002 class). This pins it back IN the app run set.
     #[test]
     fn recovery_dispatcher_runs_in_app_mode_1694a() {
-        let names: Vec<&str> = app_tick_handlers().iter().map(|h| h.name()).collect();
+        let names: Vec<&str> =
+            app_tick_handlers(Arc::new(std::sync::atomic::AtomicBool::new(false)))
+                .iter()
+                .map(|h| h.name())
+                .collect();
         assert!(
             names.contains(&"recovery_dispatcher"),
             "recovery_dispatcher must RUN in app mode (#1694a) — got {names:?}"
@@ -1583,7 +1595,7 @@ mod tests {
             externals: &externals,
             configs: &configs,
         };
-        for h in app_tick_handlers() {
+        for h in app_tick_handlers(Arc::new(std::sync::atomic::AtomicBool::new(false))) {
             h.run(&ctx); // panic here = test failure
         }
         std::fs::remove_dir_all(&home).ok();

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -573,6 +573,7 @@ pub(crate) fn register_event_subscribers(registry: &AgentRegistry) {
 pub(crate) fn build_default_handlers(
     crash_tx: crossbeam_channel::Sender<crate::agent::AgentExitEvent>,
     stage2_dispatch_available: bool,
+    daemon_binary_stale: crate::daemon::mcp_registry_watcher::DaemonBinaryStale,
 ) -> Vec<Box<dyn per_tick::PerTickHandler>> {
     let watchdog_dry_run = watchdog::watchdog_dry_run_from_env();
     // Vec order MUST match the pre-extraction call order (zero-behavior-change guarantee).
@@ -628,6 +629,26 @@ pub(crate) fn build_default_handlers(
         // + WARN if a dialog swallowed it. Cheap (iterates a usually-empty
         // map); claude-only in practice (arm self-gates on hook history).
         Box::new(per_tick::InjectDeliveryHandler::new(1)),
+        // ── W1.1 (#2050): the 12 trackers migrated from the supervisor
+        // `run_loop` (supervisor.rs:384-395). Appended in their original
+        // relative order; each self-throttles internally (TICKS_PER_SCAN), so
+        // running them every tick here is the same cadence the supervisor ran.
+        // They previously executed on the supervisor thread; the main loop
+        // ticks at the identical 10s interval and holds no lock across them, so
+        // this is behavior-preserving on unix (both run_core and app mode).
+        // Cadence-hoist to the handler (`should_fire`) is W2.4, not W1.1.
+        Box::new(per_tick::AntiStallHandler::new()),
+        Box::new(per_tick::IdleWatchdogHandler::new()),
+        Box::new(per_tick::DecisionTimeoutHandler::new()),
+        Box::new(per_tick::HelperStalenessHandler::new()),
+        Box::new(per_tick::McpRegistryHandler::new(daemon_binary_stale)),
+        Box::new(per_tick::WaitingOnStaleHandler::new()),
+        Box::new(per_tick::ConflictNotifyHandler::new()),
+        Box::new(per_tick::CanonicalDriftHandler::new()),
+        Box::new(per_tick::AutoReleaseHandler::new()),
+        Box::new(per_tick::DispatchIdleHandler::new()),
+        Box::new(per_tick::DispatchIdleNudgeHandler::new()),
+        Box::new(per_tick::RetentionHandler::new()),
     ]
 }
 
@@ -1145,13 +1166,7 @@ fn build_tick_infrastructure(
 
     #[cfg(unix)]
     {
-        let daemon_binary_stale: crate::daemon::mcp_registry_watcher::DaemonBinaryStale =
-            Arc::new(AtomicBool::new(false));
-        supervisor::spawn(
-            home.to_path_buf(),
-            Arc::clone(&ctx.registry),
-            daemon_binary_stale,
-        );
+        supervisor::spawn(home.to_path_buf(), Arc::clone(&ctx.registry));
     }
     router::spawn(home.to_path_buf(), Arc::clone(&ctx.registry));
     crate::instance_monitor::spawn_monitor_tick(home.to_path_buf(), Arc::clone(&ctx.registry));
@@ -1168,8 +1183,13 @@ fn build_tick_infrastructure(
     crate::daemon::orphan_sweep::run(home);
 
     // #1694(a): run_core wires `crash_rx` → `handle_crash_respawn`, so Stage2
-    // restarts have a live consumer here (true).
-    let handlers = build_default_handlers(ctx.crash_tx.clone(), true);
+    // restarts have a live consumer here (true). `run_core` is headless (no
+    // TUI), so the `DaemonBinaryStale` flag the `mcp_registry` handler flips is
+    // a throwaway here — nothing surfaces it, exactly as the pre-W1.1
+    // supervisor-side flag was in run_core.
+    let daemon_binary_stale: crate::daemon::mcp_registry_watcher::DaemonBinaryStale =
+        Arc::new(AtomicBool::new(false));
+    let handlers = build_default_handlers(ctx.crash_tx.clone(), true, daemon_binary_stale);
 
     let tick_rx = {
         let (tx, rx) = crossbeam_channel::bounded(1);

--- a/src/daemon/per_tick/mod.rs
+++ b/src/daemon/per_tick/mod.rs
@@ -50,6 +50,7 @@ pub(crate) mod poll_reminder;
 pub(crate) mod pr_state_scan;
 pub(crate) mod recovery_dispatcher;
 pub(crate) mod snapshot;
+pub(crate) mod supervisor_trackers;
 pub(crate) mod thread_dump;
 pub(crate) mod tmp_review_gc;
 pub(crate) mod watchdog;
@@ -71,6 +72,11 @@ pub(crate) use poll_reminder::PollReminderHandler;
 pub(crate) use pr_state_scan::PrStateScanHandler;
 pub(crate) use recovery_dispatcher::RecoveryDispatcherHandler;
 pub(crate) use snapshot::SnapshotRotationHandler;
+pub(crate) use supervisor_trackers::{
+    AntiStallHandler, AutoReleaseHandler, CanonicalDriftHandler, ConflictNotifyHandler,
+    DecisionTimeoutHandler, DispatchIdleHandler, DispatchIdleNudgeHandler, HelperStalenessHandler,
+    IdleWatchdogHandler, McpRegistryHandler, RetentionHandler, WaitingOnStaleHandler,
+};
 pub(crate) use thread_dump::ThreadDumpHandler;
 pub(crate) use tmp_review_gc::TmpReviewGcHandler;
 pub(crate) use watchdog::WatchdogHandler;

--- a/src/daemon/per_tick/notification_flush.rs
+++ b/src/daemon/per_tick/notification_flush.rs
@@ -232,7 +232,9 @@ mod tests {
     #[test]
     fn registered_in_default_daemon_pipeline() {
         let (crash_tx, _crash_rx) = crossbeam_channel::bounded(1);
-        let handlers = crate::daemon::build_default_handlers(crash_tx, false);
+        let stale: crate::daemon::mcp_registry_watcher::DaemonBinaryStale =
+            std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let handlers = crate::daemon::build_default_handlers(crash_tx, false, stale);
         assert!(
             handlers.iter().any(|h| h.name() == "notification_flush"),
             "NotificationFlushHandler must run in headless run_core — \

--- a/src/daemon/per_tick/supervisor_trackers.rs
+++ b/src/daemon/per_tick/supervisor_trackers.rs
@@ -1,0 +1,390 @@
+//! W1.1 (#2050 REFACTOR-PLAN, survey 01-R2): the 12 periodic trackers that
+//! historically ran inline in the supervisor thread's `run_loop`
+//! (`supervisor.rs:266`, lines 384–395) wrapped as [`PerTickHandler`]s so the
+//! daemon has ONE periodic-work pipeline (`build_default_handlers`) instead of
+//! two parallel mechanisms (the trait handler set + the supervisor inline
+//! calls). This is the #694 extraction finished for the supervisor side and
+//! the unification survey 01-R2 / S3 flagged.
+//!
+//! ## Pure relocation (zero behavior change)
+//!
+//! Each wrapper owns its tracker behind a `Mutex` (the trait's `run(&self)`
+//! requires interior mutability; the original `run_loop` held them as `&mut`
+//! locals) and calls `maybe_scan` / `maybe_sweep` EVERY tick. The trackers
+//! self-throttle internally via their own `TICKS_PER_SCAN` counter — so wrapping
+//! them with NO additional handler-level cadence gate preserves the exact scan
+//! cadence. Hoisting that cadence onto the handler (the `should_fire` pattern the
+//! other handlers use) is deliberately deferred to W2.4 (`CadenceGate`); W1.1 is
+//! relocation only.
+//!
+//! The main loop ticks at the same 10s interval the supervisor did
+//! (`daemon/mod.rs` `build_tick_infrastructure` tick producer ≡ `supervisor::TICK`),
+//! and the trackers take no lock held by the loop, so moving them from the
+//! supervisor thread to the main-loop handler thread is behavior-preserving on
+//! unix (both `run_core` and app mode). The one platform delta — Windows
+//! `run_core` (headless `start --foreground`), whose supervisor is
+//! `#[cfg(unix)]`-gated and thus never ran these trackers — is documented in the
+//! W1.1 PR body: the universal handler set now runs them there too, matching
+//! app mode (the live daemon, which already ran them on every platform). That
+//! closes a latent #1720-class wiring gap rather than introducing one.
+
+use super::{PerTickHandler, TickContext};
+use crate::daemon::anti_stall::AntiStallTracker;
+use crate::daemon::auto_release::AutoReleaseTracker;
+use crate::daemon::canonical_drift::CanonicalDriftTracker;
+use crate::daemon::conflict_notify::ConflictNotifyTracker;
+use crate::daemon::decision_timeout::DecisionTimeoutTracker;
+use crate::daemon::dispatch_idle::team_nudge::DispatchIdleNudgeTracker;
+use crate::daemon::dispatch_idle::DispatchIdleTracker;
+use crate::daemon::helper_staleness_watchdog::HelperStalenessWatchdogTracker;
+use crate::daemon::idle_watchdog::IdleWatchdogTracker;
+use crate::daemon::mcp_registry_watcher::{DaemonBinaryStale, McpRegistryWatcherTracker};
+use crate::daemon::retention::RetentionSupervisor;
+use crate::daemon::waiting_on_stale::WaitingOnStaleTracker;
+use parking_lot::Mutex;
+use std::collections::HashSet;
+
+/// Sprint 59 Wave 1 PR-1 (#9): per-task ETA stall scan, throttled to 5min.
+pub(crate) struct AntiStallHandler {
+    tracker: Mutex<AntiStallTracker>,
+}
+impl AntiStallHandler {
+    pub(crate) fn new() -> Self {
+        Self {
+            tracker: Mutex::new(AntiStallTracker::default()),
+        }
+    }
+}
+impl PerTickHandler for AntiStallHandler {
+    fn name(&self) -> &'static str {
+        "anti_stall"
+    }
+    fn run(&self, ctx: &TickContext<'_>) {
+        self.tracker.lock().maybe_scan(ctx.home);
+    }
+}
+
+/// Sprint 59 Wave 1 PR-2 (#10+#12): per-agent + fleet idle thresholds, 5min.
+pub(crate) struct IdleWatchdogHandler {
+    tracker: Mutex<IdleWatchdogTracker>,
+}
+impl IdleWatchdogHandler {
+    pub(crate) fn new() -> Self {
+        Self {
+            tracker: Mutex::new(IdleWatchdogTracker::default()),
+        }
+    }
+}
+impl PerTickHandler for IdleWatchdogHandler {
+    fn name(&self) -> &'static str {
+        "idle_watchdog"
+    }
+    fn run(&self, ctx: &TickContext<'_>) {
+        self.tracker.lock().maybe_scan(ctx.home);
+    }
+}
+
+/// Sprint 59 Wave 1 PR-4-recover (B): operator-decision auto-default on
+/// timeout, 5min throttle.
+pub(crate) struct DecisionTimeoutHandler {
+    tracker: Mutex<DecisionTimeoutTracker>,
+}
+impl DecisionTimeoutHandler {
+    pub(crate) fn new() -> Self {
+        Self {
+            tracker: Mutex::new(DecisionTimeoutTracker::default()),
+        }
+    }
+}
+impl PerTickHandler for DecisionTimeoutHandler {
+    fn name(&self) -> &'static str {
+        "decision_timeout"
+    }
+    fn run(&self, ctx: &TickContext<'_>) {
+        self.tracker.lock().maybe_scan(ctx.home);
+    }
+}
+
+/// Sprint 59 Wave 2 PR-3 (#13): deployment-cadence helper-staleness ping.
+pub(crate) struct HelperStalenessHandler {
+    tracker: Mutex<HelperStalenessWatchdogTracker>,
+}
+impl HelperStalenessHandler {
+    pub(crate) fn new() -> Self {
+        Self {
+            tracker: Mutex::new(HelperStalenessWatchdogTracker::default()),
+        }
+    }
+}
+impl PerTickHandler for HelperStalenessHandler {
+    fn name(&self) -> &'static str {
+        "helper_staleness"
+    }
+    fn run(&self, ctx: &TickContext<'_>) {
+        self.tracker.lock().maybe_scan(ctx.home);
+    }
+}
+
+/// Sprint 60 W1 PR-2 (#P0-2): daemon-binary hot-reload detector. Flips the
+/// shared TUI status-bar flag (`DaemonBinaryStale`) the render loop reads —
+/// the handler holds the SAME `Arc` app's TUI created (threaded through
+/// `build_default_handlers`), so the move off the supervisor thread keeps the
+/// status-bar wiring intact. `run_core` (headless) passes a throwaway `Arc`,
+/// exactly as before.
+pub(crate) struct McpRegistryHandler {
+    tracker: Mutex<McpRegistryWatcherTracker>,
+    binary_stale: DaemonBinaryStale,
+}
+impl McpRegistryHandler {
+    pub(crate) fn new(binary_stale: DaemonBinaryStale) -> Self {
+        Self {
+            tracker: Mutex::new(McpRegistryWatcherTracker::default()),
+            binary_stale,
+        }
+    }
+}
+impl PerTickHandler for McpRegistryHandler {
+    fn name(&self) -> &'static str {
+        "mcp_registry"
+    }
+    fn run(&self, _ctx: &TickContext<'_>) {
+        self.tracker.lock().maybe_scan(&self.binary_stale);
+    }
+}
+
+/// `set_waiting_on` staleness scan, 5min.
+pub(crate) struct WaitingOnStaleHandler {
+    tracker: Mutex<WaitingOnStaleTracker>,
+}
+impl WaitingOnStaleHandler {
+    pub(crate) fn new() -> Self {
+        Self {
+            tracker: Mutex::new(WaitingOnStaleTracker::default()),
+        }
+    }
+}
+impl PerTickHandler for WaitingOnStaleHandler {
+    fn name(&self) -> &'static str {
+        "waiting_on_stale"
+    }
+    fn run(&self, ctx: &TickContext<'_>) {
+        self.tracker.lock().maybe_scan(ctx.home);
+    }
+}
+
+/// Phase A: per-tick git-conflict observation + 30min escalation. Needs the
+/// registry. The supervisor used to prune this tracker's per-agent state
+/// (`retain_active`, `supervisor.rs:430`, the #1923 G5 cleanup-on-delete);
+/// that prune moves here with the tracker so a deleted agent's conflict state
+/// still drops out next tick.
+pub(crate) struct ConflictNotifyHandler {
+    tracker: Mutex<ConflictNotifyTracker>,
+}
+impl ConflictNotifyHandler {
+    pub(crate) fn new() -> Self {
+        Self {
+            tracker: Mutex::new(ConflictNotifyTracker::default()),
+        }
+    }
+}
+impl PerTickHandler for ConflictNotifyHandler {
+    fn name(&self) -> &'static str {
+        "conflict_notify"
+    }
+    fn run(&self, ctx: &TickContext<'_>) {
+        self.tracker.lock().maybe_scan(ctx.home, ctx.registry);
+        // #1923 G5 cleanup-on-delete (was supervisor.rs:425-430): prune
+        // per-agent conflict state for agents no longer in the registry. Runs
+        // every tick, unconditionally, exactly as the supervisor `.retain` did.
+        let live: HashSet<String> = {
+            let reg = crate::agent::lock_registry(ctx.registry);
+            reg.values().map(|h| h.name.to_string()).collect()
+        };
+        self.tracker.lock().retain_active(&live);
+    }
+}
+
+/// #852 residual PR-B: per-tick canonical-drift (detached-HEAD residue) scan.
+pub(crate) struct CanonicalDriftHandler {
+    tracker: Mutex<CanonicalDriftTracker>,
+}
+impl CanonicalDriftHandler {
+    pub(crate) fn new() -> Self {
+        Self {
+            tracker: Mutex::new(CanonicalDriftTracker::default()),
+        }
+    }
+}
+impl PerTickHandler for CanonicalDriftHandler {
+    fn name(&self) -> &'static str {
+        "canonical_drift"
+    }
+    fn run(&self, ctx: &TickContext<'_>) {
+        self.tracker.lock().maybe_scan(ctx.home);
+    }
+}
+
+/// #870: per-tick auto-release scan (faster ~30s cadence, internal).
+pub(crate) struct AutoReleaseHandler {
+    tracker: Mutex<AutoReleaseTracker>,
+}
+impl AutoReleaseHandler {
+    pub(crate) fn new() -> Self {
+        Self {
+            tracker: Mutex::new(AutoReleaseTracker::default()),
+        }
+    }
+}
+impl PerTickHandler for AutoReleaseHandler {
+    fn name(&self) -> &'static str {
+        "auto_release"
+    }
+    fn run(&self, ctx: &TickContext<'_>) {
+        self.tracker.lock().maybe_scan(ctx.home);
+    }
+}
+
+/// PR1 watchdog L1: cross-team-safe dispatch-idle scan (~60s, internal).
+pub(crate) struct DispatchIdleHandler {
+    tracker: Mutex<DispatchIdleTracker>,
+}
+impl DispatchIdleHandler {
+    pub(crate) fn new() -> Self {
+        Self {
+            tracker: Mutex::new(DispatchIdleTracker::default()),
+        }
+    }
+}
+impl PerTickHandler for DispatchIdleHandler {
+    fn name(&self) -> &'static str {
+        "dispatch_idle"
+    }
+    fn run(&self, ctx: &TickContext<'_>) {
+        self.tracker.lock().maybe_scan(ctx.home);
+    }
+}
+
+/// PR1 watchdog L2: generic per-team auto-nudge on exceeded dispatches.
+pub(crate) struct DispatchIdleNudgeHandler {
+    tracker: Mutex<DispatchIdleNudgeTracker>,
+}
+impl DispatchIdleNudgeHandler {
+    pub(crate) fn new() -> Self {
+        Self {
+            tracker: Mutex::new(DispatchIdleNudgeTracker::default()),
+        }
+    }
+}
+impl PerTickHandler for DispatchIdleNudgeHandler {
+    fn name(&self) -> &'static str {
+        "dispatch_idle_nudge"
+    }
+    fn run(&self, ctx: &TickContext<'_>) {
+        self.tracker.lock().maybe_scan(ctx.home);
+    }
+}
+
+/// Retention sweep (review-task / tmp GC supervisor).
+pub(crate) struct RetentionHandler {
+    tracker: Mutex<RetentionSupervisor>,
+}
+impl RetentionHandler {
+    pub(crate) fn new() -> Self {
+        Self {
+            tracker: Mutex::new(RetentionSupervisor::default()),
+        }
+    }
+}
+impl PerTickHandler for RetentionHandler {
+    fn name(&self) -> &'static str {
+        "retention"
+    }
+    fn run(&self, ctx: &TickContext<'_>) {
+        self.tracker.lock().maybe_sweep(ctx.home);
+    }
+}
+
+/// The 12 supervisor trackers migrated by W1.1, in the relative order they ran
+/// in the supervisor `run_loop` (supervisor.rs:384-395, pre-W1.1). The
+/// completeness invariant below pins this exact list against the registered
+/// handler set.
+#[cfg(test)]
+pub(crate) const MIGRATED_TRACKER_NAMES: &[&str] = &[
+    "anti_stall",
+    "idle_watchdog",
+    "decision_timeout",
+    "helper_staleness",
+    "mcp_registry",
+    "waiting_on_stale",
+    "conflict_notify",
+    "canonical_drift",
+    "auto_release",
+    "dispatch_idle",
+    "dispatch_idle_nudge",
+    "retention",
+];
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::MIGRATED_TRACKER_NAMES;
+
+    /// W1.1 completeness invariant (#2050; the #1002 / #1719 app-mode-wiring-
+    /// drift class applied to the supervisor → handler migration).
+    ///
+    /// Every tracker moved off the supervisor `run_loop` MUST be registered in
+    /// `build_default_handlers`. The existing `app_tick_handlers_cover_*`
+    /// invariant CANNOT catch a dropped migration: a forgotten tracker is absent
+    /// from BOTH the daemon and app sets, so their set-difference stays empty and
+    /// that test stays green. This one pins the full expected set against the
+    /// registered handler names directly, so dropping (or never adding) a tracker
+    /// fails CI. It also asserts the 12 keep their original RELATIVE order —
+    /// handler order in the `build_default_handlers` Vec is load-bearing.
+    #[test]
+    fn all_twelve_supervisor_trackers_registered_in_order() {
+        let (crash_tx, _rx) = crossbeam_channel::bounded(1);
+        let stale: crate::daemon::mcp_registry_watcher::DaemonBinaryStale =
+            std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let names: Vec<&str> = crate::daemon::build_default_handlers(crash_tx, true, stale)
+            .iter()
+            .map(|h| h.name())
+            .collect();
+
+        // Present.
+        for n in MIGRATED_TRACKER_NAMES {
+            assert!(
+                names.contains(n),
+                "supervisor tracker '{n}' must be registered as a PerTickHandler (W1.1) — got {names:?}"
+            );
+        }
+
+        // Relative order preserved (subsequence of the registered Vec).
+        let positions: Vec<usize> = MIGRATED_TRACKER_NAMES
+            .iter()
+            .map(|n| {
+                names
+                    .iter()
+                    .position(|x| x == n)
+                    .unwrap_or_else(|| panic!("'{n}' present"))
+            })
+            .collect();
+        let mut sorted = positions.clone();
+        sorted.sort_unstable();
+        assert_eq!(
+            positions, sorted,
+            "the 12 migrated trackers must keep their original relative order (load-bearing); positions={positions:?}"
+        );
+
+        // No duplicate handler names (HANDLER_TIMING + the completeness invariant
+        // both key on name; a collision would silently merge two handlers).
+        let mut uniq = names.clone();
+        uniq.sort_unstable();
+        let before = uniq.len();
+        uniq.dedup();
+        assert_eq!(
+            before,
+            uniq.len(),
+            "handler names must be unique — got {names:?}"
+        );
+    }
+}

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -243,16 +243,13 @@ fn parse_unlock_at(pane_text: &str) -> Option<String> {
 /// Spawn the supervisor thread. Idempotent per process is the caller's
 /// responsibility — in practice each entry point calls it exactly once.
 ///
-/// `daemon_binary_stale` is the shared TUI status-bar flag the
-/// mcp_registry_watcher tracker flips when a post-startup binary
-/// refresh is detected (#1027). Callers without a TUI (headless daemon
-/// mode) pass a throwaway `Arc<AtomicBool>` — the flag still gets set
-/// but nothing is wired to surface it.
-pub fn spawn(
-    home: PathBuf,
-    registry: AgentRegistry,
-    daemon_binary_stale: crate::daemon::mcp_registry_watcher::DaemonBinaryStale,
-) {
+/// W1.1 (#2050): the 12 periodic trackers that used to run inline in this
+/// loop (anti_stall … retention) moved to `PerTickHandler`s in
+/// `build_default_handlers`. The `mcp_registry` tracker owned the only
+/// external dependency this thread needed (the `DaemonBinaryStale` TUI flag),
+/// so with it gone the supervisor no longer takes that argument — the handler
+/// now holds the flag.
+pub fn spawn(home: PathBuf, registry: AgentRegistry) {
     // fire-and-forget: supervisor tick loop runs for the process lifetime
     // (per module-doc rationale at lines 6-8 — "shutdown is implicit: when
     // the hosting process exits, this thread dies with it"). 10s tick
@@ -260,14 +257,10 @@ pub fn spawn(
     // (per-tick metadata read + occasional channel notify).
     let _ = thread::Builder::new()
         .name("supervisor".into())
-        .spawn(move || run_loop(home, registry, daemon_binary_stale));
+        .spawn(move || run_loop(home, registry));
 }
 
-fn run_loop(
-    home: PathBuf,
-    registry: AgentRegistry,
-    daemon_binary_stale: crate::daemon::mcp_registry_watcher::DaemonBinaryStale,
-) {
+fn run_loop(home: PathBuf, registry: AgentRegistry) {
     let mut notify_tracks: HashMap<String, NotifyTrack> = HashMap::new();
     // #1523: deferred AuthError member-notifies awaiting stability confirmation.
     let mut pending_auth: HashMap<String, PendingAuthError> = HashMap::new();
@@ -285,66 +278,15 @@ fn run_loop(
         std::collections::HashMap::new();
     let mut last_continue_inject: HashMap<String, Instant> = HashMap::new();
     let mut pane_input_tracks: HashMap<String, PaneInputTrack> = HashMap::new();
-    // Sprint 59 Wave 1 PR-1 (#9 task stall watchdog): per-task ETA
-    // scanner, throttled to 5min via TICKS_PER_SCAN.
-    let mut anti_stall_tracker = crate::daemon::anti_stall::AntiStallTracker::default();
-    // Sprint 59 Wave 1 PR-2 (#10+#12 watchdog cluster): per-agent +
-    // fleet-wide idle thresholds, throttled to 5min scans.
-    let mut idle_watchdog_tracker = crate::daemon::idle_watchdog::IdleWatchdogTracker::default();
-    // #1022: purge activity sidecars for instances not in fleet.yaml
-    // so ghost agents from prior runs don't pollute the tracking list.
+    // W1.1 (#2050): the 12 periodic trackers (anti_stall, idle_watchdog,
+    // decision_timeout, helper_staleness, mcp_registry, waiting_on_stale,
+    // conflict_notify, canonical_drift, auto_release, dispatch_idle,
+    // dispatch_idle_nudge, retention) that used to be declared here and scanned
+    // inline below moved to `PerTickHandler`s in `build_default_handlers`. This
+    // one-shot boot purge is NOT a per-tick scan — it ran exactly once at
+    // supervisor start, before the loop — so it stays here, unchanged (#1022:
+    // drop ghost activity sidecars for instances no longer in fleet.yaml).
     crate::daemon::idle_watchdog::gc_stale_activity_sidecars(&home);
-    // Sprint 59 Wave 1 PR-4-recover ((B) decision default with
-    // timeout): tracks pending operator decisions, fires auto-default
-    // on timeout. 5min throttle matches anti-stall cadence.
-    let mut decision_timeout_tracker =
-        crate::daemon::decision_timeout::DecisionTimeoutTracker::default();
-    // Sprint 59 Wave 2 PR-3 (#13 deployment-cadence proactive helper-
-    // staleness): periodically reuses cli::classify_helper_staleness
-    // and pings general+lead when a helper goes stale, closing the
-    // operator-pull gap from Sprint 58 PR-1 #11.
-    let mut helper_staleness_tracker =
-        crate::daemon::helper_staleness_watchdog::HelperStalenessWatchdogTracker::default();
-    // Sprint 60 W1 PR-2 (#P0-2 daemon hot-reload tool registry): 5th
-    // tracker. Detects when the daemon binary at current_exe() has
-    // been refreshed AFTER the running process started — running
-    // process's MCP tool registry then lags the on-disk binary's
-    // compiled-in registry. Closes the PR-5 → PR-4 chicken-and-egg loop.
-    let mut mcp_registry_tracker =
-        crate::daemon::mcp_registry_watcher::McpRegistryWatcherTracker::default();
-    let mut waiting_on_stale_tracker =
-        crate::daemon::waiting_on_stale::WaitingOnStaleTracker::default();
-    // Phase A Piece-1+2: per-tick git conflict observation + 30min
-    // escalation. Sibling to waiting_on_stale (same TICKS_PER_SCAN
-    // cadence, same REALERT_INTERVAL_SECS dedup window). No new
-    // spawn site — supervisor's per-tick loop hosts the scan.
-    let mut conflict_notify_tracker =
-        crate::daemon::conflict_notify::ConflictNotifyTracker::default();
-    // #852 residual PR-B: per-tick canonical-drift scan. Sibling to
-    // waiting_on_stale + conflict_notify (same TICKS_PER_SCAN cadence,
-    // same supervisor-hosted no-new-spawn-site pattern). Catches
-    // detached-HEAD residue accrued AFTER daemon boot for long-lived
-    // daemons; reuses the boot-time canonical_hygiene helper.
-    let mut canonical_drift_tracker =
-        crate::daemon::canonical_drift::CanonicalDriftTracker::default();
-    // #870: per-tick auto-release scan. Sibling pattern; faster
-    // cadence (TICKS_PER_SCAN=3 ≈ 30s) than the 30-tick siblings
-    // because release latency directly gates the next-cycle lease-
-    // conflict surface this module exists to eliminate. No new spawn
-    // site — supervisor's per-tick loop hosts the scan.
-    let mut auto_release_tracker = crate::daemon::auto_release::AutoReleaseTracker::default();
-    // PR1 watchdog L1: cross-team-safe dispatch-idle scan. Sibling
-    // pattern; TICKS_PER_SCAN=6 (~60s) because the threshold this
-    // gates (single-digit-minute orchestrator dispatches) demands
-    // sub-minute fire-time accuracy. No new spawn site — supervisor's
-    // per-tick loop hosts the scan.
-    let mut dispatch_idle_tracker = crate::daemon::dispatch_idle::DispatchIdleTracker::default();
-    // PR1 watchdog L2: generic per-team auto-nudge on exceeded dispatches. Same
-    // cadence as L1; fires for ANY team (t-dehardcode-fixup-nudge-multiteam — was
-    // hard-coded to the fixup team).
-    let mut dispatch_idle_nudge_tracker =
-        crate::daemon::dispatch_idle::team_nudge::DispatchIdleNudgeTracker::default();
-    let mut retention_supervisor = crate::daemon::retention::RetentionSupervisor::default();
     // #1741 boot-grace anchor: this Instant ≈ supervisor/daemon boot (set once,
     // never reset). It gates the every-tick pane-input diagnostic so a restart's
     // freshly-empty `pane_input_tracks` dedup map can't re-emit for inputs typed
@@ -381,18 +323,11 @@ fn run_loop(
                 &mut pane_input_tracks,
                 loop_started_at,
             );
-            anti_stall_tracker.maybe_scan(&home);
-            idle_watchdog_tracker.maybe_scan(&home);
-            decision_timeout_tracker.maybe_scan(&home);
-            helper_staleness_tracker.maybe_scan(&home);
-            mcp_registry_tracker.maybe_scan(&daemon_binary_stale);
-            waiting_on_stale_tracker.maybe_scan(&home);
-            conflict_notify_tracker.maybe_scan(&home, &registry);
-            canonical_drift_tracker.maybe_scan(&home);
-            auto_release_tracker.maybe_scan(&home);
-            dispatch_idle_tracker.maybe_scan(&home);
-            dispatch_idle_nudge_tracker.maybe_scan(&home);
-            retention_supervisor.maybe_sweep(&home);
+            // W1.1 (#2050): the 12 inline tracker scans that ran here
+            // (anti_stall … retention) moved to `PerTickHandler`s in
+            // `build_default_handlers`, which the main loop runs at the same
+            // 10s cadence. The trackers keep their internal TICKS_PER_SCAN
+            // throttle, so the effective scan cadence is unchanged.
             // #986: the supervisor loop NO LONGER scans pr_state directly. The
             // `PrStateScanHandler` per-tick handler is the SINGLE scanner in ALL
             // modes — it runs in run_core's handler vec (daemon) AND in
@@ -414,20 +349,21 @@ fn run_loop(
 
             // #1923 G4/G5: prune per-agent in-memory tracker state for agents no
             // longer in the registry (deleted / redeployed), mirroring the #1470
-            // retry_tracks sweep in `process_error_recovery`. These maps live in
-            // `run_loop` (not reachable from the cross-thread `full_delete_instance`
-            // delete path), so the per-tick `.retain` IS their cleanup-on-delete:
-            // a deleted agent leaves the registry → drops out of `live_agents` →
-            // its entries are pruned next tick. Without it a same-name redeploy
-            // inherits the old instance's state — a false-SUPPRESSED crash notify
-            // (notify_tracks dedup) or a false-FIRED conflict escalation
-            // (conflict_notify `last_conflict_at`/`last_escalated_at`).
+            // retry_tracks sweep in `process_error_recovery`. `notify_tracks`
+            // lives in `run_loop` (not reachable from the cross-thread
+            // `full_delete_instance` delete path), so the per-tick `.retain` IS
+            // its cleanup-on-delete: a deleted agent leaves the registry → drops
+            // out of `live_agents` → its entries are pruned next tick. Without
+            // it a same-name redeploy inherits the old instance's state — a
+            // false-SUPPRESSED crash notify (notify_tracks dedup).
+            // W1.1 (#2050): the sibling `conflict_notify_tracker.retain_active`
+            // prune moved into `ConflictNotifyHandler::run` alongside the
+            // tracker it cleans (its state now lives in that handler).
             let live_agents: std::collections::HashSet<String> = {
                 let reg = agent::lock_registry(&registry);
                 reg.values().map(|h| h.name.to_string()).collect()
             };
             notify_tracks.retain(|name, _| live_agents.contains(name));
-            conflict_notify_tracker.retain_active(&live_agents);
         }));
         if let Err(payload) = outcome {
             let msg = if let Some(s) = payload.downcast_ref::<String>() {


### PR DESCRIPTION
## What (REFACTOR-PLAN W1.1 · survey 01-R2 — \"best value-to-risk, do first\")

The supervisor `run_loop` (`supervisor.rs:266`) inlined **12 periodic trackers** — a second periodic-work mechanism parallel to the trait `PerTickHandler` set (the #694 / survey-S3 incomplete-extraction drift). This finishes the extraction: each tracker becomes a thin `PerTickHandler` registered in `build_default_handlers`; the inline supervisor calls are deleted.

Migrated (in original order): `anti_stall`, `idle_watchdog`, `decision_timeout`, `helper_staleness`, `mcp_registry`, `waiting_on_stale`, `conflict_notify`, `canonical_drift`, `auto_release`, `dispatch_idle`, `dispatch_idle_nudge`, `retention`.

## How — pure relocation, zero behavior change on unix

- Each wrapper owns its tracker behind a `Mutex` (the trait's `run(&self)` needs interior mutability; `run_loop` held `&mut` locals) and calls `maybe_scan`/`maybe_sweep` **every tick**. The trackers **self-throttle** internally via their own `TICKS_PER_SCAN`, so **no handler-level cadence gate is added** — scan cadence is identical. (Cadence-hoist is W2.4 `CadenceGate`, explicitly after W1.1.)
- Appended to the handler `Vec` in the **same relative order** they ran inline (load-bearing). They ran on the supervisor thread with no in-tick ordering vs the main-loop handlers → tail-append is the conservative choice.
- Main loop ticks at the **identical 10s** interval (`build_tick_infrastructure` ≡ `supervisor::TICK`) and holds no lock across handlers, matching the supervisor's call conditions.
- `conflict_notify`'s per-tick `retain_active` prune (#1923 G5 cleanup-on-delete, was `supervisor.rs:430`) moves into `ConflictNotifyHandler::run` with its tracker. `notify_tracks.retain` stays (it belongs to `tick()`).
- `mcp_registry`'s `DaemonBinaryStale` TUI flag is threaded through `build_default_handlers` so the handler holds the **same `Arc`** app's render loop reads; `supervisor::spawn` no longer takes it. The one-shot boot `gc_stale_activity_sidecars` purge stays in `run_loop` (never a per-tick scan).

## Completeness invariant (core deliverable; #1002/#1719 class)

`all_twelve_supervisor_trackers_registered_in_order` pins that **all 12 migrated names are registered** in `build_default_handlers` AND keep their relative order. The existing `app_tick_handlers_cover_*` (app⊇daemon) invariant **cannot** catch a dropped migration — a forgotten tracker is absent from *both* sets, so the difference stays empty. This pins the full expected set directly, with teeth.

## Platform delta (honest)

On **unix** (both `run_core` and app mode) this is **strictly behavior-preserving** — same cadence, same lock conditions, trackers just move from the supervisor thread to the main-loop handler thread. The **one delta**: Windows headless `run_core`, whose supervisor is `#[cfg(unix)]`-gated and thus *never ran these trackers* — the universal handler set now runs them there too, matching **app mode (the live daemon, which already ran them on every platform)**. That closes a latent #1720-class gap rather than introducing one.

## LOC-EST

Large by design (relocation): `supervisor.rs` **-128 net**; new `per_tick/supervisor_trackers.rs` **~390 LOC** (12 thin wrappers + module doc + invariant test). All files under the LOC cap (`file_size_invariant` green).

## Tests

`cargo fmt --check` clean · `clippy --all-targets --features tray -D warnings` clean · full `nextest` green (the two env-mutually-exclusive `*_1834` git-checkout tests pass under `AGEND_GIT_BYPASS=1`, as CI runs them). `app_tick_handlers_no_panic_on_empty_context` now exercises all 12 new handlers on empty context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)