### PR TITLE
fix(CR-2026-06-14 daemon-dispatch-idle): locked dedup-refresh RMW + idle_watchdog GC + anti_stall doc

### DIFF
--- a/src/daemon/anti_stall.rs
+++ b/src/daemon/anti_stall.rs
@@ -6,9 +6,9 @@
 //! - Runs every 5 minutes via the supervisor's tick loop (10s
 //!   `TICK` × `TICKS_PER_SCAN = 30`).
 //! - Scans `task` board for entries with `status == in_progress`
-//!   AND `eta_secs.is_some()` AND `dispatched_at.is_some()`.
+//!   AND `eta_secs.is_some()` AND `started_at.is_some()`.
 //! - For each, computes elapsed since [`task_progress::read_last_progress_at`]
-//!   (falls back to `dispatched_at` when no progress sidecar exists).
+//!   (falls back to `started_at` when no progress sidecar exists).
 //! - When elapsed > eta_secs * 1.5 → enqueue `kind=task_stalled`
 //!   inbox message to general + lead.
 //! - Per-task dedup: tracks emitted-at timestamp per task to
@@ -17,7 +17,7 @@
 //! Failure modes (all fail-open):
 //! - Inbox enqueue failure: logged, scan continues.
 //! - Task list load failure: scan skipped, retried next tick.
-//! - Missing sidecar: falls back to `dispatched_at` (still valid).
+//! - Missing sidecar: falls back to `started_at` (still valid).
 
 use crate::task_events::TaskStatus;
 use crate::tasks::Task;
@@ -126,7 +126,7 @@ pub(crate) fn scan_and_emit(
 }
 
 /// Returns `Some(human_reason)` when the task has stalled, `None`
