### PR TITLE
fix(release): re-pin sysinfo 0.38.4 to restore MSRV 1.88 (v0.9.0 blocker)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); projec
 - **Faster, smoother restarts** — app-mode shutdown teardown is parallelized (~6 s → the grace window, #2311); the old-exit→new-launch gap and restart timing are instrumented (#2310, #2275); release builds use ThinLTO + more codegen units (#2265).
 - **Canonical worktree reconcile (#2234 — flag-gated, default OFF)** — reconcile `workspace/<agent>` into canonical git worktrees (#2262), with layout-aware GC + agent attribution (#2263, #2266, #2269), in-place dispatch checkout (#2264), reconcile-backups retention GC (#2272), and a reverse-reconcile rollback primitive (#2267). The `agend-git` shim warns on cwd↔worktree drift (#2254, #2278) and now DENIES an agent's `AGEND_GIT_BYPASS` provisioning op in a canonical-rooted repo (#2316) — the deny now sees through a leading `-C` to resolve the real subcommand and effective cwd, so `git -C <canonical> worktree add` is denied from any cwd (#2336), and its message reads as a conditional for no-branch dispatches that have no auto-bound worktree (#2334).
 - **Governance gates mechanized** — repeatedly hand-checked review rules became invariant tests: state files must use `store::atomic_write` (D2, #2323) and instrument/audit paths must never affect control-flow or exit code (D3, #2324); three protocol rules + a context-full self-restart procedure were formalized (#2329, #2157).
-- **Dependency bumps** — crossterm 0.29, sysinfo 0.39, regex, serde_json, insta (#2285–#2289).
+- **Dependency bumps** — crossterm 0.29, regex, serde_json, insta (#2285–#2289).
 
 ### Fixed
 

--- a/CHANGELOG.zh-TW.md
+++ b/CHANGELOG.zh-TW.md
@@ -26,7 +26,7 @@
 - **更快更順的 restart** — app-mode shutdown teardown 平行化(~6 秒 → grace 窗,#2311);old-exit→new-launch 的 gap 與 restart timing 加上 instrument(#2310、#2275);release build 採 ThinLTO + 更多 codegen units(#2265)。
 - **canonical worktree reconcile(#2234 —— flag-gated、預設 OFF)** — 把 `workspace/<agent>` reconcile 成 canonical git worktree(#2262),含 layout-aware GC + agent 歸屬(#2263、#2266、#2269)、in-place dispatch checkout(#2264)、reconcile-backups 保留 GC(#2272)、reverse-reconcile 回滾原語(#2267)。`agend-git` shim 對 cwd↔worktree 漂移發 WARN(#2254、#2278),並在 canonical-rooted repo 中 DENY agent 的 `AGEND_GIT_BYPASS` provisioning op(#2316)—— 此 deny 現在會穿透 leading `-C` 解析真正的 subcommand 與 effective cwd,使 `git -C <canonical> worktree add` 從任何 cwd 都正確 DENY(#2336),訊息也改為條件式措辭以涵蓋無 auto-bind worktree 的 no-branch dispatch(#2334)。
 - **治理閘機械化** — 反覆手追的 review 規則變成 invariant 測:狀態檔必須走 `store::atomic_write`(D2,#2323),instrument/audit 路徑永不影響 control-flow 或 exit code(D3,#2324);三條 protocol 規則 + context-full 自我 restart 流程已形式化(#2329、#2157)。
-- **依賴升級** — crossterm 0.29、sysinfo 0.39、regex、serde_json、insta(#2285–#2289)。
+- **依賴升級** — crossterm 0.29、regex、serde_json、insta(#2285–#2289)。
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,7 +159,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -170,7 +170,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -589,7 +589,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1013,7 +1013,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1163,7 +1163,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2281,7 +2281,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "160f2eade097f30263b548aae5deb12ad349c909baa710fa24b92c9090b2e006"
 dependencies = [
  "scopeguard",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2548,7 +2548,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2579,7 +2579,7 @@ dependencies = [
  "once_cell",
  "png",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2674,7 +2674,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2870,17 +2870,6 @@ dependencies = [
  "bitflags 2.11.0",
  "objc2",
  "objc2-core-foundation",
-]
-
-[[package]]
-name = "objc2-open-directory"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb82bed227edf5201dfedf072bba4015a33d3d4a98519837295a90f0a23f676d"
-dependencies = [
- "objc2",
- "objc2-core-foundation",
- "objc2-foundation",
 ]
 
 [[package]]
@@ -3856,7 +3845,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4335,7 +4324,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4354,7 +4343,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4446,16 +4435,15 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.39.3"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21d0d938c10fcda3e897e28aaddf4ab462375d411f4378cd63b1c945f69aba96"
+checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
 dependencies = [
  "libc",
  "memchr",
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
- "objc2-open-directory",
  "windows 0.62.2",
 ]
 
@@ -4621,7 +4609,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5150,7 +5138,7 @@ dependencies = [
  "once_cell",
  "png",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5707,7 +5695,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,7 +136,9 @@ tracing-appender = "0.2"
 arboard = "3.6.1"
 unicode-width = "0.2"
 which = "8"
-sysinfo = "0.39"
+# #2288 re-bumped sysinfo 0.38→0.39.3, which requires rustc 1.95 and broke the
+# v0.9.0 release MSRV (1.88) gate. Re-pinned to 0.38 (MSRV 1.88) — see [0.9.0].
+sysinfo = "0.38"
 # Crypto-grade random for API-connection cookie (P1-10)
 getrandom = "0.4"
 iana-time-zone = "0.1.65"


### PR DESCRIPTION
🔴 **v0.9.0 release blocker.**

## Cause
Dependabot #2288 (2026-06-17) re-bumped `sysinfo` 0.38 → 0.39.3, which requires **rustc 1.95**. Regular CI doesn't run the MSRV check — only the release `Pre-release gate` does (`cargo +1.88 check --locked`) — so it passed CI and failed at `v0.9.0` tag time with `sysinfo@0.39.3 requires rustc 1.95`.

## Fix (restore MSRV 1.88, NOT bump it)
A 1.95 floor is uninstallable for everyone on 1.88–1.94, so this re-pins to the established 0.38 floor.
- `Cargo.toml`: `sysinfo = "0.39"` → `"0.38"`.
- `Cargo.lock`: sysinfo 0.39.3 → 0.38.4 (drops transitive `objc2-open-directory`).
- `CHANGELOG.md` + `CHANGELOG.zh-TW.md`: removed "sysinfo 0.39" from the [0.9.0] dependency-bumps line (the [0.9.0] MSRV rationale already documents the 0.38 pin).

## Verification
- `cargo check --features tray` compiles on 0.38.4 (#2288 was a pure dep bump — no code change).
- **Reproduced the release gate locally**: `cargo +1.88 check --locked` is **GREEN** (confirmed `cargo +1.88` → 1.88.0), proving the **entire locked set** is ≤ MSRV 1.88 — not just sysinfo, but also crossterm 0.29 / insta 1.48 / regex / serde_json (#2285–#2289). No other dep crosses the line.

After merge: re-tag v0.9.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)