### PR TITLE
docs(#2050): W1 close-out — mark W1.1/1.2/1.3 done + correct W1.2 scope + sync architecture.md

### DIFF
--- a/docs/REFACTOR-PLAN.md
+++ b/docs/REFACTOR-PLAN.md
@@ -40,6 +40,10 @@ class). Preserve relative order — handler order is load-bearing
 (daemon/mod.rs:577-579).
 **Effort** ~1 day · **Risk** low (each tracker already self-contained) ·
 **Source** survey 01-R2 / 06-A. Best value-to-risk in the plan; do first.
+**Status** ✅ Done — PR #2065. All 12 trackers wrapped as `PerTickHandler`s
+and appended to `build_default_handlers` (now 32 handlers) in their original
+relative order; supervisor inline calls deleted; completeness invariant
+`all_twelve_supervisor_trackers_registered_in_order` pins the full set.
 
 ### W1.2 `git_cmd` helper — absorb daemon-side raw-git boilerplate
 `git_cmd(dir, args) -> Result<String>` (always-bypass, trimmed stdout,
@@ -51,6 +55,14 @@ wanting raw control. Makes "forgot `AGEND_GIT_BYPASS`" structurally
 impossible daemon-side and kills a flaky-test class.
 **Effort** 0.5–1 day · **Risk** low, mechanical, reviewable per call-site ·
 **Source** survey 05-R1.
+**Status** ✅ First slice done — PR #2068. `git_cmd`/`git_ok` landed; 4 modules
+migrated + sealed (`branch_sweep`, `worktree_cleanup`, `worktree_pool`,
+`binding`) by the `tests/daemon_git_helper_invariant.rs` per-slice
+`MODULE_SCOPE` scanner (FAILs CI on an unmarked raw `Command::new("git")` in a
+sealed module). **Scope correction**: the daemon has **~150** raw git sites
+across **~25** modules (not the ~51 estimate above); `MODULE_SCOPE` grows
+monotonically as each later slice adds its module, so the seal never claims
+unearned coverage. Remaining-module migration is the backlog: task `t-…766-17`.
 
 ### W1.3 Quick wins (one small PR each)
 - Unify the duplicated tool-timeout maps (`request_dedup.rs:465` ↔
@@ -59,6 +71,18 @@ impossible daemon-side and kills a flaky-test class.
   out of the api server file into `agent_ops`. (survey 02-#4)
 - Fix `skills.rs` doc drift (says 5 backends, code has 4 — Gemini
   retired). (survey 06-E)
+
+**Status** ✅ Done — three PRs: #2066 (skills doc 5→4 backends), #2067
+(`spawn_one` → `agent_ops`, + a `// fire-and-forget:` rationale upgrade off
+`api/mod.rs`'s legacy spawn-audit exemption), #2069 (tool-timeout). NOTE: the
+tool-timeout item was **not** a duplicate-map merge — there is one per-tool map
+(`mcp_proxy::tool_timeout`); `request_dedup::method_wait_timeout` already
+delegates to it. The premise-check turned it into a **behavior-fix**: stale
+post-consolidation names (`deploy_template`/`watch_ci`/`checkout_repo`) had
+stopped matching, silently degrading `deployment`/`ci`/`repo` to the 30s
+default (a latent false-timeout on long ops). #2069 restores the intended 60s,
+adds a registry-coverage invariant (`tool_timeout_keys_are_registered_tools`,
+the #2055 add/remove-tool closure), and de-dups the 5/30/60s band constants.
 
 ## Wave 2 — cap relief & mechanical decomposition
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,18 +35,19 @@ The heart: observe each agent's state machine, react, recover.
 
 | Module | LOC | Role |
 |---|---|---|
-| `daemon/supervisor.rs` | 5408 | Per-agent state OBSERVATION + reaction emission + error recovery (SRL/ApiError) + 12 inline slow-tracker scans |
-| `daemon/mod.rs` | 2764 | Entry/init/shutdown; builds the per-tick handler set (`build_default_handlers` → 20 handlers) |
-| `daemon/per_tick/` | — | `PerTickHandler` trait + 20 handler impls, panic-guarded dispatch, boot-grace gate |
+| `daemon/supervisor.rs` | 5408 | Per-agent state OBSERVATION + reaction emission + error recovery (SRL/ApiError). The 12 inline slow-tracker scans moved to `PerTickHandler`s in W1.1 (#2065) |
+| `daemon/mod.rs` | 2764 | Entry/init/shutdown; builds the per-tick handler set (`build_default_handlers` → 32 handlers) |
+| `daemon/per_tick/` | — | `PerTickHandler` trait + 32 handler impls, panic-guarded dispatch, boot-grace gate |
 | `daemon/crash_respawn.rs` | 568 | Crash→respawn decision: health budget, escalation persist, respawn worker |
 | `health.rs` | 2385 | Per-agent hang/crash budgets, blocked-reason, escalation persist+rehydrate |
 | `state/mod.rs` | 2176 | Per-agent `StateTracker` — screen-heuristic state machine (see 2.4) |
 
-Two periodic-work mechanisms coexist (see §6.1): the supervisor `run_loop`
-(every 10s) hosts 12 inline `*_tracker.maybe_scan/sweep` calls
-(supervisor.rs:266), while the daemon loop dispatches the 20 extracted
-`PerTickHandler`s with per-handler `catch_unwind` + timing
-(per_tick/mod.rs:182-214).
+Periodic work is now a single pipeline (W1.1 / #2065, see §6.1): the daemon
+loop dispatches all 32 `PerTickHandler`s with per-handler `catch_unwind` +
+timing (per_tick/mod.rs:182-214). The 12 trackers that used to run inline in
+the supervisor `run_loop` were wrapped as handlers and appended in their
+original relative order; the supervisor `run_loop` now hosts only `tick()` /
+`process_error_recovery()` / a boot-time sidecar GC (still its own 10s thread).
 
 ### 2.2 MCP layer + inter-agent comms (~22K LOC)
 
@@ -219,9 +220,10 @@ supervisor refactor.
 These are the deliberate or accreted dual-paths. Each is a REFACTOR-PLAN
 entry; none is free to "just clean up" without the listed care.
 
-1. **Two periodic-work mechanisms** (§2.1): 20 extracted `PerTickHandler`s
-   vs 12 inline supervisor `maybe_scan` trackers — one concept, two
-   mechanisms, two mental models. Finish-the-extraction is W1 work.
+1. **Two periodic-work mechanisms** (§2.1): ✅ RESOLVED by W1.1 (#2065). The 12
+   inline supervisor `maybe_scan` trackers are now `PerTickHandler`s in the one
+   `build_default_handlers` pipeline (32 handlers); a completeness invariant
+   pins the full set so the two-mechanism split can't silently reappear.
 2. **Heuristic vs hook state, dual readers** (§2.4): the snapshot path is
    promoted (hook-aware), but hang/watchdog/recovery/supervisor escalation
    still read raw heuristic — in a single tick, dispatch_idle can suppress
@@ -229,9 +231,15 @@ entry; none is free to "just clean up" without the listed care.
    (raw=heuristic-Idle). Bounded today by the #1999 escalation throttle.
    Convergence = #1523 phase-2 (W3; lock-ordering design required — a
    naive shared cache inverts registry⨯core order).
-3. **Raw `Command::new("git")` vs `git_bypass`**: 209 raw sites; any site
-   that forgets `AGEND_GIT_BYPASS=1` silently hits the shim (a whole
-   flaky-test class). W1 makes this structurally impossible daemon-side.
+3. **Raw `Command::new("git")` vs `git_bypass`**: ~150 daemon raw git sites
+   across ~25 modules; any site that forgets `AGEND_GIT_BYPASS=1` silently hits
+   the shim (a whole flaky-test class). W1.2 (#2068) landed `git_cmd`/`git_ok`
+   and SEALED its first 4 modules (`branch_sweep`, `worktree_cleanup`,
+   `worktree_pool`, `binding`) behind `tests/daemon_git_helper_invariant.rs`, a
+   per-slice `MODULE_SCOPE` scanner that grows monotonically as each later
+   slice migrates its module. The remaining modules are the backlog
+   (`t-…766-17`) — the seal makes regression structurally impossible only for
+   already-migrated modules, never claiming unearned coverage.
 4. **Size-driven extraction at the MCP cap**: `instance.rs`/`comms.rs` at
    the 750-LOC cap with "extracted for file_size_invariant" cross-file
    seams; `handle_delegate_task` is a 317-LOC god-fn with gates inlined.
@@ -250,7 +258,9 @@ CI: 3-platform Check + LOC-overrun gate + cargo audit (required);
 Coverage + daemon-boot flake-gate (non-required). Architecture-level
 invariants are pinned by dedicated tests: `file_size_invariant` (750-LOC
 handler cap), `tick_emitters_run_after_core_lock_drops` (#1644),
-heartbeat-pair atomicity audit, spawn-rationale invariant (Phase 5b).
+heartbeat-pair atomicity audit, spawn-rationale invariant (Phase 5b),
+`daemon_git_helper_invariant` (#2068 — per-slice `MODULE_SCOPE` seal: no
+unmarked raw `Command::new("git")` in a migrated module).
 Worktree-side test runs need `AGEND_GIT_BYPASS=1` (the shim intercepts
 raw-git subprocesses in managed worktrees). Review discipline §3.9: tests
 enter through real entry points with representative fixtures — synthetic


### PR DESCRIPTION
## What

Wave 1 of the refactor plan is fully merged (#2065 W1.1, #2068 W1.2, #2066/#2067/#2069 W1.3). Surgical **docs-only** close-out — only the listed paragraphs are touched.

## REFACTOR-PLAN.md

- **W1.1 Status**: ✅ Done — #2065 (12 trackers → `PerTickHandler`, 32-handler unified pipeline, completeness invariant).
- **W1.2 Status**: ✅ first slice done — #2068. Corrected the **~51 → ~150** raw git sites / **~25 modules** estimate; documented the per-slice `MODULE_SCOPE` seal (`tests/daemon_git_helper_invariant.rs`, grows monotonically) + the remaining-module backlog task `t-…766-17`.
- **W1.3 Status**: ✅ Done — #2066 (skills 5→4), #2067 (`spawn_one`→`agent_ops`), #2069 (tool-timeout). Recorded that the tool-timeout item was a **premise-check → behavior-fix**: there was no duplicate map; the stale post-consolidation names had degraded `deployment`/`ci`/`repo` to the 30s default → #2069 restores 60s + adds the registry-coverage invariant + de-dups the band constants.

## architecture.md

- **§2.1**: supervisor row + handler counts (20→32) + the "two periodic-work mechanisms coexist" narrative rewritten to the single unified pipeline (W1.1).
- **§6 tension #1** (two periodic-work mechanisms): marked ✅ RESOLVED by #2065.
- **§6 tension #3** (raw git vs bypass): 209→~150 sites, W1.2 sealed 4 modules via the per-slice `MODULE_SCOPE` scanner; rest is backlog.
- **§7**: added `daemon_git_helper_invariant` to the enforcement-tests list.

No code; no other sections altered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)