### PR TITLE
refactor(#2050 W1.3②): move spawn_one from api/mod.rs to agent_ops

### DIFF
--- a/src/agent_ops.rs
+++ b/src/agent_ops.rs
@@ -10,9 +10,11 @@
 //! (Commit 2) will delete the duplicates and switch imports, at which
 //! point the drift is automatically fixed for MCP callers.
 
+use crate::agent::{self, AgentRegistry};
 use crate::identity::Sender;
 use serde_json::{json, Value};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 // ---------------------------------------------------------------------------
 // Messaging
@@ -441,6 +443,110 @@ pub fn cleanup_working_dir(home: &Path, name: &str, working_dir: &Path) {
 /// canonical helper landed in PR1 (#923).
 pub fn list_agents() -> Vec<String> {
     crate::runtime::list_agents_with_fallback(&crate::home_dir())
+}
+
+/// Spawn a single agent into `registry` and start its TUI-serve thread.
+/// Shared by the SPAWN and CREATE_TEAM API handlers.
+///
+/// `env` carries the resolved process env to apply on top of inherited
+/// vars (post sensitive-env deny-list filter; see
+/// `agent::is_sensitive_env_key`). Callers are expected to resolve from
+/// `params.env` or `FleetConfig::resolve_instance(name).env` BEFORE
+/// invoking — `spawn_one` is a pure data consumer here, not a re-resolver,
+/// so a single canonical resolve site at the handler boundary stays
+/// authoritative (#900 hybrid (b)+(c) design).
+///
+/// W1.3② (#2050): moved verbatim from `api/mod.rs` to its cohesive home next
+/// to `remove_metadata` (which it calls) — `api/mod.rs` was the server file,
+/// not the owner of agent-spawn primitives. Behavior unchanged.
+#[allow(clippy::too_many_arguments)]
+pub fn spawn_one(
+    home: &Path,
+    registry: &AgentRegistry,
+    name: &str,
+    backend: &str,
+    args: &[String],
+    spawn_mode: crate::backend::SpawnMode,
+    work_dir: &Path,
+    size: (u16, u16),
+    env: Option<&std::collections::HashMap<String, String>>,
+) -> anyhow::Result<crate::backend::SpawnMode> {
+    std::fs::create_dir_all(work_dir).ok();
+    // #1080: skills auto-install for dynamically spawned instances.
+    // spawn_one is the SPAWN-RPC choke point — without this, instances
+    // created via create_instance / start_instance / replace_instance
+    // never get skill symlinks (only cold-boot spawn_and_register_agent
+    // called install_for_agent). Respects fleet.yaml `instance.<name>.skills:`
+    // allowlist, same as cold-boot path.
+    let skills_filter: Option<Vec<String>> =
+        crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))
+            .ok()
+            .and_then(|c| c.instances.get(name).and_then(|i| i.skills.clone()));
+    let backend_skill =
+        crate::backend::Backend::from_command(backend).and_then(|b| b.skill_dir_name());
+    match crate::skills::install_for_agent_backend(
+        home,
+        work_dir,
+        skills_filter.as_deref(),
+        backend_skill,
+    ) {
+        Ok(outcomes) => {
+            let modes: Vec<(&str, crate::skills::InstallMode)> = outcomes
+                .iter()
+                .map(|o| (o.backend.as_str(), o.mode))
+                .collect();
+            tracing::info!(agent = %name, ?modes, "spawn_one skills auto-install complete");
+        }
+        Err(e) => {
+            tracing::warn!(agent = %name, error = %e, "spawn_one skills auto-install failed, proceeding");
+        }
+    }
+    // Sprint 34: clear stale metadata from a previous instance with the
+    // same name. spawn_one is the true choke point — both handle_spawn
+    // (direct) and team.rs (team-spawn) flow through here.
+    // #1682: clear BOTH the legacy name file and the id-resolved file — post-#1680
+    // readers use `<uuid>.json`, which the old name-only remove left stale.
+    remove_metadata(home, name);
+    let preset_submit_key = crate::backend::Backend::from_command(backend)
+        .map(|b| b.preset().submit_key)
+        .unwrap_or("\r");
+    // No-op when caller already passed Fresh; downgrades Resume → Fresh when
+    // there is no resumable session in `work_dir` (see
+    // `SpawnMode::downgraded_for`). Returned so callers (e.g. the
+    // `create_instance` API handler) can see the actual mode used and gate
+    // post-spawn behavior like the "skip broadcast on Resume" rule.
+    let spawn_mode = spawn_mode.downgraded_for(backend, Some(work_dir));
+    agent::spawn_agent(
+        &agent::SpawnConfig {
+            name,
+            backend_command: backend,
+            args,
+            spawn_mode,
+            cols: size.0,
+            rows: size.1,
+            env,
+            working_dir: Some(work_dir),
+            submit_key: preset_submit_key,
+            home: Some(home),
+            crash_tx: None,
+            shutdown: None,
+        },
+        registry,
+    )?;
+    let rdir = crate::daemon::run_dir(home);
+    let reg = Arc::clone(registry);
+    let n = name.to_string();
+    // fire-and-forget: per-agent TUI-socket server; runs for the agent's
+    // lifetime and self-terminates when `serve_agent_tui` sees the agent leave
+    // the registry / the run dir socket closes (no graceful-join needed —
+    // mirrors the cold-boot `spawn_and_register_agent` TUI thread). §10.5: this
+    // spawn previously rode `api/mod.rs`'s legacy exemption; the W1.3② move into
+    // an in-scope file gives it a real rationale instead.
+    std::thread::Builder::new()
+        .name(format!("{n}_tui"))
+        .spawn(move || crate::daemon::serve_agent_tui(&n, &rdir, &reg))
+        .ok();
+    Ok(spawn_mode)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/api/handlers/instance.rs
+++ b/src/api/handlers/instance.rs
@@ -242,7 +242,7 @@ pub(crate) fn handle_spawn(params: &Value, ctx: &HandlerCtx) -> Value {
     };
     let env_for_spawn = env_from_params.as_ref().or(env_from_fleet.as_ref());
 
-    match crate::api::spawn_one(
+    match crate::agent_ops::spawn_one(
         ctx.home,
         ctx.registry,
         name,
@@ -797,7 +797,7 @@ mod tests {
         let size = (80u16, 24u16);
         let work_dir = crate::paths::workspace_dir(&home).join("team-meta");
         std::fs::create_dir_all(&work_dir).ok();
-        let result = crate::api::spawn_one(
+        let result = crate::agent_ops::spawn_one(
             ctx.home,
             ctx.registry,
             "team-meta",

--- a/src/api/handlers/team.rs
+++ b/src/api/handlers/team.rs
@@ -203,7 +203,7 @@ pub(crate) fn handle_create_team(params: &Value, ctx: &HandlerCtx) -> Value {
         if let Some(model) = resolved.as_ref().and_then(|r| r.model.as_deref()) {
             crate::backend::Backend::push_model_arg(&mut member_args, backend, model);
         }
-        match crate::api::spawn_one(
+        match crate::agent_ops::spawn_one(
             ctx.home,
             ctx.registry,
             inst_name,

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -4,7 +4,7 @@
 //! Port is published to `{run_dir}/api.port`; see `ipc.rs` for the port
 //! registry and loopback-binding rules.
 
-use crate::agent::{self, AgentRegistry, ExternalRegistry};
+use crate::agent::{AgentRegistry, ExternalRegistry};
 use anyhow::Context;
 use parking_lot::Mutex;
 use serde_json::{json, Value};
@@ -649,100 +649,6 @@ fn spawn_peer_pid_watcher(pid: u32, stream: std::net::TcpStream) {
             }
         })
         .ok();
-}
-
-/// Spawn a single agent, register it, and start its TUI socket thread.
-/// Shared by the SPAWN and CREATE_TEAM API handlers.
-///
-/// `env` carries the resolved process env to apply on top of inherited
-/// vars (post sensitive-env deny-list filter; see
-/// `agent::is_sensitive_env_key`). Callers are expected to resolve from
-/// `params.env` or `FleetConfig::resolve_instance(name).env` BEFORE
-/// invoking — `spawn_one` is a pure data consumer here, not a re-resolver,
-/// so a single canonical resolve site at the handler boundary stays
-/// authoritative (#900 hybrid (b)+(c) design).
-#[allow(clippy::too_many_arguments)]
-fn spawn_one(
-    home: &Path,
-    registry: &AgentRegistry,
-    name: &str,
-    backend: &str,
-    args: &[String],
-    spawn_mode: crate::backend::SpawnMode,
-    work_dir: &Path,
-    size: (u16, u16),
-    env: Option<&std::collections::HashMap<String, String>>,
-) -> anyhow::Result<crate::backend::SpawnMode> {
-    std::fs::create_dir_all(work_dir).ok();
-    // #1080: skills auto-install for dynamically spawned instances.
-    // spawn_one is the SPAWN-RPC choke point — without this, instances
-    // created via create_instance / start_instance / replace_instance
-    // never get skill symlinks (only cold-boot spawn_and_register_agent
-    // called install_for_agent). Respects fleet.yaml `instance.<name>.skills:`
-    // allowlist, same as cold-boot path.
-    let skills_filter: Option<Vec<String>> =
-        crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))
-            .ok()
-            .and_then(|c| c.instances.get(name).and_then(|i| i.skills.clone()));
-    let backend_skill =
-        crate::backend::Backend::from_command(backend).and_then(|b| b.skill_dir_name());
-    match crate::skills::install_for_agent_backend(
-        home,
-        work_dir,
-        skills_filter.as_deref(),
-        backend_skill,
-    ) {
-        Ok(outcomes) => {
-            let modes: Vec<(&str, crate::skills::InstallMode)> = outcomes
-                .iter()
-                .map(|o| (o.backend.as_str(), o.mode))
-                .collect();
-            tracing::info!(agent = %name, ?modes, "spawn_one skills auto-install complete");
-        }
-        Err(e) => {
-            tracing::warn!(agent = %name, error = %e, "spawn_one skills auto-install failed, proceeding");
-        }
-    }
-    // Sprint 34: clear stale metadata from a previous instance with the
-    // same name. spawn_one is the true choke point — both handle_spawn
-    // (direct) and team.rs (team-spawn) flow through here.
-    // #1682: clear BOTH the legacy name file and the id-resolved file — post-#1680
-    // readers use `<uuid>.json`, which the old name-only remove left stale.
-    crate::agent_ops::remove_metadata(home, name);
-    let preset_submit_key = crate::backend::Backend::from_command(backend)
-        .map(|b| b.preset().submit_key)
-        .unwrap_or("\r");
-    // No-op when caller already passed Fresh; downgrades Resume → Fresh when
-    // there is no resumable session in `work_dir` (see
-    // `SpawnMode::downgraded_for`). Returned so callers (e.g. the
-    // `create_instance` API handler) can see the actual mode used and gate
-    // post-spawn behavior like the "skip broadcast on Resume" rule.
-    let spawn_mode = spawn_mode.downgraded_for(backend, Some(work_dir));
-    agent::spawn_agent(
-        &agent::SpawnConfig {
-            name,
-            backend_command: backend,
-            args,
-            spawn_mode,
-            cols: size.0,
-            rows: size.1,
-            env,
-            working_dir: Some(work_dir),
-            submit_key: preset_submit_key,
-            home: Some(home),
-            crash_tx: None,
-            shutdown: None,
-        },
-        registry,
-    )?;
-    let rdir = crate::daemon::run_dir(home);
-    let reg = Arc::clone(registry);
-    let n = name.to_string();
-    std::thread::Builder::new()
-        .name(format!("{n}_tui"))
-        .spawn(move || crate::daemon::serve_agent_tui(&n, &rdir, &reg))
-        .ok();
-    Ok(spawn_mode)
 }
 
 /// Send a request to the daemon API and read one NDJSON response.


### PR DESCRIPTION
## What (REFACTOR-PLAN W1.3 item ② · survey 02-#4)

`spawn_one` — the SPAWN / CREATE_TEAM choke point (80-LOC cohesive agent-spawn fn) — lived in the api **server** file `api/mod.rs`, but it's an agent-spawn primitive: it already calls `agent_ops::remove_metadata` and is invoked from `api/handlers/{instance,team}` via `crate::api::spawn_one`. Moved to its cohesive home `agent_ops`.

## How (verbatim move, behavior-unchanged)

- Moved `spawn_one` from `api/mod.rs` → `agent_ops.rs`, made `pub` (was module-private, visible to `api::handlers` descendants; now needs `pub` for the sibling callers).
- Repointed the 3 callers: `api/handlers/instance.rs` (×2) + `api/handlers/team.rs` → `crate::agent_ops::spawn_one`.
- `crate::agent_ops::remove_metadata(...)` call simplifies to `remove_metadata(...)` (same module now).
- Dropped the now-unused `self` from `api/mod.rs`'s `use crate::agent::{...}`.
- The `spawn_one_resolves_preset_submit_key` test **stays** in `api/mod.rs` — it exercises `Backend::from_command`/`preset`, not the moved symbol.

## §10.5 spawn-rationale

The TUI-serve thread spawn previously rode `api/mod.rs`'s `EXEMPTED_LEGACY_FILES` grandfather. `agent_ops.rs` is **in-scope** for the spawn-rationale audit, so the move upgrades it with a real `// fire-and-forget:` rationale (naming the shutdown trigger). The audit explicitly warns the exemption list should shrink, not grow — so this is a net improvement, not a new exemption.

## Tests

`cargo fmt --check` clean · `clippy --all-targets --features tray -D warnings` clean · `spawn_rationale_audit` + `agent_ops` + `instance` + `team` + `spawn_one*` tests green · full `nextest` green (the two env-mutually-exclusive `*_1834` git tests pass under `AGEND_GIT_BYPASS=1`, as CI runs them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)