### PR TITLE
fix(CR-2026-06-14 comms M/L): reject plain self-dispatch pre-lease + locked pickup-id RMW

### DIFF
--- a/src/agent_ops.rs
+++ b/src/agent_ops.rs
@@ -243,6 +243,37 @@ pub fn save_metadata(home: &Path, instance_name: &str, key: &str, value: Value) 
     );
 }
 
+/// CR-2026-06-14 (concurrency): locked read-modify-write of a single metadata
+/// key via a transform closure. The flock spans the whole load→modify→write, and
+/// — unlike `save_metadata` (which overwrites a key with a precomputed value) —
+/// the new value is DERIVED from the current on-disk value INSIDE the lock. Use
+/// this when the write depends on the current value (e.g. filtering an array):
+/// computing the remainder outside the lock and writing it back races with a
+/// concurrent append, which the stale-remainder write then clobbers (the
+/// `pending_pickup_ids` lost-update class). `current` is `Null` if the key is
+/// absent.
+pub fn update_metadata(
+    home: &Path,
+    instance_name: &str,
+    key: &str,
+    f: impl FnOnce(&Value) -> Value,
+) {
+    let meta_dir = home.join("metadata");
+    std::fs::create_dir_all(&meta_dir).ok();
+    let meta_path = metadata_path_resolved(home, instance_name);
+    persist_or_log!(
+        crate::store::with_json_state_or_create::<Value, _, _, _>(
+            &meta_path,
+            || json!({}),
+            |meta| {
+                let current = meta.get(key).cloned().unwrap_or(Value::Null);
+                meta[key] = f(&current);
+            },
+        ),
+        "update_metadata"
+    );
+}
+
 /// Persist multiple metadata key/value pairs in a single locked read-modify-write.
 /// #1886 C2: the flock spans the whole load→modify→write (not just the write), so
 /// concurrent `save_metadata`/`save_metadata_batch` on the same instance never read

--- a/src/agent_ops.rs
+++ b/src/agent_ops.rs
@@ -650,6 +650,71 @@ mod tests {
     }
 
     #[test]
