### PR TITLE
fix(router): char-boundary-safe mirror buffer drain (no panic on multibyte UTF-8)

### DIFF
--- a/src/daemon/router.rs
+++ b/src/daemon/router.rs
@@ -20,6 +20,19 @@ const SILENCE_TIMEOUT: Duration = Duration::from_secs(3);
 /// Maximum mirror text length (chars) to dispatch.
 const MAX_MIRROR_LEN: usize = 4000;
 
+/// Byte index at which to start draining the mirror buffer to keep it under
+/// `MAX_MIRROR_LEN`, snapped forward to the next char boundary so we never slice
+/// a multi-byte UTF-8 char (e.g. Chinese) mid-character. `String::drain(..n)`
+/// panics when `n` is not a char boundary (router.rs char_boundary panics on
+/// long Chinese turns, 2026-06-12).
+fn mirror_drain_start(buf: &str) -> usize {
+    let mut drain = buf.len().saturating_sub(MAX_MIRROR_LEN);
+    while drain < buf.len() && !buf.is_char_boundary(drain) {
+        drain += 1;
+    }
+    drain
+}
+
 /// Registration message: agent name + PTY output receiver.
 pub struct AgentSubscription {
     pub name: String,
@@ -99,7 +112,7 @@ fn run_loop(home: PathBuf, reg_rx: crossbeam_channel::Receiver<AgentSubscription
                     let text = String::from_utf8_lossy(&data);
                     buf.buffer.push_str(&text);
                     if buf.buffer.len() > MAX_MIRROR_LEN * 2 {
-                        let drain = buf.buffer.len() - MAX_MIRROR_LEN;
+                        let drain = mirror_drain_start(&buf.buffer);
                         buf.buffer.drain(..drain);
                     }
                 } else {
@@ -259,6 +272,28 @@ mod tests {
     #[test]
     fn max_mirror_len_is_4000() {
         assert_eq!(MAX_MIRROR_LEN, 4000);
+    }
+
+    #[test]
+    fn mirror_drain_start_never_splits_multibyte_char() {
+        // 3-byte chars; buffer well over 2*MAX_MIRROR_LEN so the trim branch runs.
+        let s: String = "界".repeat(MAX_MIRROR_LEN); // 12000 bytes
+        let start = mirror_drain_start(&s);
+        // Raw byte target 12000-4000=8000 is NOT a char boundary (8000 % 3 != 0);
+        // the fix must snap it forward to one.
+        assert!(
+            s.is_char_boundary(start),
+            "drain start must be a char boundary"
+        );
+        let mut owned = s.clone();
+        owned.drain(..start); // must not panic (regression: assertion failed is_char_boundary)
+        assert!(owned.len() <= MAX_MIRROR_LEN + 3);
+    }
+
+    #[test]
+    fn mirror_drain_start_is_zero_when_short() {
+        let s = "界界界".to_string();
+        assert_eq!(mirror_drain_start(&s), 0);
     }
 
     // ── #1102 prefer-chain tests ──────────────────────────────────────


### PR DESCRIPTION
## What & why

The mirror buffer cap in `src/daemon/router.rs` drains by a **raw byte index**:

```rust
if buf.buffer.len() > MAX_MIRROR_LEN * 2 {
    let drain = buf.buffer.len() - MAX_MIRROR_LEN;
    buf.buffer.drain(..drain);   // panics if `drain` is not a char boundary
}
```

When the buffer holds multibyte UTF-8 (e.g. CJK), `drain` can land mid-character and `String::drain(..n)` panics (`assertion failed: self.is_char_boundary(n)`), killing the mirror thread. Observed: `router.rs` panicked at this line twice on a live deployment carrying Chinese text.

This adds a `mirror_drain_start()` helper that snaps the drain index forward to the next char boundary, plus regression tests.

## Prior art check (required)

- [x] Checked `docs/KNOWN_ISSUES.md` — not listed there.
- [x] Compared against current `main` — the `buf.buffer.drain(..drain)` path is still a raw byte index; only the sibling `mirror_text` slice path has an `is_char_boundary` guard.
- [x] Searched closed issues/PRs — found **#1109 / #1110** ("low findings batch — comms & router review"), which made the **`mirror_text` slice** char-boundary-safe (`&text[..MAX_MIRROR_LEN]` → an `is_char_boundary` back-off loop). This PR fixes the **remaining sibling call site** — the `buf.buffer.drain` cap — that #1110 did not touch. Same bug class, different line.

- `cargo build --release` of the fix set — compiles clean.
- `cargo fmt --check` on this branch — clean.
- 2 regression tests added (above): `mirror_drain_start_never_splits_multibyte_char` drains a buffer whose CJK chars straddle the cap (panics before the fix, passes after) and `mirror_drain_start_is_zero_when_short`.
- CI runs the full `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings` + test matrix on Ubuntu/macOS/Windows (`.github/workflows/ci.yml`) — please rely on the PR checks as the cross-platform gate.

## Compatibility (on-disk formats)

- [x] No tier (a)/(b) on-disk format is changed.

## Notes for reviewers

- Mirrors #1110's approach (snap to a char boundary) but for the buffer-drain cap rather than the text-slice cap, so the two sibling caps are now both UTF-8-safe.
