### PR TITLE
fix(CR-2026-06-14 dispatch_hook M/L): validate branch arg-injection + doc + bounded dispatch fetch

### DIFF
--- a/src/git_helpers.rs
+++ b/src/git_helpers.rs
@@ -11,11 +11,12 @@ use std::time::Duration;
 /// hanging the daemon forever (the #1893/RC1 root cause).
 pub(crate) const LOCAL_GIT_TIMEOUT: Duration = Duration::from_secs(60);
 
-/// #1897: bound for NETWORK git ops (fetch / clone). A large fetch can legitimately
-/// take minutes, so this is generous — strictly wider than the prior hard-coded
-/// 60s at the fetch sites, so it can only ADD tolerance (never newly false-kills a
-/// fetch that passed before) while still capping a wedged network op.
-pub(crate) const NETWORK_GIT_TIMEOUT: Duration = Duration::from_secs(300);
+// CR-2026-06-14 F3: the former `NETWORK_GIT_TIMEOUT` (300s) const was consumed
+// only by `dispatch_hook::ensure_branch_exists`'s dispatch-time fetches. Those
+// now use the tighter `DISPATCH_FETCH_TIMEOUT` (bounded under the 30s `send`
+// proxy budget), leaving the 300s const with zero users — removed rather than
+// left as dead code. A future network-git op that genuinely needs minutes
+// should reintroduce a purpose-named bound at its own call site.
 
 /// #781 Piece 6 — daemon-internal `git` subprocess wrapper that always
 /// sets `AGEND_GIT_BYPASS=1`. Centralizes the bypass-env contract so

--- a/src/mcp/handlers/dispatch_hook/from_ref.rs
+++ b/src/mcp/handlers/dispatch_hook/from_ref.rs
@@ -1,0 +1,43 @@
+//! `from_ref` → (remote, branch) resolution for the dispatch auto-create path.
+//!
+//! Extracted from `dispatch_hook/mod.rs` (CR-2026-06-14) to keep that file under
+//! its grandfathered LOC ceiling while the F1/F3 security fixes land. Pure helper
+//! (reads `git remote` only); re-exported from `mod.rs` so `super::` references
+//! in the sibling test module keep resolving.
+
+use std::path::Path;
+
+/// #2010 (cheerc RCA): resolve which git remote a `from_ref` names, by
+/// LONGEST-PREFIX match against the repo's actual remote list. Branch names can
+/// contain `/`, so a naive `split('/')` mis-parses `upstream/feat/x`; matching
+/// against the real remotes (longest name first, so `forkpa` wins over `fork`
+/// on `forkpa/x`) is the only correct split. Returns the remote name and the
+/// branch portion with that remote's prefix stripped — `None` branch when
+/// `from_ref` carries no remote prefix (a bare local ref). Falls back to
+/// `("origin", None)` when nothing matches (origin-only setups unaffected).
+///
+/// Documented ambiguity (§3.9 case 4): when a branch's first segment equals a
+/// remote name — remote `fork` + a literal `from_ref` of `fork/feature` —
+/// longest-prefix treats it as remote-qualified (remote=`fork`, branch=
+/// `feature`). Fully-qualify (`origin/fork/feature`) to force the other reading.
+pub(crate) fn resolve_from_ref_remote(source: &Path, from_ref: &str) -> (String, Option<String>) {
+    let mut remotes: Vec<String> = crate::git_helpers::git_bypass(source, &["remote"])
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| {
+            String::from_utf8_lossy(&o.stdout)
+                .lines()
+                .map(|l| l.trim().to_string())
+                .filter(|l| !l.is_empty())
+                .collect()
+        })
+        .unwrap_or_default();
+    // Longest remote name first so a longer name wins the prefix race.
+    remotes.sort_by_key(|r| std::cmp::Reverse(r.len()));
+    for r in &remotes {
+        if let Some(rest) = from_ref.strip_prefix(&format!("{r}/")) {
+            return (r.clone(), Some(rest.to_string()));
+        }
+    }
+    ("origin".to_string(), None)
+}

