### PR TITLE
fix(#2117 Q2): resolve depends_on across project boards

### DIFF
--- a/src/daemon/task_sweep.rs
+++ b/src/daemon/task_sweep.rs
@@ -357,7 +357,7 @@ fn sweep_board_with_prs(
 
     // Snapshot of THIS board's currently-open tasks (read via the P1 `_at`
     // variant so a merged PR is matched only against tasks on its own board).
-    let open_tasks = crate::tasks::list_all_at(&board);
+    let open_tasks = crate::tasks::list_all_at(home, &board);
     let open_ids: std::collections::HashMap<String, &crate::tasks::Task> = open_tasks
         .iter()
         .filter(|t| {
@@ -1145,7 +1145,7 @@ mod tests {
         );
 
         let status_on = |project: &str, id: &str| -> crate::task_events::TaskStatus {
-            crate::tasks::list_all_at(&crate::task_events::board_root(&home, project))
+            crate::tasks::list_all_at(&home, &crate::task_events::board_root(&home, project))
                 .into_iter()
                 .find(|t| t.id == id)
                 .unwrap_or_else(|| panic!("task {id} not found on board {project}"))

--- a/src/mcp/handlers/dispatch_hook/tests.rs
+++ b/src/mcp/handlers/dispatch_hook/tests.rs
@@ -879,7 +879,7 @@ teams:
     // invariant on the literal log path). The auto-created task must be on the
     // TARGET's (teamB) board …
     let on_board =
-        |proj: &str| crate::tasks::list_all_at(&crate::task_events::board_root(&home, proj));
+        |proj: &str| crate::tasks::list_all_at(&home, &crate::task_events::board_root(&home, proj));
     assert_eq!(
         on_board("orgB_projB").len(),
         1,

--- a/src/tasks/board_router.rs
+++ b/src/tasks/board_router.rs
@@ -400,7 +400,7 @@ pub(super) fn list_all_boards(home: &Path) -> Vec<(String, Vec<Task>)> {
     enumerate_projects(home)
         .into_iter()
         .map(|project| {
-            let tasks = super::list_all_at(&board_root(home, &project));
+            let tasks = super::list_all_at(home, &board_root(home, &project));
             (project, tasks)
         })
         .collect()

--- a/src/tasks/handler.rs
+++ b/src/tasks/handler.rs
@@ -253,7 +253,7 @@ fn handle_list(home: &Path, caller: &str, args: &Value) -> Value {
             .as_str()
             .map(String::from)
             .unwrap_or_else(|| super::board_router::resolve_current_project(home, caller));
-        super::list_all_at(&crate::task_events::board_root(home, &project))
+        super::list_all_at(home, &crate::task_events::board_root(home, &project))
     };
     let mut filtered: Vec<Task> = tasks
         .iter()
@@ -377,7 +377,10 @@ fn handle_claim(
     let board = super::board_router::board_for_task(home, &id);
     let result = crate::task_events::append_checked_at(&board, &emitter, event, |state| {
         let mut tasks: Vec<Task> = state.tasks.values().map(record_to_task).collect();
-        super::apply_dependency_eval_in_memory(&mut tasks);
+        // #2117 Q2: cross-board dep eval — a claim gate on a task whose
+        // `depends_on` points at another project's board must read that board's
+        // status, not just this one's. Pass home + the task's board.
+        super::apply_dependency_eval_in_memory(&mut tasks, home, &board);
         let tv = tasks
             .iter()
             .find(|t| t.id == claim_id)

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -124,15 +124,85 @@ fn load(home: &Path) -> TaskStore {
     )
 }
 
-/// Evaluate dependency status for a single task.
-/// Returns the effective status after considering depends_on:
+/// #2117 Q2 cross-board dependency resolver. Resolves a `depends_on` id's
+/// PERSISTED status, reaching beyond the local board when a dep isn't found
+/// locally. Built once per eval pass with a per-board replay cache, so a board
+/// with many cross-board deps replays each foreign board at most once (no
+/// per-dep replay explosion). Single-project / same-board deps resolve from
+/// `local` alone and never touch the filesystem → byte-identical to the
+/// pre-#2117 path.
+///
+/// We only ever ask "is this dep Done". `Done` is a PERSISTED status (never
+/// dep-derived), so a raw cross-board replay is authoritative — no need to
+/// recursively dep-evaluate a foreign task (and no cross-board cycles).
+struct DepResolver<'a> {
+    home: &'a Path,
+    /// The board the current pass's tasks live on. A dep that resolves back to
+    /// this board is, by construction, already covered by `local` (absent here =
+    /// absent there) → skip the redundant replay.
+    local_board: &'a Path,
+    local: std::collections::HashMap<String, crate::task_events::TaskStatus>,
+    /// Memoized `resolve_task_project` per dep_id (its index-miss fallback is a
+    /// full-board scan — resolve each distinct dep at most once per pass).
+    proj_cache: std::collections::HashMap<String, String>,
+    /// Lazily-replayed foreign boards: board path → {task_id → status}.
+    board_cache: std::collections::HashMap<
+        std::path::PathBuf,
+        std::collections::HashMap<String, crate::task_events::TaskStatus>,
+    >,
+}
+
+impl<'a> DepResolver<'a> {
+    fn new(home: &'a Path, local_board: &'a Path, snapshot: &[Task]) -> Self {
+        let local = snapshot.iter().map(|t| (t.id.clone(), t.status)).collect();
+        Self {
+            home,
+            local_board,
+            local,
+            proj_cache: std::collections::HashMap::new(),
+            board_cache: std::collections::HashMap::new(),
+        }
+    }
+
+    /// Persisted status of `dep_id`, or `None` if it exists nowhere reachable
+    /// (treated as not-done → blocking, matching the pre-#2117 missing-dep rule).
+    fn status_of(&mut self, dep_id: &str) -> Option<crate::task_events::TaskStatus> {
+        if let Some(s) = self.local.get(dep_id) {
+            return Some(*s);
+        }
+        let project = self
+            .proj_cache
+            .entry(dep_id.to_string())
+            .or_insert_with(|| board_router::resolve_task_project(self.home, dep_id))
+            .clone();
+        let board = crate::task_events::board_root(self.home, &project);
+        if board.as_path() == self.local_board {
+            // Resolves back to the local board → already covered by `local`
+            // (and definitively absent, since the local check above missed).
+            return None;
+        }
+        let map = self.board_cache.entry(board.clone()).or_insert_with(|| {
+            crate::task_events::replay_at(&board)
+                .map(|st| {
+                    st.tasks
+                        .iter()
+                        .map(|(id, r)| (id.0.clone(), r.status))
+                        .collect()
+                })
+                .unwrap_or_default()
+        });
+        map.get(dep_id).copied()
+    }
+}
+
+/// Evaluate dependency status for a single task against a [`DepResolver`].
 /// - open + any dep not done → "blocked"
 /// - blocked + all deps done → "open" (auto-unblock)
 /// - claimed/done/cancelled → unchanged
-///
-/// Uses a visited set to prevent infinite loops on circular deps
-/// (circular → treated as blocked).
-pub fn evaluate_dependency_status(tasks: &[Task], task: &Task) -> crate::task_events::TaskStatus {
+fn evaluate_with_resolver(
+    resolver: &mut DepResolver,
+    task: &Task,
+) -> crate::task_events::TaskStatus {
     use crate::task_events::TaskStatus;
     if task.depends_on.is_empty()
         || matches!(
@@ -142,13 +212,10 @@ pub fn evaluate_dependency_status(tasks: &[Task], task: &Task) -> crate::task_ev
     {
         return task.status;
     }
-    let all_deps_done = task.depends_on.iter().all(|dep_id| {
-        tasks
-            .iter()
-            .find(|t| t.id == *dep_id)
-            .map(|t| t.status == TaskStatus::Done)
-            .unwrap_or(false) // missing dep → not done → blocked
-    });
+    let all_deps_done = task
+        .depends_on
+        .iter()
+        .all(|dep_id| resolver.status_of(dep_id) == Some(TaskStatus::Done));
     if all_deps_done {
         if task.status == TaskStatus::Blocked {
             TaskStatus::Open
@@ -164,10 +231,17 @@ pub fn evaluate_dependency_status(tasks: &[Task], task: &Task) -> crate::task_ev
 /// list-time, **not** persisted as Blocked/Unblocked events. The event
 /// log captures only explicit operator/agent transitions; dep-derived
 /// status is a view-layer concern, not part of the canonical history.
-fn apply_dependency_eval_in_memory(tasks: &mut [Task]) {
+///
+/// #2117 Q2: `home` + `board` enable cross-board dep resolution — a dep on
+/// another project's board is read from that board (cached), so a satisfied
+/// cross-board dependency auto-unblocks and an unsatisfied one blocks. `board`
+/// is the board these `tasks` were replayed from. Single-project → every dep is
+/// local → byte-identical.
+fn apply_dependency_eval_in_memory(tasks: &mut [Task], home: &Path, board: &Path) {
     let snapshot: Vec<Task> = tasks.to_vec();
+    let mut resolver = DepResolver::new(home, board, &snapshot);
     for task in tasks.iter_mut() {
-        let effective = evaluate_dependency_status(&snapshot, task);
+        let effective = evaluate_with_resolver(&mut resolver, task);
         if effective != task.status {
             task.status = effective;
         }
@@ -234,16 +308,21 @@ pub fn load_by_id(home: &Path, task_id: &str) -> Option<Task> {
 /// per m-42); explicit operator-emitted Blocked/Unblocked events are
 /// honoured by replay's `apply()` as before.
 pub fn list_all(home: &Path) -> Vec<Task> {
-    list_all_at(home)
+    list_all_at(home, home)
 }
 
 /// #2117 P1: list a specific board's tasks (board-root replay + in-memory dep
-/// eval). `list_all(home)` is exactly `list_all_at(home)` — byte-identical,
+/// eval). `list_all(home)` is exactly `list_all_at(home, home)` — byte-identical,
 /// since `home` is the default board root (`board_root(home, DEFAULT)`).
-pub(crate) fn list_all_at(board: &Path) -> Vec<Task> {
+///
+/// #2117 Q2: `home` is threaded so the in-memory dep eval can resolve a task's
+/// `depends_on` across project boards (a dep on another board is read from that
+/// board, cached per pass). For single-project deployments every dep is on this
+/// same board → no cross-board read → byte-identical.
+pub(crate) fn list_all_at(home: &Path, board: &Path) -> Vec<Task> {
     let state = crate::task_events::replay_at(board).unwrap_or_default();
     let mut tasks: Vec<Task> = state.tasks.values().map(record_to_task).collect();
-    apply_dependency_eval_in_memory(&mut tasks);
+    apply_dependency_eval_in_memory(&mut tasks, home, board);
     tasks
 }
 

--- a/src/tasks/tests.rs
+++ b/src/tasks/tests.rs
@@ -1095,6 +1095,153 @@ fn test_task_auto_unblock_when_all_deps_done() {
     std::fs::remove_dir_all(&home).ok();
 }
 
+// ── #2117 Q2: cross-board depends_on resolution (multi-project) ──
+
+/// Multi-project fleet: teamA(devA)@orgA/projA, teamB(devB)@orgB/projB. A task
+/// created by devA lands on board orgA_projA; by devB on orgB_projB.
+fn cross_board_fleet(home: &std::path::Path) {
+    let yaml = r#"
+instances:
+  devA:
+    backend: claude
+  devB:
+    backend: claude
+teams:
+  teamA:
+    members:
+      - devA
+    source_repo: /repos/orgA/projA
+  teamB:
+    members:
+      - devB
+    source_repo: /repos/orgB/projB
+"#;
+    std::fs::write(crate::fleet::fleet_yaml_path(home), yaml).unwrap();
+}
+
+fn create_on(home: &std::path::Path, caller: &str, title: &str, deps: &[String]) -> String {
+    handle(
+        home,
+        caller,
+        &serde_json::json!({
+            "action": "create", "title": title, "assignee": caller, "depends_on": deps
+        }),
+    )["id"]
+        .as_str()
+        .unwrap()
+        .to_string()
+}
+
+fn status_via_list(home: &std::path::Path, caller: &str, title: &str) -> String {
+    handle(home, caller, &serde_json::json!({"action": "list"}))["tasks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|t| t["title"] == title)
+        .unwrap_or_else(|| panic!("task '{title}' not in {caller}'s list"))["status"]
+        .as_str()
+        .unwrap()
+        .to_string()
+}
+
+/// Manifestation 1 (list display): A@teamA depends_on B@teamB; B open → A blocked.
+/// Pre-#2117-Q2 this was ALSO blocked, but for the wrong reason (dep not found
+/// on the local board) — here the dep genuinely exists and is genuinely open.
+#[test]
+fn cross_board_dep_not_done_blocks_dependent_2117_q2() {
+    let home = tmp_home("xboard-blocked");
+    cross_board_fleet(&home);
+    let b = create_on(&home, "devB", "B", &[]);
+    create_on(&home, "devA", "A", &[b]);
+    assert_eq!(
+        status_via_list(&home, "devA", "A"),
+        "blocked",
+        "A must be blocked by its cross-board dep B (open on teamB)"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// Manifestation 2 (auto-unblock): completing B@teamB unblocks A@teamA. This is
+/// the bug the resolver fixes — pre-Q2, A stayed Blocked FOREVER because the
+/// eval never looked at teamB's board to see B was Done.
+#[test]
+fn cross_board_dep_done_unblocks_dependent_2117_q2() {
+    let home = tmp_home("xboard-unblock");
+    cross_board_fleet(&home);
+    let b = create_on(&home, "devB", "B", &[]);
+    create_on(&home, "devA", "A", std::slice::from_ref(&b));
+    assert_eq!(status_via_list(&home, "devA", "A"), "blocked");
+    handle(
+        &home,
+        "devB",
+        &serde_json::json!({"action": "done", "id": b, "result": "ok"}),
+    );
+    assert_eq!(
+        status_via_list(&home, "devA", "A"),
+        "open",
+        "A must auto-unblock once its cross-board dep B is done"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// Manifestation 3 (claim gate): A cannot be claimed while B@teamB is open; the
+/// claim precondition must read teamB's board for B's status, not just teamA's.
+#[test]
+fn cross_board_dep_gates_claim_2117_q2() {
+    let home = tmp_home("xboard-claim");
+    cross_board_fleet(&home);
+    let b = create_on(&home, "devB", "B", &[]);
+    let a = create_on(&home, "devA", "A", std::slice::from_ref(&b));
+    let rejected = handle(
+        &home,
+        "devA",
+        &serde_json::json!({"action": "claim", "id": a}),
+    );
+    assert!(
+        rejected["error"].as_str().is_some(),
+        "claim must be rejected while cross-board dep B is open: {rejected}"
+    );
+    handle(
+        &home,
+        "devB",
+        &serde_json::json!({"action": "done", "id": b, "result": "ok"}),
+    );
+    let ok = handle(
+        &home,
+        "devA",
+        &serde_json::json!({"action": "claim", "id": a}),
+    );
+    assert!(
+        ok["error"].is_null(),
+        "claim must succeed after cross-board dep B is done: {ok}"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// Control (single-board within a multi-project fleet): a same-board dep still
+/// blocks/unblocks via the local-first path — the cross-board machinery does not
+/// alter same-board behavior (the byte-identical local resolution guarantee).
+#[test]
+fn same_board_dep_in_multiproject_fleet_byte_identical_2117_q2() {
+    let home = tmp_home("xboard-control");
+    cross_board_fleet(&home);
+    // Both tasks created by devA → both on teamA's board.
+    let dep = create_on(&home, "devA", "dep", &[]);
+    create_on(&home, "devA", "child", std::slice::from_ref(&dep));
+    assert_eq!(status_via_list(&home, "devA", "child"), "blocked");
+    handle(
+        &home,
+        "devA",
+        &serde_json::json!({"action": "done", "id": dep, "result": "ok"}),
+    );
+    assert_eq!(
+        status_via_list(&home, "devA", "child"),
+        "open",
+        "same-board dep eval unchanged inside a multi-project fleet"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
 /// PR3 — depends_on is set in the Created event and immutable via
 /// the MCP surface (no "depends_on update" event variant). Circular
 /// deps can still arise from migration of a circular legacy
@@ -1420,7 +1567,7 @@ fn cross_project_parent_id_rejected_at_create_2117_p3a() {
     );
     // And nothing was written to teamB's board.
     assert!(
-        super::list_all_at(&crate::task_events::board_root(&home, "orgB/projB")).is_empty(),
+        super::list_all_at(&home, &crate::task_events::board_root(&home, "orgB/projB")).is_empty(),
         "rejected subtask must not land on any board"
     );
 
@@ -1499,7 +1646,7 @@ teams:
         );
     }
     // Nothing mutated — task still Open on board B (slug `orgB_projB`).
-    let tb_status = super::list_all_at(&crate::task_events::board_root(&home, "orgB_projB"))
+    let tb_status = super::list_all_at(&home, &crate::task_events::board_root(&home, "orgB_projB"))
         .into_iter()
         .find(|t| t.id == tb)
         .unwrap()


### PR DESCRIPTION
## #2117 Q2 — resolve `depends_on` across project boards

Phase 2a of the #2117 multi-project epic (operator chose option A — full cross-board resolver; scoping spike confirmed this was the real gap). **Review class: DUAL** (correctness, cross-cutting task-board data flow).

### The bug
Per-project boards (P1–P3b) route each task to its project's board, but the in-memory dependency eval (`evaluate_dependency_status`) only searched the **local** board's task slice. A task whose `depends_on` pointed at a task on **another** project's board could never find it → treated as not-done → **Blocked forever** even after the dep completed, and **un-claimable**. `create` already allows cross-board `depends_on` unguarded (`handler.rs`), so this was a real stored-but-broken correctness bug for multi-project fleets.

### Fix — single choke point, three manifestations
Both eval call sites route through `apply_dependency_eval_in_memory`, so fixing it there fixes all three manifestations at once: **auto-unblock**, **`task list` display**, and the **claim precondition gate**.

- **`DepResolver`** resolves a dep_id's PERSISTED status, **local-first**. A dep on another board triggers **ONE cached replay** of that board, shared by every dep pointing at it (per-board cache + memoized `resolve_task_project`) — no per-dep replay explosion. We only ask "is it Done"; `Done` is persisted (never dep-derived) → a raw cross-board replay is authoritative → **no cross-board recursion / cycles**.
- `apply_dependency_eval_in_memory(tasks, home, board)` + `list_all_at(home, board)` gain `home`; ~8 callers updated (all already had `home`). Claim precondition passes the task's resolved board + home.
- The unused `evaluate_dependency_status(&[Task], …)` wrapper (no remaining callers — only an archived doc referenced it) was removed; `evaluate_with_resolver` carries the block/auto-unblock logic.

### Single-project byte-identical
Every dep is on the home/DEFAULT board → resolved from `local` alone → no `resolve_task_project`, no extra replay, no behavior change. Existing dep tests + the control case below + 219 tasks/dep tests pass unchanged.

### §3.10 RED→GREEN (two-project fleet: teamA@orgA/projA, teamB@orgB/projB)
- `cross_board_dep_not_done_blocks_dependent` — A@teamA depends_on open B@teamB → blocked
- `cross_board_dep_done_unblocks_dependent` — done B@teamB → A auto-unblocks to open
- `cross_board_dep_gates_claim` — claim A rejected while B open, succeeds after B done
- `same_board_dep_in_multiproject_fleet_byte_identical` — control (local path unchanged)

Mutation (skip the cross-board lookup → `return None`) makes exactly the two positive cross-board cases (unblock + claim) FAIL while blocked + control stay GREEN; reverted to GREEN. `cargo fmt` + `clippy --tests --features tray` clean.

### Out of scope
Q1 (flat→per-board backfill) is a separate operator-decision item (see scoping spike); not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
