### PR TITLE
chore: enforce DCO sign-off on all pull requests

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,65 @@
+name: DCO
+
+# Verifies every commit in a pull request carries a Developer Certificate of
+# Origin `Signed-off-by` trailer (see /DCO). Pure inline shell over the
+# pre-installed `gh` CLI + `jq` — no third-party actions, no checkout, zero
+# supply-chain surface. Merge commits (no original authorship to certify) and
+# bot authors (cannot sign a DCO) are exempt. Lead wires this as a required
+# status check via branch protection separately.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: dco-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  dco:
+    name: Signed-off-by
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Verify Signed-off-by on every commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          # All commits in the PR (paginated — handles the >250 ceiling).
+          commits="$(gh api --paginate "repos/${REPO}/pulls/${PR}/commits")"
+
+          # jq does the whole gate in one pass: skip merge commits (>=2 parents)
+          # and bot authors, then keep only commits whose message has NO valid
+          # `Signed-off-by: Name <email>` trailer. Output = one line per offender.
+          unsigned="$(printf '%s' "$commits" | jq -r '
+            .[]
+            | select((.parents | length) < 2)
+            | select(((.commit.author.email // "") | test("\\[bot\\]")) | not)
+            | select((.commit.message | test("(?im)^[ \\t]*Signed-off-by:[ \\t]+.+ <[^>]+@[^>]+>[ \\t]*$")) | not)
+            | "  - \(.sha[0:12])  \(.commit.message | split("\n")[0])"
+          ')"
+
+          if [ -n "$unsigned" ]; then
+            echo "::error::One or more commits are missing a Developer Certificate of Origin sign-off."
+            echo "Commits without a valid 'Signed-off-by:' trailer:"
+            echo "$unsigned"
+            echo ""
+            echo "By signing off you certify the Developer Certificate of Origin (see ./DCO)."
+            echo "Fix it:"
+            echo "  - new commits:       git commit -s"
+            echo "  - amend the last:    git commit --amend -s --no-edit && git push --force-with-lease"
+            echo "  - all PR commits:    git rebase --signoff origin/main && git push --force-with-lease"
+            echo "See CONTRIBUTING.md for details."
+            exit 1
+          fi
+
+          echo "All non-merge, non-bot commits carry a DCO Signed-off-by. ✓"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,24 @@ Coverage is observation-only — not a merge gate. PRs that drop project coverag
    - `merge:` PR-style aggregation (used when landing review rounds)
 4. **PR description** — what changed and why. Tie bug fixes to evidence (stack trace, repro, test that failed before).
 
+## Sign-off (Developer Certificate of Origin)
+
+Every commit must be **signed off**. By signing off you certify the [Developer Certificate of Origin](DCO) (DCO 1.1) — that you wrote the change, or otherwise have the right to submit it under the project's [Apache-2.0](LICENSE) license. CI enforces this on every pull request (`.github/workflows/dco.yml`): a commit without a valid `Signed-off-by` trailer fails the **DCO** check (merge commits and bot commits are exempt).
+
+Add the trailer automatically with `-s`:
+
+```bash
+git commit -s -m "fix: ..."     # appends: Signed-off-by: Your Name <you@example.com>
+```
+
+The `Signed-off-by` line uses your `git config user.name` / `user.email`. To sign off commits you already made:
+
+```bash
+git commit --amend -s --no-edit            # the last commit
+git rebase --signoff origin/main           # every commit on the branch
+# then: git push --force-with-lease
+```
+
 ## Review Process
 
 Here's what to expect once you open an issue or PR — the aim is fast, concrete feedback, not ceremony.

--- a/CONTRIBUTING.zh-TW.md
+++ b/CONTRIBUTING.zh-TW.md
@@ -62,6 +62,24 @@ cargo llvm-cov --workspace --tests --html     # HTML report at target/llvm-cov/h
    - `merge:` PR 風格的彙整（用於合進多輪 review 時）
 4. **PR 描述**——說明改了什麼、為什麼改。把 bug fix 連結到證據（stack trace、重現步驟、修復前會失敗的測試）。
 
+## 簽署（Developer Certificate of Origin）
+
+每個 commit 都必須**簽署（sign-off）**。簽署即代表你認證 [Developer Certificate of Origin](DCO)（DCO 1.1）——你撰寫了這項變更，或以其他方式擁有在本專案 [Apache-2.0](LICENSE) 授權下提交它的權利。CI 會在每個 pull request 強制檢查（`.github/workflows/dco.yml`）:任何缺少有效 `Signed-off-by` trailer 的 commit 會讓 **DCO** 檢查失敗（merge commit 與 bot commit 豁免）。
+
+用 `-s` 自動加上 trailer:
+
+```bash
+git commit -s -m "fix: ..."     # 附上:Signed-off-by: Your Name <you@example.com>
+```
+
+`Signed-off-by` 會使用你的 `git config user.name` / `user.email`。要替已經做好的 commit 補簽署:
+
+```bash
+git commit --amend -s --no-edit            # 最後一個 commit
+git rebase --signoff origin/main           # 分支上的每個 commit
+# 然後:git push --force-with-lease
+```
+
 ## Review 流程
 
 以下是你開 issue 或 PR 之後可以預期的狀況——目標是快速、具體的回饋，而不是繁文縟節。

--- a/DCO
+++ b/DCO
@@ -1,0 +1,34 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.

--- a/README.md
+++ b/README.md
@@ -150,6 +150,10 @@ graph LR
 
 agend-terminal modifies git behavior for spawned agents (PATH shim, commit trailers, deny matrix, daemon-managed worktrees). Your own terminal is **not** affected. Read [`docs/GIT-BEHAVIOR.md`](docs/GIT-BEHAVIOR.md) before starting the daemon.
 
+## Contributing
+
+Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md). All commits must be signed off (`git commit -s`) to certify the [Developer Certificate of Origin](DCO); CI enforces this on every pull request.
+
 ## License
 
 MIT

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -147,6 +147,10 @@ graph LR
 
 agend-terminal 會修改被啟動 agent 的 git 行為（PATH shim、commit trailer、deny matrix、daemon 管理的 worktree）。你自己的終端機**不受影響**。啟動 daemon 前請先讀 [`docs/GIT-BEHAVIOR.zh-TW.md`](docs/GIT-BEHAVIOR.zh-TW.md)。
 
+## 貢獻
+
+歡迎貢獻——請見 [CONTRIBUTING.zh-TW.md](CONTRIBUTING.zh-TW.md)。所有 commit 都必須簽署（`git commit -s`）以認證 [Developer Certificate of Origin](DCO);CI 會在每個 pull request 強制檢查。
+
 ## 授權條款
 
 MIT


### PR DESCRIPTION
operator 黃家政 chose to require a Developer Certificate of Origin sign-off on every contribution (clean provenance chain), enforced by CI rather than a GitHub App. Pure CI/docs, zero source code.

## Changes
- **`.github/workflows/dco.yml`** — `on: pull_request`, verifies **every commit** carries a valid `Signed-off-by` trailer. **Pure inline shell** over the pre-installed `gh` CLI + `jq` — no third-party actions, no `checkout`, zero supply-chain surface. Merge commits (no original authorship to certify) and bot authors are exempt. On failure it lists the offending commits and how to fix (`git commit -s` / `git commit --amend -s` / `git rebase --signoff`).
- **`DCO`** — Developer Certificate of Origin 1.1, verbatim from developercertificate.org.
- **`CONTRIBUTING.md` + `CONTRIBUTING.zh-TW.md`** — new Sign-off section.
- **`README.md` + `README.zh-TW.md`** — new Contributing section linking CONTRIBUTING + DCO.

## Self-review notes
- **Dogfood**: this workflow runs on its own PR. The single commit here is signed off (`Signed-off-by: suzuke <suzuke789@gmail.com>`), so the DCO check should pass on itself.
- **gate logic validated locally** against sample commits: signed → pass; unsigned → flagged; merge commit (2+ parents) → skipped; `dependabot[bot]` → skipped.
- **No action to pin** — chose the zero-action `gh api` path precisely to avoid the third-party-action / SHA-pinning question.
- Lead wires the **required status check** (branch protection) via `gh api` separately — not in this PR.
- README `## Contributing` is added in a different region from the License section, so it won't conflict with the in-flight relicense PR #2279.

🤖 Generated with [Claude Code](https://claude.com/claude-code)