### PR TITLE
test(notification_queue): relax coalesce_preserves_unparseable_lines to no-loss invariant (llvm-cov flake)

### DIFF
--- a/src/notification_queue.rs
+++ b/src/notification_queue.rs
@@ -713,12 +713,22 @@ mod tests {
             raw.lines().any(|l| l == "GARBAGE not json"),
             "unparseable line preserved; got:\n{raw}"
         );
-        assert_eq!(
-            raw.lines()
-                .filter(|l| l.contains("kind=ratelimit-retry"))
-                .count(),
-            1,
-            "ratelimit coalesced to the latest; got:\n{raw}"
+        // The ratelimit nudge is never LOST, whether this enqueue hit the coalesce
+        // path (drain lock acquired → 1 line, keep-latest) or the contention
+        // fallback (lock momentarily held → plain append → 2 lines). BOTH are
+        // no-loss. coverage (llvm-cov) instrumentation perturbs scheduling and can
+        // flip the lock race, so assert the no-loss invariant (latest present, no
+        // runaway duplication) — NOT a single path — to keep this test about its
+        // actual subject: the unparseable line surviving the rewrite. The
+        // coalesce-vs-fallback paths themselves are pinned deterministically by
+        // `coalesce_falls_back_to_append_when_drain_lock_held_no_loss`.
+        let rl_count = raw
+            .lines()
+            .filter(|l| l.contains("kind=ratelimit-retry"))
+            .count();
+        assert!(
+            (1..=2).contains(&rl_count),
+            "ratelimit nudge preserved (1=coalesced, 2=fallback append; both no-loss); got:\n{raw}"
         );
     }
 


### PR DESCRIPTION
## What

Relax the over-tight assertion in `notification_queue::tests::coalesce_preserves_unparseable_lines` so it verifies the **no-loss invariant** instead of a single lock-race path — eliminating a Coverage-only (llvm-cov) intermittent failure.

## Why

`enqueue_coalesced_auto` coalesces same-kind AGEND-AUTO nudges to keep-latest **when it acquires the per-agent drain lock** (→ 1 ratelimit line), and legitimately **falls back to a plain append when the lock is momentarily contended** (→ 2 lines). Both paths are no-loss.

The test asserted exactly the coalesce path (`== 1`). Coverage (llvm-cov) instrumentation perturbs thread scheduling and can flip the lock race, so the non-required Coverage job went intermittently red (`left:2 right:1`) **while all three required Check jobs stayed green**. Verified pre-existing and not a production bug during #2332 CI evidence analysis.

## Fix

Assert the no-loss invariant — `(1..=2).contains(&rl_count)` (1 = coalesced, 2 = fallback append; both preserve the latest nudge and the unparseable line) — and keep the test focused on its actual subject (the unparseable `GARBAGE` line surviving the coalesce rewrite). No coverage is lost: the coalesce-vs-fallback paths are **already pinned deterministically** by the neighbor test `coalesce_falls_back_to_append_when_drain_lock_held_no_loss` (lock-held → 2, lock-free → 1).

Surgical: one assertion in one test. **No production code change.**

## Test plan

- `cargo test --bin agend-terminal --features tray notification_queue::` → 36 passed.
- `cargo fmt` + `cargo clippy --all-targets --features tray -- -D warnings` clean.
- Coverage job should now stay green (no longer asserts the timing-dependent path).

Task: `t-20260618174419239909-81376-3`
