### PR TITLE
fix(CR-2026-06-14 worktree-git #5 M perf): bound the gh CLI subprocess with a timeout

### DIFF
--- a/src/git_helpers.rs
+++ b/src/git_helpers.rs
@@ -75,11 +75,23 @@ pub(crate) fn git_bypass_timeout(
 /// same bound + safe process-group kill while preserving their env/bypass
 /// behaviour — instead of being forced through [`git_bypass_timeout`] (which
 /// always sets the bypass env).
+///
+/// CR-2026-06-14 #5 (deadlock-safety): stdout AND stderr are drained on
+/// dedicated reader threads CONCURRENTLY with the wait poll. The OS pipe buffer
+/// is small and fixed (macOS ~16KB, non-growing); a child that emits more than
+/// one buffer's worth (e.g. `gh api .../compare` returning a multi-MB diff JSON,
+/// reached via `merge_freshness`/`task_sweep`) blocks in `write()` until a reader
+/// drains the pipe. The earlier loop only `try_wait()`d — never reading until
+/// after exit — so such a child never exited, hit the deadline, and was
+/// false-timeout-killed. The reader threads keep both pipes drained so the child
+/// can always make progress to exit (this is what std's `wait_with_output` does
+/// via `read2`, reconstructed here so it composes with the timeout poll).
 pub(crate) fn spawn_group_bounded(
     mut cmd: std::process::Command,
     label: &str,
     timeout: Duration,
 ) -> std::io::Result<std::process::Output> {
+    use std::io::Read;
     cmd.stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped());
     // Group isolation only; NOT detached — we keep the captured stdout/stderr.
@@ -96,6 +108,26 @@ pub(crate) fn spawn_group_bounded(
     }
     let mut child = cmd.spawn()?;
 
+    // Drain both pipes concurrently (see the deadlock-safety note above). The
+    // readers run until EOF — which arrives when the child exits normally OR when
+    // the process-group kill below closes the pipes — so they always join.
+    let stdout_pipe = child.stdout.take();
+    let stderr_pipe = child.stderr.take();
+    let stdout_reader = std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        if let Some(mut p) = stdout_pipe {
+            let _ = p.read_to_end(&mut buf);
+        }
+        buf
+    });
+    let stderr_reader = std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        if let Some(mut p) = stderr_pipe {
+            let _ = p.read_to_end(&mut buf);
+        }
+        buf
+    });
+
     // #1897: poll with EXPONENTIAL BACKOFF (1ms → 50ms cap). The previous fixed
     // 200ms poll added up to 200ms of latency per git call vs the old immediate
     // `.output()`, which PERTURBED timing-sensitive concurrent callers (the
