### PR TITLE
fix(CR-2026-06-14 final cleanup): un-ignore #2166/#2171/state-capture#3 repros + fix router retain ungated push (#39)

### DIFF
--- a/src/daemon/router.rs
+++ b/src/daemon/router.rs
@@ -112,21 +112,34 @@ fn run_loop(home: PathBuf, reg_rx: crossbeam_channel::Receiver<AgentSubscription
 
         // Process PTY events from all subscribed agents.
         let mut had_activity = false;
+        // CR-2026-06-14 #39: senders that disconnected during the drain below,
+        // collected here so the post-loop `buffers.retain` can be a PURE liveness
+        // probe (see its comment) rather than a second, ungated try_recv.
+        let mut disconnected: Vec<String> = Vec::new();
         for (name, buf) in buffers.iter_mut() {
-            while let Ok(data) = buf.rx.try_recv() {
-                had_activity = true;
-                buf.last_output_at = Instant::now();
+            loop {
+                match buf.rx.try_recv() {
+                    Ok(data) => {
+                        had_activity = true;
+                        buf.last_output_at = Instant::now();
 
-                let pair = crate::daemon::heartbeat_pair::snapshot_for(name);
-                if pair.reply_to_channel.is_some() {
-                    buf.active = true;
-                    buf.input_id = pair.reply_to_input_id;
-                    let text = String::from_utf8_lossy(&data);
-                    buf.buffer.push_str(&text);
-                    apply_mirror_cap(&mut buf.buffer);
-                } else {
-                    buf.active = false;
-                    buf.buffer.clear();
+                        let pair = crate::daemon::heartbeat_pair::snapshot_for(name);
+                        if pair.reply_to_channel.is_some() {
+                            buf.active = true;
+                            buf.input_id = pair.reply_to_input_id;
+                            let text = String::from_utf8_lossy(&data);
+                            buf.buffer.push_str(&text);
+                            apply_mirror_cap(&mut buf.buffer);
+                        } else {
+                            buf.active = false;
+                            buf.buffer.clear();
+                        }
+                    }
+                    Err(crossbeam_channel::TryRecvError::Empty) => break,
+                    Err(crossbeam_channel::TryRecvError::Disconnected) => {
+                        disconnected.push(name.clone());
+                        break;
+                    }
                 }
             }
 
@@ -139,15 +152,16 @@ fn run_loop(home: PathBuf, reg_rx: crossbeam_channel::Receiver<AgentSubscription
             }
         }
 
-        buffers.retain(|_, buf| match buf.rx.try_recv() {
-            Ok(data) => {
-                let text = String::from_utf8_lossy(&data);
-                buf.buffer.push_str(&text);
-                true
-            }
-            Err(crossbeam_channel::TryRecvError::Empty) => true,
-            Err(crossbeam_channel::TryRecvError::Disconnected) => false,
-        });
+        // CR-2026-06-14 #39 (correctness): drop buffers whose sender disconnected.
+        // PURE liveness probe — no second try_recv, no payload consumption. The
+        // prior version's `Ok(data) => buf.buffer.push_str(&text)` arm pushed
+        // bytes consumed here into the mirror buffer UNGATED: it ignored the
+        // `reply_to_channel`/`heartbeat_pair` gate (mixing stray bytes in while
+        // mirroring was inactive) and skipped `apply_mirror_cap` (an oversized
+        // chunk bypassed the 2*MAX_MIRROR_LEN cap). All consume + gating now
+        // happens once, in the gated drain loop above; a chunk that races in
+        // after the drain is picked up next iteration through that same path.
+        buffers.retain(|name, _| !disconnected.contains(name));
 
         if !had_activity {
             std::thread::sleep(Duration::from_millis(100));
@@ -502,32 +516,14 @@ mod tests {
         std::fs::remove_dir_all(&home).ok();
     }
 
-    #[test]
-    fn retain_preserves_received_data() {
-        let (tx, rx) = crossbeam_channel::bounded::<Vec<u8>>(8);
-        let mut buffers = std::collections::HashMap::new();
-        buffers.insert(
-            "agent".to_string(),
-            AgentBuffer {
-                rx,
-                buffer: String::new(),
-                active: false,
-                last_output_at: Instant::now(),
-                input_id: None,
-            },
-        );
-        tx.send(b"hello".to_vec()).unwrap();
-        buffers.retain(|_, buf| match buf.rx.try_recv() {
-            Ok(data) => {
-                let text = String::from_utf8_lossy(&data);
-                buf.buffer.push_str(&text);
-                true
-            }
-            Err(crossbeam_channel::TryRecvError::Empty) => true,
-            Err(crossbeam_channel::TryRecvError::Disconnected) => false,
-        });
-        assert_eq!(buffers["agent"].buffer, "hello");
-    }
+    // CR-2026-06-14 #39: `retain_preserves_received_data` was REMOVED. It built a
+    // COPY of the trailing `buffers.retain` closure and asserted its Ok-arm pushed
+    // consumed bytes into `buf.buffer` — i.e. it PINNED the ungated-push bug this
+    // fix removes. The post-fix `buffers.retain` is a pure liveness probe (drops
+    // disconnected buffers, no payload push); the source-scan repro
+    // `router_retain_probe_does_not_ungated_push_into_mirror_buffer_daemon_supervisor`
+    // (tests/) now guards that invariant. Gated consume is covered by
+    // `apply_mirror_cap` tests + the run_loop drain path.
 
     #[test]
     fn mirror_dispatch_falls_back_to_active_channel_when_lookup_fails() {

--- a/tests/review_api_dedup_fingerprint_api.rs
+++ b/tests/review_api_dedup_fingerprint_api.rs
@@ -49,7 +49,6 @@ fn request_dedup_rs() -> PathBuf {
 }
 
 #[test]
-#[ignore = "dedup-keys-only-on-request_id-no-fingerprint: red until fix; remove #[ignore] after fix to confirm"]
 fn dedup_entry_carries_a_request_fingerprint_api() {
     let path = request_dedup_rs();
     let src = std::fs::read_to_string(&path).expect("read request_dedup.rs");

--- a/tests/review_misleading_dedup_comment_state_capture.rs
+++ b/tests/review_misleading_dedup_comment_state_capture.rs
@@ -36,7 +36,6 @@ fn collect_rs(dir: &Path, out: &mut Vec<PathBuf>) {
 }
 
 #[test]
-#[ignore = "state-capture #3: red until fix; remove #[ignore] after fix to confirm"]
 fn unclassified_throttle_dedup_comment_is_not_misleading() {
     let src = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src");
     let mut files = Vec::new();

--- a/tests/router_retain_gate_daemon_supervisor.rs
+++ b/tests/router_retain_gate_daemon_supervisor.rs
@@ -53,7 +53,6 @@ fn run_loop_body(src: &str) -> &str {
 }
 
 #[test]
-#[ignore = "daemon-supervisor router-retain-ungated-push: red until fix; remove #[ignore] after fix to confirm"]
 fn router_retain_probe_does_not_ungated_push_into_mirror_buffer_daemon_supervisor() {
     let src = router_src();
     let body = run_loop_body(&src);


### PR DESCRIPTION
## CR-2026-06-14 final cleanup — un-ignore #2166/#2171/state-capture#3 repros + fix router retain ungated push

operator-reported residual cleanup (audit table). **Review class: DUAL** (B3 is a correctness change; A1/A2/B4 are test-only un-ignores bundled in).

### A — missing un-ignore (fix landed, `#[ignore]` left on → repro never ran)
| Item | Repro | Result |
|---|---|---|
| **A1** #2166 dedup-fingerprint seam (72ffd9ec) | `dedup_entry_carries_a_request_fingerprint_api` | un-ignore → GREEN (test-only) |
| **A2** #2171 sweep-cancel row232 (564e66bc) | `sweep_apply_*_row232` cluster | already un-ignored + GREEN — operator audit entry was **stale**, no change |
| **B4** state-capture#3 (design / misleading comment) | `unclassified_throttle_dedup_comment_is_not_misleading` | false "bounds this to once per screen" claim already gone (the #2100/#2115 throttle fix reworded the rationale to the fire-once `last_unclassified_throttle_sig` latch) → un-ignore → GREEN (test-only) |

### B3 — real correctness fix: router retain-block ungated push (finding #39, `src/daemon/router.rs`)
The trailing `buffers.retain` did a **second** `try_recv` whose `Ok(data)` arm pushed the consumed chunk into `buf.buffer` **ungated** — ignoring the `reply_to_channel`/`heartbeat_pair` gate (stray bytes mixed into the mirror buffer while mirroring is inactive) and skipping `apply_mirror_cap` (an oversized chunk bypassed the `2*MAX_MIRROR_LEN` cap until the next push).

**Fix:** detect sender disconnection inside the gated drain loop (collect dead names), and make the post-loop `buffers.retain` a **pure liveness probe** (drop disconnected buffers — no payload consumption, no push). All consume+gating happens once in the gated loop; a chunk racing in after the drain is picked up next iteration through that same path. Removed `retain_preserves_received_data` unit test (it built a copy of the closure and **pinned the ungated-push bug**); the source-scan repro now guards the invariant.

### §3.10 RED→GREEN
A1/B4 were RED-when-ignored, GREEN after un-ignore (fixes already landed). B3 repro proven RED via a `buf.buffer.push_str` mutation in the retain → reverted to GREEN. 12 router/row232 unit tests + the 3 repros pass; `cargo fmt` + `clippy --tests --features tray` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
