### PR TITLE
test: fix 18 high-severity test-audit findings (false-confidence + vacuous)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1676,11 +1676,17 @@ mod tests {
         let source = std::fs::read_to_string("src/app/mod.rs")
             .or_else(|_| std::fs::read_to_string("agend-terminal/src/app/mod.rs"))
             .expect("source file must be readable from test cwd");
+        // Search only the production region. This assertion's own literal
+        // lives in the #[cfg(test)] module below, so a whole-file substring
+        // check self-matches and would stay green even if the real call were
+        // deleted. Require the call form (with `(`) before the test cutoff.
+        let prod = &source[..source.find("#[cfg(test)]").unwrap_or(source.len())];
         assert!(
-            source.contains("inject_notification_with_submit"),
+            prod.contains("inject_notification_with_submit("),
             "flush_idle_notifications must wire the submit-aware injector \
-             (#982 reviewer #999 verdict) — searched for \
-             'inject_notification_with_submit' in src/app/mod.rs"
+             (#982 reviewer #999 verdict) — no call to \
+             'inject_notification_with_submit(' found in the production region \
+             of src/app/mod.rs"
         );
     }
 
@@ -1926,12 +1932,17 @@ mod tests {
         let source = std::fs::read_to_string("src/app/mod.rs")
             .or_else(|_| std::fs::read_to_string("agend-terminal/src/app/mod.rs"))
             .expect("source file must be readable from test cwd");
+        // Search only the production region. This assertion's own literal
+        // lives in the #[cfg(test)] module below, so a whole-file substring
+        // check self-matches and would stay green even if the real call were
+        // deleted. Require the call form (with `(`) before the test cutoff.
+        let prod = &source[..source.find("#[cfg(test)]").unwrap_or(source.len())];
         assert!(
-            source.contains("register_event_subscribers"),
+            prod.contains("register_event_subscribers("),
             "run_app must call daemon::register_event_subscribers in owned mode \
              (app mode never reaches run_core's registration — #1720 app-mode \
-             silent-drop root fix). Searched for 'register_event_subscribers' in \
-             src/app/mod.rs"
+             silent-drop root fix). No call to 'register_event_subscribers(' \
+             found in the production region of src/app/mod.rs"
         );
     }
 

--- a/src/daemon/ci_watch/poller.rs
+++ b/src/daemon/ci_watch/poller.rs
@@ -1196,6 +1196,24 @@ struct PollResult {
     effective_last_run_id: Option<u64>,
 }
 
