### PR TITLE
fix(ci-watch): gate [ci-fail] on required-check failures only (#t-29025-19)

### DIFF
--- a/src/daemon/ci_watch/poller.rs
+++ b/src/daemon/ci_watch/poller.rs
@@ -1180,6 +1180,23 @@ async fn check_early_job_failures(
         return false;
     }
 
+    // #t-29025-19: required-only gate (mirror of the terminal path). The early-fail
+    // detector fires on ANY failed job; if the failing job(s) are NON-required checks
+    // (e.g. Coverage) and no required check is failing, suppress — it doesn't block
+    // merge, so the early [ci-fail] is pure noise. Return WITHOUT persisting dedup
+    // state, so each poll re-evaluates and a later required job failure on this sha is
+    // never hidden (lead's hard rule). fail-OPEN: only a definitive Some(false)
+    // suppresses; None (no open PR / API error / no rollup) proceeds to the emit.
+    if provider.required_check_failed(ctx.repo, ctx.branch).await == Some(false) {
+        tracing::debug!(
+            repo = ctx.repo,
+            branch = ctx.branch,
+            sha = %pr.current_sha,
+            "#t-29025-19: suppressing early [ci-fail] — only non-required job(s) failed (merge not blocked)"
+        );
+        return false;
+    }
+
     let sha_short = &pr.current_sha[..pr.current_sha.len().min(7)];
     let headline = format!(
         "[ci-fail] {}@{} ({}): failure",
@@ -1681,6 +1698,27 @@ async fn fan_out_notifications(
             new_notified_run_attempt = Some(run.run_attempt);
             new_notified_run_conclusion = run.conclusion.clone();
             new_stale_emitted_sha = Some(sha.to_string());
+            continue;
+        }
+
+        // #t-29025-19: required-only [ci-fail] gate (see provider::required_check_failed).
+        // Here *sha == current_sha and the aggregate is terminal. When the aggregate is
+        // "failure" but GitHub says NO required check is failing (only a non-required
+        // check like Coverage — a non-required job inside the required CI workflow),
+        // suppress: it doesn't block merge, so [ci-fail]+re-nudge is pure noise. We
+        // `continue` WITHOUT advancing the dedup/tracking state below, so each poll
+        // re-evaluates — a LATER required failure on this same sha is never hidden
+        // (the lead's hard rule). fail-OPEN: only a definitive Some(false) suppresses;
+        // None (no open PR / API error / no rollup) falls through to the normal emit.
+        if conclusion == Some("failure")
+            && provider.required_check_failed(ctx.repo, ctx.branch).await == Some(false)
+        {
+            tracing::debug!(
+                repo = ctx.repo,
+                branch = ctx.branch,
+                sha = %sha,
+                "#t-29025-19: suppressing [ci-fail] — only non-required check(s) failed (merge not blocked)"
+            );
             continue;
         }
 

--- a/src/daemon/ci_watch/poller_tests.rs
+++ b/src/daemon/ci_watch/poller_tests.rs
@@ -986,6 +986,11 @@ struct MockCiProvider {
     mergeable: Mutex<MergeableState>,
     /// #1326: per-run_id job lists for early-fail testing.
     jobs: Mutex<std::collections::HashMap<u64, Vec<super::CiJob>>>,
+    /// #t-29025-19: pre-seeded `required_check_failed` answer. Defaults to
+    /// `None` (fail-open) so existing tests are unaffected — a failure still
+    /// emits `[ci-fail]`. Tests targeting the required-only gate set this via
+    /// `with_required_failed`.
+    required_failed: Mutex<Option<bool>>,
 }
 
 impl MockCiProvider {
@@ -1000,6 +1005,7 @@ impl MockCiProvider {
             failure_summary: Mutex::new("Build / Test".to_string()),
             mergeable: Mutex::new(MergeableState::Unknown),
             jobs: Mutex::new(std::collections::HashMap::new()),
+            required_failed: Mutex::new(None),
         }
     }
 
@@ -1018,6 +1024,7 @@ impl MockCiProvider {
             failure_summary: Mutex::new("Build / Test".to_string()),
             mergeable: Mutex::new(MergeableState::Unknown),
             jobs: Mutex::new(std::collections::HashMap::new()),
+            required_failed: Mutex::new(None),
         }
     }
 
@@ -1032,6 +1039,7 @@ impl MockCiProvider {
             failure_summary: Mutex::new("Build / Test".to_string()),
             mergeable: Mutex::new(MergeableState::Unknown),
             jobs: Mutex::new(std::collections::HashMap::new()),
+            required_failed: Mutex::new(None),
         }
     }
 
