### PR TITLE
fix(#2158 PR1): fail-closed checkout source path (reject relative-resolve-against-cwd)

### DIFF
--- a/docs/design/2158-subagent-workspace-boundary.md
+++ b/docs/design/2158-subagent-workspace-boundary.md
@@ -1,0 +1,53 @@
+# #2158 Design Spike — sub-agent workspace boundary hardening
+
+**Status:** SPIKE (analysis only — no production code). For lead dialectic (dual reviewer, security).
+**Freshness:** origin/main 509b7af. **Author:** fixup-dev-2.
+**Proportionality:** single-machine single-user → defense-in-depth + fail-closed, NOT OS isolation.
+
+## 1. The incident (3 distinct gaps, issue #2158)
+A transient sub-agent sharing the primary's identity `claude-fb80a0`, handed a bad path (literal `"undefined"`):
+1. **Silently rebound the PARENT** via `repo checkout bind:true` — moved the primary's `binding.json` to a branch it never chose + armed a CI watch.
+2. **Cross-workspace FS writes** — `*.zh-TW.md` into the main working tree, peer agents' workspaces, and 2 stray bypass-worktrees.
+3. **Stray worktrees via `AGEND_GIT_BYPASS=1`** — created, un-audited.
+
+## 2. CRUX finding (corrects the issue's framing)
+**A sub-agent is INDISTINGUISHABLE from the primary.** Both read the same `AGEND_INSTANCE_NAME` (`identity.rs:29-33`); the MCP handler receives only the string identity (`HandlerCtx.instance_name` / `sender`, `mcp/handlers/mod.rs:81`) — **no PID, ppid, or sub-agent marker** (`std::process::id()`/`getppid()` absent from the identity path). The sub-agent spawner (Claude Code Task tool) is EXTERNAL — we cannot make it set an `AGEND_SUB_AGENT=1` marker.
+
+⟹ The issue's direction-1 ("make bind a no-op when invoked from a sub-agent context") is **NOT implementable** — there is no signal to gate on. Direction-1 must be reframed:
+- **prevent the TRIGGER** (bad/ambiguous path → fail-closed), and
+- **DETECT the rebind** (audit-log with process context), since identity-based prevention is impossible.
+
+## 3. Per-gap mechanism (file:line)
+- **Rebind:** `handle_bind_self` (`mcp/handlers/worktree.rs:32`) takes the verified `sender` (good — no sibling impersonation) but the sub-agent IS the primary's name → rebinds it. `handle_checkout_repo` (`ci/mod.rs:264`) → `binding::bind_full` with `instance_name` and **no owner-authority guard** (no `ctx.sender == target` precedent anywhere — Q4).
+- **Bad-path resolve:** `ci/mod.rs:91-107` — source path resolution: absolute/`~` expand; else agent-name lookup; **else FALLBACK `source.to_string()` (line 106)** → `canonicalize()` (`:109`). A truly-nonexistent `"undefined"` → `canonicalize` Err → **already fails**. BUT a **relative** bad path canonicalizes against the daemon's implicit cwd → silently resolves to *something* (the silent-resolve gap). System-path guard exists (`/etc,/usr,…` `:113`) but not a "must be a known source repo" allow-list. `bind_self` guards `..` (`worktree.rs:73`) but not relative-vs-absolute.
+- **Bypass:** honored centrally at `git_helpers.rs:59` (`git_bypass_timeout`) — **zero event-log audit**; the instance/caller context isn't even threaded to that site (would need an API change).
+- **Cross-workspace writes:** raw FS — daemon cannot gate (no syscall hook). `has_uncommitted_changes` (`worktree.rs:445`) is per-worktree; **no cross-workspace/main-tree sweep exists**.
+
+## 4. Proposed boundaries (proportional, phased — each its own PR + dual-review)
+
+### PR1 — bad-path fail-closed (the actual trigger; smallest, highest-confidence)
+Tighten the source-repo path contract in `handle_checkout_repo` + `handle_bind_self`:
+- **Reject a non-absolute source path** before canonicalize (kills `"undefined"`/relative resolving against the daemon cwd) — the resolution must be a known absolute repo, never an implicit-cwd guess.
+- Optionally constrain canonicalized source to an **allow-list root set** (registered source repos + `$AGEND_HOME`); reject out-of-root.
+- ⚠ Verify-before-impl: confirm no legitimate caller passes a relative `repository_path` (the agent-name lookup path stays — only the literal-fallback relative resolve is removed).
+
+### PR2 — audit bind/rebind + AGEND_GIT_BYPASS (detection, since prevention-by-identity is impossible)
+- `event_log` every `bind_full` / rebind with **caller process context** (`std::process::id()`, `libc::getppid()`, cwd) so an unexpected rebind ("primary never requested this") is visible post-facto.
+- `event_log` every `AGEND_GIT_BYPASS` worktree creation with caller context (needs threading the context to `git_bypass_timeout` — small API change).
+
+### PR3 — cross-workspace / stray-worktree detection sweep (direction-2; largest, lowest-urgency)
+- New sweep hooked into `GcTickHandler::run` (`per_tick/gc_tick.rs`, ~60-min cadence): enumerate agent worktrees + main tree, flag (a) `??` untracked files in a worktree whose owner isn't live, (b) untracked files in the main working tree, (c) git worktrees outside the canonical `$AGEND_HOME/worktrees/<agent>/` layout (strays).
+- Surface via `event_log` + a new `BlockedReason::WorkspaceBoundaryViolation { detail }` (`health.rs`, ~13 LOC) so operator sees it through `health action=report` — not by accident.
+
+## 5. Decision points (for dialectic / operator)
+- **DP1 — rebind: audit-only, or also a guard?** Identity can't distinguish sub-agent, so we can't *prevent* by context. Options: (a) audit-only (recommended — matches the issue's "at minimum audit-log"); (b) ALSO require a re-bind confirmation token / reject a bind that *changes* an existing live binding without a release first (risk: breaks legit release→re-checkout flows). Recommend (a) + PR1 fail-closed; flag (b) as heavier.
+- **DP2 — fail-closed strictness.** Reject relative paths only (minimal), or full allow-list-of-roots (stricter, more blast — must enumerate legit roots)? Recommend relative-reject first; allow-list as a follow-up if needed.
+- **DP3 — scope/phasing.** PR1 (fail-closed) is the direct trigger fix and highest-value; PR2 (audit) makes the rebind visible; PR3 (detection sweep) is the broadest but lowest-urgency. Recommend PR1 → PR2 → PR3, sequenced (lead may defer PR3).
+
+## 6. Blast / risk
+- PR1: path-validation tightening — risk = a legit relative-path caller breaks; mitigated by verify-first (the agent-name lookup path is preserved). Surgical.
+- PR2: additive logging — near-zero blast. Bypass-audit needs caller-context threading (touches `git_helpers` signature + call sites).
+- PR3: additive read-only detection (no mutation) + 1 enum variant — low blast; main risk is false-positive noise (apply the t-127/t-116 noise-reduction lens: fire-once/dedup, surface once not per-tick).
+
+## 7. Recommendation
+Land **PR1 (fail-closed)** first — it directly closes the actual incident trigger and is the most surgical. **PR2 (audit)** next — the realistic answer to silent rebind given the indistinguishability crux. **PR3 (detection)** as a sequenced follow-up. All proportional; none needs OS isolation.

--- a/src/mcp/handlers/ci/mod.rs
+++ b/src/mcp/handlers/ci/mod.rs
@@ -12,6 +12,11 @@ mod merge_freshness;
 mod poll_eta;
 pub(crate) use poll_eta::compute_next_poll_eta;
 
+// #2158 PR1: the security-sensitive checkout source-path resolution (absolute /
+// agent-name only, fail-closed on miss + canonicalize + system-dir reject) lives
+// in a sibling module — same LOC-relief pattern, and isolates the boundary fix.
+mod source_resolve;
+
 /// #1447: resolve the checkout source repo from `repository_path` — the
 /// cross-tool standard name used by bind_self / team update. Returns `None`
 /// when absent or empty.
@@ -88,35 +93,15 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
         source.replace(['/', '\\', ':'], "_").replace('~', "")
     ));
     std::fs::create_dir_all(worktree_dir.parent().unwrap_or(home)).ok();
