### PR TITLE
fix(#2050 W1.3①): repair stale tool_timeout names + registry-coverage invariant

### DIFF
--- a/src/api/handlers/mcp_proxy.rs
+++ b/src/api/handlers/mcp_proxy.rs
@@ -11,29 +11,59 @@ use std::time::Duration;
 
 use super::HandlerCtx;
 
-/// Per-tool timeout in milliseconds. Fast read-only tools get a short
-/// timeout; slow spawn/deploy tools get a longer one.
+/// Per-tool dispatch timeout bands. Fast read-only / atomic-flip tools get a
+/// short budget; tools with a process-spawning / network action get the long
+/// upper-bound budget. Per-tool granularity (no per-action timeout — YAGNI):
+/// a multi-action tool like `repo` or `deployment` takes its SLOWEST action's
+/// band, which is a harmless upper bound for its fast actions.
 ///
-/// Made `pub(crate)` for `request_dedup::method_wait_timeout` to reuse
-/// the same mapping when the API method is `mcp_tool` — shared source
-/// of truth keeps the dispatch budget and the dedup wait budget in lock-step.
+/// The band constants are `pub(crate)` so `request_dedup::method_wait_timeout`
+/// reuses them — one source of truth keeps the dispatch budget and the dedup
+/// wait budget in lock-step.
+pub(crate) const FAST_TOOL_TIMEOUT: Duration = Duration::from_secs(5);
+pub(crate) const DEFAULT_TOOL_TIMEOUT: Duration = Duration::from_secs(30);
+pub(crate) const SLOW_TOOL_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Fast read-only / atomic-flip tools (~5s). Every name is a registered MCP
+/// tool — `tool_timeout_keys_are_registered_tools` pins this against
+/// `registry::all()` so a consolidation/rename can't silently leave a stale
+/// (never-matching) entry here again.
+const FAST_TOOLS: &[&str] = &[
+    "inbox",
+    "list_instances",
+    "set_waiting_on",
+    "set_display_name",
+    "set_description",
+    "health",
+];
+
+/// Tools whose slowest action spawns a process / does network I/O (~60s).
+///
+/// #2050 W1.3①: `deployment` / `ci` / `repo` are the action-consolidated
+/// successors of the old `deploy_template` / `watch_ci` / `checkout_repo`
+/// names. Those stale names stopped matching after the consolidation, so these
+/// genuinely-long operations (deploy, CI watch, repo checkout/merge) were
+/// silently falling back to the 30s default — a false-timeout risk this fix
+/// closes. #1814: `restart_daemon` spawns a successor + runs a ≤30s Phase-1
+/// gate. `team` (create) spawns agents like `create_instance` (and mirrors the
+/// `method_wait_timeout` CREATE_TEAM 60s band).
+const SLOW_TOOLS: &[&str] = &[
+    "create_instance",
+    "replace_instance",
+    "restart_daemon",
+    "deployment",
+    "ci",
+    "repo",
+    "team",
+];
+
 pub(crate) fn tool_timeout(tool: &str) -> Duration {
-    match tool {
-        // Fast read-only tools (~5s)
-        "inbox" | "describe_message" | "describe_thread" | "list_instances"
-        | "describe_instance" | "list_teams" | "list_decisions" | "list_schedules"
-        | "list_deployments" | "set_waiting_on" | "set_display_name" | "set_description"
-        | "react" | "report_health" => Duration::from_secs(5),
-
-        // Slow tools that spawn processes or do network I/O (~60s).
-        // #1814: restart_daemon (self-respawn) spawns a successor + runs a
-        // ≤30s Phase-1 health gate before returning — give it the 60s budget so
-        // the gate can't collide with the default 30s tool timeout.
-        "create_instance" | "deploy_template" | "replace_instance" | "watch_ci"
-        | "checkout_repo" | "restart_daemon" => Duration::from_secs(60),
-
-        // Default for everything else (~30s)
-        _ => Duration::from_secs(30),
+    if FAST_TOOLS.contains(&tool) {
+        FAST_TOOL_TIMEOUT
+    } else if SLOW_TOOLS.contains(&tool) {
+        SLOW_TOOL_TIMEOUT
+    } else {
+        DEFAULT_TOOL_TIMEOUT
     }
 }
 
@@ -208,20 +238,46 @@ mod tests {
     fn fast_tools_get_short_timeout() {
         assert_eq!(tool_timeout("inbox"), Duration::from_secs(5));
         assert_eq!(tool_timeout("list_instances"), Duration::from_secs(5));
-        assert_eq!(tool_timeout("describe_message"), Duration::from_secs(5));
+        assert_eq!(tool_timeout("health"), Duration::from_secs(5));
     }
 
     #[test]
     fn slow_tools_get_long_timeout() {
         assert_eq!(tool_timeout("create_instance"), Duration::from_secs(60));
-        assert_eq!(tool_timeout("deploy_template"), Duration::from_secs(60));
+        // #2050 W1.3①: the action-consolidated successors of the old stale
+        // names (deploy_template / watch_ci / checkout_repo) — these were the
+        // false-timeout bug (long ops silently getting the 30s default).
+        assert_eq!(tool_timeout("deployment"), Duration::from_secs(60));
+        assert_eq!(tool_timeout("ci"), Duration::from_secs(60));
+        assert_eq!(tool_timeout("repo"), Duration::from_secs(60));
     }
 
     #[test]
     fn default_tools_get_30s() {
-        assert_eq!(tool_timeout("send_to_instance"), Duration::from_secs(30));
-        assert_eq!(tool_timeout("delegate_task"), Duration::from_secs(30));
+        assert_eq!(tool_timeout("send"), Duration::from_secs(30));
+        assert_eq!(tool_timeout("task"), Duration::from_secs(30));
         assert_eq!(tool_timeout("unknown_tool"), Duration::from_secs(30));
+    }
+
+    /// #2050 W1.3① coverage invariant: every tool the timeout map classifies
+    /// MUST be a registered MCP tool. This is the closure that prevents the
+    /// stale-name drift this PR fixed (`deploy_template`/`watch_ci`/
+    /// `checkout_repo`/`describe_*`/`list_*`/`react`/`report_health` had all
+    /// gone stale after consolidation, silently degrading their tools to the
+    /// 30s default). A future rename/removal now fails CI here instead.
+    #[test]
+    fn tool_timeout_keys_are_registered_tools() {
+        use std::collections::HashSet;
+        let registered: HashSet<&str> =
+            crate::mcp::registry::all().iter().map(|t| t.name).collect();
+        for &t in FAST_TOOLS.iter().chain(SLOW_TOOLS.iter()) {
+            assert!(
+                registered.contains(t),
+                "tool_timeout classifies '{t}' but it is not a registered MCP tool \
+                 (registry::all) — stale after a tool consolidation/rename? Update the \
+                 name (or add a documented retired-allowlist). #2050 W1.3①"
+            );
+        }
     }
 
     // ── R3#1 candidate 2: timeout → accepted_in_progress for side-effect tools ──

--- a/src/api/request_dedup.rs
+++ b/src/api/request_dedup.rs
@@ -463,7 +463,13 @@ pub fn global() -> &'static DedupCache {
 /// this map degrades to a longer-than-needed wait rather than a panic
 /// or hang.
 pub fn method_wait_timeout(method: &str, params: &Value) -> Duration {
+    use crate::api::handlers::mcp_proxy::{
+        DEFAULT_TOOL_TIMEOUT, FAST_TOOL_TIMEOUT, SLOW_TOOL_TIMEOUT,
+    };
     use crate::api::method as m;
+    // #2050 W1.3①: the band durations are the SAME 5s/30s/60s bands
+    // `mcp_proxy::tool_timeout` uses — reference the shared constants rather
+    // than re-hardcoding `from_secs(..)` so the two budgets can't drift.
     match method {
         // Fast read-only / atomic-flip operations.
         m::LIST
@@ -475,10 +481,10 @@ pub fn method_wait_timeout(method: &str, params: &Value) -> Duration {
         | m::CLEAR_BLOCKED_REASON
         | m::REGISTER_EXTERNAL
         | m::DEREGISTER_EXTERNAL
-        | m::MOVE_PANE => Duration::from_secs(5),
+        | m::MOVE_PANE => FAST_TOOL_TIMEOUT,
 
         // Slow operations that spawn processes / write a lot of state.
-        m::SPAWN | m::CREATE_TEAM | m::UPDATE_TEAM => Duration::from_secs(60),
+        m::SPAWN | m::CREATE_TEAM | m::UPDATE_TEAM => SLOW_TOOL_TIMEOUT,
 
         // `mcp_tool` dispatches the actual tool inside the daemon with
         // its OWN per-tool budget (see `mcp_proxy::tool_timeout`).
@@ -491,7 +497,7 @@ pub fn method_wait_timeout(method: &str, params: &Value) -> Duration {
 
         // Middle band — covers `send`, `inject`, `kill`, `delete`,
         // `verify_push`, and any future method not yet classified.
-        m::SEND | m::INJECT | m::KILL | m::DELETE | m::VERIFY_PUSH => Duration::from_secs(30),
+        m::SEND | m::INJECT | m::KILL | m::DELETE | m::VERIFY_PUSH => DEFAULT_TOOL_TIMEOUT,
 
         // Unknown / unmapped — fall back to the conservative default.
         _ => DEFAULT_WAIT_TIMEOUT,


### PR DESCRIPTION
## Premise correction first

REFACTOR-PLAN W1.3① was scoped as "unify two duplicate tool→timeout maps". On investigation there is **only one** per-tool map (`mcp_proxy::tool_timeout`); `request_dedup::method_wait_timeout` is a per-**method** map that already delegates the `mcp_tool` case to it. But that investigation surfaced a **real latent bug** (see decision `d-…306-1`); lead ruled **behavior-fix + invariant** (option B).

## The bug

`tool_timeout` classified tools by name, but many names went stale after the action-based tool consolidation and silently stopped matching → those tools fell to the 30s default. The harmful cases are the **slow band**:

| stale name | current tool | was (stale→default) | intended |
|---|---|---|---|
| `deploy_template` | `deployment` | 30s | **60s** |
| `watch_ci` | `ci` | 30s | **60s** |
| `checkout_repo` | `repo` | 30s | **60s** |

These are genuinely-long ops (deploy / CI watch / repo checkout+merge) → 30s was a **false-timeout risk on the supported surface**. (The stale *fast*-band names `describe_*`/`list_*`/`react`/`report_health` only over-waited — never false-timed-out.)

## How

- **Table-driven rewrite** (`FAST_TOOLS`/`SLOW_TOOLS` slices) over **current registered** names:
  - **SLOW (60s)**: `create_instance`, `replace_instance`, `restart_daemon`, `deployment`, `ci`, `repo`, `team`.
  - **FAST (5s)**: `inbox`, `list_instances`, `set_waiting_on`, `set_display_name`, `set_description`, `health`.
  - Stale fast names with no standalone successor are dropped → 30s default (= what they already got while stale, **no regression**).
- **Per-tool granularity kept** (no per-action timeout — YAGNI per lead): a multi-action tool (`repo`/`deployment`/`ci`) takes its slowest action's band — a harmless upper bound for its fast actions.
- **Band-constant de-dup** (zero-behavior): `mcp_proxy` owns `FAST/DEFAULT/SLOW_TOOL_TIMEOUT`; `request_dedup::method_wait_timeout` references them instead of re-hardcoding `from_secs(..)` — kills the dispatch-budget ↔ dedup-wait drift.
- **Coverage invariant** (`tool_timeout_keys_are_registered_tools`): every map key MUST be a registered MCP tool (`registry::all()`). This is the closure — a future rename/removal fails CI instead of silently degrading a tool (the #2055 tool add/remove precondition).

## Behavior changes (please audit)

`deployment` 30s→**60s**, `ci` 30s→**60s**, `repo` 30s→**60s**, `team` 30s→**60s**, `health` 30s→**5s**. All other tools unchanged.

One judgment call beyond pure rename: **`team` → 60s** (it wasn't a stale entry, it was absent). Rationale: `team` create spawns agents like `create_instance`, and `method_wait_timeout` already treats CREATE_TEAM as 60s — leaving the MCP `team` tool at 30s is the same false-timeout class. Flagging for your call; trivial to drop if you'd rather keep scope to the renames.

## Tests

`fmt --check` clean · `clippy -D warnings` clean · full `nextest` **4063 passed** · new invariant + updated band tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)