### PR TITLE
fix(CR-2026-06-14 zombie-kill): identity-compare before signal — no TOCTOU kill of recycled PID

### DIFF
--- a/src/admin/cleanup_zombies.rs
+++ b/src/admin/cleanup_zombies.rs
@@ -53,6 +53,12 @@ pub enum KillOutcome {
     /// from `ForceKilled` so operator logs reflect the platform.
     #[allow(dead_code)] // Windows-only constructed; CI lints Linux/macOS test profile
     WindowsTerminated,
+    /// CR-2026-06-14: the live PID's OS start-time token did not match the
+    /// token recorded in `.daemon` (or no token was recorded / it couldn't be
+    /// read). The PID was recycled onto a different process — signalling it
+    /// would TOCTOU-kill an innocent. NO signal was sent; the stale run dir is
+    /// left for the next-boot sweep (fail-closed-skip, DP3).
+    IdentityMismatch,
 }
 
 /// Describes one zombie candidate discovered by [`find_zombie_candidates`].
@@ -63,6 +69,11 @@ pub struct ZombieInfo {
     /// Age computed from `<run_dir>/.daemon` mtime relative to the
     /// caller's `now` parameter (typically `SystemTime::now()`).
     pub age: Duration,
+    /// OS process start-time token recorded in `.daemon` (third field), or
+    /// `None` for a legacy file written before CR-2026-06-14. Passed to
+    /// [`cleanup_zombie_daemon`] so it can verify the live PID is still the
+    /// same process before signalling. `None` → fail-closed-skip.
+    pub start_token: Option<u64>,
 }
 
 /// Cross-platform check: is the process with `pid` still alive?
@@ -119,21 +130,63 @@ pub fn log_zombie_state(pid: u32) {
     }
 }
 
+/// Pure decision core (CR-2026-06-14): may we send a kill signal to a PID?
+///
+/// Returns `true` ONLY when BOTH the start-token recorded in `.daemon`
+/// (`recorded`) AND the live process's current start-token (`current`) are
+/// known AND equal. Every other case fails closed (returns `false`):
+/// - `recorded == None` — legacy `.daemon` with no token / unreadable → can't
+///   prove identity → skip (DP3 fail-closed-skip, next-boot sweep handles it).
+/// - `current == None` — couldn't read the live process's token → skip.
+/// - `recorded != current` — the PID was recycled onto a different process →
+///   signalling it would kill an innocent → skip.
+///
+/// This is the load-bearing core; the kill primitive and the grace poll both
+/// gate on it. Kept pure (no syscalls) so it is exhaustively unit-testable.
+pub fn should_signal(recorded: Option<u64>, current: Option<u64>) -> bool {
+    matches!((recorded, current), (Some(r), Some(c)) if r == c)
+}
+
 /// Core kill primitive. Sends SIGTERM, polls liveness up to `term_grace`,
 /// escalates to SIGKILL on timeout and polls up to `kill_grace`.
 ///
+/// CR-2026-06-14 identity-compare: before EVERY signal the live PID's OS
+/// start-token is compared against `recorded_token` (read from `.daemon`) via
+/// [`should_signal`]. A mismatch — the original daemon exited and the OS
+/// recycled its PID onto an unrelated process — short-circuits to
+/// [`KillOutcome::IdentityMismatch`] with NO signal sent. This closes the
+/// TOCTOU where a stale run-dir PID could be SIGKILLed after the kernel had
+/// reassigned it to an innocent process.
+///
 /// Returns [`KillOutcome::AlreadyExited`] if the PID is already gone at
-/// entry. Returns [`KillOutcome::Graceful(elapsed)`] if SIGTERM landed.
-/// Returns [`KillOutcome::ForceKilled`] if SIGKILL was needed and
-/// succeeded. Returns [`KillOutcome::RefusedToDie`] if both stages
-/// timed out.
+/// entry. Returns [`KillOutcome::IdentityMismatch`] if the token check fails
+/// (no/wrong identity). Returns [`KillOutcome::Graceful(elapsed)`] if SIGTERM
+/// landed. Returns [`KillOutcome::ForceKilled`] if SIGKILL was needed and
+/// succeeded. Returns [`KillOutcome::RefusedToDie`] if both stages timed out.
 ///
 /// Windows: short-circuits to [`KillOutcome::WindowsTerminated`] via
 /// `TerminateProcess` (no SIGTERM equivalent). The two-stage grace is
 /// Unix-only.
