### PR TITLE
test(#2140): pin KNOWN_OVERSIZED ↔ merge-freshness gate via shared const (follow-up A)

### DIFF
--- a/src/invariant_inputs.rs
+++ b/src/invariant_inputs.rs
@@ -1,0 +1,26 @@
+//! #2140 follow-up A: the single source of truth for the grandfathered
+//! oversized handler files.
+//!
+//! These two paths are referenced in two places that must never drift:
+//! - `tests/file_size_invariant.rs::KNOWN_OVERSIZED` — the per-file LOC ceilings
+//!   that grandfather them past `MAX_LOC`.
+//! - `mcp::handlers::ci::merge_freshness::is_invariant_input` — the
+//!   merge-freshness gate that refuses a stale-base merge touching them.
+//!
+//! If a third oversized handler is grandfathered into `KNOWN_OVERSIZED` but not
+//! into the freshness gate, that file is *silently un-gated* from the #2140
+//! protection (the exact silent-gate-miss class #2140 exists to close). This
+//! file is compiled into BOTH the binary crate (`mod invariant_inputs` in
+//! `main.rs`) and the lib crate (`#[path]` re-home in `lib.rs`), so the gate and
+//! the file-size test read the *same* literal list — they cannot diverge. The
+//! `known_oversized_paths_match_merge_freshness_inputs` test in
+//! `tests/file_size_invariant.rs` pins `KNOWN_OVERSIZED`'s paths to this list so
+//! any future addition to one without the other fails CI loud.
+
+/// Pre-existing oversized handler files, grandfathered past the file-size
+/// invariant AND gated as merge-freshness invariant inputs. Add a new path here
+/// (and its ceiling in `KNOWN_OVERSIZED`) when grandfathering another file.
+pub const GRANDFATHERED_OVERSIZED_HANDLERS: &[&str] = &[
+    "src/mcp/handlers/ci/mod.rs",
+    "src/mcp/handlers/dispatch_hook/mod.rs",
+];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,13 @@
 pub mod capture;
 pub mod sync_audit;
 
+/// Re-export for integration tests. Same source file as the binary crate's
+/// `invariant_inputs` module (`#[path]`), so the merge-freshness gate and the
+/// `file_size_invariant` cross-check read the identical grandfathered list and
+/// cannot drift. #2140 follow-up A.
+#[path = "invariant_inputs.rs"]
+pub mod invariant_inputs;
+
 /// Re-export for integration tests. The actual implementation lives in the
 /// binary crate's `daemon::heartbeat_pair` module.
 pub mod daemon {

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,7 @@ mod inbox;
 mod instance_monitor;
 mod instructions;
 mod integrity_core;
+mod invariant_inputs;
 mod ipc;
 mod keybinds;
 mod layout;

--- a/src/mcp/handlers/ci/merge_freshness.rs
+++ b/src/mcp/handlers/ci/merge_freshness.rs
@@ -24,15 +24,15 @@ use crate::scm::ScmProvider;
 use serde_json::{json, Value};
 
 /// A whole-tree invariant's INPUT files — the ones whose combined change across
-/// interleaved PRs can violate a tree-wide check. Kept in sync with the
-/// `KNOWN_OVERSIZED` handler paths in `tests/file_size_invariant.rs`, plus every
-/// invariant *test* itself (a PR that tightens an invariant can RED main the same
-/// way a ceiling-setter did).
+/// interleaved PRs can violate a tree-wide check. The grandfathered handler
+/// paths come from the single source of truth in
+/// [`crate::invariant_inputs::GRANDFATHERED_OVERSIZED_HANDLERS`] (the same list
+/// `tests/file_size_invariant.rs::KNOWN_OVERSIZED` records ceilings for), plus
+/// every invariant *test* itself (a PR that tightens an invariant can RED main
+/// the same way a ceiling-setter did).
 pub(super) fn is_invariant_input(path: &str) -> bool {
-    matches!(
-        path,
-        "src/mcp/handlers/ci/mod.rs" | "src/mcp/handlers/dispatch_hook/mod.rs"
-    ) || (path.starts_with("tests/") && path.ends_with("_invariant.rs"))
+    crate::invariant_inputs::GRANDFATHERED_OVERSIZED_HANDLERS.contains(&path)
+        || (path.starts_with("tests/") && path.ends_with("_invariant.rs"))
 }
 
 /// Verdict of the freshness gate. `StaleRisky` carries the offending

--- a/tests/file_size_invariant.rs
+++ b/tests/file_size_invariant.rs
@@ -129,3 +129,29 @@ fn mcp_handler_files_under_max_loc() {
         );
     }
 }
