### PR TITLE
fix(#2271): emit restart_timing instrument under a captured tracing target

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -369,7 +369,7 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
     // per-agent PTY spawns are done. Sum of the per-agent `restore-spawn`
     // lines ≈ this; the gap to `pre-render-loop` below is post-spawn wiring.
     tracing::info!(
-        target: "restart_timing",
+        phase = "restore-complete",
         elapsed_ms = restore_start.elapsed().as_millis() as u64,
         attached = attached_mode,
         "restore-complete: session restore + fleet PTY spawns done"
@@ -466,7 +466,7 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
     // boot critical path the operator perceives as the restart freeze
     // (restore + per-agent spawns + post-spawn wiring). Pure tracing.
     tracing::info!(
-        target: "restart_timing",
+        phase = "pre-render-loop",
         elapsed_ms = restore_start.elapsed().as_millis() as u64,
         attached = attached_mode,
         "pre-render-loop: entering render loop (first draw imminent)"

--- a/src/app/session.rs
+++ b/src/app/session.rs
@@ -244,7 +244,7 @@ pub(super) fn restore_with_reconciliation(
                 )
                 .ok();
                 tracing::info!(
-                    target: "restart_timing",
+                    phase = "restore-spawn",
                     agent = %name,
                     elapsed_ms = spawn_start.elapsed().as_millis() as u64,
                     ok = pane.is_some(),


### PR DESCRIPTION
## Problem
#2271's restart-freeze instrument (3 `tracing::info!` points) shipped + deployed but captured **zero** log lines. Lead confirmed via the 16:43 restart: the instrument is in the binary (`strings`), other default-target INFO logs appear, but `grep restart_timing` over all logs = 0.

## Root cause
The 3 points used `tracing::info!(target: "restart_timing", …)`. The EnvFilter default (`src/logging.rs:73`) is `agend_terminal=info` — a module-path directive matching only targets prefixed `agend_terminal`. The literal `restart_timing` target matches nothing → filtered out. A normal `info!` uses its module path as target (matches → captured), which is why every *other* INFO log appears.

## Fix (pure instrument, zero behavior)
Drop `target: "restart_timing"` from all 3 sites → each falls back to its module-path target (`agend_terminal::app::session`, `agend_terminal::app`), captured by the filter. Add a structured `phase` field (`restore-spawn` / `restore-complete` / `pre-render-loop`) so the timings stay greppable.

## Verification (next restart)
After deploy, the operator's next restart can run:
```
grep 'phase="restore' app.<date>.log   # per-agent restore-spawn elapsed_ms + restore-complete
grep 'phase="pre-render-loop"' app.<date>.log   # full boot critical path
```

Local: fmt ✓, clippy --features tray --bins --tests -D warnings ✓, full `nextest --features tray --profile ci` = 4430/4430 pass. Net 0 LOC (target→phase swap). No test references these log lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)