### PR TITLE
docs(protocol): align §12.4 Worktree Mandatory with §10.4 / #2234

### DIFF
--- a/docs/FLEET-DEV-PROTOCOL.md
+++ b/docs/FLEET-DEV-PROTOCOL.md
@@ -744,7 +744,7 @@ gh run list -b main --limit 1
 or wait for ci_watch [ci-pass] on main. Only declare task `done` after main CI is confirmed green. If main CI fails post-merge, immediately investigate and fix (revert if necessary).
 
 ### 12.4 Worktree Mandatory
-Impl/reviewer must use worktrees. `git worktree add -b <branch> <path> origin/main`. **Never** `git worktree add <path> main`.
+Impl/reviewer must work in a worktree, never the canonical working tree. For dispatched tasks the daemon **already auto-binds** one — find it via `binding_state(agent: <self>)`, `cd` in, and use **normal git** (no bypass; the shim routes it). Do NOT self-provision: the `agend-git` shim DENIES an agent's `AGEND_GIT_BYPASS git worktree add` in a canonical-rooted repo (#2234 — a stray provision detaches the operator's canonical HEAD). Only the `nextest` line needs `AGEND_GIT_BYPASS=1` (its internal git). Provision deliberately via `bind_self {repository_path, branch}`; **never** `git worktree add <path> main`. Full rule + escape hatch: §10.4.
 
 ### 12.5 Spawn Site Rationale
 Every spawn must have `// fire-and-forget: <reason>` OR store JoinHandle. Test-only exempt.


### PR DESCRIPTION
Fixes a stale-guidance contradiction surfaced during #2329 review.

## Problem
§12.4 "Worktree Mandatory" still told agents to self-provision:
> `git worktree add -b <branch> <path> origin/main`

This contradicts §10.4 (the #2234 fix B): the daemon **already auto-binds** the worktree at dispatch, and the `agend-git` shim now **DENIES** an agent's `AGEND_GIT_BYPASS git worktree add` in a canonical-rooted repo (a stray provision detaches the operator's canonical HEAD). The stale §12.4 quick-ref walks agents straight into the footgun #2234 blocks.

## Fix (surgical — only §12.4)
Rewrites §12.4 to the §10.4 wording: daemon auto-binds → `binding_state` → `cd` in → **normal git** (no bypass); do NOT self-provision (shim denies); only the `nextest` line needs `AGEND_GIT_BYPASS=1`; `bind_self` to provision deliberately; never `git worktree add <path> main`. Points to §10.4 for the full rule + escape hatch.

## Where / verification
Edits `docs/FLEET-DEV-PROTOCOL.md` (the `include_str!` source @ `src/protocol.rs:12`), **not** the live `.default/` copy. Rebuild verified: `cargo build` (34.5s, real compile) re-embedded the doc; binary grep finds the new §12.4 wording and the stale line is gone.

Docs-only, 1 line changed. Not eligible for §3.6 self-merge (PR-affecting normative text) → single review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)