### PR TITLE
fix(#2200): telegram polling backs off instead of panic-looping on network failure

### DIFF
--- a/src/channel/telegram/inbound.rs
+++ b/src/channel/telegram/inbound.rs
@@ -6,17 +6,28 @@ use teloxide::prelude::*;
 use teloxide::types::{MessageId, ThreadId};
 
 use super::error::cleanup_deleted_topic;
+use super::poll_supervisor;
 use super::state::{lock_state, TelegramState};
 use super::topic_registry::load_topic_registry;
 
 /// Start Telegram polling in a dedicated thread with its own tokio runtime.
-/// Supervisor loop: auto-restarts on error/panic with 5s backoff.
+///
+/// Supervisor loop (#2200): drives teloxide's `try_dispatch_with_listener`,
+/// which RETURNS the initial `get_me` error instead of panicking like
+/// `dispatch()` (`.expect("Couldn't prepare dispatching context")`). A cold
+/// `api.telegram.org` therefore yields an `Err` we handle with exponential
+/// backoff (5s → cap 60s) + a degraded latch + fire-once logging, instead of a
+/// fixed-5s panic-backtrace flood that washed the TUI. A definitively-bad token
+/// stops the loop. `catch_unwind` is retained as belt-and-suspenders for
+/// teloxide's OTHER internal `.expect()`s (worker-join / TX), which are not on
+/// the network path and should now ~never fire.
 pub fn start_polling(state: Arc<Mutex<TelegramState>>) {
     // fire-and-forget: telegram supervisor thread runs for the daemon's lifetime.
     if let Err(e) = std::thread::Builder::new()
         .name("telegram".into())
         .spawn(move || {
             let _census = crate::thread_census::register("telegram_poll");
+            let mut health = poll_supervisor::PollingHealth::default();
             loop {
                 tracing::info!("telegram dispatcher starting");
                 let state_clone = Arc::clone(&state);
@@ -26,36 +37,98 @@ pub fn start_polling(state: Arc<Mutex<TelegramState>>) {
                         .build()
                     else {
                         tracing::error!("failed to build tokio runtime");
-                        return;
+                        // Treat as a benign transient exit so the loop backs off
+                        // rather than spinning on a runtime-build failure.
+                        return Ok(());
                     };
-                    rt.block_on(async {
-                        let bot = lock_state(&state_clone)
-                            .bot
-                            .clone()
-                            .expect("telegram bot not initialized (polling thread)");
-                        let state2 = Arc::clone(&state_clone);
-                        let handler =
-                            Update::filter_message().endpoint(move |_bot: Bot, msg: Message| {
-                                let state = Arc::clone(&state2);
-                                async move {
-                                    handle_message(&state, &msg).await;
-                                    respond(())
-                                }
-                            });
-                        tracing::info!("polling started");
-                        Dispatcher::builder(bot, handler).build().dispatch().await;
-                    });
+                    rt.block_on(drive_dispatch_once(&state_clone))
                 }));
-                match result {
-                    Ok(()) => tracing::warn!("telegram dispatcher exited, restarting in 5s"),
-                    Err(_) => tracing::error!("telegram dispatcher panicked, restarting in 5s"),
+
+                // Normalize the attempt into success / classified-failure. An
+                // outer `Err` is a teloxide-internal panic NOT on the get_me path
+                // (rare) — treat as transient; the panic hook already logged it.
+                let attempt = match result {
+                    Ok(Ok(())) => Ok(()),
+                    Ok(Err(e)) => Err((poll_supervisor::classify_connect_error(&e), e.to_string())),
+                    Err(_) => Err((
+                        poll_supervisor::ConnectErrorClass::Transient,
+                        "dispatcher panicked (caught)".to_string(),
+                    )),
+                };
+
+                match attempt {
+                    Ok(()) => {
+                        // get_me succeeded; the dispatcher ran and exited (stream
+                        // end / shutdown). Reset backoff; log recovery once.
+                        if health.on_success() {
+                            tracing::info!("telegram channel recovered");
+                        }
+                        std::thread::sleep(poll_supervisor::POLL_BACKOFF_BASE);
+                    }
+                    Err((class, detail)) => match health.on_failure(class) {
+                        poll_supervisor::FailureOutcome::Stop => {
+                            tracing::error!(
+                                detail = %detail,
+                                "telegram bot token invalid/unauthorized — stopping polling (no retry)"
+                            );
+                            break;
+                        }
+                        poll_supervisor::FailureOutcome::Retry { delay, log } => {
+                            match log {
+                                poll_supervisor::FailureLog::FirstWarn => tracing::warn!(
+                                    detail = %detail,
+                                    backoff_secs = delay.as_secs(),
+                                    "telegram polling failed — retrying with backoff"
+                                ),
+                                poll_supervisor::FailureLog::DegradedEntered => tracing::info!(
+                                    consecutive_failures = poll_supervisor::POLL_DEGRADE_AFTER,
+                                    "telegram channel degraded (offline) — retries continue silently until recovery"
+                                ),
+                                poll_supervisor::FailureLog::Silent => {}
+                            }
+                            std::thread::sleep(delay);
+                        }
+                    },
                 }
-                std::thread::sleep(std::time::Duration::from_secs(5));
             }
         })
     {
         tracing::error!(error = %e, "failed to spawn polling thread");
     }
+}
+
+/// One dispatch attempt. Builds a poll-only `Polling` listener (no
+/// `delete_webhook` pre-flight — agend never sets a webhook, so skipping it
+/// avoids an extra per-cycle network call + its error log) and drives
+/// `try_dispatch_with_listener`, which returns the initial `get_me` error as
+/// `Err` instead of panicking (#2200). `Ok(())` means the connection succeeded
+/// and the dispatcher later exited normally.
+async fn drive_dispatch_once(
+    state: &Arc<Mutex<TelegramState>>,
+) -> Result<(), teloxide::RequestError> {
+    let bot = lock_state(state)
+        .bot
+        .clone()
+        .expect("telegram bot not initialized (polling thread)");
+    let state2 = Arc::clone(state);
+    let handler = Update::filter_message().endpoint(move |_bot: Bot, msg: Message| {
+        let state = Arc::clone(&state2);
+        async move {
+            handle_message(&state, &msg).await;
+            respond(())
+        }
+    });
+    let listener = teloxide::update_listeners::Polling::builder(bot.clone())
+        .timeout(std::time::Duration::from_secs(10))
+        .build();
+    let err_handler = teloxide::error_handlers::LoggingErrorHandler::with_custom_text(
+        "telegram update listener error",
+    );
+    tracing::info!("polling started");
+    Dispatcher::builder(bot, handler)
+        .build()
+        .try_dispatch_with_listener(listener, err_handler)
+        .await
 }
 
 /// Resolve a topic_id to an instance name.

