### PR TITLE
test(shim): e2e runtime proof of #2234 agent-bypass deny (§3.17)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -59,11 +59,11 @@ test-group = 'git-subprocess'
 slow-timeout = { period = "120s", terminate-after = 3 }
 
 [[profile.ci.overrides]]
-filter = 'test(/(^(worktree|worktree_pool|worktree_cleanup|admin|mcp::handlers::(ci|dispatch_hook|force_release|worktree|p0b_tests)|daemon::(retention::worktrees|pr_state|auto_release|conflict_notify|per_tick::tmp_review_gc)|bootstrap::(agent_resolve|canonical_hygiene))::|checkout_repo_|dispatch_branch_skips_metadata_stub|send_with_branch_checkout_failure|task_done_cleans_post_lease|closes_markers_extract_cleanly_from_actual_main|resolve_sweep_boards_pairs_each_project_with_its_own_repo_2117_p2)/)'
+filter = 'test(/(^(worktree|worktree_pool|worktree_cleanup|admin|mcp::handlers::(ci|dispatch_hook|force_release|worktree|p0b_tests)|daemon::(retention::worktrees|pr_state|auto_release|conflict_notify|per_tick::tmp_review_gc)|bootstrap::(agent_resolve|canonical_hygiene))::|checkout_repo_|dispatch_branch_skips_metadata_stub|send_with_branch_checkout_failure|task_done_cleans_post_lease|closes_markers_extract_cleanly_from_actual_main|resolve_sweep_boards_pairs_each_project_with_its_own_repo_2117_p2|shim_denies_agent_bypass_canonical_provisioning_2234)/)'
 test-group = 'git-subprocess'
 
 # Local `default` profile has no terminate-after, so no false-kill risk — just
 # serialize the same cluster for parity with CI.
 [[profile.default.overrides]]
-filter = 'test(/(^(worktree|worktree_pool|worktree_cleanup|admin|mcp::handlers::(ci|dispatch_hook|force_release|worktree|p0b_tests)|daemon::(retention::worktrees|pr_state|auto_release|conflict_notify|per_tick::tmp_review_gc)|bootstrap::(agent_resolve|canonical_hygiene))::|checkout_repo_|dispatch_branch_skips_metadata_stub|send_with_branch_checkout_failure|task_done_cleans_post_lease|closes_markers_extract_cleanly_from_actual_main|resolve_sweep_boards_pairs_each_project_with_its_own_repo_2117_p2)/)'
+filter = 'test(/(^(worktree|worktree_pool|worktree_cleanup|admin|mcp::handlers::(ci|dispatch_hook|force_release|worktree|p0b_tests)|daemon::(retention::worktrees|pr_state|auto_release|conflict_notify|per_tick::tmp_review_gc)|bootstrap::(agent_resolve|canonical_hygiene))::|checkout_repo_|dispatch_branch_skips_metadata_stub|send_with_branch_checkout_failure|task_done_cleans_post_lease|closes_markers_extract_cleanly_from_actual_main|resolve_sweep_boards_pairs_each_project_with_its_own_repo_2117_p2|shim_denies_agent_bypass_canonical_provisioning_2234)/)'
 test-group = 'git-subprocess'

--- a/tests/agend_git_shim_phase2.rs
+++ b/tests/agend_git_shim_phase2.rs
@@ -279,3 +279,141 @@ fn stress_shim_recursion_attempt() {
 
     std::fs::remove_dir_all(&fake_agend_bin).ok();
 }
