### PR TITLE
fix(CR-2026-06-14 app-tui Low ×3): resize ghost-clear, agent_is_alive try_lock+doc, enqueue append doc

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -707,6 +707,12 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
                     Event::Resize(cols, rows) => {
                         let pane_area = ratatui::layout::Rect::new(0, 1, cols, rows.saturating_sub(2));
                         crate::layout::resize_panes(pane_area, &mut layout, &registry);
+                        // #1140: an interactive terminal resize reflows pane widths
+                        // (the wide→narrow transition that leaves stale wide-char
+                        // spacer cells in ratatui's Buffer::diff), so force the same
+                        // full clear the needs_resize path performs — otherwise the
+                        // ghost artifacts reappear after the resize.
+                        let _ = terminal.clear();
                     }
                     _ => {}
                 }
@@ -1486,8 +1492,12 @@ fn kill_agent(home: &Path, registry: &AgentRegistry, name: &str) {
 /// Used by the scratch shell overlay to self-close when the user exits the
 /// shell naturally (`exit`, Ctrl+D) or the process crashes. Returns `false`
 /// if the name is no longer registered (already reaped) or `try_wait`
-/// reports the child has exited. A poisoned child mutex is treated as alive
-/// so a spurious poison doesn't auto-dismiss the overlay — Esc still works.
+/// reports the child has exited. `AgentHandle.child` is a `parking_lot::Mutex`
+/// (which never poisons), so a CONTENDED lock is read via `try_lock()` and
+/// treated as alive: this runs on the TUI main loop, and a blocking `.lock()`
+/// would wedge the whole UI if another thread panicked while holding the child
+/// lock (parking_lot leaves it locked). Transient contention just keeps the
+/// overlay open for that tick — Esc still works.
 fn agent_is_alive(registry: &AgentRegistry, name: &str) -> bool {
     let reg = agent::lock_registry(registry);
     // #1441: registry is UUID-keyed; the overlay only knows the display name,
@@ -1498,9 +1508,11 @@ fn agent_is_alive(registry: &AgentRegistry, name: &str) -> bool {
     // Bind to a local so the child-lock's temporary MutexGuard drops
     // before `reg` does — returning the match expression directly trips
     // the borrow checker because temporaries outlive the registry lock.
-    let alive = {
-        let mut child = handle.child.lock();
-        !matches!(child.try_wait(), Ok(Some(_)))
+    let alive = match handle.child.try_lock() {
+        Some(mut child) => !matches!(child.try_wait(), Ok(Some(_))),
+        // Contended → cannot prove the child exited without blocking the main
+        // loop; treat as alive and re-check next tick.
+        None => true,
     };
     alive
 }

--- a/src/app/review_repro_app_tui.rs
+++ b/src/app/review_repro_app_tui.rs
@@ -17,7 +17,6 @@
 /// replaced (or the code must switch to `try_lock()` with the bogus claim
 /// gone). Red while the sentence is present.
 #[test]
-#[ignore = "maintainability/agent_is_alive-poison-doc: red until fix; remove #[ignore] after fix to confirm"]
 fn agent_is_alive_doc_drops_parking_lot_poison_claim_app_tui() {
     let src = include_str!("mod.rs");
 
@@ -51,7 +50,6 @@ fn agent_is_alive_doc_drops_parking_lot_poison_claim_app_tui() {
 /// reappear after an interactive resize. Red while the arm performs neither
 /// the deferral nor the clear.
 #[test]
-#[ignore = "correctness/resize-arm-skips-ghost-clear: red until fix; remove #[ignore] after fix to confirm"]
 fn terminal_resize_arm_performs_ghost_clear_app_tui() {
     let src = include_str!("mod.rs");
 

--- a/src/inbox/mod.rs
+++ b/src/inbox/mod.rs
@@ -5,8 +5,11 @@
 //! Resilience layers:
 //! - **Readonly mode**: when available disk space < 1 GiB (customizable via AGEND_LOW_DISK_THRESHOLD in bytes), enqueue returns an
 //!   error while drain continues to work (let agents consume backlog).
-//! - **Atomic append**: each enqueue writes to a temp file, fsyncs, then
-//!   renames — no half-written lines on crash.
+//! - **Append durability**: each enqueue is an in-place flock'd append + fsync
+//!   (NOT tmp+rename — that path is used only by the read-modify-write
+//!   rewriters: drain/sweep/clear/supersede). A crash can leave a half-written
+//!   trailing line, which read paths skip and `recover_half_writes` quarantines
+//!   at startup.
 //! - **Half-write recovery**: on startup, stale `.tmp` files and corrupt
 //!   JSONL lines are moved to `inbox.recovery/` for forensics.
 

--- a/src/inbox/storage.rs
+++ b/src/inbox/storage.rs
@@ -106,7 +106,13 @@ fn with_inbox_lock<T>(home: &Path, name: &str, f: impl FnOnce(&Path) -> T) -> an
     Ok(f(&path))
 }
 
-/// Enqueue a message — atomic append via flock + tmp + fsync + rename.
+/// Enqueue a message — in-place flock'd append + fsync (O(1) JSONL append).
+///
+/// NOT crash-atomic: enqueue appends in place — no tmp+rename (only the
+/// read-modify-write rewriters drain/sweep/clear/supersede use that). A crash
+/// mid-write can leave a half-written trailing line; every read path skips an
+/// unparseable line and [`recover_half_writes`] quarantines it (to
+/// `inbox.recovery/`) at startup.
 ///
 /// Returns an error when the inbox is in readonly mode (disk full).
 /// Callers should invoke [`check_disk_space`] periodically (e.g. daemon tick);

--- a/tests/review_inbox_enqueue_doc_atomicity_inbox_notify.rs
+++ b/tests/review_inbox_enqueue_doc_atomicity_inbox_notify.rs
@@ -18,7 +18,6 @@ fn read_source_file(path: &PathBuf) -> String {
 }
 
 #[test]
-#[ignore = "enqueue-doc-contradicts-impl: red until fix; remove #[ignore] after fix to confirm"]
 fn enqueue_doc_does_not_claim_tmp_rename_atomicity_inbox_notify() {
     let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let storage = read_source_file(&root.join("src/inbox/storage.rs"));


### PR DESCRIPTION
app-tui domain **Low bundle** from `docs/CODE-REVIEW-2026-06-14.md`. Each finding's review-repro went RED→GREEN; `#[ignore]` removed to lock the behavior. (#12 confirmclose PTY-child leak already merged via #2190 → dropped after `--run-ignored` showed it PASS.)

## Findings fixed
| # | finding | site | fix | tier |
|---|---------|------|-----|------|
| #14 | Resize event arm skips the wide-char ghost-clear the needs_resize path performs | `app/mod.rs:707` | add `terminal.clear()` after the inline `resize_panes` (#1140) | correctness |
| #13 | agent_is_alive doc claims parking_lot poison-safety that can't exist; real risk is a main-loop deadlock | `app/mod.rs:1489` | read `child` via `try_lock()` (contended→alive) instead of blocking `.lock()` on the TUI loop; doc corrected to parking_lot semantics | correctness/concurrency |
| #48 | enqueue docstring + module header claim a tmp+rename atomic append the code doesn't do | `inbox/storage.rs:109`, `inbox/mod.rs:8` | reword to the real contract: in-place flock'd append + fsync; tmp+rename only in the rewriters; torn tail quarantined by `recover_half_writes` | doc |

## Evidence
- 3 repros RED before → GREEN after (`#[ignore]` removed); #12 confirmed already-merged (PASS) and dropped.
- Regression: 251 `app::` + `inbox::` tests pass (incl. agent_is_alive callers, enqueue concurrency, half-write recovery).
- `cargo fmt --check` clean; `cargo clippy --features tray --bins --tests -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)