### PR TITLE
fix(CR-2026-06-14 agent-binding Lows): symlink cleanup + hook warn + bootstrap lock nesting (3)

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -1300,6 +1300,14 @@ pub fn spawn_agent(config: &SpawnConfig, registry: &AgentRegistry) -> anyhow::Re
     Ok(())
 }
 
+/// #CR-2026-06-14: lock the per-agent core (OFF the registry lock path) and
+/// report whether it has reached Idle. Kept as a helper so the readiness check
+/// snapshots `Arc::clone(&h.core)` under the registry lock, drops that guard, and
+/// only then acquires the core lock here — never registry→core nested.
+fn bootstrap_core_is_idle(core: &std::sync::Arc<CoreMutex<AgentCore>>) -> bool {
+    core.lock().state.get_state() == crate::state::AgentState::Idle
+}
+
 /// Poll until the agent reaches Idle, then inject the pre-read instructions
 /// content as a first user message. Used by backends (Kiro) whose CLI does
 /// not auto-load the steering file.
@@ -1339,17 +1347,20 @@ fn spawn_instructions_bootstrap(
                 return;
             }
 
-            let ready = {
-                let reg = &registry.lock();
+            // #CR-2026-06-14 (concurrency): snapshot the core Arc under the tier-1
+            // registry lock, DROP the registry guard, THEN lock the core (in the
+            // helper) — never nest the per-agent core lock inside the registry
+            // lock. The old registry→core nesting established an acquisition order
+            // a core→registry path could deadlock against, every 200ms at startup.
+            // Mirrors the inject snapshot below.
+            let core = {
+                let reg = registry.lock();
                 match reg.get(&instance_id) {
-                    Some(h) => {
-                        let core = &h.core.lock();
-                        core.state.get_state() == crate::state::AgentState::Idle
-                    }
+                    Some(h) => std::sync::Arc::clone(&h.core),
                     None => return, // agent gone
                 }
             };
-            if ready {
+            if bootstrap_core_is_idle(&core) {
                 break;
             }
             std::thread::sleep(poll_interval);

--- a/src/agent_ops.rs
+++ b/src/agent_ops.rs
@@ -386,8 +386,22 @@ pub fn ensure_not_protected_json(branch: &str) -> Result<(), serde_json::Value> 
 pub fn cleanup_working_dir(home: &Path, name: &str, working_dir: &Path) {
     let workspaces = crate::paths::workspace_dir(home);
 
-    // If under $AGEND_HOME/workspace/, remove the whole directory
-    if working_dir.starts_with(&workspaces) {
+    // If under $AGEND_HOME/workspace/, remove the whole directory.
+    // CR-2026-06-14 (security): a purely LEXICAL `starts_with` lets a symlink
+    // under workspace/ whose real target is ELSEWHERE take this whole-dir
+    // `remove_dir_all` and follow the symlink out of the workspace, destroying
+    // real user data. Require the path to ALSO resolve canonically inside the
+    // canonicalized workspace root (canonicalize BOTH so a symlinked
+    // $AGEND_HOME — e.g. macOS /tmp→/private/tmp — still matches).
+    let under_workspace = working_dir.starts_with(&workspaces)
+        && match (
+            dunce::canonicalize(working_dir),
+            dunce::canonicalize(&workspaces),
+        ) {
+            (Ok(wd), Ok(ws)) => wd.starts_with(&ws),
+            _ => false,
+        };
+    if under_workspace {
         if let Err(e) = std::fs::remove_dir_all(working_dir) {
             tracing::debug!(dir = %working_dir.display(), error = %e, "cleanup: remove workspace");
         } else {

--- a/src/agent_ops/review_repro_agent_binding.rs
+++ b/src/agent_ops/review_repro_agent_binding.rs
@@ -25,7 +25,6 @@ use super::cleanup_working_dir;
 /// (dunce::canonicalize + re-check): the victim file survives.
 #[cfg(unix)]
 #[test]
-#[ignore = "cleanup-working-dir-symlink: red until fix; remove #[ignore] after fix to confirm"]
 fn cleanup_working_dir_does_not_follow_symlink_out_of_workspace_agent_binding() {
     use std::sync::atomic::{AtomicU32, Ordering};
     static COUNTER: AtomicU32 = AtomicU32::new(0);

--- a/src/binding.rs
+++ b/src/binding.rs
@@ -393,10 +393,20 @@ pub fn install_hooks(home: &Path, worktree: &Path) {
     // ran raw `git` with NO bypass env). `git config` against a fleet-managed
     // worktree is exactly the forgot-bypass latent class (#821/#1463): a daemon
     // git mutation should always bypass the agend-git shim. Intended fix.
-    let _ = crate::git_helpers::git_ok(
+    let hooks_set = crate::git_helpers::git_ok(
         worktree,
         &["config", "core.hooksPath", &hooks_dir.display().to_string()],
     );
+    // CR-2026-06-14: surface the silent failure. If the worktree isn't a git repo
+    // yet (or the config write fails) the prepare-commit-msg hook is never wired
+    // up; warn so an operator can notice rather than the binding/commit-msg
+    // enforcement vanishing silently for that worktree.
+    if !hooks_set {
+        tracing::warn!(
+            worktree = %worktree.display(),
+            "install_hooks: `git config core.hooksPath` failed — prepare-commit-msg hook NOT wired up for this worktree"
+        );
+    }
 }
 
 /// Install hooks on all existing worktrees (daemon startup reconcile).

--- a/src/binding/review_repro_agent_binding.rs
+++ b/src/binding/review_repro_agent_binding.rs
@@ -24,7 +24,6 @@ use super::install_hooks;
 /// RED now: no log fires (`install_hooks` swallows the failure). GREEN after
 /// fix: a warn about the hook failure is emitted.
 #[test]
-#[ignore = "install-hooks-silent-failure: red until fix; remove #[ignore] after fix to confirm"]
 #[tracing_test::traced_test]
 fn install_hooks_warns_when_git_config_fails_agent_binding() {
     use std::sync::atomic::{AtomicU32, Ordering};

--- a/tests/review_bootstrap_lock_nesting_agent_binding.rs
+++ b/tests/review_bootstrap_lock_nesting_agent_binding.rs
@@ -24,7 +24,6 @@
 use std::path::PathBuf;
 
 #[test]
-#[ignore = "bootstrap-lock-nesting: red until fix; remove #[ignore] after fix to confirm"]
 fn bootstrap_does_not_nest_core_lock_in_registry_lock_agent_binding() {
     let file = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/agent/mod.rs");
     let text = std::fs::read_to_string(&file).expect("read src/agent/mod.rs");


### PR DESCRIPTION
## CR-2026-06-14 — agent-binding Low bundle (3 fixes)

Three co-located Low findings in the agent-binding subsystem, each RED→GREEN against its repro.

| sev | site | category | fix |
|-----|------|----------|-----|
| L | `agent_ops.rs:386` | **security** | canonicalize working_dir + re-check inside canonical workspace before `remove_dir_all` |
| L | `binding.rs` install_hooks | error-handling | warn when `git config core.hooksPath` fails (silent hook absence) |
| L | `agent/mod.rs` bootstrap | concurrency | snapshot core Arc under registry lock, drop guard, then lock core (no registry→core nesting) |

### Highlights
- **symlink cleanup (#238)** — a purely lexical `working_dir.starts_with(workspace)` let a symlink under `workspace/` whose real target is elsewhere take the whole-dir `remove_dir_all` and follow the symlink **out of the workspace**, destroying real user data. Now requires canonical containment (`dunce::canonicalize` **both** sides so a symlinked `$AGEND_HOME` — macOS `/tmp→/private/tmp` — still matches); a non-resolving path falls through to the safe agend-files-only branch.
- **lock nesting (#223-class)** — `spawn_instructions_bootstrap` acquired the per-agent `core.lock()` while holding the tier-1 `registry.lock()` (every 200ms at startup), an acquisition order a `core→registry` path could deadlock against. Snapshots `Arc::clone(&h.core)` under the registry lock, drops the guard, then locks the core in a `bootstrap_core_is_idle` helper — mirrors the inject snapshot already in the same fn. (The static-invariant repro scans the fn body for `core.lock()` near `registry.lock()`; the helper keeps the lock genuinely off the registry path.)

### §3.10 RED→GREEN
Anchor `a60c5eb` (un-ignore) → 3/3 repros RED. HEAD `eb33f87` → 3/3 GREEN.

### Evidence
```
ran: cargo test --bin agend-terminal cleanup_working_dir_does_not_follow_symlink install_hooks_warns_when_git_config_fails → 2 passed
ran: cargo test --test review_bootstrap_lock_nesting_agent_binding → 1 passed
ran: cargo test --bin agend-terminal agent_ops:: → 33 ; binding:: → 27 ; agent::tests → 75 — all pass
ran: cargo fmt --check → clean ; cargo clippy --tests --features tray -- -D warnings → clean
```
(local runs per managed-worktree convention; PR CI authoritative cross-platform.)

### Review tier
Dual (security: symlink-traversal canonicalization + concurrency: lock-tier nesting).

---
*fixup-dev-3* · claude-opus-4-8[1m]