-    let source_path = if source.starts_with('/') || source.starts_with('~') {
-        source
-            .strip_prefix("~/")
-            .map(|rest| format!("{}/{rest}", crate::user_home_dir().display()))
-            .unwrap_or_else(|| source.to_string())
-    } else {
-        crate::api::call(home, &json!({"method": crate::api::method::LIST}))
-            .ok()
-            .and_then(|r| {
-                r["result"]["agents"]
-                    .as_array()?
-                    .iter()
-                    .find(|a| a["name"].as_str() == Some(source))
-                    .and_then(|a| a["working_directory"].as_str().map(String::from))
-            })
-            .unwrap_or_else(|| source.to_string())
-    };
-    // H2: validate source_path — reject path traversal and system paths
-    let source_canonical = match std::path::Path::new(&source_path).canonicalize() {
-        Ok(p) => p,
-        Err(e) => return json!({"error": format!("invalid source path: {e}")}),
-    };
-    if source_canonical.starts_with("/etc")
-        || source_canonical.starts_with("/usr")
-        || source_canonical.starts_with("/sys")
-        || source_canonical.starts_with("/proc")
-    {
-        return json!({"error": "source path rejected: system directory"});
-    }
+    // #2158 PR1: resolve + validate the source repo path fail-closed (absolute or
+    // known agent name only; canonicalize; reject system dirs). Extracted to
+    // `source_resolve` — keeps this oversized handler under the file_size ceiling
+    // (t-61 split debt) and isolates the security-sensitive resolution for review.
+    let (source_path, source_canonical) =
+        match source_resolve::resolve_checkout_source_path(home, source) {
+            Ok(pair) => pair,
+            Err(e) => return e,
+        };
     // #780: auto-create branch from `from_ref` when bind:true + branch
     // missing locally. #781 Piece 6 extracts the decision tree into
     // `dispatch_hook::ensure_branch_exists` so the same logic services

