### PR TITLE
fix(CR-2026-06-14 row232): sweep apply guards Cancelled against a raced-Done task

### DIFF
--- a/src/tasks/sweep.rs
+++ b/src/tasks/sweep.rs
@@ -405,6 +405,11 @@ pub(super) fn emit_cancelled_batch(
         }
         "validation_leftovers"
     };
+    // Collect (id, category) so the `task_sweep_apply` audit lines are written
+    // only AFTER the cancel actually commits — the in-lock guard below can
+    // reject the batch, and an audit line for a cancel that never happened
+    // would mislead.
+    let mut audit: Vec<(String, &'static str)> = Vec::new();
     for id in confirm_ids {
         let category = lookup_category(id);
         events.push(TaskEvent::Cancelled {
@@ -412,18 +417,50 @@ pub(super) fn emit_cancelled_batch(
             by: emitter.clone(),
             reason: format!("sweep:{category}: {audit_reason}"),
         });
-        crate::event_log::log(
-            home,
-            "task_sweep_apply",
-            "system:task_sweep",
-            &format!("task={id} category={category} reason={audit_reason}"),
-        );
+        audit.push((id.clone(), category));
     }
     let count = events.len();
     if count == 0 {
         return Ok(0);
     }
-    crate::task_events::append_batch(home, &emitter, events)
-        .map(|_| count)
-        .map_err(|e| e.to_string())
+    // CR-2026-06-14 (row232): re-validate UNDER the append lock against FRESH
+    // committed state. The dry-run that produced `confirm_ids` is out-of-lock, so
+    // a task can race to a terminal state (Done/Cancelled) before apply. A bare
+    // `append_batch` would clobber that terminal status (replay does not re-guard
+    // transitions). Fail closed: if ANY confirmed task is no longer cancellable,
+    // reject the whole batch — the operator re-runs the sweep, whose dry-run
+    // re-scans and drops the now-terminal task. The closure only inspects the
+    // replayed state — no `api::call` under the lock (#1629).
+    let checked = crate::task_events::append_batch_checked(home, &emitter, events, |state| {
+        for id in confirm_ids {
+            if let Some(rec) = state.tasks.get(&TaskId(id.clone())) {
+                if !rec
+                    .status
+                    .can_transition_to(crate::task_events::TaskStatus::Cancelled)
+                {
+                    return Err(format!(
+                        "task '{id}' is no longer cancellable (now {}); sweep aborted to avoid \
+                         clobbering a terminal task — re-run the sweep",
+                        super::status_to_legacy_str(rec.status)
+                    ));
+                }
+            }
+        }
+        Ok(())
+    });
+    match checked {
+        Ok(Ok(_)) => {
+            for (id, category) in &audit {
+                crate::event_log::log(
+                    home,
+                    "task_sweep_apply",
+                    "system:task_sweep",
+                    &format!("task={id} category={category} reason={audit_reason}"),
+                );
+            }
+            Ok(count)
+        }
+        Ok(Err(reason)) => Err(reason),
+        Err(e) => Err(e.to_string()),
+    }
 }

--- a/src/tasks/tests.rs
+++ b/src/tasks/tests.rs
@@ -3061,6 +3061,146 @@ fn test_sweep_apply_emits_cancelled_and_logs_audit() {
     std::fs::remove_dir_all(&home).ok();
 }
 
+// ── CR-2026-06-14 row232 — sweep apply must not clobber a concurrently-Done
+//    task (the dry-run → apply window is a TOCTOU; the in-lock guard fails
+//    closed). ──
+
+/// RED pre-fix: a task confirmed during the out-of-lock dry-run that races to
+/// Done before apply is clobbered back to Cancelled by the bare `append_batch`.
+/// GREEN: the in-lock legality guard rejects the batch and the Done is preserved.
+#[test]
+fn sweep_apply_does_not_clobber_concurrently_done_task_row232() {
+    let home = tmp_home("sweep_row232_clobber");
+    write_fleet_yaml(&home, &["alive"]);
+    let r = handle(
+        &home,
+        "alive",
+        &serde_json::json!({"action":"create","title":"raced task","assignee":"alive"}),
+    );
+    let task_id = r["id"].as_str().expect("id").to_string();
+    // The task races to Done after the operator confirmed it for the sweep.
+    let upd = handle(
+        &home,
+        "alive",
+        &serde_json::json!({"action":"update","id":task_id,"status":"done"}),
+    );
+    assert!(upd.get("error").is_none(), "setup: mark done: {upd}");
+
+    let confirm: std::collections::HashSet<String> = [task_id.clone()].into_iter().collect();
+    let res = sweep::emit_cancelled_batch(
+        &home,
+        &sweep::Categories::default(),
+        &confirm,
+        "row232 clobber fixture",
+    );
+    assert!(
+        res.is_err(),
+        "apply must reject when a confirmed task raced to Done (no clobber)"
+    );
+    assert!(res.unwrap_err().contains("no longer cancellable"));
+
+    let after = list_all(&home)
+        .into_iter()
+        .find(|t| t.id == task_id)
+        .expect("task");
+    assert_eq!(
+        after.status,
+        crate::task_events::TaskStatus::Done,
+        "the concurrently-Done task must NOT be clobbered to Cancelled"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// Control: a genuinely-stale, still-cancellable task is still cancelled (the
+/// guard must not over-reject).
+#[test]
+fn sweep_apply_still_cancels_genuinely_stale_task_row232() {
+    let home = tmp_home("sweep_row232_control");
+    write_fleet_yaml(&home, &["alive"]);
+    let r = handle(
+        &home,
+        "alive",
+        &serde_json::json!({"action":"create","title":"stale task","assignee":"alive"}),
+    );
+    let task_id = r["id"].as_str().expect("id").to_string();
+    let confirm: std::collections::HashSet<String> = [task_id.clone()].into_iter().collect();
+    let count = sweep::emit_cancelled_batch(
+        &home,
+        &sweep::Categories::default(),
+        &confirm,
+        "row232 control",
+    )
+    .expect("a still-cancellable task must be swept");
+    assert_eq!(count, 1);
+    let after = list_all(&home)
+        .into_iter()
+        .find(|t| t.id == task_id)
+        .expect("task");
+    assert_eq!(
+        after.status,
+        crate::task_events::TaskStatus::Cancelled,
+        "a genuinely-stale cancellable task must still be cancelled"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// Fail-closed is atomic: a batch mixing a cancellable task with a raced-Done
+/// task aborts wholesale — neither is mutated (the operator re-runs the sweep).
+#[test]
+fn sweep_apply_mixed_batch_fails_closed_row232() {
+    let home = tmp_home("sweep_row232_mixed");
+    write_fleet_yaml(&home, &["alive"]);
+    let open_id = handle(
+        &home,
+        "alive",
+        &serde_json::json!({"action":"create","title":"open one","assignee":"alive"}),
+    )["id"]
+        .as_str()
+        .expect("id")
+        .to_string();
+    let done_id = handle(
+        &home,
+        "alive",
+        &serde_json::json!({"action":"create","title":"raced one","assignee":"alive"}),
+    )["id"]
+        .as_str()
+        .expect("id")
+        .to_string();
+    handle(
+        &home,
+        "alive",
+        &serde_json::json!({"action":"update","id":done_id,"status":"done"}),
+    );
+
+    let confirm: std::collections::HashSet<String> =
+        [open_id.clone(), done_id.clone()].into_iter().collect();
+    let res = sweep::emit_cancelled_batch(
+        &home,
+        &sweep::Categories::default(),
+        &confirm,
+        "row232 mixed",
+    );
+    assert!(
+        res.is_err(),
+        "a batch containing a raced-Done task must fail closed (atomic)"
+    );
+
+    let listed = list_all(&home);
+    let open_after = listed.iter().find(|t| t.id == open_id).expect("open task");
+    let done_after = listed.iter().find(|t| t.id == done_id).expect("done task");
+    assert_eq!(
+        open_after.status,
+        crate::task_events::TaskStatus::Open,
+        "fail-closed: the open task is NOT cancelled (operator re-runs)"
+    );
+    assert_eq!(
+        done_after.status,
+        crate::task_events::TaskStatus::Done,
+        "the Done task is preserved"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
 // ── #2061 stale_open category ──
 
 /// Create one Open task owned by a LIVE agent (so team_disbanded never fires)


### PR DESCRIPTION
## CR-2026-06-14 — sweep bare Cancelled, no in-lock legality guard (row232)

**Finding** (`src/tasks/sweep.rs:408-426`): `emit_cancelled_batch` built `Cancelled` events from the operator-confirmed `confirm_ids` (produced by the **out-of-lock** dry-run) and committed them via a bare `append_batch` — **no in-lock legality check**. A task that raced to a terminal state (Done/Cancelled) between dry-run and apply would be **clobbered** back to Cancelled (replay does not re-guard transitions). Same in-lock-emit class as **:231 (#2169)**, on the sweep path.

**Fast-follow to #2169, separate PR per lead DP2** (not bundled — avoids coupling two findings' repros).

### Change (`sweep.rs`)
Switch the commit from `append_batch` → `append_batch_checked` with a precondition that re-validates **under the append lock against FRESH committed state**: if ANY confirmed task is no longer cancellable (`can_transition_to(Cancelled)` false → already Done/Cancelled), reject the whole batch **fail-closed**. The operator re-runs the sweep, whose dry-run re-scans and drops the now-terminal task. The closure only inspects replayed state — **no `api::call` under the lock** (#1629). The `task_sweep_apply` audit lines now write **only after** the cancel commits, so a rejected batch leaves no misleading trail.

**No shared helper with :231's `update_batch_precondition`** — the legality conditions differ (cancel-if-not-terminal here vs ACL + by-drift there), so each stays inline and clear (YAGNI, per lead).

### Tests (red→green; RED proven by neutering the guard → clobber + mixed tests failed, control stayed green)
- a confirmed task that raced to **Done** → rejected, Done preserved (no clobber)
- a genuinely-stale **cancellable** task → still cancelled (no over-rejection)
- a **mixed** batch (Open + raced-Done) → fails closed atomically, neither mutated

### Verification
- `cargo nextest run --features tray 'tasks::'` → 136/136 pass
- `cargo fmt --check` clean · `cargo clippy --features tray --tests -- -D warnings` clean

Requesting **dual-review** (concurrency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)