### PR TITLE
fix(#2234): make agend-git deny message conditional on actual auto-bind

### DIFF
--- a/src/bin/agend-git.rs
+++ b/src/bin/agend-git.rs
@@ -1362,8 +1362,8 @@ fn enforce_agent_canonical_bypass_deny(args: &[String]) {
     let sub = args.first().map(|s| s.as_str()).unwrap_or("");
     eprintln!(
         "agend-git: DENIED — agent '{agent}' must not bypass-{sub} in a canonical-rooted repo.\n\
-         The daemon already auto-bound your worktree at dispatch; cd into it and use normal git \
-         (no AGEND_GIT_BYPASS). A stray provision here detaches the operator's canonical HEAD (#2234).\n\
+         If the daemon auto-bound a worktree for this task (check `binding_state`), cd into it and use normal git \
+         (no AGEND_GIT_BYPASS); otherwise use `bind_self` or ask lead. A stray provision here detaches the operator's canonical HEAD (#2234).\n\
          If you genuinely must: ask lead, or set AGEND_GIT_ALLOW_CANONICAL_MUTATE=1 for a one-shot."
     );
     std::process::exit(1);


### PR DESCRIPTION
## Problem
The `agend-git` canonical-bypass DENIED message asserted as fact:
> The daemon already auto-bound your worktree at dispatch; cd into it…

But a **no-branch dispatch** leaves `binding_state` at `bound:false` (no worktree auto-bound), so an agent following that advice hits a dead end. Surfaced by the #2234 deny-UX behavior test.

## Fix (surgical — message string only)
Reword to a conditional (the wording proposed in the behavior-test report):
> If the daemon auto-bound a worktree for this task (check `binding_state`), cd into it and use normal git (no AGEND_GIT_BYPASS); otherwise use `bind_self` or ask lead. A stray provision here detaches the operator's canonical HEAD (#2234).

The escape-hatch line (`ask lead` / `AGEND_GIT_ALLOW_CANONICAL_MUTATE=1`) is unchanged. No logic change — `eprintln!` string only (2 lines).

## Verification
fmt + clippy (`--features tray -D warnings`) clean. Full `nextest --features tray --profile ci` green (4540/4540) — incl. the shim source-scan + #2234 e2e deny tests (which assert "DENIED"/env vars, not the reworded phrase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)