@@ -1067,6 +1075,15 @@ impl MockCiProvider {
         self.jobs.lock().insert(run_id, jobs);
         self
     }
+
+    /// #t-29025-19: seed the `required_check_failed` answer for the
+    /// required-only `[ci-fail]` gate. `Some(false)` = no required check
+    /// failing (suppress), `Some(true)` = a required check failed (emit),
+    /// `None` = undeterminable (fail-open → emit).
+    fn with_required_failed(self, answer: Option<bool>) -> Self {
+        *self.required_failed.lock() = answer;
+        self
+    }
 }
 
 #[async_trait::async_trait]
@@ -1086,6 +1103,9 @@ impl CiProvider for MockCiProvider {
     }
     async fn fetch_run_jobs(&self, _repo: &str, run_id: u64) -> Vec<super::CiJob> {
         self.jobs.lock().get(&run_id).cloned().unwrap_or_default()
+    }
+    async fn required_check_failed(&self, _repo: &str, _branch: &str) -> Option<bool> {
+        *self.required_failed.lock()
     }
     fn token_warning(&self) -> Option<&'static str> {
         None
@@ -1485,6 +1505,7 @@ fn mock_rate_limit_writes_backoff_and_propagates_error() {
         failure_summary: Mutex::new(String::new()),
         mergeable: Mutex::new(MergeableState::Unknown),
         jobs: Mutex::new(std::collections::HashMap::new()),
+        required_failed: Mutex::new(None),
     };
     let result = run_ci_check(&dir, &base_watch(), &provider);
     assert!(result.is_err(), "rate-limit must propagate as error");
