### PR TITLE
feat(#2117 P3a): per-board ACL on mutation paths + fail-closed fleet resolve

### DIFF
--- a/src/tasks/acl.rs
+++ b/src/tasks/acl.rs
@@ -142,7 +142,16 @@ pub(crate) fn can_mutate_on_board(home: &Path, caller: &str, board_project: &str
     if is_system_identity(caller) {
         return true;
     }
-    super::board_router::resolve_current_project(home, caller) == board_project
+    // #2117 P3a (reviewer-4 #2133): use the FAIL-CLOSED resolver. The plain
+    // `resolve_current_project` returns DEFAULT_PROJECT on a hard fleet.yaml read
+    // failure, conflating it with a legitimate no-team caller — an ACL on that
+    // would fail-OPEN to the default board. `_checked` returns `Err` on a hard
+    // read failure (→ deny) while still returning `Ok(DEFAULT)` for a legitimate
+    // no-team caller (→ single-project byte-identical).
+    match super::board_router::resolve_current_project_checked(home, caller) {
+        Ok(project) => project == board_project,
+        Err(_) => false,
+    }
 }
 
 #[cfg(test)]

--- a/src/tasks/board_router.rs
+++ b/src/tasks/board_router.rs
@@ -99,6 +99,28 @@ pub(super) fn resolve_current_project(home: &Path, caller: &str) -> String {
         .unwrap_or_else(|| DEFAULT_PROJECT.to_string())
 }
 
+/// #2117 P3a (reviewer-4 #2133 finding): the fail-closed counterpart of
+/// [`resolve_current_project`] for the per-board ACL. `resolve_current_project`
+/// collapses a HARD fleet.yaml read/parse failure into [`DEFAULT_PROJECT`] — right
+/// for `create`/`list` board routing (a missing/unreadable fleet just means
+/// single-project → the `home` board), but WRONG for authorization: an ACL that
+/// reads DEFAULT on a fleet read error would fail-OPEN to the default board.
+///
+/// This distinguishes the two cases the plain resolver conflates, mirroring the
+/// #1744-M7 three-state [`crate::teams::try_load_fleet`] (missing file =
+/// `Ok(default)`, file present but unreadable/corrupt = `Err`):
+/// - hard read/parse failure → `Err` → the ACL denies (fail-closed);
+/// - a *legitimate* no-team / no-`source_repo` caller → `Ok(DEFAULT_PROJECT)` →
+///   the ACL still allows on the default board, so single-project stays
+///   byte-identical (no new denial).
+pub(super) fn resolve_current_project_checked(home: &Path, caller: &str) -> anyhow::Result<String> {
+    let fleet = crate::teams::try_load_fleet(home)?;
+    Ok(crate::teams::find_team_for_in(&fleet, caller)
+        .and_then(|t| t.source_repo)
+        .map(|repo| project_id_from_source_repo(&repo))
+        .unwrap_or_else(|| DEFAULT_PROJECT.to_string()))
+}
+
 /// The project a dispatch **target** acts in — identical
 /// agent→team→`source_repo`→project resolution as [`resolve_current_project`],
 /// but keyed on the dispatch target rather than the caller. The comms

--- a/src/tasks/handler.rs
+++ b/src/tasks/handler.rs
@@ -301,6 +301,30 @@ fn handle_list(home: &Path, caller: &str, args: &Value) -> Value {
     })
 }
 
