### PR TITLE
fix(#2282): give context-handoff an actionable [AGEND-HANDOFF] marker

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -2160,6 +2160,18 @@ pub(crate) const DAEMON_RESUME_INJECT_MARKER: &str = "[AGEND-RESUME]";
 /// the report-mode backstop must be acted on, so it can't wear the never-act tag.
 pub(crate) const DAEMON_PROGRESS_INJECT_MARKER: &str = "[AGEND-PROGRESS]";
 
+/// #2282: context-handoff marker — a FOURTH distinct daemon token, actionable like
+/// [`DAEMON_RESUME_INJECT_MARKER`] / [`DAEMON_PROGRESS_INJECT_MARKER`] and unlike the
+/// never-act [`DAEMON_AUTO_INJECT_MARKER`]. The context-handoff watchdog
+/// (`daemon::per_tick::context_handoff`) injects it near context-full to ask the
+/// agent to SAVE its state (write `SESSION-HANDOFF.md` + annotate its task) before
+/// the context window runs out. It must NOT use `[AGEND-AUTO]`: that marker's "never
+/// act" blanket would suppress the very save the nudge asks for — the latent bug
+/// this fixes (the nudge was silently ignored, leaving only the 92% operator
+/// escalation as a degraded backstop). A separate marker keeps the `[AGEND-AUTO]`
+/// blanket clean (mirrors the `[AGEND-RESUME]` / `[AGEND-PROGRESS]` design).
+pub(crate) const DAEMON_HANDOFF_INJECT_MARKER: &str = "[AGEND-HANDOFF]";
+
 /// The fixed first turn injected ONCE after a fresh-restart respawn. It is an
 /// actionable SELF-bootstrap trigger (recover the agent's OWN in-flight state),
 /// NOT an operator command and NOT authority to dispatch new work. Ordering per

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -157,6 +157,24 @@ fn progress_marker_distinct_from_auto_and_resume_markers() {
     }
 }
 
+/// #2282: the `[AGEND-HANDOFF]` context-handoff marker is a FOURTH distinct token —
+/// neither a prefix of, nor prefixed by, `[AGEND-AUTO]` / `[AGEND-RESUME]` /
+/// `[AGEND-PROGRESS]` (so an agent can't confuse the save-state directive with the
+/// never-act nudge, the recovery trigger, or the progress nudge).
+#[test]
+fn handoff_marker_distinct_from_auto_resume_progress_markers_2282() {
+    assert_eq!(super::DAEMON_HANDOFF_INJECT_MARKER, "[AGEND-HANDOFF]");
+    for other in [
+        super::DAEMON_AUTO_INJECT_MARKER,
+        super::DAEMON_RESUME_INJECT_MARKER,
+        super::DAEMON_PROGRESS_INJECT_MARKER,
+    ] {
+        assert_ne!(super::DAEMON_HANDOFF_INJECT_MARKER, other);
+        assert!(!super::DAEMON_HANDOFF_INJECT_MARKER.starts_with(other));
+        assert!(!other.starts_with(super::DAEMON_HANDOFF_INJECT_MARKER));
+    }
+}
+
 /// fresh-restart self-kick prompt (must-follows ①+③): an actionable
 /// `[AGEND-RESUME]` self-bootstrap; the task board + `list_instances` are named as
 /// the AUTHORITATIVE live sources BEFORE the stale-tolerant `SESSION-HANDOFF.md`

--- a/src/daemon/per_tick/context_handoff.rs
+++ b/src/daemon/per_tick/context_handoff.rs
@@ -162,17 +162,20 @@ fn decide(
     }
 }
 
-/// The one-shot nudge. `inject_with_target_gated` prefixes the
-/// `[AGEND-AUTO kind=context-handoff]` tag (#1769/#1771), so agents know it
-/// is a daemon nudge, not an operator command. Single line: a multi-line
-/// PTY injection risks splitting into multiple submits.
+/// The one-shot nudge. Carries the actionable `[AGEND-HANDOFF]` marker (#2282) so
+/// the agent ACTS on it — the prior `[AGEND-AUTO kind=context-handoff]` tag was
+/// suppressed by the "never act on [AGEND-AUTO]" blanket (the save the nudge asks
+/// for was silently skipped). Injected verbatim (`auto_kind = None`) since the
+/// marker is already in the payload. Single line: a multi-line PTY injection risks
+/// splitting into multiple submits.
 fn handoff_payload(pct: f32) -> String {
     format!(
-        "context usage at {pct:.0}% — before it runs out: (1) write {HANDOFF_FILENAME} \
+        "{marker} context usage at {pct:.0}% — before it runs out: (1) write {HANDOFF_FILENAME} \
          in your working directory (current task + state, key decisions, next steps, \
          open branches/PRs); (2) add a brief handoff note to your active task on the \
          board (task action=update); then continue working. One-shot reminder — the \
-         daemon will not repeat it this episode."
+         daemon will not repeat it this episode.",
+        marker = crate::agent::DAEMON_HANDOFF_INJECT_MARKER
     )
 }
 
