### PR TITLE
fix(latch-prune): retain per-agent latch maps against live registry on run (cleanup-on-delete)

### DIFF
--- a/src/daemon/per_tick/context_alert.rs
+++ b/src/daemon/per_tick/context_alert.rs
@@ -105,14 +105,21 @@ impl PerTickHandler for ContextAlertHandler {
         // — statusline pattern only (#1945-disable: no transcript estimate;
         // an unreadable pane is unknown and never alerts).
         let mut resolved: Vec<(String, f32, &'static str)> = Vec::new();
-        {
+        // #latch-prune (cleanup-on-delete, #1923 G5 class): capture ALL live
+        // agent names — not just those with a context reading — so the per-agent
+        // `states` latch can drop deleted agents below. Without it a same-name
+        // redeploy inherits a stale armed/alerted latch.
+        let live: std::collections::HashSet<String> = {
             let reg = crate::agent::lock_registry(ctx.registry);
+            let mut live = std::collections::HashSet::new();
             for handle in reg.values() {
+                live.insert(handle.name.as_str().to_string());
                 if let Some((pct, source)) = handle.core.lock().state.resolved_context() {
                     resolved.push((handle.name.as_str().to_string(), pct, source));
                 }
             }
-        }
+            live
+        };
 
         // Phase 2: threshold/hysteresis evaluation + orchestrator notify.
         let threshold = alert_threshold();
@@ -156,6 +163,9 @@ impl PerTickHandler for ContextAlertHandler {
             }
             tracing::info!(agent = %name, %recipient, pct, source, "context_alert: alerted orchestrator");
         }
+        // #latch-prune: drop latch entries for agents gone from the registry
+        // (cleanup-on-delete) so a deleted agent leaves no stale state.
+        states.retain(|name, _| live.contains(name));
     }
 }
 
@@ -228,5 +238,39 @@ mod tests {
         let now = Instant::now();
         assert!(!decide(&mut s, 0.0, T, now));
         assert!(!decide(&mut s, 79.9, T, now));
+    }
+
+    /// #latch-prune (cleanup-on-delete, #1923 G5 class): a latch entry for an
+    /// agent no longer in the registry (deleted) is dropped on the next `run`,
+    /// via the REAL handler entry (empty registry = the agent was deleted) — so
+    /// a same-name redeploy never inherits stale alert state.
+    #[test]
+    fn deleted_agent_latch_pruned_on_run() {
+        use parking_lot::Mutex as PLMutex;
+        use std::collections::HashMap;
+        use std::sync::Arc;
+        let home =
+            std::env::temp_dir().join(format!("agend-ctxalert-prune-{}", std::process::id()));
+        std::fs::create_dir_all(&home).ok();
+        let registry: crate::agent::AgentRegistry = Arc::new(PLMutex::new(HashMap::new()));
+        let externals: crate::agent::ExternalRegistry = Arc::new(PLMutex::new(HashMap::new()));
+        let configs: Arc<PLMutex<HashMap<String, crate::daemon::AgentConfig>>> =
+            Arc::new(PLMutex::new(HashMap::new()));
+        let h = ContextAlertHandler::new(1); // fire every tick (no boot-grace)
+        h.states
+            .lock()
+            .insert("ghost".to_string(), AlertState::default());
+        let ctx = TickContext {
+            home: &home,
+            registry: &registry,
+            externals: &externals,
+            configs: &configs,
+        };
+        h.run(&ctx); // real entry: live={} from the empty registry → retain
+        assert!(
+            !h.states.lock().contains_key("ghost"),
+            "a deleted agent's latch must be pruned on run (cleanup-on-delete)"
+        );
+        std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/daemon/per_tick/context_alert.rs
+++ b/src/daemon/per_tick/context_alert.rs
@@ -273,4 +273,43 @@ mod tests {
         );
         std::fs::remove_dir_all(&home).ok();
     }
