### PR TITLE
fix(CR-2026-06-14 medium): word-anchor compliance review-verdict (UNVERIFIED/NOT VERIFIED ≠ pass)

### DIFF
--- a/src/daemon/task_sweep.rs
+++ b/src/daemon/task_sweep.rs
@@ -744,10 +744,52 @@ fn get_pr_changed_files(pr_number: u64, repo: &str) -> Vec<String> {
     }
 }
 
-/// Check 1: PR body contains "VERIFIED" verdict.
+/// Check 1: PR body contains a genuine passing `VERIFIED` verdict.
+///
+/// Word-anchored, NOT a bare substring: `"VERIFIED"` is a substring of
+/// `"UNVERIFIED"` and appears in `"NOT VERIFIED"`, so the old
+/// `to_uppercase().contains("VERIFIED")` passed an explicitly *rejected* review
+/// — the exact rejected-but-merged false-negative Issue #664 exists to surface.
+/// A `VERIFIED` token counts only when it is (a) bounded by non-alphanumeric
+/// chars (rejects `UNVERIFIED` / `VERIFIEDx`) and (b) not immediately preceded
+/// by a `NOT` word (rejects `NOT VERIFIED`). Scans every occurrence so a body
+/// that mentions both (`was UNVERIFIED, now VERIFIED`) still passes on the
+/// genuine one. Mirrors the auto-release word-anchoring (auto_release.rs:432)
+/// rather than a loose substring.
 fn has_review_verdict(pr: &PrMeta) -> bool {
+    const WORD: &str = "VERIFIED";
     let body_upper = pr.body.to_uppercase();
-    body_upper.contains("VERIFIED")
+    let mut from = 0;
+    while let Some(rel) = body_upper[from..].find(WORD) {
+        let start = from + rel;
+        let end = start + WORD.len();
+        let preceded_by_alnum = body_upper[..start]
+            .chars()
+            .next_back()
+            .is_some_and(|c| c.is_alphanumeric());
+        let followed_by_alnum = body_upper[end..]
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_alphanumeric());
+        if !preceded_by_alnum && !followed_by_alnum {
+            // Reject an explicit `NOT` negation directly before the token
+            // (the immediately preceding word, ignoring punctuation/space).
+            let prev_word: String = body_upper[..start]
+                .chars()
+                .rev()
+                .skip_while(|c| !c.is_alphanumeric())
+                .take_while(|c| c.is_alphanumeric())
+                .collect::<Vec<_>>()
+                .into_iter()
+                .rev()
+                .collect();
+            if prev_word != "NOT" {
+                return true;
+            }
+        }
+        from = end;
+    }
+    false
 }
 
 /// #PR-C: client-side reproduction of site-6's prior `gh` `--jq`:

--- a/src/daemon/task_sweep/review_repro_daemon_retention.rs
+++ b/src/daemon/task_sweep/review_repro_daemon_retention.rs
@@ -32,7 +32,6 @@ fn pr_with_body(body: &str) -> PrMeta {
 }
 
 #[test]
-#[ignore = "daemon-retention review-verdict-substring: red until fix; remove #[ignore] after fix to confirm"]
 fn unverified_body_is_not_a_passing_review_verdict_daemon_retention() {
     // A review that came back UNVERIFIED must NOT satisfy the verdict gate.
     let unverified = pr_with_body("Review result: UNVERIFIED by reviewer-codex");


### PR DESCRIPTION
## Finding (CR-2026-06-14 Medium, correctness / merge-gate safety)

`src/daemon/task_sweep.rs` `has_review_verdict` (Issue #664 post-merge
compliance scanner) gated on:

```rust
pr.body.to_uppercase().contains("VERIFIED")
```

`"VERIFIED"` is a substring of `"UNVERIFIED"` and appears in `"NOT VERIFIED"`,
so a PR whose review came back **explicitly UNVERIFIED / NOT VERIFIED PASSED**
the gate. The compliance/auto-close path then treated a rejected-but-merged PR
as compliant — the exact false-negative #664 exists to surface.

## Fix

Word-anchor the match (mirrors the existing auto-release anchoring at
`auto_release.rs:432`, not a loose substring). A `VERIFIED` token counts only
when it is:
- (a) **bounded by non-alphanumeric chars** → rejects `UNVERIFIED` (preceded by
  `N`) and `VERIFIEDx`;
- (b) **not immediately preceded by a `NOT` word** → rejects `NOT VERIFIED`.

Scans every occurrence, so a body mentioning both (`was UNVERIFIED, now
VERIFIED`) still passes on the genuine one. A genuine `VERIFIED` still passes —
no over-correction (the spec's "don't kill legit VERIFIED").

## Repro (red→green)

`unverified_body_is_not_a_passing_review_verdict_daemon_retention` un-ignored:
- **red** (verified by temporarily reverting to the buggy one-liner): panics at
  the UNVERIFIED assertion — `bare contains("VERIFIED") matches UNVERIFIED as a
  pass`.
- **green** (fix in place): all three pass — UNVERIFIED fails the gate, NOT
  VERIFIED fails the gate, genuine `VERIFIED` passes.
- Existing `compliance_review_verdict_detected` / `_missing` still pass.

## CI parity

`cargo fmt --check` ✓, `cargo clippy --tests --features tray -D warnings` (0
warnings) ✓, targeted nextest green ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)