### PR TITLE
feat(#2117 P3a): reject cross-project parent_id at create + close-isolation e2e

### DIFF
--- a/src/daemon/task_sweep.rs
+++ b/src/daemon/task_sweep.rs
@@ -312,7 +312,27 @@ fn sweep_board(
     fleet_cfg: Option<&crate::fleet::FleetConfig>,
     dry_run: bool,
 ) -> anyhow::Result<bool> {
+    // #2117 P3a: the `list_recently_merged_prs` network fetch is the ONLY thing
+    // this adds over the testable close logic; delegate the rest to
+    // `sweep_board_with_prs` (the injectable seam).
     let prs = list_recently_merged_prs(repo, api_base)?;
+    sweep_board_with_prs(home, project_id, &prs, fleet_cfg, dry_run)
+}
+
+/// #2117 P3a: the close logic of [`sweep_board`] with the PR list INJECTED. Seam
+/// for the close-isolation integration test without a GitHub round-trip — a merged
+/// PR scanned against board A is matched ONLY against board A's open tasks (read
+/// via the P1 `list_all_at` `_at` variant), so it can never auto-close a task that
+/// lives on board B (#2105), even if the PR body's `Closes t-…` marker references
+/// it. Returns `Ok(true)` if a full scan ran (PR list AND open-task set both
+/// non-empty), `Ok(false)` if it short-circuited.
+fn sweep_board_with_prs(
+    home: &Path,
+    project_id: &str,
+    prs: &[PrMeta],
+    fleet_cfg: Option<&crate::fleet::FleetConfig>,
+    dry_run: bool,
+) -> anyhow::Result<bool> {
     if prs.is_empty() {
         return Ok(false);
     }
@@ -344,7 +364,7 @@ fn sweep_board(
     let emitter = InstanceName::from(SWEEP_EMITTER);
     let sweep_id = format!("sweep-{}", chrono::Utc::now().to_rfc3339());
 
-    for pr in &prs {
+    for pr in prs {
         if !pr.merged {
             continue;
         }
@@ -1027,6 +1047,66 @@ mod tests {
             empty.is_empty(),
             "no repo + no teams → no boards: {empty:?}"
         );
+        fs::remove_dir_all(&home).ok();
+    }
+
+    /// #2117 close-isolation e2e (the #2125-review gap reviewer-2+4 both flagged):
+    /// a merged PR swept against board A auto-closes ONLY board A's task, even when
+    /// its body's `Closes t-…` marker also references a task on board B (#2105).
+    /// Exercises the real close path through the `sweep_board_with_prs` seam (no
+    /// GitHub round-trip) with a representative two-board fixture built via the real
+    /// `tasks::handle` create path.
+    #[test]
+    fn sweep_closes_only_same_board_task_2117_close_isolation() {
+        let home = tmp_home("close-isolation");
+        // Two project boards, each with an OPEN task created + assigned to
+        // "test-user" (so the sweep's authorship gate passes via direct-name
+        // compare — `make_pr_meta` stamps `author_login = "test-user"`).
+        let mk = |project: &str| -> String {
+            crate::tasks::handle(
+                &home,
+                "test-user",
+                &serde_json::json!({"action": "create", "title": "t", "assignee": "test-user", "project": project}),
+            )["id"]
+                .as_str()
+                .unwrap()
+                .to_string()
+        };
+        let ta = mk("orgA/projA");
+        let tb = mk("orgB/projB");
+
+        // A merged PR in repo A whose body references BOTH boards' tasks.
+        let pr = make_pr_meta(1, "fix", &format!("Closes {ta}\nCloses {tb}"));
+
+        // Sweep board A only.
+        let scanned =
+            sweep_board_with_prs(&home, "orgA/projA", std::slice::from_ref(&pr), None, false)
+                .unwrap();
+        assert!(
+            scanned,
+            "board A had a merged PR + an open task → full scan ran"
+        );
+
+        let status_on = |project: &str, id: &str| -> crate::task_events::TaskStatus {
+            crate::tasks::list_all_at(&crate::task_events::board_root(&home, project))
+                .into_iter()
+                .find(|t| t.id == id)
+                .unwrap_or_else(|| panic!("task {id} not found on board {project}"))
+                .status
+        };
+        // Board A's task auto-closed; board B's task UNTOUCHED — the sweep matched
+        // the markers only against board A's `open_ids` (#2105 cross-board isolation).
+        assert_eq!(
+            status_on("orgA/projA", &ta),
+            crate::task_events::TaskStatus::Done,
+            "board A's task must auto-close"
+        );
+        assert_ne!(
+            status_on("orgB/projB", &tb),
+            crate::task_events::TaskStatus::Done,
+            "board B's task must NOT be closed by repo A's PR (#2105 isolation)"
+        );
+
         fs::remove_dir_all(&home).ok();
     }
 

--- a/src/tasks/handler.rs
+++ b/src/tasks/handler.rs
@@ -137,6 +137,28 @@ fn handle_create(home: &Path, emitter: crate::task_events::InstanceName, args: &
         .as_str()
         .map(String::from)
         .unwrap_or_else(|| super::board_router::resolve_current_project(home, emitter.as_str()));
+    // #2117 P3a: `parent_id` is subtask COMPOSITION ("A is composed of B/C/D").
+    // DP4 invariant — a subtask MUST live in its parent's project. Cross-project
+    // composition breaks board isolation: `cascade_cancel_children` only replays
+    // the PARENT's board, so a cross-project child would be silently orphaned when
+    // the parent is cancelled. Enforce the invariant at the only write point that
+    // can violate it — reject here, fail-closed, rather than detect it later.
+    // Single-project → `resolve_task_project(parent) == project` always → never
+    // fires → byte-identical. (`depends_on` is execution-order dependency, NOT
+    // composition — cross-board references are allowed there per the epic and are
+    // NOT guarded here.)
+    if let Some(parent_id) = args["parent_id"].as_str() {
+        let parent_project = super::board_router::resolve_task_project(home, parent_id);
+        if parent_project != project {
+            return serde_json::json!({
+                "error": format!(
+                    "cross-project parent_id rejected: parent {parent_id} resolves to project \
+                     '{parent_project}' but this subtask targets project '{project}' — a subtask \
+                     must live in its parent's project (board isolation, #2117 P3a)"
+                )
+            });
+        }
+    }
     let board = crate::task_events::board_root(home, &project);
     match crate::task_events::append_at(&board, &emitter, event) {
         Ok(_) => {

--- a/src/tasks/tests.rs
+++ b/src/tasks/tests.rs
@@ -1385,6 +1385,59 @@ teams:
     std::fs::remove_dir_all(&home).ok();
 }
 
+/// #2117 P3a: a subtask (`parent_id` = composition, "A is composed of B/C/D")
+/// MUST live in its parent's project — the DP4 board-isolation invariant.
+/// `handle_create` rejects a cross-project `parent_id` fail-closed, so
+/// `cascade_cancel_children` (same-board replay) can never silently orphan a
+/// cross-project child on parent cancel. Same-project composition is allowed.
+/// (`depends_on` — execution-order dependency, a cross-board *reference* the epic
+/// allows — is deliberately NOT guarded here.)
+#[test]
+fn cross_project_parent_id_rejected_at_create_2117_p3a() {
+    let home = tmp_home("p3a-parent-id-guard");
+
+    let parent = handle(
+        &home,
+        "dev",
+        &serde_json::json!({"action": "create", "title": "parent", "project": "orgA/projA"}),
+    )["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Cross-project subtask → rejected (fail-closed).
+    let bad = handle(
+        &home,
+        "dev",
+        &serde_json::json!({"action": "create", "title": "child", "project": "orgB/projB", "parent_id": parent}),
+    );
+    assert!(
+        bad["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("cross-project parent_id"),
+        "cross-project parent_id must be rejected: {bad}"
+    );
+    // And nothing was written to teamB's board.
+    assert!(
+        super::list_all_at(&crate::task_events::board_root(&home, "orgB/projB")).is_empty(),
+        "rejected subtask must not land on any board"
+    );
+
+    // Same-project subtask → allowed (control).
+    let ok = handle(
+        &home,
+        "dev",
+        &serde_json::json!({"action": "create", "title": "child2", "project": "orgA/projA", "parent_id": parent}),
+    );
+    assert!(
+        ok["id"].is_string(),
+        "same-project subtask must be allowed: {ok}"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+}
+
 #[test]
 fn test_claim_unknown_instance_rejected() {
     let home = tmp_home("claim-unknown");


### PR DESCRIPTION
## #2117 P3a (first batch) — composition invariant + close-isolation test

Epic finale, first batch. Design dual-reviewed (reviewer-2 VERIFIED, d-20260614092552580460-5). **ACL callers (item 2) are deferred** until #2127 Phase1 lands the shared `can_mutate_on_board` primitive — not touched here. Items 3 + 5 only.

### Item 3 — cross-project `parent_id` reject (`handler.rs`)
`parent_id` is subtask **composition** ("A is composed of B/C/D"). The DP4 board-isolation invariant requires a subtask to live in its **parent's** project — otherwise `cascade_cancel_children` (which only replays the *parent's* board) would silently orphan a cross-project child when the parent is cancelled. Enforce the invariant at the only write point that can violate it: `handle_create` rejects a `parent_id` whose `resolve_task_project` differs from the child's project, **fail-closed** with a clear error.

- `cascade_cancel_children` is **unchanged** — same-board replay is complete once the invariant holds (the lead's original "guard inside cascade" framing couldn't work: cascade only sees same-board children; the violation is only observable at create).
- **Scope**: only `parent_id` (composition). `depends_on` (execution-order dependency — a cross-board *reference* the epic explicitly allows) is **not** guarded here; that's the separate "cross-board dep resolver" block, out of P3a.
- **Single-project**: `resolve_task_project(parent) == project` always → guard never fires → byte-identical.

### Item 5 — close-isolation e2e (`task_sweep.rs`, fills the #2125-review gap)
Extracted `sweep_board_with_prs(home, project_id, prs, fleet, dry_run)` — the close logic with the PR list **injected** (`sweep_board` now = `list_recently_merged_prs` fetch + delegate). Pure refactor → byte-identical. New test `sweep_closes_only_same_board_task_2117_close_isolation`: two real project boards each with an open task; a merged PR in repo A whose body references **both** tasks; swept against board A only → **board A's task closes, board B's task is untouched** (#2105 cross-board isolation) — the gap reviewer-2+4 both flagged on #2125.

### Verification
- **§3.10 anchor (item 3)**: neutering the guard condition → the cross-project subtask is created **silently** (RED, the child task is born with a cross-project `parent_id`); restore → rejected (GREEN).
- **Byte-identical**: `tasks` (122) / `task_sweep` (32) / `cascade` (6) pass with zero existing-assertion changes.
- **Full suite**: `cargo nextest run --profile ci --features tray --no-fail-fast` → **4160 passed, 33 skipped**.
- `cargo fmt --check` ✓ · `cargo clippy --bin agend-terminal --features tray --tests -D warnings` ✓.
- Neither new test spawns git → both stay parallel (no nextest serialize-group change needed).

### Reviewer focus (dual review)
- Item 3: the `resolve_task_project(parent) != project` reject — including a bogus/unknown `parent_id` resolving to DEFAULT (rejected only in multi-project; single-project byte-identical).
- Item 5: the `sweep_board_with_prs` extraction is a pure split (no behaviour change to `sweep_board`).

Part of epic #2117. Spike: t-20260614090733386254-7.

*fixup-dev* · claude-opus-4-8

🤖 Generated with [Claude Code](https://claude.com/claude-code)