### PR TITLE
fix(#2158 PR2): bind_full guard-b + binding-change audit + bypass audit

### DIFF
--- a/src/binding.rs
+++ b/src/binding.rs
@@ -164,6 +164,48 @@ pub fn bind_full(
     let lock_path = dir.join(".binding.json.lock");
     let _lock = crate::store::acquire_file_lock(&lock_path)
         .map_err(|e| format!("acquire_file_lock {}: {e}", lock_path.display()))?;
+    // #2158 PR2: read the CURRENT on-disk binding UNDER the lock (the in-memory
+    // index can be stale) — drives guard-b + the binding-CHANGE audit.
+    let existing: Option<serde_json::Value> = std::fs::read_to_string(&path)
+        .ok()
+        .and_then(|c| parse_binding_guarded(&c));
+    // #2158 PR2 (i) guard-b — identity-INDEPENDENT prevention. Reject a rebind that
+    // moves a LIVE binding to a DIFFERENT branch with NO intervening release (a
+    // release clears binding.json, so a present binding + an existing worktree on a
+    // DIFFERENT branch == no release happened). ALLOWS first-bind (no existing) and
+    // same-branch idempotent reuse (#2226). Gates on STATE, so — unlike a
+    // caller-identity check — it is not defeated by the sub-agent/primary
+    // indistinguishability: it stops a transient helper silently moving the primary's
+    // live binding to a branch it never chose (#2158). Verified free: every legit
+    // rebind flow is fresh-lease / same-branch-early-return / cross-branch-rejected
+    // upstream (dispatch_hook LeaseConflict), so none does a live cross-branch
+    // bind-over.
+    if let Some(ref ex) = existing {
+        let ex_branch = ex
+            .get("branch")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default();
+        let ex_worktree_live = ex
+            .get("worktree")
+            .and_then(|v| v.as_str())
+            .map(|w| std::path::Path::new(w).exists())
+            .unwrap_or(false);
+        if ex_worktree_live && !ex_branch.is_empty() && ex_branch != branch {
+            crate::event_log::log(
+                home,
+                "binding_rebind_rejected",
+                agent,
+                &format!(
+                    "live binding on '{ex_branch}' — refused cross-branch rebind to '{branch}' (#2158); {}",
+                    crate::event_log::caller_process_context()
+                ),
+            );
+            return Err(format!(
+                "#2158: agent '{agent}' is bound to a LIVE worktree on branch '{ex_branch}' — \
+                 release_worktree first before binding to '{branch}' (no silent cross-branch rebind)"
+            ));
+        }
+    }
     let wt_str = worktree.display().to_string();
     let src_str = source_repo.display().to_string();
     let mut binding = json!({
@@ -203,6 +245,35 @@ pub fn bind_full(
     if let Ok(mut map) = binding_index().write() {
         map.insert(index_key(home, agent), binding);
     }
+    // #2158 PR2 (ii) binding-CHANGE audit — DETECTION, not attribution (a sub-agent
+    // shares the primary's identity/process tree, so we log the CHANGE + caller
+    // process context, not "who"). Fires on a CREATE (first bind) or a CHANGE
+    // (branch / worktree differs), making the #2158 first-bind hijack — and the
+    // #2234 reset-to-origin/main churn — visible even though identity can't prevent
+    // it. The realistic defense for the variant guard-b can't catch (first-bind).
+    let prev_branch = existing
+        .as_ref()
+        .and_then(|e| e.get("branch").and_then(|v| v.as_str()))
+        .map(String::from);
+    let prev_worktree = existing
+        .as_ref()
+        .and_then(|e| e.get("worktree").and_then(|v| v.as_str()))
+        .map(String::from);
+    let changed = existing.is_none()
+        || prev_branch.as_deref() != Some(branch)
+        || prev_worktree.as_deref() != Some(wt_str.as_str());
+    if changed {
+        crate::event_log::log(
+            home,
+            "binding_changed",
+            agent,
+            &format!(
+                "branch={branch} worktree={wt_str} prev_branch={} task_id={task_id}; {}",
+                prev_branch.as_deref().unwrap_or("<none>"),
+                crate::event_log::caller_process_context()
+            ),
+        );
+    }
     Ok(())
 }
 
@@ -215,6 +286,24 @@ fn binding_sig_path(dir: &Path) -> PathBuf {
 /// Clear a binding for an agent (task completed/released).
 pub fn unbind(home: &Path, agent: &str) {
     let dir = crate::paths::runtime_dir(home).join(agent);
+    // #2158 PR2 (ii): audit the release/clear side of binding-change detection with
+    // caller process context (read the prior branch before removal). Only logs when
+    // a binding actually existed (a no-op unbind stays silent).
+    if let Some(prev_branch) = std::fs::read_to_string(dir.join("binding.json"))
+        .ok()
+        .and_then(|c| parse_binding_guarded(&c))
+        .and_then(|v| v.get("branch").and_then(|b| b.as_str()).map(String::from))
+    {
+        crate::event_log::log(
+            home,
+            "binding_released",
+            agent,
+            &format!(
+                "prev_branch={prev_branch}; {}",
+                crate::event_log::caller_process_context()
+            ),
+        );
+    }
     let _ = std::fs::remove_file(dir.join("binding.json"));
     // #1651: drop the HMAC sidecar too, so a stale signature can't linger.
     let _ = std::fs::remove_file(binding_sig_path(&dir));
@@ -959,6 +1048,101 @@ mod tests {
             );
             std::fs::remove_dir_all(&home).ok();
         }
+    }
+
+    // ── #2158 PR2: bind_full guard-b + binding-change audit ──────────────────
+
+    fn read_event_log(home: &Path) -> String {
+        std::fs::read_to_string(home.join("event-log.jsonl")).unwrap_or_default()
+    }
+
+    /// guard-b: a cross-branch rebind of a LIVE binding (worktree dir exists) with
+    /// no intervening release is REJECTED and does NOT mutate the binding. RED
+    /// pre-fix: `bind_full` unconditionally overwrote → branch silently moved.
+    #[test]
+    fn guard_b_rejects_cross_branch_rebind_of_live_binding_2158() {
+        let home = tmp_home("guardb-reject");
+        let wt = home.join("wt-live");
+        std::fs::create_dir_all(&wt).unwrap(); // LIVE worktree on disk
+        let src = home.join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        bind_full(&home, "agentA", "", "feat/x", &wt, &src).expect("first bind ok");
+
+        let err = bind_full(&home, "agentA", "", "feat/y", &wt, &src)
+            .expect_err("cross-branch rebind of a live binding must be rejected");
+        assert!(
+            err.contains("#2158") && err.contains("release_worktree first"),
+            "expected fail-closed cross-branch reject: {err}"
+        );
+        assert_eq!(
+            read(&home, "agentA")
+                .and_then(|b| b.get("branch").and_then(|v| v.as_str()).map(String::from))
+                .as_deref(),
+            Some("feat/x"),
+            "a rejected rebind must NOT mutate the binding"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// guard-b allows the two legitimate shapes: first-bind (no existing) and
+    /// same-branch idempotent reuse (#2226).
+    #[test]
+    fn guard_b_allows_first_bind_and_same_branch_2158() {
+        let home = tmp_home("guardb-allow");
+        let wt = home.join("wt");
+        std::fs::create_dir_all(&wt).unwrap();
+        let src = home.join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        bind_full(&home, "ag", "", "feat/x", &wt, &src).expect("first-bind allowed");
+        bind_full(&home, "ag", "", "feat/x", &wt, &src).expect("same-branch reuse allowed");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// guard-b gates on a LIVE worktree: if the prior worktree dir is gone (stale
+    /// binding), a cross-branch rebind is allowed (no live binding to protect).
+    #[test]
+    fn guard_b_allows_rebind_when_prior_worktree_is_dead_2158() {
+        let home = tmp_home("guardb-dead");
+        let dead = home.join("wt-gone"); // NOT created → not live
+        let src = home.join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        bind_full(&home, "ag", "", "feat/x", &dead, &src).expect("first bind ok");
+        bind_full(&home, "ag", "", "feat/y", &dead, &src)
+            .expect("rebind allowed when the prior worktree is dead (stale binding)");
+        assert_eq!(
+            read(&home, "ag")
+                .and_then(|b| b.get("branch").and_then(|v| v.as_str()).map(String::from))
+                .as_deref(),
+            Some("feat/y"),
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// (ii) binding-change audit: a bind emits `binding_changed` and an unbind emits
+    /// `binding_released`, both carrying caller process context (`pid=`).
+    #[test]
+    fn binding_change_and_release_are_audited_2158() {
+        let home = tmp_home("audit");
+        let wt = home.join("wt");
+        std::fs::create_dir_all(&wt).unwrap();
+        let src = home.join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        bind_full(&home, "ag", "", "feat/x", &wt, &src).expect("bind ok");
+        unbind(&home, "ag");
+        let log = read_event_log(&home);
+        assert!(
+            log.contains("binding_changed"),
+            "bind must audit a binding_changed event: {log}"
+        );
+        assert!(
+            log.contains("binding_released"),
+            "unbind must audit a binding_released event: {log}"
+        );
+        assert!(
+            log.contains("pid="),
+            "audit lines must carry caller process context: {log}"
+        );
+        std::fs::remove_dir_all(&home).ok();
     }
 }
 

--- a/src/event_log.rs
+++ b/src/event_log.rs
@@ -45,6 +45,23 @@ fn rotate(base: &Path) {
     let _ = std::fs::rename(base, &first);
 }
 
+/// #2158 PR2: best-effort caller PROCESS context for binding / bypass audit lines
+/// — `pid`, parent `ppid`, and `cwd`. A transient sub-agent shares the primary's
+/// `instance_name` (so it can't be ATTRIBUTED to "sub-agent vs primary"), but it
+/// has its own pid/ppid/cwd — enough to trace an unexpected binding change to a
+/// process tree post-facto. ppid is unix-only (`libc::getppid`); `-1` elsewhere.
+pub(crate) fn caller_process_context() -> String {
+    let pid = std::process::id();
+    let cwd = std::env::current_dir()
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|_| "?".to_string());
+    #[cfg(unix)]
+    let ppid = unsafe { libc::getppid() };
+    #[cfg(not(unix))]
+    let ppid: i32 = -1;
+    format!("pid={pid} ppid={ppid} cwd={cwd}")
+}
+
 /// Append an event to the log file. Rotates when size exceeds MAX_LOG_SIZE.
 pub fn log(home: &Path, kind: &'static str, instance: &str, detail: &str) {
     let event = Event {

--- a/src/git_helpers.rs
+++ b/src/git_helpers.rs
@@ -55,6 +55,32 @@ pub(crate) fn git_bypass_timeout(
     args: &[&str],
     timeout: Duration,
 ) -> std::io::Result<std::process::Output> {
+    // #2158 PR2 (iii): audit a MUTATING bypass git op with caller process context so
+    // a transient process creating stray worktrees / branches via AGEND_GIT_BYPASS
+    // is traceable in daemon.log (the operator forensics surface). Read-only ops
+    // (status / rev-parse / log / …) are skipped to avoid flooding the log.
+    //
+    // Scope note: this audits the DAEMON's OWN bypass git. The #2158 incident's
+    // stray worktrees were created SHIM-side (the `agend-git` binary honouring
+    // AGEND_GIT_BYPASS for a sub-agent's own `git worktree add`) — a separate
+    // process + surface, tracked as a follow-up. `event_log` (operator-visible) is
+    // not used here: this choke has no `home`, and threading it through every caller
+    // is disproportionate — `tracing` keeps the line greppable without that churn.
+    if let Some(sub) = args.first() {
+        if matches!(
+            *sub,
+            "worktree" | "branch" | "checkout" | "switch" | "reset" | "clean" | "commit" | "push"
+        ) {
+            tracing::info!(
+                target: "agend_git_bypass",
+                op = %sub,
+                args = ?args,
+                cwd = %cwd.display(),
+                ctx = %crate::event_log::caller_process_context(),
+                "#2158 AGEND_GIT_BYPASS mutating git op"
+            );
+        }
+    }
     let mut cmd = std::process::Command::new("git");
     cmd.args(args).current_dir(cwd).env("AGEND_GIT_BYPASS", "1");
     spawn_group_bounded(cmd, &format!("git {:?}", &args[..1]), timeout)


### PR DESCRIPTION
## #2158 PR2 — dialectic-ruled scope (all three; PR1 #2237 merged)

Identity indistinguishability is acknowledged: a sub-agent shares the primary's `instance_name`/process tree, so prevention can only gate on STATE, and the first-bind-hijack variant is **detect-not-block** (the realistic optimum, per lead).

### (i) guard-b in `bind_full` (the central bind choke) — true prevention
Reject a rebind that moves a **LIVE** binding (worktree dir exists) to a **DIFFERENT** branch with **no intervening release** (a release clears `binding.json`, so present-binding + live-worktree + different-branch == no release happened). **ALLOWS** first-bind (no existing) + same-branch idempotent reuse (#2226). Gates on STATE, so it is not defeated by the sub-agent/primary indistinguishability — it stops a transient helper silently moving the primary's live binding to a branch it never chose.

**Verified free** (the verify-first lead asked for): every legitimate rebind flow is fresh-lease / same-branch-early-return / cross-branch-rejected-upstream (`dispatch_hook` LeaseConflict) — none does a live cross-branch bind-over. Confirmed empirically: `dispatch_hook`(63) / `worktree_pool`(61) / `handlers::ci`(76) / `handlers::worktree`(15) suites all green.

### (ii) binding-CHANGE audit in `bind_full` + `unbind`
Log `binding_changed` (create, or branch/worktree change) and `binding_released` with **caller process context** (`pid`/`ppid`/`cwd` via `event_log::caller_process_context`). Framing = **binding-change DETECTION, not sub-agent attribution** (shared process tree). The realistic defense for the first-bind hijack guard-b can't catch — and direct visibility into the **#2234 reset-to-origin/main churn** (which I hit landing PR1: an audited rebind would have shown who moved the binding).

### (iii) bypass audit at `git_bypass_timeout`
Tracing line for **MUTATING** bypass git ops (`worktree`/`branch`/`checkout`/`switch`/`reset`/`clean`/`commit`/`push`) with caller context; read-only ops skipped (no flood).

⚠ **Two honest deviations flagged for review** (deferred from spike, raised to lead):
- **tracing, not `event_log`** — this choke has no `home` (event_log requires it) and threading `home` through every caller is disproportionate; `daemon.log` is the operator forensics surface (CLAUDE.md recipes grep it).
- **surface**: this audits the DAEMON's own bypass git. The #2158 incident's stray worktrees were created **SHIM-side** (the `agend-git` binary honouring `AGEND_GIT_BYPASS` for a sub-agent's own `git worktree add`) — a separate process + surface, worth a **follow-up**.

## Tests (RED→GREEN, `binding.rs`) — RED proven by neutering each
- `guard_b_rejects_cross_branch_rebind_of_live_binding_2158` (rejected + binding unmutated)
- `guard_b_allows_first_bind_and_same_branch_2158`
- `guard_b_allows_rebind_when_prior_worktree_is_dead_2158`
- `binding_change_and_release_are_audited_2158` (binding_changed + binding_released + `pid=` context)

## Checks
- `cargo fmt --check` ✓, `cargo clippy --all-targets --features tray -D warnings` ✓
- binding(31) + git_helpers(10) + event_log(3) + all bind_full caller suites green.
- path tests use `Path::exists()` (no literal-path compare) — no #2237-class cross-platform fragility.

security → **dual review**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)