+
+/// #2234 fix B (r6 #2316): end-to-end RUNTIME proof that the shim BINARY itself
+/// denies an agent's `AGEND_GIT_BYPASS` provisioning op in a canonical-rooted
+/// repo — exit 1 + a `DENIED` message — and passes carve-outs through. The pure
+/// `deny_agent_canonical_bypass` unit test covers the DECISION; this covers the
+/// WIRING (`enforce_agent_canonical_bypass_deny` reading the live env + cwd) and
+/// the runtime behavior §3.17 requires for shim changes, exercised on every CI
+/// platform incl. windows-runtime.
+///
+/// Fixtures are throwaway temp dirs — NEVER the real canonical. DENY cases exit
+/// BEFORE `exec_real_git` (no git spawned). ALLOW/carve-out cases pass through to
+/// real git, which fast-fails on the fake-`.git` fixture (no objects/HEAD, so no
+/// index.lock, no checkout, no hang); we assert only that `DENIED` is absent.
+/// Joins the `git-subprocess` serialize group (.config/nextest.toml) so the
+/// passthrough git calls can't race on windows.
+#[test]
+fn shim_denies_agent_bypass_canonical_provisioning_2234() {
+    use std::process::Command;
+
+    let root = std::env::temp_dir().join(format!("agend-2234-deny-{}", std::process::id()));
+    // Throwaway "canonical" fixture: a `.git` DIR whose config carries
+    // `[remote "origin"]` → `cwd_is_canonical_rooted()` == true. No real git used
+    // to build it.
+    let canonical = root.join("canonical");
+    std::fs::create_dir_all(canonical.join(".git")).expect("mk .git dir");
+    std::fs::write(
+        canonical.join(".git").join("config"),
+        "[core]\n\trepositoryformatversion = 0\n[remote \"origin\"]\n\turl = https://example.invalid/x.git\n",
+    )
+    .expect("write .git/config");
+    // Non-canonical control dir (plain dir, no `.git`).
+    let plain = root.join("plain");
+    std::fs::create_dir_all(&plain).expect("mk plain dir");
+
+    let shim = env!("CARGO_BIN_EXE_agend-git");
+    let run = |cwd: &std::path::Path, instance: Option<&str>, escape: bool, args: &[&str]| {
+        let mut c = Command::new(shim);
+        c.args(args)
+            .current_dir(cwd)
+            .env("AGEND_GIT_BYPASS", "1")
+            // Start at shim depth 0 (don't inherit an outer shim's depth).
+            .env_remove("AGEND_GIT_SHIM_DEPTH")
+            // No AGEND_HOME → the #2158 audit log is skipped (no fleet_events).
+            .env_remove("AGEND_HOME");
+        match instance {
+            Some(n) => {
+                c.env("AGEND_INSTANCE_NAME", n);
+            }
+            None => {
+                c.env_remove("AGEND_INSTANCE_NAME");
+            }
+        }
+        if escape {
+            c.env("AGEND_GIT_ALLOW_CANONICAL_MUTATE", "1");
+        } else {
+            c.env_remove("AGEND_GIT_ALLOW_CANONICAL_MUTATE");
+        }
+        c.output().expect("run agend-git shim")
+    };
+    let is_denied = |o: &std::process::Output| {
+        o.status.code() == Some(1) && String::from_utf8_lossy(&o.stderr).contains("DENIED")
+    };
+    let not_denied =
+        |o: &std::process::Output| !String::from_utf8_lossy(&o.stderr).contains("DENIED");
+
+    // ── DENY (exit 1 + DENIED; exits before exec → no git spawned) ──
+    assert!(
+        is_denied(&run(
+            &canonical,
+            Some("test-agent"),
+            false,
+            &["worktree", "add", "/tmp/agend-2234-wt-a", "origin/main"]
+        )),
+        "agent `worktree add` in canonical must be DENIED"
+    );
+    assert!(
+        is_denied(&run(
+            &canonical,
+            Some("test-agent"),
+            false,
+            &["checkout", "origin/main"]
+        )),
+        "agent positional `checkout <ref>` in canonical must be DENIED"
+    );
+    assert!(
+        is_denied(&run(
+            &canonical,
+            Some("test-agent"),
+            false,
+            &["switch", "main"]
+        )),
+        "agent positional `switch <ref>` in canonical must be DENIED"
+    );
+
+    // ── ALLOW / carve-outs (DENIED message absent) ──
+    // (a) no AGEND_INSTANCE_NAME (daemon-internal / operator shell) → pass.
+    assert!(
+        not_denied(&run(
+            &canonical,
+            None,
+            false,
+            &["worktree", "add", "/tmp/agend-2234-wt-b", "origin/main"]
+        )),
+        "non-agent caller must NOT be denied"
+    );
+    // (c) explicit one-shot escape env → pass.
+    assert!(
+        not_denied(&run(
+            &canonical,
+            Some("test-agent"),
+            true,
+            &["worktree", "add", "/tmp/agend-2234-wt-c", "origin/main"]
+        )),
+        "AGEND_GIT_ALLOW_CANONICAL_MUTATE=1 must bypass the deny"
+    );
+    // non-`add` worktree subcommand (r4 over-block fix): `list` is read-only → pass.
+    assert!(
+        not_denied(&run(
+            &canonical,
+            Some("test-agent"),
+            false,
+            &["worktree", "list"]
+        )),
+        "`worktree list` (read-only) must NOT be denied"
+    );
+    // (b) non-canonical cwd → pass.
+    assert!(
+        not_denied(&run(
+            &plain,
+            Some("test-agent"),
+            false,
+            &["worktree", "add", "/tmp/agend-2234-wt-d", "origin/main"]
+        )),
+        "non-canonical cwd must NOT be denied"
+    );
+
+    std::fs::remove_dir_all(&root).ok();
+}


### PR DESCRIPTION
## Follow-up to #2316 (#2234 fix B) — §3.17 runtime evidence

The merged fix unit-tested the **pure** `deny_agent_canonical_bypass` decision. This adds the **runtime** evidence r6 requested (§3.17 shim surface): the shim **binary** itself exits 1 + prints `DENIED` for an agent's `AGEND_GIT_BYPASS` provisioning op in a canonical-rooted repo, and passes the carve-outs through — exercised on every CI platform **incl. windows-runtime** (the point).

- **`tests/agend_git_shim_phase2.rs`** — `shim_denies_agent_bypass_canonical_provisioning_2234` runs `CARGO_BIN_EXE_agend-git` (prebuilt artifact — no nested cargo, #1784) against a throwaway fake-`.git` canonical fixture:
  - **DENY** (exit 1 + `DENIED`; exits before `exec` → **no git spawned**): `worktree add`, positional `checkout <ref>`, `switch <ref>`.
  - **ALLOW** (`DENIED` absent; passes through to real git, which fast-fails on the fake repo — no lock, no hang): non-agent caller, escape env, `worktree list`, non-canonical cwd.
- **`.config/nextest.toml`** — register the test in the `git-subprocess` serialize group (both profiles) so the passthrough git calls can't race on windows.

**Test-only; no production change.** Single review.

### Verification
Targeted test + `clippy -D warnings` + `fmt --check` green; the identical change was full-CI-replica green (4508/0) on the fix branch before this follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)