### PR TITLE
fix(CR-2026-06-14 control-plane reliability Low ×5): dedup count-cap, preauth fd, lock order, keepalive, notify rekey

### DIFF
--- a/src/api/handlers/external.rs
+++ b/src/api/handlers/external.rs
@@ -18,6 +18,13 @@ pub(crate) fn handle_register_external(params: &Value, ctx: &HandlerCtx) -> Valu
     if crate::fleet::resolve_uuid(ctx.home, name).is_some_and(|id| reg.contains_key(&id)) {
         return json!({"ok": false, "error": format!("agent '{name}' already exists (managed)")});
     }
+    // CR-2026-06-14 (lock order): release the registry lock BEFORE taking the
+    // external lock — this was the ONLY site nesting external INSIDE registry
+    // (and it even held registry across the `resolve_uuid` disk read). Holding
+    // both established an undocumented registry→external order; a future
+    // external-then-registry holder would deadlock against it. The managed-name
+    // collision check above is the only thing that needs `reg`, so drop it here.
+    drop(reg);
     let mut ext = agent::lock_external(ctx.externals);
     if ext.contains_key(name) {
         return json!({"ok": false, "error": format!("agent '{name}' already exists (external)")});
@@ -45,7 +52,6 @@ pub(crate) fn handle_register_external(params: &Value, ctx: &HandlerCtx) -> Valu
             pid,
         },
     );
