### PR TITLE
fix(CR-2026-06-14 t-75): robustness Low×5 — liveness/panic/overflow/path-traversal/IO-error

### DIFF
--- a/src/bin/agend-mcp-bridge.rs
+++ b/src/bin/agend-mcp-bridge.rs
@@ -511,11 +511,42 @@ fn find_run_dir(home: &Path) -> Result<PathBuf, Box<dyn std::error::Error>> {
         if entry.file_type()?.is_dir() {
             let p = entry.path();
             if p.join("api.port").exists() {
+                // Liveness check: the run dir is named with the daemon PID. Skip a
+                // STALE dir whose PID is dead (crashed daemon not yet swept) —
+                // otherwise the bridge reads a dead daemon's port + cookie and
+                // burns its connect-retry budget (or, if the port was reused,
+                // handshakes against an unrelated process). Mirrors the
+                // daemon-side `find_active_run_dir` liveness contract.
+                let alive = entry
+                    .file_name()
+                    .to_str()
+                    .and_then(|s| s.parse::<u32>().ok())
+                    .map(pid_is_alive)
+                    .unwrap_or(true); // non-PID-named dir: keep prior accept behavior
+                if !alive {
+                    continue;
+                }
                 return Ok(p);
             }
         }
     }
     Err("no active daemon run dir".into())
