### PR TITLE
fix(CR-2026-06-14 worktree batch B): true default branch + keep remote-gone branch with unpushed commits

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -33,8 +33,9 @@ final-status-level = "slow"
 # don't drag pure-logic tests into max-threads=1):
 #  1. anchored MODULE prefixes — modules that are predominantly real-git/worktree
 #     /subprocess: worktree (src/worktree.rs lifecycle tests build real worktrees
-#     via the #2128 bounded-git_cmd add path), worktree_pool, admin (worktree +
-#     cleanup_zombies process spawn),
+#     via the #2128 bounded-git_cmd add path), worktree_pool, worktree_cleanup
+#     (CR-2026-06-14: real clone/fetch repro joins its sibling real-git tests),
+#     admin (worktree + cleanup_zombies process spawn),
 #     mcp::handlers::{ci,dispatch_hook,force_release,worktree,p0b_tests},
 #     daemon::{retention::worktrees,pr_state,auto_release,conflict_notify,
 #     per_tick::tmp_review_gc}, bootstrap::{agent_resolve,canonical_hygiene}.
@@ -58,11 +59,11 @@ test-group = 'git-subprocess'
 slow-timeout = { period = "120s", terminate-after = 3 }
 
 [[profile.ci.overrides]]
-filter = 'test(/(^(worktree|worktree_pool|admin|mcp::handlers::(ci|dispatch_hook|force_release|worktree|p0b_tests)|daemon::(retention::worktrees|pr_state|auto_release|conflict_notify|per_tick::tmp_review_gc)|bootstrap::(agent_resolve|canonical_hygiene))::|checkout_repo_|dispatch_branch_skips_metadata_stub|send_with_branch_checkout_failure|task_done_cleans_post_lease|closes_markers_extract_cleanly_from_actual_main|resolve_sweep_boards_pairs_each_project_with_its_own_repo_2117_p2)/)'
+filter = 'test(/(^(worktree|worktree_pool|worktree_cleanup|admin|mcp::handlers::(ci|dispatch_hook|force_release|worktree|p0b_tests)|daemon::(retention::worktrees|pr_state|auto_release|conflict_notify|per_tick::tmp_review_gc)|bootstrap::(agent_resolve|canonical_hygiene))::|checkout_repo_|dispatch_branch_skips_metadata_stub|send_with_branch_checkout_failure|task_done_cleans_post_lease|closes_markers_extract_cleanly_from_actual_main|resolve_sweep_boards_pairs_each_project_with_its_own_repo_2117_p2)/)'
 test-group = 'git-subprocess'
 
 # Local `default` profile has no terminate-after, so no false-kill risk — just
 # serialize the same cluster for parity with CI.
 [[profile.default.overrides]]
-filter = 'test(/(^(worktree|worktree_pool|admin|mcp::handlers::(ci|dispatch_hook|force_release|worktree|p0b_tests)|daemon::(retention::worktrees|pr_state|auto_release|conflict_notify|per_tick::tmp_review_gc)|bootstrap::(agent_resolve|canonical_hygiene))::|checkout_repo_|dispatch_branch_skips_metadata_stub|send_with_branch_checkout_failure|task_done_cleans_post_lease|closes_markers_extract_cleanly_from_actual_main|resolve_sweep_boards_pairs_each_project_with_its_own_repo_2117_p2)/)'
+filter = 'test(/(^(worktree|worktree_pool|worktree_cleanup|admin|mcp::handlers::(ci|dispatch_hook|force_release|worktree|p0b_tests)|daemon::(retention::worktrees|pr_state|auto_release|conflict_notify|per_tick::tmp_review_gc)|bootstrap::(agent_resolve|canonical_hygiene))::|checkout_repo_|dispatch_branch_skips_metadata_stub|send_with_branch_checkout_failure|task_done_cleans_post_lease|closes_markers_extract_cleanly_from_actual_main|resolve_sweep_boards_pairs_each_project_with_its_own_repo_2117_p2)/)'
 test-group = 'git-subprocess'

