### PR TITLE
fix(#1523 #1470-1): case-insensitive net-error matching (Connection reset by peer)

### DIFF
--- a/src/state/patterns.rs
+++ b/src/state/patterns.rs
@@ -27,7 +27,19 @@ use regex::Regex;
 // #8 Phase 2 (KiroCli migration): pub(crate) so the co-located BackendProfile
 // references this shared net-error alternation by the SAME const (not a re-typed
 // copy). (#1580: the legacy compile_for arm that also used it is now gone.)
-pub(crate) const SERVER_RATE_LIMIT_NET_ERRORS: &str = r"ECONNRESET|ETIMEDOUT|InvalidHTTPResponse|fetch failed|connection reset|socket hang up|proxy.*disconnect";
+//
+// #1523 #1470-1: the alternation is wrapped in a scoped case-insensitive group
+// `(?i:…)` so backend-rendered casing variants of the SAME literal phrase match
+// — e.g. `Connection reset by peer` (capital C, the real Node/libc wording) hit
+// the lowercased `connection reset` token, which the previous case-SENSITIVE
+// compile silently missed. The loosening is FP-safe: ServerRateLimit is a
+// `is_high_fp_state` so a const match still has to clear `in_error_line_excluding_input`
+// (the token must sit on a real error-shaped line, not a prose mention) and the
+// #1518 live-bottom-N position gate — case-folding only normalises the SAME
+// token's casing, it does not widen what counts as the token. The `(?i:…)` group
+// is scoped (not a leading `(?i)` flag) so it stays self-contained if the const
+// is ever embedded in a larger pattern.
+pub(crate) const SERVER_RATE_LIMIT_NET_ERRORS: &str = r"(?i:ECONNRESET|ETIMEDOUT|InvalidHTTPResponse|fetch failed|connection reset|socket hang up|proxy.*disconnect)";
 
 // #1757's `is_net_error_match` red-anchor EXEMPTION was removed by
 // t-coloranchor-remove-ratelimit: ServerRateLimit now uses the general content

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -2648,6 +2648,44 @@ fn claude_overloaded_529_fixture_triggers_server_rate_limit() {
     assert_eq!(t.get_state(), AgentState::ServerRateLimit);
 }
 
+/// #1523 #1470-1: the real net-error phrasing "Connection reset by peer"
+/// (capital `C`) must classify as ServerRateLimit. The shared
+/// SERVER_RATE_LIMIT_NET_ERRORS const carries the lowercase `connection reset`
+/// token; pre-#1470-1 it was compiled case-SENSITIVELY, so the capitalised
+/// real wording silently MISSED (agent read Idle while the socket dropped).
+/// The `(?i:…)` fold rescues it. The fixture deliberately carries NO
+/// `ECONNRESET` (which would have matched case-sensitively anyway), so this
+/// test isolates the case-fold: mutating the const back to a bare alternation
+/// (drop the `(?i:…)`) flips this RED.
+#[test]
+fn claude_connection_reset_capital_c_triggers_server_rate_limit_1470() {
+    let bytes = std::fs::read("tests/fixtures/state-replay/claude-net-connection-reset.raw")
+        .expect("read fixture");
+    let text = String::from_utf8_lossy(&bytes);
+    let mut t = tracker_at(&Backend::ClaudeCode, AgentState::Idle, 0);
+    t.feed(&text);
+    assert_eq!(t.get_state(), AgentState::ServerRateLimit);
+}
+
+/// #1523 #1470-1 iron-rule (unit form): the case-fold must NOT widen what
+/// counts as the token. A bare prose line that merely MENTIONS
+/// "Connection reset by peer" — with no error-line shape — must NOT classify
+/// as ServerRateLimit. (The broad raw pattern matches the substring; the
+/// `in_error_line_excluding_input` content anchor is what suppresses it —
+/// `detect()` alone would match, `feed()`'s gate is the guard.)
+#[test]
+fn connection_reset_in_prose_line_is_not_server_rate_limit_1470() {
+    let patterns = StatePatterns::for_backend(&Backend::ClaudeCode);
+    let prose = "We hit Connection reset by peer while testing the retry path yesterday.";
+    // Raw detect matches the broad token …
+    assert_eq!(patterns.detect(prose), Some(AgentState::ServerRateLimit));
+    // … but the content anchor rejects it (no error-line shape on the line).
+    assert!(
+        !crate::state::patterns::in_error_line_excluding_input(prose, "Connection reset", &["❯"]),
+        "#1470-1: a bare prose mention must not satisfy the error-line content anchor"
+    );
+}
+
 /// Fixture-based UsageLimit detection across backends — each fixture
 /// must classify as UsageLimit (patterns added by #848).
 #[test]

--- a/tests/fixtures/state-replay/MANIFEST.yaml
+++ b/tests/fixtures/state-replay/MANIFEST.yaml
@@ -705,3 +705,86 @@ fixtures:
     expected_final_detect: rate_limit
     capture_kind: synthetic_from_docs
     provenance: "t-coloranchor-corpus-gate — synthetic from the verified codex stream-error shape + OpenAI rate_limit_exceeded code"
+
+  # ── #1523 #1470-1: case-insensitive net-error matching ──────────────────
+  # The shared SERVER_RATE_LIMIT_NET_ERRORS const is now compiled `(?i:…)` so a
+  # backend's real casing of a net-error phrase ("Connection reset by peer",
+  # capital C) matches the lowercased `connection reset` token it previously
+  # missed. These fixtures pin BOTH directions of the iron rule: the phrase on a
+  # real error line MUST latch SRL (positive), and the same phrase in prose must
+  # NOT (negatives, the FP guard the content anchor provides).
+
+  - file: claude-net-connection-reset.raw
+    backend: claude-code
+    cli_version: "2.1.98"
+    recorded_on: "2026-06-15"
+    scenario: |
+      #1470-1 positive: a red `API Error: Connection reset by peer` line — the
+      real libc/Node phrasing with a capital `C`. The net-error token in the
+      shared const is lowercase `connection reset`; pre-#1470-1 the const was
+      compiled case-SENSITIVELY so this MISSED (the agent read Idle while the
+      socket was actually dropped). With the `(?i:…)` fold it now latches
+      ServerRateLimit. Deliberately carries NO `ECONNRESET` (which would match
+      case-sensitively anyway) so the fixture isolates the case-fold fix.
+    expected_transitions: [starting, server_rate_limit]
+    expected_final_state: server_rate_limit
+    expected_final_detect: server_rate_limit
+    capture_kind: synthetic_from_docs
+    provenance: "#1470-1 — synthetic from the canonical 'Connection reset by peer' net-error phrasing"
+
+  - file: claude-net-error-discussion-text.raw
+    backend: claude-code
+    cli_version: "2.1.98"
+    recorded_on: "2026-06-15"
+    scenario: |
+      #1470-1 iron-rule negative (claude): an agent DISCUSSING the
+      "Connection reset by peer" phrase in prose must NOT latch ServerRateLimit
+      as its STATE. NOTE the split: the raw `detect()` pattern is broad by design
+      and DOES match the net-error token in the prose (expected_final_detect =
+      server_rate_limit) — but the live `feed()` path keeps the STATE out of SRL
+      via the #1518 live-bottom-N position gate + the content anchor (the phrase
+      is prose, not on an error-shaped error line), so the tracker never
+      transitions into ServerRateLimit (final_state stays `starting`, like the
+      kiro-discussion-text precedent). That suppression IS the FP guard the
+      case-insensitive fold relies on; this fixture pins it. Contract: the STATE
+      must never become server_rate_limit on discussion prose.
+    expected_transitions: [starting]
+    expected_final_state: starting
+    expected_final_detect: server_rate_limit
+    capture_kind: synthetic
+    provenance: "#1470-1 regression-proof — prose mentioning the net-error phrase; raw detect matches (broad pattern) but feed gates keep STATE out of SRL"
+
+  - file: codex-discussion-text.raw
+    backend: codex
+    cli_version: "0.135.0"
+    recorded_on: "2026-06-15"
+    scenario: |
+      #1470-1 iron-rule negative (codex) + fills the codex discussion-text
+      coverage gap. codex shares the SERVER_RATE_LIMIT_NET_ERRORS const, so the
+      case-fold loosening applies here too. Same split as the claude negative:
+      raw `detect()` matches the broad net-error token in prose
+      (expected_final_detect = server_rate_limit), but `feed()`'s position +
+      content gates keep the STATE out of SRL (final_state stays `starting`).
+      Contract: discussion prose must never make the STATE server_rate_limit.
+    expected_transitions: [starting]
+    expected_final_state: starting
+    expected_final_detect: server_rate_limit
+    capture_kind: synthetic
+    provenance: "#1470-1 regression-proof — codex prose mentioning net-error phrasing; raw detect matches but feed gates keep STATE out of SRL"
+
+  - file: agy-discussion-text.raw
+    backend: agy
+    cli_version: "0.1.0"
+    recorded_on: "2026-06-15"
+    scenario: |
+      #1470-1 iron-rule negative (agy) + fills the agy discussion-text coverage
+      gap. NOTE: agy has no ServerRateLimit / net-error pattern (it does not use
+      the shared const), so the #1470-1 fold cannot affect agy — this fixture is
+      general anti-FP coverage: prose mentioning `connection reset by peer` /
+      `rate limit` must keep agy Idle. Lands Idle on the `Type your message` /
+      `? for shortcuts` chrome.
+    expected_transitions: [starting, idle]
+    expected_final_state: idle
+    expected_final_detect: idle
+    capture_kind: synthetic
+    provenance: "#1470-1 regression-proof — agy prose mentioning net-error / rate-limit phrasing, expected Idle"

