### PR TITLE
fix(H12 CR-2026-06-14): inbox dedup fallback reads the resolved (UUID) path

### DIFF
--- a/src/inbox/storage.rs
+++ b/src/inbox/storage.rs
@@ -1004,7 +1004,13 @@ pub fn has_drained_blocker_for_correlation(
 /// Read the agent's inbox JSONL and return `true` iff a message with
 /// the given `msg_id` exists AND has `read_at` set.
 pub(super) fn msg_already_drained_in_jsonl(home: &Path, agent_name: &str, msg_id: &str) -> bool {
-    let path = inbox_path(home, agent_name);
+    // H12 (CR-2026-06-14): read the RESOLVED (UUID-when-id-native) path — the same
+    // one `drain` writes `read_at` to. The old `inbox_path` (raw name) path does
+    // not exist for an id-native instance, so this #911 JSONL dedup fallback read
+    // a nonexistent file and returned `false` unconditionally — a permanent no-op
+    // that let an already-drained message be re-injected after a daemon restart
+    // (when the in-memory `OnceLock` ledger is gone).
+    let path = inbox_path_resolved(home, agent_name);
     let Ok(content) = std::fs::read_to_string(&path) else {
         return false;
     };

--- a/src/inbox/storage/review_repro_inbox_notify.rs
+++ b/src/inbox/storage/review_repro_inbox_notify.rs
@@ -53,7 +53,6 @@ fn write_fleet_with_id(home: &std::path::Path, name: &str, uuid: &str) {
 // fallback reads a nonexistent file and returns `false` unconditionally.
 // ───────────────────────────────────────────────────────────────────────────
 #[test]
-#[ignore = "#911: red until fix; remove #[ignore] after fix to confirm"]
 fn msg_already_drained_reads_resolved_uuid_path_inbox_notify() {
     let home = tmp_home("f1-msg-drained-resolved");
     let name = "idnative";


### PR DESCRIPTION
## H12 — #911 JSONL dedup fallback is a permanent no-op for id-native instances

`docs/CODE-REVIEW-2026-06-14.md` H12: `msg_already_drained_in_jsonl` (`src/inbox/storage.rs`, the #911 JSONL dedup fallback) read `inbox_path` (raw **NAME** path), but `drain` writes `read_at` via `inbox_path_resolved` (the **UUID** path for an id-native instance). An id-native instance has no `<name>.jsonl`, so the fallback read a nonexistent file and returned `false` unconditionally. Since this is the **only** dedup source after the in-memory `OnceLock` ledger is lost (daemon restart), an already-drained message could be **re-injected / re-delivered** after a restart.

## Fix
One line: read `inbox_path_resolved` (consistent with `drain` and every other inbox fn).

## Completeness
This was the **only** direct name-path READ outside `inbox_path_resolved` itself. The other in-tree `inbox_path` uses are the intentional fallback/migration logic inside `inbox_path_resolved`, and the teardown/residual paths in `instance_state/lifecycle.rs` (which already cover **both** name `inbox_path` and UUID `inbox_path_for_id` per the #1682/#1902 name↔uuid trap). The single caller (`inbox/notify.rs:482`) gets correct dedup.

## Tests
- `msg_already_drained_reads_resolved_uuid_path_inbox_notify` (#2135 repro) **un-ignored** — RED→GREEN. **Non-vacuous verified**: against the original it fails `returned false because it read the nonexistent <name>.jsonl path`.
- The repro uses an **id-bearing `fleet.yaml` fixture** so the name/UUID paths diverge (a no-id home would converge them and hide the bug — the #1680 class the lead flagged).
- Siblings #3/#4/#6 in that repro file stay `#[ignore]`d.

## Verification
- `cargo fmt --check` ✓ · `cargo clippy --features tray --all-targets -- -D warnings` ✓
- `AGEND_GIT_BYPASS=1 cargo nextest` over `inbox::storage` + `inbox::tests`: **126 passed, 0 failed**.

Diff +7/−2, 2 files. `dual-review`. Does not touch an invariant-input file → no #2140 rebase-race.

Closes: H12 of `docs/CODE-REVIEW-2026-06-14.md`

---
*fixup-dev* · claude/opus-4.8