### PR TITLE
fix(H3 CR-2026-06-14): decision-timeout persist failure no longer swallowed → no repeat-fire

### DIFF
--- a/src/daemon/decision_timeout.rs
+++ b/src/daemon/decision_timeout.rs
@@ -293,8 +293,22 @@ pub(crate) fn scan_and_emit(home: &Path) {
                 continue;
             }
             current.status = "timeout".to_string();
-            let _ = write_decision(home, &current);
-            Some(current)
+            // H3: gate the emit on a SUCCESSFUL persist. If the status flip can't
+            // be written (e.g. disk full / read-only dir), the on-disk status
+            // stays "pending", so the next scan re-times-out and re-emits — an
+            // unbounded duplicate notification every tick while disk + memory
+            // never agree. Only emit once the "timeout" status is durably
+            // recorded. The sibling `mark_resolved_for_sender` already gates this
+            // way.
+            if write_decision(home, &current) {
+                Some(current)
+            } else {
+                tracing::warn!(
+                    decision_id = %current.decision_id,
+                    "decision_timeout: persist of 'timeout' status failed; not emitting (retries next scan)"
+                );
+                None
+            }
         };
         if let Some(current) = to_emit {
             emit_timeout_event(home, &current, elapsed_secs);

--- a/src/daemon/decision_timeout/review_repro_panic_io_extra.rs
+++ b/src/daemon/decision_timeout/review_repro_panic_io_extra.rs
@@ -51,7 +51,6 @@ fn set_dir_perms(dir: &Path, mode: u32) {
 /// failed persist emits nothing -> zero events.
 #[test]
 #[serial]
-#[ignore = "decision_timeout-persist-swallowed: red until fix; remove #[ignore] after fix to confirm"]
 fn timeout_emit_gated_on_successful_persist_panic_io_extra() {
     // Default recipient resolution -> "general" when neither fleet config nor the
     // env override is set. Clear the env override for determinism.


### PR DESCRIPTION
## H3 (CR-2026-06-14)

`scan_and_emit` flipped the on-disk decision status to `"timeout"` via `write_decision` and **discarded the result** (`let _ =`), then emitted the timeout event unconditionally. If the persist failed (read-only dir / disk full), disk stayed `"pending"` while the event fired anyway — so the next scan re-timed-out and re-emitted, an **unbounded duplicate notification every tick** with disk + memory never agreeing.

## Fix

Gate the emit on a **successful persist** (mirroring the sibling `mark_resolved_for_sender`), warn-log the skipped emit, and retry on the next scan once the status is durably recorded.

```rust
if write_decision(home, &current) {
    Some(current)
} else {
    tracing::warn!(decision_id = %current.decision_id,
        "decision_timeout: persist of 'timeout' status failed; not emitting (retries next scan)");
    None
}
```

## Verification (red→green)

Repro: `timeout_emit_gated_on_successful_persist_panic_io_extra` (`#[ignore]` removed). Sets the pending-decisions dir read-only so the status flip can't persist, then asserts **zero** timeout events.

- **RED** (fix stashed): `left: 1, right: 0` — event emitted despite failed persist; "emitting anyway leaves disk 'pending' and re-fires every tick".
- **GREEN** (with fix): 1 passed.

Scope clean: H2 (#1092/#1116) logic untouched; 23 decision_timeout tests pass; `cargo fmt` + `cargo clippy --all-targets --features tray -D warnings` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)