### PR TITLE
test: fix medium test-audit findings (batch 3 — recursive guards, real events, dead-test removal)

### DIFF
--- a/src/bootstrap/telegram_init.rs
+++ b/src/bootstrap/telegram_init.rs
@@ -238,47 +238,11 @@ mod tests {
         );
     }
 
-    /// #945 Phase 1: bounded timeout when pending registry never
-    /// published. Helper exits without calling attach_registry; warn
-    /// logged (not asserted — tracing-capture out of scope here).
-    ///
-    /// Note: this test depends on `PENDING_REGISTRY` being unset.
-    /// The OnceLock semantic means once any earlier test (or the
-    /// previous test in this file) has set it, it stays set. To
-    /// keep this test useful, it uses an absolute past deadline
-    /// (Instant::now() with no offset) AND asserts the helper
-    /// returns WITHOUT calling attach when the registry is None at
-    /// the very first poll.
-    ///
-    /// In practice, when run after `..._attaches_after_publish_945`,
-    /// the OnceLock IS set, and `get_pending_registry()` returns
-    /// Some — so this assertion would FAIL with the publish-before
-    /// test running first. We sidestep this by using a fresh mock +
-    /// still verifying the `attached` flag transitions correctly: if
-    /// attach happens, it means the OnceLock was poisoned by a
-    /// sibling test, which is expected fixture behavior, not a fix
-    /// regression. Pin only the no-attach branch by asserting NOT
-    /// attached when we can confirm the helper raced the deadline
-    /// (via test-only short deadline).
-    #[test]
-    fn attach_pending_registry_when_ready_times_out_when_no_publish_945() {
-        let mock = MockChannel::new();
-        let channel_dyn: Arc<dyn crate::channel::Channel> =
-            mock.clone() as Arc<dyn crate::channel::Channel>;
-        // Past-deadline: helper exits IMMEDIATELY without attaching
-        // UNLESS the OnceLock was previously populated.
-        let past_deadline = std::time::Instant::now()
-            .checked_sub(std::time::Duration::from_secs(1))
-            .unwrap_or_else(std::time::Instant::now);
-        attach_pending_registry_when_ready_with_deadline(channel_dyn, past_deadline);
-        // Two valid outcomes:
-        // (a) PENDING_REGISTRY is unset (this test runs first in
-        //     this binary) → attached == false (timeout path)
-        // (b) PENDING_REGISTRY was set by a sibling test → attached
-        //     == true (immediate-attach path)
-        // Either outcome demonstrates the helper behaves correctly.
-        // We don't assert a specific value — just that the helper
-        // returned (no panic, no hang).
-        let _attached = mock.attached.load(Ordering::Relaxed);
-    }
+    // Removed `attach_pending_registry_when_ready_times_out_when_no_publish_945`:
+    // it had no assertion (`let _attached = ...; // we don't assert a specific
+    // value`) and was untestable for its stated "times out when no publish"
+    // contract — the process-global `PENDING_REGISTRY` OnceLock can be set by
+    // the sibling `..._attaches_after_publish_945` test and cannot be reset, so
+    // the attach/no-attach outcome is nondeterministic across run order. The
+    // attach-after-publish path remains covered by that sibling.
 }

--- a/src/daemon/ci_watch/sweep.rs
+++ b/src/daemon/ci_watch/sweep.rs
@@ -1010,31 +1010,10 @@ mod tests {
         std::fs::remove_dir_all(&dir).ok();
     }
 
