### PR TITLE
fix(#2107): re-align existing branch to from_ref (ff-only) in ensure_branch_exists

### DIFF
--- a/src/mcp/handlers/dispatch_hook/mod.rs
+++ b/src/mcp/handlers/dispatch_hook/mod.rs
@@ -797,6 +797,56 @@ pub(crate) fn ensure_branch_exists(
                 source,
                 &["update-ref", &branch_ref, &remote_branch_ref],
             );
+        } else {
+            // #2107 (cheerc production repro): origin/<branch> is absent, so the
+            // #869 fast-forward above can't apply and `from_ref` was previously
+            // DEAD CODE on the branch-exists path — an existing branch stayed on
+            // its stale creation base even when the caller asked for a different
+            // `from_ref` (`repo checkout from_ref=origin/dev` landed on
+            // origin/main). Re-align the local ref to `from_ref`.
+            //
+            // FAST-FORWARD-ONLY (the load-bearing safety decision): re-align only
+            // when the current branch tip is an ANCESTOR of from_ref, so a
+            // divergent branch with unpushed work — e.g. an in-flight dispatch
+            // branch combined with the default `from_ref=origin/main` — is left
+            // untouched and never clobbered. A hard rebase of a divergent branch
+            // would need explicit force semantics and is deliberately out of
+            // scope. This also keeps every existing caller byte-identical: they
+            // pass `from_ref=origin/main` for a branch already at origin/main, so
+            // the ff is a no-op (the pre-#2107 "leave local untouched" contract).
+            //
+            // Refresh from_ref's remote ref first (mirrors the #1755 pre-create
+            // fetch) so the re-align lands on the current base, not a stale local
+            // copy. All steps best-effort; the returned `fetched_ok` stays the
+            // #869 working-branch fetch result (this from_ref fetch is internal).
+            if let Some(rb) = from_ref_branch.as_deref() {
+                let _ = crate::git_helpers::git_bypass_timeout(
+                    source,
+                    &["fetch", &remote, rb, "--quiet"],
+                    crate::git_helpers::NETWORK_GIT_TIMEOUT,
+                );
+            }
+            let ff_safe = crate::git_helpers::git_bypass(
+                source,
+                &["merge-base", "--is-ancestor", &branch_ref, from_ref],
+            )
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+            if ff_safe {
+                if let Ok(o) =
+                    crate::git_helpers::git_bypass(source, &["rev-parse", "--verify", from_ref])
+                {
+                    if o.status.success() {
+                        let from_sha = String::from_utf8_lossy(&o.stdout).trim().to_string();
+                        if !from_sha.is_empty() {
+                            let _ = crate::git_helpers::git_bypass(
+                                source,
+                                &["update-ref", &branch_ref, &from_sha],
+                            );
+                        }
+                    }
+                }
+            }
         }
         return Ok((false, fetched_ok));
     }

--- a/src/mcp/handlers/dispatch_hook/tests.rs
+++ b/src/mcp/handlers/dispatch_hook/tests.rs
@@ -2525,6 +2525,213 @@ fn ensure_branch_exists_leaves_local_untouched_when_no_remote_ref() {
     std::fs::remove_dir_all(&home).ok();
 }
 
