### PR TITLE
feat(#2117 P1): BoardRouter + task_index + per-board task command routing

### DIFF
--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -855,6 +855,8 @@ mod tests {
             ("task", "metadata_value", "tasks/handler.rs metadata_set"),
             ("task", "bind", "tasks/handler.rs create → TaskEvent::Created.bind (#1933 declared)"),
             ("task", "eta_secs", "tasks/handler.rs create → TaskEvent::Created.eta_secs (#1933 declared)"),
+            ("task", "project", "tasks/handler.rs create board route (:136) + list project select (:221) (#2117 P1)"),
+            ("task", "scope", "tasks/handler.rs list fleet_scope aggregate (:208) (#2117 P1)"),
             // ── decision ──
             ("decision", "action", "decisions.rs routing"),
             ("decision", "title", "decisions.rs post"),

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -210,7 +210,9 @@ pub(crate) fn def_task() -> Value {
             "metadata_key": {"type": "string", "description": "Key for metadata_set action."},
             "metadata_value": {"description": "Value for metadata_set action (any JSON type)."},
             "bind": {"type": "boolean", "description": "#1933: create only — opt OUT of the daemon's auto-bind-on-dispatch (default true). Set false to leave the assignee unbound. Consumed in tasks/handler.rs (TaskEvent::Created.bind)."},
-            "eta_secs": {"type": "integer", "description": "#1933: create only — task stall-watchdog ETA in seconds; the daemon flags the task as stalled once this budget elapses. Consumed in tasks/handler.rs (TaskEvent::Created.eta_secs)."}
+            "eta_secs": {"type": "integer", "description": "#1933: create only — task stall-watchdog ETA in seconds; the daemon flags the task as stalled once this budget elapses. Consumed in tasks/handler.rs (TaskEvent::Created.eta_secs)."},
+            "project": {"type": "string", "description": "#2117 P1: target project board. create: route the task to this project (default: the caller's current project, derived from its team's source_repo). list: show this project, or `all` to aggregate every board."},
+            "scope": {"type": "string", "enum": ["fleet"], "description": "#2117 P1: list scope. `fleet` aggregates tasks across ALL project boards (each task tagged with its project id). Equivalent to `project=all`."}
         }, "required": ["action"]}})
 }
 

