### PR TITLE
fix: trim ci/mod.rs + dispatch_hook/mod.rs back under ceilings (#2137 regression)

### DIFF
--- a/src/mcp/handlers/ci/mod.rs
+++ b/src/mcp/handlers/ci/mod.rs
@@ -145,30 +145,21 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
             }
         }
     }
-    // #1494: idempotent bind. When `bind:true` and THIS agent already holds a
-    // binding on the SAME branch whose worktree is live on disk, the branch was
-    // already provisioned — by the dispatch pre-build hook (binding.json +
-    // worktree at `<agent>/<branch>`) or a prior `repo checkout`. The direct
-    // `git worktree add` below would otherwise fail with "is already checked
-    // out" (the same branch is leased at the dispatch path, a DIFFERENT dir
-    // than this handler's `<agent>-<source>` scheme), forcing a manual `cd`.
-    // Return the EXISTING worktree path as success instead — same spirit as
-    // #1465 idempotent-release: operation already at target state = success.
-    //
-    // Cross-agent safety: `binding::read` is keyed per-agent, so a DIFFERENT
-    // agent holding the branch leaves this agent's binding absent/mismatched —
-    // the short-circuit does NOT fire and the genuine `git worktree add`
-    // conflict error below is preserved. Same-agent DIFFERENT-branch bindings
-    // also fall through (branch mismatch), unchanged.
-    //
-    // #1882 (reviewer-2): repo checkout is the THIRD production bind path (besides
-    // the dispatch + bind_self funnel through dispatch_auto_bind_lease). Hold the
-    // SAME per-branch lease flock across its check-then-act (cross-agent scan +
-    // idempotent read + git worktree add + bind_full) so a concurrent dispatch or
-    // another repo checkout can't double-bind the branch. Bind-only (a `--detach`
-    // checkout writes no binding); the guard lives to fn end so it covers bind_full.
-    // #2117 P3b: lease key is (source_repo, branch); `source_canonical` is the
-    // same repo path bind_full persists below, so lock/scan/bind keys agree.
+    // #1494: idempotent bind. If THIS agent already holds a binding on the SAME
+    // branch with a live worktree (provisioned by the dispatch pre-build hook or a
+    // prior `repo checkout`), the `git worktree add` below would fail "is already
+    // checked out" (leased at a DIFFERENT dir than this handler's `<agent>-<source>`
+    // scheme). Return the EXISTING worktree as success (#1465 idempotent-release
+    // spirit). Cross-agent-safe: `binding::read` is per-agent, so a DIFFERENT agent
+    // (or same-agent DIFFERENT branch) does NOT short-circuit — the genuine `git
+    // worktree add` conflict error below is preserved.
+    // #1882 (reviewer-2): repo checkout is the THIRD bind path (besides dispatch +
+    // bind_self via dispatch_auto_bind_lease); hold the per-branch lease flock
+    // across its check-then-act (cross-agent scan + idempotent read + worktree add +
+    // bind_full) so a concurrent dispatch/checkout can't double-bind. Bind-only (a
+    // `--detach` checkout writes no binding); guard lives to fn end (covers bind_full).
+    // #2117 P3b: lease key is (source_repo, branch); `source_canonical` is the same
+    // repo path bind_full persists below, so lock/scan/bind keys agree.
     let source_repo_str = source_canonical.display().to_string();
     let _lease_lock = if bind {
         match crate::binding::acquire_branch_lease_lock(home, &source_repo_str, branch) {
@@ -506,12 +497,6 @@ pub(super) fn handle_release_repo(args: &Value) -> Value {
     }
 }
 
-/// `ci watch` action: subscribe `instance_name` to CI notifications for
-/// `repo@branch`. Sprint 54 P0-1 changes this from last-write-wins
-/// (the previous behavior overwrote the entire watch file, dropping any
-/// other agent's subscription) to APPEND idempotent semantics — the
-/// caller is added to a `subscribers` array if not already present, and
-/// existing poll state (`last_run_id`, `head_sha`, etc.) is preserved.
 /// #1619: resolve the target `owner/repo` for a PR/CI handler.
 ///
 /// Resolution order: explicit `repository` arg (canonicalized) → the
@@ -583,6 +568,9 @@ fn resolve_repo_or_error(home: &Path, instance_name: &str, args: &Value) -> Resu
     }
 }
 
+/// `ci watch` action: APPEND-idempotently subscribe `instance_name` to CI
+/// notifications for `repo@branch` (Sprint 54 P0-1: preserves other agents'
+/// subscriptions + existing poll state, vs the prior last-write-wins overwrite).
 pub(crate) fn handle_watch_ci(home: &Path, args: &Value, instance_name: &str) -> Value {
     // Sprint 55 P0-B: when caller omits `repo` arg, auto-derive from
     // sender's binding.json source_repo (set by `bind_self` /

--- a/src/mcp/handlers/dispatch_hook/mod.rs
+++ b/src/mcp/handlers/dispatch_hook/mod.rs
@@ -369,22 +369,18 @@ pub(crate) fn dispatch_auto_bind_lease_with_source_and_chain(
         });
     }
 
