### PR TITLE
feat(tui): clear pane selection highlight after a completed copy

### DIFF
--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -328,13 +328,22 @@ pub(super) fn dispatch(action: Action, ctx: &mut DispatchCtx<'_>) -> DispatchRes
         }
         Action::None => {}
         Action::CopySelection => {
-            if let Some(tab) = ctx.layout.active_tab() {
-                if let Some(pane) = tab.root().find_pane(tab.focus_id) {
+            if let Some(tab) = ctx.layout.active_tab_mut() {
+                let focus_id = tab.focus_id;
+                if let Some(pane) = tab.root_mut().find_pane_mut(focus_id) {
+                    let mut copied = false;
                     if let Some(ref sel) = pane.selection {
                         let text = pane.vterm.extract_text(sel.start, sel.end);
                         if !text.is_empty() {
                             super::mouse::copy_to_clipboard(&text);
+                            copied = true;
                         }
+                    }
+                    // Clear the highlight after a completed Cmd+C copy (mirrors the
+                    // mouse-release behavior); a no-selection / empty-text case is
+                    // left untouched.
+                    if copied {
+                        pane.selection = None;
                     }
                 }
             }
@@ -461,5 +470,82 @@ mod tests {
         assert!(result.needs_resize);
         assert_eq!(ctx.layout.active, 2);
         assert_eq!(*ctx.last_tab, 0);
+    }
+
+    // #84662: a completed copy (Cmd+C over a non-empty selection) clears the
+    // highlight; a selection with nothing to copy is left untouched.
+    #[test]
+    fn copy_selection_clears_highlight_after_copy() {
+        let registry: AgentRegistry = std::sync::Arc::new(parking_lot::Mutex::new(HashMap::new()));
+        let home = std::env::temp_dir();
+        let (tx, _rx) = crossbeam_channel::bounded(1);
+        let mut layout = Layout::new();
+        let mut pane = test_pane(1, "a");
+        pane.vterm.process(b"hello\r\n");
+        pane.selection = Some(crate::layout::Selection {
+            start: (0, 0),
+            end: (0, 4),
+        });
+        layout.add_tab(Tab::new("a".to_string(), pane));
+        layout.active = 0;
+        let mut last_tab = 0;
+        let mut names = HashMap::new();
+        let mut ctx = make_ctx(
+            &mut layout,
+            &registry,
+            &home,
+            &mut last_tab,
+            &tx,
+            &mut names,
+        );
+        dispatch(Action::CopySelection, &mut ctx);
+        let pane = ctx
+            .layout
+            .active_tab()
+            .expect("active tab")
+            .root()
+            .find_pane(1)
+            .expect("focused pane");
+        assert!(
+            pane.selection.is_none(),
+            "#84662: highlight must auto-clear after a completed copy"
+        );
+    }
+
+    #[test]
+    fn copy_selection_keeps_highlight_when_nothing_to_copy() {
+        let registry: AgentRegistry = std::sync::Arc::new(parking_lot::Mutex::new(HashMap::new()));
+        let home = std::env::temp_dir();
+        let (tx, _rx) = crossbeam_channel::bounded(1);
+        let mut layout = Layout::new();
+        let mut pane = test_pane(1, "a"); // empty vterm — selection extracts no text
+        pane.selection = Some(crate::layout::Selection {
+            start: (0, 0),
+            end: (0, 5),
+        });
+        layout.add_tab(Tab::new("a".to_string(), pane));
+        layout.active = 0;
+        let mut last_tab = 0;
+        let mut names = HashMap::new();
+        let mut ctx = make_ctx(
+            &mut layout,
+            &registry,
+            &home,
+            &mut last_tab,
+            &tx,
+            &mut names,
+        );
+        dispatch(Action::CopySelection, &mut ctx);
+        let pane = ctx
+            .layout
+            .active_tab()
+            .expect("active tab")
+            .root()
+            .find_pane(1)
+            .expect("focused pane");
+        assert!(
+            pane.selection.is_some(),
+            "#84662: nothing-to-copy is not a completed copy → highlight unchanged"
+        );
     }
 }

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -468,6 +468,7 @@ fn handle_selection(layout: &mut Layout, mouse: &MouseEvent) {
                 false
             }
             MouseEventKind::Up(MouseButton::Left) => {
+                let mut copied = false;
                 if let Some(ref sel) = pane.selection {
                     if sel.start == sel.end {
                         pane.selection = None;
@@ -475,8 +476,16 @@ fn handle_selection(layout: &mut Layout, mouse: &MouseEvent) {
                         let text = pane.vterm.extract_text(sel.start, sel.end);
                         if !text.is_empty() {
                             copy_to_clipboard(&text);
+                            copied = true;
                         }
                     }
+                }
+                // Clear the highlight once a copy has completed — a finished copy
+                // ends the selection gesture. Other paths are unchanged: a
+                // zero-width click already cleared above, and an empty-text
+                // (nothing to copy) release keeps its selection as before.
+                if copied {
+                    pane.selection = None;
                 }
                 true
             }


### PR DESCRIPTION
operator request: once selected pane text is copied, the highlight should disappear; everything else stays as-is.

## Change
Both copy triggers clear the selection **only after a real copy** (`start != end` + non-empty extracted text), via a `copied` flag → `pane.selection = None`. The renderer derives the highlight from `pane.selection`, so the next frame drops it (no explicit redraw).
- **Mouse drag-release** — `src/app/mouse.rs` `Up(Left)`.
- **Cmd+C** — `src/app/dispatch.rs` `Action::CopySelection` (switched to the mutable accessor `active_tab_mut()`/`root_mut()`/`find_pane_mut` per the established `mod.rs:302` pattern).

**Strictly additive** — a zero-width click still clears as before, and an empty-text (nothing-to-copy) release keeps its selection. The selection gesture and `copy_to_clipboard` itself are untouched. Only "highlight clears after a completed copy" is new.

## Tests
- `copy_selection_clears_highlight_after_copy` — non-empty selection → cleared.
- `copy_selection_keeps_highlight_when_nothing_to_copy` — empty vterm (nothing to copy) → highlight preserved (guards the non-copy path).

## Verification
fmt ✓, clippy --features tray --bins --tests -D warnings ✓, targeted tests pass. Full `nextest --profile ci` passes **with real git**; the one local failure (`teardown_leaves_zero_residual_after_full_exercise_1907` — a `fleet_events.jsonl` residual) is a **fleet-git-shim false-fail** (the shim on the dev PATH appends a fleet_events line during the test's git ops; CI uses real git, so it passes — verified locally with `PATH=/usr/bin`). Unrelated to this diff (mouse.rs/dispatch.rs only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)