### PR TITLE
docs(contributing): document the maintainer/fleet local git identity

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,22 @@ git rebase --signoff origin/main           # every commit on the branch
 # then: git push --force-with-lease
 ```
 
+### Maintainer / fleet identity
+
+The author, committer, and `Signed-off-by` of a commit all come from this clone's
+`git config user.name` / `user.email`. Set them as **local** config in your clone of
+this repo (not `--global`, so other projects are unaffected). The maintainer/fleet
+identity is:
+
+```bash
+git config user.name  "Huang ChiaCheng (黃家政)"
+git config user.email "1557604+suzuke@users.noreply.github.com"
+```
+
+This is local to `.git/config` and is **not** version-controlled, so re-run it after a
+fresh `git clone`. Fleet agents commit in linked worktrees of this clone and inherit
+the same identity automatically.
+
 ## Review Process
 
 Here's what to expect once you open an issue or PR — the aim is fast, concrete feedback, not ceremony.

--- a/CONTRIBUTING.zh-TW.md
+++ b/CONTRIBUTING.zh-TW.md
@@ -80,6 +80,20 @@ git rebase --signoff origin/main           # 分支上的每個 commit
 # 然後:git push --force-with-lease
 ```
 
+### Maintainer / fleet 身份
+
+commit 的 author、committer 與 `Signed-off-by`都來自這個 clone 的 `git config
+user.name` / `user.email`。請把它們設成這個 repo clone 的 **local** config（不要
+`--global`,以免影響其他專案）。maintainer/fleet 身份為:
+
+```bash
+git config user.name  "Huang ChiaCheng (黃家政)"
+git config user.email "1557604+suzuke@users.noreply.github.com"
+```
+
+這是 `.git/config` 的 local 設定、**不進版控**,所以全新 `git clone` 後要重設一次。
+Fleet agent 在這個 clone 的 linked worktree 裡 commit,會自動繼承同一個身份。
+
 ## Review 流程
 
 以下是你開 issue 或 PR 之後可以預期的狀況——目標是快速、具體的回饋，而不是繁文縟節。


### PR DESCRIPTION
## What
Documents the maintainer/fleet **local** git identity in `CONTRIBUTING.md` + `CONTRIBUTING.zh-TW.md` — the source of a commit's author, committer, and `Signed-off-by`. Follow-up to the DCO canary (#2303), which surfaced that fleet agent commits were authored as the placeholder `test <test@test.local>`.

## Context
The fake identity came from this clone's **local** `.git/config [user]` (`test <test@test.local>`); linked worktrees of the clone inherit it, so agent commits picked it up. The operator-decided fleet identity is:

```
Huang ChiaCheng (黃家政) <1557604+suzuke@users.noreply.github.com>
```

Lead has already set it as local config on the canonical clone. Since `.git/config` is **not** version-controlled, this PR documents it (with the two `git config` commands) so it survives a fresh clone — a **local** setting, never `--global`, so other projects an operator runs Agend on are unaffected.

## Verification (empirical, this task)
**Identity applies to fleet commits** — a real commit in a linked worktree of the canonical clone:
```
author : Huang ChiaCheng (黃家政) <1557604+suzuke@users.noreply.github.com>
commit : Huang ChiaCheng (黃家政) <1557604+suzuke@users.noreply.github.com>
Signed-off-by: Huang ChiaCheng (黃家政) <1557604+suzuke@users.noreply.github.com>
```
(this PR's own commit is exactly that.)

**No overflow downstream** — a separate repo with its own identity and **no** `.github/workflows/dco.yml`:
```
author : Downstream Dev <downstream@example.com>
commit : Downstream Dev <downstream@example.com>
(no Signed-off-by — the DCO hook correctly does not sign; no "Huang ChiaCheng" anywhere)
```

Identity + sign-off are both project-scoped by construction (local config + the hook's dco.yml gate). No code change, no rebuild/restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)