### PR TITLE
fix(CR-2026-06-14 E4.5): is_protected_ref case-insensitive — close branch="Main" bypass on case-insensitive FS

### DIFF
--- a/src/agent_ops.rs
+++ b/src/agent_ops.rs
@@ -302,8 +302,18 @@ pub fn validate_branch(branch: &str) -> bool {
 /// extending the set here propagates to every E4.5 enforcement site
 /// (currently `worktree_pool::lease` for worktree leases and
 /// `mcp::handlers::ci::handle_watch_ci` for CI watch subscriptions).
+///
+/// CR-2026-06-14: matched **case-insensitively**. On a case-insensitive
+/// filesystem (darwin/APFS, Windows NTFS) `refs/heads/Main` and
+/// `refs/heads/main` collide — a `branch="Main"` lease passes a case-sensitive
+/// guard, then `git worktree add -b Main` fails ("already exists") and the
+/// fallback `git worktree add <path> Main` checks out the EXISTING `main`, so
+/// the agent commits land on `main` (empirically reproduced on darwin/APFS:
+/// committing on "Main" advanced `main`). `eq_ignore_ascii_case` is a full-
+/// string compare, so substrings like `mainline` / `maintenance` /
+/// `upstream-main` stay unprotected.
 pub fn is_protected_ref(branch: &str) -> bool {
-    matches!(branch, "main" | "master")
+    branch.eq_ignore_ascii_case("main") || branch.eq_ignore_ascii_case("master")
 }
 
 pub fn ensure_not_protected(branch: &str) -> Result<(), String> {
@@ -730,20 +740,30 @@ mod tests {
     }
 
     #[test]
-    fn is_protected_ref_case_sensitive_by_design() {
-        // Git refs ARE case-sensitive on case-sensitive filesystems;
-        // matching the literal lowercase "main"/"master" is intentional.
-        // Anything else (Main, MAIN, Master) is a different ref and not
-        // protected by this invariant.
-        assert!(!is_protected_ref("Main"));
-        assert!(!is_protected_ref("MAIN"));
-        assert!(!is_protected_ref("Master"));
+    fn is_protected_ref_case_insensitive_blocks_case_variants() {
+        // CR-2026-06-14: the prior "case-sensitive by design" stance was
+        // empirically falsified on darwin/APFS — a case-insensitive FS folds
+        // refs/heads/Main onto refs/heads/main, so `branch="Main"` lands the
+        // agent's worktree on `main` (committing on "Main" advanced `main`).
+        // Every case variant of main/master MUST be protected.
+        for v in ["Main", "MAIN", "mAiN", "Master", "MASTER", "mAsTeR"] {
+            assert!(
+                is_protected_ref(v),
+                "case variant {v:?} must be protected (E4.5 case-insensitive)"
+            );
+        }
     }
 
     #[test]
     fn is_protected_ref_rejects_empty_and_substrings() {
+        // eq_ignore_ascii_case is a full-string compare, so a branch that
+        // merely CONTAINS "main"/"master" (or differs by more than case) is
+        // not over-blocked.
         assert!(!is_protected_ref(""));
         assert!(!is_protected_ref("mainline"));
+        assert!(!is_protected_ref("maintenance"));
+        assert!(!is_protected_ref("main-feature"));
+        assert!(!is_protected_ref("Maintenance"));
         assert!(!is_protected_ref("upstream-main"));
         assert!(!is_protected_ref("master/dev"));
     }

--- a/src/bin/agend-git.rs
+++ b/src/bin/agend-git.rs
@@ -289,8 +289,12 @@ enum Action {
 /// builds standalone without the full library surface. Sprint 57
 /// Wave 2 Track B introduced the lib-side helper; the literal here
 /// MUST stay in sync.
+///
+/// CR-2026-06-14: matched **case-insensitively** (mirrors the lib-side fix).
+/// A case-insensitive FS folds `Main`→`main`, so a case-sensitive guard would
+/// let `branch="Main"` slip past gh-push protection here.
 fn is_protected_ref(branch: &str) -> bool {
-    matches!(branch, "main" | "master")
+    branch.eq_ignore_ascii_case("main") || branch.eq_ignore_ascii_case("master")
 }
 
 /// #778 Option 3 (originally) + #852 residual PR-A: detect that cwd
@@ -1536,6 +1540,25 @@ fn format_conflict_guidance() -> &'static str {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+
+    // ── CR-2026-06-14: shim is_protected_ref must mirror the lib-side
+    // case-insensitive E4.5 guard (kept in sync; see agent_ops.rs). ──
+    #[test]
+    fn shim_is_protected_ref_case_insensitive() {
+        for v in ["main", "master", "Main", "MAIN", "Master", "MASTER"] {
+            assert!(is_protected_ref(v), "{v:?} must be protected");
+        }
+        // Full-string compare: substrings / case-only-prefix are not over-blocked.
+        for v in [
+            "mainline",
+            "maintenance",
+            "main-feature",
+            "upstream-main",
+            "",
+        ] {
+            assert!(!is_protected_ref(v), "{v:?} must NOT be protected");
+        }
+    }
 
     // ── #1651: binding.json HMAC verify (push-authority integrity) ──
     fn home_1651(tag: &str) -> PathBuf {


### PR DESCRIPTION
## CR-2026-06-14 security follow-up — E4.5 protected-branch case-insensitivity

**Source**: H6 #2159 dual-reviewer observation; lead decision `d-20260614194314321364-2`.

`is_protected_ref` matched `main`/`master` **case-sensitively**. On a case-insensitive filesystem (darwin/APFS, Windows NTFS) `refs/heads/Main` folds onto `refs/heads/main`, so a `branch="Main"` lease/spawn/ci-watch **passed the E4.5 guard**, then `worktree::create`'s `git worktree add -b Main` failed (`a branch named 'Main' already exists`) and the **fallback** `git worktree add <path> Main` checked out the **existing main** — the agent then committed directly onto `main`.

## Empirical verification (verify-first)

On darwin/APFS (disposable `/tmp` repo, never touched canonical/operator home):
1. FS confirmed case-insensitive.
2. `is_protected_ref("Main")` = false → passes `ensure_not_protected`.
3. `git worktree add -b Main` → `fatal: a branch named 'Main' already exists`.
4. fallback `git worktree add <path> Main` → exit 0, checks out existing `main` (same sha).
5. **Committing on the "Main" worktree advanced `main`'s sha** (afb0bcd → 72745d7).

Platform-conditional: case-sensitive Linux creates a genuinely separate "Main" branch → no bypass. But the operator runs darwin/APFS.

## Fix

`is_protected_ref` → `branch.eq_ignore_ascii_case("main") || branch.eq_ignore_ascii_case("master")` — one change propagates to every E4.5 site (`worktree_pool::lease`, CI watch, `cleanup_merged_branch`). The shim's standalone mirror (`src/bin/agend-git.rs:292`, gh-push protection — a separate enforcement layer that can't `use` the bin-crate helper, so kept as two copies) gets the same fix for cross-layer consistency. `eq_ignore_ascii_case` is a full-string compare → substrings (`mainline`/`maintenance`/`main-feature`/`upstream-main`) stay unprotected.

## Repro (red→green) — deterministic unit guard-contract

Per lead: **not** the behavioral worktree-lands-on-main test (platform-dependent → would false-green on case-sensitive Linux CI). The CI gate is the pure guard contract:
- `is_protected_ref_case_insensitive_blocks_case_variants` (flipped from the old `is_protected_ref_case_sensitive_by_design`, whose premise was empirically falsified): `Main/MAIN/mAiN/Master/MASTER/mAsTeR` all protected.
- `shim_is_protected_ref_case_insensitive`: mirror coverage in `agend-git.rs`.
- negative cases (`mainline`/`maintenance`/`main-feature`/`upstream-main`/`""`) confirm no over-block.

RED (pre-fix `matches!` → "Main" false) verified by reverting the guard: both case-variant tests FAIL; GREEN with the fix.

## CI-parity

`cargo fmt --check` + `clippy --all-targets --features tray -D warnings` + **Windows cross-check** (`cargo xwin`) all green; full `--tests` green except the pre-existing agent-env git-shim false-fail `dispatch_branch_..._1834` (passes under `AGEND_GIT_BYPASS=1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)