### PR TITLE
test: fix medium test-audit findings (batch 2 — false_confidence, redundant, tests_test_code)

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -1576,7 +1576,10 @@ fn sweep_child_tree(id: &crate::types::InstanceId, registry: &AgentRegistry) {
 
 /// Handle PTY close: determine if crash, graceful exit, or daemon shutdown.
 /// Exit classification for handle_pty_close dispatch.
-enum ExitKind {
+// pub(crate) + derives so the daemon respawn tests can assert on the real
+// `classify_exit` output instead of re-implementing the match inline.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum ExitKind {
     UserExit,
     SignalKill,
     Crash,
@@ -1592,7 +1595,7 @@ fn signal_kill_self_orch_should_escalate(home: &Option<std::path::PathBuf>, name
         .unwrap_or(false)
 }
 
-fn classify_exit(exit_code: Option<i32>) -> ExitKind {
+pub(crate) fn classify_exit(exit_code: Option<i32>) -> ExitKind {
     match exit_code {
         Some(0) | Some(130) => ExitKind::UserExit,
         Some(137) | Some(143) => {

--- a/src/channel/telegram/reply.rs
+++ b/src/channel/telegram/reply.rs
@@ -308,9 +308,11 @@ instances:
     topic_id: 42
 ";
         std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).expect("write fleet.yaml");
-        std::fs::create_dir_all(home.join("channel")).ok();
-        std::fs::write(home.join("channel").join("topics.json"), "{\"B\":42}")
-            .expect("write topics.json");
+        // Seed the topic registry at the PRODUCTION path (home/topics.json via
+        // topic_registry_path) using the real API. The previous version wrote
+        // home/channel/topics.json — a path production never reads or writes —
+        // so the immutability assertion below was a tautology.
+        register_topic(&home, 42, "B").expect("seed topic registry");
 
         std::env::set_var("PR57_ROUND2_FAKE_TOKEN", "fake");
         set_forced_send_error(anyhow::anyhow!("Bad Request: message thread not found"));
@@ -328,8 +330,10 @@ instances:
             "provenance failure mutated fleet.yaml (removed B): {fleet_yaml}"
         );
 
-        let topics_json =
-            std::fs::read_to_string(home.join("channel").join("topics.json")).unwrap_or_default();
+        let topics_json = std::fs::read_to_string(
+            crate::channel::telegram::topic_registry::topic_registry_path(&home),
+        )
+        .unwrap_or_default();
         assert!(
             topics_json.contains("\"B\""),
             "provenance failure unregistered target's topic: {topics_json}"

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -2340,53 +2340,50 @@ mod tests {
         );
     }
 
+    // These four drive the REAL production `crate::agent::classify_exit` (now
+    // pub(crate)) instead of re-implementing its `match` inline, so a refactor
+    // that reclassifies an exit code is actually caught.
+    use crate::agent::{classify_exit, ExitKind};
+
     #[test]
     fn sigint_130_treated_as_clean_exit() {
         // SIGINT (exit code 130 = 128+2) from /quit in some CLIs must be
         // treated as clean exit, not crash.
-        let exit_code = Some(130_i32);
-        let is_crash = !matches!(exit_code, Some(0) | Some(130));
-        assert!(!is_crash, "exit code 130 (SIGINT) must not be a crash");
-        let is_user_clean = matches!(exit_code, Some(0) | Some(130));
-        assert!(
-            is_user_clean,
-            "exit code 130 must be user-initiated clean exit"
+        assert_eq!(
+            classify_exit(Some(130)),
+            ExitKind::UserExit,
+            "exit code 130 (SIGINT) must be a user-initiated clean exit"
         );
     }
 
     #[test]
     fn sigkill_137_not_clean_exit() {
         // SIGKILL (137) is daemon-initiated, not user /exit.
-        let exit_code = Some(137_i32);
-        let is_user_clean = matches!(exit_code, Some(0) | Some(130));
-        assert!(
-            !is_user_clean,
-            "SIGKILL must NOT be user-initiated clean exit"
+        assert_eq!(
+            classify_exit(Some(137)),
+            ExitKind::SignalKill,
+            "SIGKILL (137) must classify as SignalKill, not a clean UserExit"
         );
     }
 
     #[test]
     fn sigterm_143_not_clean_exit() {
         // SIGTERM (143) is daemon-initiated, not user /exit.
-        let exit_code = Some(143_i32);
-        let is_user_clean = matches!(exit_code, Some(0) | Some(130));
-        assert!(
-            !is_user_clean,
-            "SIGTERM must NOT be user-initiated clean exit"
+        assert_eq!(
+            classify_exit(Some(143)),
+            ExitKind::SignalKill,
+            "SIGTERM (143) must classify as SignalKill, not a clean UserExit"
         );
     }
 
     #[test]
     fn nonzero_exit_is_crash() {
         // Exit code 1 (error) must trigger crash respawn.
-        let exit_code = Some(1_i32);
-        let is_crash = match exit_code {
-            Some(0) | Some(130) => false,
-            Some(137) | Some(143) => false,
-            Some(_) => true,
-            None => true,
-        };
-        assert!(is_crash, "exit code 1 must be a crash");
+        assert_eq!(
+            classify_exit(Some(1)),
+            ExitKind::Crash,
+            "exit code 1 must classify as a crash"
+        );
     }
 
     // ─────────────────────────────────────────────────────────────

--- a/src/daemon_config.rs
+++ b/src/daemon_config.rs
@@ -52,9 +52,24 @@ mod tests {
 
     #[test]
     fn daemon_config_default_returns_expected_values() {
-        let _cfg = DaemonConfig::default();
-        // pointer_only_inject depends on env var; in test context should be false
-        // unless explicitly set
+        let cfg = DaemonConfig::default();
+        // `display_timezone` defaults to None unconditionally.
+        assert_eq!(
+            cfg.display_timezone, None,
+            "display_timezone default is None"
+        );
+        // `pointer_only_inject` is derived from AGEND_POINTER_ONLY_INJECT
+        // (true only when the var is exactly "1"). Compute the expectation the
+        // same way so the assertion is deterministic regardless of the ambient
+        // env, while still pinning that `default()` actually honors the var —
+        // the previous body asserted nothing at all.
+        let expect_pointer = std::env::var("AGEND_POINTER_ONLY_INJECT")
+            .map(|v| v == "1")
+            .unwrap_or(false);
+        assert_eq!(
+            cfg.pointer_only_inject, expect_pointer,
+            "pointer_only_inject default must reflect AGEND_POINTER_ONLY_INJECT"
+        );
     }
 
     #[test]

--- a/src/mcp_config.rs
+++ b/src/mcp_config.rs
@@ -893,10 +893,20 @@ mod tests {
         let cmd = config["mcpServers"]["agend-terminal"]["command"]
             .as_str()
             .expect("command str");
-        // In test env, bridge binary doesn't exist → falls back to agend-terminal
+        // Assert on the binary's FILE NAME, not a path substring. `cmd` is an
+        // absolute path; under this repo it always contains "agend-terminal"
+        // (the checkout dir name), so the old `cmd.contains("agend-terminal")`
+        // disjunct was a tautology. The command must be the bridge binary
+        // (`agend-mcp-bridge`) or the `agend-terminal` fallback by filename.
+        let fname = std::path::Path::new(cmd)
+            .file_name()
+            .and_then(|f| f.to_str())
+            .unwrap_or("");
+        let stem = fname.strip_suffix(".exe").unwrap_or(fname);
         assert!(
-            cmd.contains("agend-terminal") || cmd.contains("agend-mcp-bridge"),
-            "command must be bridge or fallback, got: {cmd}"
+            stem == "agend-mcp-bridge" || stem == "agend-terminal",
+            "command must be the bridge binary or the agend-terminal fallback, \
+             got filename {fname:?} (full path: {cmd})"
         );
         std::fs::remove_dir_all(&dir).ok();
     }

--- a/tests/agent_path_colon_split_invariant_1504.rs
+++ b/tests/agent_path_colon_split_invariant_1504.rs
@@ -22,7 +22,10 @@ fn agent_mod_no_hardcoded_path_colon_split_1504() {
         if t.starts_with("//") || t.starts_with('*') {
             continue;
         }
-        if line.contains(".split(':')") {
+        // Match both the char-literal `.split(':')` and the string-literal
+        // `.split(":")` form — `str::split` takes any Pattern, so the
+        // double-quoted spelling shreds a Windows `C:\...` PATH identically.
+        if line.contains(".split(':')") || line.contains(".split(\":\")") {
             violations.push(format!("{}: {}", i + 1, line.trim()));
         }
     }

--- a/tests/core_mutex_invariant.rs
+++ b/tests/core_mutex_invariant.rs
@@ -32,8 +32,13 @@ fn coremutex_is_sole_agentcore_mutex_wrapper_1535() {
     // `parking_lot::Mutex<T>`, so its own definition never matches these.
     let needles = [
         "Mutex<AgentCore>",
+        // `agent::AgentCore` short-path form — the most idiomatic spelling in
+        // this codebase, previously missed between the bare and fully-qualified
+        // forms.
+        "Mutex<agent::AgentCore>",
         "Mutex<crate::agent::AgentCore>",
         "Mutex::new(AgentCore",
+        "Mutex::new(agent::AgentCore",
         "Mutex::new(crate::agent::AgentCore",
     ];
 

--- a/tests/git_test_bypass_invariant.rs
+++ b/tests/git_test_bypass_invariant.rs
@@ -28,6 +28,13 @@ const MUTATING: &[&str] = &[
     "\"stash\"",
     "\"rm\"",
     "\"mv\"",
+    // ref-mutating subcommands that go through the shim's ChdirPass redirect —
+    // the canonical bad pattern in tests/common/git_isolated.rs is exactly
+    // `git checkout -b`, which the prior list omitted.
+    "\"checkout\"",
+    "\"switch\"",
+    "\"branch\"",
+    "\"push\"",
 ];
 
 #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -701,25 +701,12 @@ fn bridge_rejects_cookie_wrong_permissions() {
     // When permission check is added, this test should verify rejection.
 }
 
-#[test]
-fn bridge_rejects_cookie_mismatch() {
-    // Start daemon, then try to connect with wrong cookie
-    let mut daemon = TestDaemon::start("bridge_mismatch");
-    let port = TestDaemon::find_api_port(&daemon.home).expect("api port");
-    let mut stream =
-        TcpStream::connect(SocketAddr::from((Ipv4Addr::LOCALHOST, port))).expect("connect");
-    stream.set_read_timeout(Some(Duration::from_secs(5))).ok();
-    // Send wrong cookie (all zeros)
-    let fake_hex = "00".repeat(32);
-    writeln!(stream, r#"{{"auth":"{}"}}"#, fake_hex).expect("write");
-    stream.flush().expect("flush");
-    let mut reader = BufReader::new(stream);
-    let mut line = String::new();
-    reader.read_line(&mut line).expect("read");
-    let resp: serde_json::Value = serde_json::from_str(line.trim()).expect("parse");
-    assert_eq!(resp["ok"], false, "wrong cookie must be rejected: {resp}");
-    daemon.stop();
-}
+// Removed `bridge_rejects_cookie_mismatch`: it was a strict subset of
+// `test_api_rejects_connection_with_wrong_cookie` (both spawn a daemon, send a
+// valid-hex-but-wrong cookie, and assert `ok == false`, hitting the identical
+// `auth_cookie::server_handshake_ndjson` reject path). The sibling additionally
+// asserts the "auth" error text, so it strictly dominates. Dropped to avoid a
+// redundant daemon spawn.
 
 #[test]
 fn bridge_rejects_malformed_mcp_json() {

--- a/tests/mcp_subprocess_is_zero_state.rs
+++ b/tests/mcp_subprocess_is_zero_state.rs
@@ -70,6 +70,10 @@ fn rule1_no_state_file_reads() {
         "task_events",
         "inbox",
         "metadata.json",
+        // Merged from the former `rule4_no_state_files`: its other four
+        // patterns (fleet.yaml/topics.json/tasks.json/task_events.jsonl) were
+        // already covered here, so only `agents/` was unique. Consolidated.
+        "agents/",
     ];
     for (num, line) in &lines {
         for pat in &forbidden {
@@ -122,26 +126,11 @@ fn rule3_no_globals() {
     }
 }
 
-/// Rule 4: No state file references.
-#[test]
-fn rule4_no_state_files() {
-    let lines = active_lines(&bridge_source());
-    let forbidden = [
-        "fleet.yaml",
-        "topics.json",
-        "tasks.json",
-        "task_events.jsonl",
-        "agents/",
-    ];
-    for (num, line) in &lines {
-        for pat in &forbidden {
-            assert!(
-                !line.contains(pat),
-                "Rule 4 violation at line {num}: bridge must not reference '{pat}'\n  {line}"
-            );
-        }
-    }
-}
+// Rule 4 (`rule4_no_state_files`) was merged into `rule1_no_state_file_reads`:
+// four of its five forbidden patterns (fleet.yaml/topics.json/tasks.json/
+// task_events.jsonl, the last covered by rule1's `task_events` substring) were
+// already enforced there over the identical line set; only `agents/` was
+// unique, and it now lives in rule1's list.
 
 /// Rule 5: No channel state.
 #[test]

--- a/tests/spawn_rationale_audit.rs
+++ b/tests/spawn_rationale_audit.rs
@@ -259,10 +259,20 @@ fn dispatch_scoped_sweep_sites_have_rationale() {
         ("channel/telegram/inbound.rs", "std::thread::Builder::new()"),
         ("app/telegram_hooks.rs", "std::thread::spawn"),
     ];
-    for (rel_suffix, _expected_substr) in swept_sites {
+    for (rel_suffix, expected_substr) in swept_sites {
         let path = src_root.join(rel_suffix);
         let content = std::fs::read_to_string(&path)
             .unwrap_or_else(|_| panic!("dispatch-scoped file must exist: {}", rel_suffix));
+        // Pin that the spawn site itself is still present (the `_expected_substr`
+        // was previously dead code — never read — so a file could pass on the
+        // strength of an unrelated `fire-and-forget:` comment even after the
+        // tracked spawn was removed).
+        assert!(
+            content.contains(expected_substr),
+            "swept file `{}` must still contain its tracked spawn site `{}`",
+            rel_suffix,
+            expected_substr
+        );
         assert!(
             content.contains("fire-and-forget:"),
             "swept file `{}` must contain at least one `fire-and-forget:` rationale comment",

--- a/tests/vte_gotchas.rs
+++ b/tests/vte_gotchas.rs
@@ -174,13 +174,13 @@ fn safe_cell_resize_shrink_no_panic() {
     }
     // Shrink terminal — content that was at cols 40-79 is now out of bounds
     client.resize(40, 10);
-    // Read screen after shrink — must not panic
-    let screen = client.screen_text(10);
-    // After resize, some content should still be readable
-    assert!(
-        screen.contains("row") || screen.is_empty(),
-        "screen_text after resize-shrink must not panic and should contain content or be empty: '{screen}'"
-    );
+    // Read screen after shrink — the call itself must not panic on out-of-
+    // bounds cells (the point of this test). The previous assertion here was
+    // `screen.contains("row") || screen.is_empty()` — unfalsifiable (the screen
+    // is always either empty or contains the fed "rowN" content), so it could
+    // never catch a regression; dropped. The no-panic guarantee is the call
+    // completing, and the post-resize functional check is asserted below.
+    let _ = client.screen_text(10);
     // Verify dimensions actually changed by feeding new content
     client.feed(b"after_resize\r\n");
     let screen2 = client.screen_text(5);


### PR DESCRIPTION
## What

Second batch of the **medium-severity** test-audit findings (follow-up to #2130 highs and #2138 medium batch 1). Lands **14 more fixes**. Same standard: `cargo check --all-targets` clean (no warnings), `cargo fmt --check` clean, every touched test re-run and passing.

⚠️ **One small production change** (flagged): the daemon exit-code commit makes `agent::classify_exit` + `ExitKind` `pub(crate)` (+ derive Debug/PartialEq/Eq) so the tests can call the real function. No behavior change. Everything else is test-only.

## Fixes

**Redundant (2)**
- `integration::bridge_rejects_cookie_mismatch`: deleted — a strict subset of `test_api_rejects_connection_with_wrong_cookie` (same reject path, the sibling also asserts the "auth" error text), saving a redundant daemon spawn.
- `mcp_subprocess::rule4_no_state_files`: merged into `rule1_no_state_file_reads` — 4 of its 5 patterns were already enforced there; only `agents/` was unique.

**Vacuous → real (2)**
- `vte_gotchas::safe_cell_resize_shrink_no_panic`: dropped `screen.contains("row") || screen.is_empty()` (unfalsifiable); the no-panic guarantee + post-resize functional check remain.
- `daemon_config_default_returns_expected_values`: asserted nothing → now checks `display_timezone` default + `pointer_only_inject` reflects its env var.

**false_confidence grep-guards strengthened (4)**
- `agent_path_colon_split`: also match the string-literal `.split(":")`, not just `.split(':')`.
- `core_mutex_invariant`: add the `agent::AgentCore` short-path needles.
- `git_test_bypass_invariant`: add ref-mutating checkout/switch/branch/push to MUTATING (`git checkout -b` is the canonical bad pattern, was omitted).
- `mcp_config::kiro_mcp_json_uses_bridge_command`: assert the binary file name, not `cmd.contains("agend-terminal")` (the absolute path always contains the checkout dir name — a tautology).

**false_confidence wrong-path / dead-code (2)**
- `reply::inject_provenance_failure_does_not_mutate_*`: wrote/read `home/channel/topics.json` but production uses `home/topics.json` — a tautology. Seed via the real `register_topic` API + read `topic_registry_path`.
- `spawn_rationale_audit::dispatch_scoped_sweep_sites_have_rationale`: the `_expected_substr` (tracked spawn line) was dead code; now assert the spawn site is still present too.

**tests_test_code → real production (4)**
- daemon `sigint_130` / `sigkill_137` / `sigterm_143` / `nonzero_exit_is_crash`: re-implemented `classify_exit`'s match inline; now call the real `agent::classify_exit` and assert the real `ExitKind` (the pub(crate) change above).

## Note

A few audit findings recommended deleting whole tests (`boot_sweep`, `sprint52`, `bridge_rejects` etc.); on inspection most needed only a local fix — only genuinely-redundant tests were removed, each with the dominating sibling cited. (Same discipline as the corrected false-flags in #2130/#2138.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)