### PR TITLE
feat(#2061): task sweep stale_open category (terminal refs / no-ref+age)

### DIFF
--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -188,7 +188,7 @@ pub(crate) fn def_decision() -> Value {
 }
 
 pub(crate) fn def_task() -> Value {
-    json!({"name": "task", "description": "Manage task board. Actions: create, list, claim, done, update, sweep, health, activity, metadata_set, metadata_get. #806: default list trims to actionable statuses (open/claimed/in_progress/blocked); pass include_history=true to surface done/cancelled. `sweep` is operator-triggered manual hygiene (4 stale-task categories with dry-run + confirm_ids round-trip). #830: `health` is a one-shot board-hygiene snapshot — totals + by_status + ghost_owners + stale_claims + age aggregates + recommendations array.",
+    json!({"name": "task", "description": "Manage task board. Actions: create, list, claim, done, update, sweep, health, activity, metadata_set, metadata_get. #806: default list trims to actionable statuses (open/claimed/in_progress/blocked); pass include_history=true to surface done/cancelled. `sweep` is operator-triggered manual hygiene (5 stale-task categories with dry-run + confirm_ids round-trip). #830: `health` is a one-shot board-hygiene snapshot — totals + by_status + ghost_owners + stale_claims + age aggregates + recommendations array.",
         "inputSchema": {"type": "object", "properties": {
             "action": {"type": "string", "enum": ["create", "list", "claim", "done", "update", "sweep", "health", "activity", "metadata_set", "metadata_get"]},
             "title": {"type": "string"}, "description": {"type": "string"},

--- a/src/scm/mod.rs
+++ b/src/scm/mod.rs
@@ -53,6 +53,16 @@ pub(crate) struct PrSummary {
     pub files: Option<Vec<String>>,
 }
 
+/// A single issue, provider-neutral. Mirrors [`PrSummary`] — only the
+/// `--json` subset requested is populated. For the #2061 task-sweep
+/// `stale_open` category only `state` (OPEN vs CLOSED) is consulted.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct IssueSummary {
+    pub number: u64,
+    /// gh's `state`: "OPEN" | "CLOSED".
+    pub state: Option<String>,
+}
+
 /// A single PR CI check.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct CheckState {
@@ -140,6 +150,9 @@ pub(crate) trait ScmProvider: Send + Sync {
     ) -> anyhow::Result<Vec<PrSummary>>;
     /// `gh pr merge …` — the only WRITE (site 3).
     fn pr_merge(&self, repo: &str, pr: u64, opts: &MergeOpts) -> anyhow::Result<MergeOutcome>;
+    /// `gh issue view <number> --json <fields>` → one issue (#2061 task-sweep
+    /// `stale_open`: resolve whether a referenced issue is CLOSED/terminal).
+    fn issue_view(&self, repo: &str, number: u64, fields: &[&str]) -> anyhow::Result<IssueSummary>;
 }
 
 // ---------------------------------------------------------------------------
@@ -230,6 +243,18 @@ fn pr_merge_args(repo: &str, pr: u64, opts: &MergeOpts) -> Vec<String> {
     a
 }
 
+fn issue_view_args(repo: &str, number: u64, fields: &[&str]) -> Vec<String> {
+    vec![
+        "issue".into(),
+        "view".into(),
+        number.to_string(),
+        "--repo".into(),
+        repo.into(),
+        "--json".into(),
+        fields.join(","),
+    ]
+}
+
 // ---------------------------------------------------------------------------
 // parsers — pure + unit-tested. All gh-schema knowledge lives here, never
 // in the call sites.
@@ -263,6 +288,14 @@ fn parse_pr_summary(v: &Value) -> PrSummary {
                 .filter_map(|f| f["path"].as_str().map(String::from))
                 .collect()
         }),
+    }
+}
+
+/// Parse one `gh issue view --json …` JSON object into an [`IssueSummary`].
+fn parse_issue_summary(v: &Value) -> IssueSummary {
+    IssueSummary {
+        number: v["number"].as_u64().unwrap_or(0),
+        state: v["state"].as_str().map(String::from),
     }
 }
 
@@ -372,6 +405,19 @@ impl ScmProvider for GitHubScmProvider {
             })
         }
     }
+
+    fn issue_view(&self, repo: &str, number: u64, fields: &[&str]) -> anyhow::Result<IssueSummary> {
+        let out = Self::run(&issue_view_args(repo, number, fields), None)?;
+        if !out.status.success() {
+            anyhow::bail!(
+                "gh issue view #{number} ({repo}) exited {}: {}",
+                out.status,
+                String::from_utf8_lossy(&out.stderr).trim()
+            );
+        }
+        let v: Value = serde_json::from_slice(&out.stdout)?;
+        Ok(parse_issue_summary(&v))
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -410,6 +456,14 @@ macro_rules! not_supported_provider {
                 _pr: u64,
                 _opts: &MergeOpts,
             ) -> anyhow::Result<MergeOutcome> {
+                Err(NotSupported($kind).into())
+            }
+            fn issue_view(
+                &self,
+                _repo: &str,
+                _number: u64,
+                _fields: &[&str],
+            ) -> anyhow::Result<IssueSummary> {
                 Err(NotSupported($kind).into())
             }
         }
