### PR TITLE
build: ThinLTO + codegen-units=16 for faster release builds (#2247 profile only)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,9 +55,15 @@ default = []
 tray = ["dep:tray-icon", "dep:tao", "dep:toml"]
 discord = ["dep:twilight-gateway", "dep:twilight-http", "dep:twilight-model"]
 
+# #2247 (build-profile only — NO feature code): ThinLTO + parallel codegen units
+# cut release link time substantially (operator-measured ~40m→17m) at a
+# negligible runtime cost. `lto = "thin"` parallelizes the cross-crate optimize
+# that fat LTO serializes; `codegen-units = 16` (made explicit) lets the
+# pre-LTO codegen run in parallel. `strip` retained.
 [profile.release]
 strip = true
-lto = true
+lto = "thin"
+codegen-units = 16
 
 [dependencies]
 # PTY


### PR DESCRIPTION
## What
Adopt #2247's **build-profile speedup independently** — `Cargo.toml [profile.release]` **only**, **no feature code** (the #2247 feature rework is a separate internal effort, unrelated to this).

```toml
[profile.release]
strip = true
lto = "thin"        # was: lto = true  (fat)
codegen-units = 16  # made explicit (release default; fat LTO masked the parallelism)
```

`lto = "thin"` parallelizes the cross-crate optimize that fat LTO serializes; `codegen-units = 16` lets the pre-LTO codegen run in parallel.

## Before/after (r6 sanity — same clean tree, `cargo build --release`, `cargo clean` between)
| profile | clean release build |
|---|---|
| `lto = true` (fat) | **134s** |
| `lto = "thin"`, `codegen-units = 16` | **50s** (~63% faster) |

(This host is fast; the operator measured ~40m→17m on a slower CI-class host. The relative win is the point.)

## Runtime smoke (no regression)
- Built binary reports version (`agend-terminal 0.8.0`).
- Daemon **boots on an isolated `$AGEND_HOME` to `.ready`** (daemon-init-complete) with no crash, then cleanly killed.
- CI's 3-platform build+test **with the new profile** is the authoritative regression gate.

## Scope
Single-file diff (`Cargo.toml`, +7/-1). No code, no `Cargo.lock` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)