### PR TITLE
fix(#2158): GR1 binding hardening — drop self-claim ci_watch auto-arm + operator-visible out-of-dispatch bind

### DIFF
--- a/src/binding.rs
+++ b/src/binding.rs
@@ -273,8 +273,89 @@ pub fn bind_full(
                 crate::event_log::caller_process_context()
             ),
         );
+        // #2158 GR1: a binding CREATE/CHANGE with NO task_id is OUT-OF-DISPATCH (a
+        // self-claim `repo checkout bind:true` or a `bind_self` without a task) —
+        // exactly the first-bind-hijack / accidental-sub-agent vector guard-b cannot
+        // prevent (identity-indistinguishable). Surface it to the operator, ONCE per
+        // (agent, branch), so an unexpected rebind is NOTICED. The daemon dispatch
+        // path always carries a task_id, so normal delegation is unaffected.
+        if task_id.is_empty() {
+            notify_operator_out_of_dispatch_bind(
+                home,
+                agent,
+                branch,
+                &wt_str,
+                prev_branch.as_deref(),
+            );
+        }
     }
     Ok(())
+}
+
+/// #2158 GR1: surface an OUT-OF-DISPATCH binding CREATE/CHANGE (no task_id) to the
+/// operator — the realistic accidental-sub-agent / first-bind-hijack vector that
+/// guard-b can't prevent. Dedup is per `(agent, branch)` via a runtime-dir sidecar
+/// so a stable or re-applied binding never re-notifies (fire-once). Honest about
+/// attribution: the daemon CANNOT name the caller — a transient Claude Code Task
+/// sub-agent shares the primary's `instance_name` AND its process, so neither
+/// `instance_name` nor a pid separates them (the binding audit's
+/// `caller_process_context` is daemon-side regardless). Best-effort + file-based
+/// (the same `inbox::notify_agent` primitive as `canonical_auto_stash`); never
+/// blocks and runs under the caller's binding lock, so no network/no spawn.
+fn notify_operator_out_of_dispatch_bind(
+    home: &Path,
+    agent: &str,
+    branch: &str,
+    wt_str: &str,
+    prev_branch: Option<&str>,
+) {
+    let sidecar = crate::paths::runtime_dir(home)
+        .join(agent)
+        .join(".out_of_dispatch_notified");
+    // Dedup: skip if this (agent, branch) was already surfaced.
+    if let Ok(seen) = std::fs::read_to_string(&sidecar) {
+        if seen.lines().any(|l| l == branch) {
+            return;
+        }
+    }
+    // Mark BEFORE notifying so a delivery hiccup can't drive a re-notify loop.
+    if let Ok(mut f) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&sidecar)
+    {
+        use std::io::Write;
+        let _ = writeln!(f, "{branch}");
+    }
+    // Distinct, greppable marker (also the regression-test hook) — separate from the
+    // always-on `binding_changed` audit above.
+    crate::event_log::log(
+        home,
+        "binding_out_of_dispatch",
+        agent,
+        &format!(
+            "branch={branch} worktree={wt_str} prev_branch={}",
+            prev_branch.unwrap_or("<none>")
+        ),
+    );
+    // Operator-visible delivery (best-effort, file-based inbox to the operator-mapped
+    // `general` agent — mirrors `canonical_auto_stash`).
+    let was = prev_branch
+        .map(|p| format!(", was `{p}`"))
+        .unwrap_or_default();
+    let text = format!(
+        "[system:binding_out_of_dispatch] instance `{agent}` bound to branch `{branch}`{was} \
+         OUTSIDE a task dispatch (no task_id). If unexpected, a transient sub-agent or a \
+         self-claim may have moved this instance's worktree. The daemon CANNOT name the exact \
+         caller — a Task sub-agent shares the primary's identity and process. Inspect with \
+         `binding_state instance={agent}`; undo with `release_worktree`. (#2158 GR1)"
+    );
+    crate::inbox::notify_agent(
+        home,
+        "general",
+        &crate::inbox::NotifySource::System("binding_out_of_dispatch"),
+        &text,
+    );
 }
 
 /// #1651: the HMAC sidecar path for a binding dir. The agend-git shim hard-codes