--- a/tests/fixtures/state-replay/agy-discussion-text.raw
+++ b/tests/fixtures/state-replay/agy-discussion-text.raw
@@ -1,0 +1,6 @@
+[2J[H[0mAntigravity CLI session. Discussing how connection reset by peer and rate limit
+phrases show up in prose without being real backend faults; the detector must keep
+this pane Idle while the conversation merely talks about them.
+
+Type your message
+? for shortcuts

--- a/tests/fixtures/state-replay/claude-net-connection-reset.raw
+++ b/tests/fixtures/state-replay/claude-net-connection-reset.raw
@@ -1,0 +1,3 @@
+[2J[H[31mAPI Error: Connection reset by peer[0m
+
+Retrying automatically...

--- a/tests/fixtures/state-replay/claude-net-error-discussion-text.raw
+++ b/tests/fixtures/state-replay/claude-net-error-discussion-text.raw
@@ -1,0 +1,6 @@
+[2J[H[0mInvestigating #1470-1: the classifier used to miss the phrase Connection reset by peer
+because the net-error regex compared connection reset case-sensitively. The fix folds
+case so the same token matches; this discussion text mentions connection reset by peer
+in prose only and must stay Idle (this is normal conversation, not a backend fault).
+
+❯ 

--- a/tests/fixtures/state-replay/codex-discussion-text.raw
+++ b/tests/fixtures/state-replay/codex-discussion-text.raw
@@ -1,0 +1,5 @@
+[2J[H[0mNotes on codex net-error handling: a transient connection reset is treated as
+ServerRateLimit only when it sits on a real backend fault line. This prose mentions
+connection reset and rate limit in passing and must not latch any state.
+
+› 


### PR DESCRIPTION
## #1523 #1470-1 — case-insensitive net-error matching

**Production detection change → DUAL review.**

### The bug
`SERVER_RATE_LIMIT_NET_ERRORS` (the net-error alternation shared by claude/codex/
kiro/opencode ServerRateLimit detection) was compiled **case-SENSITIVELY**
(`Regex::new`, no `(?i)`). Its `connection reset` token is lowercase, so the real
libc/Node wording **"Connection reset by peer"** (capital C) silently missed —
the agent read **Idle while the socket was actually dropped**. `ETIMEDOUT` etc.
are likewise case-pinned.

### The fix
Wrap the alternation in a scoped `(?i:…)` group. One const → all 4 backends.
Scoped group (not a leading `(?i)` flag) so it stays self-contained if ever
embedded.

### Scope (per lead dialectic-lite ruling)
- **DP1 (this PR)**: case-fold the net-error const only.
- **DP2 deferred**: "Request timed out" / new tokens — needs operator confirmation
  (no real fixture, prose-FP risk). **Not in this PR.**
- **DP3**: other backend error patterns left untouched — audit reported to lead
  separately (no blind flips of non-anchored patterns).

### FP-safety — the iron rule
ServerRateLimit is `is_high_fp_state`: a const match still must clear
`in_error_line_excluding_input` (token on a real error-shaped line, not prose) +
the #1518 live-bottom-N position gate. Case-folding only normalises the SAME
token's casing — it does **not** widen what counts as the token.

### Corpus (B1 — both directions)
| fixture | role | behaviour |
|---|---|---|
| `claude-net-connection-reset.raw` | **positive** | NO `ECONNRESET` → isolates the fold. RED (Idle) pre-fix, GREEN (ServerRateLimit) post-fix. |
| `claude-net-error-discussion-text.raw` | negative | raw `detect()` matches the broad token in prose, but `feed()` gates keep STATE out of SRL (`final_state=starting`). Pins the suppression that IS the guard. |
| `codex-discussion-text.raw` | negative | same split; fills codex discussion-text gap. |
| `agy-discussion-text.raw` | negative | agy has no net-error pattern → clean Idle; fills agy discussion-text gap. |

Plus 2 unit tests (`claude_connection_reset_capital_c_triggers_server_rate_limit_1470`,
`connection_reset_in_prose_line_is_not_server_rate_limit_1470`).

### §3.10 RED→GREEN
Dropping the `(?i:…)` flips the positive fixture + unit test RED (lands Idle).
`replay_manifest_regression` + 59 SRL/net-error tests + `fixture_corpus_measurement`
+ `state_pattern_coverage` all green. `cargo fmt` + `clippy --tests --features tray -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
