### PR TITLE
fix(CR-2026-06-14 t-91): teams write reason-enum (accurate logs) + exclude_team control repro

### DIFF
--- a/src/fleet/mod.rs
+++ b/src/fleet/mod.rs
@@ -10,7 +10,7 @@ pub use watchdog::WatchdogConfig;
 pub use persist::{
     add_instance_to_yaml, add_instances_to_yaml, add_team_to_yaml, migrate_teams_json_to_yaml,
     remove_instance_from_yaml, remove_instances_from_yaml, remove_team_from_yaml,
-    update_channel_telegram_group_id, update_instance_field, update_team_in_yaml,
+    update_channel_telegram_group_id, update_instance_field, update_team_in_yaml, TeamWriteOutcome,
 };
 
 use crate::backend::Backend;

--- a/src/fleet/persist.rs
+++ b/src/fleet/persist.rs
@@ -302,8 +302,24 @@ fn first_member_conflict(
     None
 }
 
-pub fn add_team_to_yaml(home: &Path, name: &str, config: &TeamConfig) -> Result<bool> {
-    let mut inserted = false;
+/// Outcome of a lock-held team write (#t-91 F1/F2). Distinguishes the two
+/// rejection reasons so callers log accurate messages instead of a blanket
+/// "team already exists". `MemberConflict` carries the offending member and the
+/// team it already belongs to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TeamWriteOutcome {
+    /// The team was created (add) or updated (update).
+    Written,
+    /// add only: a team with this name already exists.
+    NameExists,
+    /// update only: no team with this name exists to update.
+    NotFound,
+    /// One-agent-one-team rejection: `member` already belongs to `team`.
+    MemberConflict { member: String, team: String },
+}
+
+pub fn add_team_to_yaml(home: &Path, name: &str, config: &TeamConfig) -> Result<TeamWriteOutcome> {
+    let mut outcome = TeamWriteOutcome::Written;
     mutate_fleet_yaml(home, "teams: {}\n", |doc| {
         if doc.get("teams").is_none() {
             doc["teams"] = serde_yaml_ng::Value::Mapping(serde_yaml_ng::Mapping::new());
@@ -314,6 +330,7 @@ pub fn add_team_to_yaml(home: &Path, name: &str, config: &TeamConfig) -> Result<
             .context("teams is not a mapping")?;
         let key = serde_yaml_ng::Value::String(name.to_string());
         if teams.contains_key(&key) {
+            outcome = TeamWriteOutcome::NameExists;
             return Ok(false);
         }
         // #CR-2026-06-14 (teams.rs:174 TOCTOU): enforce one-agent-one-team INSIDE
@@ -327,17 +344,21 @@ pub fn add_team_to_yaml(home: &Path, name: &str, config: &TeamConfig) -> Result<
                 %member, %existing_team, attempted_team = %name,
                 "team create rejected under lock: member already in another team (one-agent-one-team)"
             );
+            outcome = TeamWriteOutcome::MemberConflict {
+                member,
+                team: existing_team,
+            };
             return Ok(false);
         }
         teams.insert(
             key,
             serde_yaml_ng::Value::Mapping(team_config_to_mapping(config)),
         );
-        inserted = true;
+        outcome = TeamWriteOutcome::Written;
         tracing::info!(%name, "added team to fleet.yaml");
         Ok(true)
     })?;
