### PR TITLE
fix(#2207): fail-fast on empty telegram allowlist + quickstart auto-fill user_id

### DIFF
--- a/src/bootstrap/doctor.rs
+++ b/src/bootstrap/doctor.rs
@@ -139,6 +139,57 @@ fn check_channel_user_allowlist(config: &FleetConfig, diags: &mut Vec<Diagnostic
     }
 }
 
+/// #2207 A1 (detached-start fail-fast gate): returns `Some(channel_label)` when
+/// a configured telegram channel has an empty/missing `user_allowlist` AND its
+/// bot token is actually set (telegram WILL run → every inbound command +
+/// outbound notification WILL be silently dropped by the fail-closed gate).
+///
+/// This is the D001 condition narrowed by a token-presence check. It is
+/// deliberately D001-ONLY (not all Critical diagnostics): D002 (task_sweep
+/// without github_login) is feature-degradation, not daemon-uselessness —
+/// hard-aborting on it would brick an otherwise-functional daemon. And it is
+/// token-GATED: a telegram block whose token env is unset is inert (telegram
+/// never registers — see `telegram_init::init` / `creds::resolve_token_value`),
+/// so its empty allowlist is harmless and must NOT block startup.
+///
+/// Returns `None` (do not block) when: no telegram channel, allowlist is
+/// populated, or the token is unset. D001 itself (`check_channel_user_allowlist`)
+/// is unchanged — it still warns regardless of token so operators keep the
+/// log/foreground signal.
+pub fn empty_allowlist_with_token_set(config: &FleetConfig) -> Option<String> {
+    let check = |ch: &ChannelConfig, label: &str| -> Option<String> {
+        let ChannelConfig::Telegram {
+            user_allowlist,
+            bot_token_env,
+            ..
+        } = ch
+        else {
+            return None;
+        };
+        let allowlist_empty = match user_allowlist {
+            None => true,
+            Some(list) => list.is_empty(),
+        };
+        let token_set =
+            crate::channel::telegram::creds::resolve_token_value(bot_token_env).is_some();
+        (allowlist_empty && token_set).then(|| label.to_string())
+    };
+
+    if let Some(ch) = &config.channel {
+        if let Some(label) = check(ch, "telegram") {
+            return Some(label);
+        }
+    }
+    if let Some(channels) = &config.channels {
+        for (name, ch) in channels {
+            if let Some(label) = check(ch, name) {
+                return Some(label);
+            }
+        }
+    }
+    None
+}
+
 /// D002: task_sweep is configured but no agent has a `github_login`
 /// mapping declared in fleet.yaml. Sprint 56 Track F (#496): the sweep's
 /// authorship gate compares `pr.author_login` against
@@ -314,6 +365,71 @@ mod tests {
             diags[0].message
         );
         assert!(diags[0].fix_stanza.is_some());
+    }
+
+    /// #2207 A1 gate: `empty_allowlist_with_token_set` blocks startup ONLY when
+    /// the telegram bot token is actually set (telegram would run and drop
+    /// everything). A token-less telegram block is inert → must NOT block. This
+    /// is D001-only + token-gated. Mutates the real token env vars to exercise
+    /// the runtime-parity token check → `#[serial]` + save/restore.
+    #[test]
+    #[serial_test::serial]
+    fn empty_allowlist_with_token_set_gates_on_token_presence() {
+        const CANONICAL: &str = "AGEND_TELEGRAM_BOT_TOKEN";
+        const LEGACY: &str = "AGEND_BOT_TOKEN";
+        let saved_c = std::env::var(CANONICAL).ok();
+        let saved_l = std::env::var(LEGACY).ok();
+        std::env::remove_var(CANONICAL);
+        std::env::remove_var(LEGACY);
+
+        // telegram_config pins bot_token_env = CANONICAL.
+        let empty = || FleetConfig {
+            channel: Some(telegram_config(Some(vec![]))),
+            ..Default::default()
+        };
+        let missing = || FleetConfig {
+            channel: Some(telegram_config(None)),
+            ..Default::default()
+        };
+        let populated = || FleetConfig {
+            channel: Some(telegram_config(Some(vec![42]))),
+            ..Default::default()
+        };
+
+        // No token → telegram inert → must NOT block even with empty allowlist.
+        assert!(
+            empty_allowlist_with_token_set(&empty()).is_none(),
+            "empty allowlist but NO token must not block (telegram inert)"
+        );
+
+        // Token set → telegram runs → empty/missing allowlist drops all → block.
+        std::env::set_var(CANONICAL, "123:dummy-token");
+        assert_eq!(
+            empty_allowlist_with_token_set(&empty()).as_deref(),
+            Some("telegram"),
+            "empty allowlist + token set must block"
+        );
+        assert_eq!(
+            empty_allowlist_with_token_set(&missing()).as_deref(),
+            Some("telegram"),
+            "missing allowlist + token set must block"
+        );
+        // Populated allowlist never blocks.
+        assert!(
+            empty_allowlist_with_token_set(&populated()).is_none(),
+            "populated allowlist must not block"
+        );
+        // No telegram channel never blocks.
+        assert!(empty_allowlist_with_token_set(&FleetConfig::default()).is_none());
+
+        // Restore prior env.
+        std::env::remove_var(CANONICAL);
+        if let Some(v) = saved_c {
+            std::env::set_var(CANONICAL, v);
+        }
+        if let Some(v) = saved_l {
+            std::env::set_var(LEGACY, v);
+        }
     }
 
     /// The two D001 surface variants must produce visibly distinct

