### PR TITLE
fix(#2098): app/owned-mode fail-closed for restart_daemon (control-plane brick)

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -157,6 +157,21 @@ pub(crate) static SHUTDOWN_REASON: AtomicU8 = AtomicU8::new(0);
 /// without API-layer plumbing.
 pub(crate) static RESTART_PENDING: AtomicBool = AtomicBool::new(false);
 
+/// #2098: positive "this process's `run_core` loop is the active restart
+/// consumer" marker. Set true at `run_core` entry; stays false in every other
+/// mode — notably `agend-terminal app` (combined TUI+daemon, `run_app`), which
+/// brings up the api server under an `OwnedFleet`/`ApiGuard` but NEVER enters
+/// `run_core`. Only `run_core` consumes `RESTART_PENDING` (the tail
+/// `confirm_shutdown_or_abort_respawn` + post-serve exit/promote); app mode has
+/// NO consumer, so setting `RESTART_PENDING` there bricks the control plane
+/// permanently (api/mod.rs breaks every session, the held-flock successor
+/// 30s-times-out and dies, the flag stays latched). The `restart_daemon` MCP
+/// handler reads this fail-SAFE: it proceeds with the restart machinery ONLY
+/// when run_core is the active loop, and fail-closes otherwise (default-deny —
+/// any future non-run_core mode is blocked without code change). See
+/// `mcp::handlers::restart::handle_restart_daemon`.
+pub(crate) static RUN_CORE_ACTIVE: AtomicBool = AtomicBool::new(false);
+
 /// #1814 FIX2 (reviewer race High): the spawned successor's child handle, parked
 /// by `handle_self_respawn` at commit so the run_core loop can do a FINAL
 /// liveness recheck (`try_wait`, which also reaps) before the irreversible
@@ -736,6 +751,14 @@ fn write_control_ready(home: &Path) {
 
 fn run_core(home: &Path, source: FleetSource) -> anyhow::Result<()> {
     let started_at = std::time::Instant::now();
+
+    // #2098: mark run_core as the active restart consumer. Set at entry (before
+    // the api server is brought up below, so it is always true by the time any
+    // `restart_daemon` MCP call can arrive) — once we are in run_core we will
+    // reach the tail that consumes RESTART_PENDING, so an in-process self-respawn
+    // is safe here. The handoff successor also runs through run_core, so it
+    // inherits this and can restart normally in turn.
+    RUN_CORE_ACTIVE.store(true, Ordering::Release);
 
     // For the handoff path, the channel inits post-lock (its registry attaches
     // via the #945 pending-registry bridge that `init_daemon_services` arms),

--- a/src/mcp/handlers/restart.rs
+++ b/src/mcp/handlers/restart.rs
@@ -2,6 +2,39 @@ use serde_json::{json, Value};
 use std::path::Path;
 
 pub(super) fn handle_restart_daemon(home: &Path) -> Value {
+    // #2098 app/owned-mode fail-closed (FIRST, before any path selection): the
+    // restart machinery below — BOTH the #1814 self-respawn handoff AND the
+    // legacy exit(42) path — only completes when `run_core` is the active loop,
+    // because it is run_core's tail that consumes `RESTART_PENDING`
+    // (confirm_shutdown_or_abort_respawn + post-serve exit/promote). In
+    // `agend-terminal app` (combined TUI+daemon, run_app) run_core is NEVER
+    // entered: the api server runs under an OwnedFleet/ApiGuard that holds the
+    // flock for the whole TUI lifetime and there is NO RESTART_PENDING consumer.
+    // Under the #2094 self-respawn DEFAULT the successor writes control-ready
+    // (passing Phase-1) BEFORE blocking on the held flock, so the handler would
+    // set RESTART_PENDING, brick every api session (api/mod.rs), and the
+    // successor would 30s-time-out on the flock and die — latching the brick
+    // permanently. So fail CLOSED whenever run_core is not the active loop
+    // (fail-safe default-deny via the positive RUN_CORE_ACTIVE marker), and
+    // NEVER set RESTART_PENDING here — mirroring the unsupervised
+    // fail-closed-no-flag invariant below.
+    if !crate::daemon::RUN_CORE_ACTIVE.load(std::sync::atomic::Ordering::Acquire) {
+        tracing::warn!(
+            target: "handoff",
+            event = "fail_closed_app_mode",
+            "#2098 restart_daemon refused: run_core is not the active loop (app/owned mode) — no in-process restart consumer"
+        );
+        return json!({
+            "ok": false,
+            "error": "restart_daemon is not supported in `agend-terminal app` (combined TUI+daemon) \
+                      mode: that process runs no in-process restart consumer, so an in-process \
+                      self-respawn would brick the control plane. To restart, quit the app (the TUI \
+                      owns the daemon) and relaunch `agend-terminal app` — or send the process \
+                      SIGTERM and start it again. (A standalone `agend-terminal start` daemon \
+                      restarts in-process as normal.)"
+        });
+    }
+
     // #1814: self-respawn is the DEFAULT (Stage 4). By default the daemon owns
     // its own respawn (spawn successor → Phase-1 health gate → abort-stay-alive
     // on failure), so restart never hinges on an external supervisor being
@@ -66,6 +99,11 @@ pub(super) fn handle_restart_daemon(home: &Path) -> Value {
 /// spawn a successor, gate on its health, and only commit the predecessor's
 /// shutdown if the successor is confirmed up. On failure the predecessor is
 /// never signalled → it stays fully alive with its agents intact.
+///
+/// #2098 precondition: only ever reached via `handle_restart_daemon`, whose
+/// leading guard guarantees `RUN_CORE_ACTIVE` (run_core is the active
+/// RESTART_PENDING consumer) — so this never runs in app/owned mode and the
+/// `RESTART_PENDING.store(true)` on commit always has a consumer.
 fn handle_self_respawn(home: &Path) -> Value {
     let old_pid = std::process::id();
     let handoff_value = crate::daemon::restart::make_handoff_value(old_pid);
@@ -223,6 +261,11 @@ mod tests {
             .map(|k| (k.to_string(), std::env::var(k).ok()))
             .collect();
         let prior_restart_pending = crate::daemon::RESTART_PENDING.load(Ordering::Acquire);
+        // #2098: the new app-mode guard reads `RUN_CORE_ACTIVE`, a process-global
+        // static. Save + restore it so these tests (which set it per-case to
+        // pick the mode under test) don't leak into sibling tests sharing this
+        // process under plain `cargo test`.
+        let prior_run_core_active = crate::daemon::RUN_CORE_ACTIVE.load(Ordering::Acquire);
 
         // SAFETY: test-only mutation, serialised via the mutex above.
         unsafe {
@@ -246,6 +289,7 @@ mod tests {
             }
         }
         crate::daemon::RESTART_PENDING.store(prior_restart_pending, Ordering::Release);
+        crate::daemon::RUN_CORE_ACTIVE.store(prior_run_core_active, Ordering::Release);
 
         result
     }
@@ -271,6 +315,12 @@ mod tests {
                 "XPC_SERVICE_NAME",
             ],
             || {
+                // #2098: the legacy supervisor-detection branch under test is
+                // only reachable in run_core mode — the leading app-mode guard
+                // fail-closes first otherwise. Simulate run_core so this test
+                // reaches the branch it pins (positive control: the app guard
+                // does NOT over-block run_core).
+                crate::daemon::RUN_CORE_ACTIVE.store(true, Ordering::Release);
                 // Manual tempdir — matches the std::env::temp_dir pattern
                 // used elsewhere in this crate (e.g. claim_verifier.rs
                 // tests). Avoids adding tempfile as a dev-dep just for
@@ -330,6 +380,9 @@ mod tests {
             &[("XPC_SERVICE_NAME", "0"), ("AGEND_RESTART_HANDOFF", "0")],
             &["AGEND_WRAPPED", "AGEND_SUPERVISED", "INVOCATION_ID"],
             || {
+                // #2098: run_core mode so the legacy XPC false-positive guard is
+                // reached (the app-mode guard fail-closes first otherwise).
+                crate::daemon::RUN_CORE_ACTIVE.store(true, Ordering::Release);
                 let tmp = std::env::temp_dir().join(format!(
                     "agend-restart-gui-test-{}-{}",
                     std::process::id(),
@@ -352,6 +405,67 @@ mod tests {
                 assert!(
                     !tmp.join("restart-requested").exists(),
                     "restart-requested marker must NOT be written on fail-closed"
+                );
+                let _ = std::fs::remove_dir_all(&tmp);
+            },
+        );
+    }
+
+    /// #2098 app/owned-mode fail-closed. `agend-terminal app` (combined
+    /// TUI+daemon, run_app) never enters run_core, so it has NO RESTART_PENDING
+    /// consumer: an in-process self-respawn would set RESTART_PENDING, brick the
+    /// api session loop (api/mod.rs), and the held-flock successor would
+    /// 30s-time-out and die — latching the brick permanently. With self-respawn
+    /// the DEFAULT (#2094: `AGEND_RESTART_HANDOFF=1`), the handler MUST fail-closed
+    /// whenever run_core is not the active loop — BEFORE selecting any path or
+    /// spawning a successor, and WITHOUT setting RESTART_PENDING. Drives the
+    /// production `handle_restart_daemon` with `RUN_CORE_ACTIVE=false` (the real
+    /// app-mode state); the §3.9 `app_mode_restart_fails_closed_no_brick_2098`
+    /// PTY test in tests/self_respawn_handoff.rs is the end-to-end reproduction.
+    #[test]
+    fn handle_restart_daemon_fails_closed_in_app_mode_no_run_core() {
+        with_env_and_reset(
+            // #2094 default: self-respawn ON — the exact brick scenario. The app
+            // guard must short-circuit BEFORE this path is even selected.
+            &[("AGEND_RESTART_HANDOFF", "1")],
+            &[
+                "AGEND_WRAPPED",
+                "AGEND_SUPERVISED",
+                "INVOCATION_ID",
+                "XPC_SERVICE_NAME",
+            ],
+            || {
+                // App/owned mode: run_core was never entered in this process, so
+                // RUN_CORE_ACTIVE is false (its default, set here explicitly so
+                // the test is order-independent).
+                crate::daemon::RUN_CORE_ACTIVE.store(false, Ordering::Release);
+                let tmp = std::env::temp_dir().join(format!(
+                    "agend-restart-appmode-{}-{}",
+                    std::process::id(),
+                    std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .map(|d| d.as_nanos())
+                        .unwrap_or(0),
+                ));
+                std::fs::create_dir_all(&tmp).expect("create tempdir");
+                let response = handle_restart_daemon(&tmp);
+                assert_eq!(
+                    response["ok"], false,
+                    "app-mode (no run_core consumer) restart must fail-closed, got {response}"
+                );
+                let error = response["error"].as_str().unwrap_or("");
+                assert!(
+                    error.contains("app"),
+                    "fail-closed error must name `app` mode (actionable) — got {error:?}"
+                );
+                assert!(
+                    !crate::daemon::RESTART_PENDING.load(Ordering::Acquire),
+                    "RESTART_PENDING must NOT be set in app mode — with no run_core \
+                     consumer it would latch and permanently brick the control plane"
+                );
+                assert!(
+                    !tmp.join("restart-requested").exists(),
+                    "restart-requested marker must NOT be written on app-mode fail-closed"
                 );
                 let _ = std::fs::remove_dir_all(&tmp);
             },

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -225,7 +225,7 @@ pub(crate) fn def_task_sweep_config() -> Value {
 }
 
 pub(crate) fn def_restart_daemon() -> Value {
-    json!({"name": "restart_daemon", "description": "Request graceful daemon restart. Daemon exits with code 42 after shutdown; a supervisor (launchd/systemd/Task Scheduler from `agend-terminal service install`, or `scripts/agend-wrapper.sh` for manual mode) respawns it. Returns ok:false when no supervisor is detected (bare `agend-terminal start`) — operator must install a supervisor before retry. Idempotent.",
+    json!({"name": "restart_daemon", "description": "Request a graceful daemon restart. Default (#1814): the daemon self-respawns — it spawns a successor, health-gates it, and only then exits(0) so the successor takes over; NO external supervisor required. Opt-out `AGEND_RESTART_HANDOFF=0` takes the legacy path (exit code 42 + a launchd/systemd/Task-Scheduler supervisor from `agend-terminal service install`, or `scripts/agend-wrapper.sh`, respawns it; returns ok:false if no supervisor is detected). Returns ok:false in `agend-terminal app` (combined TUI+daemon) mode — that process has no in-process restart consumer, so quit and relaunch the app, or SIGTERM + restart. Idempotent.",
         "inputSchema": {"type": "object", "properties": {}}})
 }
 

--- a/tests/self_respawn_handoff.rs
+++ b/tests/self_respawn_handoff.rs
@@ -18,8 +18,9 @@
 //! Stage 1; Windows keeps `exit(42)` + Task Scheduler.
 #![cfg(unix)]
 
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufRead, BufReader, Read, Write};
 use std::net::TcpStream;
+use std::os::unix::io::{FromRawFd, RawFd};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
@@ -598,5 +599,230 @@ fn flag_on_concurrent_respawn_cannot_double_bind_via_flock_1814() {
         "the flock loser MUST exit via the try_lock fail-fast with the exact production lock \
          error (this is the test's sole purpose — proving the double-bind guard fired, not just \
          that some process exited); stderr was: {loser_stderr:?}"
+    );
+}
+
+/// #2098 §3.9: boot a REAL `agend-terminal app` (combined TUI+daemon, `run_app`)
+/// under a libc PTY so its `ratatui::init` TUI setup succeeds without an
+/// interactive terminal, then its in-process api server comes up (run/<pid>/
+/// api.port + api.cookie — IDENTICAL layout to run_core, via the shared
+/// `bootstrap::prepare` → OwnedFleet that also writes `.daemon`). Self-respawn is
+/// the #2094 DEFAULT (AGEND_RESTART_HANDOFF unset) and every external-supervisor
+/// signal is stripped — the exact brick scenario. Returns the child; a DETACHED
+/// thread drains the pty master so the TUI never blocks on a full buffer. The
+/// drain thread is deliberately NOT joined: a surviving child that inherited the
+/// slave fd (e.g. a doomed successor on the pre-fix brick path) would keep the
+/// master open forever, so a join could hang. It is a per-test process, so the
+/// thread + fd are reclaimed on test-process exit.
+fn boot_app_under_pty(home: &Path) -> Child {
+    std::fs::create_dir_all(home).ok();
+    std::fs::write(
+        home.join("fleet.yaml"),
+        "instances:\n  probe:\n    backend: shell\n    command: /bin/sh\n",
+    )
+    .expect("write fleet.yaml");
+
+    // openpty with a non-zero winsize so the TUI has a sane render area.
+    // NB: openpty's `termp`/`winp` are `*mut` on macOS but `*const` on Linux;
+    // a `*mut` coerces to `*const`, so pass `*mut` to compile on both.
+    let mut winsize = libc::winsize {
+        ws_row: 40,
+        ws_col: 120,
+        ws_xpixel: 0,
+        ws_ypixel: 0,
+    };
+    let mut master: RawFd = -1;
+    let mut slave: RawFd = -1;
+    // SAFETY: openpty fills master+slave with fresh valid fds on success (rc==0).
+    let rc = unsafe {
+        libc::openpty(
+            &mut master,
+            &mut slave,
+            std::ptr::null_mut(),
+            std::ptr::null_mut::<libc::termios>(),
+            &mut winsize as *mut libc::winsize,
+        )
+    };
+    assert_eq!(rc, 0, "openpty must succeed");
+
+    let mut cmd = Command::new(bin());
+    cmd.env("AGEND_HOME", home)
+        // self-respawn is the #2094 DEFAULT — do NOT set AGEND_RESTART_HANDOFF.
+        // Strip ambient supervisor + handoff env so this is the genuine
+        // "app mode, self-respawn default ON, no supervisor" brick scenario.
+        .env_remove("AGEND_RESTART_HANDOFF")
+        .env_remove("AGEND_WRAPPED")
+        .env_remove("AGEND_SUPERVISED")
+        .env_remove("XPC_SERVICE_NAME")
+        .env_remove("INVOCATION_ID")
+        .env_remove("AGEND_SUCCESSOR_HANDOFF")
+        .arg("app");
+    // SAFETY: dup the slave fd for each std stream; std::process owns + closes
+    // the dup'd fds. The child's stdio is therefore a real tty (the pty slave),
+    // so `ratatui::init` / crossterm raw-mode succeed headlessly.
+    unsafe {
+        cmd.stdin(Stdio::from_raw_fd(libc::dup(slave)));
+        cmd.stdout(Stdio::from_raw_fd(libc::dup(slave)));
+        cmd.stderr(Stdio::from_raw_fd(libc::dup(slave)));
+    }
+    let child = cmd.spawn().expect("app must spawn under pty");
+    // Parent no longer needs the slave end (the child holds its own dups).
+    // SAFETY: slave is a valid fd we opened above.
+    unsafe {
+        libc::close(slave);
+    }
+
+    // Drain the master so the TUI's writes never block on a full pty buffer.
+    // DETACHED (not joined — see fn doc): ends on EOF when the child + any
+    // fd-inheriting descendants exit, otherwise on test-process exit.
+    std::thread::spawn(move || {
+        // SAFETY: master is a valid fd owned here; the File closes it on drop.
+        let mut f = unsafe { std::fs::File::from_raw_fd(master) };
+        let mut buf = [0u8; 4096];
+        loop {
+            match f.read(&mut buf) {
+                Ok(0) | Err(_) => break,
+                Ok(_) => {}
+            }
+        }
+    });
+    child
+}
+
+/// Connect to a SPECIFIC daemon's api socket (by pid run dir), do the cookie
+/// handshake, and send a STATUS request — true iff a well-formed reply comes
+/// back within `budget`. A live control plane answers; a bricked one
+/// (RESTART_PENDING latched → the session loop breaks before reading the
+/// request, api/mod.rs:499) completes the handshake but never replies.
+fn api_status_ok_within(home: &Path, pid: u32, budget: Duration) -> bool {
+    let deadline = Instant::now() + budget;
+    while Instant::now() < deadline {
+        if api_status_once(home, pid) == Some(true) {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(250));
+    }
+    false
+}
+
+fn api_status_once(home: &Path, pid: u32) -> Option<bool> {
+    let run_dir = home.join("run").join(pid.to_string());
+    let port: u16 = std::fs::read_to_string(run_dir.join("api.port"))
+        .ok()?
+        .trim()
+        .parse()
+        .ok()?;
+    let cookie_bytes = std::fs::read(run_dir.join("api.cookie")).ok()?; // raw 32 bytes
+    let stream = TcpStream::connect(("127.0.0.1", port)).ok()?;
+    stream.set_read_timeout(Some(Duration::from_secs(5))).ok();
+    let mut writer = stream.try_clone().ok()?;
+    let mut reader = BufReader::new(stream);
+    writeln!(writer, "{{\"auth\":\"{}\"}}", hex(&cookie_bytes)).ok()?;
+    writer.flush().ok();
+    let mut ack = String::new();
+    reader.read_line(&mut ack).ok()?;
+    let ack: serde_json::Value = serde_json::from_str(ack.trim()).ok()?;
+    if !ack.get("ok").and_then(|b| b.as_bool()).unwrap_or(false) {
+        return Some(false);
+    }
+    writeln!(writer, "{}", serde_json::json!({"method": "status"})).ok()?;
+    writer.flush().ok();
+    let mut line = String::new();
+    if reader.read_line(&mut line).ok()? == 0 {
+        // EOF before a reply = the session loop broke before reading our
+        // request (the brick: RESTART_PENDING latched).
+        return Some(false);
+    }
+    let reply: serde_json::Value = serde_json::from_str(line.trim()).ok()?;
+    Some(reply.is_object())
+}
+
+/// #2098 §3.9 — `agend-terminal app` (combined TUI+daemon) must NOT brick its
+/// control plane on `restart_daemon`. With self-respawn the DEFAULT (#2094) and
+/// no external supervisor, the pre-fix handler set RESTART_PENDING in the app
+/// process — which has NO run_core consumer — so api/mod.rs broke every session
+/// and the held-flock successor 30s-timed-out and died, latching the brick
+/// permanently. The fix fails CLOSED in app mode: restart_daemon returns
+/// ok:false (actionable) and the app's control plane stays fully alive.
+///
+/// Plugs the dual-review blind spot: the sibling `self_respawn_*` tests boot
+/// `start --foreground` (run_core mode, which DOES consume RESTART_PENDING), so
+/// they never exercised the app-mode brick. Here the predecessor is the REAL
+/// `app` binary (under a PTY so ratatui::init succeeds headlessly). Post-fix the
+/// handler fail-closes BEFORE spawning any successor, so this GREEN run brings up
+/// only the one app process (no successor subprocess).
+#[test]
+fn app_mode_restart_fails_closed_no_brick_2098() {
+    let home = std::env::temp_dir().join(format!("agend-2098-appmode-{}", std::process::id()));
+    std::fs::create_dir_all(&home).expect("mkdir AGEND_HOME");
+
+    let mut child = boot_app_under_pty(&home);
+
+    // The app's in-process api server must come up (run dir + api.port + live pid).
+    let pid = match wait_for_single_active(&home, Duration::from_secs(30), pid_alive) {
+        Some(p) => p,
+        None => {
+            let _ = child.kill();
+            let _ = child.wait();
+            cleanup_test_home(&home);
+            panic!("app-mode api server never became the single active daemon");
+        }
+    };
+
+    // Operator gate allows restart only when Active (fresh daemon → Away).
+    set_mode_active(&home);
+
+    // Real restart_daemon over the real app api socket.
+    let resp = trigger_restart(&home, pid);
+
+    // ── Load-bearing: NO BRICK ── a NEW session must STILL be served after
+    // restart_daemon. Pre-fix the app latched RESTART_PENDING → api/mod.rs broke
+    // every session → this STATUS round-trip fails. Post-fix (fail-closed, no
+    // flag set) it succeeds.
+    let still_alive = api_status_ok_within(&home, pid, Duration::from_secs(15));
+    // The SAME app process must remain the single active daemon (no exit, no
+    // successor double-bind).
+    let same_single = active_pids(&home) == vec![pid] && pid_alive(pid);
+
+    // Cleanup BEFORE asserting so a failure never leaks the child. (The drain
+    // thread is detached — see boot_app_under_pty — so there is nothing to join;
+    // cleanup_test_home reaps any spawned successor on the pre-fix brick path.)
+    let _ = child.kill();
+    let _ = child.wait();
+    cleanup_test_home(&home);
+
+    // restart_daemon must report fail-closed (mcp_tool wraps handler output as
+    // {ok:true, result:{...}}; the app-mode refusal is result.ok == false).
+    if let Some(resp) = resp {
+        let result_ok = resp
+            .get("result")
+            .and_then(|r| r.get("ok"))
+            .and_then(|b| b.as_bool());
+        assert_eq!(
+            result_ok,
+            Some(false),
+            "app-mode restart_daemon must report result.ok=false (fail-closed), got {resp}"
+        );
+        let err = resp
+            .get("result")
+            .and_then(|r| r.get("error"))
+            .and_then(|e| e.as_str())
+            .unwrap_or("");
+        assert!(
+            err.contains("app"),
+            "fail-closed error must name `app` mode (actionable) — got {err:?}"
+        );
+    } else {
+        panic!(
+            "app-mode restart must return a reply (the predecessor is never signalled — it stays alive to answer)"
+        );
+    }
+    assert!(
+        still_alive,
+        "app control plane must stay alive after restart_daemon (no brick) — a new STATUS round-trip failed"
+    );
+    assert!(
+        same_single,
+        "the SAME app process must remain the single active daemon (no exit, no double-bind)"
     );
 }


### PR DESCRIPTION
## Problem (#2098)

#2094 made self-respawn the **default**. In `agend-terminal app` (combined TUI+daemon, `run_app`) `restart_daemon` then **bricks the control plane permanently**:

1. App mode never enters `run_core`, so there is **no `RESTART_PENDING` consumer**.
2. The self-respawn successor writes `control-ready` (passing the Phase-1 gate) **before** blocking on the app's held flock.
3. So `handle_self_respawn` sets `RESTART_PENDING` → `api/mod.rs:499` breaks **every** session before reading the request.
4. The successor 30s-times-out on the flock (held by the app's `ApiGuard` for the whole TUI lifetime) and dies.
5. `RESTART_PENDING` stays latched forever → every later MCP call is dead.

The existing §3.9 handoff tests boot `start --foreground` (= `run_core` mode, which **does** consume `RESTART_PENDING`), so this app-mode path slipped dual-review.

## Fix

Fail **closed** whenever `run_core` is not the active restart consumer, via a positive `RUN_CORE_ACTIVE` marker (fail-safe default-deny) set at `run_core` entry. The guard sits at the **top of `handle_restart_daemon`**, before path selection — so it blocks all three brick steps at once:

- ① no doomed successor spawn,
- ② no `SELF_RESPAWN_SUCCESSOR` park (zombie `Child`),
- ③ no `RESTART_PENDING` store (mirrors the existing unsupervised fail-closed-no-flag invariant).

`run_core` self-respawn — the #2094 benefit — is **untouched**: it sets `RUN_CORE_ACTIVE` at entry, and the handoff successor (which also runs through `run_core`) inherits it.

Also: refresh the stale `restart_daemon` tool description (was exit(42)+supervisor only).

## Tests (instrument-first, mutation-verified)

- **§3.9** `app_mode_restart_fails_closed_no_brick_2098`: boots the **real `app` binary under a libc pty** (so `ratatui::init` succeeds headless), invokes the real `restart_daemon` over the api socket, asserts `result.ok:false` + the control plane still serves a fresh STATUS session (no brick). RED-verified: with the guard removed it commits self-respawn (`result.ok:true`) and bricks.
- **unit** `handle_restart_daemon_fails_closed_in_app_mode_no_run_core`: RED proves the guard blocks the spawn (without it, app mode falls through to `handle_self_respawn`).
- Existing legacy unit tests pinned to `RUN_CORE_ACTIVE=true` (precondition audit — they exercise the run_core-only legacy branch).
- Existing `run_core` integration tests are the **run_core-unaffected regression** (all pass).

## Verification

- `cargo fmt --check` ✓, `cargo clippy --all-targets --features tray -D warnings` ✓
- `cargo nextest run --features tray --no-fail-fast`: **4122/4123 pass**; the 1 failure is the pre-existing env-mutually-exclusive `dispatch_branch_..._1834` (needs `AGEND_GIT_BYPASS=1`, confirmed passing under it) — unrelated to this change.
- Rebased onto current `origin/main` (ee8ff8f, #2101) — net diff is exactly the 4 files below.

## Scope

App-mode fail-closed branch + tool desc + fixtures only. `run_core` handoff, the #2093 template, and the #2094 default are untouched.

Fixes #2098.