### PR TITLE
fix(H6 CR-2026-06-14): create_instance enforces E4.5 protected-branch gate

### DIFF
--- a/src/mcp/handlers/instance_state/spawn.rs
+++ b/src/mcp/handlers/instance_state/spawn.rs
@@ -97,6 +97,14 @@ pub(in crate::mcp::handlers) fn spawn_single_instance_impl(
         if !validate_branch(branch) {
             return json!({"error": format!("invalid branch name '{branch}'")});
         }
+        // H6 (CR-2026-06-14): validate_branch ALLOWS main/master, so the spawn
+        // path must also fire the E4.5 protected-branch gate — else
+        // create_instance(branch="main") checks a protected branch into an agent
+        // worktree, violating the system-wide "worktree never takes main"
+        // invariant (the same guard bind_self / worktree_pool::lease enforce).
+        if let Err(e) = crate::agent_ops::ensure_not_protected_json(branch) {
+            return e;
+        }
         let wd = std::path::PathBuf::from(&work_dir);
         // Sprint 57 Wave 4 (#546 Item 4): worktree creation now takes
         // `home` so the canonical external layout

--- a/src/mcp/handlers/review_repro_mcp_core_surface.rs
+++ b/src/mcp/handlers/review_repro_mcp_core_surface.rs
@@ -57,7 +57,6 @@ fn error_str(v: &Value) -> String {
 /// "successfully" (returns `{"name":...,"backend":...}` with NO `error` key).
 /// After the fix it must return an `error` mentioning the protected branch.
 #[test]
-#[ignore = "mcp-core-surface F1: red until create_instance enforces E4.5 on branch=main; remove #[ignore] after fix to confirm"]
 fn create_instance_branch_main_rejected_e4_5_mcp_core_surface() {
     let home = tmp_home("f1-branch-main");
 


### PR DESCRIPTION
## H6 — `create_instance(branch="main")` bypasses the E4.5 protected-branch gate

`docs/CODE-REVIEW-2026-06-14.md` H6: `spawn_single_instance_impl` (`src/mcp/handlers/instance_state/spawn.rs`) called only `validate_branch` (which **permits** `main`/`master`), never `ensure_not_protected`. So `create_instance(branch="main")` created a worktree on a protected branch — violating the system-wide "an agent worktree never checks out main/master" invariant that `worktree_pool::lease` and `bind_self` already enforce.

## Fix (as prescribed by the review)
Add `ensure_not_protected_json(branch)` immediately after the `validate_branch` check, **before any side-effect** (`worktree::create`, `create_dir_all`, fleet.yaml add, SPAWN RPC). Returns the canonical `e4_5_protected_branch` error. Uses the JSON-returning variant (handler returns `serde_json::Value`), matching the sibling guard sites `ci` checkout/watch handlers (`ci/mod.rs:65,600`).

## Completeness (audited)
`spawn` was the **one** unguarded `worktree::create` caller with a user-controlled branch. The only other production caller, `worktree_pool::lease` (`worktree_pool.rs:43`), was already guarded (`:38`). `bind_self` and the `dispatch_hook` lease path route through `worktree_pool::lease`; the daemon-side `handle_spawn`/`handle_create_team` and `replace_instance`/`restart_instance` never create a branch-backed worktree. So every reachable protected-branch worktree path is now closed.

## Tests
- `create_instance_branch_main_rejected_e4_5_mcp_core_surface` (#2135 repro) **un-ignored** — was RED, now GREEN. **Non-vacuous verified**: removing the guard → handler returns a success response → test FAILs.
- Findings 3 & 4 in that repro file stay `#[ignore]`d (out of scope).

## Verification
- `cargo fmt --check` ✓ · `cargo clippy --features tray --all-targets -- -D warnings` ✓
- `AGEND_GIT_BYPASS=1 cargo nextest` over `mcp_core_surface` + `instance_964` + `instance_state` + `spawn`: **35 passed, 0 failed**
- `cargo test --features tray --test file_size_invariant` ✓ (spawn.rs 295 LOC, well under 750)
- No existing test/flow spawns with `branch="main"` expecting success (the only such call is the repro, now expecting rejection).

## Out of scope (pre-existing — separate findings, NOT this PR)
1. `dispatch_hook::ensure_branch_exists` validates `from_ref` but not the target `branch` — the review's **separate** Medium finding (`docs/CODE-REVIEW-2026-06-14.md:127`, argument-injection). For E4.5 it is backstopped by the downstream `lease` guard.
2. Case-insensitive-FS `"Main"` aliasing is an **intentional, unit-tested** property of `is_protected_ref` (`agent_ops.rs:733`). Any change there belongs in the canonical helper (propagates to all E4.5 sites), not the spawn caller.

Diff: +8/−1, 2 files. `dual-review` (security gate).

Closes: H6 of `docs/CODE-REVIEW-2026-06-14.md`

---
*fixup-dev* · claude/opus-4.8