+
+    /// #latch-prune reverse-regression (reviewer-2 #2097): the prune's `live`
+    /// set MUST capture EVERY live agent — NOT just those with a context
+    /// reading this tick. A live agent without a reading keeps its latch; if a
+    /// future edit moved `live.insert` INTO the `resolved_context()` `if`
+    /// (degrading `live` to the reading-subset), this agent would be wrongly
+    /// pruned + re-alerted (worse than the leak). Drives the REAL `run()` with a
+    /// live agent that produces NO context reading; asserts its latch SURVIVES.
+    #[test]
+    fn live_agent_without_context_reading_keeps_latch() {
+        use parking_lot::Mutex as PLMutex;
+        use std::collections::HashMap;
+        use std::sync::Arc;
+        let home = std::env::temp_dir().join(format!("agend-ctxalert-keep-{}", std::process::id()));
+        std::fs::create_dir_all(&home).ok();
+        let registry: crate::agent::AgentRegistry = Arc::new(PLMutex::new(HashMap::new()));
+        let (handle, _reader) = crate::daemon::per_tick::mock_live_agent_no_context("alive");
+        registry.lock().insert(handle.id, handle);
+        let externals: crate::agent::ExternalRegistry = Arc::new(PLMutex::new(HashMap::new()));
+        let configs: Arc<PLMutex<HashMap<String, crate::daemon::AgentConfig>>> =
+            Arc::new(PLMutex::new(HashMap::new()));
+        let h = ContextAlertHandler::new(1);
+        h.states
+            .lock()
+            .insert("alive".to_string(), AlertState::default());
+        let ctx = TickContext {
+            home: &home,
+            registry: &registry,
+            externals: &externals,
+            configs: &configs,
+        };
+        h.run(&ctx);
+        assert!(
+            h.states.lock().contains_key("alive"),
+            "a LIVE agent with no context reading must KEEP its latch — `live.insert` must be \
+             UNCONDITIONAL, not gated on resolved_context()"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
 }

--- a/src/daemon/per_tick/context_handoff.rs
+++ b/src/daemon/per_tick/context_handoff.rs
@@ -225,16 +225,23 @@ impl PerTickHandler for ContextHandoffHandler {
         // Agents without a pattern reading (every non-claude backend today)
         // produce nothing here and are never injected.
         let mut snapshot: Vec<(String, f32, bool)> = Vec::new();
-        {
+        // #latch-prune (cleanup-on-delete, #1923 G5 class): capture ALL live
+        // agent names so the per-agent `states` episode-latch can drop deleted
+        // agents below — else a same-name redeploy inherits a stale episode
+        // (e.g. an Injected latch suppressing the new agent's first handoff).
+        let live: std::collections::HashSet<String> = {
             let reg = crate::agent::lock_registry(ctx.registry);
+            let mut live = std::collections::HashSet::new();
             for handle in reg.values() {
+                live.insert(handle.name.as_str().to_string());
                 let core = handle.core.lock();
                 if let Some((pct, _source)) = core.state.resolved_context() {
                     let is_idle = core.state.get_state() == crate::state::AgentState::Idle;
                     snapshot.push((handle.name.as_str().to_string(), pct, is_idle));
                 }
             }
-        }
+            live
+        };
 
         let handoff_pct = handoff_threshold();
         let escalate_pct = escalate_threshold();
@@ -320,6 +327,9 @@ impl PerTickHandler for ContextHandoffHandler {
                 None => {}
             }
         }
+        // #latch-prune: drop episode latches for agents gone from the registry
+        // (cleanup-on-delete) so a deleted agent leaves no stale episode state.
+        states.retain(|name, _| live.contains(name));
     }
 }
 
