### PR TITLE
fix(H4 CR-2026-06-14): ci unwatch uses validated caller, not daemon-env fallback

### DIFF
--- a/src/daemon/pr_state/auto_arm.rs
+++ b/src/daemon/pr_state/auto_arm.rs
@@ -253,6 +253,7 @@ mod tests {
         crate::mcp::handlers::ci::handle_unwatch_ci(
             &home,
             &serde_json::json!({"repository": REPO, "branch": "feat/x", "instance": "dev-x"}),
+            "dev-x",
         );
         assert!(
             watch_exists(&home, "feat/x"),

--- a/src/mcp/handlers/ci/mod.rs
+++ b/src/mcp/handlers/ci/mod.rs
@@ -814,20 +814,21 @@ pub(crate) fn compute_next_poll_eta(watch: &Value) -> Option<i64> {
 /// (no other agent is still interested in this branch).
 // pub(crate): the #1991 auto-arm tombstone regression test (pr_state::auto_arm)
 // exercises the real unwatch → tombstone → no-re-arm chain.
-pub(crate) fn handle_unwatch_ci(home: &Path, args: &Value) -> Value {
+pub(crate) fn handle_unwatch_ci(home: &Path, args: &Value, instance_name: &str) -> Value {
     let repo = match args["repository"].as_str() {
         Some(r) => r,
         None => return json!({"error": "missing 'repository'"}),
     };
     let branch = args["branch"].as_str().unwrap_or("main");
-    // Caller identity for selective removal. Falls back to the env-set
-    // identity (the standard sender resolution path) when MCP `instance`
-    // arg is omitted.
+    // Caller identity for selective removal (H4, CR-2026-06-14): the VALIDATED
+    // sender when `instance` arg is absent/empty (`.filter`, mirroring the
+    // sibling cleanup handlers) — NOT a daemon `std::env::var` read (was EMPTY in
+    // the daemon → the empty-caller `subscribers.clear()` path below).
     let caller = args["instance"]
         .as_str()
         .map(String::from)
-        .or_else(|| std::env::var("AGEND_INSTANCE_NAME").ok())
-        .unwrap_or_default();
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| instance_name.to_string());
     let filename = crate::daemon::ci_watch::watch_filename(repo, branch);
     let path = crate::daemon::ci_watch::ci_watches_dir(home).join(&filename);
 

--- a/src/mcp/handlers/ci/review_repro_mcp_ci_worktree.rs
+++ b/src/mcp/handlers/ci/review_repro_mcp_ci_worktree.rs
@@ -52,7 +52,6 @@ fn read_watch(path: &Path) -> serde_json::Value {
 // `#[serial]`). RED now: the empty-caller fallback wipes `dev` too.
 // ===========================================================================
 #[test]
-#[ignore = "mcp-ci-worktree-1: ci-unwatch-clears-all-on-empty-caller; red until fix; remove #[ignore] after fix to confirm"]
 #[serial_test::serial]
 fn unwatch_uses_validated_caller_not_clear_all_mcp_ci_worktree() {
     // The bug surfaces only when no `instance` arg is given AND the daemon's

--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -268,7 +268,7 @@ fn ci_unwatch_removes_caller_only_when_others_remain() {
         "branch": "feat-test",
         "instance": "lead",
     });
-    let resp = handle_unwatch_ci(&home, &unwatch_args);
+    let resp = handle_unwatch_ci(&home, &unwatch_args, "lead");
 
     assert_eq!(
         resp["watching"].as_bool(),
@@ -313,7 +313,7 @@ fn ci_unwatch_last_subscriber_leaves_tombstone_not_delete() {
         "branch": "feat-test",
         "instance": "lead",
     });
-    let resp = handle_unwatch_ci(&home, &unwatch_args);
+    let resp = handle_unwatch_ci(&home, &unwatch_args, "lead");
 
     assert_eq!(resp["watching"].as_bool(), Some(false));
     assert!(
@@ -342,7 +342,7 @@ fn ci_unwatch_unknown_caller_is_noop_keeps_watch() {
         "branch": "feat-test",
         "instance": "stranger",
     });
-    handle_unwatch_ci(&home, &unwatch_args);
+    handle_unwatch_ci(&home, &unwatch_args, "stranger");
 
     assert!(
         path.exists(),
@@ -356,6 +356,41 @@ fn ci_unwatch_unknown_caller_is_noop_keeps_watch() {
         .map(|s| s["instance"].as_str().unwrap())
         .collect();
     assert_eq!(subs, vec!["lead"]);
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn ci_unwatch_explicit_empty_instance_keeps_other_subscribers() {
+    // H4 hardening (CR-2026-06-14): an agent-supplied EXPLICIT empty
+    // `instance:""` arg must not reach the empty-caller `subscribers.clear()`
+    // branch (same blast radius as the original H4 bug). The
+    // `.filter(|s| !s.is_empty())` drops the empty arg so resolution falls
+    // through to the validated caller (instance_name) — removing only the
+    // caller. Without the filter, caller="" wipes every other subscriber.
+    let home = std::env::temp_dir().join(format!("agend-unwatch-empty-arg-{}", std::process::id()));
+    std::fs::create_dir_all(&home).ok();
+    let args = serde_json::json!({"repository": "owner/repo", "branch": "feat-test"});
+    handle_watch_ci(&home, &args, "lead");
+    handle_watch_ci(&home, &args, "dev");
+
+    let path = watch_path_for(&home, "owner/repo", "feat-test");
+    // lead unwatches with an EXPLICIT empty instance arg; validated caller = "lead".
+    let unwatch_args = serde_json::json!({
+        "repository": "owner/repo",
+        "branch": "feat-test",
+        "instance": "",
+    });
+    handle_unwatch_ci(&home, &unwatch_args, "lead");
+
+    let subs = crate::daemon::ci_watch::parse_subscribers(&read_watch(&path));
+    assert!(
+        subs.iter().any(|s| s == "dev"),
+        "dev must remain subscribed; an empty instance arg must not clear-all. got {subs:?}"
+    );
+    assert!(
+        !subs.iter().any(|s| s == "lead"),
+        "lead (the validated caller) should be removed. got {subs:?}"
+    );
     std::fs::remove_dir_all(&home).ok();
 }
 
@@ -2426,6 +2461,7 @@ fn unwatch_to_empty_leaves_tombstone_1991() {
     let resp = super::handle_unwatch_ci(
         &home,
         &serde_json::json!({"repository": "o/r", "branch": "feat/x", "instance": "dev-1"}),
+        "dev-1",
     );
     assert_eq!(resp["watching"], false);
     assert_eq!(resp["tombstone"], true);
@@ -2456,6 +2492,7 @@ fn rewatch_clears_tombstone_optout_1991() {
     super::handle_unwatch_ci(
         &home,
         &serde_json::json!({"repository": "o/r", "branch": "feat/x", "instance": "dev-1"}),
+        "dev-1",
     );
     // Explicit re-watch: the human decision overrides the optout.
     super::handle_watch_ci(

--- a/src/mcp/handlers/dispatch.rs
+++ b/src/mcp/handlers/dispatch.rs
@@ -282,7 +282,7 @@ adapter!(dispatch_task, hai, task::handle_task);
 
 action_adapter!(dispatch_ci, "ci", [
     "watch"   => ci::handle_watch_ci,   hai;
-    "unwatch" => ci::handle_unwatch_ci, ha;
+    "unwatch" => ci::handle_unwatch_ci, hai;
     "status"  => ci::handle_status_ci,  hai;
 ]);
 


### PR DESCRIPTION
## H4 — `ci unwatch` unsubscribes ALL agents via daemon-env fallback

`docs/CODE-REVIEW-2026-06-14.md` H4: `handle_unwatch_ci` (`src/mcp/handlers/ci/mod.rs`) resolved the caller via `std::env::var("AGEND_INSTANCE_NAME")`. That handler runs **in the daemon process**, whose env lacks the calling agent's name → `caller` resolved EMPTY → the empty-caller `subscribers.clear()` branch unsubscribed **every** agent on that branch's CI watch (contradicting Sprint 54 P0-1 "only the caller is removed"). `handle_watch_ci` already used the validated dispatch identity (`hai`); `unwatch` was the asymmetric gap.

## Fix (as prescribed by the review)
- `handle_unwatch_ci` now takes `instance_name` — dispatch table `ha → hai` (`dispatch.rs:285`), so the validated `ctx.instance_name` flows in.
- `caller = explicit args["instance"]` (operator override, preserved) **else** the validated `instance_name`. The `std::env::var` fallback is **deleted**.

## Hardening (surfaced by an adversarial review of this change)
An authenticated agent passing an **explicit empty** `instance:""` would still resolve `caller=""` and hit `clear()` (same blast radius). Added `.filter(|s| !s.is_empty())` so an empty arg falls through to the validated identity — **mirroring the two sibling cleanup handlers in this same file** (`handle_cleanup_init_commits` mod.rs:414-417, `handle_cleanup_merged_branches` mod.rs:1063-1066). After this, `caller` is empty **only** for a genuinely unauthenticated/operator call (no sender) → the legacy clear-all cleanup. This completes H4's "never clear-all from an agent" property (the absent-arg path alone left it half-closed).

## Tests
- `unwatch_uses_validated_caller_not_clear_all_mcp_ci_worktree` (#2135 repro) **un-ignored** — was RED, now GREEN. **Non-vacuous verified**: re-introducing the env-fallback → FAIL (`subscribers after = []`).
- New `ci_unwatch_explicit_empty_instance_keeps_other_subscribers` pins the hardening — **RED without the `.filter`** (verified), GREEN with.
- Findings 4 & 5 in the repro file stay `#[ignore]`d (out of scope).
- Existing `ci_unwatch_*` / `1991` tombstone / `auto_arm` tests unchanged & green.

## Verification
- `cargo fmt --check` ✓ · `cargo clippy --features tray --all-targets -- -D warnings` ✓
- `cargo test --features tray --test file_size_invariant` ✓ (`ci/mod.rs` = 1435, at the 1435 ceiling)
- ci + dispatch handler unit tests: **148 passed, 0 failed**
- All callers audited (only production caller is the MCP dispatch table; `auto_arm.rs` ref is a `#[test]`).

## Out of scope (pre-existing — separate follow-up tickets, NOT regressions of this diff)
1. Cross-agent griefing via explicit `instance:"B"` (agent A unwatches B). **Byte-identical** old-vs-new (`args["instance"]` always won); the `watch` side is safe (ignores the arg). Hardening idea: gate `args["instance"] != instance_name` to operator/None-sender.
2. The empty-caller branch's comment ("Operator-driven cleanup, e.g. via daemon CLI") names a caller that does not exist in-tree.

Diff: +49/−11, 5 files. `dual-review` (merge-adjacent / security-relevant).

Closes: H4 of `docs/CODE-REVIEW-2026-06-14.md`

---
*fixup-dev* · claude/opus-4.8