@@ -718,7 +772,36 @@ mod tests {
         );
     }
 
+    #[test]
+    fn issue_view_args_match_gh_issue_view_call() {
+        // #2061 task-sweep stale_open: `gh issue view <n> --repo R --json state`.
+        assert_eq!(
+            issue_view_args("suzuke/agend-terminal", 2061, &["state"]),
+            vec![
+                "issue",
+                "view",
+                "2061",
+                "--repo",
+                "suzuke/agend-terminal",
+                "--json",
+                "state",
+            ]
+        );
+    }
+
     // ---- parsers ----
+
+    #[test]
+    fn parse_issue_summary_reads_state() {
+        let closed = parse_issue_summary(&serde_json::json!({"number": 2061, "state": "CLOSED"}));
+        assert_eq!(closed.number, 2061);
+        assert_eq!(closed.state.as_deref(), Some("CLOSED"));
+        let open = parse_issue_summary(&serde_json::json!({"number": 7, "state": "OPEN"}));
+        assert_eq!(open.state.as_deref(), Some("OPEN"));
+        // Absent state stays None (caller treats as Unknown → not terminal).
+        let bare = parse_issue_summary(&serde_json::json!({"number": 1}));
+        assert_eq!(bare.state, None);
+    }
 
     #[test]
     fn parse_pr_summary_reads_present_fields() {

--- a/src/tasks/handler.rs
+++ b/src/tasks/handler.rs
@@ -812,8 +812,15 @@ fn handle_sweep(home: &Path, args: &Value) -> Value {
     .unwrap_or_default();
     let now = chrono::Utc::now();
     let pr_lookup: super::sweep::PrLookup = &super::sweep::gh_pr_lookup;
-    let categories =
-        super::sweep::scan_categories(home, &live_instances, pr_lookup, repo_owned.as_deref(), now);
+    let issue_lookup: super::sweep::IssueLookup = &super::sweep::gh_issue_lookup;
+    let categories = super::sweep::scan_categories(
+        home,
+        &live_instances,
+        pr_lookup,
+        issue_lookup,
+        repo_owned.as_deref(),
+        now,
+    );
     if !apply {
         return serde_json::json!({
             "dry_run": true,

--- a/src/tasks/sweep.rs
+++ b/src/tasks/sweep.rs
@@ -45,6 +45,37 @@ pub(super) fn gh_pr_lookup(repo: &str, num: u32) -> Result<PrState, String> {
     })
 }
 
+/// State of an issue referenced by a task title/description (#2061
+/// `stale_open`). Only the terminal-vs-live distinction matters.
+#[derive(Debug, Clone, PartialEq)]
+pub(super) enum IssueState {
+    /// Issue is closed — terminal.
+    Closed,
+    /// Issue is still open — task may still be in flight.
+    Open,
+    /// Issue doesn't exist or query failed — treat as possibly-live (skip).
+    Unknown,
+}
+
+/// Function-pointer abstraction over `gh issue view` (mirrors [`PrLookup`]).
+/// Tests inject a stub; production uses [`gh_issue_lookup`].
+pub(super) type IssueLookup<'a> = &'a dyn Fn(&str, u32) -> Result<IssueState, String>;
+
+/// Production issue-state lookup via [`crate::scm::ScmProvider`] (mirrors
+/// [`gh_pr_lookup`]). A non-zero exit / parse failure surfaces as `Err`; the
+/// sole caller maps that to [`IssueState::Unknown`] (never abort the sweep).
+pub(super) fn gh_issue_lookup(repo: &str, num: u32) -> Result<IssueState, String> {
+    let summary = crate::scm::make_scm_provider(repo, None)
+        .issue_view(repo, num as u64, &["state"])
+        .map_err(|e| e.to_string())?;
+    Ok(match summary.state.as_deref() {
+        // CLOSED covers both COMPLETED and NOT_PLANNED — either way terminal.
+        Some("CLOSED") => IssueState::Closed,
+        Some("OPEN") => IssueState::Open,
+        _ => IssueState::Unknown,
+    })
+}
+
 #[derive(Debug, Clone, serde::Serialize)]
 pub(super) struct Candidate {
     pub id: String,
@@ -59,6 +90,9 @@ pub(super) struct Categories {
     pub superseded: Vec<Candidate>,
     pub team_disbanded: Vec<Candidate>,
     pub validation_leftovers: Vec<Candidate>,
+    /// #2061: open/backlog tasks whose referenced issue/PR are ALL terminal,
+    /// or which carry no ref and are >14d stale.
+    pub stale_open: Vec<Candidate>,
 }
 
 impl Categories {
@@ -69,6 +103,7 @@ impl Categories {
             .chain(self.superseded.iter())
             .chain(self.team_disbanded.iter())
             .chain(self.validation_leftovers.iter())
+            .chain(self.stale_open.iter())
             .map(|c| c.id.clone())
             .collect();
         v.sort();
@@ -86,15 +121,17 @@ impl Categories {
             "superseded": self.superseded,
             "team_disbanded": self.team_disbanded,
             "validation_leftovers": self.validation_leftovers,
+            "stale_open": self.stale_open,
         })
     }
 }
 
-/// Scan the task board and bucket non-terminal tasks into the 4
+/// Scan the task board and bucket non-terminal tasks into the 5
 /// hygiene categories. Tasks already in `done`/`cancelled`/
 /// `verified` are skipped — they're already cleaned up. Each task
 /// lands in at most one category (first match wins, order:
-/// validation_leftovers → team_disbanded → shipped/superseded).
+/// validation_leftovers → team_disbanded → shipped/superseded →
+/// stale_open).
 ///
 /// `now` is parameterized so tests can fast-forward age thresholds
 /// without forging event-log timestamps.
@@ -102,12 +139,14 @@ pub(super) fn scan_categories(
     home: &Path,
     live_instances: &HashSet<String>,
     pr_lookup: PrLookup,
+    issue_lookup: IssueLookup,
     repo: Option<&str>,
     now: DateTime<Utc>,
 ) -> Categories {
     let tasks = list_all(home);
     let mut cats = Categories::default();
     let mut pr_cache: HashMap<u32, PrState> = HashMap::new();
+    let mut issue_cache: HashMap<u32, IssueState> = HashMap::new();
     for t in &tasks {
         if matches!(
             t.status,
@@ -155,41 +194,110 @@ pub(super) fn scan_categories(
                 continue;
             }
         }
-        // (3) shipped / (4) superseded — extract PR ref + query.
-        let Some(repo) = repo else { continue };
         let search_text = format!("{}\n{}", t.title, t.description);
-        let Some(pr_num) = extract_pr_number(&search_text) else {
-            continue;
-        };
-        let state = pr_cache
-            .entry(pr_num)
-            .or_insert_with(|| pr_lookup(repo, pr_num).unwrap_or(PrState::Unknown))
-            .clone();
-        match state {
-            PrState::Merged { merged_at } => {
-                if let Some(a) = age {
-                    if a > Duration::days(7) {
-                        cats.shipped.push(Candidate {
+        // (3) shipped / (4) superseded — first PR ref + query. Unchanged
+        // predicates; only a `continue` is added after each push so an
+        // already-bucketed task is not re-examined by the new stale_open arm
+        // below (behaviour-identical: the loop body ended here previously).
+        if let Some(repo) = repo {
+            if let Some(pr_num) = extract_pr_number(&search_text) {
+                let state = pr_cache
+                    .entry(pr_num)
+                    .or_insert_with(|| pr_lookup(repo, pr_num).unwrap_or(PrState::Unknown))
+                    .clone();
+                match state {
+                    PrState::Merged { merged_at } => {
+                        if let Some(a) = age {
+                            if a > Duration::days(7) {
+                                cats.shipped.push(Candidate {
+                                    id: t.id.clone(),
+                                    reason: format!(
+                                        "PR #{pr_num} merged at {merged_at}, task {}d stale",
+                                        a.num_days()
+                                    ),
+                                    owner: t.assignee.clone(),
+                                    pr: Some(pr_num),
+                                });
+                                continue;
+                            }
+                        }
+                    }
+                    PrState::Closed => {
+                        cats.superseded.push(Candidate {
                             id: t.id.clone(),
-                            reason: format!(
-                                "PR #{pr_num} merged at {merged_at}, task {}d stale",
-                                a.num_days()
-                            ),
+                            reason: format!("PR #{pr_num} closed without merge"),
                             owner: t.assignee.clone(),
                             pr: Some(pr_num),
+                        });
+                        continue;
+                    }
+                    PrState::Open | PrState::Unknown => {}
+                }
+            }
+        }
+        // (5) stale_open (#2061) — OPEN/Backlog tasks the shipped/superseded
+        // arms didn't claim. Conservative (under-report): flag ONLY when EVERY
+        // referenced issue/PR resolves terminal, OR there is no ref and the
+        // task is >14d stale. Any non-terminal/unknown ref disqualifies the
+        // whole task. Operator-gated downstream (dry-run + confirm_ids).
+        if !matches!(
+            t.status,
+            crate::task_events::TaskStatus::Open | crate::task_events::TaskStatus::Backlog
+        ) {
+            continue;
+        }
+        let refs = extract_refs(&search_text);
+        if refs.is_empty() {
+            // No PARSEABLE #N / PR #N ref. Take the age-only fallback ONLY when
+            // the task is GENUINELY ref-less (`!saw_token`): no #N / PR #N token
+            // and no GitHub issue|pull URL at all. If a token IS present but
+            // unverifiable here — an unparseable (overflowing) #N, or an
+            // issue/PR named only by URL (which #2061 does not resolve) — the
+            // task references work we cannot confirm is done, so do NOT
+            // age-flag it; skip conservatively (better to MISS than to surface a
+            // live ref-bearing task).
+            if !refs.saw_token {
+                if let Some(a) = age {
+                    if a > Duration::days(14) {
+                        cats.stale_open.push(Candidate {
+                            id: t.id.clone(),
+                            reason: format!("no PR/issue ref, open {}d stale", a.num_days()),
+                            owner: t.assignee.clone(),
+                            pr: None,
                         });
                     }
                 }
             }
-            PrState::Closed => {
-                cats.superseded.push(Candidate {
-                    id: t.id.clone(),
-                    reason: format!("PR #{pr_num} closed without merge"),
-                    owner: t.assignee.clone(),
-                    pr: Some(pr_num),
-                });
-            }
-            PrState::Open | PrState::Unknown => {}
+            continue;
+        }
+        // Has >=1 parseable ref → every one must resolve terminal. (A merged-PR
+        // open task is flagged regardless of the shipped arm's 7d grace: that
+        // grace governs the `shipped` category; for stale_open an all-terminal
+        // ref means the work is done.) Without a repo we cannot verify → skip.
+        let Some(repo) = repo else { continue };
+        let all_terminal = refs.pr_nums.iter().all(|&n| {
+            matches!(
+                pr_cache
+                    .entry(n)
+                    .or_insert_with(|| pr_lookup(repo, n).unwrap_or(PrState::Unknown)),
+                PrState::Merged { .. } | PrState::Closed
+            )
+        }) && refs.issue_nums.iter().all(|&n| {
+            *issue_cache
+                .entry(n)
+                .or_insert_with(|| issue_lookup(repo, n).unwrap_or(IssueState::Unknown))
+                == IssueState::Closed
+        });
+        if all_terminal {
+            cats.stale_open.push(Candidate {
+                id: t.id.clone(),
+                reason: format!(
+                    "all referenced issue/PR terminal (PR {:?}, issue {:?})",
+                    refs.pr_nums, refs.issue_nums
+                ),
+                owner: t.assignee.clone(),
+                pr: refs.pr_nums.first().copied(),
+            });
         }
     }
     cats
@@ -204,6 +312,67 @@ fn extract_pr_number(text: &str) -> Option<u32> {
     re.captures(text)
         .and_then(|c| c.get(1))
         .and_then(|m| m.as_str().parse::<u32>().ok())
+}
+
+/// All issue/PR references in a haystack, for the #2061 stale_open
+/// ALL-quantifier check. PR refs use the same strict `PR #?N` form as
+/// [`extract_pr_number`]; issue refs are bare `#N` MINUS any number already
+/// captured as a PR (so `PR #12` is counted once, as a PR). De-duplicated.
+///
+/// `saw_token` records whether the text contained ANY recognised reference
+/// token — a `#N` / `PR #N`, or a GitHub `/issues/N` / `/pull/N` URL —
+/// INCLUDING tokens we could not turn into a verifiable number (an
+/// absurdly-large `#N` that overflows, or an issue/PR named only by URL, which
+/// #2061 deliberately does not resolve). It distinguishes a *genuinely* ref-less
+/// task (eligible for the no-ref age-only fallback) from one that references
+/// work we cannot fully verify (which must NOT be age-flagged — see
+/// [`scan_categories`]). This is what keeps the sweep conservative: an
+/// unrecognised/unparseable ref makes the sweep MISS a candidate (skip), never
+/// wrongly age-flag a live ref-bearing task.
+#[derive(Debug, Default, PartialEq)]
+struct Refs {
+    pr_nums: Vec<u32>,
+    issue_nums: Vec<u32>,
+    saw_token: bool,
+}
+
+fn extract_refs(text: &str) -> Refs {
+    static PR_RE: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
+    static ISSUE_RE: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
+    static URL_RE: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
+    let pr_re = PR_RE.get_or_init(|| regex::Regex::new(r"\bPR #?(\d+)\b").expect("pr regex"));
+    let issue_re = ISSUE_RE.get_or_init(|| regex::Regex::new(r"#(\d+)\b").expect("issue regex"));
+    let url_re =
+        URL_RE.get_or_init(|| regex::Regex::new(r"/(?:issues|pull)/\d+").expect("url regex"));
+    let mut pr_nums: Vec<u32> = pr_re
+        .captures_iter(text)
+        .filter_map(|c| c.get(1).and_then(|m| m.as_str().parse::<u32>().ok()))
+        .collect();
+    pr_nums.sort_unstable();
+    pr_nums.dedup();
+    let mut issue_nums: Vec<u32> = issue_re
+        .captures_iter(text)
+        .filter_map(|c| c.get(1).and_then(|m| m.as_str().parse::<u32>().ok()))
+        .filter(|n| !pr_nums.contains(n))
+        .collect();
+    issue_nums.sort_unstable();
+    issue_nums.dedup();
+    // Token PRESENCE is regex-match (not parse): a `#N` that overflows u32, or a
+    // URL we don't resolve, still means the task references work — so it must
+    // not look ref-less. GitHub numbers fit u32, so a `#N` that fails to parse
+    // is malformed/unverifiable, not a smaller real ref.
+    let saw_token = pr_re.is_match(text) || issue_re.is_match(text) || url_re.is_match(text);
+    Refs {
+        pr_nums,
+        issue_nums,
+        saw_token,
+    }
+}
+
+impl Refs {
+    fn is_empty(&self) -> bool {
+        self.pr_nums.is_empty() && self.issue_nums.is_empty()
+    }
 }
 
 /// Apply phase — emit `Cancelled` events for the `confirm_ids`
@@ -230,6 +399,9 @@ pub(super) fn emit_cancelled_batch(
         }
         if categories.team_disbanded.iter().any(|c| c.id == id) {
             return "team_disbanded";
+        }
+        if categories.stale_open.iter().any(|c| c.id == id) {
+            return "stale_open";
         }
         "validation_leftovers"
     };

--- a/src/tasks/tests.rs
+++ b/src/tasks/tests.rs
@@ -2582,6 +2582,17 @@ fn stub_pr_lookup(repo: &str, num: u32) -> Result<sweep::PrState, String> {
     }
 }
 
+/// Stub issue lookup for #2061 stale_open sweep tests — bypasses
+/// `gh issue view`. 100 = open (in-flight → must NOT flag), 101 = closed
+/// (terminal → flaggable); anything else = Unknown (non-terminal → must NOT flag).
+fn stub_issue_lookup(repo: &str, num: u32) -> Result<sweep::IssueState, String> {
+    match (repo, num) {
+        ("test/repo", 100) => Ok(sweep::IssueState::Open),
+        ("test/repo", 101) => Ok(sweep::IssueState::Closed),
+        _ => Ok(sweep::IssueState::Unknown),
+    }
+}
+
 #[test]
 fn test_sweep_scan_identifies_team_disbanded_category() {
     // GREEN 2: scan_categories puts tasks owned by instances NOT
@@ -2599,7 +2610,7 @@ fn test_sweep_scan_identifies_team_disbanded_category() {
     let task_id = r["id"].as_str().expect("id").to_string();
     let live: std::collections::HashSet<String> = ["alive".to_string()].into_iter().collect();
     let now = chrono::Utc::now() + chrono::Duration::days(60);
-    let cats = sweep::scan_categories(&home, &live, &stub_pr_lookup, None, now);
+    let cats = sweep::scan_categories(&home, &live, &stub_pr_lookup, &stub_issue_lookup, None, now);
     assert_eq!(
         cats.team_disbanded.len(),
         1,
@@ -2637,7 +2648,14 @@ fn test_sweep_scan_identifies_shipped_via_pr_lookup_stub() {
     // the 30d team_disbanded threshold (which wouldn't fire
     // anyway because owner is alive).
     let now = chrono::Utc::now() + chrono::Duration::days(14);
-    let cats = sweep::scan_categories(&home, &live, &stub_pr_lookup, Some("test/repo"), now);
+    let cats = sweep::scan_categories(
+        &home,
+        &live,
+        &stub_pr_lookup,
+        &stub_issue_lookup,
+        Some("test/repo"),
+        now,
+    );
     assert_eq!(
         cats.shipped.len(),
         1,
@@ -2738,7 +2756,7 @@ fn test_sweep_apply_emits_cancelled_and_logs_audit() {
     let task_id = r["id"].as_str().expect("id").to_string();
     let live: std::collections::HashSet<String> = ["alive".to_string()].into_iter().collect();
     let now = chrono::Utc::now() + chrono::Duration::days(60);
-    let cats = sweep::scan_categories(&home, &live, &stub_pr_lookup, None, now);
+    let cats = sweep::scan_categories(&home, &live, &stub_pr_lookup, &stub_issue_lookup, None, now);
     assert_eq!(cats.team_disbanded.len(), 1);
     let confirm: std::collections::HashSet<String> = [task_id.clone()].into_iter().collect();
     let count = sweep::emit_cancelled_batch(&home, &cats, &confirm, "post-#806 sweep test fixture")
@@ -2759,6 +2777,245 @@ fn test_sweep_apply_emits_cancelled_and_logs_audit() {
     assert!(
         log.contains("post-#806 sweep test fixture"),
         "event-log.jsonl must carry the audit_reason"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+// ── #2061 stale_open category ──
+
+/// Create one Open task owned by a LIVE agent (so team_disbanded never fires)
+/// and return its id. `title` carries any issue/PR ref.
+fn create_open_task(home: &Path, title: &str) -> String {
+    let r = handle(
+        home,
+        "alive",
+        &serde_json::json!({"action": "create", "title": title, "assignee": "alive"}),
+    );
+    r["id"].as_str().expect("id").to_string()
+}
+
+#[test]
+fn test_sweep_stale_open_all_refs_terminal_flagged() {
+    // #2061: an open task whose only referenced issue is CLOSED (terminal)
+    // lands in stale_open. (#101 → Closed in stub_issue_lookup.)
+    let home = tmp_home("sweep_stale_terminal");
+    write_fleet_yaml(&home, &["alive"]);
+    let id = create_open_task(&home, "follow-up for #101");
+    let live: std::collections::HashSet<String> = ["alive".to_string()].into_iter().collect();
+    let now = chrono::Utc::now() + chrono::Duration::days(2);
+    let cats = sweep::scan_categories(
+        &home,
+        &live,
+        &stub_pr_lookup,
+        &stub_issue_lookup,
+        Some("test/repo"),
+        now,
+    );
+    assert!(
+        cats.stale_open.iter().any(|c| c.id == id),
+        "task with an all-terminal issue ref must be flagged stale_open, got {cats:?}"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn test_sweep_stale_open_open_ref_not_flagged() {
+    // #2061 conservative bias: an OPEN referenced issue means the task may be
+    // in flight — must NOT flag even when very old. (#100 → Open.)
+    let home = tmp_home("sweep_stale_openref");
+    write_fleet_yaml(&home, &["alive"]);
+    let id = create_open_task(&home, "blocked on #100");
+    let live: std::collections::HashSet<String> = ["alive".to_string()].into_iter().collect();
+    let now = chrono::Utc::now() + chrono::Duration::days(60);
+    let cats = sweep::scan_categories(
+        &home,
+        &live,
+        &stub_pr_lookup,
+        &stub_issue_lookup,
+        Some("test/repo"),
+        now,
+    );
+    assert!(
+        !cats.all_ids().contains(&id),
+        "task with an OPEN issue ref must NOT be flagged (in flight), got {cats:?}"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn test_sweep_stale_open_no_ref_old_flagged() {
+    // #2061: a ref-less open task >14d stale lands in stale_open. Fires even
+    // with NO repo (the no-ref fallback needs no GitHub query).
+    let home = tmp_home("sweep_stale_noref_old");
+    write_fleet_yaml(&home, &["alive"]);
+    let id = create_open_task(&home, "plain stale task no refs");
+    let live: std::collections::HashSet<String> = ["alive".to_string()].into_iter().collect();
+    let now = chrono::Utc::now() + chrono::Duration::days(15);
+    let cats = sweep::scan_categories(&home, &live, &stub_pr_lookup, &stub_issue_lookup, None, now);
+    assert!(
+        cats.stale_open.iter().any(|c| c.id == id),
+        "ref-less open task >14d must be flagged stale_open (no repo needed), got {cats:?}"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn test_sweep_stale_open_no_ref_fresh_not_flagged() {
+    // #2061: a ref-less open task <14d must NOT be flagged.
+    let home = tmp_home("sweep_stale_noref_fresh");
+    write_fleet_yaml(&home, &["alive"]);
+    let id = create_open_task(&home, "plain fresh task no refs");
+    let live: std::collections::HashSet<String> = ["alive".to_string()].into_iter().collect();
+    let now = chrono::Utc::now() + chrono::Duration::days(13);
+    let cats = sweep::scan_categories(&home, &live, &stub_pr_lookup, &stub_issue_lookup, None, now);
+    assert!(
+        !cats.all_ids().contains(&id),
+        "ref-less open task <14d must NOT be flagged, got {cats:?}"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn test_sweep_stale_open_mixed_ref_not_flagged() {
+    // #2061 ALL-quantifier (load-bearing conservative bias): one closed (#101)
+    // + one OPEN (#100) ref — the open ref disqualifies the WHOLE task even
+    // though another ref is terminal.
+    let home = tmp_home("sweep_stale_mixed");
+    write_fleet_yaml(&home, &["alive"]);
+    let id = create_open_task(&home, "done with #101 but still #100");
+    let live: std::collections::HashSet<String> = ["alive".to_string()].into_iter().collect();
+    let now = chrono::Utc::now() + chrono::Duration::days(30);
+    let cats = sweep::scan_categories(
+        &home,
+        &live,
+        &stub_pr_lookup,
+        &stub_issue_lookup,
+        Some("test/repo"),
+        now,
+    );
+    assert!(
+        !cats.all_ids().contains(&id),
+        "ANY non-terminal ref must disqualify the whole task, got {cats:?}"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn test_sweep_stale_open_unknown_ref_not_flagged() {
+    // #2061: an unresolvable ref (#404 → Unknown, e.g. gh query failed / bogus
+    // number) is treated as possibly-live → must NOT flag (fail safe).
+    let home = tmp_home("sweep_stale_unknown");
+    write_fleet_yaml(&home, &["alive"]);
+    let id = create_open_task(&home, "see #404");
+    let live: std::collections::HashSet<String> = ["alive".to_string()].into_iter().collect();
+    let now = chrono::Utc::now() + chrono::Duration::days(30);
+    let cats = sweep::scan_categories(
+        &home,
+        &live,
+        &stub_pr_lookup,
+        &stub_issue_lookup,
+        Some("test/repo"),
+        now,
+    );
+    assert!(
+        !cats.all_ids().contains(&id),
+        "an Unknown (unresolvable) ref must NOT be flagged (fail safe), got {cats:?}"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn test_sweep_stale_open_apply_labels_category() {
+    // #2061: the apply leg labels a stale_open candidate correctly (NOT the
+    // bare validation_leftovers fallback) in both the Cancelled.reason and the
+    // task_sweep_apply audit line.
+    let home = tmp_home("sweep_stale_apply");
+    write_fleet_yaml(&home, &["alive"]);
+    let id = create_open_task(&home, "ref-less stale task to cancel");
+    let live: std::collections::HashSet<String> = ["alive".to_string()].into_iter().collect();
+    let now = chrono::Utc::now() + chrono::Duration::days(20);
+    let cats = sweep::scan_categories(&home, &live, &stub_pr_lookup, &stub_issue_lookup, None, now);
+    assert!(
+        cats.stale_open.iter().any(|c| c.id == id),
+        "precondition: task must be a stale_open candidate, got {cats:?}"
+    );
+    let confirm: std::collections::HashSet<String> = [id.clone()].into_iter().collect();
+    let count = sweep::emit_cancelled_batch(&home, &cats, &confirm, "stale_open sweep test")
+        .expect("emit_cancelled_batch");
+    assert_eq!(count, 1);
+    let log = std::fs::read_to_string(home.join("event-log.jsonl")).unwrap_or_default();
+    assert!(
+        log.contains("category=stale_open"),
+        "audit line must label the category stale_open (not the fallback), got: {log}"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn test_sweep_stale_open_overflow_ref_token_not_flagged() {
+    // #2061 conservative bias: a `#N` token that overflows u32 is present-but-
+    // unparseable. It must NOT make the task look ref-less and get age-flagged
+    // (the task DOES reference work); it is skipped (saw_token, no parseable ref).
+    let home = tmp_home("sweep_stale_overflow");
+    write_fleet_yaml(&home, &["alive"]);
+    let id = create_open_task(&home, "tracking upstream #99999999999999999999");
+    let live: std::collections::HashSet<String> = ["alive".to_string()].into_iter().collect();
+    let now = chrono::Utc::now() + chrono::Duration::days(20);
+    let cats = sweep::scan_categories(&home, &live, &stub_pr_lookup, &stub_issue_lookup, None, now);
+    assert!(
+        !cats.all_ids().contains(&id),
+        "an unparseable (overflow) #N ref must NOT be age-flagged as ref-less, got {cats:?}"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn test_sweep_stale_open_url_ref_not_flagged() {
+    // #2061 conservative bias: an issue named only by GitHub URL (no `#N`) is a
+    // reference — must NOT be treated as ref-less and age-flagged. Skipped
+    // (saw_token via the URL, no parseable ref to verify).
+    let home = tmp_home("sweep_stale_url");
+    write_fleet_yaml(&home, &["alive"]);
+    let id = create_open_task(
+        &home,
+        "see https://github.com/suzuke/agend-terminal/issues/1234",
+    );
+    let live: std::collections::HashSet<String> = ["alive".to_string()].into_iter().collect();
+    let now = chrono::Utc::now() + chrono::Duration::days(20);
+    let cats = sweep::scan_categories(&home, &live, &stub_pr_lookup, &stub_issue_lookup, None, now);
+    assert!(
+        !cats.all_ids().contains(&id),
+        "an issue referenced only by URL must NOT be age-flagged as ref-less, got {cats:?}"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn test_sweep_stale_open_merged_pr_fresh_flagged() {
+    // #2061: an Open task whose merged PR ref is younger than the shipped 7d
+    // grace still lands in stale_open (all-terminal ⇒ done). Pins that the
+    // shipped arm's `continue` does NOT fire for age<7d, and that stale_open has
+    // no age gate on the all-terminal path. (PR #999 = Merged in stub.)
+    let home = tmp_home("sweep_stale_merged_fresh");
+    write_fleet_yaml(&home, &["alive"]);
+    let id = create_open_task(&home, "PR #999 landed, wrapping up");
+    let live: std::collections::HashSet<String> = ["alive".to_string()].into_iter().collect();
+    let now = chrono::Utc::now() + chrono::Duration::days(3);
+    let cats = sweep::scan_categories(
+        &home,
+        &live,
+        &stub_pr_lookup,
+        &stub_issue_lookup,
+        Some("test/repo"),
+        now,
+    );
+    assert!(
+        cats.shipped.is_empty(),
+        "shipped must NOT fire under its 7d grace, got {cats:?}"
+    );
+    assert!(
+        cats.stale_open.iter().any(|c| c.id == id),
+        "merged-PR open task must land in stale_open regardless of shipped grace, got {cats:?}"
     );
     std::fs::remove_dir_all(&home).ok();
 }


### PR DESCRIPTION
## Problem (#2061)

The operator found **76 rotting tasks** the 4 existing `task action=sweep` categories miss. shipped/superseded only parse `PR #NNN` (strict `\bPR #?\d+\b`), but bug-hunt dispatch tasks reference an **issue** `#NNN` — and `src/tasks/` had no issue-state lookup at all. `#1201 lifecycle_pass` (auto-cancel of Open + owner.none + 14d) also misses them.

## Fix

Add a 5th **operator-triggered** sweep category `stale_open`: an **Open/Backlog** task is flagged when **either**
- every referenced issue/PR resolves **GitHub-terminal** (issue CLOSED, PR MERGED/CLOSED), **or**
- it carries **no reference token** and is **>14d stale**.

**Conservative under-report bias** (never wrongly flag a live task):
- ALL-quantifier — **any** non-terminal ref disqualifies the whole task.
- A gh-query failure / unresolvable ref → `Unknown` → non-terminal → skip.
- A task that references work via an **unparseable `#N`** (overflow) or a **bare GitHub issues/pull URL** is treated as ref-bearing and **skipped**, never age-flagged. A recognised-but-unverified ref can only make the sweep **MISS** a candidate, never surface a live one. (Gated by `extract_refs.saw_token`.)

### Layers
- **scm**: new `ScmProvider::issue_view` (`gh issue view --json state`) + `GitHubScmProvider` impl + `NotSupported` macro stub + pure `issue_view_args`/`parse_issue_summary` (unit-pinned). Sweep consumes it via a `gh_issue_lookup`/`IssueLookup` fn-pointer seam **mirroring the existing `gh_pr_lookup`/`PrLookup`** — so tests stub the fn pointer, no trait mock.
- **sweep**: `stale_open` branch in `scan_categories`, placed **after** the shipped/superseded arms (which now `continue` after pushing — behaviour-identical; the loop body ended there). The no-ref fallback is reachable when `repo` is `None`. `Categories.stale_open` wired into `all_ids`/`as_json` + `emit_cancelled_batch`'s `lookup_category`.
- Rails preserved: dry-run / `confirm_ids` / `audit_reason` (handler only threads the new lookup). tool desc `4 → 5` categories.

## Verification

- `cargo fmt --check` ✓, `cargo clippy --all-targets --features tray -D warnings` ✓
- `cargo nextest run --features tray --no-fail-fast`: **4139/4140 pass**; the 1 failure is the pre-existing env-mutually-exclusive `dispatch_branch_..._1834` (needs `AGEND_GIT_BYPASS=1`, confirmed passing under it) — unrelated.
- **Mutation-verified** (ultracode adversarial bar): the ALL-quantifier (`.all()→.any()`) and the `saw_token` gate (overflow/URL) both confirmed RED without the guard.
- Reviewed via a **4-lens adversarial workflow** (spec / no-regression / conservative-bias / scope+rails, 8 agents). The conservative-bias finding (dropped ref tokens → wrong age-flag) is the `saw_token` fix above; all other lenses clean.
- Rebased onto current `origin/main` (ed17632, #2099/#2108) — net diff is exactly the 5 files below.

### Tests (`src/tasks/tests.rs`, stubbed lookup)
all-terminal→flag · open-ref→NOT · no-ref+>14d→flag · no-ref+<14d→NOT · mixed(open+closed)→NOT · unknown-ref→NOT · overflow-`#N`→NOT · URL-only-ref→NOT · merged-PR-<7d→flag · apply-leg labels `stale_open`. Plus scm `issue_view_args`/`parse_issue_summary` pins.

## Scope

Only the new category + `issue_view` + wiring + tests. The existing 4 category predicates, `#1201 lifecycle_pass`, and `daemon/task_sweep` are untouched.

Fixes #2061.