### PR TITLE
test(CR test-audit t-3): 6 vacuous medium repros → drive real prod fns (PR-1)

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -1685,19 +1685,32 @@ fn cleanup_agent(
     }
 }
 
+/// Pure startup-grace decision, split out of [`is_startup_failure`] so it is
+/// unit-testable without a live registry / PTY-backed `AgentHandle` (which can't
+/// be constructed in a unit test). An exit is a startup FAILURE — meaning NO
+/// shell fallback — when the agent has been up < 5s AND no user input arrived
+/// since it was spawned. `uptime` is `(elapsed, spawned_at_epoch_ms)` for the
+/// agent, or `None` when it is absent from the registry.
+fn startup_failure_from(uptime: Option<(std::time::Duration, u64)>, last_input_at_ms: u64) -> bool {
+    match uptime {
+        // Input at/after the spawn epoch is a real user session → not a startup
+        // failure. Input timestamped before the spawn epoch is stale (a prior
+        // session) and must NOT suppress the startup-failure path.
+        Some((elapsed, spawned_at_epoch_ms)) => {
+            elapsed < std::time::Duration::from_secs(5) && last_input_at_ms < spawned_at_epoch_ms
+        }
+        None => false,
+    }
+}
+
 fn is_startup_failure(name: &str, id: &crate::types::InstanceId, registry: &AgentRegistry) -> bool {
     let uptime = {
         let reg = registry.lock();
         reg.get(id)
             .map(|h| (h.spawned_at.elapsed(), h.spawned_at_epoch_ms))
     };
-    let had_user_input = {
-        let pair = crate::daemon::heartbeat_pair::snapshot_for(name);
-        uptime
-            .map(|(_, epoch_ms)| pair.last_input_at_ms >= epoch_ms)
-            .unwrap_or(false)
-    };
-    matches!(uptime, Some((d, _)) if d < std::time::Duration::from_secs(5) && !had_user_input)
+    let last_input_at_ms = crate::daemon::heartbeat_pair::snapshot_for(name).last_input_at_ms;
+    startup_failure_from(uptime, last_input_at_ms)
 }
 
 fn on_startup_failure(

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -614,27 +614,31 @@ fn ansi_header_detected_as_system_header() {
 /// Startup failure: exit within 5s + no user input since spawn → no shell fallback.
 #[test]
 fn startup_failure_no_input_no_shell_fallback() {
-    // spawned_at_epoch_ms = 1000, last_input_at_ms = 500 → input before spawn
-    let spawned_at_epoch_ms: u64 = 1000;
-    let last_input_at_ms: u64 = 500;
-    let had_user_input_since_spawn = last_input_at_ms >= spawned_at_epoch_ms;
+    // Drive the REAL decision (`startup_failure_from`) rather than re-implementing
+    // the `last_input_at_ms >= spawned_at_epoch_ms` comparison inline. Up < 5s
+    // with only pre-spawn input (500 < spawn epoch 1000) → startup failure.
     assert!(
-        !had_user_input_since_spawn,
-        "input before spawn should not count as user input"
+        startup_failure_from(Some((std::time::Duration::from_millis(200), 1000)), 500),
+        "exit <5s with only stale pre-spawn input is a startup failure (no shell fallback)"
     );
 }
 
 /// Quick user exit: input AFTER spawn → normal clean exit, not startup failure.
 #[test]
 fn quick_user_exit_still_clean() {
-    // spawned_at_epoch_ms = 1000, last_input_at_ms = 1500 → input after spawn
-    let spawned_at_epoch_ms: u64 = 1000;
-    let last_input_at_ms: u64 = 1500;
-    let had_user_input_since_spawn = last_input_at_ms >= spawned_at_epoch_ms;
+    // Input at/after the spawn epoch (1500 >= 1000) is a real session → clean.
     assert!(
-        had_user_input_since_spawn,
-        "input after spawn should count as user input → not startup failure"
+        !startup_failure_from(Some((std::time::Duration::from_millis(200), 1000)), 1500),
+        "input at/after the spawn epoch is a real session → not a startup failure"
     );
+    // Past the 5s startup grace, a quick exit is not a startup failure even with
+    // no input — the fallback path applies normally.
+    assert!(
+        !startup_failure_from(Some((std::time::Duration::from_secs(6), 1000)), 500),
+        "after the 5s grace window, a no-input exit is not a startup failure"
+    );
+    // Absent from the registry → never a startup failure.
+    assert!(!startup_failure_from(None, 0));
 }
 
 /// #1915 chokepoint: `spawn_agent` refuses an instance that is mid-delete,

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -875,15 +875,43 @@ mod tests {
 
     #[test]
     fn drag_start_sets_dragging_pane_on_title_hit() {
-        let mut layout = Layout::new();
-        layout.add_tab(Tab::new("src".to_string(), leaf(1, "a")));
-        layout.tabs[0].split_focused(SplitDir::Vertical, leaf(2, "b"));
-        layout.active = 0;
-        layout.tabs[0].focus_id = 2;
-        layout.tabs[0].dragging_pane = Some(2);
-        layout.tabs[0].drag_target = None;
+        // Drive the REAL `handle_down`: a Down(Left) on pane 2's title-bar text
+        // must begin dragging pane 2 (and focus it). The earlier version set
+        // `dragging_pane = Some(2)` by hand and asserted it back — a tautology
+        // that never exercised handle_down's title-hit branch.
+        let mut layout = two_pane_layout("right");
+        layout.tabs[0].focus_id = 1; // focus the OTHER pane to prove the move
 
-        assert_eq!(layout.tabs[0].dragging_pane, Some(2));
+        // pane 2 rect = (10, 1, 10, 10); its " right " title text spans cols
+        // [11, 17). Click at col 12, row 1 (the pane's top row, not the tab bar).
+        let click = down_left_at(12, 1);
+        assert_eq!(
+            layout.tabs[0].title_bar_at(12, 1),
+            Some(2),
+            "test precondition: synthetic click must land on pane 2's title text"
+        );
+
+        let mut state = MouseState::default();
+        let mut out = MouseOutcome::default();
+        let fleet_path = std::path::Path::new("/nonexistent/fleet.yaml");
+        handle_down(
+            click,
+            &mut layout,
+            &mut state,
+            fleet_path,
+            &empty_registry(),
+            &mut out,
+        );
+
+        assert_eq!(
+            layout.tabs[0].dragging_pane,
+            Some(2),
+            "handle_down on a pane title bar must begin dragging that pane"
+        );
+        assert_eq!(
+            layout.tabs[0].focus_id, 2,
+            "title-bar hit also focuses the clicked pane"
+        );
         assert_eq!(layout.tabs[0].drag_target, None);
     }
 

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -899,26 +899,30 @@ mod tests {
     #[serial_test::serial]
     #[tracing_test::traced_test]
     fn t704_phase1b_capture_fixtures_active_emits_privacy_warn() {
-        // SAFETY: serial-gated; restore at end. The bootstrap step
-        // wrapper reads the env var directly so we set/unset around
-        // the invocation. Bare `time_step(...)` runs the closure
-        // in-band without daemon scaffolding.
+        // SAFETY: serial-gated; restore at end. Drive the REAL
+        // `boot_hygiene_sweeps` (which reads the env var directly) rather than
+        // re-implementing its if/warn inline — the earlier version pasted a
+        // STALE copy of the warn text and only asserted `#704` / `active`, so a
+        // text drift (or removal of the warn) in production would not be caught.
         unsafe { std::env::set_var("AGEND_CAPTURE_FIXTURES", "1") };
         let home = tmp_home("capture-warn-active");
-        time_step("capture_fixtures_privacy_warn", || {
-            if std::env::var("AGEND_CAPTURE_FIXTURES").as_deref() == Ok("1") {
-                tracing::warn!(
-                    "#704 AGEND_CAPTURE_FIXTURES=1 active — PTY captures may contain \
-                     secrets / prompts. Operator MUST review tests/fixtures/state-replay/ \
-                     before commit. Promote workflow: see docs/CONTRIBUTING.md."
-                );
-            }
-        });
+        boot_hygiene_sweeps(&home);
+        // Bind to phrases unique to the production text (mod.rs:263-268), not
+        // just the operator-facing `active` token, so the test tracks the real
+        // warn and breaks on a material text change.
         assert!(
             logs_contain("AGEND_CAPTURE_FIXTURES=1 active"),
             "privacy warn must fire when env var is active"
         );
         assert!(logs_contain("#704"), "warn must self-identify as #704 hook");
+        assert!(
+            logs_contain("$AGEND_HOME/captures"),
+            "warn must point operators at the real capture path (prod text)"
+        );
+        assert!(
+            logs_contain(".raw before"),
+            "warn must instruct review of the raw fixtures before commit (prod text)"
+        );
         unsafe { std::env::remove_var("AGEND_CAPTURE_FIXTURES") };
         std::fs::remove_dir_all(&home).ok();
     }
@@ -931,11 +935,7 @@ mod tests {
     fn t704_phase1b_no_warn_when_capture_fixtures_unset() {
         unsafe { std::env::remove_var("AGEND_CAPTURE_FIXTURES") };
         let home = tmp_home("capture-warn-inactive");
-        time_step("capture_fixtures_privacy_warn", || {
-            if std::env::var("AGEND_CAPTURE_FIXTURES").as_deref() == Ok("1") {
-                tracing::warn!("#704 AGEND_CAPTURE_FIXTURES=1 active — should NOT fire here");
-            }
-        });
+        boot_hygiene_sweeps(&home);
         assert!(
             !logs_contain("AGEND_CAPTURE_FIXTURES=1 active"),
             "privacy warn MUST NOT fire when env var is unset"

--- a/src/git_helpers.rs
+++ b/src/git_helpers.rs
@@ -512,11 +512,36 @@ mod tests {
     }
 
     #[test]
-    fn strip_prefix_preserves_slashes() {
-        // Simulate the parsing logic directly
-        let output = "refs/remotes/origin/release/2026";
-        let prefix = "refs/remotes/origin/";
-        let result = output.strip_prefix(prefix).unwrap_or(output);
-        assert_eq!(result, "release/2026");
+    fn default_branch_strips_only_remote_prefix_preserving_inner_slashes() {
+        // Drive the REAL `default_branch` against a git fixture whose
+        // `refs/remotes/origin/HEAD` points to a slash-containing branch. The
+        // earlier version of this test re-implemented `strip_prefix` inline and
+        // never called `default_branch`, so a regression in the prod parse (e.g.
+        // `split('/').last()`, which would yield "2026") would not be caught.
+        let repo = tmp_repo("slashed-default");
+        for args in [
+            // A remote-tracking ref whose name itself contains a slash.
+            vec!["update-ref", "refs/remotes/origin/release/2026", "HEAD"],
+            // origin/HEAD → that slashed branch (what `default_branch` reads).
+            vec![
+                "symbolic-ref",
+                "refs/remotes/origin/HEAD",
+                "refs/remotes/origin/release/2026",
+            ],
+        ] {
+            std::process::Command::new("git")
+                .env("AGEND_GIT_BYPASS", "1")
+                .args(&args)
+                .current_dir(&repo)
+                .output()
+                .unwrap();
+        }
+        assert_eq!(
+            default_branch(&repo),
+            "release/2026",
+            "default_branch must strip only the `refs/remotes/<remote>/` prefix, \
+             preserving slashes inside the branch name"
+        );
+        std::fs::remove_dir_all(&repo).ok();
     }
 }

--- a/src/render/panels_fleet.rs
+++ b/src/render/panels_fleet.rs
@@ -6,70 +6,6 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
 use ratatui::Frame;
 
-/// Pure function: build fleet view text lines for testing.
-#[cfg(test)]
-pub fn build_fleet_view_lines(
-    tasks: &[crate::tasks::Task],
-    teams: &[crate::teams::Team],
-    all_instances: &[String],
-) -> Vec<String> {
-    let mut agent_tasks: std::collections::HashMap<&str, Vec<&crate::tasks::Task>> =
-        std::collections::HashMap::new();
-    for t in tasks {
-        if t.status == crate::task_events::TaskStatus::Claimed {
-            if let Some(ref a) = t.assignee {
-                agent_tasks.entry(a.as_str()).or_default().push(t);
-            }
-        }
-    }
-    let mut lines = Vec::new();
-    let mut assigned: std::collections::HashSet<&str> = std::collections::HashSet::new();
-    for team in teams {
-        lines.push(format!(
-            "═══ {} (orchestrator: {}) ═══",
-            team.name,
-            team.orchestrator.as_deref().unwrap_or("none")
-        ));
-        for member in &team.members {
-            assigned.insert(member.as_str());
-            let symbol = if agent_tasks.contains_key(member.as_str()) {
-                "🟠"
-            } else {
-                "🟢"
-            };
-            let task_info = agent_tasks
-                .get(member.as_str())
-                .and_then(|ts| ts.first())
-                .map(|t| format!(" → {} ({})", t.title, t.id))
-                .unwrap_or_else(|| " idle".to_string());
-            lines.push(format!("  {symbol} {member}{task_info}"));
-        }
-    }
-    let mut unassigned: Vec<&str> = all_instances
-        .iter()
-        .filter(|n| !assigned.contains(n.as_str()))
-        .map(String::as_str)
-        .collect();
-    unassigned.sort_unstable();
-    if !unassigned.is_empty() {
-        lines.push("═══ unassigned ═══".to_string());
-        for name in &unassigned {
-            let symbol = if agent_tasks.contains_key(name) {
-                "🟠"
-            } else {
-                "🟢"
-            };
-            let task_info = agent_tasks
-                .get(name)
-                .and_then(|ts| ts.first())
-                .map(|t| format!(" → {} ({})", t.title, t.id))
-                .unwrap_or_else(|| " idle".to_string());
-            lines.push(format!("  {symbol} {name}{task_info}"));
-        }
-    }
-    lines
-}
-
 pub(super) fn render_monitor_view(frame: &mut Frame, area: Rect) {
     let metrics = crate::instance_monitor::latest_metrics();
     if metrics.is_empty() {
@@ -296,18 +232,44 @@ fn build_agent_line<'a>(
 mod tests {
     use super::*;
 
+    fn tmp_home(tag: &str) -> std::path::PathBuf {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static C: AtomicU32 = AtomicU32::new(0);
+        let dir = std::env::temp_dir().join(format!(
+            "agend-panels-fleet-{}-{}-{}",
+            tag,
+            std::process::id(),
+            C.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    /// Drive the REAL `render_fleet_view` end-to-end (teams + instances loaded
+    /// from fleet.yaml, rendered into a TestBackend buffer). The earlier version
+    /// tested a `#[cfg(test)]`-only `build_fleet_view_lines` re-implementation
+    /// that DIVERGED from production (different symbols/header/idle text), so it
+    /// could pass while the rendered output was wrong.
     #[test]
-    fn test_fleet_view_content() {
-        let teams = vec![crate::teams::Team {
-            name: "dev".to_string(),
-            members: vec!["dev-lead".to_string(), "dev-impl".to_string()],
-            orchestrator: Some("dev-lead".to_string()),
-            description: None,
-            created_at: "2026-01-01T00:00:00Z".to_string(),
-            source_repo: None,
-            stale_members: Vec::new(),
-            accept_from: Vec::new(),
-        }];
+    fn render_fleet_view_groups_team_members_and_unassigned() {
+        let home = tmp_home("render");
+        // Instances live in fleet.yaml; `instance_names()` feeds the unassigned
+        // group, and `teams::create` (the prod write path) records the team.
+        std::fs::write(
+            crate::fleet::fleet_yaml_path(&home),
+            "instances:\n  dev-lead:\n    backend: claude\n  \
+             dev-impl:\n    backend: claude\n  general:\n    backend: claude\n",
+        )
+        .unwrap();
+        crate::teams::create(
+            &home,
+            &serde_json::json!({
+                "name": "dev",
+                "members": ["dev-lead", "dev-impl"],
+                "orchestrator": "dev-lead",
+            }),
+        );
+
         let tasks = vec![crate::tasks::Task {
             id: "t-1".to_string(),
             title: "busy work".to_string(),
@@ -330,37 +292,33 @@ mod tests {
             parent_id: None,
             metadata: std::collections::BTreeMap::new(),
         }];
-        let all_instances = vec![
-            "dev-lead".to_string(),
-            "dev-impl".to_string(),
-            "general".to_string(),
-        ];
-        let lines = build_fleet_view_lines(&tasks, &teams, &all_instances);
+
+        let backend = ratatui::backend::TestBackend::new(110, 24);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                render_fleet_view(frame, &tasks, frame.area(), &home);
+            })
+            .unwrap();
+        let buf = terminal.backend().buffer().clone();
+        let mut out = String::new();
+        for y in 0..buf.area.height {
+            for x in 0..buf.area.width {
+                out.push_str(buf.cell((x, y)).map(|c| c.symbol()).unwrap_or(" "));
+            }
+            out.push('\n');
+        }
+
+        assert!(out.contains("═══ dev ═══"), "team header missing:\n{out}");
         assert!(
-            lines
-                .iter()
-                .any(|l| l.contains("dev") && l.contains("orchestrator: dev-lead")),
-            "must have team header: {lines:?}"
+            out.contains("dev-impl") && out.contains("busy work"),
+            "claimed-task member must show its task title:\n{out}"
         );
+        assert!(out.contains("dev-lead"), "team member missing:\n{out}");
         assert!(
-            lines
-                .iter()
-                .any(|l| l.contains("🟠") && l.contains("dev-impl") && l.contains("busy work")),
-            "busy member must show task: {lines:?}"
+            out.contains("unassigned") && out.contains("general"),
+            "non-team instance must appear under unassigned:\n{out}"
         );
-        assert!(
-            lines
-                .iter()
-                .any(|l| l.contains("🟢") && l.contains("dev-lead") && l.contains("idle")),
-            "idle member must show idle: {lines:?}"
-        );
-        assert!(
-            lines.iter().any(|l| l.contains("unassigned")),
-            "must have unassigned group: {lines:?}"
-        );
-        assert!(
-            lines.iter().any(|l| l.contains("general")),
-            "unassigned agent must appear: {lines:?}"
-        );
+        std::fs::remove_dir_all(&home).ok();
     }
 }


### PR DESCRIPTION
## What

CR-2026-06-14 **medium test-audit epic (t-3)**, PR-1 of 2 — the "call-the-real-fn" group. Six previously-vacuous medium findings: the tests PASSED but re-implemented prod logic inline (or exercised a `#[cfg(test)]`-only re-impl), so a real regression went uncaught. Each now drives the **real production fn**.

All confirmed still RED on `origin/main` before fixing (today's CR merges did not address them); none touch in-flight files (`external.rs` #2213, etc.).

## Fixes

| Test | Before | After |
|---|---|---|
| git_helpers `strip_prefix_preserves_slashes` → `default_branch_strips_only_remote_prefix_preserving_inner_slashes` | inline `strip_prefix`, never called `default_branch` | drives `default_branch` against a real-git fixture whose `refs/remotes/origin/HEAD` → `release/2026` |
| app/mouse `drag_start_sets_dragging_pane_on_title_hit` | `Some(2)` → assert `Some(2)` tautology | calls real `handle_down` with a synthetic title-bar `Down(Left)` |
| bootstrap `t704_phase1b_*` (×2) | inline re-impl of the `if env==1 { warn }`, with a **stale copy** of the message | call real `boot_hygiene_sweeps` + assert the production warn text |
| render/panels_fleet `test_fleet_view_content` → `render_fleet_view_groups_team_members_and_unassigned` | tested `#[cfg(test)]`-only `build_fleet_view_lines`, which **diverged** from prod | deletes the dead fn (zero prod callers) + renders real `render_fleet_view` into a `TestBackend` |
| agent `startup_failure_no_input_no_shell_fallback` / `quick_user_exit_still_clean` | inline `last_input_at_ms >= spawned_at_epoch_ms` re-impl | extract pure `startup_failure_from` (behavior-identical) + call it |

## Production deltas (test-enablement only, behavior-preserving)

- `agent/mod.rs`: `is_startup_failure` split into pure `startup_failure_from` + IO shell. `AgentHandle` can't be constructed without a live PTY (which is *why* the original test faked the comparison), so the pure-decision extraction is the minimal honest seam. Behavior verified byte-identical.
- `render/panels_fleet.rs`: removed the dead `#[cfg(test)]` `build_fleet_view_lines` — grep confirms **zero production callers** (only the def + its own test).

## Verification

- `cargo test` — 7 tests GREEN.
- **§3.10 RED→GREEN**: mutated each prod fn (e.g. `default_branch` strip → `rsplit('/')` yields `"2026"`; flip `startup_failure_from`'s `<`→`>`; blank the t704 env match; `dragging_pane = None`; team-header glyph swap) → every corresponding test FAILED. Mutations reverted; re-run GREEN.
- `cargo clippy --tests --features tray -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
