### PR TITLE
fix(reliability): fresh-restart self-kick — daemon injects a recovery first turn

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -1325,6 +1325,58 @@ fn bootstrap_core_is_idle(core: &std::sync::Arc<CoreMutex<AgentCore>>) -> bool {
 /// The `content` is captured at spawn time (see call site) rather than
 /// re-read after Ready: this closes the mutation window where an external
 /// process could swap the instructions file between write and inject.
+/// Poll until the agent reaches Idle (or timeout / shutdown / agent-gone), then
+/// settle and snapshot its [`InjectTarget`] with the registry lock released.
+/// `None` => do not inject. Shared by the Kiro instructions bootstrap and the
+/// fresh-restart self-kick — both "wait for the freshly-spawned session to reach
+/// the prompt, then type one first turn" (injecting while the backend is still
+/// `Starting` would be swallowed).
+///
+/// #CR-2026-06-14 (concurrency): snapshot the core Arc under the tier-1 registry
+/// lock, DROP the registry guard, THEN lock the core (in `bootstrap_core_is_idle`)
+/// — never nest the per-agent core lock inside the registry lock. The old
+/// registry→core nesting established an acquisition order a core→registry path
+/// could deadlock against, every 200ms at startup.
+fn wait_for_idle_inject_target(
+    registry: &AgentRegistry,
+    instance_id: crate::types::InstanceId,
+    name: &str,
+    timeout: std::time::Duration,
+    shutdown: Option<&Arc<std::sync::atomic::AtomicBool>>,
+    what: &str,
+) -> Option<InjectTarget> {
+    let deadline = std::time::Instant::now() + timeout;
+    let poll_interval = std::time::Duration::from_millis(200);
+    loop {
+        if let Some(s) = shutdown {
+            if s.load(std::sync::atomic::Ordering::Relaxed) {
+                return None;
+            }
+        }
+        if std::time::Instant::now() >= deadline {
+            tracing::warn!(agent = %name, what, "bootstrap timed out waiting for Idle");
+            return None;
+        }
+        let core = {
+            let reg = registry.lock();
+            match reg.get(&instance_id) {
+                Some(h) => std::sync::Arc::clone(&h.core),
+                None => return None, // agent gone
+            }
+        };
+        if bootstrap_core_is_idle(&core) {
+            break;
+        }
+        std::thread::sleep(poll_interval);
+    }
+    // Small settle delay so the prompt is fully painted before we type.
+    std::thread::sleep(std::time::Duration::from_millis(500));
+    // #1530/F1: snapshot the inject target under the registry lock, release it,
+    // THEN inject (caller side) — never hold the registry across the blocking write.
+    let reg = registry.lock();
+    reg.get(&instance_id).map(InjectTarget::from_handle)
+}
+
 fn spawn_instructions_bootstrap(
     registry: AgentRegistry,
     instance_id: crate::types::InstanceId,
@@ -1334,62 +1386,20 @@ fn spawn_instructions_bootstrap(
     shutdown: Option<Arc<std::sync::atomic::AtomicBool>>,
 ) {
     let thread_name = format!("{name}_instr_boot");
-    // fire-and-forget: instruction-bootstrap thread polls Idle then injects
-    // the snapshotted instructions content. Observes shutdown flag inside the
-    // poll loop (returns early on shutdown). JoinHandle dropped because the
-    // thread is short-lived and one missed bootstrap on shutdown is cosmetic.
+    // fire-and-forget: instruction-bootstrap thread polls Idle then injects the
+    // snapshotted instructions content. Observes shutdown inside the poll loop.
+    // JoinHandle dropped — short-lived; one missed bootstrap on shutdown is cosmetic.
     let spawn_result = std::thread::Builder::new().name(thread_name).spawn(move || {
         let _census = crate::thread_census::register("instr_boot"); // M3: was "pty_reader"
-        let deadline = std::time::Instant::now() + timeout;
-        let poll_interval = std::time::Duration::from_millis(200);
-
-        loop {
-            if let Some(ref s) = shutdown {
-                if s.load(std::sync::atomic::Ordering::Relaxed) {
-                    return;
-                }
-            }
-            if std::time::Instant::now() >= deadline {
-                tracing::warn!(
-                    agent = %name,
-                    "instructions bootstrap timed out waiting for Idle"
-                );
-                return;
-            }
-
-            // #CR-2026-06-14 (concurrency): snapshot the core Arc under the tier-1
-            // registry lock, DROP the registry guard, THEN lock the core (in the
-            // helper) — never nest the per-agent core lock inside the registry
-            // lock. The old registry→core nesting established an acquisition order
-            // a core→registry path could deadlock against, every 200ms at startup.
-            // Mirrors the inject snapshot below.
-            let core = {
-                let reg = registry.lock();
-                match reg.get(&instance_id) {
-                    Some(h) => std::sync::Arc::clone(&h.core),
-                    None => return, // agent gone
-                }
-            };
-            if bootstrap_core_is_idle(&core) {
-                break;
-            }
-            std::thread::sleep(poll_interval);
-        }
-
-        // Small settle delay so the prompt is fully painted before we type.
-        // This is a UI-layer concern (avoiding a torn prompt paint) — the
-        // content itself was already snapshotted at spawn, so the delay no
-        // longer widens an external-mutation window.
-        std::thread::sleep(std::time::Duration::from_millis(500));
-
-        // #1530/F1: snapshot the inject target under the registry lock, release
-        // it, THEN inject — don't hold the registry across the blocking write.
         // force=true bootstrap → use the (non-gated) target inject directly.
-        let inject_snap = {
-            let reg = registry.lock();
-            reg.get(&instance_id).map(InjectTarget::from_handle)
-        };
-        if let Some(tgt) = inject_snap {
+        if let Some(tgt) = wait_for_idle_inject_target(
+            &registry,
+            instance_id,
+            &name,
+            timeout,
+            shutdown.as_ref(),
+            "instructions",
+        ) {
             if let Err(e) = inject_with_target(&tgt, content.as_bytes()) {
                 tracing::warn!(agent = %name, error = %e, "instructions bootstrap inject failed");
             } else {
@@ -1403,6 +1413,57 @@ fn spawn_instructions_bootstrap(
     });
     if let Err(e) = spawn_result {
         tracing::warn!(error = %e, "failed to spawn instructions bootstrap thread");
+    }
+}
+
+/// fresh-restart SELF-KICK. After a `restart_instance mode=fresh` respawn the new
+/// session sits idle with no first turn — nothing drives the agent to recover its
+/// in-flight state, so an operator-absent overnight restart silently strands the
+/// fleet (the recurring "lead restarted and just sat there" failure). This polls
+/// the freshly-spawned session to Idle (so the inject isn't swallowed while the
+/// backend is still `Starting`) and injects a single `[AGEND-RESUME]`
+/// self-bootstrap first turn, armed for ≤1 re-delivery via the inject-delivery
+/// verifier. Fired ONLY from the SPAWN handler when `restart_spawn_params` set the
+/// independent `self_kick_on_ready` flag (fresh restart) — the flag is NEVER
+/// derived from `SpawnMode::Fresh` (initial fleet spawns are Fresh too, and must
+/// not self-kick).
+pub(crate) fn spawn_self_kick_bootstrap(
+    registry: AgentRegistry,
+    instance_id: crate::types::InstanceId,
+    name: String,
+    timeout: std::time::Duration,
+    shutdown: Option<Arc<std::sync::atomic::AtomicBool>>,
+) {
+    let thread_name = format!("{name}_selfkick");
+    // fire-and-forget: mirrors spawn_instructions_bootstrap's lifetime/discipline.
+    let spawn_result = std::thread::Builder::new().name(thread_name).spawn(move || {
+        let _census = crate::thread_census::register("self_kick");
+        let prompt = fresh_restart_self_kick_prompt();
+        if let Some(tgt) = wait_for_idle_inject_target(
+            &registry,
+            instance_id,
+            &name,
+            timeout,
+            shutdown.as_ref(),
+            "self-kick",
+        ) {
+            // force=true: we already waited for Idle; the submit key drives the turn.
+            match inject_with_target(&tgt, prompt.as_bytes()) {
+                Ok(()) => {
+                    // Re-delivery verification (≤1 redeliver, operator-visible if
+                    // undelivered) so a swallowed first turn can't silently strand
+                    // the restart. arm is a no-op for non-hook backends.
+                    crate::daemon::inject_delivery::arm(&name, &prompt);
+                    tracing::info!(agent = %name, "fresh-restart self-kick injected");
+                }
+                Err(e) => {
+                    tracing::warn!(agent = %name, error = %e, "fresh-restart self-kick inject failed");
+                }
+            }
+        }
+    });
+    if let Err(e) = spawn_result {
+        tracing::warn!(error = %e, "failed to spawn self-kick bootstrap thread");
     }
 }
 
@@ -2077,6 +2138,36 @@ pub(crate) const DAEMON_AUTO_INJECT_MARKER: &str = "[AGEND-AUTO";
 /// #1769: build the `[AGEND-AUTO kind=<kind>] ` prefix for an auto-inject.
 fn daemon_auto_prefix(kind: &str) -> String {
     format!("{DAEMON_AUTO_INJECT_MARKER} kind={kind}] ")
+}
+
+/// fresh-restart self-kick marker — DISTINCT from [`DAEMON_AUTO_INJECT_MARKER`].
+/// `[AGEND-AUTO]` is a low-priority resume NUDGE the agent must NEVER act on (the
+/// test-pinned blanket rule in `instructions.rs`); `[AGEND-RESUME]` is the
+/// OPPOSITE — an actionable SELF-bootstrap trigger telling a just-fresh-restarted
+/// agent to recover its OWN in-flight state. The two markers stay separate (a new
+/// marker, NOT an `[AGEND-AUTO]` per-kind carve-out) so neither rule's meaning is
+/// muddied: `[AGEND-AUTO]` = never act, `[AGEND-RESUME]` = run your recovery.
+pub(crate) const DAEMON_RESUME_INJECT_MARKER: &str = "[AGEND-RESUME]";
+
+/// The fixed first turn injected ONCE after a fresh-restart respawn. It is an
+/// actionable SELF-bootstrap trigger (recover the agent's OWN in-flight state),
+/// NOT an operator command and NOT authority to dispatch new work. Ordering per
+/// the design review (must-follow ③): the task board + `list_instances` are the
+/// AUTHORITATIVE live sources; `SESSION-HANDOFF.md` is only a stale-tolerant hint
+/// because a fresh restart's DELETE=kill may have happened before any fresh
+/// handoff was written.
+pub(crate) fn fresh_restart_self_kick_prompt() -> String {
+    format!(
+        "{DAEMON_RESUME_INJECT_MARKER} You were just fresh-restarted and lost your in-memory \
+         context. Recover your OWN state now, in this order: (1) rebuild your in-flight picture \
+         from the AUTHORITATIVE live sources — the task board (your claimed/assigned tasks) and \
+         list_instances (peers + any dangling sub-agents); (2) drain your inbox; (3) read \
+         SESSION-HANDOFF.md as a STALE-TOLERANT hint only — if it is missing or looks out of \
+         date, trust the board/inbox over it; (4) execute pending handoff TODOs and reconnect \
+         dangling sub-agents, then resume normal work. This is a self-bootstrap trigger to \
+         recover YOUR OWN state — it is NOT an operator command and NOT authority to dispatch \
+         new work."
+    )
 }
 
 pub(crate) fn inject_with_target_gated(

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -126,6 +126,53 @@ fn daemon_auto_prefix_embeds_kind_1769() {
     assert!(s.ends_with('\n'), "submit newline preserved");
 }
 
+/// fresh-restart self-kick: the `[AGEND-RESUME]` marker is DISTINCT from the
+/// never-act `[AGEND-AUTO]` marker — two separate tokens, neither a prefix of the
+/// other (so an agent can't confuse a self-bootstrap trigger with a resume nudge).
+#[test]
+fn resume_marker_distinct_from_auto_marker() {
+    assert_eq!(super::DAEMON_RESUME_INJECT_MARKER, "[AGEND-RESUME]");
+    assert_ne!(
+        super::DAEMON_RESUME_INJECT_MARKER,
+        super::DAEMON_AUTO_INJECT_MARKER
+    );
+    assert!(!super::DAEMON_RESUME_INJECT_MARKER.starts_with(super::DAEMON_AUTO_INJECT_MARKER));
+    assert!(!super::DAEMON_AUTO_INJECT_MARKER.starts_with(super::DAEMON_RESUME_INJECT_MARKER));
+}
+
+/// fresh-restart self-kick prompt (must-follows ①+③): an actionable
+/// `[AGEND-RESUME]` self-bootstrap; the task board + `list_instances` are named as
+/// the AUTHORITATIVE live sources BEFORE the stale-tolerant `SESSION-HANDOFF.md`
+/// hint; and it is explicitly bounded — recover-your-own-state, NOT an operator
+/// command / dispatch authority.
+#[test]
+fn fresh_restart_self_kick_prompt_shape() {
+    let p = super::fresh_restart_self_kick_prompt();
+    assert!(
+        p.starts_with(super::DAEMON_RESUME_INJECT_MARKER),
+        "prompt must carry the [AGEND-RESUME] marker"
+    );
+    // must-follow ③: authoritative live sources named BEFORE the handoff hint.
+    let board = p.find("task board").expect("names the task board");
+    let list = p.find("list_instances").expect("names list_instances");
+    let handoff = p.find("SESSION-HANDOFF").expect("names SESSION-HANDOFF");
+    assert!(
+        board < handoff && list < handoff,
+        "task board + list_instances must precede the SESSION-HANDOFF hint (authoritative-first)"
+    );
+    assert!(
+        p.contains("STALE-TOLERANT") || p.contains("stale-tolerant"),
+        "SESSION-HANDOFF must be framed as a stale-tolerant hint"
+    );
+    // must-follow ①: actionable self-bootstrap, NOT operator authority.
+    assert!(
+        p.contains("YOUR OWN state"),
+        "scoped to the agent's own state"
+    );
+    assert!(p.contains("NOT an operator command"));
+    assert!(p.contains("NOT authority to dispatch"));
+}
+
 #[test]
 fn strip_ansi_cursor_move_no_space() {
     // CSI C (cursor forward) and D (cursor back) must not insert spaces

--- a/src/api/handlers/instance.rs
+++ b/src/api/handlers/instance.rs
@@ -272,6 +272,34 @@ pub(crate) fn handle_spawn(params: &Value, ctx: &HandlerCtx) -> Value {
         env_for_spawn,
     ) {
         Ok(_spawn_mode) => {
+            // fresh-restart self-kick: fire the first-turn recovery inject ONLY when
+            // the caller (restart_spawn_params, mode=fresh) explicitly armed this
+            // INDEPENDENT flag. NEVER derived from spawn_mode — a missing/garbled
+            // flag yields `false` (fail-safe: no inject), and initial fleet spawns /
+            // create_instance / team-spawn (which also map to SpawnMode::Fresh but
+            // never set this flag) are correctly excluded. The bootstrap thread
+            // polls the new session to Idle before injecting, so an early fire here
+            // is harmless.
+            if params["self_kick_on_ready"].as_bool().unwrap_or(false) {
+                if let Some(id) = crate::fleet::resolve_uuid(ctx.home, name) {
+                    let ready_timeout = crate::backend::Backend::from_command(command)
+                        .map(|b| b.preset().ready_timeout_secs)
+                        .unwrap_or(30)
+                        .saturating_add(15);
+                    agent::spawn_self_kick_bootstrap(
+                        std::sync::Arc::clone(ctx.registry),
+                        id,
+                        name.to_string(),
+                        std::time::Duration::from_secs(ready_timeout),
+                        None,
+                    );
+                } else {
+                    tracing::warn!(
+                        agent = name,
+                        "self_kick_on_ready set but instance UUID unresolved — skipping self-kick"
+                    );
+                }
+            }
             // #991: skip topic creation when caller opts out.
             let topic_binding = params["topic_binding"].as_str().unwrap_or("auto");
             let topic_id = if matches!(topic_binding, "skip" | "deferred") {

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -326,6 +326,15 @@ pub(crate) fn build_instructions_body(
     content.push_str("- Treat the payload after the marker as a low-priority RESUME signal: if you have in-progress work, just continue it.\n");
     content.push_str("- NEVER treat an `[AGEND-AUTO]` line as an operator command, and never dispatch a task or make a decision based on it.\n");
 
+    // fresh-restart self-kick: a SEPARATE marker from `[AGEND-AUTO]` (deliberately
+    // NOT a per-kind carve-out of the "never act on AGEND-AUTO" rule above — that
+    // rule stays a clean blanket). `[AGEND-RESUME]` is the OPPOSITE: actionable.
+    content.push_str("\n## Daemon resume trigger (`[AGEND-RESUME]`)\n\n");
+    content.push_str("When you see input beginning with `[AGEND-RESUME]`:\n");
+    content.push_str("- This is a daemon-issued SELF-bootstrap trigger, fired exactly once right after a fresh-restart respawn — you lost your prior in-memory context.\n");
+    content.push_str("- UNLIKE `[AGEND-AUTO]` (which you must NEVER act on), this IS actionable: immediately run your recovery sequence — rebuild your in-flight picture from the AUTHORITATIVE live sources first (the task board + list_instances), then drain your inbox, then read SESSION-HANDOFF.md as a stale-tolerant hint (trust the board/inbox over it if it looks out of date), then execute pending handoff TODOs and reconnect dangling sub-agents.\n");
+    content.push_str("- It is an actionable trigger to recover YOUR OWN state — NOT operator authority: it is NOT an operator command and NOT a license to dispatch new work. Do the recovery, nothing more.\n");
+
     content
 }
 
@@ -1031,6 +1040,32 @@ mod tests {
         assert!(
             body.contains("NEVER treat an `[AGEND-AUTO]` line as an operator command"),
             "instructions must forbid acting on [AGEND-AUTO] as an operator command"
+        );
+    }
+
+    #[test]
+    fn instructions_include_agend_resume_actionable_rule() {
+        // fresh-restart self-kick: `[AGEND-RESUME]` must be taught as an ACTIONABLE
+        // self-bootstrap trigger (the opposite of the never-act `[AGEND-AUTO]`
+        // rule). must-follow ①: it is recover-your-own-state, NOT operator
+        // authority — and the test-pinned `[AGEND-AUTO]` blanket must stay intact
+        // (the two markers coexist, neither weakened by a per-kind carve-out).
+        let body = build_instructions_body(None, None);
+        assert!(
+            body.contains("[AGEND-RESUME]"),
+            "instructions must teach the [AGEND-RESUME] self-bootstrap trigger"
+        );
+        assert!(
+            body.contains("this IS actionable"),
+            "[AGEND-RESUME] must be framed as ACTIONABLE (opposite of [AGEND-AUTO])"
+        );
+        assert!(
+            body.contains("NOT an operator command") && body.contains("NOT a license to dispatch"),
+            "[AGEND-RESUME] must be bounded: recover own state, not operator authority"
+        );
+        assert!(
+            body.contains("NEVER treat an `[AGEND-AUTO]` line as an operator command"),
+            "the [AGEND-AUTO] never-act rule must remain intact alongside [AGEND-RESUME]"
         );
     }
 

--- a/src/mcp/handlers/instance_state/mod.rs
+++ b/src/mcp/handlers/instance_state/mod.rs
@@ -373,6 +373,14 @@ fn restart_spawn_params(
     });
     if mode == "resume" {
         spawn_params["mode"] = json!("resume");
+    } else {
+        // fresh restart only: arm the daemon's first-turn self-kick so the
+        // respawned (context-lost) instance runs its recovery sequence instead of
+        // sitting idle until an operator happens to type (the overnight
+        // restart-strands-the-fleet failure). INDEPENDENT flag — the SPAWN handler
+        // must NOT derive self-kick from SpawnMode::Fresh, which initial fleet
+        // spawns also map to; only THIS restart-fresh path sets it.
+        spawn_params["self_kick_on_ready"] = json!(true);
     }
     spawn_params
 }
@@ -471,6 +479,8 @@ mod tests {
         assert_eq!(p["layout"], "same-tab");
         // fresh must NOT request a resume.
         assert!(p.get("mode").is_none());
+        // fresh restart arms the daemon self-kick (the independent flag).
+        assert_eq!(p["self_kick_on_ready"].as_bool(), Some(true));
     }
 
     #[test]
@@ -479,5 +489,28 @@ mod tests {
         let p = restart_spawn_params("dev", "claude", &[], None, &env, "resume");
         assert_eq!(p["layout"], "same-tab");
         assert_eq!(p["mode"], "resume");
+        // resume preserves context → must NOT self-kick.
+        assert!(p.get("self_kick_on_ready").is_none());
+    }
+
+    /// must-follow ②: the self-kick flag is INDEPENDENT — set ONLY by the
+    /// fresh-restart path, NEVER derived from `SpawnMode::Fresh` (initial fleet
+    /// spawns / create_instance / team-spawn are Fresh too but never set it). The
+    /// SPAWN handler reads `self_kick_on_ready` with `unwrap_or(false)`, so any
+    /// spawn-params shape that lacks the flag (every non-restart-fresh spawn)
+    /// gates the self-kick OUT, fail-safe.
+    #[test]
+    fn self_kick_flag_set_only_by_fresh_restart_fail_safe_default() {
+        let env = HashMap::new();
+        // fresh restart → flag present + true.
+        let fresh = restart_spawn_params("dev", "claude", &[], None, &env, "fresh");
+        assert!(fresh["self_kick_on_ready"].as_bool().unwrap_or(false));
+        // resume restart → no flag → reads false.
+        let resume = restart_spawn_params("dev", "claude", &[], None, &env, "resume");
+        assert!(!resume["self_kick_on_ready"].as_bool().unwrap_or(false));
+        // a generic spawn-params object (the initial-fleet / create_instance shape,
+        // which also maps to SpawnMode::Fresh) carries no flag → reads false.
+        let initial = json!({"name": "dev", "backend": "claude", "layout": "tab"});
+        assert!(!initial["self_kick_on_ready"].as_bool().unwrap_or(false));
     }
 }


### PR DESCRIPTION
## fresh-restart self-kick — daemon injects a recovery first turn (t-…82256-9)

**Production daemon-behaviour change → DUAL review.** Design VERIFIED by r6 adversarial review.

### Problem
`restart_instance mode=fresh` does DELETE + SPAWN and lands a **context-lost** instance at an idle prompt with **no first turn** (crash-respawn already injects one; the restart path doesn't). When the operator is absent — the long autonomous/overnight runs where a context-full self-restart happens — nothing drives the new session to recover, so it sits idle and the drive disconnects.

### Fix — 3 design-review must-follows
1. **New `[AGEND-RESUME]` marker**, distinct from `[AGEND-AUTO]`. AGEND-AUTO = a low-priority nudge the agent must NEVER act on (test-pinned blanket, **left untouched** — no per-kind carve-out). AGEND-RESUME = the opposite: an **actionable SELF-bootstrap** trigger to recover the agent's OWN state, explicitly **NOT** operator authority / not a dispatch license. Taught as a separate `instructions.rs` section.
2. **`self_kick_on_ready` is an INDEPENDENT spawn param**, set true **only** by `restart_spawn_params` when `mode=="fresh"`. **Never derived from `SpawnMode::Fresh`** — the SPAWN handler maps absent mode → Fresh, so initial fleet spawns / create_instance / team-spawn are Fresh too; deriving would mis-inject on every initial spawn. Read with `unwrap_or(false)` (fail-safe).
3. **Prompt names the task board + `list_instances` as AUTHORITATIVE first**; `SESSION-HANDOFF.md` is only a stale-tolerant hint (a fresh restart's DELETE=kill may precede any fresh handoff write).

### Mechanism (reuses proven primitives)
`spawn_self_kick_bootstrap` shares a new `wait_for_idle_inject_target` helper with the existing Kiro instructions bootstrap (poll `state==Idle` 200ms → 500ms settle → snapshot `InjectTarget`; injecting while `Starting` would be swallowed), injects the `[AGEND-RESUME]` turn, and arms `inject_delivery` for ≤1 operator-visible re-delivery. **Fire-once** = one thread per restart event. **crash_respawn upgrade deferred** to a same-epic fast-follow.

### Tests (RED→GREEN matrix from the spike)
- `restart_spawn_params` gating: fresh arms / resume doesn't / generic spawn-params reads false (fail-safe, must-follow ②)
- prompt shape + ordering: `[AGEND-RESUME]`, board+list before stale-tolerant handoff, NOT-operator-command (must-follows ①+③)
- instructions: `[AGEND-RESUME]` actionable taught **and** the `[AGEND-AUTO]` never-act rule intact (coexistence)
- marker distinctness

§3.10: mutating the flag-set and the prompt bound each flip the matching test RED (verified). `clippy --tests --features tray -D warnings` + `fmt` clean; agent/instructions/instance-handler suites green (45 + 121).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