-    Ok(inserted)
+    Ok(outcome)
 }
 
 pub fn remove_team_from_yaml(home: &Path, name: &str) -> Result<bool> {
@@ -357,8 +378,12 @@ pub fn remove_team_from_yaml(home: &Path, name: &str) -> Result<bool> {
     Ok(removed)
 }
 
-pub fn update_team_in_yaml(home: &Path, name: &str, config: &TeamConfig) -> Result<bool> {
-    let mut existed = false;
+pub fn update_team_in_yaml(
+    home: &Path,
+    name: &str,
+    config: &TeamConfig,
+) -> Result<TeamWriteOutcome> {
+    let mut outcome = TeamWriteOutcome::NotFound;
     mutate_fleet_yaml(home, "", |doc| {
         if let Some(teams) = doc.get_mut("teams").and_then(|v| v.as_mapping_mut()) {
             let key = serde_yaml_ng::Value::String(name.to_string());
@@ -376,18 +401,24 @@ pub fn update_team_in_yaml(home: &Path, name: &str, config: &TeamConfig) -> Resu
                         %member, %existing_team, attempted_team = %name,
                         "team update rejected under lock: member already in another team (one-agent-one-team)"
                     );
+                    outcome = TeamWriteOutcome::MemberConflict {
+                        member,
+                        team: existing_team,
+                    };
                     return Ok(false);
                 }
                 teams.insert(
                     key,
                     serde_yaml_ng::Value::Mapping(team_config_to_mapping(config)),
                 );
-                existed = true;
+                outcome = TeamWriteOutcome::Written;
+                return Ok(true);
             }
         }
-        Ok(existed)
+        // team absent → outcome stays NotFound, no write
+        Ok(false)
     })?;
