### PR TITLE
test(#1814): pin flock fail-fast vs double-bind + handoff observability

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -202,6 +202,8 @@ fn confirm_shutdown_or_abort_respawn(shutdown: &AtomicBool) -> bool {
     }
     if self_respawn_successor_died() {
         tracing::error!(
+            target: "handoff",
+            event = "abort_stay_alive",
             "#1814 self-respawn: successor died after commit but before predecessor exit — \
              ABORTING restart, staying alive (no brick). Operator may retry restart_daemon."
         );
@@ -938,9 +940,11 @@ fn run_core(home: &Path, source: FleetSource) -> anyhow::Result<()> {
             std::thread::sleep(self_respawn_settle());
             if self_respawn_successor_died() {
                 tracing::error!(
-                "#1814 self-respawn: successor died DURING predecessor teardown — recovering as \
-                 primary (re-spawning agents, resuming; no brick)."
-            );
+                    target: "handoff",
+                    event = "recover_as_primary",
+                    "#1814 self-respawn: successor died DURING predecessor teardown — recovering as \
+                     primary (re-spawning agents, resuming; no brick)."
+                );
                 RESTART_PENDING.store(false, Ordering::Release);
                 ctx.shutdown.store(false, Ordering::Relaxed);
                 *SELF_RESPAWN_SUCCESSOR

--- a/src/mcp/handlers/restart.rs
+++ b/src/mcp/handlers/restart.rs
@@ -8,7 +8,18 @@ pub(super) fn handle_restart_daemon(home: &Path) -> Value {
     // supervisor being correctly detected (retires the #851/#1812 brick class
     // at the root). Flag OFF → the legacy supervisor + exit(42) path below runs
     // byte-identically.
-    if crate::daemon::restart::self_respawn_enabled() {
+    // #1814 observability: record which restart path this request takes so the
+    // pre-soak operator A/B (legacy exit42 vs self-respawn) is greppable on one
+    // tag. `target: "handoff"` + an `event` field make the handoff lifecycle
+    // events countable from the rolling log without a metrics framework.
+    let self_respawn = crate::daemon::restart::self_respawn_enabled();
+    tracing::info!(
+        target: "handoff",
+        event = "restart_requested",
+        path = if self_respawn { "self-respawn" } else { "legacy-exit42" },
+        "#1814 restart_daemon path selected"
+    );
+    if self_respawn {
         return handle_self_respawn(home);
     }
 
@@ -98,6 +109,8 @@ fn handle_self_respawn(home: &Path) -> Value {
         crate::daemon::RESTART_PENDING.store(true, std::sync::atomic::Ordering::Release);
         std::fs::write(home.join("restart-requested"), "").ok();
         tracing::info!(
+            target: "handoff",
+            event = "committed",
             successor_pid = succ_pid,
             "#1814 self-respawn: committed — predecessor exiting"
         );
@@ -113,6 +126,8 @@ fn handle_self_respawn(home: &Path) -> Value {
         // a client to a half-dead successor. The predecessor was NEVER signalled
         // → it stays fully alive with its agents intact.
         tracing::warn!(
+            target: "handoff",
+            event = "abort_phase1_failed",
             successor_pid = succ.pid,
             "#1814 self-respawn: successor FAILED Phase-1 gate — aborting; predecessor stays alive"
         );
@@ -131,7 +146,8 @@ fn handle_self_respawn(home: &Path) -> Value {
 /// cookie-authenticated api round-trip succeeds. Returns false on the
 /// successor dying, the timeout, or a persistently unreachable api.
 fn phase1_gate(succ: &mut crate::bootstrap::daemon_spawn::SuccessorHandle) -> bool {
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+    let started = std::time::Instant::now();
+    let deadline = started + std::time::Duration::from_secs(30);
     let control_ready = succ.run_dir.join(crate::daemon::CONTROL_READY_FILE);
     loop {
         // `try_wait` detects a crash-on-launch immediately AND reaps the child
@@ -139,7 +155,11 @@ fn phase1_gate(succ: &mut crate::bootstrap::daemon_spawn::SuccessorHandle) -> bo
         // as alive). `Ok(Some(_))` = exited.
         if matches!(succ.child.try_wait(), Ok(Some(_))) {
             tracing::warn!(
+                target: "handoff",
+                event = "phase1_failed",
+                reason = "successor_exited",
                 successor_pid = succ.pid,
+                elapsed_ms = started.elapsed().as_millis() as u64,
                 "#1814 Phase-1: successor process exited during startup"
             );
             return false;
@@ -151,11 +171,22 @@ fn phase1_gate(succ: &mut crate::bootstrap::daemon_spawn::SuccessorHandle) -> bo
             )
             .is_ok()
         {
+            tracing::info!(
+                target: "handoff",
+                event = "phase1_passed",
+                successor_pid = succ.pid,
+                elapsed_ms = started.elapsed().as_millis() as u64,
+                "#1814 Phase-1: successor control-ready + api healthy"
+            );
             return true;
         }
         if std::time::Instant::now() >= deadline {
             tracing::warn!(
+                target: "handoff",
+                event = "phase1_failed",
+                reason = "timeout",
                 successor_pid = succ.pid,
+                elapsed_ms = started.elapsed().as_millis() as u64,
                 "#1814 Phase-1: successor not control-ready within timeout"
             );
             return false;

--- a/tests/self_respawn_handoff.rs
+++ b/tests/self_respawn_handoff.rs
@@ -577,18 +577,26 @@ fn flag_on_concurrent_respawn_cannot_double_bind_via_flock_1814() {
         !loser.success(),
         "the flock loser must exit NON-zero (failed to acquire the lock), got {loser:?}"
     );
-    // Mechanism confirmation (best-effort): the fail-fast is the `.daemon.lock`
-    // try_lock → "already running (lock held)". Captured from stderr when the
-    // CLI surfaces it there; if the build routes the error only to the rolling
-    // log the non-zero exit + single-active assertions above still prove the
-    // guard, so this is a soft check (logged, asserted only when stderr carried
-    // the error).
+    // MECHANISM PIN (codex #2088 — the test's whole point): the loser MUST have
+    // died from the `.daemon.lock` `try_lock` fail-fast, NOT any other exit
+    // reason — otherwise this test (which exists solely to pin the spike's
+    // double-bind risk) would pass on an unrelated loser crash. So this is
+    // MANDATORY (stderr non-empty) and asserts the EXACT production error:
+    //   - our authored prefix (bootstrap/mod.rs `acquire_daemon_lock`:
+    //     `another agend-terminal daemon is already running (lock held): {e}`),
+    //     emitted by NOTHING else, and
+    //   - fs4 1.1's `{e}` = `lock_contended_error()`, a crate-CONSTANT
+    //     `io::Error(WouldBlock, "try_lock failed because the operation would
+    //     block")` — identical on macOS and Linux (not an OS strerror), so the
+    //     full string is cross-platform stable.
     eprintln!("[1814] flock-loser stderr: {loser_stderr:?}");
-    if !loser_stderr.trim().is_empty() {
-        assert!(
-            loser_stderr.to_lowercase().contains("already running")
-                || loser_stderr.to_lowercase().contains("lock"),
-            "loser stderr present but not the lock fail-fast: {loser_stderr:?}"
-        );
-    }
+    assert!(
+        loser_stderr.contains(
+            "another agend-terminal daemon is already running (lock held): \
+             try_lock failed because the operation would block"
+        ),
+        "the flock loser MUST exit via the try_lock fail-fast with the exact production lock \
+         error (this is the test's sole purpose — proving the double-bind guard fired, not just \
+         that some process exited); stderr was: {loser_stderr:?}"
+    );
 }

--- a/tests/self_respawn_handoff.rs
+++ b/tests/self_respawn_handoff.rs
@@ -465,3 +465,130 @@ fn self_respawn_recovers_as_primary_when_successor_dies_during_teardown() {
         "predecessor must re-spawn + keep serving its agent after recover-as-primary"
     );
 }
+
+/// Boot a daemon like `boot` but with stderr PIPED (so the loser's
+/// already-running / lock error is capturable) and self-respawn ON. Shares the
+/// `fleet.yaml` write so concurrent racers resolve the same probe agent.
+fn boot_capturing_stderr(home: &Path) -> Child {
+    std::fs::create_dir_all(home).ok();
+    std::fs::write(
+        home.join("fleet.yaml"),
+        "instances:\n  probe:\n    backend: shell\n    command: /bin/sh\n",
+    )
+    .expect("write fleet.yaml");
+    Command::new(bin())
+        .env("AGEND_HOME", home)
+        .env("AGEND_RESTART_HANDOFF", "1")
+        .env_remove("AGEND_WRAPPED")
+        .env_remove("XPC_SERVICE_NAME")
+        .env_remove("INVOCATION_ID")
+        .env_remove("AGEND_SUCCESSOR_HANDOFF")
+        .args(["start", "--foreground"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("daemon must spawn")
+}
+
+/// #1814 Phase 1 — the spike's biggest UNVERIFIED risk, now pinned: a flag-ON
+/// self-respawn `exit(0)` can race an external supervisor (launchd `KeepAlive`)
+/// respawn. Two daemons must NEVER both bind. This drives the REAL race: two
+/// daemon binaries started near-simultaneously on the SAME `AGEND_HOME` — at
+/// that instant neither's api socket is up yet, so each one's early
+/// `try_attach` finds nothing and BOTH reach `bootstrap::acquire_daemon_lock`,
+/// where the `.daemon.lock` `try_lock` fail-fast lets exactly ONE win. The
+/// loser exits non-zero with the "already running" lock error — it does NOT
+/// become a second daemon. (§3.9: real binaries competing for the real flock,
+/// no mock.)
+#[test]
+fn flag_on_concurrent_respawn_cannot_double_bind_via_flock_1814() {
+    let home = std::env::temp_dir().join(format!("agend-1814-dualbind-{}", std::process::id()));
+    std::fs::create_dir_all(&home).expect("mkdir AGEND_HOME");
+
+    // Two real daemons, same home, fired back-to-back to maximise the flock
+    // race (the launchd-KeepAlive-vs-self-respawn collision the spike flagged).
+    let mut a = boot_capturing_stderr(&home);
+    let mut b = boot_capturing_stderr(&home);
+
+    // Exactly ONE must become the active daemon (the flock winner).
+    let winner = wait_for_single_active(&home, Duration::from_secs(30), pid_alive);
+
+    // The other must EXIT (a daemon stays alive; the flock loser does not).
+    // Poll both for exit within a generous window.
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let mut a_status = None;
+    let mut b_status = None;
+    while Instant::now() < deadline && (a_status.is_none() || b_status.is_none()) {
+        if a_status.is_none() {
+            a_status = a.try_wait().ok().flatten();
+        }
+        if b_status.is_none() {
+            b_status = b.try_wait().ok().flatten();
+        }
+        if a_status.is_some() || b_status.is_some() {
+            // One has exited — the invariant we care about; stop early once the
+            // active-daemon count is confirmed single below.
+            std::thread::sleep(Duration::from_millis(100));
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+
+    let active = active_pids(&home);
+    // Capture the loser's stderr for the lock-error assertion before cleanup.
+    let loser_stderr = {
+        let mut s = String::new();
+        for (child, status) in [(&mut a, &a_status), (&mut b, &b_status)] {
+            if status.is_some() {
+                if let Some(mut err) = child.stderr.take() {
+                    use std::io::Read;
+                    let _ = err.read_to_string(&mut s);
+                }
+            }
+        }
+        s
+    };
+
+    // Tear down whichever is still alive (the winner) + reap.
+    let _ = a.kill();
+    let _ = b.kill();
+    let _ = a.wait();
+    let _ = b.wait();
+    cleanup_test_home(&home);
+
+    // ── Load-bearing invariant: NO double-bind ──
+    assert!(
+        winner.is_some(),
+        "exactly one daemon must win the flock and serve — neither came up"
+    );
+    assert_eq!(
+        active.len(),
+        1,
+        "NO double-bind: exactly one active daemon (run dir + api.port + live pid), got {}",
+        active.len()
+    );
+    // The loser must EXIT (a real second daemon stays alive); the winner is
+    // still running (we killed it above). Exactly one should have exited during
+    // the poll window — and with a non-success status (it FAILED to bind, did
+    // not clean-exit as a daemon).
+    let loser_status = a_status.or(b_status);
+    let loser = loser_status.expect("the flock loser must EXIT — neither process exited");
+    assert!(
+        !loser.success(),
+        "the flock loser must exit NON-zero (failed to acquire the lock), got {loser:?}"
+    );
+    // Mechanism confirmation (best-effort): the fail-fast is the `.daemon.lock`
+    // try_lock → "already running (lock held)". Captured from stderr when the
+    // CLI surfaces it there; if the build routes the error only to the rolling
+    // log the non-zero exit + single-active assertions above still prove the
+    // guard, so this is a soft check (logged, asserted only when stderr carried
+    // the error).
+    eprintln!("[1814] flock-loser stderr: {loser_stderr:?}");
+    if !loser_stderr.trim().is_empty() {
+        assert!(
+            loser_stderr.to_lowercase().contains("already running")
+                || loser_stderr.to_lowercase().contains("lock"),
+            "loser stderr present but not the lock fail-fast: {loser_stderr:?}"
+        );
+    }
+}


### PR DESCRIPTION
## What (#1814 Phase 1 — operator-gated soak prerequisite, tests-first)

From the #1814 design-spike: successor-handoff is already implemented (Stage-1, flag-gated `AGEND_RESTART_HANDOFF=1`, **default OFF**). Before the operator opens the flag for a soak, this adds the safety mat the spike called for — pinning its **biggest UNVERIFIED risk** and adding handoff observability. **Flag default unchanged (OFF).**

## The risk, now pinned

A flag-ON self-respawn `exit(0)` can race an external supervisor (launchd `KeepAlive`) respawn → must NEVER yield two live daemons. The backstop is the `.daemon.lock` `try_lock` fail-fast (`bootstrap/mod.rs`), which the spike flagged as **theoretically-blocks-but-untested**.

`flag_on_concurrent_respawn_cannot_double_bind_via_flock_1814` (§3.9, **real binaries**, not mock): boots two real daemons near-simultaneously on one `AGEND_HOME`. At that instant neither's api socket is up, so each one's early `try_attach` finds nothing and **both reach the flock** → exactly one wins. Asserts:
- exactly **one** active daemon (run dir + api.port + live pid) — no double-bind;
- the loser **exits non-zero**;
- (captured from stderr) with the real lock error: `another agend-terminal daemon is already running (lock held): try_lock failed because the operation would block`.

Verified locally — the flock genuinely blocks the second daemon (the loser's exact stderr is asserted).

## Observability (the spike's Phase-1 ask)

All under `target: "handoff"` with an `event` field, so the handoff lifecycle is greppable/countable from the rolling log without a metrics framework:
- `restart_requested` + `path=self-respawn|legacy-exit42` — **which path**;
- `phase1_passed` / `phase1_failed{reason=successor_exited|timeout}` + `elapsed_ms` — **per-phase timing**;
- `committed`, `abort_phase1_failed`, `abort_stay_alive`, `recover_as_primary` — the **lifecycle / fallback events**.

## Scope / safety

Flag default stays **OFF** (Phase 2 flip-to-default is a separate operator decision). Low-risk: a new integration test + additive structured logs only — no behaviour change to the handoff or legacy path.

## Tests

`fmt --check` clean · `clippy --all-targets --features tray -D warnings` clean · full `nextest` **4092 passed** · the new flock test + all existing `self_respawn_handoff` / `restart` tests green (40).

🤖 Generated with [Claude Code](https://claude.com/claude-code)