### PR TITLE
refactor(W2.6): name the pane resize contract (PaneContentRect/ResizeDecision)

### DIFF
--- a/src/layout/pane.rs
+++ b/src/layout/pane.rs
@@ -164,6 +164,13 @@ impl Pane {
     }
 
     /// Resize this pane's underlying PTY / remote agent.
+    ///
+    /// W2.6 resize contract (see [`crate::render::resize`]): this is the shared
+    /// primitive both chokepoints drive. LAYOUT pre-computes `(cols, rows)` from
+    /// the split geometry and calls this before the first frame (an estimate);
+    /// RENDER then recomputes the actual content rect and calls this again as the
+    /// authoritative correction. `(cols, rows)` here is always a
+    /// [`crate::render::resize::PaneContentRect`] dimension.
     pub fn resize_pty(&self, registry: &AgentRegistry, cols: u16, rows: u16) {
         match &self.source {
             PaneSource::Local => {

--- a/src/render/core_render.rs
+++ b/src/render/core_render.rs
@@ -420,13 +420,11 @@ fn render_pane(
         crate::runtime_config::get().show_pane_state,
     );
 
-    let inner = Rect::new(
-        area.x + 1,
-        area.y + 1,
-        area.width.saturating_sub(2),
-        area.height.saturating_sub(2),
-    );
-    if inner.width == 0 || inner.height == 0 {
+    // W2.6: the pane content rect is the authority for the vterm/PTY size, and
+    // render is the authoritative chokepoint that corrects to it (layout
+    // pre-computes an estimate). See `crate::render::resize`.
+    let content = crate::render::resize::PaneContentRect::from_bordered_area(area);
+    if content.is_empty() {
         return PaneBorderInfo {
             area,
             border_style,
@@ -434,9 +432,12 @@ fn render_pane(
             priority,
         };
     }
-    if inner.width != pane.vterm.cols() || inner.height != pane.vterm.rows() {
-        pane.vterm.resize(inner.width, inner.height);
-        pane.resize_pty(registry, inner.width, inner.height);
+    let inner = content.rect();
+    if let Some(d) =
+        crate::render::resize::ResizeDecision::needed(inner, pane.vterm.cols(), pane.vterm.rows())
+    {
+        pane.vterm.resize(d.cols, d.rows);
+        pane.resize_pty(registry, d.cols, d.rows);
     }
     let render_offset = pane.scroll_offset;
     pane.vterm

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -5,6 +5,7 @@ pub mod core_render;
 pub mod overlay;
 pub mod panels;
 pub mod panels_fleet;
+pub mod resize;
 pub mod scratch;
 
 pub use core_render::render;

--- a/src/render/resize.rs
+++ b/src/render/resize.rs
@@ -1,0 +1,139 @@
+//! W2.6: the pane resize contract (#2048), named.
+//!
+//! A pane's PTY/vterm is sized at TWO chokepoints — kept deliberately separate
+//! by #2048:
+//!
+//! 1. **Layout pre-computes** (`layout::collect_resize_needs` →
+//!    [`crate::layout::Pane::resize_pty`]): derives `(cols, rows)` from the split
+//!    geometry and sizes the PTY before the first frame. An ESTIMATE — enough to
+//!    spawn the child with a sane size, but not necessarily the final on-screen
+//!    rect (chrome / rounding / a mid-frame layout change can shift it).
+//!
+//! 2. **Render is AUTHORITATIVE** (`core_render::render_pane` and `scratch`):
+//!    recomputes the pane's content rect from the actually-rendered `area` and
+//!    corrects the vterm + PTY to it. The final rendered inner rect WINS — this
+//!    is what keeps the PTY rows aligned with what is actually drawn (#2046/#2048,
+//!    `render_resizes_vterm_to_pane_content_rows_2046`).
+//!
+//! These two helpers NAME that contract: [`PaneContentRect`] is the content
+//! region of a bordered pane; [`ResizeDecision`] is the render-time "does the
+//! vterm need correcting to the content rect?" decision.
+//!
+//! Do NOT remove the render-time resize: the layout estimate alone leaves the
+//! PTY misaligned on the frames between a layout change and the next layout pass,
+//! and the render path is the only one with the truly-final rect.
+
+use ratatui::layout::Rect;
+
+/// The content region of a bordered pane: its outer `area` inset by the 1-cell
+/// border on every side. This rect is the authority for the pane's PTY / vterm
+/// dimensions — the agent's terminal content occupies exactly these cells.
+///
+/// Equivalent to `Block::default().borders(Borders::ALL).inner(area)` — ratatui
+/// insets each border with `saturating_sub`, and a title rides on the top border
+/// without consuming an extra row. It is written explicitly here so the edge
+/// behaviour is local and the concept has a name; `core_render::render_pane`
+/// (which does not build a `Block` for the inner calc) uses it, while the
+/// `scratch` path derives the same rect via `block.inner(oa)` because it already
+/// constructs the `Block` to draw the border. The equivalence is pinned by
+/// `pane_content_rect_matches_block_inner_borders_all`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PaneContentRect(pub Rect);
+
+impl PaneContentRect {
+    /// Inset `area` by the pane border (1 cell on each side).
+    pub fn from_bordered_area(area: Rect) -> Self {
+        PaneContentRect(Rect::new(
+            area.x + 1,
+            area.y + 1,
+            area.width.saturating_sub(2),
+            area.height.saturating_sub(2),
+        ))
+    }
+
+    /// The inner content rect.
+    pub fn rect(self) -> Rect {
+        self.0
+    }
+
+    /// True when the content area has zero cells (the border consumed the whole
+    /// pane). Render must skip vterm/PTY work in that case.
+    pub fn is_empty(self) -> bool {
+        self.0.width == 0 || self.0.height == 0
+    }
+}
+
+/// The render-time resize decision — the AUTHORITATIVE half of the contract.
+///
+/// [`ResizeDecision::needed`] returns `Some` with the target dimensions when the
+/// content rect differs from the vterm's current size (render must correct the
+/// vterm + PTY) and `None` when they already match (the steady-state frame, no
+/// resize work). The decision is identical at both render chokepoints; only the
+/// way each computes its content rect differs (see [`PaneContentRect`]).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ResizeDecision {
+    pub cols: u16,
+    pub rows: u16,
+}
+
+impl ResizeDecision {
+    /// Decide whether `content` requires resizing a vterm currently sized
+    /// `vterm_cols` × `vterm_rows`.
+    pub fn needed(content: Rect, vterm_cols: u16, vterm_rows: u16) -> Option<Self> {
+        if content.width != vterm_cols || content.height != vterm_rows {
+            Some(ResizeDecision {
+                cols: content.width,
+                rows: content.height,
+            })
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pane_content_rect_insets_border() {
+        let c = PaneContentRect::from_bordered_area(Rect::new(0, 0, 40, 20));
+        assert_eq!(c.rect(), Rect::new(1, 1, 38, 18));
+        assert!(!c.is_empty());
+    }
+
+    #[test]
+    fn pane_content_rect_saturates_tiny_area() {
+        // 1×1 area → border consumes everything → empty content (no underflow).
+        let c = PaneContentRect::from_bordered_area(Rect::new(5, 5, 1, 1));
+        assert_eq!(c.rect(), Rect::new(6, 6, 0, 0));
+        assert!(c.is_empty());
+    }
+
+    #[test]
+    fn pane_content_rect_matches_block_inner_borders_all() {
+        // The contract relies on this equivalence: the `scratch` render path
+        // computes the same content rect via `block.inner(oa)`.
+        use ratatui::widgets::{Block, Borders};
+        let area = Rect::new(2, 3, 30, 12);
+        let block_inner = Block::default().borders(Borders::ALL).inner(area);
+        assert_eq!(
+            PaneContentRect::from_bordered_area(area).rect(),
+            block_inner
+        );
+    }
+
+    #[test]
+    fn resize_decision_some_when_differs_none_when_equal() {
+        let content = Rect::new(1, 1, 38, 18);
+        assert_eq!(ResizeDecision::needed(content, 38, 18), None);
+        assert_eq!(
+            ResizeDecision::needed(content, 10, 18),
+            Some(ResizeDecision { cols: 38, rows: 18 })
+        );
+        assert_eq!(
+            ResizeDecision::needed(content, 38, 5),
+            Some(ResizeDecision { cols: 38, rows: 18 })
+        );
+    }
+}

--- a/src/render/scratch.rs
+++ b/src/render/scratch.rs
@@ -45,9 +45,14 @@ pub fn render_scratch_shell(
 
     pane.drain_output();
 
-    if inner.width != pane.vterm.cols() || inner.height != pane.vterm.rows() {
-        pane.vterm.resize(inner.width, inner.height);
-        pane.resize_pty(registry, inner.width, inner.height);
+    // W2.6: the same render-authoritative resize as `core_render::render_pane`.
+    // `block.inner(oa)` here equals `PaneContentRect::from_bordered_area(oa)`
+    // (the block has `Borders::ALL`); see `crate::render::resize`.
+    if let Some(d) =
+        crate::render::resize::ResizeDecision::needed(inner, pane.vterm.cols(), pane.vterm.rows())
+    {
+        pane.vterm.resize(d.cols, d.rows);
+        pane.resize_pty(registry, d.cols, d.rows);
     }
 
     pane.vterm


### PR DESCRIPTION
## What

REFACTOR-PLAN **W2.6** (`docs/REFACTOR-PLAN.md:142-147`, survey 03-C). The pane-resize logic was spread across two unnamed chokepoints (#2048). **Both chokepoints are kept**; this extracts a shared `crate::render::resize` module that **names** the contract and **documents the invariant**: *layout pre-computes, render is authoritative for the final inner rect.*

The two chokepoints:
1. **Layout pre-computes** — `layout::collect_resize_needs` → `Pane::resize_pty` derives `(cols, rows)` from the split geometry before the first frame (an estimate).
2. **Render is authoritative** — `core_render::render_pane` (and `scratch`) recompute the content rect from the actually-rendered `area` and correct the vterm + PTY to it. The final rendered inner rect wins (this is what #2048/#2046 fixed).

## Helpers

- **`PaneContentRect::from_bordered_area(area)`** — names the content region of a bordered pane (outer `area` inset 1 cell each side). `core_render::render_pane` previously used an inline `Rect::new(x+1, y+1, w-2, h-2)`; it now uses this. A pinned test proves it equals `Block::default().borders(ALL).inner(area)` — which the `scratch` path uses (it already builds the Block).
- **`ResizeDecision::needed(content, vterm_cols, vterm_rows)`** — names the render-time "correct the vterm/PTY to the content rect?" decision. **Both** render chokepoints route their identical `if inner != vterm { vterm.resize; resize_pty }` block through it.
- `Pane::resize_pty` doc now states it is the shared primitive both chokepoints drive.

## Byte-identical (MEDIUM risk — render path)

No chokepoint removed; no resize decision changed.
- core_render: `PaneContentRect::from_bordered_area(area).rect()` is the same `Rect` as the old inline `Rect::new`; `is_empty()` is the same `w==0||h==0` early-return; `ResizeDecision::needed` is the same `!=` guard; the resize args are the same width/height.
- scratch: keeps its `block.inner(oa)` (zero-risk, idiomatic) — only the resize-decision block is shared.

**The render path IS touched, so it is covered by the #2048 render-frame test `render_resizes_vterm_to_pane_content_rows_2046` (TestBackend), which passes UNCHANGED** — the byte-identity proof for the render-time resize. + 4 new unit tests for the helpers (incl. the `block.inner` equivalence pin). All existing render/vterm/resize tests pass unchanged. `clippy --all-targets --features tray -- -D warnings` + Windows `x86_64-pc-windows-msvc` clean; full `cargo nextest run` **4150/4151** (the 1 = pre-existing `dispatch_branch_1834` shim artifact in an untouched file).

Scope: name + extract helper + document the invariant only. Diff: +166/-13 across 5 files (incl. the new `resize.rs`).

> Dual review requested — render-time resize wrong = screen garble. codex quota-blocked → reviewer-2 + one more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)