@@ -1287,6 +1368,59 @@ mod tests {
         assert!(
             log.contains("pid="),
             "audit lines must carry caller process context: {log}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    // ── #2158 GR1: out-of-dispatch bind → operator-visible, fire-once ────────
+
+    /// An OUT-OF-DISPATCH bind (no task_id) surfaces a distinct
+    /// `binding_out_of_dispatch` marker and DEDUPS per (agent, branch): a repeated
+    /// CHANGE on the SAME branch (here a new worktree path) must NOT re-surface
+    /// (fire-once, no flood).
+    #[test]
+    fn out_of_dispatch_bind_surfaces_once_per_branch_2158_gr1() {
+        let home = tmp_home("gr1-once");
+        let wt = home.join("wt");
+        std::fs::create_dir_all(&wt).unwrap();
+        let wt2 = home.join("wt2");
+        std::fs::create_dir_all(&wt2).unwrap();
+        let src = home.join("src");
+        std::fs::create_dir_all(&src).unwrap();
+
+        // first out-of-dispatch bind (no task_id) → surfaced.
+        bind_full(&home, "ag", "", "feat/x", &wt, &src).expect("first out-of-dispatch bind");
+        // SAME branch, different worktree → changed=true again, but dedup suppresses.
+        bind_full(&home, "ag", "", "feat/x", &wt2, &src).expect("same-branch rebind allowed");
+
+        let log = read_event_log(&home);
+        assert_eq!(
+            log.matches("binding_out_of_dispatch").count(),
+            1,
+            "out-of-dispatch bind must surface exactly once per (agent, branch): {log}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// A DISPATCH bind (task_id present — the normal delegation path) must NOT
+    /// surface the out-of-dispatch operator notify; only the always-on
+    /// `binding_changed` audit fires.
+    #[test]
+    fn dispatch_bind_does_not_surface_out_of_dispatch_2158_gr1() {
+        let home = tmp_home("gr1-dispatch");
+        let wt = home.join("wt");
+        std::fs::create_dir_all(&wt).unwrap();
+        let src = home.join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        bind_full(&home, "ag", "T-1", "feat/x", &wt, &src).expect("dispatch bind ok");
+        let log = read_event_log(&home);
+        assert!(
+            log.contains("binding_changed"),
+            "a dispatch bind is still audited: {log}"
+        );
+        assert!(
+            !log.contains("binding_out_of_dispatch"),
+            "a dispatch bind (task_id set) must NOT surface as out-of-dispatch: {log}"
         );
         std::fs::remove_dir_all(&home).ok();
     }

--- a/src/binding.rs
+++ b/src/binding.rs
@@ -125,6 +125,7 @@ pub fn bind(home: &Path, agent: &str, task_id: &str, branch: &str) {
         branch,
         std::path::Path::new(""),
         std::path::Path::new(""),
+        false, // #2158 GR1: internal convenience bind — not a self-claim, no notify
     ) {
         tracing::warn!(%agent, task_id, branch, error = %e, "bind failed (fail-closed)");
     }
@@ -153,6 +154,11 @@ pub fn bind_full(
     branch: &str,
     worktree: &std::path::Path,
     source_repo: &std::path::Path,
+    // #2158 GR1: true ⟺ an AGENT SELF-CLAIM (`bind_self` / `repo checkout bind:true`),
+    // which surfaces to the operator. Dispatch / internal binds pass false. Keyed on
+    // the caller's EXPLICIT intent, NOT on task_id — a single-target auto-create
+    // `send kind=task` legitimately binds with task_id="" and must NOT false-notify.
+    is_self_claim: bool,
 ) -> Result<(), String> {
     // #1888 phase-2: the agent claiming a branch is acting on any pending
     // ci-handoff for it — resolve the track (re-nudge stops). Scoped to this
@@ -273,21 +279,16 @@ pub fn bind_full(
                 crate::event_log::caller_process_context()
             ),
         );
-        // #2158 GR1: a binding CREATE/CHANGE with NO task_id is OUT-OF-DISPATCH (a
-        // self-claim `repo checkout bind:true` or a `bind_self` without a task) —
-        // exactly the first-bind-hijack / accidental-sub-agent vector guard-b cannot
-        // prevent (identity-indistinguishable). Surface it to the operator, ONCE per
-        // (agent, branch), so an unexpected rebind is NOTICED. The daemon dispatch
-        // path always carries a task_id, so normal delegation is unaffected.
-        if task_id.is_empty() {
-            notify_operator_out_of_dispatch_bind(
-                home,
-                agent,
-                branch,
-                &wt_str,
-                prev_branch.as_deref(),
-            );
-        }
+    }
+    // #2158 GR1: notify the operator on an AGENT SELF-CLAIM (`bind_self` /
+    // `repo checkout bind:true`) — the first-bind-hijack / accidental-sub-agent vector
+    // guard-b cannot prevent (identity-indistinguishable). NOT gated on `changed`: the
+    // dispatch flow double-binds (lease then re-bind), so a self-claim's intent-bind is
+    // frequently a no-op (changed=false); the per-(agent,branch) sidecar in the helper
+    // gives fire-once. Keyed on the caller's explicit `is_self_claim`, NOT task_id — a
+    // single-target auto-create dispatch legitimately binds with task_id="".
+    if is_self_claim {
+        notify_operator_out_of_dispatch_bind(home, agent, branch, &wt_str, prev_branch.as_deref());
     }
     Ok(())
 }
@@ -1186,6 +1187,7 @@ mod tests {
             "branch",
             std::path::Path::new(""),
             std::path::Path::new(""),
+            false,
         );
         assert!(
             result.is_err(),
@@ -1293,9 +1295,9 @@ mod tests {
         std::fs::create_dir_all(&wt).unwrap(); // LIVE worktree on disk
         let src = home.join("src");
         std::fs::create_dir_all(&src).unwrap();
-        bind_full(&home, "agentA", "", "feat/x", &wt, &src).expect("first bind ok");
+        bind_full(&home, "agentA", "", "feat/x", &wt, &src, false).expect("first bind ok");
 
-        let err = bind_full(&home, "agentA", "", "feat/y", &wt, &src)
+        let err = bind_full(&home, "agentA", "", "feat/y", &wt, &src, false)
             .expect_err("cross-branch rebind of a live binding must be rejected");
         assert!(
             err.contains("#2158") && err.contains("release_worktree first"),
@@ -1320,8 +1322,8 @@ mod tests {
         std::fs::create_dir_all(&wt).unwrap();
         let src = home.join("src");
         std::fs::create_dir_all(&src).unwrap();
-        bind_full(&home, "ag", "", "feat/x", &wt, &src).expect("first-bind allowed");
-        bind_full(&home, "ag", "", "feat/x", &wt, &src).expect("same-branch reuse allowed");
+        bind_full(&home, "ag", "", "feat/x", &wt, &src, false).expect("first-bind allowed");
+        bind_full(&home, "ag", "", "feat/x", &wt, &src, false).expect("same-branch reuse allowed");
         std::fs::remove_dir_all(&home).ok();
     }
 
@@ -1333,8 +1335,8 @@ mod tests {
         let dead = home.join("wt-gone"); // NOT created → not live
         let src = home.join("src");
         std::fs::create_dir_all(&src).unwrap();
-        bind_full(&home, "ag", "", "feat/x", &dead, &src).expect("first bind ok");
-        bind_full(&home, "ag", "", "feat/y", &dead, &src)
+        bind_full(&home, "ag", "", "feat/x", &dead, &src, false).expect("first bind ok");
+        bind_full(&home, "ag", "", "feat/y", &dead, &src, false)
             .expect("rebind allowed when the prior worktree is dead (stale binding)");
         assert_eq!(
             read(&home, "ag")
@@ -1354,7 +1356,7 @@ mod tests {
         std::fs::create_dir_all(&wt).unwrap();
         let src = home.join("src");
         std::fs::create_dir_all(&src).unwrap();
-        bind_full(&home, "ag", "", "feat/x", &wt, &src).expect("bind ok");
+        bind_full(&home, "ag", "", "feat/x", &wt, &src, false).expect("bind ok");
         unbind(&home, "ag");
         let log = read_event_log(&home);
         assert!(
@@ -1372,14 +1374,14 @@ mod tests {
         std::fs::remove_dir_all(&home).ok();
     }
 
-    // ── #2158 GR1: out-of-dispatch bind → operator-visible, fire-once ────────
+    // ── #2158 GR1: agent self-claim bind → operator-visible, fire-once ──────
 
-    /// An OUT-OF-DISPATCH bind (no task_id) surfaces a distinct
+    /// An AGENT SELF-CLAIM bind (`is_self_claim=true`) surfaces a distinct
     /// `binding_out_of_dispatch` marker and DEDUPS per (agent, branch): a repeated
     /// CHANGE on the SAME branch (here a new worktree path) must NOT re-surface
     /// (fire-once, no flood).
     #[test]
-    fn out_of_dispatch_bind_surfaces_once_per_branch_2158_gr1() {
+    fn self_claim_bind_surfaces_once_per_branch_2158_gr1() {
         let home = tmp_home("gr1-once");
         let wt = home.join("wt");
         std::fs::create_dir_all(&wt).unwrap();
@@ -1388,31 +1390,34 @@ mod tests {
         let src = home.join("src");
         std::fs::create_dir_all(&src).unwrap();
 
-        // first out-of-dispatch bind (no task_id) → surfaced.
-        bind_full(&home, "ag", "", "feat/x", &wt, &src).expect("first out-of-dispatch bind");
+        // first self-claim bind → surfaced.
+        bind_full(&home, "ag", "", "feat/x", &wt, &src, true).expect("first self-claim bind");
         // SAME branch, different worktree → changed=true again, but dedup suppresses.
-        bind_full(&home, "ag", "", "feat/x", &wt2, &src).expect("same-branch rebind allowed");
+        bind_full(&home, "ag", "", "feat/x", &wt2, &src, true).expect("same-branch rebind allowed");
 
         let log = read_event_log(&home);
         assert_eq!(
             log.matches("binding_out_of_dispatch").count(),
             1,
-            "out-of-dispatch bind must surface exactly once per (agent, branch): {log}"
+            "self-claim bind must surface exactly once per (agent, branch): {log}"
         );
         std::fs::remove_dir_all(&home).ok();
     }
 
-    /// A DISPATCH bind (task_id present — the normal delegation path) must NOT
-    /// surface the out-of-dispatch operator notify; only the always-on
-    /// `binding_changed` audit fires.
+    /// #2158 GR1 (r2's catch): a DISPATCH bind must NOT surface even when its task_id
+    /// is EMPTY — a single-target `send kind=task` is auto-create-exempt and binds with
+    /// task_id="" (#1050 assigns the id AFTER the bind). Keying notify on
+    /// `is_self_claim=false` (the dispatch intent), NOT task_id, avoids the false
+    /// operator alert the old task_id heuristic + non-empty-task_id test masked.
     #[test]
-    fn dispatch_bind_does_not_surface_out_of_dispatch_2158_gr1() {
+    fn empty_task_id_dispatch_does_not_surface_2158_gr1() {
         let home = tmp_home("gr1-dispatch");
         let wt = home.join("wt");
         std::fs::create_dir_all(&wt).unwrap();
         let src = home.join("src");
         std::fs::create_dir_all(&src).unwrap();
-        bind_full(&home, "ag", "T-1", "feat/x", &wt, &src).expect("dispatch bind ok");
+        // EMPTY task_id but a real dispatch (is_self_claim=false) — the masked case.
+        bind_full(&home, "ag", "", "feat/x", &wt, &src, false).expect("dispatch bind ok");
         let log = read_event_log(&home);
         assert!(
             log.contains("binding_changed"),
@@ -1420,7 +1425,7 @@ mod tests {
         );
         assert!(
             !log.contains("binding_out_of_dispatch"),
-            "a dispatch bind (task_id set) must NOT surface as out-of-dispatch: {log}"
+            "#2158 GR1: an EMPTY-task_id dispatch (is_self_claim=false) must NOT false-notify: {log}"
         );
         std::fs::remove_dir_all(&home).ok();
     }

--- a/src/daemon/auto_release.rs
+++ b/src/daemon/auto_release.rs
@@ -1675,7 +1675,7 @@ mod tests {
         done: bool,
     ) -> std::path::PathBuf {
         let lease = crate::worktree_pool::lease(home, repo, agent, branch).expect("lease");
-        crate::binding::bind_full(home, agent, task_id, branch, &lease.path, repo)
+        crate::binding::bind_full(home, agent, task_id, branch, &lease.path, repo, false)
             .expect("bind_full");
         seed_task(home, task_id, agent, branch, done);
         lease.path
@@ -1835,7 +1835,8 @@ mod tests {
             "merge",
         );
         // Re-lease the SAME agent to a new task → snapshot is now stale.
-        crate::binding::bind_full(&home, "dev", "t-c2", "feat/c", &wt, &repo).expect("rebind");
+        crate::binding::bind_full(&home, "dev", "t-c2", "feat/c", &wt, &repo, false)
+            .expect("rebind");
         drain_queue(&home);
         assert!(
             bound(&home, "dev"),

--- a/src/event_log.rs
+++ b/src/event_log.rs
@@ -45,11 +45,15 @@ fn rotate(base: &Path) {
     let _ = std::fs::rename(base, &first);
 }
 
-/// #2158 PR2: best-effort caller PROCESS context for binding / bypass audit lines
-/// — `pid`, parent `ppid`, and `cwd`. A transient sub-agent shares the primary's
-/// `instance_name` (so it can't be ATTRIBUTED to "sub-agent vs primary"), but it
-/// has its own pid/ppid/cwd — enough to trace an unexpected binding change to a
-/// process tree post-facto. ppid is unix-only (`libc::getppid`); `-1` elsewhere.
+/// #2158 PR2: best-effort PROCESS context for binding / bypass audit lines —
+/// `pid`, parent `ppid`, and `cwd`. ppid is unix-only (`libc::getppid`); `-1` else.
+///
+/// #2158 GR1 CAVEAT (verified): this captures the context of WHOEVER CALLS it. All
+/// current call sites (`bind_full`, `git_helpers`) run DAEMON-side (MCP handler →
+/// `execute_tool`), so the captured pid/ppid/cwd is the DAEMON's, NOT the calling
+/// agent's — it does NOT attribute a binding change to a caller. Even agent-side
+/// context wouldn't separate a transient Task sub-agent from the primary (they
+/// share one process). Treat these audit fields as daemon-side, not caller identity.
 pub(crate) fn caller_process_context() -> String {
     let pid = std::process::id();
     let cwd = std::env::current_dir()

--- a/src/mcp/handlers/ci/checkout.rs
+++ b/src/mcp/handlers/ci/checkout.rs
@@ -239,6 +239,7 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
                     branch,
                     &worktree_dir,
                     &source_canonical,
+                    true, // #2158 GR1: agent self-claim (repo checkout bind:true) → notify operator
                 ) {
                     // #1310: rollback worktree on binding failure to prevent orphans
                     tracing::warn!(

--- a/src/mcp/handlers/ci/checkout.rs
+++ b/src/mcp/handlers/ci/checkout.rs
@@ -257,29 +257,16 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
                         "branch": branch,
                     });
                 }
-                if let Some(r) = crate::mcp::handlers::dispatch_hook::derive_repo_from_remote_pub(
-                    &source_canonical,
-                ) {
-                    // t-ci-ready-pr2-drop-derive-reviewer (operator-approved B): the
-                    // #1040/#1037 `<team>-reviewer` auto-derive was REMOVED from the
-                    // dev-self-claim path too (consistent decouple with the dispatch
-                    // side). A self-claimed `repo action=checkout bind=true` now arms
-                    // the watch with NO chain target → on CI pass the dev (a
-                    // subscriber) gets the informational `[ci-pass]`; chaining the
-                    // actionable `[ci-ready-for-action]` to a reviewer requires an
-                    // EXPLICIT `next_after_ci` (review handoff is now explicit, not a
-                    // silent naming-convention auto-handoff).
-                    let watch_args = json!({"repository": &r, "branch": branch});
-                    let watch_resp = super::handle_watch_ci(home, &watch_args, instance_name);
-                    if let Some(err_msg) = watch_resp.get("error").and_then(|v| v.as_str()) {
-                        let code = watch_resp
-                            .get("code")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("unknown");
-                        warnings.push(format!("watch_ci: {err_msg} (code={code})"));
-                    }
-                }
+                // #2158 GR1 (operator-approved): a self-claimed `repo action=checkout
+                // bind=true` no longer SILENTLY arms a ci_watch. The silent auto-arm
+                // was part of the #2158 incident blast — a transient sub-agent (sharing
+                // the primary's identity) self-claiming a worktree also armed a watch
+                // the operator never asked for. The daemon's DISPATCH path
+                // (`dispatch_hook`) is a SEPARATE code path and STILL arms ci_watch for
+                // normal task delegation — it is untouched. A self-claiming agent that
+                // wants CI notifications must now arm it explicitly via `ci action=watch`.
                 resp["bound"] = json!(true);
+                resp["ci_watch_armed"] = json!(false);
                 resp["auto_created_branch"] = json!(auto_created_branch);
                 resp["fetch_attempted"] = json!(fetch_attempted);
             }

--- a/src/mcp/handlers/ci/checkout.rs
+++ b/src/mcp/handlers/ci/checkout.rs
@@ -259,14 +259,14 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
                 }
                 // #2158 GR1 (operator-approved): a self-claimed `repo action=checkout
                 // bind=true` no longer SILENTLY arms a ci_watch — neither here (this
-                // inline arm is removed) NOR via the shared dispatch_hook path (the
-                // companion `bind_self` self-claim reached `handle_watch_ci` there with
-                // task_id="" — now gated on a non-empty task_id). The silent auto-arm was
-                // part of the #2158 incident blast: a transient sub-agent (sharing the
-                // primary's identity) self-claiming a worktree also armed a watch the
-                // operator never asked for. The daemon DISPATCH path (which always carries
-                // a task_id) STILL arms for normal task delegation. A self-claiming agent
-                // that wants CI notifications must arm explicitly via `ci action=watch`.
+                // inline arm is removed) NOR via the shared dispatch_hook path
+                // (`bind_self` self-claims pass `arm_ci_watch=false`). The silent
+                // auto-arm was part of the #2158 incident blast: a transient sub-agent
+                // (sharing the primary's identity) self-claiming a worktree also armed a
+                // watch the operator never asked for. The daemon DISPATCH path passes
+                // `arm_ci_watch=true` and STILL arms for normal delegation. A
+                // self-claiming agent that wants CI notifications arms it explicitly via
+                // `ci action=watch`.
                 resp["bound"] = json!(true);
                 resp["ci_watch_armed"] = json!(false);
                 resp["auto_created_branch"] = json!(auto_created_branch);

--- a/src/mcp/handlers/ci/checkout.rs
+++ b/src/mcp/handlers/ci/checkout.rs
@@ -258,13 +258,15 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
                     });
                 }
                 // #2158 GR1 (operator-approved): a self-claimed `repo action=checkout
-                // bind=true` no longer SILENTLY arms a ci_watch. The silent auto-arm
-                // was part of the #2158 incident blast — a transient sub-agent (sharing
-                // the primary's identity) self-claiming a worktree also armed a watch
-                // the operator never asked for. The daemon's DISPATCH path
-                // (`dispatch_hook`) is a SEPARATE code path and STILL arms ci_watch for
-                // normal task delegation — it is untouched. A self-claiming agent that
-                // wants CI notifications must now arm it explicitly via `ci action=watch`.
+                // bind=true` no longer SILENTLY arms a ci_watch — neither here (this
+                // inline arm is removed) NOR via the shared dispatch_hook path (the
+                // companion `bind_self` self-claim reached `handle_watch_ci` there with
+                // task_id="" — now gated on a non-empty task_id). The silent auto-arm was
+                // part of the #2158 incident blast: a transient sub-agent (sharing the
+                // primary's identity) self-claiming a worktree also armed a watch the
+                // operator never asked for. The daemon DISPATCH path (which always carries
+                // a task_id) STILL arms for normal task delegation. A self-claiming agent
+                // that wants CI notifications must arm explicitly via `ci action=watch`.
                 resp["bound"] = json!(true);
                 resp["ci_watch_armed"] = json!(false);
                 resp["auto_created_branch"] = json!(auto_created_branch);

--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -727,72 +727,18 @@ fn p778_setup_source_repo(parent: &Path, branch: &str) -> std::path::PathBuf {
     repo
 }
 
-#[test]
-#[cfg(unix)]
-fn checkout_bind_true_no_longer_auto_derives_next_after_ci_pr2() {
-    // t-ci-ready-pr2-drop-derive-reviewer (operator-approved B): the #1040/#1037
-    // `<team>-reviewer` auto-derive was REMOVED from the dev-self-claim checkout
-    // path too (consistent decouple with the dispatch side). A self-claimed
-    // `repo action=checkout bind=true` now arms the watch with `next_after_ci`
-    // UNSET → on CI pass the dev (a subscriber) gets the informational `[ci-pass]`;
-    // the actionable `[ci-ready-for-action]` review handoff is now EXPLICIT
-    // (lead dispatches the reviewer, or an explicit `next_after_ci`), not a silent
-    // naming-convention auto-handoff.
-    let home = p778_tmp_home("1040-derive");
-    let parent = p778_tmp_home("1040-derive-src");
-    let source = p778_setup_source_repo(&parent, "feat/1040-derive");
-    let agent = "val-dev";
-
-    // Seed fleet.yaml with team `val` containing `val-dev` + `val-reviewer`.
-    // The auto-derive scans the target's team for a `*-reviewer` member.
-    let yaml = format!(
-        "instances: {{}}\nteams:\n  val:\n    members:\n      - val-dev\n      - val-reviewer\n    source_repo: {}\n",
-        source.display()
-    );
-    std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).unwrap();
-
-    let resp = super::handle_checkout_repo(
-        &home,
-        &serde_json::json!({
-            "repository_path": source.display().to_string(),
-            "branch": "feat/1040-derive",
-            "bind": true,
-        }),
-        agent,
-    );
-    assert!(resp.get("error").is_none(), "checkout must succeed: {resp}");
-
-    let watch_path = crate::daemon::ci_watch::ci_watches_dir(&home).join(
-        crate::daemon::ci_watch::watch_filename("owner/repo", "feat/1040-derive"),
-    );
-    assert!(watch_path.exists(), "ci-watch sidecar must be armed");
-
-    let watch: serde_json::Value =
-        serde_json::from_str(&std::fs::read_to_string(&watch_path).expect("read watch"))
-            .expect("parse watch");
-    assert!(
-        watch["next_after_ci"].as_str().is_none(),
-        "PR-2: checkout-bound watch must NOT auto-derive next_after_ci from the \
-         `<team>-reviewer` convention (explicit-only now). Got: {watch}"
-    );
-    // The dev (armer) stays a subscriber → it receives [ci-pass] on CI pass.
-    let subscriber_names: Vec<&str> = watch["subscribers"]
-        .as_array()
-        .map(|a| a.iter().filter_map(|s| s["instance"].as_str()).collect())
-        .unwrap_or_default();
-    assert!(
-        subscriber_names.contains(&"val-dev"),
-        "dev (armer) must remain a subscriber (for [ci-pass]). Got: {watch}"
-    );
-
-    std::fs::remove_dir_all(&home).ok();
-    std::fs::remove_dir_all(&parent).ok();
-}
+// #2158 GR1: `checkout_bind_true_no_longer_auto_derives_next_after_ci_pr2` was
+// DELETED here — it asserted a self-claim `repo checkout bind:true` armed a watch
+// (without next_after_ci). GR1 removes that silent self-claim auto-arm entirely, so
+// the test's whole premise (a self-claim watch sidecar) no longer exists; the new
+// "no longer arms" behavior is pinned by the test just below.
 
 #[test]
 #[cfg(unix)]
-fn checkout_bind_true_writes_binding_marker_and_arms_watch() {
-    // Empirical regression-proof anchor for #778 Option 1.
+fn checkout_bind_true_writes_binding_marker_and_no_longer_arms_watch_2158_gr1() {
+    // Empirical regression-proof anchor for #778 Option 1 (bind / marker / HEAD),
+    // now ALSO pinning #2158 GR1: the dev-self-claim path NO LONGER auto-arms a
+    // ci_watch. The daemon DISPATCH path still arms (dispatch_hook tests).
     let home = p778_tmp_home("ok");
     let parent = p778_tmp_home("ok-src-parent");
     let source = p778_setup_source_repo(&parent, "feat/p778");
@@ -835,13 +781,19 @@ fn checkout_bind_true_writes_binding_marker_and_arms_watch() {
         "atomic bind must record empty task_id (no sentinel)"
     );
 
-    // Auto-watch_ci must have been armed via derive_repo_from_remote_pub.
+    // #2158 GR1: the dev-self-claim `repo checkout bind:true` must NO LONGER
+    // auto-arm ci_watch — no sidecar for the derived repo+branch.
     let watch_path = crate::daemon::ci_watch::ci_watches_dir(&home).join(
         crate::daemon::ci_watch::watch_filename("owner/repo", "feat/p778"),
     );
     assert!(
-        watch_path.exists(),
-        "watch_ci must be armed for derived repo on bind:true"
+        !watch_path.exists(),
+        "#2158 GR1: self-claim checkout bind:true must NOT auto-arm ci_watch"
+    );
+    assert_eq!(
+        resp["ci_watch_armed"].as_bool(),
+        Some(false),
+        "self-claim checkout must report ci_watch_armed:false: {resp}"
     );
 
     // HEAD must be on the named branch (NOT detached). Verifies the
@@ -1628,15 +1580,14 @@ fn checkout_bind_true_auto_create_path_preserves_779_tail_ops() {
     assert_eq!(v["branch"].as_str(), Some("feat/p780-tail"));
     assert_eq!(v["task_id"].as_str(), Some(""));
 
-    // ci_watch arming uses derive_repo_from_remote_pub on origin URL —
-    // the fixture's `https://github.com/owner/repo.git` resolves to
-    // `owner/repo`.
+    // #2158 GR1: the self-claim path (including the auto-create branch case) no
+    // longer auto-arms ci_watch — no sidecar for the derived repo+branch.
     let watch_path = crate::daemon::ci_watch::ci_watches_dir(&home).join(
         crate::daemon::ci_watch::watch_filename("owner/repo", "feat/p780-tail"),
     );
     assert!(
-        watch_path.exists(),
-        "watch_ci must be armed on auto-create path"
+        !watch_path.exists(),
+        "#2158 GR1: self-claim auto-create path must NOT auto-arm ci_watch"
     );
 
     std::fs::remove_dir_all(&home).ok();
@@ -1798,56 +1749,11 @@ fn handle_watch_ci_atomic_write_failure_returns_error_field() {
     std::fs::remove_dir_all(&home).ok();
 }
 
-#[test]
-#[cfg(unix)]
-fn checkout_bind_true_watch_ci_failure_surfaces_warning() {
-    // Test 2 (depends on Piece 3 hardening landed in C3): pre-create
-    // ci-watches as a regular file. handle_watch_ci's site-A hardening
-    // returns `{error, code: ci_watches_dir_create_failed}`. handle_
-    // checkout_repo captures it into `warnings: ["watch_ci: ... (code=ci_watches_dir_create_failed)"]`.
-    // `bound: true` MUST still hold (lease succeeded).
-    let home = p778_tmp_home("779p2-watch-warn");
-    let parent = p778_tmp_home("779p2-watch-warn-src");
-    let source = p778_setup_source_repo(&parent, "feat/p779p2-watch");
-    let agent = "p779p2-agent-watch-warn";
-
-    // Block ci-watches dir create by pre-creating the path as a file.
-    let ci_watches = crate::daemon::ci_watch::ci_watches_dir(&home);
-    if let Some(p) = ci_watches.parent() {
-        std::fs::create_dir_all(p).ok();
-    }
-    std::fs::write(&ci_watches, "blocking file (not a dir)").unwrap();
-
-    let resp = super::handle_checkout_repo(
-        &home,
-        &serde_json::json!({
-            "repository_path": source.display().to_string(),
-            "branch": "feat/p779p2-watch",
-            "bind": true,
-        }),
-        agent,
-    );
-
-    assert_eq!(
-        resp["bound"].as_bool(),
-        Some(true),
-        "lease success → bound=true must hold despite watch_ci failure: {resp}"
-    );
-    let warnings = resp["warnings"]
-        .as_array()
-        .expect("warnings array must be present when watch_ci failed");
-    let watch_warning = warnings
-        .iter()
-        .find_map(|w| w.as_str().filter(|s| s.starts_with("watch_ci:")))
-        .expect("warnings must contain a `watch_ci:` prefix entry");
-    assert!(
-        watch_warning.contains("code=ci_watches_dir_create_failed"),
-        "watch_ci warning must surface the canonical code: {watch_warning}"
-    );
-
-    std::fs::remove_dir_all(&home).ok();
-    std::fs::remove_dir_all(&parent).ok();
-}
+// #2158 GR1: `checkout_bind_true_watch_ci_failure_surfaces_warning` was DELETED
+// here — it injected a ci-watches-dir failure and asserted the self-claim checkout
+// surfaced a `watch_ci:` warning. GR1 removes the self-claim watch auto-arm entirely,
+// so there is no watch_ci call to fail and no such warning. (The dispatch path's
+// watch-arm error handling is covered by dispatch_hook's `auto_watch_arm_error` test.)
 
 #[test]
 #[cfg(unix)]

--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -795,6 +795,14 @@ fn checkout_bind_true_writes_binding_marker_and_no_longer_arms_watch_2158_gr1() 
         Some(false),
         "self-claim checkout must report ci_watch_armed:false: {resp}"
     );
+    // #2158 GR1: a self-claim `repo checkout bind:true` MUST notify the operator
+    // (it passes is_self_claim=true to bind_full).
+    assert!(
+        std::fs::read_to_string(home.join("event-log.jsonl"))
+            .unwrap_or_default()
+            .contains("binding_out_of_dispatch"),
+        "#2158 GR1: self-claim checkout bind:true must notify the operator"
+    );
 
     // HEAD must be on the named branch (NOT detached). Verifies the
     // `--detach` omission for bind:true so subsequent commits land

--- a/src/mcp/handlers/dispatch_hook/auto_watch.rs
+++ b/src/mcp/handlers/dispatch_hook/auto_watch.rs
@@ -1,0 +1,60 @@
+//! #2158 GR1: the dispatch-time ci-watch auto-arm, split out of `dispatch_hook/mod.rs`.
+//!
+//! Two reasons for the extraction: (1) keep `mod.rs` under its file-size ceiling, and
+//! (2) make arming a clean unit reached ONLY when the caller passed an explicit
+//! `arm_ci_watch=true` (a real dispatch). Out-of-dispatch self-claims — `bind_self`
+//! provisioning — pass `arm_ci_watch=false` and never call this, so they no longer
+//! silently arm a watch the operator never asked for (the #2158 GR1 fix). The intent
+//! is the caller's explicit bool, NOT `task_id` presence: a single-target
+//! `send kind=task` (auto-create-exempt) legitimately reaches dispatch with an empty
+//! task_id and MUST still arm.
+
+use serde_json::json;
+use std::path::Path;
+
+/// Arm the dispatch ci-watch for `target` on `repo`+`branch`. Best-effort: a failed
+/// arm is logged (never fatal — the dispatch + lease already succeeded).
+pub(super) fn arm(
+    home: &Path,
+    target: &str,
+    repo: &str,
+    branch: &str,
+    next_after_ci: Option<&str>,
+    review_class: Option<&str>,
+    task_id: &str,
+) {
+    // #931 Fix 2 (H5a): propagate the dispatcher's `next_after_ci` chain target into
+    // the watch so the poll loop fires `[ci-ready-for-action]` to it on CI pass.
+    // Explicit-only since t-ci-ready-pr2 dropped the #1037 `<team>-reviewer`
+    // name-derive; unset → no chain target (subscribers still get the informational
+    // `[ci-pass]`, #1796).
+    let effective_next = next_after_ci.filter(|s| !s.is_empty()).map(String::from);
+    let mut watch_args = json!({"repository": repo, "branch": branch});
+    if let Some(ref next) = effective_next {
+        watch_args["next_after_ci"] = json!(next);
+    }
+    // #1031: persist the dispatch task_id so the ci_check_repo emit can back-link the
+    // `[ci-ready-for-action]` event to the originating dispatch (verdict correlation).
+    if !task_id.is_empty() {
+        watch_args["task_id"] = json!(task_id);
+    }
+    // #1877: a `second_reviewer=true` dispatch arms `review_class=dual` (poller enforces).
+    if let Some(rc) = review_class.filter(|s| !s.is_empty()) {
+        watch_args["review_class"] = json!(rc);
+    }
+    let watch_result = crate::mcp::handlers::ci::handle_watch_ci(home, &watch_args, target);
+    // #1750 A1: surface a failed arm as an error log, not a false success.
+    if let Some((code, err)) = super::auto_watch_arm_error(&watch_result) {
+        tracing::error!(
+            %target, repo, %branch, code, error = %err,
+            "dispatch auto-watch_ci FAILED — no CI watch armed (ci-ready will not fire)"
+        );
+    } else {
+        tracing::info!(
+            %target, repo, %branch,
+            next_after_ci = ?effective_next,
+            explicit = next_after_ci.is_some(),
+            "dispatch auto-watch_ci"
+        );
+    }
+}

--- a/src/mcp/handlers/dispatch_hook/mod.rs
+++ b/src/mcp/handlers/dispatch_hook/mod.rs
@@ -5,6 +5,7 @@
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
+mod auto_watch;
 mod from_ref;
 pub(crate) use from_ref::resolve_from_ref_remote; // CR-2026-06-14 extraction
 
@@ -232,6 +233,7 @@ pub(crate) fn dispatch_auto_bind_lease(
 ) -> Result<DispatchOutcome, DispatchError> {
     dispatch_auto_bind_lease_with_source_and_chain(
         home, target, task_id, branch, repo, None, None, None,
+        true, // #2158 GR1: dispatch entry → arm ci-watch
     )
 }
 
@@ -275,6 +277,7 @@ pub(crate) fn dispatch_auto_bind_lease_with_chain(
         None,
         next_after_ci,
         review_class,
+        true, // #2158 GR1: dispatch entry (delegate/comms) → arm ci-watch
     )
 }
 
@@ -288,6 +291,11 @@ pub(crate) fn dispatch_auto_bind_lease_with_chain(
 /// Option 1 atomic fresh provision). Both share this dispatch path —
 /// caller chooses entry based on whether the caller already knows the
 /// source repo (bind:true) or relies on fleet.yaml resolution (bind_self).
+///
+/// #2158 GR1: passes `arm_ci_watch=false` — a `bind_self` self-provision NEVER
+/// silently arms a ci-watch (the agent arms `ci action=watch` explicitly if it
+/// wants CI notifications). The dispatch wrappers (`_with_chain` / the bare entry)
+/// pass `true`.
 ///
 /// #781 Piece 7: returns structured [`DispatchOutcome`] / [`DispatchError`].
 /// C2 commit performs the signature migration mechanically — `source_repo_tier`,
@@ -310,6 +318,7 @@ pub(crate) fn dispatch_auto_bind_lease_with_source(
         source_repo_override,
         None,
         None,
+        false, // #2158 GR1: bind_self self-claim → do NOT silently arm ci-watch
     )
 }
 
@@ -349,6 +358,11 @@ pub(crate) fn dispatch_auto_bind_lease_with_source_and_chain(
     // the MCP boundary (comms.rs) silently evaporates and CI gates single review.
     // 4th re-marshal-drop of an MCP-accepted dispatch directive.
     review_class: Option<&str>,
+    // #2158 GR1: explicit "this is a real dispatch, arm the ci-watch" intent — true
+    // for the delegate/dispatch wrappers, false for `bind_self` self-claims. NOT keyed
+    // on task_id, which a single-target auto-create `send kind=task` legitimately leaves
+    // empty (the arm must still fire for it).
+    arm_ci_watch: bool,
 ) -> Result<DispatchOutcome, DispatchError> {
     let _guard = BindGuard::try_acquire(home, target).map_err(|msg| DispatchError {
         message: msg,
@@ -562,74 +576,21 @@ pub(crate) fn dispatch_auto_bind_lease_with_source_and_chain(
                 .and_then(|s| canonicalize_repo_slug(&s))
         })
         .or_else(|| derive_repo_from_remote(&source_repo));
-    // #2158 GR1: ONLY a real DISPATCH auto-arms ci_watch. A dispatch always carries a
-    // task_id (send kind=task rejects an empty one — comms_gates/anti_stall.rs), so
-    // gating the arm on a non-empty task_id arms every legit dispatch while skipping
-    // OUT-OF-DISPATCH self-claims that reach here with task_id="" — namely `bind_self`
-    // without a task. This is the SECOND silent-arm path (the first, checkout.rs's
-    // inline arm, was removed); both were the #2158 silent-arm blast. Same task_id
-    // gate as the out-of-dispatch operator-notify in `bind_full`. The bind/lease above
-    // is unaffected — only the convenience auto-watch is gated.
-    if let Some(r) = resolved_repo.filter(|_| !task_id.is_empty()) {
-        // #931 Fix 2 (H5a): when the dispatcher declared a workflow chain
-        // via `next_after_ci` (e.g. lead → dev with reviewer as the next
-        // step), propagate it into the auto-armed watch so the daemon's
-        // poll loop fires `[ci-ready-for-action]` to the chain target on
-        // CI pass. Pre-#931 callers had to issue a follow-up
-        // `ci action=watch next_after_ci=…` manually — easily forgotten
-        // and one of the root causes of the 4-in-a-row PR stalls.
-        //
-        // t-ci-ready-pr2-drop-derive-reviewer (operator-approved B): the #1037
-        // `<team>-reviewer` name-derived auto-default was REMOVED — it baked the
-        // `-reviewer` naming convention into the daemon and only worked for teams
-        // that follow it. `next_after_ci` is now explicit-only: unset → the watch
-        // arms with no chain target, and on CI pass the dev/subscribers receive
-        // the informational `[ci-pass]` (PR-1 #1796); routing the actionable
-        // `[ci-ready-for-action]` to a reviewer requires an EXPLICIT
-        // `next_after_ci` (lead dispatches the reviewer, or passes it). Role-based
-        // auto-handoff is a future follow-up (needs role infra).
-        let effective_next = next_after_ci.filter(|s| !s.is_empty()).map(String::from);
-        let mut watch_args = serde_json::json!({"repository": &r, "branch": branch});
-        if let Some(ref next) = effective_next {
-            watch_args["next_after_ci"] = serde_json::json!(next);
-        }
-        // #1031: persist the dispatch task_id alongside the watch so
-        // the ci_check_repo emit site can back-link the
-        // `[ci-ready-for-action]` event to the originating dispatch.
-        // Reviewer's verdict report can then echo this task_id in
-        // its correlation_id, closing the [[feedback-dispatch-task-id-mirror]]
-        // false-positive class on the verdict-reply side.
-        if !task_id.is_empty() {
-            watch_args["task_id"] = serde_json::json!(task_id);
-        }
-        // #1877: propagate the dual-review directive so a `second_reviewer=true`
-        // dispatch arms a `review_class=dual` watch (handle_watch_ci → ci/mod.rs
-        // stores it; the poller's `record_ci_result` then enforces dual review).
-        // Unset (normal dispatch) leaves the watch single — no over-upgrade.
-        if let Some(rc) = review_class.filter(|s| !s.is_empty()) {
-            watch_args["review_class"] = serde_json::json!(rc);
-        }
-        let watch_result = crate::mcp::handlers::ci::handle_watch_ci(home, &watch_args, target);
-        // #1750 A1: `handle_watch_ci` returns `{"error":..,"code":..}` on a failed
-        // arm (watch_write_failed / ci_watches_dir_create_failed / binding-stale).
-        // Previously this Result was discarded and the success log fired
-        // unconditionally — a silently-failed arm left no trace, the surface
-        // behind "CI green but no watch armed, ci-ready never fires". Surface the
-        // failure as an error log instead of a false success (the dispatch itself
-        // still proceeds — auto-watch is best-effort convenience, not a gate).
-        if let Some((code, err)) = auto_watch_arm_error(&watch_result) {
-            tracing::error!(
-                %target, repo = %r, %branch, code, error = %err,
-                "dispatch auto-watch_ci FAILED — no CI watch armed (ci-ready will not fire)"
-            );
-        } else {
-            tracing::info!(
-                %target,
-                repo = %r,
-                %branch,
-                next_after_ci = ?effective_next,
-                explicit = next_after_ci.is_some(),
-                "dispatch auto-watch_ci"
+    // #2158 GR1: auto-arm the dispatch ci-watch ONLY on an explicit dispatch intent
+    // (`arm_ci_watch`), NOT on task_id presence — a single-target `send kind=task`
+    // (auto-create-exempt) reaches here with task_id="" and MUST still arm. bind_self
+    // self-claims pass `arm_ci_watch=false` and skip the silent arm (#2158 GR1). The
+    // arming body lives in `auto_watch.rs` (file-size split).
+    if arm_ci_watch {
+        if let Some(r) = resolved_repo {
+            auto_watch::arm(
+                home,
+                target,
+                &r,
+                branch,
+                next_after_ci,
+                review_class,
+                task_id,
             );
         }
     }

--- a/src/mcp/handlers/dispatch_hook/mod.rs
+++ b/src/mcp/handlers/dispatch_hook/mod.rs
@@ -562,7 +562,15 @@ pub(crate) fn dispatch_auto_bind_lease_with_source_and_chain(
                 .and_then(|s| canonicalize_repo_slug(&s))
         })
         .or_else(|| derive_repo_from_remote(&source_repo));
-    if let Some(r) = resolved_repo {
+    // #2158 GR1: ONLY a real DISPATCH auto-arms ci_watch. A dispatch always carries a
+    // task_id (send kind=task rejects an empty one — comms_gates/anti_stall.rs), so
+    // gating the arm on a non-empty task_id arms every legit dispatch while skipping
+    // OUT-OF-DISPATCH self-claims that reach here with task_id="" — namely `bind_self`
+    // without a task. This is the SECOND silent-arm path (the first, checkout.rs's
+    // inline arm, was removed); both were the #2158 silent-arm blast. Same task_id
+    // gate as the out-of-dispatch operator-notify in `bind_full`. The bind/lease above
+    // is unaffected — only the convenience auto-watch is gated.
+    if let Some(r) = resolved_repo.filter(|_| !task_id.is_empty()) {
         // #931 Fix 2 (H5a): when the dispatcher declared a workflow chain
         // via `next_after_ci` (e.g. lead → dev with reviewer as the next
         // step), propagate it into the auto-armed watch so the daemon's

--- a/src/mcp/handlers/dispatch_hook/mod.rs
+++ b/src/mcp/handlers/dispatch_hook/mod.rs
@@ -520,7 +520,18 @@ pub(crate) fn dispatch_auto_bind_lease_with_source_and_chain(
 
     // Bind with worktree + source-repo paths. Bind file write error stays graceful (Q1).
     // #779 P2: bind_full returns Result; preserves pre-#779-P2 silent semantic.
-    match crate::binding::bind_full(home, target, task_id, branch, &wt_path, &source_repo) {
+    // #2158 GR1: the only `arm_ci_watch=false` path through this sink is `bind_self`
+    // (an agent self-claim → operator notify); dispatch wrappers pass true. So
+    // self-claim ⟺ !arm_ci_watch — reuse the dispatch-intent, no task_id heuristic.
+    match crate::binding::bind_full(
+        home,
+        target,
+        task_id,
+        branch,
+        &wt_path,
+        &source_repo,
+        !arm_ci_watch,
+    ) {
         Ok(()) => tracing::info!(
             %target, %branch, path = %wt_path.display(),
             "dispatch auto-bind OK"

--- a/src/mcp/handlers/dispatch_hook/tests.rs
+++ b/src/mcp/handlers/dispatch_hook/tests.rs
@@ -1590,16 +1590,14 @@ fn dispatch_auto_bind_lease_sets_next_after_ci_from_dispatch_hook_931() {
     std::fs::remove_dir_all(&parent).ok();
 }
 
-/// #2158 GR1: the auto-watch arm is gated on a non-empty task_id. An OUT-OF-DISPATCH
-/// self-claim — `bind_self` reaches `dispatch_auto_bind_lease_with_source` with
-/// task_id="" — must NOT arm a ci_watch (the second silent-arm path r4 caught; the
-/// first, checkout.rs's inline arm, was already removed). A REAL dispatch always
-/// carries a task_id (send kind=task rejects an empty one) → STILL arms — proving the
-/// gate doesn't kill legit dispatch arming (companion to the existing #931/#1877 arm
-/// tests).
+/// #2158 GR1: the dispatch ci-watch auto-arm is gated on the caller's EXPLICIT
+/// `arm_ci_watch` intent, NOT on task_id presence (r6's catch: a single-target
+/// `send kind=task` is auto-create-exempt and reaches dispatch with task_id=""). The
+/// wrappers encode the intent: `_with_source` (bind_self) → false; `_with_chain`
+/// (delegate/dispatch) → true.
 #[test]
 #[cfg(unix)]
-fn out_of_dispatch_bind_self_does_not_arm_watch_but_dispatch_does_2158_gr1() {
+fn arm_ci_watch_gated_on_dispatch_intent_not_task_id_2158_gr1() {
     let mk_parent = |tag: &str| {
         std::env::temp_dir().join(format!(
             "agend-2158-gr1-{tag}-{}-{}",
@@ -1610,59 +1608,83 @@ fn out_of_dispatch_bind_self_does_not_arm_watch_but_dispatch_does_2158_gr1() {
                 .as_nanos()
         ))
     };
+    let watch_for = |home: &std::path::Path, branch: &str| {
+        crate::daemon::ci_watch::ci_watches_dir(home).join(crate::daemon::ci_watch::watch_filename(
+            "owner/repo",
+            branch,
+        ))
+    };
 
-    // (a) OUT-OF-DISPATCH: bind_self path with task_id="" → bind succeeds, NO arm.
-    let parent_a = mk_parent("noarm");
-    let (home_a, _c) = p781_canonical_with_team_source_repo(
-        &parent_a,
-        "feat/gr1-noarm",
-        true,
-        "val",
-        &["val-dev"],
-    );
+    // (a) bind_self self-claim (`_with_source`) → NO arm, even WITH a task_id
+    //     (self-provision must never silently arm).
+    let parent_a = mk_parent("bindself");
+    let (home_a, _c) =
+        p781_canonical_with_team_source_repo(&parent_a, "feat/gr1-bs", true, "val", &["val-dev"]);
     let r = super::dispatch_auto_bind_lease_with_source(
         &home_a,
         "val-dev",
-        "", // out-of-dispatch
-        "feat/gr1-noarm",
+        "T-has-task",
+        "feat/gr1-bs",
         None,
         None,
     );
+    assert!(r.is_ok(), "bind_self bind must succeed: {:?}", r.err());
     assert!(
-        r.is_ok(),
-        "out-of-dispatch bind must still succeed (bind/lease unaffected): {:?}",
-        r.err()
-    );
-    let watch_a = crate::daemon::ci_watch::ci_watches_dir(&home_a).join(
-        crate::daemon::ci_watch::watch_filename("owner/repo", "feat/gr1-noarm"),
-    );
-    assert!(
-        !watch_a.exists(),
-        "#2158 GR1: out-of-dispatch self-claim (task_id=\"\") must NOT arm ci_watch"
+        !watch_for(&home_a, "feat/gr1-bs").exists(),
+        "#2158 GR1: bind_self self-claim must NOT auto-arm ci_watch"
     );
     std::fs::remove_dir_all(&parent_a).ok();
 
-    // (b) REAL DISPATCH: same path, non-empty task_id → STILL arms.
-    let parent_b = mk_parent("arm");
+    // (b) dispatch (`_with_chain`) WITH a task_id → arms.
+    let parent_b = mk_parent("disp-tid");
     let (home_b, _c) =
-        p781_canonical_with_team_source_repo(&parent_b, "feat/gr1-arm", true, "val", &["val-dev"]);
-    let r2 = super::dispatch_auto_bind_lease_with_source(
+        p781_canonical_with_team_source_repo(&parent_b, "feat/gr1-tid", true, "val", &["val-dev"]);
+    let r2 = super::dispatch_auto_bind_lease_with_chain(
         &home_b,
         "val-dev",
-        "T-gr1-arm", // real dispatch
-        "feat/gr1-arm",
+        "T-gr1",
+        "feat/gr1-tid",
+        None,
         None,
         None,
     );
     assert!(r2.is_ok(), "dispatch bind must succeed: {:?}", r2.err());
-    let watch_b = crate::daemon::ci_watch::ci_watches_dir(&home_b).join(
-        crate::daemon::ci_watch::watch_filename("owner/repo", "feat/gr1-arm"),
-    );
     assert!(
-        watch_b.exists(),
-        "a real dispatch (task_id set) must STILL arm ci_watch (gate must not kill legit arming)"
+        watch_for(&home_b, "feat/gr1-tid").exists(),
+        "a dispatch with a task_id must arm ci_watch"
     );
     std::fs::remove_dir_all(&parent_b).ok();
+
+    // (c) r6's REGRESSION: dispatch (`_with_chain`) OMITTING the task_id — a
+    //     single-target `send kind=task` is auto-create-exempt and reaches dispatch
+    //     with task_id="" → must STILL arm (the task_id heuristic wrongly skipped this).
+    let parent_c = mk_parent("disp-notid");
+    let (home_c, _c) = p781_canonical_with_team_source_repo(
+        &parent_c,
+        "feat/gr1-notid",
+        true,
+        "val",
+        &["val-dev"],
+    );
+    let r3 = super::dispatch_auto_bind_lease_with_chain(
+        &home_c,
+        "val-dev",
+        "",
+        "feat/gr1-notid",
+        None,
+        None,
+        None,
+    );
+    assert!(
+        r3.is_ok(),
+        "dispatch (no task_id) bind must succeed: {:?}",
+        r3.err()
+    );
+    assert!(
+        watch_for(&home_c, "feat/gr1-notid").exists(),
+        "#2158 GR1: a dispatch with an EMPTY task_id (single-target auto-create) must STILL arm"
+    );
+    std::fs::remove_dir_all(&parent_c).ok();
 }
 
 /// #1877 §3.9 + regression guard: EVERY MCP-accepted dispatch directive must

--- a/src/mcp/handlers/dispatch_hook/tests.rs
+++ b/src/mcp/handlers/dispatch_hook/tests.rs
@@ -1590,6 +1590,81 @@ fn dispatch_auto_bind_lease_sets_next_after_ci_from_dispatch_hook_931() {
     std::fs::remove_dir_all(&parent).ok();
 }
 
+/// #2158 GR1: the auto-watch arm is gated on a non-empty task_id. An OUT-OF-DISPATCH
+/// self-claim — `bind_self` reaches `dispatch_auto_bind_lease_with_source` with
+/// task_id="" — must NOT arm a ci_watch (the second silent-arm path r4 caught; the
+/// first, checkout.rs's inline arm, was already removed). A REAL dispatch always
+/// carries a task_id (send kind=task rejects an empty one) → STILL arms — proving the
+/// gate doesn't kill legit dispatch arming (companion to the existing #931/#1877 arm
+/// tests).
+#[test]
+#[cfg(unix)]
+fn out_of_dispatch_bind_self_does_not_arm_watch_but_dispatch_does_2158_gr1() {
+    let mk_parent = |tag: &str| {
+        std::env::temp_dir().join(format!(
+            "agend-2158-gr1-{tag}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ))
+    };
+
+    // (a) OUT-OF-DISPATCH: bind_self path with task_id="" → bind succeeds, NO arm.
+    let parent_a = mk_parent("noarm");
+    let (home_a, _c) = p781_canonical_with_team_source_repo(
+        &parent_a,
+        "feat/gr1-noarm",
+        true,
+        "val",
+        &["val-dev"],
+    );
+    let r = super::dispatch_auto_bind_lease_with_source(
+        &home_a,
+        "val-dev",
+        "", // out-of-dispatch
+        "feat/gr1-noarm",
+        None,
+        None,
+    );
+    assert!(
+        r.is_ok(),
+        "out-of-dispatch bind must still succeed (bind/lease unaffected): {:?}",
+        r.err()
+    );
+    let watch_a = crate::daemon::ci_watch::ci_watches_dir(&home_a).join(
+        crate::daemon::ci_watch::watch_filename("owner/repo", "feat/gr1-noarm"),
+    );
+    assert!(
+        !watch_a.exists(),
+        "#2158 GR1: out-of-dispatch self-claim (task_id=\"\") must NOT arm ci_watch"
+    );
+    std::fs::remove_dir_all(&parent_a).ok();
+
+    // (b) REAL DISPATCH: same path, non-empty task_id → STILL arms.
+    let parent_b = mk_parent("arm");
+    let (home_b, _c) =
+        p781_canonical_with_team_source_repo(&parent_b, "feat/gr1-arm", true, "val", &["val-dev"]);
+    let r2 = super::dispatch_auto_bind_lease_with_source(
+        &home_b,
+        "val-dev",
+        "T-gr1-arm", // real dispatch
+        "feat/gr1-arm",
+        None,
+        None,
+    );
+    assert!(r2.is_ok(), "dispatch bind must succeed: {:?}", r2.err());
+    let watch_b = crate::daemon::ci_watch::ci_watches_dir(&home_b).join(
+        crate::daemon::ci_watch::watch_filename("owner/repo", "feat/gr1-arm"),
+    );
+    assert!(
+        watch_b.exists(),
+        "a real dispatch (task_id set) must STILL arm ci_watch (gate must not kill legit arming)"
+    );
+    std::fs::remove_dir_all(&parent_b).ok();
+}
+
 /// #1877 §3.9 + regression guard: EVERY MCP-accepted dispatch directive must
 /// reach the auto-armed watch together. This re-marshal-drop class has recurred
 /// 4× — #931 (next_after_ci), #1031 (task_id), #1877 (review_class from a

--- a/src/mcp/handlers/dispatch_hook/tests.rs
+++ b/src/mcp/handlers/dispatch_hook/tests.rs
@@ -1614,9 +1614,16 @@ fn arm_ci_watch_gated_on_dispatch_intent_not_task_id_2158_gr1() {
             branch,
         ))
     };
+    // #2158 GR1: the SAME dispatch-intent signal gates the operator NOTIFY (inverted):
+    // self-claim notifies, dispatch does not — regardless of task_id.
+    let notified = |home: &std::path::Path| {
+        std::fs::read_to_string(home.join("event-log.jsonl"))
+            .unwrap_or_default()
+            .contains("binding_out_of_dispatch")
+    };
 
     // (a) bind_self self-claim (`_with_source`) → NO arm, even WITH a task_id
-    //     (self-provision must never silently arm).
+    //     (self-provision must never silently arm) — and DOES notify the operator.
     let parent_a = mk_parent("bindself");
     let (home_a, _c) =
         p781_canonical_with_team_source_repo(&parent_a, "feat/gr1-bs", true, "val", &["val-dev"]);
@@ -1632,6 +1639,10 @@ fn arm_ci_watch_gated_on_dispatch_intent_not_task_id_2158_gr1() {
     assert!(
         !watch_for(&home_a, "feat/gr1-bs").exists(),
         "#2158 GR1: bind_self self-claim must NOT auto-arm ci_watch"
+    );
+    assert!(
+        notified(&home_a),
+        "#2158 GR1: bind_self self-claim MUST notify the operator"
     );
     std::fs::remove_dir_all(&parent_a).ok();
 
@@ -1652,6 +1663,10 @@ fn arm_ci_watch_gated_on_dispatch_intent_not_task_id_2158_gr1() {
     assert!(
         watch_for(&home_b, "feat/gr1-tid").exists(),
         "a dispatch with a task_id must arm ci_watch"
+    );
+    assert!(
+        !notified(&home_b),
+        "a dispatch (task_id set) must NOT notify the operator"
     );
     std::fs::remove_dir_all(&parent_b).ok();
 
@@ -1683,6 +1698,10 @@ fn arm_ci_watch_gated_on_dispatch_intent_not_task_id_2158_gr1() {
     assert!(
         watch_for(&home_c, "feat/gr1-notid").exists(),
         "#2158 GR1: a dispatch with an EMPTY task_id (single-target auto-create) must STILL arm"
+    );
+    assert!(
+        !notified(&home_c),
+        "#2158 GR1 (r2's catch): an EMPTY-task_id dispatch must NOT false-notify the operator"
     );
     std::fs::remove_dir_all(&parent_c).ok();
 }

--- a/src/mcp/handlers/instance_state/lifecycle/tests.rs
+++ b/src/mcp/handlers/instance_state/lifecycle/tests.rs
@@ -564,6 +564,7 @@ fn full_delete_clears_binding_and_succeeds_1879() {
         "feat/x",
         std::path::Path::new("/tmp/wt-agent-b"),
         std::path::Path::new("/tmp/repo-agent-b"),
+        false,
     )
     .expect("bind_full");
     assert!(

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -61,7 +61,10 @@ pub fn lease(
     // source_repo persistence (P0-X r1): release_full reads this back to run
     // `git worktree remove --force` from the owning repo's cwd, which
     // prevents stale registry entries that would block re-lease.
-    if let Err(e) = crate::binding::bind_full(home, agent, "", branch, &info.path, source_repo) {
+    // #2158 GR1: internal lease bind — not an agent self-claim, no operator notify.
+    if let Err(e) =
+        crate::binding::bind_full(home, agent, "", branch, &info.path, source_repo, false)
+    {
         tracing::warn!(%agent, %branch, error = %e, "lease: bind_full failed — worktree created but binding missing");
     }
 
@@ -2738,7 +2741,7 @@ mod tests {
         reverse_reconcile(&home, "devd").expect("no-op on unconverted");
 
         let ws = converted_workspace_with_commit(&home, &repo, "devd", "feat/off");
-        crate::binding::bind_full(&home, "devd", "T-1", "feat/off", &ws, &repo).ok();
+        crate::binding::bind_full(&home, "devd", "T-1", "feat/off", &ws, &repo, false).ok();
         let wt_listed = |repo: &Path| {
             crate::git_helpers::git_cmd(repo, &["worktree", "list", "--porcelain"])
                 .unwrap_or_default()


### PR DESCRIPTION
## What (operator-approved GR1, accidental-sub-agent threat model)

Implements #2158 guard-rail 1 from the dev-2 spike. The incident vector: a transient Claude Code Task **sub-agent** (sharing the primary's instance identity) silently rebinds the parent's worktree via `repo checkout bind:true` / `bind_self` AND auto-arms a ci_watch.

**Key spike finding**: the daemon **cannot** distinguish a sub-agent's MCP call from the primary's — a Task sub-agent runs in-process, sharing the primary's MCP bridge, `AGEND_INSTANCE_NAME`, connection, and PID. So a caller-identity "block non-primary" guard is infeasible. GR1 therefore **reduces blast + adds operator visibility** on top of the existing identity-INDEPENDENT state guard (guard-b), per operator's accidental-threat ruling.

## Changes

1. **Stop the silent self-claim ci_watch auto-arm** (`ci/checkout.rs`). A self-claimed `repo action=checkout bind:true` no longer arms a ci_watch; it reports `ci_watch_armed:false`. The daemon **dispatch** path (`dispatch_hook`) is a separate code path and **still arms** ci_watch for normal delegation — untouched.

2. **Operator-visible out-of-dispatch bind** (`binding.rs` `bind_full`). A binding CREATE/CHANGE with **no `task_id`** (self-claim / `bind_self` without a task) surfaces to the operator-mapped `general` agent (same `inbox::notify_agent` primitive as `canonical_auto_stash`), **once per (agent, branch)** via a dedup sidecar. The dispatch path always carries a `task_id` → unaffected. No spawn (file-based, runs under the existing binding lock).

3. **Guard-b retained** (`binding.rs:183-208` unchanged) + regression tests confirm Changes 1/2 don't weaken it.

## Caveat confirmed (the task's ⚠)

`caller_process_context()` runs **daemon-side** inside `bind_full` (MCP handler → `execute_tool`), so its `pid/ppid/cwd` is the **daemon's**, not the caller's — and an in-process sub-agent shares the primary's pid anyway. So forwarding agent context would be useless; the notify is **honest** (surfaces the event, does not claim to name the caller). The misleading `caller_process_context` doc comment is corrected.

## Tests (all 4 success-criteria)

- ① self-claim **no longer arms** ci_watch — flipped the existing real-git `checkout_bind_true_*_arms_watch` + auto-create tests to assert no sidecar + `ci_watch_armed:false`.
- ② out-of-dispatch bind **surfaces once** per (agent, branch) + **dedup** (`binding.rs` unit tests; distinct `binding_out_of_dispatch` event marker).
- ③ **guard-b regression** (existing `guard_b_*_2158` tests, unchanged guard).
- ④ **dispatch ci-watch not broken** — `dispatch_hook` tests (63) still pass (untouched path).
- 2 obsolete self-claim-watch tests deleted (`_no_longer_auto_derives_next_after_ci_pr2`, `_watch_ci_failure_surfaces_warning`) — their premise (a self-claim watch) no longer exists.

`cargo clippy --all-targets --features tray -D warnings` clean. nextest: all GR1 tests green. (Two unrelated local-only failures — a `cargo test` shared-global flake in `recovery_shadow` gone under nextest's process isolation, and a `teardown_completeness` residual that reproduces on **unmodified main** because the agend-git shim on the agent PATH writes `fleet_events.jsonl` into the test home; neither occurs in CI's clean/no-shim env.)

## Review

🔒 **DUAL review requested** (binding + operator-notify sensitive).

Task: `t-20260619031116634341-84833-5`
