### PR TITLE
perf: gate startup dismiss scans

### DIFF
--- a/src/agent/dismiss.rs
+++ b/src/agent/dismiss.rs
@@ -28,6 +28,27 @@ static DISMISS_IN_FLIGHT: std::sync::LazyLock<
     parking_lot::Mutex<std::collections::HashSet<String>>,
 > = std::sync::LazyLock::new(|| parking_lot::Mutex::new(std::collections::HashSet::new()));
 
+#[cfg(test)]
+static DISMISS_SCAN_COUNT: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+#[cfg(test)]
+pub(crate) fn reset_dismiss_scan_count_for_test() {
+    DISMISS_SCAN_COUNT.store(0, std::sync::atomic::Ordering::SeqCst);
+}
+
+#[cfg(test)]
+pub(crate) fn dismiss_scan_count_for_test() -> usize {
+    DISMISS_SCAN_COUNT.load(std::sync::atomic::Ordering::SeqCst)
+}
+
+#[derive(Clone)]
+pub struct PreparedDismissPattern {
+    pattern: String,
+    literal_hint: String,
+    regex: std::sync::Arc<regex::Regex>,
+    key_seq: Vec<u8>,
+}
+
 /// #1886 follow-up: RAII guard that removes an agent from `DISMISS_IN_FLIGHT` on
 /// drop — including on a panic or early-return of the dismiss thread. Previously
 /// the removal was a trailing statement, so a panic before it left a stale entry
