### PR TITLE
fix(#2089): rescue a hard-wrapped SRL that detect lands as Idle (narrow-pane word-wrap)

### DIFF
--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -396,6 +396,14 @@ pub(crate) const SERVER_RATE_LIMIT_RECOVERY_SILENCE: Duration = Duration::from_s
 /// structural-marker scan) — do not collapse the two.
 const ERROR_TAIL_SCAN_LINES: usize = 15;
 
+/// #2089: window for the hard-wrap throttle fallback's flatten. A long SRL error
+/// on a narrow (~24-col) pane wraps across ~7-9 rows; with the spinner + input
+/// box below, its `⏺ API Error:` indicator prefix lands well above
+/// `ERROR_TAIL_SCAN_LINES`. This wider span captures the wrapped indicator
+/// (still only the visible grid, never scrollback) so `throttle_indicator_adjacent`
+/// can validate the real throttle; the char-proximity guard keeps it FP-safe.
+const HARD_WRAP_TAIL_LINES: usize = 40;
+
 fn recent_screen_tail(screen_text: &str, n: usize) -> String {
     let lines: Vec<&str> = screen_text.lines().collect();
     let start = lines.len().saturating_sub(n);
@@ -847,7 +855,14 @@ fn flattened_throttle_detect(
     screen_text: &str,
     input_line_markers: &[&str],
 ) -> Option<AgentState> {
-    let tail = recent_screen_tail(screen_text, ERROR_TAIL_SCAN_LINES);
+    // #2089: a long SRL error on a NARROW pane word-wraps across many rows, so its
+    // `⏺ API Error:` indicator prefix sits well above the bottom-`ERROR_TAIL_SCAN_LINES`
+    // window — `throttle_indicator_adjacent` then can't find it and the rescue
+    // wrongly rejects (the fixup-reviewer-2 miss). Flatten a LARGER window so the
+    // wrapped indicator is included; this only widens the LINE span (the visible
+    // grid `tail_lines` produced — never scrollback), and the char-proximity guard
+    // in `throttle_indicator_adjacent` still rejects a distant unrelated indicator.
+    let tail = recent_screen_tail(screen_text, HARD_WRAP_TAIL_LINES);
     // #1947: drop input / user-message lines BEFORE flattening — flattening
     // destroys the line structure the input-line exclusion needs, so an
     // operator-typed error string would otherwise flatten into a legit-looking
@@ -1231,6 +1246,22 @@ impl StateTracker {
             // `anchor_on_red` is false (Shell/Raw backends) OR no color mask
             // was supplied (text-only callers).
             match patterns.detect_with_match(screen_text) {
+                Some((detected, matched))
+                    if !is_high_fp_state(detected)
+                        && !matches!(detected, AgentState::UsageLimit)
+                        && screen_has_throttle_hint(screen_text)
+                        && self.try_hard_wrap_throttle(patterns, screen_text) =>
+                {
+                    // #2089: `detect_with_match` landed a BENIGN state (Idle/Thinking
+                    // — the ❯ prompt / a spinner) because a long SRL error
+                    // word-wrapped across a narrow pane and the single-line regex
+                    // missed it. The cheap throttle-hint pre-filter gates the cost;
+                    // `try_hard_wrap_throttle` re-detected the throttle on the
+                    // flattened tail and transitioned to it (overriding the
+                    // idle-prompt chrome). Nothing more to do this arm. `matched` is
+                    // unused on this path.
+                    let _ = matched;
+                }
                 Some((detected, matched)) => {
                     let high_fp = is_high_fp_state(detected);
                     let usage_limit = matches!(detected, AgentState::UsageLimit);
@@ -1563,19 +1594,38 @@ impl StateTracker {
     /// raw text, so a hard-wrapped throttle with a working marker below is not
     /// overridden here — accepted; `recovered_within` still releases a
     /// genuinely-recovered pane.)
-    fn handle_no_raw_match(&mut self, patterns: &'static StatePatterns, screen_text: &str) {
-        if let Some(throttle) =
+    /// #SRL-phase2 / #2089: rescue a hard-wrapped throttle error that the
+    /// single-line `detect_with_match` missed (narrow-pane word-wrap). Runs the
+    /// flattened-tail re-detect; if it finds a throttle, transitions to it (via
+    /// the same recovered→Idle gate as the raw SRL path) and returns `true`.
+    /// Called from BOTH the no-raw-match arm AND the benign-detection arm (#2089:
+    /// a wrapped SRL co-existing with the idle `❯` prompt makes `detect_with_match`
+    /// return `Idle`, so the `None` arm alone was unreachable).
+    fn try_hard_wrap_throttle(
+        &mut self,
+        patterns: &'static StatePatterns,
+        screen_text: &str,
+    ) -> bool {
+        let Some(throttle) =
             flattened_throttle_detect(patterns, screen_text, self.input_line_markers)
+        else {
+            return false;
+        };
+        let landed = if matches!(throttle, AgentState::ServerRateLimit)
+            && self.recovered_within(SERVER_RATE_LIMIT_RECOVERY_SILENCE)
         {
-            let landed = if matches!(throttle, AgentState::ServerRateLimit)
-                && self.recovered_within(SERVER_RATE_LIMIT_RECOVERY_SILENCE)
-            {
-                AgentState::Idle
-            } else {
-                throttle
-            };
-            let gated = self.gate_on_heartbeat(landed);
-            self.transition(gated);
+            AgentState::Idle
+        } else {
+            throttle
+        };
+        let gated = self.gate_on_heartbeat(landed);
+        self.transition(gated);
+        true
+    }
+
+    fn handle_no_raw_match(&mut self, patterns: &'static StatePatterns, screen_text: &str) {
+        if self.try_hard_wrap_throttle(patterns, screen_text) {
+            // hard-wrapped throttle rescued + transitioned.
         } else if matches!(self.current, AgentState::Starting)
             && is_generic_startup_prompt(screen_text)
         {

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -2269,6 +2269,131 @@ fn claude_server_throttle_fixture_triggers_server_rate_limit() {
     assert_eq!(t.get_state(), AgentState::ServerRateLimit);
 }
 
+/// strip CSI/SGR escapes to recover the plain screen_text from an ansi_colored_tail.
+fn strip_ansi_2089(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\u{1b}' {
+            if chars.peek() == Some(&'[') {
+                chars.next();
+                for x in chars.by_ref() {
+                    if x.is_ascii_alphabetic() {
+                        break;
+                    }
+                }
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+/// #2089 — the REAL captured fixup-reviewer-2 screen REPRODUCES the suppression:
+/// a narrow-pane hard-wrapped SRL → single-line `detect_with_match` misses it and
+/// matches the idle `❯` prompt → classified Idle. (This capture is truncated to
+/// the bottom-15 rows the #1562 instrument logs, so it lacks the wrapped
+/// `⏺ API Error:` prefix that lived higher on the real full-height pane — hence
+/// it can't be *rescued* here; the full-pane latch is pinned in the test below.)
+#[test]
+fn srl_narrow_wrap_real_capture_reproduces_idle_suppression_2089() {
+    let raw =
+        std::fs::read_to_string("tests/fixtures/state-replay/claude-srl-narrow-wrap-2089.raw")
+            .expect("real reviewer-2 fixture");
+    let screen = strip_ansi_2089(&raw);
+    let patterns = StatePatterns::for_backend(&Backend::ClaudeCode);
+    assert_ne!(
+        patterns.detect_with_match(&screen).map(|(s, _)| s),
+        Some(AgentState::ServerRateLimit),
+        "#2089: the single-line regex misses the hard-wrapped SRL (this is the miss)"
+    );
+}
+
+/// #2089 dual-control ① — a narrow-pane hard-wrapped SRL with its `⏺ API Error:`
+/// indicator wrapped a few rows above the phrase (the REAL full-height layout)
+/// must LATCH. Pre-fix: `detect_with_match` matched the `❯` idle prompt (the
+/// wrapped SRL is invisible to the single-line regex) → Idle, and the `None`-arm
+/// hard-wrap fallback was unreachable. The fix runs that fallback on the benign
+/// Idle arm too (A) and widens the indicator search window (B).
+#[test]
+fn srl_hard_wrapped_narrow_pane_latches_2089() {
+    // Faithful reconstruction of the reviewer-2 narrow pane (matches the real
+    // capture's wrap pattern): the SRL error hard-wrapped (Ink `\n` per row, NOT
+    // a soft-wrap); `⏺ API Error:` sits ABOVE the bottom-15 window (the real
+    // capture started mid-phrase at "Server is"); a Baked spinner + the live `❯`
+    // input box below.
+    let screen = "⏺ API Error:\n\
+                  Server is\n\
+                  temporarily\n\
+                  limiting\n\
+                  requests (not\n\
+                  your usage\n\
+                  limit) · Rate\n\
+                  limited\n\
+                  \n\
+                  ✻ Baked for 23s\n\
+                  \n\
+                  ────────────────────────\n\
+                  ❯\n\
+                  ────────────────────────\n\
+                  Model: Opus 4.8\n\
+                  bypass permissions\n";
+    let patterns = StatePatterns::for_backend(&Backend::ClaudeCode);
+    // Suppression precondition: single-line detect does NOT see the SRL.
+    assert_ne!(
+        patterns.detect_with_match(screen).map(|(s, _)| s),
+        Some(AgentState::ServerRateLimit),
+        "precondition: the hard-wrapped SRL is invisible to the single-line regex"
+    );
+    // B precondition: the `⏺ API Error:` indicator is OUTSIDE the bottom-15
+    // (ERROR_TAIL_SCAN_LINES) window but INSIDE the widened HARD_WRAP_TAIL_LINES
+    // window — so the rescue only succeeds because B widened the indicator search.
+    assert!(
+        !recent_screen_tail(screen, ERROR_TAIL_SCAN_LINES).contains("API Error"),
+        "B precondition: indicator must be ABOVE the old bottom-15 window"
+    );
+    assert!(
+        recent_screen_tail(screen, HARD_WRAP_TAIL_LINES).contains("API Error"),
+        "B precondition: the widened window must reach the wrapped indicator"
+    );
+    // The fix: full feed rescues it via the flattened hard-wrap fallback.
+    let mut t = tracker_at(&Backend::ClaudeCode, AgentState::Idle, 0);
+    t.feed(screen);
+    assert_eq!(
+        t.get_state(),
+        AgentState::ServerRateLimit,
+        "#2089: a hard-wrapped SRL with an adjacent (wrapped) API Error: indicator must latch"
+    );
+}
+
+/// #2089 dual-control ② — FP guard: a conversation line that merely MENTIONS a
+/// throttle word ("limiting"/"throttle") with NO error indicator nearby must NOT
+/// be misclassified as a throttle — even though (A) now runs the flattened
+/// fallback on benign Idle/Thinking screens. The (B) indicator-adjacency guard
+/// is what holds the line.
+#[test]
+fn prose_throttle_mention_without_indicator_not_misclassified_2089() {
+    let screen = "⏺ I updated the rate limiter so the server stops\n\
+                  limiting requests during the throttle test window.\n\
+                  \n\
+                  ────────────────────────\n\
+                  ❯\n\
+                  ────────────────────────\n";
+    let mut t = tracker_at(&Backend::ClaudeCode, AgentState::Idle, 0);
+    t.feed(screen);
+    assert_ne!(
+        t.get_state(),
+        AgentState::ServerRateLimit,
+        "#2089 FP guard: prose mentioning 'limiting/throttle' with no error indicator must NOT latch"
+    );
+    assert_ne!(
+        t.get_state(),
+        AgentState::RateLimit,
+        "#2089 FP guard: prose mention must not latch RateLimit either"
+    );
+}
+
 /// #2086 SPIKE: reproduce the live incident at the state.feed level — an IDLE
 /// agent, then a static ServerRateLimit screen appears and persists for many
 /// ticks. Does feed() latch (and stay latched)? Instrument every feed.

--- a/tests/fixtures/state-replay/claude-srl-narrow-wrap-2089.raw
+++ b/tests/fixtures/state-replay/claude-srl-narrow-wrap-2089.raw
@@ -1,0 +1,15 @@
+[39m  [39mServer[39m [39mis[0m
+[39m  [39mtemporarily[0m
+[39m  [39mlimiting[0m
+[39m  [39mrequests[39m [39m(not[0m
+[39m  [39myour[39m [39musage[0m
+[39m  [39mlimit)[39m [39m·[39m [39mRate[0m
+[39m  [39mlimited[0m
+[0m
+[39m✻[39m [39mBaked[39m [39mfor[39m [39m23s[0m
+[0m
+[39m────────────────────────[0m
+[39m❯[0m
+[39m────────────────────────[0m
+[39m  [39mModel: Opus 4.8[39m | [39mC…[0m
+[39m  [31m⏵⏵[39m [31mbypass[39m        [39m ·[0m


### PR DESCRIPTION
Fixes #2089 (sister of #2086). **SENSITIVE — FP-suppression core → dual review requested.**

## Symptom
fixup-reviewer-2's pane showed a live `Server is temporarily limiting requests` but the daemon classified **Idle** → no SRL recovery/retry. Operator-hit. #2086's fix doesn't cover it (different path).

## RCA (empirical — real captured screen + instrumented trace; the position-gate hypothesis was falsified)
On a **narrow pane (~24 cols)** the SRL error **word-wraps across ~7 rows**, so the single-line `detect_with_match` regex misses it and matches the idle `❯` prompt → `Some(Idle)`. Instrumented:
```
detect_with_match(raw)  = Some(Idle)            ← ❯ prompt; wrapped SRL invisible to single-line regex
detect_with_match(flat) = Some(ServerRateLimit) ← flattening recovers it
flattened_throttle_detect = None                 ← but the fallback rejects
full feed → Idle
```
Two compounding gaps:
1. The `#SRL-phase2` hard-wrap fallback (`flattened_throttle_detect`) lived **only in the `None` arm** — a wrapped SRL co-existing with the idle prompt (`Some(Idle)`, not `None`) never reached it.
2. Even forced, the bottom-15 flatten started mid-phrase; the `⏺ API Error:` indicator wrapped **above** the window, so `throttle_indicator_adjacent` (the #1857 prose-FP guard) found no indicator and rejected.

(Distinct from #2086's working-marker override and from the #1518 position gate — full write-up in the [#2089 issue comment](https://github.com/suzuke/agend-terminal/issues/2089#issuecomment-4698561624).)

## Fix (A + B)
- **A** — run the hard-wrap fallback (`try_hard_wrap_throttle`) when raw detection lands a **benign Idle/Thinking** (not just `None`), gated by a cheap `screen_has_throttle_hint` pre-filter so the common no-throttle screen stays on the fast path. A real wrapped throttle overrides idle-prompt chrome.
- **B** — widen the fallback's flatten window (`HARD_WRAP_TAIL_LINES = 40`) so a wrapped `⏺ API Error:` indicator above the bottom-15 is captured. **Only the line span widens** (still the visible grid `tail_lines` produced, never scrollback); the **char-proximity guard is unchanged** — a distant unrelated indicator is still rejected. Keeps the FP guard, does **not** exempt it.

## §3.9 dual-control (RED-verified)
- `srl_hard_wrapped_narrow_pane_latches_2089` — wrapped SRL + indicator above the 15-window → **latch**. **RED-verified**: with `HARD_WRAP_TAIL_LINES=15` this test FAILS (indicator unreachable), proving B is load-bearing; preconditions assert the indicator is outside-15 / inside-40.
- `prose_throttle_mention_without_indicator_not_misclassified_2089` — prose mentioning "limiting/throttle" with **no** error indicator → does **not** latch (the FP guard A's wider reach depends on).
- `srl_narrow_wrap_real_capture_reproduces_idle_suppression_2089` — the real captured (15-line-truncated) screen reproduces the single-line miss.

`cargo clippy --all-targets --features tray -D warnings` clean; 466 state+supervisor tests green. Real captured screen committed as a regression fixture (truncated to the #1562 instrument's 15 rows; the full-height latch is pinned via the faithful reconstruction above).

Note (follow-up): narrow-pane hard-wrap makes ANY single-line state regex fragile, not just SRL — a systemic state-detection concern. This PR scopes to SRL (operator-hit + has a fallback to extend); the general case is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)