--- a/src/channel/telegram/mod.rs
+++ b/src/channel/telegram/mod.rs
@@ -16,6 +16,7 @@ pub(crate) mod bootstrap;
 pub(crate) mod bot_api;
 pub(crate) mod creds;
 pub(crate) mod notify;
+pub(crate) mod poll_supervisor;
 pub(crate) mod reply;
 pub(crate) mod ux_sink;
 

--- a/src/channel/telegram/poll_supervisor.rs
+++ b/src/channel/telegram/poll_supervisor.rs
@@ -1,0 +1,230 @@
+//! Telegram long-poll supervisor health — issue #2200.
+//!
+//! A cold `api.telegram.org` (firewall / offline / region-block — common on
+//! Chinese networks) used to make teloxide's `Dispatcher::dispatch()` PANIC via
+//! `.expect("Couldn't prepare dispatching context")` (teloxide-0.17
+//! `dispatcher.rs:385`) when the initial `get_me` failed. The old supervisor
+//! caught the panic and restarted on a FIXED 5 s loop, so every cycle re-printed
+//! teloxide's panic backtrace to stderr and washed the TUI.
+//!
+//! [`inbound::start_polling`] now drives `try_dispatch_with_listener`, which
+//! RETURNS the `get_me` error instead of panicking, and feeds the outcome to the
+//! pure state machine here. This module owns ONLY the decision logic
+//! (classification + exponential backoff + degraded latch + noise discipline) so
+//! it is unit-testable without a network, a runtime, or real sleeps.
+//!
+//! Noise discipline ([[feedback_system_noise_reduction_priority]]): the fix must
+//! not become a new flood. We log ONE WARN on the first failure of an outage,
+//! ONE INFO when the channel crosses into "degraded", then stay SILENT until a
+//! single INFO on recovery — never per-retry-cycle.
+
+use std::time::Duration;
+
+use teloxide::{ApiError, RequestError};
+
+/// Base backoff after the first transient failure.
+pub(super) const POLL_BACKOFF_BASE: Duration = Duration::from_secs(5);
+/// Backoff ceiling — exponential growth is clamped here.
+pub(super) const POLL_BACKOFF_CAP: Duration = Duration::from_secs(60);
+/// Consecutive transient failures before the channel is marked degraded.
+pub(super) const POLL_DEGRADE_AFTER: u32 = 3;
+
+/// How a connect failure should be treated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ConnectErrorClass {
+    /// Retry with backoff — a network timeout / flood-wait / I/O blip / unknown
+    /// API error. Expected at runtime, never fatal.
+    Transient,
+    /// A definitively bad / expired bot token — retrying NEVER recovers, so the
+    /// supervisor stops polling instead of looping forever on a broken token.
+    PermanentAuth,
+}
+
+/// Classify the error `try_dispatch_with_listener` returns from its initial
+/// `get_me`. ONLY a definitively-permanent auth failure (`InvalidToken`, which
+/// teloxide raises for HTTP 401 `Unauthorized` / `Not Found`) stops the
+/// supervisor; everything else — including unknown API errors and 5xx — is
+/// transient, so a momentary server blip never permanently disables the channel.
+pub(super) fn classify_connect_error(err: &RequestError) -> ConnectErrorClass {
+    match err {
+        RequestError::Api(ApiError::InvalidToken) => ConnectErrorClass::PermanentAuth,
+        _ => ConnectErrorClass::Transient,
+    }
+}
+
+/// Exactly which log line (if any) a transient failure should emit. Fire-once
+/// per state EDGE — never per retry cycle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum FailureLog {
+    /// First failure of a fresh outage → one WARN carrying the error.
+    FirstWarn,
+    /// Just crossed [`POLL_DEGRADE_AFTER`] → one INFO "channel offline".
+    DegradedEntered,
+    /// Already warned / already degraded → emit NOTHING.
+    Silent,
+}
+
+/// What the supervisor loop should do after one failed attempt.
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum FailureOutcome {
+    /// Sleep `delay`, emit `log` (if any), then retry.
+    Retry { delay: Duration, log: FailureLog },
+    /// Permanent auth failure → emit one ERROR, then stop polling.
+    Stop,
+}
+
+/// Pure backoff + degraded state machine. No I/O, no clock.
+#[derive(Debug, Default)]
+pub(super) struct PollingHealth {
+    consecutive_failures: u32,
+    degraded: bool,
+}
+
+impl PollingHealth {
+    /// Record a failed connect attempt and decide the next action.
+    pub(super) fn on_failure(&mut self, class: ConnectErrorClass) -> FailureOutcome {
+        if class == ConnectErrorClass::PermanentAuth {
+            return FailureOutcome::Stop;
+        }
+        self.consecutive_failures = self.consecutive_failures.saturating_add(1);
+        let delay = backoff_delay(self.consecutive_failures);
+        let log = if self.consecutive_failures == 1 {
+            FailureLog::FirstWarn
+        } else if self.consecutive_failures == POLL_DEGRADE_AFTER && !self.degraded {
+            self.degraded = true;
+            FailureLog::DegradedEntered
+        } else {
+            FailureLog::Silent
+        };
+        FailureOutcome::Retry { delay, log }
+    }
+
+    /// Record a successful connect (`get_me` ok). Returns `true` EXACTLY once
+    /// when recovering from a prior outage, so the loop emits a single recovery
+    /// INFO; resets the backoff + degraded state either way.
+    pub(super) fn on_success(&mut self) -> bool {
+        let recovering = self.consecutive_failures > 0 || self.degraded;
+        self.consecutive_failures = 0;
+        self.degraded = false;
+        recovering
+    }
+}
+
+/// Exponential backoff `base * 2^(n-1)`, clamped to [`POLL_BACKOFF_CAP`].
+/// Saturating + exponent-capped so a long outage can never overflow.
+pub(super) fn backoff_delay(consecutive_failures: u32) -> Duration {
+    let exp = consecutive_failures.saturating_sub(1).min(20);
+    let mult = 1u32 << exp; // exp <= 20 → no overflow
+    POLL_BACKOFF_BASE.saturating_mul(mult).min(POLL_BACKOFF_CAP)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // (b) exponential backoff sequence, capped at 60s.
+    #[test]
+    fn backoff_is_exponential_then_capped() {
+        let got: Vec<u64> = (1..=7).map(|n| backoff_delay(n).as_secs()).collect();
+        assert_eq!(got, vec![5, 10, 20, 40, 60, 60, 60]);
+        // never panics / overflows for a very long outage:
+        assert_eq!(backoff_delay(u32::MAX), POLL_BACKOFF_CAP);
+    }
+
+    // (c) degraded after exactly N consecutive failures; (d) at most one WARN +
+    // one DegradedEntered across a whole outage (no per-cycle flood).
+    #[test]
+    fn degrades_after_n_and_logs_once_per_edge() {
+        let mut h = PollingHealth::default();
+        let mut logs = Vec::new();
+        for _ in 0..6 {
+            match h.on_failure(ConnectErrorClass::Transient) {
+                FailureOutcome::Retry { log, .. } => logs.push(log),
+                FailureOutcome::Stop => panic!("transient must not stop"),
+            }
+        }
+        assert_eq!(
+            logs,
+            vec![
+                FailureLog::FirstWarn,       // #1
+                FailureLog::Silent,          // #2
+                FailureLog::DegradedEntered, // #3 == POLL_DEGRADE_AFTER
+                FailureLog::Silent,          // #4
+                FailureLog::Silent,          // #5
+                FailureLog::Silent,          // #6
+            ],
+            "exactly one WARN + one degraded INFO over an outage; the rest silent"
+        );
+    }
+
+    // (e) recovery emits the one-shot INFO and resets backoff + degraded.
+    #[test]
+    fn recovery_logs_once_and_resets() {
+        let mut h = PollingHealth::default();
+        h.on_failure(ConnectErrorClass::Transient);
+        h.on_failure(ConnectErrorClass::Transient);
+        h.on_failure(ConnectErrorClass::Transient); // now degraded
+        assert!(
+            h.on_success(),
+            "first success after an outage logs recovery"
+        );
+        assert!(
+            !h.on_success(),
+            "a second consecutive success is silent (no repeat recovery flood)"
+        );
+        // backoff reset to base after recovery:
+        assert_eq!(
+            h.on_failure(ConnectErrorClass::Transient),
+            FailureOutcome::Retry {
+                delay: POLL_BACKOFF_BASE,
+                log: FailureLog::FirstWarn
+            },
+            "post-recovery the next outage starts from base backoff + a fresh WARN"
+        );
+    }
+
+    // (d)/permanent: an invalid token stops; a network error is transient.
+    #[test]
+    fn classify_invalid_token_permanent_network_transient() {
+        assert_eq!(
+            classify_connect_error(&RequestError::Api(ApiError::InvalidToken)),
+            ConnectErrorClass::PermanentAuth
+        );
+        assert_eq!(
+            classify_connect_error(&RequestError::RetryAfter(
+                teloxide::types::Seconds::from_seconds(3)
+            )),
+            ConnectErrorClass::Transient
+        );
+        // permanent auth → Stop, regardless of prior state.
+        let mut h = PollingHealth::default();
+        assert_eq!(
+            h.on_failure(ConnectErrorClass::PermanentAuth),
+            FailureOutcome::Stop
+        );
+    }
+
+    // (a) No-panic guarantee — STRUCTURAL. The #2200 panic was teloxide's
+    // `dispatch()` → `.expect("Couldn't prepare dispatching context")`; the only
+    // network-safe entry is `try_dispatch_with_listener`, which RETURNS the
+    // get_me error. A runtime panic-injection would need a real (failing)
+    // network call, so we instead pin that `inbound.rs` drives the result-typed
+    // API and the supervisor consumes a `Result` (no `.expect()` on the dispatch
+    // outcome). A regression to the panicking `dispatch()` would drop these.
+    #[test]
+    fn inbound_drives_result_typed_dispatch_not_panicking_dispatch() {
+        let src = include_str!("inbound.rs");
+        let safe_api = "try_dispatch_with_listener";
+        let result_boundary = "Result<(), teloxide::RequestError>";
+        assert!(
+            src.contains(safe_api),
+            "inbound.rs must drive the non-panicking `{safe_api}` (not `dispatch()`, \
+             whose `.expect(\"Couldn't prepare dispatching context\")` is the #2200 panic)"
+        );
+        assert!(
+            src.contains(result_boundary),
+            "the dispatch attempt must surface `{result_boundary}` so the supervisor \
+             handles the connect error with backoff instead of panicking"
+        );
+    }
+}


