### PR TITLE
fix(CR-2026-06-14 :231): re-validate handle_update ACL + by-identity in-lock

### DIFF
--- a/src/tasks/handler.rs
+++ b/src/tasks/handler.rs
@@ -585,6 +585,72 @@ fn handle_done(
     }
 }
 
+/// CR-2026-06-14 (:231) — the in-lock precondition for `handle_update`'s atomic
+/// event batch. Runs under the append lock against FRESH committed `state`, so
+/// it is the AUTHORITATIVE gate the out-of-lock ACL/transition checks only
+/// fast-reject. Fails closed when, since the out-of-lock read:
+/// - the task vanished;
+/// - ownership drifted so `caller` is no longer authorized (`force` bypasses,
+///   mirroring the out-of-lock gate at :633) — this covers BOTH status and
+///   non-status updates (the latter had no in-lock guard at all before);
+/// - the status transition became illegal (the prior #1868 guard); or
+/// - the owner moved out from under a Claimed/InProgress/Done event whose `by`
+///   was baked from the now-stale owner (attribution would be wrong).
+///
+/// Pure decision logic over the supplied `state` (no `api::call` — #1629-safe to
+/// run under the lock) and a directly-testable seam.
+#[allow(clippy::too_many_arguments)]
+fn update_batch_precondition(
+    state: &crate::task_events::TaskBoardState,
+    home: &Path,
+    caller: &str,
+    upd_id: &str,
+    force: bool,
+    target_status: Option<crate::task_events::TaskStatus>,
+    stale_owner: &Option<crate::task_events::InstanceName>,
+) -> Result<(), String> {
+    let fresh = state
+        .tasks
+        .get(&crate::task_events::TaskId(upd_id.to_string()))
+        .ok_or_else(|| format!("task '{upd_id}' not found"))?;
+    // (1) Ownership ACL re-check against fresh state — same `can_mutate_record`
+    //     + force semantics as the out-of-lock gate (:633).
+    if !force && !can_mutate_record(home, caller, fresh) {
+        return Err(format!(
+            "task '{upd_id}' ownership changed since authorization; \
+             caller '{caller}' no longer authorized (retry)"
+        ));
+    }
+    // (2) Status-transition legality (#1868), keyed on the fresh record.
+    if let Some(target) = target_status {
+        if !fresh.status.can_transition_to(target) {
+            return Err(format!(
+                "illegal transition: {} → {} (task {upd_id})",
+                status_to_legacy_str(fresh.status),
+                status_to_legacy_str(target)
+            ));
+        }
+    }
+    // (3) `by`-identity drift: Claimed/InProgress/Done bake `by` from the
+    //     out-of-lock owner. If the owner moved, that attribution is stale →
+    //     reject (we don't rebuild events under the lock).
+    if matches!(
+        target_status,
+        Some(
+            crate::task_events::TaskStatus::Claimed
+                | crate::task_events::TaskStatus::InProgress
+                | crate::task_events::TaskStatus::Done
+        )
+    ) && fresh.owner != *stale_owner
+    {
+        return Err(format!(
+            "task '{upd_id}' owner changed since read; event attribution \
+             would be stale (retry)"
+        ));
+    }
+    Ok(())
+}
+
 fn handle_update(
     home: &Path,
     instance_name: &str,
@@ -839,33 +905,44 @@ fn handle_update(
         let target_status = new_status
             .as_deref()
             .and_then(crate::task_events::TaskStatus::from_str);
+        // CR-2026-06-14 (:231): the ownership ACL (`can_mutate_record` above) and
+        // the `by` field baked into Claimed/InProgress/Done events were BOTH
+        // computed from the OUT-OF-LOCK `record` read. Re-validate under the
+        // append lock against FRESH committed state so a concurrent owner change
+        // can neither (a) slip an unauthorized write past the now-stale ACL, nor
+        // (b) commit an event whose `by` attributes the transition to a former
+        // owner. Fail closed on drift — the caller retries against the new state.
+        // The pre-built events are kept (no in-lock rebuild); the drift check
+        // guarantees their `by` is still correct at commit time.
+        let stale_owner = record.owner.clone();
         let checked = crate::task_events::append_batch_checked_at(
             &board,
             &emitter,
             pending_events,
             |state| {
-                if let Some(target) = target_status {
-                    let tv = state
-                        .tasks
-                        .values()
-                        .map(record_to_task)
-                        .find(|t| t.id == upd_id)
-                        .ok_or_else(|| format!("task '{upd_id}' not found"))?;
-                    if !tv.status.can_transition_to(target) {
-                        return Err(format!(
-                            "illegal transition: {} → {} (task {upd_id})",
-                            status_to_legacy_str(tv.status),
-                            status_to_legacy_str(target)
-                        ));
-                    }
-                }
-                Ok(())
+                update_batch_precondition(
+                    state,
+                    home,
+                    &caller,
+                    &upd_id,
+                    force,
+                    target_status,
+                    &stale_owner,
+                )
             },
         );
         match checked {
             Ok(Ok(_)) => {}
             Ok(Err(reason)) => {
-                return serde_json::json!({"error": reason, "code": "illegal_transition"});
+                // Preserve the legacy `illegal_transition` code for the #1868
+                // transition guard; the new in-lock ACL/owner-drift rejections
+                // (:231) are a distinct, retryable precondition failure.
+                let code = if reason.starts_with("illegal transition") {
+                    "illegal_transition"
+                } else {
+                    "precondition_failed"
+                };
+                return serde_json::json!({"error": reason, "code": code});
             }
             Err(e) => {
                 return serde_json::json!({"error": format!("event log append_batch failed: {e}")});
@@ -1353,6 +1430,123 @@ mod tests {
         )
         .expect("create task");
         let _ = args;
+    }
+
+    /// Simulate a concurrent reassignment landing between handle_update's
+    /// out-of-lock read and its in-lock append.
+    fn reassign(home: &std::path::Path, task_id: &str, new_owner: &str) {
+        crate::task_events::append(
+            home,
+            &crate::task_events::InstanceName::from("lead"),
+            crate::task_events::TaskEvent::OwnerAssigned {
+                task_id: crate::task_events::TaskId(task_id.into()),
+                by: crate::task_events::InstanceName::from("lead"),
+                owner: Some(crate::task_events::InstanceName::from(new_owner)),
+                routed_to: None,
+            },
+        )
+        .expect("reassign");
+    }
+
+    /// CR-2026-06-14 (:231) ②, the core gap — a NON-status update (target=None)
+    /// by an unauthorized caller. Pre-fix the in-lock closure did nothing when
+    /// target_status was None, so the write slipped past the in-lock gate (RED).
+    #[test]
+    fn inlock_precond_rejects_unauthorized_nonstatus_update_231() {
+        let home = tmp_home("231-nonstatus-acl");
+        create_task(&home, "t-231-a"); // owner = dev-agent
+        let state = crate::task_events::replay(&home).unwrap();
+        let res = update_batch_precondition(
+            &state,
+            &home,
+            "intruder",
+            "t-231-a",
+            false,
+            None,
+            &Some(crate::task_events::InstanceName::from("dev-agent")),
+        );
+        assert!(
+            res.is_err(),
+            "unauthorized non-status update must be rejected in-lock"
+        );
+        assert!(res.unwrap_err().contains("no longer authorized"));
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// CR-2026-06-14 (:231) ① — a status update whose caller WAS authorized at
+    /// the out-of-lock read (stale_owner == caller), but the owner drifted to
+    /// someone else before the in-lock commit. The in-lock ACL must reject.
+    #[test]
+    fn inlock_precond_rejects_status_update_after_owner_reassign_231() {
+        let home = tmp_home("231-reassign");
+        create_task(&home, "t-231-b"); // owner = dev-agent
+        reassign(&home, "t-231-b", "other-owner");
+        let state = crate::task_events::replay(&home).unwrap();
+        let res = update_batch_precondition(
+            &state,
+            &home,
+            "dev-agent",
+            "t-231-b",
+            false,
+            Some(crate::task_events::TaskStatus::InProgress),
+            &Some(crate::task_events::InstanceName::from("dev-agent")),
+        );
+        assert!(
+            res.is_err(),
+            "status update after owner drift must be rejected"
+        );
+        assert!(res.unwrap_err().contains("no longer authorized"));
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// CR-2026-06-14 (:231) ③ — the done-arm `by` drift. A system identity
+    /// (ACL-bypassed, so the ACL gate alone wouldn't catch this) marks the task
+    /// Done; the Done event's `by` was baked from the stale owner (dev-agent),
+    /// but the task is now owned by new-owner → committing would mis-attribute.
+    #[test]
+    fn inlock_precond_rejects_done_when_by_owner_drifted_231() {
+        let home = tmp_home("231-by-drift");
+        create_task(&home, "t-231-c"); // owner = dev-agent
+        reassign(&home, "t-231-c", "new-owner");
+        let state = crate::task_events::replay(&home).unwrap();
+        let res = update_batch_precondition(
+            &state,
+            &home,
+            "system:task_sweep", // ACL bypassed → only the drift check can reject
+            "t-231-c",
+            false,
+            Some(crate::task_events::TaskStatus::Done),
+            &Some(crate::task_events::InstanceName::from("dev-agent")),
+        );
+        assert!(
+            res.is_err(),
+            "done with drifted by-owner must be rejected fail-closed"
+        );
+        assert!(res.unwrap_err().contains("attribution would be stale"));
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// CR-2026-06-14 (:231) control — a legitimate authorized update with no
+    /// drift MUST pass (guards against over-rejection from the new in-lock gate).
+    #[test]
+    fn inlock_precond_allows_legitimate_authorized_update_231() {
+        let home = tmp_home("231-control");
+        create_task(&home, "t-231-d"); // owner = dev-agent
+        let state = crate::task_events::replay(&home).unwrap();
+        let res = update_batch_precondition(
+            &state,
+            &home,
+            "dev-agent",
+            "t-231-d",
+            false,
+            Some(crate::task_events::TaskStatus::InProgress),
+            &Some(crate::task_events::InstanceName::from("dev-agent")),
+        );
+        assert!(
+            res.is_ok(),
+            "legitimate authorized non-drift update must pass: {res:?}"
+        );
+        std::fs::remove_dir_all(&home).ok();
     }
 
     /// §3.9 #1916 WIRING (real entry point, not just the helper): a `task update`


### PR DESCRIPTION
## CR-2026-06-14 — handle_update in-lock emit (:231)

**Finding** (`src/tasks/handler.rs:617-632, 655-676`): `handle_update` reads the task record **out of lock** (:613) and from that stale snapshot decides the ownership ACL (:633) and bakes the `by` field of Claimed/InProgress/Done events. The only in-lock re-check (#1868, the `append_batch_checked_at` precondition) gated **status-transition legality only** — not ownership, and **nothing at all for non-status updates** (priority/desc/tags/owner). Between the read and the in-lock append, a concurrent owner change can:
- **(a)** slip an unauthorized write past the now-stale ACL, or
- **(b)** commit an event attributing the transition to a **former** owner (`by` drift).

**Lead ruling (d-20260614192249834552-1): DP1 = Option A — reject-on-drift, fail-closed.**

### Change (`src/tasks/handler.rs` only)
Extend the **existing** `append_batch_checked_at` precondition (no new mechanism), extracted to a named, directly-testable `update_batch_precondition`. Under the append lock, against FRESH committed state:
1. re-run the **same** `can_mutate_record` + `force` ACL (mirrors :633) → covers **status AND non-status** updates; fail closed if no longer authorized;
2. keep the #1868 status-transition guard;
3. reject if the owner **drifted** out from under a Claimed/InProgress/Done event whose `by` was baked from the stale owner.

Events are kept as built (**no in-lock rebuild**); the drift check guarantees `by` is correct at commit. The precondition is fs-read-only — **no `api::call` under the lock** (#1629). Rejections carry a distinct `precondition_failed` code; the transition guard keeps `illegal_transition`.

**Scope:** handler.rs only. Sibling `sweep.rs:408` (row232, same class) is a separate fast-follow per lead **DP2** — not bundled (YAGNI; no forced shared abstraction).

### Tests (red→green; RED proven by neutering the ACL + drift checks → all 3 reject tests failed, control stayed green)
- unauthorized **non-status** update → rejected (the core pre-fix gap — had zero in-lock guard)
- status update after **owner reassign** → rejected
- **Done with drifted `by`-owner** (system caller, ACL-bypassed, so only the drift check can reject) → rejected
- legitimate authorized non-drift update → **passes** (guards against over-rejection)

### Verification
- `cargo nextest run --features tray 'tasks::'` → 133/133 pass
- `cargo fmt --check` clean · `cargo clippy --features tray --tests -- -D warnings` clean

Requesting **dual-review** (concurrency / ACL = high risk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)