+
+/// #2140 follow-up A: pin `KNOWN_OVERSIZED`'s paths to the merge-freshness gate's
+/// grandfathered list (the shared single source of truth). Without this, adding a
+/// third oversized handler here but forgetting `is_invariant_input` would silently
+/// un-gate that file from the #2140 stale-base merge protection — the very
+/// silent-gate-miss class #2140 closes. Both sides read
+/// `GRANDFATHERED_OVERSIZED_HANDLERS` (the gate via `is_invariant_input`, this
+/// test directly), so any divergence fails CI loud.
+#[test]
+fn known_oversized_paths_match_merge_freshness_inputs() {
+    use std::collections::BTreeSet;
+    let ceiling_paths: BTreeSet<&str> = KNOWN_OVERSIZED.iter().map(|(p, _)| *p).collect();
+    let gate_paths: BTreeSet<&str> =
+        agend_terminal::invariant_inputs::GRANDFATHERED_OVERSIZED_HANDLERS
+            .iter()
+            .copied()
+            .collect();
+    assert_eq!(
+        ceiling_paths, gate_paths,
+        "drift between KNOWN_OVERSIZED and the merge-freshness gate's grandfathered \
+         list (GRANDFATHERED_OVERSIZED_HANDLERS): a grandfathered oversized file must \
+         appear in BOTH, else it is silently un-gated from #2140's stale-base merge \
+         refusal. Add the new path to GRANDFATHERED_OVERSIZED_HANDLERS (gate input) \
+         and KNOWN_OVERSIZED (with its LOC ceiling)."
+    );
+}


### PR DESCRIPTION
## #2140 follow-up A — silent-gate-miss prevention

**Problem (reviewer-2 + reviewer-4 flagged, non-blocking).** `is_invariant_input` (`src/mcp/handlers/ci/merge_freshness.rs`) hardcoded the two `KNOWN_OVERSIZED` handler paths (`ci/mod.rs`, `dispatch_hook/mod.rs`), manually kept in sync with `tests/file_size_invariant.rs::KNOWN_OVERSIZED`. A future 3rd grandfathered file added to `KNOWN_OVERSIZED` but **not** to the gate would be silently un-gated from #2140's stale-base merge refusal — the exact silent-gate-miss class #2140 exists to close.

**Fix — single source of truth (option i, root fix).** New `src/invariant_inputs.rs` holds `GRANDFATHERED_OVERSIZED_HANDLERS`, compiled into **both** crates:
- binary crate — `mod invariant_inputs;` in `main.rs`; `is_invariant_input` now reads the const (cannot drift from it).
- lib crate — `#[path = "invariant_inputs.rs"] pub mod invariant_inputs;` in `lib.rs` (same source file → identical list).

The new enforcing test `known_oversized_paths_match_merge_freshness_inputs` pins `KNOWN_OVERSIZED`'s paths to the same const; any divergence fails CI loud.

**Why not a lib-side mirror (option ii naive form).** The binary crate does not import `agend_terminal::` (the lib/bin convention here is to *mirror* types). A mirror would let `mirror + KNOWN_OVERSIZED` move together while the real binary-side `is_invariant_input` stays stale — passing silently, missing the exact bug. The `#[path]` shared-source module is the only form that pins the gate itself.

**Verification.**
- `cargo fmt --check` ✓
- `cargo test --features tray --test file_size_invariant` ✓ (2 pass)
- `cargo test --features tray --bin agend-terminal merge_freshness` ✓ (8 pass)
- `cargo clippy --features tray --all-targets -- -D warnings` ✓
- **Non-vacuous proof:** simulated a 3rd `KNOWN_OVERSIZED` path absent from the const → enforcing test FAILS with the exact missing path; reverted.

Surgical: +42/-8, 1 new shared module + 3 wiring/read sites + 1 test. No behavior change to the gate (reads identical list).

correlation_id: t-20260614140254496797-16

---
*fixup-dev* · claude/opus-4.8