### PR DESCRIPTION
Closes #2200.

## Problem
A cold `api.telegram.org` (firewall / offline / region-block — common on Chinese networks) made teloxide's `Dispatcher::dispatch()` **panic** via `.expect("Couldn't prepare dispatching context")` (teloxide-0.17 `dispatcher.rs:385`) when the initial `get_me` failed. The supervisor caught the panic and restarted on a **fixed 5s loop**, so every cycle re-printed teloxide's panic backtrace to stderr (the panic hook chains the default hook — `logging.rs:186`) and washed the TUI.

## Premise-check (corrections to the issue)
- ✅ `inbound.rs` did have `catch_unwind` + a **fixed 5s** restart — that IS the "loop".
- ✅ **No-token already skips cleanly** — `bootstrap.rs:37-47` logs "skipping" and never calls `start_polling`. The issue's "no token → same panic?" is a non-issue. The still-open auth case is an **invalid/expired** token (handled below).
- ✅ **Root cause pinpointed**: `dispatch()` → `.expect()` at `dispatcher.rs:385` on the initial `get_me`. teloxide exposes `try_dispatch_with_listener`, which **returns `Err` instead of panicking**.

## Fix
- Drive **`try_dispatch_with_listener`** → the network failure is a handled `Err`, **no panic → no backtrace flood**. Build the `Polling` listener directly **without `.delete_webhook()`** (agend is poll-only), skipping an extra per-cycle network call + its error log.
- New **`poll_supervisor`** module (pure, unit-testable): exponential backoff **5s → cap 60s** (reset on a successful connect), a **degraded latch after N=3** consecutive failures, and error **classification** — a definitively-bad token (`ApiError::InvalidToken`, teloxide's HTTP-401 mapping) **stops** polling instead of looping forever; everything else is transient and backs off.
- **Noise discipline** (#2200 was a per-cycle flood; the fix must not become one): **one** WARN on the first failure, **one** INFO entering degraded, then **silent** until **one** INFO on recovery — never per retry cycle.
- `catch_unwind` kept as belt-and-suspenders for teloxide's other internal `.expect()`s (worker-join / TX), off the network path.

## Decision points (lead-ruled)
- Backoff: exp 5s→60s, reset-to-base on connect. **Degraded threshold: N=3.** **Silent-until-recovery.**
- **Invalid/expired token (4xx) → log ERROR once + STOP** (no infinite retry on a broken token).
- **Degraded is log-only** this round. A **live TUI marker is left as an operator follow-up option** — `TelegramStatus{NotConfigured,NoToken,Connected}` is currently a *static startup snapshot*; a live `Degraded` variant would need a runtime signal (e.g. `Arc<AtomicU8>` the TUI polls), deferred to keep the overnight blast radius small.

## Known residual (out of this PR's scope)
After `get_me` succeeds, *mid-stream* poll errors go to teloxide's `LoggingErrorHandler` (logs via the `log` crate, no panic). The issue's case is the **cold** path (never connects), which this PR fixes. A flapping mid-stream connection would still log per error — notable only if it becomes a problem; can be quieted with a custom handler later.

## Tests (deterministic — no network, no sleeps)
- (a) structural no-panic guard: `inbound.rs` drives the Result-typed `try_dispatch_with_listener` (not the panicking `dispatch()`).
- (b) backoff sequence `5,10,20,40,60,60` (+ `u32::MAX` → cap, no overflow).
- (c) degraded after exactly N=3.
- (d) ≤1 WARN + 1 degraded-INFO across a whole outage (no per-cycle flood).
- (e) recovery logs-once + resets backoff/degraded.
- classification: `InvalidToken`→Stop, network/`RetryAfter`→Transient.

## Verification
- `cargo fmt --check` ✓
- `cargo clippy --features tray --bins --tests -- -D warnings` ✓
- **FULL** `cargo nextest run --features tray` → **4334 passed**, 40 skipped ✓

channel-sensitive → **dual review** requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)