### PR TITLE
test(#2171 CR-2026-06-14 final): un-ignore review_tasks_7:40 (#2238 miss) + mark cookie-UDS repro deferred

### DIFF
--- a/tests/review_tasks_7.rs
+++ b/tests/review_tasks_7.rs
@@ -37,7 +37,6 @@ fn emit_cancelled_body(text: &str) -> String {
 }
 
 #[test]
-#[ignore = "tasks-sweep-cancel-no-guard: red until fix; remove #[ignore] after fix to confirm"]
 fn sweep_cancel_uses_legality_guard_not_bare_append_tasks() {
     let text = read_sweep();
     let body = emit_cancelled_body(&text);

--- a/tests/review_xcut_security_2.rs
+++ b/tests/review_xcut_security_2.rs
@@ -51,7 +51,7 @@ fn collect_rs(dir: &Path, out: &mut Vec<PathBuf>) {
 }
 
 #[test]
-#[ignore = "cookie-only-operator-authority: red until fix; remove #[ignore] after fix to confirm"]
+#[ignore = "cookie-only-operator-authority: deferred — operator WONTFIX, single-user trust model (decision d-20260615162503510062-0)"]
 fn operator_connection_uses_kernel_verified_peer_credential_xcut_security() {
     let src = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src");
     let mut files = Vec::new();


### PR DESCRIPTION
Closes the **last loop** of CR-2026-06-14 (105 findings → 104 red→green + 1 deferred).

## ① un-ignore `tests/review_tasks_7.rs:40` (#2238 miss)
`sweep_cancel_uses_legality_guard_not_bare_append_tasks` was still `#[ignore]`'d.
The fix **#2171 (564e66bc)** — `emit_cancelled_batch` now routes through
`append_batch_checked` (re-validates non-terminal under the append lock) instead of
a bare `append_batch` — is already on `main`. #2238 claimed to un-ignore the #2171
repro but only handled `tasks/tests.rs` row232 and **missed this independent
static-invariant test**.

- Removed `#[ignore]` → test now **GREEN** (fix verified effective):
  `PASS sweep_cancel_uses_legality_guard_not_bare_append_tasks`

## ② mark cookie-UDS repro deferred (operator WONTFIX)
`cookie-only-operator-authority` (`tests/review_xcut_security_2.rs`,
`operator_connection_uses_kernel_verified_peer_credential_xcut_security`): operator
confirmed **DEFER** — single-user same-user trust model is acceptable
(decision `d-20260615162503510062-0`). Kept `#[ignore]`, relabeled the reason to
`"deferred — operator WONTFIX, single-user trust model (...)"` so it reads as an
accepted deferral, not unfinished work.

## Verification
- `cargo nextest run --test review_tasks_7 sweep_cancel_...` → 1 passed
- `cargo fmt --check` → clean
- `cargo clippy --tests --features tray` → clean

Test-only change. ① per §3.6 single-review. Branch based on latest `main` (8307f229).

🤖 Generated with [Claude Code](https://claude.com/claude-code)