### PR TITLE
refactor(#W1.2-slice3): migrate agent_ops worktree-remove to git_ok; seal 3 more modules

### DIFF
--- a/src/agent_ops.rs
+++ b/src/agent_ops.rs
@@ -390,15 +390,20 @@ pub fn cleanup_working_dir(home: &Path, name: &str, working_dir: &Path) {
         // Clean up worktree if exists
         let wt_dir = working_dir.join(".worktrees").join(name);
         if wt_dir.exists() {
-            let _ = std::process::Command::new("git")
-                .args([
+            // W1.2: LOCAL best-effort worktree-remove via the bypass+bounded
+            // helper (was a raw UNBOUNDED `.output()` whose result was already
+            // discarded). git_ok adds the LOCAL_GIT_TIMEOUT bound so a stuck
+            // remove can't hang teardown; the bypass env is a no-op in the
+            // daemon's shim-free PATH. Result stays discarded → same effect.
+            let _ = crate::git_helpers::git_ok(
+                working_dir,
+                &[
                     "worktree",
                     "remove",
                     "--force",
                     &wt_dir.display().to_string(),
-                ])
-                .current_dir(working_dir)
-                .output();
+                ],
+            );
             tracing::info!(dir = %wt_dir.display(), "removed worktree");
         }
     }

--- a/src/mcp/handlers/ci/mod.rs
+++ b/src/mcp/handlers/ci/mod.rs
@@ -472,6 +472,9 @@ pub(super) fn handle_release_repo(args: &Value) -> Value {
     // spawn_group_bounded only adds the LOCAL timeout + safe process-group kill,
     // without forcing the bypass env. (Whether it SHOULD bypass like ci/mod:270
     // is a separate behaviour question, out of scope for this timeout PR.)
+    // git-raw-allowed: deliberate non-bypass + no current_dir; already bounded via
+    // spawn_group_bounded; the Ok(non-zero) arm surfaces stderr in the JSON `note`
+    // (git_ok would discard it), so git_cmd/git_ok would not be byte-identical.
     let mut cmd = std::process::Command::new("git");
     cmd.args(["worktree", "remove", "--force", &path_str]);
     match crate::git_helpers::spawn_group_bounded(

--- a/tests/daemon_git_helper_invariant.rs
+++ b/tests/daemon_git_helper_invariant.rs
@@ -62,6 +62,15 @@ const MODULE_SCOPE: &[&str] = &[
     "claim_verifier.rs",
     "deployments.rs",
     "bootstrap/canonical_hygiene.rs",
+    // W1.2 slice 3: agent_ops (best-effort worktree-remove → git_ok). ci/mod's
+    // worktree-remove is kept raw (deliberate non-bypass, already bounded via
+    // spawn_group_bounded, surfaces stderr in JSON note) via git-raw-allowed.
+    // auto_release + retention/worktrees already do all LOCAL git via git_bypass
+    // (zero raw Command::new in production) — sealed against a future regression.
+    "agent_ops.rs",
+    "mcp/handlers/ci/mod.rs",
+    "daemon/auto_release.rs",
+    "daemon/retention/worktrees.rs",
 ];
 
 /// One violation entry — `(file, line_number, snippet)`.


### PR DESCRIPTION
## W1.2 slice 3 — daemon-internal LOCAL git → helpers

Continues the W1.2 line (slice 1 #2120, slice 2 #2123): route LOCAL daemon git through the bypass+bounded `git_helpers` (#1897 `LOCAL_GIT_TIMEOUT`, #781 bypass-env) instead of raw `Command::new("git")`, and grow the invariant guard's `MODULE_SCOPE`.

### Migrated
| Site | Op | Treatment |
|---|---|---|
| `agent_ops::cleanup_working_dir` | `git worktree remove --force` | → `git_ok`. Was a raw **UNBOUNDED** `.output()` with result already discarded; `git_ok` adds the `LOCAL_GIT_TIMEOUT` bound (stuck remove can't hang teardown) + bypass env (no-op in daemon's shim-free PATH). Result stays discarded → same effect. |

### Kept raw (`// git-raw-allowed:` + rationale)
- **`ci/mod` worktree-remove** — deliberate non-bypass + no `current_dir`, **already bounded** via `spawn_group_bounded`, and its `Ok(non-zero)` arm surfaces stderr in the JSON `note` (`git_ok` would discard it) → not byte-identical. Sealed via MODULE_SCOPE + marker so the deliberate choice is documented & guarded.

### Sealed (zero migration — production already 100% `git_bypass`)
- `daemon/auto_release.rs`, `daemon/retention/worktrees.rs` — LOCAL git (porcelain `status` / `worktree prune`) already via `git_bypass`; added to MODULE_SCOPE to guard a future raw regression.

### Deferred
- `worktree.rs` (11 sites, complex worktree porcelain) — left for a dedicated slice per the lead's scope guidance.

### Proof
- Existing `agent_ops` / `ci` / `auto_release` / `retention` tests pass with **zero assertion changes**.
- `daemon_git_helper_invariant` green on the 4 new MODULE_SCOPE entries (incl. the `ci/mod` raw marker).
- Full suite **4154/4155** — the lone fail is the known `spawn_group_bounded_preserves_caller_env_no_bypass_1899` env-set artifact (passes in CI's clean env).
- `clippy --all-targets --features tray -- -D warnings` clean; Windows `x86_64-pc-windows-msvc` cross-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)