### PR TITLE
feat(dco): project-scoped Signed-off-by in prepare-commit-msg hook

### DIFF
--- a/assets/hooks/prepare-commit-msg
+++ b/assets/hooks/prepare-commit-msg
@@ -69,10 +69,17 @@ add_dco_signoff() {
     name=$(git config user.name 2>/dev/null)
     email=$(git config user.email 2>/dev/null)
     [ -n "$name" ] && [ -n "$email" ] || return 0
+    # dco.yml requires `<...@...>`; a malformed (no-`@`) email would FAIL the
+    # check, so skip rather than write a bad trailer.
+    case "$email" in *@*) ;; *) return 0 ;; esac
 
-    # Idempotent: this author already signed off (any Signed-off-by with this
-    # email — e.g. the agent used `git commit -s` or amended).
-    grep -qi "^[[:space:]]*Signed-off-by:.*<${email}>" "$msg_file" 2>/dev/null && return 0
+    # Idempotent: this author already signed off (any Signed-off-by carrying this
+    # email — e.g. the agent used `git commit -s` or amended). Match the literal
+    # `<email>` with `grep -F` so regex metacharacters in the address (`.`/`+`)
+    # cannot mis-match.
+    if grep -i "^[[:space:]]*Signed-off-by:" "$msg_file" 2>/dev/null | grep -qF "<${email}>"; then
+        return 0
+    fi
 
     # Keep the sign-off in the trailer block: contiguous with the Agend-* trailers
     # when present, otherwise separated from the body by one blank line.

--- a/assets/hooks/prepare-commit-msg
+++ b/assets/hooks/prepare-commit-msg
@@ -1,50 +1,92 @@
 #!/bin/sh
-# agend-terminal prepare-commit-msg hook — injects fleet trailers.
-# Reads binding.json for the current agent and appends metadata trailers.
-# Always exits 0 (hook failure must not block commits).
+# agend-terminal prepare-commit-msg hook — injects fleet trailers and, for repos
+# that opt into DCO, a `Signed-off-by` trailer. Always exits 0 (hook failure must
+# not block commits).
 
 COMMIT_MSG_FILE="$1"
 COMMIT_SOURCE="$2"
 
-# Skip merge/squash/template commits.
+# Skip merge/squash/template commits. DCO also exempts merge commits (no original
+# authorship to certify), so this keeps the two in lockstep.
 case "$COMMIT_SOURCE" in
     merge|squash|template) exit 0 ;;
 esac
 