--- a/src/channel/telegram/creds.rs
+++ b/src/channel/telegram/creds.rs
@@ -76,6 +76,28 @@ pub(super) fn resolve_channel_only() -> anyhow::Result<TelegramCreds> {
     resolve_channel().map(|(ch, _)| ch)
 }
 
+/// #2207: resolve `bot_token_env` to its value using the SAME symmetric
+/// canonical/legacy fallback as [`resolve_channel_from`], but without loading
+/// config or emitting tracing warnings. Returns `None` when no token is set
+/// under either name (telegram will not run).
+///
+/// Shared so the doctor's detached-start pre-flight gate (#2207 A1) decides
+/// "telegram will actually run" with the exact same token resolution the
+/// runtime uses — a divergence would false-pass or false-block the
+/// empty-allowlist fail-fast.
+pub(crate) fn resolve_token_value(bot_token_env: &str) -> Option<String> {
+    const CANONICAL: &str = "AGEND_TELEGRAM_BOT_TOKEN";
+    const LEGACY: &str = "AGEND_BOT_TOKEN";
+    std::env::var(bot_token_env).ok().or_else(|| {
+        let fallback_name = if bot_token_env == CANONICAL {
+            LEGACY
+        } else {
+            CANONICAL
+        };
+        std::env::var(fallback_name).ok()
+    })
+}
+
 /// Like [`resolve_channel_only`] but reads `fleet.yaml` from a caller-
 /// supplied home instead of the process-wide `AGEND_HOME`. Telegram
 /// helpers that already receive a `home` argument (e.g.

