### PR TITLE
test(#2234 PR3 fast-follow): lock marker-less workspace gitlink not GC-reclaimed

### DIFF
--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -3247,6 +3247,41 @@ mod tests {
         std::fs::remove_dir_all(&home).ok();
     }
 
+    /// #2234 Phase 2 gc-safety (r6 #2269 observation): a MARKER-LESS
+    /// `workspace/<agent>` gitlink worktree — a real worktree (`.git` is a gitlink
+    /// FILE) but missing the `.agend-managed` marker (e.g. an interrupted
+    /// reconcile) — is enumerated by the new (B) `workspace_gitlink_worktrees`
+    /// scan (gitlink-alone gate), so it DOES reach `evaluate_candidate`; it MUST
+    /// NOT become a GC candidate because the `is_daemon_managed` marker-gate
+    /// rejects it. The sibling `gc_candidates_includes_only_daemon_tagged` only
+    /// covers a NESTED `.worktrees/human` dir that the marker-walk collect stage
+    /// filters BEFORE evaluate, so it never exercises this workspace-gitlink path.
+    #[test]
+    fn gc_candidates_excludes_marker_less_workspace_gitlink_2234() {
+        let home = tmp_home("gc-markerless-ws");
+        let repo = tmp_repo("gc-markerless-ws-repo");
+        // Same fixture as `managed_workspace_worktree`, minus the marker write.
+        let ws = managed_workspace_worktree(&home, &repo, "deve", "feat/markerless");
+        std::fs::remove_file(ws.join(MANAGED_MARKER)).expect("drop marker");
+        assert!(
+            ws.join(".git").is_file(),
+            "fixture is a real gitlink worktree"
+        );
+        // Precondition: the (B) scan DOES enumerate it (so it reaches evaluate).
+        assert!(
+            fs_managed_worktrees(&home).iter().any(|p| p == &ws),
+            "marker-less workspace gitlink must be enumerated (reaches evaluate_candidate)"
+        );
+        // Property under test: the marker-gate keeps it OUT of the candidate set.
+        let candidates = gc_candidates(&home);
+        assert!(
+            candidates.iter().all(|c| c.path != ws),
+            "marker-less workspace gitlink must NOT be a GC candidate: {candidates:?}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+        std::fs::remove_dir_all(&repo).ok();
+    }
+
     #[test]
     fn gc_candidates_excludes_pinned() {
         let home = tmp_home("gc-pinned");


### PR DESCRIPTION
## What
Adds one committed regression test (`worktree_pool::tests::gc_candidates_excludes_marker_less_workspace_gitlink_2234`) locking a destructive-safety property r6 observed during #2269 review but which had **no committed test**.

## Why
After #2269, `gc_candidates` scans `workspace/<agent>` gitlinks via `fs_managed_worktrees`. The only new "must-not-delete" item is a **marker-less workspace gitlink** — a real worktree (`.git` is a gitlink file) missing the `.agend-managed` marker (e.g. an interrupted reconcile). It IS enumerated (`workspace_gitlink_worktrees` is a gitlink-alone gate) so it reaches `evaluate_candidate`, where the `is_daemon_managed` marker-gate must reject it.

The existing `gc_candidates_includes_only_daemon_tagged` only covers a **nested** `.worktrees/human` dir that the marker-walk collect stage filters *before* `evaluate_candidate` — it never exercises the workspace-gitlink path.

## Test design (not vacuous)
- Fixture = `managed_workspace_worktree` minus the marker write → real gitlink worktree, no `.agend-managed`.
- **Precondition assert**: `fs_managed_worktrees` DOES enumerate it (proves it reaches `evaluate_candidate` — guards against a vacuous pass).
- **Property**: `gc_candidates` excludes it (the marker-gate is the only thing keeping it out).

test-only, single review (low-blast). Base = post-#2269 main. Aligns with the "destructive-safety properties deserve a required test" guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)