### PR TITLE
docs(#2050 W1.3③): align skills.rs module doc to 4 backends (gemini retired)

### DIFF
--- a/src/skills.rs
+++ b/src/skills.rs
@@ -1,6 +1,7 @@
-//! Sprint 60 W2 PR-1 (#P1-1 Skills System Plan IMPL) — 5-backend
+//! Sprint 60 W2 PR-1 (#P1-1 Skills System Plan IMPL) — 4-backend
 //! community skill discovery via unified source + symlink (Windows
-//! copy fallback).
+//! copy fallback). (Originally 5 backends; #1580 retired gemini-cli —
+//! see `BACKEND_SKILL_DIRS`.)
 //!
 //! ## Architecture
 //!
@@ -13,12 +14,11 @@
 //! agent-working-dir/
 //!   ├── .claude/skills/  → symlink → ~/.agend-terminal/skills/
 //!   ├── .codex/skills/   → symlink → ~/.agend-terminal/skills/
-//!   ├── .gemini/skills/  → symlink → ~/.agend-terminal/skills/
 //!   ├── .opencode/skills/→ symlink → ~/.agend-terminal/skills/
 //!   └── .kiro/skills/    → symlink → ~/.agend-terminal/skills/
 //! ```
 //!
-//! Unified source means: one skill file, all 5 backends discover.
+//! Unified source means: one skill file, all 4 backends discover.
 //! No file copies on Unix (symlink = zero maintenance). Windows
 //! falls back to copy with hash-compare staleness detection on
 //! subsequent installs (file-watch infra is out of scope per
@@ -1010,7 +1010,7 @@ mod tests {
     #[test]
     fn install_for_agent_succeeds_with_empty_source_root() {
         // Empty source: install_for_agent ensures the source root exists
-        // (via ensure_skills_root) then iterates 5 backends; each install
+        // (via ensure_skills_root) then iterates 4 backends; each install
         // creates an empty symlink/copy target with the marker. The
         // outcomes vec has one entry per backend, all in Symlink/Copy
         // mode (no Skipped from missing source). This is the daemon's


### PR DESCRIPTION
## What (REFACTOR-PLAN W1.3 item ③ · survey 06-E)

`BACKEND_SKILL_DIRS` lists **4** backends (claude, codex, opencode, kiro) — #1580 retired gemini-cli's `.gemini/skills` — but the `skills.rs` module doc header still said **"5-backend"**, drew `.gemini/skills/` in the architecture diagram, and claimed "all 5 backends discover".

## How

Doc-only alignment to the actual 4-backend reality:
- Header `5-backend` → `4-backend` (+ a note pointing at the const for the #1580 retirement).
- Removed the `.gemini/skills/` line from the architecture diagram.
- `all 5 backends` → `all 4 backends`.
- Fixed one stale `iterates 5 backends` test comment.

The inline comment at `BACKEND_SKILL_DIRS` already recorded the #1580 retirement; the historical "Originally 5 backends" notes are intentionally kept.

**Zero behavior change** — comments/docs only. `skills` test module 28/28 green, `fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)