### PR TITLE
fix(#2099): GC no_report_expected dispatch rows after the retention window

### DIFF
--- a/src/dispatch_tracking.rs
+++ b/src/dispatch_tracking.rs
@@ -271,8 +271,8 @@ pub fn active_target_names(home: &Path) -> Vec<String> {
     names
 }
 
-/// M3: Remove terminal entries (completed/orphaned) older than 30 days.
-/// Prevents unbounded growth of dispatch_tracking.json.
+/// M3: Remove terminal entries (completed/orphaned/no_report_expected) older
+/// than 30 days. Prevents unbounded growth of dispatch_tracking.json.
 pub fn gc_old_entries(home: &Path) {
     const RETENTION_DAYS: i64 = 30;
     let now = chrono::Utc::now();
@@ -281,7 +281,16 @@ pub fn gc_old_entries(home: &Path) {
     // rows, and the next maintenance tick retries. Intentionally not logged.
     let _ = crate::store::mutate_versioned(&store_path(home), |store: &mut DispatchStore| {
         store.entries.retain(|entry| {
-            if entry.status != "completed" && entry.status != "orphaned" {
+            // #2099 follow-up: `no_report_expected` (fire-and-forget) is
+            // terminal-for-GC — it joins this AGE-BASED retention prune so the
+            // row can't linger forever. It is deliberately NOT in
+            // `sweep_terminal_entries` (immediate removal): its audit row is kept
+            // until the 30-day window, unlike completed (dropped at report) /
+            // orphaned (given up at 24h).
+            if entry.status != "completed"
+                && entry.status != "orphaned"
+                && entry.status != "no_report_expected"
+            {
                 return true; // keep active entries
             }
             let delegated = match chrono::DateTime::parse_from_rfc3339(&entry.delegated_at) {
@@ -301,6 +310,10 @@ pub fn gc_old_entries(home: &Path) {
 /// #1727) and would otherwise sit until the 30-day TTL. Called at boot
 /// (`orphan_sweep`) and each retention cycle so terminal rows don't accumulate.
 /// Returns the number removed. Best-effort: a dropped pass just delays pruning.
+///
+/// #2099 follow-up: `no_report_expected` is deliberately NOT swept here — it is
+/// retention-windowed via [`gc_old_entries`], so its audit row must survive to
+/// the 30-day window (this fn removes regardless of age).
 pub fn sweep_terminal_entries(home: &Path) -> usize {
     let mut removed = 0usize;
     let _ = crate::store::mutate_versioned(&store_path(home), |store: &mut DispatchStore| {
@@ -715,6 +728,94 @@ mod tests {
         let entries = store["entries"].as_array().expect("entries");
         assert_eq!(entries.len(), 1, "old entry should be removed: {entries:?}");
         assert_eq!(entries[0]["task_id"], "t-recent");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #2099 follow-up: a `no_report_expected` row is terminal-for-GC — pruned
+    /// by gc_old_entries once PAST the 30-day retention window, but KEPT before
+    /// it (the audit row survives the window, mirroring completed/orphaned).
+    #[test]
+    fn gc_prunes_old_no_report_expected_2099() {
+        let home = tmp_home("gc_no_report");
+        track_dispatch(
+            &home,
+            DispatchEntry {
+                task_id: Some("t-old-ff".into()),
+                from: "lead".into(),
+                to: "scout".into(),
+                from_id: None,
+                to_id: None,
+                delegated_at: (chrono::Utc::now() - chrono::Duration::days(31)).to_rfc3339(),
+                status: "no_report_expected".into(),
+            },
+        );
+        track_dispatch(
+            &home,
+            DispatchEntry {
+                task_id: Some("t-recent-ff".into()),
+                from: "lead".into(),
+                to: "scout".into(),
+                from_id: None,
+                to_id: None,
+                delegated_at: chrono::Utc::now().to_rfc3339(),
+                status: "no_report_expected".into(),
+            },
+        );
+        gc_old_entries(&home);
+        let store: serde_json::Value =
+            crate::store::load(&crate::store::store_path(&home, "dispatch_tracking.json"));
+        let entries = store["entries"].as_array().expect("entries");
+        assert_eq!(
+            entries.len(),
+            1,
+            "old fire-and-forget row pruned past window, recent kept: {entries:?}"
+        );
+        assert_eq!(entries[0]["task_id"], "t-recent-ff");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #2099 follow-up: `sweep_terminal_entries` (immediate, regardless of age)
+    /// must NOT remove a `no_report_expected` row — that audit row is
+    /// retention-windowed (gc_old_entries owns it). A fresh `completed` row IS
+    /// removed in the same call, proving the deliberate per-status difference.
+    #[test]
+    fn sweep_terminal_keeps_no_report_expected_2099() {
+        let home = tmp_home("sweep_keeps_no_report");
+        track_dispatch(
+            &home,
+            DispatchEntry {
+                task_id: Some("t-ff".into()),
+                from: "lead".into(),
+                to: "scout".into(),
+                from_id: None,
+                to_id: None,
+                delegated_at: chrono::Utc::now().to_rfc3339(),
+                status: "no_report_expected".into(),
+            },
+        );
+        track_dispatch(
+            &home,
+            DispatchEntry {
+                task_id: Some("t-done".into()),
+                from: "lead".into(),
+                to: "dev".into(),
+                from_id: None,
+                to_id: None,
+                delegated_at: chrono::Utc::now().to_rfc3339(),
+                status: "completed".into(),
+            },
+        );
+        let removed = sweep_terminal_entries(&home);
+        assert_eq!(removed, 1, "only the completed row is swept immediately");
+        let store: serde_json::Value =
+            crate::store::load(&crate::store::store_path(&home, "dispatch_tracking.json"));
+        let entries = store["entries"].as_array().expect("entries");
+        assert_eq!(
+            entries.len(),
+            1,
+            "no_report_expected survives the immediate sweep: {entries:?}"
+        );
+        assert_eq!(entries[0]["task_id"], "t-ff");
         std::fs::remove_dir_all(&home).ok();
     }
 


### PR DESCRIPTION
## What

#2099 follow-up — the out-of-scope item I flagged in #2108. #2108 added the `no_report_expected` dispatch status (fire-and-forget; skipped by `sweep_stuck`/`sweep_orphans` so it never false-nags), but the GC path only pruned `completed`/`orphaned`, so a `no_report_expected` row **lingered forever**.

## Fix

Add `no_report_expected` to `gc_old_entries`' terminal-for-GC set, so it is pruned by the **existing age-based retention prune** (30-day `RETENTION_DAYS`, unchanged). The audit row is kept until the window, then GC'd — same lifecycle as completed/orphaned.

**Deliberately NOT added to `sweep_terminal_entries`** (which removes terminal rows *immediately, regardless of age*): the `no_report_expected` audit row must survive to the retention window — unlike `completed` (dropped at report time) / `orphaned` (given up at 24h). This is the read-first distinction the success criteria require ("kept until the window, pruned after"); putting it in the immediate sweep would violate that. (GC = prune-after-window; ≠ the `sweep_stuck` no-nag skip already shipped in #2108 — two different mechanisms.)

## Scope & proof

Only `no_report_expected` added to the `gc_old_entries` terminal set + tests. Retention policy/window unchanged; other statuses' GC unaffected.

- `gc_prunes_old_no_report_expected_2099` — a 31-day-old row is pruned, a fresh one kept (the retention window).
- `sweep_terminal_keeps_no_report_expected_2099` — the immediate sweep **keeps** a fresh `no_report_expected` while removing a fresh `completed` in the same call (the deliberate per-status difference).

All existing GC + #2099 tests pass unchanged. `clippy --all-targets --features tray -- -D warnings` + Windows `x86_64-pc-windows-msvc` clean; full `AGEND_GIT_BYPASS=1 cargo nextest run` **4152/4153** (the 1 = the inverse shim env artifact `no_bypass_1899`, expected *with* the bypass env). Diff: 1 file, `+104/-3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)