### PR TITLE
fix(H5 CR-2026-06-14): flock the MCP ci watch/unwatch read→atomic_write RMW

### DIFF
--- a/src/mcp/handlers/ci/mod.rs
+++ b/src/mcp/handlers/ci/mod.rs
@@ -607,12 +607,9 @@ pub(crate) fn handle_watch_ci(home: &Path, args: &Value, instance_name: &str) ->
     }
 
     let ci_dir = crate::daemon::ci_watch::ci_watches_dir(home);
-    // #779 P2 Piece 3 site A: pre-#779-P2 swallowed dir-create errors
-    // silently and continued, returning happy-path Value even when the
-    // subsequent atomic_write was destined to fail. Now surface as
-    // structured error matching the existing `{error, code}` shape so
-    // handle_checkout_repo (and direct callers of `ci action=watch`)
-    // observe the partial-failure class.
+    // #779 P2 Piece 3 site A: surface a dir-create failure as a structured
+    // `{error, code}` (pre-#779-P2 swallowed it and returned happy-path even when
+    // the subsequent atomic_write was doomed).
     if let Err(e) = std::fs::create_dir_all(&ci_dir) {
         return json!({
             "error": format!("ci-watches dir create failed: {e}"),
@@ -622,12 +619,14 @@ pub(crate) fn handle_watch_ci(home: &Path, args: &Value, instance_name: &str) ->
     let filename = crate::daemon::ci_watch::watch_filename(repo, branch);
     let watch_path = ci_dir.join(&filename);
 
+    // H5 (CR-2026-06-14): flock the read→mutate→atomic_write window (mirrors
+    // registry.rs / the poll loop). atomic_write makes each write atomic but not
+    // the read→write gap, so an unlocked MCP RMW loses poll-state/subscriber
+    // updates racing a concurrent poll/unwatch.
+    let _watch_lock = crate::store::acquire_file_lock(&watch_path.with_extension("lock"));
+
     let now_rfc3339 = chrono::Utc::now().to_rfc3339();
 
-    // Read existing watch (if any) to preserve poll state and existing
-    // subscribers. A fresh write would clobber `last_run_id` /
-    // `last_polled_at` / `last_notified_head_sha` and trigger duplicate
-    // notifications on the next poll.
     let mut watch = std::fs::read_to_string(&watch_path)
         .ok()
         .and_then(|s| serde_json::from_str::<Value>(&s).ok())
@@ -831,6 +830,8 @@ pub(crate) fn handle_unwatch_ci(home: &Path, args: &Value, instance_name: &str) 
         .unwrap_or_else(|| instance_name.to_string());
     let filename = crate::daemon::ci_watch::watch_filename(repo, branch);
     let path = crate::daemon::ci_watch::ci_watches_dir(home).join(&filename);
+    // H5: flock the per-watch read→atomic_write RMW (see handle_watch_ci).
+    let _watch_lock = crate::store::acquire_file_lock(&path.with_extension("lock"));
 
     let mut watch = match std::fs::read_to_string(&path)
         .ok()
@@ -847,8 +848,7 @@ pub(crate) fn handle_unwatch_ci(home: &Path, args: &Value, instance_name: &str) 
     if !caller.is_empty() {
         subscribers.retain(|s| s != &caller);
     } else {
-        // No caller identity supplied — clear ALL subscribers (legacy
-        // behavior). Operator-driven cleanup, e.g. via daemon CLI.
+        // No caller identity (unauthenticated/operator call) — clear ALL.
         subscribers.clear();
     }
 

--- a/src/mcp/handlers/dispatch_hook/tests.rs
+++ b/src/mcp/handlers/dispatch_hook/tests.rs
@@ -752,11 +752,16 @@ fn delegate_task_idempotent_existing_watch() {
     );
     assert!(r2.is_ok(), "re-dispatch must succeed: {:?}", r2.err());
 
-    // ci-watches dir must still contain exactly one entry.
+    // ci-watches dir must still contain exactly one *watch* entry. Count
+    // only `.json` watch files — the `.lock` sidecar that
+    // `handle_watch_ci`'s RMW flock leaves behind (#2165 H5) is a legitimate
+    // co-resident artifact, not a watch (prod registry.rs filters on
+    // `.json` the same way).
     let ci_dir = crate::daemon::ci_watch::ci_watches_dir(&home);
     let entry_count = std::fs::read_dir(&ci_dir)
         .expect("read ci-watches")
         .flatten()
+        .filter(|e| e.path().extension().and_then(|x| x.to_str()) == Some("json"))
         .count();
     assert_eq!(entry_count, 1, "must remain exactly one watch entry");
 

--- a/tests/review_mcp_ci_worktree_2.rs
+++ b/tests/review_mcp_ci_worktree_2.rs
@@ -75,7 +75,6 @@ fn fn_body_after(text: &str, signature_needle: &str) -> String {
 }
 
 #[test]
-#[ignore = "mcp-ci-worktree-2: mcp-watch-rmw-missing-flock; red until fix; remove #[ignore] after fix to confirm"]
 fn mcp_ci_watch_handlers_hold_per_watch_flock_mcp_ci_worktree() {
     let src = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src");
     let mut files = Vec::new();


### PR DESCRIPTION
Closes **H5** of `docs/CODE-REVIEW-2026-06-14.md` — the **last** of the C1+High batch. 🎯

## H5 — MCP watch handler does lock-free RMW
`handle_watch_ci` / `handle_unwatch_ci` (`src/mcp/handlers/ci/mod.rs`) read the watch JSON, mutate it in memory, then `atomic_write` it back **without** the per-watch flock that every daemon-side writer holds (`registry.rs` flush/update/cleanup/reassign all take `acquire_file_lock(&path.with_extension("lock"))`). `atomic_write` makes each write all-or-nothing but does **not** serialize the read→write gap — so an MCP `ci watch`/`ci unwatch` racing the poll loop loses updates: restoring `last_notified_head_sha`/`last_run_id` (duplicate `[ci-pass]`), losing the poll cursor, or clobbering a just-added/removed subscriber.

## Fix
Acquire the same per-watch flock across the whole RMW window in both handlers (RAII, from before the read until after `atomic_write`). **#1629-safe**: neither handler makes an `api::call`, so holding the flock cannot block a self-IPC under the lock (verified).

## ci/mod.rs is KNOWN_OVERSIZED (ceiling 1435)
The 2 lock lines are offset by trimming verbose comments **in the same handlers**, keeping the file **at** 1435 (not over). The ceiling was **not** lowered (that would RED main, #2137 class). The static repro requires the literal `acquire_file_lock` *inside* each handler body in ci/mod.rs, so the lock can't be extracted to a sibling. H4's unwatch caller-resolution is untouched.

## Tests
- `mcp_ci_watch_handlers_hold_per_watch_flock` (#2135 static-invariant repro) **un-ignored** — RED→GREEN. **Non-vacuous verified**: against original it FAILs naming both `handle_watch_ci` + `handle_unwatch_ci`.
- `cargo fmt --check` ✓ · `cargo clippy --features tray --all-targets -- -D warnings` ✓ · `file_size_invariant` ✓ (ci/mod.rs = 1435).
- `AGEND_GIT_BYPASS=1 cargo nextest` ci/watch/unwatch: **252 passed**.

## Merge note
ci/mod.rs is a `KNOWN_OVERSIZED` (invariant-input) file → my own #2140 merge-freshness gate applies when this PR is behind main; the lead merges via the verified-safe-stale path. `dual-review` (concurrency).

---
*fixup-dev* · claude/opus-4.8