### PR TITLE
test(vte_gotchas): correct module-doc overclaim (medium batch 4)

### DIFF
--- a/tests/vte_gotchas.rs
+++ b/tests/vte_gotchas.rs
@@ -1,7 +1,15 @@
 //! Sprint 42 Phase 3 — 7 vte gotchas tests on TuiClient vterm.
 //!
-//! Exercises alacritty_terminal::Term edge cases via the Phase 2
-//! TuiClient harness to verify zero parser divergence with production.
+//! Exercises `alacritty_terminal::Term` parser edge cases (CRLF, SGR, cursor
+//! save/restore, wide chars, resize) via the Phase 2 `TuiClient` harness. NOTE:
+//! these run against the harness's in-process `TestVTerm`, which uses the SAME
+//! `alacritty_terminal` library as production `src/vterm.rs` — so the
+//! parser-level behavior is genuinely exercised — but its screen-EXTRACTION
+//! layer (`tail_lines`, scrollback) is a hand-copy that diverges from
+//! production's (`tail_lines_impl` de-wraps soft-wrap, etc.). So this file does
+//! NOT prove "zero divergence with production"; production VTerm extraction is
+//! covered by the `src/vterm.rs` unit tests. Treat these as parser-edge-case +
+//! harness tests, not production-extraction tests.
 
 mod common;
 


### PR DESCRIPTION
Medium test-audit batch 4 (after #2138/#2143/#2144). Doc-only.

`vte_gotchas.rs` module-doc claimed the tests "verify zero parser divergence with production". In reality they run against the harness `TestVTerm` — the SAME `alacritty_terminal` parser (so parser behavior IS exercised) but a hand-copied screen-extraction layer that diverges from production `tail_lines_impl`. Corrected the scope claim; production VTerm extraction is covered by `src/vterm.rs` unit tests. Addresses the `crlf_lf_handling` + sibling `keep_with_caveat` findings.

Remaining ~30 medium findings (the production-wiring / fixture / handler-extraction / flaky-sync-rewrite category) are documented per-finding in SESSION-HANDOFF.md for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)