--- a/src/task_events.rs
+++ b/src/task_events.rs
@@ -981,7 +981,7 @@ pub(crate) fn board_root(home: &Path, project_id: &str) -> PathBuf {
 /// canonical `owner__repo` for an `owner/repo` slug; otherwise sanitizes any
 /// remaining path/URL separators. (P0: deterministic + round-trippable enough
 /// for an isolated subtree; P1 may refine the canonicalization.)
-fn project_slug(project_id: &str) -> String {
+pub(crate) fn project_slug(project_id: &str) -> String {
     let trimmed = project_id
         .trim()
         .trim_end_matches('/')
@@ -1100,6 +1100,11 @@ pub(crate) fn append_batch_at(
 /// events emitted as one batch). On precondition failure NO event is written and
 /// the reason is returned as `Ok(Err(reason))`; the outer `Err` is reserved for
 /// IO / replay failures.
+// #2117 P1: every non-test in-tree caller now routes via `append_batch_checked_at`
+// (the task command handlers resolve a board first). This home-default wrapper is
+// retained for the symmetric storage API (home + `_at` pair) and its test callers;
+// `allow(dead_code)` because non-test builds have no remaining caller.
+#[allow(dead_code)]
 pub fn append_batch_checked<F>(
     home: &Path,
     instance: &InstanceName,
@@ -1195,6 +1200,9 @@ where
 /// failures. Replay/append semantics are otherwise unchanged — this reuses
 /// `replay_uncached` (lock-free) for the read and the same seq/cache plumbing
 /// as [`append_batch`].
+// #2117 P1: non-test callers route via `append_checked_at` (board-resolved); this
+// home-default wrapper is retained for the symmetric storage API + test callers.
+#[allow(dead_code)]
 pub fn append_checked<F>(
     home: &Path,
     instance: &InstanceName,
@@ -1532,13 +1540,11 @@ fn replay_uncached(board: &Path) -> anyhow::Result<TaskBoardState> {
     Ok(state)
 }
 
-/// Return all task event envelopes for a given `task_id`, sorted chronologically.
-/// Used by `task action=activity` to build a timeline.
-pub fn envelopes_for_task(home: &Path, task_id: &str) -> anyhow::Result<Vec<TaskEventEnvelope>> {
-    envelopes_for_task_at(&board_root(home, DEFAULT_PROJECT), task_id)
-}
-
-/// #2117 board-root variant of [`envelopes_for_task`].
+/// Return all task event envelopes for a given `task_id` on a board, sorted
+/// chronologically. Used by `task action=activity` to build a timeline. (#2117
+/// P1: the activity handler resolves the task's board and calls this directly,
+/// so the former `home`-default wrapper — which had no other callers — was
+/// removed; `board_root(home, DEFAULT)` is `home` for a default-board read.)
 pub(crate) fn envelopes_for_task_at(
     board: &Path,
     task_id: &str,

--- a/src/tasks/board_router.rs
+++ b/src/tasks/board_router.rs
@@ -1,0 +1,157 @@
+//! #2117 P1 BoardRouter — the single resolution path from a caller or a task_id
+//! to the on-disk board it belongs to.
+//!
+//! P0 (#2119) added the `board_root` storage seam (every `task_events` storage
+//! fn has an `_at(board, …)` variant). P1 decides WHICH board each `task`
+//! command targets:
+//!
+//! - [`resolve_current_project`] maps a caller → its team's `source_repo` →
+//!   project id (used by `create` and the `list` default).
+//! - [`resolve_task_project`] maps a task_id → project id via the append-only
+//!   `task_index.jsonl` (a task never changes project, so the index is
+//!   immutable), with a full-board-scan fallback that repairs a missing entry.
+//!
+//! **Single-project byte-identical:** a deployment with no per-team
+//! `source_repo` resolves every caller/task to [`DEFAULT_PROJECT`], whose
+//! `board_root` IS `home` — so the index holds one project, `list` defaults to
+//! that one board (= the whole board), and every path/behaviour matches pre-P1.
+//!
+//! A **project id is itself the filesystem-safe slug** (so the board directory
+//! name equals the project id → reversible for enumeration / the fallback
+//! scan). `board_root(home, project_id)` is idempotent on an already-safe id.
+
+use crate::task_events::{board_root, project_slug, TaskId, DEFAULT_PROJECT};
+use std::path::{Path, PathBuf};
+
+use super::Task;
+
+// ── task_index (home/task_index.jsonl) ─────────────────────────────
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct IndexEntry {
+    task_id: String,
+    project_id: String,
+}
+
+fn index_path(home: &Path) -> PathBuf {
+    home.join("task_index.jsonl")
+}
+
+/// Record a task's project at create time. Append-only under the shared
+/// file-lock; a task never moves project, so the first entry for a task_id is
+/// authoritative and a stray duplicate is harmless ([`lookup_task_project`]
+/// takes the first match).
+pub(super) fn record_task_project(
+    home: &Path,
+    task_id: &str,
+    project_id: &str,
+) -> anyhow::Result<()> {
+    let line = serde_json::to_string(&IndexEntry {
+        task_id: task_id.to_string(),
+        project_id: project_id.to_string(),
+    })?;
+    // `append_lines_under_lock(home, "task_index", …)` writes the same
+    // `home/task_index.jsonl` as `index_path`, under `<file>.jsonl.lock`.
+    crate::event_log::append_lines_under_lock(home, "task_index", |_p| Ok(vec![line]))?;
+    Ok(())
+}
+
+fn lookup_task_project(home: &Path, task_id: &str) -> Option<String> {
+    let content = std::fs::read_to_string(index_path(home)).ok()?;
+    content.lines().find_map(|line| {
+        serde_json::from_str::<IndexEntry>(line)
+            .ok()
+            .filter(|e| e.task_id == task_id)
+            .map(|e| e.project_id)
+    })
+}
+
+// ── project resolution ─────────────────────────────────────────────
+
+/// Derive a stable, filesystem-safe project id from a team's `source_repo`.
+/// Uses the trailing `owner/repo` segments (`.git` stripped) when present, then
+/// slugs to a safe directory name (the same `project_slug` `board_root` applies,
+/// so the result is idempotent under `board_root`).
+fn project_id_from_source_repo(repo: &Path) -> String {
+    let segs: Vec<String> = repo
+        .components()
+        .filter_map(|c| match c {
+            std::path::Component::Normal(s) => s.to_str().map(|x| x.to_string()),
+            _ => None,
+        })
+        .collect();
+    let strip_git = |s: &str| s.strip_suffix(".git").unwrap_or(s).to_string();
+    let raw = match segs.len() {
+        0 => repo.to_string_lossy().into_owned(),
+        1 => strip_git(&segs[0]),
+        n => format!("{}/{}", segs[n - 2], strip_git(&segs[n - 1])),
+    };
+    project_slug(&raw)
+}
+
+/// The project a caller currently acts in: its team's `source_repo`, else the
+/// fleet-wide [`DEFAULT_PROJECT`]. (No team / no `source_repo` → default → the
+/// `home` board → byte-identical for single-project deployments.)
+pub(super) fn resolve_current_project(home: &Path, caller: &str) -> String {
+    crate::teams::find_team_for(home, caller)
+        .and_then(|t| t.source_repo)
+        .map(|repo| project_id_from_source_repo(&repo))
+        .unwrap_or_else(|| DEFAULT_PROJECT.to_string())
+}
+
+/// The project a task lives in: the `task_index` entry, else a full-board scan
+/// that repairs the index on a hit, else [`DEFAULT_PROJECT`] (the `home` board)
+/// when the task is unknown — which keeps a missing/legacy task resolving to the
+/// historical board.
+pub(super) fn resolve_task_project(home: &Path, task_id: &str) -> String {
+    if let Some(p) = lookup_task_project(home, task_id) {
+        return p;
+    }
+    let tid = TaskId(task_id.to_string());
+    for project in enumerate_projects(home) {
+        let found = crate::task_events::replay_at(&board_root(home, &project))
+            .map(|state| state.tasks.contains_key(&tid))
+            .unwrap_or(false);
+        if found {
+            // Repair the index so the next lookup is O(1).
+            let _ = record_task_project(home, task_id, &project);
+            return project;
+        }
+    }
+    DEFAULT_PROJECT.to_string()
+}
+
+/// Every project with an on-disk board: the default (fleet) project plus each
+/// `home/boards/<project_id>` subdir (the dir name IS the project id).
+fn enumerate_projects(home: &Path) -> Vec<String> {
+    let mut out = vec![DEFAULT_PROJECT.to_string()];
+    if let Ok(entries) = std::fs::read_dir(home.join("boards")) {
+        for e in entries.flatten() {
+            if e.path().is_dir() {
+                if let Some(name) = e.file_name().to_str() {
+                    out.push(name.to_string());
+                }
+            }
+        }
+    }
+    out
+}
+
+// ── board handles + cross-board listing ────────────────────────────
+
+/// Board root for an existing task (via [`resolve_task_project`]).
+pub(super) fn board_for_task(home: &Path, task_id: &str) -> PathBuf {
+    board_root(home, &resolve_task_project(home, task_id))
+}
+
+/// All tasks across every board, tagged with their project id — for the
+/// `list project=all` / `scope=fleet` aggregate view.
+pub(super) fn list_all_boards(home: &Path) -> Vec<(String, Vec<Task>)> {
+    enumerate_projects(home)
+        .into_iter()
+        .map(|project| {
+            let tasks = super::list_all_at(&board_root(home, &project));
+            (project, tasks)
+        })
+        .collect()
+}

--- a/src/tasks/handler.rs
+++ b/src/tasks/handler.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use super::acl::{can_mutate_record, instance_exists};
 use super::orphan::build_health_response;
-use super::{list_all, record_to_task, status_to_legacy_str, Task};
+use super::{record_to_task, status_to_legacy_str, Task};
 
 fn parse_due_at(args: &Value) -> Option<String> {
     let due = args["due_at"].as_str()?;
@@ -15,7 +15,18 @@ fn parse_due_at(args: &Value) -> Option<String> {
 /// `handle`'s mutation arms to validate `(prev_status, transition)`
 /// before emitting an event.
 pub(super) fn read_task_record(home: &Path, id: &str) -> Option<crate::task_events::TaskRecord> {
-    let state = crate::task_events::replay(home).ok()?;
+    // #2117 P1: home IS the default board root (`board_root(home, DEFAULT)`), so
+    // this is byte-identical; routed callers use `read_task_record_at` with the
+    // task's resolved board.
+    read_task_record_at(home, id)
+}
+
+/// #2117 P1: board-root variant of [`read_task_record`].
+pub(super) fn read_task_record_at(
+    board: &Path,
+    id: &str,
+) -> Option<crate::task_events::TaskRecord> {
+    let state = crate::task_events::replay_at(board).ok()?;
     state
         .tasks
         .get(&crate::task_events::TaskId(id.to_string()))
@@ -31,7 +42,7 @@ pub fn handle(home: &Path, instance_name: &str, args: &Value) -> Value {
 
     match action {
         "create" => handle_create(home, emitter, args),
-        "list" => handle_list(home, args),
+        "list" => handle_list(home, instance_name, args),
         "claim" => handle_claim(home, instance_name, emitter, args),
         "done" => handle_done(home, instance_name, emitter, args),
         "update" => handle_update(home, instance_name, emitter, args),
@@ -118,9 +129,19 @@ fn handle_create(home: &Path, emitter: crate::task_events::InstanceName, args: &
             .as_str()
             .map(|s| crate::task_events::TaskId(s.to_string())),
     };
-    match crate::task_events::append(home, &emitter, event) {
+    // #2117 P1: route create to the caller's current project board (or an
+    // explicit `project` arg override). Single-project → DEFAULT → board == home
+    // (byte-identical). Record the task→project mapping in the append-only index
+    // so later done/update/claim/activity resolve the board in O(1).
+    let project = args["project"]
+        .as_str()
+        .map(String::from)
+        .unwrap_or_else(|| super::board_router::resolve_current_project(home, emitter.as_str()));
+    let board = crate::task_events::board_root(home, &project);
+    match crate::task_events::append_at(&board, &emitter, event) {
         Ok(_) => {
-            let task = read_task_record(home, &id).map(|r| record_to_task(&r));
+            let _ = super::board_router::record_task_project(home, &id, &project);
+            let task = read_task_record_at(&board, &id).map(|r| record_to_task(&r));
             // #1496 Option 1: `task(action:create)` is a PURE board record
             // with ZERO dispatch side-effects — no inbox enqueue, no
             // dispatch_tracking, no PTY notify. Dispatch (notify + worktree
@@ -147,7 +168,7 @@ fn handle_create(home: &Path, emitter: crate::task_events::InstanceName, args: &
     }
 }
 
-fn handle_list(home: &Path, args: &Value) -> Value {
+fn handle_list(home: &Path, caller: &str, args: &Value) -> Value {
     // #2037 ①: accept the natural names as aliases of the filter_* params —
     // `status`/`assignee` are create/update params elsewhere, but on the
     // `list` action they can only mean filtering (three real mis-calls in
@@ -176,7 +197,33 @@ fn handle_list(home: &Path, args: &Value) -> Value {
     ];
     let now = chrono::Utc::now();
     let done_ttl = chrono::Duration::days(14);
-    let tasks = list_all(home);
+    // #2117 P1: choose the source board(s).
+    //   - `project=all` / `scope=fleet` → aggregate EVERY board (cross-board
+    //     view; each task tagged with its project id in the response).
+    //   - explicit `project=<id>` → that one board.
+    //   - default → the caller's current project board.
+    // Single-project resolves to DEFAULT → `board_root == home` → the source is
+    // exactly `list_all(home)` and the response is byte-identical.
+    let fleet_scope =
+        args["project"].as_str() == Some("all") || args["scope"].as_str() == Some("fleet");
+    let mut project_of: std::collections::HashMap<String, String> =
+        std::collections::HashMap::new();
+    let tasks: Vec<Task> = if fleet_scope {
+        let mut all = Vec::new();
+        for (project, ts) in super::board_router::list_all_boards(home) {
+            for t in &ts {
+                project_of.insert(t.id.clone(), project.clone());
+            }
+            all.extend(ts);
+        }
+        all
+    } else {
+        let project = args["project"]
+            .as_str()
+            .map(String::from)
+            .unwrap_or_else(|| super::board_router::resolve_current_project(home, caller));
+        super::list_all_at(&crate::task_events::board_root(home, &project))
+    };
     let mut filtered: Vec<Task> = tasks
         .iter()
         .filter(|t| filter_assignee.is_none_or(|a| t.assignee.as_deref() == Some(a)))
@@ -206,6 +253,25 @@ fn handle_list(home: &Path, args: &Value) -> Value {
     if let Some(n) = limit {
         filtered.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
         filtered.truncate(n as usize);
+    }
+    // #2117 P1: the default/single-project response is byte-identical; the
+    // fleet aggregate additionally tags each task with its project id.
+    if fleet_scope {
+        let tagged: Vec<Value> = filtered
+            .iter()
+            .map(|t| {
+                let mut v = serde_json::to_value(t).unwrap_or(Value::Null);
+                if let (Some(obj), Some(p)) = (v.as_object_mut(), project_of.get(&t.id)) {
+                    obj.insert("project".to_string(), Value::String(p.clone()));
+                }
+                v
+            })
+            .collect();
+        return serde_json::json!({
+            "tasks": tagged,
+            "filtered_default": filtered_default,
+            "scope": "fleet",
+        });
     }
     serde_json::json!({
         "tasks": filtered,
@@ -246,7 +312,9 @@ fn handle_claim(
         task_id: crate::task_events::TaskId(id.clone()),
         by: crate::task_events::InstanceName(iname.clone()),
     };
-    let result = crate::task_events::append_checked(home, &emitter, event, |state| {
+    // #2117 P1: operate on the task's resolved board (default → home).
+    let board = super::board_router::board_for_task(home, &id);
+    let result = crate::task_events::append_checked_at(&board, &emitter, event, |state| {
         let mut tasks: Vec<Task> = state.tasks.values().map(record_to_task).collect();
         super::apply_dependency_eval_in_memory(&mut tasks);
         let tv = tasks
@@ -270,7 +338,7 @@ fn handle_claim(
             // ("claimed"), but the field is still the action
             // event name semantically — kept as alias for
             // shape consistency.
-            let task = read_task_record(home, &id).map(|r| record_to_task(&r));
+            let task = read_task_record_at(&board, &id).map(|r| record_to_task(&r));
             serde_json::json!({
                 "id": id,
                 "event": "claimed",
@@ -298,7 +366,9 @@ fn handle_done(
     };
     let result_text = args["result"].as_str().map(String::from);
     let caller = instance_name.to_string();
-    let record = match read_task_record(home, &id) {
+    // #2117 P1: operate on the task's resolved board (default → home).
+    let board = super::board_router::board_for_task(home, &id);
+    let record = match read_task_record_at(&board, &id) {
         Some(r) => r,
         None => return serde_json::json!({"error": format!("task '{id}' not found")}),
     };
@@ -387,7 +457,7 @@ fn handle_done(
     // replay's `apply_done` does NOT re-guard transitions — so this precondition
     // is the authoritative gate (mirrors `handle_claim`'s `append_checked`).
     let done_id = id.clone();
-    match crate::task_events::append_checked(home, &emitter, event, |state| {
+    match crate::task_events::append_checked_at(&board, &emitter, event, |state| {
         let tv = state
             .tasks
             .values()
@@ -445,7 +515,7 @@ fn handle_done(
             // work the task board already confirmed done.
             let _ = crate::daemon::dispatch_idle::cleanup_pending_for_task_id(home, &id);
             // #807 Item 1: see create arm note.
-            let task = read_task_record(home, &id).map(|r| record_to_task(&r));
+            let task = read_task_record_at(&board, &id).map(|r| record_to_task(&r));
             serde_json::json!({
                 "id": id,
                 "event": "done",
@@ -482,7 +552,9 @@ fn handle_update(
         None
     };
     let caller = instance_name.to_string();
-    let record = match read_task_record(home, &id) {
+    // #2117 P1: operate on the task's resolved board (default → home).
+    let board = super::board_router::board_for_task(home, &id);
+    let record = match read_task_record_at(&board, &id) {
         Some(r) => r,
         None => return serde_json::json!({"error": format!("task '{id}' not found")}),
     };
@@ -707,8 +779,11 @@ fn handle_update(
         let target_status = new_status
             .as_deref()
             .and_then(crate::task_events::TaskStatus::from_str);
-        let checked =
-            crate::task_events::append_batch_checked(home, &emitter, pending_events, |state| {
+        let checked = crate::task_events::append_batch_checked_at(
+            &board,
+            &emitter,
+            pending_events,
+            |state| {
                 if let Some(target) = target_status {
                     let tv = state
                         .tasks
@@ -725,7 +800,8 @@ fn handle_update(
                     }
                 }
                 Ok(())
-            });
+            },
+        );
         match checked {
             Ok(Ok(_)) => {}
             Ok(Err(reason)) => {
@@ -744,7 +820,7 @@ fn handle_update(
                 let _ = crate::daemon::dispatch_idle::cleanup_pending_for_task_id(home, &id);
             }
             if s == "cancelled" {
-                cascade_cancel_children(home, &id, &emitter);
+                cascade_cancel_children(home, &board, &id, &emitter);
             }
         }
         // #1916: a reassign (OwnerAssigned with a new owner) must retarget the
@@ -765,7 +841,7 @@ fn handle_update(
         }
     }
     // #807 Item 1: see create arm note.
-    let task = read_task_record(home, &id).map(|r| record_to_task(&r));
+    let task = read_task_record_at(&board, &id).map(|r| record_to_task(&r));
     serde_json::json!({
         "id": id,
         "event": "updated",
@@ -913,7 +989,9 @@ fn handle_metadata_set(
     } else {
         return serde_json::json!({"error": "missing 'metadata_value'"});
     };
-    let record = match read_task_record(home, id) {
+    // #2117 P1: operate on the task's resolved board (default → home).
+    let board = super::board_router::board_for_task(home, id);
+    let record = match read_task_record_at(&board, id) {
         Some(r) => r,
         None => return serde_json::json!({"error": format!("task not found: {id}")}),
     };
@@ -926,9 +1004,9 @@ fn handle_metadata_set(
         key: key.to_string(),
         value,
     };
-    match crate::task_events::append(home, &emitter, event) {
+    match crate::task_events::append_at(&board, &emitter, event) {
         Ok(_) => {
-            let task = read_task_record(home, id).map(|r| record_to_task(&r));
+            let task = read_task_record_at(&board, id).map(|r| record_to_task(&r));
             serde_json::json!({"id": id, "event": "metadata_set", "task": task})
         }
         Err(e) => serde_json::json!({"error": format!("{e}")}),
@@ -940,7 +1018,8 @@ fn handle_metadata_get(home: &Path, args: &Value) -> Value {
         Some(i) => i,
         None => return serde_json::json!({"error": "missing 'id' (alias: task_id)"}),
     };
-    match read_task_record(home, id) {
+    let board = super::board_router::board_for_task(home, id);
+    match read_task_record_at(&board, id) {
         Some(r) => {
             serde_json::json!({"id": id, "metadata": r.metadata})
         }
@@ -950,7 +1029,9 @@ fn handle_metadata_get(home: &Path, args: &Value) -> Value {
 
 /// #1147: Build a chronological activity timeline for a task.
 fn activity_timeline(home: &Path, task_id: &str) -> Value {
-    let envelopes = match crate::task_events::envelopes_for_task(home, task_id) {
+    // #2117 P1: read the task's resolved board (default → home).
+    let board = super::board_router::board_for_task(home, task_id);
+    let envelopes = match crate::task_events::envelopes_for_task_at(&board, task_id) {
         Ok(e) => e,
         Err(e) => return serde_json::json!({"error": format!("failed to read task events: {e}")}),
     };
@@ -1062,10 +1143,14 @@ fn summarize_event(env: &crate::task_events::TaskEventEnvelope) -> (&str, String
 
 fn cascade_cancel_children(
     home: &Path,
+    board: &Path,
     parent_id: &str,
     emitter: &crate::task_events::InstanceName,
 ) {
-    let Ok(state) = crate::task_events::replay(home) else {
+    // #2117 P1: a parent's children live on the parent's board — replay + cancel
+    // there. `home` is kept only for the cross-instance cascade NOTIFICATION
+    // (route_cascade_cancel), which is fleet-global. Single-project → board == home.
+    let Ok(state) = crate::task_events::replay_at(board) else {
         return;
     };
     let parent_tid = crate::task_events::TaskId(parent_id.to_string());
@@ -1090,7 +1175,7 @@ fn cascade_cancel_children(
         }
     }
     if !cancel_events.is_empty() {
-        let _ = crate::task_events::append_batch(home, emitter, cancel_events);
+        let _ = crate::task_events::append_batch_at(board, emitter, cancel_events);
     }
     for (child_id, owner) in notify_ids {
         if let Some(ref owner_name) = owner {

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -2,6 +2,7 @@
 
 mod acl;
 pub mod auto_close;
+mod board_router;
 mod handler;
 pub mod lifecycle;
 mod orphan;
@@ -224,7 +225,14 @@ pub fn load_by_id(home: &Path, task_id: &str) -> Option<Task> {
 /// per m-42); explicit operator-emitted Blocked/Unblocked events are
 /// honoured by replay's `apply()` as before.
 pub fn list_all(home: &Path) -> Vec<Task> {
-    let state = crate::task_events::replay(home).unwrap_or_default();
+    list_all_at(home)
+}
+
+/// #2117 P1: list a specific board's tasks (board-root replay + in-memory dep
+/// eval). `list_all(home)` is exactly `list_all_at(home)` — byte-identical,
+/// since `home` is the default board root (`board_root(home, DEFAULT)`).
+pub(crate) fn list_all_at(board: &Path) -> Vec<Task> {
+    let state = crate::task_events::replay_at(board).unwrap_or_default();
     let mut tasks: Vec<Task> = state.tasks.values().map(record_to_task).collect();
     apply_dependency_eval_in_memory(&mut tasks);
     tasks

--- a/src/tasks/tests.rs
+++ b/src/tasks/tests.rs
@@ -1289,6 +1289,102 @@ fn write_fleet_yaml(home: &std::path::Path, instances: &[&str]) {
     std::fs::write(crate::fleet::fleet_yaml_path(home), yaml).ok();
 }
 
+/// #2117 P1: two teams with distinct `source_repo`s get ISOLATED boards. A task
+/// created by teamA's member lands on teamA's board and is invisible to teamB's
+/// default (current-project) `list` — the new cross-board isolation. The
+/// `task_index` routes a later `done` to the right board, and `scope=fleet`
+/// aggregates both.
+#[test]
+fn two_projects_get_isolated_boards_2117() {
+    let home = tmp_home("p1-board-isolation");
+    let yaml = r#"
+instances:
+  devA:
+    backend: claude
+  devB:
+    backend: claude
+teams:
+  teamA:
+    members:
+      - devA
+    source_repo: /repos/orgA/projA
+  teamB:
+    members:
+      - devB
+    source_repo: /repos/orgB/projB
+"#;
+    std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).unwrap();
+
+    let ta = handle(
+        &home,
+        "devA",
+        &serde_json::json!({"action": "create", "title": "TA", "assignee": "devA"}),
+    )["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let tb = handle(
+        &home,
+        "devB",
+        &serde_json::json!({"action": "create", "title": "TB", "assignee": "devB"}),
+    )["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let list_ids = |caller: &str, args: serde_json::Value| -> Vec<String> {
+        handle(&home, caller, &args)["tasks"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|t| t["id"].as_str().map(String::from))
+            .collect()
+    };
+
+    // Default list = caller's current project → isolated.
+    let a_ids = list_ids("devA", serde_json::json!({"action": "list"}));
+    let b_ids = list_ids("devB", serde_json::json!({"action": "list"}));
+    assert!(
+        a_ids.contains(&ta) && !a_ids.contains(&tb),
+        "teamA must see only its own task: {a_ids:?}"
+    );
+    assert!(
+        b_ids.contains(&tb) && !b_ids.contains(&ta),
+        "teamB must see only its own task: {b_ids:?}"
+    );
+
+    // Each task lands on its own board subtree; nothing leaks to the default board.
+    assert!(home.join("boards/orgA_projA/task_events.jsonl").exists());
+    assert!(home.join("boards/orgB_projB/task_events.jsonl").exists());
+    assert!(
+        !home.join("task_events.jsonl").exists(),
+        "no task should land on the default/home board"
+    );
+
+    // scope=fleet aggregates across boards.
+    let all_ids = list_ids(
+        "devA",
+        serde_json::json!({"action": "list", "scope": "fleet"}),
+    );
+    assert!(
+        all_ids.contains(&ta) && all_ids.contains(&tb),
+        "fleet scope must see both boards' tasks: {all_ids:?}"
+    );
+
+    // done routes via task_index to the task's board (cross-board O(1)).
+    let done = handle(
+        &home,
+        "devA",
+        &serde_json::json!({"action": "done", "id": ta}),
+    );
+    assert_eq!(
+        done["event"], "done",
+        "teamA task done must route to its board: {done}"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+}
+
 #[test]
 fn test_claim_unknown_instance_rejected() {
     let home = tmp_home("claim-unknown");


### PR DESCRIPTION
Builds on **P0 (#2119)**'s `board_root` storage seam. P1 decides WHICH board each `task` command targets. **Single-project deployments resolve to the DEFAULT project → `board_root == home` → byte-identical to pre-P1.**

## What
- **`tasks/board_router.rs`** (new): `resolve_current_project(home, caller)` (caller → its team's `source_repo` → project id; else DEFAULT), `resolve_task_project(home, task_id)` (append-only `task_index.jsonl` lookup → full-board-scan fallback that repairs the index), `record_task_project`, `board_for_task`, `list_all_boards`, `enumerate_projects`. A **project id IS its filesystem-safe slug** → the board dir name equals the project id (reversible for enumeration/fallback).
- **Routed `handle()`**: create (resolve project + write index + `append_at`), list (caller's project default; `project=all`/`scope=fleet` aggregates every board, tagging each task — default response byte-identical), claim/done/update/activity/metadata_set/get (resolve the task's board via the index → `_at` variants), `cascade_cancel_children` (parent's board).
- `tasks/mod.rs`: `list_all_at(board)` (`list_all` delegates). `task_events.rs`: `project_slug`→`pub(crate)`; removed the now-unused `envelopes_for_task` home wrapper; `append_checked`/`append_batch_checked` home wrappers `#[allow(dead_code)]` (test-only post-routing; symmetric storage API). `mcp/tools.rs`: declared `project`+`scope` task args (required by the `mcp_handler_arg_reads` invariant).

## Acceptance — byte-identical
**ALL 158 existing task_events + tasks tests pass with ZERO assertion changes** (single-project → DEFAULT → home). New `two_projects_get_isolated_boards_2117`: two teams with distinct `source_repo`s → separate boards; teamA's task invisible to teamB's default `list`; each lands on its own `home/boards/<id>` subtree; `scope=fleet` aggregates both; `done` routes via the index to the right board.

`cargo fmt --check` ✓, `cargo clippy --all-targets --features tray -D warnings` ✓. Full `nextest --no-fail-fast`: only the pre-existing env-mutually-exclusive `dispatch_branch_..._1834` fails (passes under `AGEND_GIT_BYPASS=1`). Rebased onto current origin/main (93397e2, #2121).

## Scope
NO dispatch auto-create stamp / sweep-per-board / binding-lease-key — P2/P3. Flagged for reviewers: append-family emitter resolution + the fail-closed audit take the `board` arg (byte-identical while board==home; graceful-degrade else); `invalidate_replay_cache` stays a global generation bump (over-invalidates cross-board = safe).