### PR TITLE
fix(#2234 Phase 2): gc_candidates + list_residual via shared fs_managed_worktrees (PR3)

### DIFF
--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -659,11 +659,9 @@ pub fn sync_worktree_to_head(worktree_dir: &Path) {
 /// is repo-independent — agent dirs live under the central daemon
 /// state, not per-repo.
 pub fn list_residual(home: &Path) -> Vec<String> {
+    // `worktrees/<...>` first-level entries — UNCHANGED (byte-identical OFF).
     let wt_base = home.join("worktrees");
-    if !wt_base.exists() {
-        return Vec::new();
-    }
-    std::fs::read_dir(&wt_base)
+    let mut out: Vec<String> = std::fs::read_dir(&wt_base)
         .ok()
         .map(|entries| {
             entries
@@ -672,7 +670,15 @@ pub fn list_residual(home: &Path) -> Vec<String> {
                 .map(|e| e.file_name().to_string_lossy().to_string())
                 .collect()
         })
-        .unwrap_or_default()
+        .unwrap_or_default();
+    // #2234 Phase 2: also surface cure-(B) `workspace/<agent>` gitlink worktrees
+    // (shared single-impl scan). Empty when (B) is OFF → byte-identical.
+    out.extend(
+        crate::worktree_pool::workspace_gitlink_worktrees(home)
+            .iter()
+            .filter_map(|p| p.file_name().and_then(|n| n.to_str()).map(String::from)),
+    );
+    out
 }
 
 #[cfg(test)]
@@ -1489,6 +1495,34 @@ mod tests {
         assert!(
             ws.exists(),
             "#2234: the live branchY workspace must NOT be destroyed by a stale remove(branchX)"
+        );
+        std::fs::remove_dir_all(&home).ok();
+        std::fs::remove_dir_all(&repo).ok();
+    }
+
+    /// #2234 Phase 2: list_residual also surfaces cure-(B) `workspace/<agent>`
+    /// gitlink worktrees (the worktrees_root first-level scan is unchanged →
+    /// byte-identical OFF; this adds the workspace coverage when (B) is on).
+    #[test]
+    fn list_residual_includes_workspace_gitlink_2234() {
+        let home = tmp_home("lr-ws");
+        let repo = tmp_repo("lr-ws-repo");
+        let ws = crate::paths::workspace_dir(&home).join("devw");
+        std::fs::create_dir_all(ws.parent().unwrap()).unwrap();
+        let out = std::process::Command::new("git")
+            .args(["worktree", "add", "-b", "feat/y", &ws.display().to_string()])
+            .current_dir(&repo)
+            .env("AGEND_GIT_BYPASS", "1")
+            .output()
+            .unwrap();
+        assert!(
+            out.status.success(),
+            "git worktree add: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        assert!(
+            list_residual(&home).contains(&"devw".to_string()),
+            "#2234: cure-(B) workspace gitlink agent must appear in list_residual"
         );
         std::fs::remove_dir_all(&home).ok();
         std::fs::remove_dir_all(&repo).ok();

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -1288,6 +1288,43 @@ fn parse_worktree_porcelain(out: &str) -> Vec<(PathBuf, Option<String>)> {
     records
 }
 
+/// #2234 Phase 2: cure-(B) workspace worktrees — `workspace/<agent>` dirs whose
+/// `.git` is a gitlink FILE (a real worktree, Phase 0's discriminator). Empty
+/// when (B) is OFF (no workspace dir is a worktree), so every consumer stays
+/// byte-identical until (B) ships. Marker-LESS interrupted-reconcile worktrees
+/// are still caught here (gitlink-alone). Single impl shared by
+/// `fs_managed_worktrees` (→ enumerate / gc) and `worktree::list_residual`.
+pub(crate) fn workspace_gitlink_worktrees(home: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(crate::paths::workspace_dir(home)) {
+        for entry in entries.flatten() {
+            let p = entry.path();
+            if p.join(".git").is_file() {
+                out.push(p);
+            }
+        }
+    }
+    out
+}
+
+/// #2234 Phase 2: the fs-scan portion of [`enumerate_managed_worktrees`] —
+/// every daemon-managed worktree dir on disk across BOTH layouts:
+/// `worktrees/<agent>/<branch...>` (marker-walk, slash-branch aware) +
+/// cure-(B) `workspace/<agent>` (gitlink). The SINGLE marker-walk impl shared by
+/// `enumerate` (registry ∪ fs) and `gc_candidates` — no parallel rewrite, no
+/// drift. Home-only (no `source_repo`): gc/list are home-wide and need no
+/// `git worktree list`. byte-identical when (B) OFF (the workspace part is empty).
+pub(crate) fn fs_managed_worktrees(home: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    collect_managed_worktrees(
+        &daemon_managed_worktree_root(home),
+        MARKER_WALK_MAX_DEPTH,
+        &mut out,
+    );
+    out.extend(workspace_gitlink_worktrees(home));
+    out
+}
+
 /// #2234 Phase 2: enumerate EVERY daemon-managed worktree across BOTH layouts
 /// (`worktrees/<agent>/<branch>` and cure-(B) `workspace/<agent>`), unioning the
 /// canonical registry (authoritative for any path) with an fs-scan of the known
@@ -1355,22 +1392,10 @@ pub fn enumerate_managed_worktrees(home: &Path, source_repo: &Path) -> Vec<Manag
         }
     }
 
-    // fs pass — catch orphan dirs the registry doesn't know. worktrees_root:
-    // marker-walk (slash-branch aware). workspace: gitlink-alone gate (a `.git`
-    // FILE ⟹ a worktree, aligned with Phase 0's discriminator — marker-less
-    // interrupted-reconcile worktrees are still caught; the registry pass covers
-    // the rest).
-    let mut fs_found = Vec::new();
-    collect_managed_worktrees(&worktrees_root, MARKER_WALK_MAX_DEPTH, &mut fs_found);
-    if let Ok(entries) = std::fs::read_dir(&workspace) {
-        for entry in entries.flatten() {
-            let p = entry.path();
-            if p.join(".git").is_file() {
-                fs_found.push(p);
-            }
-        }
-    }
-    for p in fs_found {
+    // fs pass — catch orphan dirs the registry doesn't know. Shared
+    // `fs_managed_worktrees` is the SINGLE marker-walk + workspace-gitlink impl
+    // (also used by gc_candidates / list_residual — no parallel rewrite).
+    for p in fs_managed_worktrees(home) {
         let cp = canon(&p);
         by_path
             .entry(cp.clone())
@@ -1395,18 +1420,13 @@ pub fn gc_candidates(home: &Path) -> Vec<GcCandidate> {
             .into_iter()
             .collect();
 
-    // New layout: <home>/worktrees/<agent>/<branch>/ — but a SLASH branch
-    // (`fix/xxx`, `feat/yyy` = the common case) nests an EXTRA level
-    // (`<agent>/fix/xxx`), so the old fixed 1-level descent enumerated `fix` (not a
-    // worktree, no marker) and missed the real worktree entirely (reviewer-2 #4, a
-    // pre-existing GC bug that silently disabled GC — clean-release AND
-    // force-reclaim — for most branches). Walk DOWN to the `.agend-managed` marker
-    // instead of assuming a fixed depth.
-    let new_root = daemon_managed_worktree_root(home);
-    let mut managed = Vec::new();
-    collect_managed_worktrees(&new_root, MARKER_WALK_MAX_DEPTH, &mut managed);
-    for wt_path in &managed {
-        if let Some(candidate) = evaluate_candidate(home, wt_path, &live_agents) {
+    // New layout `worktrees/<agent>/<branch>/` (marker-walk, slash-branch aware)
+    // + cure-(B) `workspace/<agent>` gitlink worktrees, via the shared
+    // `fs_managed_worktrees` (#2234 Phase 2 — single marker-walk impl). The
+    // workspace part is empty when (B) is OFF → byte-identical candidate set; the
+    // `evaluate_candidate` marker-gate filters anything non-managed regardless.
+    for wt_path in fs_managed_worktrees(home) {
+        if let Some(candidate) = evaluate_candidate(home, &wt_path, &live_agents) {
             candidates.push(candidate);
         }
     }
@@ -4610,6 +4630,42 @@ mod tests {
         assert!(
             !orp.registered,
             "orphan dir is NOT git-registered (caught only by the fs-scan)"
+        );
+        std::fs::remove_dir_all(&home).ok();
+        std::fs::remove_dir_all(&repo).ok();
+    }
+
+    /// #2234 Phase 2 byte-identical-OFF: with no cure-(B) workspace worktree,
+    /// `fs_managed_worktrees` == the worktrees_root marker-walk (gc's prior scan).
+    #[test]
+    fn fs_managed_worktrees_off_byte_identical_2234() {
+        let home = tmp_home("fsm-off");
+        let wt = home.join("worktrees").join("dev").join("fix").join("x");
+        std::fs::create_dir_all(&wt).unwrap();
+        std::fs::write(wt.join(MANAGED_MARKER), "agent=dev\n").unwrap();
+        let mut collected = Vec::new();
+        collect_managed_worktrees(
+            &daemon_managed_worktree_root(&home),
+            MARKER_WALK_MAX_DEPTH,
+            &mut collected,
+        );
+        assert_eq!(
+            fs_managed_worktrees(&home),
+            collected,
+            "#2234 OFF: fs_managed == worktrees_root marker-walk (workspace part empty → byte-identical)"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #2234 Phase 2 (B) ON: a `workspace/<agent>` gitlink worktree is included.
+    #[test]
+    fn fs_managed_worktrees_includes_workspace_gitlink_2234() {
+        let home = tmp_home("fsm-b");
+        let repo = tmp_repo("fsm-b-repo");
+        let ws = managed_workspace_worktree(&home, &repo, "devb", "feat/y");
+        assert!(
+            fs_managed_worktrees(&home).iter().any(|p| p == &ws),
+            "#2234: cure-(B) workspace gitlink worktree must be enumerated by fs_managed_worktrees"
         );
         std::fs::remove_dir_all(&home).ok();
         std::fs::remove_dir_all(&repo).ok();


### PR DESCRIPTION
## What (#2234 (B) Phase 2, PR3)
Make `gc_candidates` + `list_residual` cover cure-(B) `workspace/<agent>` worktrees, **byte-identical when (B) is OFF**, via a **single shared fs-scan** (no parallel rewrite, no drift — the lead's req #1).

- **`workspace_gitlink_worktrees(home)`** + **`fs_managed_worktrees(home)`**: the single marker-walk (`worktrees_root`) + workspace-gitlink fs-scan, **extracted from `enumerate_managed_worktrees`'s fs-pass** — `enumerate` now calls it (`enumerate = registry ∪ fs_managed_worktrees`). Home-only (no `source_repo`): gc/list are home-wide (multi-project) and need no `git worktree list`; the registry pass adds nothing for them (gc's marker-gate filters registry-only entries; list is log-only).
- **`gc_candidates`**: scans via `fs_managed_worktrees` (+ keeps the legacy `workspace/*/.worktrees/*` scan). OFF: workspace part empty + `evaluate_candidate`'s marker-gate ⟹ **candidate set unchanged**; ON: covers `/workspace`.
- **`list_residual`**: `worktrees/` first-level scan **UNCHANGED** (byte-identical) + appends workspace gitlink agents (empty OFF).

Full `enumerate` (registry ∪ fs) untouched, still used by Phase 1c.

## Tests
- `fs_managed_worktrees_off_byte_identical_2234`: OFF == `worktrees_root` marker-walk.
- `fs_managed_worktrees_includes_workspace_gitlink_2234`: (B) on → workspace gitlink included.
- `list_residual_includes_workspace_gitlink_2234`: (B) workspace agent surfaced.
- **byte-identical-OFF lock**: the existing `gc_candidates` (5) + `list_residual` (2) tests stay green (candidate set / list output unchanged).

Local green: `fmt` · `clippy --all-targets --features tray -D warnings` · worktree_pool:: (83) · worktree:: (40) · git_subprocess + daemon_git_helper invariants.

Design dialectic-VERIFIED by r6; fs-subset approach is the lead's approved resolution to the `source_repo`-vs-home-wide mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)