### PR TITLE
refactor(#W1.2-slice2): migrate claim_verifier + deployments LOCAL git to git_cmd

### DIFF
--- a/src/claim_verifier.rs
+++ b/src/claim_verifier.rs
@@ -392,20 +392,16 @@ pub fn verify(
 
 /// Run `git diff --stat base..head` and return the list of changed file paths.
 fn git_diff_files(repo_dir: &Path, base: &str, head: &str) -> Result<Vec<String>, String> {
-    let output = std::process::Command::new("git")
-        .args(["diff", "--name-only", &format!("{base}..{head}")])
-        .current_dir(repo_dir)
-        .env("AGEND_GIT_BYPASS", "1")
-        .output()
-        .map_err(|e| format!("git diff failed: {e}"))?;
-    if !output.status.success() {
-        return Err(format!(
-            "git diff exited {}: {}",
-            output.status,
-            String::from_utf8_lossy(&output.stderr)
-        ));
-    }
-    Ok(String::from_utf8_lossy(&output.stdout)
+    // W1.2: LOCAL diff via the bypass+bounded helper (was a raw `.output()` that
+    // already set AGEND_GIT_BYPASS=1). git_cmd trims trailing whitespace, but
+    // the `filter(!is_empty)` already dropped the trailing blank line, so the
+    // collected path list is byte-identical.
+    let stdout = crate::git_helpers::git_cmd(
+        repo_dir,
+        &["diff", "--name-only", &format!("{base}..{head}")],
+    )
+    .map_err(|e| format!("git diff failed: {e}"))?;
+    Ok(stdout
         .lines()
         .filter(|l| !l.is_empty())
         .map(String::from)
@@ -419,20 +415,13 @@ fn git_diff_path_empty(
     head: &str,
     path: &str,
 ) -> Result<bool, String> {
-    let output = std::process::Command::new("git")
-        .args(["diff", &format!("{base}..{head}"), "--", path])
-        .current_dir(repo_dir)
-        .env("AGEND_GIT_BYPASS", "1")
-        .output()
-        .map_err(|e| format!("git diff failed: {e}"))?;
-    if !output.status.success() {
-        return Err(format!(
-            "git diff exited {}: {}",
-            output.status,
-            String::from_utf8_lossy(&output.stderr)
-        ));
-    }
-    Ok(output.stdout.is_empty())
+    // W1.2: LOCAL diff via the bypass+bounded helper (was a raw `.output()` that
+    // already set AGEND_GIT_BYPASS=1). A real diff has non-empty content and an
+    // unchanged path produces empty output; trimming preserves that
+    // empty-vs-non-empty distinction, so `is_empty()` is byte-identical.
+    crate::git_helpers::git_cmd(repo_dir, &["diff", &format!("{base}..{head}"), "--", path])
+        .map(|s| s.is_empty())
+        .map_err(|e| format!("git diff failed: {e}"))
 }
 
 // --- Individual claim checks ---
@@ -657,6 +646,10 @@ fn check_only_formatting(repo_dir: &Path, base: &str, head: &str) -> ClaimResult
 
 /// Get file content at a given revision and run rustfmt on it.
 fn git_show_and_fmt(repo_dir: &Path, rev: &str, path: &str) -> Result<String, String> {
+    // git-raw-allowed: git_cmd is wrong here on two counts — (1) it trims, but the
+    // raw file bytes must reach rustfmt's stdin unmodified; (2) a non-zero exit is
+    // the NORMAL "path absent at this rev → treat as empty" case below, which
+    // git_cmd would collapse into an Err. Kept raw with the explicit bypass env.
     let show = std::process::Command::new("git")
         .args(["show", &format!("{rev}:{path}")])
         .current_dir(repo_dir)

--- a/src/deployments.rs
+++ b/src/deployments.rs
@@ -237,25 +237,29 @@ fn prepare_work_dir(
 ) -> String {
     if let Some(br) = branch {
         let branch_name = format!("{deploy_name}/{inst_suffix}");
-        match std::process::Command::new("git")
-            .args([
+        // W1.2: LOCAL `git worktree add` via the bypass+bounded helper. The 3-way
+        // match maps onto GitError: NonZero (git ran, rejected) keeps the
+        // stderr-bearing "worktree failed" warn; Spawn (git never produced a
+        // status) keeps the "git not available" warn. GitError's stderr is already
+        // trimmed, matching the prior `.trim()`.
+        match crate::git_helpers::git_cmd(
+            parent_dir,
+            &[
                 "worktree",
                 "add",
                 "-b",
                 &branch_name,
                 &inst_dir.display().to_string(),
                 br,
-            ])
-            .current_dir(parent_dir)
-            .output()
-        {
-            Ok(o) if o.status.success() => {
+            ],
+        ) {
+            Ok(_) => {
                 tracing::info!(%inst_name, %branch_name, "created worktree");
             }
-            Ok(o) => {
-                tracing::warn!(%inst_name, error = %String::from_utf8_lossy(&o.stderr).trim(), "worktree failed");
+            Err(crate::git_helpers::GitError::NonZero { stderr, .. }) => {
+                tracing::warn!(%inst_name, error = %stderr, "worktree failed");
             }
-            Err(e) => {
+            Err(crate::git_helpers::GitError::Spawn(e)) => {
                 tracing::warn!(error = %e, "git not available");
             }
         }

--- a/tests/daemon_git_helper_invariant.rs
+++ b/tests/daemon_git_helper_invariant.rs
@@ -54,6 +54,14 @@ const MODULE_SCOPE: &[&str] = &[
     "mcp_config.rs",
     "instructions.rs",
     "skills.rs",
+    // W1.2 slice 2: claim_verifier (git diff --name-only / git diff -- path →
+    // git_cmd; git show piped to rustfmt kept raw via git-raw-allowed),
+    // deployments (git worktree add → git_cmd). canonical_hygiene already does
+    // all its LOCAL git via git_bypass (zero raw Command::new in production) —
+    // sealed here to guard against a future raw regression.
+    "claim_verifier.rs",
+    "deployments.rs",
+    "bootstrap/canonical_hygiene.rs",
 ];
 
 /// One violation entry — `(file, line_number, snippet)`.


### PR DESCRIPTION
## W1.2 slice 2 — daemon-internal LOCAL git → `git_cmd`

Continues the W1.2 line (slice 1 = #2120): route LOCAL daemon git through the bypass+bounded `git_helpers::git_cmd` helper (#1897 `LOCAL_GIT_TIMEOUT`, #781 bypass-env contract) instead of raw `Command::new("git")`, and grow the invariant guard's `MODULE_SCOPE`.

### Migrated (byte-identical)
| Site | Op | Treatment |
|---|---|---|
| `claim_verifier::git_diff_files` | `git diff --name-only base..head` | → `git_cmd`. Already set `AGEND_GIT_BYPASS=1` → pure swap; `filter(!is_empty)` already dropped the trailing blank line `git_cmd` trims. |
| `claim_verifier::git_diff_path_empty` | `git diff base..head -- path` | → `git_cmd` + `.map(|s| s.is_empty())`; trimming preserves empty-vs-non-empty. |
| `deployments::prepare_work_dir` | `git worktree add -b` | → `git_cmd`; 3-way match maps onto `GitError::{NonZero,Spawn}`, keeping the exact `tracing` targets/fields. Gains `LOCAL_GIT_TIMEOUT` + bypass-env consistency (no-op in the daemon's shim-free PATH). |

### Kept raw (`// git-raw-allowed:` + rationale)
- `claim_verifier::git_show_and_fmt` (`git show rev:path` piped to rustfmt) — `git_cmd` would (1) trim the file bytes before they reach rustfmt's stdin and (2) collapse the normal "path absent at rev → empty" non-zero into an `Err`.

### MODULE_SCOPE additions
`claim_verifier.rs`, `deployments.rs`, and `bootstrap/canonical_hygiene.rs` (already 100% `git_bypass` in production — sealed to guard a future raw regression; zero migration).

### Proof
- Existing `claim_verifier` / `deployments` tests pass with **zero assertion changes**.
- `daemon_git_helper_invariant` green on the 3 new MODULE_SCOPE entries (incl. the `git show` raw marker).
- Full suite **4153/4154** — the lone fail is the known `spawn_group_bounded_preserves_caller_env_no_bypass_1899` env-set artifact (passes in CI's clean env).
- `clippy --all-targets --features tray -- -D warnings` clean; Windows `x86_64-pc-windows-msvc` cross-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)