### PR TITLE
fix(CR-2026-06-14 H1): char-aware parse_unlock_at — no panic on non-ASCII pane content

### DIFF
--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -228,11 +228,25 @@ fn parse_unlock_at(pane_text: &str) -> Option<String> {
     for line in pane_text.lines().rev() {
         let lower = line.to_lowercase();
         if lower.contains("reset") || lower.contains("try again") || lower.contains("limit") {
-            // Extract time-like pattern HH:MM
+            // Extract time-like pattern HH:MM. `idx` and the slice must come
+            // from the SAME string: `to_lowercase()` is not byte-length-
+            // preserving (U+212A Kelvin 'K' is 3 bytes, lowercases to ASCII 'k'),
+            // so an offset found in `lower` can land mid-multibyte-char in `line`
+            // and panic. Slice `lower`, and match the HH:MM shape char-by-char
+            // (\d{2}:\d{2}) instead of fixed byte indexing, since `pane_text` is
+            // content-controlled PTY output that may contain multibyte chars.
             if let Some(idx) = lower.find(|c: char| c.is_ascii_digit()) {
-                let rest = &line[idx..];
-                if rest.len() >= 5 && rest.as_bytes()[2] == b':' {
-                    return Some(rest[..5].to_string());
+                let mut chars = lower[idx..].chars();
+                let hhmm: Option<Vec<char>> = (0..5).map(|_| chars.next()).collect();
+                if let Some(hhmm) = hhmm {
+                    if hhmm[0].is_ascii_digit()
+                        && hhmm[1].is_ascii_digit()
+                        && hhmm[2] == ':'
+                        && hhmm[3].is_ascii_digit()
+                        && hhmm[4].is_ascii_digit()
+                    {
+                        return Some(hhmm.into_iter().collect());
+                    }
                 }
             }
         }

--- a/src/daemon/supervisor/review_repro_daemon_supervisor.rs
+++ b/src/daemon/supervisor/review_repro_daemon_supervisor.rs
@@ -27,7 +27,6 @@
 //! simply: never panic on content-controlled bytes).
 
 #[test]
-#[ignore = "daemon-supervisor parse_unlock_at-nonascii-panic: red until fix; remove #[ignore] after fix to confirm"]
 fn parse_unlock_at_does_not_panic_on_nonascii_pane_content_daemon_supervisor() {
     // Silence the default panic hook so the (expected, caught) panics don't
     // spam the test output; restore it after.
@@ -64,7 +63,6 @@ fn parse_unlock_at_does_not_panic_on_nonascii_pane_content_daemon_supervisor() {
 }
 
 #[test]
-#[ignore = "daemon-supervisor parse_unlock_at-nonascii-panic: red until fix; remove #[ignore] after fix to confirm"]
 fn parse_unlock_at_still_extracts_ascii_time_after_fix_daemon_supervisor() {
     // Correct-behavior baselines that ANY valid fix must preserve. These pass
     // today AND after the fix; paired with the panic-vector test above so a fix


### PR DESCRIPTION
## CR-2026-06-14 — H1 (High): `supervisor.rs` `parse_unlock_at` cross-string / non-boundary byte-slice panic

### Problem
`parse_unlock_at` (`src/daemon/supervisor.rs:226`) finds the first ASCII-digit **byte offset in the lowercased COPY** (`lower`) but then slices the **ORIGINAL** `line` (`&line[idx..]`). `str::to_lowercase()` is **not** byte-length-preserving — U+212A (Kelvin sign 'K', 3 bytes) lowercases to ASCII 'k' (1 byte) — so the offset can land **mid-multibyte-char** in `line` and panic *"byte index N is not a char boundary"*. Separately, `rest[..5]` slices at a fixed byte index 5 that can straddle a multibyte char.

`pane_text` is raw, fully content-controlled PTY output (the supervisor passes `core.vterm.tail_lines(10)`). The per-tick `catch_unwind` swallows the panic but **aborts the ENTIRE supervision tick** (every agent's reaction/recovery/pane-input scan) on every cycle the offending content is displayed.

### Fix
Slice `lower` (the **same** string the offset came from) and match the HH:MM shape **char-by-char** (`\d{2}:\d{2}`) instead of fixed byte indexing — per the review's recommendation:

```rust
if let Some(idx) = lower.find(|c: char| c.is_ascii_digit()) {
    let mut chars = lower[idx..].chars();
    let hhmm: Option<Vec<char>> = (0..5).map(|_| chars.next()).collect();
    if let Some(hhmm) = hhmm {
        if hhmm[0].is_ascii_digit() && hhmm[1].is_ascii_digit()
            && hhmm[2] == ':' && hhmm[3].is_ascii_digit() && hhmm[4].is_ascii_digit()
        {
            return Some(hhmm.into_iter().collect());
        }
    }
}
```

Plain-ASCII usage-limit lines extract identically (`"…Resets at 15:14 UTC"` → `Some("15:14")`); non-ASCII content no longer panics.

### Verification (RED→GREEN)
- **closes CR-2026-06-14 H1; un-ignores** `parse_unlock_at_does_not_panic_on_nonascii_pane_content_daemon_supervisor` (+ the paired baseline `parse_unlock_at_still_extracts_ascii_time_after_fix_daemon_supervisor`).
- RED proven: with `#[ignore]` removed and the fix absent, the panic-vector test **panics** on `"limit \u{212A}\u{e9} 5:14"` (U+212A lowercases 3→1 byte). GREEN after fix: **3/3** `parse_unlock_at` tests pass (2 repro + the existing `parse_unlock_at_extracts_time`).
- Scope: **only** `supervisor.rs` (fix) + the H1 repro file (`-2` `#[ignore]`). No other `#[ignore]` touched.
- `cargo fmt --check` clean; `clippy --all-targets --features tray -- -D warnings` clean. Branch off `origin/main` @ `9eb439a`.

### Reviewer focus (dual review — crash/panic fix)
The offset is now computed and sliced on the **same** string (`lower`); the HH:MM extraction is char-aware (no fixed byte index); ASCII extraction is behavior-preserving.

---
*fixup-dev-2* · claude/opus-4.8