### PR TITLE
test(CR-2026-06-14 #231 t-71): realign review_tasks_6 to the resolved interim drift-guard

### DIFF
--- a/tests/review_tasks_6.rs
+++ b/tests/review_tasks_6.rs
@@ -1,23 +1,26 @@
-//! Review-repro static-invariant (SCOPEKEY: tasks) — FINDING #6.
+//! Review-repro static-invariant (SCOPEKEY: tasks) — FINDING #6 (#231),
+//! RESOLVED-BY-INTERIM-GUARD (t-71 design decision).
 //!
-//! `handle_update`'s Claimed / InProgress / Done transition events take their
-//! `by` actor from the OUT-OF-LOCK `record` snapshot
-//! (`record.owner ... unwrap_or(caller.as_str())`). The in-lock
-//! `append_batch_checked_at` precondition re-validates ONLY the status
-//! transition — not the actor — so a concurrent `OwnerAssigned` between the
-//! out-of-lock read and the append makes the persisted event attribute the
-//! action to the PREVIOUS owner (audit/actor drift).
+//! Original premise: `handle_update`'s Claimed/InProgress/Done transition events
+//! built their `by` actor from the OUT-OF-LOCK `record` snapshot, so a concurrent
+//! `OwnerAssigned` between the read and the append could persist an event that
+//! attributes the action to the PREVIOUS owner.
 //!
-//! The fix is architectural: the `by`/owner stamped on the emitted transition
-//! events must be resolved from the FRESH state inside the precondition
-//! closure, not from the stale `record`. That restructuring does not yet exist,
-//! so this is an interim guard (see redesign_note in the manifest).
+//! Resolution (KISS, NOT the Option-A append-API rewrite — see t-71 spike): the
+//! events keep their out-of-lock `by`, but `handle_update` captures the
+//! out-of-lock `stale_owner` and `update_batch_precondition` re-checks it against
+//! FRESH committed state under the append lock — a FAIL-CLOSED guard that REJECTS
+//! the write (retryable) if the owner drifted, so a stale-`by` event can never
+//! commit. Rebuilding the actor inside the append closure (Option A) was judged
+//! over-engineering for this human-driven, low-contention path.
 //!
-//! The drift site is uniquely identified by `unwrap_or(caller.as_str())`, which
-//! appears EXACTLY at the three transition arms (Claimed/InProgress/Done) of
-//! `handle_update` that build `by` from the out-of-lock record. RED now
-//! (present); GREEN once the actor is re-derived in-lock and the stale-record
-//! `by` construction is removed.
+//! ⚠ This is a STRUCTURAL gate ONLY: it asserts the drift guard is WIRED. The
+//! actual BEHAVIORAL safety — reject on owner drift, including the
+//! system-identity (ACL-bypassed) by-drift case — is verified by `handler.rs`'s
+//! `inlock_precond_*_231` unit tests, which call `update_batch_precondition`
+//! directly against a crafted fresh-state-with-changed-owner. Per #2018, a source
+//! scan is a CLAIM, not behavioral proof; those unit tests are the proof, and
+//! this gate exists only to catch a regression that silently REMOVES the guard.
 
 use std::path::PathBuf;
 
@@ -26,37 +29,27 @@ fn read_handler() -> String {
     std::fs::read_to_string(&p).expect("read src/tasks/handler.rs")
 }
 
-/// Isolate the `handle_update` body (the drift site lives there).
-fn handle_update_body(text: &str) -> String {
-    let start = text
-        .find("fn handle_update(")
-        .expect("handle_update exists");
-    let after = &text[start..];
-    // End at the next top-level `fn ` after the body.
-    let end = after[1..]
-        .find("\nfn ")
-        .map(|e| start + 1 + e)
-        .unwrap_or(text.len());
-    text[start..end].to_string()
-}
-
 #[test]
-#[ignore = "tasks-update-actor-drift: red until fix; remove #[ignore] after fix to confirm"]
-fn handle_update_resolves_actor_in_lock_not_from_stale_record_tasks() {
+fn handle_update_has_inlock_actor_drift_guard_tasks() {
     let text = read_handler();
-    let body = handle_update_body(&text);
 
-    // BAD pattern: the transition events' `by` is built from the out-of-lock
-    // `record.owner ... unwrap_or(caller.as_str())`. The fix re-derives the
-    // actor from fresh in-lock state, eliminating these call sites.
-    let stale_actor_uses = body.matches("unwrap_or(caller.as_str())").count();
+    // (1) `handle_update` captures the out-of-lock owner and threads it into the
+    //     in-lock precondition for re-validation.
+    let captures_stale_owner =
+        text.contains("let stale_owner = record.owner.clone();") && text.contains("&stale_owner");
 
-    assert_eq!(
-        stale_actor_uses, 0,
-        "FINDING #6: handle_update builds the `by` actor of Claimed/InProgress/Done \
-         transition events from the OUT-OF-LOCK record (found {stale_actor_uses} \
-         `unwrap_or(caller.as_str())` site(s)). A concurrent OwnerAssigned makes the \
-         persisted event attribute the action to the previous owner. Resolve the actor \
-         from the FRESH state inside the append_batch_checked_at precondition closure."
+    // (2) `update_batch_precondition` rejects (fail-closed) when the fresh owner
+    //     has drifted from the stale one on an attribution-bearing transition.
+    let drift_check =
+        text.contains("fresh.owner != *stale_owner") && text.contains("attribution would be stale");
+
+    assert!(
+        captures_stale_owner && drift_check,
+        "#231 in-lock actor-drift guard must remain wired: handle_update must capture \
+         the out-of-lock owner (`stale_owner`) and pass it to update_batch_precondition, \
+         which must reject fail-closed when the fresh owner drifted \
+         (`fresh.owner != *stale_owner` → \"attribution would be stale\"). Behavioral \
+         coverage lives in handler.rs `inlock_precond_*_231`. \
+         captures_stale_owner={captures_stale_owner} drift_check={drift_check}"
     );
 }


### PR DESCRIPTION
## CR-2026-06-14 #231 (t-71) — realign repro to the resolved interim drift-guard (test-only)

The t-71 spike judged #231 STRUCTURAL, and the lead's KISS decision resolved it **not** via the Option-A append-API rewrite, but by recognizing the existing **fail-closed drift guard**: `handle_update` captures the out-of-lock `stale_owner` and `update_batch_precondition` rejects (retryable) under the append lock when the fresh owner drifted — so a stale-`by` transition event can never commit.

**That safety mechanism is already fully behaviorally covered** by `handler.rs`'s 4 `inlock_precond_*_231` unit tests (which call `update_batch_precondition` directly against a crafted fresh-state-with-changed-owner), including `inlock_precond_rejects_done_when_by_owner_drifted_231` asserting *"attribution would be stale"* for the ACL-bypassed system-identity case.

### Change
`review_tasks_6` previously asserted `unwrap_or(caller)`×3 == 0 — the **Option-A premise that was explicitly not adopted**, so it was permanently RED and misleading. Redefined as a structural-invariant that the drift guard stays **wired** (`stale_owner` capture + threading; `fresh.owner != *stale_owner` → "attribution would be stale" reject), with a comment that **explicitly marks it a STRUCTURAL gate** whose behavioral proof is the `inlock_precond_*_231` tests (#2018/#2206 lesson: a source scan is a claim, not behavioral proof — don't let it look behavioral).

### Evidence
```
ran: cargo test --test review_tasks_6 → 1 passed (GREEN; guard wired on main)
ran: cargo test --bin agend-terminal inlock_precond → 4 passed (the behavioral safety coverage)
ran: cargo fmt --check → clean
```
Regression direction: if the guard wiring (`stale_owner` / `fresh.owner != *stale_owner` / "attribution would be stale") is ever removed, this gate fails.

**#231 → resolved-by-interim-guard.** test-only → §3.6 single review.

---
*fixup-dev-3* · claude-opus-4-8[1m]