-    // #1882: hold a per-BRANCH lease flock across the P0-1.5 scan + the bind_full
-    // below so the check-then-bind is ATOMIC. Without it, two DIFFERENT agents
-    // racing to lease the SAME branch both passed the scan (neither had bound yet)
-    // and both bound — violating "a branch is held by at most one agent". Keyed on
-    // the branch (not the agent): the second racer blocks here, then its scan below
-    // sees the first's binding and rejects. Two of the three production bind paths
-    // funnel through this fn (dispatch auto-bind AND bind_self via
-    // dispatch_auto_bind_lease_with_source); the third — repo checkout
-    // (`ci/mod.rs`, reviewer-2 #1882) — takes the SAME `acquire_branch_lease_lock`
-    // around its own scan + bind_full, so all three serialize on the one branch
-    // lock. Lock order is consistent (per-agent BindGuard
-    // above → this branch lock → per-agent binding lock inside bind_full), so no
-    // deadlock; different branches use different lock files → no cross-branch
-    // contention. Held only across the bind (a short mutex), so release is unaffected.
-    // #2117 P3b: the lease key is (source_repo, branch). `source_repo` resolved
-    // above (tier-stubbed when unknown, so non-empty on every production path).
+    // #1882: hold a per-BRANCH lease flock across the P0-1.5 scan + bind_full so
+    // check-then-bind is ATOMIC — else two agents racing the SAME branch both pass
+    // the scan (neither bound yet) and both bind. Keyed on branch: the second racer
+    // blocks here, then its scan below sees the first's binding and rejects. All
+    // THREE production bind paths serialize on this one lock (dispatch auto-bind +
+    // bind_self via dispatch_auto_bind_lease_with_source here; repo checkout
+    // `ci/mod.rs` takes the same `acquire_branch_lease_lock`). Lock order (per-agent
+    // BindGuard above → this branch lock → per-agent binding lock in bind_full) → no
+    // deadlock; per-branch lock files → no cross-branch contention; short mutex held
+    // only across the bind → release unaffected.
+    // #2117 P3b: lease key is (source_repo, branch); `source_repo` resolved above
+    // (tier-stubbed when unknown → non-empty on every production path).
     let source_repo_str = source_repo.display().to_string();
     let _lease_lock = crate::binding::acquire_branch_lease_lock(home, &source_repo_str, branch)
         .map_err(|e| DispatchError {
@@ -657,41 +653,26 @@ fn resolve_source_repo(
     (stub, SourceRepoTier::Stub)
 }
 
-/// #781 Piece 6: shared auto-create-branch helper. Encapsulates the
-/// decision tree previously inlined in
-/// `mcp::handlers::ci::handle_checkout_repo` (introduced in #780). Both
-/// the `repo action=checkout bind:true` MCP tool entry and
-/// `dispatch_auto_bind_lease` now route through this single helper so
-/// the fast path (zero network on missing-branch-with-local-origin/main)
-/// and the lazy fetch fallback live in one place.
+/// #781 Piece 6: shared auto-create-branch helper (decision tree formerly inlined
+/// in `ci::handle_checkout_repo`, #780). Both `repo action=checkout bind:true` and
+/// `dispatch_auto_bind_lease` route through here so the fast path (zero network on
+/// missing-branch-with-local-origin/main) and the lazy-fetch fallback live in one
+/// place. Behavior (mirror #784 / decision d-20260514102305998399-0):
 ///
-/// Behavior (mirror #784 / decision d-20260514102305998399-0):
-/// 1. `rev-parse --verify refs/heads/<branch>` — if exists, **fetch
-///    `origin <branch>` + `update-ref refs/heads/<branch>
-///    refs/remotes/origin/<branch>`** so the (about-to-be-bound)
-///    local ref tracks the remote PR HEAD (#869 fix — stale local
-///    refs from prior cycles were landing the bound worktree at the
-///    wrong SHA). Returns `(auto_created=false, fetch_attempted=N)`
-///    where N reflects whether the fetch actually succeeded.
-///    `update-ref` is no-op when `origin/<branch>` doesn't exist
-///    (newly-pushed branches not yet observed locally) or when the
-///    fetch fails (network outage); in both cases the local ref is
-///    left unchanged and the caller still gets a usable lease.
-/// 2. Else `git branch <branch> <from_ref>`:
-///    - success → `(true, false)`
-///    - stderr `"already exists"` (concurrent race) → `(false, false)`
-///    - stderr `"not a valid object name"` / `"not a valid ref"` →
-///      `git fetch origin --quiet` then retry; success → `(true, true)`;
-///      retry race "already exists" → `(false, true)`; otherwise
-///      structured error.
+/// 1. `rev-parse --verify refs/heads/<branch>` exists → **fetch `origin <branch>`,
+///    then `update-ref refs/heads/<branch> refs/remotes/origin/<branch>`** so the
+///    bound local ref tracks the remote PR HEAD (#869: stale local refs landed the
+///    worktree at the wrong SHA). Returns `(auto_created=false, fetch_attempted=N)`;
+///    the `update-ref` is a no-op when `origin/<branch>` is absent or the fetch
+///    fails (local ref unchanged, lease still usable).
+/// 2. Else `git branch <branch> <from_ref>`: success → `(true,false)`; stderr
+///    `"already exists"` (race) → `(false,false)`; `"not a valid object name/ref"`
+///    → `git fetch origin --quiet` then retry (success `(true,true)`, race
+///    `(false,true)`, else structured error).
 ///
-/// `from_ref` runs through `validate_branch` (defense in depth) to
-/// reject option-injection (`--upload-pack=...`) at the daemon API
-/// boundary — same rule applied to the user-supplied `branch` arg.
-///
-/// `actor` is the agent / instance name used as `event_log` identifier
-/// for the fetch-duration breadcrumb (helps post-mortem who triggered
-/// the network I/O).
+/// `from_ref` runs through `validate_branch` (defense in depth) to reject
+/// option-injection (`--upload-pack=...`) at the daemon API boundary (same as the
+/// `branch` arg). `actor` = the event_log id for the fetch-duration breadcrumb.
 /// #2010 (cheerc RCA): resolve which git remote a `from_ref` names, by
 /// LONGEST-PREFIX match against the repo's actual remote list. Branch names can
 /// contain `/`, so a naive `split('/')` mis-parses `upstream/feat/x`; matching

--- a/tests/file_size_invariant.rs
+++ b/tests/file_size_invariant.rs
@@ -41,8 +41,8 @@ const SKIP_FILES: &[&str] = &["dispatch.rs"];
 /// debt — each may SHRINK but must not grow past its ceiling (can-shrink-not-
 /// grow), and must be removed once split back under `MAX_LOC`.
 const KNOWN_OVERSIZED: &[(&str, usize)] = &[
-    ("src/mcp/handlers/ci/mod.rs", 1441),
-    ("src/mcp/handlers/dispatch_hook/mod.rs", 1575),
+    ("src/mcp/handlers/ci/mod.rs", 1435),
+    ("src/mcp/handlers/dispatch_hook/mod.rs", 1563),
 ];
 
 /// Recursively collect every `*.rs` file under `dir`.


### PR DESCRIPTION
## 🚨 Unblock main — file_size_invariant RED (blocks every PR's CI)

#2137 (P3b lease key) added lease-site lines to two grandfathered handler files, pushing both past their `KNOWN_OVERSIZED` ceilings → `file_size_invariant` FAIL on `origin/main` → every PR's `Check`/`Coverage` job is red:
- `src/mcp/handlers/ci/mod.rs` — **1447 > 1441**
- `src/mcp/handlers/dispatch_hook/mod.rs` — **1582 > 1575**

(Root cause: #2137 and #2130 — which *set* the ceilings — interleaved at merge, so each base lacked the other; neither PR's own CI could see the combined overflow.)

## Fix — comment-condense only (byte-identical, no code change)
Per the invariant's "debt only shrinks, never raise a ceiling" rule:
- **ci/mod.rs → 1435**: condensed the #1494/#1882 idempotent-bind rationale; **relocated a misattached `ci watch` doc paragraph** off `resolve_repo_or_error` (it described `handle_watch_ci`) onto its real owner, condensed.
- **dispatch_hook/mod.rs → 1563**: condensed the #1882 lease-flock comment + the #781 auto-create-branch helper doc.
- **Lowered both `KNOWN_OVERSIZED` ceilings** to the new LOC (1441→1435, 1575→1563) — locks in the reduction (ratchet down).

All issue refs + load-bearing rationale preserved; only verbose prose tightened.

## Verification
- `src/` diff is **comment-only** (zero code lines changed — verified by grep).
- Existing **ci (64) + dispatch_hook (60)** handler tests pass unchanged (byte-identical).
- `file_size_invariant` green; `cargo fmt --check` ✓; `cargo clippy --bin agend-terminal --features tray --tests -D warnings` ✓ (fixed a `doc_lazy_continuation` lint a condensed list introduced).

Unblocks #2139 (#2131), #2138, and all in-flight PRs.

*fixup-dev* · claude-opus-4-8

🤖 Generated with [Claude Code](https://claude.com/claude-code)