@@ -461,5 +471,40 @@ mod tests {
             "file older than the injection → false"
         );
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// #latch-prune (cleanup-on-delete, #1923 G5 class): a per-agent episode
+    /// latch for an agent no longer in the registry is dropped on the next
+    /// `run` (real entry, empty registry = deleted) — so a same-name redeploy
+    /// can't inherit a stale Injected/IdleMarked episode that suppresses its
+    /// first handoff nudge.
+    #[test]
+    fn deleted_agent_episode_pruned_on_run() {
+        use parking_lot::Mutex as PLMutex;
+        use std::collections::HashMap;
+        use std::sync::Arc;
+        let home =
+            std::env::temp_dir().join(format!("agend-ctxhandoff-prune-{}", std::process::id()));
+        std::fs::create_dir_all(&home).ok();
+        let registry: crate::agent::AgentRegistry = Arc::new(PLMutex::new(HashMap::new()));
+        let externals: crate::agent::ExternalRegistry = Arc::new(PLMutex::new(HashMap::new()));
+        let configs: Arc<PLMutex<HashMap<String, crate::daemon::AgentConfig>>> =
+            Arc::new(PLMutex::new(HashMap::new()));
+        let h = ContextHandoffHandler::new(1); // fire every tick (no boot-grace)
+        h.states
+            .lock()
+            .insert("ghost".to_string(), EpisodeState::default());
+        let ctx = TickContext {
+            home: &home,
+            registry: &registry,
+            externals: &externals,
+            configs: &configs,
+        };
+        h.run(&ctx);
+        assert!(
+            !h.states.lock().contains_key("ghost"),
+            "a deleted agent's episode latch must be pruned on run (cleanup-on-delete)"
+        );
+        std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/daemon/per_tick/context_handoff.rs
+++ b/src/daemon/per_tick/context_handoff.rs
@@ -507,4 +507,42 @@ mod tests {
         );
         std::fs::remove_dir_all(&home).ok();
     }
+
+    /// #latch-prune reverse-regression (reviewer-2 #2097): a LIVE agent without
+    /// a context reading this tick must KEEP its episode latch — `live.insert`
+    /// must be UNCONDITIONAL, not gated on `resolved_context()`. If it regressed
+    /// to the reading-subset, a working agent's in-progress episode would be
+    /// wrongly dropped (re-arming a duplicate handoff). Real `run()` entry.
+    #[test]
+    fn live_agent_without_context_reading_keeps_episode() {
+        use parking_lot::Mutex as PLMutex;
+        use std::collections::HashMap;
+        use std::sync::Arc;
+        let home =
+            std::env::temp_dir().join(format!("agend-ctxhandoff-keep-{}", std::process::id()));
+        std::fs::create_dir_all(&home).ok();
+        let registry: crate::agent::AgentRegistry = Arc::new(PLMutex::new(HashMap::new()));
+        let (handle, _reader) = crate::daemon::per_tick::mock_live_agent_no_context("alive");
+        registry.lock().insert(handle.id, handle);
+        let externals: crate::agent::ExternalRegistry = Arc::new(PLMutex::new(HashMap::new()));
+        let configs: Arc<PLMutex<HashMap<String, crate::daemon::AgentConfig>>> =
+            Arc::new(PLMutex::new(HashMap::new()));
+        let h = ContextHandoffHandler::new(1);
+        h.states
+            .lock()
+            .insert("alive".to_string(), EpisodeState::default());
+        let ctx = TickContext {
+            home: &home,
+            registry: &registry,
+            externals: &externals,
+            configs: &configs,
+        };
+        h.run(&ctx);
+        assert!(
+            h.states.lock().contains_key("alive"),
+            "a LIVE agent with no context reading must KEEP its episode latch — `live.insert` \
+             must be UNCONDITIONAL, not gated on resolved_context()"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
 }

--- a/src/daemon/per_tick/inbox_stuck.rs
+++ b/src/daemon/per_tick/inbox_stuck.rs
@@ -134,4 +134,41 @@ mod tests {
         );
         std::fs::remove_dir_all(&home).ok();
     }