--- a/src/git_helpers.rs
+++ b/src/git_helpers.rs
@@ -190,15 +190,33 @@ pub fn default_branch(repo_dir: &Path) -> String {
     let remote = primary_remote(repo_dir);
     let ref_path = format!("refs/remotes/{remote}/HEAD");
     // #1897: bounded (was an unbounded `.output()`) — a stuck local git falls
-    // through to the "main" fallback instead of hanging the daemon.
-    match git_bypass_timeout(repo_dir, &["symbolic-ref", &ref_path], LOCAL_GIT_TIMEOUT) {
-        Ok(o) if o.status.success() => {
+    // through to the fallback instead of hanging the daemon.
+    if let Ok(o) = git_bypass_timeout(repo_dir, &["symbolic-ref", &ref_path], LOCAL_GIT_TIMEOUT) {
+        if o.status.success() {
             let s = String::from_utf8_lossy(&o.stdout).trim().to_string();
             let prefix = format!("refs/remotes/{remote}/");
-            s.strip_prefix(&prefix).unwrap_or(&s).to_string()
+            return s.strip_prefix(&prefix).unwrap_or(&s).to_string();
         }
-        _ => "main".to_string(),
     }
+    // CR-2026-06-14: no readable `refs/remotes/<remote>/HEAD` (no remote, or
+    // origin/HEAD unset) — do NOT blindly assume "main". A repo whose true
+    // default is e.g. `develop` would then misjudge merge state (a branch merged
+    // into `develop` is not an ancestor of the wrong `main`). Fall back to the
+    // repo's own current HEAD branch (the de-facto default of a local /
+    // remote-less repo); a detached or unreadable HEAD finally yields "main".
+    if let Ok(o) = git_bypass_timeout(
+        repo_dir,
+        &["symbolic-ref", "--short", "HEAD"],
+        LOCAL_GIT_TIMEOUT,
+    ) {
+        if o.status.success() {
+            let s = String::from_utf8_lossy(&o.stdout).trim().to_string();
+            if !s.is_empty() {
+                return s;
+            }
+        }
+    }
+    "main".to_string()
 }
 
 /// Detect the primary remote name.

--- a/src/worktree_cleanup.rs
+++ b/src/worktree_cleanup.rs
@@ -316,23 +316,28 @@ fn prune_orphaned_branches(repo_root: &Path) -> Vec<String> {
             continue;
         }
         let merged = is_branch_merged(repo_root, branch);
-        let gone = is_remote_gone(repo_root, branch);
         // #1750-B3: also reap squash-merge orphans (the 95/99 case the
         // squash-blind `--merged` missed) — gated on tip-age for the heuristic
         // squash detection only.
-        let squash = !merged && !gone && is_squash_gc_eligible(repo_root, branch, &default);
-        if !merged && !gone && !squash {
+        //
+        // CR-2026-06-14: `is_remote_gone` is NO LONGER an independent delete
+        // trigger. Remote-gone alone is not proof the branch's work is preserved
+        // — a branch pushed once, then deleted on the remote while local commits
+        // kept accruing, is remote-gone yet carries committed-but-unpushed work
+        // that `git branch -D` destroys irrecoverably. Reap a branch ONLY when
+        // its work IS in the default branch (every commit reachable): merged
+        // (ancestor) or squash-merged. A remote-gone branch that is NEITHER has
+        // unpushed local commits → KEEP. A squash-merged branch whose remote was
+        // auto-deleted stays reapable — it is now caught by the squash check
+        // (which no longer excludes the gone case) instead of the unguarded
+        // remote-gone trigger.
+        let squash = !merged && is_squash_gc_eligible(repo_root, branch, &default);
+        if !merged && !squash {
             continue;
         }
         let ok = crate::git_helpers::git_ok(repo_root, &["branch", "-D", branch]);
         if ok {
-            let reason = if merged {
-                "merged"
-            } else if gone {
-                "remote-gone"
-            } else {
-                "squash-merged"
-            };
+            let reason = if merged { "merged" } else { "squash-merged" };
             tracing::info!(branch, reason, "pruned orphaned branch");
             pruned.push(branch.clone());
         }

--- a/src/worktree_cleanup/review_repro_worktree_git.rs
+++ b/src/worktree_cleanup/review_repro_worktree_git.rs
@@ -68,7 +68,6 @@ fn branch_exists(repo: &Path, branch: &str) -> bool {
 // ──────────────────────────────────────────────────────────────────────────
 
 #[test]
-#[ignore = "worktree-git #2 remote-gone-unpushed-commits: red until fix; remove #[ignore] after fix to confirm"]
 fn prune_keeps_remote_gone_branch_with_unpushed_commits_worktree_git() {
     // A bare "remote" + a clone, so `branch.<name>.remote` is real.
     let remote = scratch("remote-gone-bare");

--- a/src/worktree_pool/review_repro_worktree_git.rs
+++ b/src/worktree_pool/review_repro_worktree_git.rs
@@ -54,7 +54,6 @@ fn git(dir: &Path, args: &[&str]) {
 // ──────────────────────────────────────────────────────────────────────────
 
 #[test]
-#[ignore = "worktree-git #1 default_branch-fallback: red until fix; remove #[ignore] after fix to confirm"]
 fn cleanup_merged_branch_uses_true_default_not_main_worktree_git() {
     let repo = scratch("default-branch-develop");
     // A repo whose TRUE default branch is `develop`, with NO remote (so


### PR DESCRIPTION
## CR-2026-06-14 — worktree-git domain (last Medium batch, 2 correctness findings)

### `git_helpers::default_branch` silently falls back to `main` (worktree_pool.rs:187)
When `refs/remotes/<remote>/HEAD` is unreadable (no remote, or `origin/HEAD` unset), `default_branch` returned `"main"`. In a repo whose true default is e.g. `develop`, a branch fully merged into `develop` is not an ancestor of the wrong `main`, so `cleanup_merged_branch` misjudges it "not merged into main" and never previews the delete.

**Fix:** fall back to the repo's own current HEAD branch before `"main"` (the de-facto default of a local/remote-less repo); a detached/unreadable HEAD still yields `"main"` (the non-repo fallback test is unchanged).

### `prune_orphaned_branches` reaps a remote-gone branch with unpushed commits (worktree_cleanup.rs:85)
The prune deleted a branch on the `is_remote_gone` signal **alone**. A branch pushed once, then deleted on the remote while local commits kept accruing, is remote-gone yet carries committed-but-unpushed work that `git branch -D` destroys irrecoverably.

**Fix:** remote-gone is no longer an independent delete trigger — reap only when the work IS in the default branch (merged, or squash-merged). The squash check no longer excludes the gone case, so a squash-merged branch whose remote was auto-deleted stays reapable; a remote-gone branch that is **neither** merged nor squash-merged is **KEPT**.

> **Sibling, not fixed here:** the phase-1 stale-worktree removal (`worktree_cleanup.rs:232`) also deletes a branch on `merged || gone` via `remove_worktree` — same `is_remote_gone` class. Left as-is because its gone path legitimately reaps squash-merged worktrees (`test_v2_remote_gone_worktree_removed`) and the repro scopes phase 2. Flagged to lead for a follow-up decision.

## Tests — red→green proven (both RED on HEAD, GREEN with fix)
- `cleanup_merged_branch_uses_true_default_not_main_worktree_git`
- `prune_keeps_remote_gone_branch_with_unpushed_commits_worktree_git`

## #1893 windows-CI safety
The new `worktree_cleanup` real-git repro (clone + fetch) joins the `git-subprocess` serialize group — added `worktree_cleanup` to the nextest.toml module-prefix filter (the `worktree_pool` repro is already covered by its prefix). This also retroactively serializes the existing `worktree_cleanup` real-git tests the filter-comment's own motivation already named.

## CI parity
`cargo fmt --check` ✓ · `clippy --tests --features tray -D warnings` ✓ · `nextest worktree_cleanup:: / worktree_pool:: / branch_sweep::` (86 pass) + `git_helpers::` (9) ✓.

_(local note: `spawn_group_bounded_preserves_caller_env_no_bypass_1899` false-fails only when the runner exports `AGEND_GIT_BYPASS` — environmental, passes clean; CI doesn't set it.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)