### PR TITLE
fix(skills): add missing agy backend to BACKEND_SKILL_DIRS symlink table

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -768,14 +768,15 @@ impl Backend {
     }
 
     /// Skill directory key matching `BACKEND_SKILL_DIRS`. Returns `None`
-    /// for backends without a skill directory (Shell, Raw, Agy).
+    /// for backends without a skill directory (Shell, Raw).
     pub fn skill_dir_name(&self) -> Option<&'static str> {
         match self {
             Backend::ClaudeCode => Some("claude"),
             Backend::Codex => Some("codex"),
             Backend::OpenCode => Some("opencode"),
             Backend::KiroCli => Some("kiro"),
-            Backend::Agy | Backend::Shell | Backend::Raw(_) => None,
+            Backend::Agy => Some("agy"),
+            Backend::Shell | Backend::Raw(_) => None,
         }
     }
 

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -1,7 +1,7 @@
-//! Sprint 60 W2 PR-1 (#P1-1 Skills System Plan IMPL) — 4-backend
+//! Sprint 60 W2 PR-1 (#P1-1 Skills System Plan IMPL) — 5-backend
 //! community skill discovery via unified source + symlink (Windows
-//! copy fallback). (Originally 5 backends; #1580 retired gemini-cli —
-//! see `BACKEND_SKILL_DIRS`.)
+//! copy fallback). (Originally 5 with gemini-cli; #1580 retired it,
+//! then agy restored the count to 5 — see `BACKEND_SKILL_DIRS`.)
 //!
 //! ## Architecture
 //!
@@ -15,10 +15,11 @@
 //!   ├── .claude/skills/  → symlink → ~/.agend-terminal/skills/
 //!   ├── .codex/skills/   → symlink → ~/.agend-terminal/skills/
 //!   ├── .opencode/skills/→ symlink → ~/.agend-terminal/skills/
-//!   └── .kiro/skills/    → symlink → ~/.agend-terminal/skills/
+//!   ├── .kiro/skills/    → symlink → ~/.agend-terminal/skills/
+//!   └── .agents/skills/  → symlink → ~/.agend-terminal/skills/
 //! ```
 //!
-//! Unified source means: one skill file, all 4 backends discover.
+//! Unified source means: one skill file, all 5 backends discover.
 //! No file copies on Unix (symlink = zero maintenance). Windows
 //! falls back to copy with hash-compare staleness detection on
 //! subsequent installs (file-watch infra is out of scope per
@@ -40,12 +41,14 @@ use std::path::{Path, PathBuf};
 /// Per-backend conventional skills directories inside the agent's working
 /// tree; the daemon installs a symlink (or copy on Windows) pointing at the
 /// unified source. (Originally 5 backends per dispatch
-/// m-20260509214553949181-385; #1580 retired gemini-cli's `.gemini/skills`.)
+/// m-20260509214553949181-385; #1580 retired gemini-cli's `.gemini/skills`;
+/// agy restores the count to 5 via `.agents/skills`.)
 pub const BACKEND_SKILL_DIRS: &[(&str, &str)] = &[
     ("claude", ".claude/skills"),
     ("codex", ".codex/skills"),
     ("opencode", ".opencode/skills"),
     ("kiro", ".kiro/skills"),
+    ("agy", ".agents/skills"),
 ];
 
 /// Unified skill source root: `<home>/skills/`.


### PR DESCRIPTION
## What
Add the missing `agy` (antigravity-cli) backend entry to `BACKEND_SKILL_DIRS` so daemon skills install creates symlinks for `.agents/skills/` alongside the existing four backends.

## Why
The daemon installs per-backend symlinks from each agent's working directory to the unified skills source (`~/.agend/skills/`). After #1580 retired `gemini-cli`, the agy backend was never added to the symlink table — so `.claude/skills/`, `.codex/skills/`, `.opencode/skills/`, and `.kiro/skills/` all get symlinks, but `.agents/skills/` (agy's Customization Roots convention) does not.

This means agy instances cannot discover daemon-managed community skills.

## Evidence
```
$ ls -la ~/.agend/workspace/agy-921c91/.claude/skills
lrwxr-xr-x  .claude/skills -> /Users/cheerc/.agend/skills   ✅

$ ls -la ~/.agend/workspace/agy-921c91/.agents/skills
ls: /Users/cheerc/.agend/workspace/agy-921c91/.agents/skills: No such file or directory   ❌
```

## Changes
- **`src/skills.rs`**: Add `("agy", ".agents/skills")` to `BACKEND_SKILL_DIRS`; update module doc (4→5 backends).
- **`src/backend.rs`**: `Backend::Agy::skill_dir_name()` now returns `Some("agy")` (was grouped with Shell/Raw as `None`).

## Tests
All 31 skills tests pass. Clippy clean (`-D warnings`). Build succeeds.

## Verification
- `cargo build` ✅
- `cargo test --bin agend-terminal -- skills` ✅ (31 passed)
- `cargo clippy -- -D warnings` ✅
- `cargo fmt` — no changes needed