### PR TITLE
feat(tui): async decision board — (b) interactive Ctrl+B D answer overlay (#2305)

### DIFF
--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -193,8 +193,14 @@ pub(super) fn dispatch(action: Action, ctx: &mut DispatchCtx<'_>) -> DispatchRes
             });
         }
         Action::ShowDecisions => {
-            let items = crate::decisions::list_all(ctx.home);
-            out.new_overlay = Some(Overlay::Decisions { items, scroll: 0 });
+            // #2305: Ctrl+B D is now the pending-question answer board — list only
+            // decisions awaiting an operator answer.
+            let items = crate::decisions::list_pending(ctx.home);
+            out.new_overlay = Some(Overlay::Decisions {
+                items,
+                selected: 0,
+                mode: super::overlay::DecisionMode::Browse,
+            });
         }
         Action::ShowTasks => {
             let items = crate::tasks::list_all(ctx.home);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -14,7 +14,7 @@ mod telegram_hooks;
 mod tui_events;
 mod tui_spawn;
 
-pub use overlay::{BoardView, MenuItem, MenuItemKind, TaskBoardMode};
+pub use overlay::{BoardView, DecisionMode, MenuItem, MenuItemKind, TaskBoardMode};
 pub(crate) use tui_events::{TuiEvent, TuiEventSender, TuiNotifier};
 
 use crate::agent::{self, AgentRegistry};
@@ -623,8 +623,12 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
                 Overlay::Command { ref input } => {
                     render::render_command_palette(frame, input);
                 }
-                Overlay::Decisions { ref items, scroll } => {
-                    render::render_decisions(frame, items, *scroll);
+                Overlay::Decisions {
+                    ref items,
+                    selected,
+                    ref mode,
+                } => {
+                    render::render_decisions(frame, items, *selected, mode);
                 }
                 Overlay::Tasks {
                     ref items,
@@ -801,8 +805,12 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
                                     Overlay::Command { ref input } => {
                                         crate::render::render_command_palette(frame, input);
                                     }
-                                    Overlay::Decisions { ref items, scroll } => {
-                                        crate::render::render_decisions(frame, items, *scroll);
+                                    Overlay::Decisions {
+                                        ref items,
+                                        selected,
+                                        ref mode,
+                                    } => {
+                                        crate::render::render_decisions(frame, items, *selected, mode);
                                     }
                                     Overlay::Tasks { ref items, col, row, ref mode, ref view } => {
                                         crate::render::render_tasks(frame, items, *col, *row, mode, *view, &home);

--- a/src/app/overlay.rs
+++ b/src/app/overlay.rs
@@ -28,6 +28,20 @@ pub(super) enum CloseTarget {
     Tab,
 }
 
+/// #2305: sub-mode of the pending-decision answer overlay.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DecisionMode {
+    /// Navigating the pending-question list (j/k select, Enter answers, q/Esc close).
+    Browse,
+    /// Answering the selected question. `option` is the highlighted option index;
+    /// `free_text` is `Some(buffer)` while typing a free-text answer (only when the
+    /// question's `allow_free_text` is set), else `None` (choosing among options).
+    Answer {
+        option: usize,
+        free_text: Option<String>,
+    },
+}
+
 pub enum TaskBoardMode {
     Board,
     Detail,
@@ -101,10 +115,15 @@ pub(super) enum Overlay {
     Command {
         input: String,
     },
-    /// Decisions overlay panel (read-only, scrollable).
+    /// #2305: pending-decision answer board (Ctrl+B D). Lists questions awaiting
+    /// an operator answer; Browse to pick one, then Answer (select an option or
+    /// type free-text). Mirrors the interactive `Tasks` overlay.
     Decisions {
         items: Vec<crate::decisions::Decision>,
-        scroll: usize,
+        /// Selected pending question (Browse mode).
+        selected: usize,
+        /// Sub-mode: Browse the list, or Answer the selected question.
+        mode: DecisionMode,
     },
     /// Task board overlay — 4-column kanban view with CRUD.
     Tasks {
@@ -125,30 +144,23 @@ pub(super) enum Overlay {
     },
 }
 
-/// Handle j/k/PgUp/PgDn scroll for list overlays. Returns true if handled, false to close.
-pub(super) fn handle_list_scroll(key: KeyCode, scroll: &mut usize, len: usize) -> bool {
-    match key {
-        KeyCode::Up | KeyCode::Char('k') => {
-            *scroll = scroll.saturating_sub(1);
-            true
-        }
-        KeyCode::Down | KeyCode::Char('j') => {
-            if *scroll + 1 < len {
-                *scroll += 1;
-            }
-            true
-        }
-        KeyCode::PageUp => {
-            *scroll = scroll.saturating_sub(10);
-            true
-        }
-        KeyCode::PageDown => {
-            *scroll = (*scroll + 10).min(len.saturating_sub(1));
-            true
-        }
-        KeyCode::Esc | KeyCode::Char('q') => false,
-        _ => true,
-    }
+/// #2305: record the operator's answer to a pending decision and reload the
+/// pending list so the answered item drops out. `answered_by` is fixed
+/// `"operator"` — the TUI is the trusted local operator. Best-effort: on a
+/// backend error the list simply doesn't change (the item stays pending), so the
+/// operator can retry; the overlay never surfaces a hard failure mid-key.
+fn submit_decision_answer(
+    home: &Path,
+    id: &str,
+    answer: String,
+    items: &mut Vec<crate::decisions::Decision>,
+) {
+    let _ = crate::decisions::answer(
+        home,
+        "operator",
+        &serde_json::json!({"id": id, "answer": answer}),
+    );
+    *items = crate::decisions::list_pending(home);
 }
 
 /// Bundle of mutable references passed to `handle_key` so overlay handlers can
@@ -570,11 +582,105 @@ pub(super) fn handle_key(
             _ => {}
         },
         Overlay::Decisions {
-            items,
-            ref mut scroll,
+            ref mut items,
+            ref mut selected,
+            ref mut mode,
         } => {
-            if !handle_list_scroll(key.code, scroll, items.len()) {
-                *overlay = Overlay::None;
+            match mode {
+                DecisionMode::Browse => match key.code {
+                    KeyCode::Up | KeyCode::Char('k') => {
+                        *selected = selected.saturating_sub(1);
+                    }
+                    KeyCode::Down | KeyCode::Char('j') if *selected + 1 < items.len() => {
+                        *selected += 1;
+                    }
+                    // Enter answers the selected question. Open free-text directly
+                    // when there are no options to choose (and free text is allowed).
+                    KeyCode::Enter => {
+                        if let Some(d) = items.get(*selected) {
+                            let free_text = if d.options.is_empty() && d.allow_free_text {
+                                Some(String::new())
+                            } else {
+                                None
+                            };
+                            // Only enter Answer mode if there's actually a way to
+                            // answer (some options, or free text allowed).
+                            if !d.options.is_empty() || d.allow_free_text {
+                                *mode = DecisionMode::Answer {
+                                    option: 0,
+                                    free_text,
+                                };
+                            }
+                        }
+                    }
+                    KeyCode::Esc | KeyCode::Char('q') => {
+                        *overlay = Overlay::None;
+                    }
+                    _ => {}
+                },
+                DecisionMode::Answer {
+                    ref mut option,
+                    ref mut free_text,
+                } => {
+                    // Snapshot the bits we need as OWNED values so the submit path
+                    // can take `&mut items` without an outstanding borrow. If the
+                    // selected decision vanished (race), bail back to Browse.
+                    let Some((id, opt_labels, allow_free)) = items.get(*selected).map(|d| {
+                        (
+                            d.id.clone(),
+                            d.options
+                                .iter()
+                                .map(|o| o.label.clone())
+                                .collect::<Vec<_>>(),
+                            d.allow_free_text,
+                        )
+                    }) else {
+                        *mode = DecisionMode::Browse;
+                        return outcome;
+                    };
+                    if let Some(buf) = free_text {
+                        // Free-text input sub-mode.
+                        match key.code {
+                            KeyCode::Enter if !buf.is_empty() => {
+                                submit_decision_answer(ctx.home, &id, buf.clone(), items);
+                                *selected = (*selected).min(items.len().saturating_sub(1));
+                                *mode = DecisionMode::Browse;
+                            }
+                            KeyCode::Char(c) => buf.push(c),
+                            KeyCode::Backspace => {
+                                buf.pop();
+                            }
+                            // Esc backs out of free-text to option select.
+                            KeyCode::Esc => *free_text = None,
+                            _ => {}
+                        }
+                    } else {
+                        // Option-select sub-mode.
+                        match key.code {
+                            KeyCode::Up | KeyCode::Char('k') => {
+                                *option = option.saturating_sub(1);
+                            }
+                            KeyCode::Down | KeyCode::Char('j')
+                                if *option + 1 < opt_labels.len() =>
+                            {
+                                *option += 1;
+                            }
+                            KeyCode::Enter => {
+                                if let Some(label) = opt_labels.get(*option) {
+                                    submit_decision_answer(ctx.home, &id, label.clone(), items);
+                                    *selected = (*selected).min(items.len().saturating_sub(1));
+                                    *mode = DecisionMode::Browse;
+                                }
+                            }
+                            // 'f' / 'e' switch to free-text entry when allowed.
+                            KeyCode::Char('f') | KeyCode::Char('e') if allow_free => {
+                                *free_text = Some(String::new());
+                            }
+                            KeyCode::Esc => *mode = DecisionMode::Browse,
+                            _ => {}
+                        }
+                    }
+                }
             }
         }
         Overlay::Tasks {
@@ -913,6 +1019,37 @@ mod tests {
         match overlay {
             Overlay::Tasks { mode, .. } => mode,
             _ => panic!("expected Tasks overlay"),
+        }
+    }
+
+    /// #2305: a per-test temp home (process+tag unique — no env, no cross-test
+    /// collision; decisions are posted with an explicit `home`).
+    fn dec_home(tag: &str) -> std::path::PathBuf {
+        let h = std::env::temp_dir().join(format!("overlay_dec_{}_{}", std::process::id(), tag));
+        std::fs::create_dir_all(&h).ok();
+        h
+    }
+
+    /// #2305: drive a sequence of keys through `handle_key` against a fresh ctx
+    /// bound to `home` (so the Decisions overlay's `decisions::answer` writes land
+    /// in this temp home).
+    fn run_keys(home: &Path, overlay: &mut Overlay, keys: &[KeyCode]) {
+        let registry: crate::agent::AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let (tx, _rx) = crossbeam_channel::unbounded();
+        let mut name_counter = HashMap::new();
+        let tg: Option<Arc<dyn crate::channel::Channel>> = None;
+        let mut layout = crate::layout::Layout::new();
+        let mut ctx = OverlayCtx {
+            layout: &mut layout,
+            registry: &registry,
+            home,
+            fleet_path: home,
+            wakeup_tx: &tx,
+            name_counter: &mut name_counter,
+            telegram_state: &tg,
+        };
+        for k in keys {
+            handle_key(overlay, press(*k), &mut ctx);
         }
     }
 
@@ -1280,50 +1417,190 @@ mod tests {
         std::fs::remove_dir_all(&home).ok();
     }
 
-    // --- Sprint 41 T-4: handle_list_scroll logic coverage ---
+    // #2305: the read-only `handle_list_scroll` helper was removed when the
+    // Decisions overlay became interactive (it was its only prod caller); its
+    // navigation is now covered by the Decisions answer-overlay tests below.
 
-    #[test]
-    fn list_scroll_up_decrements() {
-        let mut scroll = 5;
-        let consumed = handle_list_scroll(KeyCode::Up, &mut scroll, 10);
-        assert!(consumed);
-        assert_eq!(scroll, 4);
+    // ─── #2305 interactive decision answer overlay ───
+
+    fn open_decisions(home: &Path) -> Overlay {
+        Overlay::Decisions {
+            items: crate::decisions::list_pending(home),
+            selected: 0,
+            mode: DecisionMode::Browse,
+        }
     }
 
     #[test]
-    fn list_scroll_up_at_zero_stays_zero() {
-        let mut scroll = 0;
-        handle_list_scroll(KeyCode::Up, &mut scroll, 10);
-        assert_eq!(scroll, 0);
+    fn decisions_option_answer_submits_and_reloads() {
+        let home = dec_home("opt");
+        let _ = crate::decisions::post(
+            &home,
+            "lead",
+            &serde_json::json!({
+                "title": "Deploy?", "content": "ship v2?", "needs_answer": true,
+                "options": [{"label": "yes", "recommended": true}, "no"],
+            }),
+        );
+        let mut overlay = open_decisions(&home);
+        // Enter opens Answer (option-select, since options exist).
+        run_keys(&home, &mut overlay, &[KeyCode::Enter]);
+        assert!(matches!(
+            &overlay,
+            Overlay::Decisions {
+                mode: DecisionMode::Answer {
+                    option: 0,
+                    free_text: None
+                },
+                ..
+            }
+        ));
+        // Down→'no', Up→'yes', Enter submits 'yes'.
+        run_keys(
+            &home,
+            &mut overlay,
+            &[KeyCode::Down, KeyCode::Up, KeyCode::Enter],
+        );
+        match &overlay {
+            Overlay::Decisions { items, mode, .. } => {
+                assert!(
+                    matches!(mode, DecisionMode::Browse),
+                    "back to Browse after submit"
+                );
+                assert!(
+                    items.is_empty(),
+                    "answered question dropped from pending list"
+                );
+            }
+            _ => panic!("expected Decisions overlay after submit"),
+        }
+        let d = crate::decisions::list_all(&home)
+            .into_iter()
+            .next()
+            .expect("decision present");
+        assert_eq!(d.answer.as_deref(), Some("yes"));
+        assert_eq!(d.answered_by.as_deref(), Some("operator"));
+        std::fs::remove_dir_all(&home).ok();
     }
 
     #[test]
-    fn list_scroll_down_increments() {
-        let mut scroll = 3;
-        let consumed = handle_list_scroll(KeyCode::Down, &mut scroll, 10);
-        assert!(consumed);
-        assert_eq!(scroll, 4);
+    fn decisions_free_text_answer_submits() {
+        let home = dec_home("free");
+        let _ = crate::decisions::post(
+            &home,
+            "lead",
+            &serde_json::json!({
+                "title": "Why?", "content": "explain", "needs_answer": true, "allow_free_text": true,
+            }),
+        );
+        let mut overlay = open_decisions(&home);
+        // No options + free text allowed → Enter goes straight to free-text entry.
+        run_keys(&home, &mut overlay, &[KeyCode::Enter]);
+        assert!(matches!(
+            &overlay,
+            Overlay::Decisions {
+                mode: DecisionMode::Answer {
+                    free_text: Some(_),
+                    ..
+                },
+                ..
+            }
+        ));
+        run_keys(
+            &home,
+            &mut overlay,
+            &[KeyCode::Char('h'), KeyCode::Char('i'), KeyCode::Enter],
+        );
+        let d = crate::decisions::list_all(&home)
+            .into_iter()
+            .next()
+            .expect("decision present");
+        assert_eq!(d.answer.as_deref(), Some("hi"));
+        std::fs::remove_dir_all(&home).ok();
     }
 
     #[test]
-    fn list_scroll_down_at_end_stays() {
-        let mut scroll = 9;
-        handle_list_scroll(KeyCode::Down, &mut scroll, 10);
-        assert_eq!(scroll, 9);
+    fn decisions_esc_backs_out_then_closes() {
+        let home = dec_home("esc");
+        let _ = crate::decisions::post(
+            &home,
+            "lead",
+            &serde_json::json!({
+                "title": "Q", "content": "?", "needs_answer": true,
+                "options": ["a"], "allow_free_text": true,
+            }),
+        );
+        let mut overlay = open_decisions(&home);
+        // Enter→Answer(option), f→free-text.
+        run_keys(&home, &mut overlay, &[KeyCode::Enter, KeyCode::Char('f')]);
+        assert!(matches!(
+            &overlay,
+            Overlay::Decisions {
+                mode: DecisionMode::Answer {
+                    free_text: Some(_),
+                    ..
+                },
+                ..
+            }
+        ));
+        // Esc backs free-text → option-select.
+        run_keys(&home, &mut overlay, &[KeyCode::Esc]);
+        assert!(matches!(
+            &overlay,
+            Overlay::Decisions {
+                mode: DecisionMode::Answer {
+                    free_text: None,
+                    ..
+                },
+                ..
+            }
+        ));
+        // Esc backs option-select → Browse.
+        run_keys(&home, &mut overlay, &[KeyCode::Esc]);
+        assert!(matches!(
+            &overlay,
+            Overlay::Decisions {
+                mode: DecisionMode::Browse,
+                ..
+            }
+        ));
+        // Esc in Browse closes the overlay.
+        run_keys(&home, &mut overlay, &[KeyCode::Esc]);
+        assert!(matches!(&overlay, Overlay::None));
+        std::fs::remove_dir_all(&home).ok();
     }
 
     #[test]
-    fn list_scroll_esc_returns_false() {
-        let mut scroll = 5;
-        let consumed = handle_list_scroll(KeyCode::Esc, &mut scroll, 10);
-        assert!(!consumed, "Esc must return false (close overlay)");
-    }
-
-    #[test]
-    fn list_scroll_page_down_jumps_10() {
-        let mut scroll = 0;
-        handle_list_scroll(KeyCode::PageDown, &mut scroll, 50);
-        assert_eq!(scroll, 10);
+    fn decisions_browse_jk_navigates() {
+        let home = dec_home("nav");
+        for t in ["q1", "q2", "q3"] {
+            let _ = crate::decisions::post(
+                &home,
+                "lead",
+                &serde_json::json!({"title": t, "content": "?", "needs_answer": true, "allow_free_text": true}),
+            );
+        }
+        let mut overlay = open_decisions(&home);
+        run_keys(
+            &home,
+            &mut overlay,
+            &[KeyCode::Char('j'), KeyCode::Char('j')],
+        );
+        match &overlay {
+            Overlay::Decisions {
+                selected, items, ..
+            } => {
+                assert_eq!(items.len(), 3);
+                assert_eq!(*selected, 2, "j×2 moves to last");
+            }
+            _ => panic!("expected Decisions overlay"),
+        }
+        run_keys(&home, &mut overlay, &[KeyCode::Char('k')]);
+        match &overlay {
+            Overlay::Decisions { selected, .. } => assert_eq!(*selected, 1, "k moves up"),
+            _ => panic!("expected Decisions overlay"),
+        }
+        std::fs::remove_dir_all(&home).ok();
     }
 }
 

--- a/src/decisions.rs
+++ b/src/decisions.rs
@@ -316,6 +316,15 @@ pub fn list_all(home: &Path) -> Vec<Decision> {
     load_all(home).into_iter().filter(|d| !d.archived).collect()
 }
 
+/// #2305: active questions awaiting an operator answer (`needs_answer` &&
+/// `status == Pending`), newest-first. Backs the interactive answer overlay.
+pub fn list_pending(home: &Path) -> Vec<Decision> {
+    load_all(home)
+        .into_iter()
+        .filter(|d| !d.archived && d.needs_answer && d.status == Some(DecisionStatus::Pending))
+        .collect()
+}
+
 pub fn list(home: &Path, args: &Value) -> Value {
     let include_archived = args["include_archived"].as_bool().unwrap_or(false);
     let filter_tags: Vec<String> = args["tags"]
@@ -460,6 +469,17 @@ pub fn answer(home: &Path, caller: &str, args: &Value) -> Value {
         if !decision.needs_answer {
             return serde_json::json!({
                 "error": format!("decision '{id}' is not a pending question (needs_answer=false)")
+            });
+        }
+        // #2305 (r2): a question is for the OPERATOR to answer — its own author
+        // must not self-answer (an agent answering its own question would bypass
+        // the operator entirely). The TUI overlay answers as "operator" (never the
+        // author), so this only blocks the MCP self-answer path.
+        if decision.author == caller {
+            return serde_json::json!({
+                "error": format!(
+                    "decision '{id}' author '{caller}' cannot answer its own question (operator answers)"
+                )
             });
         }
         if decision.status != Some(DecisionStatus::Pending) {
@@ -871,13 +891,10 @@ mod tests {
         r["id"].as_str().expect("question id").to_string()
     }
 
-    /// Active pending questions (the PR2 overlay's prod helper lands next PR; here
-    /// we filter inline so PR1 carries no unused prod code).
+    /// Active pending questions — delegates to the prod `list_pending` (added in
+    /// PR2 now that the answer overlay calls it).
     fn pending_questions(home: &Path) -> Vec<Decision> {
-        list_all(home)
-            .into_iter()
-            .filter(|d| d.needs_answer && d.status == Some(DecisionStatus::Pending))
-            .collect()
+        list_pending(home)
     }
 
     #[test]
@@ -994,6 +1011,39 @@ mod tests {
             .find(|d| d.id == id)
             .expect("present");
         assert_eq!(d.answer.as_deref(), Some("something custom"));
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn answer_refuses_author_self_answer_2305() {
+        // r2 hardening: the question's own author must not self-answer (would
+        // bypass the operator). A different caller (the operator) still can.
+        let home = tmp_home("dec_q_self_answer");
+        let id = post_question(
+            &home,
+            serde_json::json!({"title": "Q", "content": "?", "needs_answer": true, "allow_free_text": true}),
+        );
+        // post_question authors as "lead" — lead answering its own question is refused.
+        let r = answer(&home, "lead", &serde_json::json!({"id": id, "answer": "x"}));
+        assert!(
+            r.get("error")
+                .is_some_and(|e| e.as_str().unwrap_or("").contains("cannot answer its own")),
+            "author self-answer must be refused: {r}"
+        );
+        assert_eq!(
+            pending_questions(&home).len(),
+            1,
+            "still pending after refused self-answer"
+        );
+        // The operator (different identity) answers fine.
+        assert_eq!(
+            answer(
+                &home,
+                "operator",
+                &serde_json::json!({"id": id, "answer": "x"})
+            )["status"],
+            "answered"
+        );
         std::fs::remove_dir_all(&home).ok();
     }
 

--- a/src/render/panels.rs
+++ b/src/render/panels.rs
@@ -82,56 +82,136 @@ fn format_active_status(mut names: Vec<&str>) -> String {
     }
 }
 
-pub fn render_decisions(frame: &mut Frame, items: &[crate::decisions::Decision], scroll: usize) {
+/// #2305: the pending-decision answer board (Ctrl+B D). Browse lists questions
+/// awaiting an operator answer; Answer shows the selected question's options
+/// (⭐ = recommended) and an optional free-text input.
+pub fn render_decisions(
+    frame: &mut Frame,
+    items: &[crate::decisions::Decision],
+    selected: usize,
+    mode: &crate::app::DecisionMode,
+) {
+    use crate::app::DecisionMode;
     let count = items.len();
-    let title = format!(" Decisions ({count}) | j/k scroll | q close ");
+    let title = match mode {
+        DecisionMode::Browse => {
+            format!(" Pending decisions ({count}) | j/k select · Enter answer · q close ")
+        }
+        DecisionMode::Answer {
+            free_text: Some(_), ..
+        } => " Answer · type · Enter submit · Esc back ".to_string(),
+        DecisionMode::Answer { .. } => {
+            " Answer · j/k option · Enter submit · f free-text · Esc back ".to_string()
+        }
+    };
     let inner = render_overlay_frame(frame, Color::Yellow, &title);
 
     if items.is_empty() {
         frame.render_widget(
-            Paragraph::new("  No decisions yet.").style(Style::default().fg(Color::DarkGray)),
+            Paragraph::new("  No pending decisions — nothing to answer.")
+                .style(Style::default().fg(Color::DarkGray)),
             inner,
         );
         return;
     }
 
     let mut lines: Vec<Line> = Vec::new();
-    for (i, d) in items.iter().enumerate() {
-        let marker = if i == scroll { "> " } else { "  " };
-        let style = if i == scroll {
-            Style::default()
-                .fg(Color::Black)
-                .bg(Color::Yellow)
-                .add_modifier(Modifier::BOLD)
-        } else {
-            Style::default().fg(Color::White)
-        };
-        lines.push(Line::from(Span::styled(
-            format!("{marker}[{}] {}", d.scope, d.title),
-            style,
-        )));
-        if i == scroll {
+    match mode {
+        DecisionMode::Browse => {
+            for (i, d) in items.iter().enumerate() {
+                let is_sel = i == selected;
+                let marker = if is_sel { "> " } else { "  " };
+                let style = if is_sel {
+                    Style::default()
+                        .fg(Color::Black)
+                        .bg(Color::Yellow)
+                        .add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default().fg(Color::White)
+                };
+                lines.push(Line::from(Span::styled(
+                    format!("{marker}[{}] {}", d.scope, d.title),
+                    style,
+                )));
+                if is_sel {
+                    lines.push(Line::from(Span::styled(
+                        format!(
+                            "    by {} | {}",
+                            d.author,
+                            crate::display_time::format_local_short(&d.created_at, None)
+                        ),
+                        Style::default().fg(Color::DarkGray),
+                    )));
+                    for line in d.content.lines() {
+                        lines.push(Line::from(Span::styled(
+                            format!("    {line}"),
+                            Style::default().fg(Color::Gray),
+                        )));
+                    }
+                    for o in &d.options {
+                        let star = if o.recommended { "⭐ " } else { "   " };
+                        lines.push(Line::from(Span::styled(
+                            format!("    {star}{}", o.label),
+                            Style::default().fg(Color::Cyan),
+                        )));
+                    }
+                    if d.allow_free_text {
+                        lines.push(Line::from(Span::styled(
+                            "    (free-text allowed)",
+                            Style::default().fg(Color::DarkGray),
+                        )));
+                    }
+                    lines.push(Line::from(""));
+                }
+            }
+        }
+        DecisionMode::Answer { option, free_text } => {
+            let Some(d) = items.get(selected) else {
+                return;
+            };
             lines.push(Line::from(Span::styled(
-                format!(
-                    "    by {} | {}",
-                    d.author,
-                    crate::display_time::format_local_short(&d.created_at, None)
-                ),
-                Style::default().fg(Color::DarkGray),
+                format!("[{}] {}", d.scope, d.title),
+                Style::default()
+                    .fg(Color::White)
+                    .add_modifier(Modifier::BOLD),
             )));
             for line in d.content.lines() {
                 lines.push(Line::from(Span::styled(
-                    format!("    {line}"),
+                    format!("  {line}"),
                     Style::default().fg(Color::Gray),
                 )));
             }
-            if !d.tags.is_empty() {
+            lines.push(Line::from(""));
+            for (oi, o) in d.options.iter().enumerate() {
+                let sel = free_text.is_none() && oi == *option;
+                let marker = if sel { "> " } else { "  " };
+                let star = if o.recommended { "⭐ " } else { "" };
+                let style = if sel {
+                    Style::default()
+                        .fg(Color::Black)
+                        .bg(Color::Yellow)
+                        .add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default().fg(Color::White)
+                };
                 lines.push(Line::from(Span::styled(
-                    format!("    tags: {}", d.tags.join(", ")),
-                    Style::default().fg(Color::Cyan),
+                    format!("{marker}{star}{}", o.label),
+                    style,
                 )));
             }
-            lines.push(Line::from(""));
+            if let Some(buf) = free_text {
+                lines.push(Line::from(""));
+                lines.push(Line::from(Span::styled(
+                    format!("free text > {buf}▏"),
+                    Style::default().fg(Color::Green),
+                )));
+            } else if d.allow_free_text {
+                lines.push(Line::from(""));
+                lines.push(Line::from(Span::styled(
+                    "press f to type a free-text answer",
+                    Style::default().fg(Color::DarkGray),
+                )));
+            }
         }
     }
     frame.render_widget(Paragraph::new(lines), inner);


### PR DESCRIPTION
## #2305 PR2 — (b) interactive answer overlay (base includes PR1 #2308)

Upgrades the read-only `Overlay::Decisions` (Ctrl+B D) into an interactive answer board, mirroring the existing `Overlay::Tasks` kanban. **Channel-agnostic** — the operator answers questions natively in the TUI; no channel required.

### Changes
- **`overlay.rs`** — new `DecisionMode { Browse, Answer { option, free_text } }`. Ctrl+B D now lists **pending questions** (`needs_answer && Pending`).
  - **Browse**: `j/k` select · `Enter` opens Answer · `q`/`Esc` close.
  - **Answer**: `j/k` pick option (⭐ recommended shown first by poster convention) · `Enter` submits · `f`/`e` → free-text entry (when `allow_free_text`) · `Esc` backs out.
  - Submit calls `crate::decisions::answer(home, "operator", …)` then reloads the pending list so the answered item drops out — the same in-process CRUD idiom the Tasks overlay uses on `crate::tasks`. **No event-loop / PTY / architecture change.**
- **`dispatch.rs`** — `ShowDecisions` loads `decisions::list_pending`.
- **`decisions.rs`** — add `list_pending` (now has a prod caller) + the r2-suggested hardening: `answer()` refuses `caller == author` (a question is the operator's to answer; blocks an agent self-answering via MCP). The TUI answers as `"operator"`, so it's unaffected.
- **render** — `render_decisions` rewritten for Browse (selection + option preview) and Answer (option highlight + ⭐ + free-text input box with cursor).
- Removed the now-orphaned read-only `handle_list_scroll` helper (the Decisions overlay was its only prod caller) + its tests.

### Note
Ctrl+B D is **repurposed** from "browse all decisions (read-only)" to "pending-answer board" per the #2305 spec. Browsing all decisions can be a separate key/toggle follow-up if wanted.

### Tests
option-answer submits + reloads + persists (`answered_by="operator"`); free-text answer; Esc backs out free-text→option→Browse→close; `j/k` browse navigation; author-self-answer refused (backend). Existing `ShowDecisions` keybind tests still pass.

### Verification
- `cargo nextest --features tray --profile ci` (full CI replica, real git): **4497 passed / 0 failed**.
- `cargo clippy --features tray --all-targets -- -D warnings` clean; `cargo fmt --check` clean.

single review (PR1 dual-verified the risk logic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)