+/// Force-push invalidation (pure). When the branch head has moved since the
+/// last poll (`prev_head_sha` is present and differs from `current_sha`), the
+/// cached `last_run_id` points at a run for the OLD head and is stale, so it
+/// must be reset to `None` for the new head's run to be picked up. Otherwise
+/// the cached id is preserved. The production caller (`poll_ci_runs`) layers
+/// the logging / progress-touch side effects on top of this decision.
+pub(crate) fn effective_last_run_id(
+    prev_head_sha: Option<&str>,
+    current_sha: &str,
+    last_run_id: Option<u64>,
+) -> Option<u64> {
+    if prev_head_sha.is_some_and(|prev| prev != current_sha) {
+        None
+    } else {
+        last_run_id
+    }
+}
+
 struct NotifyOutcome {
     max_notified_id: u64,
     new_notified_sha: Option<String>,
@@ -1541,10 +1559,12 @@ async fn poll_ci_runs(
                 .map(|r| r.head_sha.as_str())
                 .unwrap_or("")
                 .to_string();
-            let effective_last_run_id = if tracking
+            let head_moved = tracking
                 .prev_head_sha
-                .is_some_and(|prev| prev != current_sha)
-            {
+                .is_some_and(|prev| prev != current_sha);
+            let effective =
+                effective_last_run_id(tracking.prev_head_sha, &current_sha, tracking.last_run_id);
+            if head_moved {
                 tracing::info!(
                     repo = ctx.repo,
                     branch = ctx.branch,
@@ -1554,14 +1574,11 @@ async fn poll_ci_runs(
                 );
                 let _ =
                     crate::daemon::task_progress::touch_progress_for_branch(ctx.home, ctx.branch);
-                None
-            } else {
-                tracking.last_run_id
-            };
+            }
             Ok(Some(PollResult {
                 runs,
                 current_sha,
-                effective_last_run_id,
+                effective_last_run_id: effective,
             }))
         }
     }

--- a/src/daemon/ci_watch/poller_tests.rs
+++ b/src/daemon/ci_watch/poller_tests.rs
@@ -212,54 +212,37 @@ fn ci_watch_timed_out_notifies() {
 
 #[test]
 fn test_force_push_invalidates_run_id() {
-    // When head_sha changes between polls, the effective last_run_id
-    // should be reset to None so the new run is picked up even if
-    // the run_id hasn't changed yet.
-    let prev_sha = Some("abc123");
-    let current_sha = "def456";
-    // Simulate the logic from ci_check_repo
-    let last_run_id = Some(42u64);
-    let effective = if prev_sha.is_some_and(|prev| prev != current_sha) {
-        None
-    } else {
-        last_run_id
-    };
-    assert_eq!(effective, None, "force push must reset last_run_id");
+    // Drives the PRODUCTION helper `effective_last_run_id` (poller.rs) that
+    // `poll_ci_runs` uses to reset run tracking on a force-push / head move.
+    // Previously this re-implemented the if/else inline and asserted on its
+    // own copy, so a divergence in the real logic would not have been caught.
 
-    // Same SHA → preserve run_id
-    let same_sha = "abc123";
-    let effective2 = if prev_sha.is_some_and(|prev| prev != same_sha) {
-        None
-    } else {
-        last_run_id
-    };
-    assert_eq!(effective2, Some(42), "same SHA must preserve last_run_id");
-}
-
-#[test]
-fn test_pr_merged_clears_watcher() {
-    // When a watch file exists and the PR is terminal, the file
-    // should be removed. We test the update_watch_state + remove
-    // flow by verifying the file lifecycle.
-    let dir = std::env::temp_dir().join(format!("agend-ci-test-merged-{}", std::process::id()));
-    std::fs::create_dir_all(dir.join("ci-watches")).ok();
-    let watch_path = dir.join("ci-watches").join("test.json");
-    std::fs::write(
-        &watch_path,
-        r#"{"repo":"o/r","branch":"feat","last_run_id":null,"head_sha":null}"#,
-    )
-    .ok();
-    assert!(watch_path.exists());
-
-    // Simulate PR terminal → auto-clear
-    let _ = std::fs::remove_file(&watch_path);
-    assert!(
-        !watch_path.exists(),
-        "watcher file must be removed on PR terminal"
+    // Head moved → cached run_id points at a run for the old head → reset.
+    assert_eq!(
+        effective_last_run_id(Some("abc123"), "def456", Some(42)),
+        None,
+        "force push (head_sha changed) must reset last_run_id"
     );
-
-    std::fs::remove_dir_all(&dir).ok();
+    // Same SHA → preserve the cached run_id.
+    assert_eq!(
+        effective_last_run_id(Some("abc123"), "abc123", Some(42)),
+        Some(42),
+        "same SHA must preserve last_run_id"
+    );
+    // No prior head recorded → nothing to invalidate → preserve.
+    assert_eq!(
+        effective_last_run_id(None, "abc123", Some(42)),
+        Some(42),
+        "absent prev_head_sha must preserve last_run_id"
+    );
 }
+
+// Removed `test_pr_merged_clears_watcher`: it wrote a file, deleted it with
+// raw `std::fs::remove_file`, then asserted it was gone — exercising the std
+// library, not the production PR-terminal clear path. The real behavior is
+// covered by `test_remove_watch_on_pr_terminal_logs_event` below, which calls
+// the production `remove_watch(.., reason = "pr_terminal")` and asserts both
+// the file removal and the `ci_watch_removed` event-log entry.
 
 // --- classify_runs_response: silent-rate-limit regression pin ---
 

--- a/src/render/panels.rs
+++ b/src/render/panels.rs
@@ -851,14 +851,23 @@ mod tests {
             })
             .collect();
 
+        let viewport_rows = 10;
         let full = task_board_columns(&tasks);
-        let partial = task_board_columns_viewport(&tasks, 10);
+        let partial = task_board_columns_viewport(&tasks, viewport_rows);
 
-        assert_eq!(full[3].len(), partial[3].len());
-        let visible = DONE_VISIBLE_MAX.min(full[3].len());
+        // Done is column index 4 ([backlog, ready, working, review, done]).
+        // The previous assertion used index 3 (review), which is empty for an
+        // all-done fixture, so it compared 0 == 0 and the loop never ran.
+        assert_eq!(full[4].len(), partial[4].len());
+
+        // The viewport only guarantees the top `min(viewport_rows,
+        // DONE_VISIBLE_MAX)` done entries are correctly sorted; compare
+        // exactly that visible prefix against the fully-sorted reference.
+        let visible = viewport_rows.min(DONE_VISIBLE_MAX).min(full[4].len());
+        assert!(visible > 0, "visible range must be non-empty");
         for i in 0..visible {
             assert_eq!(
-                full[3][i].id, partial[3][i].id,
+                full[4][i].id, partial[4][i].id,
                 "done column row {i}: partial sort must match full sort in visible range"
             );
         }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -484,19 +484,29 @@ mod tests {
         // may have set it to Live first, in which case THIS test's
         // first call emits the Fallback transition log. Either way,
         // total emissions across 10 calls MUST be ≤ 1.
-        let initial_hits = logs_contain("initial mode resolved");
-        let transition_hits = logs_contain("daemon offline → falling back");
-        assert!(
-            !(initial_hits && transition_hits),
-            "should observe at most one of {{initial, transition}} log kinds — never both per a single test run"
-        );
-
-        // The strongest assertion: count actual log lines that match the
-        // helper's prefix. tracing-test's `logs_contain` returns bool;
-        // for count-precision we'd need direct subscriber introspection.
-        // Bool check above is sufficient to lock the rate-limit contract:
-        // steady-state Fallback → Fallback emits ZERO logs after the
-        // first call, so 10 calls produce at most 1 line.
+        // Count-precision assertion. `logs_contain` only returns a bool, so
+        // it cannot tell "logged once" from "logged on every call" — the old
+        // `!(initial_hits && transition_hits)` check passed even if one log
+        // kind repeated 10×. `logs_assert` exposes the captured lines, so we
+        // count actual helper emissions: every helper log carries the prefix
+        // `list_agents_with_fallback:`. Across 10 steady-state calls at most
+        // ONE such line may appear (the first-call mode-resolution entry);
+        // steady-state Fallback → Fallback hits the silent `_ => {}` arm.
+        logs_assert(|lines: &[&str]| {
+            let helper_logs = lines
+                .iter()
+                .filter(|l| l.contains("list_agents_with_fallback:"))
+                .count();
+            if helper_logs <= 1 {
+                Ok(())
+            } else {
+                Err(format!(
+                    "steady-state must emit at most ONE helper log across 10 \
+                     calls, got {helper_logs}:\n{}",
+                    lines.join("\n")
+                ))
+            }
+        });
 
         fs::remove_dir_all(&home).ok();
     }

--- a/tests/active_peer_pid_watch.rs
+++ b/tests/active_peer_pid_watch.rs
@@ -146,13 +146,20 @@ fn api_session_spawns_pid_watcher() {
     let cutoff = src.find("#[cfg(test)]").unwrap_or(src.len());
     let prod = &src[..cutoff];
 
+    // Assert the watcher is actually WIRED IN, not merely defined. The fn
+    // definition `fn spawn_peer_pid_watcher(` always exists; the regression
+    // we guard against is deletion of the *call site* in the session loop
+    // (which reintroduces the 30s-TCP-timeout dead-bridge latency). So we
+    // require at least one call beyond the single definition.
+    let total_refs = prod.matches("spawn_peer_pid_watcher(").count();
+    let definitions = prod.matches("fn spawn_peer_pid_watcher(").count();
     assert!(
-        prod.contains("spawn_peer_pid_watcher")
-            || prod.contains("pid_watcher")
-            || prod.contains("is_process_alive"),
-        "src/api/mod.rs must contain a PID watcher spawn site for active \
-         peer death detection (Sprint 25 P3). Without it, dead-bridge \
-         invalidation relies on 30s TCP read timeout instead of ~2s \
-         kill(pid,0) polling."
+        total_refs > definitions,
+        "src/api/mod.rs must CALL spawn_peer_pid_watcher from the session \
+         flow (call site, not just the fn definition) for active peer death \
+         detection (Sprint 25 P3). Found {total_refs} reference(s) and \
+         {definitions} definition(s) — no call site. Without the call, \
+         dead-bridge invalidation relies on the 30s TCP read timeout \
+         instead of ~2s kill(pid,0) polling."
     );
 }

--- a/tests/agend_git_shim_phase5_stress.rs
+++ b/tests/agend_git_shim_phase5_stress.rs
@@ -3,7 +3,6 @@
 
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -46,42 +45,47 @@ fn stress_concurrent_hotspot_query_under_commits() {
 #[test]
 #[ignore]
 fn stress_phase5_1h_soak() {
+    // Throughput / stability soak: drive the per-file hotspot-index hot path
+    // (insert last-toucher + decide hotspot) for a time budget and assert it
+    // sustains a high iteration count without slowing down or wedging.
+    //
+    // Previously this also kept a "drift" counter computed as
+    //   `let is_hotspot = EXPR; let expected = EXPR; if is_hotspot != expected`
+    // where both sides were the IDENTICAL expression — so `violations` could
+    // never increment and `assert!(drift < 0.001)` was a tautology that could
+    // not fail and exercised no real index path. That vacuous machinery is
+    // removed; the soak now drives a real HashMap insert/lookup and keeps only
+    // the genuine, failable throughput assertion.
     let duration_secs: u64 = std::env::var("AGEND_SOAK_DURATION")
         .ok()
         .and_then(|v| v.parse().ok())
         .unwrap_or(60);
     let duration = Duration::from_secs(duration_secs);
     let start = Instant::now();
-    let violations = Arc::new(AtomicU64::new(0));
-    let total = Arc::new(AtomicU64::new(0));
+    let mut total: u64 = 0;
     let mut rng: u64 = 42;
+    // last toucher per file_id — the real per-file hotspot-index shape.
+    let mut last_toucher: HashMap<u64, u64> = HashMap::new();
 
     while start.elapsed() < duration {
         rng ^= rng << 13;
         rng ^= rng >> 7;
         rng ^= rng << 17;
-        total.fetch_add(1, Ordering::Relaxed);
+        total += 1;
 
-        // Simulate hotspot decision: file touched by other agent = hotspot.
-        let _file_id = rng % 50;
+        let file_id = rng % 50;
         let current_agent = rng % 10;
-        let last_toucher = (rng >> 4) % 10;
-        let is_hotspot = current_agent != last_toucher;
-        let expected = current_agent != last_toucher;
-        if is_hotspot != expected {
-            violations.fetch_add(1, Ordering::Relaxed);
-        }
+        // Hotspot iff a DIFFERENT agent last touched this file. Driven off the
+        // index's prior value, not a copy of the same line, so the work is real.
+        let prev = last_toucher.insert(file_id, current_agent);
+        let _is_hotspot = prev.is_some_and(|p| p != current_agent);
     }
 
-    let t = total.load(Ordering::Relaxed);
-    let v = violations.load(Ordering::Relaxed);
-    let drift = if t > 0 { v as f64 / t as f64 } else { 0.0 };
-    eprintln!(
-        "phase5 soak: {t} events, {v} violations, drift={:.6}%",
-        drift * 100.0
+    eprintln!("phase5 soak: {total} iterations in {duration_secs}s budget");
+    assert!(
+        total > 1_000_000,
+        "soak must sustain >1M iterations within the {duration_secs}s budget, got {total}"
     );
-    assert!(drift < 0.001);
-    assert!(t > 1_000_000);
 }
 
 #[test]

--- a/tests/common/harness.rs
+++ b/tests/common/harness.rs
@@ -409,6 +409,51 @@ impl TestVTerm {
         };
         tail.join("\n")
     }
+
+    /// Like `tail_lines`, but also reads scrollback HISTORY. `tail_lines`
+    /// only walks the visible rows (`0..rows`); this walks the full grid
+    /// range `topmost_line()..=bottommost_line()`, whose top is negative
+    /// when lines have scrolled into history (the Term is configured with
+    /// `scrolling_history: 10000`). Returns the last `n` non-empty lines.
+    fn history_tail_lines(&self, n: usize) -> String {
+        let grid = self.term.grid();
+        let cols = self.cols as usize;
+        let top = grid.topmost_line().0;
+        let bottom = grid.bottommost_line().0;
+        let mut lines: Vec<String> = Vec::new();
+        let mut row = top;
+        while row <= bottom {
+            let mut line = String::with_capacity(cols);
+            for col in 0..cols {
+                if col < grid.columns() {
+                    let point = Point::new(Line(row), Column(col));
+                    let cell = &grid[point];
+                    if !cell.flags.contains(Flags::WIDE_CHAR_SPACER) {
+                        let ch = if cell.c == '\0' { ' ' } else { cell.c };
+                        line.push(ch);
+                    }
+                }
+            }
+            lines.push(line.trim_end().to_string());
+            row += 1;
+        }
+        let first = lines
+            .iter()
+            .position(|l| !l.is_empty())
+            .unwrap_or(lines.len());
+        let last = lines
+            .iter()
+            .rposition(|l| !l.is_empty())
+            .map(|i| i + 1)
+            .unwrap_or(first);
+        let visible = &lines[first..last];
+        let tail = if visible.len() > n {
+            &visible[visible.len() - n..]
+        } else {
+            visible
+        };
+        tail.join("\n")
+    }
 }
 
 /// TuiClient — connect to daemon API + in-process vterm for PTY output parsing.
@@ -459,10 +504,12 @@ impl TuiClient {
         self.vterm.tail_lines(lines)
     }
 
-    /// Read scrollback + visible screen as plain text.
+    /// Read scrollback HISTORY + visible screen as plain text. Unlike
+    /// `screen_text` (visible rows only), this includes lines that have
+    /// scrolled out of the visible viewport into history.
     #[allow(dead_code)]
     pub fn read_scrollback(&self, max_lines: usize) -> String {
-        self.vterm.tail_lines(max_lines) // TestVTerm uses tail_lines for both
+        self.vterm.history_tail_lines(max_lines)
     }
 
     /// Feed bytes into vterm and return screen text. Single-pass — does not

--- a/tests/file_size_invariant.rs
+++ b/tests/file_size_invariant.rs
@@ -19,11 +19,14 @@
 //!   a single file by design (centralized name→handler mapping + per-tool
 //!   action sub-routing tables), not a handler implementation.
 //! - `KNOWN_OVERSIZED` — pre-existing oversized handler implementations,
-//!   recorded explicitly so the guard still actively prevents *new* files
-//!   and the rest of the tree from regrowing. These are technical debt that
-//!   should be split; remove each from the list once it is back under
-//!   `MAX_LOC`. They are NOT silently skipped: the test asserts each one
-//!   still exists and is still over the limit, so a stale entry fails loud.
+//!   recorded explicitly so the guard still actively prevents *new* files and
+//!   the rest of the tree from regrowing. Each entry carries the file's LOC at
+//!   grandfather time as a per-file CEILING: the file may SHRINK but must not
+//!   grow past it (can-shrink-not-grow), so the debt can only get smaller.
+//!   These are technical debt that should be split; remove each from the list
+//!   once it is back under `MAX_LOC`. They are NOT silently skipped: the test
+//!   asserts each still exists, is still over `MAX_LOC`, and is `<=` its
+//!   ceiling, so a stale or regrown entry fails loud.
 
 use std::path::{Path, PathBuf};
 
@@ -33,11 +36,13 @@ const MAX_LOC: usize = 750;
 /// Files skipped by exact file name (not handler implementations).
 const SKIP_FILES: &[&str] = &["dispatch.rs"];
 
-/// Pre-existing oversized handler implementations, matched by path suffix
-/// relative to the repo root. Technical debt — split and remove from here.
-const KNOWN_OVERSIZED: &[&str] = &[
-    "src/mcp/handlers/ci/mod.rs",
-    "src/mcp/handlers/dispatch_hook/mod.rs",
+/// Pre-existing oversized handler implementations: `(path-suffix, ceiling)`
+/// where `ceiling` is the file's recorded LOC at grandfather time. Technical
+/// debt — each may SHRINK but must not grow past its ceiling (can-shrink-not-
+/// grow), and must be removed once split back under `MAX_LOC`.
+const KNOWN_OVERSIZED: &[(&str, usize)] = &[
+    ("src/mcp/handlers/ci/mod.rs", 1441),
+    ("src/mcp/handlers/dispatch_hook/mod.rs", 1575),
 ];
 
 /// Recursively collect every `*.rs` file under `dir`.
@@ -81,7 +86,7 @@ fn mcp_handler_files_under_max_loc() {
         if file_name.contains("test") || SKIP_FILES.contains(&file_name) {
             continue;
         }
-        if KNOWN_OVERSIZED.iter().any(|s| path_ends_with(path, s)) {
+        if KNOWN_OVERSIZED.iter().any(|(s, _)| path_ends_with(path, s)) {
             continue;
         }
         let loc = loc_of(path);
@@ -97,11 +102,14 @@ fn mcp_handler_files_under_max_loc() {
         violations.join("\n")
     );
 
-    // Keep the grandfather list honest: every KNOWN_OVERSIZED entry must
-    // still exist AND still be over the limit. Once a file is split back
-    // under MAX_LOC, this fails until the entry is removed — preventing the
-    // list from quietly masking a newly-regrown file under an old name.
-    for known in KNOWN_OVERSIZED {
+    // Keep the grandfather list honest AND ratcheted. Each entry records the
+    // file's LOC at grandfather time as a CEILING. Every entry must:
+    //   1. still exist (else remove it),
+    //   2. still be over MAX_LOC (else it was split — remove it so the guard
+    //      re-arms via the main scan above), and
+    //   3. be <= its recorded ceiling (can-shrink-not-grow — a regrown file
+    //      fails here; do NOT raise the number to make it pass).
+    for (known, ceiling) in KNOWN_OVERSIZED {
         let path = Path::new(known);
         assert!(
             path.exists(),
@@ -112,6 +120,12 @@ fn mcp_handler_files_under_max_loc() {
             loc > MAX_LOC,
             "KNOWN_OVERSIZED entry {known} is now {loc} LOC (<= {MAX_LOC}) — it has \
              been split; remove it from KNOWN_OVERSIZED so the guard re-arms for it"
+        );
+        assert!(
+            loc <= *ceiling,
+            "KNOWN_OVERSIZED entry {known} grew from {ceiling} to {loc} LOC — \
+             grandfathered files may shrink but must not grow past their ceiling. \
+             Split it back down; do NOT raise the recorded ceiling."
         );
     }
 }

--- a/tests/file_size_invariant.rs
+++ b/tests/file_size_invariant.rs
@@ -1,51 +1,117 @@
 //! File size invariant — prevents MCP handler monolith regrowth.
 //!
 //! Sprint 26 PR-C: after splitting src/mcp/handlers.rs (3223 LOC) into
-//! sub-modules, this test enforces that no single file in the handlers
-//! directory exceeds 750 LOC. Prevents the split-then-regrow pattern
-//! observed in prior commit 386b98d.
+//! sub-modules, this test enforces that no handler implementation file
+//! exceeds `MAX_LOC`. Prevents the split-then-regrow pattern observed in
+//! prior commit 386b98d.
 //!
-//! **Skip list** — `tests.rs` is test-only. `dispatch.rs` is the
-//! routing-table registry introduced in #694 BLOCK 2; it's a single
-//! file by design (centralized name→handler mapping + per-tool action
-//! sub-routing tables), not a handler implementation. The invariant
-//! prevents handler-file regrowth, which is a different concern.
+//! The walk is RECURSIVE: handler implementations also live in nested
+//! sub-modules (`ci/`, `dispatch_hook/`, `comms_gates/`, `force_release/`,
+//! `instance_state/`), so a top-level-only scan would let the largest
+//! handlers regrow undetected. (It did: `ci/mod.rs` and
+//! `dispatch_hook/mod.rs` had already grown past the limit while a
+//! non-recursive check stayed green.)
+//!
+//! **Skip rules**
+//! - Any file whose name contains `test` — test modules are allowed to be
+//!   large.
+//! - `dispatch.rs` — the routing-table registry introduced in #694 BLOCK 2;
+//!   a single file by design (centralized name→handler mapping + per-tool
+//!   action sub-routing tables), not a handler implementation.
+//! - `KNOWN_OVERSIZED` — pre-existing oversized handler implementations,
+//!   recorded explicitly so the guard still actively prevents *new* files
+//!   and the rest of the tree from regrowing. These are technical debt that
+//!   should be split; remove each from the list once it is back under
+//!   `MAX_LOC`. They are NOT silently skipped: the test asserts each one
+//!   still exists and is still over the limit, so a stale entry fails loud.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 const HANDLERS_DIR: &str = "src/mcp/handlers";
 const MAX_LOC: usize = 750;
-const SKIP_FILES: &[&str] = &["tests.rs", "dispatch.rs"];
+
+/// Files skipped by exact file name (not handler implementations).
+const SKIP_FILES: &[&str] = &["dispatch.rs"];
+
+/// Pre-existing oversized handler implementations, matched by path suffix
+/// relative to the repo root. Technical debt — split and remove from here.
+const KNOWN_OVERSIZED: &[&str] = &[
+    "src/mcp/handlers/ci/mod.rs",
+    "src/mcp/handlers/dispatch_hook/mod.rs",
+];
+
+/// Recursively collect every `*.rs` file under `dir`.
+fn collect_rs_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    for entry in std::fs::read_dir(dir).expect("read handlers dir") {
+        let path = entry.expect("dir entry").path();
+        if path.is_dir() {
+            collect_rs_files(&path, out);
+        } else if path.extension().map(|e| e == "rs").unwrap_or(false) {
+            out.push(path);
+        }
+    }
+}
+
+/// True if `path` ends with the given repo-relative suffix (`/`-normalized).
+fn path_ends_with(path: &Path, suffix: &str) -> bool {
+    path.to_string_lossy().replace('\\', "/").ends_with(suffix)
+}
+
+fn loc_of(path: &Path) -> usize {
+    std::fs::read_to_string(path)
+        .expect("read file")
+        .lines()
+        .count()
+}
 
 #[test]
-fn mcp_handler_files_under_500_loc() {
+fn mcp_handler_files_under_max_loc() {
     let dir = Path::new(HANDLERS_DIR);
     assert!(
         dir.is_dir(),
         "src/mcp/handlers must be a directory (not a single file)"
     );
 
+    let mut files = Vec::new();
+    collect_rs_files(dir, &mut files);
+
     let mut violations = Vec::new();
-    for entry in std::fs::read_dir(dir).expect("read handlers dir") {
-        let entry = entry.expect("dir entry");
-        let path = entry.path();
-        if path.extension().map(|e| e == "rs").unwrap_or(false) {
-            let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
-            if SKIP_FILES.contains(&file_name) {
-                continue;
-            }
-            let content = std::fs::read_to_string(&path).expect("read file");
-            let loc = content.lines().count();
-            if loc > MAX_LOC {
-                violations.push(format!("{}: {} LOC (max {})", path.display(), loc, MAX_LOC));
-            }
+    for path in &files {
+        let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+        if file_name.contains("test") || SKIP_FILES.contains(&file_name) {
+            continue;
+        }
+        if KNOWN_OVERSIZED.iter().any(|s| path_ends_with(path, s)) {
+            continue;
+        }
+        let loc = loc_of(path);
+        if loc > MAX_LOC {
+            violations.push(format!("{}: {} LOC (max {})", path.display(), loc, MAX_LOC));
         }
     }
 
     assert!(
         violations.is_empty(),
-        "MCP handler files exceed {} LOC limit:\n{}",
-        MAX_LOC,
+        "MCP handler files exceed {MAX_LOC} LOC limit (split them, or — only \
+         if intentionally a registry like dispatch.rs — add to SKIP_FILES):\n{}",
         violations.join("\n")
     );
+
+    // Keep the grandfather list honest: every KNOWN_OVERSIZED entry must
+    // still exist AND still be over the limit. Once a file is split back
+    // under MAX_LOC, this fails until the entry is removed — preventing the
+    // list from quietly masking a newly-regrown file under an old name.
+    for known in KNOWN_OVERSIZED {
+        let path = Path::new(known);
+        assert!(
+            path.exists(),
+            "KNOWN_OVERSIZED entry {known} no longer exists — remove it from the list"
+        );
+        let loc = loc_of(path);
+        assert!(
+            loc > MAX_LOC,
+            "KNOWN_OVERSIZED entry {known} is now {loc} LOC (<= {MAX_LOC}) — it has \
+             been split; remove it from KNOWN_OVERSIZED so the guard re-arms for it"
+        );
+    }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -510,9 +510,19 @@ fn test_shutdown_no_crash_log() {
         .collect::<Vec<_>>()
         .join("\n");
 
+    // A real crash logs `tracing::warn!(exit_code = c, "crash")` (see
+    // src/agent/mod.rs::classify_exit) which renders as a line containing
+    // both the `crash` message and the `exit_code=N` field. The previous
+    // assertion searched for the literal `"exit code"` (with a space), which
+    // the structured `exit_code=` field never produces — so it could never
+    // fire. Match the real rendered form, and exclude the benign signal-kill
+    // line "killed by signal, not crash".
+    let crash_logged = log
+        .lines()
+        .any(|l| l.contains("exit_code=") && l.contains("crash") && !l.contains("not crash"));
     assert!(
-        !log.contains("exit code") || log.contains("stopped (daemon shutdown)"),
-        "shutdown should not show crash messages. log:\n{log}"
+        !crash_logged,
+        "clean shutdown should not log a crash. log:\n{log}"
     );
 }
 

--- a/tests/issue_548_phase3_service.rs
+++ b/tests/issue_548_phase3_service.rs
@@ -1,43 +1,20 @@
 //! Sprint 57 Wave 3 PR-3 (#548 Phase 3) — service helper integration tests.
 //!
 //! Tier-2 dual review surface. Tests cover:
-//!   - per-platform install/uninstall round-trip (file create/remove)
-//!   - status semantics (NotInstalled vs Stopped vs Running)
-//!   - idempotency (install on existing / uninstall on missing)
 //!   - user-level no-admin guarantee (template content checks)
 //!   - asset template forward-compat (placeholder presence pins)
+//!   - escaping-wiring source pins (xml_escape / systemd_quote call sites)
+//!
+//! NOTE: the real per-platform install/uninstall FILE round-trip lives in
+//! the bin crate (`src/service/*`) and is not reachable from this
+//! integration crate — see the in-file note where the former stub-based
+//! `macos_tests`/`linux_tests` were removed.
 //!
 //! Per-platform tests are gated by `#[cfg(target_os = "...")]` so
 //! each CI runner exercises its own platform path. Cross-platform
 //! tests run on all three.
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
-
-use std::path::PathBuf;
-use std::sync::atomic::{AtomicU32, Ordering};
-
-// Sprint 57 Wave 3 PR-3 (#548 Phase 3) — `COUNTER` + `tmp_home` are
-// only consumed by the platform-gated `macos_tests` / `linux_tests`
-// submodules below. On Windows neither submodule compiles, so
-// clippy `--all-targets` flags the helpers as dead code. The
-// `#[allow]` annotations document the platform-conditional usage
-// pattern; removing them would force per-platform helper duplication
-// for the same test infrastructure.
-#[allow(dead_code)]
-static COUNTER: AtomicU32 = AtomicU32::new(0);
-
-#[allow(dead_code)]
-fn tmp_home(tag: &str) -> PathBuf {
-    let id = COUNTER.fetch_add(1, Ordering::Relaxed);
-    let dir = std::env::temp_dir().join(format!(
-        "agend-svc-test-{}-{}-{}",
-        std::process::id(),
-        tag,
-        id
-    ));
-    std::fs::create_dir_all(&dir).ok();
-    dir
-}
 
 // ---------------------------------------------------------------------
 // Cross-platform: assets + template presence pins
@@ -113,149 +90,25 @@ fn windows_template_user_level_no_admin_required() {
 }
 
 // ---------------------------------------------------------------------
-// macOS launchd
+// NOTE on per-platform install round-trip coverage:
+//
+// The real file-write + service-manager registration lives in the BIN
+// crate (`src/service/{macos,linux,windows}.rs`, `pub(super) fn install`)
+// and is NOT reachable from this integration-test crate (no lib re-export
+// of `service`). The former `macos_tests` / `linux_tests` here only called
+// a local `agend_terminal_service_install_for_test` STUB that returned
+// `Ok(())` without writing anything, yet asserted `plist.exists()` — a
+// side effect the stub could never produce (the macOS test would fail if
+// run; the Linux test guarded its asserts behind `if unit.exists()` so it
+// passed vacuously). Both gave false confidence and have been removed.
+//
+// Template rendering / substitution / no-residual-placeholder behavior IS
+// covered in-crate (`src/service/mod.rs` unit tests). A genuine install
+// round-trip belongs in-crate too, but `install()` also invokes
+// `launchctl`/`systemctl` (no sandbox session in CI), so it first needs
+// the plist/unit file-write extracted from the service-manager load step.
+// Tracked as follow-up; not faked here.
 // ---------------------------------------------------------------------
-
-#[cfg(target_os = "macos")]
-mod macos_tests {
-    use super::*;
-
-    /// Override $HOME to a temp dir for the duration of the test so
-    /// install / uninstall don't pollute the real
-    /// `~/Library/LaunchAgents/`. Returns a guard that restores the
-    /// original HOME on drop.
-    struct HomeGuard {
-        original: Option<String>,
-    }
-
-    impl HomeGuard {
-        fn new(temp: &std::path::Path) -> Self {
-            let original = std::env::var("HOME").ok();
-            // SAFETY: tests are single-threaded per `#[test]` cfg gate;
-            // env::set_var on macOS test runners is the standard pattern.
-            unsafe {
-                std::env::set_var("HOME", temp);
-            }
-            Self { original }
-        }
-    }
-
-    impl Drop for HomeGuard {
-        fn drop(&mut self) {
-            unsafe {
-                if let Some(ref h) = self.original {
-                    std::env::set_var("HOME", h);
-                } else {
-                    std::env::remove_var("HOME");
-                }
-            }
-        }
-    }
-
-    #[test]
-    #[ignore = "modifies $HOME — run with --ignored to exercise"]
-    fn service_install_creates_launchd_plist() {
-        let home_root = tmp_home("macos-install");
-        let _guard = HomeGuard::new(&home_root);
-        let agend_home = home_root.join(".agend");
-        std::fs::create_dir_all(&agend_home).unwrap();
-
-        // We can't easily trigger the full launchctl load chain in a
-        // sandboxed test (no Aqua session, no operator-owned launchd
-        // domain). Exercise the file-write path directly via the
-        // module-level public API.
-        let result = agend_terminal_service_install_for_test(&agend_home);
-        assert!(result.is_ok(), "install must not fail: {:?}", result);
-
-        let plist = home_root
-            .join("Library/LaunchAgents")
-            .join("com.agend-terminal.daemon.plist");
-        assert!(plist.exists(), "plist must be created at {plist:?}");
-        let content = std::fs::read_to_string(&plist).unwrap();
-        assert!(content.contains("com.agend-terminal.daemon"));
-        assert!(content.contains(&agend_home.display().to_string()));
-    }
-
-    // There's no public re-export of the macos sub-module from the
-    // bin crate, so the test exercises behaviour through the same
-    // `service::install` entry point production code uses. The bin
-    // crate is its own compilation root; tests that need module
-    // internals would need a `pub use service::macos as macos_test`
-    // shim. For Phase 3 scope, the public `service::install` API is
-    // sufficient for round-trip validation.
-    fn agend_terminal_service_install_for_test(_home: &std::path::Path) -> Result<(), String> {
-        // Stub: this test would normally call the real install but
-        // doing so requires `bin` -> `tests` re-export which the
-        // workspace doesn't provide for binary crates. Track in
-        // Sprint 58 follow-up: add a `lib`-target shim for service
-        // helpers so integration tests can reach them directly.
-        Ok(())
-    }
-}
-
-// ---------------------------------------------------------------------
-// Linux systemd user
-// ---------------------------------------------------------------------
-
-#[cfg(target_os = "linux")]
-mod linux_tests {
-    use super::*;
-
-    /// Override $XDG_CONFIG_HOME to a temp dir so install /
-    /// uninstall don't pollute the real
-    /// `~/.config/systemd/user/`. Returns a guard that restores
-    /// the original on drop.
-    struct XdgGuard {
-        original: Option<String>,
-    }
-
-    impl XdgGuard {
-        fn new(temp: &std::path::Path) -> Self {
-            let original = std::env::var("XDG_CONFIG_HOME").ok();
-            unsafe {
-                std::env::set_var("XDG_CONFIG_HOME", temp);
-            }
-            Self { original }
-        }
-    }
-
-    impl Drop for XdgGuard {
-        fn drop(&mut self) {
-            unsafe {
-                if let Some(ref v) = self.original {
-                    std::env::set_var("XDG_CONFIG_HOME", v);
-                } else {
-                    std::env::remove_var("XDG_CONFIG_HOME");
-                }
-            }
-        }
-    }
-
-    #[test]
-    #[ignore = "modifies $XDG_CONFIG_HOME — run with --ignored to exercise"]
-    fn service_install_creates_systemd_user_unit() {
-        let xdg_root = tmp_home("linux-install");
-        let _guard = XdgGuard::new(&xdg_root);
-        let agend_home = tmp_home("linux-install-agend");
-
-        let _ = agend_terminal_service_install_for_test(&agend_home);
-
-        let unit = xdg_root
-            .join("systemd/user")
-            .join("agend-terminal-daemon.service");
-        if unit.exists() {
-            let content = std::fs::read_to_string(&unit).unwrap();
-            assert!(content.contains("[Service]"));
-            assert!(content.contains(&agend_home.display().to_string()));
-        }
-    }
-
-    fn agend_terminal_service_install_for_test(_home: &std::path::Path) -> Result<(), String> {
-        // Same stubbing rationale as macos_tests; see Sprint 58
-        // follow-up note.
-        Ok(())
-    }
-}
 
 // ---------------------------------------------------------------------
 // Cross-platform: substitution + template-shape pins

--- a/tests/mcp_proxy_lifecycle.rs
+++ b/tests/mcp_proxy_lifecycle.rs
@@ -81,12 +81,23 @@ fn tcp_drop_mid_session_produces_error() {
     .expect("write");
     w.flush().expect("flush");
 
-    // Read response — should be empty (connection dropped) or error
+    // The peer dropped without responding, so the read must terminate cleanly
+    // at EOF — 0 bytes, empty buffer — within the 5s read timeout (i.e. no
+    // hang, no panic, no partial/garbage line). The previous assertion
+    // `bytes == 0 || resp.contains("error") || resp.is_empty()` was
+    // unfalsifiable: on a dropped connection `read_line` always yields EOF (or
+    // a timeout coerced to 0 via `unwrap_or(0)`), so `bytes` is always 0 and
+    // the whole disjunction is always true. Assert the specific observable.
     let mut resp = String::new();
     let bytes = reader.read_line(&mut resp).unwrap_or(0);
-    // Either EOF (0 bytes) or an error response — both are acceptable
-    // The key invariant: no panic, no hang
-    assert!(bytes == 0 || resp.contains("error") || resp.is_empty());
+    assert_eq!(
+        bytes, 0,
+        "dropped mid-session connection must surface as EOF, got {bytes} bytes: {resp:?}"
+    );
+    assert!(
+        resp.is_empty(),
+        "no partial response expected after a mid-session drop, got: {resp:?}"
+    );
 
     handle.join().expect("mock daemon thread");
 }

--- a/tests/no_dual_track_drift.rs
+++ b/tests/no_dual_track_drift.rs
@@ -7,7 +7,8 @@
 //! nothing prevented a future fn from being introduced into both files
 //! again.
 //!
-//! This test closes that loop: it scans `src/ops.rs` and `src/mcp/handlers.rs`
+//! This test closes that loop: it scans `src/agent_ops.rs` (the Task #12
+//! successor to the deleted `src/ops.rs`) and `src/mcp/handlers/mod.rs`
 //! for top-level fn definitions that share a name across the two files.
 //! - Divergent bodies  → panic (active drift, CI fail).
 //! - Identical bodies  → eprintln warning + pass (dedup hazard; consolidate
@@ -339,14 +340,22 @@ fn compare_fns_from_sources(ops_src: &str, handlers_src: &str) -> (Vec<String>, 
 
 #[test]
 fn no_dual_track_fn_drift_between_ops_and_mcp_handlers() {
+    // Task #12 deleted `src/ops.rs`; the canonical single-source module is now
+    // `src/agent_ops.rs` (the Option C consolidation target). Repointed here so
+    // the guard stays live for the current architecture — previously it read
+    // the deleted `src/ops.rs`, which `unwrap_or_default()` turned into a
+    // permanent empty-source trivial pass (issue: the guard had silently gone
+    // vacuous). Compared against the handlers entrypoint `mod.rs`.
+    //
     // `unwrap_or_default()` (not `.expect()`) so a future reorg that deletes
-    // either file (e.g. Task #12 collapsing `src/ops.rs`) cannot crash the
-    // test. A missing file → empty source → 0 top-level fn → no possible
-    // intersection → trivial pass. Detection remains active for whichever
-    // file does still exist; when both exist the behavior is unchanged.
+    // either file cannot crash the test. A missing file → empty source → 0
+    // top-level fn → no possible intersection → trivial pass. Detection remains
+    // active for whichever file still exists; when both exist behavior is
+    // unchanged. (Handlers are now split across sub-modules; a future
+    // enhancement could scan the whole `src/mcp/handlers/` tree, not just mod.rs.)
     let manifest = env!("CARGO_MANIFEST_DIR");
     let ops_src =
-        std::fs::read_to_string(Path::new(manifest).join("src/ops.rs")).unwrap_or_default();
+        std::fs::read_to_string(Path::new(manifest).join("src/agent_ops.rs")).unwrap_or_default();
     let handlers_src = std::fs::read_to_string(Path::new(manifest).join("src/mcp/handlers/mod.rs"))
         .unwrap_or_default();
 
@@ -355,7 +364,7 @@ fn no_dual_track_fn_drift_between_ops_and_mcp_handlers() {
     if !identical.is_empty() {
         eprintln!(
             "WARNING: dual-track DEDUP HAZARD — fn shared (byte-identical) between \
-             src/ops.rs and src/mcp/handlers.rs:\n  {}\n\
+             src/agent_ops.rs and src/mcp/handlers/mod.rs:\n  {}\n\
              Consolidate into `crate::agent_ops` before bodies diverge \
              (Task #9 Option C precedent).",
             identical.join(", ")
@@ -364,7 +373,7 @@ fn no_dual_track_fn_drift_between_ops_and_mcp_handlers() {
 
     assert!(
         divergent.is_empty(),
-        "dual-track DRIFT between src/ops.rs and src/mcp/handlers.rs — these fn \
+        "dual-track DRIFT between src/agent_ops.rs and src/mcp/handlers/mod.rs — these fn \
          share a name but their bodies differ, indicating silent divergence:\n  {}\n\n\
          Fix: consolidate into `crate::agent_ops` (single source of truth). \
          Root cause reference: 2026-04-14 `cleanup_working_dir` Kiro drift \

--- a/tests/no_per_task_json_probe_invariant.rs
+++ b/tests/no_per_task_json_probe_invariant.rs
@@ -17,8 +17,13 @@
 use std::path::{Path, PathBuf};
 
 const SRC_DIR: &str = "src";
-/// The forbidden path-build shape: `…join("tasks").join(format!(…))`.
-const FORBIDDEN: &str = "\"tasks\").join(format!";
+/// The forbidden path-build shape: `…join("tasks").join(…)` — a per-task
+/// path under a `tasks/` dir. Broadened from the original
+/// `…join("tasks").join(format!(…))`: the per-task filename need not be built
+/// with `format!` (e.g. `.join("tasks").join(&id)` is equally forbidden), and
+/// the whole-file whitespace-normalized pass below also catches the shape when
+/// rustfmt wraps it across multiple lines.
+const FORBIDDEN: &str = "\"tasks\").join(";
 const ALLOW_MARKER: &str = "allow-tasks-json-probe";
 
 fn rs_files(root: &Path) -> Vec<PathBuf> {
@@ -55,9 +60,26 @@ fn no_per_task_json_filesystem_probe() {
         let Ok(content) = std::fs::read_to_string(&file) else {
             continue;
         };
+        // (1) Line-level scan — precise location + per-line allow-marker.
+        let mut line_hit = false;
         for (i, line) in content.lines().enumerate() {
             if line.contains(FORBIDDEN) && !line.contains(ALLOW_MARKER) {
                 offenders.push(format!("{}:{}  {}", file.display(), i + 1, line.trim()));
+                line_hit = true;
+            }
+        }
+        // (2) Whole-file whitespace-normalized scan — catches the same probe
+        //     shape when rustfmt has wrapped it across multiple lines, which
+        //     the line-level check above cannot see. Reported file-level.
+        if !line_hit && !content.contains(ALLOW_MARKER) {
+            let stripped: String = content.chars().filter(|c| !c.is_whitespace()).collect();
+            let forbidden_stripped: String =
+                FORBIDDEN.chars().filter(|c| !c.is_whitespace()).collect();
+            if stripped.contains(&forbidden_stripped) {
+                offenders.push(format!(
+                    "{} (probe shape wrapped across lines)",
+                    file.display()
+                ));
             }
         }
     }

--- a/tests/no_rate_limit_recovery_nudge_invariant.rs
+++ b/tests/no_rate_limit_recovery_nudge_invariant.rs
@@ -1,21 +1,23 @@
-//! Pins the post-revert contract that `process_rate_limit_recovery_nudges`
-//! (introduced by #841, hotfixed by #846, reverted 2026-05-16 due to
-//! classifier false-positive amplification) is NOT wired into the daemon
-//! run loop. The feature MUST stay reverted until #848 ships the upstream
-//! classifier fix that prevents false-positive RateLimit states from
-//! triggering the nudge mechanism in the first place.
+//! Pins the contract that `process_rate_limit_recovery_nudges` is NOT wired
+//! into the daemon run loop — the feature is currently intentionally reverted.
 //!
-//! Failure mode this pin defends against: a future PR re-adds the
-//! `process_rate_limit_recovery_nudges` call site to supervisor's
-//! `run_loop` without coordinating with #848. Per operator directive
-//! 2026-05-16: \"先復原再考慮慢慢修根因\" — revert first, only re-enable
-//! after root cause is fixed. This test enforces that workflow gate.
+//! History (this has been re-introduced and re-reverted several times — do not
+//! assume a single linear narrative when reading the diff):
+//!   #841 introduce → #846 hotfix → #849 revert (2026-05-16, classifier
+//!   false-positive amplification) → #886 re-introduce (post-#848 classifier
+//!   fix) → reverted again → re-reverted → reverted. Net current state on
+//!   `main`: ABSENT. `git log -i --grep rate.limit.*nudge` shows the full chain.
 //!
-//! When #848 (state classifier fix) ships AND the rate-limit recovery
-//! nudge is re-introduced through a properly designed path, this test
-//! should be REMOVED in the same PR that re-wires the call site.
-//! Removing the test is the explicit signal that operator approved
-//! re-enablement.
+//! Because the feature has oscillated, this pin guards the *current* decision:
+//! the recovery nudge stays out of supervisor's `run_loop` unless re-enabled
+//! deliberately. The failure mode it defends against is a silent re-add (e.g.
+//! an accidental revert-of-a-revert or cherry-pick) of the
+//! `process_rate_limit_recovery_nudges` call site without an explicit decision.
+//!
+//! NOTE: this is a name-based source pin — it catches re-introduction under the
+//! same identifier, not a rename. If you are deliberately re-enabling the
+//! feature, update/remove this test in the same PR (removal is the explicit
+//! signal that re-enablement was approved).
 
 use std::fs;
 

--- a/tests/worktree_opt_out.rs
+++ b/tests/worktree_opt_out.rs
@@ -131,115 +131,19 @@ fn git_status_porcelain_clean() {
     std::fs::remove_dir_all(&dir).ok();
 }
 
-// --- E2E auto-prune integration tests ---
-
-/// E2e: clean worktree + flip true→false → worktree dir removed.
-#[test]
-fn e2e_clean_worktree_flip_prunes() {
-    let dir = std::env::temp_dir().join(format!("agend-wt-e2e-prune-{}", std::process::id()));
-    std::fs::create_dir_all(&dir).unwrap();
-    // Init git repo
-    // allow: raw-git-subprocess pre-#821 fixture; properly pins AGEND_GIT_BYPASS+current_dir
-    std::process::Command::new("git")
-        .env("AGEND_GIT_BYPASS", "1")
-        .args(["init", "-b", "main"])
-        .current_dir(&dir)
-        .output()
-        .unwrap();
-    // allow: raw-git-subprocess pre-#821 fixture; properly pins AGEND_GIT_BYPASS+current_dir
-    std::process::Command::new("git")
-        .env("AGEND_GIT_BYPASS", "1")
-        .args(["commit", "--allow-empty", "-m", "init"])
-        .current_dir(&dir)
-        .output()
-        .unwrap();
-    // Create a fake worktree dir
-    let wt_dir = dir.join(".worktrees").join("test-agent");
-    std::fs::create_dir_all(&wt_dir).unwrap();
-    // Init the worktree as a git repo too (so git status works)
-    // allow: raw-git-subprocess pre-#821 fixture; properly pins AGEND_GIT_BYPASS+current_dir
-    std::process::Command::new("git")
-        .env("AGEND_GIT_BYPASS", "1")
-        .args(["init", "-b", "main"])
-        .current_dir(&wt_dir)
-        .output()
-        .unwrap();
-    // allow: raw-git-subprocess pre-#821 fixture; properly pins AGEND_GIT_BYPASS+current_dir
-    std::process::Command::new("git")
-        .env("AGEND_GIT_BYPASS", "1")
-        .args(["commit", "--allow-empty", "-m", "init"])
-        .current_dir(&wt_dir)
-        .output()
-        .unwrap();
-
-    // Verify clean
-    // allow: raw-git-subprocess pre-#821 fixture; properly pins AGEND_GIT_BYPASS+current_dir
-    let output = std::process::Command::new("git")
-        .env("AGEND_GIT_BYPASS", "1")
-        .args(["status", "--porcelain"])
-        .current_dir(&wt_dir)
-        .output()
-        .unwrap();
-    assert!(
-        output.stdout.is_empty(),
-        "worktree must be clean before prune test"
-    );
-
-    // The worktree dir exists before prune
-    assert!(wt_dir.exists(), "worktree dir must exist before flip");
-
-    std::fs::remove_dir_all(&dir).ok();
-}
-
-/// E2e: dirty worktree + flip true→false → reject (worktree still exists).
-#[test]
-fn e2e_dirty_worktree_flip_rejected() {
-    let dir = std::env::temp_dir().join(format!("agend-wt-e2e-reject-{}", std::process::id()));
-    std::fs::create_dir_all(&dir).unwrap();
-    // allow: raw-git-subprocess pre-#821 fixture; properly pins AGEND_GIT_BYPASS+current_dir
-    std::process::Command::new("git")
-        .env("AGEND_GIT_BYPASS", "1")
-        .args(["init", "-b", "main"])
-        .current_dir(&dir)
-        .output()
-        .unwrap();
-    // allow: raw-git-subprocess pre-#821 fixture; properly pins AGEND_GIT_BYPASS+current_dir
-    std::process::Command::new("git")
-        .env("AGEND_GIT_BYPASS", "1")
-        .args(["commit", "--allow-empty", "-m", "init"])
-        .current_dir(&dir)
-        .output()
-        .unwrap();
-    let wt_dir = dir.join(".worktrees").join("test-agent");
-    std::fs::create_dir_all(&wt_dir).unwrap();
-    // allow: raw-git-subprocess pre-#821 fixture; properly pins AGEND_GIT_BYPASS+current_dir
-    std::process::Command::new("git")
-        .env("AGEND_GIT_BYPASS", "1")
-        .args(["init", "-b", "main"])
-        .current_dir(&wt_dir)
-        .output()
-        .unwrap();
-    // allow: raw-git-subprocess pre-#821 fixture; properly pins AGEND_GIT_BYPASS+current_dir
-    std::process::Command::new("git")
-        .env("AGEND_GIT_BYPASS", "1")
-        .args(["commit", "--allow-empty", "-m", "init"])
-        .current_dir(&wt_dir)
-        .output()
-        .unwrap();
-    // Make dirty
-    std::fs::write(wt_dir.join("dirty.txt"), "uncommitted work").unwrap();
-
-    // allow: raw-git-subprocess pre-#821 fixture; properly pins AGEND_GIT_BYPASS+current_dir
-    let output = std::process::Command::new("git")
-        .env("AGEND_GIT_BYPASS", "1")
-        .args(["status", "--porcelain"])
-        .current_dir(&wt_dir)
-        .output()
-        .unwrap();
-    assert!(!output.stdout.is_empty(), "worktree must be dirty");
-
-    // Worktree dir must still exist (not pruned)
-    assert!(wt_dir.exists(), "dirty worktree must NOT be pruned");
-
-    std::fs::remove_dir_all(&dir).ok();
-}
+// --- E2E auto-prune: covered in-crate, not reachable here ---
+//
+// The flip `true→false` auto-prune behavior lives in the BIN crate
+// (`src/bootstrap/agent_resolve.rs::resolve_one`, which calls
+// `worktree::has_uncommitted_changes` + `worktree::remove_worktree`) and is
+// NOT reachable from this integration-test crate. The former
+// `e2e_clean_worktree_flip_prunes` / `e2e_dirty_worktree_flip_rejected` tests
+// here never flipped config or invoked any prune path — each only asserted
+// that a dir it had just created still existed (`wt_dir.exists()`), which is
+// trivially true and could never catch a prune regression (the names promised
+// behavior the bodies did not exercise). The genuine behavior is covered by
+// in-crate unit tests:
+//   - agent_resolve::tests::resolve_one_worktree_false_prunes_clean_existing_worktree
+//   - agent_resolve::tests::resolve_one_worktree_false_skips_worktree_creation
+//   - the dirty-reject path via the `has_uncommitted_changes` guard there.
+// The fake E2E tests were removed rather than left as false confidence.


### PR DESCRIPTION
## What

A full audit of the test suite (308 files / ~4209 tests, reviewed in 117 clusters) found **~95% genuinely useful**, with **187 findings** (18 high / 69 medium / 100 low). This PR fixes all **18 high-severity** findings — tests that gave *false confidence* or *could never fail*. Medium/low are not in this PR.

Every fix was verified: `cargo check --all-targets` clean (no warnings), and every touched test re-run and passing (incl. the daemon-spawning `test_shutdown_no_crash_log` and a short-duration run of the phase-5 soak).

## Fixes by category

**Strengthened grep/invariant guards** (were matching text that survives the regression they claim to prevent):
- `active_peer_pid_watch`: assert the watcher **call site** exists (`calls > defs`), not just the fn definition.
- `file_size_invariant`: walk handlers **recursively** — `ci/mod.rs` (1441) and `dispatch_hook/mod.rs` (1575) were 2× the limit but invisible to the old top-level-only scan; align the fn name with `MAX_LOC=750`; record the two pre-existing oversized files in a **self-validating** `KNOWN_OVERSIZED` list.
- `no_per_task_json_probe_invariant`: broaden the forbidden shape + add a whitespace-normalized whole-file pass so rustfmt-wrapped probes are caught.
- `app/mod.rs` (×2): search only the production region (cut at `#[cfg(test)]`) so the assertion's own literal no longer self-matches.

**De-vacuoused assertions that could never fail:**
- `integration::test_shutdown_no_crash_log`: match the real `crash exit_code=N` log shape (the old `"exit code"` literal never appears), excluding the benign `"killed by signal, not crash"` line.
- `agend_git_shim_phase5` soak: drop the `let a = EXPR; let b = EXPR;` self-diff tautology; drive a real `HashMap` hot path and keep the failable throughput assertion.
- `mcp_proxy_lifecycle::tcp_drop`: assert a clean EOF (0 bytes, empty buffer) instead of an always-true disjunction.
- `render/panels` viewport test: assert the **done** column (index 4), not the empty **review** column (index 3) which compared `0 == 0`.
- `runtime` steady-state: count helper log lines via `logs_assert` (≤1) instead of a bool substring check.

**Re-pointed / repaired stale or mock-only tests:**
- `no_dual_track_drift`: read `src/agent_ops.rs` (the Task #12 successor) instead of the deleted `src/ops.rs`, which had silently gone vacuous.
- vte scrollback (harness): `read_scrollback` now walks history (negative grid lines), not just visible rows.
- `ci_watch/poller` force-push test: extract a pure `effective_last_run_id` helper, called from both `poll_ci_runs` and the test (was a re-implemented copy).

**Removed tests that faked unreachable behavior** (real coverage exists in-crate):
- `issue_548` macos/linux install: stubbed `install` returning `Ok(())` yet asserted plist/unit existence; rendering is covered by in-crate unit tests.
- `worktree_opt_out` e2e (×2): never flipped config or pruned; covered by `agent_resolve` unit tests.
- poller `test_pr_merged_clears_watcher`: tested `std::fs::remove_file`; the real path is covered by `test_remove_watch_on_pr_terminal_logs_event`.

**Docstring honesty (kept the guard):**
- `no_rate_limit_recovery_nudge_invariant`: the feature went through several re-introduce/revert cycles and is currently reverted — the pin still works; only the stale `#848` lifecycle narrative was updated. (The first-pass audit recommended deleting this; verifying git history showed that was wrong.)

## Notes / follow-ups surfaced

- `file_size_invariant` recursion exposed real debt: `ci/mod.rs` and `dispatch_hook/mod.rs` are genuinely oversized (grandfathered, with a self-checking list that fails if they are split and not removed from it).
- Removing the install/e2e stub tests exposed a real coverage gap: the service-install **file-write round-trip** has no sandbox-runnable test because `install()` also invokes `launchctl`/`systemctl`. Flagged in-code as a follow-up (extract the file-write from the service-manager load step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)