+}
+
+/// True if `pid` is a live process. Unix uses `kill(pid, 0)`; non-unix has no
+/// portable equivalent here, so it conservatively returns true (the daemon-side
+/// run-dir sweep stays the backstop) — the bug + fix are platform-agnostic but
+/// this liveness primitive is unix-only.
+fn pid_is_alive(pid: u32) -> bool {
+    #[cfg(unix)]
+    {
+        pid != 0 && unsafe { libc::kill(pid as i32, 0) == 0 }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = pid;
+        true
+    }
 }
 
 fn read_port_file(run_dir: &Path) -> Result<u16, Box<dyn std::error::Error>> {

--- a/src/bin/agend-mcp-bridge/review_repro_bootstrap_config_cli.rs
+++ b/src/bin/agend-mcp-bridge/review_repro_bootstrap_config_cli.rs
@@ -49,7 +49,6 @@ fn dead_pid() -> Option<u32> {
 
 #[cfg(unix)]
 #[test]
-#[ignore = "bridge-find-run-dir-no-liveness: red until fix; remove #[ignore] after fix to confirm"]
 fn find_run_dir_skips_dead_pid_run_dir_bootstrap_config_cli() {
     let Some(dead) = dead_pid() else {
         eprintln!("test fixture: PID recycled in wait()->check gap — skipping");
@@ -93,7 +92,6 @@ fn find_run_dir_skips_dead_pid_run_dir_bootstrap_config_cli() {
 
 #[cfg(not(unix))]
 #[test]
-#[ignore = "bridge-find-run-dir-no-liveness: red until fix; remove #[ignore] after fix to confirm"]
 fn find_run_dir_skips_dead_pid_run_dir_bootstrap_config_cli() {
     // The dead-PID fixture relies on POSIX spawn/reap + kill(0) liveness; the
     // bug and its fix are platform-agnostic but this repro is unix-only.

--- a/src/claim_verifier.rs
+++ b/src/claim_verifier.rs
@@ -762,11 +762,28 @@ fn git_show_and_fmt(repo_dir: &Path, rev: &str, path: &str) -> Result<String, St
         .map_err(|e| format!("rustfmt spawn failed: {e}"))?;
     if let Some(mut stdin) = fmt.stdin.take() {
         use std::io::Write;
-        let _ = stdin.write_all(&show.stdout);
+        // Propagate the write error instead of discarding it: a partial write /
+        // broken pipe feeds rustfmt a TRUNCATED file, and a truncated format can
+        // silently flip the 'only formatting' verdict. stdin drops at the end of
+        // this block, closing the pipe so rustfmt sees EOF before we wait below.
+        stdin
+            .write_all(&show.stdout)
+            .map_err(|e| format!("rustfmt stdin write failed: {e}"))?;
     }
     let output = fmt
         .wait_with_output()
         .map_err(|e| format!("rustfmt wait failed: {e}"))?;
+    // A non-zero rustfmt exit (e.g. after a truncated stdin, or a file rustfmt
+    // can't parse) must NOT be returned as partial stdout — that partial output
+    // could compare equal and falsely confirm 'only formatting'. Surface as Err;
+    // the caller treats an Err as a non-formatting (conservative) verdict.
+    if !output.status.success() {
+        return Err(format!(
+            "rustfmt exited non-zero ({}): {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 

--- a/src/mcp/handlers/dispatch.rs
+++ b/src/mcp/handlers/dispatch.rs
@@ -528,17 +528,22 @@ fn parse_duration_secs(s: &str) -> Option<i64> {
         } else {
             let n: i64 = num_buf.parse().ok()?;
             num_buf.clear();
-            match ch {
-                'h' => total += n * 3600,
-                'm' => total += n * 60,
-                's' => total += n,
+            // Checked arithmetic: an attacker-controlled digit run (e.g.
+            // "9999999999999999h") parses to a valid i64 whose `* 3600` overflows
+            // i64::MAX — debug builds panic, release wraps to a bogus value.
+            // Reject the overflow as invalid (None) instead.
+            let secs = match ch {
+                'h' => n.checked_mul(3600)?,
+                'm' => n.checked_mul(60)?,
+                's' => n,
                 _ => return None,
-            }
+            };
+            total = total.checked_add(secs)?;
         }
     }
     if !num_buf.is_empty() {
         let n: i64 = num_buf.parse().ok()?;
-        total += n * 60; // bare number = minutes
+        total = total.checked_add(n.checked_mul(60)?)?; // bare number = minutes
     }
     if total > 0 {
         Some(total)

--- a/src/mcp/handlers/dispatch/review_repro_mcp_dispatch_comms.rs
+++ b/src/mcp/handlers/dispatch/review_repro_mcp_dispatch_comms.rs
@@ -25,7 +25,6 @@
 /// GREEN after fix: with checked arithmetic returning `None` on overflow,
 /// the call returns `Ok(None)` — no panic — and both asserts pass.
 #[test]
-#[ignore = "mcp-dispatch-comms F5: red until parse_duration_secs uses checked arithmetic; remove #[ignore] after fix"]
 fn parse_duration_secs_does_not_overflow_on_huge_input_mcp_dispatch_comms() {
     // Sized so the `i64` parse succeeds but `n * 3600` exceeds i64::MAX.
     let malicious = "9999999999999999h";

--- a/src/quickstart.rs
+++ b/src/quickstart.rs
@@ -587,7 +587,17 @@ async fn bot_api_get(token: &str, method: &str) -> anyhow::Result<serde_json::Va
 
 fn mask_token(tok: &str) -> String {
     if tok.len() > 8 {
-        format!("{}...{}", &tok[..4], &tok[tok.len() - 4..])
+        // Char-boundary-safe prefix/suffix: a raw `&tok[..4]` / `&tok[len-4..]`
+        // panics when byte index 4 (or len-4) splits a multibyte UTF-8 char
+        // (e.g. a CJK token). Clamp to the nearest char boundary instead.
+        let prefix_end = (1..=4)
+            .rev()
+            .find(|&i| tok.is_char_boundary(i))
+            .unwrap_or(0);
+        let suffix_start = (tok.len().saturating_sub(4)..tok.len())
+            .find(|&i| tok.is_char_boundary(i))
+            .unwrap_or(tok.len());
+        format!("{}...{}", &tok[..prefix_end], &tok[suffix_start..])
     } else {
         "****".to_string()
     }

--- a/src/quickstart/review_repro_panic_io_extra.rs
+++ b/src/quickstart/review_repro_panic_io_extra.rs
@@ -17,7 +17,6 @@ use super::mask_token;
 /// RED now: `catch_unwind` returns `Err`. GREEN after fix: char-boundary-aware
 /// truncation never panics and preserves the masked "..." shape.
 #[test]
-#[ignore = "quickstart-mask_token-multibyte: red until fix; remove #[ignore] after fix to confirm"]
 fn mask_token_multibyte_does_not_panic_panic_io_extra() {
     let tok = "\u{4e2d}\u{6587}\u{4e2d}";
     assert!(

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -88,6 +88,19 @@ pub fn create(
         return None;
     }
 
+    // Defense-in-depth (xcut-concurrency F4): validate the AGENT segment too, not
+    // just the branch. `worktree_path` joins `instance_name` into the pool path,
+    // so an unvalidated `..` agent segment paired with a VALID custom branch would
+    // traverse OUT of `<home>/worktrees/`. Mirror the `validate_branch` guard
+    // below; `agent::validate_name` rejects `/` and `.` (hence `..`).
+    if crate::agent::validate_name(instance_name).is_err() {
+        tracing::warn!(
+            instance = %instance_name,
+            "invalid instance name, rejecting worktree creation"
+        );
+        return None;
+    }
+
     // Empty repo (git init without any commits) → HEAD is invalid.
     // Worktree creation requires at least one commit.
     if !has_commits(repo_dir) {

--- a/src/worktree/review_repro_xcut_concurrency.rs
+++ b/src/worktree/review_repro_xcut_concurrency.rs
@@ -77,7 +77,6 @@ fn tmp_home(name: &str) -> PathBuf {
 }
 
 #[test]
-#[ignore = "xcut-concurrency F4: red until fix; remove #[ignore] after fix to confirm"]
 fn create_rejects_path_traversal_in_agent_name_xcut_concurrency() {
     let home = tmp_home("traversal");
     let repo = tmp_repo("traversal");

--- a/tests/review_verify_claim_cost_5.rs
+++ b/tests/review_verify_claim_cost_5.rs
@@ -36,7 +36,6 @@ fn git_show_and_fmt_body(src: &str) -> String {
 }
 
 #[test]
-#[ignore = "verify-claim-cost git_show_and_fmt-swallowed-write: red until fix; remove #[ignore] after fix to confirm"]
 fn git_show_and_fmt_does_not_swallow_stdin_write_error_verify_claim_cost() {
     let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("src")


### PR DESCRIPTION
## CR-2026-06-14 Low — robustness bundle ×5 (task `t-20260615063005437016-75`)

Lead-approved theme-coherent bundle (the single-domain pools were drained by #2199/#2195/#2198/#2188/#2176). Each finding had an `#[ignore]`'d repro; §3.10 RED→GREEN on fresh main.

| Finding | Class | Fix |
|---|---|---|
| `bin/agend-mcp-bridge.rs:507` find_run_dir no liveness check | correctness | cfg(unix) `kill(0)` PID-liveness skip of stale dead-daemon run dirs (mirrors daemon `find_active_run_dir`; keeps the bridge's zero-crate-dep style) |
| `quickstart.rs` mask_token byte-slice behind byte-length guard | correctness/panic | char-boundary-clamped prefix/suffix (ASCII byte-identical) |
| `mcp/handlers/dispatch.rs:532` parse_duration_secs unchecked `n*3600` | error-handling | `checked_mul`/`checked_add` → `None` on overflow (valid inputs unchanged) |
| `worktree.rs:22` create validates only branch, not agent segment | security | `agent::validate_name(instance_name)` guard at top (rejects `/`,`.` → `..`), mirroring `validate_branch` |
| `claim_verifier.rs:740` git_show_and_fmt swallows stdin write err + ignores rustfmt exit | correctness | propagate write err + `Err` on non-zero rustfmt exit; caller already treats `Err` as conservative non-fmt verdict |

**Note:** the doc/repro labeled the last one `verify.rs`, but `git_show_and_fmt` lives in `claim_verifier.rs` (batch C #2188 already merged → no conflict). Premise-checked all 5 RED on fresh main before fixing.

### Verification
- 5 repros **RED** on fresh main → **GREEN** after fix
- existing tests green: quickstart mask_token ×5, parse_duration ×1, `worktree::tests` ×30, `claim_verifier::tests` ×37, bridge bin ×11
- fmt + clippy `--all-targets --features tray -D warnings` clean; pre-push CI-parity passed

### Review ask (lead: all dual)
Adversarial focus: (1) bridge `kill(0)` — zombie daemon edge (kill(0) succeeds on zombie; repro uses a reaped PID; matches daemon-side helper). (2) mask_token char-boundary math for the 9-byte/3-char case → `中...中`. (3) claim_verifier `Err`-on-non-zero-exit: could a legit fmt-only change with a rustfmt-unparseable file now false-reject? (conservative & pre-existing risk; old code returned garbage). (4) worktree validate_name placement before any `git worktree add`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)