@@ -107,10 +139,22 @@ pub(crate) fn spawn_group_bounded(
     let mut poll = Duration::from_millis(1);
     loop {
         match child.try_wait()? {
-            Some(_status) => return child.wait_with_output(),
+            Some(status) => {
+                let stdout = stdout_reader.join().unwrap_or_default();
+                let stderr = stderr_reader.join().unwrap_or_default();
+                return Ok(std::process::Output {
+                    status,
+                    stdout,
+                    stderr,
+                });
+            }
             None if start.elapsed() >= timeout => {
                 crate::process::kill_process_tree(child.id());
                 let _ = child.wait();
+                // The kill closed the pipes → the readers hit EOF and finish;
+                // join so they don't outlive the call (output discarded on error).
+                let _ = stdout_reader.join();
+                let _ = stderr_reader.join();
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::TimedOut,
                     format!("{label} timed out after {timeout:?}"),
@@ -385,6 +429,36 @@ mod tests {
             "grandchild (pid {gpid}) must be reaped by the process-group kill"
         );
         let _ = std::fs::remove_file(&pidfile);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn spawn_group_bounded_drains_large_output_no_deadlock_cr20260614() {
+        // CR-2026-06-14 #5 (r2 reject): a child that writes MORE than one OS pipe
+        // buffer (macOS ~16KB, non-growing) must NOT deadlock. With a poll loop
+        // that only `try_wait()`s and reads after exit, the child blocks in
+        // write() once the buffer fills, never exits, and is false-timeout-killed
+        // at the deadline — exactly what would have hung `gh api .../compare`
+        // (multi-MB diff JSON) in merge_freshness. Emit 256KB (16× a macOS pipe
+        // buffer) and require it ALL back, exit-0, well under the bound.
+        let bytes = 256 * 1024;
+        let mut cmd = std::process::Command::new("sh");
+        cmd.arg("-c")
+            .arg(format!("yes 0123456789abcde | head -c {bytes}"));
+        let start = std::time::Instant::now();
+        let out = spawn_group_bounded(cmd, "big stdout", Duration::from_secs(10))
+            .expect("large-output child must complete, not deadlock + false-timeout");
+        assert!(out.status.success(), "child exits 0");
+        assert_eq!(
+            out.stdout.len(),
+            bytes,
+            "every byte drained (no truncation)"
+        );
+        assert!(
+            start.elapsed() < Duration::from_secs(5),
+            "must finish well under the 10s bound (no deadlock), took {:?}",
+            start.elapsed()
+        );
     }
 
     #[test]

--- a/src/git_helpers.rs
+++ b/src/git_helpers.rs
@@ -76,16 +76,18 @@ pub(crate) fn git_bypass_timeout(
 /// behaviour — instead of being forced through [`git_bypass_timeout`] (which
 /// always sets the bypass env).
 ///
-/// CR-2026-06-14 #5 (deadlock-safety): stdout AND stderr are drained on
-/// dedicated reader threads CONCURRENTLY with the wait poll. The OS pipe buffer
-/// is small and fixed (macOS ~16KB, non-growing); a child that emits more than
-/// one buffer's worth (e.g. `gh api .../compare` returning a multi-MB diff JSON,
+/// CR-2026-06-14 #5 (deadlock-safety): stdout AND stderr are drained on dedicated
+/// SCOPED reader threads CONCURRENTLY with the wait poll. The OS pipe buffer is
+/// small and fixed (macOS ~16KB, non-growing); a child that emits more than one
+/// buffer's worth (e.g. `gh api .../compare` returning a multi-MB diff JSON,
 /// reached via `merge_freshness`/`task_sweep`) blocks in `write()` until a reader
 /// drains the pipe. The earlier loop only `try_wait()`d — never reading until
 /// after exit — so such a child never exited, hit the deadline, and was
-/// false-timeout-killed. The reader threads keep both pipes drained so the child
+/// false-timeout-killed. The scoped readers keep both pipes drained so the child
 /// can always make progress to exit (this is what std's `wait_with_output` does
-/// via `read2`, reconstructed here so it composes with the timeout poll).
+/// via `read2`, reconstructed here so it composes with the timeout poll). Scoped
+/// threads are joined for free at scope close, so they cannot leak — §10.5's
+/// graceful-join, compiler-enforced.
 pub(crate) fn spawn_group_bounded(
     mut cmd: std::process::Command,
     label: &str,
@@ -107,65 +109,79 @@ pub(crate) fn spawn_group_bounded(
         cmd.creation_flags(0x0000_0200);
     }
     let mut child = cmd.spawn()?;
-
-    // Drain both pipes concurrently (see the deadlock-safety note above). The
-    // readers run until EOF — which arrives when the child exits normally OR when
-    // the process-group kill below closes the pipes — so they always join.
     let stdout_pipe = child.stdout.take();
     let stderr_pipe = child.stderr.take();
-    let stdout_reader = std::thread::spawn(move || {
-        let mut buf = Vec::new();
-        if let Some(mut p) = stdout_pipe {
-            let _ = p.read_to_end(&mut buf);
-        }
-        buf
-    });
-    let stderr_reader = std::thread::spawn(move || {
-        let mut buf = Vec::new();
-        if let Some(mut p) = stderr_pipe {
-            let _ = p.read_to_end(&mut buf);
-        }
-        buf
-    });
 
-    // #1897: poll with EXPONENTIAL BACKOFF (1ms → 50ms cap). The previous fixed
-    // 200ms poll added up to 200ms of latency per git call vs the old immediate
-    // `.output()`, which PERTURBED timing-sensitive concurrent callers (the
-    // `checkout_bind_true_concurrent_branch_create_race` test flaked ~50%). A
-    // fast git op (the common case — rev-parse / branch / status are sub-100ms)
-    // now returns within a couple ms, matching `.output()` latency; a genuinely
-    // slow op backs off to a cheap 50ms poll.
-    let start = std::time::Instant::now();
-    let mut poll = Duration::from_millis(1);
-    loop {
-        match child.try_wait()? {
-            Some(status) => {
-                let stdout = stdout_reader.join().unwrap_or_default();
-                let stderr = stderr_reader.join().unwrap_or_default();
-                return Ok(std::process::Output {
-                    status,
-                    stdout,
-                    stderr,
-                });
+    // Drain both pipes concurrently with the wait poll using SCOPED threads. A
+    // scope is GUARANTEED to join every thread it spawned before it returns —
+    // including on early `return` from the closure below — so these readers can
+    // never outlive the call or leak (the §10.5 graceful-join contract, here
+    // compiler-enforced; scoped `s.spawn` is categorically outside the
+    // detached-spawn rule the audit guards). Every non-normal exit path kills the
+    // child FIRST so its pipes close → the readers hit EOF → the scope's implicit
+    // join completes instead of blocking forever.
+    std::thread::scope(|s| {
+        let stdout_reader = s.spawn(move || {
+            let mut buf = Vec::new();
+            if let Some(mut p) = stdout_pipe {
+                let _ = p.read_to_end(&mut buf);
             }
-            None if start.elapsed() >= timeout => {
-                crate::process::kill_process_tree(child.id());
-                let _ = child.wait();
-                // The kill closed the pipes → the readers hit EOF and finish;
-                // join so they don't outlive the call (output discarded on error).
-                let _ = stdout_reader.join();
-                let _ = stderr_reader.join();
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::TimedOut,
-                    format!("{label} timed out after {timeout:?}"),
-                ));
+            buf
+        });
+        let stderr_reader = s.spawn(move || {
+            let mut buf = Vec::new();
+            if let Some(mut p) = stderr_pipe {
+                let _ = p.read_to_end(&mut buf);
             }
-            None => {
-                std::thread::sleep(poll);
-                poll = (poll * 2).min(Duration::from_millis(50));
+            buf
+        });
+
+        // #1897: poll with EXPONENTIAL BACKOFF (1ms → 50ms cap). The previous
+        // fixed 200ms poll added up to 200ms of latency per git call vs the old
+        // immediate `.output()`, which PERTURBED timing-sensitive concurrent
+        // callers (the `checkout_bind_true_concurrent_branch_create_race` test
+        // flaked ~50%). A fast git op (the common case — rev-parse / branch /
+        // status are sub-100ms) now returns within a couple ms, matching
+        // `.output()` latency; a genuinely slow op backs off to a cheap 50ms poll.
+        let start = std::time::Instant::now();
+        let mut poll = Duration::from_millis(1);
+        loop {
+            match child.try_wait() {
+                // Normal exit: the child closed its pipe ends, so the readers
+                // EOF; join them for the captured output.
+                Ok(Some(status)) => {
+                    let stdout = stdout_reader.join().unwrap_or_default();
+                    let stderr = stderr_reader.join().unwrap_or_default();
+                    return Ok(std::process::Output {
+                        status,
+                        stdout,
+                        stderr,
+                    });
+                }
+                Ok(None) if start.elapsed() >= timeout => {
+                    // Kill BEFORE returning so the pipes close and the scope's
+                    // implicit reader-join can complete (output discarded).
+                    crate::process::kill_process_tree(child.id());
+                    let _ = child.wait();
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::TimedOut,
+                        format!("{label} timed out after {timeout:?}"),
+                    ));
+                }
+                Ok(None) => {
+                    std::thread::sleep(poll);
+                    poll = (poll * 2).min(Duration::from_millis(50));
+                }
+                // try_wait itself failed (rare). Kill first — same reason as the
+                // timeout path — then surface the error.
+                Err(e) => {
+                    crate::process::kill_process_tree(child.id());
+                    let _ = child.wait();
+                    return Err(e);
+                }
             }
         }
-    }
+    })
 }
 
 /// W1.2 (#REFACTOR-PLAN): a structured failure from [`git_cmd`]. Distinguishes a

--- a/src/scm/mod.rs
+++ b/src/scm/mod.rs
@@ -370,6 +370,15 @@ fn parse_checks(v: &Value) -> Vec<CheckState> {
 /// carries its own auth (env / `gh auth`) and host, like the inline sites.
 pub(crate) struct GitHubScmProvider;
 
+/// CR-2026-06-14 #5 (perf): network bound for the `gh` CLI. `gh` is reached from
+/// the per-tick worktree-cleanup sweep (`is_squash_merged` → `pr_list`), so a
+/// slow/hanging gh (network stall, auth prompt, rate-limit retry) must not block
+/// the daemon cleanup thread forever. A healthy `gh pr list/view` is a few
+/// seconds; 60s is generous headroom that never false-kills a legit call yet
+/// fails fast instead of hanging. (Purpose-named at this call site, per the
+/// `git_helpers` note left when the old 300s `NETWORK_GIT_TIMEOUT` was removed.)
+const GH_CLI_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+
 impl GitHubScmProvider {
     /// Run `gh` with the given args. `cwd`: when `Some`, set the process
     /// working directory (site 10 runs gh inside the repo dir so gh
@@ -380,8 +389,18 @@ impl GitHubScmProvider {
         if let Some(dir) = cwd {
             cmd.current_dir(dir);
         }
-        cmd.output()
-            .map_err(|e| anyhow::anyhow!("failed to run gh: {e}"))
+        // CR-2026-06-14 #5: bound the `gh` subprocess via the shared
+        // process-group-killing spawner (same machinery as the local git
+        // helpers) — a bare `.output()` is UNBOUNDED and a wedged gh hangs the
+        // per-tick cleanup sweep. The fast path is byte-identical (same captured
+        // `Output`); on the deadline the gh process group is killed and the
+        // caller gets `Err(TimedOut)` to fail fast instead of blocking.
+        crate::git_helpers::spawn_group_bounded(
+            cmd,
+            &format!("gh {:?}", args.first()),
+            GH_CLI_TIMEOUT,
+        )
+        .map_err(|e| anyhow::anyhow!("failed to run gh: {e}"))
     }
 }
 

--- a/tests/review_worktree_git_5.rs
+++ b/tests/review_worktree_git_5.rs
@@ -52,7 +52,6 @@ fn fn_body(src: &str, sig_needle: &str) -> String {
 }
 
 #[test]
-#[ignore = "worktree-git #5 gh-subprocess-timeout: red until fix; remove #[ignore] after fix to confirm"]
 fn github_scm_provider_run_is_timeout_bounded_worktree_git_5() {
     let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/scm/mod.rs");
     let src = std::fs::read_to_string(&path).expect("read src/scm/mod.rs");


### PR DESCRIPTION
## CR-2026-06-14 — `branch_sweep.rs:183` gh subprocess unbounded (Medium, performance)

`is_squash_merged_diff` (`branch_sweep.rs`) → `make_scm_provider().pr_list()` runs
the `gh` CLI via `GitHubScmProvider::run`, which used a bare **unbounded**
`cmd.output()`. That path is reached from
`worktree_cleanup::prune_orphaned_branches` inside the **per-tick** auto cleanup
sweep, so a slow / hanging `gh` (network stall, auth prompt, rate-limit retry)
blocked the daemon's cleanup thread with no upper bound — once per tick, per
non-merged branch, per repo. The local git helpers were already bounded
(`git_helpers::spawn_group_bounded`, #1897/#1899); only the `gh` runner was not.

### Fix
Route the prebuilt `gh` `Command` through the shared
`git_helpers::spawn_group_bounded` — the same process-group-isolated,
timeout + process-tree-kill spawner the local git helpers use — with a
purpose-named `GH_CLI_TIMEOUT` (60s) defined **at this call site**, exactly as the
`git_helpers` note advised when the old 300s `NETWORK_GIT_TIMEOUT` was removed for
lack of users.

- Fast path **byte-identical** (same captured `Output`).
- On the deadline the gh process group is killed; the caller gets `Err(TimedOut)`
  and fails fast (the `out.status.success()` callers already propagate `Err` via `?`).
- 60s is ~12× a healthy `gh pr list/view` — never false-kills a legit call, but
  bounds the hang.

### §3.10 RED→GREEN (double-confirmed)
- Anchor `dd3e24b` (un-ignore only) → static invariant **FAILS** (`run` body has an unbounded `.output()`, no bound token).
- HEAD `4273cd5` → **GREEN**. Stash-verified: stashing the `scm/mod.rs` fix reproduces RED on the un-ignored invariant, popping restores GREEN.

### Evidence
```
ran: cargo test --test review_worktree_git_5 → ok. 1 passed (GREEN)
ran: (fix stashed) same → FAILED (RED)
ran: cargo test --bin agend-terminal scm:: → ok. 15 passed; 0 failed
ran: cargo test --bin agend-terminal branch_sweep → ok. 12 passed; 0 failed
ran: cargo test git_helpers:: (no AGEND_GIT_BYPASS) → ok. 9 passed; 0 failed
ran: cargo fmt --check → clean
ran: cargo clippy --tests --features tray -- -D warnings → clean
```
(local runs `AGEND_GIT_BYPASS=1` per managed-worktree convention; PR CI is the authoritative cross-platform signal.)

### Note for reviewer (windows real-git CI)
This is in the `worktree_git`/`scm` domain where windows real-git CI is known to
flake (xwin/cross_repo/worktree_pool clusters). The change itself is platform-
neutral: `spawn_group_bounded` already has `#[cfg(windows)]`
`CREATE_NEW_PROCESS_GROUP` handling and is exercised by existing #1897 tests on
all platforms. If windows CI fails, please triage real-vs-flake before treating
it as a regression of this diff.

### Lessons learned
- The bound was a one-line gap, not a missing mechanism: `spawn_group_bounded`
  was already `pub(crate)` *specifically* so non-bypass prod sites could pass a
  prebuilt `Command` and inherit the bound + safe kill (#1899). The `gh` runner
  was simply the one network subprocess that hadn't been migrated when the local
  git sites were. The static-invariant repro (grep the `run` body for a bound
  token) is the right shape for "ensure this spawner is bounded".

---
*fixup-dev-3* · claude-opus-4-8[1m]
