### PR TITLE
fix(CR-2026-06-14 H2): flock the same-sender cancel in record_pending_decision

### DIFF
--- a/src/daemon/decision_timeout.rs
+++ b/src/daemon/decision_timeout.rs
@@ -118,7 +118,21 @@ pub(crate) fn record_pending_decision(
     // ones to timeout-fire unexpectedly.
     for d in list_pending(home) {
         if d.sender == sender && d.status == "pending" {
+            // #1116/H2: delete the prior sidecar UNDER its per-decision flock,
+            // so this cancel is mutually exclusive with `scan_and_emit`'s
+            // read→flip→write window. A bare `remove_file` can land mid-RMW:
+            // scan reads the sidecar, this cancel removes it, then scan's
+            // `write_decision` re-creates it as `status="timeout"` — the
+            // just-cancelled sidecar is RESURRECTED and lingers forever, and a
+            // timeout event fires for a decision the operator was superseding.
+            // Mirrors the same `acquire_file_lock(&decision_lock_path(..))` that
+            // `mark_resolved_for_sender` and `scan_and_emit` already hold.
+            let lock_path = decision_lock_path(home, &d.decision_id);
+            let guard = crate::store::acquire_file_lock(&lock_path).ok();
             let _ = std::fs::remove_file(pending_path(home, &d.decision_id));
+            // Release the OS lock BEFORE removing the lock file itself.
+            drop(guard);
+            let _ = std::fs::remove_file(&lock_path);
         }
     }
     let decision_id = next_decision_id();

--- a/tests/decision_timeout_cancel_locked_daemon_dispatch_idle.rs
+++ b/tests/decision_timeout_cancel_locked_daemon_dispatch_idle.rs
@@ -55,7 +55,6 @@ fn fn_body<'a>(src: &'a str, fn_anchor: &str) -> &'a str {
 }
 
 #[test]
-#[ignore = "daemon-dispatch-idle #1092-cancel-unlocked: red until fix; remove #[ignore] after fix to confirm"]
 fn record_pending_decision_cancel_is_flocked_daemon_dispatch_idle() {
     let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("src")


### PR DESCRIPTION
## CR-2026-06-14 — H2 (High): `decision_timeout.rs` unlocked `remove_file` cancels a pending decision → resurrection / lost-fire race

### Problem
`record_pending_decision` (`src/daemon/decision_timeout.rs:119-123`) cancels a prior same-sender pending decision with a **bare** `std::fs::remove_file`, **not** taken under the `{decision_id}.lock` that `scan_and_emit` (the supervisor-tick thread) and `mark_resolved_for_sender` both hold across their read→modify→write (#1116).

That unlocked delete can land inside `scan_and_emit`'s read→flip→write window:
1. scan reads the sidecar (`status="pending"`),
2. `record_pending_decision` `remove_file`s it (the cancel),
3. scan's `write_decision` (`atomic_write`) re-creates it as `status="timeout"`.

→ the just-cancelled sidecar is **resurrected** and lingers forever, **and** a `decision_timeout` event fires for the very decision the operator was superseding.

### Fix
Acquire the per-decision flock (`acquire_file_lock` on `decision_lock_path`) before removing the sidecar — the same lock `mark_resolved_for_sender` / `scan_and_emit` hold — then release the OS lock and remove the lock file (mirroring `dispatch_idle::delete_sidecar_locked`). The cancel is now mutually exclusive with the scan RMW window, so no resurrection / no lost-fire.

```rust
for d in list_pending(home) {
    if d.sender == sender && d.status == "pending" {
        let lock_path = decision_lock_path(home, &d.decision_id);
        let guard = crate::store::acquire_file_lock(&lock_path).ok();
        let _ = std::fs::remove_file(pending_path(home, &d.decision_id));
        drop(guard);                              // release OS lock first
        let _ = std::fs::remove_file(&lock_path);
    }
}
```

> Note: the lock acquisition is **inlined** (not extracted to a shared helper) because the H2 static-invariant repro pins `acquire_file_lock` to `record_pending_decision`'s own function body.

### Verification (RED→GREEN)
- **closes CR-2026-06-14 H2; un-ignores** `record_pending_decision_cancel_is_flocked_daemon_dispatch_idle` (`tests/decision_timeout_cancel_locked_daemon_dispatch_idle.rs`, static-invariant / source-scan).
- RED proven: with `#[ignore]` removed and the fix absent, the repro asserts the cancel is unlocked and **fails** (`record_pending_decision … UNLOCKED remove_file`). GREEN after fix: repro passes; **22/22** existing `decision_timeout` unit tests (incl. #1092 cancel + #1116 `t1116_race_resolve_vs_scan_must_not_both_succeed`) still pass.
- Scope: **only** `decision_timeout.rs` (fix) + the H2 repro file (`-1` `#[ignore]`). **H3** (the `let _ = write_decision` swallow at `scan_and_emit`) is intentionally **left untouched** — separate finding/class, its repro (`timeout_emit_gated_on_successful_persist_panic_io_extra`) stays `#[ignore]`.
- `cargo fmt --check` clean; `clippy --all-targets --features tray -- -D warnings` clean. Branch off `origin/main` @ `9eb439a`.

### Reviewer focus (dual review — concurrency / locking)
The cancel now holds the same `{decision_id}.lock` as the scan RMW and `mark_resolved`; OS lock is dropped before the lock file is removed (no self-deadlock, mirrors `delete_sidecar_locked`). No change to the happy path (single-pending-per-sender semantics preserved).

---
*fixup-dev-2* · claude/opus-4.8