### PR TITLE
fix(CR-2026-06-14 daemon-retention Low): task_sweep single-fetch + hook_shadow eviction + waiting_on_stale retain

### DIFF
--- a/src/daemon/boot_sweep/review_repro_daemon_retention.rs
+++ b/src/daemon/boot_sweep/review_repro_daemon_retention.rs
@@ -79,7 +79,7 @@ fn spawn_sigterm_respecter() -> (u32, std::thread::JoinHandle<()>) {
 
 #[cfg(unix)]
 #[test]
-#[ignore = "daemon-retention boot_sweep-unreadable-pid-guard: red until fix; remove #[ignore] after fix to confirm"]
+#[ignore = "daemon-retention boot_sweep-unreadable-pid-guard: harm already closed by #2170's cleanup start-token guard (this repro is GREEN on current main — the empty .daemon → start_token None → IdentityMismatch → not killed); boot-sweep guard-level hardening is an optional follow-up, re-confirm before un-ignoring"]
 fn unreadable_daemon_pid_must_not_be_killed_in_destructive_sweep_daemon_retention() {
     let home = tmp_home("unreadable-pid");
     let (live_pid, reaper) = spawn_sigterm_respecter();

--- a/src/daemon/hook_shadow.rs
+++ b/src/daemon/hook_shadow.rs
@@ -49,6 +49,20 @@ fn store() -> &'static Mutex<HashMap<String, HookShadow>> {
     S.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
+/// CR-2026-06-14: drop a deleted/redeployed agent's shadow entry. The global
+/// `store()` is keyed by agent NAME and only ever inserted into
+/// (`record_event`), so without an eviction path it grows one permanent entry
+/// per distinctly-named agent ever seen, and a same-name redeploy inherits the
+/// prior instance's last observation. Called from `full_delete_instance`.
+///
+/// Deliberately lifecycle-keyed, NOT an age-out sweep: the #1523 `ToolUse`
+/// snapshot is allowed to outlive [`HOOK_FRESHNESS`] (event-pair closed, no
+/// clock backstop), so an age-based `.retain` would wrongly demote a
+/// long-running tool — eviction keys on agent deletion instead.
+pub(crate) fn forget(name: &str) {
+    store().lock().remove(name);
+}
+
 /// Freshness window for a hook-derived state: a derived state is only VALID
 /// while a hook event arrived within this window — beyond it the state is
 /// STALE and resolution falls back to the screen heuristic. Kills the

--- a/src/daemon/per_tick/supervisor_trackers.rs
+++ b/src/daemon/per_tick/supervisor_trackers.rs
@@ -169,6 +169,16 @@ impl PerTickHandler for WaitingOnStaleHandler {
     }
     fn run(&self, ctx: &TickContext<'_>) {
         self.tracker.lock().maybe_scan(ctx.home);
+        // CR-2026-06-14: prune the dedup map to live agents each tick (mirrors
+        // ConflictNotifyHandler's #1923 G5 cleanup below) so `last_alerted_at`
+        // doesn't leak one permanent entry per ever-stale agent, and a same-name
+        // redeploy can't inherit a stale dedup timestamp that false-suppresses a
+        // real alert.
+        let live: HashSet<String> = {
+            let reg = crate::agent::lock_registry(ctx.registry);
+            reg.values().map(|h| h.name.to_string()).collect()
+        };
+        self.tracker.lock().retain_active(&live);
     }
 }
 

--- a/src/daemon/task_sweep.rs
+++ b/src/daemon/task_sweep.rs
@@ -230,6 +230,9 @@ fn sweep_tick(home: &Path) -> anyhow::Result<()> {
     // exactly as the pre-P2 single-repo tick did (compliance ran only once both
     // the PR list AND the open-task set were non-empty).
     let mut default_scanned = false;
+    // CR-2026-06-14: capture the DEFAULT board's merged-PR list so the compliance
+    // pass below reuses it instead of issuing a second identical GitHub fetch.
+    let mut default_prs: Option<Vec<PrMeta>> = None;
     for (project_id, repo) in &boards {
         match sweep_board(
             home,
@@ -239,9 +242,10 @@ fn sweep_tick(home: &Path) -> anyhow::Result<()> {
             fleet_cfg.as_ref(),
             cfg.dry_run,
         ) {
-            Ok(scanned) => {
+            Ok((scanned, prs)) => {
                 if project_id == crate::task_events::DEFAULT_PROJECT {
                     default_scanned = scanned;
+                    default_prs = Some(prs);
                 }
             }
             // Per-board isolation: a repo-A API/append failure must NOT abort the
@@ -259,7 +263,11 @@ fn sweep_tick(home: &Path) -> anyhow::Result<()> {
     // single-project deployment the DEFAULT board IS `cfg.repo`.
     if default_scanned && cfg.compliance_mode != "off" {
         if let Some(repo) = cfg.repo.as_deref().filter(|s| !s.is_empty()) {
-            let _ = compliance_sweep(home, repo);
+            // Reuse the DEFAULT board's already-fetched list (set together with
+            // `default_scanned` above, so it is always `Some` here).
+            if let Some(prs) = default_prs.as_deref() {
+                let _ = compliance_sweep(home, repo, prs);
+            }
         }
     }
 
@@ -312,12 +320,16 @@ fn sweep_board(
     api_base: &str,
     fleet_cfg: Option<&crate::fleet::FleetConfig>,
     dry_run: bool,
-) -> anyhow::Result<bool> {
+) -> anyhow::Result<(bool, Vec<PrMeta>)> {
     // #2117 P3a: the `list_recently_merged_prs` network fetch is the ONLY thing
     // this adds over the testable close logic; delegate the rest to
     // `sweep_board_with_prs` (the injectable seam).
+    // CR-2026-06-14: this is now the SINGLE merged-PR fetch per tick — the list
+    // is returned so `sweep_tick` can thread the DEFAULT board's slice into
+    // `compliance_sweep` instead of it re-fetching the identical data.
     let prs = list_recently_merged_prs(repo, api_base)?;
-    sweep_board_with_prs(home, project_id, &prs, fleet_cfg, dry_run)
+    let scanned = sweep_board_with_prs(home, project_id, &prs, fleet_cfg, dry_run)?;
+    Ok((scanned, prs))
 }
 
 /// #2117 P3a: the close logic of [`sweep_board`] with the PR list INJECTED. Seam
@@ -871,25 +883,22 @@ fn has_scope_linkage(pr: &PrMeta) -> bool {
 
 /// Run compliance sweep on recently merged PRs.
 /// Called from sweep_tick when compliance_mode != "off".
-fn compliance_sweep(home: &Path, repo: &str) -> Vec<ComplianceViolation> {
+///
+/// CR-2026-06-14: the merged-PR list is now fetched ONCE per tick (in
+/// `sweep_board` for the DEFAULT board) and threaded in as `prs` — this fn no
+/// longer issues its own duplicate `list_recently_merged_prs` GitHub request.
+/// Behaviour is unchanged: it operates on the same DEFAULT-board merged-PR list
+/// it used to re-fetch (DEFAULT board repo == `cfg.repo`).
+fn compliance_sweep(home: &Path, repo: &str, prs: &[PrMeta]) -> Vec<ComplianceViolation> {
     let mut cfg = load_config(home);
     if cfg.compliance_mode == "off" {
         return Vec::new();
     }
-    let api_base = cfg
-        .api_base_url
-        .as_deref()
-        .unwrap_or(DEFAULT_GITHUB_API_BASE);
-
-    let prs = match list_recently_merged_prs(repo, api_base) {
-        Ok(prs) => prs,
-        Err(_) => return Vec::new(),
-    };
 
     let mut all_violations = Vec::new();
     let mut max_merged_at: Option<String> = None;
 
-    for pr in &prs {
+    for pr in prs {
         if !pr.merged {
             continue;
         }
@@ -1692,7 +1701,7 @@ mod tests {
             api_base_url: None,
         };
         save_config(&home, &cfg).unwrap();
-        let violations = compliance_sweep(&home, "test/repo");
+        let violations = compliance_sweep(&home, "test/repo", &[]);
         assert!(
             violations.is_empty(),
             "off mode should produce no violations"

--- a/src/daemon/waiting_on_stale.rs
+++ b/src/daemon/waiting_on_stale.rs
@@ -54,6 +54,16 @@ impl WaitingOnStaleTracker {
         scan_and_emit(home, &mut self.last_alerted_at, seeding);
         true
     }
+
+    /// CR-2026-06-14: prune the dedup map to currently-active agents, mirroring
+    /// `ConflictNotifyTracker::retain_active` (the #1923 leak class). Without
+    /// this, `last_alerted_at` grows one permanent entry per agent that ever
+    /// went stale, and a same-name redeploy inherits a stale dedup timestamp
+    /// that can false-suppress a real alert. Driven each tick from
+    /// `WaitingOnStaleHandler::run`.
+    pub(crate) fn retain_active(&mut self, active: &std::collections::HashSet<String>) {
+        self.last_alerted_at.retain(|name, _| active.contains(name));
+    }
 }
 
 /// Scan all metadata files for stale `waiting_on` conditions and emit

--- a/src/mcp/handlers/instance_state/lifecycle.rs
+++ b/src/mcp/handlers/instance_state/lifecycle.rs
@@ -181,6 +181,12 @@ pub(crate) fn full_delete_instance(home: &Path, name: &str) -> Result<(), String
     // accumulate in the tracking list and inflate alert text.
     crate::daemon::idle_watchdog::remove_agent_activity(home, name);
 
+    // CR-2026-06-14: drop the in-memory hook-shadow store entry — same
+    // per-agent-residual / stale-state-on-redeploy class as the sidecars above,
+    // but this global `HashMap<name, HookShadow>` had no eviction path (it only
+    // ever inserted via `record_event`), leaking one entry per ever-seen agent.
+    crate::daemon::hook_shadow::forget(name);
+
     // #1744-H2: drop the persisted escalation state so a later agent reusing
     // this name does not rehydrate the deleted instance's crash budget /
     // cooldowns / hung anchor (the #1680 stale-state lesson).

--- a/tests/review_hook_shadow_eviction_daemon_retention.rs
+++ b/tests/review_hook_shadow_eviction_daemon_retention.rs
@@ -17,7 +17,6 @@
 use std::path::PathBuf;
 
 #[test]
-#[ignore = "daemon-retention hook_shadow-eviction: red until fix; remove #[ignore] after fix to confirm"]
 fn hook_shadow_store_has_an_eviction_path_daemon_retention() {
     let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/daemon/hook_shadow.rs");
     let src =

--- a/tests/review_task_sweep_double_fetch_daemon_retention.rs
+++ b/tests/review_task_sweep_double_fetch_daemon_retention.rs
@@ -18,7 +18,6 @@
 use std::path::PathBuf;
 
 #[test]
-#[ignore = "daemon-retention task_sweep-double-fetch: red until fix; remove #[ignore] after fix to confirm"]
 fn compliance_sweep_does_not_refetch_merged_prs_daemon_retention() {
     let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/daemon/task_sweep.rs");
     let src =

--- a/tests/review_waiting_on_stale_retain_daemon_retention.rs
+++ b/tests/review_waiting_on_stale_retain_daemon_retention.rs
@@ -36,7 +36,6 @@ fn has_code_line_with(src: &str, needle: &str) -> bool {
 }
 
 #[test]
-#[ignore = "daemon-retention waiting_on_stale-retain: red until fix; remove #[ignore] after fix to confirm"]
 fn waiting_on_stale_has_retain_active_and_is_wired_daemon_retention() {
     let tracker_src = read_src("src/daemon/waiting_on_stale.rs");
     let handler_src = read_src("src/daemon/per_tick/supervisor_trackers.rs");


### PR DESCRIPTION
## CR-2026-06-14 Low — daemon-retention batch (3 findings)

All 3 are daemon background-loop resource/perf Low findings; **RED→GREEN verified** against current `origin/main` (baseline run confirmed each repro still RED before the fix).

### task_sweep double-fetch (performance) — `daemon/task_sweep.rs`
`list_recently_merged_prs` was called **twice per tick** — `sweep_board` (auto-close) + `compliance_sweep` — doubling GitHub list-pulls + runtime builds for identical data. `sweep_board` now returns `(scanned, Vec<PrMeta>)`; `sweep_tick` captures the DEFAULT board's list and threads `&[PrMeta]` into `compliance_sweep` (fetch removed). **Single call-site now.** Behaviour-preserving: same DEFAULT-board list (DEFAULT board repo == `cfg.repo`), fetched once — auto-close / merge_freshness unchanged.

### hook_shadow eviction (resource-leak) — `daemon/hook_shadow.rs`
The global `HashMap<name, HookShadow>` only ever inserted → one entry per ever-seen agent + same-name redeploy inherits a stale observation. Added `forget(name)` wired into `full_delete_instance`. **Lifecycle-keyed, not age-out**: the #1523 `ToolUse` snapshot deliberately outlives `HOOK_FRESHNESS`, so an age `.retain` would wrongly demote a long-running tool.

### waiting_on_stale retain GC (resource-leak) — `daemon/waiting_on_stale.rs` + `per_tick/supervisor_trackers.rs`
`last_alerted_at` had no prune (unbounded; same-name redeploy inherits a stale dedup ts that false-suppresses a real alert). Added `retain_active(&HashSet)` (mirror `ConflictNotifyTracker`, #1923) + wired into `WaitingOnStaleHandler::run` (prune to live registry each tick, mirror `ConflictNotifyHandler`).

### Skipped: boot_sweep unreadable-pid guard (4th proposed)
Its repro is **already GREEN** on current main — the harm is backstopped by #2170's cleanup start-token guard (empty `.daemon` → `start_token` None → `IdentityMismatch` → not killed). Its `#[ignore]` is reworded to record this. Boot-sweep guard-level hardening is an optional follow-up.

## Repro (red→green)
3 `_daemon_retention` repros un-ignored — RED on current main (baseline run), GREEN after.

## CI-parity
Rebased onto current `origin/main` (clean, no file overlap with intervening worktree_cleanup merge). `fmt --check` + `clippy --all-targets --features tray -D warnings` + **Windows cross-check** (`cargo xwin`) all green; full `--tests` green except the pre-existing agent-env git-shim false-fail `dispatch_branch_..._1834`.

**Risk: all 3 dual** (performance/correctness/resource-leak).

🤖 Generated with [Claude Code](https://claude.com/claude-code)