### PR TITLE
docs(#1523): fix stale turn-sentinel delimiter in doc comment (DCO cutover canary)

### DIFF
--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -2372,7 +2372,7 @@ impl StateTracker {
     /// #1523 Phase 0: turn-completion sentinel shadow telemetry.
     ///
     /// When `AGEND_TURN_SENTINEL_SHADOW=1`, hook-less agents are instructed to
-    /// print `<<<AGEND-DONE:{nonce}>>>` as the final line when a turn finishes
+    /// print `=====AGEND-DONE:{nonce}=====` as the final line when a turn finishes
     /// (see [`turn_sentinel_token`]). This side-logs whether THIS agent's token
     /// is on screen alongside the heuristic classification, so emit-rate /
     /// false-emit (instruction-echo / source-view) / leak can be measured before


### PR DESCRIPTION
Cosmetic follow-up to #2297 (r2's review note) + end-to-end canary for the DCO cutover (#2298 hook + #2302 selection fix, now live).

## Change (comment-only, zero behaviour)

`capture_turn_sentinel_shadow`'s doc comment in `src/state/mod.rs` still showed the old turn-completion delimiter; the code emits `=====AGEND-DONE:{nonce}=====` since #2297. Updated the comment to match. `git grep "<<<AGEND" src/` had exactly one residual; no code touched.

## DCO cutover verification

This commit was made WITHOUT `git commit -s` — the live `prepare-commit-msg` hook auto-injected the `Signed-off-by` trailer. Expect the `Signed-off-by` / DCO check to go green.

Single review (comment-only) + CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)