### PR TITLE
fix(CR-2026-06-14 medium+low): fail-closed corrupt-config backup in mcp_config (no silent data loss)

### DIFF
--- a/src/mcp_config.rs
+++ b/src/mcp_config.rs
@@ -128,16 +128,34 @@ fn upsert_mcp_servers(path: &Path, instance_name: Option<&str>) -> Result<()> {
         match serde_json::from_str(&content) {
             Ok(v) => v,
             Err(e) => {
-                tracing::warn!(
-                    path = %path.display(),
-                    error = %e,
-                    "malformed MCP config JSON, backing up and starting fresh"
-                );
                 let backup = path.with_extension(format!(
                     "corrupt.{}",
                     chrono::Utc::now().format("%Y%m%d%H%M%S")
                 ));
-                let _ = std::fs::copy(path, &backup);
+                // Fail-CLOSED: the prior `let _ = std::fs::copy(path, &backup)`
+                // discarded the copy result, so a copy failure (disk full,
+                // permission) destroyed the user's ONLY copy on the atomic_write
+                // below while the warn claimed a backup was made. Reuse store.rs's
+                // robust rename-first backup; if it CANNOT preserve the corrupt
+                // bytes, refuse to overwrite — return Err and leave the original
+                // on disk for the operator to rescue.
+                if !crate::store::backup_corrupt_file(path, &backup) {
+                    tracing::error!(
+                        path = %path.display(),
+                        error = %e,
+                        "malformed MCP config JSON AND backup failed — refusing to overwrite (original preserved)"
+                    );
+                    anyhow::bail!(
+                        "malformed MCP config at {} and its backup failed; refusing to overwrite (original preserved for rescue)",
+                        path.display()
+                    );
+                }
+                tracing::warn!(
+                    path = %path.display(),
+                    backup = %backup.display(),
+                    error = %e,
+                    "malformed MCP config JSON, backed up corrupt file and starting fresh"
+                );
                 json!({})
             }
         }
@@ -238,7 +256,40 @@ fn upsert_state_hooks(path: &Path, instance_name: &str) -> Result<()> {
     }
     let _lock = crate::store::acquire_file_lock(&config_lock_path(path))?;
     let mut config: serde_json::Value = if path.exists() {
-        serde_json::from_str(&std::fs::read_to_string(path)?).unwrap_or(json!({}))
+        let content = std::fs::read_to_string(path)?;
+        match serde_json::from_str(&content) {
+            Ok(v) => v,
+            Err(e) => {
+                // Same fail-CLOSED contract as upsert_mcp_servers: the prior
+                // `unwrap_or(json!({}))` SILENTLY discarded the operator's whole
+                // shared settings file (permissions + other keys) with no backup
+                // before atomic_write'ing a fresh document. Back up the corrupt
+                // original (rename-first) and refuse to overwrite if it can't be
+                // preserved.
+                let backup = path.with_extension(format!(
+                    "corrupt.{}",
+                    chrono::Utc::now().format("%Y%m%d%H%M%S")
+                ));
+                if !crate::store::backup_corrupt_file(path, &backup) {
+                    tracing::error!(
+                        path = %path.display(),
+                        error = %e,
+                        "malformed settings JSON (hook upsert) AND backup failed — refusing to overwrite (original preserved)"
+                    );
+                    anyhow::bail!(
+                        "malformed settings at {} and its backup failed; refusing to overwrite (original preserved for rescue)",
+                        path.display()
+                    );
+                }
+                tracing::warn!(
+                    path = %path.display(),
+                    backup = %backup.display(),
+                    error = %e,
+                    "malformed settings JSON (hook upsert), backed up corrupt file and starting fresh"
+                );
+                json!({})
+            }
+        }
     } else {
         json!({})
     };

--- a/src/mcp_config/review_repro_bootstrap_config_cli.rs
+++ b/src/mcp_config/review_repro_bootstrap_config_cli.rs
@@ -35,7 +35,6 @@ fn tmp_dir(tag: &str) -> std::path::PathBuf {
 }
 
 #[test]
-#[ignore = "hookpoc-corrupt-silent-discard: red until fix; remove #[ignore] after fix to confirm"]
 fn upsert_state_hooks_backs_up_corrupt_settings_before_discard_bootstrap_config_cli() {
     let dir = tmp_dir("discard");
     let claude = dir.join(".claude");

--- a/src/store.rs
+++ b/src/store.rs
@@ -21,7 +21,11 @@ static CORRUPT_SURFACED: std::sync::OnceLock<std::sync::Mutex<std::collections::
 /// prior `let _ = std::fs::copy(...)` swallowed the failure, making the "backing
 /// up" warn a LIE and letting the next save destroy the only copy — so a total
 /// failure now logs at ERROR.
-fn backup_corrupt_file(path: &Path, backup: &Path) -> bool {
+///
+/// `pub(crate)` so the same robust pattern backs the per-workspace config
+/// upserts in `mcp_config.rs` (which previously swallowed the copy result the
+/// identical way this fn was written to fix).
+pub(crate) fn backup_corrupt_file(path: &Path, backup: &Path) -> bool {
     if std::fs::rename(path, backup).is_ok() {
         return true;
     }

--- a/tests/review_bootstrap_config_cli_1.rs
+++ b/tests/review_bootstrap_config_cli_1.rs
@@ -26,7 +26,6 @@
 use std::path::PathBuf;
 
 #[test]
-#[ignore = "mcp-config-corrupt-backup: red until fix; remove #[ignore] after fix to confirm"]
 fn upsert_mcp_servers_must_not_swallow_corrupt_backup_copy_bootstrap_config_cli() {
     let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/mcp_config.rs");
     let text = std::fs::read_to_string(&path).expect("read src/mcp_config.rs");


### PR DESCRIPTION
## Findings (CR-2026-06-14) — two same-class data-integrity bugs in `src/mcp_config.rs`

**MEDIUM (error-handling)** — `upsert_mcp_servers`: on a malformed config it
logged `"backing up and starting fresh"`, then ran
`let _ = std::fs::copy(path, &backup)` whose result was **discarded**, and
unconditionally `atomic_write`'d a fresh `{}`. A copy failure (disk full /
permission) **destroyed the user's only copy** while the warn claimed a backup
was made.

**LOW (error-handling)** — `upsert_state_hooks`: reads the *same* shared
`settings.local.json` but used `unwrap_or(json!({}))` on parse failure —
**silently discarding** the operator's whole settings file (permissions + other
keys) with **no backup** before writing a fresh document.

## Fix (both, same robust pattern)

Reuse the rename-first `store::backup_corrupt_file` (made `pub(crate)`; it's the
exact fn written to fix this swallow class) and **fail-closed**: back up the
corrupt original, and if the bytes **cannot** be preserved, return `Err` and
leave the original on disk for rescue instead of overwriting. The log is now
honest — only "backed up …" after a confirmed backup; `ERROR` on backup failure.

Rename-first means a successful backup takes the corrupt bytes *off* the live
path before the fresh write, so the operator's data always survives (in the
`*.corrupt.<ts>` sibling) or the write is refused.

## Repros (un-ignored, red→green)

- `upsert_mcp_servers_must_not_swallow_corrupt_backup_copy_bootstrap_config_cli`
  — source-scan: the `let _ = std::fs::copy(path` swallow is gone (red
  by-construction; passes green).
- `upsert_state_hooks_backs_up_corrupt_settings_before_discard_bootstrap_config_cli`
  — behavioral_fs: the corrupt original survives via a sibling backup. **Red
  verified** by reverting `mcp_config.rs` to HEAD → panics `silently discarded …
  with no backup`; green with the fix.

## CI parity

37 mcp_config tests pass; `cargo fmt --check` ✓, `cargo clippy --tests --features
tray -D warnings` (0 warnings) ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)