### PR TITLE
fix(CR-2026-06-14 teams TOCTOU M): enforce one-agent-one-team inside lock-held add_team_to_yaml

### DIFF
--- a/src/fleet/persist.rs
+++ b/src/fleet/persist.rs
@@ -272,6 +272,30 @@ fn team_config_to_mapping(config: &TeamConfig) -> serde_yaml_ng::Mapping {
     team
 }
 
+/// First `(new_member, existing_team)` where one of `new_members` already
+/// belongs to a team in `teams`. Drives the one-agent-one-team invariant from
+/// INSIDE the fleet.yaml lock so a concurrent `teams::create` cannot double-book
+/// a member past the stale pre-write snapshot (#CR-2026-06-14 teams.rs:174).
+fn first_member_conflict(
+    teams: &serde_yaml_ng::Mapping,
+    new_members: &[String],
+) -> Option<(String, String)> {
+    for (team_key, team_val) in teams {
+        let Some(team_name) = team_key.as_str() else {
+            continue;
+        };
+        let Some(members) = team_val.get("members").and_then(|m| m.as_sequence()) else {
+            continue;
+        };
+        for existing in members.iter().filter_map(|v| v.as_str()) {
+            if new_members.iter().any(|m| m == existing) {
+                return Some((existing.to_string(), team_name.to_string()));
+            }
+        }
+    }
+    None
+}
+
 pub fn add_team_to_yaml(home: &Path, name: &str, config: &TeamConfig) -> Result<bool> {
     let mut inserted = false;
     mutate_fleet_yaml(home, "teams: {}\n", |doc| {
@@ -284,6 +308,19 @@ pub fn add_team_to_yaml(home: &Path, name: &str, config: &TeamConfig) -> Result<
             .context("teams is not a mapping")?;
         let key = serde_yaml_ng::Value::String(name.to_string());
         if teams.contains_key(&key) {
+            return Ok(false);
+        }
+        // #CR-2026-06-14 (teams.rs:174 TOCTOU): enforce one-agent-one-team INSIDE
+        // the lock-held closure, not only on the pre-write snapshot in
+        // `teams::create`. Two concurrent creates of different team names that
+        // share a member both pass the stale snapshot check; this lock-held
+        // re-check is the authoritative guard that stops the second write from
+        // double-booking the member.
+        if let Some((member, existing_team)) = first_member_conflict(teams, &config.members) {
+            tracing::info!(
+                %member, %existing_team, attempted_team = %name,
+                "team create rejected under lock: member already in another team (one-agent-one-team)"
+            );
             return Ok(false);
         }
         teams.insert(

--- a/src/fleet/persist/review_repro_deployments_health_teams.rs
+++ b/src/fleet/persist/review_repro_deployments_health_teams.rs
@@ -47,7 +47,6 @@ fn team_with_member(member: &str) -> TeamConfig {
 }
 
 #[test]
-#[ignore = "deployments-health-teams F3: red until fix; remove #[ignore] after fix to confirm"]
 fn add_team_to_yaml_enforces_one_agent_one_team_deployments_health_teams() {
     let home = tmp_home("excl");
     std::fs::write(fleet_yaml_path(&home), "teams: {}\n").expect("seed fleet.yaml");


### PR DESCRIPTION
## CR-2026-06-14 — `teams.rs:174` one-agent-one-team TOCTOU (Medium, concurrency)

`teams::create` validated the one-agent-one-team invariant on a `load_fleet`
**snapshot** taken before the write, but the lock-held write boundary
`add_team_to_yaml` re-checked only the team-**name** key (`teams.contains_key`)
and never inspected existing teams' members. Two concurrent creates of different
team names that share one agent both pass the stale snapshot and both write —
landing the agent in two teams.

### Fix
Move the exclusivity check **into the `add_team_to_yaml` mutate closure** (under
the `fleet.yaml` lock), next to the existing atomic name-uniqueness check:
`first_member_conflict` scans the live on-disk teams and, on overlap, returns
`Ok(false)` without writing.

- The snapshot pre-check in `teams::create` stays as a friendly fast-path; the
  lock-held re-check is now the **authoritative** guard.
- `add_team_to_yaml` keeps its `Result<bool>` signature (the repro asserts on the
  inserted bool) — the only behavior change is rejecting a member-double-booking
  write.
- Same writer serves `migrate_teams_json_to_yaml`: clean legacy data is
  unaffected; malformed legacy that double-books a member now skips the second
  team (invariant preserved, graceful `Ok(false)` skip).
- `teams.rs` itself is untouched — no same-file Low findings exist in the CR doc
  for this file.

### §3.10 RED→GREEN (double-confirmed)
- Anchor `8fcf260` (un-ignore only) → repro **FAILS**: `member 'shared' ended up in 2 teams (["alpha", "beta"])`.
- HEAD `58b21c2` → **GREEN**. Also stash-verified: stashing the `persist.rs` fix reproduces the RED on the un-ignored test, popping restores GREEN.

### Evidence
```
ran: cargo test --bin agend-terminal add_team_to_yaml_enforces_one_agent_one_team → ok. 1 passed (GREEN)
ran: (fix stashed) same test → FAILED: member 'shared' in 2 teams (RED)
ran: cargo test --bin agend-terminal fleet:: → ok. 73 passed; 0 failed
ran: cargo test --bin agend-terminal teams:: → ok. 32 passed; 0 failed
ran: cargo fmt --check → clean
ran: cargo clippy --tests --features tray -- -D warnings → clean
```
(local runs `AGEND_GIT_BYPASS=1` per managed-worktree convention; PR CI is the authoritative cross-platform signal.)

### Concurrency note (§3.20 race-class)
Deterministic test possible? **Yes** — the repro drives the lock-held write seam
directly: write team `alpha` owning `shared`, then attempt team `beta` also
claiming `shared`; the invariant requires `shared` in ≤1 team. No timing
dependence — the second `add_team_to_yaml` re-reads the just-written state under
the same lock, so the check is serialized by `acquire_lock`, not by wall-clock.

### Lessons learned
- The atomic name-check already lived in the closure; the member-check just
  hadn't been moved there with it — a "half-migrated to lock-held" seam. The
  repro test correctly targets the **writer** (`add_team_to_yaml`), not the
  `create` wrapper, which is what forced the fix into the lock-held boundary
  rather than papering over it with a wider snapshot.

---
*fixup-dev-3* · claude-opus-4-8[1m]
