### PR TITLE
feat(#2300): P0 per-role MCP capability registry (visibility subsetting)

### DIFF
--- a/src/api/handlers/mcp_proxy.rs
+++ b/src/api/handlers/mcp_proxy.rs
@@ -225,9 +225,32 @@ fn handle_mcp_tool_inner(
     }
 }
 
-/// Handle `mcp_tools_list` API method: return the tool definitions.
-pub(crate) fn handle_mcp_tools_list(_params: &Value, _ctx: &HandlerCtx) -> Value {
-    json!({"ok": true, "result": crate::mcp::tools::tool_definitions()})
+/// Handle `mcp_tools_list` API method: return the tool definitions VISIBLE to
+/// the calling agent's role (#2300 P0).
+///
+/// The bridge passes the caller's `instance` in params (mirroring the tool-call
+/// path); we resolve its fleet `role` and subset the surface via
+/// [`crate::mcp::tools::tool_definitions_for_role`]. Default-all-open:
+/// no instance (old bridge / non-agent caller), unknown instance, or a role not
+/// in the capability registry (dev / lead / orchestrator / …) → the full surface.
+pub(crate) fn handle_mcp_tools_list(params: &Value, ctx: &HandlerCtx) -> Value {
+    let role = params
+        .get("instance")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .and_then(|inst| {
+            crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(ctx.home))
+                .ok()
+                .and_then(|fleet| fleet.instances.get(inst).and_then(|i| i.role.clone()))
+        });
+    // Default-all-open hot path: no instance / unlabeled instance → the canonical
+    // full surface (also keeps `tool_definitions` the single unfiltered builder
+    // the count-invariant pins). A role only narrows via the capability registry.
+    let result = match role.as_deref() {
+        None => crate::mcp::tools::tool_definitions(),
+        Some(r) => crate::mcp::tools::tool_definitions_for_role(Some(r)),
+    };
+    json!({ "ok": true, "result": result })
 }
 
 #[cfg(test)]

--- a/src/bin/agend-mcp-bridge.rs
+++ b/src/bin/agend-mcp-bridge.rs
@@ -117,7 +117,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
 
             "notifications/initialized" | "notifications/cancelled" => continue,
 
