### PR TITLE
fix(CR-2026-06-14 t-50): enforce one-agent-one-team under lock on teams::update (TOCTOU)

### DIFF
--- a/src/fleet/persist.rs
+++ b/src/fleet/persist.rs
@@ -274,16 +274,22 @@ fn team_config_to_mapping(config: &TeamConfig) -> serde_yaml_ng::Mapping {
 
 /// First `(new_member, existing_team)` where one of `new_members` already
 /// belongs to a team in `teams`. Drives the one-agent-one-team invariant from
-/// INSIDE the fleet.yaml lock so a concurrent `teams::create` cannot double-book
-/// a member past the stale pre-write snapshot (#CR-2026-06-14 teams.rs:174).
+/// INSIDE the fleet.yaml lock so a concurrent `teams::create`/`teams::update`
+/// cannot double-book a member past the stale pre-write snapshot
+/// (#CR-2026-06-14 teams.rs:174 create; t-50 update). `exclude_team` skips the
+/// team being UPDATED — its own current members are not a conflict with itself.
 fn first_member_conflict(
     teams: &serde_yaml_ng::Mapping,
     new_members: &[String],
+    exclude_team: Option<&str>,
 ) -> Option<(String, String)> {
     for (team_key, team_val) in teams {
         let Some(team_name) = team_key.as_str() else {
             continue;
         };
+        if Some(team_name) == exclude_team {
+            continue;
+        }
         let Some(members) = team_val.get("members").and_then(|m| m.as_sequence()) else {
             continue;
         };
@@ -316,7 +322,7 @@ pub fn add_team_to_yaml(home: &Path, name: &str, config: &TeamConfig) -> Result<
         // share a member both pass the stale snapshot check; this lock-held
         // re-check is the authoritative guard that stops the second write from
         // double-booking the member.
-        if let Some((member, existing_team)) = first_member_conflict(teams, &config.members) {
+        if let Some((member, existing_team)) = first_member_conflict(teams, &config.members, None) {
             tracing::info!(
                 %member, %existing_team, attempted_team = %name,
                 "team create rejected under lock: member already in another team (one-agent-one-team)"
@@ -357,6 +363,21 @@ pub fn update_team_in_yaml(home: &Path, name: &str, config: &TeamConfig) -> Resu
         if let Some(teams) = doc.get_mut("teams").and_then(|v| v.as_mapping_mut()) {
             let key = serde_yaml_ng::Value::String(name.to_string());
             if teams.contains_key(&key) {
+                // CR-2026-06-14 (t-50): enforce one-agent-one-team UNDER the lock
+                // on the UPDATE path too. `teams::update`'s pre-write
+                // `find_team_for_member` runs on a stale snapshot (TOCTOU), so two
+                // concurrent updates adding the same member to different teams
+                // could both pass it and both write (sibling of the #2189 create
+                // TOCTOU). Exclude THIS team — its own members aren't a conflict.
+                if let Some((member, existing_team)) =
+                    first_member_conflict(teams, &config.members, Some(name))
+                {
+                    tracing::info!(
+                        %member, %existing_team, attempted_team = %name,
+                        "team update rejected under lock: member already in another team (one-agent-one-team)"
+                    );
+                    return Ok(false);
+                }
                 teams.insert(
                     key,
                     serde_yaml_ng::Value::Mapping(team_config_to_mapping(config)),

--- a/src/fleet/persist/review_repro_deployments_health_teams.rs
+++ b/src/fleet/persist/review_repro_deployments_health_teams.rs
@@ -18,7 +18,7 @@
 
 #![allow(clippy::unwrap_used)]
 
-use super::add_team_to_yaml;
+use super::{add_team_to_yaml, update_team_in_yaml};
 use crate::fleet::{fleet_yaml_path, FleetConfig, TeamConfig};
 
 fn tmp_home(tag: &str) -> std::path::PathBuf {
@@ -76,6 +76,49 @@ fn add_team_to_yaml_enforces_one_agent_one_team_deployments_health_teams() {
         "one-agent-one-team must be enforced inside the lock-held mutate closure: \
          member 'shared' ended up in {} teams ({:?}); add_team_to_yaml re-checks only \
          the team-name key, not member exclusivity",
+        teams_with_shared.len(),
+        teams_with_shared
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// t-50 (sibling of #2189, surfaced by r4+r2 review): the `teams::update`
+/// add-member path runs its one-agent-one-team check on a `load_fleet` SNAPSHOT
+/// (`find_team_for_member`), but the lock-held writer `update_team_in_yaml` did
+/// NOT re-validate member exclusivity — so two concurrent updates adding the same
+/// agent to different teams could both pass the stale snapshot and both write.
+/// RED before the in-lock gate (the update double-books `shared` into `beta`);
+/// GREEN once `update_team_in_yaml` rejects a member already in ANOTHER team
+/// (excluding the team being updated).
+#[test]
+fn update_team_to_yaml_enforces_one_agent_one_team_t50() {
+    let home = tmp_home("update-excl");
+    std::fs::write(fleet_yaml_path(&home), "teams: {}\n").expect("seed fleet.yaml");
+
+    // 'alpha' owns 'shared'; 'beta' starts with its own member.
+    add_team_to_yaml(&home, "alpha", &team_with_member("shared"))
+        .expect("add_team_to_yaml alpha must not error");
+    add_team_to_yaml(&home, "beta", &team_with_member("beta-only"))
+        .expect("add_team_to_yaml beta must not error");
+
+    // UPDATE 'beta' to ALSO claim 'shared' (already alpha's). The lock-held
+    // closure must reject this double-book; pre-fix it silently writes 'beta'.
+    let _ = update_team_in_yaml(&home, "beta", &team_with_member("shared"));
+
+    let cfg = FleetConfig::load(&fleet_yaml_path(&home)).expect("reload fleet.yaml");
+    let teams_with_shared: Vec<&String> = cfg
+        .teams
+        .iter()
+        .filter(|(_, t)| t.members.iter().any(|m| m == "shared"))
+        .map(|(name, _)| name)
+        .collect();
+
+    assert!(
+        teams_with_shared.len() <= 1,
+        "one-agent-one-team must be enforced inside update_team_in_yaml's lock-held \
+         closure too: member 'shared' ended up in {} teams ({:?}); the update path \
+         re-checked only on a stale snapshot, not under the write lock",
         teams_with_shared.len(),
         teams_with_shared
     );


### PR DESCRIPTION
## CR-2026-06-14 t-50 — teams::update one-agent-one-team TOCTOU (concurrency, sibling of #2189)

Surfaced by #2189's r4+r2 dual-review. #2189 moved the one-agent-one-team check into the lock-held `add_team_to_yaml` for teams::**create**, but teams::**update**'s add-member path (`teams.rs:453`) still validated only on a `load_fleet` **snapshot** (`find_team_for_member`), and its writer `update_team_in_yaml` did **not** re-check member exclusivity. Two concurrent updates adding the same agent to different teams could both pass the stale snapshot and both write → the agent is double-booked into two teams (same TOCTOU class as #2189, the update path).

### Fix
Add the lock-held member-exclusivity gate to `update_team_in_yaml`, reusing `first_member_conflict` — extended with an `exclude_team` parameter so the team being **updated** doesn't conflict with its own current members (only a member already in **another** team is rejected). `add_team_to_yaml` passes `None` (unchanged behaviour).

### §3.10 RED→GREEN (double-confirmed)
New repro `update_team_to_yaml_enforces_one_agent_one_team_t50`:
- Anchor `e789583` (test only) → **RED** (update double-books `shared` into `beta`).
- HEAD `bf2d3de` → **GREEN**. Stash-verified: stashing the `persist.rs` fix reproduces RED, popping restores GREEN.

### Evidence
```
ran: cargo test --bin agend-terminal update_team_to_yaml_enforces_one_agent_one_team_t50 → ok (GREEN)
ran: (persist.rs fix stashed) same test → FAILED (RED, double-book)
ran: cargo test --bin agend-terminal teams:: → 33 passed ; fleet::persist → 4 passed
ran: cargo fmt --check → clean ; cargo clippy --tests --features tray -- -D warnings → clean
```

### §3.20 race-class
Deterministic test: yes — the repro drives the lock-held writer directly (write alpha owning `shared`; update beta to also claim `shared`; assert `shared` in ≤1 team). Serialized by `acquire_lock`, no wall-clock dependence.

### Scope
This PR is t-50 item ① (the concurrency fix). The F1/F2 log-wording item (reason enum to distinguish name-collision vs member-conflict in the `Ok(false)` / migration messages) is a separate low, left for a follow-up.

---
*fixup-dev-3* · claude-opus-4-8[1m]