### PR TITLE
fix(CR-2026-06-14 H8): drive Telegram notify synchronously, not onto an undriven runtime

### DIFF
--- a/src/channel/telegram/notify.rs
+++ b/src/channel/telegram/notify.rs
@@ -15,15 +15,23 @@ pub fn notify_telegram_silent(home: &std::path::Path, instance_name: &str, text:
     let _ = notify_telegram_inner(home, instance_name, text, true);
 }
 
-/// Returns the spawned send's `JoinHandle` (or `None` when nothing was sent:
-/// no telegram channel / dedup-suppressed). The public wrappers discard it;
-/// tests drive it to deterministically observe the send outcome.
+/// Drives the Telegram send to completion synchronously, returning `Some(())`
+/// when a send was attempted or `None` when nothing was sent (no telegram
+/// channel / dedup-suppressed).
+///
+/// H8 (channel-HIGH-1): this MUST drive the send rather than schedule it with
+/// `telegram_runtime().spawn(...)` and drop the `JoinHandle`. `telegram_runtime()`
+/// is a `new_current_thread` runtime with no persistent driver thread, so a
+/// spawned task makes no progress unless some later sync-context `block_on`
+/// happens to cooperatively poll it — otherwise the notification is queued
+/// forever while the dedup claim suppresses a re-emit for the whole TTL. We use
+/// the Handle-guarded `block_on_value` (#1476), mirroring `reply.rs::send_reply`.
 fn notify_telegram_inner(
     home: &std::path::Path,
     instance_name: &str,
     text: &str,
     disable_notification: bool,
-) -> Option<tokio::task::JoinHandle<()>> {
+) -> Option<()> {
     let config = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home)).ok()?;
     let (token, group_id, topic_id) = match &config.channel {
         Some(crate::fleet::ChannelConfig::Telegram {
@@ -60,8 +68,11 @@ fn notify_telegram_inner(
     let text = text.to_string();
     let home_owned = home.to_path_buf();
     let instance_owned = instance_name.to_string();
-    // fire-and-forget: losing one notification on shutdown is acceptable.
-    Some(telegram_runtime().spawn(async move {
+    // H8: drive the send to completion on the Telegram runtime via the
+    // Handle-guarded `block_on_value` (#1476) — never fire-and-forget onto the
+    // undriven current_thread runtime (see fn doc). Blocks the caller for one
+    // send, exactly as `reply.rs::send_reply` does.
+    block_on_value(async move {
         use teloxide::payloads::SendMessageSetters;
         use teloxide::prelude::Requester;
         let bot = teloxide::Bot::new(&token);
@@ -139,7 +150,8 @@ fn notify_telegram_inner(
             crate::channel::dedup::global(&home_owned).evict(&dedup_key);
             tracing::warn!(error = %e, "telegram notify failed");
         }
-    }))
+    });
+    Some(())
 }
 
 #[cfg(test)]
@@ -203,11 +215,11 @@ mod tests {
         std::env::set_var("NOTIFY_MED1_TOKEN", "fake");
 
         // First notify: records the dedup claim, then the (forced-failing) send.
+        // H8: `notify_telegram_inner` now drives the send synchronously
+        // (block_on_value), so by the time it returns the failed send has already
+        // evicted the claim — no JoinHandle to drive.
         set_forced_send_error(anyhow::anyhow!("transient network error"));
-        let h1 = notify_telegram_inner(&home, "C", "hello operator", false).expect("send spawned");
-        // Drive the spawned send (+ evict) to completion via the Handle-guarded
-        // helper (#1476: never a raw `telegram_runtime().block_on`).
-        let _ = block_on_value(h1);
+        notify_telegram_inner(&home, "C", "hello operator", false).expect("send driven");
 
         // The failed send must have rolled back the claim: record_and_check is
         // fresh again (would be `false`/suppressed without the evict).

--- a/tests/notify_undriven_runtime_invariant_channel.rs
+++ b/tests/notify_undriven_runtime_invariant_channel.rs
@@ -33,7 +33,6 @@
 use std::path::PathBuf;
 
 #[test]
-#[ignore = "channel-HIGH-1: red until fix; remove #[ignore] after fix to confirm"]
 fn notify_does_not_fire_and_forget_onto_undriven_runtime_channel() {
     let notify = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/channel/telegram/notify.rs");
     let content = std::fs::read_to_string(&notify)


### PR DESCRIPTION
## CR-2026-06-14 — H8 (High): Telegram notify dispatched onto an **undriven** current_thread runtime → notification may never be sent

### Problem
`notify_telegram_inner` (`src/channel/telegram/notify.rs:64`) scheduled the actual send with `telegram_runtime().spawn(...)`, and the public wrappers (`notify_telegram` / `notify_telegram_silent`) discard the returned `JoinHandle` (`let _ = …`).

`telegram_runtime()` is a `new_current_thread` runtime. A current_thread runtime makes **no progress** on `spawn`ed tasks unless some thread is actively inside `Runtime::block_on()` on that **same** runtime — and there is **no persistent driver thread** for `telegram_runtime()` (the Telegram polling thread builds its own runtime). So a daemon stall / recovery / crash / CI notification reached synchronously from the supervisor is delivered only **opportunistically** — IF some later sync-context `block_on` happens to cooperatively poll the queued task. Otherwise the message is queued and **never sent**, while the #969 dedup claim stays recorded and **suppresses a re-emit for the whole TTL**.

> The existing MED-1 test only passed because it explicitly drove the handle with `block_on_value(h1)` — itself proof that production has no driver.

### Fix
Drive the send to completion **synchronously** via the Handle-guarded `block_on_value` (#1476 — safe even when already inside a runtime: it runs on a scoped thread with a fresh runtime), mirroring `reply.rs::send_reply`. The `telegram_runtime().spawn(` fire-and-forget call is gone; the function returns `Option<()>` (`Some` = send attempted, `None` = no channel / dedup-suppressed).

```rust
// H8: drive the send on the Telegram runtime via the Handle-guarded
// block_on_value (#1476) — never fire-and-forget onto the undriven runtime.
block_on_value(async move { /* …same send + #969 retry + MED-1 evict… */ });
Some(())
```

The MED-1 test is updated to the synchronous shape — the failed send evicts the dedup claim **before** `notify_telegram_inner` returns, so there is no `JoinHandle` to drive.

### Verification (RED→GREEN)
- **closes CR-2026-06-14 H8; un-ignores** `notify_does_not_fire_and_forget_onto_undriven_runtime_channel` (`tests/notify_undriven_runtime_invariant_channel.rs`, static-invariant).
- The repro is **not comment-satisfiable**: it strips `//` / `*` lines before scanning, and asserts no non-comment line contains `telegram_runtime().spawn(`. RED proven (the `spawn` at notify.rs:64). GREEN after fix (the only remaining occurrence is a `///` doc line, which the scan skips).
- `notify_failed_send_evicts_dedup_med1` still passes → the synchronous drive preserves the evict-on-failure behavior.
- Scope: **only** `notify.rs` (fix + its own MED-1 test) + the H8 repro file (`-1` `#[ignore]`).
- `cargo fmt --check` clean; `clippy --all-targets --features tray -- -D warnings` clean. Branch off `origin/main` @ `9eb439a` (incl. merged #2148/#2149).

### Reviewer focus (dual review — concurrency / async bridge)
`block_on_value` is the #1476-sanctioned bridge (guards `Handle::try_current()`, scoped-thread + fresh runtime when nested — never a raw shared-runtime `block_on`). The send now blocks the caller for one round-trip, exactly as `reply.rs::send_reply` already does from the same sync contexts — the deliberate trade vs. a guaranteed-undelivered fire-and-forget.

---
*fixup-dev-2* · claude/opus-4.8