### PR TITLE
fix(ci): verdict-aware ci-ready — evict/suppress on REJECTED|Draft + unwatch dismiss (#t-92758)

### DIFF
--- a/src/daemon/ci_handoff_track.rs
+++ b/src/daemon/ci_handoff_track.rs
@@ -309,6 +309,39 @@ pub(crate) fn resolve_claimed(home: &Path, agent: &str, branch: &str) -> usize {
     resolved
 }
 
+/// #t-92758 P2: resolve the track whose TARGET is `agent` AND whose correlation
+/// is exactly `correlation` (`owner/repo@branch`) — the dismiss path for
+/// `ci unwatch`. Unlike [`resolve_by_correlation`] (which clears every target's
+/// track for the branch) and [`resolve_claimed`] (which matches by `@branch`
+/// suffix across repos), this is the precise "the caller explicitly dropped THIS
+/// handoff" eviction: only the unwatching agent's own ci-ready obligation for
+/// this exact repo@branch is cleared, leaving any co-subscriber's track intact.
+pub(crate) fn resolve_for_target_correlation(home: &Path, agent: &str, correlation: &str) -> usize {
+    let mut resolved = 0;
+    for (path, track) in list(home) {
+        if track.target == agent
+            && track.correlation == correlation
+            && remove_if_unchanged(
+                home,
+                &path,
+                &track.target,
+                &track.correlation,
+                &track.sent_at,
+            )
+        {
+            resolved += 1;
+            tracing::info!(
+                tag = "#1888-track-resolved",
+                agent = %track.target,
+                correlation = %track.correlation,
+                reason = "unwatch_dismiss",
+                "ci-handoff track resolved"
+            );
+        }
+    }
+    resolved
+}
+
 /// #2008: resolve every track for `correlation` whose recorded `head_sha` no
 /// longer matches the branch's CURRENT head — the ci-ready obligation was for a
 /// head that has since been superseded (a new push / force-push), so without this
@@ -497,6 +530,27 @@ mod tests {
         let left = list(&home);
         assert_eq!(left.len(), 1);
         assert_eq!(left[0].1.correlation, "o/r@other");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn resolve_for_target_correlation_scopes_to_exact_target_and_correlation() {
+        // #t-92758 P2: unwatch dismiss clears ONLY the caller's own track for the
+        // exact repo@branch — a co-subscriber's track (same correlation, different
+        // target) and the caller's other-branch track both survive.
+        let home = tmp_home("resolve-tc");
+        record(&home, "lead", "o/r@b", "2026-06-10T00:00:00Z", None);
+        record(&home, "reviewer", "o/r@b", "2026-06-10T00:00:00Z", None);
+        record(&home, "lead", "o/r@other", "2026-06-10T00:00:00Z", None);
+        assert_eq!(resolve_for_target_correlation(&home, "lead", "o/r@b"), 1);
+        let left = list(&home);
+        assert_eq!(left.len(), 2, "only lead's o/r@b cleared");
+        assert!(left
+            .iter()
+            .any(|(_, t)| t.target == "reviewer" && t.correlation == "o/r@b"));
+        assert!(left
+            .iter()
+            .any(|(_, t)| t.target == "lead" && t.correlation == "o/r@other"));
         std::fs::remove_dir_all(&home).ok();
     }
 

--- a/src/daemon/ci_watch/poller.rs
+++ b/src/daemon/ci_watch/poller.rs
@@ -1893,35 +1893,56 @@ fn persist_watch_state(
             match state.next_after_ci.as_deref().filter(|s| !s.is_empty()) {
                 Some(next) => {
                     let repo_branch_key = format!("{}@{}", ctx.repo, ctx.branch);
-                    let pr_number = crate::daemon::pr_state::load(ctx.home, ctx.repo, ctx.branch)
-                        .map(|s| s.pr_number);
-                    let task_id = state.task_id.as_deref();
-                    let msg = make_ci_ready_for_action_msg(
-                        ctx.repo,
-                        ctx.branch,
-                        &repo_branch_key,
-                        Some(&pr.current_sha),
-                        pr_number,
-                        task_id,
-                    );
-                    persist_or_log!(
-                        crate::inbox::enqueue_with_idle_hint(ctx.home, next, msg),
-                        "ci_watch_chain",
-                        next
-                    );
-                    // #1888 phase-2: track the handoff until RESOLUTION (report /
-                    // PR terminal / target claims the branch), decoupled from the
-                    // inbox read-state the watchdog used to scan (any drain marked
-                    // it read within seconds and blinded the re-nudge).
-                    crate::daemon::ci_handoff_track::record(
-                        ctx.home,
-                        next,
-                        &repo_branch_key,
-                        &chrono::Utc::now().to_rfc3339(),
-                        // #2008: anchor the track to the head it was recorded for so
-                        // a later head move can invalidate it (head-aware resolve).
-                        Some(&pr.current_sha),
-                    );
+                    let pr_state = crate::daemon::pr_state::load(ctx.home, ctx.repo, ctx.branch);
+                    // #t-92758 P1(b): don't emit ci-ready for a merge-BLOCKED PR
+                    // (REJECTED verdict / Draft) — the chain target can't act on it,
+                    // so emitting only spawns a re-nudge loop. This handles the
+                    // reject-before-CI ordering; the evict in `pr_state::scanner`
+                    // handles the CI-green-then-reject ordering (#2297). The
+                    // predicate NEVER suppresses VERIFIED/green/None — the normal
+                    // "your turn" handoff stays live (is_ci_ready_merge_blocked iron
+                    // rule).
+                    if pr_state
+                        .as_ref()
+                        .is_some_and(crate::daemon::pr_state::is_ci_ready_merge_blocked)
+                    {
+                        tracing::info!(
+                            target: "ci_watch",
+                            repo = ctx.repo,
+                            branch = ctx.branch,
+                            "ci-ready suppressed — PR merge-blocked (REJECTED/Draft); no chain handoff, no track"
+                        );
+                    } else {
+                        let pr_number = pr_state.as_ref().map(|s| s.pr_number);
+                        let task_id = state.task_id.as_deref();
+                        let msg = make_ci_ready_for_action_msg(
+                            ctx.repo,
+                            ctx.branch,
+                            &repo_branch_key,
+                            Some(&pr.current_sha),
+                            pr_number,
+                            task_id,
+                        );
+                        persist_or_log!(
+                            crate::inbox::enqueue_with_idle_hint(ctx.home, next, msg),
+                            "ci_watch_chain",
+                            next
+                        );
+                        // #1888 phase-2: track the handoff until RESOLUTION (report /
+                        // PR terminal / target claims the branch), decoupled from the
+                        // inbox read-state the watchdog used to scan (any drain marked
+                        // it read within seconds and blinded the re-nudge).
+                        crate::daemon::ci_handoff_track::record(
+                            ctx.home,
+                            next,
+                            &repo_branch_key,
+                            &chrono::Utc::now().to_rfc3339(),
+                            // #2008: anchor the track to the head it was recorded for
+                            // so a later head move can invalidate it (head-aware
+                            // resolve).
+                            Some(&pr.current_sha),
+                        );
+                    }
                 }
                 None if state.subscriber_names().is_empty() => {
                     tracing::warn!(

--- a/src/daemon/pr_state/mod.rs
+++ b/src/daemon/pr_state/mod.rs
@@ -446,6 +446,24 @@ pub fn is_merge_ready(state: &PrState) -> bool {
         .all(|(_, reviewed)| sha_prefix_match(&state.head_sha, reviewed))
 }
 
+/// #t-92758: a PR whose `[ci-ready-for-action]` chain handoff is pointless right
+/// now because the PR cannot be merged/acted-on — a REJECTED verdict (a reviewer
+/// bounced it; it's being reworked) or a Draft PR (`gh pr merge` refuses drafts).
+/// Used to (a) SUPPRESS a new ci-ready emission and (b) EVICT an existing
+/// ci-handoff track so the re-nudge watchdog stops pinging the chain target for a
+/// PR they can't move.
+///
+/// IRON RULE (regression-pinned): this is DELIBERATELY narrow — it returns
+/// `false` for `Verified` / `Unverified` / `Pending` / `None` verdicts. A
+/// VERIFIED+green PR is exactly the "your turn to merge" case the chain exists
+/// for and MUST keep emitting + re-nudging; this predicate must never suppress
+/// it. (Unverified/Pending/None are not merge-blocked verdicts — the reviewer
+/// hasn't bounced the PR — so the chain handoff stays live.)
+pub fn is_ci_ready_merge_blocked(state: &PrState) -> bool {
+    matches!(state.verdict_state, VerdictState::Rejected { .. })
+        || matches!(state.draft_state, DraftState::Draft)
+}
+
 // ─── storage ───────────────────────────────────────────────────────────
 
 /// Canonical path to the PR-state directory.
@@ -1251,6 +1269,52 @@ mod tests {
             created_at: now(),
             updated_at: now(),
         }
+    }
+
+    /// #t-92758 IRON RULE: `is_ci_ready_merge_blocked` blocks ONLY a REJECTED
+    /// verdict or a Draft PR — never VERIFIED / Unverified / Pending / None. A
+    /// VERIFIED+green PR is the "your turn to merge" case the ci-ready chain
+    /// exists for and MUST keep emitting + re-nudging; a regression that made the
+    /// predicate true for VERIFIED would silently kill legitimate merge handoffs.
+    #[test]
+    fn is_ci_ready_merge_blocked_only_rejected_or_draft() {
+        let mut s = new_state("sha-A", ReviewClass::Single);
+
+        // Non-blocking verdicts (Ready draft state):
+        s.verdict_state = VerdictState::None;
+        assert!(!is_ci_ready_merge_blocked(&s), "None must not block");
+        s.verdict_state = VerdictState::Pending;
+        assert!(!is_ci_ready_merge_blocked(&s), "Pending must not block");
+        s.verdict_state = VerdictState::Unverified {
+            reviewer: "r".into(),
+            reviewed_head: "sha-A".into(),
+        };
+        assert!(!is_ci_ready_merge_blocked(&s), "Unverified must not block");
+        s.verdict_state = VerdictState::Verified {
+            reviewers: vec![("r".into(), "sha-A".into())],
+        };
+        assert!(
+            !is_ci_ready_merge_blocked(&s),
+            "IRON RULE: VERIFIED must NEVER be suppressed/evicted"
+        );
+
+        // Blocking: REJECTED verdict.
+        s.verdict_state = VerdictState::Rejected {
+            reviewer: "r".into(),
+            reviewed_head: "sha-A".into(),
+            reason: None,
+        };
+        assert!(is_ci_ready_merge_blocked(&s), "REJECTED must block");
+
+        // Blocking: Draft — even with an otherwise-mergeable VERIFIED verdict.
+        s.verdict_state = VerdictState::Verified {
+            reviewers: vec![("r".into(), "sha-A".into())],
+        };
+        s.draft_state = DraftState::Draft;
+        assert!(
+            is_ci_ready_merge_blocked(&s),
+            "Draft must block even with a VERIFIED verdict"
+        );
     }
 
     /// T1: CI green at head_sha + Verified at same head_sha → MergeReady.

--- a/src/daemon/pr_state/scanner.rs
+++ b/src/daemon/pr_state/scanner.rs
@@ -368,6 +368,21 @@ pub fn scan_and_emit_with(
                 "pr_terminal",
             );
         }
+        // #t-92758 P1(a): a merge-BLOCKED-but-still-open PR (REJECTED verdict or
+        // Draft) also resolves any pending ci-handoff track — the chain target
+        // can't merge/act on it, so the ~2-min re-nudge is pure noise (#2297:
+        // REJECTED is not a terminal PR state and the head doesn't move, so none
+        // of the other resolvers fire). Symmetric with the terminal resolve above;
+        // idempotent (no-op if already gone or no track). VERIFIED/green/None are
+        // untouched — the normal "your turn / should-merge" ci-ready + re-nudge is
+        // preserved (is_ci_ready_merge_blocked iron rule).
+        if super::is_ci_ready_merge_blocked(&snapshot) {
+            let _ = crate::daemon::ci_handoff_track::resolve_by_correlation(
+                home,
+                &format!("{repo}@{branch}"),
+                "pr_merge_blocked",
+            );
+        }
         let _ = registry; // reserved for future gh-poll author lookup hook
     }
 }
@@ -695,6 +710,110 @@ fn build_event_message(
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
+    use super::super::gh_poll::tests::MockGhPoller;
+    use super::super::gh_poll::{GhPrMetadata, GhPrState};
+    use super::super::{new_for_branch, save, ReviewClass, VerdictState};
+    use super::scan_and_emit_with;
+
+    fn empty_registry() -> crate::agent::AgentRegistry {
+        std::sync::Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new()))
+    }
+
+    fn open_pr_meta(number: u64, branch: &str) -> GhPrMetadata {
+        // A live, open, non-draft PR matching the tracked branch — keeps the
+        // snapshot OPEN through `apply_gh_poll` (an EMPTY poll would drive it
+        // terminal and resolve the track via the wrong path). gh metadata never
+        // carries the review verdict, so verdict_state is untouched.
+        GhPrMetadata {
+            number,
+            author_login: "dev".into(),
+            head_ref: branch.into(),
+            is_cross_repository: false,
+            is_draft: false,
+            state: GhPrState::Open,
+            merged_at: None,
+        }
+    }
+
+    /// #t-92758 P1(a): a REJECTED-but-open PR resolves its pending ci-handoff
+    /// track on the next scan — the #2297 noise root cause (REJECTED is not a
+    /// terminal PR state, so none of the prior resolvers fired and the watchdog
+    /// re-nudged every ~2 min).
+    #[test]
+    fn scan_evicts_ci_handoff_track_for_rejected_pr() {
+        let home = std::env::temp_dir().join(format!(
+            "agend-92758-scan-evict-{}-{}",
+            std::process::id(),
+            line!()
+        ));
+        let _ = std::fs::remove_dir_all(&home);
+        std::fs::create_dir_all(&home).unwrap();
+
+        let mut s = new_for_branch("o/r", "b", "abcdef0", ReviewClass::Single);
+        s.pr_number = 42;
+        s.verdict_state = VerdictState::Rejected {
+            reviewer: "r".into(),
+            reviewed_head: "abcdef0".into(),
+            reason: None,
+        };
+        save(&home, &s).unwrap();
+        crate::daemon::ci_handoff_track::record(
+            &home,
+            "lead",
+            "o/r@b",
+            &chrono::Utc::now().to_rfc3339(),
+            Some("abcdef0"),
+        );
+
+        let poller = MockGhPoller::new(vec![Ok(vec![open_pr_meta(42, "b")])]);
+        scan_and_emit_with(&home, &empty_registry(), &poller);
+
+        assert!(
+            crate::daemon::ci_handoff_track::list(&home).is_empty(),
+            "REJECTED PR must evict the ci-handoff track (#2297 noise fix)"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #t-92758 IRON RULE (end-to-end): a VERIFIED PR must KEEP its ci-handoff
+    /// track — the normal "your turn / should-merge" handoff + re-nudge survives
+    /// the new eviction path.
+    #[test]
+    fn scan_keeps_ci_handoff_track_for_verified_pr() {
+        let home = std::env::temp_dir().join(format!(
+            "agend-92758-scan-keep-{}-{}",
+            std::process::id(),
+            line!()
+        ));
+        let _ = std::fs::remove_dir_all(&home);
+        std::fs::create_dir_all(&home).unwrap();
+
+        let mut s = new_for_branch("o/r", "b", "abcdef1", ReviewClass::Single);
+        s.pr_number = 43;
+        s.verdict_state = VerdictState::Verified {
+            reviewers: vec![("r".into(), "abcdef1".into())],
+        };
+        save(&home, &s).unwrap();
+        crate::daemon::ci_handoff_track::record(
+            &home,
+            "lead",
+            "o/r@b",
+            &chrono::Utc::now().to_rfc3339(),
+            Some("abcdef1"),
+        );
+
+        let poller = MockGhPoller::new(vec![Ok(vec![open_pr_meta(43, "b")])]);
+        scan_and_emit_with(&home, &empty_registry(), &poller);
+
+        assert!(
+            crate::daemon::ci_handoff_track::list(&home)
+                .iter()
+                .any(|(_, t)| t.correlation == "o/r@b"),
+            "IRON RULE: VERIFIED PR must KEEP its ci-handoff track"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
     /// #bughunt3 invariant (#1617 lock-while-blocking class): the worktree
     /// auto-release does a `git` subprocess + acquires a second (binding) flock,
     /// so it must NEVER run inside the `with_pr_state` closure — that closure

--- a/src/mcp/handlers/ci/watch.rs
+++ b/src/mcp/handlers/ci/watch.rs
@@ -248,6 +248,21 @@ pub(crate) fn handle_unwatch_ci(home: &Path, args: &Value, instance_name: &str) 
         .map(String::from)
         .filter(|s| !s.is_empty())
         .unwrap_or_else(|| instance_name.to_string());
+    // #t-92758 P2: unwatch is also the lead's dismiss path for a stuck ci-ready —
+    // clear the caller's own ci-handoff track for this repo@branch so the re-nudge
+    // watchdog stops (previously unwatch removed the watch subscription but NOT the
+    // decoupled ci-ready obligation, so re-nudges continued). Done unconditionally
+    // (even if the watch file is already absent below) since the intent is to drop
+    // the obligation. Precise (caller + exact correlation) so a co-subscriber's
+    // track is left intact.
+    if !caller.is_empty() {
+        let correlation = format!("{repo}@{branch}");
+        crate::daemon::ci_handoff_track::resolve_for_target_correlation(
+            home,
+            &caller,
+            &correlation,
+        );
+    }
     let filename = crate::daemon::ci_watch::watch_filename(repo, branch);
     let path = crate::daemon::ci_watch::ci_watches_dir(home).join(&filename);
     // H5: flock the per-watch read→atomic_write RMW (see handle_watch_ci).
@@ -466,4 +481,52 @@ fn build_default_provider(repo: &str) -> Option<Box<dyn crate::daemon::ci_watch:
             .map(|p| Box::new(p) as Box<dyn CiProvider>),
     };
     provider
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    /// #t-92758 P2: `ci unwatch` is the lead's dismiss path for a stuck ci-ready —
+    /// it must clear the caller's own ci-handoff track so the re-nudge watchdog
+    /// stops. Runs even when no watch file exists (the dismiss intent stands).
+    #[test]
+    fn unwatch_resolves_callers_ci_handoff_track() {
+        let home = std::env::temp_dir().join(format!(
+            "agend-92758-unwatch-{}-{}",
+            std::process::id(),
+            line!()
+        ));
+        let _ = std::fs::remove_dir_all(&home);
+        std::fs::create_dir_all(&home).unwrap();
+
+        // A ci-ready obligation pointing at the caller, plus a co-subscriber's
+        // track on the same branch that must survive (precise dismiss).
+        crate::daemon::ci_handoff_track::record(
+            &home,
+            "lead",
+            "o/r@b",
+            "2026-06-10T00:00:00Z",
+            None,
+        );
+        crate::daemon::ci_handoff_track::record(
+            &home,
+            "reviewer",
+            "o/r@b",
+            "2026-06-10T00:00:00Z",
+            None,
+        );
+
+        let args = json!({"repository": "o/r", "branch": "b", "instance": "lead"});
+        let _ = handle_unwatch_ci(&home, &args, "lead");
+
+        let left = crate::daemon::ci_handoff_track::list(&home);
+        assert_eq!(left.len(), 1, "only the caller's track is cleared");
+        assert_eq!(
+            left[0].1.target, "reviewer",
+            "co-subscriber's track must survive unwatch dismiss"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
 }


### PR DESCRIPTION
## Problem (operator noise, #2297)

`[ci-ready-for-action]` persists as a durable `ci_handoff_track` re-nudged every ~2 min until *resolved*. The resolvers are: report-with-matching-correlation, PR **terminal** (merged/closed), target-claims-branch, head-advanced, 24h backstop. A **REJECTED-but-still-open** PR hits **none** of them (REJECTED isn't a terminal PR state and the head doesn't move), so the chain target (e.g. lead) keeps getting re-nudged for a PR they can't merge — and `ci unwatch` couldn't stop it (the obligation is decoupled from the watch subscription). The reviewer's REJECTED report carries the *task-id* correlation, not `repo@branch`, so even the existing report-arrival `resolve_by_correlation` misses it.

## Fix

**P1 — verdict-aware** (shared predicate `pr_state::is_ci_ready_merge_blocked` = `Rejected || Draft`):
- **evict**: `pr_state::scanner` resolves the `ci_handoff_track` when the PR snapshot is merge-blocked — symmetric with the existing PR-terminal resolve right above it. Poll-driven; fires the tick after `record_verdict` writes REJECTED, so it handles the common **CI-green-then-reject** ordering.
- **suppress**: `ci_watch::poller` skips emitting ci-ready + recording a track when `pr_state` is merge-blocked — handles the **reject/draft-before-CI** ordering.

**P2 — dismiss**: `handle_unwatch_ci` also resolves the caller's own track for `repo@branch` (new precise `resolve_for_target_correlation`), so `unwatch` finally stops the nudge for *any* stuck cause.

**P3 (bounded re-nudge cadence) PARKED** per lead — it touches all-handoff cadence and risks false-killing legitimate pending-merge reminders; P1+P2 remove the actual noise. Recovery is self-healing: a reworked PR pushes a new head → CI re-runs → a fresh ci-ready is emitted.

## Iron rule (regression-pinned)

`is_ci_ready_merge_blocked` is **false** for VERIFIED / Unverified / Pending / None — a VERIFIED+green PR is exactly the "your turn to merge" case the chain exists for and **keeps emitting ci-ready + re-nudging**. A regression making it true for VERIFIED would silently kill legitimate merge handoffs, so it's pinned by tests.

## Tests
- `is_ci_ready_merge_blocked_only_rejected_or_draft` — the iron rule (None/Pending/Unverified/**Verified** → false; Rejected/Draft → true).
- `scan_evicts_ci_handoff_track_for_rejected_pr` + `scan_keeps_ci_handoff_track_for_verified_pr` — end-to-end via `scan_and_emit_with` + `MockGhPoller`.
- `unwatch_resolves_callers_ci_handoff_track` — P2, co-subscriber's track survives.
- `resolve_for_target_correlation_scopes_to_exact_target_and_correlation` — primitive precision.

Suppress shares the same tested predicate.

## Notes
- daemon-behavior change → takes effect only after operator rebuild+restart.
- Local: `cargo fmt --check` clean, `cargo clippy --all-targets --features tray -- -D warnings` clean, affected modules (`daemon::pr_state`, `daemon::ci_handoff_track`, `mcp::handlers::ci`) 182/182 green.
- base: origin/main @ c6e91522.

🤖 Generated with [Claude Code](https://claude.com/claude-code)