### PR TITLE
fix(CR-2026-06-14 ci-watch Lows): 6 fixes across the CI-watch subsystem

### DIFF
--- a/src/daemon/ci_watch/poller.rs
+++ b/src/daemon/ci_watch/poller.rs
@@ -9,6 +9,40 @@ use super::provider::{
 type PerKeySlot = Arc<tokio::sync::Mutex<Option<CiPollResult>>>;
 type TickCache = Arc<std::sync::Mutex<std::collections::HashMap<(String, String), PerKeySlot>>>;
 
+/// CR-2026-06-14 (xcut-concurrency F3): per-repo in-flight set bounding the
+/// fire-and-forget batch-poll spawns. `check_ci_watches_with_provider` runs once
+/// per tick and spawns one detached task per repo onto the 2-worker shared CI
+/// runtime; under a provider/network stall, each tick could enqueue new repo
+/// tasks faster than the workers drain them, growing the backlog without limit.
+/// A repo's slot is claimed before spawning and released when the task finishes
+/// (via [`RepoInFlightGuard`]'s `Drop`); a tick skips a repo whose prior cycle is
+/// still running, so at most one batch task per repo is ever outstanding.
+static IN_FLIGHT_REPOS: std::sync::LazyLock<std::sync::Mutex<std::collections::HashSet<String>>> =
+    std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashSet::new()));
+
+/// RAII claim on a repo's in-flight slot. Released on `Drop` (covers EVERY async
+/// return path of the spawned task), so a panicking or early-returning task can't
+/// strand the slot and permanently wedge that repo's polling.
+struct RepoInFlightGuard(String);
+
+impl RepoInFlightGuard {
+    /// Claim the slot for `repo`. Returns `None` if it's already in flight (the
+    /// prior cycle's task hasn't finished) → caller skips spawning this tick.
+    fn try_claim(repo: &str) -> Option<Self> {
+        let mut set = IN_FLIGHT_REPOS.lock().unwrap_or_else(|e| e.into_inner());
+        set.insert(repo.to_string()).then(|| Self(repo.to_string()))
+    }
+}
+
+impl Drop for RepoInFlightGuard {
+    fn drop(&mut self) {
+        IN_FLIGHT_REPOS
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(&self.0);
+    }
+}
+
 struct CachedCiProvider {
     inner: Box<dyn CiProvider>,
     poll_cache: TickCache,
@@ -504,6 +538,20 @@ pub(super) fn check_ci_watches_with_provider(
     // ci_check_repo (each hits the prefilled cache, or misses → per-branch fallback).
     let make_provider = std::sync::Arc::new(make_provider);
     for (repo, watches) in by_repo {
+        // CR-2026-06-14 (xcut-concurrency F3): bound the detached spawns. Claim
+        // this repo's in-flight slot; if the prior cycle's batch task is still
+        // running (provider/network stall), skip spawning a new one so the
+        // detached-task backlog on the 2-worker runtime can't grow without limit.
+        let inflight_guard = match RepoInFlightGuard::try_claim(&repo) {
+            Some(g) => g,
+            None => {
+                tracing::debug!(
+                    repo = %repo,
+                    "ci poll: prior cycle's batch task still in flight — skipping this tick to bound the detached-spawn backlog"
+                );
+                continue;
+            }
+        };
         // Union of subscribers across the repo's watches — recipients of the
         // single repo-level stalled/resumed health event.
         let mut subs_union: Vec<String> = Vec::new();
@@ -520,7 +568,10 @@ pub(super) fn check_ci_watches_with_provider(
         let make_provider = Arc::clone(&make_provider);
         let display_timezone = display_timezone.clone();
         // fire-and-forget: one batch-poll-then-fan-out task per repo per poll cycle
+        // — bounded to at most one in-flight per repo by `inflight_guard`, which is
+        // moved in below and released (via Drop) on EVERY return path of this task.
         shared_ci_runtime().spawn(async move {
+            let _inflight_guard = inflight_guard;
             // Batch poll once for the whole repo, pre-populating the per-tick cache.
             // None provider → no prefill (per-branch fallback). Returns false on a
             // repo-level ApiError (backing off) → skip the fan-out this tick.

--- a/src/daemon/ci_watch/provider.rs
+++ b/src/daemon/ci_watch/provider.rs
@@ -19,6 +19,28 @@
 /// agend-terminal push fan-out and stays well under GitHub's 100-cap.
 pub(crate) const POLL_RUNS_PAGE_SIZE: u32 = 20;
 
+/// CR-2026-06-14: percent-encode a string for safe use as a URL QUERY-component
+/// value. Git ref names may legally contain `&`, `=`, spaces, etc.; a branch like
+/// `feat&per_page=1` interpolated raw into `?branch={branch}&…` injects a spurious
+/// query parameter and corrupts the intended `branch=` filter, so the provider
+/// returns unrelated runs → wrong CI verdicts. Encode every byte outside the
+/// RFC 3986 unreserved set (`ALPHA / DIGIT / - . _ ~`), PLUS `/` — which is both
+/// query-legal (RFC 3986: `query = *( pchar / "/" / "?" )`) and ubiquitous in git
+/// ref names (`feat/foo`), so leaving it raw keeps the documented GitHub
+/// `head={owner}:{branch}` filter intact for slash-branches.
+fn percent_encode_query(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for &b in value.as_bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' | b'/' => {
+                out.push(b as char);
+            }
+            _ => out.push_str(&format!("%{b:02X}")),
+        }
+    }
+    out
+}
+
 /// Auth scheme for CI provider HTTP requests.
 pub(crate) enum CiAuth {
     /// `Authorization: Bearer <token>` (GitHub)
@@ -271,13 +293,24 @@ pub trait CiProvider: Send + Sync {
 
     /// #813: synchronous variant for non-async callers (handler-layer
     /// MCP entry points that need a blocking answer on watch-start).
-    /// Runs the async future on the shared CI runtime in a scoped
-    /// thread — works regardless of whether the caller is already
-    /// inside a tokio runtime.
+    ///
+    /// CR-2026-06-14 (CLAUDE.md "no raw shared-runtime block_on"): runs the
+    /// future on a FRESH current-thread runtime built INSIDE a scoped thread,
+    /// never on the long-lived shared CI runtime. The scoped thread escapes any
+    /// ambient tokio context (so `block_on` can't panic with "runtime within a
+    /// runtime"), and the fresh, non-shared runtime avoids the copy-paste hazard
+    /// `channel::shared_async::block_on_value` centralized away — block_on'ing a
+    /// shared `*_runtime()` accessor.
     fn check_pr_mergeable_blocking(&self, repo: &str, branch: &str) -> MergeableState {
         std::thread::scope(|s| {
             let handle = s.spawn(|| {
-                super::poller::shared_ci_runtime().block_on(self.check_pr_mergeable(repo, branch))
+                match tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                {
+                    Ok(rt) => rt.block_on(self.check_pr_mergeable(repo, branch)),
+                    Err(_) => MergeableState::Unknown,
+                }
             });
             handle.join().unwrap_or(MergeableState::Unknown)
         })
@@ -347,7 +380,8 @@ impl CiProvider for GitHubCiProvider {
         let resp = self
             .http
             .get(&format!(
-                "repos/{repo}/actions/runs?branch={branch}&per_page={POLL_RUNS_PAGE_SIZE}"
+                "repos/{repo}/actions/runs?branch={}&per_page={POLL_RUNS_PAGE_SIZE}",
+                percent_encode_query(branch)
             ))
             .send()
             .await?;
@@ -509,7 +543,8 @@ impl CiProvider for GitHubCiProvider {
         let resp: serde_json::Value = match self
             .http
             .get(&format!(
-                "repos/{repo}/pulls?head={owner}:{branch}&state=all&per_page=1"
+                "repos/{repo}/pulls?head={owner}:{}&state=all&per_page=1",
+                percent_encode_query(branch)
             ))
             .send()
             .await
@@ -578,7 +613,8 @@ impl CiProvider for GitHubCiProvider {
         let list: serde_json::Value = match self
             .http
             .get(&format!(
-                "repos/{repo}/pulls?head={owner}:{branch}&state=open&per_page=1"
+                "repos/{repo}/pulls?head={owner}:{}&state=open&per_page=1",
+                percent_encode_query(branch)
             ))
             .send()
             .await
@@ -817,7 +853,8 @@ impl CiProvider for GitLabCiProvider {
         let resp = self
             .http
             .get(&format!(
-                "projects/{project}/pipelines?ref={branch}&per_page={POLL_RUNS_PAGE_SIZE}"
+                "projects/{project}/pipelines?ref={}&per_page={POLL_RUNS_PAGE_SIZE}",
+                percent_encode_query(branch)
             ))
             .send()
             .await?;
@@ -885,7 +922,8 @@ impl CiProvider for GitLabCiProvider {
         let resp: serde_json::Value = match self
             .http
             .get(&format!(
-                "projects/{project}/merge_requests?source_branch={branch}&state=all&per_page=1"
+                "projects/{project}/merge_requests?source_branch={}&state=all&per_page=1",
+                percent_encode_query(branch)
             ))
             .send()
             .await
@@ -1036,7 +1074,8 @@ impl CiProvider for BitbucketCiProvider {
         let resp = self
             .http
             .get(&format!(
-                "repositories/{repo}/pipelines/?target.branch={branch}&pagelen={POLL_RUNS_PAGE_SIZE}&sort=-created_on"
+                "repositories/{repo}/pipelines/?target.branch={}&pagelen={POLL_RUNS_PAGE_SIZE}&sort=-created_on",
+                percent_encode_query(branch)
             ))
             .send()
             .await?;
@@ -1104,7 +1143,8 @@ impl CiProvider for BitbucketCiProvider {
         let resp: serde_json::Value = match self
             .http
             .get(&format!(
-                "repositories/{repo}/pullrequests?q=source.branch.name=\"{branch}\"&pagelen=1"
+                "repositories/{repo}/pullrequests?q=source.branch.name=\"{}\"&pagelen=1",
+                percent_encode_query(branch)
             ))
             .send()
             .await

--- a/src/daemon/ci_watch/provider/review_repro_daemon_ci_pr.rs
+++ b/src/daemon/ci_watch/provider/review_repro_daemon_ci_pr.rs
@@ -68,7 +68,6 @@ fn capture_request_path(
 }
 
 #[test]
-#[ignore = "branch-query-encoding: red until fix; remove #[ignore] after fix to confirm"]
 fn github_poll_runs_percent_encodes_branch_in_query_daemon_ci_pr() {
     // A branch name that is a LEGAL git ref but contains query metacharacters.
     // Unencoded, the trailing `&per_page=1` injects a second `per_page` param

--- a/src/mcp/handlers/ci/mod.rs
+++ b/src/mcp/handlers/ci/mod.rs
@@ -7,6 +7,11 @@ use std::path::Path;
 // file (at its LOC ceiling) gains only a single `merge_freshness::gate(...)` call.
 mod merge_freshness;
 
+// CR-2026-06-14: same LOC-relief pattern — `compute_next_poll_eta` lives in a
+// sibling module; re-exported so callers (incl. the in-module repro) are unchanged.
+mod poll_eta;
+pub(crate) use poll_eta::compute_next_poll_eta;
+
 /// #1447: resolve the checkout source repo from `repository_path` — the
 /// cross-tool standard name used by bind_self / team update. Returns `None`
 /// when absent or empty.
@@ -478,35 +483,29 @@ pub(super) fn handle_release_repo(args: &Value) -> Value {
     // (git_ok would discard it), so git_cmd/git_ok would not be byte-identical.
     let mut cmd = std::process::Command::new("git");
     cmd.args(["worktree", "remove", "--force", &path_str]);
-    match crate::git_helpers::spawn_group_bounded(
+    let result = match crate::git_helpers::spawn_group_bounded(
         cmd,
         "git worktree remove (cleanup)",
         crate::git_helpers::LOCAL_GIT_TIMEOUT,
     ) {
-        Ok(o) if o.status.success() => json!({"path": path}),
+        Ok(o) if o.status.success() => return json!({"path": path}),
         Ok(o) => {
             let _ = std::fs::remove_dir_all(&canonical);
-            if let Some(src) = &source_repo {
-                crate::worktree::prune(src);
-            } else {
-                // CR-2026-06-14: force-removed the working tree but could not
-                // resolve its source repo (unreadable `.git` pointer / unresolved
-                // gitdir), so the `<source>/.git/worktrees/<meta>/` metadata can't
-                // be pruned and would otherwise leak SILENTLY. Surface it.
-                tracing::warn!(path = %path_str, "release_repo: removed working tree but source repo unresolved — stale `.git/worktrees` metadata may leak; run force_release / worktree GC to prune");
-            }
             json!({"path": path, "note": String::from_utf8_lossy(&o.stderr).to_string()})
         }
         Err(_) => {
             let _ = std::fs::remove_dir_all(&canonical);
-            if let Some(src) = &source_repo {
-                crate::worktree::prune(src);
-            } else {
-                tracing::warn!(path = %path_str, "release_repo: removed working tree but source repo unresolved — stale `.git/worktrees` metadata may leak; run force_release / worktree GC to prune");
-            }
             json!({"path": path})
         }
+    };
+    // CR-2026-06-14: a fallback arm force-removed the working tree — prune the
+    // source's stale `.git/worktrees` metadata, or warn it'll leak if unresolved.
+    if let Some(src) = &source_repo {
+        crate::worktree::prune(src);
+    } else {
+        tracing::warn!(path = %path_str, "release_repo: source repo unresolved — stale `.git/worktrees` metadata may leak; run force_release / GC");
     }
+    result
 }
 
 /// #1619: resolve the target `owner/repo` for a PR/CI handler.
@@ -707,15 +706,10 @@ pub(crate) fn handle_watch_ci(home: &Path, args: &Value, instance_name: &str) ->
     watch["expires_at"] = json!((chrono::Utc::now()
         + chrono::Duration::hours(crate::daemon::ci_watch::WATCH_TTL_HOURS))
     .to_rfc3339());
-    // Issue #650: store next_after_ci for auto-routing on CI pass.
-    // CR-2026-06-14: an EXPLICIT empty `next_after_ci:""` means "re-arm with NO
-    // chaining" → clear any previously-stored target rather than carrying the
-    // stale one over (which would still route [ci-ready-for-action] to it). An
-    // ABSENT arg leaves the stored value untouched.
+    // Issue #650 + CR-2026-06-14: set on non-empty; explicit empty CLEARS the
+    // stale handoff (re-arm with no chaining); absent leaves it untouched.
     match args.get("next_after_ci").and_then(|v| v.as_str()) {
-        Some(next) if !next.is_empty() => {
-            watch["next_after_ci"] = json!(next);
-        }
+        Some(next) if !next.is_empty() => watch["next_after_ci"] = json!(next),
         Some(_) => {
             if let Some(obj) = watch.as_object_mut() {
                 obj.remove("next_after_ci");
@@ -809,30 +803,6 @@ pub(crate) fn handle_watch_ci(home: &Path, args: &Value, instance_name: &str) ->
         resp["setup_warning"] = json!(w);
     }
     resp
-}
-
-/// Sprint 54 P0-5 helper: estimate the next poll's epoch-millis tick
-/// from `last_polled_at` + `effective_interval_secs` (or `interval_secs`
-/// when adaptive backoff hasn't been computed yet). Returns `None` for
-/// fresh watches that haven't polled yet.
-///
-/// Pure function — no IO, no global state. Same input shape used by
-/// the `ci status` aggregator below so the two surfaces never disagree.
-pub(crate) fn compute_next_poll_eta(watch: &Value) -> Option<i64> {
-    let last_polled_at = watch["last_polled_at"].as_i64()?;
-    let interval_secs = watch["effective_interval_secs"]
-        .as_u64()
-        .or_else(|| watch["interval_secs"].as_u64())
-        .unwrap_or(60);
-    // CR-2026-06-14: a huge (attacker/buggy) `interval_secs` would overflow
-    // `(interval_secs as i64) * 1000` — a panic in debug builds, a wrapped
-    // (possibly negative) eta in release. Convert with saturation (`try_from`
-    // caps a > i64::MAX value at i64::MAX) and use saturating arithmetic so the
-    // eta is always a finite, sane value rather than a crash or garbage.
-    let interval_ms = i64::try_from(interval_secs)
-        .unwrap_or(i64::MAX)
-        .saturating_mul(1000);
-    Some(last_polled_at.saturating_add(interval_ms))
 }
 
 /// `ci unwatch` action: unsubscribe the caller from `repo@branch`.

--- a/src/mcp/handlers/ci/mod.rs
+++ b/src/mcp/handlers/ci/mod.rs
@@ -488,6 +488,12 @@ pub(super) fn handle_release_repo(args: &Value) -> Value {
             let _ = std::fs::remove_dir_all(&canonical);
             if let Some(src) = &source_repo {
                 crate::worktree::prune(src);
+            } else {
+                // CR-2026-06-14: force-removed the working tree but could not
+                // resolve its source repo (unreadable `.git` pointer / unresolved
+                // gitdir), so the `<source>/.git/worktrees/<meta>/` metadata can't
+                // be pruned and would otherwise leak SILENTLY. Surface it.
+                tracing::warn!(path = %path_str, "release_repo: removed working tree but source repo unresolved — stale `.git/worktrees` metadata may leak; run force_release / worktree GC to prune");
             }
             json!({"path": path, "note": String::from_utf8_lossy(&o.stderr).to_string()})
         }
@@ -495,6 +501,8 @@ pub(super) fn handle_release_repo(args: &Value) -> Value {
             let _ = std::fs::remove_dir_all(&canonical);
             if let Some(src) = &source_repo {
                 crate::worktree::prune(src);
+            } else {
+                tracing::warn!(path = %path_str, "release_repo: removed working tree but source repo unresolved — stale `.git/worktrees` metadata may leak; run force_release / worktree GC to prune");
             }
             json!({"path": path})
         }
@@ -699,9 +707,21 @@ pub(crate) fn handle_watch_ci(home: &Path, args: &Value, instance_name: &str) ->
     watch["expires_at"] = json!((chrono::Utc::now()
         + chrono::Duration::hours(crate::daemon::ci_watch::WATCH_TTL_HOURS))
     .to_rfc3339());
-    // Issue #650: store next_after_ci for auto-routing on CI pass
-    if let Some(next) = args["next_after_ci"].as_str().filter(|s| !s.is_empty()) {
-        watch["next_after_ci"] = json!(next);
+    // Issue #650: store next_after_ci for auto-routing on CI pass.
+    // CR-2026-06-14: an EXPLICIT empty `next_after_ci:""` means "re-arm with NO
+    // chaining" → clear any previously-stored target rather than carrying the
+    // stale one over (which would still route [ci-ready-for-action] to it). An
+    // ABSENT arg leaves the stored value untouched.
+    match args.get("next_after_ci").and_then(|v| v.as_str()) {
+        Some(next) if !next.is_empty() => {
+            watch["next_after_ci"] = json!(next);
+        }
+        Some(_) => {
+            if let Some(obj) = watch.as_object_mut() {
+                obj.remove("next_after_ci");
+            }
+        }
+        None => {}
     }
     // #1031: persist dispatch task_id when supplied (by
     // dispatch_auto_bind_lease) so the ci_check_repo emit site can
@@ -804,7 +824,15 @@ pub(crate) fn compute_next_poll_eta(watch: &Value) -> Option<i64> {
         .as_u64()
         .or_else(|| watch["interval_secs"].as_u64())
         .unwrap_or(60);
-    Some(last_polled_at + (interval_secs as i64) * 1000)
+    // CR-2026-06-14: a huge (attacker/buggy) `interval_secs` would overflow
+    // `(interval_secs as i64) * 1000` — a panic in debug builds, a wrapped
+    // (possibly negative) eta in release. Convert with saturation (`try_from`
+    // caps a > i64::MAX value at i64::MAX) and use saturating arithmetic so the
+    // eta is always a finite, sane value rather than a crash or garbage.
+    let interval_ms = i64::try_from(interval_secs)
+        .unwrap_or(i64::MAX)
+        .saturating_mul(1000);
+    Some(last_polled_at.saturating_add(interval_ms))
 }
 
 /// `ci unwatch` action: unsubscribe the caller from `repo@branch`.

--- a/src/mcp/handlers/ci/poll_eta.rs
+++ b/src/mcp/handlers/ci/poll_eta.rs
@@ -1,0 +1,24 @@
+//! CR-2026-06-14: `compute_next_poll_eta` extracted to this sibling module so
+//! `ci/mod.rs` (at its grandfathered LOC ceiling) hosts only a re-export — the
+//! same LOC-relief pattern already used for `merge_freshness`, NOT the larger
+//! ci/mod.rs split tracked separately. Pure function; no IO / global state.
+
+use serde_json::Value;
+
+/// Sprint 54 P0-5 helper: estimate the next poll's epoch-millis tick from
+/// `last_polled_at` + `effective_interval_secs` (or `interval_secs` when adaptive
+/// backoff hasn't been computed yet). Returns `None` for fresh watches that
+/// haven't polled yet. Shared with the `ci status` aggregator so the two surfaces
+/// never disagree.
+pub(crate) fn compute_next_poll_eta(watch: &Value) -> Option<i64> {
+    let last_polled_at = watch["last_polled_at"].as_i64()?;
+    let interval_secs = watch["effective_interval_secs"]
+        .as_u64()
+        .or_else(|| watch["interval_secs"].as_u64())
+        .unwrap_or(60);
+    // CR-2026-06-14: saturate — a huge interval_secs else overflows (panic/wrap).
+    let ms = i64::try_from(interval_secs)
+        .unwrap_or(i64::MAX)
+        .saturating_mul(1000);
+    Some(last_polled_at.saturating_add(ms))
+}

--- a/src/mcp/handlers/ci/review_repro_mcp_ci_worktree.rs
+++ b/src/mcp/handlers/ci/review_repro_mcp_ci_worktree.rs
@@ -129,7 +129,6 @@ fn unwatch_uses_validated_caller_not_clear_all_mcp_ci_worktree() {
 // GREEN after the fix uses clamped + saturating math.
 // ===========================================================================
 #[test]
-#[ignore = "mcp-ci-worktree-4: compute-next-poll-eta-overflow; red until fix; remove #[ignore] after fix to confirm"]
 fn compute_next_poll_eta_does_not_overflow_on_huge_interval_mcp_ci_worktree() {
     // last_polled_at present (so the function gets past its early `?`), and an
     // interval_secs that is positive-as-i64 yet overflows when multiplied by
@@ -173,7 +172,6 @@ fn compute_next_poll_eta_does_not_overflow_on_huge_interval_mcp_ci_worktree() {
 // arg is filtered out (`filter(|s| !s.is_empty())`) so the stale value persists.
 // ===========================================================================
 #[test]
-#[ignore = "mcp-ci-worktree-5: stale-next-after-ci-persists-across-rewatch; red until fix; remove #[ignore] after fix to confirm"]
 fn explicit_empty_next_after_ci_clears_stale_handoff_target_mcp_ci_worktree() {
     let home = std::env::temp_dir().join(format!(
         "agend-rewatch-clear-handoff-{}",

--- a/tests/review_mcp_ci_worktree_3.rs
+++ b/tests/review_mcp_ci_worktree_3.rs
@@ -73,7 +73,6 @@ fn fn_body_after(text: &str, signature_needle: &str) -> String {
 }
 
 #[test]
-#[ignore = "mcp-ci-worktree-3: release-repo-silent-metadata-leak; red until fix; remove #[ignore] after fix to confirm"]
 fn release_repo_surfaces_unprunable_metadata_leak_mcp_ci_worktree() {
     let src = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src");
     let mut files = Vec::new();

--- a/tests/review_xcut_concurrency_1.rs
+++ b/tests/review_xcut_concurrency_1.rs
@@ -25,7 +25,6 @@ use std::path::PathBuf;
 const NEEDLE: &str = "shared_ci_runtime().block_on";
 
 #[test]
-#[ignore = "xcut-concurrency F1: red until fix; remove #[ignore] after fix to confirm"]
 fn ci_mergeable_blocking_has_no_raw_shared_runtime_block_on_xcut_concurrency() {
     let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/daemon/ci_watch/provider.rs");
     let text = std::fs::read_to_string(&path)

--- a/tests/review_xcut_concurrency_3.rs
+++ b/tests/review_xcut_concurrency_3.rs
@@ -33,7 +33,6 @@ const GUARD_MARKERS: &[&str] = &[
 ];
 
 #[test]
-#[ignore = "xcut-concurrency F3: red until fix; remove #[ignore] after fix to confirm"]
 fn ci_poller_bounds_detached_spawn_with_inflight_guard_xcut_concurrency() {
     let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/daemon/ci_watch/poller.rs");
     let text = std::fs::read_to_string(&path)


### PR DESCRIPTION
## CR-2026-06-14 — CI-watch subsystem (6 Low, coherent bundle)

Six co-located Low findings in the CI watch/handler subsystem. Each is RED→GREEN against its pre-written repro (all 6 confirmed `#[ignore]`+RED on current origin/main before fixing — no double-work with the 14 already-merged CR PRs).

| sev | site | category | fix |
|-----|------|----------|-----|
| L | `ci/mod.rs:458` | resource-leak | `tracing::warn` on `source_repo==None` fallback (unprunable `.git/worktrees` metadata leak) |
| L | `ci/mod.rs:804` | error-handling | `try_from`+saturating math in `compute_next_poll_eta` (overflow panic/wrap) |
| L | `ci/mod.rs:695` | correctness | explicit-empty `next_after_ci` clears stale handoff (absent untouched) |
| L | `ci_watch/provider.rs:346` | correctness | percent-encode `branch` in all 7 provider query interpolations |
| L | `ci_watch/provider.rs:277` | concurrency | replace raw `shared_ci_runtime().block_on` with a fresh scoped-thread runtime |
| L | `ci_watch/poller.rs:522` | resource-leak | per-repo in-flight guard bounds the detached batch-poll spawns |

### Highlights
- **branch encoding** — added a dependency-free `percent_encode_query` (encodes outside RFC-3986 unreserved). Keeps query-legal `/` **raw** so slash-branches (`feat/foo`) still match GitHub's documented `head={owner}:{branch}` filter — this preserved the existing `github_check_pr_terminal_uses_owner_prefix_in_head_query` (caught + fixed during regression). Applied to GitHub + GitLab + Bitbucket query interpolations.
- **block_on** — `check_pr_mergeable_blocking` now builds a **fresh** `current_thread` runtime inside the scoped thread (escapes any ambient runtime context, never touches the long-lived shared CI runtime) — satisfies the CLAUDE.md no-raw-shared-runtime-block_on hard rule.
- **poller bound** — `RepoInFlightGuard` (RAII, released on **every** async return path via `Drop`) over a process-global per-repo in-flight set; a tick skips a repo whose prior cycle is still running, so at most one batch task per repo is ever outstanding even under a provider stall. (The existing `shared_ci_runtime().spawn` keeps its `// fire-and-forget:` rationale — §10.5 audit 2/2.)

### §3.10 RED→GREEN
- Anchor `b28f42b` (un-ignore only) → 6/6 repros **RED**.
- HEAD `82f9ad5` → 6/6 **GREEN**.

### Evidence
```
ran: cargo test --bin agend-terminal compute_next_poll_eta_does_not_overflow explicit_empty_next_after_ci_clears github_poll_runs_percent_encodes → 3 passed
ran: cargo test --test review_mcp_ci_worktree_3 / review_xcut_concurrency_1 / review_xcut_concurrency_3 → 1+1+1 passed
ran: cargo test --bin agend-terminal ci_watch:: → 216 passed; 0 failed
ran: cargo test --bin agend-terminal handlers::ci → 73 passed; 0 failed
ran: cargo test --test spawn_rationale_audit → 2 passed (poller guard does not trip §10.5)
ran: cargo fmt --check → clean
ran: cargo clippy --tests --features tray -- -D warnings → clean
```
(local runs `AGEND_GIT_BYPASS=1` per managed-worktree convention; PR CI is authoritative cross-platform.)

### Review tier
Dual (concurrency: block_on / detached-spawn bound + correctness: branch-encoding / handoff-clear).

### Lessons learned
- The branch encoder is the load-bearing decision: encoding **too much** (`/`) silently broke an unrelated existing test (`head=owner:feat/foo`). The right scope is "query separators only" — `/` is query-legal and must stay raw. Caught by running the full `ci_watch::` module, not just the new repro.

---
*fixup-dev-3* · claude-opus-4-8[1m]
