### PR TITLE
fix(#2234): deny `git -C <canonical> worktree add` bypass (Patch A)

### DIFF
--- a/src/bin/agend-git.rs
+++ b/src/bin/agend-git.rs
@@ -3067,29 +3067,26 @@ mod tests {
     #[test]
     fn effective_cwd_through_globals_resolves_leading_dash_c() {
         let s = |v: &[&str]| v.iter().map(|x| x.to_string()).collect::<Vec<_>>();
+        // A REAL absolute base (drive-qualified on Windows, `/`-rooted on Unix) so
+        // `is_absolute()` agrees with the assertion on every platform. A hardcoded
+        // `/abs/...` is NOT absolute on Windows — it would resolve drive-relative
+        // (`D:/abs/...`) and only this test (not the production logic) would diverge.
+        let abs = std::env::current_dir().expect("cwd").join("canon-fixture");
+        let abs_s = abs.to_str().expect("utf8 path");
         // Absolute `-C <path>` → that path, independent of the process cwd.
-        let args = s(&["-C", "/abs/canonical", "worktree", "add", "x"]);
+        let args = s(&["-C", abs_s, "worktree", "add", "x"]);
         let idx = subcommand_index(&args).expect("has subcommand");
         assert_eq!(idx, 2, "subcommand starts after `-C <path>`");
-        assert_eq!(
-            effective_cwd_through_globals(&args, idx),
-            std::path::PathBuf::from("/abs/canonical")
-        );
+        assert_eq!(effective_cwd_through_globals(&args, idx), abs);
         // Repeated `-C`: a later RELATIVE `-C` joins onto the accumulated path.
-        let args = s(&["-C", "/abs/canonical", "-C", "sub", "checkout", "main"]);
+        let args = s(&["-C", abs_s, "-C", "sub", "checkout", "main"]);
         let idx = subcommand_index(&args).expect("has subcommand");
-        assert_eq!(
-            effective_cwd_through_globals(&args, idx),
-            std::path::PathBuf::from("/abs/canonical/sub")
-        );
+        assert_eq!(effective_cwd_through_globals(&args, idx), abs.join("sub"));
         // A value-taking global (`-c k=v`) before `-C` is skipped WITH its value,
         // so `k=v` is never mistaken for the `-C` target.
-        let args = s(&["-c", "k=v", "-C", "/abs/x", "status"]);
+        let args = s(&["-c", "k=v", "-C", abs_s, "status"]);
         let idx = subcommand_index(&args).expect("has subcommand");
-        assert_eq!(
-            effective_cwd_through_globals(&args, idx),
-            std::path::PathBuf::from("/abs/x")
-        );
+        assert_eq!(effective_cwd_through_globals(&args, idx), abs);
         // No leading `-C` → process cwd unchanged.
         let args = s(&["worktree", "add", "x"]);
         let idx = subcommand_index(&args).expect("has subcommand");

--- a/src/bin/agend-git.rs
+++ b/src/bin/agend-git.rs
@@ -377,11 +377,20 @@ fn is_protected_ref(branch: &str) -> bool {
 /// — the previous name's "worktree" suffix was misleading after
 /// broadening since the canonical source repo isn't a worktree.
 fn cwd_is_canonical_rooted() -> bool {
-    let cwd = match env::current_dir() {
-        Ok(c) => c,
-        Err(_) => return false,
-    };
-    let dot_git = cwd.join(".git");
+    match env::current_dir() {
+        Ok(cwd) => path_is_canonical_rooted(&cwd),
+        Err(_) => false,
+    }
+}
+
+/// #2234 Patch A: the canonical-rooted test for an ARBITRARY directory, so a
+/// `git -C <path>` op can be judged against the dir git WOULD operate in rather
+/// than the shim's process cwd. Extracted verbatim from `cwd_is_canonical_rooted`
+/// (which now delegates with the process cwd — its behavior is byte-identical).
+/// `<dir>/.git` is a DIR (canonical source repo) or a FILE (linked worktree)
+/// whose origin config carries `[remote "origin"]`.
+fn path_is_canonical_rooted(dir: &Path) -> bool {
+    let dot_git = dir.join(".git");
     let meta = match std::fs::metadata(&dot_git) {
         Ok(m) => m,
         Err(_) => return false,
@@ -812,6 +821,44 @@ fn subcommand_index(args: &[String]) -> Option<usize> {
         }
     }
     None
+}
+
+/// #2234 Patch A: the directory git WOULD operate in after applying the leading
+/// global `-C <path>` option(s). git chdir's for each `-C`, and multiple are
+/// cumulative — a non-absolute `-C` is relative to the path accumulated so far.
+/// Only the global region `[0, sub_idx)` is walked (a post-subcommand `-C`, e.g.
+/// `git commit -C <commit>` = reuse-message, is an unrelated option). Other
+/// value-taking globals are skipped WITH their value (mirrors `subcommand_index`)
+/// so their argument is never mistaken for a `-C` target. Starts from the process
+/// cwd; returns it unchanged when there is no leading `-C`. Residual:
+/// `--git-dir`/`--work-tree` are deliberately NOT resolved (they don't move cwd;
+/// a `--git-dir` pointing at canonical is a separate, narrower vector left to a
+/// follow-up). Pure modulo the one `current_dir()` read, so the `-C` math is
+/// unit-testable from a known cwd.
+fn effective_cwd_through_globals(args: &[String], sub_idx: usize) -> PathBuf {
+    let mut cwd = env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let mut i = 0;
+    while i < sub_idx {
+        match args[i].as_str() {
+            "-C" => {
+                if let Some(p) = args.get(i + 1) {
+                    let p = PathBuf::from(p);
+                    cwd = if p.is_absolute() { p } else { cwd.join(p) };
+                }
+                i += 2;
+            }
+            // Other value-taking globals consume their value (same set as
+            // `subcommand_index`); no-value globals advance one token.
+            "-c" | "--git-dir" | "--work-tree" | "--namespace" | "--super-prefix"
+            | "--config-env" | "--exec-path" => {
+                i += 2;
+            }
+            _ => {
+                i += 1;
+            }
+        }
+    }
+    cwd
 }
 
 /// #1463 (B): on a ChdirPass for a MUTATING-local command, strip the caller's
@@ -1330,6 +1377,10 @@ fn is_positional_branch_checkout(args: &[String]) -> bool {
 /// self-help, moves a branch ref without detaching; `worktree add`'s internal
 /// reset is moot once add itself is denied); `push`/`commit`/`add`/`clean`/
 /// `branch` (agents legitimately bypass those in their own worktree).
+///
+/// `args` is the SUBCOMMAND-ROOTED slice — the caller strips leading git globals
+/// via `subcommand_index`, so `args.first()` is the real subcommand even for
+/// `git -C <path> worktree add` (#2234 Patch A r4).
 fn deny_agent_canonical_bypass(
     agent_present: bool,
     escape: bool,
@@ -1356,10 +1407,20 @@ fn deny_agent_canonical_bypass(
 fn enforce_agent_canonical_bypass_deny(args: &[String]) {
     let agent = env::var("AGEND_INSTANCE_NAME").unwrap_or_default();
     let escape = env::var("AGEND_GIT_ALLOW_CANONICAL_MUTATE").as_deref() == Ok("1");
-    if !deny_agent_canonical_bypass(!agent.is_empty(), escape, cwd_is_canonical_rooted(), args) {
+    // #2234 Patch A (r4): resolve the REAL subcommand through leading git globals
+    // (`-C`, `-c`, `--git-dir`, …) so `git -C <canonical> worktree add` is judged
+    // as `worktree add` — not the `-C` token (the `args.first()` blind spot) — AND
+    // against the dir `-C` points at, not the shim's process cwd. No subcommand
+    // (globals only) → nothing to deny.
+    let Some(sub_idx) = subcommand_index(args) else {
+        return;
+    };
+    let sub_args = &args[sub_idx..];
+    let canonical = path_is_canonical_rooted(&effective_cwd_through_globals(args, sub_idx));
+    if !deny_agent_canonical_bypass(!agent.is_empty(), escape, canonical, sub_args) {
         return;
     }
-    let sub = args.first().map(|s| s.as_str()).unwrap_or("");
+    let sub = sub_args.first().map(|s| s.as_str()).unwrap_or("");
     eprintln!(
         "agend-git: DENIED — agent '{agent}' must not bypass-{sub} in a canonical-rooted repo.\n\
          The daemon already auto-bound your worktree at dispatch; cd into it and use normal git \
@@ -2997,6 +3058,45 @@ mod tests {
         ])));
         assert!(!is_positional_branch_checkout(&s(&["status"])));
         assert!(!is_positional_branch_checkout(&s(&["commit", "main"])));
+    }
+
+    /// #2234 Patch A: leading `-C` resolution for the deny's effective cwd —
+    /// absolute target wins, repeated/relative `-C` accumulate, a value-taking
+    /// global before `-C` is skipped WITH its value, and no `-C` leaves the
+    /// process cwd untouched.
+    #[test]
+    fn effective_cwd_through_globals_resolves_leading_dash_c() {
+        let s = |v: &[&str]| v.iter().map(|x| x.to_string()).collect::<Vec<_>>();
+        // Absolute `-C <path>` → that path, independent of the process cwd.
+        let args = s(&["-C", "/abs/canonical", "worktree", "add", "x"]);
+        let idx = subcommand_index(&args).expect("has subcommand");
+        assert_eq!(idx, 2, "subcommand starts after `-C <path>`");
+        assert_eq!(
+            effective_cwd_through_globals(&args, idx),
+            std::path::PathBuf::from("/abs/canonical")
+        );
+        // Repeated `-C`: a later RELATIVE `-C` joins onto the accumulated path.
+        let args = s(&["-C", "/abs/canonical", "-C", "sub", "checkout", "main"]);
+        let idx = subcommand_index(&args).expect("has subcommand");
+        assert_eq!(
+            effective_cwd_through_globals(&args, idx),
+            std::path::PathBuf::from("/abs/canonical/sub")
+        );
+        // A value-taking global (`-c k=v`) before `-C` is skipped WITH its value,
+        // so `k=v` is never mistaken for the `-C` target.
+        let args = s(&["-c", "k=v", "-C", "/abs/x", "status"]);
+        let idx = subcommand_index(&args).expect("has subcommand");
+        assert_eq!(
+            effective_cwd_through_globals(&args, idx),
+            std::path::PathBuf::from("/abs/x")
+        );
+        // No leading `-C` → process cwd unchanged.
+        let args = s(&["worktree", "add", "x"]);
+        let idx = subcommand_index(&args).expect("has subcommand");
+        assert_eq!(
+            effective_cwd_through_globals(&args, idx),
+            std::env::current_dir().unwrap()
+        );
     }
 
     /// #2234 fix B: the pure deny decision. Deny only when agent + !escape +

--- a/tests/agend_git_shim_phase2.rs
+++ b/tests/agend_git_shim_phase2.rs
@@ -415,5 +415,58 @@ fn shim_denies_agent_bypass_canonical_provisioning_2234() {
         "non-canonical cwd must NOT be denied"
     );
 
+    // ── #2234 Patch A (r4): a leading `-C` must NOT slip the deny ──
+    let canonical_str = canonical.to_str().expect("utf8 canonical path");
+    let plain_str = plain.to_str().expect("utf8 plain path");
+    // `git -C <canonical> worktree add` from a NON-canonical cwd → DENIED. Proves
+    // BOTH fixes at once: the real subcommand is found past `-C` (not `args.first()`
+    // == "-C"), AND the effective cwd is the `-C` TARGET (canonical), not the
+    // process cwd (plain).
+    assert!(
+        is_denied(&run(
+            &plain,
+            Some("test-agent"),
+            false,
+            &[
+                "-C",
+                canonical_str,
+                "worktree",
+                "add",
+                "/tmp/agend-2234-wt-e",
+                "origin/main"
+            ]
+        )),
+        "`git -C <canonical> worktree add` from non-canonical cwd must be DENIED"
+    );
+    // Same for a positional `checkout <ref>` behind `-C`.
+    assert!(
+        is_denied(&run(
+            &plain,
+            Some("test-agent"),
+            false,
+            &["-C", canonical_str, "checkout", "origin/main"]
+        )),
+        "`git -C <canonical> checkout <ref>` from non-canonical cwd must be DENIED"
+    );
+    // Inverse (no over-block): `-C` pointing AWAY from canonical → effective cwd is
+    // the non-canonical `-C` target even though the PROCESS cwd is canonical, so the
+    // deny must NOT fire (the fix narrows by the dir git actually operates in).
+    assert!(
+        not_denied(&run(
+            &canonical,
+            Some("test-agent"),
+            false,
+            &[
+                "-C",
+                plain_str,
+                "worktree",
+                "add",
+                "/tmp/agend-2234-wt-f",
+                "origin/main"
+            ]
+        )),
+        "`git -C <non-canonical>` from canonical cwd must NOT be denied (judged by the -C target)"
+    );
+
     std::fs::remove_dir_all(&root).ok();
 }


### PR DESCRIPTION
## What (Patch A only)

Close the `git -C <canonical> worktree add` bypass of the #2234 agent-canonical-provisioning deny. r4 found this during #2316 dual-review; r6 spiked + lead vetted the scoped fix.

## Why it slipped

`enforce_agent_canonical_bypass_deny` had two `-C`-blind spots:

1. **Subcommand**: `deny_agent_canonical_bypass` reads `args.first()`. For `git -C <dir> worktree add …` that is `-C`, not `worktree`, so `worktree add` / positional `checkout|switch` were never recognized.
2. **Canonical check**: it used `cwd_is_canonical_rooted()` — the shim's **process** cwd — not the dir `-C` points at. An agent in any cwd could target canonical with `-C`.

Either way an agent could stray-provision a worktree / detach the operator's canonical HEAD despite the deny.

## Fix (r6-scoped — bypass deny path only)

- Reuse the existing `subcommand_index` (already skips `-C`/`-c`/`--git-dir`/…) to find the **real** subcommand, and pass the **subcommand-rooted** slice to the (unchanged) pure `deny_agent_canonical_bypass`.
- Add `effective_cwd_through_globals` — the dir git would operate in after applying leading `-C` (cumulative, relative-aware) — and judge canonical-rootedness against **that**.
- Extract `path_is_canonical_rooted(dir)` from `cwd_is_canonical_rooted()` (now delegates with the process cwd → **byte-identical** for the non-bypass classify path).

Only the bypass guard/deny path is touched; the non-bypass classify is left alone (blast control).

**Patch B (reset --hard deny) intentionally NOT done** — lead vet: it would block agents' legitimate in-worktree `reset --hard` self-recovery (capability risk, speculative footgun).

**Residual**: `--git-dir`/`--work-tree` are not resolved for the canonical check (they don't move cwd; a narrower, separate vector — documented in-code). The audit path (`bypass_op_is_audited` at the call site) shares the same `args.first()` blind spot but for a now-**denied** op nothing executes, so it's harmless; noted for a follow-up.

## Tests

- **Runtime wiring** (`agend_git_shim_phase2.rs`): DENY `git -C <canonical> worktree add` / `checkout <ref>` from a **non-canonical** cwd; ALLOW `git -C <non-canonical> worktree add` from a **canonical** cwd (no over-block — judged by the `-C` target).
- **Pure unit** (`effective_cwd_through_globals_resolves_leading_dash_c`): absolute / repeated+relative `-C`, value-taking-global skip, no-`-C` passthrough.
- **RED-verified**: the wiring test fails at the `-C worktree add` DENY assertion against the pre-fix `enforce`, then passes with the fix.
- Full local: `agend-git` bin 64 unit tests + `agend_git_shim_phase2` 12 tests green; `cargo fmt` + `clippy --all-targets --features tray -D warnings` clean.

Task: `t-20260618000801970476-2345-3`
