### PR TITLE
docs(tasks): #2117 P3 Gap1 — no single→multi-project backfill (operator decision a)

### DIFF
--- a/docs/FEATURE-task-board.md
+++ b/docs/FEATURE-task-board.md
@@ -156,6 +156,7 @@ foundation for sweep, health, and dependency evaluation.
 - Append acquires a lock before writing; `append_batch` fsyncs multiple events atomically.
 - Replay folds the archive first, then the hot log. It is a strict reader — unknown variants or higher-version schemas cause an abort (fail-closed).
 - Legacy `tasks.json` is consumed only during migration, which converts old tasks into events and renames the file to `.legacy_pre_v2`.
+- **No single→multi-project backfill (#2117 P3 Gap1).** Migrated legacy tasks have no `project_id`, so they land on the default board and stay there. Adopting per-project boards (#2125) later does not retroactively re-bucket them — only newly created tasks are per-project-stamped. This asymmetry is the accepted semantics, not a gap: legacy tasks carry no signal to auto-bucket, and cross-board lookups stay correct via the full-board-scan fallback. To re-home a legacy task, an operator moves it explicitly.
 
 ## 13. ACL and Permissions
 

--- a/docs/FEATURE-task-board.zh-TW.md
+++ b/docs/FEATURE-task-board.zh-TW.md
@@ -262,6 +262,7 @@
 - migration 會把 legacy tasks 轉成事件。
 - migration 成功後會把舊檔改名成 `.legacy_pre_v2`。
 - 這樣 operator 還能考古。
+- **不做單→多 project 回溯(#2117 P3 Gap1)。** 遷移過來的 legacy task 沒有 `project_id`,會落在 default board 並留在那裡。日後改用 per-project boards(#2125)不會回溯重歸這些舊任務——只有新建任務才會 per-project stamp。這個不對稱是接受的語意、不是缺口:舊任務沒有 auto-bucket 的訊號,而跨 board 查詢靠 full-board-scan fallback 仍正確。要把舊任務改 board,由 operator 顯式搬移。
 - board 的讀面已不依賴舊檔。
 - board 的寫面也不應回去改舊檔。
 

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -432,6 +432,17 @@ pub struct MigrationReport {
 /// the one-shot that ensures replay() at PR3 cutover sees every legacy
 /// task. Re-running after PR3 cutover (when `tasks.json` is gone) is a
 /// no-op via the empty-store branch.
+///
+/// **#2117 P3 Gap1 — no single→multi-project backfill (operator decision (a),
+/// 2026-06-18)**: legacy tasks migrated here carry no `project_id`, so they land
+/// on the DEFAULT board (`board_root(home, DEFAULT)`) and STAY there. When a
+/// single-repo deployment later adopts per-project boards (P2 #2125), existing
+/// default-board tasks are NOT retroactively re-bucketed — only tasks created
+/// after #2125 are per-project-stamped. This asymmetry is the ACCEPTED semantics,
+/// not a gap to close: legacy tasks predate `project_id` and carry no signal to
+/// auto-bucket, and `board_router::resolve_task_project`'s full-board-scan
+/// fallback keeps cross-board lookups correct regardless. An operator who wants a
+/// legacy task on a specific project board moves it explicitly. See #2117 P3.
 pub fn migrate_legacy_tasks_json_to_event_log(home: &Path) -> anyhow::Result<MigrationReport> {
     let store = load(home);
     if store.tasks.is_empty() {


### PR DESCRIPTION
## What

Operator chose **(a) no backfill** for #2117 P3 Gap1. Documents the accepted semantics — **zero behavior change** (doc-comment + docs only).

- `src/tasks/mod.rs` — doc-comment on `migrate_legacy_tasks_json_to_event_log`: migrated legacy tasks carry no `project_id`, land on the DEFAULT board and stay there. Adopting per-project boards (#2125) later does **not** retroactively re-bucket them — only tasks created after #2125 are per-project-stamped. This asymmetry is the accepted semantics, not a gap to close (legacy tasks predate `project_id` and carry no signal to auto-bucket; `board_router::resolve_task_project`'s full-board-scan fallback keeps cross-board lookups correct). An operator re-homes a legacy task by moving it explicitly.
- `docs/FEATURE-task-board.md` + `.zh-TW.md` — matching operator-facing bullet under §12 (Event Recording and Migration), EN/zh-TW in parity.

## Verification
- `cargo fmt --check` clean, `cargo check --features tray` clean. No code behavior touched (comment + markdown only).

docs-only, single review per lead. base origin/main @ 1c94874a (includes #2318 + #2319). Closes the doc obligation for #2117 P3 Gap1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)