### PR TITLE
fix(#2090 P2): promote UsageLimit hard-wrap rescue + bound ContextFull broad arm

### DIFF
--- a/src/backend_profile.rs
+++ b/src/backend_profile.rs
@@ -353,8 +353,19 @@ fn claudecode_profile() -> BackendProfile {
                 r"You've hit your session limit|You've hit your weekly limit|You've hit your Opus limit|Credit balance is too low|credit_balance_too_low",
             ),
             (
+                // #2090 P2: the broad `context.*(full|limit)` arm is replaced by a
+                // char-BOUNDED same-context arm `context.{0,16}(full|limit)`. The
+                // unbounded `.*` was the dominant hard-wrap-shadow false-positive
+                // source: flattening the bottom-N rows joins them into one line, so
+                // `.*` spanned the whole conversation blob and matched any "context"
+                // + any later "full"/"limit" (agents discussing context/limits while
+                // actively working — 1162 shadow records, ~97% FP). The {0,16} bound
+                // keeps real same-context wording ("context window full",
+                // "context window is full", "context limit") while killing the
+                // cross-row/cross-sentence amplification. The concrete
+                // `compacting context` arm is kept verbatim (zero FP, real signal).
                 AgentState::ContextFull,
-                r"compacting context|context.*(full|limit)",
+                r"compacting context|context.{0,16}(full|limit)",
             ),
             (
                 AgentState::PermissionPrompt,

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1039,6 +1039,45 @@ fn throttle_indicator_adjacent(flat: &str, matched: &str) -> bool {
     crate::state::patterns::line_has_error_indicator(&flat[win_start..end])
 }
 
+/// Chars around a UsageLimit match within which the banner's STRUCTURAL markers
+/// must sit for the [`flattened_guarded_detect`] prose-FP guard. The Claude
+/// weekly/session-limit banner renders inside a `⎿` box-draw block whose phrase is
+/// immediately followed by a `· resets <time>` reset stamp; after the hard-wrap
+/// flatten the box-draw lands a few tokens before the phrase and the reset stamp a
+/// few after, so 40 chars each side covers a short row prefix while staying tight.
+const USAGELIMIT_BANNER_PROXIMITY: usize = 40;
+
+/// #2090 P2: the `\n`-less line-scope replacement for UsageLimit (the analogue of
+/// SRL's [`throttle_indicator_adjacent`]). A real hard-wrapped usage-limit banner
+/// carries BOTH a `⎿` box-draw prefix BEFORE the phrase and a `resets` stamp AFTER
+/// it, within proximity. A prose verbatim quote of the phrase (an agent pasting
+/// "You've hit your weekly limit" into chat) has neither, so it is rejected — the
+/// residual FP (agent quotes the FULL banner incl. box-draw + reset stamp while
+/// itself idle) is vanishingly rare. Conservative by design: a banner variant
+/// without a `resets` stamp (e.g. the credit-balance form) is NOT rescued here —
+/// the raw non-wrapped path still catches it, and the #2090 shadow only observed
+/// the weekly/session `· resets` banners hard-wrapping.
+fn usagelimit_banner_adjacent(flat: &str, matched: &str) -> bool {
+    let Some(start) = flat.find(matched) else {
+        return false;
+    };
+    let end = start + matched.len();
+    // `⎿` box-draw block prefix within proximity BEFORE the phrase.
+    let raw_before = start.saturating_sub(USAGELIMIT_BANNER_PROXIMITY);
+    let before_start = (raw_before..=start)
+        .find(|&i| flat.is_char_boundary(i))
+        .unwrap_or(start);
+    let has_box = flat[before_start..start].contains('⎿');
+    // `resets` reset stamp within proximity AFTER the phrase.
+    let raw_after = (end + USAGELIMIT_BANNER_PROXIMITY).min(flat.len());
+    let after_end = (end..=raw_after)
+        .rev()
+        .find(|&i| flat.is_char_boundary(i))
+        .unwrap_or(end);
+    let has_reset = flat[end..after_end].contains("resets");
+    has_box && has_reset
+}
+
 /// #1562: best-effort append of one JSON record as a single `line\n` to `path`,
 /// creating parent dirs / the file as needed. Returns `Err` for the caller to
 /// log; never panics. The single small `write_all` relies on `O_APPEND`
@@ -1387,17 +1426,26 @@ impl StateTracker {
                 Some((detected, matched))
                     if !is_high_fp_state(detected)
                         && !matches!(detected, AgentState::UsageLimit)
-                        && screen_has_throttle_hint(screen_text)
-                        && self.try_hard_wrap_throttle(patterns, screen_text) =>
+                        // Each rescue has its OWN wrap-surviving cheap pre-filter:
+                        // THROTTLE_HINT_TOKENS are single words for SRL, but the
+                        // usage-limit hint must survive a hard-wrap — the multi-word
+                        // "hit your" splits across narrow-pane rows, so gate the
+                        // UsageLimit rescue on the single word `resets` (the reset
+                        // stamp the banner + `usagelimit_banner_adjacent` both carry).
+                        && ((screen_has_throttle_hint(screen_text)
+                            && self.try_hard_wrap_throttle(patterns, screen_text))
+                            || (screen_text.contains("resets")
+                                && self.try_hard_wrap_usagelimit(patterns, screen_text))) =>
                 {
-                    // #2089: `detect_with_match` landed a BENIGN state (Idle/Thinking
-                    // — the ❯ prompt / a spinner) because a long SRL error
-                    // word-wrapped across a narrow pane and the single-line regex
-                    // missed it. The cheap throttle-hint pre-filter gates the cost;
-                    // `try_hard_wrap_throttle` re-detected the throttle on the
-                    // flattened tail and transitioned to it (overriding the
-                    // idle-prompt chrome). Nothing more to do this arm. `matched` is
-                    // unused on this path.
+                    // #2089/#2090: `detect_with_match` landed a BENIGN state
+                    // (Idle/Thinking — the ❯ prompt / a spinner) because a long
+                    // SRL error OR usage-limit banner word-wrapped across a narrow
+                    // pane and the single-line regex missed it. The cheap
+                    // throttle/quota-hint pre-filter (THROTTLE_HINT_TOKENS covers
+                    // both) gates the cost; `try_hard_wrap_throttle` then (#2090 P2)
+                    // `try_hard_wrap_usagelimit` re-detected it on the flattened
+                    // tail under its own structural guard and transitioned
+                    // (overriding the idle-prompt chrome). `matched` is unused here.
                     let _ = matched;
                 }
                 Some((detected, matched)) => {
@@ -1784,9 +1832,44 @@ impl StateTracker {
         true
     }
 
+    /// #2090 P2: rescue a hard-wrapped UsageLimit banner that single-line
+    /// `detect_with_match` missed (narrow-pane word-wrap landed the bottom `❯`
+    /// idle prompt instead). Flatten-rematches with a {UsageLimit} accept-set and
+    /// the `usagelimit_banner_adjacent` structural guard (box-draw + reset stamp),
+    /// then transitions. UsageLimit is a hard quota (no recovered→Idle downgrade
+    /// like SRL); `gate_on_heartbeat` is a no-op for it. Returns `true` if rescued.
+    /// Sibling of [`try_hard_wrap_throttle`]; called from the SAME two arms.
+    fn try_hard_wrap_usagelimit(
+        &mut self,
+        patterns: &'static StatePatterns,
+        screen_text: &str,
+    ) -> bool {
+        let Some(state) = flattened_guarded_detect(
+            patterns,
+            screen_text,
+            self.input_line_markers,
+            HARD_WRAP_TAIL_LINES,
+            |s| matches!(s, AgentState::UsageLimit),
+            usagelimit_banner_adjacent,
+        ) else {
+            return false;
+        };
+        let gated = self.gate_on_heartbeat(state);
+        self.transition(gated);
+        true
+    }
+
     fn handle_no_raw_match(&mut self, patterns: &'static StatePatterns, screen_text: &str) {
-        if self.try_hard_wrap_throttle(patterns, screen_text) {
-            // hard-wrapped throttle rescued + transitioned.
+        // #2090: throttle rescue stays UNGATED here (THROTTLE_HINT_TOKENS omits the
+        // net-error tokens, so hint-gating would drop a hard-wrapped ECONNRESET);
+        // the UsageLimit rescue is gated on the wrap-surviving `resets` stamp (the
+        // multi-word quota tokens split across narrow-pane rows) to bound the
+        // flatten cost on no-match frames.
+        if self.try_hard_wrap_throttle(patterns, screen_text)
+            || (screen_text.contains("resets")
+                && self.try_hard_wrap_usagelimit(patterns, screen_text))
+        {
+            // hard-wrapped throttle / usage-limit rescued + transitioned.
         } else if matches!(self.current, AgentState::Starting)
             && is_generic_startup_prompt(screen_text)
         {

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -2269,26 +2269,29 @@ fn claude_server_throttle_fixture_triggers_server_rate_limit() {
     assert_eq!(t.get_state(), AgentState::ServerRateLimit);
 }
 
-/// #2090 P2 shadow — the instrument MUST NOT change classification (zero-behavior):
-/// a narrow-pane hard-wrapped UsageLimit that the raw grid misses stays
-/// mis-classified (the shadow only LOGS a candidate; it does not rescue).
+/// #2090 P2 shadow — the instrument MUST NOT change classification (zero-behavior)
+/// for a pattern that has NOT been promoted to a rescue. UsageLimit was promoted
+/// (see `usagelimit_hard_wrapped_banner_rescued_2090`), so this now pins the
+/// invariant on ContextFull, which stays shadow-only: a narrow-pane hard-wrapped
+/// `compacting context` that the raw grid misses is LOGGED as a candidate but NOT
+/// rescued, so the state stays Idle.
 #[test]
 fn hardwrap_miss_shadow_is_zero_behavior_2090() {
-    // "You've hit your weekly limit" hard-wrapped across narrow rows → the
-    // single-line UsageLimit regex misses it; the ❯ prompt lands Idle.
-    let screen = "⎿ You've hit\n\
-                  your weekly\n\
-                  limit · resets\n\
-                  4am\n\
+    // "compacting context" hard-wrapped across narrow rows → the single-line
+    // ContextFull regex misses it; the ❯ prompt lands Idle. The shadow logs a
+    // candidate but does not classify (no ContextFull rescue in P2).
+    let screen = "the agent is\n\
+                  compacting\n\
+                  context now\n\
                   \n\
                   ❯\n";
     let mut t = tracker_at(&Backend::ClaudeCode, AgentState::Idle, 0);
     t.feed(screen);
     assert_ne!(
         t.get_state(),
-        AgentState::UsageLimit,
-        "#2090 P2 shadow is instrument-only — it must NOT rescue/relatch (zero behavior); \
-         the raw grid still misses the hard-wrapped banner"
+        AgentState::ContextFull,
+        "#2090: ContextFull stays shadow-only (instrument-only) — the hard-wrapped \
+         phrase is logged as a candidate but NOT rescued/relatched (zero behavior)"
     );
 }
 
@@ -2456,6 +2459,117 @@ fn prose_throttle_mention_without_indicator_not_misclassified_2089() {
         t.get_state(),
         AgentState::RateLimit,
         "#2089 FP guard: prose mention must not latch RateLimit either"
+    );
+}
+
+// ── #2090 P2: UsageLimit hard-wrap rescue + ContextFull broad-arm tighten ──────
+
+/// #2090 P2: the UsageLimit banner structural guard requires BOTH the `⎿`
+/// box-draw prefix AND a `resets` stamp within proximity of the phrase — so a real
+/// (flattened) hard-wrapped banner passes while a prose quote (missing either)
+/// does not. Pins the both-required logic directly (the `\n`-less anchor analogue
+/// of SRL's `throttle_indicator_adjacent`).
+#[test]
+fn usagelimit_banner_guard_2090() {
+    let phrase = "You've hit your weekly limit";
+    // real flattened banner: box-draw before + reset stamp after → accept.
+    assert!(usagelimit_banner_adjacent(
+        "⎿ You've hit your weekly limit · resets 4am",
+        phrase
+    ));
+    // prose quote: neither marker → reject.
+    assert!(!usagelimit_banner_adjacent(
+        "the agent reported You've hit your weekly limit in its summary",
+        phrase
+    ));
+    // box-draw but no reset stamp → reject (both required).
+    assert!(!usagelimit_banner_adjacent(
+        "⎿ You've hit your weekly limit and then stopped working",
+        phrase
+    ));
+    // reset stamp but no box-draw → reject.
+    assert!(!usagelimit_banner_adjacent(
+        "note: You've hit your weekly limit, it resets soon enough",
+        phrase
+    ));
+}
+
+/// #2090 P2 (RED→GREEN, real §3.9 capture): the narrow-pane usage-limit banner
+/// from the live hardwrap_miss shadow — "You've hit your weekly limit · resets 4am"
+/// hard-wrapped across rows with the idle `❯` below, so single-line detect lands
+/// Idle. The flatten+guard rescue must recover UsageLimit. Pre-fix (no rescue) the
+/// agent read Idle while actually quota-blocked.
+#[test]
+fn usagelimit_hard_wrapped_banner_rescued_2090() {
+    let raw =
+        std::fs::read_to_string("tests/fixtures/state-replay/claude-usagelimit-narrow-wrap.raw")
+            .expect("real usage-limit narrow-wrap fixture");
+    let screen = strip_ansi_2089(&raw);
+    let patterns = StatePatterns::for_backend(&Backend::ClaudeCode);
+    // precondition: the hard-wrapped banner is invisible to single-line detect.
+    assert_ne!(
+        patterns.detect(&screen),
+        Some(AgentState::UsageLimit),
+        "#2090 precondition: hard-wrapped banner must miss the single-line regex"
+    );
+    // the rescue (feed's benign arm) recovers UsageLimit.
+    let mut t = tracker_at(&Backend::ClaudeCode, AgentState::Idle, 0);
+    t.feed(&screen);
+    assert_eq!(
+        t.get_state(),
+        AgentState::UsageLimit,
+        "#2090 P2: hard-wrapped usage-limit banner must be rescued to UsageLimit"
+    );
+}
+
+/// #2090 P2 FP guard (e2e): a WRAPPED prose quote of the banner phrase — no `⎿`
+/// box-draw, no `resets` stamp — must NOT be rescued. The flatten finds the phrase
+/// but the structural guard rejects it, so the agent stays Idle (not UsageLimit).
+#[test]
+fn usagelimit_wrapped_prose_quote_not_rescued_2090() {
+    // The quote is itself hard-wrapped (so the raw single-line path misses it and
+    // the flatten path is the one under test), but carries neither banner marker.
+    let screen = "⏺ I think the\n\
+                  \"You've hit your\n\
+                  weekly limit\"\n\
+                  message wraps in\n\
+                  a narrow pane.\n\
+                  \n\
+                  ❯\n";
+    let mut t = tracker_at(&Backend::ClaudeCode, AgentState::Idle, 0);
+    t.feed(screen);
+    assert_ne!(
+        t.get_state(),
+        AgentState::UsageLimit,
+        "#2090 P2 FP guard: a wrapped prose quote (no box-draw/reset stamp) must not latch UsageLimit"
+    );
+}
+
+/// #2090 P2: the ContextFull broad arm is char-bounded (`context.{0,16}(full|limit)`,
+/// was `context.*(full|limit)`). Real same-context wording still matches; the
+/// cross-sentence "context … limit" prose (the dominant ~97% shadow FP) no longer
+/// does. RED on the old unbounded `.*`.
+#[test]
+fn contextfull_broad_arm_bounded_2090() {
+    let p = StatePatterns::for_backend(&Backend::ClaudeCode);
+    // real wording within the bound still classifies ContextFull.
+    assert_eq!(
+        p.detect("context window full"),
+        Some(AgentState::ContextFull),
+        "#2090: real 'context window full' must still match the bounded arm"
+    );
+    assert_eq!(
+        p.detect("compacting context"),
+        Some(AgentState::ContextFull),
+        "#2090: the concrete 'compacting context' arm is kept verbatim"
+    );
+    // cross-sentence prose (a real shadow FP shape) no longer matches ContextFull.
+    let prose =
+        "context 95%, harness will auto-summarize; fixup-dev is transient rate_limit not usage_limit";
+    assert_ne!(
+        p.detect(prose),
+        Some(AgentState::ContextFull),
+        "#2090: bounded arm must not match cross-sentence 'context … limit' prose"
     );
 }
 

--- a/tests/fixtures/state-replay/claude-usagelimit-narrow-wrap.raw
+++ b/tests/fixtures/state-replay/claude-usagelimit-narrow-wrap.raw
@@ -1,0 +1,8 @@
+[39m⎿ You've hit[0m
+[39myour weekly[0m
+[39mlimit · resets[0m
+[39m4am[0m
+[0m
+[39m❯[0m
+[0m
+


### PR DESCRIPTION
## #2090 P2 — UsageLimit hard-wrap rescue + ContextFull broad-arm tighten

**Production detection change → DUAL review.** Per lead decision d-20260616003753429695-2 (scoping + r6 design VERIFIED).

### Evidence-driven scope
The live `hardwrap_miss_shadow.jsonl` (P2-shadow #2096, 1229 records) showed:
- **UsageLimit (67)** = real misses ("You've hit your weekly limit · resets 4am", landed `idle`) — specific phrase, low FP → **promote**.
- **ContextFull (1162)** = ~97% prose FP (agent conversation, landed `thinking`/`tool_use`); the broad `context.*(full|limit)` is **amplified by flatten** → **tighten, do NOT promote**.

### UsageLimit promotion
- `usagelimit_banner_adjacent` guard — the `\n`-less analogue of SRL's `throttle_indicator_adjacent`: requires **both** a `⎿` box-draw prefix **and** a `resets` stamp within proximity of the phrase. A prose quote (missing either) is rejected (residual FP: agent verbatim-quotes the full banner while idle — vanishingly rare).
- `try_hard_wrap_usagelimit` — flatten-rematch via the shared `flattened_guarded_detect` ({UsageLimit} accept-set + the guard), wired into the **same two arms** as the SRL rescue. Pre-filter is the wrap-surviving single word `resets` (the multi-word `THROTTLE_HINT_TOKENS` like "hit your" split across narrow-pane rows). **SRL throttle path byte-unchanged.**

### ContextFull noise reduction (refinement #3)
claude `context.*(full|limit)` → char-bounded `context.{0,16}(full|limit)`. The unbounded `.*` was the dominant shadow FP source (flatten spans the conversation). Bound keeps real "context window full/limit"; the concrete `compacting context` arm kept verbatim. **P3 (ApiError/AuthError/ModelUnsupported) deferred.**

### §3.9 fixture
`claude-usagelimit-narrow-wrap.raw` extracted from the real shadow `raw_tail` (a genuine narrow-pane capture — no operator session needed).

### Tests / §3.10
- `usagelimit_banner_guard_2090` (both-required guard), `usagelimit_hard_wrapped_banner_rescued_2090` (real-fixture e2e RED→GREEN), `usagelimit_wrapped_prose_quote_not_rescued_2090` (FP guard), `contextfull_broad_arm_bounded_2090` (RED on old `.*`).
- The existing `hardwrap_miss_shadow_is_zero_behavior_2090` repointed to ContextFull (still shadow-only).
- §3.10: disabling the UsageLimit accept → fixture test RED; restoring `.*` → ContextFull prose test RED. **401 `state::` + behavioral_shadow + pattern-coverage + corpus green**; `clippy --tests --features tray -D warnings` + `fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
