### PR TITLE
feat(#2117 P3b): key the branch lease on (source_repo, branch)

### DIFF
--- a/src/binding.rs
+++ b/src/binding.rs
@@ -69,31 +69,46 @@ fn index_key(home: &Path, agent: &str) -> String {
     format!("{}:{agent}", home.display())
 }
 
-/// #1882: lock-file path for the per-BRANCH lease flock. Keyed by a hash of the
-/// branch so it is path-safe (branches contain `/`) and collision-free; different
-/// branches never share a lock file.
-fn branch_lease_lock_path(home: &Path, branch: &str) -> PathBuf {
-    let key = crate::daemon::utils::sha256_hex(branch.as_bytes());
+/// #1882 / #2117 P3b: lock-file path for the per-lease flock. Keyed by a hash of
+/// the **(source_repo, branch)** pair so it is path-safe (branches contain `/`)
+/// and collision-free; a different lease never shares a lock file.
+///
+/// #2117 P3b: keying now includes `source_repo` so the SAME branch name in two
+/// DIFFERENT repos is two independent leases that never contend. An EMPTY
+/// `source_repo` (the test-only `bind()` wrapper; every production lease path
+/// carries a resolved repo) falls back to the legacy branch-only key — so the
+/// single-project world (one repo) keys on `(repo, branch)` consistently and a
+/// rare empty bind keys branch-only, both behaviorally equivalent to pre-P3b.
+fn branch_lease_lock_path(home: &Path, source_repo: &str, branch: &str) -> PathBuf {
+    let key = if source_repo.is_empty() {
+        crate::daemon::utils::sha256_hex(branch.as_bytes())
+    } else {
+        // NUL separator: unambiguous since neither path nor branch contains it.
+        crate::daemon::utils::sha256_hex(format!("{source_repo}\0{branch}").as_bytes())
+    };
     crate::paths::runtime_dir(home)
         .join(".lease-locks")
         .join(format!("{key}.lock"))
 }
 
-/// #1882: acquire the exclusive per-BRANCH lease flock so the cross-agent
-/// "a branch is held by at most one agent" check-then-bind
+/// #1882 / #2117 P3b: acquire the exclusive per-lease flock so the cross-agent
+/// "a (source_repo, branch) is held by at most one agent" check-then-bind
 /// (`scan_existing_branch_binding` → `bind_full`) is ATOMIC. Two DIFFERENT agents
-/// racing to lease the SAME branch serialize here: the first binds; the second
-/// blocks until the first's guard drops, then its rescan sees the first's binding
-/// and rejects — so neither double-binds. This is a SHORT-LIVED mutex around the
-/// bind operation, NOT a lease-lifetime lock: the persistent lease state is
-/// `binding.json` (which the scan reads), so `release_full` needs no lock cleanup.
-/// Per-branch keying means different branches never contend → normal single-agent
-/// binds are unaffected. Blocking `acquire_file_lock`; released when the guard drops.
+/// racing to lease the SAME (repo, branch) serialize here: the first binds; the
+/// second blocks until the first's guard drops, then its rescan sees the first's
+/// binding and rejects — so neither double-binds. This is a SHORT-LIVED mutex
+/// around the bind operation, NOT a lease-lifetime lock: the persistent lease
+/// state is `binding.json` (which the scan reads), so `release_full` needs no lock
+/// cleanup. Per-(repo,branch) keying means different leases never contend → normal
+/// single-agent binds are unaffected. Blocking `acquire_file_lock`; released when
+/// the guard drops. Pass `""` for `source_repo` only on the test-only empty-bind
+/// path (branch-only key).
 pub fn acquire_branch_lease_lock(
     home: &Path,
+    source_repo: &str,
     branch: &str,
 ) -> anyhow::Result<crate::store::FileFlockGuard> {
-    crate::store::acquire_file_lock(&branch_lease_lock_path(home, branch))
+    crate::store::acquire_file_lock(&branch_lease_lock_path(home, source_repo, branch))
 }
 
 /// Write a binding for an agent (task assigned).
@@ -223,10 +238,28 @@ pub fn unbind(home: &Path, agent: &str) {
 // wash-white. (Activating restart: the operator re-dispatches / has running
 // agents `bind_self` once; one-time.)
 
-/// Returns Some(agent_name) if any other agent has bound this branch.
-/// Used by dispatch_auto_bind_lease to enforce cross-agent branch uniqueness.
+/// Returns Some(agent_name) if any other agent holds the lease for this
+/// **(source_repo, branch)**. Used by dispatch_auto_bind_lease / repo-checkout to
+/// enforce cross-agent lease uniqueness.
+///
+/// #2117 P3b: the lease key is now `(source_repo, branch)` — the SAME branch name
+/// in a DIFFERENT repo is a DIFFERENT lease and does not conflict. Pass `""` for
+/// `source_repo` to keep the legacy branch-only semantics (callers that only want
+/// "who holds this branch anywhere", e.g. pr-state / auto-arm / auto-release,
+/// which does its own slug-based repo guard).
+///
+/// **Backward-compat wildcard gate (reviewer-2, the P3b core risk)**: `bind_full`
+/// only writes the `source_repo` field when non-empty, so a pre-P3b "legacy" live
+/// binding can lack it. On rescan after P3b ships, requiring `source_repo`
+/// equality would make `None != Some(repo)` MISS that legacy binding → a second
+/// agent binds the same branch → **double-bind**. To prevent that, a missing/empty
+/// `source_repo` on EITHER side (the scanned binding OR the query) falls back to
+/// **branch-only** exclusion (match-any); only when BOTH carry a non-empty
+/// `source_repo` is the match tightened to `(source_repo, branch)`. Fail-closed:
+/// when in doubt (a field is absent), we still treat the branch as taken.
 pub fn scan_existing_branch_binding(
     home: &Path,
+    source_repo: &str,
     branch: &str,
     exclude_agent: &str,
 ) -> Option<String> {
@@ -244,7 +277,14 @@ pub fn scan_existing_branch_binding(
         let Ok(v) = serde_json::from_str::<serde_json::Value>(&content) else {
             continue;
         };
-        if v["branch"].as_str() == Some(branch) {
+        if v["branch"].as_str() != Some(branch) {
+            continue;
+        }
+        // Wildcard backward-compat gate: branch-only exclusion unless BOTH the
+        // query and the scanned binding carry a non-empty source_repo.
+        let binding_repo = v["source_repo"].as_str().unwrap_or("");
+        let both_present = !source_repo.is_empty() && !binding_repo.is_empty();
+        if !both_present || binding_repo == source_repo {
             return Some(agent);
         }
     }
@@ -504,34 +544,133 @@ mod tests {
 
         let home = tmp_home("lease-lock-1882");
 
+        let repo = "/repo/a";
         // Different branches must NOT contend — both acquire while both are held.
-        let g_x = acquire_branch_lease_lock(&home, "feat/x").expect("lock x");
-        let g_y = acquire_branch_lease_lock(&home, "feat/y").expect("lock y must not block on x");
+        let g_x = acquire_branch_lease_lock(&home, repo, "feat/x").expect("lock x");
+        let g_y =
+            acquire_branch_lease_lock(&home, repo, "feat/y").expect("lock y must not block on x");
         drop((g_x, g_y));
 
-        // Same branch: a second acquirer BLOCKS until the first guard drops.
+        // #2117 P3b: the SAME branch in a DIFFERENT repo is a DIFFERENT lease and
+        // must NOT contend (the per-repo independence P3b adds).
+        let g_a = acquire_branch_lease_lock(&home, "/repo/a", "feat/shared").expect("lock a");
+        let g_b = acquire_branch_lease_lock(&home, "/repo/b", "feat/shared")
+            .expect("same branch, different repo must not block");
+        drop((g_a, g_b));
+
+        // Same (repo, branch): a second acquirer BLOCKS until the first guard drops.
         let got = Arc::new(AtomicBool::new(false));
-        let g1 = acquire_branch_lease_lock(&home, "feat/z").expect("lock z (holder)");
+        let g1 = acquire_branch_lease_lock(&home, repo, "feat/z").expect("lock z (holder)");
         let home2 = home.clone();
         let got2 = got.clone();
         let t = std::thread::spawn(move || {
             // Blocks here until the holder drops g1.
-            let _g2 = acquire_branch_lease_lock(&home2, "feat/z").expect("lock z (waiter)");
+            let _g2 =
+                acquire_branch_lease_lock(&home2, "/repo/a", "feat/z").expect("lock z (waiter)");
             got2.store(true, Ordering::SeqCst);
         });
 
         std::thread::sleep(Duration::from_millis(150));
         assert!(
             !got.load(Ordering::SeqCst),
-            "#1882: a second same-branch lock MUST block while the first is held"
+            "#1882: a second same-(repo,branch) lock MUST block while the first is held"
         );
         drop(g1); // release → the waiter proceeds.
         t.join().expect("waiter thread");
         assert!(
             got.load(Ordering::SeqCst),
-            "#1882: the second same-branch lock must proceed once the first drops"
+            "#1882: the second same-(repo,branch) lock must proceed once the first drops"
         );
 
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Write a `binding.json` for `agent` directly, controlling whether the
+    /// `source_repo` field is present — to construct a pre-P3b "legacy" binding
+    /// (field absent) that `bind_full` would only write when non-empty.
+    fn write_binding_json(home: &Path, agent: &str, branch: &str, source_repo: Option<&str>) {
+        let dir = crate::paths::runtime_dir(home).join(agent);
+        std::fs::create_dir_all(&dir).unwrap();
+        let mut v = json!({
+            "version": BINDING_SCHEMA_VERSION,
+            "agent": agent,
+            "task_id": "T-test",
+            "branch": branch,
+            "issued_at": "2026-01-01T00:00:00+00:00",
+        });
+        if let Some(r) = source_repo {
+            v["source_repo"] = json!(r);
+        }
+        std::fs::write(
+            dir.join("binding.json"),
+            serde_json::to_string_pretty(&v).unwrap(),
+        )
+        .unwrap();
+    }
+
+    /// #2117 P3b CORE GATE (reviewer-2): a pre-P3b "legacy" live binding that
+    /// LACKS the `source_repo` field must STILL exclude a new (repo, branch) bind
+    /// on the post-P3b rescan — else `None != Some(repo)` would miss it and a
+    /// second agent double-binds. This is the CI-runnable form of the cross-deploy
+    /// restart smoke: construct a field-less legacy binding fixture, then rescan as
+    /// a post-P3b dispatch would (with a real source_repo). The wildcard fallback
+    /// must match it branch-only. (True end-to-end verification — an operator
+    /// restart carrying a real legacy binding — is the PR's dogfood caveat.)
+    #[test]
+    fn scan_legacy_binding_missing_source_repo_still_excludes_p3b() {
+        let home = tmp_home("p3b-legacy-rescan");
+        write_binding_json(&home, "legacy-agent", "feat/shared", None); // no source_repo field
+        assert_eq!(
+            scan_existing_branch_binding(&home, "/repo/new", "feat/shared", "new-agent"),
+            Some("legacy-agent".to_string()),
+            "legacy binding (missing source_repo) MUST still exclude — no double-bind on P3b rollout"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #2117 P3b key semantics: same (repo, branch) conflicts; same branch in a
+    /// DIFFERENT repo is an independent lease; an empty-source_repo query falls
+    /// back to branch-only (byte-identical for the pre-P3b wildcard callers).
+    #[test]
+    fn scan_p3b_lease_key_repo_scoped() {
+        let home = tmp_home("p3b-key");
+        write_binding_json(&home, "holder", "feat/x", Some("/repo/a"));
+        assert_eq!(
+            scan_existing_branch_binding(&home, "/repo/a", "feat/x", "other"),
+            Some("holder".to_string()),
+            "same (repo, branch) is one lease → conflict"
+        );
+        assert_eq!(
+            scan_existing_branch_binding(&home, "/repo/b", "feat/x", "other"),
+            None,
+            "same branch in a different repo is a different lease → no conflict (P3b)"
+        );
+        assert_eq!(
+            scan_existing_branch_binding(&home, "", "feat/x", "other"),
+            Some("holder".to_string()),
+            "empty-source_repo query falls back to branch-only (pre-P3b callers byte-identical)"
+        );
+        // The querying agent's own binding is always excluded.
+        assert_eq!(
+            scan_existing_branch_binding(&home, "/repo/a", "feat/x", "holder"),
+            None,
+            "self-agent binding is excluded"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Reverse of the legacy gate: when BOTH sides carry a non-empty source_repo,
+    /// a DIFFERENT repo must NOT match (the tightening that makes per-repo leases
+    /// independent). Pins that the wildcard is scoped to the missing-field case.
+    #[test]
+    fn scan_both_present_different_repo_does_not_match_p3b() {
+        let home = tmp_home("p3b-both-present");
+        write_binding_json(&home, "holder", "feat/x", Some("/repo/a"));
+        assert_eq!(
+            scan_existing_branch_binding(&home, "/repo/b", "feat/x", "other"),
+            None,
+            "both source_repos present + different → independent leases, no false conflict"
+        );
         std::fs::remove_dir_all(&home).ok();
     }
 

--- a/src/daemon/auto_release.rs
+++ b/src/daemon/auto_release.rs
@@ -743,7 +743,9 @@ fn is_worktree_clean(worktree: &Path) -> bool {
 /// conservative force-reclaim backstop (PR-2).
 pub(crate) fn enqueue_release_recompute(home: &Path, repo: &str, branch: &str, event_kind: &str) {
     let Some(agent) =
-        crate::binding::scan_existing_branch_binding(home, branch, /* exclude */ "")
+        // #2117 P3b: branch-only scan (source_repo="") — this caller does its own
+        // slug-based cross-repo guard below (repo_slug_from_binding vs event repo).
+        crate::binding::scan_existing_branch_binding(home, "", branch, /* exclude */ "")
     else {
         return; // no bound agent → nothing to release.
     };

--- a/src/daemon/pr_state/auto_arm.rs
+++ b/src/daemon/pr_state/auto_arm.rs
@@ -48,7 +48,9 @@ pub fn auto_arm_unwatched_open_prs(home: &Path, repo: &str, prs: &[GhPrMetadata]
 
         // Binding-based resolution (shared-account-proof): which agent is bound
         // to this branch? That is the agent who pushed and is waiting.
-        let Some(agent) = crate::binding::scan_existing_branch_binding(home, branch, "") else {
+        // #2117 P3b: branch-only scan (source_repo="") — route CI-pass to whoever
+        // is bound to this branch; repo precision unnecessary for this lookup.
+        let Some(agent) = crate::binding::scan_existing_branch_binding(home, "", branch, "") else {
             // Fail LOUD — never silently drop. We cannot reliably route a
             // `[ci-pass]` for an open PR with no bound agent (released worktree /
             // external PR); notifying the wrong agent is worse than a loud log.

--- a/src/daemon/pr_state/mod.rs
+++ b/src/daemon/pr_state/mod.rs
@@ -1065,7 +1065,9 @@ pub fn resolve_author(state: &PrState) -> String {
 /// unchanged. The binding lookup is a plain FS read (no flock / subprocess), so it
 /// is safe inside a `with_pr_state` closure.
 pub fn resolve_notify_recipient(home: &Path, state: &PrState) -> String {
-    crate::binding::scan_existing_branch_binding(home, &state.branch, "")
+    // #2117 P3b: branch-only scan (source_repo="") — "who holds this branch" for
+    // notify routing; cross-repo precision is not needed here.
+    crate::binding::scan_existing_branch_binding(home, "", &state.branch, "")
         .unwrap_or_else(|| resolve_author(state))
 }
 

--- a/src/mcp/handlers/ci/mod.rs
+++ b/src/mcp/handlers/ci/mod.rs
@@ -167,8 +167,11 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
     // idempotent read + git worktree add + bind_full) so a concurrent dispatch or
     // another repo checkout can't double-bind the branch. Bind-only (a `--detach`
     // checkout writes no binding); the guard lives to fn end so it covers bind_full.
+    // #2117 P3b: lease key is (source_repo, branch); `source_canonical` is the
+    // same repo path bind_full persists below, so lock/scan/bind keys agree.
+    let source_repo_str = source_canonical.display().to_string();
     let _lease_lock = if bind {
-        match crate::binding::acquire_branch_lease_lock(home, branch) {
+        match crate::binding::acquire_branch_lease_lock(home, &source_repo_str, branch) {
             Ok(g) => Some(g),
             Err(e) => {
                 return json!({
@@ -186,9 +189,12 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
         // this branch is refused (mirrors the dispatch path's scan), rather than
         // leaning on `git worktree add`'s "already checked out" error. The
         // same-agent idempotent short-circuit below handles THIS agent re-checkout.
-        if let Some(other) =
-            crate::binding::scan_existing_branch_binding(home, branch, instance_name)
-        {
+        if let Some(other) = crate::binding::scan_existing_branch_binding(
+            home,
+            &source_repo_str,
+            branch,
+            instance_name,
+        ) {
             return json!({
                 "error": format!(
                     "branch '{branch}' already leased by '{other}' — release first or use a different branch"

--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -884,7 +884,7 @@ fn checkout_bind_rejects_cross_agent_branch_conflict_1882() {
     );
     // Exactly one binding holds feat/shared (it is agent-a's).
     assert_eq!(
-        crate::binding::scan_existing_branch_binding(&home, "feat/shared", ""),
+        crate::binding::scan_existing_branch_binding(&home, "", "feat/shared", ""),
         Some("agent-a".to_string()),
         "#1882: exactly one agent must hold the branch after the conflict"
     );

--- a/src/mcp/handlers/dispatch_hook/mod.rs
+++ b/src/mcp/handlers/dispatch_hook/mod.rs
@@ -383,8 +383,11 @@ pub(crate) fn dispatch_auto_bind_lease_with_source_and_chain(
     // above → this branch lock → per-agent binding lock inside bind_full), so no
     // deadlock; different branches use different lock files → no cross-branch
     // contention. Held only across the bind (a short mutex), so release is unaffected.
-    let _lease_lock =
-        crate::binding::acquire_branch_lease_lock(home, branch).map_err(|e| DispatchError {
+    // #2117 P3b: the lease key is (source_repo, branch). `source_repo` resolved
+    // above (tier-stubbed when unknown, so non-empty on every production path).
+    let source_repo_str = source_repo.display().to_string();
+    let _lease_lock = crate::binding::acquire_branch_lease_lock(home, &source_repo_str, branch)
+        .map_err(|e| DispatchError {
             message: format!("could not acquire branch lease lock for '{branch}': {e}"),
             code: ErrorCode::LeaseConflict,
             stage: Stage::WorktreeLeaseConflict,
@@ -392,8 +395,12 @@ pub(crate) fn dispatch_auto_bind_lease_with_source_and_chain(
             raw: None,
         })?;
 
-    // P0-1.5: central lease registry check — reject if another agent holds this branch.
-    if let Some(other) = crate::binding::scan_existing_branch_binding(home, branch, target) {
+    // P0-1.5: central lease registry check — reject if another agent holds this
+    // (source_repo, branch) lease (legacy bindings without the field fall back to
+    // branch-only exclusion — see `scan_existing_branch_binding`).
+    if let Some(other) =
+        crate::binding::scan_existing_branch_binding(home, &source_repo_str, branch, target)
+    {
         return Err(DispatchError {
             message: format!(
                 "branch '{branch}' already leased by '{other}' — release first or use a different branch"

--- a/src/mcp/handlers/dispatch_hook/tests.rs
+++ b/src/mcp/handlers/dispatch_hook/tests.rs
@@ -226,25 +226,29 @@ fn main_branch_rejects_dispatch() {
 fn lease_conflict_rejects_dispatch() {
     let home = std::env::temp_dir().join(format!("agend-s53-prod-{}-conflict", std::process::id()));
     std::fs::create_dir_all(&home).ok();
-    // CRITICAL: each agent has its OWN working_directory (production topology).
-    setup_test_repo(&home, "agent-a");
-    setup_test_repo(&home, "agent-b");
+    // #2117 P3b: the lease key is now (source_repo, branch). Production team
+    // topology is a SHARED source_repo (one clone) with per-agent WORKTREES, so two
+    // agents dispatched to the SAME branch in the SAME repo still conflict. Both
+    // agents resolve to one shared source_repo (tier-2 fleet `source_repo`). (The
+    // cross-repo independence P3b adds is covered by
+    // `cross_repo_same_branch_independent_p3b` below.)
+    setup_test_repo(&home, "shared-repo");
+    let shared = crate::paths::workspace_dir(&home).join("shared-repo");
     std::fs::write(
             crate::fleet::fleet_yaml_path(&home),
-            format!("instances:\n  agent-a:\n    backend: claude\n    working_directory: {}\n  agent-b:\n    backend: claude\n    working_directory: {}\n",
-                crate::paths::workspace_dir(&home).join("agent-a").display(),
-                crate::paths::workspace_dir(&home).join("agent-b").display()),
+            format!("instances:\n  agent-a:\n    backend: claude\n    source_repo: {}\n  agent-b:\n    backend: claude\n    source_repo: {}\n",
+                shared.display(), shared.display()),
         ).ok();
 
-    // First dispatch succeeds in agent-a's clone.
+    // First dispatch succeeds (leases (shared, feat/shared) for agent-a).
     let r1 = super::dispatch_auto_bind_lease(&home, "agent-a", "T-1", "feat/shared", None);
     assert!(r1.is_ok(), "first dispatch must succeed: {:?}", r1.err());
 
-    // Second dispatch SAME branch DIFFERENT agent → REJECT via central registry.
+    // Second dispatch SAME (repo, branch) DIFFERENT agent → REJECT via central registry.
     let r2 = super::dispatch_auto_bind_lease(&home, "agent-b", "T-2", "feat/shared", None);
     assert!(
         r2.is_err(),
-        "central registry must REJECT cross-agent same-branch, got: {:?}",
+        "central registry must REJECT cross-agent same-(repo,branch), got: {:?}",
         r2
     );
     let err = r2.expect_err("must err");
@@ -260,6 +264,40 @@ fn lease_conflict_rejects_dispatch() {
     assert!(
         !binding_b.exists(),
         "rejected dispatch must not create binding"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// #2117 P3b: the SAME branch NAME in two DIFFERENT source_repos is two
+/// INDEPENDENT leases — both dispatches succeed (this is the behavior P3b adds;
+/// pre-P3b the branch-only key wrongly rejected the second). Each agent has its
+/// own repo (tier-3 working_directory), so the lease keys differ.
+#[test]
+fn cross_repo_same_branch_independent_p3b() {
+    let home = std::env::temp_dir().join(format!("agend-p3b-prod-{}-xrepo", std::process::id()));
+    std::fs::create_dir_all(&home).ok();
+    setup_test_repo(&home, "agent-a");
+    setup_test_repo(&home, "agent-b");
+    std::fs::write(
+            crate::fleet::fleet_yaml_path(&home),
+            format!("instances:\n  agent-a:\n    backend: claude\n    source_repo: {}\n  agent-b:\n    backend: claude\n    source_repo: {}\n",
+                crate::paths::workspace_dir(&home).join("agent-a").display(),
+                crate::paths::workspace_dir(&home).join("agent-b").display()),
+        ).ok();
+
+    let r1 = super::dispatch_auto_bind_lease(&home, "agent-a", "T-1", "feat/shared", None);
+    assert!(
+        r1.is_ok(),
+        "agent-a (repo-a) dispatch must succeed: {:?}",
+        r1.err()
+    );
+    // Same branch NAME, DIFFERENT repo → independent lease → must ALSO succeed.
+    let r2 = super::dispatch_auto_bind_lease(&home, "agent-b", "T-2", "feat/shared", None);
+    assert!(
+        r2.is_ok(),
+        "P3b: same branch name in a DIFFERENT repo is an independent lease — must NOT conflict: {:?}",
+        r2.err()
     );
 
     std::fs::remove_dir_all(&home).ok();

--- a/src/mcp/handlers/worktree.rs
+++ b/src/mcp/handlers/worktree.rs
@@ -496,28 +496,32 @@ mod tests {
     #[test]
     fn bind_self_rejects_cross_agent_branch_conflict() {
         // Gate 4: P0-1.5 cross-agent registry — agent A binds, agent B
-        // attempts the same branch → B is rejected.
+        // attempts the same (source_repo, branch) → B is rejected.
+        // #2117 P3b: the lease key is (source_repo, branch). Both agents claim the
+        // SAME repo (via `repository_path`) and branch — the same-repo conflict P3b
+        // preserves. (Cross-repo independence is covered by the dispatch-side
+        // `cross_repo_same_branch_independent_p3b` test.)
         let home =
             std::env::temp_dir().join(format!("agend-p17-self-{}-cross", std::process::id()));
         std::fs::create_dir_all(&home).ok();
-        p17_setup_repo(&home, "agent-A");
-        p17_setup_repo(&home, "agent-B");
+        let shared = p17_setup_repo(&home, "shared-repo");
+        let shared_path = shared.display().to_string();
 
         let r1 = handle_bind_self(
             &home,
-            &json!({"repository": "owner/name", "branch": "feat/cross"}),
+            &json!({"repository_path": shared_path, "branch": "feat/cross"}),
             &sender_for("agent-A"),
         );
         assert_eq!(r1["bound"].as_bool(), Some(true), "A binds first: {r1}");
 
         let r2 = handle_bind_self(
             &home,
-            &json!({"repository": "owner/name", "branch": "feat/cross"}),
+            &json!({"repository_path": shared_path, "branch": "feat/cross"}),
             &sender_for("agent-B"),
         );
         assert!(
             r2.get("error").is_some(),
-            "B must be rejected on shared branch: {r2}"
+            "B must be rejected on the same (repo, branch): {r2}"
         );
         assert_eq!(
             r2["code"].as_str(),


### PR DESCRIPTION
## #2117 P3b — key the branch lease on (source_repo, branch)

The cross-agent lease key was **branch-only**, so the SAME branch name in two DIFFERENT repos wrongly conflicted (a single-repo assumption). P3b keys the lease on **(source_repo, branch)**: the same branch name in different repos is now two independent leases. `binding.json` already persists `source_repo` → **zero schema migration**.

### Changes
- `branch_lease_lock_path` / `acquire_branch_lease_lock` — key on `(source_repo, branch)` (NUL-separated hash); empty `source_repo` → legacy branch-only key.
- `scan_existing_branch_binding` — new `source_repo` param; returns the holder of the `(source_repo, branch)` lease.
- **Lease-bind callers** (`dispatch_auto_bind_lease`, ci repo-checkout) pass the resolved `source_repo` (the same path they `bind_full` with → lock/scan/bind keys agree).
- **Non-lease callers** (`auto_release` — keeps its own slug-based cross-repo guard —, `pr_state` notify, `auto_arm`) pass `""` → branch-only → **byte-identical**.

### ⚠ Backward-compat wildcard gate (reviewer-2 — the P3b core risk)
`bind_full` only writes `source_repo` when non-empty, so a pre-P3b **legacy** live binding can lack the field. Requiring equality on rescan would make `None != Some(repo)` **MISS** it → a second agent **double-binds**. Fix: a missing/empty `source_repo` on **EITHER side** (the scanned binding OR the query) falls back to **branch-only** exclusion (match-any); only when **BOTH** carry a non-empty `source_repo` is it tightened to `(source_repo, branch)`. Fail-closed: an absent field still treats the branch as taken.

### Tests
- **Restart-smoke (CI-runnable form of the cross-deploy rescan)**: `scan_legacy_binding_missing_source_repo_still_excludes_p3b` constructs a **field-less legacy binding fixture**, rescans as a post-P3b dispatch would (with a real `source_repo`), and asserts it STILL excludes (no double-bind). The lead flagged that "existing tests zero change" is insufficient for P3b — this is the dedicated missing-field test.
- P3b key semantics: same `(repo,branch)` conflicts; same branch / different repo independent; empty-query → branch-only; both-present-different → no match; self excluded.
- Lease-lock test gains a same-branch / different-repo non-contention case.
- The two cross-agent CONFLICT tests used **separate per-agent repos** (`git init` each) — under P3b that is legitimately independent, not a conflict. Updated to **production team topology** (ONE shared `source_repo`, per-agent worktrees) so the same-repo conflict still asserts rejection; added `cross_repo_same_branch_independent_p3b` for the new independence. These are multi-repo tests, NOT the single-project "zero assertion change" set.

**single-project byte-identical**: one project → key degenerates to branch-only → existing single-repo binding/lease tests unchanged.

### ⚠ Dogfood caveat
This changes the **live-bind path**, so the PR's own dogfood lags — **true verification needs an operator restart carrying a real legacy binding** (suggest a post-merge operator loop). The restart-smoke test above is the CI-runnable proxy (legacy fixture + rescan), not a full daemon restart.

### Proof
- Full suite **4174/4175** — lone fail = known `spawn_group_bounded_preserves_caller_env_no_bypass_1899` env-set artifact (passes in CI's clean env).
- `clippy --all-targets --features tray -- -D warnings` clean; Windows `x86_64-pc-windows-msvc` cross-check clean.

### Reviewer focus (dual review)
The epic's most dangerous item. Key checks: the **wildcard backward-compat gate** (no legacy double-bind on rollout), the lock/scan/bind key agreement, the non-lease callers staying branch-only (byte-identical), and the updated conflict tests faithfully preserving same-repo rejection while the new test proves cross-repo independence.

---
*fixup-dev-2* · claude/opus-4.8