+    fn update_metadata_concurrent_append_and_filter_no_lost_or_resurrected() {
+        // CR-2026-06-14: the pickup-id lost-update race a ONE-SIDED lock could
+        // not close. The two production mutators of `pending_pickup_ids` — the
+        // telegram inbound APPEND and the inbox-drain FILTER — both run as
+        // `update_metadata` locked RMWs. Seed P "processed" ids; concurrently
+        // each filter thread removes one while each append thread adds a fresh
+        // one. Because BOTH sides take the same flock and derive their new value
+        // from the CURRENT on-disk value inside the lock, the operations
+        // serialize: the final set is EXACTLY the appended ids — nothing lost, no
+        // processed id resurrected. (A one-sided unlocked append could write a
+        // stale array back over a concurrent filter, resurrecting a removed id.)
+        let home = tmp_home("update-meta-append-filter");
+        const P: usize = 16;
+        let seed: Vec<Value> = (0..P)
+            .map(|i| json!({ "msg_id": format!("p{i}") }))
+            .collect();
+        save_metadata(&home, "agent-z", "pending_pickup_ids", json!(seed));
+
+        let mut handles = Vec::new();
+        for i in 0..P {
+            // Filter thread: remove processed id pI (mirrors handle_inbox).
+            let home_f = home.clone();
+            handles.push(std::thread::spawn(move || {
+                update_metadata(&home_f, "agent-z", "pending_pickup_ids", |current| {
+                    let remaining: Vec<Value> = current
+                        .as_array()
+                        .cloned()
+                        .unwrap_or_default()
+                        .into_iter()
+                        .filter(|e| e["msg_id"].as_str() != Some(format!("p{i}").as_str()))
+                        .collect();
+                    json!(remaining)
+                });
+            }));
+            // Append thread: add a fresh id aI (mirrors telegram inbound).
+            let home_a = home.clone();
+            handles.push(std::thread::spawn(move || {
+                update_metadata(&home_a, "agent-z", "pending_pickup_ids", |current| {
+                    let mut ids: Vec<Value> = current.as_array().cloned().unwrap_or_default();
+                    ids.push(json!({ "msg_id": format!("a{i}") }));
+                    json!(ids)
+                });
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        let content = std::fs::read_to_string(metadata_path_resolved(&home, "agent-z")).unwrap();
+        let meta: Value = serde_json::from_str(&content).unwrap();
+        let final_ids: std::collections::HashSet<String> = meta["pending_pickup_ids"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|e| e["msg_id"].as_str().unwrap().to_string())
+            .collect();
+        let expected: std::collections::HashSet<String> = (0..P).map(|i| format!("a{i}")).collect();
+        assert_eq!(
+            final_ids, expected,
+            "after concurrent append+filter the set must be exactly the appended ids \
+             (no processed id resurrected, no append lost)"
+        );
+    }
+
+    #[test]
     fn concurrent_save_metadata_clear_vs_set_both_survive_1886() {
         // #1886 C2 §3.9 (clear-vs-set): one writer clears `waiting_on` while
         // another sets a different field on the same instance — both updates

--- a/src/channel/telegram/inbound.rs
+++ b/src/channel/telegram/inbound.rs
@@ -428,27 +428,23 @@ async fn handle_message(state: &Arc<Mutex<TelegramState>>, msg: &Message) {
             "kind": "telegram",
             "msg_id": msg.id.0.to_string(),
         });
-        let meta_path = crate::agent_ops::metadata_path_resolved(&home, &instance_name);
-        let existing: serde_json::Value = std::fs::read_to_string(&meta_path)
-            .ok()
-            .and_then(|c| serde_json::from_str(&c).ok())
-            .unwrap_or(serde_json::json!({}));
-        let mut ids: Vec<serde_json::Value> = existing
-            .get("pending_pickup_ids")
-            .and_then(|v| v.as_array())
-            .cloned()
-            .unwrap_or_default();
-        ids.push(entry);
-        // M2: cap to prevent unbounded growth (keep newest 100)
-        if ids.len() > 100 {
-            ids = ids.split_off(ids.len() - 100);
-        }
-        crate::agent_ops::save_metadata(
-            &home,
-            &instance_name,
-            "pending_pickup_ids",
-            serde_json::json!(ids),
-        );
+        // CR-2026-06-14 (concurrency): append under the metadata flock (locked
+        // read-modify-write). The prior unlocked read + `save_metadata`
+        // overwrite raced the inbox-drain FILTER (comms.rs handle_inbox): the
+        // append could read a stale set, then write its precomputed array back
+        // AFTER the filter had removed a processed id — resurrecting it (a
+        // processed pickup re-confirmed). Both the append (here) and the filter
+        // now run as `update_metadata` locked RMWs on the same key, so they
+        // serialize and neither clobbers the other.
+        crate::agent_ops::update_metadata(&home, &instance_name, "pending_pickup_ids", |current| {
+            let mut ids: Vec<serde_json::Value> = current.as_array().cloned().unwrap_or_default();
+            ids.push(entry);
+            // M2: cap to prevent unbounded growth (keep newest 100)
+            if ids.len() > 100 {
+                ids = ids.split_off(ids.len() - 100);
+            }
+            serde_json::json!(ids)
+        });
     }
     // Also store as last_message_id for the `react` MCP tool's fallback.
     crate::agent_ops::save_metadata(

--- a/src/mcp/handlers/comms.rs
+++ b/src/mcp/handlers/comms.rs
@@ -165,6 +165,17 @@ pub(super) fn handle_delegate_task(home: &Path, args: &Value, sender: &Option<Se
             raw_target, sender.as_str()
         )});
     }
+    // CR-2026-06-14 (resource-leak): reject a plain self-dispatch BEFORE the
+    // auto-bind/lease. The qualified guard above only fires when team-orchestrator
+    // resolution COLLAPSED the target onto the sender; a plain self-dispatch
+    // (raw_target == resolved == sender) skipped it and fell through to
+    // `dispatch_auto_bind_lease_with_chain` (which leases a worktree + writes a
+    // binding) before the API-layer self-send check rejected the send — orphaning
+    // the leased worktree with no rollback on this path. Reject unconditionally
+    // here so no lease happens for a dispatch the send would reject anyway.
+    if *sender == target {
+        return json!({"error": "cannot delegate task to self — use a different instance"});
+    }
     let task = match args["task"].as_str() {
         Some(t) => t,
         None => return json!({"error": "missing 'task'"}),
@@ -647,25 +658,30 @@ pub(super) fn handle_inbox(home: &Path, instance_name: &str) -> Value {
             }
         }
         if !processed_msg_ids.is_empty() {
-            // Known TOCTOU window: a message arriving between this re-read
-            // and the save_metadata call below can lose its pickup_id.
-            // The window is narrow (JSON parse + filter) and self-healing
-            // (next handle_inbox drains surviving IDs).
-            let remaining: Vec<Value> = std::fs::read_to_string(&meta_path)
-                .ok()
-                .and_then(|c| serde_json::from_str::<Value>(&c).ok())
-                .and_then(|m| m["pending_pickup_ids"].as_array().cloned())
-                .unwrap_or_default()
-                .into_iter()
-                .filter(|e| {
-                    !processed_msg_ids.contains(&e["msg_id"].as_str().unwrap_or("").to_string())
-                })
-                .collect();
-            crate::agent_ops::save_metadata(
+            // CR-2026-06-14 (concurrency): filter the processed pickup ids out of
+            // `pending_pickup_ids` under the metadata flock (atomic read-modify-
+            // write). The prior code re-read the file UNLOCKED, filtered, then
+            // wrote the remainder via save_metadata — a pickup id appended between
+            // the unlocked re-read and the write was clobbered (lost update).
+            // Filtering inside the locked closure reads the CURRENT on-disk set,
+            // so a concurrently-appended id is preserved.
+            crate::agent_ops::update_metadata(
                 home,
                 instance_name,
                 "pending_pickup_ids",
-                json!(remaining),
+                |current| {
+                    let remaining: Vec<Value> = current
+                        .as_array()
+                        .cloned()
+                        .unwrap_or_default()
+                        .into_iter()
+                        .filter(|e| {
+                            !processed_msg_ids
+                                .contains(&e["msg_id"].as_str().unwrap_or("").to_string())
+                        })
+                        .collect();
+                    json!(remaining)
+                },
             );
         }
     }

--- a/tests/review_mcp_dispatch_comms_4.rs
+++ b/tests/review_mcp_dispatch_comms_4.rs
@@ -56,7 +56,6 @@ fn pre_auto_bind_lines() -> Vec<String> {
 }
 
 #[test]
-#[ignore = "mcp-dispatch-comms F4: red until an unconditional self-send rejection precedes the auto-bind; remove #[ignore] after fix"]
 fn self_dispatch_rejected_before_auto_bind_lease_mcp_dispatch_comms() {
     let lines = pre_auto_bind_lines();
 

--- a/tests/review_mcp_dispatch_comms_6.rs
+++ b/tests/review_mcp_dispatch_comms_6.rs
@@ -73,3 +73,45 @@ fn handle_inbox_pickup_id_rmw_has_no_toctou_lost_update_mcp_dispatch_comms() {
          under the metadata file lock (atomic read-modify-write) so no pickup id is lost."
     );
 }
+
+/// CR-2026-06-14 (dual-2 REJECT follow-up): a lock on ONE side of a read-modify-
+/// write is no mutual exclusion. The inbox-drain FILTER (handle_inbox) is locked
+/// above, but the telegram inbound APPEND (`src/channel/telegram/inbound.rs`)
+/// also read-derive-writes `pending_pickup_ids` — and was using an UNLOCKED
+/// `read_to_string` + `save_metadata` overwrite, which could write a stale array
+/// back over a concurrent filter, resurrecting a just-processed id. BOTH sides
+/// must go through the locked `update_metadata` RMW.
+///
+/// RED if the append site regresses to an unlocked `save_metadata` write of
+/// `pending_pickup_ids`; GREEN once it derives the new value inside
+/// `update_metadata`'s lock.
+#[test]
+fn pending_pickup_id_append_uses_locked_update_metadata_mcp_dispatch_comms() {
+    let p = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/channel/telegram/inbound.rs");
+    let src = std::fs::read_to_string(&p).expect("read src/channel/telegram/inbound.rs");
+
+    // The append must run as a locked read-modify-write keyed on pending_pickup_ids.
+    let appends_via_locked_rmw =
+        src.contains("update_metadata") && src.contains("\"pending_pickup_ids\"");
+    assert!(
+        appends_via_locked_rmw,
+        "the telegram inbound pickup-id APPEND must use the locked `update_metadata` RMW \
+         (mirroring the inbox-drain FILTER); it was not found in inbound.rs."
+    );
+
+    // ...and must NOT write pending_pickup_ids via the key-overwriting
+    // `save_metadata` (the unlocked-derive path that loses the concurrent filter).
+    // `save_metadata` for OTHER keys (e.g. last_message_id) is fine, so scan a
+    // window around each save_metadata call for the pending_pickup_ids key.
+    let bad_unlocked_write = src.match_indices("save_metadata").any(|(i, _)| {
+        let window_end = (i + 240).min(src.len());
+        src[i..window_end].contains("pending_pickup_ids")
+    });
+    assert!(
+        !bad_unlocked_write,
+        "telegram inbound writes `pending_pickup_ids` via the key-overwriting `save_metadata` \
+         (unlocked read-derive-write) — a stale array written back over a concurrent \
+         handle_inbox filter resurrects a processed id. Use `update_metadata` (locked RMW) so \
+         both the append and the filter serialize on the same flock."
+    );
+}

--- a/tests/review_mcp_dispatch_comms_6.rs
+++ b/tests/review_mcp_dispatch_comms_6.rs
@@ -56,7 +56,6 @@ fn handle_inbox_body() -> String {
 }
 
 #[test]
-#[ignore = "mcp-dispatch-comms F6: red until the pickup-id read-modify-write is locked (no TOCTOU lost-update); remove #[ignore] after fix"]
 fn handle_inbox_pickup_id_rmw_has_no_toctou_lost_update_mcp_dispatch_comms() {
     let body = handle_inbox_body();
 


### PR DESCRIPTION
## CR-2026-06-14 — two same-file findings (`src/mcp/handlers/comms.rs`)

> The originally-dispatched fetch-budget Medium (`comms.rs:213`, repro `ensure_branch_exists_fetch_budget_under_send_timeout`) was **already closed by #2179** (repros #60/#61 green, `DISPATCH_FETCH_TIMEOUT` in use, no `NETWORK_GIT_TIMEOUT`). Per lead, this PR addresses the two **still-open** same-file findings instead.

### resource-leak (#62) — plain self-dispatch leases before the API rejects it
`handle_delegate_task` only rejected a self-send when team-orchestrator resolution **changed** the target (`*sender == target && raw_target != target`). A plain self-dispatch (`raw_target == resolved == sender`) slipped past that guard into `dispatch_auto_bind_lease_with_chain` — leasing a worktree + writing a binding — **before** the API-layer self-send check rejected the send, orphaning the worktree with no rollback.

**Fix:** an unconditional `*sender == target` rejection **before** the auto-bind, so no lease happens for a dispatch the send would reject anyway. (The qualified team-loop guard stays above it for its specific error message.)

### concurrency (#63) — pickup-id lost update
`handle_inbox` cleared processed pickup ids via an **unlocked** re-read + filter + `save_metadata` write — a "Known TOCTOU window" (its own comment) where a pickup id appended between the unlocked re-read and the write was clobbered.

**Fix:** new `agent_ops::update_metadata` does a locked read-modify-write (flock spans load→modify→write) with a transform closure that derives the new value from the **current** on-disk value **inside** the lock — siblings `save_metadata`/`save_metadata_batch` only overwrite a key with a precomputed value, which is exactly what raced here. `handle_inbox` filters under that lock, so a concurrently-appended id is preserved.

## Tests — red→green proven (both RED on HEAD, GREEN with fix)
- `self_dispatch_rejected_before_auto_bind_lease_mcp_dispatch_comms`
- `handle_inbox_pickup_id_rmw_has_no_toctou_lost_update_mcp_dispatch_comms`

## CI parity
`cargo fmt --check` ✓ · `clippy --tests --features tray -D warnings` ✓ · `nextest mcp::handlers::comms / agent_ops / delegate_task` (145 pass) ✓ · comms.rs 707 LOC (<750).

🤖 Generated with [Claude Code](https://claude.com/claude-code)