@@ -88,33 +109,66 @@ fn dismiss_regex_cache_contains(pattern: &str) -> bool {
 /// and any future cursor variant introduced by a backend's TUI without
 /// requiring a new patch per backend.
 const DISMISS_REGEX_PREFIX: &str = r"(?m)^[^A-Za-z\n]{0,8}";
+const DISMISS_REGEX_WIDE_PREFIX: &str = r"(?m)^[^A-Za-z\n]*";
 
 fn dismiss_literal_hint(pattern: &str) -> &str {
     pattern
         .strip_prefix(DISMISS_REGEX_PREFIX)
+        .or_else(|| pattern.strip_prefix(DISMISS_REGEX_WIDE_PREFIX))
         .unwrap_or(pattern)
 }
 
+pub fn prepare_dismiss_patterns(
+    dismiss_patterns: &[(String, Vec<u8>)],
+) -> Vec<PreparedDismissPattern> {
+    dismiss_patterns
+        .iter()
+        .filter_map(|(pattern, key_seq)| {
+            let regex = compile_dismiss_regex(pattern)?;
+            Some(PreparedDismissPattern {
+                pattern: pattern.clone(),
+                literal_hint: dismiss_literal_hint(pattern).to_string(),
+                regex,
+                key_seq: key_seq.clone(),
+            })
+        })
+        .collect()
+}
+
+#[allow(dead_code)]
 pub fn try_dismiss_dialog(
     name: &str,
     screen: &str,
     pty_writer: &PtyWriter,
     dismiss_patterns: &[(String, Vec<u8>)],
 ) -> bool {
+    let prepared = prepare_dismiss_patterns(dismiss_patterns);
+    try_prepared_dismiss_dialog(name, screen, pty_writer, &prepared)
+}
+
+pub fn try_prepared_dismiss_dialog(
+    name: &str,
+    screen: &str,
+    pty_writer: &PtyWriter,
+    dismiss_patterns: &[PreparedDismissPattern],
+) -> bool {
+    #[cfg(test)]
+    DISMISS_SCAN_COUNT.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+
     if dismiss_patterns.is_empty() {
         return false;
     }
 
-    for (pattern, key_seq) in dismiss_patterns {
+    for pattern in dismiss_patterns {
+        if !pattern.literal_hint.is_empty() && !screen.contains(&pattern.literal_hint) {
+            continue;
+        }
         // Issue #468: regex match anchored to line start + optional TUI prefix.
         // Substring match (the prior behavior) auto-injected `2\n` / `3\n`
         // whenever the phrase appeared anywhere on screen — including in agent
         // output and scrollback — sending input the user never authorized.
-        let Some(re) = compile_dismiss_regex(pattern) else {
-            continue;
-        };
-        if re.is_match(screen) {
-            tracing::info!(agent = name, pattern, "auto-dismissing dialog");
+        if pattern.regex.is_match(screen) {
+            tracing::info!(agent = name, pattern = %pattern.pattern, "auto-dismissing dialog");
             // Delayed write: TUI escape-sequence parsers need time to distinguish
             // \x1b (ESC key) from \x1b[ (CSI start).  Writing immediately causes
             // Ink-based TUIs (kiro-cli) to interpret \x1b as "ESC to cancel".
@@ -128,7 +182,7 @@ pub fn try_dismiss_dialog(
                 inflight.insert(name.to_string());
             }
             let writer = Arc::clone(pty_writer);
-            let keys = key_seq.clone();
+            let keys = pattern.key_seq.clone();
             let agent = name.to_string();
             // fire-and-forget: dialog-dismiss keystroke writer is short-lived
             // (sleep 300ms then write). H2: in-flight slot freed by InFlightGuard
@@ -179,12 +233,11 @@ pub fn try_dismiss_dialog(
         // would have triggered the old substring path but the new regex
         // anchor declined — surfaces realistic false positives (mid-paragraph
         // matches, scrollback echoes) without auto-injecting bytes.
-        let literal = dismiss_literal_hint(pattern);
-        if literal != pattern.as_str() && !literal.is_empty() && screen.contains(literal) {
+        if pattern.literal_hint != pattern.pattern && !pattern.literal_hint.is_empty() {
             tracing::debug!(
                 agent = name,
-                pattern,
-                literal,
+                pattern = %pattern.pattern,
+                literal = %pattern.literal_hint,
                 "dismiss substring seen but regex didn't match — likely false positive"
             );
         }

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -16,7 +16,9 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 mod dismiss;
+#[allow(unused_imports)]
 pub use dismiss::try_dismiss_dialog;
+use dismiss::{prepare_dismiss_patterns, try_prepared_dismiss_dialog, PreparedDismissPattern};
 
 pub mod deleting;
 
@@ -1208,6 +1210,7 @@ pub fn spawn_agent(config: &SpawnConfig, registry: &AgentRegistry) -> anyhow::Re
                 .collect()
         })
         .unwrap_or_default();
+    let dismiss = prepare_dismiss_patterns(&dismiss);
     let shutdown_for_reaper = shutdown.clone();
     let deleted_for_reaper = {
         let reg = registry.lock();
@@ -1490,7 +1493,7 @@ struct PtyReadContext {
     registry: AgentRegistry,
     home: Option<std::path::PathBuf>,
     crash_tx: Option<CrashChannel>,
-    dismiss_patterns: Vec<(String, Vec<u8>)>,
+    dismiss_patterns: Vec<PreparedDismissPattern>,
     shutdown: Option<Arc<std::sync::atomic::AtomicBool>>,
     deleted: Arc<std::sync::atomic::AtomicBool>,
 }
@@ -1558,6 +1561,7 @@ fn pty_read_loop(
     } = ctx;
     let mut buf = [0u8; 8192];
     let mut dismiss_cooldown_until: Option<std::time::Instant> = None;
+    let mut dismiss_scan_enabled = !dismiss_patterns.is_empty();
     // #t-23: debug-only seam — verbose per-read PTY logging (read counts / byte
     // totals). Off by default; enable with `AGEND_DEBUG_PTY_READ=1`. Tightened
     // from presence-based (`is_ok()`: any value, even `=0`, enabled it) to the
@@ -1607,7 +1611,7 @@ fn pty_read_loop(
                 // post-render means we match what the user actually sees —
                 // Ink-style TUIs that draw char-by-char with cursor positioning
                 // won't defeat us (VTerm resolves the geometry). Cooldown: 10s.
-                let screen = {
+                let (screen, state_changed, dismiss_latch_off) = {
                     let mut c = core.lock();
                     // Disjoint field borrows so the lazy-fg closure may read
                     // `vterm` while `state` is borrowed mutably (both fields of
@@ -1633,17 +1637,28 @@ fn pty_read_loop(
                     // mask off the resolved grid cells (alacritty has normalized
                     // 16/256/truecolor SGR) via `tail_lines_with_fg().1`.
                     let screen = vterm.tail_lines_dewrapped(rows);
-                    state.feed_with_lazy_fg(&screen, || vterm.tail_lines_with_fg(rows).1);
+                    let state_changed =
+                        state.feed_with_lazy_fg(&screen, || vterm.tail_lines_with_fg(rows).1);
+                    let dismiss_latch_off = state_changed
+                        && (state.get_state() == crate::state::AgentState::Idle
+                            || state.has_productive_output());
                     broadcast_pty_output(subscribers, data, &mut dropped_chunks, name);
-                    screen
+                    (screen, state_changed, dismiss_latch_off)
                 };
 
                 let in_cooldown = dismiss_cooldown_until
                     .map(|t| std::time::Instant::now() < t)
                     .unwrap_or(false);
-                if !in_cooldown && try_dismiss_dialog(name, &screen, pty_writer, dismiss_patterns) {
+                if dismiss_scan_enabled
+                    && state_changed
+                    && !in_cooldown
+                    && try_prepared_dismiss_dialog(name, &screen, pty_writer, dismiss_patterns)
+                {
                     dismiss_cooldown_until =
                         Some(std::time::Instant::now() + std::time::Duration::from_secs(10));
+                }
+                if dismiss_latch_off {
+                    dismiss_scan_enabled = false;
                 }
             }
             Err(e) => {

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+static R8_DISMISS_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 /// #945 Phase 1: pending-registry slot publishes the agent registry
 /// to the background `telegram_init` thread. The slot is a
 /// `OnceLock` (set-once-per-process) so the test asserts that
@@ -1706,6 +1708,149 @@ fn pty_read_error_triggers_cleanup() {
         "#1144: read error path must call handle_pty_close which removes \
              agent from registry (shutdown=true path). Before fix, the Err \
              branch broke without cleanup, leaving a zombie entry."
+    );
+}
+
+struct ChunkReader {
+    chunks: Vec<&'static [u8]>,
+    next: usize,
+}
+
+impl std::io::Read for ChunkReader {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let Some(chunk) = self.chunks.get(self.next) else {
+            return Ok(0);
+        };
+        self.next += 1;
+        let n = chunk.len().min(buf.len());
+        buf[..n].copy_from_slice(&chunk[..n]);
+        Ok(n)
+    }
+}
+
+#[derive(Clone)]
+struct RecordingWriter {
+    bytes: Arc<Mutex<Vec<u8>>>,
+}
+
+impl std::io::Write for RecordingWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.bytes.lock().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+fn run_pty_read_loop_for_r8(
+    chunks: Vec<&'static [u8]>,
+    backend: Backend,
+    dismiss_patterns: Vec<(String, Vec<u8>)>,
+) -> Arc<Mutex<Vec<u8>>> {
+    let written = Arc::new(Mutex::new(Vec::new()));
+    let writer: PtyWriter = Arc::new(Mutex::new(Box::new(RecordingWriter {
+        bytes: Arc::clone(&written),
+    })));
+    let core = Arc::new(crate::sync_audit::CoreMutex::new(AgentCore {
+        vterm: VTerm::new(120, 24),
+        subscribers: Vec::new(),
+        state: StateTracker::new(Some(&backend)),
+        health: HealthTracker::new(),
+    }));
+    let ctx = PtyReadContext {
+        name: "r8-dismiss-test".to_string(),
+        instance_id: crate::types::InstanceId::default(),
+        core,
+        pty_writer: writer,
+        registry: Arc::new(Mutex::new(std::collections::HashMap::new())),
+        home: None,
+        crash_tx: None,
+        dismiss_patterns: dismiss::prepare_dismiss_patterns(&dismiss_patterns),
+        shutdown: Some(Arc::new(std::sync::atomic::AtomicBool::new(true))),
+        deleted: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    };
+    let mut reader = ChunkReader { chunks, next: 0 };
+    let capture = crate::capture::make_capture_writer(None, "r8-dismiss-test", backend.name());
+    pty_read_loop(&mut reader, &ctx, capture);
+    written
+}
+
+#[test]
+fn r8_dismiss_scan_skips_unchanged_frames() {
+    let _guard = R8_DISMISS_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    dismiss::reset_dismiss_scan_count_for_test();
+
+    let patterns = vec![(r"(?m)^[^A-Za-z\n]*Do you trust".to_string(), b"\r".to_vec())];
+    run_pty_read_loop_for_r8(
+        vec![b"\x1b[2J\x1b[Hbooting", b"\x1b[2J\x1b[Hbooting"],
+        Backend::Codex,
+        patterns,
+    );
+
+    assert_eq!(
+        dismiss::dismiss_scan_count_for_test(),
+        1,
+        "R8: identical post-render screens must hit the state dedup gate and skip dismiss scanning"
+    );
+}
+
+#[test]
+fn r8_dismiss_scan_latches_off_after_idle() {
+    let _guard = R8_DISMISS_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    dismiss::reset_dismiss_scan_count_for_test();
+
+    let patterns = vec![(r"(?m)^[^A-Za-z\n]*Do you trust".to_string(), b"\r".to_vec())];
+    run_pty_read_loop_for_r8(
+        vec![
+            b"\x1b[2J\x1b[HOpenAI Codex\n\xe2\x80\xba ",
+            b"\x1b[2J\x1b[HDo you trust this folder?\nYes, continue",
+        ],
+        Backend::Codex,
+        patterns,
+    );
+
+    assert_eq!(
+        dismiss::dismiss_scan_count_for_test(),
+        1,
+        "R8: once the agent reaches Idle, later changed frames must not keep scanning dismiss patterns"
+    );
+}
+
+#[test]
+fn r8_startup_dialog_still_dismisses_before_latch_off() {
+    let _guard = R8_DISMISS_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    dismiss::reset_dismiss_scan_count_for_test();
+
+    let patterns: Vec<(String, Vec<u8>)> = Backend::Codex
+        .preset()
+        .dismiss_patterns
+        .iter()
+        .map(|p| (p.label.to_string(), p.sequence.to_vec()))
+        .collect();
+    let written = run_pty_read_loop_for_r8(
+        vec![b"\x1b[2J\x1b[HDo you trust this folder?\nYes, continue"],
+        Backend::Codex,
+        patterns,
+    );
+    std::thread::sleep(std::time::Duration::from_millis(700));
+
+    assert_eq!(
+        dismiss::dismiss_scan_count_for_test(),
+        1,
+        "R8: startup modal frame must still run the dismiss scanner"
+    );
+    assert_eq!(
+        written.lock().as_slice(),
+        b"\r",
+        "R8: startup trust dialog must still send the configured dismiss keystroke"
     );
 }
 

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1451,14 +1451,15 @@ impl StateTracker {
     /// Fail-open conditions (HIGH_FP transition fires WITHOUT a red check):
     /// `anchor_on_red == false` (Shell/Raw) OR `fg` is empty (text-only
     /// callers / cold paths) — matching pre-#919 unconditional behavior.
-    pub fn feed_with_fg(&mut self, screen_text: &str, fg: &[CellFg]) {
+    pub fn feed_with_fg(&mut self, screen_text: &str, fg: &[CellFg]) -> bool {
         // Gate 1 — hash-dedup (skip unchanged frames; throttle-hint override).
         // On a MISS the post-dedup pipeline runs (see `feed_after_dedup`).
         let hash = hash_screen(screen_text);
         if self.apply_hash_dedup_gate(screen_text, hash) {
-            return;
+            return false;
         }
         self.feed_after_dedup(screen_text, fg);
+        true
     }
 
     /// #perf-R1: hot-path entry. Runs the cheap text-only hash-dedup gate FIRST
@@ -1473,13 +1474,18 @@ impl StateTracker {
     /// [`crate::vterm::VTerm::tail_lines_dewrapped`], whose text equals
     /// `tail_lines_with_fg().0`. `build_fg` then yields the colour mask aligned
     /// 1:1 with that text (same grid, same de-wrap ⇒ `tail_lines_with_fg().1`).
-    pub fn feed_with_lazy_fg(&mut self, screen_text: &str, build_fg: impl FnOnce() -> Vec<CellFg>) {
+    pub fn feed_with_lazy_fg(
+        &mut self,
+        screen_text: &str,
+        build_fg: impl FnOnce() -> Vec<CellFg>,
+    ) -> bool {
         let hash = hash_screen(screen_text);
         if self.apply_hash_dedup_gate(screen_text, hash) {
-            return;
+            return false;
         }
         let fg = build_fg();
         self.feed_after_dedup(screen_text, &fg);
+        true
     }
 
     /// Shared post-dedup body of [`feed_with_fg`] / [`feed_with_lazy_fg`] —
@@ -2588,6 +2594,10 @@ impl StateTracker {
     pub fn recovered_within(&self, window: Duration) -> bool {
         self.last_productive_output
             .is_some_and(|t| t.elapsed() < window)
+    }
+
+    pub fn has_productive_output(&self) -> bool {
+        self.last_productive_output.is_some()
     }
 
     /// Periodic tick — expire stale latched states without requiring new PTY


### PR DESCRIPTION
## Summary
- prepare dismiss regexes once at spawn and scan prepared patterns in the PTY loop
- skip dismiss scanning on unchanged screen frames using the state dedup result
- latch dismiss scanning off after the agent reaches Idle or records productive output
- add deterministic R8 regressions for unchanged frames, post-Idle latch-off, and startup trust-dialog dismissal

## Tests
- `env -u AGEND_INSTANCE_NAME AGEND_GIT_BYPASS=1 cargo test r8_ -- --nocapture`
- `env -u AGEND_INSTANCE_NAME cargo nextest run r8_`
- `cargo fmt --check`
- `git diff --check`
- `env -u AGEND_INSTANCE_NAME AGEND_GIT_BYPASS=1 cargo nextest run` failed in unrelated `git_helpers::tests::spawn_group_bounded_preserves_caller_env_no_bypass_1899` because that test asserts `AGEND_GIT_BYPASS` is absent while the requested command sets it
- `env -u AGEND_INSTANCE_NAME cargo nextest run` hit timing-budget test `api_port_published_before_agent_spawn_loop_completes` at 1.524s vs 1.5s; rerun of that single test passed in 0.661s

Closes t-20260619123342496191-84833-19