### PR TITLE
fix(#1814 Stage 2): launchd KeepAlive → SuccessfulExit:false (restart-on-failure-only)

### DIFF
--- a/assets/service/launchd.plist.template
+++ b/assets/service/launchd.plist.template
@@ -42,8 +42,19 @@ Placeholders (substituted at install time by service::install):
     </dict>
     <key>RunAtLoad</key>
     <true/>
+    <!-- #1814 Stage 2: restart on FAILURE only (matches the autostart plist's
+         long-standing form, src/tray/autostart/macos.rs). A bare KeepAlive=true
+         respawns on ANY exit, including the graceful exit(0) handoff a
+         self-respawning daemon does — launchd's relaunch would then race the
+         self-respawn successor for the singleton flock (brick class). With
+         SuccessfulExit=false: exit(42) legacy-restart → non-success → relaunch;
+         exit(0) handoff → success → NO relaunch (successor is the sole daemon);
+         crash (panic/signal) → non-success → relaunch (crash-recovery intact). -->
     <key>KeepAlive</key>
-    <true/>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
     <key>StandardOutPath</key>
     <string>/dev/null</string>
     <key>StandardErrorPath</key>

--- a/src/daemon/restart.rs
+++ b/src/daemon/restart.rs
@@ -21,6 +21,36 @@
 //! `{ok: false, error: "..."}` with an actionable hint and the daemon
 //! stays up.
 //!
