### PR TITLE
fix(restart-freeze): reconcile_hooks marker-walk (hook-install correctness) + background off boot path

### DIFF
--- a/src/binding.rs
+++ b/src/binding.rs
@@ -500,23 +500,22 @@ pub fn install_hooks(home: &Path, worktree: &Path) {
 
 /// Install hooks on all existing worktrees (daemon startup reconcile).
 pub fn reconcile_hooks(home: &Path) {
-    // New layout: <home>/worktrees/<agent>/<branch>/
+    // New layout: <home>/worktrees/<agent>/<branch>/. #restart-freeze: marker-walk
+    // to the real worktree LEAVES (mirrors gc_candidates / collect_managed_worktrees).
+    // The old fixed 2-level descent hit the INTERMEDIATE dir for a slash branch
+    // (`<agent>/fix`, NOT a git worktree) → `git config core.hooksPath` failed
+    // there → the prepare-commit-msg hook was silently never installed for
+    // slash-branch worktrees (the common case), plus one wasted failing `git
+    // config` subprocess per intermediate dir on the boot critical path.
     let new_root = crate::worktree_pool::daemon_managed_worktree_root(home);
-    if new_root.is_dir() {
-        if let Ok(agents) = std::fs::read_dir(&new_root) {
-            for agent_entry in agents.flatten() {
-                if !agent_entry.path().is_dir() {
-                    continue;
-                }
-                if let Ok(branches) = std::fs::read_dir(agent_entry.path()) {
-                    for branch_entry in branches.flatten() {
-                        if branch_entry.path().is_dir() {
-                            install_hooks(home, &branch_entry.path());
-                        }
-                    }
-                }
-            }
-        }
+    let mut worktrees = Vec::new();
+    crate::worktree_pool::collect_managed_worktrees(
+        &new_root,
+        crate::worktree_pool::MARKER_WALK_MAX_DEPTH,
+        &mut worktrees,
+    );
+    for wt in &worktrees {
+        install_hooks(home, wt);
     }
 
     // Legacy layout: <home>/workspace/*/.worktrees/*/
@@ -1143,6 +1142,65 @@ mod tests {
             "audit lines must carry caller process context: {log}"
         );
         std::fs::remove_dir_all(&home).ok();
+    }
+
+    // ── #restart-freeze: reconcile_hooks marker-walk (correctness) ──────────
+    /// RED→GREEN: a SLASH-branch daemon worktree (`<home>/worktrees/<agent>/fix/x`)
+    /// must get its prepare-commit-msg hook wired (`core.hooksPath` set on the
+    /// LEAF). The old fixed 2-level descent hit the intermediate `<agent>/fix`
+    /// (not a git worktree) → `git config` failed there → the leaf's hook was
+    /// silently never installed. The marker-walk targets the real leaf.
+    #[test]
+    fn reconcile_hooks_installs_into_slash_branch_worktree_restart_freeze() {
+        use std::process::Command;
+        let home = tmp_home("reconcile-slash");
+        let repo = tmp_home("reconcile-slash-repo");
+        let git = |args: &[&str], dir: &std::path::Path| {
+            Command::new("git")
+                .args(args)
+                .current_dir(dir)
+                .env("AGEND_GIT_BYPASS", "1")
+                .env("GIT_AUTHOR_NAME", "t")
+                .env("GIT_AUTHOR_EMAIL", "t@t")
+                .env("GIT_COMMITTER_NAME", "t")
+                .env("GIT_COMMITTER_EMAIL", "t@t")
+                .output()
+                .expect("git")
+        };
+        // Source repo with one commit so `worktree add` has a base.
+        assert!(git(&["init", "-b", "main"], &repo).status.success());
+        std::fs::write(repo.join("README.md"), "x\n").unwrap();
+        assert!(git(&["add", "README.md"], &repo).status.success());
+        assert!(git(&["commit", "-m", "init"], &repo).status.success());
+
+        // A SLASH-branch daemon worktree at <home>/worktrees/dev/fix/x.
+        let wt = home.join("worktrees").join("dev").join("fix").join("x");
+        std::fs::create_dir_all(wt.parent().unwrap()).unwrap();
+        assert!(
+            git(
+                &["worktree", "add", "-b", "fix/x", &wt.display().to_string()],
+                &repo
+            )
+            .status
+            .success(),
+            "git worktree add (slash branch) must succeed"
+        );
+        // Daemon-managed marker (as lease() writes it).
+        std::fs::write(wt.join(crate::worktree_pool::MANAGED_MARKER), "").unwrap();
+
+        reconcile_hooks(&home);
+
+        // GREEN: the LEAF worktree's core.hooksPath points at <home>/hooks.
+        // RED (fixed-depth): the leaf was never visited → core.hooksPath unset.
+        let out = git(&["config", "--get", "core.hooksPath"], &wt);
+        let cfg = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        assert_eq!(
+            cfg,
+            home.join("hooks").display().to_string(),
+            "slash-branch worktree must have core.hooksPath set (hook installed)"
+        );
+        std::fs::remove_dir_all(&home).ok();
+        std::fs::remove_dir_all(&repo).ok();
     }
 }
 

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -321,9 +321,18 @@ pub(crate) fn resolve_fleet_and_reconcile(
     time_step("protocol::extract_default", || {
         crate::protocol::extract_default(home);
     });
-    time_step("binding::reconcile_hooks", || {
-        crate::binding::reconcile_hooks(home);
-    });
+    // #restart-freeze: hook installation only matters at COMMIT time, never
+    // before the render loop — running the worktree walk inline blocked boot
+    // (~1.3s of the restart-freeze window, on the main thread before TUI render).
+    // fire-and-forget: install_hooks is idempotent + per-worktree (writes
+    // $AGEND_HOME/hooks/* + sets each worktree's core.hooksPath via bypass git),
+    // independent of the rest of boot, so it runs safely off the critical path.
+    {
+        let home_owned = home.to_path_buf();
+        let _ = std::thread::Builder::new()
+            .name("reconcile-hooks".into())
+            .spawn(move || crate::binding::reconcile_hooks(&home_owned));
+    }
     time_step("binding::symlink_shim", || {
         crate::binding::symlink_shim(home);
     });
@@ -870,7 +879,10 @@ mod tests {
             "boot_sweep_zombies",
             "migrate_legacy_watch_filenames",
             "protocol::extract_default",
-            "binding::reconcile_hooks",
+            // #restart-freeze: `binding::reconcile_hooks` is intentionally NOT a
+            // synchronous bootstrap-step anymore — it runs fire-and-forget off the
+            // boot critical path (hooks only matter at commit time), so it no
+            // longer emits a `time_step` line. Removed from this pin deliberately.
             "binding::symlink_shim",
             "binding::reconcile_orphans",
             "worktree_pool::reconcile_orphan_leases",

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -652,14 +652,17 @@ pub struct GcCandidate {
 /// flat (`<agent>-<enc>/` = depth 1), nested (`<agent>/<branch>/` = depth 2), and
 /// slash-branch (`<agent>/fix/xxx/` = depth 3) layouts with headroom; bounded so a
 /// pathological tree can't make the walk unbounded.
-const MARKER_WALK_MAX_DEPTH: usize = 5;
+pub(crate) const MARKER_WALK_MAX_DEPTH: usize = 5;
 
 /// t-worktree-leak (reviewer-2 #4): recursively collect daemon-managed worktree
 /// dirs (those holding a `.agend-managed` marker) under `root`, to any depth up to
 /// `max_depth`. Once a dir carries the marker it IS a worktree → collected and NOT
 /// descended into (so we never walk a worktree's own working tree). This replaces
 /// the old fixed-depth scan that missed slash-branch worktrees.
-fn collect_managed_worktrees(root: &Path, max_depth: usize, out: &mut Vec<PathBuf>) {
+///
+/// Shared by `gc_candidates` and (#restart-freeze) `binding::reconcile_hooks` —
+/// both need every real worktree leaf regardless of slash-branch nesting depth.
+pub(crate) fn collect_managed_worktrees(root: &Path, max_depth: usize, out: &mut Vec<PathBuf>) {
     if max_depth == 0 {
         return;
     }


### PR DESCRIPTION
## What
Two issues in startup `binding::reconcile_hooks`, found in the daemon **restart-freeze RCA** (it ran ~1.3s on the main thread *before* the TUI render loop, contributing to the post-restart freeze).

### 1. Correctness — hooks silently not installed for slash-branch worktrees
The new-layout scan used a **fixed 2-level descent** (`<agent>/<branch_entry>`). For a slash branch (`fix/x` → `worktrees/<agent>/fix/x`) it called `install_hooks` on the *intermediate* `<agent>/fix` dir — **not a git worktree** → `git config core.hooksPath` failed there → the `prepare-commit-msg` hook was **silently never installed** for slash-branch worktrees (the common case). Each failing call was also a wasted `git config` subprocess on the boot critical path (~48 failures × ~28ms ≈ 1.3s observed).

Fix: **marker-walk to the real worktree leaves**, reusing `worktree_pool::collect_managed_worktrees` (now `pub(crate)`) — the *same* fix `gc_candidates` already adopted for this identical fixed-depth bug class (its own doc comment notes it "replaces the old fixed-depth scan that missed slash-branch worktrees"). reconcile_hooks never followed.

### 2. Boot latency — moved off the critical path
Hook installation only matters at **commit** time, never before render. The bootstrap call is now **fire-and-forget** (§10.5 rationale comment), removing ~1.3s from the boot freeze window. `binding::reconcile_hooks` is intentionally no longer a synchronous bootstrap-step; the step-pin test (`prepare_emits_bootstrap_step_lines_for_every_instrumented_site`) is updated to reflect that.

## Scope
3 files: `binding.rs` (reconcile rewrite + test), `bootstrap/mod.rs` (background + test-pin), `worktree_pool.rs` (visibility `pub(crate)`).

## Tests (RED→GREEN)
- `reconcile_hooks_installs_into_slash_branch_worktree_restart_freeze`: a real slash-branch daemon worktree's `core.hooksPath` is set after reconcile. **RED** with the fixed-depth descent (leaf never visited → unset, verified by neuter); **GREEN** with marker-walk.
- `collect_managed_worktrees` visibility change keeps its own test green.

Local green: `fmt` · `clippy --all-targets --features tray -D warnings` · binding:: (32) · bootstrap (65) · worktree_pool:: (61) · spawn_rationale_audit (the new fire-and-forget thread carries its §10.5 comment).

This is the correctness half of the restart-freeze RCA; the fleet-spawn parallelization half (the other ~1s) is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)