### PR TITLE
fix(CR-2026-06-14 H7): validate team name at the MCP boundary (path traversal)

### DIFF
--- a/src/mcp/handlers/instance_state/mod.rs
+++ b/src/mcp/handlers/instance_state/mod.rs
@@ -14,6 +14,12 @@ pub(super) fn handle_create_instance(home: &Path, args: &Value, instance_name: &
             .and_then(|v| v.as_str())
             .filter(|s| !s.is_empty()),
     ) {
+        // H7 (high/security): validate the team name at the MCP boundary. It
+        // becomes member names (`<team>-N`) + `workspace_dir(home).join(name)`
+        // downstream; `PathBuf::join` keeps `..`, so an unvalidated traversal
+        // name like "../../tmp/evil" escapes the workspace root. Reject here,
+        // exactly as the single-instance path does.
+        crate::validate_name_or_err!(team_name);
         if args.get("count").and_then(|v| v.as_u64()).unwrap_or(1) > 1
             || args.get("backends").is_some()
         {
@@ -41,6 +47,13 @@ pub(super) fn handle_create_instance(home: &Path, args: &Value, instance_name: &
     }
     // Team mode: spawn count instances and group them
     if let Some(team_name) = args.get("team").and_then(|v| v.as_str()) {
+        // H7 (high/security): validate the team name BEFORE the CREATE_TEAM RPC.
+        // `create_team` derives member names `<team>-N` and `workspace_dir(home)
+        // .join(name)`; `PathBuf::join` preserves `..`, so an unvalidated name
+        // like "../../tmp/evil" creates + registers fleet entries outside the
+        // workspace root. The single-instance path already validates; this
+        // forwarded the raw name straight to the daemon.
+        crate::validate_name_or_err!(team_name);
         let default_backend = args["backend"]
             .as_str()
             .or_else(|| args["command"].as_str())

--- a/src/mcp/handlers/review_repro_mcp_core_surface.rs
+++ b/src/mcp/handlers/review_repro_mcp_core_surface.rs
@@ -98,7 +98,6 @@ fn create_instance_branch_main_rejected_e4_5_mcp_core_surface() {
 /// After the fix, `validate_name_or_err!(team_name)` rejects it at the MCP
 /// boundary with a "... invalid characters ..." error BEFORE the RPC.
 #[test]
-#[ignore = "mcp-core-surface F2: red until create_instance validates the team name; remove #[ignore] after fix to confirm"]
 fn create_instance_team_name_traversal_rejected_mcp_core_surface() {
     let home = tmp_home("f2-team-traversal");
 


### PR DESCRIPTION
## CR-2026-06-14 — H7 (High / security): unvalidated team name → member names + workspace dir → path traversal out of `workspace/`

### Problem
`handle_create_instance` (`src/mcp/handlers/instance_state/mod.rs`) has two team branches — the `name`+`team` join (line 11) and team-mode spawn (line 43) — and **both forward `args["team"]` without `validate_name`**, unlike the single-instance path. Downstream, `create_team` derives member names via `format!("{team}-{n}")` and builds dirs with `workspace_dir(home).join(&inst_name)`. `PathBuf::join` **preserves `..`**, so a traversal team name like `"../../tmp/evil"` creates and registers fleet entries **outside the workspace root**.

### Fix
Add `crate::validate_name_or_err!(team_name)` at the **top of both team branches**, rejecting any name with characters outside `[a-z0-9-_]` (or empty / >64 chars) at the MCP boundary **before** the `CREATE_TEAM` RPC / `teams::update` — exactly the gate the single-instance path already applies. `validate_name` returns an *"… contains invalid characters …"* error, so the traversal name is refused with a clear message instead of reaching the daemon.

### Verification (RED→GREEN)
- **closes CR-2026-06-14 H7; un-ignores** `create_instance_team_name_traversal_rejected_mcp_core_surface` (`src/mcp/handlers/review_repro_mcp_core_surface.rs`, behavioral-unit).
- RED proven: with `#[ignore]` removed and the fix absent, `{"team":"../../tmp/evil","count":1}` reaches the RPC → `"API unavailable: no active daemon"` (the bad name flowed past the boundary) → assertion `err.contains("invalid")` fails. GREEN after fix: rejected at the boundary with an "invalid characters" error.
- Valid team names still spawn: **13/13** `create_instance` unit tests pass (incl. the #2037 name+team conflict path).
- Scope: **only** `instance_state/mod.rs` (fix, both branches) + the H7 repro file (`-1` `#[ignore]`). Sibling findings F1 (E4.5 branch=main → H6) and F3 (count cap) in the same repro file stay `#[ignore]`d / untouched.
- `cargo fmt --check` clean; `clippy --all-targets --features tray -- -D warnings` clean. Branch off `origin/main` @ `9eb439a`.

### Reviewer focus (dual review — security)
Both team entry points now validate before any side effect; the gate is the shared `validate_name` (same allowlist the rest of the MCP surface uses), so it's consistent and can't be bypassed via the join-path branch.

---
*fixup-dev-2* · claude/opus-4.8