### PR TITLE
fix(CR-2026-06-14 xcut-security Low): validate_branch rejects leading-dot / .lock / empty path components

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -1288,6 +1288,16 @@ pub fn spawn_agent(config: &SpawnConfig, registry: &AgentRegistry) -> anyhow::Re
         let reg = lock_registry(registry);
         if let Some(handle) = reg.get(&instance_id) {
             let (tx, rx) = crossbeam_channel::bounded(1024);
+            // Lock order: registry → core (registry held here, core acquired
+            // under it = the canonical direction). `core` is a short,
+            // non-self-IPC temporary (subscriber push only) dropped on this
+            // statement, so it neither trips the #1492/#1535 self-IPC-under-lock
+            // guard (`sync_audit::assert_no_registry_lock_for_self_ipc`, which
+            // fail-fasts any self-IPC entered while CORE_LOCK_DEPTH>0) nor needs
+            // a snapshot-Arc: there is no reverse core→registry path in-tree
+            // (the supervisor inversion #1593 killed; the hot tick loop pinned
+            // by `tick_does_not_reacquire_registry_under_core_f2`, #1530/F2), so
+            // this AB-BA pair cannot form. See docs/DAEMON-LOCK-ORDERING.md.
             handle.core.lock().subscribers.push(tx);
             crate::daemon::router::register_agent(name, rx);
         }
@@ -1734,6 +1744,11 @@ fn on_clean_exit_shell_fallback(
         let reg = registry.lock();
         reg.get(id)
             .map(|h| {
+                // registry → core order; `c` is a short non-self-IPC temporary
+                // (vterm dims read) dropped at the closure end. Safe per the
+                // unidirectional registry→core invariant — no reverse path
+                // in-tree (#1593 killed it; runtime guard #1492/#1535) — so no
+                // snapshot-Arc. See the spawn-site note + docs/DAEMON-LOCK-ORDERING.md.
                 let c = h.core.lock();
                 (c.vterm.cols(), c.vterm.rows())
             })
@@ -1810,6 +1825,11 @@ fn on_crash_exit(
     {
         let reg = registry.lock();
         if let Some(handle) = reg.get(id) {
+            // registry → core order; `core` is a short non-self-IPC temporary
+            // (set_restarting only) dropped on this statement. Safe per the
+            // unidirectional registry→core invariant — no reverse path in-tree
+            // (#1593 killed it; runtime guard #1492/#1535) — so no snapshot-Arc.
+            // See the spawn-site note + docs/DAEMON-LOCK-ORDERING.md.
             handle.core.lock().state.set_restarting();
         }
     }

--- a/src/agent_ops.rs
+++ b/src/agent_ops.rs
@@ -316,8 +316,18 @@ pub fn get_submit_key(home: &Path, target: &str) -> String {
 // Git branch validation
 // ---------------------------------------------------------------------------
 
-/// Validate a git branch name. Only allows [a-zA-Z0-9/_.-], rejects ".."
-/// and leading "-".
+/// Validate a git branch name. Allows the char set `[a-zA-Z0-9/_.-]`, rejects
+/// `..` anywhere and a leading `-`, and enforces per-component refname/path
+/// rules that matter because the branch doubles as a filesystem path component
+/// in `worktree_path` (`home/worktrees/<agent>/<branch>`): every `/`-separated
+/// component must be
+/// - non-empty (rejects a trailing/leading/double `/`),
+/// - not begin with `.` (a leading-dot component like `.git` / `.agend-managed`
+///   collides with worktree-pool control files; a lone `.`/`..` is a no-op /
+///   parent path component and an invalid git refname), and
+/// - not end in `.lock` (git rejects `.lock`-suffixed refs).
+///
+/// Interior dots stay valid (`v1.0.0`, `release_2.0`).
 pub fn validate_branch(branch: &str) -> bool {
     !branch.is_empty()
         && !branch.contains("..")
@@ -325,6 +335,9 @@ pub fn validate_branch(branch: &str) -> bool {
         && branch
             .chars()
             .all(|c| c.is_ascii_alphanumeric() || c == '/' || c == '_' || c == '-' || c == '.')
+        && branch.split('/').all(|component| {
+            !component.is_empty() && !component.starts_with('.') && !component.ends_with(".lock")
+        })
 }
 
 /// E4.5 protected-branch invariant. Returns `true` for branches that

--- a/src/agent_ops/review_repro_xcut_security.rs
+++ b/src/agent_ops/review_repro_xcut_security.rs
@@ -20,7 +20,6 @@
 /// RED now: every bad case below currently returns `true` (verified
 /// empirically). GREEN after the fix tightens the validator.
 #[test]
-#[ignore = "validate-branch-leading-dot: red until fix; remove #[ignore] after fix to confirm"]
 fn validate_branch_rejects_leading_dot_and_git_invalid_refs_xcut_security() {
     // ── Must be REJECTED after the fix (currently all accepted = the bug). ──
     // Lone `.` — a no-op path component (resolves to the parent dir) and an


### PR DESCRIPTION
xcut-security Low from `docs/CODE-REVIEW-2026-06-14.md` (`validate_branch`, `src/agent_ops.rs`). #2202 unblocked this file. Repro `validate_branch_rejects_leading_dot_and_git_invalid_refs_xcut_security` RED→GREEN; `#[ignore]` removed.

## Problem
The branch name doubles as a filesystem path component in `worktree_path` (`home/worktrees/<agent>/<branch>`), yet `validate_branch` accepted refnames git itself rejects and unsafe path components:
- leading-dot components (`.`, `.config`, `.git`, `.agend-managed`, `feature/.hidden`) → collide with worktree-pool control files / no-op / parent path
- `.lock`-suffixed names (`foo.lock`) → git rejects these refs
- trailing/empty components (`foo/`)

## Fix
Per-`/`-component check: each component must be non-empty, must not begin with `.`, and must not end in `.lock`. Interior dots stay valid (`v1.0.0`, `release_2.0`, `main`, `feature/foo`).

## Evidence
- Repro RED before → GREEN after; existing `test_validate_branch_valid` / `test_validate_branch_rejects` + all 33 `agent_ops::` tests pass.
- `cargo fmt --check` clean; `cargo clippy --features tray --bins --tests -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)