### PR TITLE
fix(t-127 PR1): bridge reviewer verdict→review task — auto-close ghosts + clear stuck sidecar

### DIFF
--- a/docs/design/t127-noise-root-fix.md
+++ b/docs/design/t127-noise-root-fix.md
@@ -1,0 +1,85 @@
+# t-127 Design Spike — review-verdict terminal auto-close + dispatch-stuck sidecar close (noise root-fix)
+
+**Status:** SPIKE (analysis only — no production code yet). For lead dialectic (dual reviewer).
+**Freshness:** origin/main 946facb6. **Author:** fixup-dev-2.
+
+## 1. Problem (empirical)
+
+1. **Ghost review tasks pile up** (#2222/#2224/#2226 dual-review tasks: `updated_at == created_at`, never closed).
+2. **Stuck-watchdog false-pings** — r4 nudged "stuck 30min" **5× in one round** on already-VERIFIED review dispatches.
+
+## 2. Root cause — the task's framing is HALF the story
+
+The task attributes (1) to "`terminal` defaults false for verdicts" and (2) to "sidecar not closed on terminal report". Reading the code (946facb6), the **deeper, shared root cause** is a **correlation-key mismatch**:
+
+A reviewer's terminal verdict is sent as `kind=report` with **`correlation_id = "<owner>/<repo>@<branch>"`** (NOT the task id). This is REQUIRED — the pr-state/ci-handoff pipeline keys on `repo@branch` + `reviewed_head` to record the verdict and aggregate the dual-merge gate:
+- `messaging.rs:591-599` comment: *"a report carrying the handoff's `repo@branch` correlation (reviewer verdicts do) RESOLVES the ci-handoff track"*.
+- `daemon/pr_state/mod.rs:record_verdict` keys on `reviewed_head` → `[review-verdict]` message keyed `repo@branch`.
+
+But BOTH the dispatch sidecar AND the review task are keyed on **`t-xxx`**:
+- The review-dispatch sidecar (`dispatch_idle::record_dispatch`) stores `correlation_id = outbound_corr = msg.correlation_id.or(task_id)` = the review **task id** `t-94` (`messaging.rs:516,548`).
+- The review task itself is `t-94`.
+
+So in the report handler (`messaging.rs:584-609`), with `corr = repo@branch`:
+- `mark_resolved(repo@branch)` → scans sidecars for `correlation_id == repo@branch` → **the `t-94` sidecar never matches → not cleared → watchdog fires** (root of #2).
+- `auto_close_on_report` is gated behind `if corr.starts_with("t-")` → `repo@branch` skips it entirely → **the `t-94` task never closes** (root of #1). The `terminal` default is a *second* lock behind this — even if the verdict carried `t-94`, `terminal.unwrap_or(false)` would still block it.
+
+**Conclusion:** fixing "`terminal=false`" alone is insufficient — the verdict report never reaches the `t-xxx`-keyed machinery at all. The fix must **bridge `repo@branch` → the review task `t-xxx`** at verdict time, then reuse the existing, correct machinery.
+
+## 3. Existing machinery to reuse (do NOT rebuild)
+
+| Primitive | Location | What it already does correctly |
+|---|---|---|
+| `auto_close_on_report` | `tasks/auto_close.rs:7-75` | Gates: `terminal` + `kind==report` + status whitelist (incl. `InReview` #1942) + **`assignee==reporter`** (self-close guard #2010). Closes the task. |
+| `detect_verdict(summary)` | `mcp/handlers/comms_gates` (used `comms.rs:442`) | Parses leading `VERIFIED/REJECTED/UNVERIFIED` (§3.12). **Daemon already classifies a report as a verdict** — no reliance on reviewer flags. |
+| `mark_resolved` / `cleanup_pending_for_task_id` | `dispatch_idle/mod.rs:604,341` | Deletes sidecar(s) under per-sidecar lock. **Closing the task (`cleanup_pending_for_task_id`, #1018) already clears the sidecar** — so fix A transitively achieves fix B for VERIFIED. |
+| branch→task reverse lookup | `daemon/auto_release.rs:231` (`filter(|t| t.branch.as_deref()==Some(branch))`); link written by `link_branch_to_task` #1942 (`tasks/mod.rs:259`, stores `record.branch`) | Resolves a branch to its linked task(s). The review dispatch carries `branch=` (reviewers get a bound worktree on the PR branch), so `t-94.branch == PR branch` is set at dispatch time. |
+| pr-state aggregation | `daemon/pr_state/scanner.rs:162-193` | `[pr-ready-for-merge]` is emitted by the SCANNER from verdict aggregation, **orthogonal to task lifecycle** → closing a review task does NOT affect merge-readiness. ✅ Safe. |
+
+## 4. Proposed design (KISS, single choke point)
+
+**Choke point:** the `kind=="report"` branch of `track_dispatch` (`messaging.rs:584-610`) — the one place both the MCP and API-fallback send routes converge, and where `mark_resolved` + `auto_close` already live.
+
+**New bridge (additive — does not touch the existing `corr.starts_with("t-")` path):**
+
+When the report is a **verdict** (`detect_verdict(msg.text).is_some()` AND `reviewed_head` present) and `corr` is a `repo@branch` (not `t-`):
+1. Extract `branch` from `corr` (split once on `@`, take the tail).
+2. Resolve **review task(s)**: replay tasks, `filter(branch == <branch> && assignee == reporter && status ∈ {Open,Claimed,InProgress,Blocked,InReview})`. (Reporter-scoped → dual reviewers never cross-close.)
+3. For each resolved `t-xxx`:
+   - **Always** (any verdict — the reviewer responded → not stuck): `mark_resolved(home, t-xxx)` → clears its dispatch sidecar. **(fix B)**
+   - **If `VERIFIED`**: `auto_close_on_report(home, "report", t-xxx, reporter, text, terminal=true)` — `terminal=true` synthesized internally (root fix: independent of the reviewer setting any flag). **(fix A)**
+
+This reuses every existing gate (`assignee==reporter`, status whitelist) and the existing sidecar-clear, adding only the `repo@branch → t-xxx` bridge.
+
+## 5. Decision points (for dialectic / operator)
+
+- **DP1 — REJECTED/UNVERIFIED → close the review task?**
+  - The reviewer's *job* ("review PR #X") is arguably done on ANY verdict. But a REJECTED PR gets re-reviewed after rework — if the re-review **reuses** the same task, closing it loses tracking; if a **fresh** review task is dispatched, closing is correct.
+  - **Recommendation (conservative, minimal-blast):** **only `VERIFIED` auto-closes the task.** This directly kills the empirical ghost-accumulation (the ghosts were all VERIFIED). REJECTED/UNVERIFIED leave the task open for lead/reviewer to manage re-review. The **sidecar still clears on any verdict** (the reviewer responded → silence the stuck-nudge regardless of verdict).
+- **DP2 — Bridge source: branch↔task link (recommended) vs sidecar-stores-branch vs reviewer-carries-task_id.**
+  - Recommend the **branch↔task reverse lookup** (existing #1942 link + `auto_release.rs:231` pattern) — single source of truth, daemon-side, behavior-independent. (Sidecar-stores-branch is a viable alt if a review dispatch is ever found NOT to carry `branch=`; reviewer-carries-task_id is rejected — relies on agent behavior, not a root fix.)
+  - **Verify-before-impl:** confirm review dispatches reliably set `branch=` (so `t-94.branch` is populated). If not, fall back to DP2-alt (store `branch` on the sidecar from `params["branch"]` at `record_dispatch`).
+- **DP3 — fire-once latch hardening (noise-reduction defense-in-depth).** Even with the bridge, a sidecar `delete` failure (disk/lock) lets `scan_and_emit` re-fire. **Optional:** add a `reported_at: Option<String>` latch to `PendingDispatch` (mirrors the existing `long_running_escalated` latch, mod.rs:102), set in `mark_resolved` before delete; `scan_and_emit` skips firing if set. Recommend **include** — it's the noise-reduction "fire-once > repeat" principle and cheap.
+
+## 6. Related (separable) — t-116 quota-wedge fire-once
+
+`health.rs` already has `BlockedReason::QuotaExceeded` and `check_quota_gate` blocks *dispatch* to a quota-blocked agent (`messaging.rs:635`), but `scan_and_emit` still pings. **Fix:** in `scan_and_emit`, when the target's health reason is `QuotaExceeded`/`AwaitingOperator`, escalate-once + latch (reuse the `long_running_escalated` idiom) instead of re-pinging every 30 min. **Recommend a SEPARATE small PR** (different subsystem from the verdict bridge; keeps each PR surgical + independently reviewable).
+
+## 7. noise-reduction lens (operator priority)
+
+- **When NOT to send:** sidecar cleared the instant the reviewer responds (any verdict) → no post-response stuck-ping.
+- **Dedup/latch:** `reported_at` latch (DP3) + existing `long_running_escalated`/`not_working_streak` debounce; quota-wedge fire-once (§6).
+- **Auto-collect not manual:** VERIFIED auto-closes the review task → no lead `task done` drift → no ghost accumulation.
+
+## 8. Phasing (post-dialectic)
+
+- **PR1:** verdict→task bridge in `track_dispatch` (fix A VERIFIED-close + fix B any-verdict sidecar-clear) + DP3 latch. Behavioral repro: dual review dispatch → reviewer VERIFIED with `repo@branch` corr → assert task closed + sidecar gone + (control) REJECTED leaves task open but sidecar cleared. **dual-review (concurrency: sidecar RMW under lock #2028).**
+- **PR2 (separable):** §6 quota-wedge fire-once latch in `scan_and_emit`. **dual-review.**
+- Backlog cleanup of existing #2217–#2225 ghosts: **lead** via `task sweep` dry-run→confirm (out of code scope).
+
+## 9. Blast / risk
+
+- Bridge is additive; existing `t-` correlation path untouched → non-verdict reports + implementer task reports byte-identical.
+- `assignee==reporter` gate + reporter-scoped branch filter → cannot cross-close another reviewer's task or an implementer task.
+- pr-state merge-gate orthogonal → no merge-readiness regression.
+- Main risk: a review dispatch lacking `branch=` (→ DP2-alt) — verify first.

--- a/src/api/handlers/messaging.rs
+++ b/src/api/handlers/messaging.rs
@@ -608,6 +608,12 @@ fn track_dispatch(
                 );
             }
         }
+        // #t-127: bridge a reviewer VERDICT back to its review TASK + sidecar. A
+        // verdict is keyed on `repo@branch` (pr-state pipeline) OR the task id, but
+        // the review task + dispatch sidecar are `t-…`-keyed — so the `corr`-keyed
+        // handling above MISSES a `repo@branch` verdict (left review tasks ghosting
+        // + the sidecar firing spurious "stuck" nudges after the reviewer replied).
+        bridge_verdict_to_review_task(home, from, msg);
     } else if matches!(kind_str, "update" | "query") {
         // #1923 G8: key the dispatch-idle refresh by the SAME correlation as the
         // WRITE side above (~:496 records the pending-dispatch sidecar under
@@ -619,6 +625,57 @@ fn track_dispatch(
         if let Some(corr) = msg.correlation_id.as_deref().or(msg.task_id.as_deref()) {
             let _ = crate::daemon::dispatch_idle::refresh_issued_at(home, corr);
         }
+    }
+}
+
+/// #t-127: bridge a reviewer VERDICT report back to its review TASK + dispatch
+/// sidecar, root-fixing two symptoms with one mechanism:
+/// - **ghost review tasks** — VERIFIED verdicts never auto-closed their review
+///   task (the `auto_close_on_report` call above is gated on `corr.starts_with("t-")`,
+///   but a verdict's `corr` is `repo@branch`), so they piled up unclosed.
+/// - **spurious stuck-nudges** — the dispatch sidecar is `t-…`-keyed, so
+///   `mark_resolved(repo@branch)` never cleared it and the watchdog kept pinging
+///   "stuck 30min" after the reviewer had already replied.
+///
+/// Resolution is dual-path (cheaper + branch-independent — dual-2/GH-diff review
+/// dispatches carry NO branch, so a branch reverse-lookup would structurally miss
+/// them):
+/// - if the report's correlation IS a `t-…` → use it directly (exact);
+/// - else (`repo@branch` / none) → `open_review_dispatch_for_reporter` reverse-looks
+///   the reporter's single OPEN dispatch sidecar (exactly-one fail-safe).
+///
+/// Then: ANY verdict clears the sidecar (the reviewer responded → not stuck);
+/// only VERIFIED auto-closes the review task (REJECTED/UNVERIFIED stay open for the
+/// re-review cycle). `terminal=true` is synthesized internally for VERIFIED, so the
+/// close does NOT depend on the reviewer setting the flag (the root fix). Closing
+/// the task is orthogonal to the pr-state merge gate (the scanner aggregates
+/// verdicts by `reviewed_head`, independent of task lifecycle).
+fn bridge_verdict_to_review_task(home: &Path, reporter: &str, msg: &crate::inbox::InboxMessage) {
+    use crate::mcp::handlers::comms_gates::{detect_verdict, Verdict};
+    // Only ACTUAL verdict reports: a leading VERIFIED/REJECTED/UNVERIFIED token
+    // (§3.12) AND a `reviewed_head` SHA (every reviewer verdict carries it, #1024).
+    let Some(verdict) = detect_verdict(&msg.text) else {
+        return;
+    };
+    if msg.reviewed_head.is_none() {
+        return;
+    }
+    let corr = msg.correlation_id.as_deref().or(msg.task_id.as_deref());
+    let task_id: Option<String> = match corr {
+        Some(c) if c.starts_with("t-") => Some(c.to_string()),
+        _ => crate::daemon::dispatch_idle::open_review_dispatch_for_reporter(home, reporter),
+    };
+    let Some(task_id) = task_id else {
+        return;
+    };
+    // Any verdict → the reviewer responded → clear the dispatch sidecar (kills the
+    // post-response stuck-nudge), regardless of VERIFIED vs REJECTED.
+    let _ = crate::daemon::dispatch_idle::mark_resolved(home, &task_id);
+    // Only VERIFIED closes the review task. terminal=true synthesized internally.
+    if matches!(verdict, Verdict::Verified) {
+        let _ = crate::tasks::auto_close::auto_close_on_report(
+            home, "report", &task_id, reporter, &msg.text, true,
+        );
     }
 }
 
@@ -2901,6 +2958,201 @@ mod tests {
             pr_state::is_merge_ready(&state),
             "#2079: a short-SHA verdict buffered BEFORE CI must drain (prefix-match) when the full \
              head is observed and flip merge-ready; state={state:?}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    // ── #t-127: reviewer-verdict → review-task bridge (ghost-close + sidecar) ──
+
+    fn seed_review_task(home: &std::path::Path, task_id: &str, reviewer: &str) {
+        use crate::task_events::{InstanceName, TaskEvent, TaskId};
+        let emitter = InstanceName::from("test:seed");
+        let tid = TaskId(task_id.into());
+        crate::task_events::append_batch(
+            home,
+            &emitter,
+            vec![
+                TaskEvent::Created {
+                    task_id: tid.clone(),
+                    title: "review PR".into(),
+                    description: String::new(),
+                    priority: "normal".into(),
+                    owner: None,
+                    due_at: None,
+                    depends_on: Vec::new(),
+                    routed_to: None,
+                    branch: None,
+                    bind: None,
+                    eta_secs: None,
+                    tags: vec![],
+                    parent_id: None,
+                },
+                TaskEvent::Claimed {
+                    task_id: tid,
+                    by: InstanceName::from(reviewer),
+                },
+            ],
+        )
+        .expect("seed review task");
+    }
+
+    fn task_status_of(
+        home: &std::path::Path,
+        task_id: &str,
+    ) -> Option<crate::task_events::TaskStatus> {
+        crate::task_events::replay(home)
+            .unwrap_or_default()
+            .tasks
+            .get(&crate::task_events::TaskId(task_id.into()))
+            .map(|r| r.status)
+    }
+
+    fn sidecar_present(home: &std::path::Path, task_id: &str) -> bool {
+        crate::daemon::dispatch_idle::list_pending(home)
+            .iter()
+            .any(|d| d.correlation_id.as_deref() == Some(task_id))
+    }
+
+    fn t127_verdict(verdict_text: &str, corr: &str) -> crate::inbox::InboxMessage {
+        crate::inbox::InboxMessage::new_system("system:reviewer", "report", verdict_text)
+            .with_correlation_id(corr.to_string())
+            .with_reviewed_head("7e1d4228bea3cf7fe2d72aab66015297308b48bc".to_string())
+    }
+
+    fn record_review_dispatch(home: &std::path::Path, dispatcher: &str, reviewer: &str, tid: &str) {
+        crate::daemon::dispatch_idle::record_dispatch(
+            home,
+            dispatcher,
+            reviewer,
+            Some(tid),
+            "task",
+            1800,
+        )
+        .expect("review dispatch sidecar");
+    }
+
+    /// Case (a) dual-1: verdict carries the TASK id (`corr=t-…`). VERIFIED must
+    /// auto-close the task (terminal synthesized) AND clear the dispatch sidecar.
+    #[test]
+    fn verdict_dual1_taskid_verified_closes_task_and_clears_sidecar_t127() {
+        let home = tmp_home("t127-dual1");
+        let _ = std::fs::remove_dir_all(&home);
+        std::fs::create_dir_all(&home).unwrap();
+        let reviewer = "fixup-reviewer-6";
+        seed_review_task(&home, "t-rev-1", reviewer);
+        record_review_dispatch(&home, "fixup-lead", reviewer, "t-rev-1");
+
+        bridge_verdict_to_review_task(
+            &home,
+            reviewer,
+            &t127_verdict("VERIFIED looks good", "t-rev-1"),
+        );
+
+        assert_eq!(
+            task_status_of(&home, "t-rev-1"),
+            Some(crate::task_events::TaskStatus::Done),
+            "dual-1 VERIFIED (corr=t-…) must auto-close the review task"
+        );
+        assert!(
+            !sidecar_present(&home, "t-rev-1"),
+            "the dispatch sidecar must be cleared"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Case (b) dual-2: verdict carries `repo@branch` (NO task id; GH-diff review
+    /// dispatches have no branch on the task either). The bridge must reverse-look
+    /// the reporter's single open dispatch sidecar to reach the task. (RED pre-fix:
+    /// `auto_close` is gated on `corr.starts_with("t-")` → repo@branch never closes.)
+    #[test]
+    fn verdict_dual2_repobranch_verified_bridges_via_reverse_lookup_t127() {
+        let home = tmp_home("t127-dual2");
+        let _ = std::fs::remove_dir_all(&home);
+        std::fs::create_dir_all(&home).unwrap();
+        let reviewer = "fixup-reviewer-4";
+        seed_review_task(&home, "t-rev-2", reviewer);
+        record_review_dispatch(&home, "fixup-lead", reviewer, "t-rev-2");
+
+        bridge_verdict_to_review_task(
+            &home,
+            reviewer,
+            &t127_verdict("VERIFIED diff clean", "owner/repo@feat/x"),
+        );
+
+        assert_eq!(
+            task_status_of(&home, "t-rev-2"),
+            Some(crate::task_events::TaskStatus::Done),
+            "dual-2 VERIFIED (corr=repo@branch) must bridge via reverse-lookup and close the task"
+        );
+        assert!(
+            !sidecar_present(&home, "t-rev-2"),
+            "sidecar must be cleared via the reverse-lookup bridge"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// REJECTED → the reviewer responded, so the sidecar clears (no more stuck-ping),
+    /// but the review task stays OPEN for the re-review cycle (only VERIFIED closes).
+    #[test]
+    fn verdict_rejected_clears_sidecar_but_keeps_task_open_t127() {
+        let home = tmp_home("t127-rejected");
+        let _ = std::fs::remove_dir_all(&home);
+        std::fs::create_dir_all(&home).unwrap();
+        let reviewer = "fixup-reviewer-2";
+        seed_review_task(&home, "t-rev-3", reviewer);
+        record_review_dispatch(&home, "fixup-lead", reviewer, "t-rev-3");
+
+        bridge_verdict_to_review_task(
+            &home,
+            reviewer,
+            &t127_verdict("REJECTED found a bug", "owner/repo@feat/x"),
+        );
+
+        assert!(
+            !sidecar_present(&home, "t-rev-3"),
+            "any verdict clears the sidecar (reviewer responded → not stuck)"
+        );
+        assert_eq!(
+            task_status_of(&home, "t-rev-3"),
+            Some(crate::task_events::TaskStatus::Claimed),
+            "REJECTED must NOT close the review task (re-review pending)"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Exactly-one fail-safe: a reporter with MULTIPLE open dispatches (from distinct
+    /// dispatchers, so #1866 handoff-retire doesn't collapse them) → ambiguous → the
+    /// bridge skips (mis-closing the wrong task is worse than a lingering ghost).
+    #[test]
+    fn verdict_reverse_lookup_skips_when_reporter_has_multiple_open_dispatches_t127() {
+        let home = tmp_home("t127-multi");
+        let _ = std::fs::remove_dir_all(&home);
+        std::fs::create_dir_all(&home).unwrap();
+        let reviewer = "fixup-reviewer-3";
+        seed_review_task(&home, "t-rev-a", reviewer);
+        seed_review_task(&home, "t-rev-b", reviewer);
+        record_review_dispatch(&home, "fixup-lead", reviewer, "t-rev-a");
+        record_review_dispatch(&home, "fixup-dev", reviewer, "t-rev-b");
+
+        bridge_verdict_to_review_task(
+            &home,
+            reviewer,
+            &t127_verdict("VERIFIED ok", "owner/repo@feat/x"),
+        );
+
+        assert_eq!(
+            task_status_of(&home, "t-rev-a"),
+            Some(crate::task_events::TaskStatus::Claimed),
+            "ambiguous reverse-lookup must NOT close t-rev-a"
+        );
+        assert_eq!(
+            task_status_of(&home, "t-rev-b"),
+            Some(crate::task_events::TaskStatus::Claimed),
+            "ambiguous reverse-lookup must NOT close t-rev-b"
+        );
+        assert!(
+            sidecar_present(&home, "t-rev-a") && sidecar_present(&home, "t-rev-b"),
+            "ambiguous → both sidecars remain (fail-safe: no mis-close)"
         );
         std::fs::remove_dir_all(&home).ok();
     }

--- a/src/daemon/dispatch_idle/mod.rs
+++ b/src/daemon/dispatch_idle/mod.rs
@@ -109,6 +109,15 @@ pub(crate) struct PendingDispatch {
     /// SUPPRESS a real nudge.
     #[serde(default)]
     pub(crate) exceeded_at: Option<String>,
+    /// #t-127: fire-once latch — set the moment a correlated REPORT arrives
+    /// (`mark_resolved`), ATOMIC with the sidecar delete under the per-file lock.
+    /// Normally the delete removes the sidecar outright; but if the delete FAILS
+    /// (disk/permission) the persisted latch makes `scan_and_emit` SKIP the stale
+    /// sidecar instead of firing a spurious "stuck" nudge for a dispatch the
+    /// reviewer already answered. Mirrors the `long_running_escalated` latch.
+    /// Reset to `None` on re-dispatch (a fresh episode).
+    #[serde(default)]
+    pub(crate) reported_at: Option<String>,
 }
 
 /// #2008-p2: max activity-based deadline extensions before the watchdog escalates
@@ -201,6 +210,34 @@ fn delete_sidecar_locked(home: &Path, dispatch_id: &str) -> bool {
     removed
 }
 
+/// #t-127: persist the `reported_at` fire-once latch THEN delete the sidecar,
+/// both UNDER the single `{dispatch_id}.lock` acquisition (atomic with the
+/// delete). A report arriving disarms the watchdog; the normal path is the
+/// delete, but if the `remove_file` FAILS the latch is already on disk, so
+/// `scan_and_emit` sees `reported_at.is_some()` and skips firing a spurious
+/// nudge instead of resurrecting the noise. Same lock as the L1/L2 RMW (no
+/// resurrection race; correct `{id}.lock` removal). Returns `true` iff removed.
+fn mark_reported_and_delete_locked(home: &Path, dispatch_id: &str) -> bool {
+    let path = pending_path(home, dispatch_id);
+    let lock_path = dispatch_lock_path(home, dispatch_id);
+    let guard = crate::store::acquire_file_lock(&lock_path).ok();
+    // Persist the latch BEFORE the delete so a failed remove still leaves it set.
+    if let Ok(content) = std::fs::read_to_string(&path) {
+        if let Ok(mut pd) = serde_json::from_str::<PendingDispatch>(&content) {
+            if pd.reported_at.is_none() {
+                pd.reported_at = Some(chrono::Utc::now().to_rfc3339());
+                if let Ok(body) = serde_json::to_string_pretty(&pd) {
+                    let _ = crate::store::atomic_write(&path, body.as_bytes());
+                }
+            }
+        }
+    }
+    let removed = std::fs::remove_file(&path).is_ok();
+    drop(guard);
+    let _ = std::fs::remove_file(&lock_path);
+    removed
+}
+
 /// Generate a deterministic-format dispatch id (`disp-<unix_micros>-<seq>`).
 fn next_dispatch_id() -> String {
     use std::sync::atomic::{AtomicU64, Ordering};
@@ -269,6 +306,10 @@ pub(crate) fn record_dispatch(
             // stale — clear it so L2's second-window timer restarts from the next
             // real Exceeded transition (L1 re-stamps `exceeded_at` then).
             existing.exceeded_at = None;
+            // #t-127: a re-dispatch is a fresh episode — clear the report latch so
+            // the revived sidecar's watchdog is armed again (a stale latch would
+            // permanently suppress the new dispatch's nudge).
+            existing.reported_at = None;
             // CR-2026-06-14: persist the refreshed episode under the per-file flock
             // via with_json_state — NOT a bare unlocked write of the list_pending
             // snapshot. scan_and_emit concurrently re-reads and flips the SAME
@@ -307,6 +348,7 @@ pub(crate) fn record_dispatch(
         refresh_count: 0,
         long_running_escalated: false,
         exceeded_at: None,
+        reported_at: None,
     };
     let body = match serde_json::to_string_pretty(&payload) {
         Ok(s) => s,
@@ -625,7 +667,9 @@ pub(crate) fn mark_resolved(home: &Path, correlation_id: &str) -> Option<String>
         // [M2] DELETE the sidecar (rather than flip to `Resolved` and leave the
         // file to accumulate — the pre-fix primary `pending-dispatches/` leak)
         // UNDER its lock, so a concurrent team-nudge / L1 RMW can't resurrect it.
-        if delete_sidecar_locked(home, &d.dispatch_id) {
+        // #t-127: latch `reported_at` atomically with the delete, so a failed
+        // remove still disarms the watchdog (see `mark_reported_and_delete_locked`).
+        if mark_reported_and_delete_locked(home, &d.dispatch_id) {
             first_deleted.get_or_insert(d.dispatch_id);
         } else {
             // #2004: a matching sidecar whose delete failed WILL fire a
@@ -640,6 +684,43 @@ pub(crate) fn mark_resolved(home: &Path, correlation_id: &str) -> Option<String>
         }
     }
     first_deleted
+}
+
+/// #t-127: resolve the single OPEN dispatch sidecar TARGETING `reporter` to its
+/// review-task id (the sidecar's `t-…` `correlation_id`). Bridges a reviewer
+/// VERDICT report — keyed on `repo@branch`, NOT the task id — back to the review
+/// task + its sidecar, which are both `t-…`-keyed (so `mark_resolved(repo@branch)`
+/// and the `corr.starts_with("t-")` auto-close gate both miss them).
+///
+/// EXACTLY-ONE fail-safe: returns `None` if 0 or >1 candidates, so a reporter
+/// with concurrent reviews never mis-closes the WRONG task (mis-closing another's
+/// task is worse than leaving a ghost). The #1866 clear-on-handoff retire keeps
+/// this ≤1 open per (dispatcher, target) in the common case, so the single-match
+/// path is the norm. Only `Pending`/`Exceeded` sidecars with a `t-` correlation
+/// count.
+pub(crate) fn open_review_dispatch_for_reporter(home: &Path, reporter: &str) -> Option<String> {
+    if reporter.is_empty() {
+        return None;
+    }
+    let mut candidates: Vec<String> = list_pending(home)
+        .into_iter()
+        .filter(|d| {
+            d.target == reporter
+                && matches!(d.status, DispatchStatus::Pending | DispatchStatus::Exceeded)
+                && d.correlation_id
+                    .as_deref()
+                    .map(|c| c.starts_with("t-"))
+                    .unwrap_or(false)
+        })
+        .filter_map(|d| d.correlation_id)
+        .collect();
+    candidates.sort();
+    candidates.dedup();
+    if candidates.len() == 1 {
+        candidates.pop()
+    } else {
+        None
+    }
 }
 
 /// #1047: reset the timer on a pending sidecar when the dispatchee sends
@@ -910,6 +991,13 @@ pub(crate) fn scan_and_emit(home: &Path) {
     let snapshot = crate::snapshot::load(home);
     for d in list_pending(home) {
         if d.status != DispatchStatus::Pending {
+            continue;
+        }
+        // #t-127: a correlated report already arrived (reviewer responded) but its
+        // sidecar delete failed — the persisted `reported_at` latch survives that
+        // failure. Don't fire a spurious "stuck" nudge; retry the delete and move on.
+        if d.reported_at.is_some() {
+            delete_sidecar_locked(home, &d.dispatch_id);
             continue;
         }
         let issued = match chrono::DateTime::parse_from_rfc3339(&d.issued_at) {
@@ -1437,6 +1525,7 @@ mod tests {
             not_working_streak: 0,
             refresh_count: 0,
             long_running_escalated: false,
+            reported_at: None,
             exceeded_at: None,
         };
         std::fs::write(
@@ -2427,6 +2516,7 @@ mod tests {
             not_working_streak: 0,
             refresh_count: 0,
             long_running_escalated: false,
+            reported_at: None,
             exceeded_at: None,
         };
         assert_eq!(

--- a/src/daemon/dispatch_idle/team_nudge.rs
+++ b/src/daemon/dispatch_idle/team_nudge.rs
@@ -293,6 +293,7 @@ mod tests {
             not_working_streak: 0,
             refresh_count: 0,
             long_running_escalated: false,
+            reported_at: None,
             // Exceeded LONG enough ago that the #2031 second escalation window has
             // elapsed — so these mechanics tests (dedup / targeting / multiteam /
             // correlation) still see the nudge fire. The window-timing itself is
@@ -363,6 +364,7 @@ mod tests {
             not_working_streak: 0,
             refresh_count: 0,
             long_running_escalated: false,
+            reported_at: None,
             exceeded_at,
         };
         std::fs::write(
@@ -610,6 +612,7 @@ mod tests {
             not_working_streak: 0,
             refresh_count: 0,
             long_running_escalated: false,
+            reported_at: None,
             exceeded_at: None,
         };
         let path = pending_path(&home, &id);
@@ -749,6 +752,7 @@ mod tests {
             not_working_streak: 0,
             refresh_count: 0,
             long_running_escalated: false,
+            reported_at: None,
             // Exceeded LONG enough ago that the #2031 second escalation window has
             // elapsed — so these mechanics tests (dedup / targeting / multiteam /
             // correlation) still see the nudge fire. The window-timing itself is

--- a/src/mcp/handlers/comms_gates/mod.rs
+++ b/src/mcp/handlers/comms_gates/mod.rs
@@ -12,7 +12,11 @@ mod evidence_gate;
 mod sha_gate;
 
 // Report-path gates (handle_report_result).
-pub(super) use evidence_gate::{check_evidence_gate, cross_check_and_log, detect_verdict};
+pub(super) use evidence_gate::{check_evidence_gate, cross_check_and_log};
+// #t-127: `detect_verdict` + `Verdict` are also consumed by the api-layer
+// dispatch tracker (the verdict→review-task bridge in `track_dispatch`), so they
+// are crate-visible, not just `pub(super)`.
+pub(crate) use evidence_gate::{detect_verdict, Verdict};
 pub(super) use sha_gate::{check_sha_gate, fetch_pr_head_sha};
 
 // Send-invariant gate (handle_unified_send).


### PR DESCRIPTION
## t-127 PR1 (noise root-fix) — design dialectic-approved (r6 corrected; lead ratified)

Design spike: `docs/design/t127-noise-root-fix.md` (in this PR). r6 REJECTED the original branch-reverse-lookup (dual-2/GH-diff dispatches carry **no branch** → structurally misses them) and corrected the premise (`record_verdict` keys on **reviewed_head SHA**, not repo@branch). This PR implements the **branch-independent** corrected design.

## Root cause (two symptoms, one mechanism)
A reviewer's terminal verdict is `kind=report` keyed on `repo@branch` (or the task id), but the review **task** + its dispatch **sidecar** are both `t-…`-keyed. In `track_dispatch`'s report branch:
- `mark_resolved(repo@branch)` misses the `t-…` sidecar → watchdog fires spurious **"stuck 30min"** nudges after the reviewer replied (r4: 5× in one round).
- `auto_close_on_report` is gated behind `corr.starts_with("t-")` → a `repo@branch` VERIFIED **never closes** the review task → **ghost accumulation** (#2222/#2224/#2226: `updated_at==created_at`).

## Fix — `bridge_verdict_to_review_task` (api/handlers/messaging.rs)
At the report choke point, for a verdict report (`detect_verdict` + `reviewed_head` present):
1. **Resolve the review task (dual-path)**: `corr=t-…` → use directly (exact); else (`repo@branch`/none) → `open_review_dispatch_for_reporter` reverse-looks the reporter's single OPEN dispatch sidecar.
   - **EXACTLY-ONE fail-safe**: skip if 0 or >1 candidates — a reporter with concurrent reviews never mis-closes the wrong task (mis-close ≫ ghost). #1866 clear-on-handoff keeps this ≤1 per dispatcher in the common case (verified).
2. **ANY verdict → clear the sidecar** (`mark_resolved`) — the reviewer responded → not stuck (kills the post-response nudge), regardless of VERIFIED/REJECTED.
3. **Only VERIFIED → auto-close the task** — `terminal=true` synthesized internally (root fix: independent of the reviewer setting the flag). REJECTED/UNVERIFIED stay open for the re-review cycle.

## DP3 — fire-once latch (noise-reduction defense-in-depth)
`PendingDispatch` gains `reported_at`, set **atomic with the delete** (`mark_reported_and_delete_locked`, under the per-file lock) so a failed `remove_file` still disarms `scan_and_emit` (it skips a latched sidecar instead of re-firing). Mirrors the `long_running_escalated` latch; reset on re-dispatch.

## Safety / blast
- **Orthogonal to the pr-state merge gate** — the scanner aggregates verdicts by `reviewed_head`, independent of task lifecycle; closing a review task does NOT affect `[pr-ready-for-merge]`.
- **Scoped to verdicts** — `detect_verdict` + `reviewed_head` gate; an implementer's done-report (no `reviewed_head`) skips the bridge and uses the existing path. `assignee==reporter` (in `auto_close_on_report`) + reporter-scoped reverse-lookup → cannot cross-close another's task.
- `detect_verdict`/`Verdict` widened `pub(super)`→`pub(crate)` for the api-layer reuse (1-line visibility change).

## Tests — behavioral repro, 4 cases (true RED without the bridge: 3/4 fail when neutered; the 4th is a no-action guard)
- `verdict_dual1_taskid_verified_closes_task_and_clears_sidecar_t127`
- `verdict_dual2_repobranch_verified_bridges_via_reverse_lookup_t127` (the key dual-2 case)
- `verdict_rejected_clears_sidecar_but_keeps_task_open_t127`
- `verdict_reverse_lookup_skips_when_reporter_has_multiple_open_dispatches_t127` (exactly-one fail-safe)

## Checks
- `cargo fmt --check` ✓, `cargo clippy --all-targets --features tray -D warnings` ✓
- dispatch_idle (79) + auto_close (13) + messaging (53) suites pass; 4 t127 tests pass.
- 2 standing preflight failures are **pre-existing & unrelated** (touched files: dispatch_idle, comms_gates, messaging): `dispatch_branch_..._1834` = agent-env git-shim false-fail (passes with `AGEND_GIT_BYPASS=1`); `unclassified_throttle_...` = parallel-load flake (passes in isolation, #2187-fixed on main).

t-116 quota-wedge fire-once = separate PR2 (different subsystem). infra / concurrency → **dual review**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)