### PR TITLE
fix(CR-2026-06-14 security): stop Telegram bot-token leak via reqwest error URL in quickstart

### DIFF
--- a/src/quickstart.rs
+++ b/src/quickstart.rs
@@ -530,15 +530,15 @@ fn verify_bot_is_admin(token: &str, chat_id: i64) -> anyhow::Result<bool> {
         .enable_all()
         .build()?;
     rt.block_on(async {
-        let me_url = format!("https://api.telegram.org/bot{token}/getMe");
-        let me: serde_json::Value = reqwest::get(&me_url).await?.json().await?;
+        let me = bot_api_get(token, "getMe").await?;
         let bot_id = me["result"]["id"].as_i64().ok_or_else(|| {
             anyhow::anyhow!("getMe response missing result.id — cannot resolve bot user_id")
         })?;
-        let url = format!(
-            "https://api.telegram.org/bot{token}/getChatMember?chat_id={chat_id}&user_id={bot_id}"
-        );
-        let resp: serde_json::Value = reqwest::get(&url).await?.json().await?;
+        let resp = bot_api_get(
+            token,
+            &format!("getChatMember?chat_id={chat_id}&user_id={bot_id}"),
+        )
+        .await?;
         if resp["ok"].as_bool() != Some(true) {
             anyhow::bail!(
                 "getChatMember failed: {}",
@@ -557,6 +557,32 @@ fn verify_bot_is_admin(token: &str, chat_id: i64) -> anyhow::Result<bool> {
 /// other status (member / restricted / left / kicked) is non-admin.
 fn is_bot_admin_status(status: &str) -> bool {
     matches!(status, "administrator" | "creator")
+}
+
+/// Telegram Bot API host. Kept as a const, SEPARATE from the `/bot<token>/…`
+/// path, so the token interpolation lives in exactly ONE place ([`bot_api_get`])
+/// instead of being spelled out at every call site.
+const TELEGRAM_API: &str = "https://api.telegram.org";
+
+/// GET a Telegram Bot API method and parse the JSON body.
+///
+/// SECURITY (CR-2026-06-14): the bot token is part of the Bot API URL path
+/// (Telegram has no header auth, unlike the daemon's GitHub path). reqwest's
+/// `Error` `Display` echoes the full request URL on a transport failure and
+/// redacts only userinfo, NOT path segments — so a bare `reqwest::get(&url)`
+/// whose error is printed (`println!("{e}")`) leaks the token to the terminal /
+/// logs / pasted bug reports on ANY network error. We strip the URL from every
+/// error with [`reqwest::Error::without_url`] BEFORE it propagates, so the token
+/// never reaches a surfaced message. Centralising the four call sites here is
+/// what removes the inline `bot<token>` URL templates.
+async fn bot_api_get(token: &str, method: &str) -> anyhow::Result<serde_json::Value> {
+    let url = format!("{TELEGRAM_API}/bot{token}/{method}");
+    let resp = reqwest::get(&url).await.map_err(|e| e.without_url())?;
+    let json = resp
+        .json::<serde_json::Value>()
+        .await
+        .map_err(|e| e.without_url())?;
+    Ok(json)
 }
 
 fn mask_token(tok: &str) -> String {
@@ -588,8 +614,7 @@ fn verify_bot(token: &str) -> anyhow::Result<String> {
         .enable_all()
         .build()?;
     rt.block_on(async {
-        let url = format!("https://api.telegram.org/bot{token}/getMe");
-        let resp: serde_json::Value = reqwest::get(&url).await?.json().await?;
+        let resp = bot_api_get(token, "getMe").await?;
         if resp["ok"].as_bool() == Some(true) {
             let username = resp["result"]["username"].as_str().unwrap_or("unknown");
             Ok(username.to_string())
@@ -634,8 +659,11 @@ fn detect_group(token: &str) -> anyhow::Result<(i64, String)> {
         .enable_all()
         .build()?;
     rt.block_on(async {
-        let url = format!("https://api.telegram.org/bot{token}/getUpdates?timeout=180&allowed_updates=[\"message\"]");
-        let resp: serde_json::Value = reqwest::get(&url).await?.json().await?;
+        let resp = bot_api_get(
+            token,
+            "getUpdates?timeout=180&allowed_updates=[\"message\"]",
+        )
+        .await?;
         if let Some(updates) = resp["result"].as_array() {
             for update in updates {
                 if let Some(chat) = update.get("message").and_then(|m| m.get("chat")) {

--- a/tests/review_xcut_security_1.rs
+++ b/tests/review_xcut_security_1.rs
@@ -32,7 +32,6 @@
 use std::path::PathBuf;
 
 #[test]
-#[ignore = "quickstart-token-url-leak: red until fix; remove #[ignore] after fix to confirm"]
 fn quickstart_does_not_embed_bot_token_in_telegram_url_xcut_security() {
     let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/quickstart.rs");
     let text = std::fs::read_to_string(&path).expect("read src/quickstart.rs");


### PR DESCRIPTION
## Finding (CR-2026-06-14 Medium, security)

`src/quickstart.rs` built Bot API URLs with the token in the path
(`https://api.telegram.org/bot{token}/…`) and called bare `reqwest::get(&url)`
at **four** sites (`verify_bot`, `verify_bot_is_admin` ×2, `detect_group`).
reqwest's `Error` `Display` echoes the full request URL on a transport failure
and redacts only userinfo (NOT path segments), so `?` propagated the
token-bearing URL up to the call sites that print `{e}` — **leaking the bot
token** to the terminal / logs / pasted bug reports on **any** network error
(offline, DNS, proxy, TLS, Telegram blocked). The daemon GitHub path uses an
Authorization header and never leaks; quickstart was the outlier.

## Fix

Telegram has **no header auth** (the token must be in the URL path), so the leak
is in the **error path**, not the URL itself. Centralise the four GETs into one
`bot_api_get` helper that strips the URL (incl. token) from every reqwest error
via `reqwest::Error::without_url()` before it propagates — the token never
reaches a surfaced message. The host is a `TELEGRAM_API` const, separate from
the `/bot<token>/` path, so the token interpolation lives in exactly one
(scrubbed) place instead of four inline templates.

## Repro (red→green)

`quickstart_does_not_embed_bot_token_in_telegram_url_xcut_security` un-ignored
(source-scan: no inline `api.telegram.org/bot{token}` template at a bare-get
site). Red→green verified by reverting `quickstart.rs` to HEAD → flags all four
sites.

## CI parity

All 45 quickstart tests pass; `cargo fmt --check` ✓, `cargo clippy --tests
--features tray -D warnings` (0 warnings) ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)