### PR TITLE
fix(CR-2026-06-14 agent-binding): deterministic resolve_instance for id-less + classify_exit(None)=SignalKill

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -331,12 +331,19 @@ pub fn resolve_instance(
 
     // 3. Exact name match — HashMap guarantees at most one entry per name.
     if let Some(inst) = fleet.instances.get(name_or_id) {
-        let id = inst
-            .id
-            .as_deref()
-            .and_then(crate::types::InstanceId::parse)
-            .unwrap_or_default();
-        return Ok((id, name_or_id.to_string()));
+        // CR-2026-06-14: an instance whose fleet.yaml `id` is absent or
+        // unparseable has NO stable identity. The prior `.unwrap_or_default()`
+        // minted a FRESH random UUID on every call (`InstanceId::default()` =
+        // `new_v4`) — non-deterministic, silently breaking every id-keyed
+        // correlation (routing / task-event emitter / dedup / audit). Refuse
+        // instead of fabricating, matching the authoritative
+        // `fleet::resolve_uuid` (which returns `None` for the same case).
+        // Callers degrade correctly: task_events → no emitter id; comms → falls
+        // through to name/team routing.
+        return match inst.id.as_deref().and_then(crate::types::InstanceId::parse) {
+            Some(id) => Ok((id, name_or_id.to_string())),
+            None => Err(ResolveError::NotFound(name_or_id.to_string())),
+        };
     }
 
     Err(ResolveError::NotFound(name_or_id.to_string()))
@@ -1610,8 +1617,14 @@ pub(crate) fn classify_exit(exit_code: Option<i32>) -> ExitKind {
             ExitKind::Crash
         }
         None => {
-            tracing::warn!("process didn't exit in 2s, treating as crash");
-            ExitKind::Crash
+            // CR-2026-06-14: a never-observed exit (no code within the 2s poll
+            // window) is reached when the daemon force-kills / sweeps a wedged
+            // process tree — NOT a spontaneous crash. Classifying it as Crash
+            // drove a respawn of a process the daemon deliberately tore down.
+            // Treat it as a SignalKill (daemon-induced teardown), which is not
+            // respawned.
+            tracing::warn!("process didn't exit in 2s — treating as signal-kill (daemon teardown), not a respawnable crash");
+            ExitKind::SignalKill
         }
     }
 }

--- a/src/agent/review_repro_agent_binding.rs
+++ b/src/agent/review_repro_agent_binding.rs
@@ -23,7 +23,6 @@ use super::{classify_exit, resolve_instance, ExitKind};
 /// RED now: the two `Ok` ids differ (random per call). GREEN after fix:
 /// either both `Ok` and equal, or both `Err`.
 #[test]
-#[ignore = "resolve-instance-random-uuid: red until fix; remove #[ignore] after fix to confirm"]
 #[serial_test::serial]
 fn resolve_instance_idless_is_deterministic_agent_binding() {
     use std::sync::atomic::{AtomicU32, Ordering};
@@ -80,7 +79,6 @@ fn resolve_instance_idless_is_deterministic_agent_binding() {
 ///
 /// RED now: `classify_exit(None)` is `Crash`. GREEN after fix: `SignalKill`.
 #[test]
-#[ignore = "wait-for-exit-none-is-crash: red until fix; remove #[ignore] after fix to confirm"]
 fn classify_exit_none_is_not_respawnable_crash_agent_binding() {
     assert!(
         !matches!(classify_exit(None), ExitKind::Crash),


### PR DESCRIPTION
## CR-2026-06-14 agent-binding batch — `src/agent/mod.rs` (2 findings, bundled)

### M — correctness: `resolve_instance:333` non-deterministic id-less resolution
An instance whose fleet.yaml `id` is absent or unparseable hit `.unwrap_or_default()` = `InstanceId::default()` = `Uuid::new_v4()` → a **fresh random UUID on every call**. Two resolutions of the same id-less instance returned **different** ids, silently breaking every id-keyed correlation (message routing, task-event emitter id, dedup/audit).
**Fix:** refuse to fabricate — return `Err(ResolveError::NotFound)`, matching the authoritative `fleet::resolve_uuid` (which returns `None` for the same case). Both production callers degrade correctly: `task_events` → no emitter id (was a broken random one); `comms` → falls through to name/team routing (same target).

### correctness: `classify_exit(None)` mis-classified daemon teardown as Crash
A never-observed exit (no code within the 2s `wait_for_process_exit` poll) is reached when a wedged process is force-swept (the handler calls `sweep_child_tree` right after). Classifying it as `Crash` **respawned a process the daemon deliberately tore down**.
**Fix:** classify `None` as `SignalKill` (daemon-induced teardown, not respawned). `None` is the anomalous *wedged* case — normal exits return `Some` via `try_wait` — so a self-orchestrator hitting it now correctly escalates the #1744-H5 leaderless-death P0 instead of silently respawning.

## Repro (red→green, verified)
`resolve_instance_idless_is_deterministic_agent_binding` + `classify_exit_none_is_not_respawnable_crash_agent_binding` un-ignored. With the fix stashed both go RED (resolve returns two different random UUIDs; `classify_exit(None)` is `Crash`).

## CI-parity
`cargo fmt --check` + `clippy --all-targets --features tray -D warnings` + **Windows cross-check** (`cargo xwin`) all green; full `--tests` green except the pre-existing agent-env git-shim false-fail `dispatch_branch_..._1834`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)