+
+    /// #latch-prune reverse-regression (reviewer-2 #2097): a LIVE agent keeps
+    /// its re-alert timer. inbox_stuck's `live` is already unconditional
+    /// (`reg.values().map(name)`, no `resolved_context()` gate), so there is no
+    /// subset to regress into TODAY — this pins it that way (a future gating
+    /// edit that dropped a live agent would re-fire its stuck alert).
+    #[test]
+    fn live_agent_keeps_alert_timer() {
+        use parking_lot::Mutex as PLMutex;
+        use std::collections::HashMap;
+        use std::sync::Arc;
+        let home =
+            std::env::temp_dir().join(format!("agend-inboxstuck-keep-{}", std::process::id()));
+        std::fs::create_dir_all(&home).ok();
+        let registry: crate::agent::AgentRegistry = Arc::new(PLMutex::new(HashMap::new()));
+        let (handle, _reader) = crate::daemon::per_tick::mock_live_agent_no_context("alive");
+        registry.lock().insert(handle.id, handle);
+        let externals: crate::agent::ExternalRegistry = Arc::new(PLMutex::new(HashMap::new()));
+        let configs: Arc<PLMutex<HashMap<String, crate::daemon::AgentConfig>>> =
+            Arc::new(PLMutex::new(HashMap::new()));
+        let h = InboxStuckHandler::new_at(1, past_grace());
+        h.last_alerted
+            .lock()
+            .insert("alive".to_string(), chrono::Utc::now());
+        let ctx = TickContext {
+            home: &home,
+            registry: &registry,
+            externals: &externals,
+            configs: &configs,
+        };
+        h.run(&ctx);
+        assert!(
+            h.last_alerted.lock().contains_key("alive"),
+            "a LIVE agent must KEEP its re-alert timer (retain against ALL live agents)"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
 }

--- a/src/daemon/per_tick/inbox_stuck.rs
+++ b/src/daemon/per_tick/inbox_stuck.rs
@@ -50,8 +50,17 @@ impl PerTickHandler for InboxStuckHandler {
             return;
         }
         let now = chrono::Utc::now();
+        // #latch-prune (cleanup-on-delete, #1923 G5 class): snapshot live agent
+        // names (registry locked then dropped — BEFORE locking the latch, so no
+        // nesting) so the `last_alerted` dedup latch can drop deleted agents
+        // below; else a same-name redeploy inherits a stale re-alert timer.
+        let live: std::collections::HashSet<String> = {
+            let reg = crate::agent::lock_registry(ctx.registry);
+            reg.values().map(|h| h.name.as_str().to_string()).collect()
+        };
         let mut last = self.last_alerted.lock();
         crate::daemon::inbox_stuck_watchdog::scan_and_emit(ctx.home, &now, &mut last);
+        last.retain(|name, _| live.contains(name));
     }
 }
 
@@ -89,5 +98,40 @@ mod tests {
 
         let aged = InboxStuckHandler::new_at(30, past_grace());
         assert!(aged.gate.fire(), "after grace, first tick fires");
+    }
+
+    /// #latch-prune (cleanup-on-delete, #1923 G5 class): a `last_alerted` dedup
+    /// entry for an agent no longer in the registry is dropped on the next
+    /// `run` (real entry, empty registry = deleted; `new_at(.., past_grace())`
+    /// so the boot-grace gate fires) — so a same-name redeploy doesn't inherit
+    /// a stale re-alert timer that swallows its first stuck-inbox alert.
+    #[test]
+    fn deleted_agent_alert_timer_pruned_on_run() {
+        use parking_lot::Mutex as PLMutex;
+        use std::collections::HashMap;
+        use std::sync::Arc;
+        let home =
+            std::env::temp_dir().join(format!("agend-inboxstuck-prune-{}", std::process::id()));
+        std::fs::create_dir_all(&home).ok();
+        let registry: crate::agent::AgentRegistry = Arc::new(PLMutex::new(HashMap::new()));
+        let externals: crate::agent::ExternalRegistry = Arc::new(PLMutex::new(HashMap::new()));
+        let configs: Arc<PLMutex<HashMap<String, crate::daemon::AgentConfig>>> =
+            Arc::new(PLMutex::new(HashMap::new()));
+        let h = InboxStuckHandler::new_at(1, past_grace()); // past grace → gate fires
+        h.last_alerted
+            .lock()
+            .insert("ghost".to_string(), chrono::Utc::now());
+        let ctx = TickContext {
+            home: &home,
+            registry: &registry,
+            externals: &externals,
+            configs: &configs,
+        };
+        h.run(&ctx);
+        assert!(
+            !h.last_alerted.lock().contains_key("ghost"),
+            "a deleted agent's re-alert timer must be pruned on run (cleanup-on-delete)"
+        );
+        std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/daemon/per_tick/mod.rs
+++ b/src/daemon/per_tick/mod.rs
@@ -246,6 +246,65 @@ fn panic_payload_str(payload: &Box<dyn std::any::Any + Send>) -> String {
     }
 }
 
