### PR TITLE
fix(CR-2026-06-14 H13): bound dismiss PTY writes via write_with_timeout (drop raw writer lock)

### DIFF
--- a/src/agent/dismiss.rs
+++ b/src/agent/dismiss.rs
@@ -142,27 +142,28 @@ pub fn try_dismiss_dialog(
                     std::thread::sleep(std::time::Duration::from_millis(300));
                     // Send keys in chunks split on \r/\n boundaries with delay between,
                     // so TUI frameworks process navigation before confirmation.
-                    let mut w = writer.lock();
+                    // H13: route each chunk through `write_with_timeout` (bounded
+                    // worker + 5s deadline) rather than holding the raw shared
+                    // `writer.lock()` across an unbounded `write_all`. A hung agent
+                    // that has stopped draining its PTY input buffer — exactly the
+                    // state that triggers a dismiss — would otherwise pin the writer
+                    // lock forever, wedging every future inject to that agent until
+                    // daemon restart. `write_with_timeout` flushes internally.
                     let mut start = 0;
                     for (i, &b) in keys.iter().enumerate() {
                         if b == b'\r' || b == b'\n' {
                             // Send everything up to (not including) this Enter
                             if start < i {
-                                let _ = w.write_all(&keys[start..i]);
-                                let _ = w.flush();
-                                drop(w);
+                                let _ = write_with_timeout(&writer, &keys[start..i]);
                                 std::thread::sleep(std::time::Duration::from_millis(200));
-                                w = writer.lock();
                             }
                             // Send the Enter
-                            let _ = w.write_all(&keys[i..=i]);
-                            let _ = w.flush();
+                            let _ = write_with_timeout(&writer, &keys[i..=i]);
                             start = i + 1;
                         }
                     }
                     if start < keys.len() {
-                        let _ = w.write_all(&keys[start..]);
-                        let _ = w.flush();
+                        let _ = write_with_timeout(&writer, &keys[start..]);
                     }
                     tracing::debug!(agent = %agent, "dismiss keystrokes sent");
                     // H2: in-flight slot freed by `_guard` on scope exit.

--- a/tests/review_dismiss_writer_lock_agent_binding.rs
+++ b/tests/review_dismiss_writer_lock_agent_binding.rs
@@ -24,7 +24,6 @@
 use std::path::PathBuf;
 
 #[test]
-#[ignore = "dismiss-unbounded-write: red until fix; remove #[ignore] after fix to confirm"]
 fn dismiss_thread_has_no_raw_unbounded_writer_lock_agent_binding() {
     let file = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/agent/dismiss.rs");
     let text = std::fs::read_to_string(&file).expect("read src/agent/dismiss.rs");


### PR DESCRIPTION
## CR-2026-06-14 — H13 (High / concurrency): dismiss thread holds the raw PTY writer lock across an unbounded blocking write → can permanently wedge all injects to an agent

### Problem
The auto-dismiss thread (`src/agent/dismiss.rs:145-166`) acquired the shared `pty_writer` lock **directly** (`let mut w = writer.lock()`) and did raw `write_all` / `flush` with **no timeout** while holding it. Every **other** write path routes through `write_with_timeout`, which bounds the write on a spawned worker (5 s deadline) so a non-draining PTY can't pin the lock.

When a hung agent stops draining its PTY input buffer — **exactly the state that triggers a dialog-dismiss** — the dismiss thread's `write_all` blocks indefinitely while holding `pty_writer.lock()`. Other `write_with_timeout` callers then return `TimedOut` at 5 s, but their worker stays wedged on `writer.lock()`; stuck threads accumulate **unbounded**, and the agent receives **no further injects until daemon restart**.

### Fix
Route each dismiss keystroke chunk through `write_with_timeout(&writer, ..)` instead of grabbing the raw lock. `write_with_timeout` takes the lock on a bounded worker that self-cleans the write-in-progress guard on timeout (#1145), so the dismiss thread never holds the shared lock across an unbounded write.

```rust
// per chunk (split on \r/\n, 200ms inter-chunk delay preserved):
let _ = write_with_timeout(&writer, &keys[start..i]);   // bounded worker + 5s
std::thread::sleep(Duration::from_millis(200));
let _ = write_with_timeout(&writer, &keys[i..=i]);      // the Enter
```

- Chunk-on-`\r`/`\n` boundaries and the 200 ms inter-chunk delay (TUI nav-before-confirm timing) are preserved.
- `write_with_timeout` flushes internally (`w.write_all(&data)?; w.flush()`).
- On a stuck PTY the first chunk times out at 5 s and subsequent chunks fail fast (`write already in progress`), so the **dismiss thread exits** instead of hanging — and never holds the shared lock.

### Verification (RED→GREEN)
- **closes CR-2026-06-14 H13; un-ignores** `dismiss_thread_has_no_raw_unbounded_writer_lock_agent_binding` (`tests/review_dismiss_writer_lock_agent_binding.rs`, static-invariant).
- The repro is **not comment-satisfiable**: it strips `//` / `*` lines, then asserts no non-comment line in `dismiss.rs` contains `writer.lock()`. **RED proven** (lines 145 + 155); **GREEN** after fix (the only remaining `writer.lock()` is a `//` comment, which the scan skips).
- All **21** `dismiss` unit tests still pass (pattern-match / dialog-fire behavior unchanged).
- Scope: **only** `dismiss.rs` (fix) + the H13 repro file (`-1` `#[ignore]`).
- `cargo fmt --check` clean; `clippy --all-targets --features tray -- -D warnings` clean. Branch off `origin/main` (incl. merged #2148/#2149/#2153).

### Reviewer focus (dual review — concurrency / lock-across-IO)
No raw `writer.lock()` remains in the dismiss thread; the only lock acquisition is now inside `write_with_timeout`'s bounded worker. The keystroke chunking/timing contract is preserved. Confirm there's no path where the dismiss thread can still block on the shared writer.

---
*fixup-dev-2* · claude/opus-4.8