-pub fn cleanup_zombie_daemon(pid: u32, term_grace: Duration, kill_grace: Duration) -> KillOutcome {
+pub fn cleanup_zombie_daemon(
+    pid: u32,
+    recorded_token: Option<u64>,
+    term_grace: Duration,
+    kill_grace: Duration,
+) -> KillOutcome {
     if !is_alive(pid) {
         return KillOutcome::AlreadyExited;
+    }
+
+    // Identity gate: verify the live PID is still the process we recorded
+    // BEFORE sending any signal. Fail-closed on no/wrong identity.
+    if !should_signal(recorded_token, crate::process::process_start_token(pid)) {
+        tracing::warn!(
+            pid,
+            recorded_token = ?recorded_token,
+            "#927/CR-2026-06-14 cleanup-zombies: start-token mismatch — skipping kill \
+             (PID recycled or no recorded identity); next-boot sweep will reclaim the dir"
+        );
+        return KillOutcome::IdentityMismatch;
     }
 
     #[cfg(unix)]
@@ -146,12 +199,23 @@ pub fn cleanup_zombie_daemon(pid: u32, term_grace: Duration, kill_grace: Duratio
         unsafe {
             libc::kill(pid as i32, libc::SIGTERM);
         }
-        if !poll_until_dead(pid, term_grace) {
+        if !poll_until_dead_or_recycled(pid, recorded_token, term_grace) {
+            // Re-verify before escalating: the original may have exited during
+            // the SIGTERM grace and the PID been recycled. Never SIGKILL a
+            // freshly-arrived innocent process.
+            if !should_signal(recorded_token, crate::process::process_start_token(pid)) {
+                tracing::warn!(
+                    pid,
+                    "#927/CR-2026-06-14 cleanup-zombies: start-token changed during SIGTERM \
+                     grace — skipping SIGKILL (PID recycled)"
+                );
+                return KillOutcome::IdentityMismatch;
+            }
             // Stage 2: SIGKILL.
             unsafe {
                 libc::kill(pid as i32, libc::SIGKILL);
             }
-            if poll_until_dead(pid, kill_grace) {
+            if poll_until_dead_or_recycled(pid, recorded_token, kill_grace) {
                 return KillOutcome::ForceKilled;
             }
             return KillOutcome::RefusedToDie;
@@ -167,7 +231,7 @@ pub fn cleanup_zombie_daemon(pid: u32, term_grace: Duration, kill_grace: Duratio
         let _ = kill_grace;
         crate::process::terminate(pid);
         // Best-effort wait for the process to actually exit.
-        if poll_until_dead(pid, Duration::from_secs(2)) {
+        if poll_until_dead_or_recycled(pid, recorded_token, Duration::from_secs(2)) {
             KillOutcome::WindowsTerminated
         } else {
             KillOutcome::RefusedToDie
@@ -187,6 +251,12 @@ pub fn cleanup_zombie_daemon(pid: u32, term_grace: Duration, kill_grace: Duratio
 /// - `src/process.rs::test_kill_process_tree_kills_child_subprocess` —
 ///   sibling test with identical race shape
 ///
+/// CR-2026-06-14: the production kill path moved to the identity-aware
+/// [`poll_until_dead_or_recycled`]; the only remaining callers of this plain
+/// variant are `#[cfg(unix)]` tests, so it is gated `#[cfg(all(test, unix))]`
+/// — keeping it out of the non-test bin build (where it would be dead) and
+/// out of the Windows test build (where none of its unix-only callers exist).
+///
 /// ### Deadline guidance (OS-conditional)
 ///
 /// Callers killing a process whose PID they CAN `waitpid` on (it's their
@@ -205,10 +275,41 @@ pub fn cleanup_zombie_daemon(pid: u32, term_grace: Duration, kill_grace: Duratio
 ///
 /// Recommend 5s for self-reaped children, 10s for orphaned grandchildren.
 /// The 100ms poll cadence balances responsiveness vs CPU waste.
+#[cfg(all(test, unix))]
 pub(crate) fn poll_until_dead(pid: u32, timeout: Duration) -> bool {
     let deadline = std::time::Instant::now() + timeout;
     loop {
         if !is_alive(pid) {
+            return true;
+        }
+        if std::time::Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+/// Identity-aware variant of [`poll_until_dead`] (CR-2026-06-14): returns true
+/// if the PID dies OR its OS start-token stops matching `recorded_token`
+/// mid-poll. The latter means the original process exited and the kernel
+/// recycled its PID onto a different process — the daemon we were reaping IS
+/// gone, so we treat it as dead AND, crucially, the caller will not escalate
+/// to SIGKILL against the innocent newcomer (the kill primitive re-checks
+/// identity before each signal). Reached only after the entry-level identity
+/// gate passed, so `recorded_token` is always `Some` here; a transient
+/// unreadable live token (`current == None`) also returns true (safe
+/// direction — under-kill, never over-kill).
+pub(crate) fn poll_until_dead_or_recycled(
+    pid: u32,
+    recorded_token: Option<u64>,
+    timeout: Duration,
+) -> bool {
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        if !is_alive(pid) {
+            return true;
+        }
+        if !should_signal(recorded_token, crate::process::process_start_token(pid)) {
             return true;
         }
         if std::time::Instant::now() >= deadline {
@@ -251,10 +352,12 @@ pub fn find_zombie_candidates(home: &Path, min_age: Duration, now: SystemTime) -
         };
         let age = now.duration_since(mtime).unwrap_or(Duration::from_secs(0));
         if age >= min_age {
+            let start_token = crate::daemon::read_daemon_start_token(&entry.path());
             zombies.push(ZombieInfo {
                 pid,
                 run_dir: entry.path(),
                 age,
+                start_token,
             });
         }
     }
@@ -340,7 +443,10 @@ mod tests {
         // Tiny sleep to ensure the kernel has cleared the entry.
         std::thread::sleep(Duration::from_millis(50));
 
-        let outcome = cleanup_zombie_daemon(pid, Duration::from_secs(1), Duration::from_secs(1));
+        // Dead PID short-circuits to AlreadyExited before the identity gate,
+        // so the recorded token is irrelevant here (pass None).
+        let outcome =
+            cleanup_zombie_daemon(pid, None, Duration::from_secs(1), Duration::from_secs(1));
         assert!(
             matches!(outcome, KillOutcome::AlreadyExited),
             "dead PID must return AlreadyExited, got {outcome:?}"
@@ -387,7 +493,10 @@ mod tests {
         // Default `sh -c sleep 60` exits on SIGTERM (no trap).
         let (pid, reaper) = spawn_with_reaper("sh", &["-c", "sleep 60"]);
 
-        let outcome = cleanup_zombie_daemon(pid, Duration::from_secs(3), Duration::from_secs(2));
+        // Pass the live child's REAL start-token so the identity gate passes.
+        let token = crate::process::process_start_token(pid);
+        let outcome =
+            cleanup_zombie_daemon(pid, token, Duration::from_secs(3), Duration::from_secs(2));
         let _ = reaper.join();
 
         assert!(
@@ -433,9 +542,15 @@ mod tests {
     fn cleanup_zombie_daemon_sigterm_ignored_returns_force_killed() {
         let (pid, reaper, sentinel) = spawn_sigign_with_sentinel(60);
 
+        // Pass the live child's REAL start-token so the identity gate passes.
+        let token = crate::process::process_start_token(pid);
         // 500ms SIGTERM grace (short — SIG_IGN won't release), 3s SIGKILL grace.
-        let outcome =
-            cleanup_zombie_daemon(pid, Duration::from_millis(500), Duration::from_secs(3));
+        let outcome = cleanup_zombie_daemon(
+            pid,
+            token,
+            Duration::from_millis(500),
+            Duration::from_secs(3),
+        );
         let _ = reaper.join();
         let _ = std::fs::remove_file(&sentinel);
 
@@ -443,6 +558,130 @@ mod tests {
             matches!(outcome, KillOutcome::ForceKilled),
             "SIGTERM-ignored process must escalate to SIGKILL, got {outcome:?}"
         );
+    }
+
+    // ── CR-2026-06-14 zombie-kill identity-compare repro ──────────────────
+    //
+    // The TOCTOU finding: `cleanup_zombie_daemon` selected a target purely by
+    // run-dir name + `.daemon` mtime and signalled it after one entry
+    // `is_alive` — so a PID recycled onto an innocent process between selection
+    // and the signal would be killed. The fix gates every signal on
+    // `should_signal(recorded_token, live_token)`.
+    //
+    // These tests simulate PID recycling DETERMINISTICALLY without waiting for
+    // a real recycle: a live cooperative child is the "innocent" process; we
+    // vary only the RECORDED token to model the three cases.
+
+    /// Pure decision core — exhaustive table. This is the load-bearing gate;
+    /// every kill path funnels through it.
+    #[test]
+    fn should_signal_only_when_both_known_and_equal() {
+        assert!(should_signal(Some(7), Some(7)), "match → signal");
+        assert!(
+            !should_signal(Some(7), Some(8)),
+            "recycled (mismatch) → skip"
+        );
+        assert!(!should_signal(None, Some(7)), "legacy no-token → skip");
+        assert!(
+            !should_signal(Some(7), None),
+            "live token unreadable → skip"
+        );
+        assert!(!should_signal(None, None), "nothing known → skip");
+    }
+
+    /// RED→GREEN: a recycled PID (live token ≠ recorded token) must NOT be
+    /// signalled. The pre-fix primitive took only a bare pid and unconditionally
+    /// SIGTERM/SIGKILLed → it would kill this innocent live child. With the fix
+    /// the token mismatch short-circuits to `IdentityMismatch` and the child
+    /// survives untouched (zero signal sent).
+    #[cfg(unix)]
+    #[test]
+    fn cleanup_skips_when_live_token_differs_from_recorded_pid_recycled() {
+        let (pid, reaper) = spawn_with_reaper("sh", &["-c", "sleep 60"]);
+        let live = crate::process::process_start_token(pid).expect("live token");
+        // Recorded token differs from the live process's token → models a
+        // recycled PID: the `.daemon` recorded daemon D's token, but `pid` now
+        // belongs to an unrelated process.
+        let recorded = Some(live.wrapping_add(1));
+
+        let outcome = cleanup_zombie_daemon(
+            pid,
+            recorded,
+            Duration::from_secs(3),
+            Duration::from_secs(2),
+        );
+
+        assert_eq!(
+            outcome,
+            KillOutcome::IdentityMismatch,
+            "recycled PID (token mismatch) must yield IdentityMismatch, got {outcome:?}"
+        );
+        assert!(
+            is_alive(pid),
+            "innocent live process must NOT be signalled when the token mismatches"
+        );
+
+        // Cleanup the still-alive child.
+        unsafe {
+            libc::kill(pid as i32, libc::SIGKILL);
+        }
+        let _ = reaper.join();
+    }
+
+    /// CONTROL: a genuine zombie (live token == recorded token) is still
+    /// killed. This proves the identity gate didn't simply break killing — a
+    /// regression that dropped the gate would pass `cleanup_skips_…` AND this
+    /// one, but a regression that over-tightened (never signals) would fail
+    /// HERE. The pair pins the gate as load-bearing.
+    #[cfg(unix)]
+    #[test]
+    fn cleanup_kills_when_live_token_matches_recorded_real_zombie() {
+        let (pid, reaper) = spawn_with_reaper("sh", &["-c", "sleep 60"]);
+        let recorded = crate::process::process_start_token(pid); // == live token
+
+        let outcome = cleanup_zombie_daemon(
+            pid,
+            recorded,
+            Duration::from_secs(3),
+            Duration::from_secs(2),
+        );
+        let _ = reaper.join();
+
+        assert!(
+            matches!(outcome, KillOutcome::Graceful(_) | KillOutcome::ForceKilled),
+            "matching-identity zombie must be killed, got {outcome:?}"
+        );
+        assert!(
+            poll_until_dead(pid, Duration::from_secs(5)),
+            "matching-identity zombie must be dead after cleanup"
+        );
+    }
+
+    /// BACK-COMPAT: a legacy `.daemon` with no recorded token (`None`) →
+    /// fail-closed-skip (DP3). We do NOT signal when identity can't be proven;
+    /// the next-boot stale-pid sweep reclaims the dir instead.
+    #[cfg(unix)]
+    #[test]
+    fn cleanup_skips_legacy_no_token_fail_closed() {
+        let (pid, reaper) = spawn_with_reaper("sh", &["-c", "sleep 60"]);
+
+        let outcome =
+            cleanup_zombie_daemon(pid, None, Duration::from_secs(3), Duration::from_secs(2));
+
+        assert_eq!(
+            outcome,
+            KillOutcome::IdentityMismatch,
+            "legacy no-token .daemon must fail-closed-skip, got {outcome:?}"
+        );
+        assert!(
+            is_alive(pid),
+            "fail-closed-skip must not signal the process"
+        );
+
+        unsafe {
+            libc::kill(pid as i32, libc::SIGKILL);
+        }
+        let _ = reaper.join();
     }
 
     #[cfg(unix)]

--- a/src/daemon/boot_sweep.rs
+++ b/src/daemon/boot_sweep.rs
@@ -134,12 +134,19 @@ pub(crate) fn boot_sweep_impl(
             );
             continue;
         }
-        let outcome = cleanup_zombie_daemon(z.pid, term_grace, kill_grace);
+        let outcome = cleanup_zombie_daemon(z.pid, z.start_token, term_grace, kill_grace);
         let real_kill = matches!(
             outcome,
             KillOutcome::Graceful(_) | KillOutcome::ForceKilled | KillOutcome::WindowsTerminated
         );
         match outcome {
+            KillOutcome::IdentityMismatch => tracing::warn!(
+                pid = z.pid,
+                age_days = z.age.as_secs() / SECONDS_PER_DAY,
+                run_dir = %z.run_dir.display(),
+                "#933/CR-2026-06-14 boot-sweep: start-token mismatch — skipped kill (PID recycled \
+                 or legacy no-token .daemon); leaving dir for next stale-pid sweep"
+            ),
             KillOutcome::RefusedToDie => tracing::warn!(
                 pid = z.pid,
                 age_days = z.age.as_secs() / SECONDS_PER_DAY,
@@ -183,12 +190,18 @@ mod tests {
         dir
     }
 
-    /// Plant `<home>/run/<pid>/.daemon` with `<pid>:0` content (matches
-    /// production `write_daemon_id` shape).
+    /// Plant `<home>/run/<pid>/.daemon` with `<pid>:0:<start_token>` content
+    /// (matches production `write_daemon_id`'s CR-2026-06-14 3-field shape).
+    /// The third field is the live child's REAL OS start-token so the
+    /// identity-compare kill gate ([`super::cleanup_zombie_daemon`] →
+    /// `should_signal`) passes. A 2-field legacy fixture would now
+    /// fail-closed-skip, and every kill-path test below would see 0 killed —
+    /// representative fixtures must carry what production writes.
     fn plant_run_dir(home: &Path, pid: u32) -> PathBuf {
         let run = home.join("run").join(pid.to_string());
         std::fs::create_dir_all(&run).unwrap();
-        std::fs::write(run.join(".daemon"), format!("{pid}:0")).unwrap();
+        let token = crate::process::process_start_token(pid).unwrap_or(0);
+        std::fs::write(run.join(".daemon"), format!("{pid}:0:{token}")).unwrap();
         run
     }
 

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -334,9 +334,32 @@ pub fn find_active_run_dir(home: &Path) -> Option<PathBuf> {
             // Verify identity: read .daemon file with start timestamp
             let daemon_file = entry.path().join(".daemon");
             if let Ok(content) = std::fs::read_to_string(&daemon_file) {
-                // Format: "pid:start_time"
-                if let Some((file_pid, _start_time)) = content.trim().split_once(':') {
+                // Format: "pid:boot_unix:start_token" (third field appended
+                // CR-2026-06-14; legacy files have only "pid:boot_unix").
+                let mut fields = content.trim().split(':');
+                if let Some(file_pid) = fields.next() {
                     if file_pid == pid_str {
+                        // DP5: PID matches, but a recycled PID can land on the
+                        // SAME number. If the `.daemon` recorded a start-token
+                        // AND the live process's token can be read, a mismatch
+                        // means this is a different process wearing the old PID
+                        // → PID reused. (Legacy no-token or unreadable token →
+                        // fall back to PID-only accept for back-compat.)
+                        let recorded_token = fields.nth(1).and_then(|t| t.parse::<u64>().ok());
+                        if let (Some(rec), Some(cur)) =
+                            (recorded_token, crate::process::process_start_token(pid))
+                        {
+                            if rec != cur {
+                                tracing::info!(
+                                    pid,
+                                    recorded_token = rec,
+                                    current_token = cur,
+                                    "PID reused (start-token mismatch), cleaning"
+                                );
+                                let _ = std::fs::remove_dir_all(entry.path());
+                                continue;
+                            }
+                        }
                         return Some(entry.path());
                     }
                     // PID alive but .daemon file has different PID → PID was reused
@@ -400,13 +423,24 @@ pub fn sweep_stale_run_dirs(home: &Path) {
 }
 
 /// Write daemon identity file for PID reuse detection.
+///
+/// Format: `{pid}:{boot_unix}:{start_token}`. The third field
+/// (CR-2026-06-14 zombie-kill identity-compare) is the OS process start-time
+/// token (see [`crate::process::process_start_token`]) so a stale `.daemon`
+/// whose PID got recycled onto an unrelated process is detectable: the
+/// recorded token won't match the live process's. Appended (not inserted) so
+/// the existing first/second-field readers keep working. `0` when the
+/// self-token can't be resolved — a recorded `0` will never match a real
+/// live token, so the conservative outcome is fail-closed (never signal),
+/// which is the safe direction.
 pub(crate) fn write_daemon_id(run_dir: &Path) {
     let pid = std::process::id();
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs())
         .unwrap_or(0);
-    let _ = std::fs::write(run_dir.join(".daemon"), format!("{pid}:{now}"));
+    let token = crate::process::process_start_token(pid).unwrap_or(0);
+    let _ = std::fs::write(run_dir.join(".daemon"), format!("{pid}:{now}:{token}"));
 }
 
 /// Read the PID recorded in `{run_dir}/.daemon`. Returns `None` if the file is
@@ -420,14 +454,33 @@ pub(crate) fn read_daemon_pid(run_dir: &Path) -> Option<u32> {
 }
 
 /// Read the boot epoch (unix seconds) recorded in `{run_dir}/.daemon`
-/// (`{pid}:{boot_unix}`). Used by the worktree force-reclaim boot-grace
-/// (reviewer-2 #5). `None` if the file is missing or malformed.
+/// (`{pid}:{boot_unix}:{start_token}`). Used by the worktree force-reclaim
+/// boot-grace (reviewer-2 #5). `None` if the file is missing or malformed.
+///
+/// CR-2026-06-14: splits on `:` and takes field index 1 rather than
+/// `split_once(':').1` — the latter would capture `"{boot_unix}:{start_token}"`
+/// once the third field was appended and fail to parse as a u64.
 pub(crate) fn read_daemon_boot_unix(run_dir: &Path) -> Option<u64> {
     std::fs::read_to_string(run_dir.join(".daemon"))
         .ok()?
         .trim()
-        .split_once(':')
-        .and_then(|(_, ts)| ts.parse().ok())
+        .split(':')
+        .nth(1)
+        .and_then(|ts| ts.parse().ok())
+}
+
+/// Read the OS process start-time token recorded in `{run_dir}/.daemon`
+/// (`{pid}:{boot_unix}:{start_token}`, field index 2). `None` if the file is
+/// missing, malformed, or written by a pre-CR-2026-06-14 daemon (no third
+/// field) — callers MUST treat `None` as "identity unverifiable → fail
+/// closed" per the zombie-kill identity-compare design.
+pub(crate) fn read_daemon_start_token(run_dir: &Path) -> Option<u64> {
+    std::fs::read_to_string(run_dir.join(".daemon"))
+        .ok()?
+        .trim()
+        .split(':')
+        .nth(2)
+        .and_then(|t| t.parse().ok())
 }
 
 /// Agent definition tuple for daemon startup.
@@ -2190,11 +2243,23 @@ mod tests {
         write_daemon_id(&run);
         let content = std::fs::read_to_string(run.join(".daemon")).expect("read .daemon");
         let parts: Vec<&str> = content.split(':').collect();
-        assert_eq!(parts.len(), 2);
+        // CR-2026-06-14: format is now `{pid}:{boot_unix}:{start_token}`.
+        assert_eq!(parts.len(), 3);
         assert_eq!(parts[0], std::process::id().to_string());
         // Timestamp should be a positive number
         let ts: u64 = parts[1].parse().expect("parse timestamp");
         assert!(ts > 0);
+        // Start-token parses; for our own (alive) PID it resolves non-zero.
+        let token: u64 = parts[2].parse().expect("parse start_token");
+        assert_eq!(
+            token,
+            crate::process::process_start_token(std::process::id()).unwrap_or(0),
+            "recorded token must equal the live self start-token"
+        );
+        // The middle-field reader must still parse boot_unix (not "ts:token").
+        assert_eq!(read_daemon_boot_unix(&run), Some(ts));
+        // The new third-field reader returns the recorded token.
+        assert_eq!(read_daemon_start_token(&run), Some(token));
         std::fs::remove_dir_all(&home).ok();
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1066,7 +1066,8 @@ fn main() -> anyhow::Result<()> {
                 let mut refused = 0;
                 for z in &zombies {
                     log_zombie_state(z.pid);
-                    let outcome = cleanup_zombie_daemon(z.pid, term_grace, kill_grace);
+                    let outcome =
+                        cleanup_zombie_daemon(z.pid, z.start_token, term_grace, kill_grace);
                     match outcome {
                         KillOutcome::Graceful(d) => {
                             println!("  PID {} reaped gracefully ({}ms)", z.pid, d.as_millis());
@@ -1079,6 +1080,13 @@ fn main() -> anyhow::Result<()> {
                         }
                         KillOutcome::WindowsTerminated => {
                             println!("  PID {} terminated (Windows TerminateProcess)", z.pid);
+                        }
+                        KillOutcome::IdentityMismatch => {
+                            println!(
+                                "  PID {} skipped — start-token mismatch (PID recycled; \
+                                 no signal sent)",
+                                z.pid
+                            );
                         }
                         KillOutcome::RefusedToDie => {
                             eprintln!(

--- a/src/process.rs
+++ b/src/process.rs
@@ -36,6 +36,89 @@ pub fn is_pid_alive(pid: u32) -> bool {
     }
 }
 
+/// Cross-platform process start-time token: an identifier that is stable for
+/// the lifetime of a single process but (almost certainly) differs from any
+/// later process that the OS happens to recycle the same PID onto. Used to
+/// distinguish "the daemon we recorded" from "an innocent process that landed
+/// on the recycled PID" so a stale kill can't TOCTOU onto the wrong target
+/// (CR-2026-06-14 zombie-kill identity-compare).
+///
+/// Returns `None` when the value can't be obtained (process gone, syscall /
+/// parse failure, unsupported platform). Callers MUST treat `None` as
+/// "identity unknown → fail closed" (do not signal). The absolute value is
+/// opaque; only equality across two reads of the *same PID* is meaningful.
+///
+/// - **Linux**: `/proc/<pid>/stat` field 22 (`starttime`, clock ticks since
+///   boot). The `comm` field (2) can contain spaces and parens, so parse the
+///   tail after the final `)`.
+/// - **macOS**: `proc_pidinfo(PROC_PIDTBSDINFO)` → `proc_bsdinfo.pbi_start_*`
+///   (process start wall-clock, microsecond resolution).
+/// - **Windows**: `GetProcessTimes` creation `FILETIME` (100ns ticks since
+///   1601), the canonical per-process start instant.
+pub fn process_start_token(pid: u32) -> Option<u64> {
+    if pid == 0 {
+        return None;
+    }
+    #[cfg(target_os = "linux")]
+    {
+        let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+        // `pid (comm) state ppid ...` — comm may embed spaces/parens, so
+        // split AFTER the last ')'. The remainder begins at field 3 (state),
+        // so `starttime` (field 22) is index 22 - 3 = 19 of the tail.
+        let tail = &stat[stat.rfind(')')? + 1..];
+        tail.split_whitespace().nth(19)?.parse::<u64>().ok()
+    }
+    #[cfg(target_os = "macos")]
+    {
+        // SAFETY: proc_pidinfo writes at most `size_of::<proc_bsdinfo>()` bytes
+        // into our stack buffer; we pass that exact size and check the return.
+        let mut info: libc::proc_bsdinfo = unsafe { std::mem::zeroed() };
+        let size = std::mem::size_of::<libc::proc_bsdinfo>() as libc::c_int;
+        let n = unsafe {
+            libc::proc_pidinfo(
+                pid as libc::c_int,
+                libc::PROC_PIDTBSDINFO,
+                0,
+                &mut info as *mut _ as *mut libc::c_void,
+                size,
+            )
+        };
+        if n != size {
+            return None;
+        }
+        Some(info.pbi_start_tvsec * 1_000_000 + info.pbi_start_tvusec)
+    }
+    #[cfg(windows)]
+    {
+        use windows_sys::Win32::Foundation::{CloseHandle, FILETIME};
+        use windows_sys::Win32::System::Threading::{
+            GetProcessTimes, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+        };
+        let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
+        if handle.is_null() {
+            return None;
+        }
+        let mut creation: FILETIME = unsafe { std::mem::zeroed() };
+        let mut exit: FILETIME = unsafe { std::mem::zeroed() };
+        let mut kernel: FILETIME = unsafe { std::mem::zeroed() };
+        let mut user: FILETIME = unsafe { std::mem::zeroed() };
+        let ok =
+            unsafe { GetProcessTimes(handle, &mut creation, &mut exit, &mut kernel, &mut user) };
+        unsafe {
+            CloseHandle(handle);
+        }
+        if ok == 0 {
+            return None;
+        }
+        Some(((creation.dwHighDateTime as u64) << 32) | creation.dwLowDateTime as u64)
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
+    {
+        let _ = pid;
+        None
+    }
+}
+
 /// Send SIGTERM to a process (Unix) or terminate it (Windows).
 pub fn terminate(pid: u32) {
     if pid == 0 {
@@ -200,5 +283,24 @@ mod tests {
     fn kill_process_tree_with_pid_zero_is_noop() {
         // Should not panic or kill anything
         kill_process_tree(0);
+    }
+
+    #[test]
+    fn process_start_token_self_is_some_and_stable() {
+        // Our own process is alive on a supported OS → token resolves and is
+        // stable across reads (the value is constant for a process lifetime).
+        let a = process_start_token(std::process::id());
+        assert!(
+            a.is_some(),
+            "self start-token must resolve on a supported OS"
+        );
+        let b = process_start_token(std::process::id());
+        assert_eq!(a, b, "start-token must be stable across reads of same PID");
+    }
+
+    #[test]
+    fn process_start_token_pid_zero_is_none() {
+        // pid 0 is never a real tracked process — mirrors is_pid_alive's guard.
+        assert_eq!(process_start_token(0), None);
     }
 }

--- a/tests/review_bootstrap_config_cli_3.rs
+++ b/tests/review_bootstrap_config_cli_3.rs
@@ -26,7 +26,6 @@
 //! start-time vs the `.daemon` identity) before signalling.
 
 #[test]
-#[ignore = "zombie-kill-toctou: red until fix; remove #[ignore] after fix to confirm"]
 fn cleanup_zombie_daemon_must_recheck_identity_before_signal_bootstrap_config_cli() {
     let path =
         std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/admin/cleanup_zombies.rs");


### PR DESCRIPTION
## CR-2026-06-14 redesign — zombie-kill identity-compare

**Finding** (`src/admin/cleanup_zombies.rs:134-176`): `cleanup_zombie_daemon` selected its target purely by run-dir name + `.daemon` mtime and sent SIGTERM/SIGKILL after a single entry `is_alive(pid)`. Between selection and the signal the OS can recycle the PID onto an unrelated process → the **innocent newcomer gets killed** (TOCTOU).

## Fix (lead + reviewer-2 converged design)

- **DP1 — `crate::process::process_start_token(pid) -> Option<u64>`**: OS process start-time token, cross-platform 3 OS:
  - Linux: `/proc/<pid>/stat` field 22 (`starttime`)
  - macOS: `proc_pidinfo(PROC_PIDTBSDINFO)` → `pbi_start_tvsec/tvusec`
  - Windows: `GetProcessTimes` creation `FILETIME`
- **DP2 — `.daemon` append**: format is now `pid:boot_unix:start_token`. Appended (not inserted): `read_daemon_pid` (first field) unchanged; `read_daemon_boot_unix` switched `split_once`→`split.nth(1)` so the middle field still parses (old code would read `"boot:token"` and fail → would have silently broken the worktree force-reclaim boot-grace); new `read_daemon_start_token` reads the third field.
- **DP3 — pure `should_signal(recorded, current)`**: signal ONLY when both tokens known AND equal. Legacy no-token / unreadable / mismatch → fail-closed-skip → `KillOutcome::IdentityMismatch` (no signal sent; next-boot stale-pid sweep reclaims the dir).
- **kill primitive**: `cleanup_zombie_daemon` takes `recorded_token` and re-verifies before **every** signal (entry + before SIGKILL); `poll_until_dead_or_recycled` makes the grace loop identity-aware (recycle mid-grace → original gone → never escalate onto the newcomer).
- **DP5 — `find_active_run_dir`**: on a same-PID match it now also compares the recorded token vs the live process's, catching same-number reuse (legacy no-token → PID-only accept, back-compat).

`poll_until_dead` is now test-only (`#[cfg(all(test, unix))]`) — production moved to the identity-aware variant.

## Verification (red→green)

**Behavioral repro** (`src/admin/cleanup_zombies.rs` tests):
- `cleanup_skips_when_live_token_differs_from_recorded_pid_recycled` — recycled PID (live token ≠ recorded) → `IdentityMismatch`, innocent process **survives**.
- `cleanup_kills_when_live_token_matches_recorded_real_zombie` (**control**) — matching token → real zombie still killed (proves gate didn't break killing).
- `cleanup_skips_legacy_no_token_fail_closed` — `None` token → fail-closed-skip.
- `should_signal_only_when_both_known_and_equal` — pure-core table.

**RED proof**: dropping the gate (`should_signal → true`) flips both skip tests RED — `assertion failed: ... got Graceful` (the innocent process was killed) — while the control stays green. The static guard (`tests/review_bootstrap_config_cli_3.rs`, `#[ignore]` removed) stays green even with the gate dropped, demonstrating why the behavioral repro is the load-bearing one.

**CI-parity**: `cargo fmt` + `clippy --all-targets --features tray -D warnings` green; **Windows cross-check** (`cargo xwin check ... x86_64-pc-windows-msvc`) green; full `--tests` green except two pre-existing agent-env git-shim false-fails (`dispatch_branch_..._1834`, `api_port_published_...`) which pass under `AGEND_GIT_BYPASS=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)