### PR TITLE
fix(CR-2026-06-14 t-55): decouple phase-1 worktree-dir reclaim from branch -D (data-loss)

### DIFF
--- a/src/worktree_cleanup.rs
+++ b/src/worktree_cleanup.rs
@@ -125,11 +125,24 @@ fn is_worktree_dirty(worktree_path: &Path) -> bool {
         .unwrap_or(true)
 }
 
-/// Remove a worktree and delete its branch.
+/// Remove a worktree, and delete its branch ONLY when `delete_branch` is set.
+///
+/// CR-2026-06-14 (data-loss): the worktree-DIR removal and the `git branch -D`
+/// are DECOUPLED. Reclaiming the worktree directory is harmless, but deleting
+/// the branch ref is irreversible — a remote-gone branch carrying
+/// committed-but-unpushed local work would lose it. The caller passes
+/// `delete_branch = true` only when the work is preserved in the default branch
+/// (merged or squash-merged); otherwise the branch ref (and its unpushed
+/// commits) survives even though the stale worktree dir is reclaimed.
 ///
 /// On Windows, retries up to 3 times with exponential backoff (200ms, 400ms)
 /// to absorb transient EACCES from file locks held by preceding git processes.
-fn remove_worktree(repo_root: &Path, worktree_path: &str, branch: &str) -> bool {
+fn remove_worktree(
+    repo_root: &Path,
+    worktree_path: &str,
+    branch: &str,
+    delete_branch: bool,
+) -> bool {
     let max_attempts: u32 = if cfg!(windows) { 3 } else { 1 };
     let mut wt_ok = false;
     for attempt in 0..max_attempts {
@@ -144,7 +157,7 @@ fn remove_worktree(repo_root: &Path, worktree_path: &str, branch: &str) -> bool 
             break;
         }
     }
-    if wt_ok {
+    if wt_ok && delete_branch {
         // W1.2: best-effort branch delete (result was already ignored).
         let _ = crate::git_helpers::git_ok(repo_root, &["branch", "-D", branch]);
     }
@@ -214,6 +227,13 @@ pub fn sweep_from_registry(
             .env("AGEND_GIT_BYPASS", "1")
             .output();
 
+        // CR-2026-06-14: needed to decide whether a stale worktree's branch is
+        // safe to `branch -D` (its work is in the default branch) vs must be kept
+        // (committed-but-unpushed local work that a remote-gone signal alone
+        // would otherwise destroy). Mirrors the phase-2 `prune_orphaned_branches`
+        // safety gate.
+        let default = crate::git_helpers::default_branch(repo);
+
         // Phase 1: clean worktrees (existing logic + remote-gone)
         let entries = list_worktrees(repo);
         for entry in &entries {
@@ -235,13 +255,24 @@ pub fn sweep_from_registry(
                 continue;
             }
 
+            // CR-2026-06-14 (data-loss): reclaim the stale worktree DIR on
+            // (merged || gone), but `branch -D` ONLY when the work is preserved
+            // in the default branch — merged (ancestor) or squash-merged. A
+            // remote-gone worktree whose branch is NEITHER carries
+            // committed-but-unpushed local work; deleting the ref would lose it
+            // irrecoverably (phase-1 only skips *dirty* worktrees, not
+            // committed-but-unpushed ones). The worktree dir is still reclaimed.
+            let branch_safe_to_delete =
+                merged || is_squash_gc_eligible(repo, &entry.branch, &default);
+
             tracing::info!(
                 branch = %entry.branch,
                 path = %entry.path,
                 reason = if merged { "merged" } else { "remote-gone" },
+                delete_branch = branch_safe_to_delete,
                 "removing stale worktree"
             );
-            if remove_worktree(repo, &entry.path, &entry.branch) {
+            if remove_worktree(repo, &entry.path, &entry.branch, branch_safe_to_delete) {
                 removed.push((entry.branch.clone(), entry.path.clone()));
             }
         }

--- a/src/worktree_cleanup/review_repro_worktree_git.rs
+++ b/src/worktree_cleanup/review_repro_worktree_git.rs
@@ -10,10 +10,11 @@
 
 #![allow(clippy::expect_used)]
 
-use super::prune_orphaned_branches;
+use super::{prune_orphaned_branches, sweep_from_registry};
 // `is_in_use` is only exercised by the #[cfg(unix)] symlink-based test below
 #[cfg(unix)]
 use super::is_in_use;
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU32, Ordering};
 
@@ -127,6 +128,106 @@ fn prune_keeps_remote_gone_branch_with_unpushed_commits_worktree_git() {
     assert!(
         branch_exists(&repo, "feat/unpushed"),
         "the branch ref (and its unpushed commits) must survive the prune"
+    );
+
+    std::fs::remove_dir_all(&repo).ok();
+    std::fs::remove_dir_all(&remote).ok();
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// t-55 (CR follow-up, data-loss): the PHASE-1 stale-worktree sweep had the same
+// unrecoverable data-loss bug as the phase-2 prune (#2193). `remove_worktree`
+// ran `git worktree remove --force` AND an unconditional `git branch -D`, and
+// the phase-1 gate only skips DIRTY worktrees — a remote-gone worktree whose
+// branch carries committed-but-unpushed local work (clean tree, work not in
+// default) was reaped, destroying the commits. CORRECT (decouple): reclaim the
+// worktree DIR, but keep the branch ref unless its work is in the default branch
+// (merged or squash-merged).
+// ──────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn phase1_remote_gone_worktree_keeps_unpushed_branch_ref_worktree_git() {
+    // A bare "remote" + a clone, so `branch.<name>.remote` is real.
+    let remote = scratch("p1-remote-gone-bare");
+    git(&remote, &["init", "--bare", "-b", "main"]);
+
+    let repo = scratch("p1-remote-gone-clone");
+    std::process::Command::new("git")
+        .args([
+            "clone",
+            &remote.display().to_string(),
+            &repo.display().to_string(),
+        ])
+        .env("AGEND_GIT_BYPASS", "1")
+        .env("GIT_AUTHOR_NAME", "test")
+        .env("GIT_AUTHOR_EMAIL", "t@t")
+        .env("GIT_COMMITTER_NAME", "test")
+        .env("GIT_COMMITTER_EMAIL", "t@t")
+        .output()
+        .expect("git clone");
+
+    std::fs::write(repo.join("README.md"), "init").ok();
+    git(&repo, &["add", "."]);
+    git(&repo, &["commit", "-m", "init"]);
+    git(&repo, &["push", "-u", "origin", "main"]);
+
+    // Feature branch with REAL committed work (so it is NOT in `main` → neither
+    // merged nor squash-merged): push it (configures upstream), add an unpushed
+    // local commit, then put a worktree on it.
+    git(&repo, &["checkout", "-b", "feat/unpushed-wt"]);
+    std::fs::write(repo.join("feat.txt"), "feature").ok();
+    git(&repo, &["add", "."]);
+    git(&repo, &["commit", "-m", "first (pushed)"]);
+    git(&repo, &["push", "-u", "origin", "feat/unpushed-wt"]);
+    std::fs::write(repo.join("feat.txt"), "more local work").ok();
+    git(&repo, &["add", "."]);
+    git(&repo, &["commit", "-m", "unpushed local work"]);
+    git(&repo, &["checkout", "main"]);
+
+    let wt = repo.join("wt-unpushed");
+    git(
+        &repo,
+        &[
+            "worktree",
+            "add",
+            &wt.display().to_string(),
+            "feat/unpushed-wt",
+        ],
+    );
+
+    // Remote head deleted (PR closed / branch removed), then prune so the local
+    // remote-tracking ref disappears → is_remote_gone() == true.
+    git(&remote, &["branch", "-D", "feat/unpushed-wt"]);
+    git(&repo, &["fetch", "--prune"]);
+
+    assert!(
+        branch_exists(&repo, "feat/unpushed-wt"),
+        "precondition: branch must exist before the sweep"
+    );
+
+    // Drive the phase-1 sweep (auto-cleanup is on by default; set explicitly for
+    // determinism — the git-subprocess serialize group prevents an env race).
+    std::env::set_var("AGEND_WORKTREE_AUTO_CLEANUP", "1");
+    let mut configs: HashMap<String, (Option<PathBuf>, Option<PathBuf>)> = HashMap::new();
+    configs.insert(
+        "other".to_string(),
+        (Some(repo.join("other")), Some(repo.clone())),
+    );
+    let removed = sweep_from_registry(&configs, &[]);
+    std::env::remove_var("AGEND_WORKTREE_AUTO_CLEANUP");
+
+    // The stale worktree DIR IS still reclaimed (harmless disk cleanup)...
+    assert!(
+        removed.iter().any(|(b, _)| b == "feat/unpushed-wt"),
+        "the stale remote-gone worktree dir must still be reclaimed: {removed:?}"
+    );
+    // ...but the branch ref (and its committed-but-unpushed commits) MUST survive
+    // — phase-1's `branch -D` is gated on merged||squash, not the remote-gone
+    // signal alone. Pre-fix `remove_worktree` force-deleted the branch here.
+    assert!(
+        branch_exists(&repo, "feat/unpushed-wt"),
+        "a remote-gone worktree with committed-but-unpushed local work must keep \
+         its branch ref after the sweep (dir reclaimed, ref + commits survive)"
     );
 
     std::fs::remove_dir_all(&repo).ok();


### PR DESCRIPTION
## CR-2026-06-14 follow-up (t-55) — phase-1 stale-worktree sweep loses unpushed commits

r6's #2193 dual-2 confirmed the **phase-1** stale-worktree sweep carries the **same unrecoverable data-loss bug** the phase-2 prune did (fixed in #2193): `remove_worktree` ran `git worktree remove --force` **and** an unconditional `git branch -D`, and the phase-1 gate only skips **dirty** worktrees. So a remote-gone worktree whose branch holds committed-but-unpushed local work (clean tree, work not in default) was reaped — destroying the commits.

### Fix — decouple (per r6, cleaner than mirroring phase-2)
`remove_worktree` now takes a `delete_branch` flag:
- the worktree **DIR** is still reclaimed on `(merged || gone)` — harmless disk cleanup;
- `git branch -D` runs **only** when the work is in the default branch — `merged`, or squash-merged (`is_squash_gc_eligible`, the same gate as the #2193 phase-2 fix).

A remote-gone worktree that is neither keeps its branch ref (and unpushed commits). `remove_worktree` has a single caller, so the signature change is local.

### Repro — red→green proven
`phase1_remote_gone_worktree_keeps_unpushed_branch_ref_worktree_git` (real-git clone + fetch --prune, mirrors the #2193 prune repro): drives `sweep_from_registry` and asserts the stale worktree dir **is** reclaimed but the branch ref **survives**. RED on HEAD (branch force-deleted), GREEN with the decouple. Lands in the `worktree_cleanup` git-subprocess serialize group (#2193 added the module prefix). `test_v2_remote_gone_worktree_removed` stays green (it only asserts worktree removal).

## CI parity
`cargo fmt --check` ✓ · `clippy --tests --features tray -D warnings` ✓ · `nextest worktree_cleanup::` (15 pass) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)