### PR TITLE
feat(#2158): hourly stray-managed-worktree sweep + fleet health surface (item 2, stray-only)

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -709,6 +709,10 @@ pub(crate) fn build_default_handlers(
         Box::new(per_tick::LogRotationHandler::new(360)),
         Box::new(per_tick::ThreadDumpHandler::new()),
         Box::new(per_tick::GcTickHandler::new(360)),
+        // #2158 item 2: hourly stray-managed-worktree sweep (edge-triggered
+        // event-log + fleet health count). Same 360-tick GC cadence; runs in app
+        // mode too (not allowlisted out) since the live daemon is app-mode.
+        Box::new(per_tick::WorkspaceBoundarySweepHandler::new(360)),
         // #1747: slow-cadence backstop GC for stale /tmp review worktrees (mtime
         // > 2d). Same 360-tick cadence as the other GC siblings; runs in app mode
         // (not allowlisted out) since the live daemon is app-mode.

--- a/src/daemon/per_tick/mod.rs
+++ b/src/daemon/per_tick/mod.rs
@@ -59,6 +59,7 @@ pub(crate) mod supervisor_trackers;
 pub(crate) mod thread_dump;
 pub(crate) mod tmp_review_gc;
 pub(crate) mod watchdog;
+pub(crate) mod workspace_boundary_sweep;
 
 pub(crate) use check_schedules::CheckSchedulesHandler;
 pub(crate) use ci_watch_poll::CiWatchPollHandler;
@@ -90,6 +91,7 @@ pub(crate) use supervisor_trackers::{
 pub(crate) use thread_dump::ThreadDumpHandler;
 pub(crate) use tmp_review_gc::TmpReviewGcHandler;
 pub(crate) use watchdog::WatchdogHandler;
+pub(crate) use workspace_boundary_sweep::WorkspaceBoundarySweepHandler;
 
 /// Shared per-tick context. Field types match what the daemon main loop
 /// holds verbatim — the trait is pure relocation, not abstraction. New

--- a/src/daemon/per_tick/workspace_boundary_sweep.rs
+++ b/src/daemon/per_tick/workspace_boundary_sweep.rs
@@ -1,0 +1,201 @@
+//! #2158 item 2 (lead decision (b)): hourly workspace-boundary sweep. Detects
+//! stray daemon-managed worktrees via [`crate::workspace_boundary::detect_violations`]
+//! and emits EDGE-TRIGGERED fleet event-log entries: exactly one `appear` when a
+//! violation first shows up and one `resolve` when it clears — NEVER one-per-hour
+//! while a violation stands (the noise-safety core, [[system_noise_reduction]]).
+//!
+//! The seen-set lives on the handler so the appear/resolve edges survive across
+//! hourly ticks within a daemon process. Restart-survival (a persisted marker) is
+//! a deliberate follow-up — a single re-`appear` per restart is acceptable.
+//! Best-effort: a detect/emit failure logs and continues; it never breaks the
+//! tick (the per-tick panic guard isolates it further).
+
+use super::{PerTickHandler, TickContext};
+use parking_lot::Mutex;
+use std::collections::HashSet;
+use std::path::Path;
+use std::sync::Arc;
+
+pub(crate) struct WorkspaceBoundarySweepHandler {
+    /// Cadence + boot-grace (suppresses the first sweep within the grace window
+    /// of daemon boot, so a backlog of pre-restart strays doesn't all `appear` at
+    /// once before the fleet settles).
+    gate: crate::daemon::cadence_gate::CadenceGate,
+    /// Violation identities seen on the previous sweep — drives appear/resolve
+    /// edge detection. In-memory; survives ticks within a process.
+    seen: Arc<Mutex<HashSet<String>>>,
+}
+
+impl WorkspaceBoundarySweepHandler {
+    pub(crate) fn new(every_n_ticks: u64) -> Self {
+        Self {
+            gate: crate::daemon::cadence_gate::CadenceGate::new_with_boot_grace(
+                every_n_ticks,
+                super::NOTIFICATION_BOOT_GRACE,
+            ),
+            seen: Arc::new(Mutex::new(HashSet::new())),
+        }
+    }
+
+    #[cfg(test)]
+    fn new_at(every_n_ticks: u64, created_at: std::time::Instant) -> Self {
+        Self {
+            gate: crate::daemon::cadence_gate::CadenceGate::new_with_boot_grace_at(
+                every_n_ticks,
+                created_at,
+                super::NOTIFICATION_BOOT_GRACE,
+            ),
+            seen: Arc::new(Mutex::new(HashSet::new())),
+        }
+    }
+
+    /// The edge-trigger core, split out so tests drive it without the cadence
+    /// gate. Emits `appear` for newly-seen identities + `resolve` for gone ones,
+    /// then replaces the seen-set with the current one. Returns (appeared,
+    /// resolved) for assertions.
+    fn sweep_once(&self, home: &Path) -> (usize, usize) {
+        let current: std::collections::HashMap<String, crate::workspace_boundary::Violation> =
+            crate::workspace_boundary::detect_violations(home)
+                .into_iter()
+                .map(|v| (v.identity(), v))
+                .collect();
+        let mut seen = self.seen.lock();
+        let mut appeared = 0;
+        for (id, v) in &current {
+            if !seen.contains(id) {
+                appeared += 1;
+                crate::event_log::log(
+                    home,
+                    "workspace_violation_appear",
+                    v.agent.as_deref().unwrap_or("-"),
+                    &format!("kind={} path={}", v.kind.as_str(), v.path.display()),
+                );
+            }
+        }
+        let gone: Vec<String> = seen
+            .iter()
+            .filter(|id| !current.contains_key(*id))
+            .cloned()
+            .collect();
+        let resolved = gone.len();
+        for id in &gone {
+            crate::event_log::log(
+                home,
+                "workspace_violation_resolve",
+                "-",
+                &format!("id={id}"),
+            );
+        }
+        *seen = current.into_keys().collect();
+        (appeared, resolved)
+    }
+}
+
+impl PerTickHandler for WorkspaceBoundarySweepHandler {
+    fn name(&self) -> &'static str {
+        "workspace_boundary_sweep"
+    }
+
+    fn run(&self, ctx: &TickContext<'_>) {
+        if !self.gate.fire() {
+            return;
+        }
+        self.sweep_once(ctx.home);
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn tmp_home(tag: &str) -> PathBuf {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "agend-wsb-sweep-{}-{}-{}",
+            std::process::id(),
+            tag,
+            id
+        ));
+        std::fs::create_dir_all(&dir).ok();
+        dir
+    }
+
+    fn stray_worktree(home: &Path, agent: &str, branch: &str) -> PathBuf {
+        let wt = crate::worktree_pool::daemon_managed_worktree_root(home)
+            .join(agent)
+            .join(branch);
+        std::fs::create_dir_all(&wt).unwrap();
+        std::fs::write(wt.join(".agend-managed"), "").unwrap();
+        wt
+    }
+
+    fn appear_count(home: &Path) -> usize {
+        std::fs::read_to_string(home.join("event-log.jsonl"))
+            .unwrap_or_default()
+            .lines()
+            .filter(|l| l.contains("workspace_violation_appear"))
+            .count()
+    }
+
+    /// NOISE-SAFETY CORE: a standing violation across N sweeps emits exactly ONE
+    /// `appear` (not N×) — the in-memory seen-set dedups subsequent sweeps.
+    #[test]
+    fn standing_violation_appears_once_across_n_sweeps() {
+        let home = tmp_home("standing");
+        let h = WorkspaceBoundarySweepHandler::new(1);
+        stray_worktree(&home, "ghost", "feat/x");
+
+        assert_eq!(h.sweep_once(&home), (1, 0), "first sweep: appear once");
+        assert_eq!(
+            h.sweep_once(&home),
+            (0, 0),
+            "second sweep: silent (standing)"
+        );
+        assert_eq!(h.sweep_once(&home), (0, 0), "third sweep: still silent");
+        assert_eq!(
+            appear_count(&home),
+            1,
+            "exactly ONE appear event for a standing violation across 3 sweeps"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// A resolved violation emits exactly ONE `resolve`, then stays silent.
+    #[test]
+    fn resolved_violation_emits_resolve_once() {
+        let home = tmp_home("resolve");
+        let h = WorkspaceBoundarySweepHandler::new(1);
+        let wt = stray_worktree(&home, "ghost", "feat/x");
+
+        assert_eq!(h.sweep_once(&home), (1, 0), "appear");
+        std::fs::remove_dir_all(&wt).unwrap(); // violation clears
+        assert_eq!(h.sweep_once(&home), (0, 1), "resolve once");
+        assert_eq!(h.sweep_once(&home), (0, 0), "silent after resolve");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Boot-grace suppresses the first sweep (the `run` gate), so a stale backlog
+    /// doesn't all-`appear` before the fleet settles; past grace it fires.
+    #[test]
+    fn boot_grace_suppresses_then_fires() {
+        let fresh = WorkspaceBoundarySweepHandler::new(30); // created ≈ now → in grace
+        assert!(!fresh.gate.fire(), "in boot-grace → suppressed");
+        let past = std::time::Instant::now()
+            - super::super::NOTIFICATION_BOOT_GRACE
+            - std::time::Duration::from_secs(1);
+        let aged = WorkspaceBoundarySweepHandler::new_at(30, past);
+        assert!(aged.gate.fire(), "after grace, first tick fires");
+    }
+
+    #[test]
+    fn name_matches_module() {
+        assert_eq!(
+            WorkspaceBoundarySweepHandler::new(360).name(),
+            "workspace_boundary_sweep"
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,6 +84,7 @@ mod tui;
 pub mod types;
 mod verify;
 mod vterm;
+mod workspace_boundary;
 mod worktree;
 mod worktree_cleanup;
 #[allow(dead_code)]

--- a/src/status_summary.rs
+++ b/src/status_summary.rs
@@ -93,6 +93,26 @@ pub fn build_summary(home: &Path) -> String {
         }
     }
 
+    // #2158 item 3: fleet-level surface for workspace-boundary violations
+    // (NOT a per-agent reason). Re-derived via the shared detector so the count
+    // matches what the hourly sweep edge-triggers on.
+    let violations = crate::workspace_boundary::detect_violations(home);
+    if !violations.is_empty() {
+        lines.push(format!("▸ Workspace violations: {}", violations.len()));
+        for v in violations.iter().take(5) {
+            let who = v.agent.as_deref().unwrap_or("?");
+            lines.push(format!(
+                "  ⚠ {} {} [{}]",
+                v.kind.as_str(),
+                who,
+                v.path.display()
+            ));
+        }
+        if violations.len() > 5 {
+            lines.push(format!("  ... +{} more", violations.len() - 5));
+        }
+    }
+
     lines.join("\n")
 }
 

--- a/src/workspace_boundary.rs
+++ b/src/workspace_boundary.rs
@@ -1,0 +1,168 @@
+//! #2158 item 2 (lead decision (b), 2026-06-19): detect stray daemon-managed
+//! worktrees — a marker-managed worktree dir whose agent is neither live nor
+//! bound, i.e. an orphan GC could not reclaim (e.g. a dirty worktree it
+//! backs-up-but-leaves). Surfaced via an edge-triggered fleet event-log (exactly
+//! appear + resolve per violation, NOT per-hour) + the fleet health summary —
+//! NOT a per-agent BlockedReason slot (lead's clobber decision: a hygiene reason
+//! must not clobber an execution reason like rate-limit / hang / crash).
+//!
+//! SCOPE NOTE: the original #2158 item-2 also named "cross-workspace drift", but
+//! that half is deliberately NOT done here. An at-rest hourly sweep has no view
+//! of an agent's live cwd, so it cannot replicate the shim's
+//! `is_workspace_clone_drift` cwd gate; the naive at-rest predicate
+//! (`workspace/<agent>` foreign to the bound worktree) false-positives on EVERY
+//! agent, because `workspace/<agent>` is normally a SEPARATE clone from the
+//! canonical worktree the agent is bound to. Active-cwd drift is already covered
+//! by the #2290 shim-side bypass audit.
+
+use std::path::{Path, PathBuf};
+
+/// A detected workspace-boundary violation kind. (Currently one kind; the enum
+/// keeps the surface ready for future kinds without reshaping callers.)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ViolationKind {
+    /// A daemon-managed worktree whose agent is neither live nor bound.
+    StrayWorktree,
+}
+
+impl ViolationKind {
+    /// Stable string form — the identity prefix + event-log greppability anchor.
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            ViolationKind::StrayWorktree => "stray_worktree",
+        }
+    }
+}
+
+/// A single detected violation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Violation {
+    pub(crate) kind: ViolationKind,
+    /// The agent the offending dir is filed under (None when unresolvable).
+    pub(crate) agent: Option<String>,
+    /// Canonical path of the offending worktree dir.
+    pub(crate) path: PathBuf,
+}
+
+impl Violation {
+    /// Stable identity for edge-trigger dedup + event-log correlation: kind +
+    /// canonical path. The path alone is unique; the kind prefix keeps it
+    /// unambiguous if more kinds are ever added.
+    pub(crate) fn identity(&self) -> String {
+        format!("{}:{}", self.kind.as_str(), self.path.display())
+    }
+}
+
+/// Scan for current workspace-boundary violations. Pure, best-effort, no
+/// mutation. The SINGLE source of truth shared by the hourly sweep handler
+/// (which edge-triggers appear/resolve events off it) and the fleet health
+/// summary (which reports the live count) — so the two never disagree.
+pub(crate) fn detect_violations(home: &Path) -> Vec<Violation> {
+    let canon = |p: &Path| dunce::canonicalize(p).unwrap_or_else(|_| p.to_path_buf());
+    // Liveness signals, mirroring `gc_candidates`: a managed worktree is
+    // legitimate while its agent is in the live-agent set OR holds a binding
+    // (covers an idle-but-running agent + a future-version binding via
+    // `present_including_future`). A stray = NEITHER signal present.
+    let live: std::collections::HashSet<String> = crate::runtime::list_agents_with_fallback(home)
+        .into_iter()
+        .collect();
+    let mut out = Vec::new();
+    // Reuse gc_run's enumeration (the SINGLE marker-walk + workspace-gitlink
+    // impl) rather than a raw "dir exists" scan — so anything non-managed is
+    // never mistaken for a stray, and the two stay in lockstep.
+    for wt in crate::worktree_pool::fs_managed_worktrees(home) {
+        let agent = crate::worktree_pool::agent_from_layout(home, &wt);
+        let bound = agent
+            .as_deref()
+            .is_some_and(|a| crate::binding::present_including_future(home, a));
+        let alive = agent.as_deref().is_some_and(|a| live.contains(a));
+        if !bound && !alive {
+            out.push(Violation {
+                kind: ViolationKind::StrayWorktree,
+                agent,
+                path: canon(&wt),
+            });
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn tmp_home(tag: &str) -> PathBuf {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "agend-wsb-test-{}-{}-{}",
+            std::process::id(),
+            tag,
+            id
+        ));
+        std::fs::create_dir_all(&dir).ok();
+        dir
+    }
+
+    /// Create a marker-managed worktree at `worktrees/<agent>/<branch>`.
+    fn managed_worktree(home: &Path, agent: &str, branch: &str) -> PathBuf {
+        let wt = crate::worktree_pool::daemon_managed_worktree_root(home)
+            .join(agent)
+            .join(branch);
+        std::fs::create_dir_all(&wt).unwrap();
+        std::fs::write(wt.join(".agend-managed"), "").unwrap();
+        wt
+    }
+
+    fn write_binding(home: &Path, agent: &str, wt: &Path) {
+        let dir = crate::paths::runtime_dir(home).join(agent);
+        std::fs::create_dir_all(&dir).unwrap();
+        let v = serde_json::json!({
+            "version": 1, "agent": agent, "task_id": "T", "branch": "b",
+            "worktree": wt.to_str().unwrap(),
+        });
+        std::fs::write(dir.join("binding.json"), v.to_string()).unwrap();
+    }
+
+    /// A marker-managed worktree whose agent is neither live nor bound is flagged
+    /// as a StrayWorktree (the core detection).
+    #[test]
+    fn stray_managed_worktree_with_no_agent_flagged() {
+        let home = tmp_home("stray");
+        let wt = managed_worktree(&home, "ghost", "feat/x");
+        let v = detect_violations(&home);
+        assert_eq!(
+            v.len(),
+            1,
+            "an orphan managed worktree must be flagged: {v:?}"
+        );
+        assert_eq!(v[0].kind, ViolationKind::StrayWorktree);
+        assert_eq!(v[0].agent.as_deref(), Some("ghost"));
+        assert_eq!(v[0].path, dunce::canonicalize(&wt).unwrap());
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// A BOUND managed worktree (binding.json present) must NOT be flagged — the
+    /// #1 false-positive guard.
+    #[test]
+    fn bound_managed_worktree_not_flagged() {
+        let home = tmp_home("bound");
+        let wt = managed_worktree(&home, "boundy", "feat/y");
+        write_binding(&home, "boundy", &wt);
+        assert!(
+            detect_violations(&home).is_empty(),
+            "a bound managed worktree must NOT be flagged as stray"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Empty home → no managed worktrees → no violations (no spurious flags).
+    #[test]
+    fn empty_home_no_violations() {
+        let home = tmp_home("empty");
+        assert!(detect_violations(&home).is_empty());
+        std::fs::remove_dir_all(&home).ok();
+    }
+}

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -1287,7 +1287,7 @@ pub(crate) fn collect_managed_worktrees(root: &Path, max_depth: usize, out: &mut
 /// `None` when the path is under neither managed root — the caller treats that
 /// as unresolvable and SKIPS the worktree (fail-toward-alive), never guessing
 /// from the parent dir.
-fn agent_from_layout(home: &Path, wt_path: &Path) -> Option<String> {
+pub(crate) fn agent_from_layout(home: &Path, wt_path: &Path) -> Option<String> {
     for root in [
         daemon_managed_worktree_root(home),
         crate::paths::workspace_dir(home),


### PR DESCRIPTION
#2158 items 2+3 (lead decision (b), 2026-06-19). An hourly GC-cadence sweep that detects **stray daemon-managed worktrees** and surfaces them noise-safely.

## What
- **Detection** (`src/workspace_boundary.rs`): a marker-managed worktree whose agent is neither live (`list_agents_with_fallback`) nor bound (`present_including_future`) = an orphan GC couldn't reclaim. Reuses `gc_run`'s enumeration (`fs_managed_worktrees`) + liveness signals — not a raw "dir exists" check. `detect_violations` is the single source of truth shared by the sweep handler + the health summary.
- **Edge-trigger sweep** (`src/daemon/per_tick/workspace_boundary_sweep.rs`): `WorkspaceBoundarySweepHandler` on the 360-tick (hourly) cadence + boot-grace, with an in-memory seen-set (mirrors `InboxStuckHandler`). Emits **exactly one `appear` per violation and one `resolve`** — never one-per-hour while it stands (the noise-safety core). Best-effort; runs in both `run_core` and app mode (passes `app_tick_handlers_cover_every_non_allowlisted_daemon_handler`).
- **Fleet health surface** (`status_summary`): a "Workspace violations" count/list, re-derived via the shared detector. **No per-agent `BlockedReason`** (lead's clobber decision — a hygiene reason must not clobber rate-limit/hang/crash).

## Scope (drift dropped from the daemon — verify-first finding)
The original item-2 also named "cross-workspace drift", but that half is **deliberately not done in the daemon sweep**: an at-rest hourly sweep has no view of an agent's live cwd, so it can't replicate the shim's `is_workspace_clone_drift` cwd gate — the naive at-rest predicate (`workspace/<agent>` foreign to the bound worktree) **false-positives on every agent** (workspace/`<agent>` is normally a separate clone from the bound canonical worktree). Active-cwd drift is already covered by the merged #2290 shim-side bypass audit. (Lead confirmed (b).)

## Tests
standing-violation → exactly 1 `appear` across N sweeps (noise core); resolve → exactly 1; bound/tracked worktree not flagged; boot-grace suppress; empty-home no-op. Full `nextest --features tray --profile ci` green (4547/4547). fmt + clippy (`--features tray -D warnings`) clean.

Daemon behavior → needs rebuild+restart to go live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)