### PR TITLE
fix(CR-2026-06-14 tasks L): process-unique task id + widen sweep Closes-marker to accept it

### DIFF
--- a/src/daemon/task_sweep.rs
+++ b/src/daemon/task_sweep.rs
@@ -11,8 +11,9 @@
 //! 1. **HTML-comment injection sanitize** — `<!-- Closes t-victim -->`
 //!    rejected (the regex never sees the directive).
 //! 2. **Non-ASCII codepoint reject** on task-ID match — strict ASCII-digit
-//!    regex `(?m)Closes\s+(t-[0-9]+-[0-9]+)` defeats zero-width-char
-//!    homoglyph attacks.
+//!    regex `(?m)Closes\s+(t-[0-9]+-[0-9]+(?:-[0-9]+)?)` defeats zero-width-char
+//!    homoglyph attacks (accepts the legacy two-segment id and the
+//!    three-segment cross-process-unique `t-<ts>-<pid>-<seq>`).
 //! 3. **PR.user.login authorship ONLY** (not git trailer co-author) —
 //!    defends the pre-PR-220 `update_decision` bug class.
 //! 4. **GitHub API schema-mismatch fail-closed** — missing required
@@ -508,8 +509,13 @@ fn extract_closes_markers(body: &str) -> Vec<String> {
     static MARKER: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
     let re = MARKER.get_or_init(|| {
         // Multi-line; case-sensitive on `Closes` to match GitHub's
-        // closing-keyword convention.
-        regex::Regex::new(r"(?m)Closes\s+(t-[0-9]+-[0-9]+)\b").expect("static regex must compile")
+        // closing-keyword convention. CR-2026-06-14: accept BOTH the legacy
+        // two-segment id `t-<ts>-<seq>` and the three-segment cross-process-
+        // unique id `t-<ts>-<pid>-<seq>` (the optional third numeric group). The
+        // trailing `\b` still bounds the marker so it doesn't swallow following
+        // prose.
+        regex::Regex::new(r"(?m)Closes\s+(t-[0-9]+-[0-9]+(?:-[0-9]+)?)\b")
+            .expect("static regex must compile")
     });
     re.captures_iter(body)
         .filter_map(|c| c.get(1).map(|m| m.as_str().to_string()))
@@ -1336,6 +1342,48 @@ mod tests {
         );
     }
 
