### PR TITLE
chore(restart-freeze): instrument restore-loop + render-entry timing (RCA confirm)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -282,6 +282,13 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
     let mut known_remote_agents: std::collections::HashSet<String> =
         std::collections::HashSet::new();
 
+    // restart-freeze RCA (t-…55279): anchor for the boot critical path the
+    // operator sees freeze on daemon restart — session restore + the
+    // synchronous per-agent PTY spawns, then post-spawn wiring, up to the
+    // first render. Logged at restore-complete and pre-render-loop below.
+    // Pure tracing, zero behavior.
+    let restore_start = std::time::Instant::now();
+
     if let Some(ref run_dir) = attached_run_dir {
         // Attached (#895 fix): tabs derive from the union of
         //   (a) daemon's `*.port` files (live agent registry — source of truth
@@ -357,6 +364,16 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
     // controlling TTY (e.g. a winsize written to fd 0/1 instead of a pane's
     // pty master).
     trace_tty_size(size_debug, "post-fleet-spawn");
+
+    // restart-freeze RCA (t-…55279): session restore + all synchronous
+    // per-agent PTY spawns are done. Sum of the per-agent `restore-spawn`
+    // lines ≈ this; the gap to `pre-render-loop` below is post-spawn wiring.
+    tracing::info!(
+        target: "restart_timing",
+        elapsed_ms = restore_start.elapsed().as_millis() as u64,
+        attached = attached_mode,
+        "restore-complete: session restore + fleet PTY spawns done"
+    );
 
     // Flag to trigger resize pass after layout changes (split, close, zoom, tab switch).
     // Start true so restored split panes get correct sizes before first draw.
@@ -443,6 +460,17 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
     // tick threads). The per-frame `#2057-size` probe below only ever sees this
     // post-shrink value (confirmed by the operator A/B), so the cause is here.
     trace_tty_size(size_debug, "pre-render-loop");
+
+    // restart-freeze RCA (t-…55279): entering the render loop — the first
+    // `terminal.draw` is imminent. Elapsed from `restore_start` is the full
+    // boot critical path the operator perceives as the restart freeze
+    // (restore + per-agent spawns + post-spawn wiring). Pure tracing.
+    tracing::info!(
+        target: "restart_timing",
+        elapsed_ms = restore_start.elapsed().as_millis() as u64,
+        attached = attached_mode,
+        "pre-render-loop: entering render loop (first draw imminent)"
+    );
 
     loop {
         if crate::bootstrap::signals::term_requested() {

--- a/src/app/session.rs
+++ b/src/app/session.rs
@@ -225,7 +225,12 @@ pub(super) fn restore_with_reconciliation(
         match sp.fleet_instance_name.as_deref() {
             Some(name) => {
                 let resolved = fleet.as_ref().and_then(|f| f.resolve_instance(name))?;
-                super::pane_factory::create_pane_from_resolved(
+                // restart-freeze RCA (t-…55279): time the per-agent local-PTY
+                // spawn. The owned-restore path runs these synchronously in
+                // apply_session_layout order, so the sum is the boot critical
+                // path the operator sees freeze. Pure tracing, zero behavior.
+                let spawn_start = std::time::Instant::now();
+                let pane = super::pane_factory::create_pane_from_resolved(
                     name,
                     &resolved,
                     layout,
@@ -237,7 +242,15 @@ pub(super) fn restore_with_reconciliation(
                     name_counter,
                     crate::backend::SpawnMode::Resume,
                 )
-                .ok()
+                .ok();
+                tracing::info!(
+                    target: "restart_timing",
+                    agent = %name,
+                    elapsed_ms = spawn_start.elapsed().as_millis() as u64,
+                    ok = pane.is_some(),
+                    "restore-spawn: per-agent local-PTY spawn (synchronous)"
+                );
+                pane
             }
             None => {
                 let shell =


### PR DESCRIPTION
## What

Instrument-only (pure `tracing`, **zero behavior change**) for the daemon-restart freeze RCA (task `t-…55279`). Adds a `restart_timing` tracing target at three points on the owned `app`-mode boot critical path (`run_app` → `restore_with_reconciliation`):

- **per-agent `restore-spawn`** `elapsed_ms` — each synchronous local-PTY spawn in the restore loop (`session.rs` `pane_builder`), labelled by `agent` + `ok`.
- **`restore-complete`** `elapsed_ms` — session restore + all fleet PTY spawns done.
- **`pre-render-loop`** `elapsed_ms` — entering the render loop (first draw imminent); elapsed from `restore_start` is the full freeze window the operator perceives.

## Why

Production-confirm the RCA's **revised** root cause (decision `d-20260616062203769803-1`): the restart freeze is the **synchronous per-agent child fork/exec** in the owned restore loop (`agent::spawn_agent`), **NOT** the #908 port-publish blocking (that path is `run_core`'s `spawn_and_register_agent`, which `app` mode never calls — see memory `app_mode_never_calls_run_core`).

Instrument-first per the doubt-add-log-confirm discipline: merge → next operator restart emits the evidence → confirm fork/exec dominates → then implement render-first (pending r6 dialectic on the design).

## How to read

\`\`\`bash
grep restart_timing \$AGEND_HOME/daemon.log
\`\`\`

## Scope

- `src/app/session.rs` — per-agent spawn timing (wraps the existing `create_pane_from_resolved` call in a `let`; identical result).
- `src/app/mod.rs` — `restore_start` anchor + restore-complete + pre-render-loop logs.

No logic change; `+43 / -2`. fmt + clippy (`--all-targets --features tray`) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)