-            "tools/list" => match proxy_tools_list_with_retry(&home, &mut conn) {
+            "tools/list" => match proxy_tools_list_with_retry(&home, &instance, &mut conn) {
                 Ok(r) => serde_json::json!({"jsonrpc": "2.0", "id": id, "result": r}).to_string(),
                 Err(e) => {
                     // #879v4 C2 — Bug 2 fix: a `tools/list` failure surfaces
@@ -273,6 +273,7 @@ fn proxy_tool_call(
 /// waiting the full 30 s). Operators never set it.
 fn proxy_tools_list_with_retry(
     home: &Path,
+    instance: &str,
     conn: &mut Option<(BufReader<TcpStream>, TcpStream)>,
 ) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
     // test-only seam (see fn doc): prod always falls through to the 30_000 default.
@@ -282,7 +283,11 @@ fn proxy_tools_list_with_retry(
         .unwrap_or(30_000);
     let deadline = std::time::Instant::now() + std::time::Duration::from_millis(timeout_ms);
     let interval = std::time::Duration::from_millis(100);
-    let envelope = serde_json::json!({"method": "mcp_tools_list", "params": {}});
+    // #2300 P0: pass the caller's instance so the daemon can subset the tool
+    // list by role (mirrors the tool-call path). Empty → daemon serves the full
+    // surface (default-all-open).
+    let envelope =
+        serde_json::json!({"method": "mcp_tools_list", "params": {"instance": instance}});
     loop {
         match proxy_request(home, conn, &envelope) {
             Ok(resp) => {

--- a/src/mcp/registry.rs
+++ b/src/mcp/registry.rs
@@ -17,6 +17,110 @@ pub(crate) fn all() -> &'static [ToolEntry] {
     &ALL_TOOLS
 }
 
+/// #2300 P0: declarative per-role MCP tool subsets (capability registry).
+///
+/// Maps a free-form fleet.yaml `role` label → the tool names that role may SEE.
+/// **Default-all-open**: a role NOT listed here — including dev / lead /
+/// orchestrator / unlabeled — gets the full `all()` surface, byte-identical to
+/// pre-#2300. Only the listed read/report roles are trimmed, hiding footgun
+/// lifecycle/bind/orchestration tools they never legitimately use (cuts #2055
+/// surface + mis-trigger). P0 is VISIBILITY-ONLY: a trimmed tool is hidden from
+/// the role's `tools/list` but still dispatches if hard-called (behavior-
+/// preserving); the structural DENY is P1 (#2158). Conservative — when unsure a
+/// tool is KEPT (default-all-open backs any gap). Subsets vetted by lead/operator.
+const ROLE_TOOL_SUBSETS: &[(&str, &[&str])] = &[
+    // reviewer: reads code + runs/checks CI + checks out the PR (`repo`) +
+    // reports verdicts (`send`/`decision`) + tracks its own review `task`. Drops
+    // instance & worktree lifecycle (the #2158 vector) + fleet orchestration.
+    (
+        "reviewer",
+        &[
+            "reply",
+            "send",
+            "inbox",
+            "download_attachment",
+            "list_instances",
+            "binding_state",
+            "pane_snapshot",
+            "tui_screenshot",
+            "task",
+            "decision",
+            "ci",
+            "repo",
+            "config",
+            "set_waiting_on",
+            "tokens",
+            "health",
+            "mode",
+        ],
+    ),
+    // planner: reads code/CI to plan + reports. Same read/report surface as
+    // reviewer (no lifecycle/bind/orchestration).
+    (
+        "planner",
+        &[
+            "reply",
+            "send",
+            "inbox",
+            "download_attachment",
+            "list_instances",
+            "binding_state",
+            "pane_snapshot",
+            "tui_screenshot",
+            "task",
+            "decision",
+            "ci",
+            "repo",
+            "config",
+            "set_waiting_on",
+            "tokens",
+            "health",
+            "mode",
+        ],
+    ),
+    // explorer: read-only investigation + report. Strictest — also drops `repo`
+    // (checkout = provisioning) and `ci` (run/dispatch); keeps comms + read +
+    // observe + self-status.
+    (
+        "explorer",
+        &[
+            "reply",
+            "send",
+            "inbox",
+            "download_attachment",
+            "list_instances",
+            "binding_state",
+            "pane_snapshot",
+            "tui_screenshot",
+            "task",
+            "decision",
+            "config",
+            "set_waiting_on",
+            "tokens",
+            "health",
+            "mode",
+        ],
+    ),
+];
+
+/// #2300 P0: the MCP tool entries a given `role` may SEE. Default-all-open:
+/// `None`, an unlisted role (dev / lead / orchestrator / …), or an unknown label
+/// → the full `all()` surface (byte-identical, registry order). A listed role is
+/// narrowed to its subset; a subset name not in the registry is ignored (never
+/// widens). Order always follows the registry, not the subset list.
+pub(crate) fn tool_subset_for_role(role: Option<&str>) -> Vec<&'static ToolEntry> {
+    let subset = role.and_then(|r| {
+        ROLE_TOOL_SUBSETS
+            .iter()
+            .find(|(name, _)| *name == r)
+            .map(|(_, tools)| *tools)
+    });
+    match subset {
+        Some(names) => all().iter().filter(|e| names.contains(&e.name)).collect(),
+        None => all().iter().collect(),
+    }
+}
+
 static ALL_TOOLS: [ToolEntry; 36] = [
     // ── Channel ──
     ToolEntry {
@@ -215,3 +319,125 @@ static ALL_TOOLS: [ToolEntry; 36] = [
         handler: super::handlers::dispatch::dispatch_mode,
     },
 ];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn names(role: Option<&str>) -> Vec<&'static str> {
+        tool_subset_for_role(role).iter().map(|e| e.name).collect()
+    }
+
+    /// #2300 P0 byte-identical invariant: full-capability roles (dev / lead),
+    /// `None`, and any UNKNOWN role surface the ENTIRE registry in registry order
+    /// — zero behavior change. If this breaks, default-all-open regressed.
+    #[test]
+    fn full_capability_roles_surface_all_36_byte_identical() {
+        let all_names: Vec<&str> = all().iter().map(|e| e.name).collect();
+        assert_eq!(all_names.len(), 36, "registry baseline is 36 tools");
+        for role in [
+            None,
+            Some("dev"),
+            Some("lead"),
+            Some("orchestrator"),
+            Some("totally-unknown-role"),
+        ] {
+            assert_eq!(
+                names(role),
+                all_names,
+                "role {role:?} must surface all 36 tools in registry order (default-all-open)"
+            );
+        }
+    }
+
+    /// A narrowed role drops the footgun lifecycle/bind tools and KEEPS the
+    /// tools its workflow needs. Pins the conservative subset contract.
+    #[test]
+    fn reviewer_drops_lifecycle_keeps_review_tools() {
+        let r = names(Some("reviewer"));
+        // Dropped: instance/worktree lifecycle (the #2158 vector) + orchestration.
+        for cut in [
+            "bind_self",
+            "release_worktree",
+            "force_release_worktree",
+            "create_instance",
+            "delete_instance",
+            "restart_instance",
+            "replace_instance",
+            "start_instance",
+            "restart_daemon",
+            "team",
+            "deployment",
+            "schedule",
+            "watchdog",
+        ] {
+            assert!(
+                !r.contains(&cut),
+                "reviewer must NOT see lifecycle/orchestration tool '{cut}'"
+            );
+        }
+        // Kept: a reviewer must still review (repo/ci), report (send/decision),
+        // and track its task — cutting these would break its workflow.
+        for keep in [
+            "reply",
+            "send",
+            "inbox",
+            "task",
+            "decision",
+            "ci",
+            "repo",
+            "set_waiting_on",
+        ] {
+            assert!(
+                r.contains(&keep),
+                "reviewer must still see review tool '{keep}'"
+            );
+        }
+        // Narrowed (strictly fewer than the full surface).
+        assert!(
+            r.len() < all().len(),
+            "reviewer subset must be narrower than full"
+        );
+    }
+
+    /// explorer is the strictest read-only role: also drops `repo` (provisioning)
+    /// and `ci` (run/dispatch) that reviewer/planner keep.
+    #[test]
+    fn explorer_is_strictest_read_only() {
+        let e = names(Some("explorer"));
+        for cut in ["repo", "ci", "bind_self", "create_instance"] {
+            assert!(
+                !e.contains(&cut),
+                "explorer (read-only) must NOT see '{cut}'"
+            );
+        }
+        for keep in [
+            "reply",
+            "send",
+            "inbox",
+            "task",
+            "list_instances",
+            "pane_snapshot",
+        ] {
+            assert!(
+                e.contains(&keep),
+                "explorer must still see read/report tool '{keep}'"
+            );
+        }
+    }
+
+    /// Every name in a subset list must be a REAL registered tool — a typo'd
+    /// subset entry is silently ignored by the filter, so this guards intent.
+    #[test]
+    fn subset_names_are_all_registered_tools() {
+        let registered: std::collections::HashSet<&str> = all().iter().map(|e| e.name).collect();
+        for (role, tools) in ROLE_TOOL_SUBSETS {
+            for t in *tools {
+                assert!(
+                    registered.contains(t),
+                    "role '{role}' subset names '{t}' which is not a registered tool (typo?)"
+                );
+            }
+        }
+    }
+}

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -10,6 +10,19 @@ pub fn tool_definitions() -> Value {
     json!({"tools": tools})
 }
 
+/// #2300 P0: tool definitions VISIBLE to `role` (per
+/// [`crate::mcp::registry::tool_subset_for_role`]). Default-all-open — `None` /
+/// dev / lead / unknown role → the full set, byte-identical to
+/// [`tool_definitions`]. Used by the daemon `tools/list` handler to subset the
+/// surface a read/report role advertises.
+pub fn tool_definitions_for_role(role: Option<&str>) -> Value {
+    let tools: Vec<Value> = crate::mcp::registry::tool_subset_for_role(role)
+        .iter()
+        .map(|entry| (entry.definition)())
+        .collect();
+    json!({"tools": tools})
+}
+
 pub(crate) fn def_reply() -> Value {
     json!({"name": "reply", "description": "Reply to the user via the active channel. Requires daemon API. Sprint 59 Wave 1 PR-4 ((B) decision default with timeout): when both `default_action` and `timeout_secs` are set, the daemon records a pending operator decision sidecar and auto-fires the default after the timeout window. Subsequent reply calls without `default_action` resolve the pending decision (operator override / explicit answer arrived).",
         "inputSchema": {"type": "object", "properties": {


### PR DESCRIPTION
P0 of the per-role capability registry — the clean structural route toward #2158 + cuts #2055 surface bloat. **Visibility-only** (lead-vetted): a narrowed role no longer *sees* footgun tools in its `tools/list`; a hard call still dispatches (behavior-preserving). Structural **deny is P1**.

## How
- `registry.rs`: `ROLE_TOOL_SUBSETS` (declarative role→tool allow-list) + `tool_subset_for_role(role)`. **Default-all-open** — `None` / dev / lead / orchestrator / any unlisted-or-unknown role → the full 36 tools, **byte-identical**.
- `tools.rs`: `tool_definitions_for_role(role)` (the unfiltered `tool_definitions` stays the canonical builder + count-invariant input).
- `mcp_proxy.rs::handle_mcp_tools_list`: resolves the caller's fleet `role` → serves its subset; no-role hot path → full surface.
- `agend-mcp-bridge.rs`: `tools/list` now passes the caller `instance` in params (mirrors the tool-call path) so the daemon can resolve the role.

## ⚠ Conservative subset draft — for lead + operator vet
Default-all-open backs any gap, so a too-aggressive cut here only affects the 3 narrowed roles (dev/lead unaffected). Cut = clearly-footgun lifecycle/bind/orchestration the role never legitimately uses.

| Role | KEEPS | DROPS |
|---|---|---|
| **reviewer** | reply, send, inbox, download_attachment, list_instances, binding_state, pane_snapshot, tui_screenshot, **task, decision, ci, repo**, config, set_waiting_on, tokens, health, mode (17) | bind_self, release_worktree, force_release_worktree, create/delete/start/replace/restart_instance, restart_daemon, team, deployment, schedule, watchdog, task_sweep_config, gc_dry_run, interrupt, move_pane, set_display_name, set_description (19) |
| **planner** | same 17 as reviewer | same 19 |
| **explorer** (strictest, read-only) | reviewer's set **minus `repo` + `ci`** (15) | reviewer's drops **+ repo + ci** (21) |

Rationale: reviewer/planner must still review (repo/ci), report (send/decision), and track their task — so those stay; explorer is pure read-only investigation → also drops checkout (`repo`) + run/dispatch (`ci`). **Note**: explorer/planner roles may not exist in the fleet yet — their subsets are dormant until such roles are created (zero effect now).

## Tests
dev/lead/unknown == `all()` 36 byte-identical regression; reviewer drops lifecycle / keeps review tools; explorer strictest; every subset name is a real registered tool. Existing count-invariant (==36, unfiltered) + timeout-key invariant (vs `all()`) stay green. Full `nextest --features tray --profile ci` green (4559/4559); `clippy --all-targets --features tray -D warnings` clean.

Needs rebuild+restart to take effect. P1 (structural deny at `handle_tool` on the same registry) + eligibility = follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)