-    Ok(existed)
+    Ok(outcome)
 }
 
 pub fn migrate_teams_json_to_yaml(home: &Path) -> Result<()> {
@@ -443,7 +474,7 @@ pub fn migrate_teams_json_to_yaml(home: &Path) -> Result<()> {
             accept_from: Vec::new(),
         };
         match add_team_to_yaml(home, &team.name, &cfg) {
-            Ok(true) => {
+            Ok(TeamWriteOutcome::Written) => {
                 tracing::info!(name = %team.name, "migrated team to fleet.yaml");
                 tracing::warn!(
                     name = %team.name,
@@ -460,8 +491,22 @@ pub fn migrate_teams_json_to_yaml(home: &Path) -> Result<()> {
                      set via team(action=update) to avoid Tier 4 stub fallback",
                 );
             }
-            Ok(false) => tracing::info!(name = %team.name,
+            Ok(TeamWriteOutcome::NameExists) => tracing::info!(name = %team.name,
                 "team already in fleet.yaml, skipping migration entry"),
+            // #t-91 F2: accurate message — a member-conflict skip is NOT a
+            // name-collision. (Behavior unchanged: the second team is still
+            // dropped from the migration; the source rows survive in
+            // teams.json.migrated. Making it non-lossy is a separate change.)
+            Ok(TeamWriteOutcome::MemberConflict {
+                member,
+                team: existing,
+            }) => {
+                tracing::warn!(name = %team.name, %member, existing_team = %existing,
+                    "migration skipped team: member already in another team (one-agent-one-team); entry dropped (recoverable from teams.json.migrated)")
+            }
+            // update-only outcome; unreachable on the add path, logged defensively.
+            Ok(TeamWriteOutcome::NotFound) => tracing::warn!(name = %team.name,
+                "unexpected NotFound from add_team_to_yaml during migration"),
             Err(e) => {
                 tracing::warn!(name = %team.name, error = %e,
                     "team migration failed, leaving teams.json in place");

--- a/src/fleet/persist/review_repro_deployments_health_teams.rs
+++ b/src/fleet/persist/review_repro_deployments_health_teams.rs
@@ -18,7 +18,7 @@
 
 #![allow(clippy::unwrap_used)]
 
-use super::{add_team_to_yaml, update_team_in_yaml};
+use super::{add_team_to_yaml, update_team_in_yaml, TeamWriteOutcome};
 use crate::fleet::{fleet_yaml_path, FleetConfig, TeamConfig};
 
 fn tmp_home(tag: &str) -> std::path::PathBuf {
@@ -54,7 +54,11 @@ fn add_team_to_yaml_enforces_one_agent_one_team_deployments_health_teams() {
     // Establish team 'alpha' owning member 'shared'.
     let inserted_alpha = add_team_to_yaml(&home, "alpha", &team_with_member("shared"))
         .expect("add_team_to_yaml alpha must not error");
-    assert!(inserted_alpha, "team 'alpha' should be newly inserted");
+    assert_eq!(
+        inserted_alpha,
+        TeamWriteOutcome::Written,
+        "team 'alpha' should be newly inserted"
+    );
 
     // Now attempt to add a DIFFERENT team 'beta' that also claims 'shared'.
     // The team-name key is free, so the lock-held closure's name-only re-check
@@ -121,6 +125,45 @@ fn update_team_to_yaml_enforces_one_agent_one_team_t50() {
          re-checked only on a stale snapshot, not under the write lock",
         teams_with_shared.len(),
         teams_with_shared
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// t-91 / #2208 r6 control: a legitimate update that KEEPS the team's own
+/// existing member and ADDS a brand-new (unclaimed) member must NOT be
+/// false-rejected by the one-agent-one-team gate — `exclude_team` must skip the
+/// team being updated so its own members never count as a conflict against
+/// itself. Guards against a regression where the exclude_team logic starts
+/// false-rejecting legitimate self-updates.
+#[test]
+fn update_team_keeping_own_member_plus_new_is_not_false_rejected_t91() {
+    let home = tmp_home("update-control");
+    std::fs::write(fleet_yaml_path(&home), "teams: {}\n").expect("seed fleet.yaml");
+
+    // 'alpha' owns 'a1'; no other team claims 'a2'.
+    add_team_to_yaml(&home, "alpha", &team_with_member("a1")).expect("add alpha must not error");
+
+    // Update 'alpha' to keep 'a1' AND add a brand-new, unclaimed 'a2'.
+    let mut cfg = team_with_member("a1");
+    cfg.members = vec!["a1".to_string(), "a2".to_string()];
+    let outcome =
+        update_team_in_yaml(&home, "alpha", &cfg).expect("update_team_in_yaml must not error");
+    assert_eq!(
+        outcome,
+        TeamWriteOutcome::Written,
+        "a legitimate self-update (keep own member + add a new unclaimed one) must NOT be \
+         rejected by the one-agent-one-team gate; exclude_team must skip the team being \
+         updated. got {outcome:?}"
+    );
+
+    // Both members must have landed.
+    let reload = FleetConfig::load(&fleet_yaml_path(&home)).expect("reload fleet.yaml");
+    let alpha = reload.teams.get("alpha").expect("alpha exists");
+    assert!(
+        alpha.members.iter().any(|m| m == "a1") && alpha.members.iter().any(|m| m == "a2"),
+        "both a1 and a2 must be present after the update: {:?}",
+        alpha.members
     );
 
     std::fs::remove_dir_all(&home).ok();

--- a/src/teams.rs
+++ b/src/teams.rs
@@ -215,7 +215,7 @@ pub fn create(home: &Path, args: &Value) -> Value {
         accept_from,
     };
     match crate::fleet::add_team_to_yaml(home, &name, &cfg) {
-        Ok(true) => {
+        Ok(crate::fleet::TeamWriteOutcome::Written) => {
             if cfg.orchestrator.is_some() {
                 cleanup_orchestrator_tasks_for_team(home, &name);
             }
@@ -225,8 +225,18 @@ pub fn create(home: &Path, args: &Value) -> Value {
             }
             result
         }
-        // Race: someone wrote the team between our check and write.
-        Ok(false) => serde_json::json!({"error": format!("team '{name}' already exists")}),
+        // #t-91 F1: distinguish the two lock-held rejection reasons so the error
+        // is accurate (the previous blanket "already exists" mis-described a
+        // member-conflict race).
+        Ok(crate::fleet::TeamWriteOutcome::NameExists) => {
+            serde_json::json!({"error": format!("team '{name}' already exists")})
+        }
+        Ok(crate::fleet::TeamWriteOutcome::MemberConflict { member, team }) => {
+            serde_json::json!({"error": format!("member '{member}' already in team '{team}'")})
+        }
+        Ok(crate::fleet::TeamWriteOutcome::NotFound) => {
+            serde_json::json!({"error": format!("team '{name}' could not be created")})
+        }
         Err(e) => serde_json::json!({"error": format!("{e}")}),
     }
 }
@@ -496,14 +506,24 @@ pub fn update(home: &Path, args: &Value) -> Value {
         accept_from: new_accept_from,
     };
     match crate::fleet::update_team_in_yaml(home, &name, &cfg) {
-        Ok(true) => {
+        Ok(crate::fleet::TeamWriteOutcome::Written) => {
             if cfg.orchestrator.is_some() {
                 cleanup_orchestrator_tasks_for_team(home, &name);
             }
             serde_json::json!({"status": "updated", "name": name})
         }
         // Disappeared between load and write.
-        Ok(false) => serde_json::json!({"error": format!("team '{name}' not found")}),
+        Ok(crate::fleet::TeamWriteOutcome::NotFound) => {
+            serde_json::json!({"error": format!("team '{name}' not found")})
+        }
+        // #t-91 F1: a concurrent add/update double-booked a member — report it
+        // accurately instead of the stale "not found".
+        Ok(crate::fleet::TeamWriteOutcome::MemberConflict { member, team }) => {
+            serde_json::json!({"error": format!("member '{member}' already in team '{team}'")})
+        }
+        Ok(crate::fleet::TeamWriteOutcome::NameExists) => {
+            serde_json::json!({"error": format!("team '{name}' already exists")})
+        }
         Err(e) => serde_json::json!({"error": format!("{e}")}),
     }
 }


### PR DESCRIPTION
## CR-2026-06-14 t-91 — teams write reason-enum + exclude_team control repro

Teams maintainability follow-up split from t-50 (F1/F2 log accuracy + #2208 r6 nit).

### item 1 (F1/F2, maintainability)
`add_team_to_yaml` / `update_team_in_yaml` returned a bare `bool`, so every lock-held rejection surfaced as **"team already exists"** even when the real reason was a one-agent-one-team **member conflict** (create + update paths), and migration logged **"skipping migration entry"** for a member conflict.

Introduce `TeamWriteOutcome { Written, NameExists, NotFound, MemberConflict { member, team } }`; both writers return it; callers log the accurate reason:
- `teams::create` → `NameExists` vs `MemberConflict("member 'X' already in team 'Y'")`
- `teams::update` → `NotFound` vs `MemberConflict` (was the stale "not found")
- migrate → member-conflict now gets an accurate, member-naming message

⚠ The `first_member_conflict` gate logic and the #2189 / t-50 concurrency behavior are **unchanged** — only the `Ok(false)` sentinel is replaced by a reason-carrying enum. Migration still drops the second double-booked team (recoverable from `teams.json.migrated`); **only its message changed** (no scope creep — making it non-lossy is a separate item).

### item 2 (#2208 r6 control, test)
Permanent control repro `update_team_keeping_own_member_plus_new_is_not_false_rejected_t91`: an update that keeps the team's own existing member **and** adds a brand-new unclaimed one must return `Written` — guards `exclude_team` against regressing to false-reject legitimate self-updates (r6 verified this manually with a temporary control on #2208; now permanent).

### §3.10 / evidence
The two existing repros (#2189 add, t-50 update) updated to assert on the enum and stay GREEN; the new control repro GREEN.
```
ran: cargo test --bin agend-terminal fleet::persist → 5 passed (3 team repros incl. new control)
ran: cargo test --bin agend-terminal teams:: → 34 passed
ran: cargo fmt --check → clean ; cargo clippy --tests --features tray -- -D warnings → clean
```

### Review tier
Dual (item 1 changes the writer return type = behavioral).

---
*fixup-dev-3* · claude-opus-4-8[1m]