--- a/src/mcp/handlers/dispatch_hook/mod.rs
+++ b/src/mcp/handlers/dispatch_hook/mod.rs
@@ -5,6 +5,9 @@
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
+mod from_ref;
+pub(crate) use from_ref::resolve_from_ref_remote; // CR-2026-06-14 extraction
+
 /// #781 Piece 7: structured dispatch outcome. Mirrors the #784 success
 /// response shape for `repo action=checkout bind:true` so callers across
 /// the fleet observe a single canonical schema regardless of whether the
@@ -87,6 +90,10 @@ pub enum SourceRepoTier {
 pub enum Stage {
     /// `from_ref` rejected by `validate_branch` charset / option-injection guard.
     ValidateFromRef,
+    /// `branch` rejected by `validate_branch` (charset / option-injection) or by
+    /// `is_protected_ref` (E4.5) — at the validation boundary, before any git
+    /// subprocess runs (CR-2026-06-14 F1).
+    ValidateBranch,
     /// First `git branch <name> <from_ref>` attempt failed for a reason
     /// other than "already exists" / "not a valid ref".
     CreateBranch,
@@ -111,6 +118,9 @@ pub enum Stage {
 pub enum ErrorCode {
     /// `from_ref` arg rejected by `validate_branch` charset rules.
     InvalidFromRef,
+    /// `branch` arg rejected by `validate_branch` charset / option-injection
+    /// rules (CR-2026-06-14 F1).
+    InvalidBranch,
     /// `git branch` failed at a stage we can't recover from (not
     /// already-exists, not invalid-ref).
     BranchCreateFailed,
@@ -653,61 +663,26 @@ fn resolve_source_repo(
     (stub, SourceRepoTier::Stub)
 }
 
-/// #781 Piece 6: shared auto-create-branch helper (decision tree formerly inlined
-/// in `ci::handle_checkout_repo`, #780). Both `repo action=checkout bind:true` and
-/// `dispatch_auto_bind_lease` route through here so the fast path (zero network on
-/// missing-branch-with-local-origin/main) and the lazy-fetch fallback live in one
-/// place. Behavior (mirror #784 / decision d-20260514102305998399-0):
-///
-/// 1. `rev-parse --verify refs/heads/<branch>` exists → **fetch `origin <branch>`,
-///    then `update-ref refs/heads/<branch> refs/remotes/origin/<branch>`** so the
-///    bound local ref tracks the remote PR HEAD (#869: stale local refs landed the
-///    worktree at the wrong SHA). Returns `(auto_created=false, fetch_attempted=N)`;
-///    the `update-ref` is a no-op when `origin/<branch>` is absent or the fetch
-///    fails (local ref unchanged, lease still usable).
-/// 2. Else `git branch <branch> <from_ref>`: success → `(true,false)`; stderr
-///    `"already exists"` (race) → `(false,false)`; `"not a valid object name/ref"`
-///    → `git fetch origin --quiet` then retry (success `(true,true)`, race
-///    `(false,true)`, else structured error).
-///
-/// `from_ref` runs through `validate_branch` (defense in depth) to reject
-/// option-injection (`--upload-pack=...`) at the daemon API boundary (same as the
-/// `branch` arg). `actor` = the event_log id for the fetch-duration breadcrumb.
-/// #2010 (cheerc RCA): resolve which git remote a `from_ref` names, by
-/// LONGEST-PREFIX match against the repo's actual remote list. Branch names can
-/// contain `/`, so a naive `split('/')` mis-parses `upstream/feat/x`; matching
-/// against the real remotes (longest name first, so `forkpa` wins over `fork`
-/// on `forkpa/x`) is the only correct split. Returns the remote name and the
-/// branch portion with that remote's prefix stripped — `None` branch when
-/// `from_ref` carries no remote prefix (a bare local ref). Falls back to
-/// `("origin", None)` when nothing matches (origin-only setups unaffected).
-///
-/// Documented ambiguity (§3.9 case 4): when a branch's first segment equals a
-/// remote name — remote `fork` + a literal `from_ref` of `fork/feature` —
-/// longest-prefix treats it as remote-qualified (remote=`fork`, branch=
-/// `feature`). Fully-qualify (`origin/fork/feature`) to force the other reading.
-fn resolve_from_ref_remote(source: &Path, from_ref: &str) -> (String, Option<String>) {
-    let mut remotes: Vec<String> = crate::git_helpers::git_bypass(source, &["remote"])
-        .ok()
-        .filter(|o| o.status.success())
-        .map(|o| {
-            String::from_utf8_lossy(&o.stdout)
-                .lines()
-                .map(|l| l.trim().to_string())
-                .filter(|l| !l.is_empty())
-                .collect()
-        })
-        .unwrap_or_default();
-    // Longest remote name first so a longer name wins the prefix race.
-    remotes.sort_by_key(|r| std::cmp::Reverse(r.len()));
-    for r in &remotes {
-        if let Some(rest) = from_ref.strip_prefix(&format!("{r}/")) {
-            return (r.clone(), Some(rest.to_string()));
-        }
-    }
-    ("origin".to_string(), None)
-}
+/// CR-2026-06-14 F3: dispatch-time `git fetch` budget. `ensure_branch_exists` is
+/// on the synchronous pre-send path bounded by the 30s `send` proxy
+/// (`DEFAULT_TOOL_TIMEOUT`); the prior 300s `NETWORK_GIT_TIMEOUT` let a fetch run
+/// long after the proxy returned `accepted_in_progress` (false success),
+/// swallowing a later bind failure. Worst path is ≤2 sequential best-effort
+/// fetches, so 12s each stays under the proxy ceiling.
+const DISPATCH_FETCH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(12);
 
+/// #781 Piece 6: shared auto-create-branch helper (decision tree formerly inlined
+/// in `ci::handle_checkout_repo`, #780) — both `repo checkout bind:true` and
+/// `dispatch_auto_bind_lease` route through here (#784 / d-20260514102305998399-0).
+/// Branch exists → fetch + `update-ref` so the local ref tracks the remote PR HEAD
+/// (#869); else `git branch <branch> <from_ref>` with a fetch-then-retry on an
+/// unresolved ref. Returns `(auto_created, fetch_attempted)`.
+///
+/// BOTH the user-supplied `branch` and `from_ref` run through `validate_branch`
+/// (defense in depth, rejecting option-injection like `--upload-pack=...` at the
+/// API boundary before any git subprocess); `branch` is additionally rejected by
+/// `is_protected_ref` (E4.5). `actor` = event_log id for the fetch breadcrumb; the
+/// `from_ref`→remote split lives in [`from_ref::resolve_from_ref_remote`].
 pub(crate) fn ensure_branch_exists(
     home: &Path,
     source: &Path,
@@ -715,6 +690,30 @@ pub(crate) fn ensure_branch_exists(
     from_ref: &str,
     actor: &str,
 ) -> Result<(bool, bool), DispatchError> {
+    // CR-2026-06-14 F1 (security): validate `branch` before it reaches
+    // `git branch <branch>` as a positional (arg-injection: `--upload-pack=...`).
+    if !crate::agent_ops::validate_branch(branch) {
+        return Err(DispatchError {
+            message: format!("invalid branch '{branch}'"),
+            code: ErrorCode::InvalidBranch,
+            stage: Stage::ValidateBranch,
+            fetch_attempted: false,
+            raw: None,
+        });
+    }
+    // E4.5 defense-in-depth: reject a protected branch before `git branch main`
+    // is even attempted (lease also enforces). "E4.5" in message kept for matchers.
+    if crate::agent_ops::is_protected_ref(branch) {
+        return Err(DispatchError {
+            message: format!(
+                "E4.5 violation: protected branch '{branch}' cannot be used for agent dispatch"
+            ),
+            code: ErrorCode::ProtectedBranch,
+            stage: Stage::ValidateBranch,
+            fetch_attempted: false,
+            raw: None,
+        });
+    }
     if !crate::agent_ops::validate_branch(from_ref) {
         return Err(DispatchError {
             message: format!("invalid from_ref '{from_ref}'"),
@@ -772,7 +771,7 @@ pub(crate) fn ensure_branch_exists(
         let fetch_out = crate::git_helpers::git_bypass_timeout(
             source,
             &["fetch", "origin", branch, "--quiet"],
-            crate::git_helpers::NETWORK_GIT_TIMEOUT,
+            DISPATCH_FETCH_TIMEOUT,
         );
         let fetched_ok = matches!(&fetch_out, Ok(o) if o.status.success());
         let remote_branch_ref = format!("refs/remotes/origin/{branch}");
@@ -811,7 +810,7 @@ pub(crate) fn ensure_branch_exists(
                 let _ = crate::git_helpers::git_bypass_timeout(
                     source,
                     &["fetch", &remote, rb, "--quiet"],
-                    crate::git_helpers::NETWORK_GIT_TIMEOUT,
+                    DISPATCH_FETCH_TIMEOUT,
                 );
             }
             let ff_safe = crate::git_helpers::git_bypass(
@@ -855,7 +854,7 @@ pub(crate) fn ensure_branch_exists(
         let fetch_out = crate::git_helpers::git_bypass_timeout(
             source,
             &["fetch", &remote, remote_branch, "--quiet"],
-            crate::git_helpers::NETWORK_GIT_TIMEOUT,
+            DISPATCH_FETCH_TIMEOUT,
         );
         create_fetched = matches!(&fetch_out, Ok(o) if o.status.success());
         crate::event_log::log(
@@ -891,7 +890,7 @@ pub(crate) fn ensure_branch_exists(
                 let fetch_out = crate::git_helpers::git_bypass_timeout(
                     source,
                     &["fetch", &remote, "--quiet"],
-                    crate::git_helpers::NETWORK_GIT_TIMEOUT,
+                    DISPATCH_FETCH_TIMEOUT,
                 );
                 let fetch_ms = fetch_start.elapsed().as_millis();
                 crate::event_log::log(

--- a/src/mcp/handlers/dispatch_hook/review_repro_mcp_dispatch_comms.rs
+++ b/src/mcp/handlers/dispatch_hook/review_repro_mcp_dispatch_comms.rs
@@ -91,7 +91,6 @@ fn mk_home_repo(tag: &str) -> (PathBuf, PathBuf) {
 /// `git branch` is never invoked with the injected option.
 #[test]
 #[cfg(unix)]
-#[ignore = "mcp-dispatch-comms F1: red until validate_branch(branch) added to ensure_branch_exists; remove #[ignore] after fix"]
 fn ensure_branch_exists_rejects_option_injection_branch_before_git_mcp_dispatch_comms() {
     let (home, repo) = mk_home_repo("f1");
 
@@ -202,7 +201,6 @@ fn strip_comments_and_blank(body: &str) -> String {
 /// `validate_branch(branch)` call) makes the comment's claim true; this
 /// scan then finds the call.
 #[test]
-#[ignore = "mcp-dispatch-comms F2: red until validate_branch(branch) present (doc comment claims it is); remove #[ignore] after fix"]
 fn ensure_branch_exists_doc_claim_matches_code_mcp_dispatch_comms() {
     let body = strip_comments_and_blank(&ensure_branch_exists_body());
     // The doc comment promises `branch` is validated by the same rule as
@@ -237,7 +235,6 @@ fn ensure_branch_exists_doc_claim_matches_code_mcp_dispatch_comms() {
 /// RED now: the body bounds its fetches with `NETWORK_GIT_TIMEOUT`.
 /// GREEN after fix: those fetches use a bounded dispatch budget instead.
 #[test]
-#[ignore = "mcp-dispatch-comms F3: red until dispatch-time fetch budget bounded under the send proxy timeout; remove #[ignore] after fix"]
 fn ensure_branch_exists_fetch_budget_under_send_timeout_mcp_dispatch_comms() {
     let body = strip_comments_and_blank(&ensure_branch_exists_body());
     assert!(


### PR DESCRIPTION
## CR-2026-06-14 Medium/Low — `dispatch_hook::ensure_branch_exists` (3 findings, same file)

### F1 — Medium / security (arg-injection)
The agent-supplied `branch` reached `git branch <branch> <from_ref>` as the first positional **without `validate_branch`** — only `from_ref` was validated. A branch like `--upload-pack=/bin/sh` is parsed by git as an **option** (argument-injection, non-shell) and only caught by git's own parser, after it already reached the subprocess.
**Fix:** `validate_branch(branch)` at the function top (new `ErrorCode::InvalidBranch` / `Stage::ValidateBranch`), before any git runs.

### F2 — Low / maintainability (doc claim)
The doc claimed `branch` ran through `validate_branch` "(same as the branch arg)" but only `from_ref` did. F1 makes the claim true; the doc is reworded to state both are validated.

### F3 — Medium / correctness (fetch budget)
Every dispatch-time `git fetch` used the 300s `NETWORK_GIT_TIMEOUT`, but `ensure_branch_exists` is on the **synchronous pre-send path** of `handle_delegate_task`, which the MCP proxy bounds with the 30s `DEFAULT_TOOL_TIMEOUT` for `send`. A dispatch could run a fetch up to 300s while the proxy already returned `accepted_in_progress` (false success) at 30s, swallowing a later bind failure.
**Fix:** new `DISPATCH_FETCH_TIMEOUT` (12s; worst path ≤2 sequential fetches < 30s) replaces all four `NETWORK_GIT_TIMEOUT` sites in the fn. `NETWORK_GIT_TIMEOUT` had no other consumers → removed (dead-code).

### Defense-in-depth (E4.5)
A protected branch (`main`/`master`, case-insensitive) is also rejected at the function top, so `git branch main` is never attempted — the lease still enforces it downstream; the message keeps "E4.5" for existing matchers.

### Refactor to fit the LOC ceiling
`mcp_handler_files_under_max_loc` grandfathers this file at 1563 LOC. To land the fixes without raising the ceiling, `resolve_from_ref_remote` + its doc were extracted to a new sibling `dispatch_hook/from_ref.rs` and re-exported (`super::` refs unchanged); the mis-attached `ensure_branch_exists` behavior doc was relocated onto the function. **mod.rs: 1563 → 1562.**

## Repro (red→green, verified)
- `ensure_branch_exists_rejects_option_injection_branch_before_git_…` (F1, behavioral) — RED with the guard removed: *"branch '--upload-pack=/bin/sh' reached git branch as an option … code=BranchCreateFailed, stage=CreateBranch"*.
- `ensure_branch_exists_doc_claim_matches_code_…` (F2, body scan for `validate_branch(branch)`).
- `ensure_branch_exists_fetch_budget_under_send_timeout_…` (F3, body must not use `NETWORK_GIT_TIMEOUT`). RED evidence: `origin/main` had 4 uses in the fn body.

All three `#[ignore]`s removed. Existing main-branch / E4.5 / `resolve_from_ref_remote` tests stay green.

## CI-parity
`cargo fmt --check` + `clippy --all-targets --features tray -D warnings` + **Windows cross-check** (`cargo xwin`) all green; full `--tests` green except the pre-existing agent-env git-shim false-fail `dispatch_branch_..._1834` (passes under `AGEND_GIT_BYPASS=1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)