-    drop(reg);
     drop(ext);
     crate::event_log::log(
         ctx.home,

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -463,7 +463,15 @@ fn handle_session(
     // on the stream (set in `serve`) ensures a silent peer closes out in 30s
     // rather than pinning this worker thread.
     // #680: 5s pre-auth timeout — prevents slow-loris holding a semaphore slot.
-    let _ = writer.set_read_timeout(Some(std::time::Duration::from_secs(5)));
+    // CR-2026-06-14: arm it on the fd that the handshake actually READS from
+    // (`reader`'s inner `cloned` stream), not on `writer`. They only happened to
+    // share `SO_RCVTIMEO` because `try_clone()`/`dup` shares one file
+    // description — an accidental coupling that any future independent-timeout
+    // change (or a platform where dup'd handles don't share the option) would
+    // silently break, removing the slow-loris guard.
+    let _ = reader
+        .get_ref()
+        .set_read_timeout(Some(std::time::Duration::from_secs(5)));
     // Sprint 25 P1 F1: extract optional peer PID for telemetry.
     let peer_pid =
         match crate::auth_cookie::server_handshake_ndjson(&mut reader, &mut writer, &cookie) {
@@ -473,8 +481,9 @@ fn handle_session(
                 return;
             }
         };
-    // Restore no-timeout for authenticated sessions
-    let _ = writer.set_read_timeout(None);
+    // Restore no-timeout for authenticated sessions (on the read fd it was
+    // armed on above — CR-2026-06-14).
+    let _ = reader.get_ref().set_read_timeout(None);
     // Telemetry only — see MCP-DAEMON-PROXY-CONTRACT §peer-PID-telemetry.
     if let Some(pid) = peer_pid {
         tracing::debug!(peer_pid = pid, "API session peer PID");

--- a/src/api/request_dedup.rs
+++ b/src/api/request_dedup.rs
@@ -69,6 +69,17 @@ pub const PER_ENTRY_CAP_BYTES: usize = 64 * 1024;
 /// entries are dropped.
 pub const TOTAL_CAP_BYTES: usize = 64 * 1024 * 1024;
 
+/// CR-2026-06-14: maximum number of cached ENTRIES, independent of the byte
+/// ceiling. Terminal `Oversized`/`Errored` entries are stored with
+/// `response_bytes == 0`, so they contribute nothing to `total_bytes` and the
+/// byte-cap eviction (which also skips zero-byte entries) can never reclaim
+/// them — a stream of unique request_ids with oversized/errored responses would
+/// otherwise grow the map unbounded for the full TTL window. This count cap
+/// evicts the oldest TERMINAL entries (any size) so the entry count stays
+/// bounded. Sized well above any realistic in-flight-plus-TTL dedup population
+/// so it never evicts a legitimately-cacheable response under normal load.
+pub const MAX_ENTRIES: usize = 16_384;
+
 /// Maximum concurrent waiters on a single in-progress entry. Over-cap
 /// callers receive an immediate `in_progress` error.
 pub const WAITER_CAP: usize = 8;
@@ -360,30 +371,49 @@ impl DedupCache {
     }
 
     fn evict_to_fit(&self, inner: &mut Inner) {
-        if inner.total_bytes <= self.total_cap {
-            return;
-        }
-        // Collect terminal entries ordered by completed_at ascending.
-        // InProgress entries (completed_at = None) are skipped — they're
-        // not "old" in any meaningful sense and can't be replayed safely.
-        let mut victims: Vec<(String, Instant, usize)> = inner
-            .entries
-            .iter()
-            .filter_map(|(k, e)| {
-                if e.response_bytes == 0 {
-                    return None;
+        // Byte-cap eviction: drop oldest byte-bearing terminal entries until
+        // under `total_cap`. InProgress entries (completed_at = None) are
+        // skipped — they're not "old" in any meaningful sense and can't be
+        // replayed safely.
+        if inner.total_bytes > self.total_cap {
+            let mut victims: Vec<(String, Instant, usize)> = inner
+                .entries
+                .iter()
+                .filter_map(|(k, e)| {
+                    if e.response_bytes == 0 {
+                        return None;
+                    }
+                    let completed = e.completed_at?;
+                    Some((k.clone(), completed, e.response_bytes))
+                })
+                .collect();
+            victims.sort_by_key(|(_, t, _)| *t);
+            for (id, _, bytes) in victims {
+                if inner.total_bytes <= self.total_cap {
+                    break;
                 }
-                let completed = e.completed_at?;
-                Some((k.clone(), completed, e.response_bytes))
-            })
-            .collect();
-        victims.sort_by_key(|(_, t, _)| *t);
-        for (id, _, bytes) in victims {
-            if inner.total_bytes <= self.total_cap {
-                break;
+                if inner.entries.remove(&id).is_some() {
+                    inner.total_bytes = inner.total_bytes.saturating_sub(bytes);
+                }
             }
-            if inner.entries.remove(&id).is_some() {
-                inner.total_bytes = inner.total_bytes.saturating_sub(bytes);
+        }
+
+        // CR-2026-06-14 count-cap eviction: the byte pass above can never reclaim
+        // zero-byte (Oversized/Errored) terminal entries, so cap the ENTRY COUNT
+        // too — evict the oldest TERMINAL entries (ANY size, including zero-byte)
+        // until back under MAX_ENTRIES. InProgress entries are never evicted.
+        if inner.entries.len() > MAX_ENTRIES {
+            let overflow = inner.entries.len() - MAX_ENTRIES;
+            let mut victims: Vec<(String, Instant, usize)> = inner
+                .entries
+                .iter()
+                .filter_map(|(k, e)| e.completed_at.map(|t| (k.clone(), t, e.response_bytes)))
+                .collect();
+            victims.sort_by_key(|(_, t, _)| *t);
+            for (id, _, bytes) in victims.into_iter().take(overflow) {
+                if inner.entries.remove(&id).is_some() {
+                    inner.total_bytes = inner.total_bytes.saturating_sub(bytes);
+                }
             }
         }
     }

--- a/src/api/request_dedup/review_repro_api.rs
+++ b/src/api/request_dedup/review_repro_api.rs
@@ -24,7 +24,6 @@ use serde_json::json;
 use std::time::Duration;
 
 #[test]
-#[ignore = "dedup-entry-count-ceiling: red until fix; remove #[ignore] after fix to confirm"]
 fn zero_byte_oversized_entries_are_count_bounded_api() {
     // per_entry_cap = 10 bytes → every response below is "oversized" and
     // gets stored as a zero-byte `Oversized` terminal entry that

--- a/src/channel/discord.rs
+++ b/src/channel/discord.rs
@@ -367,25 +367,35 @@ pub(crate) fn start_keepalive(state: std::sync::Arc<Mutex<DiscordState>>) {
                 .build()
                 .expect("keepalive tokio runtime");
             loop {
-                std::thread::sleep(std::time::Duration::from_secs(KEEPALIVE_INTERVAL_SECS));
-                let (http, channel_ids) = {
+                // CR-2026-06-14: capture the work snapshot FIRST so the very
+                // first iteration issues its keepalive PATCHes promptly; the
+                // interval sleep moves to the END of the loop body (below).
+                // Previously the loop slept a full KEEPALIVE_INTERVAL_SECS (30
+                // min) BEFORE the first refresh, so freshly-bound threads idled
+                // toward the 60-min auto-archive boundary, eroding the 30-vs-60-
+                // min margin the design assumes. `None` (no HTTP client yet)
+                // falls through to the end-sleep — re-checking next interval
+                // without busy-spinning (the old `continue` relied on the
+                // loop-top sleep that no longer exists).
+                let snapshot = {
                     let s = state.lock();
-                    let http = match s.http_client.clone() {
-                        Some(h) => h,
-                        None => continue,
-                    };
-                    let ids: Vec<u64> = s.instance_to_channel.values().copied().collect();
-                    (http, ids)
+                    s.http_client.clone().map(|http| {
+                        let ids: Vec<u64> = s.instance_to_channel.values().copied().collect();
+                        (http, ids)
+                    })
                 };
-                for cid in channel_ids {
-                    let id = twilight_model::id::Id::new(cid);
-                    let http = http.clone();
-                    rt.block_on(async {
-                        if let Err(e) = http.update_thread(id).archived(false).await {
-                            tracing::debug!(channel_id = cid, %e, "keepalive PATCH failed");
-                        }
-                    });
+                if let Some((http, channel_ids)) = snapshot {
+                    for cid in channel_ids {
+                        let id = twilight_model::id::Id::new(cid);
+                        let http = http.clone();
+                        rt.block_on(async {
+                            if let Err(e) = http.update_thread(id).archived(false).await {
+                                tracing::debug!(channel_id = cid, %e, "keepalive PATCH failed");
+                            }
+                        });
+                    }
                 }
+                std::thread::sleep(std::time::Duration::from_secs(KEEPALIVE_INTERVAL_SECS));
             }
         })
     {

--- a/src/channel/telegram/notify.rs
+++ b/src/channel/telegram/notify.rs
@@ -1,8 +1,25 @@
 //! Telegram notification helpers — daemon/supervisor notify to instance topics.
 
+use crate::channel::dedup::DedupKey;
 use crate::channel::telegram::error::*;
 use crate::channel::telegram::send::*;
 use crate::channel::telegram::state::*;
+
+/// CR-2026-06-14: after a successful notify retry to a RECREATED topic, record a
+/// dedup claim keyed on the NEW topic id. The original claim (recorded before the
+/// first send) is keyed on the now-dead OLD topic id, so without this a
+/// concurrent duplicate emission to the recreated topic finds no matching claim
+/// and is NOT suppressed — the "same content to same topic within TTL" dedup
+/// invariant would lapse precisely across the recreate window.
+fn rekey_dedup_for_recreated_topic(
+    home: &std::path::Path,
+    instance: &str,
+    new_tid: i32,
+    text: &str,
+) {
+    let key = DedupKey::new("telegram:notify", instance, Some(i64::from(new_tid)), text);
+    let _ = crate::channel::dedup::global(home).record_and_check(key);
+}
 
 /// Send a notification to Telegram (instance topic or general).
 pub fn notify_telegram(home: &std::path::Path, instance_name: &str, text: &str) {
@@ -140,6 +157,16 @@ fn notify_telegram_inner(
                         // patched twin of the reply.rs HIGH-2 evict-on-failure).
                         if req.await.is_err() {
                             crate::channel::dedup::global(&home_owned).evict(&dedup_key);
+                        } else {
+                            // CR-2026-06-14: retry to the recreated topic succeeded
+                            // — re-key the dedup claim under the NEW topic id so a
+                            // concurrent duplicate to it is still suppressed.
+                            rekey_dedup_for_recreated_topic(
+                                &home_owned,
+                                &instance_owned,
+                                new_tid,
+                                &text,
+                            );
                         }
                         return;
                     }

--- a/tests/discord_keepalive_sleep_position_channel.rs
+++ b/tests/discord_keepalive_sleep_position_channel.rs
@@ -30,7 +30,6 @@
 use std::path::PathBuf;
 
 #[test]
-#[ignore = "channel-LOW-3: red until fix; remove #[ignore] after fix to confirm"]
 fn discord_keepalive_does_not_sleep_before_first_refresh_channel() {
     let discord = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/channel/discord.rs");
     let content = std::fs::read_to_string(&discord)

--- a/tests/notify_recreated_topic_dedup_rekey_channel.rs
+++ b/tests/notify_recreated_topic_dedup_rekey_channel.rs
@@ -31,7 +31,6 @@
 use std::path::PathBuf;
 
 #[test]
-#[ignore = "channel-LOW-4: red until fix; remove #[ignore] after fix to confirm"]
 fn notify_recreated_topic_retry_rekeys_dedup_claim_channel() {
     let notify = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/channel/telegram/notify.rs");
     let content = std::fs::read_to_string(&notify)

--- a/tests/review_api_external_lock_order_api.rs
+++ b/tests/review_api_external_lock_order_api.rs
@@ -72,7 +72,6 @@ fn handle_register_external_body(src: &str) -> Vec<(usize, String)> {
 }
 
 #[test]
-#[ignore = "register-external-nests-external-lock-inside-registry-lock: red until fix; remove #[ignore] after fix to confirm"]
 fn register_external_releases_registry_lock_before_taking_external_api() {
     let path = external_rs();
     let src = std::fs::read_to_string(&path).expect("read external.rs");

--- a/tests/review_api_preauth_timeout_fd_api.rs
+++ b/tests/review_api_preauth_timeout_fd_api.rs
@@ -35,7 +35,6 @@ fn api_mod_rs() -> PathBuf {
 }
 
 #[test]
-#[ignore = "preauth-timeout-on-write-fd-not-read-fd: red until fix; remove #[ignore] after fix to confirm"]
 fn preauth_read_timeout_is_set_on_the_read_fd_api() {
     let path = api_mod_rs();
     let src = std::fs::read_to_string(&path).expect("read api/mod.rs");


### PR DESCRIPTION
## CR-2026-06-14 — control-plane reliability (5 verified-open Low findings, api/ + channel/)

> Confirmed RED via `--run-ignored` first — most CR Low repros were already fixed by merged batches (#2166/#2152/#2181/etc.); the REPRO-TESTS 🔴 marks are #2135's initial state and don't reflect later merges.

### resource-leak — `api/request_dedup.rs` dedup cache has no entry-count ceiling
Oversized/Errored terminal entries are stored with `response_bytes == 0`, contribute nothing to `total_bytes`, and `evict_to_fit` skips them — so a stream of unique request_ids with oversized/errored responses grows the map **unbounded** for the full TTL window. **Fix:** `MAX_ENTRIES = 16384` + a count-cap eviction that drops the oldest **terminal** entries (any size) regardless of `response_bytes`.

### correctness — `api/mod.rs` pre-auth read timeout on the wrong fd
The 5s slow-loris pre-auth timeout was armed on `writer`, but the handshake reads from `reader` (the cloned fd). It only bounded the read by accident (`dup()` shares `SO_RCVTIMEO`). **Fix:** arm it on `reader.get_ref()`.

### concurrency — `api/handlers/external.rs` nested lock order
`handle_register_external` was the ONLY site nesting external **inside** registry (and held both across the `resolve_uuid` disk read) — an undocumented registry→external order a future external-then-registry holder would deadlock against. **Fix:** `drop(reg)` after the managed-name check, before taking external.

### correctness — `channel/discord.rs` keepalive sleeps before first refresh
`start_keepalive` slept a full 30-min interval **before** the first refresh PATCH, so freshly-bound threads idled toward the 60-min auto-archive boundary. **Fix:** snapshot the work first; move the sleep to the loop tail (`None` falls through to the end-sleep — no busy-spin).

### concurrency — `channel/telegram/notify.rs` recreated-topic dedup not re-keyed
The topic-deleted recovery retried the send to a recreated topic but never re-keyed the dedup claim under the **new** topic id (the claim is keyed on the now-dead old `topic_id`), so a concurrent duplicate to the recreated topic was not suppressed. **Fix:** after a successful retry, `record_and_check` a `DedupKey` keyed on `Some(new_tid)`.

## Tests — red→green proven (all 5 RED on HEAD, GREEN with fix)
`zero_byte_oversized_entries_are_count_bounded_api` · `preauth_read_timeout_is_set_on_the_read_fd_api` · `register_external_releases_registry_lock_before_taking_external_api` · `discord_keepalive_does_not_sleep_before_first_refresh_channel` · `notify_recreated_topic_retry_rekeys_dedup_claim_channel`

## CI parity
`fmt --check` ✓ · `clippy --tests --features tray -D warnings` ✓ · `clippy --features discord -D warnings` (discord.rs is feature-gated) ✓ · `nextest api::request_dedup / handlers::external / channel::telegram::notify + 5 repros` (23 pass) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)