### PR TITLE
fix(restart-freeze): render-first phase-(b) — defer OWNED restore spawns to background pool (#t-84833-6)

### DIFF
--- a/.github/workflows/daemon-boot-flake-gate.yml
+++ b/.github/workflows/daemon-boot-flake-gate.yml
@@ -21,6 +21,14 @@ on:
       - 'src/agent/**'
       - 'src/daemon/**'
       - 'src/bootstrap/**'
+      # #t-84833-6: app-mode (owned daemon) boot/restore lives here — render-first
+      # builds the restore layout + spawns the per-agent attach pool in run_app.
+      # An app-boot change used to escape this gate (the MSRV-in-CI gap class).
+      # NOTE: the current gated tests boot via `start --foreground` (run_core), so
+      # they do NOT yet exercise app-mode run_app restore — this expansion closes
+      # the TRIGGER gap, but a real app-restart flake test is still owed (lead).
+      - 'src/app/**'
+      - 'src/layout/**'
       - 'tests/common/harness.rs'
       - 'tests/daemon_boot_gate_filter.txt'
       - 'tests/teardown_completeness_regression.rs'

--- a/src/app/api_server.rs
+++ b/src/app/api_server.rs
@@ -99,12 +99,11 @@ pub(super) fn noop_guard() -> ApiGuard {
 pub(super) fn auto_start_fleet(
     fleet_path: &Path,
     layout: &mut Layout,
-    registry: &AgentRegistry,
     home: &Path,
     cols: u16,
     rows: u16,
-    wakeup_tx: &crossbeam_channel::Sender<usize>,
     name_counter: &mut HashMap<String, usize>,
+    attach_jobs: &mut Vec<super::pane_factory::AttachJob>,
 ) -> bool {
     let fleet = match crate::fleet::FleetConfig::load(fleet_path) {
         Ok(f) => f,
@@ -116,28 +115,24 @@ pub(super) fn auto_start_fleet(
     }
     names.sort();
 
+    // #render-first phase-(b): like the session-restore path, build cheap
+    // placeholders + collect deferred AttachJobs (no synchronous fork/exec here).
     let mut pane_builder =
         |sp: &super::session::SessionPane, layout: &mut Layout| -> Option<crate::layout::Pane> {
             let name = sp.fleet_instance_name.as_deref()?;
             let resolved = fleet.resolve_instance(name)?;
-            match super::pane_factory::create_pane_from_resolved(
+            let (pane, job) = super::pane_factory::build_deferred_agent_pane(
                 name,
                 &resolved,
                 layout,
-                registry,
                 home,
                 cols,
                 rows,
-                wakeup_tx,
                 name_counter,
                 crate::backend::SpawnMode::Resume,
-            ) {
-                Ok(pane) => Some(pane),
-                Err(e) => {
-                    tracing::error!(instance = name, error = %e, "fleet auto-start failed");
-                    None
-                }
-            }
+            );
+            attach_jobs.push(job);
+            Some(pane)
         };
 
     super::session::place_agents_team_grouped(home, &names, &mut pane_builder, layout)

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -296,6 +296,13 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
     // Pure tracing, zero behavior.
     let restore_start = std::time::Instant::now();
 
+    // #render-first phase-(b): OWNED restore collects deferred attach jobs here;
+    // the synchronous per-agent fork/exec + skills-install is replaced by
+    // background workers spawned AFTER the render loop is live (below). Attached
+    // mode leaves this empty — its remote panes attach via the bridge, a separate
+    // cheap path not subject to the restore freeze.
+    let mut attach_jobs: Vec<pane_factory::AttachJob> = Vec::new();
+
     if let Some(ref run_dir) = attached_run_dir {
         // Attached (#895 fix): tabs derive from the union of
         //   (a) daemon's `*.port` files (live agent registry — source of truth
@@ -339,9 +346,8 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
             &home,
             &fleet_path,
             &mut layout,
-            &registry,
-            &wakeup_tx,
             &mut name_counter,
+            &mut attach_jobs,
             pane_cols,
             pane_rows,
         );
@@ -381,6 +387,59 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
         attached = attached_mode,
         "restore-complete: session restore + fleet PTY spawns done"
     );
+
+    // #render-first phase-(b): all placeholders are now in the Layout. Spawn a
+    // bounded (W=3) pool of background workers to run the deferred attaches
+    // (skills + fork/exec + subscribe) and hand results back over `attach_rx`;
+    // the render loop's select! arm applies each to its pane. The render loop is
+    // entered immediately below — the operator sees the TUI shell while attaches
+    // run in the background, instead of freezing on N synchronous spawns.
+    //
+    // attach_tx is held by the main thread for the ENTIRE render-loop scope
+    // (mirrors `wakeup_tx`): a live sender keeps `attach_rx` connected, so
+    // `recv(attach_rx)` BLOCKS instead of busy-spinning once every worker exits
+    // and drops its sender clone (the #BLOCKER must-resolve).
+    let (attach_tx, attach_rx) = crossbeam_channel::unbounded::<pane_factory::AttachOutcome>();
+    // Placeholder forwarder senders, keyed by pane id, retained until the matching
+    // AttachOutcome is applied (or the pane is closed before it arrives).
+    let mut pending_fwd: HashMap<usize, crossbeam_channel::Sender<Vec<u8>>> = HashMap::new();
+    // Stored JoinHandles — joined at teardown BEFORE the registry drain so every
+    // worker-spawned child is reaped (not fire-and-forget).
+    let mut attach_workers: Vec<std::thread::JoinHandle<()>> = Vec::new();
+    if !attach_jobs.is_empty() {
+        let (job_tx, job_rx) = crossbeam_channel::unbounded::<(usize, pane_factory::AttachSpec)>();
+        const ATTACH_WORKERS: usize = 3;
+        for w in 0..ATTACH_WORKERS {
+            let job_rx = job_rx.clone();
+            let attach_tx = attach_tx.clone();
+            let registry = Arc::clone(&registry);
+            let home = home.clone();
+            let handle = std::thread::Builder::new()
+                .name(format!("attach_worker_{w}"))
+                .spawn(move || {
+                    while let Ok((pane_id, spec)) = job_rx.recv() {
+                        let outcome = pane_factory::run_attach(spec, pane_id, &registry, &home);
+                        if attach_tx.send(outcome).is_err() {
+                            break; // render loop gone
+                        }
+                    }
+                })
+                .expect("spawn attach worker");
+            attach_workers.push(handle);
+        }
+        for job in attach_jobs.drain(..) {
+            let pane_factory::AttachJob {
+                pane_id,
+                fwd_tx,
+                spec,
+            } = job;
+            pending_fwd.insert(pane_id, fwd_tx);
+            let _ = job_tx.send((pane_id, spec));
+        }
+        // Drop job_tx → workers exit once the queue drains (after each spawn or an
+        // early-abort on the shutdown flag inside run_attach).
+        drop(job_tx);
+    }
 
     // Flag to trigger resize pass after layout changes (split, close, zoom, tab switch).
     // Start true so restored split panes get correct sizes before first draw.
@@ -759,6 +818,28 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
             recv(wakeup_rx) -> _ => {
                 // Wakeup from PTY output — triggers redraw
             }
+            recv(attach_rx) -> outcome => {
+                // #render-first phase-(b): a background worker finished a deferred
+                // attach. Apply it to its placeholder pane (instance id + dump +
+                // forwarder on Ready, or a visible "failed to start" banner on
+                // Failed). If the pane was closed before the attach completed, drop
+                // the outcome. The keepalive `attach_tx` keeps this arm from
+                // busy-spinning after all workers exit.
+                if let Ok(outcome) = outcome {
+                    let pane_id = outcome.pane_id();
+                    if let Some(fwd_tx) = pending_fwd.remove(&pane_id) {
+                        if let Some(pane) = layout.find_pane_mut(pane_id) {
+                            pane_factory::apply_attach_outcome(pane, outcome, fwd_tx, &wakeup_tx);
+                        } else if let pane_factory::AttachOutcome::Ready { name, .. } = &outcome {
+                            // F1 (r4): the pane was closed while the attach was in
+                            // flight → the agent is already spawned + registered with
+                            // no host pane. Kill it so it doesn't run orphaned until
+                            // quit (fwd_tx already removed above → forwarder/rx drop).
+                            kill_agent(&home, &registry, name);
+                        }
+                    }
+                }
+            }
             recv(tui_event_rx) -> ev => {
                 if let Ok(event) = ev {
                     // #1257: handle screenshot request directly (needs terminal access).
@@ -979,7 +1060,7 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
     // same reconciliation path Owned mode uses (parameterized over agent
     // source: fleet.yaml for Owned, `runtime::list_agents_with_fallback`
     // for Attached — see #910 for the registry-truth migration).
-    app_teardown(&home, &layout, &registry, attached_mode);
+    app_teardown(&home, &layout, &registry, attached_mode, attach_workers);
 
     Ok(())
 }
@@ -1093,7 +1174,37 @@ pub(crate) fn app_shutdown_flag() -> &'static Arc<std::sync::atomic::AtomicBool>
     APP_SHUTDOWN.get_or_init(|| Arc::new(std::sync::atomic::AtomicBool::new(false)))
 }
 
-fn app_teardown(home: &Path, layout: &Layout, registry: &AgentRegistry, attached_mode: bool) {
+/// #render-first phase-(b) F2: join attach workers, but DETACH any that haven't
+/// finished by the shared `deadline` — a worker wedged mid-spawn (fork/exec /
+/// skills / subscribe) must not hang quit (that would move the restore freeze to
+/// quit). A detached worker's child, if it registered one, is reaped by the
+/// registry drain + the OS (same stance as #2311's grace→SIGKILL). Returns the
+/// number detached (wedged past the deadline).
+fn bounded_join_attach_workers(
+    handles: Vec<std::thread::JoinHandle<()>>,
+    deadline: std::time::Instant,
+) -> usize {
+    let mut detached = 0usize;
+    for h in handles {
+        while !h.is_finished() && std::time::Instant::now() < deadline {
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        }
+        if h.is_finished() {
+            let _ = h.join();
+        } else {
+            detached += 1; // past the shared deadline → detach (drop the handle)
+        }
+    }
+    detached
+}
+
+fn app_teardown(
+    home: &Path,
+    layout: &Layout,
+    registry: &AgentRegistry,
+    attached_mode: bool,
+    attach_workers: Vec<std::thread::JoinHandle<()>>,
+) {
     session::save_session(home, layout);
     if !attached_mode {
         // Sync fleet.yaml to match current state (Owned-only — daemon owns
@@ -1117,6 +1228,33 @@ fn app_teardown(home: &Path, layout: &Layout, registry: &AgentRegistry, attached
         //     steps 5/7/8 (the registry remove is already done by the drain;
         //     app mode tracks no AgentConfig map, matching its `configs: None`).
         app_shutdown_flag().store(true, std::sync::atomic::Ordering::SeqCst);
+        // #render-first phase-(b): join the background attach workers BEFORE
+        // draining the registry. The shutdown flag (just set) makes each worker
+        // early-abort un-started attaches (run_attach checks it on entry), so a
+        // holdout is at most ONE in-flight spawn per worker. Joining first means
+        // every child a worker DID register is in the registry → the parallel
+        // terminate below reaps it.
+        //
+        // F2 (r4/r6): the join is BOUNDED — a worker wedged mid-spawn (fork/exec /
+        // skills / subscribe) must not move the restore freeze to quit. Poll up to
+        // a shared grace deadline (slightly longer than #2311's 2s SHUTDOWN_GRACE);
+        // past it, DETACH the holdout (drop its handle). `is_finished` (Rust 1.61+,
+        // MSRV 1.88) avoids a blocking `join()` on a wedged thread.
+        //
+        // Detaching is SAFE w.r.t. the one-shot drain below because we set the
+        // shutdown flag FIRST (above): a detached worker that finishes its spawn
+        // AFTER the drain sees the flag set and reaps its own child in
+        // `pane_factory::finish_attach` — so a late registration never outlives
+        // teardown (the r6 child-leak race). Children registered before the drain
+        // are reaped by the drain itself.
+        let attach_join_deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+        let detached = bounded_join_attach_workers(attach_workers, attach_join_deadline);
+        if detached > 0 {
+            tracing::warn!(
+                detached,
+                "render-first: detached attach worker(s) still wedged past the join grace at quit"
+            );
+        }
         // #t-41673 gap-instrument: clock the parallel teardown so the next
         // operator restart EMPIRICALLY confirms the ~6s sequential freeze is
         // gone (expect `teardown_elapsed_ms` ≈ one grace window). Mirrors
@@ -1606,6 +1744,34 @@ mod tests {
     use super::*;
     use crate::layout::PaneSource;
     use crate::vterm::VTerm;
+
+    /// #render-first phase-(b) F2 (r4): `bounded_join_attach_workers` must DETACH a
+    /// worker wedged past the deadline (so quit can't hang) while still joining the
+    /// finished ones. Deterministic via a parked thread held by a channel.
+    #[test]
+    fn bounded_join_detaches_wedged_worker_without_hanging() {
+        let (keep_tx, keep_rx) = std::sync::mpsc::channel::<()>();
+        // Wedged: blocks until keep_tx drops (held past the join below).
+        let wedged = std::thread::spawn(move || {
+            let _ = keep_rx.recv();
+        });
+        let quick = std::thread::spawn(|| {}); // finishes immediately
+        let start = std::time::Instant::now();
+        let detached = bounded_join_attach_workers(
+            vec![quick, wedged],
+            start + std::time::Duration::from_millis(150),
+        );
+        assert!(
+            start.elapsed() < std::time::Duration::from_secs(2),
+            "bounded join must not hang on a wedged worker (took {:?})",
+            start.elapsed()
+        );
+        assert_eq!(
+            detached, 1,
+            "the wedged worker is detached; the quick one is joined"
+        );
+        drop(keep_tx); // release the parked thread (cleanup)
+    }
 
     /// restart-freeze 真嫌#1 (t-…55279) source-scan invariant: `app_teardown`'s
     /// Owned-mode cleanup must (1) flip the shutdown flag so PTY-close handlers

--- a/src/app/pane_factory.rs
+++ b/src/app/pane_factory.rs
@@ -193,10 +193,47 @@ fn attach_agent_to_pane(
         .working_dir
         .clone()
         .unwrap_or_else(|| crate::paths::workspace_dir(home).join(&name));
+    // #render-first phase-(b): the back-to-back composition of the worker-safe
+    // expensive half (`spawn_and_subscribe`) and the main-thread cheap half
+    // (`apply_attachment`) is byte-identical to the prior inline body — same side
+    // effects, same order. Splitting here is what lets the deferred path run
+    // `spawn_and_subscribe` on a background worker (touches only the shareable
+    // registry) while the render thread runs `apply_attachment` (pane mutation).
+    let (instance_id, rx, dump) = spawn_and_subscribe(
+        registry, home, &name, command, args, spawn_mode, env, submit_key, &work_dir, cols, rows,
+    )?;
+    apply_attachment(pane, instance_id, rx, dump, fwd_tx, wakeup_tx);
+    Ok(())
+}
 
+/// Expensive, **worker-safe** half of an attach (#render-first phase-(b)): the
+/// part that touches only the shareable `registry: Arc<Mutex>` and the filesystem
+/// — generate MCP config, install skills, spawn the agent (the fork/exec), resolve
+/// its UUID, and subscribe to its output. Returns the authoritative UUID + the
+/// subscriber receiver + the initial screen dump for the main thread to finish
+/// wiring via [`apply_attachment`]. Mutates NO `Pane`/`Layout`, so it can run off
+/// the render thread on a background worker.
+#[allow(clippy::too_many_arguments)]
+fn spawn_and_subscribe(
+    registry: &AgentRegistry,
+    home: &Path,
+    name: &str,
+    command: &str,
+    args: &[String],
+    spawn_mode: crate::backend::SpawnMode,
+    env: &HashMap<String, String>,
+    submit_key: &str,
+    work_dir: &Path,
+    cols: u16,
+    rows: u16,
+) -> Result<(
+    crate::types::InstanceId,
+    crossbeam_channel::Receiver<Vec<u8>>,
+    Vec<u8>,
+)> {
     // Generate MCP config for agent backends
     if Backend::from_command(command).is_some() {
-        crate::instructions::generate(&work_dir, command);
+        crate::instructions::generate(work_dir, command);
     }
 
     // #1083: install skills for TUI-spawned panes (app mode).
@@ -208,16 +245,16 @@ fn attach_agent_to_pane(
         let skills_filter: Option<Vec<String>> =
             crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))
                 .ok()
-                .and_then(|c| c.instances.get(&name).and_then(|i| i.skills.clone()));
+                .and_then(|c| c.instances.get(name).and_then(|i| i.skills.clone()));
         let custom_skills_source: Option<std::path::PathBuf> =
             crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))
                 .ok()
-                .and_then(|c| c.instances.get(&name).and_then(|i| i.skills_path.clone()))
+                .and_then(|c| c.instances.get(name).and_then(|i| i.skills_path.clone()))
                 .map(|p| crate::fleet::resolve::expand_tilde_path(&p));
         let backend_skill = Backend::from_command(command).and_then(|b| b.skill_dir_name());
         match crate::skills::install_for_agent_backend_with_source(
             home,
-            &work_dir,
+            work_dir,
             skills_filter.as_deref(),
             backend_skill,
             custom_skills_source.as_deref(),
@@ -238,17 +275,17 @@ fn attach_agent_to_pane(
     // Backend-specific flags (Claude's --append-system-prompt-file / --mcp-config /
     // --settings) are now injected centrally by agent::spawn_agent, so callers pass
     // raw args and spawn_agent enriches them from files under work_dir.
-    let spawn_mode = spawn_mode.downgraded_for(command, Some(&work_dir));
+    let spawn_mode = spawn_mode.downgraded_for(command, Some(work_dir));
     agent::spawn_agent(
         &agent::SpawnConfig {
-            name: &name,
+            name,
             backend_command: command,
             args,
             spawn_mode,
             cols,
             rows,
             env: Some(env),
-            working_dir: Some(&work_dir),
+            working_dir: Some(work_dir),
             submit_key,
             home: Some(home),
             crash_tx: None,
@@ -266,9 +303,8 @@ fn attach_agent_to_pane(
     // key spawn_agent just used) and route the pane's registry lookups by it.
     // spawn_agent succeeded above, so the fleet.yaml entry — and thus the
     // resolution — is guaranteed present.
-    let instance_id = crate::fleet::resolve_uuid(home, &name)
+    let instance_id = crate::fleet::resolve_uuid(home, name)
         .ok_or_else(|| anyhow::anyhow!("agent '{name}' has no fleet UUID after spawn"))?;
-    pane.instance_id = instance_id;
 
     // Subscribe to the agent's output
     let (rx, dump) = {
@@ -279,11 +315,31 @@ fn attach_agent_to_pane(
         agent::subscribe_with_dump(handle)
     };
 
-    // Feed the screen dump into the placeholder's (empty) local VTerm
+    Ok((instance_id, rx, dump))
+}
+
+/// Cheap, **main-thread** half of an attach (#render-first phase-(b)): apply the
+/// [`spawn_and_subscribe`] result to the placeholder pane and start the output
+/// forwarder. MUST run on the render thread — it mutates the `Pane` (which lives
+/// in the main-thread-owned `Layout`) and processes the dump BEFORE the forwarder
+/// is started, so the initial screen is seeded ahead of any post-subscribe stream
+/// (the render loop's `drain_output` only ever sees post-dump bytes → no
+/// out-of-order first frame).
+fn apply_attachment(
+    pane: &mut Pane,
+    instance_id: crate::types::InstanceId,
+    rx: crossbeam_channel::Receiver<Vec<u8>>,
+    dump: Vec<u8>,
+    fwd_tx: crossbeam_channel::Sender<Vec<u8>>,
+    wakeup_tx: &crossbeam_channel::Sender<usize>,
+) {
+    pane.instance_id = instance_id;
+    // Feed the screen dump into the placeholder's local VTerm
     pane.vterm.process(&dump);
 
     // Forward subscriber output to wakeup channel via the placeholder's fwd_tx
     let pane_id = pane.id;
+    let name = pane.agent_name.to_string();
     let tx = wakeup_tx.clone();
     // fire-and-forget: forwarder exits when fwd_tx.send() fails (pane
     // dropped → fwd_rx dropped → send returns Err) or rx.recv() fails
@@ -300,8 +356,442 @@ fn attach_agent_to_pane(
             }
         })
         .ok();
+}
 
-    Ok(())
+// ── #render-first phase-(b): deferred (background) attach ──────────────────
+//
+// OWNED restore builds all placeholders synchronously (µs) then schedules the
+// expensive per-agent spawn on a bounded background pool, so the TUI's first
+// draw no longer waits on N sequential fork/exec + skills-install. Layout +
+// name_counter stay main-thread-exclusive; workers only touch the shareable
+// `registry: Arc<Mutex>` and hand results back over a channel.
+
+/// The worker-side recipe for a deferred attach. Holds NO `Pane`/`Layout`
+/// reference (those are the render thread's exclusive `&mut`), only owned data
+/// safe to move to a background worker.
+// One per restored agent/shell, moved once into a worker — the `Agent`
+// (carries a `ResolvedInstance`) vs `Direct` size gap doesn't matter.
+#[allow(clippy::large_enum_variant)]
+pub(super) enum AttachSpec {
+    /// A fleet agent — the worker re-runs the per-agent prep (peers/team/worktree/
+    /// model/args + fleet-aware instructions) then spawns, mirroring the
+    /// synchronous `create_pane_from_resolved` ordering off the render thread.
+    Agent {
+        fleet_name: String,
+        deduped_name: String,
+        resolved: crate::fleet::ResolvedInstance,
+        spawn_mode: crate::backend::SpawnMode,
+        cols: u16,
+        rows: u16,
+    },
+    /// A shell (or any direct command) — final spawn params already resolved.
+    Direct {
+        name: String,
+        command: String,
+        args: Vec<String>,
+        spawn_mode: crate::backend::SpawnMode,
+        env: HashMap<String, String>,
+        submit_key: String,
+        work_dir: std::path::PathBuf,
+        cols: u16,
+        rows: u16,
+    },
+}
+
+impl AttachSpec {
+    fn name(&self) -> &str {
+        match self {
+            AttachSpec::Agent { deduped_name, .. } => deduped_name,
+            AttachSpec::Direct { name, .. } => name,
+        }
+    }
+}
+
+/// A placeholder pane awaiting background attach: its id + the forwarder sender
+/// the attach result wires up + the worker recipe.
+pub(super) struct AttachJob {
+    pub pane_id: usize,
+    pub fwd_tx: crossbeam_channel::Sender<Vec<u8>>,
+    pub spec: AttachSpec,
+}
+
+/// Result a worker hands back to the render thread over `attach_rx`.
+// A handful of these are sent per restart (one per restored agent), so the
+// `Ready`/`Failed` size gap is irrelevant — boxing would only add an alloc on
+// the hot success path.
+#[allow(clippy::large_enum_variant)]
+pub(super) enum AttachOutcome {
+    Ready {
+        pane_id: usize,
+        instance_id: crate::types::InstanceId,
+        rx: crossbeam_channel::Receiver<Vec<u8>>,
+        dump: Vec<u8>,
+        /// The real spawn cwd (worktree-resolved for agents) → update the pane.
+        work_dir: std::path::PathBuf,
+        /// The agent's (deduped) name — used to kill the orphan if its pane was
+        /// closed while the attach was in flight (F1).
+        name: String,
+    },
+    Failed {
+        pane_id: usize,
+        name: String,
+        err: String,
+    },
+}
+
+impl AttachOutcome {
+    /// The placeholder pane this outcome targets (used to look it up in the Layout).
+    pub(super) fn pane_id(&self) -> usize {
+        match self {
+            AttachOutcome::Ready { pane_id, .. } | AttachOutcome::Failed { pane_id, .. } => {
+                *pane_id
+            }
+        }
+    }
+}
+
+/// Pre-feed the placeholder VTerm with a "Starting" banner so the operator sees a
+/// labelled shell immediately, before the background attach completes. This is the
+/// one behavioral change vs the empty-VTerm phase-(a) placeholder.
+fn prefeed_starting(vterm: &mut VTerm, name: &str) {
+    vterm.process(format!("\u{23f3} Starting {name}\u{2026}\r\n").as_bytes());
+}
+
+/// Main-thread: build the cheap placeholder pane for a fleet AGENT (name dedup +
+/// pane id + "Starting" banner) plus the [`AttachJob`] a worker will run. The
+/// expensive spawn (skills + fork/exec + subscribe + fleet instructions) is
+/// deferred to [`run_attach`]; nothing here forks a process.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn build_deferred_agent_pane(
+    fleet_name: &str,
+    resolved: &crate::fleet::ResolvedInstance,
+    layout: &mut Layout,
+    home: &Path,
+    cols: u16,
+    rows: u16,
+    name_counter: &mut HashMap<String, usize>,
+    spawn_mode: crate::backend::SpawnMode,
+) -> (Pane, AttachJob) {
+    let (mut pane, fwd_tx) = build_pane_placeholder(
+        layout,
+        home,
+        fleet_name,
+        &resolved.backend_command,
+        resolved.working_directory.as_deref(),
+        cols,
+        rows,
+        name_counter,
+    );
+    let deduped_name = pane.agent_name.to_string();
+    pane.fleet_instance_name = Some(fleet_name.to_string());
+    prefeed_starting(&mut pane.vterm, &deduped_name);
+    let job = AttachJob {
+        pane_id: pane.id,
+        fwd_tx,
+        spec: AttachSpec::Agent {
+            fleet_name: fleet_name.to_string(),
+            deduped_name,
+            resolved: resolved.clone(),
+            spawn_mode,
+            cols,
+            rows,
+        },
+    };
+    (pane, job)
+}
+
+/// Main-thread: build the cheap placeholder pane for a SHELL / direct command
+/// plus its [`AttachJob`] (final spawn params already resolved).
+#[allow(clippy::too_many_arguments)]
+pub(super) fn build_deferred_direct_pane(
+    layout: &mut Layout,
+    home: &Path,
+    base_name: &str,
+    command: &str,
+    args: &[String],
+    spawn_mode: crate::backend::SpawnMode,
+    working_dir: Option<&Path>,
+    env: &HashMap<String, String>,
+    submit_key: &str,
+    cols: u16,
+    rows: u16,
+    name_counter: &mut HashMap<String, usize>,
+) -> (Pane, AttachJob) {
+    let (mut pane, fwd_tx) = build_pane_placeholder(
+        layout,
+        home,
+        base_name,
+        command,
+        working_dir,
+        cols,
+        rows,
+        name_counter,
+    );
+    let deduped_name = pane.agent_name.to_string();
+    let work_dir = pane
+        .working_dir
+        .clone()
+        .unwrap_or_else(|| crate::paths::workspace_dir(home).join(&deduped_name));
+    prefeed_starting(&mut pane.vterm, &deduped_name);
+    let job = AttachJob {
+        pane_id: pane.id,
+        fwd_tx,
+        spec: AttachSpec::Direct {
+            name: deduped_name,
+            command: command.to_string(),
+            args: args.to_vec(),
+            spawn_mode,
+            env: env.clone(),
+            submit_key: submit_key.to_string(),
+            work_dir,
+            cols,
+            rows,
+        },
+    };
+    (pane, job)
+}
+
+/// #render-first phase-(b) F2 (r6): if app teardown began while a worker was
+/// spawning, reap the just-registered child so no live orphan survives quit.
+/// Remove + terminate happen UNDER the registry lock, serialized against the
+/// teardown's one-shot drain. The teardown sets the shutdown flag BEFORE the
+/// drain, so every interleaving is covered: a child registered before the drain
+/// is reaped by the drain itself (this call then finds None), and a child
+/// registered after the drain is observed here (the late finisher always sees the
+/// flag) and reaped. No registered-but-unterminated child can outlive teardown.
+/// Returns true if a child was reaped (i.e. we are shutting down).
+fn reap_late_registration_if_shutdown(
+    registry: &AgentRegistry,
+    instance_id: crate::types::InstanceId,
+    shutting_down: bool,
+) -> bool {
+    if !shutting_down {
+        return false;
+    }
+    let drained: Vec<(String, crate::daemon::ChildHandle)> = {
+        let mut reg = agent::lock_registry(registry);
+        reg.remove(&instance_id)
+            .map(|h| (h.name.to_string(), h.child))
+            .into_iter()
+            .collect()
+    };
+    crate::daemon::terminate_agents_parallel(drained);
+    true
+}
+
+/// Commit a successful deferred spawn as a `Ready` outcome — UNLESS app teardown
+/// began while we were spawning (the worker passed `run_attach`'s entry shutdown
+/// check, then `spawn_agent` registered a child). In that case reap our own child
+/// (`reap_late_registration_if_shutdown`) and report `Failed` instead of leaking a
+/// live agent the one-shot teardown drain may have missed (the F2 race r6 found).
+#[allow(clippy::too_many_arguments)]
+fn finish_attach(
+    registry: &AgentRegistry,
+    pane_id: usize,
+    instance_id: crate::types::InstanceId,
+    rx: crossbeam_channel::Receiver<Vec<u8>>,
+    dump: Vec<u8>,
+    work_dir: std::path::PathBuf,
+    name: String,
+) -> AttachOutcome {
+    let shutting_down = super::app_shutdown_flag().load(std::sync::atomic::Ordering::SeqCst);
+    if reap_late_registration_if_shutdown(registry, instance_id, shutting_down) {
+        return AttachOutcome::Failed {
+            pane_id,
+            name,
+            err: "app shutting down during spawn".to_string(),
+        };
+    }
+    AttachOutcome::Ready {
+        pane_id,
+        instance_id,
+        rx,
+        dump,
+        work_dir,
+        name,
+    }
+}
+
+/// Worker entry: run ONE deferred [`AttachJob`]'s spec off the render thread,
+/// returning an [`AttachOutcome`] for the main thread to apply. Honors the app
+/// shutdown flag at TWO points: at entry (early-abort: never fork a NEW child once
+/// teardown began) and, via [`finish_attach`], right after a successful spawn
+/// (reap a child registered after the one-shot teardown drain — the F2 race).
+pub(super) fn run_attach(
+    spec: AttachSpec,
+    pane_id: usize,
+    registry: &AgentRegistry,
+    home: &Path,
+) -> AttachOutcome {
+    if super::app_shutdown_flag().load(std::sync::atomic::Ordering::SeqCst) {
+        return AttachOutcome::Failed {
+            pane_id,
+            name: spec.name().to_string(),
+            err: "app shutting down".to_string(),
+        };
+    }
+    match spec {
+        AttachSpec::Agent {
+            fleet_name,
+            deduped_name,
+            resolved,
+            spawn_mode,
+            cols,
+            rows,
+        } => {
+            // Mirror create_pane_from_resolved's per-agent prep, off-thread.
+            let fleet_path = crate::fleet::fleet_yaml_path(home);
+            let peers: Vec<(String, Option<String>)> = crate::fleet::FleetConfig::load(&fleet_path)
+                .map(|f| {
+                    f.instances
+                        .iter()
+                        .map(|(n, c)| (n.clone(), c.role.clone()))
+                        .collect()
+                })
+                .unwrap_or_default();
+            let team_record = crate::teams::find_team_for(home, &fleet_name);
+            let extra_instructions = crate::instructions::resolve_extra_for(
+                &resolved,
+                fleet_path.parent().unwrap_or(home),
+            );
+            // #render-first phase-(b) F3 (accepted residual, lead-tracked follow-up):
+            // W=3 workers may now resolve auto-worktrees CONCURRENTLY, so the FIRST
+            // concurrent same-repo `git worktree add` can race on `.git/index.lock`
+            // and the loser falls back (losing isolation that once). Bounded: git
+            // serializes the op, only the #2234 reconcile-flag-ON create() path forks
+            // a worktree here (default OFF), and RESTART is idempotent — so not fixed
+            // in this PR.
+            let mut working_dir = resolved.working_directory.clone();
+            if let Some(wt) = crate::worktree::resolve_auto_worktree(home, &fleet_name, &resolved) {
+                working_dir = Some(wt);
+            }
+            let mut args = resolved.args.clone();
+            if let Some(ref model) = resolved.model {
+                let model_val = Backend::from_command(&resolved.backend_command)
+                    .map(|b| b.format_model_arg(model))
+                    .unwrap_or_else(|| model.clone());
+                args.push("--model".to_string());
+                args.push(model_val);
+            }
+            let command = resolved.backend_command.clone();
+            let work_dir = working_dir
+                .clone()
+                .unwrap_or_else(|| crate::paths::workspace_dir(home).join(&deduped_name));
+            match spawn_and_subscribe(
+                registry,
+                home,
+                &deduped_name,
+                &command,
+                &args,
+                spawn_mode,
+                &resolved.env,
+                &resolved.submit_key,
+                &work_dir,
+                cols,
+                rows,
+            ) {
+                Ok((instance_id, rx, dump)) => {
+                    // Overwrite basic instructions with the fleet-aware version
+                    // (same ordering as the synchronous create_pane_from_resolved).
+                    let team_ctx = team_record
+                        .as_ref()
+                        .map(|t| crate::instructions::TeamContext {
+                            name: t.name.as_str(),
+                            orchestrator: t.orchestrator.as_deref(),
+                            members: t.members.as_slice(),
+                        });
+                    let ctx = crate::instructions::AgentContext {
+                        name: &fleet_name,
+                        role: resolved.role.as_deref(),
+                        fleet_peers: &peers,
+                        team: team_ctx.as_ref(),
+                        extra_instructions: extra_instructions.as_deref(),
+                    };
+                    crate::instructions::generate_with_context(&work_dir, &command, Some(&ctx));
+                    finish_attach(
+                        registry,
+                        pane_id,
+                        instance_id,
+                        rx,
+                        dump,
+                        work_dir,
+                        deduped_name,
+                    )
+                }
+                Err(e) => AttachOutcome::Failed {
+                    pane_id,
+                    name: deduped_name,
+                    err: e.to_string(),
+                },
+            }
+        }
+        AttachSpec::Direct {
+            name,
+            command,
+            args,
+            spawn_mode,
+            env,
+            submit_key,
+            work_dir,
+            cols,
+            rows,
+        } => match spawn_and_subscribe(
+            registry,
+            home,
+            &name,
+            &command,
+            &args,
+            spawn_mode,
+            &env,
+            &submit_key,
+            &work_dir,
+            cols,
+            rows,
+        ) {
+            Ok((instance_id, rx, dump)) => {
+                finish_attach(registry, pane_id, instance_id, rx, dump, work_dir, name)
+            }
+            Err(e) => AttachOutcome::Failed {
+                pane_id,
+                name,
+                err: e.to_string(),
+            },
+        },
+    }
+}
+
+/// Main-thread: apply a worker's [`AttachOutcome`] to its placeholder pane. On
+/// `Ready` wires the agent in (instance id, dump, real cwd, forwarder); on
+/// `Failed` flips the placeholder VTerm to a visible "failed to start" banner
+/// (the pane stays a normal, closable Layout pane — no zombie). `fwd_tx` is the
+/// placeholder's forwarder sender, retained by the caller keyed on `pane_id`.
+pub(super) fn apply_attach_outcome(
+    pane: &mut Pane,
+    outcome: AttachOutcome,
+    fwd_tx: crossbeam_channel::Sender<Vec<u8>>,
+    wakeup_tx: &crossbeam_channel::Sender<usize>,
+) {
+    match outcome {
+        AttachOutcome::Ready {
+            instance_id,
+            rx,
+            dump,
+            work_dir,
+            ..
+        } => {
+            pane.working_dir = Some(work_dir);
+            apply_attachment(pane, instance_id, rx, dump, fwd_tx, wakeup_tx);
+        }
+        AttachOutcome::Failed { name, err, .. } => {
+            // Dropping fwd_tx disconnects the placeholder's output channel
+            // (no forwarder ever starts); the pane shows the failure and is
+            // closable via the normal close path.
+            drop(fwd_tx);
+            tracing::error!(agent = %name, error = %err, "render-first: deferred attach failed");
+            pane.vterm
+                .process(format!("\u{26a0} failed to start {name}: {err}\r\n").as_bytes());
+        }
+    }
 }
 
 /// Attach a pane to an already-running agent (no spawn — subscribe only).
@@ -629,6 +1119,224 @@ mod tests {
         let _ = std::fs::remove_dir_all(&p);
         std::fs::create_dir_all(&p).expect("create tmp home");
         p
+    }
+
+    // ── #render-first phase-(b) ──────────────────────────────────────────────
+
+    fn screen_of(pane: &Pane) -> String {
+        String::from_utf8_lossy(&pane.vterm.dump_screen()).to_string()
+    }
+
+    /// #render-first phase-(b) — must-resolve #4 (new behavior) + deferral proof:
+    /// the placeholder is built WITHOUT spawning (no registry needed) and shows a
+    /// "Starting" banner; the spawn recipe rides along in the AttachJob.
+    #[test]
+    fn deferred_placeholder_shows_starting_and_defers_spawn() {
+        let home = tmp_home("rf_starting");
+        let mut layout = Layout::new();
+        let mut name_counter = HashMap::new();
+        let (pane, job) = build_deferred_direct_pane(
+            &mut layout,
+            &home,
+            "shell",
+            "/bin/sh",
+            &[],
+            crate::backend::SpawnMode::Fresh,
+            None,
+            &HashMap::new(),
+            "\r",
+            80,
+            24,
+            &mut name_counter,
+        );
+        let screen = screen_of(&pane);
+        assert!(
+            screen.contains("Starting") && screen.contains("shell"),
+            "placeholder must show a 'Starting <name>' banner; got:\n{screen}"
+        );
+        assert_eq!(job.pane_id, pane.id, "job targets its placeholder");
+        assert!(matches!(job.spec, AttachSpec::Direct { .. }));
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// must-resolve: a worker `Ready` outcome seeds the dump into the pane and
+    /// starts the forwarder (subscriber bytes reach the pane's output channel).
+    #[test]
+    fn apply_ready_outcome_seeds_dump_and_starts_forwarder() {
+        let home = tmp_home("rf_ready");
+        let mut layout = Layout::new();
+        let mut name_counter = HashMap::new();
+        let (mut pane, _job) = build_deferred_direct_pane(
+            &mut layout,
+            &home,
+            "shell",
+            "/bin/sh",
+            &[],
+            crate::backend::SpawnMode::Fresh,
+            None,
+            &HashMap::new(),
+            "\r",
+            80,
+            24,
+            &mut name_counter,
+        );
+        let pid = pane.id;
+        let (sub_tx, sub_rx) = crossbeam_channel::unbounded::<Vec<u8>>();
+        let (fwd_tx, fwd_rx) = crossbeam_channel::unbounded::<Vec<u8>>();
+        let (wakeup_tx, _wakeup_rx) = crossbeam_channel::unbounded::<usize>();
+        apply_attach_outcome(
+            &mut pane,
+            AttachOutcome::Ready {
+                pane_id: pid,
+                instance_id: crate::types::InstanceId::default(),
+                rx: sub_rx,
+                dump: b"DUMP-XYZ".to_vec(),
+                work_dir: home.clone(),
+                name: "shell".into(),
+            },
+            fwd_tx,
+            &wakeup_tx,
+        );
+        assert!(
+            screen_of(&pane).contains("DUMP-XYZ"),
+            "the worker's dump must be seeded into the pane vterm"
+        );
+        // Forwarder is live: a subscriber byte reaches the (passed) fwd channel.
+        sub_tx
+            .send(b"hello".to_vec())
+            .expect("send on an open channel");
+        let got = fwd_rx
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .expect("forwarded byte");
+        assert_eq!(got, b"hello");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// must-resolve #3: a `Failed` outcome flips the placeholder to a visible
+    /// "failed to start" banner and leaves it a never-routed (closable) pane.
+    #[test]
+    fn apply_failed_outcome_shows_banner_and_stays_closable() {
+        let home = tmp_home("rf_failed");
+        let mut layout = Layout::new();
+        let mut name_counter = HashMap::new();
+        let (mut pane, _job) = build_deferred_direct_pane(
+            &mut layout,
+            &home,
+            "shell",
+            "/bin/sh",
+            &[],
+            crate::backend::SpawnMode::Fresh,
+            None,
+            &HashMap::new(),
+            "\r",
+            80,
+            24,
+            &mut name_counter,
+        );
+        let pid = pane.id;
+        // The placeholder's instance_id is the never-routed id assigned at build;
+        // a Failed attach must NOT wire it to any agent (stays closable, no zombie).
+        let orig_iid = pane.instance_id;
+        let (fwd_tx, _fwd_rx) = crossbeam_channel::unbounded::<Vec<u8>>();
+        let (wakeup_tx, _w) = crossbeam_channel::unbounded::<usize>();
+        apply_attach_outcome(
+            &mut pane,
+            AttachOutcome::Failed {
+                pane_id: pid,
+                name: "shell".into(),
+                err: "boom".into(),
+            },
+            fwd_tx,
+            &wakeup_tx,
+        );
+        let screen = screen_of(&pane);
+        assert!(
+            screen.contains("failed to start") && screen.contains("boom"),
+            "failed attach must show a visible banner; got:\n{screen}"
+        );
+        assert_eq!(
+            pane.instance_id, orig_iid,
+            "Failed must leave the pane's routing id unchanged (never-routed placeholder)"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// must-resolve #1 [BLOCKER]: with the main-thread keepalive `attach_tx`
+    /// alive, the channel is NOT disconnected after every worker sender drops, so
+    /// `recv` BLOCKS (Empty) rather than busy-spinning (Disconnected).
+    #[test]
+    fn attach_rx_keepalive_blocks_not_disconnects() {
+        let (attach_tx, attach_rx) = crossbeam_channel::unbounded::<AttachOutcome>();
+        let worker_senders: Vec<_> = (0..3).map(|_| attach_tx.clone()).collect();
+        drop(worker_senders); // all workers exited
+        assert!(
+            matches!(
+                attach_rx.try_recv(),
+                Err(crossbeam_channel::TryRecvError::Empty)
+            ),
+            "keepalive must keep the channel connected (block, not spin)"
+        );
+        drop(attach_tx); // drop the keepalive too → now it disconnects
+        assert!(
+            matches!(
+                attach_rx.try_recv(),
+                Err(crossbeam_channel::TryRecvError::Disconnected)
+            ),
+            "without the keepalive the channel disconnects (the busy-spin we avoid)"
+        );
+    }
+
+    /// The render-loop handback locates a placeholder by id across ALL tabs.
+    #[test]
+    fn layout_find_pane_mut_locates_placeholder_across_tabs() {
+        let home = tmp_home("rf_find");
+        let mut layout = Layout::new();
+        let mut name_counter = HashMap::new();
+        let (pane, _job) = build_deferred_direct_pane(
+            &mut layout,
+            &home,
+            "shell",
+            "/bin/sh",
+            &[],
+            crate::backend::SpawnMode::Fresh,
+            None,
+            &HashMap::new(),
+            "\r",
+            80,
+            24,
+            &mut name_counter,
+        );
+        let pid = pane.id;
+        layout.add_tab(Tab::new("t".to_string(), pane));
+        assert!(
+            layout.find_pane_mut(pid).is_some(),
+            "handback must find the pane"
+        );
+        assert!(layout.find_pane_mut(987654).is_none());
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #render-first phase-(b) F2 (r6) — the child-leak RACE regression. A worker
+    /// that finishes its spawn (registers a child) AFTER teardown's one-shot drain
+    /// must still have that child reaped, not orphaned. We model the post-drain
+    /// state by inserting a real PTY-backed agent, then running the worker's reap
+    /// path with `shutting_down=true` (the flag is set before the drain, so a late
+    /// finisher always observes it) — the agent must be terminated + removed.
+    #[cfg(unix)]
+    #[test]
+    fn reap_late_registration_kills_child_registered_after_drain() {
+        let registry: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let id = crate::types::InstanceId::default();
+        agent::lock_registry(&registry).insert(id, agent::mk_test_handle("rf-late", id));
+        assert!(agent::lock_registry(&registry).contains_key(&id));
+        // Detached worker finishing AFTER the drain → shutting_down=true → reap.
+        assert!(reap_late_registration_if_shutdown(&registry, id, true));
+        assert!(
+            !agent::lock_registry(&registry).contains_key(&id),
+            "a child registered after the drain must be terminated + removed, not orphaned"
+        );
+        // Control: not shutting down → never reaps (short-circuits before the registry).
+        assert!(!reap_late_registration_if_shutdown(&registry, id, false));
     }
 
     #[test]

--- a/src/app/session.rs
+++ b/src/app/session.rs
@@ -17,7 +17,6 @@
 //!   mode the daemon's registry naturally drifts as agents are added/removed
 //!   between attaches; warning every transient mismatch would be noise.
 
-use crate::agent::AgentRegistry;
 use crate::fleet;
 use crate::layout::{Layout, Pane, PaneNode, SplitDir, Tab};
 
@@ -192,9 +191,8 @@ pub(super) fn restore_with_reconciliation(
     home: &Path,
     fleet_path: &Path,
     layout: &mut Layout,
-    registry: &AgentRegistry,
-    wakeup_tx: &crossbeam_channel::Sender<usize>,
     name_counter: &mut HashMap<String, usize>,
+    attach_jobs: &mut Vec<super::pane_factory::AttachJob>,
     cols: u16,
     rows: u16,
 ) -> bool {
@@ -218,46 +216,35 @@ pub(super) fn restore_with_reconciliation(
         .map(|f| f.instance_names().into_iter().collect())
         .unwrap_or_default();
 
-    // Owned pane builder: agent → spawn local PTY (Resume mode); shell →
-    // spawn local shell (Fresh mode). Single closure to avoid dual-mutable-
-    // borrow on `name_counter` + `registry`.
+    // #render-first phase-(b): Owned pane builder now builds the CHEAP
+    // placeholder (name dedup + pane id + "Starting" banner, µs) and collects an
+    // `AttachJob` for the deferred background spawn — the per-agent fork/exec +
+    // skills-install no longer runs synchronously here (that was the ~1s restore
+    // freeze). `run_app` schedules the jobs on a bounded pool AFTER the render
+    // loop is live. Single closure to keep `name_counter` + `attach_jobs` as the
+    // only mutable captures (Layout is passed in).
     let mut pane_builder = |sp: &SessionPane, layout: &mut Layout| -> Option<Pane> {
         match sp.fleet_instance_name.as_deref() {
             Some(name) => {
                 let resolved = fleet.as_ref().and_then(|f| f.resolve_instance(name))?;
-                // restart-freeze RCA (t-…55279): time the per-agent local-PTY
-                // spawn. The owned-restore path runs these synchronously in
-                // apply_session_layout order, so the sum is the boot critical
-                // path the operator sees freeze. Pure tracing, zero behavior.
-                let spawn_start = std::time::Instant::now();
-                let pane = super::pane_factory::create_pane_from_resolved(
+                let (pane, job) = super::pane_factory::build_deferred_agent_pane(
                     name,
                     &resolved,
                     layout,
-                    registry,
                     home,
                     cols,
                     rows,
-                    wakeup_tx,
                     name_counter,
                     crate::backend::SpawnMode::Resume,
-                )
-                .ok();
-                tracing::info!(
-                    phase = "restore-spawn",
-                    agent = %name,
-                    elapsed_ms = spawn_start.elapsed().as_millis() as u64,
-                    ok = pane.is_some(),
-                    "restore-spawn: per-agent local-PTY spawn (synchronous)"
                 );
-                pane
+                attach_jobs.push(job);
+                Some(pane)
             }
             None => {
                 let shell =
                     std::env::var("SHELL").unwrap_or_else(|_| crate::default_shell().to_string());
-                super::pane_factory::create_pane(
+                let (pane, job) = super::pane_factory::build_deferred_direct_pane(
                     layout,
-                    registry,
                     home,
                     "shell",
                     &shell,
@@ -268,10 +255,10 @@ pub(super) fn restore_with_reconciliation(
                     "\r",
                     cols,
                     rows,
-                    wakeup_tx,
                     name_counter,
-                )
-                .ok()
+                );
+                attach_jobs.push(job);
+                Some(pane)
             }
         }
     };
@@ -287,12 +274,11 @@ pub(super) fn restore_with_reconciliation(
         return super::api_server::auto_start_fleet(
             fleet_path,
             layout,
-            registry,
             home,
             cols,
             rows,
-            wakeup_tx,
             name_counter,
+            attach_jobs,
         );
     }
 

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -85,6 +85,15 @@ impl Layout {
         }
     }
 
+    /// #render-first phase-(b): find a pane by id across ALL tabs (a deferred
+    /// attach handback may target any tab, not just the active one). Returns the
+    /// first match (pane ids are unique).
+    pub fn find_pane_mut(&mut self, id: usize) -> Option<&mut Pane> {
+        self.tabs
+            .iter_mut()
+            .find_map(|t| t.root_mut().find_pane_mut(id))
+    }
+
     /// #1431/#1939: record where `agent`'s pane currently sits (tab + parent
     /// split geometry) so a later `SameTab` spawn can restore it. Call BEFORE
     /// removing the pane; no-op if the agent has no pane.


### PR DESCRIPTION
<!-- LOC-EST: 600-780 -->

## Problem
The TUI froze ~1s on every restart: the new daemon ran the OWNED restore **synchronously** — N × (skills-install + fork/exec + subscribe) before the first draw. #2311 already parallelized the *shutdown* half (6s→2s); this closes the residual *restore* freeze the operator re-reported.

## Fix (render-first, OWNED restore only)
- Build all panes as **cheap placeholders** (name dedup + pane id + empty VTerm pre-fed with a `⏳ Starting <name>…` banner, µs each) → **enter the render loop immediately** (operator sees a responsive shell at once).
- The expensive attach (skills + fork/exec + subscribe) runs on a bounded **W=3 worker pool**; each result is handed back over a new `attach_rx` channel and applied to its pane by the render thread. One wedged backend now stalls only its own pane.

## Design (lead-vetted — decision `d-20260619062823832662-1`, extends `d-…4619-0`; r6 5 must-resolve)
1. **[BLOCKER] busy-spin** → main thread holds a long-lived `attach_tx` **keepalive** for the whole render-loop scope (mirrors `wakeup_tx`); `attach_rx` never disconnects → `recv` blocks, never spins after workers exit.
2. **[SHOULD] starvation** → W=3 bounded pool (per-placeholder timeout deferred — fork can't be cancelled).
3. **[SPEC] failed pane** → `⚠ failed to start <name>: <err>` banner; stays a normal closable pane (no zombie). retry deferred; orphan-child kill opportunistic.
4. **[SPEC] phase-(a) byte-identical** → `attach_agent_to_pane` is now the back-to-back composition of the extracted `spawn_and_subscribe` (worker-safe) + `apply_attachment` (main-thread; processes dump BEFORE starting the forwarder → no out-of-order first frame). `create_pane` unchanged.
5. **[SPEC] app-quit** → flip shutdown flag → `run_attach` early-aborts un-started spawns → **JOIN workers BEFORE the registry drain** → `terminate_agents_parallel` reaps every worker-spawned child (no mid-fork orphan).

**Invariants:** Layout + name_counter stay main-thread-exclusive (workers touch only `registry: Arc<Mutex>` + return owned `AttachOutcome`); #908 daemon path untouched (app `spawn_agent` has no port-bind); `core_render` renders a registry-less placeholder without panic.

## Tests
6 new unit tests: placeholder shows "Starting" without spawning; `Ready` seeds dump + starts forwarder; `Failed` shows banner + stays unrouted; **busy-spin guard** (keepalive → `try_recv`=`Empty`, not `Disconnected`); cross-tab handback lookup. Green: `pane_factory` 12/12, `layout` 47/47, `app::session` 12/12, `app_teardown` + `spawn_rationale_audit` invariants; `clippy --all-targets -D warnings` + `cargo fmt --check` clean.

Integration "first-draw ts << all-attached ts" is observable via the merged #2271 `restore_start` instrument on the next operator restart (the deferral is proven at unit level: `build_deferred_*` creates panes without any spawn/registry write).

⚠ daemon-lifecycle → only takes effect after operator rebuild+restart. **Dual review** + Daemon-boot flake-gate requested.
Task: t-20260619061647662859-84833-6

🤖 Generated with [Claude Code](https://claude.com/claude-code)