### PR TITLE
feat(#2127 P1): reclaim board tasks from non-recoverable usage_limit agents

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -595,6 +595,12 @@ pub(crate) fn build_default_handlers(
     daemon_binary_stale: crate::daemon::mcp_registry_watcher::DaemonBinaryStale,
 ) -> Vec<Box<dyn per_tick::PerTickHandler>> {
     let watchdog_dry_run = watchdog::watchdog_dry_run_from_env();
+    // #2127 Phase 1: the inbox-stuck handler and the new reclaim handler share one
+    // dedup latch so reclaim can clear an agent's repeat-alert entry. Construct the
+    // inbox-stuck handler first, clone its latch, then move it into the vec at its
+    // original position (order preserved).
+    let inbox_stuck = per_tick::InboxStuckHandler::new(30);
+    let work_stuck_latch = inbox_stuck.latch();
     // Vec order MUST match the pre-extraction call order (zero-behavior-change guarantee).
     vec![
         Box::new(per_tick::HangDetectionHandler::new()),
@@ -612,7 +618,7 @@ pub(crate) fn build_default_handlers(
         Box::new(per_tick::PollReminderHandler::new(30)),
         // #1491(A): inbox-stuck watchdog — every 30 ticks (~5min). Detects an
         // agent receiving but not draining its inbox; notifies lead (no auto-restart).
-        Box::new(per_tick::InboxStuckHandler::new(30)),
+        Box::new(inbox_stuck),
         // #1491(B): next_after_ci handoff-timeout watchdog. #1859 lowered the
         // cadence to ~2min (12 ticks) so the daemon-side RE-NUDGE of the target
         // (Fix A) is timely; the lead ESCALATION stays gated by its own 10min age
@@ -674,6 +680,13 @@ pub(crate) fn build_default_handlers(
         // nothing; runs in app mode (the live daemon) so the data accrues for
         // the phase-2 go/no-go.
         Box::new(per_tick::DivergenceTelemetryHandler::new(360)),
+        // #2127 Phase 1: reclaim board tasks from agents stuck in a non-recoverable
+        // usage_limit window (operator decision d-…085112: Phase 1, grace=10min).
+        // Every 30 ticks (~5min). Fires ONLY for UsageLimit/QuotaExceeded with a
+        // remaining window > grace and no recent recovery — releases the agent's
+        // claimed/in_progress tasks back to Open + clears the work-stuck latch.
+        // Runs in both run_core and app mode (live daemon is app-mode).
+        Box::new(per_tick::ReclaimHandler::new(30, work_stuck_latch)),
     ]
 }
 

--- a/src/daemon/per_tick/inbox_stuck.rs
+++ b/src/daemon/per_tick/inbox_stuck.rs
@@ -7,24 +7,45 @@
 use super::{PerTickHandler, TickContext};
 use parking_lot::Mutex;
 use std::collections::HashMap;
+use std::sync::Arc;
+
+/// #2127 Phase 1: the inbox-stuck dedup latch (agent → last-alert time), shared so
+/// the reclaim handler can drop an agent's entry after reclaiming its board work
+/// (resetting the repeat stuck-alert). `Arc<Mutex<…>>` because the two handlers
+/// are independent `Box<dyn PerTickHandler>` instances and cannot reach each
+/// other directly.
+pub(crate) type AlertLatch = Arc<Mutex<HashMap<String, chrono::DateTime<chrono::Utc>>>>;
 
 pub(crate) struct InboxStuckHandler {
     /// Cadence + boot-grace, bundled (see [`super::NOTIFICATION_BOOT_GRACE`]):
     /// suppresses firing within the grace window of construction without
     /// advancing the counter, then fires on tick indices 0, N, 2N, ….
     gate: crate::daemon::cadence_gate::CadenceGate,
-    last_alerted: Mutex<HashMap<String, chrono::DateTime<chrono::Utc>>>,
+    last_alerted: AlertLatch,
 }
 
 impl InboxStuckHandler {
     pub(crate) fn new(every_n_ticks: u64) -> Self {
+        Self::with_latch(every_n_ticks, Arc::new(Mutex::new(HashMap::new())))
+    }
+
+    /// Construct sharing an externally-owned [`AlertLatch`] so another handler
+    /// (the #2127 reclaim handler) can clear an agent's entry. Production wiring
+    /// in `build_default_handlers` uses this; `new` keeps a private latch.
+    pub(crate) fn with_latch(every_n_ticks: u64, last_alerted: AlertLatch) -> Self {
         Self {
             gate: crate::daemon::cadence_gate::CadenceGate::new_with_boot_grace(
                 every_n_ticks,
                 super::NOTIFICATION_BOOT_GRACE,
             ),
-            last_alerted: Mutex::new(HashMap::new()),
+            last_alerted,
         }
+    }
+
+    /// A clone of the shared dedup latch, for the reclaim handler to clear an
+    /// agent's repeat-alert entry after reclaim.
+    pub(crate) fn latch(&self) -> AlertLatch {
+        self.last_alerted.clone()
     }
 
     #[cfg(test)]
@@ -35,7 +56,7 @@ impl InboxStuckHandler {
                 created_at,
                 super::NOTIFICATION_BOOT_GRACE,
             ),
-            last_alerted: Mutex::new(HashMap::new()),
+            last_alerted: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 }

--- a/src/daemon/per_tick/mod.rs
+++ b/src/daemon/per_tick/mod.rs
@@ -49,6 +49,7 @@ pub(crate) mod log_rotation;
 pub(crate) mod notification_flush;
 pub(crate) mod poll_reminder;
 pub(crate) mod pr_state_scan;
+pub(crate) mod reclaim;
 pub(crate) mod recovery_dispatcher;
 pub(crate) mod snapshot;
 pub(crate) mod supervisor_trackers;
@@ -72,6 +73,7 @@ pub(crate) use log_rotation::LogRotationHandler;
 pub(crate) use notification_flush::NotificationFlushHandler;
 pub(crate) use poll_reminder::PollReminderHandler;
 pub(crate) use pr_state_scan::PrStateScanHandler;
+pub(crate) use reclaim::ReclaimHandler;
 pub(crate) use recovery_dispatcher::RecoveryDispatcherHandler;
 pub(crate) use snapshot::SnapshotRotationHandler;
 pub(crate) use supervisor_trackers::{

--- a/src/daemon/per_tick/reclaim.rs
+++ b/src/daemon/per_tick/reclaim.rs
@@ -1,0 +1,761 @@
+//! #2127 Phase 1 — reclaim board tasks from agents stuck in a *non-recoverable*
+//! usage-limit window. Today the daemon only ALERTS (inbox_stuck / dispatch_idle)
+//! when an agent goes `usage_limit`; its claimed/in-progress board tasks sit dead
+//! on it until manual reassignment. This handler RELEASES those tasks back to
+//! `Open` (so a same-role peer can pick them up) and clears the work-stuck latch.
+//!
+//! Scope is deliberately Tier 0: ONLY board tasks. Unread inbox dispatches (P2)
+//! and worktree bindings (P3) are out of scope — see #2127.
+//!
+//! The trigger is intentionally conservative (operator decision
+//! d-20260614085112365602-2: Phase 1, grace=10min). Reclaim fires iff ALL hold:
+//!   - state is `UsageLimit` OR health reason is `QuotaExceeded`,
+//!   - the state is NOT one of the self-healing / transient classes (a
+//!     brief `RateLimit`/`ServerRateLimit`/`ApiError` auto-retries and must NOT
+//!     be interrupted — see `EXCLUDED`),
+//!   - the agent has not produced productive output within `RECOVERY_SILENCE`
+//!     (it is genuinely stuck, not mid-recovery),
+//!   - the usage window has MORE than `RECLAIM_GRACE` (10min) left — a block
+//!     about to lift self-recovers, so we leave it alone. No parseable unlock
+//!     time ⇒ treated as a long block (`USAGE_LIMIT_EXPIRY` fallback).
+//!
+//! Safety: per-task `reclaim_count` cap (`RECLAIM_CAP`) → stop + escalate the
+//! operator once; fire-once is provided structurally (a released task is no
+//! longer owned by the blocked agent, so the next scan re-enumerates nothing).
+//! Same-board fail-closed: each owned task is gated by the shared
+//! `tasks::can_mutate_on_board` ACL primitive (#2117 P3) — the blocked agent's
+//! project must equal the task's board project, else the task is SKIPPED (never
+//! wrongly mutated). Single-project fleets resolve to one board, so this is
+//! byte-identical today; multi-board (#2117) reuses the same primitive.
+
+use super::{PerTickHandler, TickContext};
+use crate::state::AgentState;
+use std::path::Path;
+use std::time::Duration;
+
+/// A usage-limit window must have MORE than this remaining to be reclaimed — a
+/// block lifting within the grace self-recovers (operator decision: 10min).
+const RECLAIM_GRACE: Duration = Duration::from_secs(10 * 60);
+/// Fallback "remaining" when the agent is `usage_limit` but the pane carried no
+/// parseable reset time — treat as a long block (> grace ⇒ reclaim).
+const USAGE_LIMIT_EXPIRY: Duration = Duration::from_secs(30 * 60);
+/// Per-task reclaim cap. Beyond this, auto-reclaim stops and the operator is
+/// escalated (a task that keeps landing on usage-limited agents needs a human).
+const RECLAIM_CAP: u32 = 3;
+/// If a reclaimed agent is observed recovered within this window after reclaim,
+/// record a `collision` instrument line — empirical input to the Phase 2
+/// lease-epoch go/no-go (was the 10min grace too aggressive?).
+const COLLISION_WINDOW: Duration = Duration::from_secs(30 * 60);
+
+/// AgentState classes that are transient / self-healing / operator-gated and must
+/// NEVER be reclaimed even if a stale `QuotaExceeded` reason lingers. (`IdleLong`
+/// in the issue is a *health* state, not an `AgentState`; a merely-idle agent is
+/// excluded anyway because it fails the usage-limit gate below.)
+fn is_excluded_state(state: AgentState) -> bool {
+    matches!(
+        state,
+        AgentState::RateLimit
+            | AgentState::ServerRateLimit
+            | AgentState::ApiError
+            | AgentState::ContextFull
+            | AgentState::AwaitingOperator
+            | AgentState::InteractivePrompt
+            | AgentState::PermissionPrompt
+            | AgentState::Starting
+            | AgentState::Restarting
+    )
+}
+
+/// The pure reclaim predicate (testable in isolation). See module docs for the
+/// rationale of each clause.
+pub(crate) fn should_reclaim(
+    state: AgentState,
+    quota_exceeded: bool,
+    recovered: bool,
+    remaining: Duration,
+    grace: Duration,
+) -> bool {
+    if is_excluded_state(state) {
+        return false;
+    }
+    let usage_blocked = state == AgentState::UsageLimit || quota_exceeded;
+    if !usage_blocked {
+        return false;
+    }
+    if recovered {
+        // Mid-recovery (transient backoff self-healing) — do not interrupt.
+        return false;
+    }
+    remaining > grace
+}
+
+fn tracking_path(home: &Path) -> std::path::PathBuf {
+    home.join("reclaim_tracking.json")
+}
+
+fn instrument_path(home: &Path) -> std::path::PathBuf {
+    home.join("reclaim_instrument.jsonl")
+}
+
+/// Persistent reclaim bookkeeping (survives restarts; the cap must, since the
+/// reassignment churn it bounds spans many handler runs).
+#[derive(serde::Serialize, serde::Deserialize, Default)]
+struct ReclaimTracking {
+    /// task_id → number of times reclaimed (bounded by `RECLAIM_CAP`).
+    task_reclaim_count: std::collections::HashMap<String, u32>,
+    /// task_ids already escalated at the cap (fire-once operator escalation).
+    capped_escalated: Vec<String>,
+    /// agent → last reclaim time (RFC3339) — anchors the collision instrument.
+    last_reclaim_at: std::collections::HashMap<String, String>,
+}
+
+/// Append one structured instrument line (best-effort; never panics).
+fn instrument(home: &Path, line: serde_json::Value) {
+    use std::io::Write;
+    if let Ok(mut f) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(instrument_path(home))
+    {
+        let _ = writeln!(f, "{line}");
+    }
+}
+
+pub(crate) struct ReclaimHandler {
+    gate: crate::daemon::cadence_gate::CadenceGate,
+    /// Shared with [`super::InboxStuckHandler`] so reclaim can drop an agent's
+    /// repeat-alert entry once its work is reclaimed.
+    work_stuck_latch: super::inbox_stuck::AlertLatch,
+}
+
+impl ReclaimHandler {
+    pub(crate) fn new(
+        every_n_ticks: u64,
+        work_stuck_latch: super::inbox_stuck::AlertLatch,
+    ) -> Self {
+        Self {
+            gate: crate::daemon::cadence_gate::CadenceGate::new_with_boot_grace(
+                every_n_ticks,
+                super::NOTIFICATION_BOOT_GRACE,
+            ),
+            work_stuck_latch,
+        }
+    }
+}
+
+/// Per-agent reclaim decision + action (the unit the registry loop drives, and
+/// the unit the adversarial tests exercise directly without a mock registry).
+/// Returns the number of tasks actually released. `now` is injected for testing.
+fn reclaim_if_eligible(
+    home: &Path,
+    latch: &super::inbox_stuck::AlertLatch,
+    agent: &str,
+    state: AgentState,
+    quota_exceeded: bool,
+    recovered: bool,
+    now: chrono::DateTime<chrono::Utc>,
+) -> usize {
+    let remaining = crate::daemon::supervisor::usage_limit_remaining(home, agent, now)
+        .unwrap_or(USAGE_LIMIT_EXPIRY);
+    if !should_reclaim(state, quota_exceeded, recovered, remaining, RECLAIM_GRACE) {
+        return 0;
+    }
+    do_reclaim(home, latch, agent, remaining, now)
+}
+
+/// Release the agent's claimed/in-progress board tasks back to Open + cascade.
+fn do_reclaim(
+    home: &Path,
+    latch: &super::inbox_stuck::AlertLatch,
+    agent: &str,
+    remaining: Duration,
+    now: chrono::DateTime<chrono::Utc>,
+) -> usize {
+    let board = crate::task_events::replay(home).unwrap_or_default();
+    let owned: Vec<crate::task_events::TaskId> = board
+        .tasks
+        .values()
+        .filter(|r| {
+            r.owner.as_ref().is_some_and(|o| o.0 == agent)
+                && matches!(
+                    r.status,
+                    crate::task_events::TaskStatus::Claimed
+                        | crate::task_events::TaskStatus::InProgress
+                )
+        })
+        .map(|r| r.id.clone())
+        .collect();
+    if owned.is_empty() {
+        // Structural fire-once: nothing owned (already reclaimed / never had work).
+        return 0;
+    }
+
+    // Same-board fail-closed (#2117 P3 shared primitive): only reclaim a task if
+    // the blocked agent is authorized on that task's board (caller-project ==
+    // task-board-project). A cross-board task is SKIPPED (never wrongly mutated)
+    // and instrumented. Single-project fleets resolve everything to the default
+    // board → every owned task passes → byte-identical today.
+    let mut agent_tasks: Vec<crate::task_events::TaskId> = Vec::new();
+    for tid in owned {
+        let board_project = crate::tasks::resolve_task_project(home, &tid.0);
+        if crate::tasks::can_mutate_on_board(home, agent, &board_project) {
+            agent_tasks.push(tid);
+        } else {
+            tracing::warn!(
+                agent,
+                task = %tid.0,
+                board = %board_project,
+                "#2127 reclaim cross-board skip (fail-closed): agent not authorized on task's board"
+            );
+            instrument(
+                home,
+                serde_json::json!({
+                    "ts": now.to_rfc3339(),
+                    "event": "cross_board_skip",
+                    "agent": agent,
+                    "task": tid.0,
+                    "board": board_project,
+                }),
+            );
+        }
+    }
+    if agent_tasks.is_empty() {
+        return 0;
+    }
+
+    // RMW the cap store: decide reclaim-vs-cap per task + increment counts +
+    // record the reclaim time. Emit the actual events OUTSIDE the store lock.
+    let mut to_reclaim: Vec<crate::task_events::TaskId> = Vec::new();
+    let mut to_escalate: Vec<String> = Vec::new();
+    let _ = crate::store::with_json_state_or_create::<ReclaimTracking, _, _, _>(
+        &tracking_path(home),
+        ReclaimTracking::default,
+        |t| {
+            for tid in &agent_tasks {
+                let count = t.task_reclaim_count.get(&tid.0).copied().unwrap_or(0);
+                if count >= RECLAIM_CAP {
+                    if !t.capped_escalated.contains(&tid.0) {
+                        t.capped_escalated.push(tid.0.clone());
+                        to_escalate.push(tid.0.clone());
+                    }
+                    continue; // cap reached — stop reclaiming this task
+                }
+                t.task_reclaim_count.insert(tid.0.clone(), count + 1);
+                to_reclaim.push(tid.clone());
+            }
+            t.last_reclaim_at
+                .insert(agent.to_string(), now.to_rfc3339());
+        },
+    );
+
+    let emitter = crate::task_events::InstanceName::from("system:reclaim_usage_limit");
+    let mins = remaining.as_secs() / 60;
+    let mut reclaimed = 0usize;
+    for tid in &to_reclaim {
+        let event = crate::task_events::TaskEvent::Released {
+            task_id: tid.clone(),
+            reason: format!("reclaimed: {agent} usage_limit (~{mins}m window remaining)"),
+        };
+        match crate::task_events::append(home, &emitter, event) {
+            Ok(_) => {
+                // Cascade: clear the task's dispatch-idle pending + dispatch-tracking
+                // + ci-watch handoff so no stale nag follows the released task.
+                crate::daemon::dispatch_idle::reassign_pending_for_task(home, &tid.0, None);
+                crate::dispatch_tracking::reassign_to(home, &tid.0, None);
+                let _ = crate::daemon::ci_watch::reassign_next_after_ci(home, &tid.0, None);
+                reclaimed += 1;
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, task = %tid.0, "reclaim: Released append failed; will retry next pass");
+            }
+        }
+    }
+
+    // Per-task cap escalation (operator) — fire-once per task.
+    for tid in &to_escalate {
+        let msg = format!(
+            "⚠️ task {tid} hit the usage-limit reclaim cap ({RECLAIM_CAP}×) — auto-reclaim stopped, manual reassignment needed."
+        );
+        crate::channel::notify_all_escalation_channels(
+            agent,
+            crate::channel::NotifySeverity::Error,
+            &msg,
+            false,
+        );
+        instrument(
+            home,
+            serde_json::json!({"ts": now.to_rfc3339(), "event": "cap_escalated", "agent": agent, "task": tid}),
+        );
+    }
+
+    if reclaimed > 0 {
+        // Clear the work-stuck latch so the agent's repeat stuck-alert resets now
+        // that its board work has been handled. NOTE (Tier 0): unread inbox
+        // dispatches are NOT reclaimed here (P2), so if the agent still has an
+        // unread pile the inbox-stuck watchdog will legitimately re-alert next
+        // cadence — that is the P2 surface, not a regression.
+        latch.lock().remove(agent);
+        instrument(
+            home,
+            serde_json::json!({
+                "ts": now.to_rfc3339(),
+                "event": "reclaim",
+                "agent": agent,
+                "tasks": reclaimed,
+                "remaining_secs": remaining.as_secs(),
+            }),
+        );
+        tracing::warn!(
+            agent,
+            reclaimed,
+            remaining_secs = remaining.as_secs(),
+            "#2127 reclaimed usage_limit board tasks → Open"
+        );
+    }
+    reclaimed
+}
+
+/// For agents that were reclaimed and have since recovered (no longer eligible),
+/// record a `collision` instrument line if recovery happened within
+/// `COLLISION_WINDOW` of the reclaim, then clear the marker (fire-once).
+fn process_collisions(
+    home: &Path,
+    recovered_agents: &[String],
+    now: chrono::DateTime<chrono::Utc>,
+) {
+    if recovered_agents.is_empty() || !tracking_path(home).exists() {
+        return;
+    }
+    let mut collisions: Vec<(String, i64)> = Vec::new();
+    let _ = crate::store::with_json_state::<ReclaimTracking, _, _>(&tracking_path(home), |t| {
+        for agent in recovered_agents {
+            if let Some(ts) = t.last_reclaim_at.get(agent) {
+                if let Ok(reclaimed_at) = chrono::DateTime::parse_from_rfc3339(ts) {
+                    let age = now.signed_duration_since(reclaimed_at.with_timezone(&chrono::Utc));
+                    if age.to_std().map(|d| d < COLLISION_WINDOW).unwrap_or(false) {
+                        collisions.push((agent.clone(), age.num_seconds()));
+                    }
+                }
+                t.last_reclaim_at.remove(agent); // fire-once
+            }
+        }
+    });
+    for (agent, secs) in collisions {
+        instrument(
+            home,
+            serde_json::json!({
+                "ts": now.to_rfc3339(),
+                "event": "collision",
+                "agent": agent,
+                "recovered_after_secs": secs,
+            }),
+        );
+        tracing::warn!(
+            agent,
+            recovered_after_secs = secs,
+            "#2127 reclaim collision: agent recovered shortly after reclaim (grace data for Phase 2)"
+        );
+    }
+}
+
+impl PerTickHandler for ReclaimHandler {
+    fn name(&self) -> &'static str {
+        "reclaim_usage_limit"
+    }
+
+    fn run(&self, ctx: &TickContext<'_>) {
+        if !self.gate.fire() {
+            return;
+        }
+        let now = chrono::Utc::now();
+        // Snapshot per-agent signals under the locks, then DROP them before any
+        // task/store file IO (avoids holding the registry/core lock across the
+        // #1617 lock-while-blocking class).
+        let recovery_window = crate::state::SERVER_RATE_LIMIT_RECOVERY_SILENCE;
+        let mut eligible: Vec<(String, AgentState, bool)> = Vec::new();
+        let mut recovered_agents: Vec<String> = Vec::new();
+        {
+            let reg = crate::agent::lock_registry(ctx.registry);
+            for handle in reg.values() {
+                let name = handle.name.as_str().to_string();
+                let core = handle.core.lock();
+                let state = core.state.current;
+                let quota = matches!(
+                    core.health.current_reason,
+                    Some(crate::health::BlockedReason::QuotaExceeded)
+                );
+                let recovered = core.state.recovered_within(recovery_window);
+                drop(core);
+                if (state == AgentState::UsageLimit || quota) && !is_excluded_state(state) {
+                    eligible.push((name, state, quota));
+                } else if recovered {
+                    recovered_agents.push(name);
+                }
+            }
+        }
+        for (name, state, quota) in eligible {
+            // recovered=false here: an eligible agent that had recovered would have
+            // gone to `recovered_agents`. Re-read recovery defensively is overkill;
+            // the snapshot already excluded recovered agents from `eligible`.
+            reclaim_if_eligible(
+                ctx.home,
+                &self.work_stuck_latch,
+                &name,
+                state,
+                quota,
+                false,
+                now,
+            );
+        }
+        process_collisions(ctx.home, &recovered_agents, now);
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use parking_lot::Mutex;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    fn tmp_home(tag: &str) -> std::path::PathBuf {
+        static C: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+        let id = C.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "agend-reclaim-{}-{}-{}",
+            std::process::id(),
+            tag,
+            id
+        ));
+        std::fs::create_dir_all(&dir).ok();
+        dir
+    }
+
+    fn fresh_latch() -> super::super::inbox_stuck::AlertLatch {
+        Arc::new(Mutex::new(HashMap::new()))
+    }
+
+    /// Seed a Claimed task owned by `agent` on the default board.
+    fn seed_claimed_task(home: &Path, task_id: &str, agent: &str) {
+        let tid = crate::task_events::TaskId(task_id.to_string());
+        let owner = crate::task_events::InstanceName::from(agent);
+        let creator = crate::task_events::InstanceName::from("system:test");
+        crate::task_events::append(
+            home,
+            &creator,
+            crate::task_events::TaskEvent::Created {
+                task_id: tid.clone(),
+                title: "t".into(),
+                description: "d".into(),
+                priority: "normal".into(),
+                owner: Some(owner.clone()),
+                due_at: None,
+                depends_on: vec![],
+                routed_to: None,
+                branch: None,
+                bind: None,
+                eta_secs: None,
+                tags: vec![],
+                parent_id: None,
+            },
+        )
+        .unwrap();
+        crate::task_events::append(
+            home,
+            &owner,
+            crate::task_events::TaskEvent::Claimed {
+                task_id: tid,
+                by: owner.clone(),
+            },
+        )
+        .unwrap();
+    }
+
+    /// Write a usage_limit_notify.json record so `usage_limit_remaining` returns a
+    /// window `mins_from_now` minutes ahead of `notified_at == now`.
+    fn seed_usage_notify(
+        home: &Path,
+        agent: &str,
+        now: chrono::DateTime<chrono::Utc>,
+        mins_from_now: i64,
+    ) {
+        let unlock = (now + chrono::Duration::minutes(mins_from_now))
+            .format("%H:%M")
+            .to_string();
+        let rec =
+            serde_json::json!({ agent: { "unlock_at": unlock, "notified_at": now.to_rfc3339() } });
+        std::fs::write(
+            home.join("usage_limit_notify.json"),
+            serde_json::to_string(&rec).unwrap(),
+        )
+        .unwrap();
+    }
+
+    fn task_status(home: &Path, task_id: &str) -> crate::task_events::TaskStatus {
+        let st = crate::task_events::replay(home).unwrap();
+        st.tasks
+            .get(&crate::task_events::TaskId(task_id.to_string()))
+            .unwrap()
+            .status
+    }
+
+    fn task_owner(home: &Path, task_id: &str) -> Option<String> {
+        let st = crate::task_events::replay(home).unwrap();
+        st.tasks
+            .get(&crate::task_events::TaskId(task_id.to_string()))
+            .unwrap()
+            .owner
+            .as_ref()
+            .map(|o| o.0.clone())
+    }
+
+    // ── Pure predicate unit tests (full branch coverage) ──────────────────────
+
+    #[test]
+    fn predicate_excludes_self_healing_states() {
+        let long = Duration::from_secs(3600);
+        for s in [
+            AgentState::RateLimit,
+            AgentState::ServerRateLimit,
+            AgentState::ApiError,
+            AgentState::ContextFull,
+            AgentState::AwaitingOperator,
+            AgentState::InteractivePrompt,
+            AgentState::PermissionPrompt,
+            AgentState::Starting,
+            AgentState::Restarting,
+        ] {
+            assert!(
+                !should_reclaim(s, true, false, long, RECLAIM_GRACE),
+                "{s:?} is self-healing/operator-gated and must NEVER be reclaimed"
+            );
+        }
+    }
+
+    #[test]
+    fn predicate_reclaims_usage_limit_past_grace() {
+        let long = RECLAIM_GRACE + Duration::from_secs(60);
+        assert!(should_reclaim(
+            AgentState::UsageLimit,
+            false,
+            false,
+            long,
+            RECLAIM_GRACE
+        ));
+        // QuotaExceeded reason on a non-excluded state also qualifies.
+        assert!(should_reclaim(
+            AgentState::Idle,
+            true,
+            false,
+            long,
+            RECLAIM_GRACE
+        ));
+    }
+
+    #[test]
+    fn predicate_skips_within_grace_and_when_recovered() {
+        let short = RECLAIM_GRACE - Duration::from_secs(60);
+        let long = RECLAIM_GRACE + Duration::from_secs(60);
+        assert!(
+            !should_reclaim(AgentState::UsageLimit, false, false, short, RECLAIM_GRACE),
+            "a window lifting within grace self-recovers — do not reclaim"
+        );
+        assert!(
+            !should_reclaim(AgentState::UsageLimit, false, true, long, RECLAIM_GRACE),
+            "an agent mid-recovery must not be interrupted"
+        );
+        assert!(
+            !should_reclaim(AgentState::Idle, false, false, long, RECLAIM_GRACE),
+            "a non-usage-limit agent is never reclaimed"
+        );
+    }
+
+    // ── §3.10 three adversarial path tests (real task store + latch) ──────────
+
+    /// (a) A brief transient block (RateLimit / ServerRateLimit / ApiError) must
+    /// NOT be reclaimed even with a usage window present — it auto-recovers.
+    #[test]
+    fn adversarial_a_transient_states_not_reclaimed() {
+        let now = chrono::Utc::now();
+        for (i, state) in [
+            AgentState::RateLimit,
+            AgentState::ServerRateLimit,
+            AgentState::ApiError,
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let home = tmp_home(&format!("adv-a-{i}"));
+            seed_claimed_task(&home, "t-a", "dev-x");
+            seed_usage_notify(&home, "dev-x", now, 60); // long window present
+            let latch = fresh_latch();
+            let n = reclaim_if_eligible(&home, &latch, "dev-x", state, false, false, now);
+            assert_eq!(n, 0, "{state:?} must not be reclaimed");
+            assert_eq!(
+                task_status(&home, "t-a"),
+                crate::task_events::TaskStatus::Claimed,
+                "{state:?}: task must stay Claimed"
+            );
+            std::fs::remove_dir_all(&home).ok();
+        }
+    }
+
+    /// (b) A genuine usage_limit with > grace remaining IS reclaimed: task → Open,
+    /// owner cleared, work-stuck latch entry removed.
+    #[test]
+    fn adversarial_b_usage_limit_past_grace_reclaimed() {
+        let now = chrono::Utc::now();
+        let home = tmp_home("adv-b");
+        seed_claimed_task(&home, "t-b", "dev-y");
+        seed_usage_notify(&home, "dev-y", now, 30); // 30min > 10min grace
+        let latch = fresh_latch();
+        latch.lock().insert("dev-y".to_string(), now);
+
+        let n = reclaim_if_eligible(
+            &home,
+            &latch,
+            "dev-y",
+            AgentState::UsageLimit,
+            false,
+            false,
+            now,
+        );
+        assert_eq!(n, 1, "one task must be reclaimed");
+        assert_eq!(
+            task_status(&home, "t-b"),
+            crate::task_events::TaskStatus::Open,
+            "task must be released to Open"
+        );
+        assert_eq!(task_owner(&home, "t-b"), None, "owner must be cleared");
+        assert!(
+            !latch.lock().contains_key("dev-y"),
+            "work-stuck latch entry must be cleared on reclaim"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// (c) A usage_limit window lifting within grace (< 10min) is NOT reclaimed —
+    /// it will self-recover.
+    #[test]
+    fn adversarial_c_usage_limit_within_grace_not_reclaimed() {
+        let now = chrono::Utc::now();
+        let home = tmp_home("adv-c");
+        seed_claimed_task(&home, "t-c", "dev-z");
+        seed_usage_notify(&home, "dev-z", now, 5); // 5min < 10min grace
+        let latch = fresh_latch();
+        let n = reclaim_if_eligible(
+            &home,
+            &latch,
+            "dev-z",
+            AgentState::UsageLimit,
+            false,
+            false,
+            now,
+        );
+        assert_eq!(n, 0, "within-grace window must not be reclaimed");
+        assert_eq!(
+            task_status(&home, "t-c"),
+            crate::task_events::TaskStatus::Claimed,
+            "task must stay Claimed"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// No usage_notify record ⇒ conservative long-block fallback ⇒ reclaimed.
+    #[test]
+    fn no_notify_record_falls_back_to_long_block() {
+        let now = chrono::Utc::now();
+        let home = tmp_home("nofallback");
+        seed_claimed_task(&home, "t-f", "dev-f");
+        // intentionally no seed_usage_notify
+        let latch = fresh_latch();
+        let n = reclaim_if_eligible(
+            &home,
+            &latch,
+            "dev-f",
+            AgentState::UsageLimit,
+            false,
+            false,
+            now,
+        );
+        assert_eq!(n, 1, "missing reset time ⇒ long-block fallback ⇒ reclaim");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Per-task cap: the 4th reclaim of the same task is blocked (cap=3).
+    #[test]
+    fn per_task_cap_stops_after_three() {
+        let now = chrono::Utc::now();
+        let home = tmp_home("cap");
+        let latch = fresh_latch();
+        let mut total = 0;
+        for round in 0..5 {
+            // Re-seed the same task as Claimed each round (simulating re-dispatch
+            // back to a usage-limited agent), then reclaim.
+            if round == 0 {
+                seed_claimed_task(&home, "t-cap", "dev-c");
+            } else {
+                // re-claim the now-Open task
+                let owner = crate::task_events::InstanceName::from("dev-c");
+                crate::task_events::append(
+                    &home,
+                    &owner,
+                    crate::task_events::TaskEvent::Claimed {
+                        task_id: crate::task_events::TaskId("t-cap".into()),
+                        by: owner.clone(),
+                    },
+                )
+                .unwrap();
+            }
+            seed_usage_notify(&home, "dev-c", now, 30);
+            total += reclaim_if_eligible(
+                &home,
+                &latch,
+                "dev-c",
+                AgentState::UsageLimit,
+                false,
+                false,
+                now,
+            );
+        }
+        assert_eq!(total, RECLAIM_CAP as usize, "reclaim must stop at the cap");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Structural fire-once: a second scan with no owned tasks reclaims nothing.
+    #[test]
+    fn fire_once_when_no_owned_tasks() {
+        let now = chrono::Utc::now();
+        let home = tmp_home("fireonce");
+        seed_claimed_task(&home, "t-o", "dev-o");
+        seed_usage_notify(&home, "dev-o", now, 30);
+        let latch = fresh_latch();
+        assert_eq!(
+            reclaim_if_eligible(
+                &home,
+                &latch,
+                "dev-o",
+                AgentState::UsageLimit,
+                false,
+                false,
+                now
+            ),
+            1
+        );
+        // task is now Open + unowned → second pass finds nothing.
+        assert_eq!(
+            reclaim_if_eligible(
+                &home,
+                &latch,
+                "dev-o",
+                AgentState::UsageLimit,
+                false,
+                false,
+                now
+            ),
+            0
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+}

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -597,6 +597,35 @@ fn unlock_deadline(
     })
 }
 
+/// #2127 Phase 1: time until `name`'s usage-limit window unlocks, per the
+/// persisted notify record. `None` when there is no record, no parseable
+/// `unlock_at`, or an unparseable `notified_at` — the reclaim caller then falls
+/// back to a conservative long default (a missing reset time is treated as a long
+/// block). A past deadline clamps to `Duration::ZERO`. Lock-free read; reuses the
+/// same record + `unlock_deadline` math as the notify-suppression path so the two
+/// agree on what "this window" means.
+pub(crate) fn usage_limit_remaining(
+    home: &std::path::Path,
+    name: &str,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Option<std::time::Duration> {
+    let map: std::collections::HashMap<String, UsageNotifyRecord> =
+        std::fs::read_to_string(usage_limit_notify_path(home))
+            .ok()
+            .and_then(|c| serde_json::from_str(&c).ok())?;
+    let rec = map.get(name)?;
+    let unlock_at = rec.unlock_at.as_deref()?;
+    let notified_at = chrono::DateTime::parse_from_rfc3339(&rec.notified_at)
+        .ok()?
+        .with_timezone(&chrono::Utc);
+    let deadline = unlock_deadline(unlock_at, notified_at)?;
+    Some(
+        (deadline - now)
+            .to_std()
+            .unwrap_or(std::time::Duration::ZERO),
+    )
+}
+
 /// True ⇒ suppress this usage_limit notify (already notified for the same still-
 /// open window). Lock-free FAIL-OPEN read: a missing/corrupt record ⇒ NOT
 /// suppressed (notify), so a real new limit is never silently swallowed.

--- a/src/tasks/acl.rs
+++ b/src/tasks/acl.rs
@@ -83,6 +83,7 @@ const SYSTEM_IDENTITIES: &[&str] = &[
     "system:auto_orphan",
     "system:branch_sweep",
     "system:overdue_sweep",
+    "system:reclaim_usage_limit",
     "system:task_sweep",
 ];
 
@@ -117,5 +118,69 @@ pub(super) fn can_mutate_record(
             }
             false
         }
+    }
+}
+
+/// #2127 Phase 1 / #2117 P3 — per-board mutation authority. May `caller` mutate
+/// tasks on the board identified by `board_project`?
+///
+/// Semantics (aligned with [`can_mutate_record`]): a recognized system identity
+/// bypasses; otherwise the caller's resolved project
+/// (agent→team→`source_repo`→project, via
+/// [`super::board_router::resolve_current_project`]) must equal `board_project`,
+/// else **deny (fail-closed)**. A single-project fleet resolves every caller and
+/// task to `DEFAULT_PROJECT`, so this never adds a denial until multi-board
+/// (#2117) lands — byte-identical today.
+///
+/// Shared primitive: #2127's reclaim/reroute authorization (caller = the blocked
+/// task owner, `board_project` = the task's board) and #2117 P3a's explicit
+/// `project=<id>` mutation path both route through this — one ACL, no second
+/// slug/resolution implementation. Re-exported `pub(crate)` via
+/// `tasks::can_mutate_on_board` for callers outside the `tasks` module (the
+/// reclaim per-tick handler).
+pub(crate) fn can_mutate_on_board(home: &Path, caller: &str, board_project: &str) -> bool {
+    if is_system_identity(caller) {
+        return true;
+    }
+    super::board_router::resolve_current_project(home, caller) == board_project
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn tmp_home(tag: &str) -> std::path::PathBuf {
+        let dir =
+            std::env::temp_dir().join(format!("agend-acl-board-{}-{tag}", std::process::id()));
+        std::fs::create_dir_all(&dir).ok();
+        dir
+    }
+
+    #[test]
+    fn can_mutate_on_board_system_identity_bypasses() {
+        let home = tmp_home("sys");
+        // A system identity is authorized on any board, even a non-default one.
+        assert!(can_mutate_on_board(
+            &home,
+            "system:reclaim_usage_limit",
+            "owner/repo"
+        ));
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn can_mutate_on_board_default_project_matches_and_mismatches() {
+        let home = tmp_home("default");
+        // No fleet/team → caller resolves to DEFAULT_PROJECT ("default").
+        assert!(
+            can_mutate_on_board(&home, "dev-a", "default"),
+            "same (default) board → allowed (single-project byte-identical)"
+        );
+        assert!(
+            !can_mutate_on_board(&home, "dev-a", "owner/other-repo"),
+            "different board → fail-closed deny"
+        );
+        std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/tasks/board_router.rs
+++ b/src/tasks/board_router.rs
@@ -114,7 +114,7 @@ pub(crate) fn resolve_target_project(home: &Path, target: &str) -> String {
 /// that repairs the index on a hit, else [`DEFAULT_PROJECT`] (the `home` board)
 /// when the task is unknown — which keeps a missing/legacy task resolving to the
 /// historical board.
-pub(super) fn resolve_task_project(home: &Path, task_id: &str) -> String {
+pub(crate) fn resolve_task_project(home: &Path, task_id: &str) -> String {
     if let Some(p) = lookup_task_project(home, task_id) {
         return p;
     }

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -21,7 +21,12 @@ pub use handler::register_subscriber as register_cascade_subscriber;
 // #2117 P2: resolution helpers for the out-of-`tasks` callers — comms dispatch
 // auto-create (target board) and the per-board task sweep (project id from a
 // team's source_repo).
-pub(crate) use board_router::{project_id_from_source_repo, resolve_target_project};
+pub(crate) use board_router::{
+    project_id_from_source_repo, resolve_target_project, resolve_task_project,
+};
+// #2127 Phase 1 / #2117 P3: shared per-board mutation ACL primitive, re-exported
+// for callers outside the `tasks` module (the reclaim per-tick handler).
+pub(crate) use acl::can_mutate_on_board;
 pub use orphan::{
     cancel_tasks_for_owner, orphan_tasks_for_owner, reconcile_orphan_owners_with_live,
     release_inprogress_orphans_with_live,


### PR DESCRIPTION
## #2127 Phase 1 — reclaim board tasks from non-recoverable usage_limit agents

Today the daemon only **alerts** (inbox_stuck / dispatch_idle) when an agent goes `usage_limit`; its claimed/in-progress board tasks sit dead on it until a human reassigns. This adds a per-tick `ReclaimHandler` that **releases** those tasks back to `Open` (so a same-role peer can pick them up) and clears the work-stuck latch. Operator decision `d-20260614085112365602-2`: Phase 1, grace = 10min.

**Scope = Tier 0 (board tasks ONLY).** Unread inbox dispatches (P2) and worktree bindings (P3) are out of scope per #2127.

### Trigger predicate (conservative; pure-fn unit-tested)
Reclaim iff ALL hold:
- `state == UsageLimit` OR health reason `QuotaExceeded`,
- AND state NOT in the self-healing / operator-gated EXCLUDE set (`RateLimit`/`ServerRateLimit`/`ApiError`/`ContextFull`/`AwaitingOperator`/`InteractivePrompt`/`PermissionPrompt`/`Starting`/`Restarting`) — a brief rate-limit auto-retries and must NOT be interrupted,
- AND no productive output within `RECOVERY_SILENCE` (genuinely stuck, not mid-recovery),
- AND the usage window has **> `RECLAIM_GRACE` (10min)** left (a block lifting within grace self-recovers). No parseable reset time ⇒ long-block fallback ⇒ reclaim. New `supervisor::usage_limit_remaining` reuses the existing `unlock_at`/`unlock_deadline` math.

### Action
`TaskEvent::Released` → Open + cascade (`dispatch_idle` / `dispatch_tracking` / `ci_watch` → `None`) + clear the **shared** `inbox_stuck` work-stuck latch (NOT the usage-limit health notify latch).

### Safety
- **Per-task reclaim_count cap (3)** → stop + escalate the operator once (churn guard).
- **Fire-once is structural**: a released task is no longer owned by the blocked agent, so the next scan re-enumerates nothing.
- **Same-board fail-closed** via the shared `acl::can_mutate_on_board` primitive (#2117 P3, signature locked with @fixup-dev): the blocked agent's project must equal the task's board project, else SKIP + instrument. Single-project fleets resolve to one board → every owned task passes → **byte-identical today**.
- **Instrument** (`reclaim_instrument.jsonl`): `reclaim` / `collision` (agent recovered within `COLLISION_WINDOW` after reclaim — empirical grace data for the Phase 2 lease-epoch go/no-go) / `cap_escalated` / `cross_board_skip`.

### Wiring
`ReclaimHandler` shares the `inbox_stuck` `AlertLatch` (`Arc`) via `build_default_handlers`; runs in both `run_core` and app mode (not allowlisted — the app-completeness test auto-covers it).

### Shared ACL primitive (cross-PR coordination)
`acl::can_mutate_on_board(home, caller, board_project)` is the one per-board mutation ACL — #2127 reclaim (here) and #2117 P3a (explicit `project=<id>` mutations, @fixup-dev) both route through it. System-identity bypass + `resolve_current_project(caller) == board_project` fail-closed. No second slug/resolution implementation. `pub(crate)` body so the out-of-`tasks` reclaim handler can call it; @fixup-dev's in-`tasks` callers use `super::acl::`.

### Proof (§3.10 test-first)
- Pure predicate + **3 adversarial path tests** (transient-not-reclaimed / usage>grace-reclaimed-to-Open+latch-cleared / usage<grace-skipped) verified **RED→GREEN** (weakened predicate → tests fail; real predicate → pass).
- Plus per-task-cap, structural-fire-once, no-record-fallback, and `can_mutate_on_board` (system-bypass / same-board / cross-board) unit tests.
- Full suite **4168/4169** — lone fail = known `spawn_group_bounded_preserves_caller_env_no_bypass_1899` env-set artifact (passes in CI's clean env).
- `clippy --all-targets --features tray -- -D warnings` clean; Windows `x86_64-pc-windows-msvc` cross-check clean.

### Reviewer focus (dual review)
HIGH-risk double-execution surface. Key checks: the trigger predicate (exclude set + grace + recovered — must never reclaim a self-healing agent), the same-board fail-closed ACL, the cap/fire-once safety, and the collision instrument (grace-sufficiency data). NOTE: Tier 0 does not reclaim inbox dispatches, so clearing `inbox_stuck.last_alerted` resets the dedup timer — if the agent still has an unread pile the watchdog legitimately re-alerts next cadence (that's the P2 surface, not a regression).

---
*fixup-dev-2* · claude/opus-4.8