### PR TITLE
test(CR-2026-06-14 t-16/t-25): upgrade two weak source-scan repros to runtime behavioral tests

### DIFF
--- a/src/agent/dismiss.rs
+++ b/src/agent/dismiss.rs
@@ -201,6 +201,47 @@ mod tests {
         Arc::new(Mutex::new(Box::new(Vec::<u8>::new())))
     }
 
+    /// A PTY writer whose `write` BLOCKS — simulates a backend that stopped
+    /// draining its input (the exact #2160/H13 wedge). Bounded at 60s (>> the 5s
+    /// `PTY_WRITE_TIMEOUT`) so the timeout fires first while the helper thread +
+    /// in-progress guard still self-clean instead of leaking for the whole run.
+    struct ParkWriter;
+    impl std::io::Write for ParkWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            std::thread::sleep(std::time::Duration::from_secs(60));
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// CR-2026-06-14 t-25 (RUNTIME behavioral hardening of #2160/H13): the
+    /// static-grep repro (`writer.lock()` absent in dismiss.rs) is bypassable by
+    /// aliasing / an API rename. This test proves the actual property the fix
+    /// exists for — the dismiss write path is BOUNDED: a parked PTY writer must
+    /// make `write_with_timeout` (the primitive every dismiss keystroke routes
+    /// through) RETURN `Err(TimedOut)` within its bound, never hang the caller and
+    /// pin the writer lock forever.
+    #[test]
+    fn write_with_timeout_returns_on_parked_writer_h13_2160() {
+        let writer: PtyWriter = Arc::new(Mutex::new(Box::new(ParkWriter)));
+        let start = std::time::Instant::now();
+        let res = write_with_timeout(&writer, b"dismiss-keystrokes");
+        let elapsed = start.elapsed();
+        let err = res.expect_err("a parked PTY write must time out, not report success");
+        assert_eq!(
+            err.kind(),
+            std::io::ErrorKind::TimedOut,
+            "a parked write must surface TimedOut"
+        );
+        assert!(
+            elapsed < std::time::Duration::from_secs(8),
+            "write_with_timeout must return within its ~5s bound even when the writer \
+             parks (H13/#2160 — no unbounded lock-pinning hang); took {elapsed:?}"
+        );
+    }
+
     #[test]
     fn inflight_guard_clears_entry_on_panic_1886() {
         // #1886 follow-up §3.9: a dismiss thread that panics before its normal

--- a/src/tasks/lifecycle.rs
+++ b/src/tasks/lifecycle.rs
@@ -287,6 +287,100 @@ mod tests {
 
         std::fs::remove_dir_all(&home).ok();
     }
+
+    /// CR-2026-06-14 t-16 (behavioral hardening of #2177): the source-scan repro
+    /// (`prod.contains("sync_all")`, review_tasks_3.rs) is comment-satisfiable —
+    /// it cannot prove the durable-append actually error-CHECKS the write. This
+    /// BEHAVIORAL test does: when the archive append fails, `archive_done_tasks`
+    /// must count 0 (nothing claimed as archived) and leave the records
+    /// un-archived so a later pass RETRIES — vs the pre-#2177 `let _ = writeln!`
+    /// that swallowed the error and counted a never-written task.
+    ///
+    /// Failure is injected by making `tasks-archive.jsonl` a DIRECTORY, so the
+    /// append `OpenOptions::open` fails deterministically on every platform
+    /// (more robust than a read-only file, which root/CI can bypass).
+    #[test]
+    fn archive_append_failure_counts_zero_and_retries_t16() {
+        use crate::task_events::{
+            DoneSource, InstanceName, TaskEvent, TaskEventEnvelope, TaskId, SCHEMA_VERSION,
+        };
+        let home = std::env::temp_dir().join(format!(
+            "agend-test-lifecycle-failarch-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&home).ok();
+        let tid = TaskId::from("t-failarch");
+        let old_ts = (chrono::Utc::now() - chrono::Duration::days(30)).to_rfc3339();
+        let seed = |seq: u64, event: TaskEvent| {
+            let env = TaskEventEnvelope {
+                schema_version: SCHEMA_VERSION,
+                seq,
+                timestamp: old_ts.clone(),
+                instance: InstanceName::from("system:lifecycle"),
+                emitter_id: None,
+                event,
+            };
+            use std::io::Write;
+            let mut f = std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(home.join(format!("task_events.{}", "jsonl")))
+                .unwrap();
+            writeln!(f, "{}", serde_json::to_string(&env).unwrap()).unwrap();
+            crate::task_events::invalidate_replay_cache();
+        };
+        seed(
+            1,
+            TaskEvent::Created {
+                task_id: tid.clone(),
+                title: "shipped".into(),
+                description: String::new(),
+                priority: "normal".into(),
+                owner: None,
+                due_at: None,
+                depends_on: vec![],
+                routed_to: None,
+                branch: None,
+                bind: None,
+                eta_secs: None,
+                tags: vec![],
+                parent_id: None,
+            },
+        );
+        seed(
+            2,
+            TaskEvent::Done {
+                task_id: tid.clone(),
+                by: InstanceName::from("dev"),
+                source: DoneSource::OperatorManual {
+                    authored_at: old_ts.clone(),
+                    result: None,
+                },
+            },
+        );
+
+        // Make the archive path un-writable: a directory at the file path makes
+        // the append open() fail every time.
+        let archive_path = home.join("tasks-archive.jsonl");
+        std::fs::create_dir(&archive_path).unwrap();
+
+        // Failure must NOT be counted as archived.
+        assert_eq!(
+            archive_done_tasks(&home),
+            0,
+            "a failed archive append must count 0 (not claim a never-written task)"
+        );
+
+        // Remove the blocker → the un-archived record is retried and now lands.
+        std::fs::remove_dir(&archive_path).unwrap();
+        assert_eq!(
+            archive_done_tasks(&home),
+            1,
+            "the previously-failed record must be retried and archived on the next pass"
+        );
+
+        std::fs::remove_dir_all(&home).ok();
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## CR-2026-06-14 t-16 / t-25 — source-scan → runtime behavioral hardening (test-only)

Backlog test-hardening. reviewer-2/r6 flagged that some CR repros are source-scans a comment can satisfy or an alias can bypass. This upgrades the **two with a ready seam** to real runtime behavioral tests. **No production change.**

### t-16 — #2177 lifecycle archive durability
Source-scan `prod.contains("sync_all")` is **comment-satisfiable** — it can't prove the durable append actually error-**checks** the write. New behavioral test `archive_append_failure_counts_zero_and_retries_t16`:
- Inject an archive-write failure (make `tasks-archive.jsonl` a **directory** → the append `open()` fails deterministically on every platform — more robust than a read-only file root/CI can bypass).
- Assert `archive_done_tasks` counts **0** (does NOT claim a never-written task), then — after the blocker is removed — the un-archived record is **retried and lands**.
- Proves the failure-handling the pre-#2177 `let _ = writeln!` lacked.

### t-25 — #2160/H13 dismiss writer-lock
Static-grep repro (`writer.lock()` absent in dismiss.rs) is bypassable by aliasing / an API rename. New **runtime** test `write_with_timeout_returns_on_parked_writer_h13_2160`:
- A `ParkWriter` whose `write` blocks (60s ≫ the 5s `PTY_WRITE_TIMEOUT`) must make `write_with_timeout` — the primitive every dismiss keystroke routes through — return `Err(TimedOut)` within its bound (asserted **< 8s**, observed ~5s).
- Proves the dismiss write path can't hang the caller and pin the writer lock forever.

### Evidence
```
ran: cargo test --bin agend-terminal lifecycle::tests → 29 passed (incl. archive_append_failure…t16)
ran: cargo test --bin agend-terminal agent::dismiss::tests → 14 passed (parked test returns in ~5s)
ran: cargo fmt --check → clean ; cargo clippy --tests --features tray -- -D warnings → clean
```

### Deferred (reported to lead)
The static-grep tightening for the dismiss repro and the #2176 mcp_config / #2203 scanner source-scans need separate seam assessment — not bundled here to keep this PR focused on the two ready runtime upgrades.

### Review tier
test-only → §3.6 single review.

---
*fixup-dev-3* · claude-opus-4-8[1m]