### PR TITLE
fix(CR-2026-06-14 token_cost L #244): correct stale 'MAX per file' Codex comment

### DIFF
--- a/src/token_cost.rs
+++ b/src/token_cost.rs
@@ -547,10 +547,12 @@ fn read_file_tail(path: &Path, max_bytes: u64) -> Option<String> {
 //
 // Source: `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`. Each session file
 // carries a `session_meta` line with `payload.cwd` (attribution), `turn_context`
-// lines with `payload.model`, and `event_msg`/`token_count` lines with
-// `payload.info.total_token_usage` — which is SESSION-CUMULATIVE, so we take
-// the MAX (final total) per file, never a sum. Verified against real files
-// 2026-05-29: `total_tokens == input_tokens + output_tokens`,
+// lines with `payload.model`, and `event_msg`/`token_count` lines whose
+// `payload.info` carries both `total_token_usage` (session-cumulative) and
+// `last_token_usage` (the per-turn DELTA). `parse_codex_rows` emits one Row per
+// `token_count` line from the per-turn delta and SUMS them — Σdelta reconciles to
+// the cumulative total (see `codex_delta_sum_equals_cumulative`). Verified against
+// real files 2026-05-29: `total_tokens == input_tokens + output_tokens`,
 // `cached_input_tokens ⊆ input_tokens`, `reasoning_output_tokens ⊆ output_tokens`.
 
 /// `~/.codex/sessions` — the Codex rollout root.

--- a/src/token_cost.rs
+++ b/src/token_cost.rs
@@ -13,9 +13,10 @@
 //!   3. prices the deduped totals against a hardcoded Claude table (input /
 //!      output / cache-read / cache-write split 5m vs 1h).
 //!
-//! Phase 2 adds Codex (`~/.codex/sessions/.../rollout-*.jsonl`,
-//! `payload.info.total_token_usage` — session-cumulative, so the MAX per file
-//! is taken, never summed), merged into the same per-instance aggregation.
+//! Phase 2 adds Codex (`~/.codex/sessions/.../rollout-*.jsonl`, summing the
+//! per-turn `payload.info.last_token_usage` deltas — Σdelta reconciles to the
+//! session-cumulative `total_token_usage`, see `codex_delta_sum_equals_cumulative`),
+//! merged into the same per-instance aggregation.
 //! OpenCode is deferred (its SQLite store needs a new `rusqlite`/`sqlx`
 //! dependency — pending operator sign-off). Kiro has no usable token
 //! surface and is reported as unsupported (never fabricated).

--- a/tests/review_verify_claim_cost_4.rs
+++ b/tests/review_verify_claim_cost_4.rs
@@ -18,7 +18,6 @@
 use std::path::PathBuf;
 
 #[test]
-#[ignore = "verify-claim-cost stale-max-per-file-comment: red until fix; remove #[ignore] after fix to confirm"]
 fn token_cost_comment_does_not_claim_max_per_file_verify_claim_cost() {
     let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("src")

--- a/tests/review_verify_claim_cost_4.rs
+++ b/tests/review_verify_claim_cost_4.rs
@@ -25,15 +25,19 @@ fn token_cost_comment_does_not_claim_max_per_file_verify_claim_cost() {
     let text = std::fs::read_to_string(&path).expect("read src/token_cost.rs");
 
     // Stale phrasings describing the ABANDONED MAX strategy. The real code sums
-    // per-turn deltas, so these must not survive.
-    let stale_phrases = ["MAX per file", "is taken, never summed"];
-
+    // per-turn deltas, so these must not survive. Match VARIANTS, not fixed
+    // strings: the module header said "MAX per file" / "is taken, never summed",
+    // the Codex section header said "MAX (final total) per file" / "never a sum".
+    // Co-occurrence (`MAX` + `per file`) and a `never …sum(med)` check catch both
+    // — a fixed-substring list previously false-GREENed on the section-header
+    // variant (#2206 r6).
     let mut hits = Vec::new();
     for (i, line) in text.lines().enumerate() {
-        for phrase in &stale_phrases {
-            if line.contains(phrase) {
-                hits.push(format!("{}:{}: {}", path.display(), i + 1, line.trim()));
-            }
+        let stale_max = line.contains("MAX") && line.contains("per file");
+        let stale_never_sum =
+            line.contains("never") && (line.contains("a sum") || line.contains("summed"));
+        if stale_max || stale_never_sum {
+            hits.push(format!("{}:{}: {}", path.display(), i + 1, line.trim()));
         }
     }
 


### PR DESCRIPTION
## CR-2026-06-14 — token_cost #244 (maintainability, doc-only)

The `token_cost.rs` module header claimed Codex's session-cumulative `total_token_usage` means "the MAX per file is taken, never summed". The actual implementation (`parse_codex_rows`) **sums per-turn `last_token_usage` deltas** (Σdelta reconciles to the cumulative total, asserted by `codex_delta_sum_equals_cumulative`). The stale comment would mislead a maintainer reasoning about reconciliation. Rewrote it to describe the delta-sum design.

**Doc-only** (comment text). §3.10 RED→GREEN: `review_verify_claim_cost_4` (un-ignored) RED before, GREEN after; `token_cost::` 30 pass; fmt clean.

**Review tier:** trivial maintainability → §3.6 single review.

Scope note: the sibling #191 (`parse_since` overflow) is already covered on main (dev batch C / t-40) — its repro is un-ignored + green, so excluded.

---
*fixup-dev-3* · claude-opus-4-8[1m]