### PR TITLE
fix(CR-2026-06-14 tasks L #234): auto_close emitter underscore to match ACL allow-list

### DIFF
--- a/src/tasks/auto_close.rs
+++ b/src/tasks/auto_close.rs
@@ -60,7 +60,10 @@ pub fn auto_close_on_report(
             closed_at: chrono::Utc::now().to_rfc3339(),
         },
     };
-    let emitter = crate::task_events::InstanceName::from("system:auto-close");
+    // CR-2026-06-14: underscore form, matching `acl::SYSTEM_IDENTITIES` +
+    // status_summary. The prior hyphen variant was absent from the ACL allow-list,
+    // so `is_system_identity` denied it if routed through `can_mutate_record`.
+    let emitter = crate::task_events::InstanceName::from("system:auto_close");
     // #1873: re-validate →Done UNDER the lock — a concurrent cancel between the
     // out-of-lock status check above and this append must not be flipped to Done.
     let closed =

--- a/tests/review_tasks_9.rs
+++ b/tests/review_tasks_9.rs
@@ -29,7 +29,6 @@ fn production_region(text: &str) -> &str {
 }
 
 #[test]
-#[ignore = "tasks-auto-close-emitter-hyphen: red until fix; remove #[ignore] after fix to confirm"]
 fn auto_close_emitter_matches_acl_allow_list_tasks() {
     let text = read_auto_close();
     let prod = production_region(&text);


### PR DESCRIPTION
## CR-2026-06-14 — tasks/ Low bundle (1 fix; 2 already-covered; 2 redesign gaps reported)

Git-history-aware triage of the 5 tasks/ Low findings — only **one** is genuinely open:

| finding | repro | status |
|---------|-------|--------|
| **#234** auto_close emitter hyphen vs ACL | `auto_close_emitter_matches_acl_allow_list_tasks` | **FIXED here** (RED→GREEN) |
| #230 cross-board ACL `..` escape | `board_root_dotdot_…` | already covered on main (repro un-ignored + green) → skip |
| #232 sweep bare-Cancelled legality (t-59) | `sweep_cancel_uses_legality_guard_…` | already covered on main (repro green) → skip |
| #231 handle_update actor-in-lock | `handle_update_resolves_actor_in_lock_…` | RED — **redesign-required gap**, reported to lead |
| #235 board_router repair dedup | `index_repair_is_guarded_against_duplicate_reappend_…` | RED — **redesign-required gap**, reported to lead |

### The fix (#234)
`auto_close_on_report` emitted `InstanceName::from("system:auto-close")` (hyphen). `acl::SYSTEM_IDENTITIES` (acl.rs:82) and `status_summary` use `system:auto_close` (underscore); `is_system_identity` returns false for the hyphen form, so the emitter would be denied if routed through `can_mutate_record`, and the audit trail carried two names for one subsystem. One-char standardization to the underscore form.

### §3.10 RED→GREEN
`tests/review_tasks_9.rs` (un-ignored) RED before, GREEN after. `tasks::` 144 pass; fmt + clippy `--tests --features tray -D warnings` clean.

### Redesign gaps (NOT fixed here — for lead triage)
- **#231** (`review_tasks_6`): #2169 moved handle_update's emit in-lock, but the transition events' `by` is still built from the **out-of-lock** record (the repro's BAD pattern) — actor resolution not yet in-lock (the repro's "interim guard").
- **#235** (`review_tasks_10`): #2168 added Phase-1 size-gated lazy dedup, but `resolve_task_project`'s repair `record_task_project` call is still **unconditional** (no existence/dedup guard) — likely #2168's deferred Phase-2.

---
*fixup-dev-3* · claude-opus-4-8[1m]