+    /// CR-2026-06-14 regression pin: a task id minted by the REAL
+    /// `tasks::handle(create)` path (now the three-segment cross-process-unique
+    /// `t-<ts>-<pid>-<seq>`) must round-trip through the `Closes`-marker
+    /// extractor WHOLE. With the pre-fix two-group regex the `\b` truncated it to
+    /// `t-<ts>-<pid>` (≠ the real id) → `open_ids.get(marker)` missed → the
+    /// PR-merge auto-close never fired for any new-format task. The narrow
+    /// id-format unit repro missed this cross-module consumer; this pins it.
+    #[test]
+    fn closes_marker_round_trips_real_minted_three_segment_id() {
+        let home = std::env::temp_dir().join(format!(
+            "agend-sweep-closes-roundtrip-{}-{}",
+            std::process::id(),
+            "rt"
+        ));
+        std::fs::create_dir_all(&home).expect("create temp home");
+        let created = crate::tasks::handle(
+            &home,
+            "operator",
+            &serde_json::json!({ "action": "create", "title": "round-trip me" }),
+        );
+        let id = created["id"]
+            .as_str()
+            .expect("create returns id")
+            .to_string();
+        // Sanity: the minted id is the new three-segment shape.
+        assert_eq!(
+            id.matches('-').count(),
+            3,
+            "expected three-segment id `t-<ts>-<pid>-<seq>`, got {id}"
+        );
+
+        let body = format!("Closes {id}");
+        let markers = extract_closes_markers(&body);
+        assert_eq!(
+            markers,
+            vec![id.clone()],
+            "the extractor must return the WHOLE minted id, not a truncated prefix"
+        );
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
     /// `parse_pr_meta` rejects the PR if `user.login` is missing — our
     /// authorship anchor (must-have #3) requires it. Better to drop the
     /// PR than fall back to git trailer (the bug class we're defending).
@@ -1556,8 +1604,9 @@ mod tests {
         let markers = extract_closes_markers(&text);
         // Every extracted marker MUST conform to strict format. A
         // regression where the extractor accepts (e.g.) `t-foo-1`
-        // surfaces here.
-        let strict = regex::Regex::new(r"^t-[0-9]+-[0-9]+$").unwrap();
+        // surfaces here. CR-2026-06-14: accept both the legacy two-segment id
+        // and the three-segment cross-process-unique id `t-<ts>-<pid>-<seq>`.
+        let strict = regex::Regex::new(r"^t-[0-9]+-[0-9]+(?:-[0-9]+)?$").unwrap();
         for m in &markers {
             assert!(
                 strict.is_match(m),

--- a/src/tasks/handler.rs
+++ b/src/tasks/handler.rs
@@ -74,7 +74,16 @@ fn handle_create(home: &Path, emitter: crate::task_events::InstanceName, args: &
     static ID_SEQ: AtomicU64 = AtomicU64::new(0);
     let ts = chrono::Utc::now().format("%Y%m%d%H%M%S%6f");
     let seq = ID_SEQ.fetch_add(1, Ordering::Relaxed);
-    let id = format!("t-{ts}-{seq}");
+    // CR-2026-06-14 (correctness): `tasks::handle` runs in every MCP server
+    // process AND the daemon. ts (microseconds) + ID_SEQ is only PROCESS-unique,
+    // so two processes minting in the same microsecond both produce `t-<ts>-0`
+    // and `apply_created`'s `or_insert_with` silently drops the second Created at
+    // replay. The pid disambiguates across processes. Format is now a THREE-
+    // numeric-segment id `t-<ts>-<pid>-<seq>`; the sweep `Closes`-marker regex,
+    // its strict validator, and the `has_task_id` probe accept both this and the
+    // legacy two-segment form (see src/daemon/task_sweep.rs).
+    let pid = std::process::id();
+    let id = format!("t-{ts}-{pid}-{seq}");
     let assignee = args["assignee"].as_str().map(String::from);
     let routed_to = if let Some(ref name) = assignee {
         match crate::teams::resolve_team_orchestrator(home, name) {

--- a/src/tasks/handler/review_repro_tasks.rs
+++ b/src/tasks/handler/review_repro_tasks.rs
@@ -164,7 +164,6 @@ fn system_identity_may_set_forensic_done_source_tasks() {
 /// process-unique component (pid / uuid / random). RED now (none present);
 /// GREEN once the id format is made globally unique across processes.
 #[test]
-#[ignore = "tasks-id-cross-process-collision: red until fix; split to its own PR — the id-format change needs the sweep Closes-marker regex (task_sweep.rs) + strict validator + doc widened together; un-ignore there"]
 fn task_id_has_process_unique_component_tasks() {
     let src = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/tasks/handler.rs");
     let text = std::fs::read_to_string(&src).expect("read handler.rs");


### PR DESCRIPTION
## CR-2026-06-14 (Low, correctness) — cross-process task-id collision

Split out of #2180 per reviewer-4: the id-format change has to land **together with** every positional consumer of the old two-segment `t-<ts>-<seq>` shape, so the daemon PR-merge auto-close keeps working for new ids.

### Finding — `src/tasks/handler.rs:73`
`tasks::handle` runs in every MCP server process **and** the daemon. The id was `t-<ts>-<process-local ID_SEQ>` — only process-unique. Two processes minting in the same microsecond both produce `t-<ts>-0`, and `apply_created`'s `or_insert_with` silently drops the second `Created` at replay. **Fix:** add the pid → `t-<ts>-<pid>-<seq>` (three numeric segments).

### The blast (why this is its own PR) — `src/daemon/task_sweep.rs`
The sweep `Closes`-marker extractor regex `(?m)Closes\s+(t-[0-9]+-[0-9]+)\b` matched only **two** numeric groups. A three-segment id would be truncated by the trailing `\b` to `t-<ts>-<pid>` (≠ the real id) → `open_ids.get(marker)` missed → **PR-merge auto-close never fires for any new-format task**. This is exactly what surfaced as `sweep_closes_only_same_board_task_2117_close_isolation` going red on the original #2180.

**Fix:** widen the extractor regex and the strict-format validator to `t-[0-9]+-[0-9]+(?:-[0-9]+)?` — accept BOTH the legacy two-segment and the new three-segment id. `has_scope_linkage`'s presence-probe needs no change (a 3-segment id contains a matching 2-segment prefix). Module-doc regex synced. `tools.rs:221` is a generic `t-XXX-N` placeholder — left as-is.

## Tests — red→green proven in BOTH directions
- un-ignored `task_id_has_process_unique_component_tasks` — RED without the pid (format change is load-bearing).
- NEW `closes_marker_round_trips_real_minted_three_segment_id` — a REAL `tasks::handle`-minted id must round-trip through `extract_closes_markers` WHOLE. RED with the old regex + new format (truncated). This pins the cross-module consumer the narrow id-format repro missed.

Verified: regex-revert (keep new format) → both round-trip + sweep_closes RED; format-revert (keep new regex) → repro #84 RED.

## CI parity
`cargo fmt --check` ✓ · `clippy --tests --features tray -D warnings` ✓ · `nextest tasks::/task_events::/daemon::task_sweep::` (213 pass) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)