### PR TITLE
test(#2117 Q2): pin dep-derived block is in-memory, not persisted as an event

### DIFF
--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -231,6 +231,12 @@ fn evaluate_with_resolver(
 /// list-time, **not** persisted as Blocked/Unblocked events. The event
 /// log captures only explicit operator/agent transitions; dep-derived
 /// status is a view-layer concern, not part of the canonical history.
+/// This persistence contract is pinned by
+/// `tests::cross_board_dep_derived_block_is_in_memory_not_persisted_2117_q2`
+/// (a `replay_at` of a dep-blocked task's board still yields its un-derived
+/// persisted status). Keeping the block in-memory is also what lets the
+/// cross-board resolver stay acyclic: `Done` is the only persisted status it
+/// reads, so a foreign-board replay is authoritative without recursive eval.
 ///
 /// #2117 Q2: `home` + `board` enable cross-board dep resolution — a dep on
 /// another project's board is read from that board (cached), so a satisfied

--- a/src/tasks/tests.rs
+++ b/src/tasks/tests.rs
@@ -1242,6 +1242,47 @@ fn same_board_dep_in_multiproject_fleet_byte_identical_2117_q2() {
     std::fs::remove_dir_all(&home).ok();
 }
 
+/// Contract (in-memory by design — option (a)/m-42): a dep-derived block is a
+/// LIST-TIME VIEW, never persisted as a Blocked event. `list` derives A as
+/// blocked while its cross-board dep B is open, but A's CANONICAL status — a raw
+/// `replay_at` of A's board — stays Open: the event log records only explicit
+/// operator/agent transitions, not the derived block. This pins what
+/// `apply_dependency_eval_in_memory` documents; a future "persist the derived
+/// block" refactor would silently write phantom Blocked events into history (and
+/// reopen the cross-board cycle risk the in-memory design avoids), and this test
+/// would catch it.
+#[test]
+fn cross_board_dep_derived_block_is_in_memory_not_persisted_2117_q2() {
+    let home = tmp_home("xboard-inmem");
+    cross_board_fleet(&home);
+    let b = create_on(&home, "devB", "B", &[]);
+    let a = create_on(&home, "devA", "A", std::slice::from_ref(&b));
+
+    // List view DERIVES the block (B is open on teamB's board).
+    assert_eq!(
+        status_via_list(&home, "devA", "A"),
+        "blocked",
+        "list must derive A as blocked while cross-board dep B is open"
+    );
+
+    // But the canonical event log persisted NO Blocked transition for A: a raw
+    // replay of A's own board still yields Open.
+    let board_a = super::board_router::board_for_task(&home, &a);
+    let persisted = crate::task_events::replay_at(&board_a)
+        .expect("replay A's board")
+        .tasks
+        .get(&crate::task_events::TaskId(a.clone()))
+        .expect("A present on its board")
+        .status;
+    assert_eq!(
+        persisted,
+        crate::task_events::TaskStatus::Open,
+        "dep-derived block must NOT be persisted — A's replayed status stays Open \
+         (the block is a list-time view, not an event)"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
 /// PR3 — depends_on is set in the Created event and immutable via
 /// the MCP surface (no "depends_on update" event variant). Circular
 /// deps can still arise from migration of a circular legacy


### PR DESCRIPTION
## Context (scoping correction)

Lead dispatched this as "#2117 P3 Gap 2 補測+doc". The scoping spike found the cross-board `depends_on` resolver (**#2117 Q2**, `DepResolver` in `src/tasks/mod.rs:127-196`) is **already fully implemented** and already covered by representative tests:
- `cross_board_dep_done_unblocks_dependent_2117_q2` (auto-unblock)
- `cross_board_dep_not_done_blocks_dependent_2117_q2` (blocks)
- `cross_board_dep_gates_claim_2117_q2` (claim gate)
- `cross_board_mutation_denied_same_board_allowed_2117_p3a` (ACL deny via real `done`/`claim`/`update`)
- `cross_project_parent_id_rejected_at_create_2117_p3a` (parent_id reject)
- `same_board_dep_in_multiproject_fleet_byte_identical_2117_q2` (control)

The **one contract not pinned** was the design property the module doc states: dep-derived blocking is a **list-time in-memory view** (option (a)/m-42), never persisted as Blocked/Unblocked events. This PR pins exactly that, and makes the doc explicit.

## Change

1. **New test** `cross_board_dep_derived_block_is_in_memory_not_persisted_2117_q2`: with a cross-board dep open, `list` derives A as `blocked`, but a raw `replay_at` of A's board still yields `Open` → proves no Blocked event was persisted (the block is a view, not history). Uses the existing representative two-project `cross_board_fleet` fixture through the real `handle`/`list` entry (§3.9).
2. **Doc**: `apply_dependency_eval_in_memory` now references the pinning test and spells out why in-memory keeps the cross-board resolver acyclic (`Done` is the only persisted status it reads → foreign-board replay is authoritative, no recursive eval).

## Verification
- `cargo nextest run` — 9 dep/cross-board tests pass (new + siblings)
- **Load-bearing**: temporarily neutering `DepResolver::status_of` (force foreign deps → `Done`) turns this test + the 3 sibling cross-board tests RED (confirmed locally, reverted).
- `cargo fmt --check` clean; `cargo clippy --tests --features tray` clean

Test+doc only. Base latest `main` (ae9458af).

🤖 Generated with [Claude Code](https://claude.com/claude-code)