### PR TITLE
fix(test): serialize divergence_telemetry WINDOW tests (#2056 — recurring Coverage flake)

### DIFF
--- a/src/daemon/divergence_telemetry.rs
+++ b/src/daemon/divergence_telemetry.rs
@@ -155,12 +155,14 @@ fn append_line(path: &Path, line: &Value) -> std::io::Result<()> {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     fn reset() {
         *WINDOW.lock() = None;
     }
 
     #[test]
+    #[serial(divergence_window)] // shares the global WINDOW accumulator
     fn record_buckets_agree_disagree_no_signal() {
         reset();
         // Fresh + same state → agree.
@@ -234,6 +236,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(divergence_window)] // shares the global WINDOW accumulator
     fn flush_takes_and_resets_window_and_writes_jsonl() {
         reset();
         let home = std::env::temp_dir().join(format!("agend-div-tel-{}", std::process::id()));


### PR DESCRIPTION
## The recurring Coverage flake — `divergence_telemetry`

The Coverage job intermittently failed `daemon::divergence_telemetry::tests::flush_takes_and_resets_window_and_writes_jsonl` (assert on `disagree` count / `WINDOW.is_none()`, line number floating :250/:253) — it bit #2077's Coverage twice. A **global-shared-state** flake (#2056 class), **not** the #2074 transient-contention class, so the right tool is serialize, not retry-tolerate.

### RCA
`static WINDOW: Mutex<Option<Window>>` is a **process-global accumulator**. Two unit tests touch it:
- `record_buckets_agree_disagree_no_signal` — `reset()` then `record()` ×N
- `flush_takes_and_resets_window_and_writes_jsonl` — `reset()`, `record()`, `flush()`, asserts exact counts + `WINDOW.is_none()`

Under parallel execution (the window widened by llvm-cov's slower timing) they **interleave**: one `reset()`s+`record()`s while the other `flush()`es, so the flusher's window carries the other test's records → `assert_eq!(line["disagree"], 1)` (or `is_none()`) fails.

The only production caller of `record`/`flush` is the per-tick handler (`per_tick/divergence_telemetry.rs`), which no concurrent unit test exercises; `build_line_shape_for_phase2` uses a **local** `Window`. So those don't pollute and stay parallel — only the two global-`WINDOW` tests need serializing.

### Fix
Tag both global-`WINDOW` tests `#[serial(divergence_window)]` — mirroring the existing `#[serial(task_replay_latch)] // shares the global …` pattern (`task_events.rs`). `serial_test` guarantees sequential execution, so the interleave is **structurally impossible**.

### Verification
- `cargo llvm-cov --no-report --all-targets -- divergence_telemetry` — **5/5 stable green**.
- Both tests pass under a **full-suite `cargo llvm-cov`** (the exact CI condition that flaked).
- `cargo clippy --all-targets --features tray -D warnings` clean.
- 3-line change: one import + two attributes.

(Local-only: `dispatch_branch_..._1834` is the documented agend-git-shim env false-fail; CI has no shim.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)