### PR TITLE
refactor(inbox): remove misleading dead HEADER_SIZE_THRESHOLD=300 const (#t-109)

### DIFF
--- a/src/channel/telegram/inbound.rs
+++ b/src/channel/telegram/inbound.rs
@@ -204,9 +204,10 @@ pub(super) fn resolve_text_after_image_download_failure(initial: &str) -> String
 /// short PTY-inject path only when it is under the char cap AND carries no
 /// attachments; otherwise it goes inbox + pointer hint. Extracted from
 /// `handle_message` (byte-identical: `chars().count() < 200 && empty`) so the
-/// routing decision is unit-testable. The `< 200` cap is the CURRENT production
-/// behavior — distinct from the test-only `HEADER_SIZE_THRESHOLD` (300) const;
-/// reconciling the two is an operator semantics call, intentionally untouched.
+/// routing decision is unit-testable. The `< 200` char cap is the production
+/// behavior, kept by operator decision (d-20260617102838730641-2); the unused
+/// `HEADER_SIZE_THRESHOLD` (300) const that production never consulted was
+/// removed (#t-109).
 pub(super) fn is_short_inject(
     text: &str,
     attachments: &[crate::channel::event::Attachment],
@@ -729,13 +730,11 @@ mod tests {
         }
     }
 
-    /// #t-3 audit: drives the REAL #1352 long/short delivery split. The prior
-    /// `inbox::tests::test_short_msg_below_threshold` asserted `300 <= 300`
-    /// against `HEADER_SIZE_THRESHOLD`, a const production never consults — the
-    /// actual gate is `is_short_inject`'s `< 200` (was inlined at the
-    /// handle_message call-site). Pins CURRENT behavior (char-count, 200 cap,
-    /// attachments force the long path); the 200-vs-300 reconciliation is an
-    /// operator semantics call and is intentionally NOT decided here.
+    /// #t-3 / #t-109: drives the REAL #1352 long/short delivery split — the gate
+    /// is `is_short_inject`'s `< 200` char cap (was inlined at the handle_message
+    /// call-site). Pins the production behavior (char-count, 200 cap, attachments
+    /// force the long path), kept by operator decision (d-20260617102838730641-2)
+    /// when the unused 300 `HEADER_SIZE_THRESHOLD` const was removed.
     #[test]
     fn is_short_inject_routes_by_char_count_and_attachments() {
         assert!(

--- a/src/inbox/mod.rs
+++ b/src/inbox/mod.rs
@@ -52,7 +52,7 @@ pub(crate) use notify::{
 #[cfg(test)]
 pub use notify::{
     format_header, format_notification_for_inject, pointer_only_inject, HEADER_PREFIX,
-    HEADER_SIZE_THRESHOLD, PENDING_HEADER_PREFIX,
+    PENDING_HEADER_PREFIX,
 };
 
 #[cfg(test)]

--- a/src/inbox/notify.rs
+++ b/src/inbox/notify.rs
@@ -3,11 +3,6 @@ use std::path::Path;
 use super::message::{BroadcastContext, InboxMessage, NotifySource};
 use super::storage;
 
-/// Size threshold for header-only PTY injection. Messages with body > this
-/// value inject only a structured header line; the full body stays in inbox.
-#[allow(dead_code)]
-pub const HEADER_SIZE_THRESHOLD: usize = 300;
-
 /// Returns true when the `AGEND_POINTER_ONLY_INJECT` feature flag is set to "1".
 /// When enabled, PTY injection uses header-only format for all messages,
 /// forcing agents to call `inbox` to read content (solves dispatch non-FIFO).

--- a/src/inbox/tests.rs
+++ b/src/inbox/tests.rs
@@ -1800,48 +1800,22 @@ fn test_format_header_escapes_control_chars() {
     );
 }
 
-// #t-3 audit: removed the vacuous `test_short_msg_below_threshold` — it
-// asserted `300 <= 300` (HEADER_SIZE_THRESHOLD against itself) and never
-// exercised any production decision. The real short/long delivery split is
-// `< 200` (NOT this 300 const) and is now driven by
+// #t-109: the misleading dead `HEADER_SIZE_THRESHOLD` (300) const has been
+// removed (operator decision d-20260617102838730641-2: keep the real `< 200`
+// gate; production never consulted the 300 const). The vacuous
+// `test_short_msg_below_threshold` (asserted `300 <= 300`) was removed earlier
+// (#t-3); the prior `test_long_msg_above_threshold` is redundant with
+// `test_header_format_all_fields_present` (500-char body → `size=500`, single
+// line). The real short/long split is locked by
 // `channel::telegram::inbound::tests::is_short_inject_routes_by_char_count_and_attachments`.
 
 #[test]
-fn test_long_msg_above_threshold() {
-    // Messages > HEADER_SIZE_THRESHOLD should use header-only injection
-    let long = "a".repeat(HEADER_SIZE_THRESHOLD + 1);
-    assert!(long.len() > HEADER_SIZE_THRESHOLD);
-    // format_header produces a compact single-line representation
-    let msg = msg()
-        .id("m-1")
-        .sender("from:x")
-        .text_owned(long)
-        .kind("task")
-        .timestamp("2026-01-01T00:00:00Z")
-        .build();
-    let header = format_header(&msg);
-    assert!(
-        header.len() < HEADER_SIZE_THRESHOLD,
-        "header must be compact"
-    );
-    assert!(header.contains(&format!("size={}", HEADER_SIZE_THRESHOLD + 1)));
-}
-
-#[test]
-fn test_threshold_uses_char_count_not_bytes() {
-    // 100 CJK chars = 100 chars but 300 bytes (3 bytes each in UTF-8).
-    // Must be treated as short (100 < 300 threshold), not long.
+fn format_header_size_reports_char_count_not_bytes() {
+    // 100 CJK chars = 100 chars but 300 bytes (3 bytes each in UTF-8). The
+    // header's `size=` must report the CHAR count, not the byte count (#1077).
     let cjk = "你".repeat(100);
     assert_eq!(cjk.chars().count(), 100);
     assert_eq!(cjk.len(), 300); // bytes
-                                // 100 chars < HEADER_SIZE_THRESHOLD (300) → should be short path
-    assert!(cjk.chars().count() <= HEADER_SIZE_THRESHOLD);
-
-    // 301 CJK chars = 301 chars → should be long path
-    let long_cjk = "你".repeat(HEADER_SIZE_THRESHOLD + 1);
-    assert!(long_cjk.chars().count() > HEADER_SIZE_THRESHOLD);
-
-    // format_header size= should report char count, not byte count
     let msg = msg()
         .sender("from:x")
         .text_owned(cjk)


### PR DESCRIPTION
## Remove the misleading dead `HEADER_SIZE_THRESHOLD=300` const

dev-3's test-audit found `HEADER_SIZE_THRESHOLD=300` (`notify.rs`) had **zero production decision consumers** (`git grep`: definition + re-export + tests + two doc-comments only — it was `#[allow(dead_code)]`). The real short/long delivery split is hard-coded `chars().count() < 200` in `is_short_inject` (`inbound.rs`). Declaring 300 while behaving at 200 made the const stale/misleading.

**Operator decision** `d-20260617102838730641-2`: keep the `< 200` behavior, delete the misleading 300 const (not a roadmap item; not a change to 300).

### Changes (surgical — the `< 200` logic is untouched)
- Delete the const (`notify.rs`) + its `inbox` re-export.
- Delete `test_long_msg_above_threshold` — redundant with `test_header_format_all_fields_present` (500-char body → `size=500`, single-line).
- Reframe `test_threshold_uses_char_count_not_bytes` → `format_header_size_reports_char_count_not_bytes`: keeps the **unique** CJK char-count-vs-byte `size=` assertion (#1077), drops the dead-const references + vacuous threshold lines.
- Update the two `is_short_inject` doc-comments to state the 200 cap is the operator-decided production behavior (no longer "reconciliation pending").

### 200-behavior regression lock (already exists — not duplicated)
`channel::telegram::inbound::tests::is_short_inject_routes_by_char_count_and_attachments` asserts 199→short, 200/201→not, CJK char-count, attachment→long. This pins the `< 200` gate so future drift is caught.

### Verify-first
Confirmed against origin/main that all refs were def + re-export + tests + 2 doc-comments — **no production consumer** (premise held).

### Verification
- `cargo nextest --features tray --profile ci` (full CI replica, real git): **4506 passed / 0 failed**.
- `cargo clippy --features tray --all-targets -- -D warnings` clean; `cargo fmt --check` clean; no orphaned imports/symbols.

🤖 Generated with [Claude Code](https://claude.com/claude-code)