### PR TITLE
fix(CR-2026-06-14 t-56): durable atomic-write / persist-result hardening (Low×7)

### DIFF
--- a/src/app/session.rs
+++ b/src/app/session.rs
@@ -134,7 +134,7 @@ fn serialize_session(layout: &Layout) -> Option<String> {
 pub(super) fn save_session(home: &Path, layout: &Layout) {
     if let Some(json) = serialize_session(layout) {
         let path = home.join("session.json");
-        let _ = std::fs::write(&path, &json);
+        let _ = crate::store::atomic_write(&path, json.as_bytes());
         tracing::info!(path = %path.display(), "session saved");
     }
 }
@@ -157,7 +157,7 @@ pub(super) fn save_session_if_changed(
         return false;
     }
     let path = home.join("session.json");
-    if std::fs::write(&path, &json).is_ok() {
+    if crate::store::atomic_write(&path, json.as_bytes()).is_ok() {
         *cache = Some(json);
         true
     } else {

--- a/src/channel/telegram/bootstrap.rs
+++ b/src/channel/telegram/bootstrap.rs
@@ -214,7 +214,13 @@ pub(super) fn resolve_fleet_binding(
             let tid = topic.thread_id.0 .0;
             tracing::info!(topic_id = tid, %name, "created fleet_binding topic");
             reg.insert(tid, FLEET_BINDING_SENTINEL.to_string());
-            let _ = save_topic_registry(home, reg);
+            // Propagate the persist result (mirror the sibling call site above):
+            // if the write fails the in-memory registry has the new topic but
+            // disk does not, so a restart re-runs this slow path and
+            // create_forum_topic mints a DUPLICATE named topic.
+            if let Err(e) = save_topic_registry(home, reg) {
+                tracing::warn!(error = %e, %name, "failed to save fleet_binding topic registry");
+            }
             Some(tid)
         }
         Err(e) => {

--- a/src/operator_mode.rs
+++ b/src/operator_mode.rs
@@ -204,7 +204,7 @@ pub fn set_mode(
         delegate_scope,
     };
     let json = serde_json::to_string_pretty(&state).map_err(|e| e.to_string())?;
-    std::fs::write(path(home), &json).map_err(|e| e.to_string())?;
+    crate::store::atomic_write(&path(home), json.as_bytes()).map_err(|e| e.to_string())?;
     // #1576: sign so the next reload trusts only operator-written content.
     write_sidecar(home, json.as_bytes()).map_err(|e| e.to_string())?;
     *global().write() = state.clone();

--- a/src/service/linux.rs
+++ b/src/service/linux.rs
@@ -47,7 +47,7 @@ pub(super) fn install(home: &Path, exe: &Path) -> Result<PathBuf, String> {
     if let Some(parent) = unit.parent() {
         std::fs::create_dir_all(parent).map_err(|e| format!("create_dir_all {parent:?}: {e}"))?;
     }
-    std::fs::write(&unit, resolved.as_bytes())
+    crate::store::atomic_write(&unit, resolved.as_bytes())
         .map_err(|e| format!("write systemd unit {unit:?}: {e}"))?;
 
     // Idempotent register: daemon-reload first (picks up our write),

--- a/src/service/macos.rs
+++ b/src/service/macos.rs
@@ -51,7 +51,7 @@ pub(super) fn install(home: &Path, exe: &Path) -> Result<PathBuf, String> {
     if let Some(parent) = plist.parent() {
         std::fs::create_dir_all(parent).map_err(|e| format!("create_dir_all {parent:?}: {e}"))?;
     }
-    std::fs::write(&plist, resolved.as_bytes())
+    crate::store::atomic_write(&plist, resolved.as_bytes())
         .map_err(|e| format!("write plist {plist:?}: {e}"))?;
 
     // Idempotent register: unload first (no-op if not loaded), then load.

--- a/src/service/windows.rs
+++ b/src/service/windows.rs
@@ -60,7 +60,8 @@ pub(super) fn install(home: &Path, exe: &Path) -> Result<PathBuf, String> {
     for unit in utf16 {
         bytes.extend_from_slice(&unit.to_le_bytes());
     }
-    std::fs::write(&xml_path, &bytes).map_err(|e| format!("write task xml {xml_path:?}: {e}"))?;
+    crate::store::atomic_write(&xml_path, &bytes)
+        .map_err(|e| format!("write task xml {xml_path:?}: {e}"))?;
 
     // Idempotent register: schtasks /Create /F overwrites any existing
     // task with the same name, so no separate delete-first step is

--- a/src/store.rs
+++ b/src/store.rs
@@ -193,6 +193,16 @@ pub fn atomic_write(path: &Path, bytes: &[u8]) -> anyhow::Result<()> {
     }
     std::fs::rename(&tmp, path)?;
     guard.disarm();
+    // Durability: fsync the parent directory after the rename so the new
+    // directory entry is flushed. The temp file's contents are already synced
+    // above, but a crash/power-loss after `rename(2)` returns yet before the
+    // directory entry reaches disk can lose the rename — defeating the
+    // "atomic AND durable replace" contract. Directory fsync is a Unix idiom;
+    // Windows has no clean equivalent in std, so it is skipped there.
+    #[cfg(unix)]
+    if let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) {
+        std::fs::File::open(parent)?.sync_all()?;
+    }
     Ok(())
 }
 

--- a/tests/review_bootstrap_config_cli_4.rs
+++ b/tests/review_bootstrap_config_cli_4.rs
@@ -54,19 +54,16 @@ fn assert_atomic_install(module: &str, src: &str) {
 }
 
 #[test]
-#[ignore = "service-plist-nonatomic: red until fix; remove #[ignore] after fix to confirm"]
 fn macos_service_install_writes_plist_atomically_bootstrap_config_cli() {
     assert_atomic_install("macos", include_str!("../src/service/macos.rs"));
 }
 
 #[test]
-#[ignore = "service-unit-nonatomic: red until fix; remove #[ignore] after fix to confirm"]
 fn linux_service_install_writes_unit_atomically_bootstrap_config_cli() {
     assert_atomic_install("linux", include_str!("../src/service/linux.rs"));
 }
 
 #[test]
-#[ignore = "service-taskxml-nonatomic: red until fix; remove #[ignore] after fix to confirm"]
 fn windows_service_install_writes_taskxml_atomically_bootstrap_config_cli() {
     assert_atomic_install("windows", include_str!("../src/service/windows.rs"));
 }

--- a/tests/review_panic_io_extra_operator_mode.rs
+++ b/tests/review_panic_io_extra_operator_mode.rs
@@ -24,7 +24,6 @@ use std::path::PathBuf;
 const NEEDLE: &str = "std::fs::write(path(home), &json)";
 
 #[test]
-#[ignore = "operator_mode-nonatomic-gate: red until fix; remove #[ignore] after fix to confirm"]
 fn operator_mode_data_write_is_atomic_panic_io_extra() {
     let file = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/operator_mode.rs");
     let text = std::fs::read_to_string(&file).expect("read src/operator_mode.rs");

--- a/tests/review_panic_io_extra_session.rs
+++ b/tests/review_panic_io_extra_session.rs
@@ -24,7 +24,6 @@ use std::path::PathBuf;
 const NEEDLE: &str = "std::fs::write(&path, &json)";
 
 #[test]
-#[ignore = "session-json-nonatomic: red until fix; remove #[ignore] after fix to confirm"]
 fn session_json_data_write_is_atomic_panic_io_extra() {
     let file = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/app/session.rs");
     let text = std::fs::read_to_string(&file).expect("read src/app/session.rs");

--- a/tests/review_panic_io_extra_telegram_bootstrap.rs
+++ b/tests/review_panic_io_extra_telegram_bootstrap.rs
@@ -24,7 +24,6 @@ use std::path::PathBuf;
 const NEEDLE: &str = "let _ = save_topic_registry(";
 
 #[test]
-#[ignore = "telegram-topic-registry-dropped: red until fix; remove #[ignore] after fix to confirm"]
 fn fleet_binding_topic_persist_result_not_dropped_panic_io_extra() {
     let file = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/channel/telegram/bootstrap.rs");
     let text = std::fs::read_to_string(&file).expect("read src/channel/telegram/bootstrap.rs");

--- a/tests/review_xcut_concurrency_2.rs
+++ b/tests/review_xcut_concurrency_2.rs
@@ -18,7 +18,6 @@
 use std::path::PathBuf;
 
 #[test]
-#[ignore = "xcut-concurrency F2: red until fix; remove #[ignore] after fix to confirm"]
 fn atomic_write_fsyncs_parent_dir_after_rename_xcut_concurrency() {
     let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/store.rs");
     let text =


### PR DESCRIPTION
## CR-2026-06-14 Low batch — durable atomic-write / persist-result bundle

Coherent bundle (panic-io-extra + xcut-concurrency + bootstrap-config-cli atomic-write subset). Lead-approved (task `t-20260615051258852484-56`), branch deconflicted. Each finding had an `#[ignore]`'d repro; §3.10 RED→GREEN all 7 assertions.

### Findings & fixes
| Finding | Fix |
|---|---|
| `store.rs:166` atomic_write never fsyncs parent dir after rename | post-rename `File::open(parent)?.sync_all()?` (cfg(unix); Windows has no clean std equiv) — completes durable-replace contract. **Root helper.** |
| `operator_mode.rs` set_mode truncate-then-write of `operator-mode.json` | route via `store::atomic_write` (fail-closed reader otherwise silently reverts on mid-write crash) |
| `app/session.rs` save_session / save_session_if_changed | route `session.json` via `store::atomic_write` (×2 sites) |
| `channel/telegram/bootstrap.rs` resolve_fleet_binding drops `save_topic_registry` result | propagate/warn (mirror sibling site) — dropped write → restart mints DUPLICATE forum topic |
| `service/{macos,linux,windows}.rs` install non-atomic lifecycle-file write | route plist/unit/task-xml via `store::atomic_write` |

### Verification
- **RED** (original): all 7 FAILED (3 service + 4 source-scan)
- **GREEN** (fixed): all 7 pass
- `store::atomic_write` existing tests green (drop-guard / no-extension / no-tmp-on-success)
- `cargo fmt` + `cargo clippy --all-targets --features tray -D warnings` clean
- pre-push CI-parity (`cargo test --tests`) passed

### Review ask
- `store.rs` atomic_write = cross-used correctness root → **dual** (concurrency/durability lens)
- rest = routing-through-atomic_write static-invariants — lower risk

🤖 Generated with [Claude Code](https://claude.com/claude-code)