### PR TITLE
test(flake): de-flake unclassified_throttle repro (#[serial] + own-record filter)

### DIFF
--- a/src/state/review_repro_state_capture.rs
+++ b/src/state/review_repro_state_capture.rs
@@ -79,7 +79,13 @@ const SRL_LINE: &str = "API Error: Server is temporarily limiting requests (not 
 // non-retryable state therefore appends a FULL-screen JSONL record on every
 // PTY read of the SAME screen — unbounded file growth.
 
+// #[serial]: this test mutates the process-global `AGEND_HOME` env var
+// (set_var below). The sibling `state::tests` AGEND_HOME tests are already
+// `#[serial]`; without joining that serial group this test races them on the
+// shared env var under parallel `cargo test` (writes scatter across homes →
+// nondeterministic record count), which surfaced as a flaky Coverage-job RED.
 #[test]
+#[serial_test::serial]
 fn unclassified_throttle_static_screen_logs_once_not_per_tick() {
     // Isolate the on-disk sidecar to a throwaway HOME so we don't touch the
     // operator's real $AGEND_HOME/unclassified_errors.jsonl.
@@ -111,7 +117,17 @@ fn unclassified_throttle_static_screen_logs_once_not_per_tick() {
     }
 
     let contents = std::fs::read_to_string(&path).unwrap_or_default();
-    let records = contents.lines().filter(|l| !l.trim().is_empty()).count();
+    // Count ONLY this test's own records (matched by its distinctive screen
+    // text). `capture_unclassified_throttle` writes to the PROCESS-GLOBAL
+    // `AGEND_HOME`-derived path, so any concurrently-running feed()-driven test
+    // can append to this same file while our `set_var` is in effect — filtering
+    // by our screen makes the assertion immune to that cross-test pollution
+    // (the #[serial] marker prevents it among serial tests; this covers any
+    // non-serial feeder too).
+    let records = contents
+        .lines()
+        .filter(|l| l.contains("Overloaded errors are transient"))
+        .count();
     let _ = std::fs::remove_file(&path);
 
     assert!(


### PR DESCRIPTION
## De-flake `unclassified_throttle_static_screen_logs_once_not_per_tick`

The long-standing "known flake → just re-run coverage" test. **Review class: SINGLE** (§3.6, test-only, single file). Root cause found during #2230's CI triage.

### Root cause
`state::review_repro_state_capture::unclassified_throttle_static_screen_logs_once_not_per_tick` passes isolated / `--test-threads=1` but FAILS in the parallel `state::` module run on clean main. It does `set_var("AGEND_HOME", temp)` (process-global) and asserts the **count** of lines in `<AGEND_HOME>/unclassified_errors.jsonl`. But `StateTracker::capture_unclassified_throttle` writes that file via the process-global `home_dir()`, so any concurrently-running `feed()`-driven test (e.g. the sibling `srl_*` repros in this file) appends to the **same** file while our `set_var` is live → the count is inflated by other tests' records → `records <= 1` fails nondeterministically. (The fire-once latch is a per-tracker field and was never the bug.)

### Fix (test-only)
- `#[serial_test::serial]` — the AGEND_HOME mutation no longer interleaves with the other serial state tests.
- Count **only this test's own records** (filter by its distinctive screen text) instead of every line → immune to cross-test pollution from any non-serial feeder too. The latch is still genuinely exercised: a regressed latch writes the same screen 6× → 6 matching records → FAIL.

### Verification
Full `state::` parallel run passes **3/3** (was reliably failing). `cargo fmt` + `clippy --tests --features tray` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
