### PR TITLE
test(t-43 nit#3): pin SRL/throttle fire-once repros to == 1 (core + nit#2 already in #2221)

### DIFF
--- a/src/state/review_repro_state_capture.rs
+++ b/src/state/review_repro_state_capture.rs
@@ -130,12 +130,16 @@ fn unclassified_throttle_static_screen_logs_once_not_per_tick() {
         .count();
     let _ = std::fs::remove_file(&path);
 
-    assert!(
-        records <= 1,
+    // r6 nit#3: assert EXACTLY one, not `<= 1`. The fire-once contract is "log
+    // once per distinct screen" — `<= 1` also passes when the throttle hint logs
+    // ZERO times, which would silently hide a regression that stops logging the
+    // incident at all. `== 1` pins both directions (fires, and only once).
+    assert_eq!(
+        records, 1,
         "#1 resource-leak: a STATIC unclassified-throttle screen fed 6× appended \
-         {records} JSONL records to unclassified_errors.jsonl (one per tick via the \
-         hash-dedup throttle-hint bypass). After the per-signature fire-once latch \
-         it must log at most once per distinct screen."
+         {records} JSONL records to unclassified_errors.jsonl (expected exactly one \
+         per distinct screen — the per-signature fire-once latch must log once, not \
+         per-tick and not zero)."
     );
 }
 
@@ -177,12 +181,16 @@ fn srl_keep_latched_warn_dedups_across_spinner_ticks() {
         "#2 precondition: the stuck SRL must remain latched across the ticks"
     );
     let warns = logs.matches("#2086-srl-keep-latched").count();
-    assert!(
-        warns <= 1,
+    // r6 nit#3: `== 1`, not `<= 1` — a dedup that silently stopped firing entirely
+    // would also satisfy `<= 1`, hiding the loss of the incident WARN. Pin
+    // exactly-once (fires, and only once per distinct stuck-error signature).
+    assert_eq!(
+        warns,
+        1,
         "#2 maintainability: the #2086-srl-keep-latched WARN fired {warns} times for ONE \
-         stuck SRL across {} spinner ticks (per-tick flood reproducing the #1450 \
-         14k-lines/incident class). After a dedup latch keyed on srl_match_signature it \
-         must fire at most once per distinct stuck-error signature.",
+         stuck SRL across {} spinner ticks (expected exactly one — the dedup latch keyed \
+         on srl_match_signature must fire once per distinct stuck-error signature, not \
+         per-tick and not zero).",
         spinners.len()
     );
 }


### PR DESCRIPTION
## #2187 SRL latch symmetry (t-43) — nit#3 only (core + nit#2 already shipped)

**test-only, zero production delta** (§3.6 single review).

### Premise correction
The board task (t-43) predates PR **#2221**, which already shipped:
- **the core fix** — reset `last_srl_keep_latched_sig` + `last_srl_phantom_warn_sig` on genuine recovery (`recovered_within`-gated, at the `non_srl_since_last_srl` point), so a recover-then-re-stuck on the same line re-logs once; and
- **r6 nit#2** — the phantom dedup key now folds by `kind` via `(sig.0, cross_cycle)` (was `Some(sig.0)`).

Verified on latest main (`mod.rs` 1463-1483 + 2000-2001). The §3.10 recovery repro (`srl_phantom_warn_relogs_after_genuine_recovery`) + its control also landed in #2221. **Only r6 nit#3 remained.**

### nit#3 (this PR)
The two fire-once dedup repros asserted `<= 1`, which also passes when the WARN / throttle record fires **zero** times — silently hiding a regression that stops logging the incident entirely. Tighten both to `== 1` (exactly-once), pinning both directions:
- `unclassified_throttle_static_screen_logs_once_not_per_tick` → `records == 1`
- `srl_keep_latched_warn_dedups_across_spinner_ticks` → `warns == 1`

### Teeth
Mutating the `#2086-srl-keep-latched` WARN to never fire makes `warns == 1` RED (0 ≠ 1) where `<= 1` passed silently — exactly the regression class nit#3 closes. Both repros GREEN; `fmt` + `clippy --tests --features tray -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