--- a/src/main.rs
+++ b/src/main.rs
@@ -672,6 +672,33 @@ fn main() -> anyhow::Result<()> {
                 .map(PathBuf::from)
                 .unwrap_or_else(|| crate::fleet::fleet_yaml_path(&home));
             if !force_foreground {
+                // #2207 A1 — parent pre-flight fail-fast. In detached mode the
+                // child's stdio is /dev/null (daemon_spawn) and the parent
+                // judges "started" purely on run-dir publication, so a daemon
+                // whose telegram token is set but `user_allowlist` is empty
+                // would silently drop EVERY inbound command + outbound
+                // notification while printing "daemon started". The child's
+                // D001 eprintln lands in /dev/null. Catch it HERE, in the
+                // operator-attached parent, before spawning: refuse to start
+                // with an actionable message + non-zero exit (D001-only,
+                // token-gated — see doctor::empty_allowlist_with_token_set).
+                if fleet_path.exists() {
+                    if let Ok(config) = crate::fleet::FleetConfig::load(&fleet_path) {
+                        if let Some(label) =
+                            bootstrap::doctor::empty_allowlist_with_token_set(&config)
+                        {
+                            println!(
+                                "daemon NOT started: telegram channel '{label}' has its bot token \
+                                 set but `user_allowlist` is empty → all inbound commands and \
+                                 outbound notifications would be silently dropped (fail-closed gate).\n\
+                                 Fix: add your Telegram user_id to `user_allowlist` in {} \
+                                 (run `agend-terminal quickstart` to auto-detect it), then start again.",
+                                fleet_path.display()
+                            );
+                            std::process::exit(1);
+                        }
+                    }
+                }
                 // Sprint 57 Wave 3 PR-2 (#548 Q1) default branch: detach.
                 // Spawn self as a background process and exit. Child inherits
                 // a clean environment from the parent shell but runs in its

--- a/src/quickstart.rs
+++ b/src/quickstart.rs
@@ -62,7 +62,7 @@ pub fn run(home: &Path, unattended: bool) -> anyhow::Result<()> {
         .and_then(|content| serde_yaml_ng::from_str::<serde_yaml_ng::Value>(&content).ok())
         .and_then(|config| config["channel"]["group_id"].as_i64());
 
-    let (token, group_id) = if existing_token.is_some() && existing_group_id.is_some() {
+    let (token, group_id, user_id) = if existing_token.is_some() && existing_group_id.is_some() {
         let tok = existing_token.clone().unwrap_or_default();
         let gid = existing_group_id.unwrap_or(0);
         println!("  ── Telegram ──\n");
@@ -72,7 +72,9 @@ pub fn run(home: &Path, unattended: bool) -> anyhow::Result<()> {
             telegram_setup(home)?
         } else {
             println!();
-            (tok, Some(gid))
+            // Reusing an existing config — no fresh getUpdates poll, so no
+            // auto-detected sender (#2207 B); the existing allowlist stands.
+            (tok, Some(gid), None)
         }
     } else if let Some(tok) = existing_token {
         println!("  ── Telegram ──\n");
@@ -85,13 +87,13 @@ pub fn run(home: &Path, unattended: bool) -> anyhow::Result<()> {
             print!("  Waiting for group message (3 min timeout)... ");
             io::stdout().flush().ok();
             match detect_group(&tok) {
-                Ok((gid, title)) => {
+                Ok((gid, title, sender)) => {
                     println!("✓ {title} ({gid})\n");
-                    (tok, Some(gid))
+                    (tok, Some(gid), sender)
                 }
                 Err(e) => {
                     println!("timeout: {e}\n");
-                    (tok, None)
+                    (tok, None, None)
                 }
             }
         }
@@ -108,6 +110,7 @@ pub fn run(home: &Path, unattended: bool) -> anyhow::Result<()> {
         &selected,
         group_id,
         if token.is_empty() { None } else { Some(&token) },
+        user_id,
         false,
     )?;
 
@@ -185,6 +188,9 @@ fn run_unattended(home: &Path) -> anyhow::Result<()> {
         &selected,
         resolved.group_id,
         resolved.token.as_deref(),
+        // Unattended never runs detect_group (no network) → no auto-detected
+        // sender; the allowlist stays as-is (#2207 B is interactive-only).
+        None,
         true,
     )?;
 
@@ -325,7 +331,7 @@ enum TimeoutChoice {
 const MAX_TOKEN_RETRIES: u32 = 3;
 
 /// Full Telegram setup flow — BotFather → token → group detection.
-fn telegram_setup(_home: &Path) -> anyhow::Result<(String, Option<i64>)> {
+fn telegram_setup(_home: &Path) -> anyhow::Result<(String, Option<i64>, Option<i64>)> {
     println!("  ── Telegram Setup ──\n");
     println!("  1. Open Telegram, talk to @BotFather");
     println!("  2. Send /newbot and follow instructions");
@@ -344,7 +350,7 @@ fn telegram_setup(_home: &Path) -> anyhow::Result<(String, Option<i64>)> {
         let token = token.trim().to_string();
         if token.is_empty() {
             println!("\n  Skipping Telegram. Configure later in fleet.yaml.\n");
-            return Ok((String::new(), None));
+            return Ok((String::new(), None, None));
         }
 
         if !is_valid_token_format(&token) {
@@ -354,7 +360,7 @@ fn telegram_setup(_home: &Path) -> anyhow::Result<(String, Option<i64>)> {
                 TokenChoice::ReEnter => continue,
                 TokenChoice::Skip => {
                     println!("\n  Skipping Telegram. Configure later in fleet.yaml.\n");
-                    return Ok((String::new(), None));
+                    return Ok((String::new(), None, None));
                 }
                 TokenChoice::Continue => {
                     // fall through to verify_bot — operator may have a
@@ -382,7 +388,7 @@ fn telegram_setup(_home: &Path) -> anyhow::Result<(String, Option<i64>)> {
                     TokenChoice::ReEnter => continue,
                     TokenChoice::Skip => {
                         println!("\n  Skipping Telegram. Configure later in fleet.yaml.\n");
-                        return Ok((String::new(), None));
+                        return Ok((String::new(), None, None));
                     }
                     TokenChoice::Continue => break token,
                 }
@@ -400,7 +406,7 @@ fn telegram_setup(_home: &Path) -> anyhow::Result<(String, Option<i64>)> {
         print!("  Waiting for group message (3 min timeout)... ");
         io::stdout().flush().ok();
         match detect_group(&token) {
-            Ok((group_id, group_title)) => {
+            Ok((group_id, group_title, sender)) => {
                 println!("✓ {group_title} ({group_id})\n");
                 // Sprint 56 Track H2 (#525 item 3): verify the bot is
                 // admin in the captured group. Topic mode (the only mode
@@ -424,7 +430,7 @@ fn telegram_setup(_home: &Path) -> anyhow::Result<(String, Option<i64>)> {
                         println!("  ⚠ Could not verify admin status: {e} — continuing anyway\n")
                     }
                 }
-                return Ok((token, Some(group_id)));
+                return Ok((token, Some(group_id), sender));
             }
             Err(e) => {
                 println!("timeout: {e}");
@@ -435,7 +441,7 @@ fn telegram_setup(_home: &Path) -> anyhow::Result<(String, Option<i64>)> {
                     }
                     TimeoutChoice::Skip => {
                         println!("\n  Set group_id manually in fleet.yaml later.\n");
-                        return Ok((token, None));
+                        return Ok((token, None, None));
                     }
                     TimeoutChoice::Quit => {
                         anyhow::bail!("quickstart aborted by operator after group-detect timeout");
@@ -664,7 +670,37 @@ fn classify_quickstart_chat(chat: &serde_json::Value) -> anyhow::Result<Option<(
     }
 }
 
-fn detect_group(token: &str) -> anyhow::Result<(i64, String)> {
+/// #2207 B: pick the operator's `user_id` from a `getUpdates` batch — but ONLY
+/// when there is exactly ONE distinct sender across the polled messages. During
+/// quickstart the operator is told to send a message to their group, so a single
+/// sender is overwhelmingly the operator. We deliberately return `None` for 0 or
+/// ≥2 distinct senders (e.g. someone else in the group messaged during the poll
+/// window) so quickstart never auto-allowlists the wrong user — the detached
+/// fail-fast (#2207 A1) then backstops the still-empty allowlist. Pure (no HTTP)
+/// so the single-sender policy is unit-testable.
+fn extract_single_sender(updates: &[serde_json::Value]) -> Option<i64> {
+    let mut senders = std::collections::BTreeSet::new();
+    for update in updates {
+        if let Some(id) = update
+            .get("message")
+            .and_then(|m| m.get("from"))
+            .and_then(|f| f.get("id"))
+            .and_then(|v| v.as_i64())
+        {
+            senders.insert(id);
+        }
+    }
+    if senders.len() == 1 {
+        senders.into_iter().next()
+    } else {
+        None
+    }
+}
+
+/// Returns `(group_id, group_title, sole_sender_user_id)`. The third element is
+/// the #2207 B auto-fill candidate (see [`extract_single_sender`]) — `None`
+/// unless exactly one sender appeared in the same poll.
+fn detect_group(token: &str) -> anyhow::Result<(i64, String, Option<i64>)> {
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()?;
@@ -674,16 +710,20 @@ fn detect_group(token: &str) -> anyhow::Result<(i64, String)> {
             "getUpdates?timeout=180&allowed_updates=[\"message\"]",
         )
         .await?;
-        if let Some(updates) = resp["result"].as_array() {
-            for update in updates {
-                if let Some(chat) = update.get("message").and_then(|m| m.get("chat")) {
-                    if let Some(hit) = classify_quickstart_chat(chat)? {
-                        return Ok(hit);
-                    }
+        let Some(updates) = resp["result"].as_array() else {
+            anyhow::bail!("No group message received")
+        };
+        let mut group: Option<(i64, String)> = None;
+        for update in updates {
+            if let Some(chat) = update.get("message").and_then(|m| m.get("chat")) {
+                if let Some(hit) = classify_quickstart_chat(chat)? {
+                    group = Some(hit);
+                    break;
                 }
             }
         }
-        anyhow::bail!("No group message received")
+        let (gid, title) = group.ok_or_else(|| anyhow::anyhow!("No group message received"))?;
+        Ok((gid, title, extract_single_sender(updates)))
     })
 }
 
@@ -692,6 +732,11 @@ fn generate_fleet_yaml(
     backend: &Backend,
     group_id: Option<i64>,
     _token: Option<&str>,
+    // #2207 B: the sole sender detected during group detection, auto-filled
+    // into `user_allowlist` so a fresh quickstart yields a usable channel
+    // instead of the silently-dropping empty `[]`. `None` → emit the TODO
+    // template (multi/zero sender, reused config, or unattended).
+    user_id: Option<i64>,
     unattended: bool,
 ) -> anyhow::Result<()> {
     let fleet_path = crate::fleet::fleet_yaml_path(home);
@@ -724,6 +769,19 @@ fn generate_fleet_yaml(
     let backend_name = backend.name();
 
     let channel_section = if let Some(gid) = group_id {
+        // #2207 B: auto-fill the allowlist when quickstart detected exactly one
+        // sender (assumed to be the operator — they were just told to message
+        // the group). Otherwise emit the TODO `[]` template; the detached
+        // fail-fast (#2207 A1) backstops a still-empty allowlist at start.
+        let allowlist_line = match user_id {
+            Some(uid) => format!(
+                "user_allowlist:\n  - {uid}  # auto-detected by quickstart (sole sender during group detection)"
+            ),
+            None => {
+                "user_allowlist: []  # add your Telegram user_id (message @userinfobot to get it)"
+                    .to_string()
+            }
+        };
         format!(
             r#"
 channel:
@@ -731,7 +789,7 @@ channel:
   bot_token_env: AGEND_TELEGRAM_BOT_TOKEN
   group_id: {gid}
   mode: topic
-  user_allowlist: []  # add your Telegram user_id (message @userinfobot to get it)
+  {allowlist_line}
 "#
         )
     } else {
@@ -1578,7 +1636,8 @@ mod tests {
             std::env::temp_dir().join(format!("agend-quickstart-test-{}", std::process::id()));
         std::fs::create_dir_all(&home).ok();
         let backend = Backend::all()[0].clone();
-        generate_fleet_yaml(&home, &backend, Some(-1001234567890), None, false).expect("test");
+        generate_fleet_yaml(&home, &backend, Some(-1001234567890), None, None, false)
+            .expect("test");
         let yaml = std::fs::read_to_string(crate::fleet::fleet_yaml_path(&home)).expect("test");
         assert!(
             yaml.contains("user_allowlist"),
@@ -1637,6 +1696,90 @@ mod tests {
         }
     }
 
+    // ── #2207 B: single-sender auto-detect for user_allowlist auto-fill ──
+
+    fn fake_update_from(sender_id: i64) -> serde_json::Value {
+        serde_json::json!({
+            "message": {
+                "from": { "id": sender_id },
+                "chat": { "type": "supergroup", "id": -100, "title": "G" }
+            }
+        })
+    }
+
+    #[test]
+    fn extract_single_sender_returns_id_for_sole_sender() {
+        // One distinct sender, even across repeated messages → that id.
+        let updates = vec![fake_update_from(555), fake_update_from(555)];
+        assert_eq!(extract_single_sender(&updates), Some(555));
+    }
+
+    #[test]
+    fn extract_single_sender_none_for_multiple_distinct() {
+        // ≥2 distinct senders → None: never auto-allowlist the wrong user when
+        // someone else messaged the group during the poll window.
+        let updates = vec![fake_update_from(1), fake_update_from(2)];
+        assert_eq!(extract_single_sender(&updates), None);
+    }
+
+    #[test]
+    fn extract_single_sender_none_for_empty_or_senderless() {
+        assert_eq!(extract_single_sender(&[]), None);
+        // Updates lacking message.from.id contribute no sender.
+        let no_from = vec![serde_json::json!({"message": {"chat": {"id": -1}}})];
+        assert_eq!(extract_single_sender(&no_from), None);
+    }
+
+    #[test]
+    fn generate_fleet_yaml_auto_fills_allowlist_for_single_sender() {
+        let home = std::env::temp_dir().join(format!("agend-2207-autofill-{}", std::process::id()));
+        std::fs::create_dir_all(&home).ok();
+        let backend = Backend::all()[0].clone();
+        generate_fleet_yaml(
+            &home,
+            &backend,
+            Some(-100123),
+            Some("t"),
+            Some(987654),
+            false,
+        )
+        .expect("gen");
+        let yaml = std::fs::read_to_string(crate::fleet::fleet_yaml_path(&home)).expect("read");
+        assert!(
+            yaml.contains("- 987654"),
+            "single detected sender must be auto-filled into user_allowlist: {yaml}"
+        );
+        // Must parse into a real, populated allowlist (not just a string match).
+        let config = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&home))
+            .expect("generated fleet.yaml must parse");
+        let Some(crate::fleet::ChannelConfig::Telegram { user_allowlist, .. }) = config.channel
+        else {
+            panic!("expected a telegram channel in generated config");
+        };
+        assert_eq!(
+            user_allowlist.expect("allowlist must be present").len(),
+            1,
+            "exactly the one detected sender is allowlisted"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn generate_fleet_yaml_keeps_empty_allowlist_without_sender() {
+        // No detected sender (multi/zero sender, reused config, unattended) →
+        // the TODO `[]` template stays; #2207 A1 backstops it at start.
+        let home = std::env::temp_dir().join(format!("agend-2207-nofill-{}", std::process::id()));
+        std::fs::create_dir_all(&home).ok();
+        let backend = Backend::all()[0].clone();
+        generate_fleet_yaml(&home, &backend, Some(-100123), Some("t"), None, false).expect("gen");
+        let yaml = std::fs::read_to_string(crate::fleet::fleet_yaml_path(&home)).expect("read");
+        assert!(
+            yaml.contains("user_allowlist: []"),
+            "no detected sender → empty TODO template: {yaml}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
     /// Snapshot test: commented-out channel section also mentions
     /// user_allowlist so operators know to add it.
     #[test]
@@ -1647,7 +1790,7 @@ mod tests {
         ));
         std::fs::create_dir_all(&home).ok();
         let backend = Backend::all()[0].clone();
-        generate_fleet_yaml(&home, &backend, None, None, false).expect("test");
+        generate_fleet_yaml(&home, &backend, None, None, None, false).expect("test");
         let yaml = std::fs::read_to_string(crate::fleet::fleet_yaml_path(&home)).expect("test");
         assert!(
             yaml.contains("user_allowlist"),
@@ -1680,7 +1823,7 @@ mod tests {
         let home = std::env::temp_dir().join(format!("agend-2005-fresh-{}", std::process::id()));
         std::fs::create_dir_all(&home).ok();
         let backend = Backend::all()[0].clone();
-        generate_fleet_yaml(&home, &backend, Some(-100123), Some("t"), false).expect("gen");
+        generate_fleet_yaml(&home, &backend, Some(-100123), Some("t"), None, false).expect("gen");
         let yaml = std::fs::read_to_string(crate::fleet::fleet_yaml_path(&home)).expect("read");
         assert!(
             yaml.contains("bot_token_env: AGEND_TELEGRAM_BOT_TOKEN"),
@@ -1704,7 +1847,7 @@ mod tests {
         let home = std::env::temp_dir().join(format!("agend-2005-legacy-{}", std::process::id()));
         std::fs::create_dir_all(&home).ok();
         let backend = Backend::all()[0].clone();
-        generate_fleet_yaml(&home, &backend, Some(-100123), Some("t"), false).expect("gen");
+        generate_fleet_yaml(&home, &backend, Some(-100123), Some("t"), None, false).expect("gen");
         std::env::set_var("AGEND_BOT_TOKEN", "123:legacy");
         let res = crate::channel::telegram::creds::resolve_channel_from(&home);
         clear_token_envs();
@@ -1746,7 +1889,7 @@ mod tests {
         let home = std::env::temp_dir().join(format!("agend-2005-none-{}", std::process::id()));
         std::fs::create_dir_all(&home).ok();
         let backend = Backend::all()[0].clone();
-        generate_fleet_yaml(&home, &backend, Some(-1), Some("t"), false).expect("gen");
+        generate_fleet_yaml(&home, &backend, Some(-1), Some("t"), None, false).expect("gen");
         let err = crate::channel::telegram::creds::resolve_channel_from(&home)
             .expect_err("no env set must error");
         assert!(
@@ -1822,7 +1965,7 @@ mod tests {
         let fleet_path = crate::fleet::fleet_yaml_path(&home);
         std::fs::write(&fleet_path, "# operator-owned\ninstances: {}\n").expect("test");
         let backend = Backend::all()[0].clone();
-        generate_fleet_yaml(&home, &backend, Some(1), Some("tok"), true).expect("test");
+        generate_fleet_yaml(&home, &backend, Some(1), Some("tok"), None, true).expect("test");
         let after = std::fs::read_to_string(&fleet_path).expect("test");
         assert_eq!(
             after, "# operator-owned\ninstances: {}\n",


### PR DESCRIPTION
## #2207 — empty telegram `user_allowlist` silently drops all messages; D001 invisible in detached mode

Fixes [#2207](https://github.com/suzuke/agend-terminal/issues/2207). **Review class: DUAL** (channel-sensitive: comms-path + boot fail-fast). Design report + premise-check + operator decision points were confirmed by lead before impl (issue/thread).

### Root cause (premise-checked on main)
An empty/missing `user_allowlist` is a fail-closed gate (`auth.rs`) that silently drops **all** inbound commands + outbound notifications. quickstart writes `user_allowlist: []` as a TODO template (`quickstart.rs`). The D001 Critical diagnostic exists but in **detached mode** it's invisible: the spawned child's stdio is `/dev/null` (`daemon_spawn.rs:65-67`) and the parent reports `daemon started` purely on run-dir publication — so the operator sees false success while every message drops.

### A1 — parent pre-flight fail-fast (daemon-start only)
Before spawning the detached child (`main.rs` Start arm, where stdout still reaches the operator), refuse to start with a clear actionable message + non-zero exit when telegram is actually configured-and-running but the allowlist is empty.
- **`doctor::empty_allowlist_with_token_set(config) -> Option<label>`** — the D001 condition narrowed by a token-presence check.
  - **D001-only** (not all Critical): D002 (task_sweep w/o github_login) is feature-degradation — hard-aborting would brick an otherwise-functional daemon.
  - **token-gated**: a token-less telegram block is inert (`telegram_init` returns None) → its empty allowlist is harmless → must not block.
- **`creds::resolve_token_value(bot_token_env)`** — pure helper mirroring runtime token resolution (symmetric canonical/legacy fallback) so the gate matches *exactly* whether telegram will run (no false-pass / false-block).
- **D001 unchanged** — still warns (log / foreground eprintln) regardless of token, preserving the existing signal.

### B — quickstart auto-fill (interactive only)
`detect_group` already polls `getUpdates` for the group_id; it now also returns the **sole sender's** user_id (new pure `extract_single_sender` — `Some` ONLY when exactly one distinct sender, so a stranger messaging during the poll never auto-allowlists the wrong user). `generate_fleet_yaml` writes it into `user_allowlist`, so a fresh quickstart yields a usable channel. Multi/zero sender, reused config, and unattended keep the `[]` TODO template (A1 backstops it).

### Scope guards (per lead)
- A1 is **daemon-start-only** — foreground/app keep their existing operator-attached eprintln; successor-handoff/app boot are untouched (avoids the brick risk of a universal `resolve_fleet` Err).
- The **200-vs-300** const inconsistency (`HEADER_SIZE_THRESHOLD`) is unrelated to this issue and out of scope.
- B is interactive-only (no network in unattended).

### §3.10 RED→GREEN
- token-gate: drop `&& token_set` → no-token blocks → `gates_on_token_presence` FAILS
- single-sender: `== 1` → `>= 1` → 2-sender returns Some → `none_for_multiple_distinct` FAILS
- auto-fill plumbing: force the None branch → id absent → `auto_fills_allowlist_for_single_sender` FAILS

All reverted to GREEN. quickstart + doctor modules (64 tests) pass; `cargo fmt` + `clippy --tests --features tray` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