@@ -5576,6 +5597,153 @@ fn empty_run_poll_does_not_refresh_expires_at_1750() {
     assert_eq!(
         new_expires, old_expires,
         "empty-run poll must NOT refresh expires_at (#1750 A2) — leave the watch to age out"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+// --- #t-29025-19 required-only [ci-fail] gate ---
+// The aggregate can read "failure" purely from a NON-required check (e.g.
+// Coverage — a non-required job inside the required CI workflow). That doesn't
+// block merge, so [ci-fail]+re-nudge is pure noise. The gate asks GitHub which
+// checks are required (provider::required_check_failed) and suppresses only on a
+// definitive "no required check failed". fail-OPEN on None (query miss).
+
+/// One terminal failing run (the aggregate → "failure", so the terminal Site-1
+/// path would emit `[ci-fail]` unless the required-gate suppresses it).
+fn req_gate_failure_runs() -> Vec<CiRun> {
+    vec![CiRun {
+        run_attempt: 1,
+        id: 800,
+        conclusion: Some("failure".into()),
+        head_sha: "ff00aa".into(),
+        url: "https://example.com/800".into(),
+        name: "CI".into(),
+    }]
+}
+
+#[test]
+fn required_gate_nonrequired_only_failure_suppresses_ci_fail() {
+    // ① only a non-required check (Coverage) failed → NO [ci-fail].
+    let dir = tmp_dir("reqgate-suppress");
+    let provider =
+        MockCiProvider::with_runs(req_gate_failure_runs()).with_required_failed(Some(false));
+    run_ci_check(&dir, &base_watch(), &provider).unwrap();
+    let content =
+        std::fs::read_to_string(dir.join("inbox").join("agent1.jsonl")).unwrap_or_default();
+    assert!(
+        !content.contains("[ci-fail]"),
+        "#t-29025-19: only-non-required failure must NOT emit [ci-fail]; inbox:\n{content}"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn required_gate_required_failure_still_emits_ci_fail() {
+    // ② a required check failed → [ci-fail] as before.
+    let dir = tmp_dir("reqgate-required");
+    let provider =
+        MockCiProvider::with_runs(req_gate_failure_runs()).with_required_failed(Some(true));
+    run_ci_check(&dir, &base_watch(), &provider).unwrap();
+    let content =
+        std::fs::read_to_string(dir.join("inbox").join("agent1.jsonl")).unwrap_or_default();
+    assert!(
+        content.contains("[ci-fail]"),
+        "#t-29025-19: a required-check failure MUST still emit [ci-fail]; inbox:\n{content}"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn required_gate_unknown_fails_open_emits_ci_fail() {
+    // ③ undeterminable (no open PR / API error / no rollup) → fail-OPEN: emit.
+    let dir = tmp_dir("reqgate-failopen");
+    let provider = MockCiProvider::with_runs(req_gate_failure_runs()).with_required_failed(None);
+    run_ci_check(&dir, &base_watch(), &provider).unwrap();
+    let content =
+        std::fs::read_to_string(dir.join("inbox").join("agent1.jsonl")).unwrap_or_default();
+    assert!(
+        content.contains("[ci-fail]"),
+        "#t-29025-19: undeterminable required-status must FAIL-OPEN and emit [ci-fail]; inbox:\n{content}"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// In-progress run with a failed NON-required job → exercises the early-fail
+/// (Site-2) path of the same gate.
+fn req_gate_early_provider() -> MockCiProvider {
+    use super::CiJob;
+    MockCiProvider::with_runs(vec![CiRun {
+        run_attempt: 1,
+        id: 900,
+        conclusion: None,
+        head_sha: "ee11bb".into(),
+        url: "https://example.com/900".into(),
+        name: "CI".into(),
+    }])
+    .with_jobs(
+        900,
+        vec![
+            CiJob {
+                name: "Coverage".into(),
+                conclusion: Some("failure".into()),
+            },
+            CiJob {
+                name: "Check (ubuntu)".into(),
+                conclusion: None,
+            },
+        ],
+    )
+}
+
+#[test]
+fn required_gate_early_nonrequired_only_suppresses() {
+    // ① early-fail on a non-required job + no required failing → NO [ci-fail],
+    // and dedup state is NOT persisted (so a later required failure re-evaluates).
+    let dir = tmp_dir("reqgate-early-suppress");
+    let provider = req_gate_early_provider().with_required_failed(Some(false));
+    run_ci_check(&dir, &base_watch(), &provider).unwrap();
+    let content =
+        std::fs::read_to_string(dir.join("inbox").join("agent1.jsonl")).unwrap_or_default();
+    assert!(
+        !content.contains("[ci-fail]"),
+        "#t-29025-19: early-fail on only-non-required job must NOT emit [ci-fail]; inbox:\n{content}"
+    );
+    let watch_path = dir.join("ci-watches").join(watch_filename("o/r", "feat"));
+    let updated: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&watch_path).unwrap()).unwrap();
+    assert!(
+        updated["early_fail_notified_sha"].is_null(),
+        "#t-29025-19: suppression must NOT persist early_fail_notified_sha (re-evaluate next poll so a later required failure is never hidden)"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn required_gate_early_required_failure_emits() {
+    // ② early-fail with a required check failing → [ci-fail].
+    let dir = tmp_dir("reqgate-early-required");
+    let provider = req_gate_early_provider().with_required_failed(Some(true));
+    run_ci_check(&dir, &base_watch(), &provider).unwrap();
+    let content =
+        std::fs::read_to_string(dir.join("inbox").join("agent1.jsonl")).unwrap_or_default();
+    assert!(
+        content.contains("[ci-fail]"),
+        "#t-29025-19: early-fail with a required-check failure MUST emit [ci-fail]; inbox:\n{content}"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn required_gate_early_unknown_fails_open() {
+    // ③ undeterminable on the early path → fail-OPEN: emit.
+    let dir = tmp_dir("reqgate-early-failopen");
+    let provider = req_gate_early_provider().with_required_failed(None);
+    run_ci_check(&dir, &base_watch(), &provider).unwrap();
+    let content =
+        std::fs::read_to_string(dir.join("inbox").join("agent1.jsonl")).unwrap_or_default();
+    assert!(
+        content.contains("[ci-fail]"),
+        "#t-29025-19: undeterminable required-status must FAIL-OPEN on the early path; inbox:\n{content}"
     );
     std::fs::remove_dir_all(&dir).ok();
 }

--- a/src/daemon/ci_watch/provider.rs
+++ b/src/daemon/ci_watch/provider.rs
@@ -114,6 +114,34 @@ impl CiHttpClient {
         req
     }
 
+    /// Build a POST request with auth + User-Agent + JSON body applied.
+    /// #t-29025-19: GraphQL (the only POST we make) can't carry its query in a
+    /// GET — the `isRequired` per-check flag is GraphQL-only. Mirrors `get`'s
+    /// auth/UA/Accept handling.
+    pub(crate) fn post(&self, path: &str, body: serde_json::Value) -> reqwest::RequestBuilder {
+        let url = if self.path_prefix.is_empty() {
+            format!("{}/{path}", self.base_url)
+        } else {
+            format!("{}/{}/{path}", self.base_url, self.path_prefix)
+        };
+        let mut req = self
+            .client
+            .post(&url)
+            .header("User-Agent", "agend-terminal")
+            .json(&body);
+        if let Some(ref accept) = self.default_accept {
+            req = req.header("Accept", accept.as_str());
+        }
+        if let Some(auth) = (self.auth_fn)() {
+            req = match auth {
+                CiAuth::Bearer(token) => req.bearer_auth(token),
+                CiAuth::Header(name, value) => req.header(name, value),
+                CiAuth::Basic(user, pass) => req.basic_auth(user, Some(pass)),
+            };
+        }
+        req
+    }
+
     /// Parse rate-limit reset timestamp from response headers.
     /// Checks both GitHub (`x-ratelimit-reset`) and GitLab (`ratelimit-reset`) header names.
     #[allow(dead_code)] // available for providers to use; wired per-provider as needed
@@ -323,6 +351,24 @@ pub trait CiProvider: Send + Sync {
     /// Default returns empty — only GitHub implements this currently.
     async fn fetch_run_jobs(&self, _repo: &str, _run_id: u64) -> Vec<CiJob> {
         Vec::new()
+    }
+
+    /// #t-29025-19: does the open PR for `branch` have a REQUIRED status check
+    /// that is currently FAILING? Gates `[ci-fail]` to real merge-blocking
+    /// failures — a non-required check (e.g. `Coverage`, a non-required job
+    /// inside the required `CI` workflow) failing must NOT fire `[ci-fail]` +
+    /// re-nudge (it doesn't block merge → pure noise).
+    ///
+    /// - `Some(true)`  — at least one required check has a failure-class conclusion.
+    /// - `Some(false)` — no required check is failing (only non-required, or all good).
+    /// - `None`        — undeterminable (no open PR / API error / no rollup / a
+    ///   failing check whose `isRequired` GitHub couldn't classify).
+    ///
+    /// Callers MUST fail-OPEN on `None`: keep the existing emit so a real
+    /// required failure is never hidden by a query miss. Default `None`
+    /// (fail-open) — non-GitHub providers and mocks don't gate.
+    async fn required_check_failed(&self, _repo: &str, _branch: &str) -> Option<bool> {
+        None
     }
 
     /// CI-fail-notify: fetch the tail of the failed-job logs (~`max_lines`) so
@@ -717,6 +763,83 @@ impl CiProvider for GitHubCiProvider {
                     .collect()
             })
             .unwrap_or_default()
+    }
+
+    async fn required_check_failed(&self, repo: &str, branch: &str) -> Option<bool> {
+        let owner = repo.split('/').next().unwrap_or("");
+        let name = repo.split('/').nth(1).unwrap_or("");
+        // (1) Resolve the open PR number for this branch (same as check_pr_mergeable).
+        //     `isRequired(pullRequestNumber:)` needs the PR's number to evaluate
+        //     against the PR's base-branch protection. No open PR → None (fail-open).
+        let list: serde_json::Value = self
+            .http
+            .get(&format!(
+                "repos/{repo}/pulls?head={owner}:{}&state=open&per_page=1",
+                percent_encode_query(branch)
+            ))
+            .send()
+            .await
+            .ok()?
+            .json()
+            .await
+            .ok()?;
+        let pr_number = list
+            .as_array()
+            .and_then(|a| a.first())
+            .and_then(|pr| pr["number"].as_u64())?;
+        // (2) GraphQL statusCheckRollup with per-check `isRequired(pullRequestNumber:)`
+        //     — GitHub's authoritative "does this check block merge for THIS PR" flag.
+        //     A non-required job inside a required workflow (e.g. Coverage in CI) is
+        //     where the noise comes from; this is the only API that distinguishes it.
+        let query = "query($owner:String!,$name:String!,$pr:Int!){\
+            repository(owner:$owner,name:$name){pullRequest(number:$pr){\
+            commits(last:1){nodes{commit{statusCheckRollup{contexts(first:100){nodes{\
+            __typename ... on CheckRun{conclusion isRequired(pullRequestNumber:$pr)} \
+            ... on StatusContext{state isRequired(pullRequestNumber:$pr)}}}}}}}}}}";
+        let body = serde_json::json!({
+            "query": query,
+            "variables": { "owner": owner, "name": name, "pr": pr_number },
+        });
+        let resp: serde_json::Value = self
+            .http
+            .post("graphql", body)
+            .send()
+            .await
+            .ok()?
+            .json()
+            .await
+            .ok()?;
+        let nodes = resp["data"]["repository"]["pullRequest"]["commits"]["nodes"][0]["commit"]
+            ["statusCheckRollup"]["contexts"]["nodes"]
+            .as_array()?;
+        // No rollup / empty contexts (or a GraphQL error → data is null) → None (fail-open).
+        if nodes.is_empty() {
+            return None;
+        }
+        let mut any_required_failed = false;
+        for n in nodes {
+            // CheckRun carries `conclusion`; StatusContext carries `state`.
+            let verdict = n["conclusion"].as_str().or_else(|| n["state"].as_str());
+            let failing = matches!(
+                verdict.map(|s| s.to_ascii_uppercase()).as_deref(),
+                Some("FAILURE")
+                    | Some("TIMED_OUT")
+                    | Some("STARTUP_FAILURE")
+                    | Some("ACTION_REQUIRED")
+                    | Some("ERROR")
+            );
+            if !failing {
+                continue;
+            }
+            match n["isRequired"].as_bool() {
+                Some(true) => any_required_failed = true,
+                Some(false) => {} // non-required failure → not merge-blocking → ignore
+                // A failing check we can't classify as required-or-not → fail-OPEN
+                // (never suppress a possibly-required failure on a missing flag).
+                None => return None,
+            }
+        }
+        Some(any_required_failed)
     }
 
     async fn fetch_failure_log_tail(


### PR DESCRIPTION
<!-- LOC-EST: 250-340 -->

## Problem
ci-watch fired `[ci-fail]` + re-nudge whenever the workflow-run aggregate read "failure" — including when ONLY a **non-required** check failed (e.g. `Coverage`, a non-required JOB inside the **required** `CI` workflow). A non-required failure doesn't block merge, so the alert + re-nudge was pure noise — every Coverage-red / unsigned agent PR ate one (lead's #2332 Coverage-red hit it).

Root cause: the failure path used the workflow-run-level aggregate (`/actions/runs`), which can't tell that a non-required job *inside a required workflow* caused the "failure". The pre-existing `required_checks` mechanism (#1151) is (a) dormant in prod (always `None`, registry.rs) and (b) a workflow-NAME filter — structurally unable to exclude an in-workflow job.

## Fix
- New `provider::required_check_failed(repo, branch) -> Option<bool>`: resolves the open PR, then queries GraphQL `statusCheckRollup` with per-check **`isRequired(pullRequestNumber:)`** — GitHub's authoritative "does this check block merge for THIS PR" flag (the only API that distinguishes a non-required job inside a required workflow). Verified live on #2332: required checks all `SUCCESS`, only `Coverage` (`isRequired=false`) `CANCELLED`, yet rollup `state=FAILURE`.
- Gate BOTH `[ci-fail]` emit sites on a real required-check failure:
  - terminal `fan_out_notifications`
  - early job-level `check_early_job_failures`
- Suppress ONLY on a definitive `Some(false)` (no required check failing). **fail-OPEN** on `None` (no open PR / API error / no rollup / a failing check GitHub can't classify) → keep the existing emit, so a real required failure is never hidden.
- Suppression does NOT persist dedup state → each poll re-evaluates, so a LATER required failure on the same sha is never hidden.

## Design (lead-vetted, corr t-…29025-19)
1. 降級 = 完全不發 `[ci-fail]` + 不 re-nudge (no softer alarm)
2. 資料源 = GraphQL `statusCheckRollup.isRequired`
3. fail-open = YES (hard rule)
4. 範圍 = both emit sites

## Tests (the 3 mandated cases × both paths = 6)
① non-required-only failure → NO `[ci-fail]`  ② required failure → `[ci-fail]`  ③ unknown/query-miss → fail-OPEN `[ci-fail]`.
Local: 6/6 new green; full `ci_watch::poller` module 190/190 (no regression); `cargo fmt --check` clean; `cargo clippy --all-targets -D warnings` clean.

## Reviewer — please verify
- Gate suppresses ONLY on `Some(false)`, fail-opens on `None` (never hides a required failure).
- The suppress-without-advancing-dedup choice (re-evaluate each poll): bounded re-query while a non-required check is red; the PR is mergeable so the watch clears on merge. Trade-off = query-thrift vs the hard never-hide rule — I chose the hard rule.
- GraphQL query + JSON-path parsing in `required_check_failed`.

⚠ daemon-behavior → only takes effect after operator rebuild+restart (release binary).
Task: t-20260616164249315868-29025-19

🤖 Generated with [Claude Code](https://claude.com/claude-code)