+//! ## Exit-code × supervisor behavior (#1814 Stage 2)
+//!
+//! What happens after the daemon exits depends on BOTH the exit code and the
+//! supervisor's restart policy. The policies are aligned so a graceful
+//! `exit(0)` handoff (a self-respawned successor is already the live daemon) is
+//! NOT relaunched by the supervisor — otherwise the supervisor's relaunch races
+//! the successor for the singleton flock (the brick class #1814 closes):
+//!
+//! | exit | meaning              | launchd `KeepAlive{SuccessfulExit:false}` | systemd `Restart=on-failure` | Windows schtasks `RestartOnFailure` | none (bare shell) |
+//! |------|----------------------|-------------------------------------------|------------------------------|-------------------------------------|-------------------|
+//! | 0    | graceful handoff     | NOT relaunched (success)                  | NOT relaunched (success)     | NOT relaunched (success)            | process ends      |
+//! | 42   | legacy restart_daemon| relaunched (non-success)                  | relaunched (non-success)     | relaunched (non-zero result)        | brick (no respawn)|
+//! | ≠0 / signal | crash         | relaunched (non-success)                  | relaunched (non-success)     | relaunched (non-zero result)        | process ends      |
+//!
+//! All three real supervisors converge on "restart on FAILURE, not on a graceful
+//! `exit(0)`" — which is exactly what the `exit(0)` handoff needs (the
+//! self-respawned successor is already the sole daemon; a supervisor relaunch
+//! would race it for the singleton flock):
+//! - launchd: the `KeepAlive` `{SuccessfulExit:false}` dict (NOT a bare
+//!   `KeepAlive=true`, which respawns on ANY exit) — the #1814 Stage 2 fix here,
+//!   pinned in `service::tests::launchd_template_carries_keepalive_and_runatload`.
+//! - systemd: `Restart=on-failure` (already correct).
+//! - Windows Task Scheduler: `<RestartOnFailure>` (`scheduler.task.xml.template`)
+//!   restarts only when the action's last result is non-zero — so `exit(0)` is a
+//!   no-op, `exit(42)`/crash relaunch. (Task Scheduler is a logon-triggered
+//!   restart-on-failure supervisor, NOT an unconditional exit-respawn.)
+//!
+//! `none` (bare `agend-terminal start` from a shell) has no supervisor: `exit(42)`
+//! bricks unless the daemon's own self-respawn path runs.
+//!
 //! ## Detection signals
 //!
 //! Composite env-var check. A supervisor signal means SOME process in

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -302,11 +302,26 @@ mod tests {
 
     #[test]
     fn launchd_template_carries_keepalive_and_runatload() {
-        // Pin the lifecycle policy: KeepAlive (auto-restart on crash)
-        // + RunAtLoad (start at login). These are the operator-facing
-        // contract — disabling them would silently change behaviour.
+        // Pin the lifecycle policy: KeepAlive + RunAtLoad (start at login).
+        // These are the operator-facing contract — disabling them would
+        // silently change behaviour.
         assert!(LAUNCHD_TEMPLATE.contains("<key>KeepAlive</key>"));
         assert!(LAUNCHD_TEMPLATE.contains("<key>RunAtLoad</key>"));
+        // #1814 Stage 2: KeepAlive MUST be the SuccessfulExit=false dict form,
+        // not a bare `<true/>`. A bare true respawns on the graceful exit(0)
+        // handoff and races the self-respawn successor for the singleton flock
+        // (brick class). Pinned to prevent regressing to the bare form.
+        assert!(
+            LAUNCHD_TEMPLATE.contains("<key>SuccessfulExit</key>")
+                && LAUNCHD_TEMPLATE.contains("<false/>"),
+            "launchd KeepAlive must use the SuccessfulExit=false dict (restart-on-failure-only), \
+             not a bare <true/> — see #1814 Stage 2"
+        );
+        // Negative pin: the bare `<key>KeepAlive</key>` → `<true/>` adjacency must be gone.
+        assert!(
+            !LAUNCHD_TEMPLATE.contains("<key>KeepAlive</key>\n    <true/>"),
+            "launchd KeepAlive must NOT be the bare <true/> form (respawns on graceful exit(0))"
+        );
     }
 
     #[test]


### PR DESCRIPTION
#1814 Stage 2 (precondition for the Stage 4 default flip). Source of truth: the #1814 Stage 2 design.

## The gap (single point)
`assets/service/launchd.plist.template` used a bare `<key>KeepAlive</key><true/>` → launchd relaunches the daemon on **any** exit, including the graceful `exit(0)` handoff a self-respawning daemon performs. After Stage 4 flips the restart-handoff default, that relaunch would **race the self-respawn successor for the singleton flock** (brick class). The autostart plist (`src/tray/autostart/macos.rs`) has used the safe `{SuccessfulExit:false}` dict all along — the inconsistency was the root.

## Fix
Align the template to:
```xml
<key>KeepAlive</key>
<dict>
    <key>SuccessfulExit</key>
    <false/>
</dict>
```
All three behaviors hold (reviewer-verifiable):
| exit | meaning | launchd result |
|------|---------|----------------|
| 42 | legacy `restart_daemon` | non-success → **RELAUNCH** (#851/#1812 brick-guard intact) |
| 0 | graceful handoff | success → **NO relaunch** (successor is the sole daemon) |
| ≠0 / signal | crash | non-success → **RELAUNCH** (crash-recovery intact) |

## Also (Stage 2 scope)
- **Pin test tightened** (`service::tests::launchd_template_carries_keepalive_and_runatload`): asserts the `SuccessfulExit=false` dict + a **negative pin** against the bare `<true/>` form (anti-regression).
- **`daemon::restart` module doc**: added an exit-code × supervisor matrix (launchd / systemd / Windows schtasks / none).
- **Windows correction**: the task XML (`scheduler.task.xml.template`) has `<RestartOnFailure>` (Interval PT1M, Count 3) — Task Scheduler restarts only on a **non-zero** last result, so it already mirrors the fixed launchd (`exit(0)` is a no-op). It's a restart-on-failure supervisor, **not** an unconditional exit-respawn (correcting the "n/a" assumption). One-line note + matrix row.

## Untouched (already safe)
systemd template (`Restart=on-failure`), autostart plist (`SuccessfulExit=false`). **No `restart.rs` behavior change, no default flip** (Stage 4 is a separate follow-up).

## Verification
`cargo clippy --all-targets --features tray -D warnings` clean. Affected tests green: 38 `service::`/`restart::`, 11 `issue_548_phase3_service`, 5 `self_respawn_handoff`. (Full nextest surfaced one unrelated daemon-boot **timing flake** — `api_port_published_before_agent_spawn_loop_completes` — which passes 3/3 in isolation and is untouched by this template/doc/test change; CI is the backstop.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)