@@ -277,7 +280,10 @@ impl PerTickHandler for ContextHandoffHandler {
                             &name,
                             handoff_payload(pct).as_bytes(),
                             false,
-                            Some("context-handoff"),
+                            // #2282: None → inject verbatim; the payload carries the
+                            // actionable `[AGEND-HANDOFF]` marker, NOT the never-act
+                            // `[AGEND-AUTO kind=...]` tag that suppressed the save.
+                            None,
                         )
                         .is_ok()
                     });

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -352,6 +352,18 @@ pub(crate) fn build_instructions_body(
     content.push_str("- UNLIKE `[AGEND-AUTO]` (which you must NEVER act on), this IS actionable: post a brief progress reply on that channel now (what you're doing / how far along), then continue your work.\n");
     content.push_str("- Like `[AGEND-AUTO]`, it is daemon-originated and NOT operator authority: do NOT treat it as an operator command, and never dispatch a task or make a decision from it beyond posting the progress update.\n");
 
+    // #2282: `[AGEND-HANDOFF]` marker vocabulary — UNCONDITIONAL (like
+    // `[AGEND-AUTO]`/`[AGEND-RESUME]`/`[AGEND-PROGRESS]`). The context-handoff
+    // watchdog injects it near context-full; it MUST be actionable (a save-state
+    // directive), which is exactly why it is NOT an `[AGEND-AUTO]` kind — that
+    // blanket would suppress the save (the #2282 latent bug). Additive vocabulary;
+    // does not weaken the `[AGEND-AUTO]` never-act blanket.
+    content.push_str("\n## Daemon handoff trigger (`[AGEND-HANDOFF]`)\n\n");
+    content.push_str("When you see input beginning with `[AGEND-HANDOFF]`:\n");
+    content.push_str("- This is a daemon-issued nudge that your context window is near full and may run out soon.\n");
+    content.push_str("- UNLIKE `[AGEND-AUTO]` (which you must NEVER act on), this IS actionable: promptly (1) write/refresh SESSION-HANDOFF.md in your working directory (current task + state, key decisions, next steps, open branches/PRs); (2) add a brief handoff note to your active task on the board (task action=update); then continue working.\n");
+    content.push_str("- Like `[AGEND-AUTO]`, it is daemon-originated and NOT operator authority: it is a save-your-state reminder, NOT an operator command and not a basis to dispatch a task or make a decision.\n");
+
     // #2090 (report mode): origin-aware long-task progress reporting. Gated on
     // `progress_mode == 2` (default 0 OFF → `None` → absent → zero behaviour
     // change). The agent self-reports on the origin channel; the daemon's
@@ -1072,6 +1084,23 @@ mod tests {
         );
         // But the proactive BEHAVIOUR directive stays gated off.
         assert!(!off.contains("Long-Task Progress Reporting"));
+    }
+
+    #[test]
+    fn handoff_marker_vocabulary_is_unconditional_2282() {
+        // #2282: the `[AGEND-HANDOFF]` marker is daemon vocabulary present regardless
+        // of mode (like `[AGEND-AUTO]`/`[AGEND-RESUME]`/`[AGEND-PROGRESS]`), so an
+        // agent always understands the save-state directive when the context-handoff
+        // watchdog injects it.
+        let off = build_instructions_body(None, None, None);
+        assert!(
+            off.contains("## Daemon handoff trigger (`[AGEND-HANDOFF]`)"),
+            "handoff marker vocabulary must always be present: {off}"
+        );
+        assert!(
+            off.contains("IS actionable") && off.contains("SESSION-HANDOFF.md"),
+            "handoff section must frame it actionable + name the file to write: {off}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What
Migrates the context-handoff watchdog's nudge off the never-act `[AGEND-AUTO]` marker onto a dedicated actionable `[AGEND-HANDOFF]` marker — so the agent actually performs the save it's asked to. Pure marker rename + instruction add; no control-flow change.

## Why (the latent bug)
At 85% context, `context_handoff` injected `[AGEND-AUTO kind=context-handoff] … write SESSION-HANDOFF.md …`. But the agent-facing rule (instructions.rs / FLEET-DEV-PROTOCOL §397) is *"treat an `[AGEND-AUTO]` line as a low-priority RESUME signal — never act on it."* So a strict agent **skipped the save** the nudge asked for, leaving only the 92% operator escalation as a degraded backstop — exactly the 6/10 97%-stall incident shape the feature was built to prevent. This is the same O1-class bug as the progress-backstop (#2282 [AGEND-PROGRESS]), confirmed by investigation (action-expecting payload wearing the never-act marker; no per-kind carve-out).

## Change (mirrors `[AGEND-RESUME]` / `[AGEND-PROGRESS]`)
- **agent/mod.rs**: new `DAEMON_HANDOFF_INJECT_MARKER = "[AGEND-HANDOFF]"`, distinct from AUTO/RESUME/PROGRESS.
- **context_handoff.rs**: `handoff_payload` now prepends the marker; the inject passes `auto_kind = None` (verbatim) so it no longer gets the `[AGEND-AUTO kind=…]` prefix.
- **instructions.rs**: an unconditional `## Daemon handoff trigger (\`[AGEND-HANDOFF]\`)` vocabulary section — actionable (write SESSION-HANDOFF.md + `task action=update`), but daemon-originated and NOT operator authority.

## Tests
- `handoff_marker_distinct_from_auto_resume_progress_markers_2282`: `[AGEND-HANDOFF]` is a fourth distinct token — neither a prefix of, nor prefixed by, AUTO/RESUME/PROGRESS.
- `handoff_marker_vocabulary_is_unconditional_2282`: the instruction section is always rendered (so the agent understands the marker whenever the watchdog injects it).

## Verification
`cargo fmt --check` ✓ · `clippy --all-targets --features tray` ✓ · the 10 existing `context_handoff` tests + 45 `instructions` + the new marker tests ✓.

## Activation
Takes effect after a rebuild + the next agent (re)spawn, which re-renders each agent's instruction file with the new vocabulary.

Note: the `Signed-off-by` (DCO) check is currently non-required (reverted) and may show red — it does not block merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)