### PR TITLE
fix(#2079): prefix-match short reviewed_head so verdicts can't silently buffer

### DIFF
--- a/src/api/handlers/messaging.rs
+++ b/src/api/handlers/messaging.rs
@@ -2732,4 +2732,91 @@ mod tests {
         );
         std::fs::remove_dir_all(&home).ok();
     }
+
+    // ── #2079: short-SHA reviewed_head must still flip merge-ready ──
+    //
+    // §3.9 + #1493 producer-fed: drive a REAL verdict-report `InboxMessage`
+    // carrying an ABBREVIATED `reviewed_head` (the #2078 `7e1d422` shape)
+    // through the REAL ingestion entry (`process_verdicts`), not a synthetic
+    // `record_verdict` call — a representative fixture is what catches the
+    // wiring gap. Pre-fix the exact `==` missed the short SHA → silent buffer →
+    // 24h TTL.
+
+    const FULL_HEAD_2079: &str = "7e1d4228bea3cf7fe2d72aab66015297308b48bc";
+    const SHORT_HEAD_2079: &str = "7e1d422"; // 7-char hex prefix of FULL_HEAD_2079
+
+    fn verdict_report_msg(corr: &str, reviewed_head: &str) -> crate::inbox::InboxMessage {
+        crate::inbox::InboxMessage::new_system("system:reviewer", "report", "VERIFIED looks good")
+            .with_correlation_id(corr.to_string())
+            .with_reviewed_head(reviewed_head.to_string())
+    }
+
+    #[test]
+    fn short_sha_verdict_flips_merge_ready_via_real_ingestion_2079() {
+        use crate::daemon::pr_state;
+        let home = tmp_home("2079-shortsha-flip");
+        let _ = std::fs::remove_dir_all(&home);
+        std::fs::create_dir_all(&home).unwrap();
+
+        // CI observed green at the FULL head_sha (single-review gate).
+        pr_state::record_ci_result(
+            &home,
+            "owner/repo",
+            "feat/x",
+            FULL_HEAD_2079,
+            pr_state::CiConclusion::Green,
+            vec!["dev".to_string()],
+            pr_state::ReviewClass::Single,
+        );
+
+        // Reviewer's report carries the ABBREVIATED head — real ingestion entry.
+        process_verdicts(
+            &home,
+            "fixup-reviewer",
+            &verdict_report_msg("owner/repo@feat/x", SHORT_HEAD_2079),
+        );
+
+        let state = pr_state::load(&home, "owner/repo", "feat/x").expect("state exists");
+        assert!(
+            pr_state::is_merge_ready(&state),
+            "#2079: a VERIFIED carrying a 7-char reviewed_head must flip merge-ready against the \
+             full canonical head_sha (prefix-match), not silently buffer; state={state:?}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn short_sha_verdict_before_ci_drains_from_buffer_2079() {
+        use crate::daemon::pr_state;
+        let home = tmp_home("2079-shortsha-buffer");
+        let _ = std::fs::remove_dir_all(&home);
+        std::fs::create_dir_all(&home).unwrap();
+
+        // Verdict arrives FIRST (no pr-state yet) with a short head → buffered.
+        process_verdicts(
+            &home,
+            "fixup-reviewer",
+            &verdict_report_msg("owner/repo@feat/x", SHORT_HEAD_2079),
+        );
+
+        // Then CI observes the branch at the FULL head → drain must prefix-match
+        // the buffered short verdict and replay it onto the new state.
+        pr_state::record_ci_result(
+            &home,
+            "owner/repo",
+            "feat/x",
+            FULL_HEAD_2079,
+            pr_state::CiConclusion::Green,
+            vec!["dev".to_string()],
+            pr_state::ReviewClass::Single,
+        );
+
+        let state = pr_state::load(&home, "owner/repo", "feat/x").expect("state exists");
+        assert!(
+            pr_state::is_merge_ready(&state),
+            "#2079: a short-SHA verdict buffered BEFORE CI must drain (prefix-match) when the full \
+             head is observed and flip merge-ready; state={state:?}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
 }

--- a/src/daemon/pr_state/mod.rs
+++ b/src/daemon/pr_state/mod.rs
@@ -382,6 +382,29 @@ pub fn apply(state: &mut PrState, event: Event<'_>) {
     }
 }
 
+/// #2079: match a reviewer-asserted SHA against a full canonical head SHA,
+/// tolerating an ABBREVIATED prefix. `full` is the canonical head (gh-poll /
+/// CI always supply the 40-char SHA); `asserted` is what a reviewer's report
+/// carried — gh and humans routinely abbreviate to 7–12 chars (the #2078 case:
+/// `7e1d422` silently buffered to its 24h TTL because the exact `==` never met
+/// the full-SHA-keyed drain).
+///
+/// Exact equality when the strings match. Otherwise `asserted` must be a HEX
+/// prefix of `full`, ≥7 chars (git's abbreviation floor; collisions across a
+/// single repo's PR set are negligible — noted in #2079). A non-hex or
+/// <7-char `asserted` (e.g. a test's `"sha-A"`) gets NO loosening — it falls
+/// back to exact equality, so this can never widen a non-SHA comparison.
+pub(crate) fn sha_prefix_match(full: &str, asserted: &str) -> bool {
+    if full == asserted {
+        return true;
+    }
+    let n = asserted.len();
+    (7..40).contains(&n)
+        && asserted.bytes().all(|b| b.is_ascii_hexdigit())
+        && full.len() > n
+        && full.starts_with(asserted)
+}
+
 /// §4.2 stale-head invariant — CI's green SHA AND every reviewer's
 /// reviewed_head MUST equal the current PR head_sha. If `head_sha`
 /// advanced after VERIFIED, the verdict is stale; refuse to fire
@@ -406,9 +429,11 @@ pub fn is_merge_ready(state: &PrState) -> bool {
     if reviewers.len() < state.review_class.required_verified_count() {
         return false;
     }
+    // #2079: prefix-tolerant — a reviewer that asserted an abbreviated SHA
+    // (e.g. `7e1d422`) still counts toward merge-ready against the full head.
     reviewers
         .iter()
-        .all(|(_, reviewed)| reviewed == &state.head_sha)
+        .all(|(_, reviewed)| sha_prefix_match(&state.head_sha, reviewed))
 }
 
 // ─── storage ───────────────────────────────────────────────────────────
@@ -936,7 +961,10 @@ pub fn record_verdict(
         let Ok(state): Result<PrState, _> = serde_json::from_str(&content) else {
             continue;
         };
-        if state.head_sha != reviewed_head {
+        // #2079: prefix-tolerant — a reviewer's abbreviated `reviewed_head`
+        // (e.g. `7e1d422`) matches the PR state's full canonical head_sha,
+        // instead of silently falling through to the 24h-TTL buffer.
+        if !sha_prefix_match(&state.head_sha, reviewed_head) {
             continue;
         }
         matched_any = true;

--- a/src/daemon/pr_state/verdict_buffer.rs
+++ b/src/daemon/pr_state/verdict_buffer.rs
@@ -133,7 +133,12 @@ pub(crate) fn drain_for_head(home: &Path, head: &str) -> Vec<BufferedVerdict> {
         let Ok(v) = serde_json::from_str::<BufferedVerdict>(&content) else {
             continue;
         };
-        if v.reviewed_head == head {
+        // #2079: prefix-tolerant — a buffered verdict whose `reviewed_head` is an
+        // abbreviated SHA (e.g. `7e1d422`) drains when the full canonical `head`
+        // is observed (the #2078 silent-buffer bug: short reviewed_head never met
+        // the full-SHA drain key). `head` is canonical-full; `v.reviewed_head` is
+        // what the reviewer asserted.
+        if super::sha_prefix_match(head, &v.reviewed_head) {
             let _ = std::fs::remove_file(&path);
             out.push(v);
         }


### PR DESCRIPTION
## The bug (A/B empirical, issue body)

| PR | reviewed_head | result |
|---|---|---|
| #2076 | full 40-char SHA | pr-ready auto-fires ✓ |
| #2078 | `7e1d422` (7-char) | verdict **silently stuck in buffer → 24h TTL** ✗ |

Root cause: `record_verdict` did an EXACT `state.head_sha == reviewed_head`, so an abbreviated `reviewed_head` never matched → fell to the buffer (keyed by the short string) → `record_ci_result` drained with the FULL `head_sha` → **the two never intersect**.

## Fix (KISS, issue-directed)

`sha_prefix_match(full, asserted)`: exact equality, else `asserted` must be a **hex prefix** of `full` (**≥7 chars** — git's abbreviation floor; single-repo PR-set collisions negligible). A non-hex / <7-char `asserted` (e.g. a test's `"sha-A"`) gets **no loosening** → exact `==`, so non-SHA comparisons are unchanged.

Applied at the **three** comparison sites that must agree (else only half-fixed):
- `record_verdict` (`pr_state/mod.rs`) — the match-or-buffer decision;
- `verdict_buffer::drain_for_head` — the full-head drain vs the buffered short SHA;
- `is_merge_ready` — the per-reviewer `reviewed_head == head` equality.

## Guard (§3.9 + #1493 producer-fed)

Two tests drive a **real** verdict-report `InboxMessage` carrying a 7-char `reviewed_head` through the **real ingestion entry** (`process_verdicts`) — not a synthetic `record_verdict` call (a representative fixture is what catches the wiring gap):
- `short_sha_verdict_flips_merge_ready_via_real_ingestion_2079` (CI observed first → verdict);
- `short_sha_verdict_before_ci_drains_from_buffer_2079` (verdict buffered first → CI drains it).

Both assert merge-ready flips; both are **RED pre-fix** (full ≠ short under `==`).

## Scope / safety

Only the `reviewed_head` comparison at the 3 sites + tests — no other verdict/CI logic. Existing **87** pr_state/verdict_buffer tests + the `"sha-A"` fixtures pass unchanged (byte-identical for the full-SHA + non-hex paths). `clippy --all-targets --features tray -D warnings` clean · `fmt` clean · full `nextest` green (the lone `*_no_bypass_1899` miss is the known env-mutually-exclusive test under the `AGEND_GIT_BYPASS=1` run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)