+/// #2107 (cheerc production repro): `repo checkout from_ref=origin/dev` when the
+/// branch ALREADY exists must re-align the local ref to from_ref, not leave it on
+/// the branch's stale creation base. RED before the fix (foo stays on
+/// origin/main). The re-align is FAST-FORWARD-ONLY — foo@main is an ancestor of
+/// origin/dev — so it never loses commits (see the divergent-clobber guard
+/// below). origin/<branch> is deliberately ABSENT so the #869 ff path can't
+/// apply and the from_ref re-align is the only thing that can move the ref.
+#[test]
+fn ensure_branch_exists_realigns_existing_branch_to_from_ref_2107() {
+    let home = std::env::temp_dir().join(format!(
+        "agend-2107-realign-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&home).ok();
+    let repo = setup_test_repo(&home, "dev-2107");
+    let bypass = |args: &[&str]| -> std::process::Output {
+        std::process::Command::new("git")
+            .args(args)
+            .current_dir(&repo)
+            .env("AGEND_GIT_BYPASS", "1")
+            .output()
+            .expect("git spawn")
+    };
+    // origin/main is at A (the initial commit). Build origin/dev one commit AHEAD
+    // at B (A is an ancestor of B), then put HEAD + the new branch back at A.
+    let sha_a = String::from_utf8(bypass(&["rev-parse", "HEAD"]).stdout)
+        .unwrap()
+        .trim()
+        .to_string();
+    std::fs::write(repo.join("dev.txt"), "dev-ahead").ok();
+    assert!(bypass(&["add", "dev.txt"]).status.success());
+    assert!(bypass(&[
+        "-c",
+        "user.name=test",
+        "-c",
+        "user.email=t@t",
+        "commit",
+        "-m",
+        "dev ahead"
+    ])
+    .status
+    .success());
+    let sha_b = String::from_utf8(bypass(&["rev-parse", "HEAD"]).stdout)
+        .unwrap()
+        .trim()
+        .to_string();
+    assert_ne!(sha_a, sha_b);
+    assert!(bypass(&["update-ref", "refs/remotes/origin/dev", &sha_b])
+        .status
+        .success());
+    assert!(bypass(&["reset", "--hard", &sha_a]).status.success());
+    let branch = "feat/2107-foo";
+    // foo created at A (== origin/main); origin/<branch> deliberately NOT populated.
+    assert!(bypass(&["branch", branch]).status.success());
+    assert_eq!(
+        String::from_utf8(bypass(&["rev-parse", &format!("refs/heads/{branch}")]).stdout)
+            .unwrap()
+            .trim(),
+        sha_a,
+        "precondition: branch starts on origin/main (A)"
+    );
+
+    let result = super::ensure_branch_exists(&home, &repo, branch, "origin/dev", "dev-2107");
+    assert!(result.is_ok(), "must succeed: {result:?}");
+
+    let post = String::from_utf8(bypass(&["rev-parse", &format!("refs/heads/{branch}")]).stdout)
+        .unwrap()
+        .trim()
+        .to_string();
+    assert_eq!(
+        post, sha_b,
+        "#2107: existing branch must re-align to from_ref (origin/dev @ B), not stay on its creation base (origin/main @ A)"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// #2107 clobber guard: the from_ref re-align is FAST-FORWARD-ONLY. A divergent
+/// existing branch (commits NOT in from_ref — e.g. an in-flight dev branch with
+/// unpushed work + the default `from_ref=origin/main`) must be left UNTOUCHED, so
+/// the fix can never destroy work. Here feat/x is one commit AHEAD of origin/main
+/// (not an ancestor), so the re-align must skip.
+#[test]
+fn ensure_branch_exists_does_not_clobber_divergent_branch_2107() {
+    let home = std::env::temp_dir().join(format!(
+        "agend-2107-noclobber-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&home).ok();
+    let repo = setup_test_repo(&home, "dev-2107-nc");
+    let bypass = |args: &[&str]| -> std::process::Output {
+        std::process::Command::new("git")
+            .args(args)
+            .current_dir(&repo)
+            .env("AGEND_GIT_BYPASS", "1")
+            .output()
+            .expect("git spawn")
+    };
+    let branch = "feat/2107-work";
+    // feat/x with a unique commit AHEAD of origin/main; origin/<branch> absent.
+    assert!(bypass(&["checkout", "-b", branch]).status.success());
+    std::fs::write(repo.join("work.txt"), "unpushed work").ok();
+    assert!(bypass(&["add", "work.txt"]).status.success());
+    assert!(bypass(&[
+        "-c",
+        "user.name=test",
+        "-c",
+        "user.email=t@t",
+        "commit",
+        "-m",
+        "unpushed work"
+    ])
+    .status
+    .success());
+    let work_sha =
+        String::from_utf8(bypass(&["rev-parse", &format!("refs/heads/{branch}")]).stdout)
+            .unwrap()
+            .trim()
+            .to_string();
+
+    // Default from_ref=origin/main (A). feat/x (work_sha) is NOT an ancestor of A.
+    let result = super::ensure_branch_exists(&home, &repo, branch, "origin/main", "dev-2107-nc");
+    assert!(result.is_ok(), "must succeed: {result:?}");
+
+    let post = String::from_utf8(bypass(&["rev-parse", &format!("refs/heads/{branch}")]).stdout)
+        .unwrap()
+        .trim()
+        .to_string();
+    assert_eq!(
+        post, work_sha,
+        "#2107: ff-only re-align must NOT clobber a divergent branch's unpushed work"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// #2107 companion: the branch-CREATE path already honors from_ref — pin it
+/// alongside the exists-path fix so BOTH paths assert HEAD == from_ref's SHA.
+#[test]
+fn ensure_branch_exists_create_path_uses_from_ref_2107() {
+    let home = std::env::temp_dir().join(format!(
+        "agend-2107-create-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&home).ok();
+    let repo = setup_test_repo(&home, "dev-2107-cr");
+    let bypass = |args: &[&str]| -> std::process::Output {
+        std::process::Command::new("git")
+            .args(args)
+            .current_dir(&repo)
+            .env("AGEND_GIT_BYPASS", "1")
+            .output()
+            .expect("git spawn")
+    };
+    // Build origin/dev ahead at B, then put HEAD back at A.
+    let sha_a = String::from_utf8(bypass(&["rev-parse", "HEAD"]).stdout)
+        .unwrap()
+        .trim()
+        .to_string();
+    std::fs::write(repo.join("dev.txt"), "dev-ahead").ok();
+    assert!(bypass(&["add", "dev.txt"]).status.success());
+    assert!(bypass(&[
+        "-c",
+        "user.name=test",
+        "-c",
+        "user.email=t@t",
+        "commit",
+        "-m",
+        "dev ahead"
+    ])
+    .status
+    .success());
+    let sha_b = String::from_utf8(bypass(&["rev-parse", "HEAD"]).stdout)
+        .unwrap()
+        .trim()
+        .to_string();
+    assert!(bypass(&["update-ref", "refs/remotes/origin/dev", &sha_b])
+        .status
+        .success());
+    assert!(bypass(&["reset", "--hard", &sha_a]).status.success());
+
+    let branch = "feat/2107-fresh"; // does NOT exist → create path
+    let result = super::ensure_branch_exists(&home, &repo, branch, "origin/dev", "dev-2107-cr");
+    assert!(result.is_ok(), "must succeed: {result:?}");
+    let (auto_created, _) = result.unwrap();
+    assert!(auto_created, "fresh branch must be auto-created");
+    let post = String::from_utf8(bypass(&["rev-parse", &format!("refs/heads/{branch}")]).stdout)
+        .unwrap()
+        .trim()
+        .to_string();
+    assert_eq!(
+        post, sha_b,
+        "#2107: create path must base the new branch on from_ref (origin/dev @ B)"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
 /// #869 protection: the new sync path must not interfere with the
 /// existing "branch doesn't exist locally → create from origin/main"
 /// flow. After the fix, dispatching a brand-new branch must still


### PR DESCRIPTION
## Bug (cheerc production repro, retro #50 F1)

`repo action=checkout from_ref=origin/dev` when the branch **already exists** left the worktree HEAD on the branch's stale creation base (tracking `origin/main`) instead of the requested `origin/dev` — the impl had to manually `git reset --hard origin/dev`.

## RCA

`ensure_branch_exists`'s branch-**exists** path only did the #869 `fetch` + `update-ref` against the branch's *own* `origin/<branch>` remote-tracking ref; `from_ref` was **dead code** on that path. When `origin/<branch>` is absent (branch created locally, never pushed) the path did nothing, so an explicit `from_ref` was silently ignored.

## Fix (verify-first; careful semantics — dual-review requested)

In the `origin/<branch>`-absent else-branch (where the #869 ff can't apply and the bug lives), re-align the local ref to `from_ref` — **FAST-FORWARD-ONLY** (only when the current branch tip is an ancestor of `from_ref`). The load-bearing safety decision:

- ✅ **Fixes the bug**: `foo@origin/main` + `from_ref=origin/dev` (dev ⊇ main) → `foo` fast-forwards to `origin/dev`.
- ✅ **Never clobbers work**: a divergent branch with unpushed commits — e.g. an in-flight dispatch branch + the default `from_ref=origin/main` — is *not* an ancestor → re-align **skips**, leaving it untouched. A hard rebase of a divergent branch would need explicit force semantics and is deliberately out of scope.
- ✅ **#869 preserved exactly**: `origin/<branch>` present → ff to it, `from_ref` untouched (the common dispatch re-bind).
- ✅ **Byte-identical for every existing caller**: both callers pass `from_ref=origin/main` for a branch already at `origin/main`, so the ff is a **no-op** — the pre-#2107 "leave local untouched" contract holds (all 7 existing `ensure_branch_exists` tests pass unchanged).

Refreshes `from_ref`'s remote ref first (mirrors the #1755 pre-create fetch); all steps best-effort; the returned `fetched_ok` stays the #869 working-branch result.

**Scope**: only the branch-exists path's `from_ref` alignment — `validate_branch` / `resolve_from_ref_remote` / the dispatch `from_ref=origin/main` default are untouched.

## Tests (both paths assert HEAD == from_ref's SHA + the clobber guard)

- `ensure_branch_exists_realigns_existing_branch_to_from_ref_2107` — the cheerc repro (**RED before the fix**: branch stayed on origin/main).
- `ensure_branch_exists_create_path_uses_from_ref_2107` — create path bases on from_ref.
- `ensure_branch_exists_does_not_clobber_divergent_branch_2107` — ff-only safety: a divergent unpushed branch + `from_ref=origin/main` is left untouched.

All 7 existing `ensure_branch_exists` tests pass unchanged (#869 sync, leaves-untouched, #2010, #1755, #2047, auto-create, dispatch-existing). `clippy --all-targets --features tray -- -D warnings` + Windows `x86_64-pc-windows-msvc` clean; full `cargo nextest run` **4143/4144** (the 1 = pre-existing `dispatch_branch_1834` shim env artifact in an untouched file).

> Dual review requested (touches repo-checkout semantics / destructive ref ops). codex quota-blocked → reviewer-2 + one more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)