### PR TITLE
fix(CR-2026-06-14 C1): claim_verifier extract_task_id non-ASCII slice panic

### DIFF
--- a/src/claim_verifier.rs
+++ b/src/claim_verifier.rs
@@ -113,9 +113,19 @@ fn extract_paths(s: &str) -> Vec<String> {
 
 /// Extract a task ID from a "scope follows dispatch spec X" claim.
 fn extract_task_id(s: &str) -> Option<String> {
-    let lower = s.to_lowercase();
+    // #CR-2026-06-14 C1: the marker offset MUST be computed on `s` itself. A byte
+    // offset from `s.to_lowercase()` can land mid-char on `s` — `to_lowercase` is
+    // NOT byte-length-preserving (İ→i̇, ß→ss) — so `s[idx..]` panicked on
+    // agent/operator-supplied non-ASCII claim text. The marker is ASCII, so find
+    // it case-insensitively over `s`'s own char boundaries via `get` (an Option,
+    // never panics). For ASCII text the offset is identical to the old path.
     let marker = "scope follows dispatch spec";
-    let idx = lower.find(marker)? + marker.len();
+    let idx = s.char_indices().find_map(|(i, _)| {
+        let end = i + marker.len();
+        s.get(i..end)
+            .filter(|sub| sub.eq_ignore_ascii_case(marker))
+            .map(|_| end)
+    })?;
     let rest = s[idx..].trim();
     // Task ID is the next whitespace-delimited token
     let id = rest.split_whitespace().next()?;

--- a/src/claim_verifier/review_repro_panic_io_extra.rs
+++ b/src/claim_verifier/review_repro_panic_io_extra.rs
@@ -25,7 +25,6 @@ use super::{parse_claims, Claim};
 /// GREEN after fix: a same-string offset / `s.get(idx..)` never slices on a
 /// non-boundary; the call returns a `ScopeFollowsDispatchSpec` claim.
 #[test]
-#[ignore = "claim_verifier-non-ascii-slice: red until fix; remove #[ignore] after fix to confirm"]
 fn extract_task_id_non_ascii_prefix_does_not_panic_panic_io_extra() {
     let claim_text = "\u{130} scope follows dispatch spec\u{4e2d}t-1";
 


### PR DESCRIPTION
## CR-2026-06-14 **C1** — `claim_verifier::extract_task_id` non-ASCII slice panic 🔴

`extract_task_id` computed the scope-marker byte offset from `s.to_lowercase()` but sliced the **original** `s` (`s[idx..]`). `to_lowercase()` is **not** byte-length-preserving (İ→i̇ 2→3 bytes, ß→ss), so for agent/operator-supplied **non-ASCII** claim text `idx` lands on a non-char-boundary of `s` → **slice panic**. Reachable from the public `parse_claims` entry via the `verify_push` flow.

### Fix
Compute the marker offset on `s` itself. The marker is ASCII, so find it **case-insensitively over `s`'s own char boundaries** via `.get()` (an `Option` — never panics) instead of reusing the lowercased copy's offset:

```rust
let idx = s.char_indices().find_map(|(i, _)| {
    let end = i + marker.len();
    s.get(i..end).filter(|sub| sub.eq_ignore_ascii_case(marker)).map(|_| end)
})?;
let rest = s[idx..].trim();  // idx is a valid boundary (get succeeded)
```

For ASCII claim text the offset is identical to the old path → **extraction byte-identical** (existing `scope_spec_*` tests unchanged); non-ASCII text no longer panics.

### Verification (RED→GREEN)
- **closes CR-2026-06-14 C1; un-ignores** `extract_task_id_non_ascii_prefix_does_not_panic_panic_io_extra` (#2135 repro: `İ scope follows dispatch spec中t-1`).
- RED→GREEN proven: with the fix stashed, the un-ignored test **panics at `claim_verifier.rs:119`** (the `s[idx..]` slice); with the fix, **40/40** claim_verifier tests pass.
- Scope: **only** `claim_verifier.rs` (fix) + the C1 repro file (`-1` `#[ignore]`). The `verify_claim_cost` repro tests stay `#[ignore]` (untouched).
- `clippy --all-targets --features tray -- -D warnings` clean; Windows `x86_64-pc-windows-msvc` clean. Rebased onto main @ `9eb439a`.

### Reviewer focus (dual review — crash fix)
The offset is now computed on `s` (not the lowercased copy); `.get()` makes the marker search panic-proof on char boundaries; ASCII extraction is byte-identical.

---
*fixup-dev-2* · claude/opus-4.8