### PR TITLE
fix(test): notification_queue drain tests tolerate #2028 transient Unavailable→empty (#2072 flake)

### DIFF
--- a/src/notification_queue.rs
+++ b/src/notification_queue.rs
@@ -542,12 +542,43 @@ mod tests {
         dir
     }
 
+    /// Retry-accumulate `drain` to absorb #2028's transient `Unavailable→empty`.
+    /// `drain()` is contractually allowed to return an empty vec when
+    /// `try_acquire_file_lock` hits a transient open/lock hiccup under heavy
+    /// parallel load (llvm-cov-grade fd pressure) — production's flusher simply
+    /// retries next tick, so a one-shot drain is NOT authoritative. A test that
+    /// trusts it indexes an empty vec → index panic (the #2072 coverage flake,
+    /// notification_queue.rs `again[0]`). This helper models the retry: it keeps
+    /// draining (accumulating, since `drain` is destructive) until it has `want`
+    /// items or the bounded budget elapses. The happy path returns on the first
+    /// attempt — zero behavior change when the drain succeeds immediately.
+    fn drain_settled(home: &Path, agent_name: &str, want: usize) -> Vec<QueuedNotification> {
+        drain_settled_with_stale(home, agent_name, want, STALE_DRAINING_MS)
+    }
+
+    fn drain_settled_with_stale(
+        home: &Path,
+        agent_name: &str,
+        want: usize,
+        stale_ms: u128,
+    ) -> Vec<QueuedNotification> {
+        let mut acc = Vec::new();
+        for _ in 0..200 {
+            acc.extend(drain_with_stale_threshold(home, agent_name, stale_ms));
+            if acc.len() >= want {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+        acc
+    }
+
     #[test]
     fn enqueue_classified_round_trips_actionable_and_deferred_since_1513() {
         let home = tmp_home("classified");
         enqueue_classified(&home, "a", "work", true).expect("enqueue actionable");
         enqueue(&home, "a", "ambient").expect("enqueue ambient"); // actionable=false default
-        let drained = drain(&home, "a");
+        let drained = drain_settled(&home, "a", 2);
         assert_eq!(drained.len(), 2);
         let actionable = drained
             .iter()
@@ -566,11 +597,58 @@ mod tests {
         // requeue preserves the original deferred_since (cap counts from first defer)
         let since = actionable.deferred_since_ms;
         requeue_all(&home, "a", std::slice::from_ref(actionable));
-        let again = drain(&home, "a");
+        let again = drain_settled(&home, "a", 1);
         assert_eq!(
             again[0].deferred_since_ms, since,
             "requeue preserves deferred_since"
         );
+        std::fs::remove_dir_all(home).ok();
+    }
+
+    #[test]
+    fn drain_settled_retries_through_transient_lock_contention_2072() {
+        // Deterministic reproduction of the #2072 coverage-flake MECHANISM:
+        // while a peer holds the drain lock, a one-shot `drain()` returns empty
+        // (#2028 `Unavailable→empty`), so a test that trusts it indexes an empty
+        // vec → index panic (the live failure at `again[0]`). `drain_settled`
+        // must RETRY across the contention window and recover the item once the
+        // lock frees — exactly what the production flusher does next tick.
+        use std::sync::mpsc;
+        let home = tmp_home("transient_lock_2072");
+        std::fs::remove_dir_all(&home).ok();
+        std::fs::create_dir_all(&home).ok();
+        enqueue(&home, "a", "delayed").expect("enqueue");
+
+        let (held_tx, held_rx) = mpsc::channel::<()>();
+        let (go_tx, go_rx) = mpsc::channel::<()>();
+        let lock_path = drain_lock_path(&home, "a");
+        let peer = std::thread::spawn(move || {
+            let guard = crate::store::try_acquire_file_lock(&lock_path)
+                .expect("lock op")
+                .expect("peer acquires drain lock");
+            held_tx.send(()).expect("signal held");
+            // Hold until the test has observed the contention, then release
+            // inside `drain_settled`'s retry window.
+            go_rx.recv().expect("await go");
+            std::thread::sleep(std::time::Duration::from_millis(20));
+            drop(guard);
+        });
+
+        held_rx.recv().expect("peer holds the lock");
+        // A one-shot drain while the lock is held is empty — the exact trap.
+        assert!(
+            drain(&home, "a").is_empty(),
+            "one-shot drain under contention returns empty (#2028 Unavailable→empty)"
+        );
+        go_tx.send(()).expect("let the peer schedule its release");
+        let got = drain_settled(&home, "a", 1);
+        peer.join().ok();
+        assert_eq!(
+            got.len(),
+            1,
+            "drain_settled recovers the item after the lock frees"
+        );
+        assert_eq!(got[0].text, "delayed");
         std::fs::remove_dir_all(home).ok();
     }
 
@@ -588,7 +666,7 @@ mod tests {
         let home = tmp_home("drain");
         enqueue(&home, "agent1", "a").expect("enqueue a");
         enqueue(&home, "agent1", "b").expect("enqueue b");
-        let drained = drain(&home, "agent1");
+        let drained = drain_settled(&home, "agent1", 2);
         assert_eq!(drained.len(), 2);
         assert_eq!(drained[0].text, "a");
         assert_eq!(pending_count(&home, "agent1"), 0);
@@ -964,7 +1042,7 @@ mod tests {
         enqueue(&home, "a", "crashed-claim").expect("enqueue");
         std::fs::rename(queue_path(&home, "a"), draining_path(&home, "a"))
             .expect("simulate crashed drainer's leftover claim");
-        let got = drain_with_stale_threshold(&home, "a", 0);
+        let got = drain_settled_with_stale(&home, "a", 1, 0);
         assert_eq!(got.len(), 1, "stale leftover must be recovered");
         assert_eq!(got[0].text, "crashed-claim");
         assert_eq!(pending_count(&home, "a"), 0, "leftover consumed");


### PR DESCRIPTION
## The #2072 Coverage flake — RCA + fix

`notification_queue::tests::enqueue_classified_round_trips_actionable_and_deferred_since_1513` failed in the #2072 Coverage job, unrelated to that PR (which only touched `state/mod.rs`).

### Verify-first RCA (corrects my own earlier hypothesis)
On #2072 I guessed "llvm-cov timing flake on the `deferred_since_ms` ms assertion." **That was wrong**, and verifying it falsified it:
- The CI panic was at `notification_queue.rs:571:18` — **column 18 is the `again[0]` index**, not the `assert_eq!` comparison. So `again` was **empty**, and the panic was index-out-of-bounds, not an assertion mismatch.
- `again` is empty because the step-5 `drain()` returned nothing. `drain()` → `drain_with_stale_threshold` → `try_drain_with_stale_threshold`, which returns `Unavailable` (collapsed to `Vec::new()` by `drain()`) when `try_acquire_file_lock` hits a transient open/lock hiccup. The #2028 doc comment on that path calls this out verbatim: *"under llvm-cov-grade load a transient open/lock hiccup was reported as 'queue empty'."* Under the full Coverage suite's parallel fd pressure, the lock-file `open()` transiently failed → `Unavailable` → empty → `again[0]` panicked.

Falsified along the way (so the fix targets the real cause): tight-timing-assert (it's an index panic), `FLOCK_DEPTH` cross-test (it's `thread_local`), cross-`home` contamination (every queue path is `home`-scoped; `home` is PID+suffix unique per test). So this is **neither** a tight timing assert **nor** a #2056 shared-state/isolation case.

### The fix
Production's flusher already retries `drain` next tick — a single `drain()` is **not** authoritative (it's contractually allowed to return empty under transient contention). The tests trusted it. The fix models the retry: a `drain_settled(home, agent, want)` test helper that accumulates `drain()` across a bounded retry budget (200 × 5 ms) until it has `want` items. **Happy path returns on the first attempt → zero behavior change** when the drain succeeds immediately.

Routed the 4 vulnerable "non-empty result from a single drain" assertions through it:
- `enqueue_classified_round_trips_...since_1513` (both drains)
- `drain_roundtrip`
- `drain_recovers_stale_draining_leftover`

(`drain_does_not_steal_fresh_foreign_draining_file` asserts `is_empty()` — a transient empty would falsely *pass*, not flake — so it's left untouched.)

### Deterministic regression test
`drain_settled_retries_through_transient_lock_contention_2072` reproduces the mechanism with **no timing race** (mpsc channel-synchronized): a peer thread holds the drain lock, a one-shot `drain()` is asserted empty (the exact trap), the test signals the peer to release inside the retry window, and `drain_settled` recovers the item. Deterministic — passes 20/20.

### Verification
- `notification_queue` 4/4 green under `cargo llvm-cov` full suite (×2, the real CI condition that flaked).
- Module 10/10 green under parallel `cargo test` (33 tests each).
- Regression test 20/20 stable.
- `cargo fmt` ✓ · `cargo clippy --all-targets --features tray -D warnings` ✓.

(Local `cargo llvm-cov` also surfaces `dispatch_branch_..._1834` — the documented agend-git-shim local-env false-fail, unrelated; passes in CI which has no shim.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)