### PR TITLE
docs(protocol): add §9.1 Context-Full Self-Restart (agent self-help fresh-restart)

### DIFF
--- a/docs/FLEET-DEV-PROTOCOL.md
+++ b/docs/FLEET-DEV-PROTOCOL.md
@@ -534,6 +534,23 @@ Task state changes emit to Telegram. Instance lifecycle events (non-fleet.yaml o
 ### Supervisor Notify
 Daemon detects agent entering error state (UsageLimit/RateLimit/Hang/Crashed/AuthError/PermissionPrompt) → notifies orchestrator. 60s debounce per agent.
 
+### 9.1 Context-Full Self-Restart (Sprint 63, empirically validated 2026-06-15)
+
+When an agent (especially a lead/orchestrator) detects its own context approaching full (~80-85%; the pane footer shows `N% context used`), it restarts **itself** — the daemon performs the kill+respawn; no second agent is required to trigger it.
+
+- **`mode="fresh"`, never `resume`** — `resume` reloads the full prior context, giving zero relief. Only `restart_instance(instance=<self>, mode="fresh")` starts clean.
+- **Procedure**:
+  1. Land all live state on durable stores **before** restarting — update `SESSION-HANDOFF.md` to current (handoff entry point, in-flight PRs, merge procedure, member status, pending dispatches, decisions), post any open `decision`s, ensure work is on the `task` board. Nothing may depend on in-memory context.
+  2. **Self-schedule a kick** so the fresh instance auto-resumes (a fresh boot otherwise sits idle indefinitely — nothing starts it). Before restarting:
+     `schedule(action="create", instance=<self>, run_at=<now + ~90s, ISO 8601>, message="resume: read SESSION-HANDOFF.md + MEMORY.md and continue", label="self-restart-kick")`.
+     The schedule is daemon-side and keyed by instance name, so it survives the restart; the one-shot fires ~90s after respawn and wakes the fresh self to continue. (Delete it after resuming, or let the one-shot auto-complete.)
+  3. Pick a lull — never mid-merge or mid-step of an irreversible action.
+  4. Call `restart_instance(instance=<self>, mode="fresh", reason="context-full self-restart")`.
+  5. The daemon cleanly kills the process (`delete: child exited cleanly`) and respawns it fresh (Ctx 0.0%). On boot the SessionStart hook auto-loads `MEMORY.md`; the fresh self reads `SESSION-HANDOFF.md` and continues.
+- **The one caveat (and its mitigation)**: the self-restart call's response never returns (the caller's process is gone), so no external party confirms the fresh instance booted. Mitigation: handoff + `MEMORY.md` auto-load make the fresh self self-sufficient. A peer (e.g. `general`) is **optional** for a post-restart liveness confirm but is **no longer required to trigger** the restart — this supersedes the earlier "ask general to fresh-restart you" convention (delegation is now confirm-only, not the trigger path).
+
+**Empirical basis**: validated 2026-06-15 — an agent called `restart_instance(self, mode="fresh")`; daemon logs showed the tool call → `delete: child exited cleanly` → fresh respawn at Ctx 0.0% with no prior-context memory. A second agent is not part of the mechanism. Also validated 2026-06-15 — the fresh instance sat idle ~80s doing nothing, then the self-scheduled one-shot kick fired (`schedule_trigger`) and it resumed, with zero peer involvement.
+
 ## §10. Git Workflow
 
 - Never commit directly to main; always use worktree + branch


### PR DESCRIPTION
## Operator-requested: document the agent self-help fresh-restart flow

Adds a new **§9.1 Context-Full Self-Restart** subsection to `docs/FLEET-DEV-PROTOCOL.md`, between `### Supervisor Notify` and `## §10. Git Workflow`.

### What it documents
Empirically validated 2026-06-15: an agent (especially a lead/orchestrator) whose own context is approaching full restarts **itself** via `restart_instance(instance=<self>, mode="fresh")` — the daemon performs the clean kill+respawn (`delete: child exited cleanly` → fresh respawn at Ctx 0.0%). **No second agent is required to trigger it.**

Key points captured:
- `mode="fresh"`, never `resume` (resume reloads full prior context → zero relief).
- Procedure: land all live state on durable stores (`SESSION-HANDOFF.md`, `decision`s, `task` board) first → pick a lull → call the self-restart → fresh self auto-loads `MEMORY.md` and reads the handoff.
- The one caveat (the self-call's response never returns since the caller's process is gone) and its mitigation (handoff + `MEMORY.md` auto-load make the fresh self self-sufficient; a peer is **optional** for a liveness confirm, **no longer required to trigger**). This **supersedes** the earlier "ask general to fresh-restart you" convention — delegation is now confirm-only.

### Source-of-truth correctness (the key review point)
- Edited the **repo source** `docs/FLEET-DEV-PROTOCOL.md`, which is embedded at compile time via `src/protocol.rs` `include_str!("../docs/FLEET-DEV-PROTOCOL.md")` — **NOT** the live `$AGEND_HOME/protocol/.default/` extraction (which is regenerated from the binary on boot; editing it directly is lost on rebuild — the §3.21 failure mode).
- **Rebuild-verified**: `AGEND_GIT_BYPASS=1 cargo build --release` succeeded, and `strings target/release/agend-terminal | grep "Context-Full Self-Restart"` → found, proving the `include_str!` embedded the edit.

### Scope
- Docs-only — single change to `docs/FLEET-DEV-PROTOCOL.md` (one added subsection, no other lines touched). §3.6 single review.
- `cargo fmt --check` clean. Branch off `origin/main` @ `9eb439a`.

Reviewer focus: confirm the edit is in `docs/` source (not `.default/`), and that the wording matches the actual mechanism (`restart_instance(self, mode="fresh")`, daemon-driven, no second agent to trigger).

---
*fixup-dev-2* · claude/opus-4.8