### PR TITLE
perf(#perf-R1): PTY reader pre-hash gate — skip fg colour-mask build on unchanged frames

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -1609,17 +1609,32 @@ fn pty_read_loop(
                 // won't defeat us (VTerm resolves the geometry). Cooldown: 10s.
                 let screen = {
                     let mut c = core.lock();
-                    c.vterm.process(data);
-                    let rows = c.vterm.rows() as usize;
-                    // #1450: pull the screen text together with the per-char
-                    // foreground color mask. The HIGH_FP color anchor reads
-                    // the mask off the resolved grid cells (alacritty has
-                    // already normalized 16/256/truecolor SGR), replacing the
-                    // #919 raw-byte SGR ring that missed truecolor and broke
-                    // on Ink redraw fragmentation.
-                    let (screen, fg) = c.vterm.tail_lines_with_fg(rows);
-                    c.state.feed_with_fg(&screen, &fg);
-                    broadcast_pty_output(&mut c.subscribers, data, &mut dropped_chunks, name);
+                    // Disjoint field borrows so the lazy-fg closure may read
+                    // `vterm` while `state` is borrowed mutably (both fields of
+                    // the same guarded `AgentCore`).
+                    let AgentCore {
+                        vterm,
+                        state,
+                        subscribers,
+                        ..
+                    } = &mut *c;
+                    vterm.process(data);
+                    let rows = vterm.rows() as usize;
+                    // #perf-R1: hash the CHEAP de-wrapped text-only tail for the
+                    // unchanged-frame dedup gate and build the per-char fg colour
+                    // mask LAZILY — only on a dedup MISS. A redraw flood (Ink /
+                    // spinner re-emitting an identical frame) thus skips the
+                    // O(rows*cols) `classify_fg` rebuild + per-row allocations
+                    // while holding the contended core lock. `tail_lines_dewrapped`
+                    // is byte-identical to `tail_lines_with_fg().0`, so the dedup
+                    // decision and the post-render dismiss scan below are unchanged.
+                    //
+                    // #1450: on a MISS the HIGH_FP colour anchor still reads the
+                    // mask off the resolved grid cells (alacritty has normalized
+                    // 16/256/truecolor SGR) via `tail_lines_with_fg().1`.
+                    let screen = vterm.tail_lines_dewrapped(rows);
+                    state.feed_with_lazy_fg(&screen, || vterm.tail_lines_with_fg(rows).1);
+                    broadcast_pty_output(subscribers, data, &mut dropped_chunks, name);
                     screen
                 };
 

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1452,17 +1452,46 @@ impl StateTracker {
     /// `anchor_on_red == false` (Shell/Raw) OR `fg` is empty (text-only
     /// callers / cold paths) — matching pre-#919 unconditional behavior.
     pub fn feed_with_fg(&mut self, screen_text: &str, fg: &[CellFg]) {
-        // Gate sequence (order-critical — read top-to-bottom):
-        //   1. hash-dedup gate        — skip unchanged frames (throttle-hint override)
-        //   2. classify + transition  — anchor/position suppression → landing
-        //                               pipeline → heartbeat gate → transition
-        //   3. post-classify instrumentation (zero behavior): unclassified-throttle
-        //      capture, shadow telemetry, F9 productive-output detection
+        // Gate 1 — hash-dedup (skip unchanged frames; throttle-hint override).
+        // On a MISS the post-dedup pipeline runs (see `feed_after_dedup`).
         let hash = hash_screen(screen_text);
         if self.apply_hash_dedup_gate(screen_text, hash) {
             return;
         }
+        self.feed_after_dedup(screen_text, fg);
+    }
 
+    /// #perf-R1: hot-path entry. Runs the cheap text-only hash-dedup gate FIRST
+    /// and builds the fg colour mask (via `build_fg`) ONLY on a dedup MISS, so an
+    /// unchanged redraw (Ink/spinner re-emitting an identical frame) skips the
+    /// O(rows*cols) `classify_fg` pass + per-row allocations entirely — all while
+    /// holding the contended per-agent core lock.
+    ///
+    /// Behaviourally identical to `feed_with_fg(screen_text, &build_fg())`: the
+    /// gate's dedup decision is byte-identical because `screen_text` MUST be the
+    /// SAME de-wrapped text `feed_with_fg` would hash — callers pass
+    /// [`crate::vterm::VTerm::tail_lines_dewrapped`], whose text equals
+    /// `tail_lines_with_fg().0`. `build_fg` then yields the colour mask aligned
+    /// 1:1 with that text (same grid, same de-wrap ⇒ `tail_lines_with_fg().1`).
+    pub fn feed_with_lazy_fg(&mut self, screen_text: &str, build_fg: impl FnOnce() -> Vec<CellFg>) {
+        let hash = hash_screen(screen_text);
+        if self.apply_hash_dedup_gate(screen_text, hash) {
+            return;
+        }
+        let fg = build_fg();
+        self.feed_after_dedup(screen_text, &fg);
+    }
+
+    /// Shared post-dedup body of [`feed_with_fg`] / [`feed_with_lazy_fg`] —
+    /// order-critical, read top-to-bottom:
+    ///   2. classify + transition  — anchor/position suppression → landing
+    ///                               pipeline → heartbeat gate → transition
+    ///   3. post-classify instrumentation (zero behavior): unclassified-throttle
+    ///      capture, shadow telemetry, F9 productive-output detection
+    ///
+    /// The caller MUST have already passed the hash-dedup gate (gate 1) for this
+    /// `screen_text`; entering here re-runs detection unconditionally.
+    fn feed_after_dedup(&mut self, screen_text: &str, fg: &[CellFg]) {
         // Sprint 27 shadow-mode: capture silence duration BEFORE updating
         // last_output, so we measure time since previous feed (not current).
         let silence_since_last_feed = self.last_output.elapsed();

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -5641,3 +5641,171 @@ fn turn_sentinel_fires_for_prod_constructed_tracker_2297() {
         "the agent's name-derived token was detected via the prod path"
     );
 }
+
+// ── #perf-R1: lazy-fg gate — unchanged frames skip the fg colour-mask build ──
+//
+// The PTY hot path (agent/mod.rs `pty_read_loop`) used to build the full
+// O(rows*cols) fg colour mask on EVERY chunk, then discard it inside
+// `feed_with_fg`'s hash-dedup early-return whenever the frame was unchanged (an
+// Ink/spinner redraw flood). `feed_with_lazy_fg` defers the mask build behind
+// the dedup gate. These pins are DETERMINISTIC (a call counter, never a timing
+// assertion — machine-independent, never flaky).
+
+/// Drive the NEW hot-path ingress (`tail_lines_dewrapped` → `feed_with_lazy_fg`),
+/// mirroring agent/mod.rs `pty_read_loop`, so a test can prove it transitions
+/// identically to the eager [`drive`] (`tail_lines_with_fg` → `feed_with_fg`).
+fn drive_lazy(vterm: &mut VTerm, state: &mut StateTracker, bytes: &[u8]) {
+    vterm.process(bytes);
+    let rows = vterm.rows() as usize;
+    let screen = vterm.tail_lines_dewrapped(rows);
+    state.feed_with_lazy_fg(&screen, || vterm.tail_lines_with_fg(rows).1);
+}
+
+/// An unchanged (dedup-HIT) frame must NOT invoke the fg-mask builder.
+#[test]
+fn lazy_fg_skips_build_on_unchanged_frame() {
+    use std::cell::Cell;
+    let mut t = StateTracker::new(Some(&Backend::ClaudeCode));
+    let frame = "some benign idle output\n❯";
+    let n = frame.chars().count();
+    let builds = Cell::new(0u32);
+
+    // First feed: a NEW frame ⇒ dedup MISS ⇒ fg built exactly once.
+    t.feed_with_lazy_fg(frame, || {
+        builds.set(builds.get() + 1);
+        vec![CellFg::Default; n]
+    });
+    assert_eq!(
+        builds.get(),
+        1,
+        "a new frame must build the fg mask exactly once"
+    );
+
+    // Second feed: IDENTICAL frame ⇒ dedup HIT ⇒ fg builder NOT invoked.
+    t.feed_with_lazy_fg(frame, || {
+        builds.set(builds.get() + 1);
+        vec![CellFg::Default; n]
+    });
+    assert_eq!(
+        builds.get(),
+        1,
+        "an unchanged frame must skip the fg-mask build (dedup HIT via the lazy gate)"
+    );
+}
+
+/// A CHANGED frame (dedup MISS) must build the fg mask AND run detection — a
+/// red-rendered SRL error still latches through the lazy path (fg is consumed).
+#[test]
+fn lazy_fg_builds_on_changed_frame_and_red_anchor_fires() {
+    use std::cell::Cell;
+    let mut t = StateTracker::new(Some(&Backend::Codex));
+    let screen = "Error: socket hang up";
+    let n = screen.chars().count();
+    let builds = Cell::new(0u32);
+
+    t.feed_with_lazy_fg(screen, || {
+        builds.set(builds.get() + 1);
+        vec![CellFg::Red; n]
+    });
+    assert_eq!(builds.get(), 1, "a changed frame builds the fg mask");
+    assert_eq!(
+        t.get_state(),
+        AgentState::ServerRateLimit,
+        "#perf-R1: a red SRL error still latches through the lazy-fg path (fg consumed on MISS)"
+    );
+}
+
+/// The lazy hot path must produce the SAME state transitions as the eager path
+/// across a realistic sequence (idle → SRL latch → recovery), driven through the
+/// REAL vterm render. `saw_srl` guards against a vacuously-all-Idle equality.
+#[test]
+fn lazy_fg_path_matches_eager_path() {
+    let seq: &[&[u8]] = &[
+        b"\x1b[2J\x1b[Hidle output here\r\n\xe2\x9d\xaf ",
+        "\x1b[2J\x1b[HAPI Error: Server is\r\ntemporarily limiting\r\nrequests (not your\r\nusage limit)\r\n"
+            .as_bytes(),
+        b"\x1b[2J\x1b[Hrecovered, idle again\r\n\xe2\x9d\xaf ",
+    ];
+    let mut vt_e = VTerm::new(120, 24);
+    let mut st_e = StateTracker::new(Some(&Backend::ClaudeCode));
+    let mut vt_l = VTerm::new(120, 24);
+    let mut st_l = StateTracker::new(Some(&Backend::ClaudeCode));
+
+    let mut saw_srl = false;
+    for (i, f) in seq.iter().enumerate() {
+        drive(&mut vt_e, &mut st_e, f);
+        drive_lazy(&mut vt_l, &mut st_l, f);
+        assert_eq!(
+            st_l.get_state(),
+            st_e.get_state(),
+            "frame {i}: the lazy hot path must transition identically to the eager path"
+        );
+        saw_srl |= st_e.get_state() == AgentState::ServerRateLimit;
+    }
+    assert!(
+        saw_srl,
+        "the sequence must exercise a real SRL transition (else the equality is vacuous)"
+    );
+}
+
+/// #SRL-phase2 throttle-hint override through the lazy path. While a pane is
+/// already latched an identical frame is a plain dedup HIT (no fg rebuild); but a
+/// SETTLED pane that was spuriously cleared must RE-DETECT on the next identical
+/// frame, and the fg mask IS rebuilt on that re-detect (the override deliberately
+/// falls through the dedup gate — correctness over the perf skip). Mirrors
+/// `static_srl_pane_redetected_after_dedup_blindspot_phase2`.
+#[test]
+fn lazy_fg_rebuilds_and_redetects_static_throttle_pane() {
+    use std::cell::Cell;
+    let mut vt = VTerm::new(120, 24);
+    let mut st = StateTracker::new(Some(&Backend::ClaudeCode));
+    let hw =
+        "API Error: Server is\r\ntemporarily limiting\r\nrequests (not your\r\nusage limit)\r\n";
+    vt.process(hw.as_bytes());
+    let rows = vt.rows() as usize;
+    let screen = vt.tail_lines_dewrapped(rows);
+    let builds = Cell::new(0u32);
+
+    // First feed (NEW frame ⇒ MISS): builds the mask, latches.
+    st.feed_with_lazy_fg(&screen, || {
+        builds.set(builds.get() + 1);
+        vt.tail_lines_with_fg(rows).1
+    });
+    assert_eq!(
+        st.get_state(),
+        AgentState::ServerRateLimit,
+        "first feed latches"
+    );
+    assert_eq!(builds.get(), 1, "the first (MISS) feed builds the fg mask");
+
+    // Identical frame while STILL latched: `already_throttle` ⇒ plain dedup HIT.
+    st.feed_with_lazy_fg(&screen, || {
+        builds.set(builds.get() + 1);
+        vt.tail_lines_with_fg(rows).1
+    });
+    assert_eq!(st.get_state(), AgentState::ServerRateLimit, "stays latched");
+    assert_eq!(
+        builds.get(),
+        1,
+        "an identical frame while already throttle-latched is a plain dedup HIT (no fg rebuild)"
+    );
+
+    // Spurious clear; the pane stays STATIC (same de-wrapped text ⇒ same hash).
+    st.current = AgentState::Idle;
+    // Identical frame, now NOT latched: throttle-hint override falls through the
+    // dedup gate ⇒ re-detect ⇒ the fg mask IS rebuilt ⇒ re-latches.
+    st.feed_with_lazy_fg(&screen, || {
+        builds.set(builds.get() + 1);
+        vt.tail_lines_with_fg(rows).1
+    });
+    assert_eq!(
+        st.get_state(),
+        AgentState::ServerRateLimit,
+        "#SRL-phase2: a static throttle pane must re-detect through the lazy gate"
+    );
+    assert_eq!(
+        builds.get(),
+        2,
+        "#perf-R1: the throttle-hint re-detect override still rebuilds the fg mask"
+    );
+}

--- a/src/vterm.rs
+++ b/src/vterm.rs
@@ -642,7 +642,18 @@ impl VTerm {
     /// Used by AwaitingOperator to snapshot "what the CLI printed before
     /// it started waiting for stdin" for forwarding to Telegram.
     pub fn tail_lines(&self, n: usize) -> String {
-        self.tail_lines_impl(n, false).0
+        self.tail_lines_impl(n, false, false).0
+    }
+
+    /// #perf-R1: the de-wrapped detection text WITHOUT the per-cell foreground
+    /// classification. Byte-identical to [`tail_lines_with_fg`]'s `String` (same
+    /// `WRAPLINE` de-wrap), but skips the O(rows*cols) `classify_fg` pass and the
+    /// per-row colour/dim allocations. The PTY hot path hashes this for the
+    /// unchanged-frame dedup gate and builds the colour mask lazily only on a
+    /// dedup MISS (see [`crate::state::StateTracker::feed_with_lazy_fg`]), so a
+    /// redraw flood of identical frames never pays the colour cost.
+    pub fn tail_lines_dewrapped(&self, n: usize) -> String {
+        self.tail_lines_impl(n, false, true).0
     }
 
     /// #1948(b): the last `n` rows + a per-character DIM-attribute mask aligned
@@ -651,7 +662,7 @@ impl VTerm {
     /// the operator's normal-intensity input — colour-only [`CellFg`] can't,
     /// because the ghost is dim on the DEFAULT foreground colour.
     pub fn tail_lines_with_dim(&self, n: usize) -> (String, Vec<bool>) {
-        let (text, _fg, dim) = self.tail_lines_impl(n, true);
+        let (text, _fg, dim) = self.tail_lines_impl(n, true, true);
         (text, dim)
     }
 
@@ -663,20 +674,33 @@ impl VTerm {
     /// the phrase is rendered red. Building both in one pass guarantees the
     /// mask and the text can never drift out of alignment.
     pub fn tail_lines_with_fg(&self, n: usize) -> (String, Vec<CellFg>) {
-        let (text, fg, _dim) = self.tail_lines_impl(n, true);
+        let (text, fg, _dim) = self.tail_lines_impl(n, true, true);
         (text, fg)
     }
 
-    /// Shared core for [`tail_lines`] / [`tail_lines_with_fg`]. When
-    /// `collect_fg` is false the returned `Vec<CellFg>` is empty (no per-cell
-    /// classification cost) AND physical rows are joined verbatim with `\n`
-    /// (byte-identical to the legacy output — text-only display/dialog callers
-    /// unaffected). When `collect_fg` is true (the state-detection feed) a
-    /// `WRAPLINE`-soft-wrapped row is DE-WRAPPED — joined to its continuation
-    /// WITHOUT a `\n` — so a single logical line the terminal wrapped across
-    /// rows stays one line for the single-line detection regexes (#1808). The
-    /// fg mask stays aligned 1:1 with the de-wrapped text.
-    fn tail_lines_impl(&self, n: usize, collect_fg: bool) -> (String, Vec<CellFg>, Vec<bool>) {
+    /// Shared core for [`tail_lines`] / [`tail_lines_with_fg`] /
+    /// [`tail_lines_dewrapped`]. Two orthogonal knobs (decoupled #perf-R1):
+    ///
+    /// * `collect_fg` — when false the returned `Vec<CellFg>` (and dim vec) are
+    ///   empty, skipping the per-cell `classify_fg` classification cost.
+    /// * `dewrap` — when false physical rows are joined verbatim with `\n`
+    ///   (byte-identical to the legacy text-only output — display/dialog callers
+    ///   unaffected). When true a `WRAPLINE`-soft-wrapped row is DE-WRAPPED —
+    ///   joined to its continuation WITHOUT a `\n` — so a single logical line the
+    ///   terminal wrapped across rows stays one line for the single-line
+    ///   detection regexes (#1808).
+    ///
+    /// The state-detection feed uses `(collect_fg=true, dewrap=true)`; the cheap
+    /// pre-hash gate uses `(collect_fg=false, dewrap=true)` — same de-wrapped
+    /// text, no colour cost. The fg mask (when collected) stays aligned 1:1 with
+    /// the returned text. (Previously `dewrap` was implicitly `collect_fg`; they
+    /// are now independent so a text-only caller can still de-wrap.)
+    fn tail_lines_impl(
+        &self,
+        n: usize,
+        collect_fg: bool,
+        dewrap: bool,
+    ) -> (String, Vec<CellFg>, Vec<bool>) {
         let grid = self.term.grid();
         let cols = self.cols as usize;
         let rows = self.rows as usize;
@@ -718,7 +742,7 @@ impl VTerm {
                 }
                 col += 1;
             }
-            let row_wrapped = collect_fg
+            let row_wrapped = dewrap
                 && cols > 0
                 && safe_cell(grid, Line(row as i32), cols - 1)
                     .flags
@@ -2274,6 +2298,96 @@ mod tests {
         assert_ne!(
             ptr2, ptr0,
             "each pane's VTerm must own a distinct scratch buffer (no shared state)"
+        );
+    }
+
+    /// #perf-R1: `tail_lines_dewrapped` must return text BYTE-IDENTICAL to
+    /// `tail_lines_with_fg().0` (the de-wrapped detection text) while skipping the
+    /// colour mask. Under a soft-wrap it must DIFFER from the verbatim
+    /// `tail_lines` — proving the pre-hash dedup gate keys on the SAME text
+    /// detection consumes, NOT the verbatim tail (whose `\n`/trailing-space
+    /// divergence at the wrap column would desync the dedup decision).
+    #[test]
+    fn tail_lines_dewrapped_matches_detection_text_and_dewraps() {
+        // 20-col terminal; a 30-char line auto-wraps (soft WRAPLINE) across 2 rows.
+        let mut vt = VTerm::new(20, 6);
+        vt.process(b"abcdefghijklmnopqrstuvwxyz0123\r\n");
+        let n = vt.rows() as usize;
+
+        let dewrapped = vt.tail_lines_dewrapped(n);
+        let (with_fg_text, _fg) = vt.tail_lines_with_fg(n);
+        assert_eq!(
+            dewrapped, with_fg_text,
+            "#perf-R1: the cheap pre-hash text must equal the de-wrapped detection text"
+        );
+
+        let verbatim = vt.tail_lines(n);
+        assert_ne!(
+            dewrapped, verbatim,
+            "under a soft-wrap the de-wrapped text must DIFFER from the verbatim tail \
+             (the gate keys on detection text, not `tail_lines`)"
+        );
+        assert!(
+            dewrapped.contains("abcdefghijklmnopqrstuvwxyz0123"),
+            "de-wrap rejoins the soft-wrapped logical line WITHOUT a newline"
+        );
+        assert!(
+            verbatim.contains('\n'),
+            "verbatim text keeps the soft-wrap as a newline split"
+        );
+    }
+
+    /// #perf-R1 spike measurement (NOT a regression gate — `#[ignore]`, run in
+    /// release: `cargo test --release --ignored perf_r1_tail_extract_cost --
+    /// --nocapture`). Isolates the wasted work on an UNCHANGED frame: the PTY hot
+    /// path used to build the full fg mask (`tail_lines_with_fg`, O(rows*cols) +
+    /// per-cell `classify_fg` + 2 Vecs/row) on EVERY chunk, then discard it inside
+    /// the text-only dedup gate when the frame was identical. The shipped fix
+    /// hashes the cheap `tail_lines_dewrapped` (de-wrapped text-only, the REAL
+    /// pre-hash path — same text, no colour cost) and builds the mask lazily only
+    /// on a dedup MISS. This prints both costs + the per-identical-frame saving.
+    #[test]
+    #[ignore = "perf measurement, run explicitly in release"]
+    fn perf_r1_tail_extract_cost() {
+        use std::time::Instant;
+        // ~200 cols × 50 visible rows, filled with mixed colored content so
+        // classify_fg has realistic work (red anchors + 256/rgb + default).
+        let mut vt = VTerm::new(200, 50);
+        for r in 0..50 {
+            let line = format!(
+                "\x1b[31mERROR\x1b[0m row {r} \x1b[38;5;208midx\x1b[0m \
+                 \x1b[38;2;10;200;30mrgb\x1b[0m normal padding text to widen the row {r}\r\n"
+            );
+            vt.process(line.as_bytes());
+        }
+        let n = 100_000u32;
+        let rows = vt.rows() as usize;
+
+        // black-box the results so the optimizer can't elide the work.
+        let t0 = Instant::now();
+        let mut acc = 0usize;
+        for _ in 0..n {
+            let (text, fg) = vt.tail_lines_with_fg(rows);
+            acc = acc.wrapping_add(text.len()).wrapping_add(fg.len());
+        }
+        let with_fg = t0.elapsed();
+
+        let t1 = Instant::now();
+        for _ in 0..n {
+            let text = vt.tail_lines_dewrapped(rows);
+            acc = acc.wrapping_add(text.len());
+        }
+        let dewrapped = t1.elapsed();
+
+        let wf = with_fg.as_nanos() as f64 / n as f64;
+        let dw = dewrapped.as_nanos() as f64 / n as f64;
+        println!("#perf-R1 (200x50, n={n}, acc={acc}):");
+        println!("  tail_lines_with_fg (old: built per identical frame): {wf:.0} ns/call");
+        println!("  tail_lines_dewrapped (new pre-hash gate path)       : {dw:.0} ns/call");
+        println!(
+            "  saving per unchanged frame                          : {:.0} ns ({:.1}x)",
+            wf - dw,
+            wf / dw
         );
     }
 }


### PR DESCRIPTION
## What
Producer-side (PTY reader) sibling of the redraw-storm fix #2346 (dev-3's consumer/TUI 30fps render cap). Different file/thread (`agent/mod.rs` pty_read_loop vs `app/mod.rs` render loop) — no overlap.

The PTY read loop built the full **O(rows*cols)** fg colour mask (`tail_lines_with_fg`: per-cell `classify_fg` + per-row `Vec`s) on **every** chunk, then discarded it inside `feed_with_fg`'s hash-dedup early-return whenever the frame was unchanged. Under a redraw flood (Ink/spinner re-emitting an identical frame, ~300–741 chunks/s × N agents) that wasted colour rebuild ran on every duplicate — all while holding the contended per-agent core lock (supervisor / hang-detection / snapshot / TUI readback all contend on it).

## How
Defer the colour-mask build behind the dedup gate:
- **vterm**: decouple `dewrap` from `collect_fg`; add `tail_lines_dewrapped` — the de-wrapped detection text **without** the colour pass. Its text is **byte-identical** to `tail_lines_with_fg().0`, so the dedup hash is unchanged.
- **state**: extract `feed_after_dedup` (shared post-gate body); add `feed_with_lazy_fg(text, build_fg)` that runs the **identical** gate and invokes `build_fg` **only on a dedup MISS**. `feed_with_fg` keeps exact behaviour (all existing callers + the `feed()` seam untouched).
- **pty_read_loop**: hash the cheap `tail_lines_dewrapped`; build fg lazily on a MISS via `tail_lines_with_fg().1`.

## Correctness — detection is byte-identical
The dedup gate hashes the **de-wrapped** text (what detection consumes), so the cheap path uses `tail_lines_dewrapped` (de-wrapped, no colour), **not** the verbatim `tail_lines` — which diverges from the detection text at soft-wrap boundaries (`\n` + trailing-space). On a MISS the same fg mask is built (same grid, same de-wrap ⇒ `tail_lines_with_fg().1`) and consumed identically.

## (b) lock-shrink — DROPPED (spike judged UNSAFE, lead-confirmed)
Moving the fg build / `feed` out of the core lock is unsafe: `feed_with_fg` **mutates** the `StateTracker` that supervisor/render read **under the same lock**; there is no independent state-lock. (a) already shaves the wasted hold off the flood path without moving anything.

## Tests (deterministic — no timing assertions)
- `tail_lines_dewrapped_matches_detection_text_and_dewraps` — proves byte-identity to `tail_lines_with_fg().0` and divergence from verbatim under soft-wrap.
- `lazy_fg_skips_build_on_unchanged_frame` — fg-build **call counter** stays 1 on an identical frame (the regression guard).
- `lazy_fg_builds_on_changed_frame_and_red_anchor_fires` — changed red SRL still latches through the lazy path.
- `lazy_fg_path_matches_eager_path` — lazy hot path == eager path across idle→SRL→recovery via the real vterm.
- `lazy_fg_rebuilds_and_redetects_static_throttle_pane` — throttle-hint override still re-detects (and rebuilds fg) across the dedup blind spot.
- `#[ignore]` manual bench `perf_r1_tail_extract_cost` (release): ~**38µs / 1.8×** saved per unchanged frame. Not a CI gate.

## Verification
`cargo fmt --check` ✓ · `cargo clippy --tests --features tray -D warnings` ✓ · full state/vterm/agent module tests (516) ✓ · relevant invariant meta-tests (28, incl. `state_current_mutation`, `core_mutex`, `file_size`, `spawn_rationale`) ✓.

⚠ Lock-concurrency-sensitive hot path → **DUAL review** requested. Merge requires an operator restart to go live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)