-    /// #bughunt-r2 #4 source-scan: in `gc_stale_watches`, `acquire_file_lock`
-    /// must be reached BEFORE any `remove_watch(` call — i.e. the lock guards the
-    /// removal. Backstops a regression that moves/drops the lock acquisition.
-    #[test]
-    fn gc_acquires_lock_before_remove_watch_bughunt_r2() {
-        let src = include_str!("sweep.rs");
-        let start = src
-            .find("pub fn gc_stale_watches(")
-            .expect("gc_stale_watches present");
-        // Scope to the fn — stop at the `#[cfg(test)]` module so the scan can't
-        // reach this test's own `remove_watch(` / `acquire_file_lock` literals.
-        let after = &src[start..];
-        let cfg_test = ["#[cfg(", "test)]"].concat();
-        let body = &after[..after.find(&cfg_test).unwrap_or(after.len())];
-
-        let lock_at = body
-            .find("acquire_file_lock(")
-            .expect("gc must acquire the per-watch lock");
-        let remove_at = body
-            .find("remove_watch(")
-            .expect("gc still removes stale watches");
-        assert!(
-            lock_at < remove_at,
-            "#bughunt-r2 #4: gc_stale_watches must acquire the per-watch lock \
-             BEFORE removing a watch (lock-before-remove serialises against the poll flush)"
-        );
-    }
+    // Removed `gc_acquires_lock_before_remove_watch_bughunt_r2`: it was a
+    // source-text ordering check (`acquire_file_lock(` byte-offset < `remove_watch(`
+    // byte-offset via include_str!), which a rename/refactor breaks even when the
+    // logic is correct, and which a non-obvious rewrite could satisfy while the
+    // race exists. The companion `gc_blocks_on_held_watch_lock_then_removes_bughunt_r2`
+    // exercises the actual runtime lock serialisation and is sufficient coverage.
 }

--- a/src/daemon/dispatch_idle/mod.rs
+++ b/src/daemon/dispatch_idle/mod.rs
@@ -2806,19 +2806,37 @@ mod tests {
         )
         .unwrap();
         let task_id = "t-live-99";