+/// Test-only: build a LIVE `AgentHandle` (real openpty, child `cat`) with a
+/// default `StateTracker` — so `core.state.resolved_context()` returns `None`
+/// (no context statusline parsed). Used by the #latch-prune reverse-regression
+/// tests: an agent present in the registry but WITHOUT a context reading this
+/// tick must still appear in each handler's `live` set (the latch maps are
+/// retained against ALL live agents, not just those with a reading), so its
+/// latch is NOT wrongly pruned. Returns the master reader for the caller to
+/// keep alive (binding `_reader`). Mirrors `supervisor::tests::mock_agent_handle`.
+#[cfg(test)]
+pub(crate) fn mock_live_agent_no_context(
+    name: &str,
+) -> (crate::agent::AgentHandle, Box<dyn std::io::Read + Send>) {
+    use std::sync::Arc;
+    let pty_system = portable_pty::native_pty_system();
+    let pair = pty_system
+        .openpty(portable_pty::PtySize {
+            rows: 10,
+            cols: 80,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .expect("open pty");
+    #[cfg(not(target_os = "windows"))]
+    let cmd = portable_pty::CommandBuilder::new("cat");
+    #[cfg(target_os = "windows")]
+    let cmd = {
+        let mut c = portable_pty::CommandBuilder::new("cmd");
+        c.args(["/c", "findstr", ".*"]);
+        c
+    };
+    let child = pair.slave.spawn_command(cmd).expect("spawn cat");
+    drop(pair.slave);
+    let reader = pair.master.try_clone_reader().expect("clone reader");
+    let writer = pair.master.take_writer().expect("take writer");
+    let pty_writer: crate::agent::PtyWriter = Arc::new(parking_lot::Mutex::new(writer));
+    let core = Arc::new(crate::sync_audit::CoreMutex::new(crate::agent::AgentCore {
+        vterm: crate::vterm::VTerm::with_pty_writer(80, 10, Arc::clone(&pty_writer)),
+        subscribers: Vec::new(),
+        state: crate::state::StateTracker::new(None),
+        health: crate::health::HealthTracker::new(),
+    }));
+    let handle = crate::agent::AgentHandle {
+        id: crate::types::InstanceId::default(),
+        name: name.to_string().into(),
+        backend_command: "claude".to_string(),
+        pty_writer,
+        pty_master: Arc::new(parking_lot::Mutex::new(pair.master)),
+        core,
+        child: Arc::new(parking_lot::Mutex::new(child)),
+        submit_key: "\r".to_string(),
+        inject_prefix: String::new(),
+        typed_inject: false,
+        spawned_at: std::time::Instant::now(),
+        spawned_at_epoch_ms: 0,
+        deleted: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    };
+    (handle, reader)
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {


### PR DESCRIPTION
## What (backlog: cleanup-on-delete class — flagged during W2.4)

Three per-tick handlers hold `Mutex<HashMap<String, T>>` latches that **never prune** — a deleted agent's entry persists until restart, so a **same-name redeploy inherits stale latch state** (a swallowed first alert, or a suppressing episode). This is the #1923 G5 `conflict_notify::retain_active` cleanup-on-delete class, unaddressed for these three.

## How (mirrors #1923 G5)

On each handler `run`, snapshot the live agent names from the registry and `retain` the latch map against them:
- `context_alert.states` — per-agent alert latch;
- `context_handoff.states` — per-agent episode latch;
- `inbox_stuck.last_alerted` — per-agent re-alert timer.

`context_alert`/`context_handoff` already lock the registry for their snapshot — widened to capture **all** live names (not just agents with a context reading). `inbox_stuck` reads only the home dir, so it snapshots the registry (locked then **dropped before** the latch lock — no nesting) then retains.

## `handoff_timeout` — evaluated, deliberately NOT changed

Its `last_escalated` / `last_renudged` keys are `(target, repo@branch-correlation)` — **not agent-keyed** — and `handoff_timeout_watchdog::scan_and_emit` **already self-prunes** entries whose handoff is no longer live (the #1598-mirror). A registry-name retain would be **wrong** (the `target` is often an orchestrator, not the volatile agent) and redundant.

## Tests / safety

Behaviour fix (in-mem-reset class), not a refactor — alert/notify logic untouched. §3.9 producer-fed: one test per fixed handler drives the **real `run()`** with a stale latch entry + an empty registry (= the agent deleted) and asserts the entry is pruned (`inbox_stuck` uses `new_at(.., past_grace())` so its boot-grace gate fires). `clippy --all-targets --features tray -D warnings` clean · full `nextest` **4106** green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)