### PR TITLE
fix(#2063 follow-up): merge-authority fallback self-notifies author, not literal "fixup-lead"

### DIFF
--- a/src/daemon/pr_state/mod.rs
+++ b/src/daemon/pr_state/mod.rs
@@ -1057,8 +1057,10 @@ pub fn resolve_notify_recipient(home: &Path, state: &PrState) -> String {
 /// Candidate members, fleet-name sources first (the gh-login `pr_author` is the
 /// least reliable under the shared account, so it's last): the reviewers (from
 /// the recorded verdict), then the watch subscribers, then `pr_author`. The
-/// first whose team has an orchestrator wins; else the explicit `fixup-lead`
-/// fallback (same terminal default as `resolve_author`).
+/// first whose team has an orchestrator wins; else (no team for anyone — a
+/// single-agent deployment) the author self-notifies, since they merge their
+/// own PR; `fixup-lead` remains only as the last-ditch when the author is
+/// unknown.
 pub fn resolve_merge_authority(home: &Path, state: &PrState) -> String {
     let mut candidates: Vec<&str> = Vec::new();
     match &state.verdict_state {
@@ -1081,6 +1083,16 @@ pub fn resolve_merge_authority(home: &Path, state: &PrState) -> String {
         {
             return orch;
         }
+    }
+    // No candidate belongs to a team with an orchestrator — a single-agent /
+    // no-team deployment. There is no separate merge authority to route to, so
+    // self-notify the AUTHOR (they merge their own PR). A literal "fixup-lead"
+    // here would route into the void on any deployment that has no fixup-lead
+    // instance — the #2058 dead-zone recurring on someone else's machine
+    // (de-hardcode follow-up to #2063). "fixup-lead" stays only as the
+    // last-ditch when even the author is unknown.
+    if !state.pr_author.is_empty() {
+        return state.pr_author.clone();
     }
     "fixup-lead".to_string()
 }
@@ -3169,9 +3181,12 @@ mod tests {
         std::fs::remove_dir_all(&home).ok();
     }
 
-    /// #2059-#3: no team for any member → explicit fixup-lead fallback.
+    /// #2063 de-hardcode follow-up: no team for any member (a single-agent /
+    /// no-team deployment) → the AUTHOR self-notifies (they merge their own PR),
+    /// NOT a literal `fixup-lead` that would route into the void on a deployment
+    /// with no fixup-lead instance.
     #[test]
-    fn resolve_merge_authority_fallback_fixup_lead_2059() {
+    fn resolve_merge_authority_no_team_self_notifies_author_2059() {
         let home = tmp_home_for_1002("merge-auth-fallback");
         // No fleet.yaml teams written → find_team_for returns None for all.
         let mut s = new_state("sha-C", ReviewClass::Single);
@@ -3179,8 +3194,26 @@ mod tests {
         s.subscribers = vec!["stranger".to_string()];
         assert_eq!(
             resolve_merge_authority(&home, &s),
+            "stranger",
+            "no resolvable team → self-notify the author, not the void"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #2063 de-hardcode follow-up: no team AND no known author → the last-ditch
+    /// `fixup-lead` default still applies (nothing better to route to).
+    #[test]
+    fn resolve_merge_authority_no_team_no_author_last_ditch_fixup_lead_2059() {
+        let home = tmp_home_for_1002("merge-auth-lastditch");
+        let mut s = new_state("sha-D", ReviewClass::Single);
+        // Empty author + no subscribers + no verdict + no teams → nothing to
+        // route to but the last-ditch default.
+        s.pr_author = String::new();
+        s.subscribers = vec![];
+        assert_eq!(
+            resolve_merge_authority(&home, &s),
             "fixup-lead",
-            "no resolvable team → explicit fixup-lead fallback"
+            "no team and no author → last-ditch fixup-lead default"
         );
         std::fs::remove_dir_all(&home).ok();
     }


### PR DESCRIPTION
## De-hardcode `resolve_merge_authority`'s `"fixup-lead"` fallback (operator-flagged, #2063 follow-up)

`resolve_merge_authority`'s terminal fallback hard-coded the literal `"fixup-lead"`. On any deployment **without** a `fixup-lead` instance — a single-agent / no-team setup, i.e. most people's machines — that routes `[pr-ready-for-merge]` into the void: the #2058 merge-signal dead-zone recurring on someone else's deployment. A product-surface correctness bug.

### Fix
When no candidate (reviewers → subscribers → `pr_author`) belongs to a team with an orchestrator, **self-notify the author**: in a single-agent deployment the author merges their own PR, so they are the merge authority. `"fixup-lead"` remains only as the last-ditch default when even the author is unknown.

```rust
for member in candidates { … return orch; }            // team → orchestrator (unchanged)
if !state.pr_author.is_empty() { return state.pr_author.clone(); }  // no team → author
"fixup-lead".to_string()                                // last-ditch (author unknown)
```

### Semantics
| topology | merge authority | change |
|---|---|---|
| candidate has a team | team orchestrator | unchanged |
| no team, author known (single-agent) | **the author (self-notify)** | was `"fixup-lead"` |
| no team, author unknown | `"fixup-lead"` | unchanged (last-ditch) |

### Tests
- `resolve_merge_authority_routes_to_orchestrator_2059` / `..._no_binding_still_routes_2059` — **untouched**, both green (they return via the orchestrator loop, before the fallback).
- `resolve_merge_authority_no_team_self_notifies_author_2059` (was `..._fallback_fixup_lead_2059`) — no-team fixture through the resolver entry point asserts the author (`"stranger"`), not the void.
- `resolve_merge_authority_no_team_no_author_last_ditch_fixup_lead_2059` — new edge: empty author + no team → `"fixup-lead"` last-ditch.

`cargo clippy --all-targets --features tray -D warnings` clean; 84 `daemon::pr_state` tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)