+/// #2117 P3a (FM5 / board isolation): per-board mutation authority. A task
+/// mutation resolves its board from the task_id, so a caller can name a task that
+/// lives on ANOTHER project's board. Deny unless the caller acts in that board's
+/// project — `super::acl::can_mutate_on_board` (system identities bypass; a hard
+/// fleet read failure fail-closes). `force` — the audited operator override, the
+/// SAME axis as the owner-ACL `can_mutate_record` — bypasses it on the paths that
+/// carry it. Single-project → caller project == task board project (both DEFAULT)
+/// → allow → byte-identical (no new denial). Returns `Some(error)` when denied.
+fn cross_board_denied(home: &Path, caller: &str, id: &str, force: bool) -> Option<Value> {
+    if force {
+        return None;
+    }
+    let board_project = super::board_router::resolve_task_project(home, id);
+    if super::acl::can_mutate_on_board(home, caller, &board_project) {
+        return None;
+    }
+    Some(serde_json::json!({
+        "error": format!(
+            "cross-board mutation denied: task '{id}' lives on the '{board_project}' project \
+             board but caller '{caller}' acts in a different project (board isolation, #2117 P3a)"
+        )
+    }))
+}
+
 fn handle_claim(
     home: &Path,
     instance_name: &str,
@@ -314,6 +338,12 @@ fn handle_claim(
     let iname = instance_name.to_string();
     if !instance_exists(home, &iname) {
         return serde_json::json!({"error": format!("instance '{iname}' not found in fleet.yaml")});
+    }
+    // #2117 P3a: board-isolation gate — a caller may only claim tasks on its own
+    // project's board (claim has no `force`/owner-ACL — an open task is claimable
+    // by anyone, but only within the board). Single-project → allow.
+    if let Some(deny) = cross_board_denied(home, &iname, &id, false) {
+        return deny;
     }
     // #t-21: validate + append in ONE critical section to close the
     // claim race. Pre-fix, the claimable check ran here (against a
@@ -405,6 +435,10 @@ fn handle_done(
         return serde_json::json!({
             "error": "force=true requires a non-empty 'force_reason'"
         });
+    }
+    // #2117 P3a: board-isolation gate (outer boundary, before the owner-ACL).
+    if let Some(deny) = cross_board_denied(home, &caller, &id, force) {
+        return deny;
     }
     if !force && !can_mutate_record(home, &caller, &record) {
         return serde_json::json!({
@@ -591,6 +625,10 @@ fn handle_update(
         return serde_json::json!({
             "error": "force=true requires a non-empty 'force_reason'"
         });
+    }
+    // #2117 P3a: board-isolation gate (outer boundary, before the owner-ACL).
+    if let Some(deny) = cross_board_denied(home, &caller, &id, force) {
+        return deny;
     }
     if !force && !can_mutate_record(home, &caller, &record) {
         return serde_json::json!({
@@ -1017,6 +1055,11 @@ fn handle_metadata_set(
         Some(r) => r,
         None => return serde_json::json!({"error": format!("task not found: {id}")}),
     };
+    // #2117 P3a: board-isolation gate (no force on metadata_set — mirror its
+    // unconditional owner-ACL below).
+    if let Some(deny) = cross_board_denied(home, instance_name, id, false) {
+        return deny;
+    }
     if !can_mutate_record(home, instance_name, &record) {
         return serde_json::json!({"error": "permission denied: caller is not owner/creator"});
     }

--- a/src/tasks/tests.rs
+++ b/src/tasks/tests.rs
@@ -1438,6 +1438,137 @@ fn cross_project_parent_id_rejected_at_create_2117_p3a() {
     std::fs::remove_dir_all(&home).ok();
 }
 
+/// #2117 P3a (FM5 / board isolation): a task mutation resolves its board from the
+/// task_id, so the per-board ACL must deny a caller acting in a DIFFERENT project
+/// than the task's board. devA (teamA→projA) cannot `done`/`claim` a task on
+/// teamB's (projB) board; devB (teamB, same board) can. Single-project never
+/// triggers (caller and task both DEFAULT) — see the unchanged existing
+/// done/claim/update tests.
+#[test]
+fn cross_board_mutation_denied_same_board_allowed_2117_p3a() {
+    let home = tmp_home("p3a-board-acl");
+    std::fs::write(
+        crate::fleet::fleet_yaml_path(&home),
+        r#"
+instances:
+  devA:
+    backend: claude
+  devB:
+    backend: claude
+teams:
+  teamA:
+    members:
+      - devA
+    source_repo: /repos/orgA/projA
+  teamB:
+    members:
+      - devB
+    source_repo: /repos/orgB/projB
+"#,
+    )
+    .unwrap();
+
+    // A task on teamB's board, created+owned by devB. No explicit `project` — it
+    // resolves from devB's team `source_repo` (/repos/orgB/projB → slug
+    // `orgB_projB`), so the recorded board id is exactly what
+    // `resolve_current_project(devB)` yields (the production-consistent path; an
+    // explicit raw `project: "orgB/projB"` would NOT match the slugged caller id).
+    let tb = handle(
+        &home,
+        "devB",
+        &serde_json::json!({"action": "create", "title": "B", "assignee": "devB"}),
+    )["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // (a) devA (projA) mutating teamB's (projB) task → cross-board deny, on every
+    // mutation path.
+    for action in ["done", "claim", "update"] {
+        let denied = handle(
+            &home,
+            "devA",
+            &serde_json::json!({"action": action, "id": tb, "status": "blocked"}),
+        );
+        assert!(
+            denied["error"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("cross-board mutation denied"),
+            "devA must be denied cross-board on {action}: {denied}"
+        );
+    }
+    // Nothing mutated — task still Open on board B (slug `orgB_projB`).
+    let tb_status = super::list_all_at(&crate::task_events::board_root(&home, "orgB_projB"))
+        .into_iter()
+        .find(|t| t.id == tb)
+        .unwrap()
+        .status;
+    assert_eq!(
+        tb_status,
+        crate::task_events::TaskStatus::Open,
+        "a denied cross-board mutation must not change the task"
+    );
+
+    // (b) devB (projB, same board) → allowed (board gate passes; claim succeeds on
+    // the Open task).
+    let ok = handle(
+        &home,
+        "devB",
+        &serde_json::json!({"action": "claim", "id": tb}),
+    );
+    assert_eq!(
+        ok["event"], "claimed",
+        "devB same-board mutation must succeed: {ok}"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// #2117 P3a (reviewer-4 #2133): a HARD fleet.yaml read/parse failure must
+/// fail-CLOSED — the per-board ACL can't determine the caller's project, so it
+/// DENIES rather than fall through to the default board (fail-open). Distinct from
+/// a legitimate no-team caller (missing fleet.yaml = single-project → allow).
+#[test]
+fn fleet_read_failure_denies_mutation_fail_closed_2117_p3a() {
+    let home = tmp_home("p3a-fleet-fail-closed");
+    // Create the task with a VALID single-project fleet (lands on the default board).
+    write_fleet_yaml(&home, &["dev"]);
+    let t = handle(
+        &home,
+        "dev",
+        &serde_json::json!({"action": "create", "title": "t", "assignee": "dev"}),
+    )["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Now CORRUPT fleet.yaml (file PRESENT but unparseable → try_load_fleet = Err,
+    // NOT the missing-file Ok(default) path).
+    std::fs::write(
+        crate::fleet::fleet_yaml_path(&home),
+        "{{{ not: : valid yaml ][",
+    )
+    .unwrap();
+
+    // A non-system caller's mutation fail-closes (without the #2133 hardening the
+    // unchecked resolver would return DEFAULT and ALLOW — fail-open).
+    let denied = handle(
+        &home,
+        "dev",
+        &serde_json::json!({"action": "done", "id": t}),
+    );
+    assert!(
+        denied["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("cross-board mutation denied"),
+        "a fleet.yaml hard read failure must fail-closed deny: {denied}"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+}
+
 #[test]
 fn test_claim_unknown_instance_rejected() {
     let home = tmp_home("claim-unknown");


### PR DESCRIPTION
## #2117 P3a item 2 — per-board ACL callers + fail-closed hardening

Wires the `can_mutate_on_board` primitive (landed in #2133/#2127 P1) into the explicit task-mutation paths, plus the reviewer-4 #2133 fail-closed hardening (d-20260614094223278268-6).

### Board-isolation gate (FM5, d-20260614082717611054-1)
A task mutation resolves its board from the `task_id`, so a caller can name a task that lives on **another** project's board. New `cross_board_denied(home, caller, id, force)` helper gates `claim` / `done` / `update` / `metadata_set`: **deny unless the caller acts in the task's board project** (`super::acl::can_mutate_on_board` — system identities bypass).

- `force` (the audited operator override, the **same axis** as the owner-ACL `can_mutate_record`) bypasses it on `done`/`update`; `claim`/`metadata_set` have no `force`, mirroring their owner-ACL.
- Gate is the outer boundary, checked before the owner-ACL (clearer cross-board error).
- **Single-project** → caller project == task board project (both DEFAULT) → allow → byte-identical.

### Fail-closed fleet resolve (reviewer-4 #2133 finding)
`resolve_current_project` collapses a **hard** fleet.yaml read/parse failure into `DEFAULT_PROJECT`, conflating it with a legitimate no-team caller — an ACL on that **fails OPEN** to the default board on a fleet read error. Added `resolve_current_project_checked` (mirrors the #1744-M7 three-state `try_load_fleet`: missing file = `Ok(default)`, present-but-corrupt = `Err`); `can_mutate_on_board` now uses it and **denies on `Err`**. A legitimate no-team caller still resolves `Ok(DEFAULT)` → allow → single-project byte-identical. `resolve_current_project` (create/list board routing) is **unchanged** — a transient fleet hiccup must not break create routing, only authorization.

### Verification
- **§3.10 anchors (3 cases)**: (a) cross-board mutation by an other-project caller → deny on `done`/`claim`/`update`; (b) same-board → allow; (c) corrupt fleet.yaml → deny (fail-closed). Neutering `can_mutate_on_board` to always-true REDs (a)+(c); restore → GREEN.
- **Byte-identical**: `tasks` (124+3) / `acl` (3) pass with zero existing-assertion changes.
- **Full suite**: `cargo nextest run --profile ci --features tray --no-fail-fast` → **4172 passed**, 33 skipped (the lone fail = `api_port_published…` 1.515s vs 1500ms — a load-sensitive startup-timing flake; passes in isolation and was green on CI for #2134).
- `cargo fmt --check` ✓ · `cargo clippy --bin agend-terminal --features tray --tests -D warnings` ✓.

### Reviewer focus (dual review)
- The `force` composition: board gate bypassed by `force` on `done`/`update` (operator cleanup), not on `claim`/`metadata_set` (no force there). Confirm this is the intended boundary.
- The fail-closed hardening: a corrupt fleet.yaml now denies ALL non-system mutations until it reads cleanly (system identities — sweep/reclaim — bypass, so daemon ops continue). Intended fail-closed posture.
- Shared primitive unchanged for #2127's reclaim caller (the hardening also strengthens it — a fleet read failure no longer fail-opens reclaim authorization).

Part of epic #2117. Spike: t-20260614090733386254-7.

*fixup-dev* · claude-opus-4-8

🤖 Generated with [Claude Code](https://claude.com/claude-code)