### PR TITLE
ci: add MSRV (1.88) check to regular CI (root-fix for Dependabot-raises-MSRV)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,6 +218,31 @@ jobs:
           path: target/release/agend-terminal.exe
           retention-days: 14
 
+  # #2288/#2339: MSRV gate in REGULAR CI (root-fix for the Dependabot-raises-MSRV
+  # class). release.yml's Pre-release gate runs this too, but only at TAG time —
+  # so a dep bump that silently raises the floor (sysinfo 0.39.3 → needs rustc
+  # 1.95) passed every PR's CI and only blew up at `git tag v0.9.0`. Running it on
+  # each PR fails the offending bump at PR time instead. Mirrors the release-gate
+  # step exactly (dtolnay 1.88 + `cargo +1.88 check --locked`); default features
+  # only (matches the release gate — `tray` needs GTK and is covered by the
+  # `check` matrix). NO path-filter: a required check that path-skips stays
+  # permanently `pending` and blocks merge. release.yml's MSRV step is unchanged —
+  # the two gates are independent and the release gate stays the final backstop.
+  msrv:
+    name: MSRV check (1.88)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.88"
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ci-msrv-1.88
+      - name: MSRV check (1.88)
+        run: cargo +1.88 check --locked
+
   audit:
     runs-on: ubuntu-latest
     # rustsec/audit-check@v2 POSTs results to /repos/.../check-runs to surface


### PR DESCRIPTION
Root-fix for the process gap that blocked v0.9.0 (#2288 → #2339).

## Problem
The MSRV gate ran **only** in `release.yml`'s Pre-release gate (at `git tag` time), not in regular CI. So Dependabot #2288 bumping `sysinfo` 0.38→0.39.3 (needs rustc 1.95) passed every PR's CI and only failed at `v0.9.0` tag time (#2339).

## Fix (CI-config only)
Adds a `msrv` job to `ci.yml` that **mirrors the release-gate step exactly**: `dtolnay/rust-toolchain@master` (1.88) + `Swatinem/rust-cache@v2` + `cargo +1.88 check --locked` (default features). An MSRV-raising dep bump now fails at **PR time**, not tag time.

- **No path-filter** — inherits ci.yml's `push`/`pull_request` trigger. A required check that path-skips stays permanently `pending` and blocks merge, so this deliberately runs on every PR (cached ~2-3 min).
- **Default features only** — matches the release gate; `tray` needs GTK and is covered by the `check` matrix.
- **`release.yml` untouched** — the two gates are independent; the release gate stays the final backstop.
- Job name `MSRV check (1.88)` so it can be set as a required check in branch protection (lead's follow-up after merge).

## Verification
This PR's own `MSRV check (1.88)` job validates the change. Locally reproduced: `cargo +1.88 check --locked` is **GREEN** on current main (sysinfo pinned 0.38.4 via #2339), so the new job passes immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)