### PR TITLE
refactor(W1.2): git_cmd/git_ok daemon-git helpers + seal migrated modules

### DIFF
--- a/src/binding.rs
+++ b/src/binding.rs
@@ -349,10 +349,14 @@ pub fn install_hooks(home: &Path, worktree: &Path) {
     let _ = std::fs::write(&ps_path, ps_hook);
 
     // Set core.hooksPath on the worktree.
-    let _ = std::process::Command::new("git")
-        .args(["config", "core.hooksPath", &hooks_dir.display().to_string()])
-        .current_dir(worktree)
-        .output();
+    // W1.2 class-2: BEHAVIOR DELTA — adds AGEND_GIT_BYPASS (this site previously
+    // ran raw `git` with NO bypass env). `git config` against a fleet-managed
+    // worktree is exactly the forgot-bypass latent class (#821/#1463): a daemon
+    // git mutation should always bypass the agend-git shim. Intended fix.
+    let _ = crate::git_helpers::git_ok(
+        worktree,
+        &["config", "core.hooksPath", &hooks_dir.display().to_string()],
+    );
 }
 
 /// Install hooks on all existing worktrees (daemon startup reconcile).

--- a/src/branch_sweep.rs
+++ b/src/branch_sweep.rs
@@ -118,24 +118,19 @@ impl Categories {
 /// Enumerate local branches via `git for-each-ref`, parsing name +
 /// tip SHA + ISO-8601 committerdate per line.
 fn enumerate_branches(repo: &Path) -> Result<Vec<BranchInfo>, String> {
-    let output = std::process::Command::new("git")
-        .args([
+    // W1.2: git_cmd = always-bypass + bounded + trimmed stdout; its GitError
+    // covers both the spawn-fail and non-zero-exit branches this used to handle
+    // separately (same semantics, more structured message).
+    let stdout = crate::git_helpers::git_cmd(
+        repo,
+        &[
             "for-each-ref",
             "--sort=-committerdate",
             "--format=%(refname:short)|%(objectname)|%(committerdate:iso8601-strict)",
             "refs/heads/",
-        ])
-        .current_dir(repo)
-        .env("AGEND_GIT_BYPASS", "1")
-        .output()
-        .map_err(|e| format!("git for-each-ref spawn failed: {e}"))?;
-    if !output.status.success() {
-        return Err(format!(
-            "git for-each-ref failed: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
-        ));
-    }
-    let stdout = String::from_utf8_lossy(&output.stdout);
+        ],
+    )
+    .map_err(|e| format!("git for-each-ref: {e}"))?;
     let branches: Vec<BranchInfo> = stdout
         .lines()
         .filter_map(|line| {
@@ -160,16 +155,11 @@ fn enumerate_branches(repo: &Path) -> Result<Vec<BranchInfo>, String> {
 /// commit (`git branch --merged base` includes it). Used to detect
 /// the `clean_merged` category.
 fn is_clean_merged(repo: &Path, base: &str, branch: &str) -> bool {
-    let output = std::process::Command::new("git")
-        .args(["branch", "--merged", base])
-        .current_dir(repo)
-        .env("AGEND_GIT_BYPASS", "1")
-        .output();
-    let Ok(o) = output else { return false };
-    if !o.status.success() {
+    // W1.2: git_cmd → trimmed stdout on success; both the spawn-error and
+    // non-zero-exit `return false` branches collapse to the `Err → false` arm.
+    let Ok(stdout) = crate::git_helpers::git_cmd(repo, &["branch", "--merged", base]) else {
         return false;
-    }
-    let stdout = String::from_utf8_lossy(&o.stdout);
+    };
     stdout
         .lines()
         .map(|l| l.trim_start_matches('*').trim())
@@ -201,16 +191,11 @@ pub(crate) fn is_squash_merged(repo: &Path, base: &str, branch: &str) -> bool {
 
 /// `git cherry` based detection.
 fn is_squash_merged_cherry(repo: &Path, base: &str, branch: &str) -> bool {
-    let output = std::process::Command::new("git")
-        .args(["cherry", base, branch])
-        .current_dir(repo)
-        .env("AGEND_GIT_BYPASS", "1")
-        .output();
-    let Ok(o) = output else { return false };
-    if !o.status.success() {
+    // W1.2: git_cmd → trimmed stdout on success; spawn-error + non-zero-exit
+    // both collapse to the `Err → false` arm.
+    let Ok(stdout) = crate::git_helpers::git_cmd(repo, &["cherry", base, branch]) else {
         return false;
-    }
-    let stdout = String::from_utf8_lossy(&o.stdout);
+    };
     let mut had_any = false;
     for line in stdout.lines() {
         let trimmed = line.trim();
@@ -445,13 +430,10 @@ pub(crate) fn emit_delete_batch(
         let Some(cand) = name_to_candidate.get(name.as_str()) else {
             continue;
         };
-        let output = std::process::Command::new("git")
-            .args(["branch", "-D", name])
-            .current_dir(repo)
-            .env("AGEND_GIT_BYPASS", "1")
-            .output();
-        match output {
-            Ok(o) if o.status.success() => {
+        // W1.2: git_cmd's GitError preserves the two distinct failure logs this
+        // site emits — NonZero carries the trimmed stderr, Spawn carries the io error.
+        match crate::git_helpers::git_cmd(repo, &["branch", "-D", name]) {
+            Ok(_) => {
                 deleted += 1;
                 let category = category_of(name);
                 crate::event_log::log(
@@ -465,18 +447,15 @@ pub(crate) fn emit_delete_batch(
                     ),
                 );
             }
-            Ok(o) => {
+            Err(crate::git_helpers::GitError::NonZero { stderr, .. }) => {
                 crate::event_log::log(
                     home,
                     "branch_sweep_apply_failed",
                     "system:branch_sweep",
-                    &format!(
-                        "branch={name} stderr={}",
-                        String::from_utf8_lossy(&o.stderr).trim()
-                    ),
+                    &format!("branch={name} stderr={stderr}"),
                 );
             }
-            Err(e) => {
+            Err(crate::git_helpers::GitError::Spawn(e)) => {
                 crate::event_log::log(
                     home,
                     "branch_sweep_apply_failed",

--- a/src/branch_sweep.rs
+++ b/src/branch_sweep.rs
@@ -216,13 +216,11 @@ fn is_squash_merged_cherry(repo: &Path, base: &str, branch: &str) -> bool {
 /// branch name reuse.
 fn is_squash_merged_diff(repo: &Path, base: &str, branch: &str) -> bool {
     // Resolve owner/repo from git remote origin.
-    let remote = std::process::Command::new("git")
-        .args(["remote", "get-url", "origin"])
-        .current_dir(repo)
-        .output()
-        .ok()
-        .filter(|o| o.status.success())
-        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string());
+    // W1.2 class-2: BEHAVIOR DELTA — adds AGEND_GIT_BYPASS (this site previously
+    // ran raw `git` with NO bypass env). Daemon-side git over a fleet repo is the
+    // forgot-bypass latent class (#821/#1463); always-bypass is the intended fix.
+    // git_cmd trims stdout → identical to the prior `.trim().to_string()`.
+    let remote = crate::git_helpers::git_cmd(repo, &["remote", "get-url", "origin"]).ok();
     let Some(remote_url) = remote else {
         return false;
     };
@@ -231,13 +229,9 @@ fn is_squash_merged_diff(repo: &Path, base: &str, branch: &str) -> bool {
         return false;
     };
     // Get local branch tip SHA.
-    let local_sha = std::process::Command::new("git")
-        .args(["rev-parse", branch])
-        .current_dir(repo)
-        .output()
-        .ok()
-        .filter(|o| o.status.success())
-        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string());
+    // W1.2 class-2: BEHAVIOR DELTA — adds AGEND_GIT_BYPASS (was raw, no bypass).
+    // Same forgot-bypass class as the remote read above; git_cmd trims → identical.
+    let local_sha = crate::git_helpers::git_cmd(repo, &["rev-parse", branch]).ok();
     let Some(local_sha) = local_sha else {
         return false;
     };

--- a/src/git_helpers.rs
+++ b/src/git_helpers.rs
@@ -123,6 +123,65 @@ pub(crate) fn spawn_group_bounded(
     }
 }
 
+/// W1.2 (#REFACTOR-PLAN): a structured failure from [`git_cmd`]. Distinguishes a
+/// spawn/timeout failure (git never produced a status) from a non-zero exit (git
+/// ran and rejected). Carries the exit code + trimmed stderr so a caller that
+/// branched on `output.status.code()` / stderr keeps the same information —
+/// migration preserves error-branch semantics, only the shape is more structured.
+#[derive(Debug)]
+pub(crate) enum GitError {
+    /// git failed to spawn, or the bounded wait errored (incl. `TimedOut`).
+    Spawn(std::io::Error),
+    /// git ran but exited non-zero. `code` is `None` for a signal-kill.
+    NonZero { code: Option<i32>, stderr: String },
+}
+
+impl std::fmt::Display for GitError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GitError::Spawn(e) => write!(f, "git spawn failed: {e}"),
+            GitError::NonZero { code, stderr } => write!(
+                f,
+                "git exited {}: {}",
+                code.map(|c| c.to_string())
+                    .unwrap_or_else(|| "signal".to_string()),
+                stderr
+            ),
+        }
+    }
+}
+
+impl std::error::Error for GitError {}
+
+/// W1.2: THE ergonomic entry point for a daemon-internal LOCAL git command.
+/// Always `AGEND_GIT_BYPASS` + bounded by `LOCAL_GIT_TIMEOUT` (both via
+/// [`git_bypass`]), returns **trimmed stdout** on success or a structured
+/// [`GitError`] on spawn-failure / non-zero exit. A caller routed through this
+/// CANNOT forget the bypass env or the timeout — that's what W1.2 makes
+/// structurally impossible (enforced by a grep invariant). For a "did it
+/// succeed?" check that discards the output, use [`git_ok`].
+pub(crate) fn git_cmd(cwd: &Path, args: &[&str]) -> Result<String, GitError> {
+    let out = git_bypass(cwd, args).map_err(GitError::Spawn)?;
+    if !out.status.success() {
+        return Err(GitError::NonZero {
+            code: out.status.code(),
+            stderr: String::from_utf8_lossy(&out.stderr).trim().to_string(),
+        });
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+/// W1.2: the boolean form of [`git_cmd`] — `true` iff git spawned AND exited 0.
+/// Swallows the output and any spawn/timeout error (→ `false`), matching the
+/// ubiquitous daemon idiom
+/// `Command::new("git")…output().map(|o| o.status.success()).unwrap_or(false)`
+/// that this absorbs (same bypass env, plus the `LOCAL_GIT_TIMEOUT` bound).
+pub(crate) fn git_ok(cwd: &Path, args: &[&str]) -> bool {
+    git_bypass(cwd, args)
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
 /// Detect the default branch of a repository.
 /// Reads `refs/remotes/origin/HEAD` → extracts branch name.
 /// Falls back to "main" if detection fails.
@@ -160,6 +219,87 @@ pub fn primary_remote(repo_dir: &Path) -> String {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+
+    /// A real, isolated git repo (one empty commit on `main`), built through the
+    /// shim bypass so a fleet-agent test run isn't ChdirPass'd (#1463).
+    fn tmp_repo(tag: &str) -> std::path::PathBuf {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static C: AtomicU32 = AtomicU32::new(0);
+        let dir = std::env::temp_dir().join(format!(
+            "agend-gitcmd-{}-{}-{}",
+            tag,
+            std::process::id(),
+            C.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        for args in [
+            vec!["init", "-b", "main"],
+            vec![
+                "-c",
+                "user.name=t",
+                "-c",
+                "user.email=t@t",
+                "commit",
+                "--allow-empty",
+                "-m",
+                "init",
+            ],
+        ] {
+            std::process::Command::new("git")
+                .env("AGEND_GIT_BYPASS", "1")
+                .args(&args)
+                .current_dir(&dir)
+                .output()
+                .unwrap();
+        }
+        dir
+    }
+
+    /// W1.2 §3.9: `git_cmd` returns TRIMMED stdout on success, a structured
+    /// `GitError::NonZero` (with code + stderr) on a non-zero exit, and never
+    /// leaks the bypass-env / timeout wiring to the caller.
+    #[test]
+    fn git_cmd_trims_stdout_and_structures_errors_w1_2() {
+        let repo = tmp_repo("ok");
+        // Success → trimmed (no trailing newline).
+        let head = git_cmd(&repo, &["rev-parse", "--abbrev-ref", "HEAD"]).unwrap();
+        assert_eq!(head, "main", "stdout must be trimmed, no newline");
+        // Non-zero exit → structured NonZero, code present, stderr captured.
+        let err = git_cmd(&repo, &["rev-parse", "definitely-no-such-ref"]).unwrap_err();
+        match err {
+            GitError::NonZero { code, stderr } => {
+                assert_eq!(code, Some(128), "git's usage/ref error exit code");
+                assert!(!stderr.is_empty(), "stderr captured for the caller");
+            }
+            GitError::Spawn(e) => panic!("expected NonZero, got spawn error: {e}"),
+        }
+        std::fs::remove_dir_all(&repo).ok();
+    }
+
+    /// W1.2 §3.9: `git_ok` is `true` on exit-0, `false` on non-zero — the
+    /// boolean idiom this absorbs.
+    #[test]
+    fn git_ok_reflects_exit_status_w1_2() {
+        let repo = tmp_repo("bool");
+        assert!(
+            git_ok(&repo, &["rev-parse", "--git-dir"]),
+            "valid repo → true"
+        );
+        assert!(
+            !git_ok(&repo, &["rev-parse", "definitely-no-such-ref"]),
+            "non-zero exit → false"
+        );
+        // A non-repo dir → git errors → false (matches the `.unwrap_or(false)` idiom).
+        let nonrepo =
+            std::env::temp_dir().join(format!("agend-gitcmd-nonrepo-{}", std::process::id()));
+        std::fs::create_dir_all(&nonrepo).ok();
+        assert!(
+            !git_ok(&nonrepo, &["rev-parse", "--git-dir"]),
+            "non-repo → false"
+        );
+        std::fs::remove_dir_all(&repo).ok();
+        std::fs::remove_dir_all(&nonrepo).ok();
+    }
 
     // #1897 §3.9: the timeout + process-group-kill mechanism, driven by `sleep`
     // stubs (unix). The git path is `spawn_group_bounded` with `git` as the

--- a/src/worktree_cleanup.rs
+++ b/src/worktree_cleanup.rs
@@ -64,13 +64,12 @@ fn list_worktrees(repo_root: &Path) -> Vec<WorktreeEntry> {
 /// Check if a branch is merged into the default branch (local check, no API needed).
 fn is_branch_merged(repo_root: &Path, branch: &str) -> bool {
     let default = crate::git_helpers::default_branch(repo_root);
-    Command::new("git")
-        .args(["merge-base", "--is-ancestor", branch, &default])
-        .current_dir(repo_root)
-        .env("AGEND_GIT_BYPASS", "1")
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false)
+    // W1.2: git_ok = always-bypass + bounded, true iff exit-0 (the
+    // `output().map(success).unwrap_or(false)` idiom, byte-for-byte).
+    crate::git_helpers::git_ok(
+        repo_root,
+        &["merge-base", "--is-ancestor", branch, &default],
+    )
 }
 
 /// Check if a branch's remote tracking ref has been deleted (i.e. the PR was
@@ -127,13 +126,10 @@ fn remove_worktree(repo_root: &Path, worktree_path: &str, branch: &str) -> bool 
         if attempt > 0 {
             std::thread::sleep(std::time::Duration::from_millis(100 * (1 << attempt)));
         }
-        wt_ok = Command::new("git")
-            .args(["worktree", "remove", "--force", worktree_path])
-            .current_dir(repo_root)
-            .env("AGEND_GIT_BYPASS", "1")
-            .output()
-            .map(|o| o.status.success())
-            .unwrap_or(false);
+        wt_ok = crate::git_helpers::git_ok(
+            repo_root,
+            &["worktree", "remove", "--force", worktree_path],
+        );
         if wt_ok {
             break;
         }
@@ -326,13 +322,7 @@ fn prune_orphaned_branches(repo_root: &Path) -> Vec<String> {
         if !merged && !gone && !squash {
             continue;
         }
-        let ok = Command::new("git")
-            .args(["branch", "-D", branch])
-            .current_dir(repo_root)
-            .env("AGEND_GIT_BYPASS", "1")
-            .output()
-            .map(|o| o.status.success())
-            .unwrap_or(false);
+        let ok = crate::git_helpers::git_ok(repo_root, &["branch", "-D", branch]);
         if ok {
             let reason = if merged {
                 "merged"

--- a/src/worktree_cleanup.rs
+++ b/src/worktree_cleanup.rs
@@ -30,12 +30,18 @@ pub struct WorktreeEntry {
 
 /// List all git worktrees (excluding the main worktree).
 fn list_worktrees(repo_root: &Path) -> Vec<WorktreeEntry> {
-    let output = Command::new("git")
+    // git-raw-allowed: TRIM-SENSITIVE parser. `--porcelain` terminates each
+    // worktree record with a blank line; the loop below flushes a pending entry
+    // on that blank line. `git_cmd` trims trailing whitespace → the final record's
+    // terminator is dropped → the last (often only) worktree is never pushed →
+    // the sweep silently finds nothing. Must read raw, untrimmed stdout.
+    // (Already AGEND_GIT_BYPASS.)
+    let output = match Command::new("git")
         .args(["worktree", "list", "--porcelain"])
         .current_dir(repo_root)
         .env("AGEND_GIT_BYPASS", "1")
-        .output();
-    let output = match output {
+        .output()
+    {
         Ok(o) if o.status.success() => o,
         _ => return Vec::new(),
     };
@@ -78,41 +84,45 @@ fn is_branch_merged(repo_root: &Path, branch: &str) -> bool {
 /// rewrites the commit hash.
 fn is_remote_gone(repo_root: &Path, branch: &str) -> bool {
     // Read upstream tracking remote name
-    let output = Command::new("git")
-        .args(["config", &format!("branch.{branch}.remote")])
-        .current_dir(repo_root)
-        .env("AGEND_GIT_BYPASS", "1")
-        .output();
-    let remote = output
-        .as_ref()
-        .ok()
-        .filter(|o| o.status.success() && !o.stdout.is_empty())
-        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string());
+    // W1.2: git_cmd → trimmed stdout on success; the `success && !stdout.is_empty()`
+    // filter becomes Ok-then-non-empty.
+    let remote =
+        crate::git_helpers::git_cmd(repo_root, &["config", &format!("branch.{branch}.remote")])
+            .ok()
+            .filter(|s| !s.is_empty());
     let Some(remote) = remote else {
         // No remote configured — not a remote-tracking branch, don't treat as "gone"
         return false;
     };
     // Check if the remote ref still exists
     let remote_ref = format!("refs/remotes/{remote}/{branch}");
+    // git-raw-allowed: error→EXISTS (`unwrap_or(true)`) is a deliberate safe
+    // default — a transient git error must NOT be read as "remote gone" (which
+    // would auto-delete a live branch). `git_ok`'s error→false would INVERT this,
+    // so do not "tidy" this into git_ok. (Already AGEND_GIT_BYPASS.)
     let exists = Command::new("git")
         .args(["rev-parse", "--verify", &remote_ref])
         .current_dir(repo_root)
         .env("AGEND_GIT_BYPASS", "1")
         .output()
         .map(|o| o.status.success())
-        .unwrap_or(true); // assume exists on error (safe default)
+        .unwrap_or(true);
     !exists
 }
 
 /// Check if a worktree has uncommitted changes.
 fn is_worktree_dirty(worktree_path: &Path) -> bool {
+    // git-raw-allowed: error→DIRTY (`unwrap_or(true)`) is a deliberate safe
+    // default — a git error must protect uncommitted work, not let it be swept.
+    // `git_ok`'s error→false would invert this (also: needs `!stdout.is_empty()`,
+    // not exit-status). (Already AGEND_GIT_BYPASS.)
     Command::new("git")
         .args(["status", "--porcelain"])
         .current_dir(worktree_path)
         .env("AGEND_GIT_BYPASS", "1")
         .output()
         .map(|o| !o.stdout.is_empty())
-        .unwrap_or(true) // assume dirty on error (safe default)
+        .unwrap_or(true)
 }
 
 /// Remove a worktree and delete its branch.
@@ -135,11 +145,8 @@ fn remove_worktree(repo_root: &Path, worktree_path: &str, branch: &str) -> bool 
         }
     }
     if wt_ok {
-        let _ = Command::new("git")
-            .args(["branch", "-D", branch])
-            .current_dir(repo_root)
-            .env("AGEND_GIT_BYPASS", "1")
-            .output();
+        // W1.2: best-effort branch delete (result was already ignored).
+        let _ = crate::git_helpers::git_ok(repo_root, &["branch", "-D", branch]);
     }
     wt_ok
 }
@@ -197,6 +204,10 @@ pub fn sweep_from_registry(
     for repo in &repos {
         // Prune stale remote refs before remote-gone detection
         let remote = crate::git_helpers::primary_remote(repo);
+        // git-raw-allowed: NETWORK op — `git_cmd` hardcodes LOCAL_GIT_TIMEOUT (60s),
+        // too tight for a fetch; use the raw form (already AGEND_GIT_BYPASS) rather
+        // than shoehorn a network op through the local helper. (A `git_cmd_network`
+        // variant is YAGNI for this single fire-and-forget fetch.)
         let _ = Command::new("git")
             .args(["fetch", "--prune", &remote])
             .current_dir(repo)
@@ -257,16 +268,10 @@ const SQUASH_GC_MIN_TIP_AGE: Duration = Duration::from_secs(24 * 60 * 60);
 /// #1750-B3: age of `branch`'s tip commit (committer date), or `None` if it
 /// can't be resolved. `%ct` is a unix timestamp (seconds), so no date parsing.
 fn branch_tip_age(repo_root: &Path, branch: &str) -> Option<Duration> {
-    let out = Command::new("git")
-        .args(["log", "-1", "--format=%ct", branch])
-        .current_dir(repo_root)
-        .env("AGEND_GIT_BYPASS", "1")
-        .output()
-        .ok()?;
-    if !out.status.success() {
-        return None;
-    }
-    let ts: u64 = String::from_utf8_lossy(&out.stdout).trim().parse().ok()?;
+    // W1.2: git_cmd → trimmed stdout; spawn-error + non-zero both collapse to `None`.
+    let ts_str =
+        crate::git_helpers::git_cmd(repo_root, &["log", "-1", "--format=%ct", branch]).ok()?;
+    let ts: u64 = ts_str.parse().ok()?;
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .ok()?
@@ -294,19 +299,16 @@ fn prune_orphaned_branches(repo_root: &Path) -> Vec<String> {
         .map(|e| e.branch)
         .collect();
 
-    let output = Command::new("git")
-        .args(["branch", "--format=%(refname:short)"])
-        .current_dir(repo_root)
-        .env("AGEND_GIT_BYPASS", "1")
-        .output();
-    let branches: Vec<String> = match output {
-        Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout)
-            .lines()
-            .filter(|b| *b != default.as_str())
-            .map(String::from)
-            .collect(),
-        _ => return Vec::new(),
-    };
+    // W1.2: git_cmd → trimmed stdout on success; spawn-error + non-zero collapse to `Err → []`.
+    let branches: Vec<String> =
+        match crate::git_helpers::git_cmd(repo_root, &["branch", "--format=%(refname:short)"]) {
+            Ok(stdout) => stdout
+                .lines()
+                .filter(|b| *b != default.as_str())
+                .map(String::from)
+                .collect(),
+            _ => return Vec::new(),
+        };
 
     let mut pruned = Vec::new();
     for branch in &branches {
@@ -340,11 +342,8 @@ fn prune_orphaned_branches(repo_root: &Path) -> Vec<String> {
 
 /// Run `git worktree prune` to clean stale worktree bookkeeping entries.
 fn prune_stale_worktrees(repo_root: &Path) {
-    let _ = Command::new("git")
-        .args(["worktree", "prune"])
-        .current_dir(repo_root)
-        .env("AGEND_GIT_BYPASS", "1")
-        .output();
+    // W1.2: best-effort prune (result was already ignored).
+    let _ = crate::git_helpers::git_ok(repo_root, &["worktree", "prune"]);
 }
 
 #[cfg(test)]

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -305,6 +305,13 @@ fn remove_worktree(agent: &str, wt_path: &Path, source_repo: &Path) -> WorktreeR
 
     let wt_str = wt_path.display().to_string();
     let result = if source_repo.as_os_str().is_empty() {
+        // git-raw-allowed: empty source_repo → this arm intentionally runs with
+        // NO `current_dir`, so `git` resolves the repo from `--force <abs wt>`
+        // itself. `git_cmd`/`git_bypass` both REQUIRE a cwd; passing `wt_path
+        // .parent()` is wrong (it's the worktrees-pool dir `~/.agend-terminal/
+        // worktrees/<agent>/`, outside the repo tree, per lead ruling). Keep raw.
+        // TODO(W1.2): audit whether the empty-source_repo branch is still
+        // reachable in practice; if dead, delete this arm rather than migrate it.
         std::process::Command::new("git")
             .args(["worktree", "remove", "--force", &wt_str])
             .env("AGEND_GIT_BYPASS", "1")
@@ -1160,6 +1167,11 @@ fn gc_remove_one(home: &Path, candidate: &GcCandidate) -> GcResult {
         error: None,
     };
 
+    // git-raw-allowed: `source_repo` may be None, in which case this runs with
+    // NO `current_dir` and git resolves the repo from the absolute worktree path.
+    // `git_cmd`/`git_bypass` both REQUIRE a cwd; there is no repo-tree dir to pass
+    // when source_repo is None (wt_path's parent is the worktrees-pool dir, per
+    // lead ruling). The conditional `current_dir` is the whole point — keep raw.
     let mut cmd = std::process::Command::new("git");
     cmd.args([
         "worktree",
@@ -1186,11 +1198,8 @@ fn gc_remove_one(home: &Path, candidate: &GcCandidate) -> GcResult {
             let _ = std::fs::remove_dir_all(wt_path);
             if !wt_path.exists() {
                 if let Some(ref sr) = source_repo {
-                    let _ = std::process::Command::new("git")
-                        .current_dir(sr)
-                        .args(["worktree", "prune"])
-                        .env("AGEND_GIT_BYPASS", "1")
-                        .output();
+                    // W1.2: best-effort prune (result already ignored).
+                    let _ = crate::git_helpers::git_ok(sr, &["worktree", "prune"]);
                 }
                 result.removed = true;
             } else {

--- a/tests/daemon_git_helper_invariant.rs
+++ b/tests/daemon_git_helper_invariant.rs
@@ -1,0 +1,204 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+//! W1.2 — daemon-git helper invariant (production-`src/` sibling of the
+//! `tests/`-scoped #821 [`git_subprocess_invariant`]).
+//!
+//! ## Why
+//!
+//! Daemon-side git over a fleet-managed repo MUST always bypass the
+//! `agend-git` shim (the #821/#1463 forgot-bypass latent class). The W1.2
+//! refactor routes daemon git through `git_helpers::git_cmd` / `git_ok`,
+//! which are always-bypass + timeout-bounded (#1897). This invariant SEALS
+//! that migration: it makes a raw `Command::new("git")` re-appearing in a
+//! migrated module a CI failure, not a silent regression — the seal is the
+//! point of W1.2, more than the migration itself.
+//!
+//! ## Scope (intentionally per-slice, NOT global daemon `src/`)
+//!
+//! Only the modules W1.2 actually migrated are in scope. The daemon has
+//! ~150 raw git sites across ~25 modules (worktree.rs, auto_release,
+//! retention, admin, claim_verifier, …); migrating all of them is the
+//! REFACTOR-PLAN's later slices, not W1.2. As each subsequent slice lands,
+//! ADD its module to `MODULE_SCOPE` below — the guard's coverage grows
+//! monotonically with the migration, never claiming a seal it hasn't earned.
+//!
+//! ## What it checks
+//!
+//! For each file in `MODULE_SCOPE`, scan the PRODUCTION portion only — every
+//! line up to the first `#[cfg(test)]` (the in-module `mod tests` carries
+//! its own raw git for fixtures and is exempt, the same way
+//! `git_subprocess_invariant` exempts nothing-but-tests). Each
+//! `Command::new("git")` / `std::process::Command::new("git")` hit in that
+//! portion must carry a `// git-raw-allowed: <rationale>` marker on the line
+//! or in the contiguous `//` block immediately above. No marker ⇒ violation:
+//! migrate it to `git_cmd`/`git_ok`, or justify keeping it raw with the
+//! marker.
+
+use std::path::{Path, PathBuf};
+
+const SRC_DIR: &str = "src";
+const ALLOW_MARKER: &str = "git-raw-allowed:";
+const PATTERN: &str = "Command::new(\"git\")";
+const CFG_TEST: &str = "#[cfg(test)]";
+
+/// Modules sealed by W1.2. GROW this list as later refactor-plan slices
+/// migrate further modules — never shrink it.
+const MODULE_SCOPE: &[&str] = &[
+    "worktree_pool.rs",
+    "worktree_cleanup.rs",
+    "branch_sweep.rs",
+    "binding.rs",
+];
+
+/// One violation entry — `(file, line_number, snippet)`.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Violation {
+    pub file: PathBuf,
+    pub line: usize,
+    pub snippet: String,
+}
+
+/// True iff the violation line (or a contiguous `//` comment line
+/// immediately preceding it) carries the allow-marker. Mirrors
+/// `git_subprocess_invariant::has_allow_marker`.
+fn has_allow_marker(lines: &[&str], line_idx: usize) -> bool {
+    if lines
+        .get(line_idx)
+        .map(|l| l.contains(ALLOW_MARKER))
+        .unwrap_or(false)
+    {
+        return true;
+    }
+    let mut cursor = line_idx;
+    while let Some(prev_idx) = cursor.checked_sub(1) {
+        let Some(prev_line) = lines.get(prev_idx) else {
+            break;
+        };
+        let trimmed = prev_line.trim_start();
+        if !trimmed.starts_with("//") {
+            break;
+        }
+        if trimmed.contains(ALLOW_MARKER) {
+            return true;
+        }
+        cursor = prev_idx;
+    }
+    false
+}
+
+/// Index of the first `#[cfg(test)]` line, or `len` if none. The
+/// production portion is `lines[..boundary]`; the in-module test module
+/// (with its own fixture git) lives at/after it and is out of scope.
+fn prod_boundary(lines: &[&str]) -> usize {
+    lines
+        .iter()
+        .position(|l| l.trim_start().starts_with(CFG_TEST))
+        .unwrap_or(lines.len())
+}
+
+/// Scan one file's production portion for unmarked raw git. Public so the
+/// RED/GREEN probes drive the SAME scanner CI runs — no mock branches.
+pub fn scan_file(path: &Path, content: &str) -> Vec<Violation> {
+    let lines: Vec<&str> = content.lines().collect();
+    let boundary = prod_boundary(&lines);
+    let mut violations = Vec::new();
+    for (idx, line) in lines.iter().enumerate().take(boundary) {
+        if !line.contains(PATTERN) {
+            continue;
+        }
+        if has_allow_marker(&lines, idx) {
+            continue;
+        }
+        violations.push(Violation {
+            file: path.to_path_buf(),
+            line: idx + 1,
+            snippet: (*line).trim().to_string(),
+        });
+    }
+    violations
+}
+
+/// Scan every in-scope module under `src_dir`.
+pub fn scan_scope(src_dir: &Path) -> Vec<Violation> {
+    let mut violations = Vec::new();
+    for name in MODULE_SCOPE {
+        let path = src_dir.join(name);
+        let Ok(content) = std::fs::read_to_string(&path) else {
+            // A missing in-scope module is itself a regression (rename
+            // without updating the guard) — surface it as a violation.
+            violations.push(Violation {
+                file: path.clone(),
+                line: 0,
+                snippet: format!("MODULE_SCOPE entry not found: {}", path.display()),
+            });
+            continue;
+        };
+        violations.extend(scan_file(&path, &content));
+    }
+    violations
+}
+
+#[test]
+fn invariant_passes_on_migrated_modules() {
+    let violations = scan_scope(Path::new(SRC_DIR));
+    if !violations.is_empty() {
+        let summary: Vec<String> = violations
+            .iter()
+            .map(|v| format!("  {}:{}: {}", v.file.display(), v.line, v.snippet))
+            .collect();
+        panic!(
+            "W1.2 daemon-git invariant FAILED — {} unmarked raw `Command::new(\"git\")` \
+             site(s) in a migrated module's production code. Either route through \
+             `git_helpers::git_cmd`/`git_ok` (always-bypass) OR justify keeping it raw \
+             with a `// {}` <rationale> marker:\n\n{}",
+            violations.len(),
+            ALLOW_MARKER,
+            summary.join("\n"),
+        );
+    }
+}
+
+#[test]
+fn scanner_flags_unmarked_raw_git_in_prod() {
+    let src = "use std::process::Command;\n\
+               fn naughty() {\n    \
+                   let _ = Command::new(\"git\").args([\"status\"]).output();\n\
+               }\n";
+    let v = scan_file(Path::new("synthetic.rs"), src);
+    assert_eq!(v.len(), 1, "must flag the one unmarked prod site: {v:?}");
+    assert_eq!(v[0].line, 3);
+}
+
+#[test]
+fn scanner_respects_allow_marker_line_and_block() {
+    let inline = "fn ok() {\n    \
+                      let _ = Command::new(\"git\").args([\"x\"]).output(); // git-raw-allowed: ok\n\
+                  }\n";
+    assert!(
+        scan_file(Path::new("a.rs"), inline).is_empty(),
+        "inline marker must suppress"
+    );
+
+    let block = "fn ok() {\n    \
+                     // git-raw-allowed: network op, LOCAL_GIT_TIMEOUT too tight\n    \
+                     let _ = Command::new(\"git\").args([\"fetch\"]).output();\n\
+                 }\n";
+    assert!(
+        scan_file(Path::new("b.rs"), block).is_empty(),
+        "preceding-comment-block marker must suppress"
+    );
+}
+
+#[test]
+fn scanner_ignores_raw_git_in_cfg_test_module() {
+    // Raw git below `#[cfg(test)]` is a test fixture — out of scope.
+    let src = "fn prod() { let _ = git_helpers::git_ok(p, &[\"x\"]); }\n\
+               #[cfg(test)]\n\
+               mod tests {\n    \
+                   fn fixture() { let _ = Command::new(\"git\").args([\"init\"]).output(); }\n\
+               }\n";
+    assert!(
+        scan_file(Path::new("c.rs"), src).is_empty(),
+        "raw git under #[cfg(test)] must NOT be flagged"
+    );
+}

--- a/tests/git_subprocess_invariant.rs
+++ b/tests/git_subprocess_invariant.rs
@@ -66,13 +66,17 @@ fn rs_files_under(root: &Path) -> Vec<PathBuf> {
 /// True iff this file is exempt from the lint:
 /// - The lint itself (`git_subprocess_invariant.rs`) — its probe
 ///   fixtures naturally contain the offending pattern as test data.
+/// - `daemon_git_helper_invariant.rs` (W1.2) — the production-`src/`
+///   sibling lint; it has the identical reason for exemption: its
+///   scanner RED/GREEN fixtures embed the literal `Command::new("git")`
+///   as test data, never as a real subprocess.
 /// - The helper module `tests/common/git_isolated.rs` — the
 ///   canonical authority is allowed to use the raw subprocess.
 fn is_exempt_file(path: &Path) -> bool {
     let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
         return false;
     };
-    if name == "git_subprocess_invariant.rs" {
+    if name == "git_subprocess_invariant.rs" || name == "daemon_git_helper_invariant.rs" {
         return true;
     }
     let parent = path


### PR DESCRIPTION
## REFACTOR-PLAN W1.2 — daemon-git helper + anti-regression seal

Introduces `git_helpers::git_cmd(cwd, args) -> Result<String, GitError>` (always-bypass, trimmed stdout, structured error) and `git_ok(cwd, args) -> bool`, then migrates the in-scope daemon git sites onto them and SEALS the migration with an invariant test.

### Helper (commit 1)
`git_cmd` = `git_bypass` (always `AGEND_GIT_BYPASS=1` + #1897 `LOCAL_GIT_TIMEOUT`) → trim stdout on exit-0, else `GitError::{Spawn, NonZero{code,stderr}}`. `git_ok` = the `output().map(success).unwrap_or(false)` idiom. Both unit-tested against a real bypass repo.

### Class-1 migrations (zero behavior delta — already-bypass sites)
`branch_sweep` (for-each-ref, merge-base probes, branch -D), `worktree_cleanup` (config read, branch_tip_age log, branch-format enum, branch -D, worktree prune), `worktree_pool` (gc-fallback prune). Same args/env/error-branch semantics; only diff = richer error strings.

### Class-2 migrations — **BEHAVIOR DELTA: adds `AGEND_GIT_BYPASS`** (intended fix)
These 3 sites previously ran raw `git` with **no bypass env** — the forgot-bypass latent class (#821/#1463) where a daemon git op over a fleet repo can be shim-intercepted. Routing through the helper makes them always-bypass. Result shapes unchanged (git_cmd trims identically). Listed per lead ruling for honest labeling:

| file:line (pre-change) | command | original env | delta |
|---|---|---|---|
| `binding.rs:352` | `git config core.hooksPath` | raw, no bypass | + bypass |
| `branch_sweep.rs:219` | `git remote get-url origin` | raw, no bypass | + bypass |
| `branch_sweep.rs:234` | `git rev-parse <branch>` | raw, no bypass | + bypass |

### Allowlist (kept raw on purpose — `// git-raw-allowed: <rationale>`)
- `worktree_cleanup` **list_worktrees** — TRIM-SENSITIVE `--porcelain` parser: the loop flushes each worktree record on its terminating blank line; `git_cmd`'s stdout-trim drops the final terminator → last worktree never pushed → sweep silently finds nothing. **RED-verified regression** (`test_v2_{remote_gone,merged}_worktree_removed` failed under git_cmd, pass under raw). Reverted to raw + marker.
- `worktree_cleanup` **rev-parse --verify** (`is_remote_gone`) — error→EXISTS safe-default (`unwrap_or(true)`); `git_ok`'s error→false would INVERT, risking auto-delete of a live branch.
- `worktree_cleanup` **status --porcelain** (`is_worktree_dirty`) — error→DIRTY safe-default; protects uncommitted work; also needs `!stdout.is_empty()`, not exit-status.
- `worktree_cleanup` **fetch --prune** — NETWORK op; `git_cmd` hardcodes the 60s `LOCAL_GIT_TIMEOUT`, too tight for fetch.
- `worktree_pool` **worktree remove --force** (2 sites) — runs with conditional/absent `current_dir` when `source_repo` is empty/None; `git_cmd` requires a cwd, and `wt_path.parent()` is the worktrees-pool dir (outside the repo tree, per lead ruling). + `TODO` to audit whether the empty-source_repo branch is still reachable.

### The seal (commit: `tests/daemon_git_helper_invariant.rs`)
Production-`src/` sibling of the `tests/`-scoped #821 `git_subprocess_invariant`. Scans the **production portion** (before the first `#[cfg(test)]`) of the migrated modules and FAILS CI on any raw `Command::new("git")` lacking a `// git-raw-allowed:` marker. RED/GREEN probes (flag-unmarked, respect inline+block marker, ignore cfg-test) drive the same scanner CI runs.

**Scope is intentionally per-slice (`MODULE_SCOPE`), NOT global daemon `src/`.** Honest scope correction: the daemon has **~150** raw git sites across ~25 modules (worktree.rs, auto_release, retention, admin, claim_verifier, instructions, skills, mcp_config, deployments, bootstrap, conflict_notify, api/messaging…), far more than the ~51 estimate. W1.2 seals its 4 migrated modules; each later REFACTOR-PLAN slice ADDs its module to `MODULE_SCOPE`, so the seal grows monotonically with the migration and never claims unearned coverage.

### Verification
- `cargo fmt --check` ✓ · `cargo clippy --all-targets --features tray -D warnings` ✓
- `cargo test --tests --features tray` → 3760 pass + new guard 4/4. Sole failure `dispatch_branch_..._1834` is the documented pre-existing agend-git-shim preflight false-fail (passes under `AGEND_GIT_BYPASS=1`; CI is the backstop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)