### PR TITLE
fix(CR-2026-06-14 mcp-core M/L): cap team spawn count + validate clear_blocked_reason instance name

### DIFF
--- a/src/mcp/handlers/instance_metadata.rs
+++ b/src/mcp/handlers/instance_metadata.rs
@@ -202,6 +202,11 @@ pub(super) fn handle_clear_blocked_reason(home: &Path, args: &Value) -> Value {
         Some(n) => n,
         None => return json!({"error": "missing 'instance'"}),
     };
+    // CR-2026-06-14: validate the instance name at the MCP boundary before the
+    // CLEAR_BLOCKED_REASON RPC, mirroring the sibling handlers in this file
+    // (handle_interrupt / handle_pane_snapshot). Without it a malformed name
+    // (`../evil`) was forwarded straight to the daemon.
+    crate::validate_name_or_err!(instance);
     let mut params = json!({"name": instance});
     if let Some(r) = args["reason"].as_str() {
         params["reason"] = json!(r);

--- a/src/mcp/handlers/instance_state/mod.rs
+++ b/src/mcp/handlers/instance_state/mod.rs
@@ -4,6 +4,13 @@ use std::path::Path;
 pub(crate) mod lifecycle;
 pub(super) mod spawn;
 
+/// CR-2026-06-14 (resource-leak): upper bound on a team-mode spawn count. A
+/// caller-supplied `count` flows into `vec![backend; count]`, so an unbounded
+/// value (e.g. a few billion) triggers an enormous allocation → OOM/abort DoS.
+/// 64 is already far beyond any real team size; reject above it at the MCP
+/// boundary, before the allocation and the CREATE_TEAM RPC.
+const MAX_TEAM_COUNT: usize = 64;
+
 pub(super) fn handle_create_instance(home: &Path, args: &Value, instance_name: &str) -> Value {
     // #2037 (6): name + team = spawn THIS name, then join the team — team-mode
     // used to silently rename to `<team>-N` (the fixup-1 incident). With
@@ -66,11 +73,27 @@ pub(super) fn handle_create_instance(home: &Path, args: &Value, instance_name: &
                 .collect(),
             None => {
                 let count = args.get("count").and_then(|v| v.as_u64()).unwrap_or(1) as usize;
+                // CR-2026-06-14 (resource-leak): cap BEFORE the `vec!` allocation
+                // — a huge `count` would OOM the daemon at the allocation itself.
+                if count > MAX_TEAM_COUNT {
+                    return json!({"error": format!(
+                        "team count {count} exceeds the maximum {MAX_TEAM_COUNT}"
+                    )});
+                }
                 vec![default_backend.to_string(); count]
             }
         };
         if per_member_backends.is_empty() {
             return json!({"error": "count must be >= 1 (or backends must be non-empty)"});
+        }
+        // CR-2026-06-14 (resource-leak): also bound the explicit-`backends` path
+        // (already materialized by serde, so no OOM here, but enforce the same
+        // team-size limit consistently at the boundary).
+        if per_member_backends.len() > MAX_TEAM_COUNT {
+            return json!({"error": format!(
+                "team size {} exceeds the maximum {MAX_TEAM_COUNT}",
+                per_member_backends.len()
+            )});
         }
         let task = args.get("task").and_then(|v| v.as_str()).map(String::from);
         match crate::api::call(

--- a/src/mcp/handlers/review_repro_mcp_core_surface.rs
+++ b/src/mcp/handlers/review_repro_mcp_core_surface.rs
@@ -130,7 +130,6 @@ fn create_instance_team_name_traversal_rejected_mcp_core_surface() {
 /// BEFORE the RPC, so the error contains neither "API unavailable" nor
 /// "no active daemon".
 #[test]
-#[ignore = "mcp-core-surface F3: red until create_instance clamps/rejects oversized count; remove #[ignore] after fix to confirm"]
 fn create_instance_team_count_capped_mcp_core_surface() {
     let home = tmp_home("f3-count-cap");
 
@@ -165,7 +164,6 @@ fn create_instance_team_count_capped_mcp_core_surface() {
 /// `validate_name_or_err!(instance)`, the malformed name is rejected at the
 /// boundary with a "... invalid characters ..." error.
 #[test]
-#[ignore = "mcp-core-surface F4: red until handle_clear_blocked_reason validates the instance name; remove #[ignore] after fix to confirm"]
 fn clear_blocked_reason_validates_instance_name_mcp_core_surface() {
     let home = tmp_home("f4-clear-blocked");
 


### PR DESCRIPTION
## CR-2026-06-14 — two same-scope (mcp-core-surface) boundary-validation findings

### resource-leak (Medium) — `instance_state/mod.rs` unbounded team `count` → OOM
A caller-supplied team `count` flows into `vec![backend; count]`, so an unbounded value (a few billion) triggers an enormous allocation → OOM/abort DoS. **Fix:** `MAX_TEAM_COUNT = 64`, rejected **before** the `vec!` allocation (the OOM site) and the `CREATE_TEAM` RPC. The explicit-`backends` path length is bounded too for consistency.

### info/correctness (Low) — `instance_metadata.rs` unvalidated `clear_blocked_reason` name
`handle_clear_blocked_reason` forwarded `args["instance"]` to the `CLEAR_BLOCKED_REASON` RPC **without** `validate_name`, unlike its siblings `handle_interrupt` / `handle_pane_snapshot` in the same file. **Fix:** `validate_name_or_err!(instance)` so a malformed name (`../evil`) is rejected at the MCP boundary.

## Tests — red→green proven (both RED on HEAD, GREEN with fix)
- `create_instance_team_count_capped_mcp_core_surface` (count=10000 → rejected before the RPC)
- `clear_blocked_reason_validates_instance_name_mcp_core_surface`

## CI parity
`cargo fmt --check` ✓ · `clippy --tests --features tray -D warnings` ✓ · `nextest mcp::handlers::instance_state / instance_metadata / mcp_core_surface` (28 pass) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)