### PR TITLE
refactor(#2050 W2.4): CadenceGate — unify ~23 hand-rolled per-tick cadence counters

### DIFF
--- a/src/daemon/anti_stall.rs
+++ b/src/daemon/anti_stall.rs
@@ -37,11 +37,10 @@ pub(crate) const TICKS_PER_SCAN: u64 = 30;
 /// Per-task dedup state: when did we last emit a stall warning.
 /// Suppresses re-emit until the next stall-window-equivalent has
 /// passed (re-warn after the operator has had a chance to act).
-#[derive(Debug, Default)]
 pub(crate) struct AntiStallTracker {
-    /// Tick counter — used to gate scans to once per
-    /// [`TICKS_PER_SCAN`] supervisor ticks.
-    tick_count: u64,
+    /// Cadence gate — throttles scans to once per [`TICKS_PER_SCAN`]
+    /// supervisor ticks (fire-on-Nth).
+    gate: crate::daemon::cadence_gate::CadenceGate,
     /// Per-task last-emitted-at timestamp. In-memory only. #1739: the first
     /// scan after a fresh daemon start *seeds* this map with every
     /// currently-stalled task (stamped now) WITHOUT emitting — restart-existing
@@ -56,16 +55,24 @@ pub(crate) struct AntiStallTracker {
     seeded: bool,
 }
 
+impl Default for AntiStallTracker {
+    fn default() -> Self {
+        Self {
+            gate: crate::daemon::cadence_gate::CadenceGate::new_interval(TICKS_PER_SCAN),
+            last_emitted_at: HashMap::new(),
+            seeded: false,
+        }
+    }
+}
+
 impl AntiStallTracker {
     /// Increment the tick counter and run the scan if we've reached
     /// [`TICKS_PER_SCAN`]. Called from the supervisor's main loop
     /// every TICK. Returns whether a scan ran (for tests).
     pub(crate) fn maybe_scan(&mut self, home: &Path) -> bool {
-        self.tick_count = self.tick_count.saturating_add(1);
-        if self.tick_count < TICKS_PER_SCAN {
+        if !self.gate.fire() {
             return false;
         }
-        self.tick_count = 0;
         let seeding = !self.seeded;
         self.seeded = true;
         scan_and_emit(home, &mut self.last_emitted_at, seeding);

--- a/src/daemon/auto_release.rs
+++ b/src/daemon/auto_release.rs
@@ -453,9 +453,18 @@ pub(crate) fn is_verdict_message(msg: &crate::inbox::InboxMessage) -> bool {
         && msg.correlation_id.is_some()
 }
 
-#[derive(Debug, Default)]
 pub(crate) struct AutoReleaseTracker {
-    tick_count: u64,
+    /// Cadence gate — throttles scans to once per [`TICKS_PER_SCAN`]
+    /// supervisor ticks (fire-on-Nth).
+    gate: crate::daemon::cadence_gate::CadenceGate,
+}
+
+impl Default for AutoReleaseTracker {
+    fn default() -> Self {
+        Self {
+            gate: crate::daemon::cadence_gate::CadenceGate::new_interval(TICKS_PER_SCAN),
+        }
+    }
 }
 
 impl AutoReleaseTracker {
@@ -463,11 +472,9 @@ impl AutoReleaseTracker {
     /// (test signal); `false` for pre-throttle ticks and the post-fire
     /// reset.
     pub(crate) fn maybe_scan(&mut self, home: &Path) -> bool {
-        self.tick_count = self.tick_count.saturating_add(1);
-        if self.tick_count < TICKS_PER_SCAN {
+        if !self.gate.fire() {
             return false;
         }
-        self.tick_count = 0;
         drain_queue(home);
         true
     }

--- a/src/daemon/cadence_gate.rs
+++ b/src/daemon/cadence_gate.rs
@@ -1,0 +1,175 @@
+//! W2.4 (#2050, survey 01-R3) — one shared per-tick cadence gate.
+//!
+//! Two hand-rolled idioms had proliferated (~15 + 12 sites):
+//!
+//! 1. **Handlers** — `counter.fetch_add(1, Relaxed).is_multiple_of(n)`: an
+//!    `AtomicU64` that fires on calls 1, N+1, 2N+1, … (tick 0 fires).
+//! 2. **Supervisor trackers** — `tick_count += 1; if tick_count < N { return
+//!    false } tick_count = 0; true`: a `&mut` counter that fires on calls N,
+//!    2N, … (the first N-1 calls don't fire; the first scan is delayed N ticks).
+//!
+//! `CadenceGate` collapses both into ONE type, preserving each idiom's exact
+//! fire phase via the counter's initial value (no behaviour change):
+//!
+//! - [`CadenceGate::new`] (counter starts 0) ≡ idiom 1 (fire-on-first).
+//! - [`CadenceGate::new_interval`] (counter starts 1) ≡ idiom 2 (fire-on-Nth).
+//!
+//! It also STRUCTURALLY bundles the notification-watchdog boot-grace
+//! (#t-watchdog-boot-suppress): [`CadenceGate::new_with_boot_grace`] suppresses
+//! firing within the grace window of construction, so a watchdog cannot forget
+//! the gate — it's inside `fire()`, not a separate hand-wired
+//! `!in_boot_grace(self.created_at) && …` conjunction a new handler can drop.
+//!
+//! Interior atomic, so `fire(&self)` works from both `&self` handler `run` and
+//! `&mut self` tracker `maybe_scan`.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+pub(crate) struct CadenceGate {
+    every_n: u64,
+    counter: AtomicU64,
+    /// `Some(boot, grace)` → `fire()` returns false (without advancing the
+    /// counter) until `grace` has elapsed since `boot` (≈ construction).
+    boot_grace: Option<(Instant, Duration)>,
+}
+
+impl CadenceGate {
+    /// Fire-on-FIRST cadence (calls 1, N+1, 2N+1, …; tick 0 fires) — the
+    /// handler `counter.fetch_add(1).is_multiple_of(n)` idiom.
+    pub(crate) fn new(every_n: u64) -> Self {
+        Self {
+            every_n: every_n.max(1),
+            counter: AtomicU64::new(0),
+            boot_grace: None,
+        }
+    }
+
+    /// Fire-on-Nth cadence (calls N, 2N, …; the first N-1 calls don't fire; the
+    /// first fire is delayed N calls) — the supervisor-tracker `tick_count <
+    /// N { reset }` idiom. Equivalent because the counter starts at 1, so the
+    /// N-th call observes the value `N` (≡ `0 % N` after the tracker's reset).
+    pub(crate) fn new_interval(every_n: u64) -> Self {
+        Self {
+            every_n: every_n.max(1),
+            counter: AtomicU64::new(1),
+            boot_grace: None,
+        }
+    }
+
+    /// Fire-on-first cadence PLUS a boot-grace suppression window: never fires
+    /// within `grace` of construction (≈ daemon boot), AND does not advance the
+    /// counter during the grace window — so the cadence phase is anchored to
+    /// grace-END (byte-identical to the old `!in_boot_grace(created_at) &&
+    /// should_fire()`, whose `&&` short-circuit skipped the `fetch_add` during
+    /// grace). #t-watchdog-boot-suppress.
+    pub(crate) fn new_with_boot_grace(every_n: u64, grace: Duration) -> Self {
+        Self {
+            every_n: every_n.max(1),
+            counter: AtomicU64::new(0),
+            boot_grace: Some((Instant::now(), grace)),
+        }
+    }
+
+    /// Test seam for the notification-watchdog `new_at` constructors: build a
+    /// boot-grace gate anchored to an explicit `boot` Instant (counter 0), so a
+    /// test can drive the grace window deterministically (a past `boot` → grace
+    /// already expired). Mirrors `new_with_boot_grace` exactly, minus the
+    /// `Instant::now()` anchor.
+    #[cfg(test)]
+    pub(crate) fn new_with_boot_grace_at(
+        every_n: u64,
+        boot: std::time::Instant,
+        grace: Duration,
+    ) -> Self {
+        Self {
+            every_n: every_n.max(1),
+            counter: AtomicU64::new(0),
+            boot_grace: Some((boot, grace)),
+        }
+    }
+
+    /// Advance one tick and report whether this tick fires. During a boot-grace
+    /// window: returns false WITHOUT advancing (preserves the old short-circuit
+    /// phase). Otherwise: fires when the pre-increment counter is a multiple of
+    /// `every_n`.
+    pub(crate) fn fire(&self) -> bool {
+        if let Some((boot, grace)) = self.boot_grace {
+            if boot.elapsed() < grace {
+                return false;
+            }
+        }
+        self.counter
+            .fetch_add(1, Ordering::Relaxed)
+            .is_multiple_of(self.every_n)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Idiom 1: fires on calls 1, N+1, 2N+1 (tick 0 fires) — matches
+    /// `counter.fetch_add(1).is_multiple_of(N)`.
+    #[test]
+    fn new_fires_on_first_then_every_n() {
+        let g = CadenceGate::new(3);
+        let fires: Vec<bool> = (0..7).map(|_| g.fire()).collect();
+        assert_eq!(
+            fires,
+            vec![true, false, false, true, false, false, true],
+            "fire-on-first: calls 1,4,7 (0-indexed 0,3,6)"
+        );
+    }
+
+    /// Idiom 2: the first N-1 calls don't fire; fires on the N-th, 2N-th — the
+    /// tracker `tick_count += 1; if < N { false } else { reset; true }` schedule.
+    #[test]
+    fn new_interval_fires_on_nth_matching_tracker() {
+        const N: u64 = 4;
+        let g = CadenceGate::new_interval(N);
+        // Reference: the literal tracker idiom.
+        let mut tick_count: u64 = 0;
+        let mut tracker_fire = || {
+            tick_count += 1;
+            if tick_count < N {
+                false
+            } else {
+                tick_count = 0;
+                true
+            }
+        };
+        for call in 1..=(3 * N) {
+            assert_eq!(
+                g.fire(),
+                tracker_fire(),
+                "CadenceGate::new_interval must match the tracker idiom on call {call}"
+            );
+        }
+    }
+
+    /// Boot-grace: no fire (and no counter advance) during the window; the
+    /// first post-grace call fires (counter still 0), matching the old
+    /// `!in_boot_grace(created_at) && should_fire()` phase.
+    #[test]
+    fn boot_grace_suppresses_then_anchors_phase_to_grace_end() {
+        // Already-expired grace (construct with a zero window): behaves like new().
+        let g = CadenceGate::new_with_boot_grace(3, Duration::from_secs(0));
+        assert!(g.fire(), "past grace, first call fires (counter 0)");
+        assert!(!g.fire());
+        assert!(!g.fire());
+        assert!(g.fire());
+
+        // Active grace: suppressed, counter not advanced.
+        let g2 = CadenceGate::new_with_boot_grace(3, Duration::from_secs(3600));
+        assert!(!g2.fire(), "within grace → suppressed");
+        assert!(!g2.fire(), "still suppressed, no counter advance");
+    }
+
+    #[test]
+    fn every_n_floored_to_one() {
+        let g = CadenceGate::new(0);
+        assert!(g.fire(), "n=0 floored to 1 → fires every call");
+        assert!(g.fire());
+    }
+}

--- a/src/daemon/canonical_drift.rs
+++ b/src/daemon/canonical_drift.rs
@@ -22,9 +22,10 @@ use std::path::{Path, PathBuf};
 /// `waiting_on_stale` + `conflict_notify`).
 const TICKS_PER_SCAN: u64 = 30;
 
-#[derive(Debug, Default)]
 pub(crate) struct CanonicalDriftTracker {
-    tick_count: u64,
+    /// Cadence gate — throttles scans to once per [`TICKS_PER_SCAN`]
+    /// supervisor ticks (fire-on-Nth).
+    gate: crate::daemon::cadence_gate::CadenceGate,
     /// Per-canonical-path last-action timestamp. Reserved for future
     /// per-path dedup / re-alert suppression (mirror of
     /// `waiting_on_stale::WaitingOnStaleTracker::last_alerted_at`).
@@ -36,16 +37,23 @@ pub(crate) struct CanonicalDriftTracker {
     last_action_at: HashMap<PathBuf, chrono::DateTime<chrono::Utc>>,
 }
 
+impl Default for CanonicalDriftTracker {
+    fn default() -> Self {
+        Self {
+            gate: crate::daemon::cadence_gate::CadenceGate::new_interval(TICKS_PER_SCAN),
+            last_action_at: HashMap::new(),
+        }
+    }
+}
+
 impl CanonicalDriftTracker {
     /// Per-tick entry. Increments the tick counter; on the throttled
     /// boundary, fires a drift scan and returns `true`. Returns `false`
     /// otherwise (pre-throttle tick OR post-fire reset).
     pub(crate) fn maybe_scan(&mut self, home: &Path) -> bool {
-        self.tick_count = self.tick_count.saturating_add(1);
-        if self.tick_count < TICKS_PER_SCAN {
+        if !self.gate.fire() {
             return false;
         }
-        self.tick_count = 0;
         run_drift_scan(home);
         true
     }

--- a/src/daemon/conflict_notify.rs
+++ b/src/daemon/conflict_notify.rs
@@ -49,9 +49,10 @@ pub(crate) const TICKS_PER_SCAN: u64 = 30;
 
 /// Per-tick conflict-notify tracker. Mirrors
 /// [`crate::daemon::waiting_on_stale::WaitingOnStaleTracker`].
-#[derive(Debug, Default)]
 pub(crate) struct ConflictNotifyTracker {
-    tick_count: u64,
+    /// Cadence gate — throttles scans to once per [`TICKS_PER_SCAN`]
+    /// supervisor ticks (fire-on-Nth).
+    gate: crate::daemon::cadence_gate::CadenceGate,
     /// agent → moment of first conflict observation (for stale gate).
     last_conflict_at: HashMap<String, chrono::DateTime<chrono::Utc>>,
     /// agent → last telegram-escalation timestamp (dedup guard).
@@ -65,6 +66,17 @@ pub(crate) struct ConflictNotifyTracker {
     /// escalation dedup itself (`last_escalated_at`) is out of scope here (#1739
     /// ②, persisted separately).
     seeded: bool,
+}
+
+impl Default for ConflictNotifyTracker {
+    fn default() -> Self {
+        Self {
+            gate: crate::daemon::cadence_gate::CadenceGate::new_interval(TICKS_PER_SCAN),
+            last_conflict_at: HashMap::new(),
+            last_escalated_at: HashMap::new(),
+            seeded: false,
+        }
+    }
 }
 
 impl ConflictNotifyTracker {
@@ -102,11 +114,9 @@ impl ConflictNotifyTracker {
         home: &Path,
         registry: &crate::agent::AgentRegistry,
     ) -> bool {
-        self.tick_count = self.tick_count.saturating_add(1);
-        if self.tick_count < TICKS_PER_SCAN {
+        if !self.gate.fire() {
             return false;
         }
-        self.tick_count = 0;
         let seeding = !self.seeded;
         self.seeded = true;
 

--- a/src/daemon/decision_timeout.rs
+++ b/src/daemon/decision_timeout.rs
@@ -214,18 +214,25 @@ pub(crate) fn mark_resolved_for_sender(home: &Path, sender: &str) -> Option<Stri
 }
 
 /// Per-loop scheduler state.
-#[derive(Debug, Default)]
 pub(crate) struct DecisionTimeoutTracker {
-    tick_count: u64,
+    /// Cadence gate — throttles scans to once per [`TICKS_PER_DECISION_SCAN`]
+    /// supervisor ticks (fire-on-Nth).
+    gate: crate::daemon::cadence_gate::CadenceGate,
+}
+
+impl Default for DecisionTimeoutTracker {
+    fn default() -> Self {
+        Self {
+            gate: crate::daemon::cadence_gate::CadenceGate::new_interval(TICKS_PER_DECISION_SCAN),
+        }
+    }
 }
 
 impl DecisionTimeoutTracker {
     pub(crate) fn maybe_scan(&mut self, home: &Path) -> bool {
-        self.tick_count = self.tick_count.saturating_add(1);
-        if self.tick_count < TICKS_PER_DECISION_SCAN {
+        if !self.gate.fire() {
             return false;
         }
-        self.tick_count = 0;
         scan_and_emit(home);
         true
     }

--- a/src/daemon/dispatch_idle/mod.rs
+++ b/src/daemon/dispatch_idle/mod.rs
@@ -1314,9 +1314,18 @@ fn emit_dispatch_idle_event(
 }
 
 /// Per-loop scheduler state.
-#[derive(Debug, Default)]
 pub(crate) struct DispatchIdleTracker {
-    tick_count: u64,
+    /// Cadence gate — throttles scans to once per [`TICKS_PER_SCAN`]
+    /// supervisor ticks (fire-on-Nth).
+    gate: crate::daemon::cadence_gate::CadenceGate,
+}
+
+impl Default for DispatchIdleTracker {
+    fn default() -> Self {
+        Self {
+            gate: crate::daemon::cadence_gate::CadenceGate::new_interval(TICKS_PER_SCAN),
+        }
+    }
 }
 
 impl DispatchIdleTracker {
@@ -1324,11 +1333,9 @@ impl DispatchIdleTracker {
     /// boundary, fires `scan_and_emit` and returns `true`. Returns
     /// `false` for all pre-boundary ticks.
     pub(crate) fn maybe_scan(&mut self, home: &Path) -> bool {
-        self.tick_count = self.tick_count.saturating_add(1);
-        if self.tick_count < TICKS_PER_SCAN {
+        if !self.gate.fire() {
             return false;
         }
-        self.tick_count = 0;
         scan_and_emit(home);
         true
     }

--- a/src/daemon/dispatch_idle/team_nudge.rs
+++ b/src/daemon/dispatch_idle/team_nudge.rs
@@ -66,18 +66,25 @@ pub(crate) fn resolve_threshold_for_dispatch(
 }
 
 /// Per-loop scheduler state for the auto-nudge tracker.
-#[derive(Debug, Default)]
 pub(crate) struct DispatchIdleNudgeTracker {
-    tick_count: u64,
+    /// Cadence gate — throttles scans to once per [`TICKS_PER_SCAN`]
+    /// supervisor ticks (fire-on-Nth).
+    gate: crate::daemon::cadence_gate::CadenceGate,
+}
+
+impl Default for DispatchIdleNudgeTracker {
+    fn default() -> Self {
+        Self {
+            gate: crate::daemon::cadence_gate::CadenceGate::new_interval(TICKS_PER_SCAN),
+        }
+    }
 }
 
 impl DispatchIdleNudgeTracker {
     pub(crate) fn maybe_scan(&mut self, home: &Path) -> bool {
-        self.tick_count = self.tick_count.saturating_add(1);
-        if self.tick_count < TICKS_PER_SCAN {
+        if !self.gate.fire() {
             return false;
         }
-        self.tick_count = 0;
         scan_and_nudge(home);
         true
     }

--- a/src/daemon/helper_staleness_watchdog.rs
+++ b/src/daemon/helper_staleness_watchdog.rs
@@ -47,9 +47,10 @@ const RECIPIENTS: &[&str] = &["general", "lead"];
 /// proactive scanner.
 const TRACKED_HELPERS: &[&str] = &["agend-git", "agend-mcp-bridge"];
 
-#[derive(Debug, Default)]
 pub(crate) struct HelperStalenessWatchdogTracker {
-    tick_count: u64,
+    /// Cadence gate — throttles scans to once per [`TICKS_PER_STALENESS_SCAN`]
+    /// supervisor ticks (fire-on-Nth).
+    gate: crate::daemon::cadence_gate::CadenceGate,
     /// Per-helper last-alert timestamp. Per-helper (not per-recipient)
     /// so a sequential rebuild that fixes one helper but not the other
     /// still produces fresh alerts for the lagging one.
@@ -61,15 +62,23 @@ pub(crate) struct HelperStalenessWatchdogTracker {
     seeded: bool,
 }
 
+impl Default for HelperStalenessWatchdogTracker {
+    fn default() -> Self {
+        Self {
+            gate: crate::daemon::cadence_gate::CadenceGate::new_interval(TICKS_PER_STALENESS_SCAN),
+            last_alerted_at: HashMap::new(),
+            seeded: false,
+        }
+    }
+}
+
 impl HelperStalenessWatchdogTracker {
     /// Increment tick counter and run the scan every
     /// [`TICKS_PER_STALENESS_SCAN`] calls.
     pub(crate) fn maybe_scan(&mut self, home: &Path) -> bool {
-        self.tick_count = self.tick_count.saturating_add(1);
-        if self.tick_count < TICKS_PER_STALENESS_SCAN {
+        if !self.gate.fire() {
             return false;
         }
-        self.tick_count = 0;
         let daemon_exe = std::env::current_exe().ok();
         let seeding = !self.seeded;
         self.seeded = true;

--- a/src/daemon/idle_watchdog.rs
+++ b/src/daemon/idle_watchdog.rs
@@ -229,9 +229,10 @@ fn enumerate_agent_activity(home: &Path) -> Vec<(String, chrono::DateTime<chrono
 }
 
 /// Per-loop watchdog state — throttles scans + dedups alerts.
-#[derive(Debug, Default)]
 pub(crate) struct IdleWatchdogTracker {
-    tick_count: u64,
+    /// Cadence gate — throttles scans to once per [`TICKS_PER_IDLE_SCAN`]
+    /// supervisor ticks (fire-on-Nth).
+    gate: crate::daemon::cadence_gate::CadenceGate,
     /// (vantage, agent_or_fleet_marker) → last alert ts.
     last_alerted_at: HashMap<(&'static str, String), chrono::DateTime<chrono::Utc>>,
     /// #1739 boot-seed latch for the DEV vantage. First scan seeds the dev
@@ -241,15 +242,23 @@ pub(crate) struct IdleWatchdogTracker {
     seeded: bool,
 }
 
+impl Default for IdleWatchdogTracker {
+    fn default() -> Self {
+        Self {
+            gate: crate::daemon::cadence_gate::CadenceGate::new_interval(TICKS_PER_IDLE_SCAN),
+            last_alerted_at: HashMap::new(),
+            seeded: false,
+        }
+    }
+}
+
 impl IdleWatchdogTracker {
     /// Increment tick counter and run scans every
     /// [`TICKS_PER_IDLE_SCAN`] calls.
     pub(crate) fn maybe_scan(&mut self, home: &Path) -> bool {
-        self.tick_count = self.tick_count.saturating_add(1);
-        if self.tick_count < TICKS_PER_IDLE_SCAN {
+        if !self.gate.fire() {
             return false;
         }
-        self.tick_count = 0;
         let seeding = !self.seeded;
         self.seeded = true;
         scan_and_emit(home, &mut self.last_alerted_at, seeding);

--- a/src/daemon/mcp_registry_watcher.rs
+++ b/src/daemon/mcp_registry_watcher.rs
@@ -64,9 +64,10 @@ pub(crate) const TICKS_PER_REGISTRY_SCAN: u64 = 30;
 /// Per-supervisor-loop tracker — captures the process-start time on
 /// first init so subsequent scans can detect a daemon binary that has
 /// been replaced post-startup.
-#[derive(Debug)]
 pub(crate) struct McpRegistryWatcherTracker {
-    tick_count: u64,
+    /// Cadence gate — throttles scans to once per [`TICKS_PER_REGISTRY_SCAN`]
+    /// supervisor ticks (fire-on-Nth).
+    gate: crate::daemon::cadence_gate::CadenceGate,
     /// Process start time. Captured at tracker init so the comparison
     /// against the daemon binary's mtime reflects "has the binary
     /// been refreshed since this process started".
@@ -76,7 +77,7 @@ pub(crate) struct McpRegistryWatcherTracker {
 impl Default for McpRegistryWatcherTracker {
     fn default() -> Self {
         Self {
-            tick_count: 0,
+            gate: crate::daemon::cadence_gate::CadenceGate::new_interval(TICKS_PER_REGISTRY_SCAN),
             started_at: SystemTime::now(),
         }
     }
@@ -86,11 +87,9 @@ impl McpRegistryWatcherTracker {
     /// Increment tick counter and run the scan every
     /// [`TICKS_PER_REGISTRY_SCAN`] calls.
     pub(crate) fn maybe_scan(&mut self, binary_stale: &AtomicBool) -> bool {
-        self.tick_count = self.tick_count.saturating_add(1);
-        if self.tick_count < TICKS_PER_REGISTRY_SCAN {
+        if !self.gate.fire() {
             return false;
         }
-        self.tick_count = 0;
         let daemon_exe = std::env::current_exe().ok();
         scan_and_set_flag(daemon_exe.as_deref(), self.started_at, binary_stale);
         true

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -4,6 +4,7 @@
 pub(crate) mod anti_stall;
 pub(crate) mod auto_release;
 pub(crate) mod boot_sweep;
+pub(crate) mod cadence_gate;
 pub(crate) mod canonical_drift;
 pub(crate) mod ci_handoff_track;
 pub(crate) mod ci_watch;

--- a/src/daemon/per_tick/context_alert.rs
+++ b/src/daemon/per_tick/context_alert.rs
@@ -22,7 +22,6 @@
 use super::{PerTickHandler, TickContext};
 use parking_lot::Mutex;
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 /// Default alert threshold (percent). Override: `AGEND_CONTEXT_ALERT_PCT`.
@@ -79,25 +78,16 @@ fn decide(state: &mut AlertState, pct: f32, threshold: f32, now: Instant) -> boo
 }
 
 pub(crate) struct ContextAlertHandler {
-    every_n_ticks: u64,
-    counter: AtomicU64,
+    gate: crate::daemon::cadence_gate::CadenceGate,
     states: Mutex<HashMap<String, AlertState>>,
 }
 
 impl ContextAlertHandler {
     pub(crate) fn new(every_n_ticks: u64) -> Self {
         Self {
-            every_n_ticks,
-            counter: AtomicU64::new(0),
+            gate: crate::daemon::cadence_gate::CadenceGate::new(every_n_ticks),
             states: Mutex::new(HashMap::new()),
         }
-    }
-
-    /// Fires at tick indices 0, N, 2N, … (matches `InboxStuckHandler`).
-    fn should_fire(&self) -> bool {
-        self.counter
-            .fetch_add(1, Ordering::Relaxed)
-            .is_multiple_of(self.every_n_ticks)
     }
 }
 
@@ -107,7 +97,7 @@ impl PerTickHandler for ContextAlertHandler {
     }
 
     fn run(&self, ctx: &TickContext<'_>) {
-        if !self.should_fire() {
+        if !self.gate.fire() {
             return;
         }
 

--- a/src/daemon/per_tick/context_handoff.rs
+++ b/src/daemon/per_tick/context_handoff.rs
@@ -32,7 +32,6 @@
 use super::{PerTickHandler, TickContext};
 use parking_lot::Mutex;
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU64, Ordering};
 
 /// Handoff-injection threshold (percent). Override: `AGEND_CONTEXT_HANDOFF_PCT`.
 const DEFAULT_HANDOFF_PCT: f32 = 85.0;
@@ -199,24 +198,16 @@ fn handoff_written_since(working_dir: Option<&std::path::Path>, since_ms: i64) -
 }
 
 pub(crate) struct ContextHandoffHandler {
-    every_n_ticks: u64,
-    counter: AtomicU64,
+    gate: crate::daemon::cadence_gate::CadenceGate,
     states: Mutex<HashMap<String, EpisodeState>>,
 }
 
 impl ContextHandoffHandler {
     pub(crate) fn new(every_n_ticks: u64) -> Self {
         Self {
-            every_n_ticks,
-            counter: AtomicU64::new(0),
+            gate: crate::daemon::cadence_gate::CadenceGate::new(every_n_ticks),
             states: Mutex::new(HashMap::new()),
         }
-    }
-
-    fn should_fire(&self) -> bool {
-        self.counter
-            .fetch_add(1, Ordering::Relaxed)
-            .is_multiple_of(self.every_n_ticks)
     }
 }
 
@@ -226,7 +217,7 @@ impl PerTickHandler for ContextHandoffHandler {
     }
 
     fn run(&self, ctx: &TickContext<'_>) {
-        if !self.should_fire() {
+        if !self.gate.fire() {
             return;
         }
 

--- a/src/daemon/per_tick/gc_tick.rs
+++ b/src/daemon/per_tick/gc_tick.rs
@@ -3,25 +3,16 @@
 //! Also cleans up stale ci-watch lock files.
 
 use super::{PerTickHandler, TickContext};
-use std::sync::atomic::{AtomicU64, Ordering};
 
 pub(crate) struct GcTickHandler {
-    every_n_ticks: u64,
-    counter: AtomicU64,
+    gate: crate::daemon::cadence_gate::CadenceGate,
 }
 
 impl GcTickHandler {
     pub(crate) fn new(every_n_ticks: u64) -> Self {
         Self {
-            every_n_ticks,
-            counter: AtomicU64::new(0),
+            gate: crate::daemon::cadence_gate::CadenceGate::new(every_n_ticks),
         }
-    }
-
-    fn should_fire(&self) -> bool {
-        self.counter
-            .fetch_add(1, Ordering::Relaxed)
-            .is_multiple_of(self.every_n_ticks)
     }
 }
 
@@ -31,7 +22,7 @@ impl PerTickHandler for GcTickHandler {
     }
 
     fn run(&self, ctx: &TickContext<'_>) {
-        if !self.should_fire() {
+        if !self.gate.fire() {
             return;
         }
         let results = crate::worktree_pool::gc_run(ctx.home);
@@ -56,10 +47,10 @@ mod tests {
     #[test]
     fn should_fire_respects_every_n_ticks() {
         let handler = GcTickHandler::new(3);
-        assert!(handler.should_fire()); // tick 0
-        assert!(!handler.should_fire()); // tick 1
-        assert!(!handler.should_fire()); // tick 2
-        assert!(handler.should_fire()); // tick 3
-        assert!(!handler.should_fire()); // tick 4
+        assert!(handler.gate.fire()); // tick 0
+        assert!(!handler.gate.fire()); // tick 1
+        assert!(!handler.gate.fire()); // tick 2
+        assert!(handler.gate.fire()); // tick 3
+        assert!(!handler.gate.fire()); // tick 4
     }
 }

--- a/src/daemon/per_tick/handoff_timeout.rs
+++ b/src/daemon/per_tick/handoff_timeout.rs
@@ -6,53 +6,41 @@
 use super::{PerTickHandler, TickContext};
 use parking_lot::Mutex;
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::Instant;
 
 pub(crate) struct HandoffTimeoutHandler {
-    every_n_ticks: u64,
-    counter: AtomicU64,
+    /// Cadence + boot-grace, bundled (see [`super::NOTIFICATION_BOOT_GRACE`]):
+    /// suppresses firing within the grace window of construction without
+    /// advancing the counter, then fires on tick indices 0, N, 2N, ….
+    gate: crate::daemon::cadence_gate::CadenceGate,
     last_escalated: Mutex<HashMap<(String, String), chrono::DateTime<chrono::Utc>>>,
     /// #1859: re-nudge dedup, owned alongside `last_escalated` so the interval
     /// gate survives across ticks.
     last_renudged: Mutex<HashMap<(String, String), chrono::DateTime<chrono::Utc>>>,
-    /// ≈ daemon boot — drives boot-grace suppression (see [`super::in_boot_grace`]).
-    created_at: Instant,
 }
 
 impl HandoffTimeoutHandler {
     pub(crate) fn new(every_n_ticks: u64) -> Self {
         Self {
-            every_n_ticks,
-            counter: AtomicU64::new(0),
+            gate: crate::daemon::cadence_gate::CadenceGate::new_with_boot_grace(
+                every_n_ticks,
+                super::NOTIFICATION_BOOT_GRACE,
+            ),
             last_escalated: Mutex::new(HashMap::new()),
             last_renudged: Mutex::new(HashMap::new()),
-            created_at: Instant::now(),
         }
     }
 
     #[cfg(test)]
-    fn new_at(every_n_ticks: u64, created_at: Instant) -> Self {
+    fn new_at(every_n_ticks: u64, created_at: std::time::Instant) -> Self {
         Self {
-            every_n_ticks,
-            counter: AtomicU64::new(0),
+            gate: crate::daemon::cadence_gate::CadenceGate::new_with_boot_grace_at(
+                every_n_ticks,
+                created_at,
+                super::NOTIFICATION_BOOT_GRACE,
+            ),
             last_escalated: Mutex::new(HashMap::new()),
             last_renudged: Mutex::new(HashMap::new()),
-            created_at,
         }
-    }
-
-    /// Fires at tick indices 0, N, 2N, … (matches `PollReminderHandler`).
-    fn should_fire(&self) -> bool {
-        self.counter
-            .fetch_add(1, Ordering::Relaxed)
-            .is_multiple_of(self.every_n_ticks)
-    }
-
-    /// Boot-grace + cadence gate. `&&` short-circuits before `should_fire`
-    /// during grace, so the counter is not consumed (see `PollReminderHandler`).
-    fn should_run(&self) -> bool {
-        !super::in_boot_grace(self.created_at) && self.should_fire()
     }
 }
 
@@ -62,7 +50,7 @@ impl PerTickHandler for HandoffTimeoutHandler {
     }
 
     fn run(&self, ctx: &TickContext<'_>) {
-        if !self.should_run() {
+        if !self.gate.fire() {
             return;
         }
         let now = chrono::Utc::now();
@@ -80,12 +68,16 @@ impl PerTickHandler for HandoffTimeoutHandler {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::time::Duration;
+    use std::time::{Duration, Instant};
+
+    fn past_grace() -> Instant {
+        Instant::now() - super::super::NOTIFICATION_BOOT_GRACE - Duration::from_secs(1)
+    }
 
     #[test]
     fn fires_at_expected_cadence() {
-        let h = HandoffTimeoutHandler::new(3);
-        let fires: Vec<bool> = (0..7).map(|_| h.should_fire()).collect();
+        let h = HandoffTimeoutHandler::new_at(3, past_grace());
+        let fires: Vec<bool> = (0..7).map(|_| h.gate.fire()).collect();
         assert_eq!(fires, vec![true, false, false, true, false, false, true]);
     }
 
@@ -104,14 +96,10 @@ mod tests {
     #[test]
     fn boot_grace_suppresses_then_fires() {
         let fresh = HandoffTimeoutHandler::new(30);
-        assert!(!fresh.should_run(), "in boot-grace → suppressed");
-        assert!(
-            !fresh.should_run(),
-            "still suppressed; counter not consumed"
-        );
+        assert!(!fresh.gate.fire(), "in boot-grace → suppressed");
+        assert!(!fresh.gate.fire(), "still suppressed; counter not consumed");
 
-        let past = Instant::now() - super::super::NOTIFICATION_BOOT_GRACE - Duration::from_secs(1);
-        let aged = HandoffTimeoutHandler::new_at(30, past);
-        assert!(aged.should_run(), "after grace, first tick fires");
+        let aged = HandoffTimeoutHandler::new_at(30, past_grace());
+        assert!(aged.gate.fire(), "after grace, first tick fires");
     }
 }

--- a/src/daemon/per_tick/inbox_maintenance.rs
+++ b/src/daemon/per_tick/inbox_maintenance.rs
@@ -7,27 +7,16 @@
 use super::{PerTickHandler, TickContext};
 use crate::api::ConfigRegistry;
 use std::path::Path;
-use std::sync::atomic::{AtomicU64, Ordering};
 
 pub(crate) struct InboxMaintenanceHandler {
-    every_n_ticks: u64,
-    counter: AtomicU64,
+    gate: crate::daemon::cadence_gate::CadenceGate,
 }
 
 impl InboxMaintenanceHandler {
     pub(crate) fn new(every_n_ticks: u64) -> Self {
         Self {
-            every_n_ticks,
-            counter: AtomicU64::new(0),
+            gate: crate::daemon::cadence_gate::CadenceGate::new(every_n_ticks),
         }
-    }
-
-    /// Matches the pre-extraction `static AtomicU64` cadence: `fetch_add`
-    /// returns prev value, so first tick (counter=0) fires.
-    fn should_fire(&self) -> bool {
-        self.counter
-            .fetch_add(1, Ordering::Relaxed)
-            .is_multiple_of(self.every_n_ticks)
     }
 }
 
@@ -37,7 +26,7 @@ impl PerTickHandler for InboxMaintenanceHandler {
     }
 
     fn run(&self, ctx: &TickContext<'_>) {
-        if !self.should_fire() {
+        if !self.gate.fire() {
             return;
         }
         // Sub-op order matches the pre-extraction inline composite verbatim.
@@ -104,7 +93,7 @@ mod tests {
     #[test]
     fn fires_on_first_tick_then_every_n() {
         let h = InboxMaintenanceHandler::new(4);
-        let fires: Vec<bool> = (0..9).map(|_| h.should_fire()).collect();
+        let fires: Vec<bool> = (0..9).map(|_| h.gate.fire()).collect();
         assert_eq!(
             fires,
             vec![true, false, false, false, true, false, false, false, true]

--- a/src/daemon/per_tick/inbox_stuck.rs
+++ b/src/daemon/per_tick/inbox_stuck.rs
@@ -7,48 +7,36 @@
 use super::{PerTickHandler, TickContext};
 use parking_lot::Mutex;
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::Instant;
 
 pub(crate) struct InboxStuckHandler {
-    every_n_ticks: u64,
-    counter: AtomicU64,
+    /// Cadence + boot-grace, bundled (see [`super::NOTIFICATION_BOOT_GRACE`]):
+    /// suppresses firing within the grace window of construction without
+    /// advancing the counter, then fires on tick indices 0, N, 2N, ….
+    gate: crate::daemon::cadence_gate::CadenceGate,
     last_alerted: Mutex<HashMap<String, chrono::DateTime<chrono::Utc>>>,
-    /// ≈ daemon boot — drives boot-grace suppression (see [`super::in_boot_grace`]).
-    created_at: Instant,
 }
 
 impl InboxStuckHandler {
     pub(crate) fn new(every_n_ticks: u64) -> Self {
         Self {
-            every_n_ticks,
-            counter: AtomicU64::new(0),
+            gate: crate::daemon::cadence_gate::CadenceGate::new_with_boot_grace(
+                every_n_ticks,
+                super::NOTIFICATION_BOOT_GRACE,
+            ),
             last_alerted: Mutex::new(HashMap::new()),
-            created_at: Instant::now(),
         }
     }
 
     #[cfg(test)]
-    fn new_at(every_n_ticks: u64, created_at: Instant) -> Self {
+    fn new_at(every_n_ticks: u64, created_at: std::time::Instant) -> Self {
         Self {
-            every_n_ticks,
-            counter: AtomicU64::new(0),
+            gate: crate::daemon::cadence_gate::CadenceGate::new_with_boot_grace_at(
+                every_n_ticks,
+                created_at,
+                super::NOTIFICATION_BOOT_GRACE,
+            ),
             last_alerted: Mutex::new(HashMap::new()),
-            created_at,
         }
-    }
-
-    /// Fires at tick indices 0, N, 2N, … (matches `PollReminderHandler`).
-    fn should_fire(&self) -> bool {
-        self.counter
-            .fetch_add(1, Ordering::Relaxed)
-            .is_multiple_of(self.every_n_ticks)
-    }
-
-    /// Boot-grace + cadence gate. `&&` short-circuits before `should_fire`
-    /// during grace, so the counter is not consumed (see `PollReminderHandler`).
-    fn should_run(&self) -> bool {
-        !super::in_boot_grace(self.created_at) && self.should_fire()
     }
 }
 
@@ -58,7 +46,7 @@ impl PerTickHandler for InboxStuckHandler {
     }
 
     fn run(&self, ctx: &TickContext<'_>) {
-        if !self.should_run() {
+        if !self.gate.fire() {
             return;
         }
         let now = chrono::Utc::now();
@@ -70,12 +58,16 @@ impl PerTickHandler for InboxStuckHandler {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::time::Duration;
+    use std::time::{Duration, Instant};
+
+    fn past_grace() -> Instant {
+        Instant::now() - super::super::NOTIFICATION_BOOT_GRACE - Duration::from_secs(1)
+    }
 
     #[test]
     fn fires_at_expected_cadence() {
-        let h = InboxStuckHandler::new(3);
-        let fires: Vec<bool> = (0..7).map(|_| h.should_fire()).collect();
+        let h = InboxStuckHandler::new_at(3, past_grace());
+        let fires: Vec<bool> = (0..7).map(|_| h.gate.fire()).collect();
         assert_eq!(fires, vec![true, false, false, true, false, false, true]);
     }
 
@@ -84,22 +76,18 @@ mod tests {
         assert_eq!(InboxStuckHandler::new(30).name(), "inbox_stuck_watchdog");
     }
 
-    /// #t-watchdog-boot-suppress: within boot-grace, `should_run` is false (no
-    /// alert for the stale backlog) and the counter is NOT consumed; past grace
-    /// the first tick fires. Combined with `inbox_stuck_watchdog`'s scan_and_emit
+    /// #t-watchdog-boot-suppress: within boot-grace, `fire` is false (no alert
+    /// for the stale backlog) and the counter is NOT consumed; past grace the
+    /// first tick fires. Combined with `inbox_stuck_watchdog`'s scan_and_emit
     /// tests (which prove a real stuck pile DOES alert), this pins "suppressed
     /// during grace, fires for a genuine stuck agent after grace".
     #[test]
     fn boot_grace_suppresses_then_fires() {
         let fresh = InboxStuckHandler::new(30); // created_at ≈ now → in grace
-        assert!(!fresh.should_run(), "in boot-grace → suppressed");
-        assert!(
-            !fresh.should_run(),
-            "still suppressed; counter not consumed"
-        );
+        assert!(!fresh.gate.fire(), "in boot-grace → suppressed");
+        assert!(!fresh.gate.fire(), "still suppressed; counter not consumed");
 
-        let past = Instant::now() - super::super::NOTIFICATION_BOOT_GRACE - Duration::from_secs(1);
-        let aged = InboxStuckHandler::new_at(30, past);
-        assert!(aged.should_run(), "after grace, first tick fires");
+        let aged = InboxStuckHandler::new_at(30, past_grace());
+        assert!(aged.gate.fire(), "after grace, first tick fires");
     }
 }

--- a/src/daemon/per_tick/inject_delivery.rs
+++ b/src/daemon/per_tick/inject_delivery.rs
@@ -5,25 +5,16 @@
 //! tick granularity (the pass is cheap — it iterates a usually-empty map).
 
 use super::{PerTickHandler, TickContext};
-use std::sync::atomic::{AtomicU64, Ordering};
 
 pub(crate) struct InjectDeliveryHandler {
-    every_n_ticks: u64,
-    counter: AtomicU64,
+    gate: crate::daemon::cadence_gate::CadenceGate,
 }
 
 impl InjectDeliveryHandler {
     pub(crate) fn new(every_n_ticks: u64) -> Self {
         Self {
-            every_n_ticks,
-            counter: AtomicU64::new(0),
+            gate: crate::daemon::cadence_gate::CadenceGate::new(every_n_ticks),
         }
-    }
-
-    fn should_fire(&self) -> bool {
-        self.counter
-            .fetch_add(1, Ordering::Relaxed)
-            .is_multiple_of(self.every_n_ticks)
     }
 }
 
@@ -33,7 +24,7 @@ impl PerTickHandler for InjectDeliveryHandler {
     }
 
     fn run(&self, ctx: &TickContext<'_>) {
-        if !self.should_fire() {
+        if !self.gate.fire() {
             return;
         }
         crate::daemon::inject_delivery::verify_pass(ctx.home);

--- a/src/daemon/per_tick/log_rotation.rs
+++ b/src/daemon/per_tick/log_rotation.rs
@@ -9,25 +9,16 @@
 //! boundaries.
 
 use super::{PerTickHandler, TickContext};
-use std::sync::atomic::{AtomicU64, Ordering};
 
 pub(crate) struct LogRotationHandler {
-    every_n_ticks: u64,
-    counter: AtomicU64,
+    gate: crate::daemon::cadence_gate::CadenceGate,
 }
 
 impl LogRotationHandler {
     pub(crate) fn new(every_n_ticks: u64) -> Self {
         Self {
-            every_n_ticks,
-            counter: AtomicU64::new(0),
+            gate: crate::daemon::cadence_gate::CadenceGate::new(every_n_ticks),
         }
-    }
-
-    fn should_fire(&self) -> bool {
-        self.counter
-            .fetch_add(1, Ordering::Relaxed)
-            .is_multiple_of(self.every_n_ticks)
     }
 }
 
@@ -37,7 +28,7 @@ impl PerTickHandler for LogRotationHandler {
     }
 
     fn run(&self, ctx: &TickContext<'_>) {
-        if !self.should_fire() {
+        if !self.gate.fire() {
             return;
         }
         let max_bytes = std::env::var("AGEND_LOG_MAX_BYTES")
@@ -64,7 +55,7 @@ mod tests {
     #[test]
     fn fires_on_first_tick_then_every_n() {
         let h = LogRotationHandler::new(4);
-        let fires: Vec<bool> = (0..9).map(|_| h.should_fire()).collect();
+        let fires: Vec<bool> = (0..9).map(|_| h.gate.fire()).collect();
         assert_eq!(
             fires,
             vec![true, false, false, false, true, false, false, false, true]

--- a/src/daemon/per_tick/mod.rs
+++ b/src/daemon/per_tick/mod.rs
@@ -287,8 +287,9 @@ mod tests {
                 .or_else(|_| std::fs::read_to_string(format!("agend-terminal/{file}")))
                 .unwrap_or_else(|_| panic!("source must be readable: {file}"));
             assert!(
-                src.contains("in_boot_grace(self.created_at)"),
-                "{file} must gate firing on in_boot_grace (boot-suppress) — #t-watchdog-boot-suppress"
+                src.contains("new_with_boot_grace("),
+                "{file} must build its cadence gate via CadenceGate::new_with_boot_grace \
+                 (which bundles the boot-suppress window) — #t-watchdog-boot-suppress"
             );
         }
     }

--- a/src/daemon/per_tick/notification_flush.rs
+++ b/src/daemon/per_tick/notification_flush.rs
@@ -19,26 +19,16 @@
 
 use super::{PerTickHandler, TickContext};
 use std::path::Path;
-use std::sync::atomic::{AtomicU64, Ordering};
 
 pub(crate) struct NotificationFlushHandler {
-    every_n_ticks: u64,
-    counter: AtomicU64,
+    gate: crate::daemon::cadence_gate::CadenceGate,
 }
 
 impl NotificationFlushHandler {
     pub(crate) fn new(every_n_ticks: u64) -> Self {
         Self {
-            every_n_ticks,
-            counter: AtomicU64::new(0),
+            gate: crate::daemon::cadence_gate::CadenceGate::new(every_n_ticks),
         }
-    }
-
-    /// Fires at tick indices 0, N, 2N, … (matches `PollReminderHandler`).
-    fn should_fire(&self) -> bool {
-        self.counter
-            .fetch_add(1, Ordering::Relaxed)
-            .is_multiple_of(self.every_n_ticks)
     }
 }
 
@@ -48,7 +38,7 @@ impl PerTickHandler for NotificationFlushHandler {
     }
 
     fn run(&self, ctx: &TickContext<'_>) {
-        if !self.should_fire() {
+        if !self.gate.fire() {
             return;
         }
         flush_all(ctx.home);
@@ -245,7 +235,7 @@ mod tests {
     #[test]
     fn fires_at_expected_cadence() {
         let h = NotificationFlushHandler::new(3);
-        let fires: Vec<bool> = (0..7).map(|_| h.should_fire()).collect();
+        let fires: Vec<bool> = (0..7).map(|_| h.gate.fire()).collect();
         assert_eq!(fires, vec![true, false, false, true, false, false, true]);
     }
 

--- a/src/daemon/per_tick/poll_reminder.rs
+++ b/src/daemon/per_tick/poll_reminder.rs
@@ -4,50 +4,33 @@
 //! counter; this handler relocates that counter onto the struct.
 
 use super::{PerTickHandler, TickContext};
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::Instant;
 
 pub(crate) struct PollReminderHandler {
-    every_n_ticks: u64,
-    counter: AtomicU64,
-    /// ≈ daemon boot (handlers are built once at startup). Drives the
-    /// boot-grace suppression — see [`super::in_boot_grace`].
-    created_at: Instant,
+    /// Cadence + boot-grace, bundled (see [`super::NOTIFICATION_BOOT_GRACE`]):
+    /// suppresses firing within the grace window of construction (≈ daemon boot)
+    /// without advancing the counter, then fires on tick indices 0, N, 2N, …
+    gate: crate::daemon::cadence_gate::CadenceGate,
 }
 
 impl PollReminderHandler {
     pub(crate) fn new(every_n_ticks: u64) -> Self {
         Self {
-            every_n_ticks,
-            counter: AtomicU64::new(0),
-            created_at: Instant::now(),
+            gate: crate::daemon::cadence_gate::CadenceGate::new_with_boot_grace(
+                every_n_ticks,
+                super::NOTIFICATION_BOOT_GRACE,
+            ),
         }
     }
 
     #[cfg(test)]
-    fn new_at(every_n_ticks: u64, created_at: Instant) -> Self {
+    fn new_at(every_n_ticks: u64, created_at: std::time::Instant) -> Self {
         Self {
-            every_n_ticks,
-            counter: AtomicU64::new(0),
-            created_at,
+            gate: crate::daemon::cadence_gate::CadenceGate::new_with_boot_grace_at(
+                every_n_ticks,
+                created_at,
+                super::NOTIFICATION_BOOT_GRACE,
+            ),
         }
-    }
-
-    /// `fetch_add` returns the PREVIOUS counter value, then atomically
-    /// increments. So fires at tick indices 0, N, 2N, ... — matching the
-    /// pre-extraction `static AtomicU64` cadence (first call returns 0,
-    /// `0.is_multiple_of(N) == true`, so the very first tick fires).
-    fn should_fire(&self) -> bool {
-        self.counter
-            .fetch_add(1, Ordering::Relaxed)
-            .is_multiple_of(self.every_n_ticks)
-    }
-
-    /// Gate combining boot-grace + cadence. During boot-grace the `&&`
-    /// short-circuits BEFORE `should_fire`, so the counter is NOT consumed —
-    /// the first tick AFTER grace sees counter 0 and fires immediately.
-    fn should_run(&self) -> bool {
-        !super::in_boot_grace(self.created_at) && self.should_fire()
     }
 }
 
@@ -57,7 +40,7 @@ impl PerTickHandler for PollReminderHandler {
     }
 
     fn run(&self, ctx: &TickContext<'_>) {
-        if self.should_run() {
+        if self.gate.fire() {
             crate::daemon::poll_reminder::poll_reminder_pass(ctx.home, ctx.registry);
         }
     }
@@ -66,43 +49,48 @@ impl PerTickHandler for PollReminderHandler {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::time::Duration;
+    use std::time::{Duration, Instant};
+
+    /// An Instant comfortably past the boot-grace window — the gate's grace has
+    /// expired, so `fire()` exercises pure cadence.
+    fn past_grace() -> Instant {
+        Instant::now() - super::super::NOTIFICATION_BOOT_GRACE - Duration::from_secs(1)
+    }
 
     /// Pin the cadence: with N=3, fires on the 1st, 4th, 7th call
     /// (counter values 0, 3, 6 — each a multiple of 3).
     #[test]
     fn fires_at_expected_cadence() {
-        let h = PollReminderHandler::new(3);
-        let fires: Vec<bool> = (0..7).map(|_| h.should_fire()).collect();
+        let h = PollReminderHandler::new_at(3, past_grace());
+        let fires: Vec<bool> = (0..7).map(|_| h.gate.fire()).collect();
         assert_eq!(fires, vec![true, false, false, true, false, false, true]);
     }
 
     /// Sanity-check the every-tick degenerate case (N=1 fires every call).
     #[test]
     fn n_equals_one_fires_every_tick() {
-        let h = PollReminderHandler::new(1);
-        let fires: Vec<bool> = (0..5).map(|_| h.should_fire()).collect();
+        let h = PollReminderHandler::new_at(1, past_grace());
+        let fires: Vec<bool> = (0..5).map(|_| h.gate.fire()).collect();
         assert_eq!(fires, vec![true; 5]);
     }
 
     /// #t-watchdog-boot-suppress: a freshly-built handler (created_at ≈ now) is
-    /// in boot-grace → `should_run` is false even though `should_fire` would be
-    /// true on tick 0. The `&&` must NOT consume the counter during grace.
+    /// in boot-grace → `fire` is false even though the cadence would fire on tick
+    /// 0. Boot-grace must NOT consume the counter during grace.
     #[test]
     fn boot_grace_suppresses_first_ticks() {
-        let h = PollReminderHandler::new(1); // N=1 → should_fire always true
-        assert!(!h.should_run(), "in boot-grace → suppressed");
-        assert!(!h.should_run(), "still suppressed; counter not consumed");
+        let h = PollReminderHandler::new(1); // N=1 → cadence always true
+        assert!(!h.gate.fire(), "in boot-grace → suppressed");
+        assert!(!h.gate.fire(), "still suppressed; counter not consumed");
     }
 
     /// Past the grace window, the first tick fires (counter still 0 because grace
     /// short-circuited it earlier).
     #[test]
     fn fires_on_first_tick_after_grace() {
-        let past = Instant::now() - super::super::NOTIFICATION_BOOT_GRACE - Duration::from_secs(1);
-        let h = PollReminderHandler::new_at(30, past);
+        let h = PollReminderHandler::new_at(30, past_grace());
         assert!(
-            h.should_run(),
+            h.gate.fire(),
             "after grace, the first post-grace tick fires"
         );
     }

--- a/src/daemon/per_tick/tmp_review_gc.rs
+++ b/src/daemon/per_tick/tmp_review_gc.rs
@@ -34,7 +34,6 @@
 
 use super::{PerTickHandler, TickContext};
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, SystemTime};
 
 /// Minimum `mtime`-age before a review-pattern `/tmp` dir is GC-eligible.
@@ -45,23 +44,14 @@ use std::time::{Duration, SystemTime};
 const MIN_AGE: Duration = Duration::from_secs(2 * 24 * 60 * 60);
 
 pub(crate) struct TmpReviewGcHandler {
-    every_n_ticks: u64,
-    counter: AtomicU64,
+    gate: crate::daemon::cadence_gate::CadenceGate,
 }
 
 impl TmpReviewGcHandler {
     pub(crate) fn new(every_n_ticks: u64) -> Self {
         Self {
-            every_n_ticks,
-            counter: AtomicU64::new(0),
+            gate: crate::daemon::cadence_gate::CadenceGate::new(every_n_ticks),
         }
-    }
-
-    /// `fetch_add` returns the prev value, so the first tick (counter=0) fires.
-    fn should_fire(&self) -> bool {
-        self.counter
-            .fetch_add(1, Ordering::Relaxed)
-            .is_multiple_of(self.every_n_ticks)
     }
 }
 
@@ -71,7 +61,7 @@ impl PerTickHandler for TmpReviewGcHandler {
     }
 
     fn run(&self, ctx: &TickContext<'_>) {
-        if !self.should_fire() {
+        if !self.gate.fire() {
             return;
         }
         let removed = gc_stale_tmp_review_worktrees(

--- a/src/daemon/retention/mod.rs
+++ b/src/daemon/retention/mod.rs
@@ -14,16 +14,25 @@ use std::time::Instant;
 
 const TICKS_PER_SCAN: u64 = 360; // ~1 hour at 10s tick rate
 
-#[derive(Default)]
 pub(crate) struct RetentionSupervisor {
-    tick_count: u64,
+    /// Cadence gate — throttles sweeps to once per [`TICKS_PER_SCAN`]
+    /// supervisor ticks (fire-on-Nth).
+    gate: crate::daemon::cadence_gate::CadenceGate,
     last_run_at: Option<Instant>,
+}
+
+impl Default for RetentionSupervisor {
+    fn default() -> Self {
+        Self {
+            gate: crate::daemon::cadence_gate::CadenceGate::new_interval(TICKS_PER_SCAN),
+            last_run_at: None,
+        }
+    }
 }
 
 impl RetentionSupervisor {
     pub(crate) fn maybe_sweep(&mut self, home: &Path) {
-        self.tick_count += 1;
-        if !self.tick_count.is_multiple_of(TICKS_PER_SCAN) {
+        if !self.gate.fire() {
             return;
         }
         let now = Instant::now();

--- a/src/daemon/waiting_on_stale.rs
+++ b/src/daemon/waiting_on_stale.rs
@@ -21,9 +21,10 @@ const REALERT_INTERVAL_SECS: i64 = 30 * 60;
 /// watchdogs).
 const TICKS_PER_SCAN: u64 = 30;
 
-#[derive(Debug, Default)]
 pub(crate) struct WaitingOnStaleTracker {
-    tick_count: u64,
+    /// Cadence gate — throttles scans to once per [`TICKS_PER_SCAN`]
+    /// supervisor ticks (fire-on-Nth).
+    gate: crate::daemon::cadence_gate::CadenceGate,
     /// agent → last alert timestamp (dedup guard).
     last_alerted_at: HashMap<String, chrono::DateTime<chrono::Utc>>,
     /// #1739 boot-seed latch. The first scan after a fresh daemon start seeds
@@ -33,13 +34,21 @@ pub(crate) struct WaitingOnStaleTracker {
     seeded: bool,
 }
 
+impl Default for WaitingOnStaleTracker {
+    fn default() -> Self {
+        Self {
+            gate: crate::daemon::cadence_gate::CadenceGate::new_interval(TICKS_PER_SCAN),
+            last_alerted_at: HashMap::new(),
+            seeded: false,
+        }
+    }
+}
+
 impl WaitingOnStaleTracker {
     pub(crate) fn maybe_scan(&mut self, home: &Path) -> bool {
-        self.tick_count = self.tick_count.saturating_add(1);
-        if self.tick_count < TICKS_PER_SCAN {
+        if !self.gate.fire() {
             return false;
         }
-        self.tick_count = 0;
         let seeding = !self.seeded;
         self.seeded = true;
         scan_and_emit(home, &mut self.last_alerted_at, seeding);


### PR DESCRIPTION
## What (REFACTOR-PLAN W2.4 · survey 01-R3, unlocked by W1.1)

Two hand-rolled per-tick cadence idioms had proliferated. `CadenceGate` (`src/daemon/cadence_gate.rs`) collapses both into ONE type, **zero behaviour change** — each idiom's exact fire phase is preserved via the counter's initial value:

- **11 handlers** (`counter.fetch_add(1).is_multiple_of(n)`, fire-on-first) → `CadenceGate::new(n)`.
- **12 supervisor trackers** (`tick_count += 1; if < N { return false } tick_count = 0`, fire-on-Nth) → `CadenceGate::new_interval(n)`.

It also **structurally bundles the notification-watchdog boot-grace** (#t-watchdog-boot-suppress): `CadenceGate::new_with_boot_grace(n, grace)` suppresses firing within the grace window AND doesn't advance the counter during it (byte-identical to the old `!in_boot_grace(self.created_at) && should_fire()` `&&` short-circuit, which anchored the cadence to grace-END). The 3 notification watchdogs (poll_reminder / inbox_stuck / handoff_timeout) use it — a new watchdog now gets boot-grace from the constructor, structurally impossible to forget (closes survey S6). The `notification_handlers_wire_boot_grace` source-pin is updated to assert the new structural form.

## Zero-behaviour proof

- `CadenceGate` unit tests include `new_interval_fires_on_nth_matching_tracker`, which runs the **literal tracker idiom side-by-side** and asserts an identical fire schedule, and `boot_grace_suppresses_then_anchors_phase_to_grace_end`.
- Every migrated handler/tracker keeps its existing cadence unit test (`maybe_scan_throttles_to_once_per_30_ticks`, context_handoff/context_alert/poll_reminder/inbox_stuck/handoff_timeout tests) — all green.
- Trackers' `#[derive(Default)]` became a hand-written `Default` (CadenceGate isn't Default); each was reviewed field-by-field to preserve every prior default.
- Full `nextest`: **4085 passed**. `clippy --all-targets --features tray -D warnings` clean · `fmt` clean.

## Scope trim (honest)

**PerAgentLatch was CANCELLED after survey** (lead ruling): its two selling points dissolved on inspection — the boot-grace structural-closure (survey S6's real goal) is already delivered here by `CadenceGate::new_with_boot_grace`, and the "built-in prune" turned out to be a dead-API-or-behaviour-change dilemma (none of the 3 `Mutex<HashMap>` latch sites currently prune; adding prune changes same-name-redeploy state, a behaviour-fix not a refactor). The remaining value was reskinning ~3 trivial maps below the churn cost (#1561 default-don't-build); a `<K,T>` generic to also fit handoff_timeout's tuple key would be YAGNI. The real in-mem-leak (latches never prune deleted agents) is tracked as a separate behaviour-fix backlog task (the #1923 G5 cleanup-on-delete class). handoff_timeout left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)