### PR TITLE
fix(CR-2026-06-14 medium): durable, error-checked lifecycle archive write (H11 row82)

### DIFF
--- a/src/tasks/lifecycle.rs
+++ b/src/tasks/lifecycle.rs
@@ -85,16 +85,20 @@ fn cancel_stale_tasks(_home: &Path) -> usize {
 fn archive_done_tasks(home: &Path) -> usize {
     let now = chrono::Utc::now();
     let state = crate::task_events::replay(home).unwrap_or_default();
-    let mut count = 0;
     let archive_path = home.join("tasks-archive.jsonl");
     let already_archived = read_archived_task_ids(&archive_path);
 
+    // Collect the records due for archival, then write them in ONE durable
+    // append (below). The prior code appended each task with a discarded-result
+    // writeln + NO fsync: a failed write was invisible and a crash could lose /
+    // tear the append, re-archiving the task next boot.
+    let mut lines: Vec<String> = Vec::new();
     for (tid, record) in &state.tasks {
         if record.status != crate::task_events::TaskStatus::Done {
             continue;
         }
         if already_archived.contains(&tid.0) {
-            continue; // idempotent — already archived on a prior pass
+            continue; // idempotent — already archived on a prior pass (H11)
         }
         let updated = match chrono::DateTime::parse_from_rfc3339(&record.updated_at) {
             Ok(dt) => dt.with_timezone(&chrono::Utc),
@@ -104,7 +108,6 @@ fn archive_done_tasks(home: &Path) -> usize {
         if age_days < DEFAULT_ARCHIVE_DAYS {
             continue;
         }
-        // Append to archive
         let entry = serde_json::json!({
             "archived_at": now.to_rfc3339(),
             "task_id": tid.0,
@@ -114,17 +117,52 @@ fn archive_done_tasks(home: &Path) -> usize {
             "created_at": record.created_at,
             "updated_at": record.updated_at,
         });
-        if let Ok(mut f) = std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&archive_path)
-        {
-            use std::io::Write;
-            let _ = writeln!(f, "{}", entry);
-            count += 1;
+        lines.push(entry.to_string());
+    }
+
+    if lines.is_empty() {
+        return 0;
+    }
+
+    // Durable, error-checked append. On failure NOTHING is counted — the records
+    // were not written, so they stay un-archived and are retried next pass (the
+    // dedup naturally re-attempts since they never reached the file).
+    match append_archive_durably(&archive_path, &lines) {
+        Ok(()) => lines.len(),
+        Err(e) => {
+            tracing::warn!(
+                path = %archive_path.display(),
+                error = %e,
+                count = lines.len(),
+                "#1201 lifecycle: archive append failed — tasks NOT archived this pass (will retry)"
+            );
+            0
         }
     }
-    count
+}
+
+/// Append newline-terminated JSONL records to the archive durably: a single
+/// buffered `write_all` + `sync_all` (fsync). The fsync makes the append survive
+/// a crash, and surfacing the IO error (vs the prior discarded-result writeln)
+/// lets the caller leave the records un-archived for a retry rather than silently
+/// dropping them. Append-only (the archive is read back by
+/// `read_archived_task_ids`); a
+/// whole-file `atomic_write` would re-read+rewrite the unbounded archive every
+/// pass.
+fn append_archive_durably(path: &Path, lines: &[String]) -> std::io::Result<()> {
+    use std::io::Write;
+    let mut buf = String::with_capacity(lines.iter().map(|l| l.len() + 1).sum());
+    for line in lines {
+        buf.push_str(line);
+        buf.push('\n');
+    }
+    let mut f = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)?;
+    f.write_all(buf.as_bytes())?;
+    f.sync_all()?;
+    Ok(())
 }
 
 /// Collect the `task_id`s already present in `tasks-archive.jsonl` so archival is

--- a/tests/review_tasks_3.rs
+++ b/tests/review_tasks_3.rs
@@ -29,7 +29,6 @@ fn production_region(text: &str) -> &str {
 }
 
 #[test]
-#[ignore = "tasks-archive-nonatomic-unfsynced: red until fix; remove #[ignore] after fix to confirm"]
 fn lifecycle_archive_write_is_durable_and_error_checked_tasks() {
     let text = read_lifecycle();
     let prod = production_region(&text);


### PR DESCRIPTION
## Finding (CR-2026-06-14 Medium, durability — H11 #2162's deferred row82)

`src/tasks/lifecycle.rs` `archive_done_tasks` appended each Done task to
`tasks-archive.jsonl` with a **discarded-result `writeln!`** (IO error
swallowed), **no fsync**, and incremented the archived `count` even on write
failure. A failed write was invisible, and a crash could **lose / tear** the
append, so the task re-archived next boot → unbounded duplicate growth. H11
(#2162) deliberately left this write path untouched and flagged it separately.

## Fix

Collect the due records, then write them in **one durable append** via a new
`append_archive_durably` helper: buffered `write_all` + `sync_all` (fsync),
**surfacing the IO error**. On failure **nothing is counted**, so the records
stay un-archived and are retried next pass (the H11 dedup naturally re-attempts
since they never reached the file).

Append-only (the archive is read back by `read_archived_task_ids`); a whole-file
`atomic_write` would re-read+rewrite the unbounded archive every pass, so a
durable append fits better. **H11's idempotent dedup + Done-status preservation
are untouched.**

## Repro (red→green)

`lifecycle_archive_write_is_durable_and_error_checked_tasks` un-ignored
(source-scan: (a) no swallowed `writeln`, (b) `sync_all` present). Red→green
verified by reverting `lifecycle.rs` to HEAD → panics on the swallowed-error
check.

## CI parity

All 36 lifecycle tests pass — including H11's
`archive_is_idempotent_and_keeps_done_status` and
`archive_does_not_flip_completed_task_to_cancelled`. `cargo fmt --check` ✓,
`cargo clippy --tests --features tray -D warnings` (0 warnings) ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)