### PR TITLE
fix(#2128): worktree.rs add/status/remove raw git → bounded git_cmd (LOCAL_GIT_TIMEOUT)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -32,7 +32,9 @@ final-status-level = "slow"
 # The filter has two parts (reviewer-2 #1896: cover the FULL real-git set, but
 # don't drag pure-logic tests into max-threads=1):
 #  1. anchored MODULE prefixes — modules that are predominantly real-git/worktree
-#     /subprocess: worktree_pool, admin (worktree + cleanup_zombies process spawn),
+#     /subprocess: worktree (src/worktree.rs lifecycle tests build real worktrees
+#     via the #2128 bounded-git_cmd add path), worktree_pool, admin (worktree +
+#     cleanup_zombies process spawn),
 #     mcp::handlers::{ci,dispatch_hook,force_release,worktree,p0b_tests},
 #     daemon::{retention::worktrees,pr_state,auto_release,conflict_notify,
 #     per_tick::tmp_review_gc}, bootstrap::{agent_resolve,canonical_hygiene}.
@@ -56,11 +58,11 @@ test-group = 'git-subprocess'
 slow-timeout = { period = "120s", terminate-after = 3 }
 
 [[profile.ci.overrides]]
-filter = 'test(/(^(worktree_pool|admin|mcp::handlers::(ci|dispatch_hook|force_release|worktree|p0b_tests)|daemon::(retention::worktrees|pr_state|auto_release|conflict_notify|per_tick::tmp_review_gc)|bootstrap::(agent_resolve|canonical_hygiene))::|checkout_repo_|dispatch_branch_skips_metadata_stub|send_with_branch_checkout_failure|task_done_cleans_post_lease|closes_markers_extract_cleanly_from_actual_main|resolve_sweep_boards_pairs_each_project_with_its_own_repo_2117_p2)/)'
+filter = 'test(/(^(worktree|worktree_pool|admin|mcp::handlers::(ci|dispatch_hook|force_release|worktree|p0b_tests)|daemon::(retention::worktrees|pr_state|auto_release|conflict_notify|per_tick::tmp_review_gc)|bootstrap::(agent_resolve|canonical_hygiene))::|checkout_repo_|dispatch_branch_skips_metadata_stub|send_with_branch_checkout_failure|task_done_cleans_post_lease|closes_markers_extract_cleanly_from_actual_main|resolve_sweep_boards_pairs_each_project_with_its_own_repo_2117_p2)/)'
 test-group = 'git-subprocess'
 
 # Local `default` profile has no terminate-after, so no false-kill risk — just
 # serialize the same cluster for parity with CI.
 [[profile.default.overrides]]
-filter = 'test(/(^(worktree_pool|admin|mcp::handlers::(ci|dispatch_hook|force_release|worktree|p0b_tests)|daemon::(retention::worktrees|pr_state|auto_release|conflict_notify|per_tick::tmp_review_gc)|bootstrap::(agent_resolve|canonical_hygiene))::|checkout_repo_|dispatch_branch_skips_metadata_stub|send_with_branch_checkout_failure|task_done_cleans_post_lease|closes_markers_extract_cleanly_from_actual_main|resolve_sweep_boards_pairs_each_project_with_its_own_repo_2117_p2)/)'
+filter = 'test(/(^(worktree|worktree_pool|admin|mcp::handlers::(ci|dispatch_hook|force_release|worktree|p0b_tests)|daemon::(retention::worktrees|pr_state|auto_release|conflict_notify|per_tick::tmp_review_gc)|bootstrap::(agent_resolve|canonical_hygiene))::|checkout_repo_|dispatch_branch_skips_metadata_stub|send_with_branch_checkout_failure|task_done_cleans_post_lease|closes_markers_extract_cleanly_from_actual_main|resolve_sweep_boards_pairs_each_project_with_its_own_repo_2117_p2)/)'
 test-group = 'git-subprocess'

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -207,29 +207,27 @@ pub fn create(
         let _ = std::fs::create_dir_all(parent);
     }
 
-    // Try creating worktree: first with -b (new branch), fallback without -b (existing branch)
-    // git-raw-allowed: byte-identical conservative. The Ok(non-zero) arm dispatches
-    // on stderr substrings ("already exists" / "is already checked out") into a
-    // NESTED -b → fallback control flow (see the long comment below). git_cmd's
-    // Err(NonZero { stderr, .. }) carries the (trimmed) stderr too, so a migration
-    // is *possible* — but it requires restructuring this load-bearing
-    // worktree-creation match. Kept raw to avoid churn on the lifecycle-critical add
-    // path. TODO(#W1.2-followup): migrate for the LOCAL_GIT_TIMEOUT bound once the
-    // nested control flow is refactored.
-    let output = std::process::Command::new("git")
-        .env("AGEND_GIT_BYPASS", "1")
-        .args([
+    // Try creating worktree: first with -b (new branch), fallback without -b (existing branch).
+    // #2128: both attempts route through the bounded `git_cmd` (AGEND_GIT_BYPASS +
+    // LOCAL_GIT_TIMEOUT + process-group-kill) so a `worktree add` wedged on
+    // `.git/index.lock` contention fails in 60s instead of hanging forever. The
+    // nested stderr-substring dispatch ("already exists" / "is already checked out")
+    // is byte-identical on `git_cmd`'s `Err(NonZero { stderr, .. })`: its stderr is
+    // `.trim()`ed but the interior substring survives trim. The ONLY behavioural
+    // change is the timeout bound — a wedged add surfaces as `Err(Spawn(TimedOut))`
+    // → the lock-contention warn below (DP2; see #2128 / #1897).
+    use crate::git_helpers::{git_cmd, GitError};
+    match git_cmd(
+        repo_dir,
+        &[
             "worktree",
             "add",
             "-b",
             &branch,
             &wt_dir.display().to_string(),
-        ])
-        .current_dir(repo_dir)
-        .output();
-
-    match output {
-        Ok(o) if o.status.success() => {
+        ],
+    ) {
+        Ok(_) => {
             tracing::info!(
                 instance = instance_name,
                 path = %wt_dir.display(),
@@ -251,79 +249,79 @@ pub fn create(
                 branch,
             })
         }
-        Ok(o) => {
-            let stderr = String::from_utf8_lossy(&o.stderr);
-            // #781 Piece 2 (Bug B): the prior `o.status.code() == Some(128)`
-            // gate was too strict. `git worktree add -b <existing-branch>`
-            // can exit with code 255 (not 128) when the failure happens
-            // after the "Preparing worktree (new branch …)" progress line
-            // has already been emitted to stderr — observed in macOS git
-            // 2.42+ in the #781 spike (raw capture: exit 255, stderr
-            // "fatal: a branch named '…' already exists"). Exit codes
-            // from `git worktree add` are not contracted in any released
-            // git manpage we could find; the stderr substring is the
-            // load-bearing semantic signal. Rely on it alone.
-            //
-            // Reasoning: across git versions / locales the stderr
-            // wording stays stable (English) for the duplicate-branch
-            // case ("already exists") and the cross-worktree-checkout
-            // case ("is already checked out"); the exit code drift is
-            // version-specific. Adding more codes to the allow-list
-            // would just chase the next git release — the substring
-            // check is what we actually want.
-            if stderr.contains("already exists") || stderr.contains("is already checked out") {
-                // git-raw-allowed: existing-branch fallback in the same nested
-                // stderr-dispatched worktree-add control flow as the primary add
-                // above; kept raw for the same byte-identical-conservative reason
-                // (migratable via git_cmd after the same refactor — see above).
-                let output2 = std::process::Command::new("git")
-                    .env("AGEND_GIT_BYPASS", "1")
-                    .args(["worktree", "add", &wt_dir.display().to_string(), &branch])
-                    .current_dir(repo_dir)
-                    .output();
-                match output2 {
-                    Ok(o2) if o2.status.success() => {
-                        tracing::info!(
-                            instance = instance_name,
-                            %branch,
-                            "created worktree on existing branch"
-                        );
-                        // #1137: write marker immediately (same as primary path above).
-                        let _ = std::fs::write(
-                            wt_dir.join(".agend-managed"),
-                            format!(
-                                "agent={instance_name}\nbranch={branch}\nleased_at={}\n",
-                                chrono::Utc::now().to_rfc3339()
-                            ),
-                        );
-                        Some(WorktreeInfo {
-                            path: wt_dir,
-                            source_repo: repo_dir.to_path_buf(),
-                            branch,
-                        })
-                    }
-                    Ok(o2) => {
-                        tracing::warn!(
-                            instance = instance_name,
-                            error = %String::from_utf8_lossy(&o2.stderr).trim(),
-                            "worktree creation failed"
-                        );
-                        None
-                    }
-                    Err(e) => {
-                        tracing::warn!(error = %e, "git not available");
-                        None
-                    }
+        // #781 Piece 2 (Bug B): the prior `o.status.code() == Some(128)` gate was
+        // too strict. `git worktree add -b <existing-branch>` can exit 255 (not 128)
+        // when the failure surfaces after the "Preparing worktree (new branch …)"
+        // progress line (macOS git 2.42+, #781 spike: exit 255, stderr "fatal: a
+        // branch named '…' already exists"). Exit codes from `worktree add` are not
+        // contracted in any released git manpage; the stderr substring is the
+        // load-bearing semantic signal — dispatch on it alone. Across git versions /
+        // locales the wording stays stable (English) for the duplicate-branch
+        // ("already exists") and cross-worktree-checkout ("is already checked out")
+        // cases; the exit-code drift is version-specific.
+        Err(GitError::NonZero { stderr, .. })
+            if stderr.contains("already exists") || stderr.contains("is already checked out") =>
+        {
+            // Existing-branch fallback (no -b): same bounded `git_cmd`.
+            match git_cmd(
+                repo_dir,
+                &["worktree", "add", &wt_dir.display().to_string(), &branch],
+            ) {
+                Ok(_) => {
+                    tracing::info!(
+                        instance = instance_name,
+                        %branch,
+                        "created worktree on existing branch"
+                    );
+                    // #1137: write marker immediately (same as primary path above).
+                    let _ = std::fs::write(
+                        wt_dir.join(".agend-managed"),
+                        format!(
+                            "agent={instance_name}\nbranch={branch}\nleased_at={}\n",
+                            chrono::Utc::now().to_rfc3339()
+                        ),
+                    );
+                    Some(WorktreeInfo {
+                        path: wt_dir,
+                        source_repo: repo_dir.to_path_buf(),
+                        branch,
+                    })
                 }
-            } else {
-                tracing::warn!(instance = instance_name, error = %stderr.trim(), "worktree creation failed");
-                None
+                Err(GitError::NonZero { stderr, .. }) => {
+                    tracing::warn!(
+                        instance = instance_name,
+                        error = %stderr,
+                        "worktree creation failed"
+                    );
+                    None
+                }
+                Err(GitError::Spawn(e)) => {
+                    warn_worktree_add_spawn_err(&e);
+                    None
+                }
             }
         }
-        Err(e) => {
-            tracing::warn!(error = %e, "git not available");
+        Err(GitError::NonZero { stderr, .. }) => {
+            tracing::warn!(instance = instance_name, error = %stderr, "worktree creation failed");
             None
         }
+        Err(GitError::Spawn(e)) => {
+            warn_worktree_add_spawn_err(&e);
+            None
+        }
+    }
+}
+
+/// #2128 DP2: log a `git worktree add` spawn error, distinguishing a
+/// `LOCAL_GIT_TIMEOUT` wedge (index.lock contention — the hang this migration
+/// bounds) from git genuinely missing, so a 60s-timed-out add is observable in
+/// logs instead of looking like an anonymous "git not available". Non-timeout
+/// spawn failures keep the prior "git not available" wording (byte-identical).
+fn warn_worktree_add_spawn_err(e: &std::io::Error) {
+    if e.kind() == std::io::ErrorKind::TimedOut {
+        tracing::warn!(error = %e, "worktree add timed out (lock contention?)");
+    } else {
+        tracing::warn!(error = %e, "git not available");
     }
 }
 
@@ -422,22 +420,17 @@ pub fn prune(repo_dir: &Path) {
 /// Check if a worktree directory has uncommitted changes.
 /// Returns true if `git status --porcelain` produces non-empty output.
 pub fn has_uncommitted_changes(worktree_dir: &Path) -> bool {
-    // git-raw-allowed: byte-identical conservative. This porcelain `status`
-    // emptiness check gates safety-critical WIP protection (lease-conflict
-    // reattach) and is fail-closed (`Err => true`). A git_cmd form
-    // (`.map(|s| !s.is_empty()).unwrap_or(true)`) WOULD be byte-identical here —
-    // trimming can't turn non-empty porcelain output empty — but it routes a
-    // normally-exit-0 command through the non-zero/spawn error mapping. Kept raw on
-    // the raw `o.stdout` bytes to keep this lifecycle WIP guard maximally explicit.
-    let output = std::process::Command::new("git")
-        .env("AGEND_GIT_BYPASS", "1")
-        .args(["status", "--porcelain"])
-        .current_dir(worktree_dir)
-        .output();
-    match output {
-        Ok(o) => !o.stdout.is_empty(),
-        Err(_) => true, // fail-closed: assume dirty if we can't check
-    }
+    // #2128: bounded `git_cmd` (AGEND_GIT_BYPASS + LOCAL_GIT_TIMEOUT) so this
+    // safety-critical WIP guard (lease-conflict reattach) can't wedge on a
+    // contended `.git/index.lock`. Fail-closed (`Err => true`) is preserved AND
+    // strengthened: a spawn failure OR a 60s timeout → assume dirty (don't risk
+    // discarding WIP). Byte-identical for a present worktree — porcelain `status`
+    // exits 0 there, and trimming can't turn non-empty porcelain output empty (a
+    // theoretical non-zero exit, unreachable for a valid worktree, now also maps to
+    // fail-closed `true` rather than the prior raw-bytes `false`).
+    crate::git_helpers::git_cmd(worktree_dir, &["status", "--porcelain"])
+        .map(|s| !s.is_empty())
+        .unwrap_or(true)
 }
 
 /// Remove a worktree and its tracking branch. Returns Ok(()) on success,
@@ -459,25 +452,29 @@ pub fn remove_worktree(
     if !wt_dir.exists() {
         return Ok(()); // already gone
     }
-    // git worktree remove --force <path>
-    // git-raw-allowed: byte-identical conservative. This remove returns two DISTINCT
-    // contracted Err strings — "git worktree remove failed: {e}" for a spawn failure
-    // vs "git worktree remove: {stderr}" for a non-zero exit. git_cmd's
-    // Err(Spawn)/Err(NonZero{stderr}) map onto both, so migration is *possible* — but
-    // git_cmd is bounded, so a (newly) timed-out remove would surface inside the
-    // "...failed: {e}" spawn string that the raw unbounded `.output()` never produces.
-    // Kept raw to hold both contracted messages on the lifecycle-critical remove path
-    // exactly. TODO(#W1.2-followup): migrate for the LOCAL_GIT_TIMEOUT bound.
-    let output = std::process::Command::new("git")
-        .env("AGEND_GIT_BYPASS", "1")
-        .args(["worktree", "remove", "--force"])
-        .arg(&wt_dir)
-        .current_dir(repo_dir)
-        .output()
-        .map_err(|e| format!("git worktree remove failed: {e}"))?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(format!("git worktree remove: {}", stderr.trim()));
+    // #2128: bounded `git_cmd` (AGEND_GIT_BYPASS + LOCAL_GIT_TIMEOUT +
+    // process-group-kill) so a `worktree remove` wedged on `.git/index.lock`
+    // contention fails in 60s instead of hanging. The two DISTINCT contracted Err
+    // strings are preserved: `Err(Spawn)` → "git worktree remove failed: {e}",
+    // `Err(NonZero{stderr})` → "git worktree remove: {stderr}". git_cmd's
+    // NonZero.stderr is already trimmed (matches the prior `stderr.trim()`); a 60s
+    // timeout surfaces as `Err(Spawn)` whose `{e}` carries "timed out after 60s" —
+    // the remove-side timeout signal, for free (DP2).
+    use crate::git_helpers::{git_cmd, GitError};
+    match git_cmd(
+        repo_dir,
+        &[
+            "worktree",
+            "remove",
+            "--force",
+            &wt_dir.display().to_string(),
+        ],
+    ) {
+        Ok(_) => {}
+        Err(GitError::Spawn(e)) => return Err(format!("git worktree remove failed: {e}")),
+        Err(GitError::NonZero { stderr, .. }) => {
+            return Err(format!("git worktree remove: {stderr}"))
+        }
     }
     // Delete tracking branch agend/<agent> (legacy default-branch shape).
     // Custom branches are not auto-deleted — operator workflow.

--- a/tests/daemon_git_helper_invariant.rs
+++ b/tests/daemon_git_helper_invariant.rs
@@ -71,15 +71,17 @@ const MODULE_SCOPE: &[&str] = &[
     "mcp/handlers/ci/mod.rs",
     "daemon/auto_release.rs",
     "daemon/retention/worktrees.rs",
-    // W1.2 worktree slice (final substantive W1.2): per-site judgement on
-    // worktree.rs's 11 production sites. Migrated the simple LOCAL ops —
-    // has_commits/empty-commit (→git_ok), branch --show-current (→git_cmd),
-    // branch -D (→git_ok), checkout_branch switch×2 (→git_cmd), prune (→git_cmd,
-    // 3-way map + LOCAL_GIT_TIMEOUT bound). Kept raw via git-raw-allowed (4 sites,
-    // byte-identical-conservative): the two `worktree add` (nested stderr-substring
-    // fallback dispatch), has_uncommitted_changes (porcelain emptiness + fail-closed
-    // WIP guard), remove_worktree (two contracted spawn-vs-non-zero Err strings).
-    // worktree lifecycle stays byte-identical.
+    // W1.2 worktree slice + #2128: worktree.rs is now FULLY migrated — ZERO
+    // production raw `Command::new("git")`. #2126 did the simple LOCAL ops
+    // (has_commits/empty-commit→git_ok, branch --show-current→git_cmd, branch -D→
+    // git_ok, checkout_branch switch×2→git_cmd, prune→git_cmd). #2128 migrated the
+    // last 4 (the prior git-raw-allowed KEEP set), all gaining the LOCAL_GIT_TIMEOUT
+    // bound: the two `worktree add` (nested stderr-substring fallback dispatch via
+    // Err(NonZero{stderr}), byte-identical), has_uncommitted_changes (→git_cmd
+    // .map().unwrap_or(true), fail-closed preserved), remove_worktree (→git_cmd, two
+    // contracted spawn-vs-non-zero Err strings preserved). worktree lifecycle stays
+    // byte-identical (non-wedge); the only behavioural change is the 60s timeout
+    // bound replacing an unbounded index.lock hang.
     "worktree.rs",
 ];
 


### PR DESCRIPTION
## #2128 — bound worktree.rs's last unbounded raw-git sites

The final 4 production raw `Command::new("git").output()` sites in `worktree.rs` (the #2126 `git-raw-allowed` KEEP set) lacked `LOCAL_GIT_TIMEOUT`, so `worktree add` / `status` / `worktree remove` could **wedge indefinitely on `.git/index.lock` contention** (concurrent dispatch / teardown). Route all 4 through the bounded `git_cmd`/`git_ok` (`AGEND_GIT_BYPASS` + 60s `LOCAL_GIT_TIMEOUT` + process-group-kill, #1897). `worktree.rs` is now **fully migrated — 0 production raw git**. Only behavioural change: a wedge fails in 60s instead of hanging forever; **non-wedge byte-identical**.

### Per-site
| Site | Migration | byte-identical reasoning |
|---|---|---|
| **A** `worktree add -b` (primary) | `Ok/Ok-nonzero/Err` match → `Ok/Err(NonZero{stderr})/Err(Spawn)` | stderr-substring dispatch ("already exists"/"is already checked out") on `NonZero.stderr`; git_cmd trims it but the interior substring survives trim |
| **B** `worktree add` (existing-branch fallback) | same | same |
| **C** `has_uncommitted_changes` | `git_cmd(...).map(|s| !s.is_empty()).unwrap_or(true)` | fail-closed preserved (spawn **or** 60s timeout → assume dirty, protect WIP); present worktree's `status` exits 0; trim can't empty non-empty porcelain |
| **D** `remove_worktree` | `git_cmd` match | both contracted Err strings preserved: `Spawn` → "git worktree remove failed: {e}", `NonZero` → "git worktree remove: {stderr}" (already trimmed) |

### DP2 — timeout observability (lead-approved)
A/B: a `Spawn(TimedOut)` logs `"worktree add timed out (lock contention?)"` vs the prior `"git not available"` (helper `warn_worktree_add_spawn_err`, ~3 LOC). D's 60s timeout rides the Spawn `{e}` string ("timed out after 60s") — its two contracted strings are unchanged. Non-wedge wording byte-identical.

### Test infra
- Removed all 4 `git-raw-allowed` markers; updated `daemon_git_helper_invariant` MODULE_SCOPE comment (worktree.rs now 0 raw → invariant green vacuously).
- Added `worktree` to the nextest `git-subprocess` serialize group (ci + default) so the real-worktree lifecycle tests run `max-threads=1` — prevents the concurrent-git **windows-hang** class (#1893 / the #2117 P2 incident).

### Verification
- **32 `worktree.rs` lifecycle tests pass with zero assertion changes** (byte-identity proof) — incl. `test_reuse_existing_worktree`, `reuse_idempotent_same_custom_branch`, `reuse_reattaches_clean_detached_worktree_2010`, `reuse_rejects_dirty_detached_worktree_2010`, `mcp::handlers::worktree::bind_self_*`.
- **§3.10 anchor (RED→GREEN):** breaking the migrated stderr-dispatch guard (`contains("already exists")…` → a never-match) REDs 4 `bind_self_*` tests (they hit the existing-branch fallback via `create()`); revert → GREEN. Proves the migrated dispatch path is covered.
- `daemon_git_helper_invariant` green.
- Full suite: `cargo nextest run --profile ci --features tray` → **4158 passed, 33 skipped**.
- `cargo fmt --check` ✓ · `cargo clippy --bin agend-terminal --features tray --tests -D warnings` ✓.

### Reviewer focus (dual review)
- C: `unwrap_or(true)` makes a *theoretical* non-zero `status` exit (unreachable for a present worktree) also fail-closed `true` (prior raw-bytes path returned `false`) — the original comment + lead endorsed this form; flagged for explicit sign-off.
- A/B: stderr-substring dispatch correctness on `NonZero.stderr` (trim-safe).
- D: the two contracted Err strings.

Closes #2128. Spike: t-20260614081712911066-2.

*fixup-dev* · claude-opus-4-8

🤖 Generated with [Claude Code](https://claude.com/claude-code)