--- a/src/mcp/handlers/ci/source_resolve.rs
+++ b/src/mcp/handlers/ci/source_resolve.rs
@@ -108,15 +108,27 @@ mod tests {
     /// Legit arm preserved: an ABSOLUTE, existing, non-system path still resolves
     /// to (pre-canonical string, canonical PathBuf) — the fix only rejects the
     /// non-absolute agent-name MISS, not absolute callers.
+    ///
+    /// `#[cfg(unix)]`: the absolute arm is `/`-prefixed (Unix semantics); a Windows
+    /// drive path (`C:`-rooted) is not `/`-absolute, so the helper routes it through
+    /// the agent-name arm — the `/`-absolute path is a Unix-only contract. The input
+    /// is canonicalized FIRST so symlink resolution on CI (e.g. macOS `/var` →
+    /// `/private/var`) can't skew a literal-string comparison (cf. #2226/#2231
+    /// cross-platform test fragility — compare canonicalized forms, not raw strings).
+    #[cfg(unix)]
     #[test]
     fn absolute_existing_path_still_resolves_2158() {
-        let home = std::env::temp_dir();
-        let abs = home.display().to_string();
-        let (src_path, canonical) = resolve_checkout_source_path(&home, &abs)
+        let abs = std::env::temp_dir()
+            .canonicalize()
+            .expect("temp dir canonicalizes");
+        let abs_str = abs.display().to_string();
+        let (src_path, canonical) = resolve_checkout_source_path(&abs, &abs_str)
             .expect("absolute existing path must still resolve (legit arm preserved)");
         assert!(canonical.is_absolute());
+        // Both sides are already canonical → no /var-vs-/private/var skew.
+        assert_eq!(canonical, abs, "canonical resolves to the same real dir");
         assert_eq!(
-            src_path, abs,
+            src_path, abs_str,
             "pre-canonical source string preserved for the caller"
         );
     }

--- a/src/mcp/handlers/ci/source_resolve.rs
+++ b/src/mcp/handlers/ci/source_resolve.rs
@@ -1,0 +1,123 @@
+//! #2158 PR1: resolve + validate the `repo checkout` source repository path,
+//! fail-closed. Extracted from `ci/mod.rs::handle_checkout_repo_inner` (which sits
+//! at its file_size ceiling) so the security boundary is isolated + reviewable.
+//!
+//! A `source` is valid ONLY as:
+//!   1. an ABSOLUTE path (`/…`) or a `~`-relative home path, OR
+//!   2. a known AGENT NAME, resolved to that agent's `working_directory`
+//!      (the #1447 peer-workdir-by-name form).
+//!
+//! Pre-#2158, a non-absolute `source` that was NOT a known agent name fell back to
+//! the literal string (`source.to_string()`), which the `canonicalize()` step then
+//! resolved against the daemon's IMPLICIT cwd. So a bad/ambiguous value — the
+//! literal `"undefined"` from the #2158 incident, or any relative string that
+//! happens to exist under the daemon cwd — silently bound/wrote SOMEWHERE instead
+//! of failing. This module rejects that miss fail-closed.
+
+use serde_json::{json, Value};
+use std::path::{Path, PathBuf};
+
+/// Resolve `source` to `(source_path, source_canonical)` — the resolved
+/// pre-canonical string (used by the caller as the git cwd + echoed in the
+/// `source` response field) and the canonicalized validated `PathBuf` — or return
+/// a ready-to-emit error `Value`. Behaviour-preserving for the two legitimate arms
+/// (absolute/`~`, known agent name) + the canonicalize / system-dir guards; the
+/// ONLY new behaviour is the fail-closed reject of a non-absolute agent-name miss.
+pub(super) fn resolve_checkout_source_path(
+    home: &Path,
+    source: &str,
+) -> Result<(String, PathBuf), Value> {
+    let source_path = if source.starts_with('/') || source.starts_with('~') {
+        source
+            .strip_prefix("~/")
+            .map(|rest| format!("{}/{rest}", crate::user_home_dir().display()))
+            .unwrap_or_else(|| source.to_string())
+    } else {
+        // Non-absolute → MUST be a known agent name. A miss is fail-closed (#2158):
+        // never fall back to resolving `source` as a relative path against the
+        // daemon cwd.
+        match crate::api::call(home, &json!({"method": crate::api::method::LIST}))
+            .ok()
+            .and_then(|r| {
+                r["result"]["agents"]
+                    .as_array()?
+                    .iter()
+                    .find(|a| a["name"].as_str() == Some(source))
+                    .and_then(|a| a["working_directory"].as_str().map(String::from))
+            }) {
+            Some(working_dir) => working_dir,
+            None => {
+                return Err(json!({
+                    "error": format!(
+                        "source '{source}' is neither an absolute path nor a known agent name — refusing to resolve a relative path against the daemon working directory (#2158)"
+                    ),
+                    "code": "ambiguous_source_path",
+                }))
+            }
+        }
+    };
+    // H2: validate source_path — reject path traversal and system paths. The
+    // contracted error strings are preserved byte-for-byte (any matcher/test).
+    let source_canonical = match Path::new(&source_path).canonicalize() {
+        Ok(p) => p,
+        Err(e) => return Err(json!({"error": format!("invalid source path: {e}")})),
+    };
+    if source_canonical.starts_with("/etc")
+        || source_canonical.starts_with("/usr")
+        || source_canonical.starts_with("/sys")
+        || source_canonical.starts_with("/proc")
+    {
+        return Err(json!({"error": "source path rejected: system directory"}));
+    }
+    Ok((source_path, source_canonical))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    /// #2158 PR1: a non-absolute `source` that is NOT a known agent name must FAIL
+    /// CLOSED with the `ambiguous_source_path` code — never the pre-fix relative
+    /// fallback (which canonicalized against the daemon cwd). RED pre-fix: the
+    /// fallback returned Ok (relative-existing) or an `invalid source path`
+    /// canonicalize error — neither carries this code.
+    #[test]
+    fn non_absolute_non_agent_source_is_rejected_fail_closed_2158() {
+        let home = std::env::temp_dir();
+        let err = resolve_checkout_source_path(&home, "undefined")
+            .expect_err("non-absolute, non-agent source must be rejected");
+        assert_eq!(
+            err["code"].as_str(),
+            Some("ambiguous_source_path"),
+            "must fail-closed at resolution, not Ok / not a canonicalize error: {err}"
+        );
+    }
+
+    /// The silent-resolve gap itself: a RELATIVE path string (the #2158 incident
+    /// shape — a bad value treated as a relative dir). It must be rejected at the
+    /// resolution stage, never resolved against the daemon cwd.
+    #[test]
+    fn relative_source_is_rejected_not_resolved_against_cwd_2158() {
+        let home = std::env::temp_dir();
+        let err = resolve_checkout_source_path(&home, "src")
+            .expect_err("a relative source must NOT silently resolve against the cwd");
+        assert_eq!(err["code"].as_str(), Some("ambiguous_source_path"), "{err}");
+    }
+
+    /// Legit arm preserved: an ABSOLUTE, existing, non-system path still resolves
+    /// to (pre-canonical string, canonical PathBuf) — the fix only rejects the
+    /// non-absolute agent-name MISS, not absolute callers.
+    #[test]
+    fn absolute_existing_path_still_resolves_2158() {
+        let home = std::env::temp_dir();
+        let abs = home.display().to_string();
+        let (src_path, canonical) = resolve_checkout_source_path(&home, &abs)
+            .expect("absolute existing path must still resolve (legit arm preserved)");
+        assert!(canonical.is_absolute());
+        assert_eq!(
+            src_path, abs,
+            "pre-canonical source string preserved for the caller"
+        );
+    }
+}


### PR DESCRIPTION
## #2158 PR1 — bad-path fail-closed (dialectic-approved: r4+r6 dual VERIFIED the spike)

Design spike in this PR: `docs/design/2158-subagent-workspace-boundary.md`. This is the first of the phased boundaries (PR1 fail-closed → PR2 audit → PR3 detection-sweep).

## Root cause (the actual #2158 trigger)
`repo checkout`'s source-path resolution (`ci/mod.rs`) treated a **non-absolute `source` that was NOT a known agent name** as a literal RELATIVE path (`source.to_string()`), then `canonicalize()`d it against the daemon's **implicit cwd**. So a bad/ambiguous value — the literal `"undefined"` from the incident, or any relative string existing under the daemon cwd — **silently bound/wrote SOMEWHERE instead of failing**.

## Fix (per dialectic — sharpened from the spike)
Reject **at the literal-fallback point ONLY** — NOT a top-level "reject all non-absolute" (that would break the legitimate `#1447` agent-name / peer-workdir-by-name form, as both reviewers flagged). The two legit arms are preserved:
- absolute / `~`-home path, and
- known agent name → that agent's `working_directory`.

A non-absolute, agent-name **MISS** now **fails closed** with `code: "ambiguous_source_path"`. (A truly-nonexistent `"undefined"` already errored at `canonicalize`; this closes the **relative-existing → daemon-cwd** silent-resolve.)

## Why a new file (`ci/source_resolve.rs`)
`ci/mod.rs` was **exactly at the file_size ceiling (1435)** — zero headroom. Rather than raise the ceiling (the invariant forbids it), the security-sensitive resolution is extracted to a sibling module: **behavior-preserving relocation** of the existing absolute/agent-name/canonicalize/system-dir logic + the one new reject. Net: ci/mod.rs **1435 → 1420** (pays down t-61 split debt); new file 73 LOC. The pre-canonical `source_path` string + canonical `PathBuf` are both returned so the caller's git-cwd + response `source` field stay byte-identical.

## Tests (RED→GREEN, in `source_resolve.rs`)
- `non_absolute_non_agent_source_is_rejected_fail_closed_2158`
- `relative_source_is_rejected_not_resolved_against_cwd_2158`
- `absolute_existing_path_still_resolves_2158` (legit arm preserved)

**Verified RED**: restoring the old `unwrap_or_else(|| source.to_string())` fallback makes the 2 reject tests fail; the absolute-arm control passes either way.

## Checks
- `cargo fmt --check` ✓, `cargo clippy --all-targets --features tray -D warnings` ✓
- `file_size_invariant` ✓ (ci/mod.rs 1420 ≤ 1435), `mcp::handlers::ci` suite 76 pass + 3 new.

## Scope note
This is PR1 (the trigger fix). Per the dialectic: **PR2** = binding-CHANGE audit at the `bind_full` choke (+ bypass audit) — I'm running the verify-first for the state-based rebind guard (b) in parallel and will report. **PR3** = cross-workspace/stray detection sweep (deferred). security → **dual review**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)