### PR TITLE
refactor(W1.2): migrate mcp_config/instructions/skills git sites to git_cmd

### DIFF
--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -64,31 +64,19 @@ pub(crate) fn ensure_project_root(dir: &Path) {
     if !dir.exists() {
         return;
     }
-    let inside = std::process::Command::new("git")
-        .args([
-            "-C",
-            &dir.display().to_string(),
-            "rev-parse",
-            "--is-inside-work-tree",
-        ])
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false);
+    // W1.2: cwd=dir replaces `-C dir`; git_ok = spawn-and-exit-0 (bypass env +
+    // local timeout + process-group kill bundled). Local rev-parse.
+    let inside = crate::git_helpers::git_ok(dir, &["rev-parse", "--is-inside-work-tree"]);
     if inside {
         return;
     }
 
-    let init_ok = std::process::Command::new("git")
-        .args(["-C", &dir.display().to_string(), "init", "--quiet"])
-        // #2071: discard stdout/stderr. In app mode this runs in the TUI
-        // process; an un-redirected child inherits the TUI's TTY and `git
-        // init`'s hints/warnings (not all silenced by --quiet) would garble
-        // the ratatui frame. We only read the exit status.
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false);
+    // #2071: an un-redirected child in app mode inherits the TUI's TTY and `git
+    // init`'s hints/warnings garble the ratatui frame. git_ok runs git via
+    // git_bypass, which CAPTURES stdout/stderr (pipes — never the inherited TTY),
+    // so the explicit Stdio::null is no longer needed; we only read the exit
+    // status. W1.2: cwd=dir replaces `-C dir`.
+    let init_ok = crate::git_helpers::git_ok(dir, &["init", "--quiet"]);
 
     if init_ok {
         let ignore_path = dir.join(".gitignore");

--- a/src/mcp_config.rs
+++ b/src/mcp_config.rs
@@ -161,22 +161,11 @@ fn configure_claude(working_dir: &Path, instance_name: Option<&str>) -> Result<(
     // Ensure working dir is a git repo (Claude Code needs git root to find .claude/)
     let git_dir = working_dir.join(".git");
     if !git_dir.exists() {
-        match std::process::Command::new("git")
-            .args(["init"])
-            .current_dir(working_dir)
-            .output()
-        {
-            Ok(o) if !o.status.success() => {
-                tracing::warn!(
-                    dir = %working_dir.display(),
-                    stderr = %String::from_utf8_lossy(&o.stderr).trim(),
-                    "git init failed"
-                );
-            }
-            Err(e) => {
-                tracing::warn!(dir = %working_dir.display(), error = %e, "git init failed");
-            }
-            _ => {}
+        // W1.2: git_cmd bundles the bypass env + LOCAL timeout + process-group
+        // kill; its GitError carries the stderr/spawn detail the warn logged by
+        // hand (init is local, so the local timeout is ample).
+        if let Err(e) = crate::git_helpers::git_cmd(working_dir, &["init"]) {
+            tracing::warn!(dir = %working_dir.display(), error = %e, "git init failed");
         }
     }
 

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -191,6 +191,10 @@ pub fn add(home: &Path, source: &str) -> Result<Skill> {
                     std::fs::remove_dir_all(&tmp)
                         .with_context(|| format!("clean clone tmp {}", tmp.display()))?;
                 }
+                // git-raw-allowed: network clone — git_ok/git_cmd impose
+                // LOCAL_GIT_TIMEOUT, which would prematurely kill a large/slow
+                // network clone. Deliberately NOT migrated in W1.2; the explicit
+                // Stdio::null below already keeps progress off the inherited TTY.
                 let status = std::process::Command::new("git")
                     .args(["clone", "--depth=1", url.as_str()])
                     .arg(&tmp)
@@ -226,6 +230,8 @@ pub fn add(home: &Path, source: &str) -> Result<Skill> {
                     .with_context(|| format!("copy subdir {sub} → {}", dest.display()))?;
                 let _ = std::fs::remove_dir_all(&tmp);
             } else {
+                // git-raw-allowed: network clone (see the subdir-clone site
+                // above) — LOCAL_GIT_TIMEOUT would kill a large clone; not migrated.
                 let status = std::process::Command::new("git")
                     .args(["clone", "--depth=1", url.as_str()])
                     .arg(&dest)
@@ -697,15 +703,11 @@ fn git_repo_name(url: &str) -> Option<String> {
 
 fn compute_version(dest: &Path, source: &str) -> String {
     if source.starts_with("http") || source.starts_with("git@") || source.starts_with("ssh://") {
-        // Git source — read HEAD SHA from the cloned tree.
-        std::process::Command::new("git")
-            .args(["rev-parse", "HEAD"])
-            .current_dir(dest)
-            .output()
-            .ok()
-            .and_then(|o| String::from_utf8(o.stdout).ok())
-            .map(|s| s.trim().to_string())
-            .unwrap_or_default()
+        // Git source — read HEAD SHA from the cloned tree. W1.2: git_cmd returns
+        // the trimmed stdout (the SHA) on success, Err on failure → "" — same
+        // result as the prior output().ok().and_then(utf8).map(trim) chain (local
+        // rev-parse, so the local timeout is ample).
+        crate::git_helpers::git_cmd(dest, &["rev-parse", "HEAD"]).unwrap_or_default()
     } else {
         // Path source — use destination dir mtime as an opaque pin.
         std::fs::metadata(dest)

--- a/tests/daemon_git_helper_invariant.rs
+++ b/tests/daemon_git_helper_invariant.rs
@@ -48,6 +48,12 @@ const MODULE_SCOPE: &[&str] = &[
     "worktree_cleanup.rs",
     "branch_sweep.rs",
     "binding.rs",
+    // W1.2 slice (#2068 follow-up): mcp_config (git init→git_cmd),
+    // instructions (rev-parse/init→git_ok), skills (rev-parse HEAD→git_cmd;
+    // network clones kept raw via git-raw-allowed).
+    "mcp_config.rs",
+    "instructions.rs",
+    "skills.rs",
 ];
 
 /// One violation entry — `(file, line_number, snippet)`.


### PR DESCRIPTION
## What

REFACTOR-PLAN **W1.2** focused slice (#2068 follow-up). Migrate 3 daemon modules' raw `Command::new("git")` production sites to the `git_cmd`/`git_ok` helpers (bypass env + LOCAL timeout + process-group kill bundled), and add them to `tests/daemon_git_helper_invariant.rs` `MODULE_SCOPE` so the guard keeps them compliant.

| module | migration |
|---|---|
| `mcp_config.rs` | `git init` → `git_cmd` (GitError carries the stderr/spawn detail the warn logged by hand) |
| `instructions.rs` | `rev-parse --is-inside-work-tree` + `init --quiet` → `git_ok` (`-C dir` → cwd arg) |
| `skills.rs` | `rev-parse HEAD` → `git_cmd`; the 2 **network `git clone`** sites kept raw with `git-raw-allowed` |

### The #2068 judgement (why the clones stay raw)

`git_cmd`/`git_ok` impose `LOCAL_GIT_TIMEOUT`, which would prematurely kill a large/slow **network** clone. A network op must not be forced through the local-timeout helper — so the clones keep `Command::new` + a `git-raw-allowed` marker, mirroring the trim-sensitivity judgement from the original W1.2 (#2068): migrate only where the helper's contract actually fits.

### #2071 preserved

`instructions.rs`'s `init --quiet` previously used `Stdio::null()` to keep `git init`'s hints off the inherited TUI TTY. `git_ok` runs via `git_bypass`, which **captures** stdout/stderr (pipes — never the inherited TTY), so the no-garble fix is preserved without the explicit redirect.

## Byte-identical

Only the call form changed, not the git semantics — each migrated site keeps the same args, cwd, and success/empty handling; all are local ops (init/rev-parse) so the local timeout is ample.

**Proof**: `tests/daemon_git_helper_invariant.rs` passes with the 3 new MODULE_SCOPE entries (no unmarked production `Command::new` in any — the clones are marked). All `mcp_config`/`instructions`/`skills` tests pass unchanged (101). `clippy --all-targets --features tray -- -D warnings` + Windows `x86_64-pc-windows-msvc` clean; full `AGEND_GIT_BYPASS=1 cargo nextest run` **4150/4151** (the 1 = the inverse shim env artifact `spawn_group_bounded_preserves_caller_env_no_bypass_1899`, which fails *with* the bypass env the worktree run requires; `git_helpers` untouched).

Scope: only these 3 modules + MODULE_SCOPE. Diff: net `-15` (the migrations remove boilerplate) + `+6` invariant. (W1 wrap-up should sync the REFACTOR-PLAN W1.2 count.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)