### PR TITLE
fix(CR-2026-06-14 worktree-git Low ×5): atomic release marker, mandatory gc cwd, slash-branch agent, fail-closed in-use, drop dead ci-watch fn

### DIFF
--- a/src/worktree_cleanup.rs
+++ b/src/worktree_cleanup.rs
@@ -170,6 +170,35 @@ fn normalize_path(p: &Path) -> PathBuf {
     PathBuf::from(s.strip_prefix(r"\\?\").unwrap_or(&s).to_string())
 }
 
+/// Canonicalize `p`, or — when it does not exist yet — resolve symlinks on its
+/// longest EXISTING ancestor and re-append the missing tail. Returns `None`
+/// only when not even an existing ancestor canonicalizes.
+///
+/// #worktree-git-7: an active agent's `working_dir` recorded through a symlink
+/// alias whose leaf is transiently absent (mid-creation) would fail
+/// `canonicalize()` outright; the prior fail-OPEN fell back to the raw path,
+/// whose textual prefix misses the canonical worktree → `is_in_use` returned
+/// false and the sweep could remove a worktree out from under a live agent.
+fn canonicalize_lenient(p: &Path) -> Option<PathBuf> {
+    if let Ok(c) = p.canonicalize() {
+        return Some(c);
+    }
+    let mut tail: Vec<&std::ffi::OsStr> = Vec::new();
+    let mut cur = p;
+    while let Some(parent) = cur.parent() {
+        if let Some(name) = cur.file_name() {
+            tail.push(name);
+        }
+        if let Ok(c) = parent.canonicalize() {
+            let mut out = c;
+            out.extend(tail.iter().rev());
+            return Some(out);
+        }
+        cur = parent;
+    }
+    None
+}
+
 /// Check if a worktree path is in use by any active agent.
 fn is_in_use(wt_path: &Path, active_dirs: &[PathBuf]) -> bool {
     let wt_norm = normalize_path(
@@ -177,9 +206,15 @@ fn is_in_use(wt_path: &Path, active_dirs: &[PathBuf]) -> bool {
             .canonicalize()
             .unwrap_or_else(|_| wt_path.to_path_buf()),
     );
-    active_dirs.iter().any(|wd| {
-        let wd_norm = normalize_path(&wd.canonicalize().unwrap_or_else(|_| wd.clone()));
-        wd_norm.starts_with(&wt_norm) || wd.starts_with(wt_path)
+    active_dirs.iter().any(|wd| match canonicalize_lenient(wd) {
+        Some(canon) => {
+            let wd_norm = normalize_path(&canon);
+            wd_norm.starts_with(&wt_norm) || wd.starts_with(wt_path)
+        }
+        // Fail-CLOSED: not even an existing ancestor canonicalizes, so we cannot
+        // prove this active dir is outside the worktree. Treat the ambiguity as
+        // in-use rather than risk sweeping a worktree a live agent is using.
+        None => true,
     })
 }
 

--- a/src/worktree_cleanup/review_repro_worktree_git.rs
+++ b/src/worktree_cleanup/review_repro_worktree_git.rs
@@ -248,7 +248,6 @@ fn phase1_remote_gone_worktree_keeps_unpushed_branch_ref_worktree_git() {
 
 #[test]
 #[cfg(unix)] // symlink-based repro
-#[ignore = "worktree-git #7 is_in_use-canonicalize-fail-open: red until fix; remove #[ignore] after fix to confirm"]
 fn is_in_use_fails_closed_on_canonicalize_error_worktree_git() {
     use std::os::unix::fs::symlink;
 

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -75,16 +75,38 @@ pub fn lease(
 /// Release a lease — marks worktree as GC candidate (does NOT delete, Phase 4).
 /// Writes `released_at` timestamp for grace period calculation.
 pub fn release(home: &Path, lease: &WorktreeLease) {
-    // Clear binding (task done).
-    crate::binding::unbind(home, &lease.agent);
-    // Write released_at into the managed marker for GC grace calculation.
-    let marker = lease.path.join(MANAGED_MARKER);
-    if let Ok(mut content) = std::fs::read_to_string(&marker) {
-        content.push_str(&format!(
-            "released_at={}\n",
-            chrono::Utc::now().to_rfc3339()
-        ));
-        let _ = crate::store::atomic_write(&marker, content.as_bytes());
+    // #worktree-git-3: hold the SAME per-agent binding lock that
+    // create()/bind_full/gc use, so the unbind + marker read-modify-write is
+    // atomic against a concurrent bind or GC pass. Without it, a racing rewrite
+    // (or a crash between read and write) can drop `released_at` from the
+    // marker, which reclassifies the worktree from the clean-release grace path
+    // into the force-reclaim backstop — changing the deletion semantics.
+    // Best-effort: an unobtainable lock must not block the release (matches the
+    // prior unlocked behaviour, only safer). Scoped so the lock is dropped
+    // before the event-log write (no nested flock).
+    let lock_path = crate::paths::runtime_dir(home)
+        .join(&lease.agent)
+        .join(".binding.json.lock");
+    {
+        let _lock = crate::store::acquire_file_lock(&lock_path);
+        // Clear binding (task done).
+        crate::binding::unbind(home, &lease.agent);
+        // Write released_at into the managed marker for GC grace calculation.
+        let marker = lease.path.join(MANAGED_MARKER);
+        if let Ok(mut content) = std::fs::read_to_string(&marker) {
+            content.push_str(&format!(
+                "released_at={}\n",
+                chrono::Utc::now().to_rfc3339()
+            ));
+            if let Err(e) = crate::store::atomic_write(&marker, content.as_bytes()) {
+                tracing::warn!(
+                    agent = %lease.agent,
+                    path = %marker.display(),
+                    error = %e,
+                    "release: failed to persist released_at into managed marker"
+                );
+            }
+        }
     }
     crate::event_log::log(
         home,
@@ -495,76 +517,6 @@ pub fn release_full(home: &Path, agent: &str, dry_run: bool) -> ReleaseOutcome {
     out
 }
 
-/// Sprint 57 Wave 2 Track B (#546 Item 2) — scan ci-watches dir,
-/// remove `agent` from EVERY watch whose subscriber list contains
-/// them. Replaces the Sprint 55 P0-B EC7 single-(repo, branch)-pair
-/// helper that left ad-hoc watches outside the binding-branch
-/// orphaned on release. Agent names are unique within the fleet so
-/// removing the name from any matching watch is always correct on
-/// release; the cross-repo bleed risk that the EC7 r1 review flagged
-/// only applies when the predicate is "branch matches" — `agent`
-/// matches doesn't have that ambiguity.
-///
-/// Per-watch behaviour: if `agent` was the last subscriber → delete
-/// the watch file entirely; otherwise rewrite it with the shrunk
-/// subscriber list. Best-effort: read/parse/write failures are
-/// logged but never abort release.
-#[allow(dead_code)] // #931: kept as the documented rollback target — see
-                    // the comment block at the former call site in `release_full`. Slated for
-                    // removal one Sprint after #931 lands assuming no rollback fires.
-fn unsubscribe_all_ci_watches_for_agent(home: &Path, agent: &str) {
-    let ci_dir = crate::daemon::ci_watch::ci_watches_dir(home);
-    let Ok(entries) = std::fs::read_dir(&ci_dir) else {
-        return;
-    };
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.extension().and_then(|s| s.to_str()) != Some("json") {
-            continue;
-        }
-        // #692: flock protects read-modify-write against concurrent ci_watch tick
-        let lock_path = path.with_extension("lock");
-        let _lock = match crate::store::acquire_file_lock(&lock_path) {
-            Ok(l) => l,
-            Err(_) => continue, // skip if can't lock
-        };
-        let Ok(content) = std::fs::read_to_string(&path) else {
-            continue;
-        };
-        let Ok(mut watch) = serde_json::from_str::<serde_json::Value>(&content) else {
-            continue;
-        };
-        let watch_branch = watch["branch"].as_str().unwrap_or("?").to_string();
-        let watch_repo = watch["repo"].as_str().unwrap_or("?").to_string();
-        let mut subs: Vec<String> = crate::daemon::ci_watch::parse_subscribers(&watch);
-        let before = subs.len();
-        subs.retain(|s| s != agent);
-        if subs.len() == before {
-            continue; // agent wasn't subscribed; nothing to do
-        }
-        if subs.is_empty() {
-            let _ = std::fs::remove_file(&path);
-            tracing::info!(%agent, repo = %watch_repo, branch = %watch_branch, path = %path.display(),
-                "ci-watch unsubscribed last subscriber → removed watch file");
-            continue;
-        }
-        let subs_json: Vec<serde_json::Value> = subs
-            .iter()
-            .map(|name| serde_json::json!({"instance": name}))
-            .collect();
-        watch["subscribers"] = serde_json::json!(subs_json);
-        watch["instance"] = serde_json::json!(subs.first().cloned().unwrap_or_default());
-        let _ = crate::store::atomic_write(
-            &path,
-            serde_json::to_string_pretty(&watch)
-                .unwrap_or_default()
-                .as_bytes(),
-        );
-        tracing::info!(%agent, repo = %watch_repo, branch = %watch_branch, remaining = subs.len(),
-            "ci-watch unsubscribed agent; subscribers shrunk");
-    }
-}
-
 /// Pin a worktree (operator override — prevents GC in Phase 4).
 pub fn pin(worktree_path: &Path) {
     let pin_file = worktree_path.join(".agend-pinned");
@@ -917,12 +869,27 @@ fn evaluate_candidate(
         .and_then(|l| l.strip_prefix("agent="))
         .map(String::from)
         .or_else(|| {
-            // New layout: <home>/worktrees/<agent>/<branch>/ → parent is agent
+            // New layout: <home>/worktrees/<agent>/<branch>/, where <branch> may
+            // contain slashes (e.g. `feat/x` → worktrees/<agent>/feat/x).
+            // #worktree-git-6: derive the agent from the FIRST path component
+            // under the worktrees root, NOT the immediate parent dir — for a
+            // slash branch the parent is `feat`, not the real agent, which would
+            // evaluate force-reclaim/liveness against the wrong agent.
+            let root = daemon_managed_worktree_root(home);
             wt_path
-                .parent()
-                .and_then(|p| p.file_name())
-                .and_then(|n| n.to_str())
+                .strip_prefix(&root)
+                .ok()
+                .and_then(|rel| rel.components().next())
+                .and_then(|c| c.as_os_str().to_str())
                 .map(String::from)
+                .or_else(|| {
+                    // Legacy / off-root fallback: immediate parent dir name.
+                    wt_path
+                        .parent()
+                        .and_then(|p| p.file_name())
+                        .and_then(|n| n.to_str())
+                        .map(String::from)
+                })
         })
         .unwrap_or_default();
     if agent_name.is_empty() {
@@ -1158,7 +1125,26 @@ fn gc_remove_one(home: &Path, candidate: &GcCandidate) -> GcResult {
         };
     }
 
-    let source_repo = resolve_source_repo(wt_path);
+    // #worktree-git-4: the owning repo's cwd is MANDATORY for `git worktree
+    // remove`. Empirically, running it with the daemon's inherited cwd (an
+    // unrelated repo) fails with "is not a working tree", leaving the dir on
+    // disk; the remove_dir_all fallback then physically deletes the dir but
+    // CANNOT prune the owning repo's registry (the prune is keyed on
+    // source_repo) → a prunable-registry leak that blocks re-lease. If the
+    // owning repo can't be resolved, skip rather than run git cwd-less; a later
+    // pass reclaims it once `.git` is resolvable.
+    let Some(source_repo) = resolve_source_repo(wt_path) else {
+        return GcResult {
+            path: wt_path.clone(),
+            agent: candidate.agent.clone(),
+            removed: false,
+            error: Some(
+                "skipped: owning source repo unresolved — refusing to run \
+                 `git worktree remove` without the owning-repo cwd"
+                    .to_string(),
+            ),
+        };
+    };
 
     let mut result = GcResult {
         path: wt_path.clone(),
@@ -1167,11 +1153,8 @@ fn gc_remove_one(home: &Path, candidate: &GcCandidate) -> GcResult {
         error: None,
     };
 
-    // git-raw-allowed: `source_repo` may be None, in which case this runs with
-    // NO `current_dir` and git resolves the repo from the absolute worktree path.
-    // `git_cmd`/`git_bypass` both REQUIRE a cwd; there is no repo-tree dir to pass
-    // when source_repo is None (wt_path's parent is the worktrees-pool dir, per
-    // lead ruling). The conditional `current_dir` is the whole point — keep raw.
+    // git-raw-allowed: kept raw (not git_cmd) per the decided #2128 migration
+    // scope; cwd is now always the resolved owning repo.
     let mut cmd = std::process::Command::new("git");
     cmd.args([
         "worktree",
@@ -1179,10 +1162,8 @@ fn gc_remove_one(home: &Path, candidate: &GcCandidate) -> GcResult {
         "--force",
         &wt_path.display().to_string(),
     ])
-    .env("AGEND_GIT_BYPASS", "1");
-    if let Some(ref sr) = source_repo {
-        cmd.current_dir(sr);
-    }
+    .env("AGEND_GIT_BYPASS", "1")
+    .current_dir(&source_repo);
     match cmd.output() {
         Ok(o) if o.status.success() => {
             result.removed = true;
@@ -1197,10 +1178,8 @@ fn gc_remove_one(home: &Path, candidate: &GcCandidate) -> GcResult {
             );
             let _ = std::fs::remove_dir_all(wt_path);
             if !wt_path.exists() {
-                if let Some(ref sr) = source_repo {
-                    // W1.2: best-effort prune (result already ignored).
-                    let _ = crate::git_helpers::git_ok(sr, &["worktree", "prune"]);
-                }
+                // W1.2: best-effort prune (result already ignored).
+                let _ = crate::git_helpers::git_ok(&source_repo, &["worktree", "prune"]);
                 result.removed = true;
             } else {
                 result.error = Some(format!("git worktree remove failed: {stderr}"));

--- a/src/worktree_pool/review_repro_worktree_git.rs
+++ b/src/worktree_pool/review_repro_worktree_git.rs
@@ -104,7 +104,6 @@ fn cleanup_merged_branch_uses_true_default_not_main_worktree_git() {
 // ──────────────────────────────────────────────────────────────────────────
 
 #[test]
-#[ignore = "worktree-git #6 gc-agent-slash-branch-fallback: red until fix; remove #[ignore] after fix to confirm"]
 fn evaluate_candidate_derives_real_agent_for_slash_branch_worktree_git() {
     let home = scratch("gc-agent-slash");
     let real_agent = "agent-real";

--- a/tests/review_worktree_git_3.rs
+++ b/tests/review_worktree_git_3.rs
@@ -54,7 +54,6 @@ fn fn_body(src: &str, sig_needle: &str) -> String {
 }
 
 #[test]
-#[ignore = "worktree-git #3 release-marker-rmw: red until fix; remove #[ignore] after fix to confirm"]
 fn release_marker_rmw_is_lock_guarded_or_record_based_worktree_git_3() {
     let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/worktree_pool.rs");
     let src = std::fs::read_to_string(&path).expect("read src/worktree_pool.rs");

--- a/tests/review_worktree_git_4.rs
+++ b/tests/review_worktree_git_4.rs
@@ -82,7 +82,6 @@ fn has_conditional_removal_cwd(body: &str) -> bool {
 }
 
 #[test]
-#[ignore = "worktree-git #4 gc-remove-one-cwd: red until fix; remove #[ignore] after fix to confirm"]
 fn gc_remove_one_worktree_remove_has_mandatory_cwd_worktree_git_4() {
     let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/worktree_pool.rs");
     let src = std::fs::read_to_string(&path).expect("read src/worktree_pool.rs");

--- a/tests/review_worktree_git_8.rs
+++ b/tests/review_worktree_git_8.rs
@@ -18,7 +18,6 @@
 use std::path::PathBuf;
 
 #[test]
-#[ignore = "worktree-git #8 dead-code-unsubscribe: red until fix; remove #[ignore] after fix to confirm"]
 fn unsubscribe_all_ci_watches_dead_code_removed_worktree_git_8() {
     let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/worktree_pool.rs");
     let src = std::fs::read_to_string(&path).expect("read src/worktree_pool.rs");


### PR DESCRIPTION
worktree-git domain **Low bundle** from `docs/CODE-REVIEW-2026-06-14.md`. Each finding's review-repro test went RED→GREEN; `#[ignore]` removed to lock the behavior in.

## Findings fixed
| # | finding | site | fix |
|---|---------|------|-----|
| #3 | release() non-atomic, unlocked marker RMW | `worktree_pool.rs` `release()` | guard unbind + `.agend-managed` RMW with the per-agent binding lock (same one create/bind_full/gc use); surface the swallowed `atomic_write` error |
| #4 | gc_remove_one runs `git worktree remove` with no cwd when source_repo is None → wrong-repo + registry leak | `worktree_pool.rs` `gc_remove_one()` | make the owning-repo cwd **mandatory**; early-return skip when source_repo is unresolved |
| #6 | GC agent-name fallback derives `feat` for slash-branch worktrees | `worktree_pool.rs` `evaluate_candidate()` | derive agent from the FIRST path component under the worktrees root (legacy parent-dir fallback kept for off-root paths) |
| #7 | is_in_use canonicalize fail-OPEN can sweep an in-use worktree | `worktree_cleanup.rs` `is_in_use()` | fail-CLOSED via lenient ancestor-resolution (resolves a symlink alias whose leaf is transiently absent) |
| #8 | dead destructive `unsubscribe_all_ci_watches_for_agent` (#931 shipped) | `worktree_pool.rs` | delete the unreferenced `#[allow(dead_code)]` ci-watch-deleting path |

## Evidence
- **#4 verified empirically**: `git worktree remove --force <abs>` from an unrelated repo cwd → `fatal: '...' is not a working tree` (exit 128), dir survives, owning registry still lists the worktree (the leak). The prior `// git resolves the repo from the absolute worktree path` comment was premise-wrong.
- All 5 repros: RED before → GREEN after (`#[ignore]` removed).
- Regression: 77 `worktree_pool::` + `worktree_cleanup::` tests pass; `git_subprocess_invariant`, `file_size_invariant`, `sync_audit::` lock-ordering all green.
- `cargo fmt --check` clean; `cargo clippy --features tray --bins --tests -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)