### PR TITLE
feat(state): in-band turn-completion sentinel — Phase 0 shadow (#1523)

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -1123,7 +1123,13 @@ pub fn spawn_agent(config: &SpawnConfig, registry: &AgentRegistry) -> anyhow::Re
     let core = Arc::new(CoreMutex::new(AgentCore {
         vterm: VTerm::with_pty_writer(*cols, *rows, Arc::clone(&pty_writer)),
         subscribers: Vec::new(),
-        state: StateTracker::new(detected_backend.as_ref()),
+        // #1523: name the tracker at construction. Per-agent telemetry (incl. the
+        // turn-completion sentinel, whose token is derived from this name) needs
+        // it; `for_agent` enforces it so a future edit can't leave it empty as the
+        // bare `StateTracker::new` did (r6 #2297). `name` here is the same fleet
+        // instance name the instruction injection uses for `ctx.name`, so the
+        // detector recomputes the SAME token the agent is told to emit.
+        state: StateTracker::for_agent(detected_backend.as_ref(), name),
         health: HealthTracker::new(),
     }));
 

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -134,10 +134,12 @@ pub(crate) fn build_instructions_body(
     // — the daemon-role sentence differs per mode; the delegation half adapts to
     // whether this backend has a subagent tool.
     progress_directive: Option<(i64, bool)>,
-    // #1523 Phase 0 (shadow): `Some(nonce)` injects the in-band turn-completion
-    // sentinel directive (the agent prints `<<<AGEND-DONE:{nonce}>>>` as its last
-    // line when a turn is fully done). `None` = absent → ZERO behaviour change.
-    // Gated by the caller to hook-less backends + `AGEND_TURN_SENTINEL_SHADOW=1`.
+    // #1523 Phase 0 (shadow): `Some(token)` injects the in-band turn-completion
+    // sentinel directive (the agent prints this exact `token` as its last line
+    // when a turn is fully done). The token is built by
+    // `crate::state::turn_sentinel_token` so this directive and the detector
+    // share ONE source of truth. `None` = absent → ZERO behaviour change. Gated
+    // by the caller to hook-less backends + `AGEND_TURN_SENTINEL_SHADOW=1`.
     turn_sentinel: Option<&str>,
 ) -> String {
     let mut content = String::new();
@@ -414,14 +416,14 @@ pub(crate) fn build_instructions_body(
     // only when `AGEND_TURN_SENTINEL_SHADOW=1`. The daemon side-logs whether the
     // token appears (telemetry only — it takes NO action on the signal in Phase 0),
     // so this directive is the sole behavioural change and a default fleet (flag
-    // off → `None`) sees none. The nonce is per-agent so the daemon can attribute
+    // off → `None`) sees none. The token is per-agent so the daemon can attribute
     // the marker; per-turn freshness comes from the daemon's dedup, not the token.
-    if let Some(nonce) = turn_sentinel {
+    if let Some(token) = turn_sentinel {
         content.push_str("\n## Turn-completion signal (AgEnD)\n\n");
         content.push_str(&format!(
             "When you have FULLY finished responding to the current request and are about to wait \
              for new input, print this exact marker on its own line as the very last line of your \
-             reply:\n\n    <<<AGEND-DONE:{nonce}>>>\n\n"
+             reply:\n\n    {token}\n\n"
         ));
         content
             .push_str("- Emit it once per completed turn, only in your normal terminal reply.\n");
@@ -526,18 +528,18 @@ fn generate_agent_instructions(working_dir: &Path, command: &str, ctx: Option<&A
     // #1523 Phase 0 (shadow): inject the turn-completion sentinel only for
     // hook-less backends (Claude is EXCLUDED — it has lifecycle hooks that emit
     // authoritative state) and only when `AGEND_TURN_SENTINEL_SHADOW=1`. The
-    // per-agent nonce is derived from the agent name so the daemon detector can
-    // recompute it without any persisted/plumbed state. Default-off → `None` →
-    // ZERO behaviour change (fail-open invariant).
-    let turn_nonce = ctx
+    // per-agent token is derived from the agent name so the daemon detector can
+    // recompute the SAME token without any persisted/plumbed state. Default-off →
+    // `None` → ZERO behaviour change (fail-open invariant).
+    let turn_token = ctx
         .map(|c| c.name)
         .filter(|_| !backend.has_state_hooks() && crate::state::turn_sentinel_shadow_enabled())
-        .map(crate::state::turn_sentinel_nonce);
+        .map(crate::state::turn_sentinel_token);
     let body = build_instructions_body(
         ctx,
         Some(&proto_str),
         progress_directive,
-        turn_nonce.as_deref(),
+        turn_token.as_deref(),
     );
 
     // Include fleet.yaml `instructions:` inside the managed block so
@@ -1155,24 +1157,31 @@ mod tests {
     }
 
     #[test]
-    fn turn_sentinel_directive_present_only_when_nonce_given_1523() {
-        // #1523 Phase 0: with no nonce the sentinel section is absent (fail-open:
+    fn turn_sentinel_directive_present_only_when_token_given_1523() {
+        // #1523 Phase 0: with no token the sentinel section is absent (fail-open:
         // a default fleet / hook-ful backend / flag-off sees ZERO behaviour change).
         let off = build_instructions_body(None, None, None, None);
         assert!(
             !off.contains("Turn-completion signal"),
-            "sentinel section must be absent when nonce is None: {off}"
+            "sentinel section must be absent when token is None: {off}"
         );
         assert!(
-            !off.contains("<<<AGEND-DONE:"),
-            "token must not leak into instructions when nonce is None: {off}"
+            !off.contains("AGEND-DONE:"),
+            "token must not leak into instructions when token is None: {off}"
         );
-        // With a nonce, the directive + the exact per-agent token are present.
-        let on = build_instructions_body(None, None, None, Some("ab12cd34"));
+        // With a token, the directive embeds that EXACT string. Build it the way
+        // prod does so a delimiter change can't silently desync directive↔detector.
+        let token = crate::state::turn_sentinel_token("dir-agent");
+        let on = build_instructions_body(None, None, None, Some(&token));
         assert!(on.contains("## Turn-completion signal (AgEnD)"));
         assert!(
-            on.contains("<<<AGEND-DONE:ab12cd34>>>"),
+            on.contains(&token),
             "directive must embed the exact per-agent token: {on}"
+        );
+        // #2243 DuDuClaw: the marker must NOT use angle-bracket delimiters.
+        assert!(
+            !token.contains('<') && !token.contains('>'),
+            "token must avoid mangle-prone <…> delimiters: {token}"
         );
         assert!(
             on.contains("never persisted content"),

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -134,6 +134,11 @@ pub(crate) fn build_instructions_body(
     // — the daemon-role sentence differs per mode; the delegation half adapts to
     // whether this backend has a subagent tool.
     progress_directive: Option<(i64, bool)>,
+    // #1523 Phase 0 (shadow): `Some(nonce)` injects the in-band turn-completion
+    // sentinel directive (the agent prints `<<<AGEND-DONE:{nonce}>>>` as its last
+    // line when a turn is fully done). `None` = absent → ZERO behaviour change.
+    // Gated by the caller to hook-less backends + `AGEND_TURN_SENTINEL_SHADOW=1`.
+    turn_sentinel: Option<&str>,
 ) -> String {
     let mut content = String::new();
     content.push_str("# AgEnD — Multi-Agent Coordination\n\n");
@@ -404,6 +409,27 @@ pub(crate) fn build_instructions_body(
         }
     }
 
+    // #1523 Phase 0: in-band turn-completion sentinel (shadow). Injected only for
+    // hook-less backends (Claude has lifecycle hooks → excluded by the caller) and
+    // only when `AGEND_TURN_SENTINEL_SHADOW=1`. The daemon side-logs whether the
+    // token appears (telemetry only — it takes NO action on the signal in Phase 0),
+    // so this directive is the sole behavioural change and a default fleet (flag
+    // off → `None`) sees none. The nonce is per-agent so the daemon can attribute
+    // the marker; per-turn freshness comes from the daemon's dedup, not the token.
+    if let Some(nonce) = turn_sentinel {
+        content.push_str("\n## Turn-completion signal (AgEnD)\n\n");
+        content.push_str(&format!(
+            "When you have FULLY finished responding to the current request and are about to wait \
+             for new input, print this exact marker on its own line as the very last line of your \
+             reply:\n\n    <<<AGEND-DONE:{nonce}>>>\n\n"
+        ));
+        content
+            .push_str("- Emit it once per completed turn, only in your normal terminal reply.\n");
+        content.push_str("- Do NOT write it into any file, code, commit message, or tool input — it is a terminal-output signal only, never persisted content.\n");
+        content.push_str("- If you are still working, mid-task, or about to take another action, do NOT emit it yet.\n");
+        content.push_str("- This marker only helps the daemon notice you are done; nothing you do depends on it, so never let it change how you work.\n");
+    }
+
     content
 }
 
@@ -497,7 +523,22 @@ fn generate_agent_instructions(working_dir: &Path, command: &str, ctx: Option<&A
         m @ (1 | 2) => Some((m, backend.supports_subagents())),
         _ => None,
     };
-    let body = build_instructions_body(ctx, Some(&proto_str), progress_directive);
+    // #1523 Phase 0 (shadow): inject the turn-completion sentinel only for
+    // hook-less backends (Claude is EXCLUDED — it has lifecycle hooks that emit
+    // authoritative state) and only when `AGEND_TURN_SENTINEL_SHADOW=1`. The
+    // per-agent nonce is derived from the agent name so the daemon detector can
+    // recompute it without any persisted/plumbed state. Default-off → `None` →
+    // ZERO behaviour change (fail-open invariant).
+    let turn_nonce = ctx
+        .map(|c| c.name)
+        .filter(|_| !backend.has_state_hooks() && crate::state::turn_sentinel_shadow_enabled())
+        .map(crate::state::turn_sentinel_nonce);
+    let body = build_instructions_body(
+        ctx,
+        Some(&proto_str),
+        progress_directive,
+        turn_nonce.as_deref(),
+    );
 
     // Include fleet.yaml `instructions:` inside the managed block so
     // shared files (AGENTS.md) don't duplicate it on each refresh (#1405).
@@ -843,7 +884,7 @@ mod tests {
             team: None,
             extra_instructions: None,
         };
-        let body = build_instructions_body(Some(&ctx), None, None);
+        let body = build_instructions_body(Some(&ctx), None, None, None);
         // After sanitisation the name contains only [A-Za-z0-9_-]. All of
         // `\n`, `#`, space, and ` got stripped, so neither the injected
         // header nor a broken backtick span can appear.
@@ -870,7 +911,7 @@ mod tests {
             team: None,
             extra_instructions: None,
         };
-        let body = build_instructions_body(Some(&ctx), None, None);
+        let body = build_instructions_body(Some(&ctx), None, None, None);
         // Role value stays on one line — a newline would let attackers open
         // a new markdown block.
         let role_line = extract_role_line(&body).expect("role line present");
@@ -905,7 +946,7 @@ mod tests {
             team: None,
             extra_instructions: None,
         };
-        let body = build_instructions_body(Some(&ctx), None, None);
+        let body = build_instructions_body(Some(&ctx), None, None, None);
         // Structural marker — a new `\n## ` section — must not appear from
         // the Fleet Peers block.
         assert!(
@@ -960,7 +1001,7 @@ mod tests {
             team: Some(&team),
             extra_instructions: None,
         };
-        let body = build_instructions_body(Some(&ctx), None, None);
+        let body = build_instructions_body(Some(&ctx), None, None, None);
 
         // Team section heading carries the team's name, not "Fleet Peers".
         assert!(
@@ -1022,7 +1063,7 @@ mod tests {
             team: Some(&team),
             extra_instructions: None,
         };
-        let body = build_instructions_body(Some(&ctx), None, None);
+        let body = build_instructions_body(Some(&ctx), None, None, None);
         assert!(
             body.contains("Orchestrator: `dev-lead`"),
             "non-orchestrator member must be pointed at the orchestrator: {body}"
@@ -1043,7 +1084,7 @@ mod tests {
             team: None,
             extra_instructions: None,
         };
-        let body = build_instructions_body(Some(&ctx), None, None);
+        let body = build_instructions_body(Some(&ctx), None, None, None);
         assert!(
             body.contains("## Fleet Peers"),
             "no team means fall back to original Fleet Peers heading: {body}"
@@ -1069,7 +1110,7 @@ mod tests {
     #[test]
     fn progress_directive_off_by_default_absent() {
         // #2090: `None` (progress_mode 0, default) → NO behavioural directive.
-        let body = build_instructions_body(None, None, None);
+        let body = build_instructions_body(None, None, None, None);
         assert!(
             !body.contains("Long-Task Progress Reporting"),
             "progress directive must be ABSENT when off: {body}"
@@ -1083,7 +1124,7 @@ mod tests {
         // present regardless of mode (like `[AGEND-AUTO]`/`[AGEND-RESUME]`), so an
         // agent always understands the marker if the backstop ever injects it —
         // even when the proactive self-report directive is OFF.
-        let off = build_instructions_body(None, None, None);
+        let off = build_instructions_body(None, None, None, None);
         assert!(
             off.contains("## Daemon progress nudge (`[AGEND-PROGRESS]`)"),
             "marker vocabulary must be present even when progress reporting is off: {off}"
@@ -1102,7 +1143,7 @@ mod tests {
         // of mode (like `[AGEND-AUTO]`/`[AGEND-RESUME]`/`[AGEND-PROGRESS]`), so an
         // agent always understands the save-state directive when the context-handoff
         // watchdog injects it.
-        let off = build_instructions_body(None, None, None);
+        let off = build_instructions_body(None, None, None, None);
         assert!(
             off.contains("## Daemon handoff trigger (`[AGEND-HANDOFF]`)"),
             "handoff marker vocabulary must always be present: {off}"
@@ -1114,16 +1155,42 @@ mod tests {
     }
 
     #[test]
+    fn turn_sentinel_directive_present_only_when_nonce_given_1523() {
+        // #1523 Phase 0: with no nonce the sentinel section is absent (fail-open:
+        // a default fleet / hook-ful backend / flag-off sees ZERO behaviour change).
+        let off = build_instructions_body(None, None, None, None);
+        assert!(
+            !off.contains("Turn-completion signal"),
+            "sentinel section must be absent when nonce is None: {off}"
+        );
+        assert!(
+            !off.contains("<<<AGEND-DONE:"),
+            "token must not leak into instructions when nonce is None: {off}"
+        );
+        // With a nonce, the directive + the exact per-agent token are present.
+        let on = build_instructions_body(None, None, None, Some("ab12cd34"));
+        assert!(on.contains("## Turn-completion signal (AgEnD)"));
+        assert!(
+            on.contains("<<<AGEND-DONE:ab12cd34>>>"),
+            "directive must embed the exact per-agent token: {on}"
+        );
+        assert!(
+            on.contains("never persisted content"),
+            "directive must warn against writing the token to files (leak surface): {on}"
+        );
+    }
+
+    #[test]
     fn progress_directive_present_and_backend_aware_when_on() {
         // Report mode (2), subagent-capable backend → self-report + delegate.
-        let on_caps = build_instructions_body(None, None, Some((2, true)));
+        let on_caps = build_instructions_body(None, None, Some((2, true)), None);
         assert!(on_caps.contains("Long-Task Progress Reporting"));
         assert!(
             on_caps.contains("subagent / Task tool. For work"),
             "subagent-capable backend gets the delegate directive: {on_caps}"
         );
         // Report mode, NO subagent tool → the inline-updates fallback instead.
-        let on_nocaps = build_instructions_body(None, None, Some((2, false)));
+        let on_nocaps = build_instructions_body(None, None, Some((2, false)), None);
         assert!(on_nocaps.contains("Long-Task Progress Reporting"));
         assert!(
             on_nocaps.contains("does NOT provide a subagent"),
@@ -1141,7 +1208,7 @@ mod tests {
         // Mirror mode (1): the daemon auto-relays the agent's output → the
         // directive must say so AND carry the exfil warning, NOT the report-mode
         // "nudge-only / never relays" wording.
-        let mirror = build_instructions_body(None, None, Some((1, true)));
+        let mirror = build_instructions_body(None, None, Some((1, true)), None);
         assert!(mirror.contains("Long-Task Progress Reporting"));
         assert!(
             mirror.contains("auto-relays your clean assistant text"),
@@ -1159,7 +1226,12 @@ mod tests {
 
     #[test]
     fn instructions_include_protocol_path() {
-        let body = build_instructions_body(None, Some("/tmp/protocol/FLEET-DEV-PROTOCOL.md"), None);
+        let body = build_instructions_body(
+            None,
+            Some("/tmp/protocol/FLEET-DEV-PROTOCOL.md"),
+            None,
+            None,
+        );
         assert!(
             body.contains("/tmp/protocol/FLEET-DEV-PROTOCOL.md"),
             "instructions must include protocol path: {body}"
@@ -1174,7 +1246,7 @@ mod tests {
     fn test_instruction_includes_agend_msg_rule() {
         // build_instructions_body is shared by all 4 backends.
         // Verify the [AGEND-MSG] handling section is present.
-        let body = build_instructions_body(None, None, None);
+        let body = build_instructions_body(None, None, None, None);
         assert!(
             body.contains("[AGEND-MSG]"),
             "instructions must include [AGEND-MSG] header handling rule"
@@ -1198,7 +1270,7 @@ mod tests {
     fn test_instruction_includes_agend_auto_rule_1769() {
         // #1769: agents must be taught that an injected `[AGEND-AUTO]` line is a
         // daemon auto-nudge, NOT an operator command (the trust-model enforcement).
-        let body = build_instructions_body(None, None, None);
+        let body = build_instructions_body(None, None, None, None);
         assert!(
             body.contains("[AGEND-AUTO"),
             "instructions must include the [AGEND-AUTO] daemon-auto-inject rule"
@@ -1216,7 +1288,7 @@ mod tests {
         // rule). must-follow ①: it is recover-your-own-state, NOT operator
         // authority — and the test-pinned `[AGEND-AUTO]` blanket must stay intact
         // (the two markers coexist, neither weakened by a per-kind carve-out).
-        let body = build_instructions_body(None, None, None);
+        let body = build_instructions_body(None, None, None, None);
         assert!(
             body.contains("[AGEND-RESUME]"),
             "instructions must teach the [AGEND-RESUME] self-bootstrap trigger"
@@ -1343,7 +1415,7 @@ mod tests {
     fn test_instruction_trigger_matches_header_prefix() {
         // Regression: locks the contract between S3-T1 (format_header) and
         // S3-T2 (instruction wording). If either side drifts, this breaks.
-        let body = build_instructions_body(None, None, None);
+        let body = build_instructions_body(None, None, None, None);
 
         // S3-T1 header always starts with ANSI prefix + [AGEND-MSG]
         let sample_msg = crate::inbox::InboxMessage {
@@ -1382,7 +1454,7 @@ mod tests {
 
     #[test]
     fn kind_aware_reply_obligation_in_prompt() {
-        let body = build_instructions_body(None, None, None);
+        let body = build_instructions_body(None, None, None, None);
         assert!(
             body.contains("Reply obligation depends on"),
             "prompt must contain kind-aware reply guidance"
@@ -1399,7 +1471,7 @@ mod tests {
 
     #[test]
     fn react_tool_mentioned_in_prompt() {
-        let body = build_instructions_body(None, None, None);
+        let body = build_instructions_body(None, None, None, None);
         assert!(
             body.contains("do not reply"),
             "prompt must mention ack-without-reply guidance"
@@ -1408,7 +1480,7 @@ mod tests {
 
     #[test]
     fn busy_response_format_in_prompt() {
-        let body = build_instructions_body(None, None, None);
+        let body = build_instructions_body(None, None, None, None);
         assert!(
             body.contains("BUSY"),
             "prompt must contain BUSY response guidance"
@@ -1442,7 +1514,7 @@ mod tests {
             fleet_peers: &[],
             extra_instructions: None,
         };
-        let body = build_instructions_body(Some(&ctx), Some("/tmp/protocol.md"), None);
+        let body = build_instructions_body(Some(&ctx), Some("/tmp/protocol.md"), None, None);
         assert!(
             !body.contains("<fleet-update>"),
             "instructions must not contain <fleet-update> marker after Sprint 35 removal"

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -376,6 +376,11 @@ pub struct StateTracker {
     /// SRL incident on the same line after recovery re-logs once; the `#1809`
     /// cross-cycle→Idle behavioral fix stays OUTSIDE this dedup.
     last_srl_phantom_warn_sig: Option<(u64, bool)>,
+    /// #1523 Phase 0 (shadow): fire-once latch for the turn-completion sentinel
+    /// telemetry — `hash` of the last side-logged sentinel observation, so a
+    /// static frame holding the token isn't re-logged every feed (mirrors the
+    /// retired `last_hardwrap_miss_sig`). Telemetry-only; never gates behavior.
+    last_turn_sentinel_sig: Option<u64>,
 }
 
 /// #1527: one recorded `current` transition, captured at the mutation site so
@@ -517,6 +522,91 @@ fn hash_screen(text: &str) -> u64 {
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     text.hash(&mut hasher);
     hasher.finish()
+}
+
+/// #1523 Phase 0: is the turn-completion sentinel shadow enabled? Default-OFF
+/// (matches the codebase env-flag idiom, e.g. `AGEND_PRODUCTIVE_GATE`). When
+/// off, neither the instruction directive nor the telemetry is active, so a
+/// default fleet sees ZERO behaviour change (the fail-open invariant).
+pub(crate) fn turn_sentinel_shadow_enabled() -> bool {
+    std::env::var("AGEND_TURN_SENTINEL_SHADOW")
+        .map(|v| v == "1")
+        .unwrap_or(false)
+}
+
+/// #1523 Phase 0: the per-agent sentinel nonce, derived deterministically from
+/// the agent name. Deriving (rather than persisting a random value) lets the
+/// instruction writer and the daemon detector compute the SAME token
+/// independently — no plumbed/persisted state, so it survives restart with no
+/// staleness surface (cf. the in-mem-reset-on-restart bug class). It is an
+/// attribution tag, not a secret; per-turn freshness comes from the detector's
+/// dedup latch, not from the nonce.
+pub(crate) fn turn_sentinel_nonce(name: &str) -> String {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    name.hash(&mut hasher);
+    // Low 32 bits as fixed-width hex → an 8-char nonce → 25-char token
+    // (`<<<AGEND-DONE:xxxxxxxx>>>`), comfortably under the #2090 ~35-char
+    // hard-wrap threshold so the marker stays on one line.
+    format!("{:08x}", hasher.finish() & 0xffff_ffff)
+}
+
+/// #1523 Phase 0: the exact in-band token for an agent's turn-completion
+/// sentinel. Shared by the instruction directive and the shadow detector so the
+/// two never drift.
+pub(crate) fn turn_sentinel_token(name: &str) -> String {
+    format!("<<<AGEND-DONE:{}>>>", turn_sentinel_nonce(name))
+}
+
+/// #1523 Phase 0: pure classification of a screen `tail` against an agent's
+/// turn-completion `token`. Separated from the I/O method so the echo /
+/// source-view FP heuristics (the sharpest risk — the instruction file itself
+/// carries the token) are unit-testable without env or home redirection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct TurnSentinelObs {
+    /// The agent's token is present anywhere in the tail (raw or de-wrapped).
+    token_seen: bool,
+    /// The token sits on the final non-empty line — the shape of a genuine
+    /// turn-end emission (vs. embedded in earlier output).
+    on_last_line: bool,
+    /// Looks like an instruction-echo / source-view rather than a real emit:
+    /// directive prose co-occurs, or the token is not the last line.
+    suspected_echo: bool,
+    /// Coarse leak proxy: token embedded as content (not a clean final-line
+    /// emit) and not obviously a directive echo — e.g. a file being viewed.
+    leak_signal: bool,
+}
+
+fn observe_turn_sentinel(tail: &str, token: &str) -> TurnSentinelObs {
+    // Also scan a de-wrapped (newline-stripped) copy so a hard-wrapped token
+    // (split mid-string across rows) still matches.
+    let dewrapped: String = tail.chars().filter(|c| *c != '\n').collect();
+    let token_seen = tail.contains(token) || dewrapped.contains(token);
+    if !token_seen {
+        return TurnSentinelObs {
+            token_seen: false,
+            on_last_line: false,
+            suspected_echo: false,
+            leak_signal: false,
+        };
+    }
+    let on_last_line = tail
+        .lines()
+        .rev()
+        .find(|l| !l.trim().is_empty())
+        .is_some_and(|l| l.contains(token));
+    // The directive that injects the token uses these exact phrases; their
+    // presence means the instruction file / system prompt is on screen.
+    let directive_echo = tail.contains("Turn-completion signal")
+        || tail.contains("never persisted content")
+        || tail.contains("print this exact marker");
+    let suspected_echo = directive_echo || !on_last_line;
+    let leak_signal = !on_last_line && !directive_echo;
+    TurnSentinelObs {
+        token_seen,
+        on_last_line,
+        suspected_echo,
+        leak_signal,
+    }
 }
 
 /// #1955: the (bottom-most) screen line containing `matched` — the UsageLimit
@@ -1148,6 +1238,7 @@ impl StateTracker {
             last_unclassified_throttle_sig: None,
             last_srl_keep_latched_sig: None,
             last_srl_phantom_warn_sig: None,
+            last_turn_sentinel_sig: None,
         }
     }
 
@@ -1469,6 +1560,11 @@ impl StateTracker {
         // miss can be diagnosed. Zero behavior change (runs AFTER classify,
         // never touches `self.current`/retry).
         self.capture_unclassified_throttle(screen_text, fg);
+
+        // #1523 Phase 0: in-band turn-completion sentinel shadow telemetry.
+        // Default-OFF (flag-gated); when on, side-logs this agent's token sighting
+        // for measurement. Runs AFTER classify, never touches `self.current`.
+        self.capture_turn_sentinel_shadow(screen_text);
 
         // Instrumentation 2 — Sprint 27 shadow-mode behavioral telemetry.
         self.record_shadow_telemetry(silence_since_last_feed);
@@ -2243,6 +2339,82 @@ impl StateTracker {
                 agent = %self.instance_name,
                 error = %e,
                 "#1562: failed to append unclassified-throttle diagnostic"
+            );
+        }
+    }
+
+    /// #1523 Phase 0: turn-completion sentinel shadow telemetry.
+    ///
+    /// When `AGEND_TURN_SENTINEL_SHADOW=1`, hook-less agents are instructed to
+    /// print `<<<AGEND-DONE:{nonce}>>>` as the final line when a turn finishes
+    /// (see [`turn_sentinel_token`]). This side-logs whether THIS agent's token
+    /// is on screen alongside the heuristic classification, so emit-rate /
+    /// false-emit (instruction-echo / source-view) / leak can be measured before
+    /// any production reliance in Phase 1. The daemon takes NO action on the
+    /// signal in Phase 0 — this only ever ADDS corroboration, never subtracts.
+    ///
+    /// Invariants (mirror the retired `capture_hardwrap_miss_shadow`):
+    /// - **Zero behaviour change** — runs after classify, never touches
+    ///   `self.current`, retry, or any timer; failures are swallowed. Gated OFF
+    ///   by default (flag absent → early return → byte-identical classification).
+    /// - **Cheap** — fast-rejects on a `str::contains` for the fixed prefix
+    ///   before building the per-agent token or allocating a tail.
+    /// - **Fire-once** — a static token-bearing frame logs once via the
+    ///   `last_turn_sentinel_sig` latch (the feed-level hash-dedup already drops
+    ///   unchanged frames; this guards token frames whose hash churns).
+    fn capture_turn_sentinel_shadow(&mut self, screen_text: &str) {
+        if !turn_sentinel_shadow_enabled() || self.instance_name.is_empty() {
+            return;
+        }
+        // Cheap fast-path: the marker prefix is fixed; bail before building the
+        // per-agent token or allocating a tail if it is nowhere on screen.
+        if !screen_text.contains("<<<AGEND-DONE:") {
+            self.last_turn_sentinel_sig = None;
+            return;
+        }
+        let token = turn_sentinel_token(&self.instance_name);
+        let tail = recent_screen_tail(screen_text, HARD_WRAP_TAIL_LINES);
+        let obs = observe_turn_sentinel(&tail, &token);
+        if !obs.token_seen {
+            // Some OTHER agent's token (or a malformed marker) is on screen — not
+            // ours. Drop the latch and skip (never attribute another agent's emit).
+            self.last_turn_sentinel_sig = None;
+            return;
+        }
+        // Consistency: a real emission means the agent just finished → the
+        // heuristic should independently read Idle. Disagreement is the
+        // corroboration value we want to measure.
+        let consistent = matches!(self.current, AgentState::Idle);
+        // Fire-once latch keyed on the token-bearing tail + derived flags so a
+        // static pane logs once, not every churned-hash frame.
+        let mut h = std::collections::hash_map::DefaultHasher::new();
+        tail.hash(&mut h);
+        obs.on_last_line.hash(&mut h);
+        obs.suspected_echo.hash(&mut h);
+        let sig = h.finish();
+        if self.last_turn_sentinel_sig == Some(sig) {
+            return;
+        }
+        self.last_turn_sentinel_sig = Some(sig);
+        let record = serde_json::json!({
+            "ts": chrono::Utc::now().to_rfc3339(),
+            "backend": self.backend_name,
+            "agent": self.instance_name,
+            "token_seen": obs.token_seen,
+            "on_last_line": obs.on_last_line,
+            "existing_state": self.current.display_name(),
+            "consistent": consistent,
+            "suspected_echo": obs.suspected_echo,
+            "leak_signal": obs.leak_signal,
+        });
+        let path = crate::home_dir().join("turn_sentinel_shadow.jsonl");
+        if let Err(e) = append_jsonl(&path, &record) {
+            // Diagnostic must never affect behavior — log and move on.
+            tracing::debug!(
+                target: "state_detection",
+                agent = %self.instance_name,
+                error = %e,
+                "#1523 Phase 0 shadow: failed to append turn-sentinel diagnostic"
             );
         }
     }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -544,17 +544,29 @@ pub(crate) fn turn_sentinel_shadow_enabled() -> bool {
 pub(crate) fn turn_sentinel_nonce(name: &str) -> String {
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     name.hash(&mut hasher);
-    // Low 32 bits as fixed-width hex → an 8-char nonce → 25-char token
-    // (`<<<AGEND-DONE:xxxxxxxx>>>`), comfortably under the #2090 ~35-char
+    // Low 32 bits as fixed-width hex → an 8-char nonce → 29-char token
+    // (`=====AGEND-DONE:xxxxxxxx=====`), comfortably under the #2090 ~35-char
     // hard-wrap threshold so the marker stays on one line.
     format!("{:08x}", hasher.finish() & 0xffff_ffff)
 }
 
+/// #1523 Phase 0: turn-completion token delimiters. `=====` (not `<…>`): the
+/// #2243 DuDuClaw lesson is that angle-bracket markers can be mangled by an
+/// agent's own markdown/HTML rendering, which would conflate "agent did not
+/// emit" with "delimiter was rewritten" and poison the Phase-0 emit/compliance
+/// data (r2 #2297). The prefix is shared by the detector fast-path so it can't
+/// drift from the token.
+const TURN_SENTINEL_PREFIX: &str = "=====AGEND-DONE:";
+const TURN_SENTINEL_SUFFIX: &str = "=====";
+
 /// #1523 Phase 0: the exact in-band token for an agent's turn-completion
-/// sentinel. Shared by the instruction directive and the shadow detector so the
-/// two never drift.
+/// sentinel. The single source of truth — the instruction directive embeds this
+/// exact string and the shadow detector scans for it, so the two never drift.
 pub(crate) fn turn_sentinel_token(name: &str) -> String {
-    format!("<<<AGEND-DONE:{}>>>", turn_sentinel_nonce(name))
+    format!(
+        "{TURN_SENTINEL_PREFIX}{}{TURN_SENTINEL_SUFFIX}",
+        turn_sentinel_nonce(name)
+    )
 }
 
 /// #1523 Phase 0: pure classification of a screen `tail` against an agent's
@@ -1242,8 +1254,22 @@ impl StateTracker {
         }
     }
 
-    /// Set instance name for behavioral telemetry logging.
-    #[allow(dead_code)] // Called by daemon supervisor when wiring up agents
+    /// Construct a tracker for a NAMED agent — the production path. The name is
+    /// required for per-agent telemetry: in particular the #1523 turn-completion
+    /// sentinel derives this agent's token from its name (see
+    /// [`turn_sentinel_token`]), so an unnamed tracker would compute the wrong
+    /// token and the shadow log would never fire. Prefer this over `new` +
+    /// `set_instance_name` at every real spawn site so the name can't be
+    /// forgotten (r6 #2297: the inline `StateTracker::new` left it empty in prod).
+    pub fn for_agent(backend: Option<&Backend>, name: &str) -> Self {
+        let mut t = Self::new(backend);
+        t.set_instance_name(name);
+        t
+    }
+
+    /// Set instance name for per-agent telemetry logging. Prefer [`for_agent`]
+    /// at construction; this stays public for the supervisor/tests that need to
+    /// (re)name an already-built tracker.
     pub fn set_instance_name(&mut self, name: &str) {
         self.instance_name = name.to_string();
     }
@@ -2368,7 +2394,7 @@ impl StateTracker {
         }
         // Cheap fast-path: the marker prefix is fixed; bail before building the
         // per-agent token or allocating a tail if it is nowhere on screen.
-        if !screen_text.contains("<<<AGEND-DONE:") {
+        if !screen_text.contains(TURN_SENTINEL_PREFIX) {
             self.last_turn_sentinel_sig = None;
             return;
         }

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -5421,3 +5421,157 @@ fn parse_usage_limit_release_forms_1955() {
         "no hint → conservative fallback path"
     );
 }
+
+// ── #1523 Phase 0: turn-completion sentinel (shadow) ───────────────────
+
+#[test]
+fn turn_sentinel_nonce_is_deterministic_and_eight_hex() {
+    let a = turn_sentinel_nonce("fixup-dev");
+    let b = turn_sentinel_nonce("fixup-dev");
+    assert_eq!(
+        a, b,
+        "nonce must be stable for the same agent (recomputable)"
+    );
+    assert_eq!(a.len(), 8, "nonce is fixed 8-char hex: {a}");
+    assert!(
+        a.chars().all(|c| c.is_ascii_hexdigit()),
+        "nonce must be hex: {a}"
+    );
+    assert_ne!(
+        turn_sentinel_nonce("fixup-dev"),
+        turn_sentinel_nonce("fixup-reviewer-2"),
+        "distinct agents should (overwhelmingly) get distinct nonces"
+    );
+}
+
+#[test]
+fn turn_sentinel_token_shape_matches_directive_literal() {
+    // The detector's token and the instructions.rs directive literal
+    // (`<<<AGEND-DONE:{nonce}>>>`) MUST stay byte-identical or detection drifts.
+    let token = turn_sentinel_token("fixup-dev");
+    assert_eq!(
+        token,
+        format!("<<<AGEND-DONE:{}>>>", turn_sentinel_nonce("fixup-dev"))
+    );
+    assert!(
+        token.len() < 35,
+        "token must dodge the #2090 hard-wrap: {token}"
+    );
+}
+
+#[test]
+fn observe_turn_sentinel_distinguishes_emit_echo_leak() {
+    let token = turn_sentinel_token("agent-x");
+
+    // Genuine emission: token alone on the final non-empty line.
+    let emit = observe_turn_sentinel(&format!("did the work\n{token}\n"), &token);
+    assert!(emit.token_seen && emit.on_last_line);
+    assert!(!emit.suspected_echo, "clean last-line emit is not an echo");
+    assert!(!emit.leak_signal);
+
+    // Source-view / instruction echo: directive prose co-occurs on screen.
+    let echo = observe_turn_sentinel(
+        &format!("## Turn-completion signal (AgEnD)\nprint this exact marker\n    {token}\n"),
+        &token,
+    );
+    assert!(
+        echo.token_seen && echo.suspected_echo,
+        "directive prose → echo"
+    );
+
+    // Leak proxy: token embedded mid-screen (not last line), no directive prose.
+    let leak = observe_turn_sentinel(&format!("file.txt:\n{token}\nmore text below\n"), &token);
+    assert!(leak.token_seen && !leak.on_last_line);
+    assert!(leak.suspected_echo, "non-last-line token is suspect");
+    assert!(leak.leak_signal, "embedded non-directive token flags leak");
+
+    // Another agent's token is not attributed to us.
+    let other = observe_turn_sentinel("<<<AGEND-DONE:deadbeef>>>\n", &token);
+    assert!(!other.token_seen, "only OUR exact token counts");
+
+    // Hard-wrapped token (split across rows) still matches via de-wrap.
+    let mid = token.len() / 2;
+    let wrapped = format!("output\n{}\n{}\n", &token[..mid], &token[mid..]);
+    assert!(
+        observe_turn_sentinel(&wrapped, &token).token_seen,
+        "de-wrapped scan must reassemble a hard-wrapped token"
+    );
+}
+
+#[test]
+fn turn_sentinel_capture_never_touches_state() {
+    // Fail-open invariant: capture runs post-classify and must NEVER move
+    // `self.current`. With the shadow flag OFF (the default) it early-returns;
+    // this pins, classifier-independently, that the wiring cannot perturb the
+    // classification. (The flag-ON path is checked in the env test below.)
+    let token = turn_sentinel_token("zb-agent");
+    let mut t = StateTracker::new(Some(&Backend::OpenCode));
+    t.set_instance_name("zb-agent");
+    t.current = AgentState::Thinking;
+    t.capture_turn_sentinel_shadow(&format!("done\n{token}"));
+    assert_eq!(
+        t.current,
+        AgentState::Thinking,
+        "capture must never change the classified state"
+    );
+}
+
+#[test]
+fn turn_sentinel_shadow_logs_record_when_on_without_changing_state() {
+    // Serialize the process-global env flips; restore on the way out so a panic
+    // can't leak them to other tests (mirrors the MED-5 convention).
+    static GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    let _g = GUARD.lock().unwrap_or_else(|e| e.into_inner());
+
+    let home = std::env::temp_dir().join(format!("agend-sentinel-{}", std::process::id()));
+    std::fs::create_dir_all(&home).expect("mk temp home");
+    let prev_home = std::env::var("AGEND_HOME").ok();
+    let prev_flag = std::env::var("AGEND_TURN_SENTINEL_SHADOW").ok();
+    std::env::set_var("AGEND_HOME", &home);
+    std::env::set_var("AGEND_TURN_SENTINEL_SHADOW", "1");
+
+    let token = turn_sentinel_token("on-agent");
+
+    // Drive the full feed → classify → capture WIRING (proves capture is
+    // actually called from feed_with_fg, not just unit-tested in isolation).
+    let mut t = StateTracker::new(Some(&Backend::OpenCode));
+    t.set_instance_name("on-agent");
+    t.current = AgentState::Thinking;
+    t.feed(&format!("all done now\n{token}"));
+    // Zero-behaviour even with the flag ON: a direct re-capture must not move
+    // the state (the heuristic owns `current`, the sentinel only side-logs).
+    t.current = AgentState::Thinking;
+    t.capture_turn_sentinel_shadow(&format!("again\n{token}"));
+    let with_state = t.current;
+
+    let log = home.join("turn_sentinel_shadow.jsonl");
+    let contents = std::fs::read_to_string(&log).unwrap_or_default();
+
+    // Restore env BEFORE asserting so a failure can't leak the flags.
+    match prev_home {
+        Some(v) => std::env::set_var("AGEND_HOME", v),
+        None => std::env::remove_var("AGEND_HOME"),
+    }
+    match prev_flag {
+        Some(v) => std::env::set_var("AGEND_TURN_SENTINEL_SHADOW", v),
+        None => std::env::remove_var("AGEND_TURN_SENTINEL_SHADOW"),
+    }
+    std::fs::remove_dir_all(&home).ok();
+
+    let line = contents
+        .lines()
+        .last()
+        .expect("a shadow record must be appended when the flag is on");
+    let rec: serde_json::Value = serde_json::from_str(line).expect("valid json record");
+    assert_eq!(rec["agent"], "on-agent");
+    assert_eq!(rec["token_seen"], true);
+    assert_eq!(rec["on_last_line"], true, "emission is on the last line");
+    assert_eq!(rec["suspected_echo"], false, "clean emit is not an echo");
+    assert!(rec["existing_state"].is_string());
+    // Zero behaviour even with the flag ON: capture did not move the state.
+    assert_eq!(
+        with_state,
+        AgentState::Thinking,
+        "capture must not change classification even when shadow is on"
+    );
+}

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -5445,13 +5445,22 @@ fn turn_sentinel_nonce_is_deterministic_and_eight_hex() {
 }
 
 #[test]
-fn turn_sentinel_token_shape_matches_directive_literal() {
-    // The detector's token and the instructions.rs directive literal
-    // (`<<<AGEND-DONE:{nonce}>>>`) MUST stay byte-identical or detection drifts.
+fn turn_sentinel_token_shape_is_single_source_and_safe() {
+    // The instructions.rs directive embeds `turn_sentinel_token(name)` verbatim,
+    // so this single source of truth pins the shape. #2243 DuDuClaw: use `=====`
+    // delimiters, NOT angle brackets an agent's renderer might mangle.
     let token = turn_sentinel_token("fixup-dev");
-    assert_eq!(
-        token,
-        format!("<<<AGEND-DONE:{}>>>", turn_sentinel_nonce("fixup-dev"))
+    assert!(
+        token.starts_with("=====AGEND-DONE:") && token.ends_with("====="),
+        "token uses ===== delimiters: {token}"
+    );
+    assert!(
+        !token.contains('<') && !token.contains('>'),
+        "token must avoid mangle-prone <…> delimiters: {token}"
+    );
+    assert!(
+        token.contains(&turn_sentinel_nonce("fixup-dev")),
+        "token carries this agent's nonce: {token}"
     );
     assert!(
         token.len() < 35,
@@ -5486,7 +5495,7 @@ fn observe_turn_sentinel_distinguishes_emit_echo_leak() {
     assert!(leak.leak_signal, "embedded non-directive token flags leak");
 
     // Another agent's token is not attributed to us.
-    let other = observe_turn_sentinel("<<<AGEND-DONE:deadbeef>>>\n", &token);
+    let other = observe_turn_sentinel("=====AGEND-DONE:deadbeef=====\n", &token);
     assert!(!other.token_seen, "only OUR exact token counts");
 
     // Hard-wrapped token (split across rows) still matches via de-wrap.
@@ -5516,12 +5525,18 @@ fn turn_sentinel_capture_never_touches_state() {
     );
 }
 
+/// Shared lock for the sentinel env-flag tests below — they all flip the same
+/// process-global `AGEND_HOME` / `AGEND_TURN_SENTINEL_SHADOW`, so they must
+/// serialize against EACH OTHER (a per-fn mutex would not), even under an
+/// in-process test runner. (CI uses nextest's process-per-test, but this keeps
+/// `cargo test` honest too.)
+static SENTINEL_ENV_GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 #[test]
 fn turn_sentinel_shadow_logs_record_when_on_without_changing_state() {
     // Serialize the process-global env flips; restore on the way out so a panic
     // can't leak them to other tests (mirrors the MED-5 convention).
-    static GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
-    let _g = GUARD.lock().unwrap_or_else(|e| e.into_inner());
+    let _g = SENTINEL_ENV_GUARD.lock().unwrap_or_else(|e| e.into_inner());
 
     let home = std::env::temp_dir().join(format!("agend-sentinel-{}", std::process::id()));
     std::fs::create_dir_all(&home).expect("mk temp home");
@@ -5573,5 +5588,56 @@ fn turn_sentinel_shadow_logs_record_when_on_without_changing_state() {
         with_state,
         AgentState::Thinking,
         "capture must not change classification even when shadow is on"
+    );
+}
+
+#[test]
+fn turn_sentinel_fires_for_prod_constructed_tracker_2297() {
+    // r6 #2297 regression: the live daemon builds the tracker via
+    // `StateTracker::for_agent` (the agent/mod.rs spawn site). If that path stops
+    // naming the tracker, `instance_name` is empty → the detector derives the
+    // WRONG token → the shadow log NEVER fires in prod (Phase-0 measurement is
+    // dead-on-arrival). The sibling tests all call `set_instance_name` manually
+    // and so MASK this. This one builds the tracker the PRODUCTION way — via
+    // `for_agent`, with NO manual setter — so a wiring regression re-surfaces.
+    let _g = SENTINEL_ENV_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+
+    let home = std::env::temp_dir().join(format!("agend-sentinel-prod-{}", std::process::id()));
+    std::fs::create_dir_all(&home).expect("mk temp home");
+    let prev_home = std::env::var("AGEND_HOME").ok();
+    let prev_flag = std::env::var("AGEND_TURN_SENTINEL_SHADOW").ok();
+    std::env::set_var("AGEND_HOME", &home);
+    std::env::set_var("AGEND_TURN_SENTINEL_SHADOW", "1");
+
+    // The token the agent is instructed to emit (derived from its name).
+    let token = turn_sentinel_token("prod-agent");
+    // Build the tracker the PROD way — named at construction, no manual setter.
+    let mut t = StateTracker::for_agent(Some(&Backend::OpenCode), "prod-agent");
+    t.feed(&format!("finished\n{token}"));
+
+    let log = home.join("turn_sentinel_shadow.jsonl");
+    let contents = std::fs::read_to_string(&log).unwrap_or_default();
+
+    match prev_home {
+        Some(v) => std::env::set_var("AGEND_HOME", v),
+        None => std::env::remove_var("AGEND_HOME"),
+    }
+    match prev_flag {
+        Some(v) => std::env::set_var("AGEND_TURN_SENTINEL_SHADOW", v),
+        None => std::env::remove_var("AGEND_TURN_SENTINEL_SHADOW"),
+    }
+    std::fs::remove_dir_all(&home).ok();
+
+    let line = contents.lines().last().expect(
+        "prod-constructed tracker must fire the shadow log — an empty instance_name would kill it",
+    );
+    let rec: serde_json::Value = serde_json::from_str(line).expect("valid json record");
+    assert_eq!(
+        rec["agent"], "prod-agent",
+        "record attributed to the named agent"
+    );
+    assert_eq!(
+        rec["token_seen"], true,
+        "the agent's name-derived token was detected via the prod path"
     );
 }


### PR DESCRIPTION
## #1523 Phase 0 — in-band turn-completion sentinel (shadow, measure-first)

Hook-less backends (opencode/agy/kiro/codex) have no lifecycle hooks (`backend.rs` `has_state_hooks()` = Claude-only), so their turn-completion detection is fragile screen-scraping. An **in-band sentinel** the agent prints when done is the one lever that needs no backend-protocol support.

**Phase 0 = shadow + telemetry only** (like #2090): inject the directive + side-log sightings, take **NO action** on the signal. Gated behind `AGEND_TURN_SENTINEL_SHADOW=1`, default-off → a default fleet sees ZERO change.

### What it does
- **Injection** (`src/instructions.rs`): `build_instructions_body` gains a `turn_sentinel: Option<&str>` param. When set, appends a `## Turn-completion signal` directive instructing the agent to print `<<<AGEND-DONE:{nonce}>>>` (25 chars, < the #2090 ~35-char hard-wrap) as its last line. Gated in `generate_agent_instructions` to `!has_state_hooks()` (**Claude excluded**) **AND** the shadow flag.
- **Nonce**: derived deterministically from the agent name (`turn_sentinel_nonce`) — the detector recomputes it, so **no persisted/plumbed state** and no restart-staleness surface (cf. the in-mem-reset-on-restart class). It is an attribution tag, not a secret; per-turn freshness comes from the detector's dedup latch.
- **Detection** (`src/state/mod.rs`): new post-classify `capture_turn_sentinel_shadow`, mirroring the retired `hardwrap_miss_shadow` (#2291): capture-after-classify, cheap prefix fast-path, fire-once latch, append to `~/turn_sentinel_shadow.jsonl`, **zero behaviour change**. Pure `observe_turn_sentinel` classifies each sighting and **flags suspected instruction-echo / source-view** (the sharpest FP risk — the instruction file itself carries the token) plus a coarse leak proxy.
- Record schema: `{ts, backend, agent, token_seen, on_last_line, existing_state, consistent, suspected_echo, leak_signal}` → per-backend emit / false-emit / leak rates.

### fail-open invariant
Flag-off / hook-ful backend / token-absent → classification **byte-identical**; the sentinel only ever ADDS corroboration, never subtracts.

### Tests
`turn_sentinel_nonce_*`, `turn_sentinel_token_shape_matches_directive_literal`, `observe_turn_sentinel_distinguishes_emit_echo_leak` (emit/echo/leak/wrong-agent/hard-wrap), `turn_sentinel_capture_never_touches_state` (fail-open), `turn_sentinel_shadow_logs_record_when_on_without_changing_state` (env-gated end-to-end), `turn_sentinel_directive_present_only_when_nonce_given_1523`.

### Notes for review
- **Design deviation to confirm**: lead's design said "static per-agent nonce (random hex per spawn)". I chose **name-derivation** over random-per-spawn — same "static per-agent" property, but recomputable by the detector with no persistence/plumbing and restart-safe. Flagging explicitly.
- **leak_signal** here is a coarse *screen-level* proxy (token embedded, not a clean last-line emit, no directive prose). Authoritative cross-artifact leak scanning (git diff / forwarded messages) is a Phase 0 follow-up, not in this PR.

### Verification
- `cargo nextest run --features tray` — new tests pass; full `instructions::`/`state::` modules (452) + invariant suite (36) green.
- `cargo clippy --features tray --all-targets -- -D warnings` clean; `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)