### PR TITLE
feat(#2117 P2): dispatch auto-create stamps target project + sweep per-board (closes #2105)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -37,8 +37,10 @@ final-status-level = "slow"
 #     daemon::{retention::worktrees,pr_state,auto_release,conflict_notify,
 #     per_tick::tmp_review_gc}, bootstrap::{agent_resolve,canonical_hygiene}.
 #  2. NAMED tests in otherwise-pure modules (messaging 2/47, tasks::tests 1/78,
-#     task_sweep, mcp::handlers::tests checkout_repo_*) — targeted by name so the
-#     ~200 pure-logic tests around them stay parallel.
+#     task_sweep `closes_markers_…` + `resolve_sweep_boards_pairs_…_2117_p2`
+#     [#2117 P2: builds 2 real git repos for the per-board sweep enumeration],
+#     mcp::handlers::tests checkout_repo_*) — targeted by name so the ~200
+#     pure-logic tests around them stay parallel.
 [test-groups]
 git-subprocess = { max-threads = 1 }
 
@@ -54,11 +56,11 @@ test-group = 'git-subprocess'
 slow-timeout = { period = "120s", terminate-after = 3 }
 
 [[profile.ci.overrides]]
-filter = 'test(/(^(worktree_pool|admin|mcp::handlers::(ci|dispatch_hook|force_release|worktree|p0b_tests)|daemon::(retention::worktrees|pr_state|auto_release|conflict_notify|per_tick::tmp_review_gc)|bootstrap::(agent_resolve|canonical_hygiene))::|checkout_repo_|dispatch_branch_skips_metadata_stub|send_with_branch_checkout_failure|task_done_cleans_post_lease|closes_markers_extract_cleanly_from_actual_main)/)'
+filter = 'test(/(^(worktree_pool|admin|mcp::handlers::(ci|dispatch_hook|force_release|worktree|p0b_tests)|daemon::(retention::worktrees|pr_state|auto_release|conflict_notify|per_tick::tmp_review_gc)|bootstrap::(agent_resolve|canonical_hygiene))::|checkout_repo_|dispatch_branch_skips_metadata_stub|send_with_branch_checkout_failure|task_done_cleans_post_lease|closes_markers_extract_cleanly_from_actual_main|resolve_sweep_boards_pairs_each_project_with_its_own_repo_2117_p2)/)'
 test-group = 'git-subprocess'
 
 # Local `default` profile has no terminate-after, so no false-kill risk — just
 # serialize the same cluster for parity with CI.
 [[profile.default.overrides]]
-filter = 'test(/(^(worktree_pool|admin|mcp::handlers::(ci|dispatch_hook|force_release|worktree|p0b_tests)|daemon::(retention::worktrees|pr_state|auto_release|conflict_notify|per_tick::tmp_review_gc)|bootstrap::(agent_resolve|canonical_hygiene))::|checkout_repo_|dispatch_branch_skips_metadata_stub|send_with_branch_checkout_failure|task_done_cleans_post_lease|closes_markers_extract_cleanly_from_actual_main)/)'
+filter = 'test(/(^(worktree_pool|admin|mcp::handlers::(ci|dispatch_hook|force_release|worktree|p0b_tests)|daemon::(retention::worktrees|pr_state|auto_release|conflict_notify|per_tick::tmp_review_gc)|bootstrap::(agent_resolve|canonical_hygiene))::|checkout_repo_|dispatch_branch_skips_metadata_stub|send_with_branch_checkout_failure|task_done_cleans_post_lease|closes_markers_extract_cleanly_from_actual_main|resolve_sweep_boards_pairs_each_project_with_its_own_repo_2117_p2)/)'
 test-group = 'git-subprocess'

--- a/src/daemon/task_sweep.rs
+++ b/src/daemon/task_sweep.rs
@@ -201,34 +201,130 @@ fn sweep_tick(home: &Path) -> anyhow::Result<()> {
     if cfg.paused {
         return Ok(());
     }
-    let repo = match &cfg.repo {
-        Some(r) if !r.is_empty() => r.clone(),
-        _ => return Ok(()),
-    };
     let api_base = cfg
         .api_base_url
         .as_deref()
         .unwrap_or(DEFAULT_GITHUB_API_BASE);
 
-    let prs = list_recently_merged_prs(&repo, api_base)?;
-    if prs.is_empty() {
+    // #2117 P2: sweep each project board against ITS OWN repo. fleet.yaml teams
+    // contribute their per-project boards; `cfg.repo` is the operator override /
+    // single-project fallback for the DEFAULT (home) board. A merged PR in repo A
+    // is matched ONLY against board A's open tasks, so it can never auto-close a
+    // task that lives on board B (#2105). Single-project deployments (no per-team
+    // `source_repo`) resolve to exactly `[(DEFAULT, cfg.repo)]` → board == home →
+    // byte-identical to the pre-P2 single-repo tick.
+    let boards = resolve_sweep_boards(home, &cfg);
+    if boards.is_empty() {
         return Ok(());
     }
 
-    // Sprint 56 Track F (#496): load fleet config so the authorship gate
-    // below can resolve `task.created_by` / `task.assignee` (agend-local
-    // instance names) into `github_login` GitHub usernames before
-    // comparing against `pr.author_login`. Pre-Track-F the gate compared
-    // disjoint namespaces and silently rejected every cross-namespace
-    // mismatch — see `docs/RCA-issue-496-task-sweep-no-auto-close-2026-05-08.md`.
-    // `Option<FleetConfig>` because a missing/malformed fleet.yaml must
-    // not abort the sweep — fall back to direct compare for compat.
+    // Sprint 56 Track F (#496): load fleet config once so the per-board
+    // authorship gate can resolve `task.created_by` / `task.assignee` (agend-local
+    // instance names) into `github_login` GitHub usernames before comparing
+    // against `pr.author_login`. `Option<FleetConfig>` because a missing/malformed
+    // fleet.yaml must not abort the sweep — fall back to direct compare for compat.
     let fleet_cfg = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home)).ok();
 
-    // Snapshot of currently-open tasks. Read from tasks::list_all (the
-    // PR2 bridge-phase legacy reader); PR3 cutover switches this to
-    // `task_events::replay` derived view.
-    let open_tasks = crate::tasks::list_all(home);
+    // The DEFAULT board's scan gates the (unchanged-scope) compliance pass below,
+    // exactly as the pre-P2 single-repo tick did (compliance ran only once both
+    // the PR list AND the open-task set were non-empty).
+    let mut default_scanned = false;
+    for (project_id, repo) in &boards {
+        match sweep_board(
+            home,
+            project_id,
+            repo,
+            api_base,
+            fleet_cfg.as_ref(),
+            cfg.dry_run,
+        ) {
+            Ok(scanned) => {
+                if project_id == crate::task_events::DEFAULT_PROJECT {
+                    default_scanned = scanned;
+                }
+            }
+            // Per-board isolation: a repo-A API/append failure must NOT abort the
+            // repo-B board scan (the #2105 multi-board goal). Log and continue.
+            Err(e) => tracing::warn!(
+                project = %project_id, repo = %repo, error = %e,
+                "task_sweep: board scan failed"
+            ),
+        }
+    }
+
+    // Issue #664: compliance scan stays keyed on the operator's primary repo
+    // (`cfg.repo`) and gated on the DEFAULT board's scan — #2117 P2 covers
+    // auto-close routing, not compliance (out of scope). Byte-identical: in a
+    // single-project deployment the DEFAULT board IS `cfg.repo`.
+    if default_scanned && cfg.compliance_mode != "off" {
+        if let Some(repo) = cfg.repo.as_deref().filter(|s| !s.is_empty()) {
+            let _ = compliance_sweep(home, repo);
+        }
+    }
+
+    Ok(())
+}
+
+/// #2117 P2: the set of `(project_id, github "owner/repo")` boards to sweep.
+///
+/// fleet.yaml teams contribute their per-project boards — each team's
+/// `source_repo` yields the board's `project_id` (the same slug
+/// [`crate::tasks::project_id_from_source_repo`] feeds `board_root`) and its
+/// GitHub slug (`derive_repo_from_remote`). `cfg.repo` contributes the DEFAULT
+/// (home) board as the operator override / single-project fallback. A
+/// `source_repo` with no GitHub `origin` remote (or a non-GitHub remote) is
+/// skipped — the poller only knows GitHub Actions. Order is deterministic
+/// (BTreeMap by project_id); distinct `source_repo`s that collapse to one
+/// project (a project can back multiple teams) dedupe to a single board.
+fn resolve_sweep_boards(home: &Path, cfg: &SweepConfig) -> Vec<(String, String)> {
+    let mut boards: std::collections::BTreeMap<String, String> = std::collections::BTreeMap::new();
+    for team in crate::teams::list_all(home) {
+        let Some(repo_path) = team.source_repo.as_deref() else {
+            continue;
+        };
+        let Some(slug) =
+            crate::mcp::handlers::dispatch_hook::derive_repo_from_remote_pub(repo_path)
+        else {
+            continue;
+        };
+        let project_id = crate::tasks::project_id_from_source_repo(repo_path);
+        boards.entry(project_id).or_insert(slug);
+    }
+    if let Some(repo) = cfg.repo.as_deref().filter(|s| !s.is_empty()) {
+        boards
+            .entry(crate::task_events::DEFAULT_PROJECT.to_string())
+            .or_insert_with(|| repo.to_string());
+    }
+    boards.into_iter().collect()
+}
+
+/// #2117 P2: scan ONE project board against ITS repo for `Closes t-…` markers in
+/// recently-merged PRs and auto-close the matching open tasks. Mutations route to
+/// the board via `append_done_if_legal_at` (the P0/P1 `_at` seam). Returns
+/// `Ok(true)` if a full scan ran (PR list AND open-task set both non-empty),
+/// `Ok(false)` if it short-circuited — the caller uses the DEFAULT board's flag
+/// to gate the compliance pass exactly as the pre-P2 single-repo tick did.
+fn sweep_board(
+    home: &Path,
+    project_id: &str,
+    repo: &str,
+    api_base: &str,
+    fleet_cfg: Option<&crate::fleet::FleetConfig>,
+    dry_run: bool,
+) -> anyhow::Result<bool> {
+    let prs = list_recently_merged_prs(repo, api_base)?;
+    if prs.is_empty() {
+        return Ok(false);
+    }
+
+    // P0/P1 board seam: a single-project deployment resolves `project_id` to
+    // DEFAULT → `board == home` → `list_all_at`/`append_done_if_legal_at` are the
+    // byte-identical home-board paths.
+    let board = crate::task_events::board_root(home, project_id);
+
+    // Snapshot of THIS board's currently-open tasks (read via the P1 `_at`
+    // variant so a merged PR is matched only against tasks on its own board).
+    let open_tasks = crate::tasks::list_all_at(&board);
     let open_ids: std::collections::HashMap<String, &crate::tasks::Task> = open_tasks
         .iter()
         .filter(|t| {
@@ -242,7 +338,7 @@ fn sweep_tick(home: &Path) -> anyhow::Result<()> {
         .map(|t| (t.id.clone(), t))
         .collect();
     if open_ids.is_empty() {
-        return Ok(());
+        return Ok(false);
     }
 
     let emitter = InstanceName::from(SWEEP_EMITTER);
@@ -308,7 +404,7 @@ fn sweep_tick(home: &Path) -> anyhow::Result<()> {
             // pure helper `compute_author_ok` resolves creator/assignee
             // via the fleet's `github_login` mapping with a fall-back to
             // a direct string compare for compat — see helper docs.
-            let author_ok = compute_author_ok(&pr.author_login, task, fleet_cfg.as_ref());
+            let author_ok = compute_author_ok(&pr.author_login, task, fleet_cfg);
             if !author_ok {
                 tracing::warn!(
                     pr = pr.number,
@@ -321,7 +417,7 @@ fn sweep_tick(home: &Path) -> anyhow::Result<()> {
                 continue;
             }
 
-            if cfg.dry_run {
+            if dry_run {
                 tracing::info!(
                     pr = pr.number,
                     marker = %marker,
@@ -363,7 +459,7 @@ fn sweep_tick(home: &Path) -> anyhow::Result<()> {
             // at sweep start; a marker task cancelled since must NOT be flipped to
             // Done (the whole Linked+Done batch is skipped — a cancelled task drops
             // out of `open_ids` next cycle, so no re-attempt).
-            let closed = task_events::append_done_if_legal(home, &emitter, &marker, events)?;
+            let closed = task_events::append_done_if_legal_at(&board, &emitter, &marker, events)?;
             if closed {
                 tracing::info!(
                     pr = pr.number,
@@ -374,12 +470,7 @@ fn sweep_tick(home: &Path) -> anyhow::Result<()> {
         }
     }
 
-    // Issue #664: run compliance checks on merged PRs
-    if cfg.compliance_mode != "off" {
-        let _ = compliance_sweep(home, &repo);
-    }
-
-    Ok(())
+    Ok(true)
 }
 
 // ── PR body sanitisation + marker extraction ─────────────────────────
@@ -829,6 +920,114 @@ mod tests {
         ));
         fs::create_dir_all(&dir).unwrap();
         dir
+    }
+
+    // ── #2117 P2: per-board sweep enumeration ──────────────────────
+
+    /// Init a git repo at `dir` with a single GitHub `origin` remote so
+    /// `derive_repo_from_remote` resolves a slug (the sweep's board→repo map).
+    fn git_repo_with_origin(dir: &Path, origin: &str) {
+        fs::create_dir_all(dir).unwrap();
+        let git = |args: &[&str]| {
+            std::process::Command::new("git")
+                .args(args)
+                .current_dir(dir)
+                .env("AGEND_GIT_BYPASS", "1")
+                .output()
+                .ok();
+        };
+        git(&["init", "-b", "main"]);
+        git(&["remote", "add", "origin", origin]);
+    }
+
+    /// #2117 P2: the sweep enumerates ONE board per project — each fleet team's
+    /// `source_repo` board paired with ITS OWN derived GitHub repo, plus the
+    /// DEFAULT (home) board paired with `cfg.repo`. This 1:1 (board, repo)
+    /// pairing is what makes a merged PR in repo A match only board A's tasks
+    /// (#2105): the sweep never scans board B against repo A.
+    #[test]
+    fn resolve_sweep_boards_pairs_each_project_with_its_own_repo_2117_p2() {
+        let home = tmp_home("p2-sweep-boards");
+        let repo_a = home.join("srcA");
+        let repo_b = home.join("srcB");
+        git_repo_with_origin(&repo_a, "https://github.com/orgA/projA.git");
+        git_repo_with_origin(&repo_b, "https://github.com/orgB/projB.git");
+        fs::write(
+            crate::fleet::fleet_yaml_path(&home),
+            format!(
+                "instances:\n  devA:\n    backend: claude\n  devB:\n    backend: claude\n\
+                 teams:\n  teamA:\n    members:\n      - devA\n    source_repo: {}\n\
+                 \x20 teamB:\n    members:\n      - devB\n    source_repo: {}\n",
+                repo_a.display(),
+                repo_b.display()
+            ),
+        )
+        .unwrap();
+
+        let cfg = SweepConfig {
+            repo: Some("operator/primary".to_string()),
+            ..Default::default()
+        };
+        let boards: std::collections::HashMap<String, String> =
+            resolve_sweep_boards(&home, &cfg).into_iter().collect();
+
+        // DEFAULT (home) board ← cfg.repo (operator override / single-project
+        // fallback) — NEVER a project repo.
+        assert_eq!(
+            boards
+                .get(crate::task_events::DEFAULT_PROJECT)
+                .map(String::as_str),
+            Some("operator/primary"),
+            "default board must map to cfg.repo: {boards:?}"
+        );
+        // Each project board ← ITS OWN derived (canonical, lowercased) repo.
+        let pa = crate::tasks::project_id_from_source_repo(&repo_a);
+        let pb = crate::tasks::project_id_from_source_repo(&repo_b);
+        assert_eq!(
+            boards.get(&pa).map(String::as_str),
+            Some("orga/proja"),
+            "teamA board must pair with orgA/projA: {boards:?}"
+        );
+        assert_eq!(
+            boards.get(&pb).map(String::as_str),
+            Some("orgb/projb"),
+            "teamB board must pair with orgB/projB: {boards:?}"
+        );
+        assert_eq!(
+            boards.len(),
+            3,
+            "exactly default + 2 project boards: {boards:?}"
+        );
+
+        fs::remove_dir_all(&home).ok();
+    }
+
+    /// #2117 P2 byte-identical: with NO per-team `source_repo` (the
+    /// single-project shape every pre-P2 test assumes), the board set is exactly
+    /// `[(DEFAULT, cfg.repo)]` → board == home → the legacy single-repo tick.
+    #[test]
+    fn resolve_sweep_boards_single_project_is_default_only_2117_p2() {
+        let home = tmp_home("p2-sweep-single");
+        let cfg = SweepConfig {
+            repo: Some("operator/primary".to_string()),
+            ..Default::default()
+        };
+        let boards = resolve_sweep_boards(&home, &cfg);
+        assert_eq!(
+            boards,
+            vec![(
+                crate::task_events::DEFAULT_PROJECT.to_string(),
+                "operator/primary".to_string()
+            )],
+            "single-project must resolve to exactly the DEFAULT board ← cfg.repo"
+        );
+        // And no repo configured at all → empty → tick is a no-op.
+        let empty = resolve_sweep_boards(&home, &SweepConfig::default());
+        assert!(
+            empty.is_empty(),
+            "no repo + no teams → no boards: {empty:?}"
+        );
+        fs::remove_dir_all(&home).ok();
     }
 
     // ── Sprint 56 Track F (#496): authorship gate via github_login ──

--- a/src/mcp/handlers/comms.rs
+++ b/src/mcp/handlers/comms.rs
@@ -246,12 +246,21 @@ pub(super) fn handle_delegate_task(home: &Path, args: &Value, sender: &Option<Se
                 .chars()
                 .take(80)
                 .collect::<String>();
+            // #2117 P2: route the auto-created task to the TARGET's board, not
+            // the dispatcher's. `handle` is called with `sender` as the emitter,
+            // so without an explicit `project` the create would default to the
+            // *caller's* project (resolve_current_project(sender)) — the P1 leak
+            // the epic flagged. Stamp the target's project so the task is born on
+            // the board the assignee actually works. Single-project → both resolve
+            // to DEFAULT → home board → byte-identical.
+            let target_project = crate::tasks::resolve_target_project(home, target);
             let create_args = json!({
                 "action": "create",
                 "title": auto_title,
                 "assignee": target,
                 "branch": args["branch"].as_str(),
                 "priority": "normal",
+                "project": target_project,
             });
             let task_result = crate::tasks::handle(home, sender.as_str(), &create_args);
             match task_result["id"].as_str() {

--- a/src/mcp/handlers/dispatch_hook/tests.rs
+++ b/src/mcp/handlers/dispatch_hook/tests.rs
@@ -785,6 +785,77 @@ fn delegate_task_with_repo_creates_ci_watch_via_handle_delegate_task() {
     std::fs::remove_dir_all(&home).ok();
 }
 
+/// #2117 P2: a dispatch from teamA's member to teamB's member auto-creates the
+/// board task on the TARGET's (teamB) board — not the dispatcher's. Pre-P2 the
+/// auto-create called `tasks::handle` with the *sender* as emitter and no
+/// explicit `project`, so the task defaulted to the CALLER's project (teamA) —
+/// the leak the epic flagged at `comms.rs`. The fix stamps
+/// `resolve_target_project(target)` into the create. No `branch` → the lease is
+/// skipped (this test pins the board-routing decision, not the CI-watch path).
+#[test]
+fn dispatch_auto_create_lands_on_target_board_2117_p2() {
+    use crate::identity::Sender;
+    let home = std::env::temp_dir().join(format!(
+        "agend-2117p2-dispatch-target-board-{}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&home).ok();
+    // Two teams, distinct source_repos → distinct boards. devA dispatches devB.
+    std::fs::write(
+        crate::fleet::fleet_yaml_path(&home),
+        r#"
+instances:
+  devA:
+    backend: claude
+  devB:
+    backend: claude
+teams:
+  teamA:
+    members:
+      - devA
+    source_repo: /repos/orgA/projA
+  teamB:
+    members:
+      - devB
+    source_repo: /repos/orgB/projB
+"#,
+    )
+    .unwrap();
+
+    let args = serde_json::json!({
+        "instance": "devB",
+        "task": "implement feature X",
+        // no task_id → auto-create; no branch → skip the lease/CI-watch path.
+    });
+    let sender = Some(Sender::new("devA").expect("sender"));
+    // `api::call(SEND)` errors in-test (no daemon) but only AFTER the auto-create
+    // commit — we assert which board the task was BORN on, not the send result.
+    let _ = super::super::comms::handle_delegate_task(&home, &args, &sender);
+
+    // Query each board via the P1 `_at` reader (avoids the task_events anti-bypass
+    // invariant on the literal log path). The auto-created task must be on the
+    // TARGET's (teamB) board …
+    let on_board =
+        |proj: &str| crate::tasks::list_all_at(&crate::task_events::board_root(&home, proj));
+    assert_eq!(
+        on_board("orgB_projB").len(),
+        1,
+        "auto-created dispatch task must land on the target's (teamB) board"
+    );
+    // … NOT on the dispatcher's (teamA) board, nor the default/home board (the
+    // pre-P2 leak: create defaulted to the caller's project).
+    assert!(
+        on_board("orgA_projA").is_empty(),
+        "task must NOT land on the dispatcher's (teamA) board — that is the #2117 P2 leak"
+    );
+    assert!(
+        on_board(crate::task_events::DEFAULT_PROJECT).is_empty(),
+        "task must NOT land on the default/home board"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+}
+
 // ─────────────────────────────────────────────────────────────────
 // Sprint 58 Wave 1 PR-3 (#15) — explicit post-Wave-4 dispatch-layer
 // guard pins.

--- a/src/tasks/board_router.rs
+++ b/src/tasks/board_router.rs
@@ -72,7 +72,7 @@ fn lookup_task_project(home: &Path, task_id: &str) -> Option<String> {
 /// Uses the trailing `owner/repo` segments (`.git` stripped) when present, then
 /// slugs to a safe directory name (the same `project_slug` `board_root` applies,
 /// so the result is idempotent under `board_root`).
-fn project_id_from_source_repo(repo: &Path) -> String {
+pub(crate) fn project_id_from_source_repo(repo: &Path) -> String {
     let segs: Vec<String> = repo
         .components()
         .filter_map(|c| match c {
@@ -97,6 +97,17 @@ pub(super) fn resolve_current_project(home: &Path, caller: &str) -> String {
         .and_then(|t| t.source_repo)
         .map(|repo| project_id_from_source_repo(&repo))
         .unwrap_or_else(|| DEFAULT_PROJECT.to_string())
+}
+
+/// The project a dispatch **target** acts in — identical
+/// agent→team→`source_repo`→project resolution as [`resolve_current_project`],
+/// but keyed on the dispatch target rather than the caller. The comms
+/// auto-create path (#2117 P2) stamps this so the spawned task lands on the
+/// TARGET's board, not the dispatcher's (P1's `create` defaulted to the
+/// *caller's* project — the leak the epic flagged at `comms.rs`). Single-project
+/// → [`DEFAULT_PROJECT`] → the `home` board → byte-identical.
+pub(crate) fn resolve_target_project(home: &Path, target: &str) -> String {
+    resolve_current_project(home, target)
 }
 
 /// The project a task lives in: the `task_index` entry, else a full-board scan

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -18,6 +18,10 @@ use std::path::Path;
 
 pub use handler::handle;
 pub use handler::register_subscriber as register_cascade_subscriber;
+// #2117 P2: resolution helpers for the out-of-`tasks` callers — comms dispatch
+// auto-create (target board) and the per-board task sweep (project id from a
+// team's source_repo).
+pub(crate) use board_router::{project_id_from_source_repo, resolve_target_project};
 pub use orphan::{
     cancel_tasks_for_owner, orphan_tasks_for_owner, reconcile_orphan_owners_with_live,
     release_inprogress_orphans_with_live,


### PR DESCRIPTION
## #2117 P2 — dispatch auto-create stamps target project + sweep per-board

Builds on P0 (#2119 `board_root`) + P1 (#2122 BoardRouter/task_index/command routing). P1 routed **direct** task commands per-board but left two leaks the epic flagged; P2 closes both. **Single-project** (no per-team `source_repo`) → DEFAULT → board == home → **byte-identical** (all existing dispatch/sweep/task tests pass with ZERO assertion changes).

### 1. dispatch auto-create stamps the TARGET's project (`comms.rs`)
`handle_delegate_task`'s #1050 auto-create called `tasks::handle` with the **sender** as emitter and no explicit `project`, so the task defaulted to the *caller's* project — a multi-project task landed on the **dispatcher's** board, not the assignee's. Now stamps `BoardRouter::resolve_target_project(target)` so the task is born on the board the assignee works.

### 2. sweep per-board (`task_sweep.rs`, closes #2105)
`sweep_tick` read one global `cfg.repo` against `list_all(home)` (the DEFAULT board only). Now `resolve_sweep_boards` enumerates fleet.yaml teams' distinct `source_repo`s → one `(project_id, github_repo)` board each, plus `cfg.repo` as the DEFAULT/single-project fallback. Extracted `sweep_board(board, repo)` scans each board's OWN open tasks (`list_all_at`) against its OWN repo's merged PRs and routes the →Done via `append_done_if_legal_at` — **a merged PR in repo A can never auto-close a task on board B**. Per-board error isolation. Compliance scan stays keyed on `cfg.repo`, gated on the DEFAULT board's scan (byte-identical; out of P2 scope).

### BoardRouter
+ `resolve_target_project` (target→team→source_repo→project; delegates to `resolve_current_project`). `project_id_from_source_repo` exposed `pub(crate)` for the sweep's board→repo map. `tasks/mod.rs` re-exports both.

### Tests
- `dispatch_auto_create_lands_on_target_board_2117_p2` — end-to-end `handle_delegate_task`, teamA→teamB dispatch lands on teamB's board, invisible to teamA/default.
- `resolve_sweep_boards_pairs_each_project_with_its_own_repo_2117_p2` — 1:1 (board,repo); default←cfg.repo, each project←its own derived github slug.
- `resolve_sweep_boards_single_project_is_default_only_2117_p2` — byte-identical shape.

### Verification
- `cargo nextest run --profile ci --features tray`: **4158 passed, 33 skipped** (full suite).
- `cargo fmt --check` ✓ · `cargo clippy --features tray --tests -D warnings` ✓

**Scope:** NO binding lease key (project,branch) / per-board fail-closed / multi-project migration backfill (all P3).

Closes #2105. Part of epic #2117.

🤖 Generated with [Claude Code](https://claude.com/claude-code)