-# Determine agent name from env.
-AGENT="${AGEND_INSTANCE_NAME:-}"
-if [ -z "$AGENT" ]; then
-    exit 0
-fi
+# --- Fleet trailers (Agend-*) — only for a bound agent commit. ---
+inject_agend_trailers() {
+    msg_file="$1"
 
-# Determine AGEND_HOME.
-HOME_DIR="${AGEND_HOME:-}"
-if [ -z "$HOME_DIR" ]; then
-    exit 0
-fi
+    AGENT="${AGEND_INSTANCE_NAME:-}"
+    [ -n "$AGENT" ] || return 0
 
-BINDING="$HOME_DIR/runtime/$AGENT/binding.json"
-if [ ! -f "$BINDING" ]; then
-    exit 0
-fi
+    HOME_DIR="${AGEND_HOME:-}"
+    [ -n "$HOME_DIR" ] || return 0
 
-# Idempotent: skip if trailer already present.
+    BINDING="$HOME_DIR/runtime/$AGENT/binding.json"
+    [ -f "$BINDING" ] || return 0
+
+    # Idempotent: skip if trailer already present.
+    grep -q "^Agend-Agent:" "$msg_file" 2>/dev/null && return 0
+
+    # Parse binding.json (minimal jq-free parsing via grep/sed).
+    TASK=$(grep -o '"task_id"[[:space:]]*:[[:space:]]*"[^"]*"' "$BINDING" | sed 's/.*"task_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/' 2>/dev/null)
+    BRANCH=$(grep -o '"branch"[[:space:]]*:[[:space:]]*"[^"]*"' "$BINDING" | sed 's/.*"branch"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/' 2>/dev/null)
+    ISSUED=$(grep -o '"issued_at"[[:space:]]*:[[:space:]]*"[^"]*"' "$BINDING" | sed 's/.*"issued_at"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/' 2>/dev/null)
+
+    # Only inject if we have at least agent name.
+    {
+        echo ""
+        echo "Agend-Agent: $AGENT"
+        [ -n "$TASK" ] && echo "Agend-Task: $TASK"
+        [ -n "$BRANCH" ] && echo "Agend-Branch: $BRANCH"
+        [ -n "$ISSUED" ] && echo "Agend-Issued-At: $ISSUED"
+    } >> "$msg_file"
+}
+
+# --- Project-scoped DCO sign-off (#t-92758-7). ---
+# Add a `Signed-off-by` ONLY when the repo being committed itself opts into DCO
+# (it ships `.github/workflows/dco.yml`). This is the core safety property: the
+# trailer NEVER overflows to other repos an operator happens to run Agend on — a
+# project without that workflow gets nothing.
+#
+# Repo resolution uses `git rev-parse --show-toplevel`, which is the repo git is
+# actually committing into (for a fleet agent the shim ChdirPass-redirects reads
+# to the bound worktree, i.e. the same repo this commit lands in — #2234), so the
+# dco.yml probe is checked against the correct project root, not a stale cwd.
+add_dco_signoff() {
+    msg_file="$1"
+    agend_trailers_present="$2"
+
+    repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || return 0
+    [ -n "$repo_root" ] || return 0
+
+    # Project-scope gate: no DCO workflow → no sign-off.
+    [ -f "$repo_root/.github/workflows/dco.yml" ] || return 0
+
+    # Identity = the real author (git config). DCO certifies the author, and
+    # dco.yml requires `Name <email>`; if either is empty, SKIP rather than write
+    # a malformed trailer that would FAIL the check.
+    name=$(git config user.name 2>/dev/null)
+    email=$(git config user.email 2>/dev/null)
+    [ -n "$name" ] && [ -n "$email" ] || return 0
+
+    # Idempotent: this author already signed off (any Signed-off-by with this
+    # email — e.g. the agent used `git commit -s` or amended).
+    grep -qi "^[[:space:]]*Signed-off-by:.*<${email}>" "$msg_file" 2>/dev/null && return 0
+
+    # Keep the sign-off in the trailer block: contiguous with the Agend-* trailers
+    # when present, otherwise separated from the body by one blank line.
+    [ "$agend_trailers_present" = "1" ] || echo "" >> "$msg_file"
+    printf 'Signed-off-by: %s <%s>\n' "$name" "$email" >> "$msg_file"
+}
+
+inject_agend_trailers "$COMMIT_MSG_FILE"
+
 if grep -q "^Agend-Agent:" "$COMMIT_MSG_FILE" 2>/dev/null; then
-    exit 0
+    AGEND_PRESENT=1
+else
+    AGEND_PRESENT=0
 fi
-
-# Parse binding.json (minimal jq-free parsing via grep/sed).
-TASK=$(grep -o '"task_id"[[:space:]]*:[[:space:]]*"[^"]*"' "$BINDING" | sed 's/.*"task_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/' 2>/dev/null)
-BRANCH=$(grep -o '"branch"[[:space:]]*:[[:space:]]*"[^"]*"' "$BINDING" | sed 's/.*"branch"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/' 2>/dev/null)
-ISSUED=$(grep -o '"issued_at"[[:space:]]*:[[:space:]]*"[^"]*"' "$BINDING" | sed 's/.*"issued_at"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/' 2>/dev/null)
-
-# Only inject if we have at least agent name.
-{
-    echo ""
-    echo "Agend-Agent: $AGENT"
-    [ -n "$TASK" ] && echo "Agend-Task: $TASK"
-    [ -n "$BRANCH" ] && echo "Agend-Branch: $BRANCH"
-    [ -n "$ISSUED" ] && echo "Agend-Issued-At: $ISSUED"
-} >> "$COMMIT_MSG_FILE"
+add_dco_signoff "$COMMIT_MSG_FILE" "$AGEND_PRESENT"
 
 exit 0

--- a/src/binding.rs
+++ b/src/binding.rs
@@ -1349,6 +1349,142 @@ mod tests {
         std::fs::remove_dir_all(&home).ok();
         std::fs::remove_dir_all(&repo).ok();
     }
