### PR TITLE
fix(#2106): allow per-instance backend credential override from operator fleet.yaml

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -775,15 +775,46 @@ fn build_command(config: &SpawnConfig) -> anyhow::Result<(CommandBuilder, Option
     // so a hostile template cannot override ANTHROPIC_API_KEY, LD_PRELOAD,
     // AGEND_HOME, etc. with attacker-controlled values inherited by the
     // spawned agent process.
+    //
+    // #2106: EXCEPTION — a sensitive key is allowed through when it is a
+    // credential the detected backend declares (`credential_env_keys`, the same
+    // per-backend override the #1440 isolation path applies in
+    // `resolve_child_env`). Operators legitimately point an instance at a
+    // third-party provider (e.g. an `ANTHROPIC_BASE_URL` proxy +
+    // `ANTHROPIC_AUTH_TOKEN`), and the operator's fleet.yaml is a TRUSTED source
+    // under the single-machine single-user threat model (anyone who can write
+    // fleet.yaml can already run arbitrary code as the user). This stays NARROW:
+    // only THIS backend's own credential keys pass — linker-injection
+    // (`LD_*`/`DYLD_*`), home/identity redirect (`AGEND_HOME`,
+    // `AGEND_INSTANCE_NAME`), and foreign credentials (`AWS_*`, `GITHUB_TOKEN`,
+    // another backend's key) are NOT in this backend's credential set, so they
+    // are still dropped even from fleet.yaml. `is_sensitive_env_key` / the
+    // deny-list itself are unchanged, so every OTHER enforcement point (the
+    // isolation passthrough, etc.) keeps its protection.
+    let backend_creds: &[&str] = detected_backend
+        .as_ref()
+        .map(|b| b.credential_env_keys())
+        .unwrap_or(&[]);
     if let Some(env_map) = *env {
         for (k, v) in env_map {
             if is_sensitive_env_key(k) {
-                tracing::warn!(
-                    instance = %name,
-                    key = %k,
-                    "dropping fleet.yaml env override for sensitive key"
-                );
-                continue;
+                if env_key_in(k, backend_creds) {
+                    // Audit the override (key NAME only — never the secret value).
+                    // One line per spawn of an instance that sets a per-instance
+                    // credential; not a per-tick flood.
+                    tracing::info!(
+                        instance = %name,
+                        key = %k,
+                        "#2106: injecting operator fleet.yaml credential override (backend-declared credential key)"
+                    );
+                } else {
+                    tracing::warn!(
+                        instance = %name,
+                        key = %k,
+                        "dropping fleet.yaml env override for sensitive key"
+                    );
+                    continue;
+                }
             }
             cmd.env(k, v);
         }

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -926,6 +926,92 @@ fn build_command_sets_git_editor_defaults() {
     }
 }
 
+/// #2106: an operator's per-instance `ANTHROPIC_AUTH_TOKEN` in fleet.yaml
+/// `env:` must reach a claude-backed instance — it is a credential the backend
+/// declares (`credential_env_keys`) — so the operator can point that instance at
+/// a third-party `ANTHROPIC_BASE_URL` proxy (e.g. DeepSeek). The deny-list still
+/// drops a non-credential sensitive key (LD_PRELOAD) from the SAME fleet.yaml
+/// env, and benign keys pass. Drop assertions use `assert_ne!` against a sentinel
+/// value so they hold regardless of the test process's own inherited env.
+#[test]
+fn build_command_allows_operator_backend_credential_2106() {
+    let mut env = std::collections::HashMap::new();
+    env.insert(
+        "ANTHROPIC_AUTH_TOKEN".to_string(),
+        "sk-operator-2106".to_string(),
+    );
+    env.insert("LD_PRELOAD".to_string(), "/tmp/evil-2106.so".to_string());
+    env.insert("MY_BENIGN_2106".to_string(), "ok".to_string());
+    let config = SpawnConfig {
+        name: "cred-2106",
+        backend_command: "claude",
+        args: &[],
+        spawn_mode: crate::backend::SpawnMode::Fresh,
+        cols: 80,
+        rows: 24,
+        env: Some(&env),
+        working_dir: None,
+        submit_key: "\r",
+        home: None,
+        crash_tx: None,
+        shutdown: None,
+    };
+    let (cmd, _) = build_command(&config).expect("build_command");
+    assert_eq!(
+        cmd.get_env("ANTHROPIC_AUTH_TOKEN")
+            .map(|v| v.to_string_lossy().into_owned()),
+        Some("sk-operator-2106".to_string()),
+        "#2106: a backend-declared credential from operator fleet.yaml must inject"
+    );
+    assert_ne!(
+        cmd.get_env("LD_PRELOAD")
+            .map(|v| v.to_string_lossy().into_owned()),
+        Some("/tmp/evil-2106.so".to_string()),
+        "deny-list must still drop a non-credential sensitive key (fleet.yaml value must NOT be injected)"
+    );
+    assert_eq!(
+        cmd.get_env("MY_BENIGN_2106")
+            .map(|v| v.to_string_lossy().into_owned()),
+        Some("ok".to_string()),
+        "benign fleet.yaml env must pass unchanged"
+    );
+}
+
+/// #2106 scope guard: the override is PER-BACKEND (it reuses
+/// `credential_env_keys`). A credential one backend declares must NOT slip
+/// through for a different backend that doesn't — `ANTHROPIC_AUTH_TOKEN` is
+/// claude's, not codex's, so codex still drops it. This proves the fix is not a
+/// blanket sensitive-key allow and preserves cross-backend credential isolation.
+#[test]
+fn build_command_credential_override_is_per_backend_2106() {
+    let mut env = std::collections::HashMap::new();
+    env.insert(
+        "ANTHROPIC_AUTH_TOKEN".to_string(),
+        "sk-codex-2106".to_string(),
+    );
+    let config = SpawnConfig {
+        name: "cred-2106-codex",
+        backend_command: "codex",
+        args: &[],
+        spawn_mode: crate::backend::SpawnMode::Fresh,
+        cols: 80,
+        rows: 24,
+        env: Some(&env),
+        working_dir: None,
+        submit_key: "\r",
+        home: None,
+        crash_tx: None,
+        shutdown: None,
+    };
+    let (cmd, _) = build_command(&config).expect("build_command");
+    assert_ne!(
+        cmd.get_env("ANTHROPIC_AUTH_TOKEN")
+            .map(|v| v.to_string_lossy().into_owned()),
+        Some("sk-codex-2106".to_string()),
+        "#2106: ANTHROPIC_AUTH_TOKEN is not a codex credential → still dropped (per-backend scope)"
+    );
+}
+
 /// #1956: opencode's interactive self-update prompt hangs the whole pane (the
 /// agent can't answer dispatches). There's no `--no-update` flag, so the spawn
 /// injects `OPENCODE_CONFIG_CONTENT` with `autoupdate:false` — MERGED onto the


### PR DESCRIPTION
## Problem (cheerc)

The `SENSITIVE_ENV_KEYS` deny-list silently dropped an `ANTHROPIC_AUTH_TOKEN` set in a fleet.yaml instance `env:` (`build_command`'s *"dropping fleet.yaml env override for sensitive key"*). Use case: an operator points one instance at a third-party provider (e.g. a DeepSeek proxy) — `ANTHROPIC_BASE_URL`/`MODEL` inject fine, but `AUTH_TOKEN` was blocked.

**Operator ruling**: under the single-machine single-user threat model, the operator's own fleet.yaml is a **trusted** source — allow this override.

## Fix (minimal — reuses the existing #1440 mechanism)

At the fleet.yaml instance-env loop in `build_command`, a sensitive key is dropped **unless it is a credential the detected backend declares** (`Backend::credential_env_keys()` — the *same* per-backend override `resolve_child_env` already applies on the #1440 isolation path). So `ANTHROPIC_AUTH_TOKEN` reaches a claude-backed instance, but the allow stays **narrow**:

- ✅ only **this backend's own** credential keys pass — `ANTHROPIC_AUTH_TOKEN` is claude's, not codex's → cross-backend credential isolation preserved (pinned by a test);
- ✅ linker injection (`LD_*`/`DYLD_*`), home/identity redirect (`AGEND_HOME`, `AGEND_INSTANCE_NAME`), and foreign credentials (`AWS_*`, `GITHUB_TOKEN`, another backend's key) are **not** in any backend's credential set → still dropped from fleet.yaml;
- ✅ `is_sensitive_env_key` / the deny-list itself are **unchanged** — every other enforcement point (the isolation passthrough, etc.) keeps full protection.

**Audit**: an allowed override logs one `INFO` line per spawn with the key **name only** (never the secret value) — traceable, not a flood.

## Threat model / blast radius

There is no operator-fleet.yaml-vs-template *source* flag at `build_command` (all instance env — fleet.yaml defaults+instance and `params.env` — resolves into `SpawnConfig.env`), so the control is by credential-key **scope**, not source — the narrowest principled allow. Anyone who can write fleet.yaml can already run arbitrary code as the user, so a per-instance credential override does not widen the real blast radius; the genuinely dangerous keys (process hijack / home redirect) stay blocked. This is a **scoped, audited relaxation — not a deny-list removal**.

## Tests

- `build_command_allows_operator_backend_credential_2106` — claude + fleet.yaml `ANTHROPIC_AUTH_TOKEN` injects; `LD_PRELOAD` from the same env still dropped; benign passes. (Sentinel-value `assert_ne!` for drops, so robust against the test process's inherited env.)
- `build_command_credential_override_is_per_backend_2106` — codex still drops `ANTHROPIC_AUTH_TOKEN` (per-backend scope; not a blanket allow).

All 3 existing `sensitive_env_keys_*` + the `build_command_*` tests pass unchanged. `clippy --all-targets --features tray -- -D warnings` + Windows `x86_64-pc-windows-msvc` clean; full `cargo nextest run` **4145/4146** (the 1 = pre-existing `dispatch_branch_1834` shim artifact in an untouched file).

> Security-sensitive — **dual review** requested. codex quota-blocked → reviewer-2 + one more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)