### PR TITLE
test(#2085): router mirror cap-drain §3.9 real-entry CJK regression

### DIFF
--- a/src/daemon/router.rs
+++ b/src/daemon/router.rs
@@ -33,6 +33,18 @@ fn mirror_drain_start(buf: &str) -> usize {
     drain
 }
 
+/// Cap the mirror buffer in place: once it grows past `2 * MAX_MIRROR_LEN`,
+/// drain the front back under the cap, starting at the char-boundary-snapped
+/// index from [`mirror_drain_start`] so a multi-byte char is never split (the
+/// #2084 `drain(..n)` panic on a non-boundary `n`). Extracted verbatim from the
+/// run-loop per-event consume so the cap-drain path is directly unit-testable.
+fn apply_mirror_cap(buf: &mut String) {
+    if buf.len() > MAX_MIRROR_LEN * 2 {
+        let drain = mirror_drain_start(buf);
+        buf.drain(..drain);
+    }
+}
+
 /// Registration message: agent name + PTY output receiver.
 pub struct AgentSubscription {
     pub name: String,
@@ -111,10 +123,7 @@ fn run_loop(home: PathBuf, reg_rx: crossbeam_channel::Receiver<AgentSubscription
                     buf.input_id = pair.reply_to_input_id;
                     let text = String::from_utf8_lossy(&data);
                     buf.buffer.push_str(&text);
-                    if buf.buffer.len() > MAX_MIRROR_LEN * 2 {
-                        let drain = mirror_drain_start(&buf.buffer);
-                        buf.buffer.drain(..drain);
-                    }
+                    apply_mirror_cap(&mut buf.buffer);
                 } else {
                     buf.active = false;
                     buf.buffer.clear();
@@ -294,6 +303,39 @@ mod tests {
     fn mirror_drain_start_is_zero_when_short() {
         let s = "界界界".to_string();
         assert_eq!(mirror_drain_start(&s), 0);
+    }
+
+    #[test]
+    fn run_loop_cap_drain_never_panics_on_oversized_cjk() {
+        // §3.9 real-entry regression for #2084/#2085: drive the run-loop
+        // per-event consume+cap path (router.rs L113-117) — repeated `push_str`
+        // of 3-byte CJK well past 2*MAX_MIRROR_LEN, capping after each push
+        // exactly as the run-loop does. The original panic was
+        // `buf.drain(..n)` on a non-char-boundary `n` (12000-byte buffer →
+        // raw target 8000, and 8000 % 3 != 0). `apply_mirror_cap` must never
+        // panic and must hold the buffer at or under 2*MAX_MIRROR_LEN.
+        //
+        // Distinct from the existing pins: `mirror_drain_start_never_splits_*`
+        // exercises only the index helper + a manual drain;
+        // `mirror_truncation_safe_on_multibyte_utf8` drives the
+        // `try_dispatch_mirror` slice path (:184). Neither calls this drain.
+        //
+        // RED proof: reverting `mirror_drain_start` to the raw byte index
+        // (`buf.len().saturating_sub(MAX_MIRROR_LEN)` without the
+        // char-boundary while-snap) makes the first `apply_mirror_cap` below
+        // panic ("byte index … is not a char boundary").
+        let mut buf = String::new();
+        for _ in 0..10 {
+            buf.push_str(&"界".repeat(MAX_MIRROR_LEN)); // 12000 bytes/push (> 2*cap)
+            apply_mirror_cap(&mut buf); // must not panic on the drain
+            assert!(
+                buf.len() <= MAX_MIRROR_LEN * 2,
+                "cap must hold buffer <= 2*MAX_MIRROR_LEN, got {}",
+                buf.len()
+            );
+        }
+        // Drain never split a char → buffer ends on a valid char boundary.
+        assert!(buf.is_char_boundary(buf.len()));
     }
 
     // ── #1102 prefer-chain tests ──────────────────────────────────────


### PR DESCRIPTION
## What

Closes the **§3.9 coverage gap** left by #2084. That PR fixed the run-loop mirror cap-drain multibyte panic (`mirror_drain_start` snaps the drain index to a char boundary), but **no test drove the run-loop `push_str`+`drain` cap path** (`router.rs` `run_loop` L113-117) — the exact site where the original `drain(..n)` panic fired. Existing pins cover only the index helper (`mirror_drain_start_never_splits_multibyte_char`) and the `try_dispatch_mirror` *slice* path (`mirror_truncation_safe_on_multibyte_utf8`, :184); neither calls the cap-drain.

- **Extract** the per-event cap into `apply_mirror_cap(&mut String)` — verbatim from the inline run-loop block (`if buf.len() > MAX_MIRROR_LEN*2 { let drain = mirror_drain_start(buf); buf.drain(..drain) }`); the call site becomes `apply_mirror_cap(&mut buf.buffer)`. **Behavior byte-identical** — existing router tests pass with zero changes.
- **New test** `run_loop_cap_drain_never_panics_on_oversized_cjk`: push >2×`MAX_MIRROR_LEN` of 3-byte CJK (`界`) through `apply_mirror_cap` repeatedly (mirroring the run-loop per-event consume), assert **no panic** + buffer stays `<= 2*MAX_MIRROR_LEN` + ends on a char boundary.

## RED proof (confirmed locally, then reverted)

Reverting `mirror_drain_start` to the raw byte index (`buf.len().saturating_sub(MAX_MIRROR_LEN)` without the char-boundary while-snap = the original #2084 bug form) makes the new test **panic**: `assertion failed: self.is_char_boundary(end)` at the `drain(..)` call. Restored → green. So the test genuinely catches the regression.

## Scope & verification

Scope: extract helper + add test only; cap-drain decision logic unchanged. Source of truth = issue #2085; freshness = `origin/main @ ee8ff8f`.

- All **10** `daemon::router::tests` green (9 existing zero-regression + 1 new).
- `cargo fmt` / `cargo clippy --all-targets --features tray -- -D warnings` / Windows `x86_64-pc-windows-msvc` cross-check — clean.
- Full `cargo nextest run --features tray --no-fail-fast`: **4121 passed / 1 failed / 33 skipped**. The 1 failure is `api::handlers::messaging::tests::dispatch_branch_skips_metadata_stub_but_checks_out_real_source_1834` — a pre-existing agent-git-shim env artifact (passes *with* `AGEND_GIT_BYPASS`, fails without; mirror-image of `..._no_bypass_1899`), in a file untouched by this change. CI's clean env passes both.

Diff: 1 file, `+46 / -4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)