### PR TITLE
fix(CR-2026-06-14 R4 Phase 1): size-gated lazy compaction for task_index.jsonl

### DIFF
--- a/src/tasks/board_router.rs
+++ b/src/tasks/board_router.rs
@@ -27,7 +27,7 @@ use super::Task;
 
 // ── task_index (home/task_index.jsonl) ─────────────────────────────
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 struct IndexEntry {
     task_id: String,
     project_id: String,
@@ -35,6 +35,101 @@ struct IndexEntry {
 
 fn index_path(home: &Path) -> PathBuf {
     home.join("task_index.jsonl")
+}
+
+/// #2135 R4 Phase 1: `task_index.jsonl` is append-only, so the
+/// `resolve_task_project` repair re-append can write a duplicate entry for a
+/// task_id already in the index, and the file grows without bound. Compaction
+/// is **size-gated lazy**: `record_task_project` calls [`maybe_compact_index`]
+/// after each append, but it only rewrites the file once it crosses a
+/// conservative threshold (so a small index is byte-identical to pre-#2135 —
+/// the rewrite never runs). Phase 1 seals only the *duplicate* vector; orphan
+/// pruning (entries for deleted tasks) is deferred to Phase 2.
+const COMPACT_LINE_THRESHOLD: usize = 2000;
+const COMPACT_BYTE_THRESHOLD: u64 = 256 * 1024;
+
+/// Keep the FIRST entry per task_id, preserving order. Mirrors
+/// [`lookup_task_project`]'s first-match semantics exactly, so compaction is
+/// resolution-preserving: a lookup before and after compaction returns the same
+/// project for every task_id. A pure fn over parsed entries — unit-testable
+/// without touching the filesystem.
+fn dedup_entries(entries: &[IndexEntry]) -> Vec<IndexEntry> {
+    let mut seen = std::collections::HashSet::new();
+    entries
+        .iter()
+        .filter(|e| seen.insert(e.task_id.clone()))
+        .cloned()
+        .collect()
+}
+
+/// Best-effort, size-gated compaction of `task_index.jsonl`. Runs after a
+/// `record_task_project` append; a failure never propagates to the record path
+/// (the append already succeeded — compaction is opportunistic cleanup).
+fn maybe_compact_index(home: &Path) {
+    if let Err(e) = compact_index_gated(home, COMPACT_LINE_THRESHOLD, COMPACT_BYTE_THRESHOLD) {
+        tracing::warn!(error = %e, "task_index compaction failed (non-fatal; append already durable)");
+    }
+}
+
+/// The gated compaction core (thresholds injected for testability). Holds the
+/// SAME `task_index.jsonl.lock` as [`crate::event_log::append_lines_under_lock`]
+/// (the append path) so concurrent appenders never observe a half-rewritten
+/// file. No `api::call` runs under the lock (#1629). Write-back mirrors
+/// `task_events`' tmp + fsync + atomic-rename so a crash mid-rewrite leaves the
+/// original file intact.
+fn compact_index_gated(
+    home: &Path,
+    line_threshold: usize,
+    byte_threshold: u64,
+) -> anyhow::Result<()> {
+    let path = index_path(home);
+    let lock_path = path.with_extension("jsonl.lock");
+    let _lock = crate::store::acquire_file_lock(&lock_path)?;
+
+    let content = match std::fs::read_to_string(&path) {
+        Ok(c) => c,
+        // Missing index → nothing to compact.
+        Err(_) => return Ok(()),
+    };
+    let raw_line_count = content.lines().count();
+    let over_threshold = raw_line_count > line_threshold || content.len() as u64 > byte_threshold;
+    if !over_threshold {
+        // Below threshold → byte-identical to pre-#2135 (no rewrite).
+        return Ok(());
+    }
+
+    // Parse good lines (skip torn/corrupt lines — same fail-safe as
+    // `lookup_task_project`'s `find_map`, which already tolerates them).
+    let entries: Vec<IndexEntry> = content
+        .lines()
+        .filter_map(|l| serde_json::from_str::<IndexEntry>(l).ok())
+        .collect();
+    let kept = dedup_entries(&entries);
+    if kept.len() == raw_line_count {
+        // No duplicates and no corrupt lines to drop → a rewrite would be a
+        // no-op (Phase 1 targets duplicates only; orphan growth is Phase 2).
+        return Ok(());
+    }
+
+    // tmp + fsync + atomic rename (mirrors task_events compaction write-back).
+    use std::io::Write;
+    let tmp = path.with_extension("jsonl.tmp");
+    let mut f = std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(&tmp)?;
+    for e in &kept {
+        writeln!(f, "{}", serde_json::to_string(e)?)?;
+    }
+    f.sync_all()?;
+    std::fs::rename(&tmp, &path)?;
+    tracing::info!(
+        before = raw_line_count,
+        after = kept.len(),
+        "compacted task_index.jsonl (deduped append-only growth)"
+    );
+    Ok(())
 }
 
 /// Record a task's project at create time. Append-only under the shared
@@ -53,6 +148,10 @@ pub(super) fn record_task_project(
     // `append_lines_under_lock(home, "task_index", …)` writes the same
     // `home/task_index.jsonl` as `index_path`, under `<file>.jsonl.lock`.
     crate::event_log::append_lines_under_lock(home, "task_index", |_p| Ok(vec![line]))?;
+    // #2135 R4 Phase 1: size-gated lazy compaction seals the append-only
+    // duplicate-growth vector. Sequential to (not nested under) the append's
+    // lock — best-effort, never fails the record.
+    maybe_compact_index(home);
     Ok(())
 }
 
@@ -187,4 +286,147 @@ pub(super) fn list_all_boards(home: &Path) -> Vec<(String, Vec<Task>)> {
             (project, tasks)
         })
         .collect()
+}
+
+// ── tests ──────────────────────────────────────────────────────────
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn tmp_home(tag: &str) -> PathBuf {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static CTR: AtomicU64 = AtomicU64::new(0);
+        let n = CTR.fetch_add(1, Ordering::Relaxed);
+        let p = std::env::temp_dir().join(format!(
+            "agend-board-router-{}-{}-{tag}",
+            std::process::id(),
+            n
+        ));
+        std::fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    fn entry(t: &str, p: &str) -> IndexEntry {
+        IndexEntry {
+            task_id: t.to_string(),
+            project_id: p.to_string(),
+        }
+    }
+
+    /// Pure dedup: keep the FIRST entry per task_id, preserving order — exactly
+    /// mirroring `lookup_task_project`'s first-match.
+    #[test]
+    fn dedup_entries_keeps_first_per_task_id_in_order() {
+        let input = vec![
+            entry("t1", "p1"),
+            entry("t1", "pX"),
+            entry("t2", "p2"),
+            entry("t1", "pY"),
+            entry("t3", "p3"),
+        ];
+        let got: Vec<(String, String)> = dedup_entries(&input)
+            .into_iter()
+            .map(|e| (e.task_id, e.project_id))
+            .collect();
+        assert_eq!(
+            got,
+            vec![
+                ("t1".to_string(), "p1".to_string()),
+                ("t2".to_string(), "p2".to_string()),
+                ("t3".to_string(), "p3".to_string()),
+            ],
+            "first project per task_id wins, order preserved"
+        );
+    }
+
+    /// File-level: an append-only index with duplicate entries, once over the
+    /// threshold, compacts to one line per task_id — and lookup still resolves
+    /// to the FIRST recorded project (resolution-preserving). RED pre-#2135 (no
+    /// compaction → all N lines remain).
+    #[test]
+    fn compact_index_dedups_over_threshold_and_preserves_lookup() {
+        let home = tmp_home("compact-over");
+        // First record wins; later "repair re-append" duplicates carry a WRONG
+        // project to prove dedup keeps the first, not the last.
+        record_task_project(&home, "T-dup", "proj-a").unwrap();
+        for _ in 0..4 {
+            record_task_project(&home, "T-dup", "proj-WRONG").unwrap();
+        }
+        record_task_project(&home, "T-other", "proj-b").unwrap();
+        // Under the real 2000-line threshold the appends did NOT compact.
+        let raw = std::fs::read_to_string(index_path(&home)).unwrap();
+        assert_eq!(raw.lines().count(), 6, "pre-compaction keeps every append");
+
+        // Force compaction with a tiny line threshold (real threshold is 2000).
+        compact_index_gated(&home, 2, u64::MAX).unwrap();
+
+        let after = std::fs::read_to_string(index_path(&home)).unwrap();
+        assert_eq!(
+            after.lines().count(),
+            2,
+            "compaction collapses duplicates to one entry per task_id"
+        );
+        assert_eq!(
+            lookup_task_project(&home, "T-dup").as_deref(),
+            Some("proj-a"),
+            "lookup still returns the FIRST recorded project after compaction"
+        );
+        assert_eq!(
+            lookup_task_project(&home, "T-other").as_deref(),
+            Some("proj-b")
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Below threshold the file is byte-identical (no rewrite), even with a
+    /// duplicate present — guarantees single-project deployments stay
+    /// byte-identical to pre-#2135.
+    #[test]
+    fn compact_index_below_threshold_is_byte_identical() {
+        let home = tmp_home("compact-under");
+        record_task_project(&home, "T-1", "proj-a").unwrap();
+        record_task_project(&home, "T-1", "proj-a").unwrap(); // a duplicate
+        let before = std::fs::read_to_string(index_path(&home)).unwrap();
+        // High thresholds → under threshold → must NOT touch the file.
+        compact_index_gated(&home, 10_000, u64::MAX).unwrap();
+        let after = std::fs::read_to_string(index_path(&home)).unwrap();
+        assert_eq!(
+            before, after,
+            "below threshold must be byte-identical (no rewrite)"
+        );
+        assert_eq!(
+            after.lines().count(),
+            2,
+            "duplicate retained below threshold"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Fail-safe: a torn/corrupt line is dropped by compaction (same tolerance
+    /// `lookup_task_project`'s `find_map` already has), and good entries survive.
+    #[test]
+    fn compact_index_drops_corrupt_lines_over_threshold() {
+        let home = tmp_home("compact-corrupt");
+        record_task_project(&home, "T-1", "proj-a").unwrap();
+        record_task_project(&home, "T-1", "proj-a").unwrap(); // dup
+        {
+            use std::io::Write;
+            let mut f = std::fs::OpenOptions::new()
+                .append(true)
+                .open(index_path(&home))
+                .unwrap();
+            writeln!(f, "{{not valid json").unwrap();
+        }
+        compact_index_gated(&home, 1, u64::MAX).unwrap();
+        let after = std::fs::read_to_string(index_path(&home)).unwrap();
+        assert_eq!(
+            after.lines().count(),
+            1,
+            "compaction drops the corrupt line and dedups the good ones"
+        );
+        assert_eq!(lookup_task_project(&home, "T-1").as_deref(), Some("proj-a"));
+        std::fs::remove_dir_all(&home).ok();
+    }
 }


### PR DESCRIPTION
## CR-2026-06-14 redesign — board_router task_index compaction (Phase 1)

**Finding R4** (CODE-REVIEW:235): `task_index.jsonl` is append-only. `resolve_task_project`'s repair path re-appends an entry for a task_id that may already be indexed → the file grows without bound (duplicate re-append + orphans never pruned).

**Lead DPs:** DP1 = size-gated lazy on-record (KISS, no new handler) · DP2 = Phase 1 seals the duplicate vector, orphan-prune deferred to Phase 2 · DP3 = conservative threshold (>2000 lines OR >256KB).

### Change (1 file: `src/tasks/board_router.rs`)
- `record_task_project` calls `maybe_compact_index(home)` after each append.
- `compact_index_gated(home, line_threshold, byte_threshold)`:
  - Below threshold → **byte-identical** to pre-#2135 (no rewrite; single-project deployments unchanged).
  - Holds the **same** `task_index.jsonl.lock` as the append path (sequential, not nested; **no `api::call` under the lock**, #1629).
  - Write-back via **tmp + fsync + atomic rename** (mirrors `task_events` compaction) — a crash mid-rewrite leaves the original intact.
  - **fail-safe:** corrupt/torn lines skipped on parse (same tolerance `lookup_task_project`'s `find_map` has) and dropped on rewrite.
- `dedup_entries(&[IndexEntry]) -> Vec<IndexEntry>`: pure, keeps the **first** entry per task_id → mirrors `lookup_task_project`'s first-match → **resolution-preserving**.

### Tests (red→green; RED proven by neutering the rewrite → file stayed at 6 lines)
- `dedup_entries` keeps first per task_id, order preserved
- over-threshold → collapses duplicates to one line/task_id; lookup still returns the **first** recorded project
- below-threshold → byte-identical even with a duplicate present
- over-threshold with a corrupt line → dropped, good entries survive

### Verification
- `cargo nextest run --features tray 'tasks::' board_router` → 134/134 pass
- `cargo fmt --check` clean · `cargo clippy --features tray --tests -- -D warnings` clean

Requesting **dual-review**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)