-        let tasks_dir = home.join("tasks");
-        std::fs::create_dir_all(&tasks_dir).unwrap();
-        std::fs::write(
-            tasks_dir.join(format!("{task_id}.json")),
-            serde_json::to_string_pretty(&serde_json::json!({
-                "id": task_id,
-                "status": "in_progress",
-                "title": "live work",
-                "assignee": "fixup-dev-2"
-            }))
-            .unwrap(),
-        )
-        .unwrap();
+        // #1608b: seed a REAL LIVE task on the event-sourced board (the path
+        // `task_still_live` reads via load_by_id → replay), NOT a
+        // `tasks/{id}.json` file — that file is never written, so the old write
+        // was ignored and the test only passed via the missing-task fail-open,
+        // not because the task was recognized as live. A freshly-Created task is
+        // `open`, which is in LIVE_TASK_STATUSES, so `task_still_live` returns
+        // Some(true) and the overdue dispatch must still fire.
+        {
+            use crate::task_events::{append, InstanceName, TaskEvent, TaskId};
+            let emitter = InstanceName::from("test:operator");
+            append(
+                &home,
+                &emitter,
+                TaskEvent::Created {
+                    task_id: TaskId(task_id.into()),
+                    title: "live work".into(),
+                    description: String::new(),
+                    priority: "normal".into(),
+                    owner: Some(InstanceName::from("fixup-dev-2")),
+                    due_at: None,
+                    depends_on: Vec::new(),
+                    routed_to: None,
+                    branch: None,
+                    bind: None,
+                    eta_secs: None,
+                    tags: vec![],
+                    parent_id: None,
+                },
+            )
+            .unwrap();
+        }
         let issued = chrono::Utc::now() - chrono::Duration::seconds(700);
         write_pending_at(
             &home,

--- a/src/daemon/per_tick/recovery_dispatcher.rs
+++ b/src/daemon/per_tick/recovery_dispatcher.rs
@@ -1235,31 +1235,12 @@ mod tests {
         assert_eq!(tracker.recovery_restart_count, 2);
     }
 
-    #[test]
-    fn stage2_pending_timeout_drives_stage3_eligible_in_unit_form() {
-        // Pin the timeout arithmetic at the helper level: if
-        // `entered_at`'s elapsed time exceeds `timeout_window`,
-        // dispatcher transitions to Stage3Eligible. The full integration
-        // with a registered agent is deferred to a §3.14 production-hook
-        // integration test if shadow telemetry reveals edge cases;
-        // here we verify the elapsed-check predicate.
-        //
-        // Cross-platform `Instant` discipline (PR #775 v2): use
-        // `base + offset` + `saturating_duration_since` rather than
-        // `Instant::now() - offset` so the test never panics on
-        // low-uptime Windows CI VMs.
-        let base = Instant::now();
-        let timeout = Duration::from_secs(30);
-
-        let entered_at = base;
-        let now_after = base + Duration::from_secs(31);
-        assert!(now_after.saturating_duration_since(entered_at) >= timeout);
-
-        // Inverse: still within window → no escalation.
-        let recent = base;
-        let now_recent = base + Duration::from_secs(5);
-        assert!(now_recent.saturating_duration_since(recent) < timeout);
-    }
+    // Removed `stage2_pending_timeout_drives_stage3_eligible_in_unit_form`: its
+    // two assertions reduced to pure arithmetic facts on locally-constructed
+    // values (`31s >= 30s`, `5s < 30s`) and called no production code, so it
+    // could never catch a regression in the real `entered_at.elapsed() >=
+    // stage2_timeout` dispatcher path. The comment itself deferred the actual
+    // integration coverage; this stub added none.
 
     // -------------------------------------------------------------------
     // `#685` sub-task 7c Stage 3 tests. Cover the new dispatcher arm

--- a/src/daemon/pr_state/gh_poll.rs
+++ b/src/daemon/pr_state/gh_poll.rs
@@ -812,25 +812,48 @@ pub(crate) mod tests {
     /// not a call site — and assembles the needle, so it never self-counts.)
     #[test]
     fn exactly_one_gh_poll_worker_spawn_site_986() {
-        let files = [
-            "src/daemon/per_tick/pr_state_scan.rs",
-            "src/daemon/supervisor.rs",
-            "src/daemon/mod.rs",
-            "src/app/mod.rs",
-        ];
+        // Scan the WHOLE src/ tree, not a hardcoded 4-file list: a new call site
+        // added in any other module (e.g. app/commands.rs, a new daemon handler)
+        // would otherwise leave the count at 1 and silently pass. Call sites =
+        // all worker-spawn references minus the single `fn` definition. (This
+        // comment intentionally avoids the literal `spawn_gh_poll_worker` + `(`
+        // sequence so the recursive scan does not count itself.)
+        fn collect(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
+            let Ok(rd) = std::fs::read_dir(dir) else {
+                return;
+            };
+            for e in rd.flatten() {
+                let p = e.path();
+                if p.is_dir() {
+                    collect(&p, out);
+                } else if p.extension().is_some_and(|x| x == "rs") {
+                    out.push(p);
+                }
+            }
+        }
+        let mut files = Vec::new();
+        let root = if std::path::Path::new("src").is_dir() {
+            std::path::PathBuf::from("src")
+        } else {
+            std::path::PathBuf::from("agend-terminal/src")
+        };
+        collect(&root, &mut files);
+        // The needle/def are assembled from fragments so THIS test never
+        // self-counts (its only reference is the split literal below).
         let needle = format!("{}(", "spawn_gh_poll_worker");
-        let count: usize = files
-            .iter()
-            .map(|f| {
-                std::fs::read_to_string(f)
-                    .or_else(|_| std::fs::read_to_string(format!("agend-terminal/{f}")))
-                    .unwrap_or_default()
-            })
-            .map(|src| src.matches(needle.as_str()).count())
-            .sum();
+        let def = format!("fn {}(", "spawn_gh_poll_worker");
+        let mut refs = 0usize;
+        let mut defs = 0usize;
+        for f in &files {
+            let src = std::fs::read_to_string(f).unwrap_or_default();
+            refs += src.matches(needle.as_str()).count();
+            defs += src.matches(def.as_str()).count();
+        }
+        let call_sites = refs - defs;
         assert_eq!(
-            count, 1,
-            "#986: gh-poll worker must be spawned exactly once across all entry points (got {count})"
+            call_sites, 1,
+            "#986: gh-poll worker must be spawned exactly once across ALL of src/ \
+             (found {call_sites} call sites; refs={refs}, defs={defs})"
         );
     }
 

--- a/tests/clippy_gate_helper_script.rs
+++ b/tests/clippy_gate_helper_script.rs
@@ -84,17 +84,30 @@ fn script_defines_all_three_ci_matrix_platforms() {
 
 #[test]
 fn script_uses_strict_clippy_invocation() {
-    // Pin: the script must invoke clippy with `-D warnings` to match
-    // CI's strictness. Anything weaker would let warnings through
-    // locally that CI then catches — defeating the gate's purpose.
+    // Pin: the script must invoke clippy with `-D warnings` + `--features tray`
+    // to match CI's strictness. Check the ACTUAL invocation — the
+    // `DEFAULT_CLIPPY_ARGS` array passed to `cargo clippy` — not a whole-file
+    // grep: the script's header comment
+    // (`#  cargo clippy --all-targets --features tray -- -D warnings`) already
+    // contains every substring, so the old whole-file check would stay green
+    // even if the real command were weakened.
     let content = std::fs::read_to_string(script_path()).expect("read");
+    let args_block = content
+        .split_once("DEFAULT_CLIPPY_ARGS=(")
+        .and_then(|(_, rest)| rest.split_once(')'))
+        .map(|(block, _)| block)
+        .expect("script must define a DEFAULT_CLIPPY_ARGS=( ... ) array");
     assert!(
-        content.contains("-D") && content.contains("warnings"),
-        "script must run clippy with -D warnings (matches CI strictness)"
+        args_block.contains("-D") && args_block.contains("warnings"),
+        "DEFAULT_CLIPPY_ARGS must run clippy with -D warnings (matches CI strictness): {args_block}"
     );
     assert!(
-        content.contains("--features") && content.contains("tray"),
-        "script must include the `tray` feature (matches CI matrix coverage)"
+        args_block.contains("--features") && args_block.contains("tray"),
+        "DEFAULT_CLIPPY_ARGS must include the `tray` feature: {args_block}"
+    );
+    assert!(
+        content.contains("cargo clippy") && content.contains("${DEFAULT_CLIPPY_ARGS[@]}"),
+        "the script must actually pass DEFAULT_CLIPPY_ARGS to `cargo clippy`"
     );
 }
 

--- a/tests/harness_smoke.rs
+++ b/tests/harness_smoke.rs
@@ -1,4 +1,14 @@
 //! Sprint 42 Phase 2 — AgendHarness + TuiClient MVP integration tests.
+//!
+//! SCOPE: these are HARNESS smoke tests. They verify the test *infrastructure*
+//! itself — that `TuiClient::feed`/`screen_text`/`feed_and_extract`/`wait_for`
+//! round-trip correctly through the in-process `TestVTerm`, and that
+//! `AgendHarness` boots a real daemon. They deliberately do NOT assert on
+//! production `src/vterm.rs` behavior; that is covered by `tests/vte_gotchas.rs`
+//! and the `src/vterm.rs` unit tests. A harness that silently breaks would make
+//! every test that depends on it (vte_gotchas, behavioral, etc.) unreliable, so
+//! smoke-testing the harness is the point — not a substitute for production
+//! coverage.
 
 mod common;
 

--- a/tests/migrated_scripts.rs
+++ b/tests/migrated_scripts.rs
@@ -149,69 +149,10 @@ fn silent_agent_spawn_observable_and_inject_path() {
     std::fs::remove_dir_all(&home).ok();
 }
 
-/// Migrated from: scripts/repro-team-tab-bug.sh
-/// Narrowed to: team creation API returns structured response (spawned
-/// array on success, descriptive error on backend unavailability).
-#[test]
-fn team_creation_returns_structured_response() {
-    let home = tmp_home("team-spawn");
-    let harness = AgendHarness::spawn(home.clone(), "defaults:\n  backend: cat\ninstances: {}\n")
-        .expect("spawn");
-
-    let client = TuiClient::new(&harness, 80, 24);
-
-    // Create a team with 2 members
-    let result = client.call(
-        "mcp_tool",
-        &json!({
-            "tool": "create_instance",
-            "arguments": {"team": "repro-team", "count": 2, "backend": "cat"},
-            "instance": "test-caller"
-        }),
-    );
-    assert!(
-        result.is_ok(),
-        "team creation must not fail: {:?}",
-        result.err()
-    );
-    let resp = result.expect("create response");
-
-    // Hard assertion: response must indicate spawned members or structured error
-    let inner = &resp["result"];
-    // Team creation via mcp_tool returns the tool's result.
-    // On success: {"team": ..., "spawned": [...]}
-    // On API error: {"error": "..."}
-    if inner.get("error").is_some() {
-        // API error (e.g., daemon couldn't spawn backend) — acceptable in CI
-        // where backends may not be installed. The test verifies the API path works.
-        let err = inner["error"].as_str().unwrap_or("unknown");
-        assert!(
-            !err.is_empty(),
-            "team creation error must be descriptive: {inner}"
-        );
-    } else {
-        let spawned = inner
-            .get("spawned")
-            .and_then(|v| v.as_array())
-            .expect("successful team creation must have 'spawned' array");
-        assert!(
-            !spawned.is_empty(),
-            "team creation must spawn at least 1 member: {inner}"
-        );
-    }
-
-    // Hard assertion: list must show agents after team creation
-    let list_resp = client
-        .call("list", &json!({}))
-        .expect("list call must succeed after team creation");
-    let agents = list_resp["result"]["agents"]
-        .as_array()
-        .expect("list must return agents array");
-    assert!(
-        !agents.is_empty(),
-        "agents list must not be empty after team creation: {list_resp}"
-    );
-
-    drop(harness);
-    std::fs::remove_dir_all(&home).ok();
-}
+// Removed `team_creation_returns_structured_response`: its branches passed on
+// EITHER success or a descriptive error, and its `list non-empty` backstop was
+// independently satisfied by the default shell agent that `AgendHarness::spawn`
+// always appends — so a complete break in team-member spawning would not fail
+// it. The stated target (team creation returns a structured spawned-array
+// response) is covered exactly by `team_recreate_extends_roster`, which asserts
+// the specific spawned ids through the same path.


### PR DESCRIPTION
## What

Third batch of medium-severity test-audit findings (after #2138, #2143). 10 fixes. `cargo check --all-targets` + `cargo fmt --check` clean; touched tests re-run and passing. All changes are test-only (one tiny `#[cfg(test)]`-region helper-scan change in src files; no production behavior change).

## Fixes

**Strengthened guards (2)**
- `gh_poll::exactly_one_gh_poll_worker_spawn_site_986`: scan the WHOLE src/ tree (recursive) instead of a hardcoded 4-file list — a spawn call site added elsewhere would otherwise slip past. Count = refs − `fn` defs.
- `clippy_gate::script_uses_strict_clippy_invocation`: pin the actual `DEFAULT_CLIPPY_ARGS` array (and that it's passed to `cargo clippy`), not a whole-file grep the script's header comment already satisfies.

**Real production path (1)**
- `dispatch_idle::t1018_a_live_dispatch_still_fires`: seed a real LIVE task via `task_events::append(Created)` (event-sourced board that `task_still_live` reads) instead of a `tasks/{id}.json` file production never reads — the old test passed only via the missing-task fail-open.

**Scope clarification (3)**
- harness_smoke (`tuiclient_*`): kept — these legitimately smoke-test the test harness (file is `harness_smoke.rs`, tests named for the `TuiClient` API); added a module-doc making the scope explicit (production VTerm is covered by vte_gotchas + unit tests).

**Removed dead tests (4)** — each tested nothing real; sibling/coverage cited inline:
- `recovery_dispatcher::stage2_pending_timeout...` (pure arithmetic).
- `telegram_init::attach_pending...times_out` (no assertion; untestable OnceLock).
- `ci_watch/sweep::gc_acquires_lock_before_remove_watch` (source-text byte-offset ordering; runtime sibling covers it).
- `migrated_scripts::team_creation_returns_structured_response` (passed on success OR error; covered by `team_recreate_extends_roster`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)