### PR TITLE
fix(#2099): fire-and-forget dispatch skips stuck tracking

### DIFF
--- a/src/api/handlers/messaging.rs
+++ b/src/api/handlers/messaging.rs
@@ -515,13 +515,24 @@ fn track_dispatch(
     if matches!(kind_str, "task" | "query") {
         let outbound_corr = msg.correlation_id.as_deref().or(msg.task_id.as_deref());
         let explicit_threshold = params["expect_reply_within_secs"].as_i64();
-        if let Some(threshold) =
+        // #2099: a fire-and-forget dispatch (`no_report_expected`) records NO
+        // dispatch-idle sidecar, so the ~threshold watchdog never nags the
+        // dispatcher (`dispatch_idle_threshold_exceeded`) nor [team-watchdog]s
+        // the target — this is the SECOND ~30min nag channel (the DispatchEntry
+        // sweep already skips the same flag). read-first: `pending_for_instance`
+        // (query.rs status) then correctly omits a no-reply dispatch, and
+        // `cleanup_pending_for_task_id` no-ops with no sidecar — the nag + that
+        // (correct) observability are the ONLY effects.
+        let threshold = if params["no_report_expected"].as_bool().unwrap_or(false) {
+            None
+        } else {
             crate::daemon::dispatch_idle::team_nudge::resolve_threshold_for_dispatch(
                 home,
                 from,
                 explicit_threshold,
             )
-        {
+        };
+        if let Some(threshold) = threshold {
             let outbound_corr = outbound_corr.map(String::from);
             // #2004: a swallowed record failure means this dispatch never gets
             // its idle-timeout nudge — surface it (non-fatal: the dispatch
@@ -1879,6 +1890,73 @@ mod tests {
             entry.threshold_secs,
             crate::daemon::dispatch_idle::team_nudge::DEFAULT_DISPATCH_THRESHOLD_SECS,
             "L2 must inject the team default threshold (#2031: 1800s)"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #2099 rework (PR #2108, reviewer-2 catch): close the SECOND ~30min nag
+    /// channel. A fixup-team dispatch auto-arms dispatch_idle at the 1800s team
+    /// default; a fire-and-forget dispatch (`no_report_expected=true`) must
+    /// record NO sidecar, so the watchdog never fires
+    /// `dispatch_idle_threshold_exceeded` (dispatcher) / `[team-watchdog]`
+    /// (target). Channel 1 (the DispatchEntry sweep) is pinned separately by
+    /// `dispatch_tracking::tests::sweep_stuck_skips_no_report_expected_2099`.
+    ///
+    /// REGRESSION-PROOF: drop the `no_report_expected` short-circuit in
+    /// `track_dispatch` → the flagged dispatch seeds a sidecar and the first
+    /// assertion fails.
+    #[test]
+    fn no_report_expected_dispatch_records_no_dispatch_idle_sidecar_2099() {
+        let home = tmp_home("ff-no-dispatch-idle");
+        write_fixup_fleet(&home, &["fixup-lead", "fixup-reviewer"]);
+        let ctx = test_ctx(&home);
+
+        // Flagged fire-and-forget kind=task → NO dispatch_idle sidecar.
+        let flagged = handle_send(
+            &json!({
+                "from": "fixup-lead",
+                "target": "fixup-reviewer",
+                "text": "[delegate_task] fire and forget",
+                "kind": "task",
+                "task_id": "t-ff",
+                "no_report_expected": true,
+            }),
+            &ctx,
+        );
+        assert_eq!(
+            flagged["ok"], true,
+            "flagged dispatch must succeed: {flagged}"
+        );
+        let pending = crate::daemon::dispatch_idle::list_pending(&home);
+        assert!(
+            !pending
+                .iter()
+                .any(|p| p.correlation_id.as_deref() == Some("t-ff")),
+            "fire-and-forget dispatch must NOT seed a dispatch_idle sidecar (no ~1800s nag): {pending:?}"
+        );
+
+        // Control: an UNflagged kind=task to the same team STILL seeds a sidecar
+        // (default unchanged — the 1800s watchdog arms as before).
+        let normal = handle_send(
+            &json!({
+                "from": "fixup-lead",
+                "target": "fixup-reviewer",
+                "text": "[delegate_task] normal work",
+                "kind": "task",
+                "task_id": "t-normal",
+            }),
+            &ctx,
+        );
+        assert_eq!(
+            normal["ok"], true,
+            "unflagged dispatch must succeed: {normal}"
+        );
+        let pending2 = crate::daemon::dispatch_idle::list_pending(&home);
+        assert!(
+            pending2
+                .iter()
+                .any(|p| p.correlation_id.as_deref() == Some("t-normal")),
+            "unflagged dispatch still seeds a sidecar (default unchanged): {pending2:?}"
         );
         std::fs::remove_dir_all(&home).ok();
     }

--- a/src/dispatch_tracking.rs
+++ b/src/dispatch_tracking.rs
@@ -20,7 +20,7 @@ pub struct DispatchEntry {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub to_id: Option<String>,
     pub delegated_at: String,
-    pub status: String, // "pending" | "completed" | "warned" | "asked"
+    pub status: String, // "pending" | "completed" | "warned" | "asked" | "orphaned" | "no_report_expected"
 }
 
 #[derive(Debug, Default, Serialize, Deserialize)]
@@ -134,7 +134,13 @@ pub fn sweep_stuck(home: &Path) -> (Vec<DispatchEntry>, Vec<DispatchEntry>) {
                 // again. (#1488 noted this re-fire but only fixed deleted-instance
                 // entries via `cleanup_for_instance`; this fixes still-existing
                 // targets whose orphaned entries otherwise nag for ~30 days.)
-                if entry.status == "completed" || entry.status == "orphaned" {
+                // #2099: `no_report_expected` is a fire-and-forget dispatch that
+                // intentionally gets no report back — never nag (audit row kept).
+                // Joins the terminal skip set alongside completed/orphaned.
+                if entry.status == "completed"
+                    || entry.status == "orphaned"
+                    || entry.status == "no_report_expected"
+                {
                     continue;
                 }
                 let delegated = match chrono::DateTime::parse_from_rfc3339(&entry.delegated_at) {
@@ -170,7 +176,13 @@ pub fn sweep_orphans(home: &Path) -> Vec<DispatchEntry> {
     persist_or_log!(
         crate::store::mutate_versioned(&store_path(home), |store: &mut DispatchStore| {
             for entry in store.entries.iter_mut() {
-                if entry.status == "completed" || entry.status == "orphaned" {
+                // #2099: skip fire-and-forget entries here too — leaving the
+                // audit row as `no_report_expected` rather than flipping it to
+                // `orphaned` at 24h (both are terminal-skip in sweep_stuck).
+                if entry.status == "completed"
+                    || entry.status == "orphaned"
+                    || entry.status == "no_report_expected"
+                {
                     continue;
                 }
                 let delegated = match chrono::DateTime::parse_from_rfc3339(&entry.delegated_at) {
@@ -410,6 +422,91 @@ mod tests {
         );
         assert_eq!(asks.len(), 1, "31min old dispatch must ask");
         assert_eq!(asks[0].to, "reviewer");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #2099: a fire-and-forget dispatch recorded as `no_report_expected` must
+    /// NOT fire the 30-min "dispatch stuck check" — it joins the terminal skip
+    /// set. A sibling UNflagged `pending` dispatch of the same age MUST still
+    /// ask, proving the default is unchanged (no masking of real stuck tasks).
+    #[test]
+    fn sweep_stuck_skips_no_report_expected_2099() {
+        let home = tmp_home("ff-skip-stuck");
+        let past = (chrono::Utc::now() - chrono::Duration::minutes(31)).to_rfc3339();
+        // fire-and-forget — must be skipped
+        track_dispatch(
+            &home,
+            DispatchEntry {
+                task_id: Some("t-ff".into()),
+                from: "lead".into(),
+                to: "scout".into(),
+                from_id: None,
+                to_id: None,
+                delegated_at: past.clone(),
+                status: "no_report_expected".into(),
+            },
+        );
+        // normal dispatch of the same age — must still ask (default unchanged)
+        track_dispatch(
+            &home,
+            DispatchEntry {
+                task_id: Some("t-normal".into()),
+                from: "lead".into(),
+                to: "reviewer".into(),
+                from_id: None,
+                to_id: None,
+                delegated_at: past,
+                status: "pending".into(),
+            },
+        );
+        let (warns, asks) = sweep_stuck(&home);
+        assert!(warns.is_empty(), "31min entries skip warn → ask: {warns:?}");
+        assert_eq!(asks.len(), 1, "only the unflagged dispatch asks: {asks:?}");
+        assert_eq!(
+            asks[0].to, "reviewer",
+            "the asked entry is the unflagged one"
+        );
+        assert!(
+            !asks.iter().any(|e| e.to == "scout"),
+            "fire-and-forget dispatch must never fire a stuck check: {asks:?}"
+        );
+        // Audit row preserved (status untouched, never flipped to "asked").
+        let raw = std::fs::read_to_string(store_path(&home)).unwrap();
+        assert!(
+            raw.contains("no_report_expected"),
+            "fire-and-forget audit row preserved: {raw}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #2099: a `no_report_expected` entry past the 24h orphan threshold is NOT
+    /// flipped to `orphaned` — the fire-and-forget audit row stays as-is.
+    #[test]
+    fn sweep_orphans_skips_no_report_expected_2099() {
+        let home = tmp_home("ff-skip-orphan");
+        let past = (chrono::Utc::now() - chrono::Duration::hours(25)).to_rfc3339();
+        track_dispatch(
+            &home,
+            DispatchEntry {
+                task_id: Some("t-ff".into()),
+                from: "lead".into(),
+                to: "scout".into(),
+                from_id: None,
+                to_id: None,
+                delegated_at: past,
+                status: "no_report_expected".into(),
+            },
+        );
+        let orphans = sweep_orphans(&home);
+        assert!(
+            orphans.is_empty(),
+            "fire-and-forget dispatch must not be orphaned: {orphans:?}"
+        );
+        let raw = std::fs::read_to_string(store_path(&home)).unwrap();
+        assert!(
+            raw.contains("no_report_expected") && !raw.contains("orphaned"),
+            "audit row stays no_report_expected, not flipped to orphaned: {raw}"
+        );
         std::fs::remove_dir_all(&home).ok();
     }
 

--- a/src/mcp/handlers/comms.rs
+++ b/src/mcp/handlers/comms.rs
@@ -287,6 +287,10 @@ pub(super) fn handle_delegate_task(home: &Path, args: &Value, sender: &Option<Se
                 "branch": args["branch"].as_str(), "expect_reply_within_secs": args["expect_reply_within_secs"].as_i64(),
                 "correlation_id": args["correlation_id"].as_str(), "reviewed_head": args["reviewed_head"].as_str(), "sequencing": args["sequencing"].as_str(), "eta_minutes": args["eta_minutes"].as_u64(), "reporting_cadence": args["reporting_cadence"].as_str(),
                 "worktree_binding_required": args["worktree_binding_required"].as_bool(), "terminal": args["terminal"].as_bool(), "thread_id": args["thread_id"].as_str(), "parent_id": args["parent_id"].as_str(),
+                // #2099: forward the fire-and-forget flag so the API-side
+                // dispatch_idle record path (the SECOND ~30min nag channel,
+                // besides the DispatchEntry sweep) can also skip it.
+                "no_report_expected": args["no_report_expected"].as_bool(),
             }
         }),
     ) {

--- a/src/mcp/handlers/comms.rs
+++ b/src/mcp/handlers/comms.rs
@@ -321,6 +321,15 @@ pub(super) fn handle_delegate_task(home: &Path, args: &Value, sender: &Option<Se
     };
     if is_ok_result(&result) {
         let task_id = task_id_str.map(str::to_string);
+        // #2099: a fire-and-forget dispatch (`no_report_expected`) is recorded
+        // with a terminal-like status so the 30-min stuck sweep never false-fires
+        // for it — the audit row is kept, but sweep_stuck/sweep_orphans skip it.
+        // Default (flag absent/false) stays "pending" → normal stuck tracking.
+        let status = if args["no_report_expected"].as_bool().unwrap_or(false) {
+            "no_report_expected"
+        } else {
+            "pending"
+        };
         // Track dispatch for timeout detection
         crate::dispatch_tracking::track_dispatch(
             home,
@@ -335,7 +344,7 @@ pub(super) fn handle_delegate_task(home: &Path, args: &Value, sender: &Option<Se
                     .ok()
                     .map(|(id, _)| id.full()),
                 delegated_at: chrono::Utc::now().to_rfc3339(),
-                status: "pending".to_string(),
+                status: status.to_string(),
             },
         );
         // Sprint 30: log branch hint for operator visibility when

--- a/src/mcp/handlers/tests.rs
+++ b/src/mcp/handlers/tests.rs
@@ -1340,6 +1340,57 @@ fn test_delegate_task_busy_returns_structured_response() {
     std::fs::remove_dir_all(&home).ok();
 }
 
+/// #2099: a kind=task dispatch with `no_report_expected=true` records its
+/// dispatch-tracking entry with the terminal-like `no_report_expected` status
+/// (so the 30-min stuck sweep skips it — see
+/// dispatch_tracking::tests::sweep_stuck_skips_no_report_expected_2099); an
+/// unflagged dispatch stays `pending`, proving the default is unchanged.
+#[test]
+fn delegate_task_no_report_expected_records_terminal_status_2099() {
+    let _g = fleet_test_guard();
+    let home = tmp_home("ff-no-report-status");
+    std::fs::write(
+        crate::fleet::fleet_yaml_path(&home),
+        "instances:\n  target:\n    backend: claude\n  sender:\n    backend: claude\n",
+    )
+    .ok();
+    std::env::set_var("AGEND_HOME", &home);
+
+    let flagged = handle_tool(
+        "send",
+        &json!({"instance": "target", "task": "fire and forget", "message": "fire and forget", "request_kind": "task", "task_id": "t-ff", "no_report_expected": true}),
+        "sender",
+    );
+    assert!(
+        is_ok_result(&flagged),
+        "flagged dispatch must succeed: {flagged}"
+    );
+
+    let normal = handle_tool(
+        "send",
+        &json!({"instance": "target", "task": "normal work", "message": "normal work", "request_kind": "task", "task_id": "t-normal"}),
+        "sender",
+    );
+    assert!(
+        is_ok_result(&normal),
+        "unflagged dispatch must succeed: {normal}"
+    );
+
+    let raw = std::fs::read_to_string(crate::store::store_path(&home, "dispatch_tracking.json"))
+        .unwrap_or_default();
+    assert!(
+        raw.contains("no_report_expected"),
+        "flagged dispatch must record the terminal-like status: {raw}"
+    );
+    assert!(
+        raw.contains("pending"),
+        "unflagged dispatch stays pending (default unchanged): {raw}"
+    );
+
+    std::env::remove_var("AGEND_HOME");
+    std::fs::remove_dir_all(&home).ok();
+}
+
 #[test]
 fn test_delegate_task_enriching_same_task_id_bypasses_busy_gate_1496() {
     // #1496 Option 1: a send(kind=task) whose `task_id` IS the target's current

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -819,7 +819,7 @@ mod tests {
             ("send", "expect_reply_within_secs", "messaging.rs → dispatch_idle threshold watchdog"),
             ("send", "next_after_ci", "comms.rs → ci_watch poller fires [ci-ready-for-action]"),
             ("send", "terminal", "messaging.rs msg.terminal → auto_close_on_report"),
-            ("send", "no_report_expected", "comms.rs handle_delegate_task track step → DispatchEntry status=no_report_expected (skipped by sweep_stuck/sweep_orphans)"),
+            ("send", "no_report_expected", "comms.rs track step → DispatchEntry status=no_report_expected (skips sweep_stuck/sweep_orphans) + messaging.rs track_dispatch skips the dispatch_idle sidecar record"),
             // ── task (all fields consumed per action; #1933 audit) ──
             ("task", "action", "tasks/handler.rs action routing"),
             ("task", "title", "tasks/handler.rs handle_create"),

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -52,7 +52,8 @@ pub(crate) fn def_send() -> Value {
             "worktree_binding_required": {"type": "boolean", "description": "Whether target must bind to a worktree before starting"},
             "expect_reply_within_secs": {"type": "integer", "description": "Opt-in dispatch-idle watchdog (PR1). When set on a kind=task/query send, the daemon records a pending-dispatch sidecar and fires `dispatch_idle_threshold_exceeded` to the dispatcher's inbox if the matching kind=report (correlation_id-keyed) hasn't arrived within this many seconds. Default unset = no tracking (cross-team-safe). Fixup-team dispatches inherit a 10-min default automatically; other teams must opt in explicitly."},
             "next_after_ci": {"type": "string", "description": "#931 Fix 2 (H5a): when dispatching kind=task with a `branch`, set this to the agent that should receive `[ci-ready-for-action]` after CI passes on that branch. The daemon's auto-armed ci-watch carries the chain target so the handoff fires without a manual follow-up `ci action=watch next_after_ci=…`. Example: lead dispatches dev with `next_after_ci=reviewer` — reviewer is auto-notified when dev's PR goes green."},
-            "terminal": {"type": "boolean", "description": "Set true on kind=report to signal task completion. When correlation_id matches a task and reporter is the assignee, the task is auto-closed. Default false — progress reports and review verdicts do not trigger auto-close."}
+            "terminal": {"type": "boolean", "description": "Set true on kind=report to signal task completion. When correlation_id matches a task and reporter is the assignee, the task is auto-closed. Default false — progress reports and review verdicts do not trigger auto-close."},
+            "no_report_expected": {"type": "boolean", "description": "#2099: set true on a fire-and-forget kind=task dispatch that intentionally expects NO kind=report back. The dispatch is recorded with a terminal-like status so the 30-min dispatch-stuck sweep never false-fires a 'dispatch stuck check' for it (the audit row is kept). Default false — every normal dispatch stays stuck-tracked. Distinct from `terminal`, which is the report-side auto-close signal."}
         }, "required": ["message"]}})
 }
 
@@ -818,6 +819,7 @@ mod tests {
             ("send", "expect_reply_within_secs", "messaging.rs → dispatch_idle threshold watchdog"),
             ("send", "next_after_ci", "comms.rs → ci_watch poller fires [ci-ready-for-action]"),
             ("send", "terminal", "messaging.rs msg.terminal → auto_close_on_report"),
+            ("send", "no_report_expected", "comms.rs handle_delegate_task track step → DispatchEntry status=no_report_expected (skipped by sweep_stuck/sweep_orphans)"),
             // ── task (all fields consumed per action; #1933 audit) ──
             ("task", "action", "tasks/handler.rs action routing"),
             ("task", "title", "tasks/handler.rs handle_create"),


### PR DESCRIPTION
## Problem

A dispatch explicitly marked "no report expected" (fire-and-forget) was still recorded by `handle_delegate_task` as `DispatchEntry.status="pending"` with no exemption. `sweep_stuck` (`dispatch_tracking.rs`, skips only `completed`/`orphaned`) therefore fired a false **"dispatch stuck check"** (`daemon/mod.rs:~1459`) at the 30-min mark — and the only thing that clears that is a correlated `kind=report`, which a fire-and-forget dispatch never sends. Pure operator noise.

## Fix (noise-reduction; default unchanged)

1. **New `no_report_expected` boolean** on the `send` tool schema (`tools.rs`) + its `CONSUMED` schema-consumption-audit entry. Deliberately distinct from:
   - `terminal` (report-side auto-close), and
   - `expect_reply_within_secs` (the separate **dispatch-idle** watchdog — a different mechanism, out of scope here).
2. **`handle_delegate_task` track step** records a flagged dispatch with the terminal-like status `"no_report_expected"` instead of `"pending"`; the **audit row is preserved**. Flag absent/false → still `"pending"`.
3. **`sweep_stuck` + `sweep_orphans`** add `"no_report_expected"` to their terminal skip set, so a fire-and-forget dispatch is never nagged or orphaned.

Scope is exactly **flag + status + skip-set + tests** — no change to the warn/ask/orphan decision logic.

### Noise-discipline guarantees
- **Default unchanged**: only the explicit flag exempts; an unflagged dispatch of the same age still warns/asks (pinned by test).
- **Audit row preserved**: the entry stays in the store as `no_report_expected` (not dropped, not flipped to `orphaned`).
- **No masking**: a genuinely-stuck *unflagged* task still fires the stuck check.

### Known follow-up (out of scope, flagged for the lead)
`gc_old_entries` / `sweep_terminal_entries` still prune only `completed`/`orphaned`, so a `no_report_expected` row is kept indefinitely. Low-volume (explicit-flag-only) and the audit row is intentionally preserved, so I left GC-eligibility as a follow-up rather than expand scope unilaterally.

## Tests

- `dispatch_tracking::tests::sweep_stuck_skips_no_report_expected_2099` — flagged aged entry **not** asked; a sibling unflagged `pending` of the same age **still asks** (default unchanged, no masking).
- `dispatch_tracking::tests::sweep_orphans_skips_no_report_expected_2099` — flagged >24h entry **not** flipped to `orphaned` (audit row preserved).
- `mcp::handlers::tests::delegate_task_no_report_expected_records_terminal_status_2099` — flag=true records `status=no_report_expected`; unflagged stays `pending` (wiring + default).

All existing delegate/dispatch_tracking tests pass with **zero changes**, and the schema-consumption audit passes. `cargo fmt` / `cargo clippy --all-targets --features tray -- -D warnings` / Windows `x86_64-pc-windows-msvc` cross-check clean. Full `cargo nextest run`: **4124/4125** (the 1 = pre-existing `dispatch_branch_1834` shim env artifact in an untouched file).

Diff: 4 files, `+164 / -5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)