+
+    // ── #t-92758-7: project-scoped DCO Signed-off-by in prepare-commit-msg ──
+    /// Run the EMBEDDED prepare-commit-msg hook in a hermetic harness: a stub `git`
+    /// on PATH answers `rev-parse --show-toplevel` + `config user.{name,email}`, so
+    /// the project-scope gate is exercised without a real repo. `dco_present`
+    /// toggles `<root>/.github/workflows/dco.yml`. No `AGEND_INSTANCE_NAME` → the
+    /// Agend-trailer block is skipped, isolating the DCO sign-off path. Returns the
+    /// resulting commit message.
+    #[cfg(unix)]
+    fn run_prepare_commit_msg(
+        tag: &str,
+        dco_present: bool,
+        name: &str,
+        email: &str,
+        initial: &str,
+    ) -> String {
+        use std::os::unix::fs::PermissionsExt;
+        use std::process::Command;
+
+        let home = tmp_home(tag);
+        let bin = home.join("bin");
+        std::fs::create_dir_all(&bin).unwrap();
+        let repo_root = home.join("repo");
+        std::fs::create_dir_all(&repo_root).unwrap();
+
+        let git_stub = bin.join("git");
+        std::fs::write(
+            &git_stub,
+            format!(
+                "#!/bin/sh\n\
+                 case \"$*\" in\n\
+                   *'rev-parse --show-toplevel'*) echo '{root}' ;;\n\
+                   *'config user.name'*) printf '%s' '{name}' ;;\n\
+                   *'config user.email'*) printf '%s' '{email}' ;;\n\
+                   *) : ;;\n\
+                 esac\n\
+                 exit 0\n",
+                root = repo_root.display(),
+                name = name,
+                email = email,
+            ),
+        )
+        .unwrap();
+        std::fs::set_permissions(&git_stub, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        if dco_present {
+            let wf = repo_root.join(".github").join("workflows");
+            std::fs::create_dir_all(&wf).unwrap();
+            std::fs::write(wf.join("dco.yml"), "name: DCO\n").unwrap();
+        }
+
+        let hook = home.join("prepare-commit-msg");
+        std::fs::write(&hook, include_str!("../assets/hooks/prepare-commit-msg")).unwrap();
+        std::fs::set_permissions(&hook, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let msg = home.join("COMMIT_EDITMSG");
+        std::fs::write(&msg, initial).unwrap();
+
+        let path = format!(
+            "{}:{}",
+            bin.display(),
+            std::env::var("PATH").unwrap_or_default()
+        );
+        let status = Command::new("sh")
+            .arg(&hook)
+            .arg(&msg)
+            .arg("message")
+            .env("PATH", &path)
+            .env_remove("AGEND_INSTANCE_NAME")
+            .status()
+            .unwrap();
+        assert!(status.success(), "hook must always exit 0");
+        let out = std::fs::read_to_string(&msg).unwrap();
+        std::fs::remove_dir_all(&home).ok();
+        out
+    }
+
+    /// (a) A DCO repo (ships dco.yml) gets a sign-off in dco.yml's required
+    /// `Name <email>` shape.
+    #[cfg(unix)]
+    #[test]
+    fn dco_repo_gets_signoff_passing_regex_92758() {
+        let out =
+            run_prepare_commit_msg("dco-a", true, "Test User", "test@example.com", "subject\n");
+        assert!(
+            out.contains("Signed-off-by: Test User <test@example.com>"),
+            "a DCO repo must get a sign-off: {out}"
+        );
+        // Mirrors dco.yml's gate: `^\s*Signed-off-by:\s+.+ <[^>]+@[^>]+>\s*$`.
+        let matches_dco = out.lines().any(|l| {
+            let l = l.trim();
+            l.starts_with("Signed-off-by:")
+                && l.contains(" <")
+                && l.contains('@')
+                && l.ends_with('>')
+        });
+        assert!(matches_dco, "sign-off must satisfy dco.yml's format: {out}");
+    }
+
+    /// (b) THE core safety property — a repo WITHOUT dco.yml is NEVER signed, so the
+    /// trailer cannot overflow to other projects an operator runs Agend on.
+    #[cfg(unix)]
+    #[test]
+    fn non_dco_repo_gets_no_signoff_92758() {
+        let out =
+            run_prepare_commit_msg("dco-b", false, "Test User", "test@example.com", "subject\n");
+        assert!(
+            !out.contains("Signed-off-by"),
+            "a repo without .github/workflows/dco.yml must NEVER be signed: {out}"
+        );
+    }
+
+    /// (c) Idempotent — an already-signed message is not double-signed.
+    #[cfg(unix)]
+    #[test]
+    fn already_signed_message_not_duplicated_92758() {
+        let initial = "subject\n\nSigned-off-by: Test User <test@example.com>\n";
+        let out = run_prepare_commit_msg("dco-c", true, "Test User", "test@example.com", initial);
+        assert_eq!(
+            out.matches("Signed-off-by:").count(),
+            1,
+            "must not duplicate an existing sign-off: {out}"
+        );
+    }
+
+    /// (d) Identity gap (empty email) → SKIP rather than emit a malformed trailer
+    /// that would fail the DCO regex.
+    #[cfg(unix)]
+    #[test]
+    fn missing_identity_skips_signoff_92758() {
+        let out = run_prepare_commit_msg("dco-d", true, "Test User", "", "subject\n");
+        assert!(
+            !out.contains("Signed-off-by"),
+            "empty email must skip the sign-off (no malformed trailer): {out}"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/src/binding.rs
+++ b/src/binding.rs
@@ -1485,6 +1485,155 @@ mod tests {
             "empty email must skip the sign-off (no malformed trailer): {out}"
         );
     }
+
+    /// (e, r2) A MALFORMED email (no `@`) must skip the sign-off — dco.yml requires
+    /// `<...@...>`, so emitting it would fail the very check.
+    #[cfg(unix)]
+    #[test]
+    fn malformed_email_no_at_skips_signoff_92758() {
+        let out =
+            run_prepare_commit_msg("dco-noat", true, "Test User", "not-an-email", "subject\n");
+        assert!(
+            !out.contains("Signed-off-by"),
+            "an email without '@' must skip the sign-off: {out}"
+        );
+    }
+
+    // ── #t-92758-7: REAL-git resolution e2e (r6) — locks the no-overflow property
+    //    against actual `git rev-parse --show-toplevel`, not a stub. ──
+    #[cfg(unix)]
+    fn run_git(args: &[&str], dir: &std::path::Path) -> std::process::Output {
+        std::process::Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .env("AGEND_GIT_BYPASS", "1")
+            .env("GIT_AUTHOR_NAME", "Test User")
+            .env("GIT_AUTHOR_EMAIL", "test@example.com")
+            .env("GIT_COMMITTER_NAME", "Test User")
+            .env("GIT_COMMITTER_EMAIL", "test@example.com")
+            .env_remove("AGEND_INSTANCE_NAME")
+            .output()
+            .expect("git")
+    }
+
+    #[cfg(unix)]
+    fn init_repo_with_identity(repo: &std::path::Path) {
+        assert!(run_git(&["init", "-b", "main"], repo).status.success());
+        run_git(&["config", "user.name", "Test User"], repo);
+        run_git(&["config", "user.email", "test@example.com"], repo);
+    }
+
+    #[cfg(unix)]
+    fn write_dco_yml(root: &std::path::Path) {
+        let wf = root.join(".github").join("workflows");
+        std::fs::create_dir_all(&wf).unwrap();
+        std::fs::write(wf.join("dco.yml"), "name: DCO\n").unwrap();
+    }
+
+    #[cfg(unix)]
+    fn head_message(dir: &std::path::Path) -> String {
+        let log = run_git(&["log", "-1", "--format=%B"], dir);
+        String::from_utf8_lossy(&log.stdout).to_string()
+    }
+
+    /// (f) Real git: a commit from a SUBDIR of a DCO repo is signed (the gate
+    /// resolves the repo root via `git rev-parse --show-toplevel`).
+    #[cfg(unix)]
+    #[test]
+    fn real_git_dco_repo_subdir_commit_signs_92758() {
+        let home = tmp_home("dco-e2e-subdir");
+        let repo = tmp_home("dco-e2e-subdir-repo");
+        init_repo_with_identity(&repo);
+        write_dco_yml(&repo);
+        let sub = repo.join("src");
+        std::fs::create_dir_all(&sub).unwrap();
+        install_hooks(&home, &repo);
+        assert!(
+            run_git(&["commit", "--allow-empty", "-m", "subj"], &sub)
+                .status
+                .success(),
+            "commit from subdir must succeed"
+        );
+        let msg = head_message(&repo);
+        assert!(
+            msg.contains("Signed-off-by: Test User <test@example.com>"),
+            "subdir commit in a DCO repo must be signed: {msg}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+        std::fs::remove_dir_all(&repo).ok();
+    }
+
+    /// (g) #2234 core, real git: a commit in a LINKED WORKTREE of a DCO repo is
+    /// signed (the gate resolves the worktree root, where the tracked dco.yml is
+    /// checked out — the cwd/worktree dual-truth case).
+    #[cfg(unix)]
+    #[test]
+    fn real_git_dco_repo_linked_worktree_commit_signs_92758() {
+        let home = tmp_home("dco-e2e-wt");
+        let repo = tmp_home("dco-e2e-wt-repo");
+        init_repo_with_identity(&repo);
+        write_dco_yml(&repo);
+        run_git(&["add", "."], &repo);
+        assert!(
+            run_git(&["commit", "-m", "init dco.yml"], &repo)
+                .status
+                .success(),
+            "seed commit must succeed"
+        );
+        let wt = home.join("wt");
+        assert!(
+            run_git(
+                &["worktree", "add", "-b", "feat/x", &wt.display().to_string()],
+                &repo
+            )
+            .status
+            .success(),
+            "worktree add must succeed"
+        );
+        install_hooks(&home, &wt);
+        assert!(
+            run_git(&["commit", "--allow-empty", "-m", "subj"], &wt)
+                .status
+                .success(),
+            "worktree commit must succeed"
+        );
+        let msg = head_message(&wt);
+        assert!(
+            msg.contains("Signed-off-by: Test User <test@example.com>"),
+            "commit in a linked worktree of a DCO repo must be signed (#2234): {msg}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+        std::fs::remove_dir_all(&repo).ok();
+    }
+
+    /// (h) THE no-overflow regression (operator-core, real git): a NON-DCO repo is
+    /// NEVER signed, even when a SIBLING directory ships a dco.yml — the gate must
+    /// key on the committed repo's OWN root, not a neighbour.
+    #[cfg(unix)]
+    #[test]
+    fn real_git_non_dco_repo_with_dco_sibling_not_signed_92758() {
+        let home = tmp_home("dco-e2e-nondco");
+        let base = tmp_home("dco-e2e-nondco-base");
+        // Sibling that DOES opt into DCO — must not leak into the repo below.
+        write_dco_yml(&base.join("sibling-dco"));
+        let repo = base.join("plain-repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        init_repo_with_identity(&repo);
+        install_hooks(&home, &repo);
+        assert!(
+            run_git(&["commit", "--allow-empty", "-m", "subj"], &repo)
+                .status
+                .success(),
+            "commit must succeed"
+        );
+        let msg = head_message(&repo);
+        assert!(
+            !msg.contains("Signed-off-by"),
+            "a non-DCO repo must NEVER be signed even with a DCO sibling (no overflow): {msg}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+        std::fs::remove_dir_all(&base).ok();
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What
Auto-adds a DCO `Signed-off-by` trailer to fleet-agent commits — but **only** in repos that opt into DCO. The `prepare-commit-msg` hook signs only when the committing repo ships `.github/workflows/dco.yml`, so the trailer **never overflows** to other projects an operator runs Agend on. This is the implementation of the operator-decided "Hook + auto-detection" DCO rollout.

## Design (`assets/hooks/prepare-commit-msg`)
The hook already injects `Agend-*` trailers; this adds a conditional `Signed-off-by`:
1. **Project-scope gate (core)**: resolve the repo with `git rev-parse --show-toplevel` — the bound worktree the commit actually lands in (the agend-git shim ChdirPass-redirects reads to that worktree, so this stays correct under #2234 cwd/worktree drift) — and probe `<root>/.github/workflows/dco.yml`. **Absent → nothing is added.**
2. **Identity** from `git config user.name`/`user.email` (the real author, per DCO semantics). Either empty → **skip** (never emit a malformed trailer that would *fail* the check).
3. **Idempotent**: an existing `Signed-off-by` from this author (matched by email) is not duplicated.
4. The sign-off joins the `Agend-*` trailer block contiguously when present (verified by a real-git e2e run in this repo).

## Tests (`src/binding.rs`, hermetic)
A stub `git` on PATH answers `rev-parse --show-toplevel` + `config user.*`, so the gate is exercised without a real repo:
- `dco_repo_gets_signoff_passing_regex_92758` — DCO repo signs + matches dco.yml's `Name <email>` regex.
- **`non_dco_repo_gets_no_signoff_92758`** — the core no-overflow guarantee: a repo without dco.yml is **never** signed.
- `already_signed_message_not_duplicated_92758` — idempotent.
- `missing_identity_skips_signoff_92758` — identity gap → skip.

Verified: fmt ✓ · clippy --all-targets --features tray ✓ · 4 DCO tests + install_hooks coexistence ✓ · real-git e2e in this repo produced a clean contiguous trailer block.

## ⚠ Activation (one operator action)
Needs **one rebuild + daemon restart**: the hook is baked into the binary and re-installed by `binding.rs::install_hooks` on boot — running agents use the *old* hook until then. **After merge + restart**, lead re-adds `Signed-off-by` to the required checks and verifies an agent PR signs green.

## Review
Requested **dual-review** (blast = every commit / every user; gate correctness is critical). This PR's own commit is not yet signed (old hook still live) — expected; DCO check is non-required until the post-restart cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)