-/// otherwise. Encapsulates the eta_secs / dispatched_at /
+/// otherwise. Encapsulates the eta_secs / started_at /
 /// last_progress_at evaluation so [`scan_and_emit`] stays focused
 /// on iteration + emit.
 pub(crate) fn check_stalled(
@@ -142,7 +142,7 @@ pub(crate) fn check_stalled(
         return None;
     }
     // Floor for "when was the task last seen alive": progress
-    // sidecar timestamp if present, else dispatched_at. No anchor →
+    // sidecar timestamp if present, else started_at. No anchor →
     // skip stall detection (can't compute elapsed without one).
     let last_alive = crate::daemon::task_progress::read_last_progress_at(home, &task.id)
         .or_else(|| task.started_at.as_deref().and_then(parse_rfc3339))?;

--- a/src/daemon/dispatch_idle/mod.rs
+++ b/src/daemon/dispatch_idle/mod.rs
@@ -245,12 +245,13 @@ pub(crate) fn record_dispatch(
     // Only when a `correlation_id` is present: without one we can't tell two
     // distinct dispatches apart, so fall through to a fresh sidecar.
     if let Some(corr) = correlation_id {
-        if let Some(mut existing) = list_pending(home).into_iter().find(|d| {
+        let is_same_intent = |d: &PendingDispatch| {
             matches!(d.status, DispatchStatus::Pending | DispatchStatus::Exceeded)
                 && d.dispatcher == dispatcher
                 && d.target == target
                 && d.correlation_id.as_deref() == Some(corr)
-        }) {
+        };
+        if let Some(mut existing) = list_pending(home).into_iter().find(is_same_intent) {
             existing.issued_at = chrono::Utc::now().to_rfc3339();
             existing.status = DispatchStatus::Pending;
             existing.nudge_sent_at = None;
@@ -268,17 +269,26 @@ pub(crate) fn record_dispatch(
             // stale — clear it so L2's second-window timer restarts from the next
             // real Exceeded transition (L1 re-stamps `exceeded_at` then).
             existing.exceeded_at = None;
-            if let Ok(body) = serde_json::to_string_pretty(&existing) {
-                if crate::store::atomic_write(
-                    &pending_path(home, &existing.dispatch_id),
-                    body.as_bytes(),
-                )
-                .is_ok()
-                {
-                    return Some(existing.dispatch_id);
-                }
+            // CR-2026-06-14: persist the refreshed episode under the per-file flock
+            // via with_json_state — NOT a bare unlocked write of the list_pending
+            // snapshot. scan_and_emit concurrently re-reads and flips the SAME
+            // sidecar to Exceeded under that lock; an unlocked write here raced it
+            // (lost update — a just-written Exceeded clobbered, or this Pending
+            // reset clobbered). The mutable state is fully reset above, so
+            // overwriting the locked-current state with `existing` IS the intended
+            // re-dispatch semantics — now serialized against the scan.
+            let dispatch_id = existing.dispatch_id.clone();
+            let refreshed = crate::store::with_json_state::<PendingDispatch, _, _>(
+                &pending_path(home, &dispatch_id),
+                move |cur| {
+                    *cur = existing;
+                },
+            );
+            if matches!(refreshed, Ok(Some(()))) {
+                return Some(dispatch_id);
             }
-            // Refresh write failed → fall through to a fresh sidecar (best effort).
+            // Refresh write failed / sidecar vanished under the lock → fall through
+            // to a fresh sidecar (best effort).
         }
     }
     let dispatch_id = next_dispatch_id();

--- a/src/daemon/idle_watchdog.rs
+++ b/src/daemon/idle_watchdog.rs
@@ -285,6 +285,20 @@ pub(crate) fn scan_and_emit(
     // own persisted snooze, so it is left as-is.
     scan_dev_vantage(home, &now, last_alerted, seeding);
     scan_fleet_vantage(home, &now, last_alerted);
+
+    // CR-2026-06-14: GC the dedup map so it doesn't grow one stale
+    // `("dev", agent)` entry per distinct agent name ever seen — deleted /
+    // redeployed agents would otherwise linger forever (unbounded growth over a
+    // long-running daemon). Mirror anti_stall.rs's `last_emitted.retain(...)`:
+    // keep the `("fleet", "*")` sentinel and any agent still present in the
+    // current activity scan; drop the rest (a re-appearing agent simply
+    // re-creates its entry on the next alert — losing the dedup stamp for an
+    // absent agent is harmless).
+    let live: HashSet<String> = enumerate_agent_activity(home)
+        .into_iter()
+        .map(|(name, _)| name)
+        .collect();
+    last_alerted.retain(|(vantage, agent), _| *vantage == "fleet" || live.contains(agent));
 }
 
 /// #1256: check if the task board has any tasks (indicating active use).

--- a/tests/anti_stall_dispatched_at_doc_daemon_dispatch_idle.rs
+++ b/tests/anti_stall_dispatched_at_doc_daemon_dispatch_idle.rs
@@ -24,7 +24,6 @@
 use std::path::PathBuf;
 
 #[test]
-#[ignore = "daemon-dispatch-idle anti-stall-dispatched-at-doc: red until fix; remove #[ignore] after fix to confirm"]
 fn anti_stall_docs_do_not_reference_nonexistent_dispatched_at_daemon_dispatch_idle() {
     let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("src")

--- a/tests/dispatch_idle_dedup_locked_daemon_dispatch_idle.rs
+++ b/tests/dispatch_idle_dedup_locked_daemon_dispatch_idle.rs
@@ -56,7 +56,6 @@ fn block_after<'a>(src: &'a str, block_anchor: &str) -> &'a str {
 }
 
 #[test]
-#[ignore = "daemon-dispatch-idle dedup-refresh-unlocked: red until fix; remove #[ignore] after fix to confirm"]
 fn record_dispatch_dedup_refresh_uses_locked_rmw_daemon_dispatch_idle() {
     let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("src")

--- a/tests/idle_watchdog_last_alerted_gc_daemon_dispatch_idle.rs
+++ b/tests/idle_watchdog_last_alerted_gc_daemon_dispatch_idle.rs
@@ -23,7 +23,6 @@
 use std::path::PathBuf;
 
 #[test]
-#[ignore = "daemon-dispatch-idle idle-watchdog-last-alerted-leak: red until fix; remove #[ignore] after fix to confirm"]
 fn idle_watchdog_last_alerted_map_is_gc_pruned_daemon_dispatch_idle() {
     let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("src")


### PR DESCRIPTION
## CR-2026-06-14 daemon-dispatch-idle batch (3 findings, bundled)

### M — concurrency: `dispatch_idle/mod.rs:271` unlocked dedup-refresh RMW
`record_dispatch`'s in-place re-dispatch dedup refresh reset the existing sidecar and persisted it via a **bare unlocked `atomic_write`**, bypassing the `{dispatch_id}.lock` that `scan_and_emit` holds while it flips the SAME sidecar to `Exceeded` → **lost update** (the Pending reset could clobber a just-written Exceeded, or vice-versa).
**Fix:** route the refresh through `crate::store::with_json_state` (the per-file flock RMW the module already uses for `reassign_pending_for_task` / `refresh_issued_at`). The `find` predicate is extracted to a named `is_same_intent` closure so the `if let … find(…)` head is brace-less and the refresh body is the locked block.

### M — resource-leak: `idle_watchdog.rs` unbounded `last_alerted`
The dedup `HashMap` only ever `insert`ed → one stale `("dev", agent)` entry per distinct agent name ever seen (deleted/redeployed agents linger forever).
**Fix:** a `retain` GC after each scan (mirroring `anti_stall.rs`'s `last_emitted.retain`) — keep the `("fleet","*")` sentinel and any agent still in the current activity scan; drop the rest.

### L — maintainability: `anti_stall.rs` stale `dispatched_at` docs
Module/inline docs named `dispatched_at`, a field #807 renamed to `started_at` (`check_stalled` anchors on `task.started_at`). Renamed the 5 prod doc references; the `#[cfg(test)]` module's historical uses are left untouched.

## Repro (red→green, verified)
3 batch repros un-ignored — `record_dispatch_dedup_refresh_uses_locked_rmw_daemon_dispatch_idle`, `idle_watchdog_last_alerted_map_is_gc_pruned_daemon_dispatch_idle`, `anti_stall_docs_do_not_reference_nonexistent_dispatched_at_daemon_dispatch_idle` — all RED before, GREEN after.

## CI-parity
Rebased onto current `origin/main` (clean, no file overlap with intervening merges). `cargo fmt --check` + `clippy --all-targets --features tray -D warnings` + **Windows cross-check** (`cargo xwin`) all green; full `--tests` green except the pre-existing agent-env git-shim false-fail `dispatch_branch_..._1834`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)