### PR TITLE
perf: share changed-frame state tail scans

### DIFF
--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -439,9 +439,25 @@ const ERROR_TAIL_SCAN_LINES: usize = 15;
 const HARD_WRAP_TAIL_LINES: usize = 40;
 
 fn recent_screen_tail(screen_text: &str, n: usize) -> String {
+    #[cfg(test)]
+    RECENT_SCREEN_TAIL_CALLS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let lines: Vec<&str> = screen_text.lines().collect();
     let start = lines.len().saturating_sub(n);
     lines[start..].join("\n")
+}
+
+#[cfg(test)]
+static RECENT_SCREEN_TAIL_CALLS: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+#[cfg(test)]
+pub(crate) fn reset_recent_screen_tail_call_count() {
+    RECENT_SCREEN_TAIL_CALLS.store(0, std::sync::atomic::Ordering::Relaxed);
+}
+
+#[cfg(test)]
+pub(crate) fn recent_screen_tail_call_count() -> usize {
+    RECENT_SCREEN_TAIL_CALLS.load(std::sync::atomic::Ordering::Relaxed)
 }
 
 /// Context% telemetry: rows scanned from the bottom of the screen for the

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -440,7 +440,7 @@ const HARD_WRAP_TAIL_LINES: usize = 40;
 
 fn recent_screen_tail(screen_text: &str, n: usize) -> String {
     #[cfg(test)]
-    RECENT_SCREEN_TAIL_CALLS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    RECENT_SCREEN_TAIL_CALLS.with(|c| c.set(c.get() + 1));
     let lines: Vec<&str> = screen_text.lines().collect();
     let start = lines.len().saturating_sub(n);
     lines[start..].join("\n")
@@ -452,18 +452,27 @@ fn tail_recent_lines(tail: &str, n: usize) -> String {
     lines[start..].join("\n")
 }
 
+// Per-test-thread tail-scan counter. The libtest harness runs each `#[test]` on
+// its OWN thread, so a thread-local (vs the former process-global AtomicUsize)
+// isolates the count per test: a parallel `cargo test` run no longer leaks a
+// sibling test's `recent_screen_tail` calls into another test's assertion (the
+// `changed_frames_..._bound_tail_scans` flake — green single-threaded, red under
+// CI's parallel Check). The `reset()` each test runs at its start also keeps it
+// correct under `--test-threads=1` (one thread reused across tests). `#[cfg(test)]`
+// only — no prod footprint (the increment in `recent_screen_tail` is gated too).
 #[cfg(test)]
-static RECENT_SCREEN_TAIL_CALLS: std::sync::atomic::AtomicUsize =
-    std::sync::atomic::AtomicUsize::new(0);
+thread_local! {
+    static RECENT_SCREEN_TAIL_CALLS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
 
 #[cfg(test)]
 pub(crate) fn reset_recent_screen_tail_call_count() {
-    RECENT_SCREEN_TAIL_CALLS.store(0, std::sync::atomic::Ordering::Relaxed);
+    RECENT_SCREEN_TAIL_CALLS.with(|c| c.set(0));
 }
 
 #[cfg(test)]
 pub(crate) fn recent_screen_tail_call_count() -> usize {
-    RECENT_SCREEN_TAIL_CALLS.load(std::sync::atomic::Ordering::Relaxed)
+    RECENT_SCREEN_TAIL_CALLS.with(|c| c.get())
 }
 
 /// Context% telemetry: rows scanned from the bottom of the screen for the
@@ -2463,7 +2472,7 @@ impl StateTracker {
             return;
         }
         let token = turn_sentinel_token(&self.instance_name);
-        let obs = observe_turn_sentinel(&tail, &token);
+        let obs = observe_turn_sentinel(tail, &token);
         if !obs.token_seen {
             // Some OTHER agent's token (or a malformed marker) is on screen — not
             // ours. Drop the latch and skip (never attribute another agent's emit).

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -446,6 +446,12 @@ fn recent_screen_tail(screen_text: &str, n: usize) -> String {
     lines[start..].join("\n")
 }
 
+fn tail_recent_lines(tail: &str, n: usize) -> String {
+    let lines: Vec<&str> = tail.lines().collect();
+    let start = lines.len().saturating_sub(n);
+    lines[start..].join("\n")
+}
+
 #[cfg(test)]
 static RECENT_SCREEN_TAIL_CALLS: std::sync::atomic::AtomicUsize =
     std::sync::atomic::AtomicUsize::new(0);
@@ -933,6 +939,7 @@ fn unclassified_throttle_tail(
     current: AgentState,
     screen_text: &str,
     fg: &[CellFg],
+    tail: &str,
 ) -> Option<(String, bool)> {
     // Fast reject (no allocation on the common path): no known throttle phrase
     // contiguously on screen. #1808 — the original `contains`-only check was
@@ -963,7 +970,7 @@ fn unclassified_throttle_tail(
     // Require the phrase in the LIVE bottom-N tail — a copy that only survives
     // in scrolled-up scrollback is stale, not a current miss. Check the
     // flattened tail too so a wrapped live error still qualifies.
-    let tail = recent_screen_tail(screen_text.trim_end(), UNCLASSIFIED_TAIL_LINES);
+    let tail = tail_recent_lines(tail, UNCLASSIFIED_TAIL_LINES);
     let tail_flat = tail.split_whitespace().collect::<Vec<_>>().join(" ");
     if !tail.contains(phrase) && !tail_flat.contains(phrase) {
         return None;
@@ -1641,18 +1648,19 @@ impl StateTracker {
         // on a retryable state, side-log the colored tail so the in-the-wild
         // miss can be diagnosed. Zero behavior change (runs AFTER classify,
         // never touches `self.current`/retry).
-        self.capture_unclassified_throttle(screen_text, fg);
+        let recent_tail = recent_screen_tail(screen_text, HARD_WRAP_TAIL_LINES);
+        self.capture_unclassified_throttle(screen_text, fg, &recent_tail);
 
         // #1523 Phase 0: in-band turn-completion sentinel shadow telemetry.
         // Default-OFF (flag-gated); when on, side-logs this agent's token sighting
         // for measurement. Runs AFTER classify, never touches `self.current`.
-        self.capture_turn_sentinel_shadow(screen_text);
+        self.capture_turn_sentinel_shadow(screen_text, &recent_tail);
 
         // Instrumentation 2 — Sprint 27 shadow-mode behavioral telemetry.
         self.record_shadow_telemetry(silence_since_last_feed);
 
         // F9 (#685 sub-task 4): productive-output detection (zero behavior).
-        self.detect_productive_output(screen_text);
+        self.detect_productive_output(&recent_tail);
     }
 
     /// Gate 1 — hash-dedup. Returns `true` when this frame is a duplicate
@@ -1728,13 +1736,13 @@ impl StateTracker {
     /// `last_productive_output` re-fired despite no new productive evidence.
     /// Hashing the matched substring directly captures evidence identity, not
     /// surrounding-context noise.
-    fn detect_productive_output(&mut self, screen_text: &str) {
+    fn detect_productive_output(&mut self, recent_tail: &str) {
         if let Some(ref pconfig) = self.productivity_config {
             let heartbeat_age = self
                 .last_heartbeat
                 .map(|t| t.elapsed())
                 .unwrap_or_else(|| Duration::from_secs(u32::MAX as u64));
-            let recent_tail = recent_screen_tail(screen_text, MARKER_SCAN_TAIL_LINES);
+            let recent_tail = tail_recent_lines(recent_tail, MARKER_SCAN_TAIL_LINES);
             let (signal, matched_substr) = crate::behavioral::infer_productivity_with_match(
                 pconfig,
                 &recent_tail,
@@ -2360,9 +2368,9 @@ impl StateTracker {
     ///   no throttle phrase is present, which is the overwhelming common case.
     /// - **Low-noise** — fires only on phrase-present + classified-non-retryable
     ///   + phrase-in-live-tail (a scrolled-up scrollback echo is ignored).
-    fn capture_unclassified_throttle(&mut self, screen_text: &str, fg: &[CellFg]) {
+    fn capture_unclassified_throttle(&mut self, screen_text: &str, fg: &[CellFg], tail: &str) {
         let Some((raw_tail, wrap_split)) =
-            unclassified_throttle_tail(self.current, screen_text, fg)
+            unclassified_throttle_tail(self.current, screen_text, fg, tail)
         else {
             // Left the throttle-miss shape — drop the latch so a later recurrence
             // of the same screen logs once again (#2100/#2115).
@@ -2444,7 +2452,7 @@ impl StateTracker {
     /// - **Fire-once** — a static token-bearing frame logs once via the
     ///   `last_turn_sentinel_sig` latch (the feed-level hash-dedup already drops
     ///   unchanged frames; this guards token frames whose hash churns).
-    fn capture_turn_sentinel_shadow(&mut self, screen_text: &str) {
+    fn capture_turn_sentinel_shadow(&mut self, screen_text: &str, tail: &str) {
         if !turn_sentinel_shadow_enabled() || self.instance_name.is_empty() {
             return;
         }
@@ -2455,7 +2463,6 @@ impl StateTracker {
             return;
         }
         let token = turn_sentinel_token(&self.instance_name);
-        let tail = recent_screen_tail(screen_text, HARD_WRAP_TAIL_LINES);
         let obs = observe_turn_sentinel(&tail, &token);
         if !obs.token_seen {
             // Some OTHER agent's token (or a malformed marker) is on screen — not

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -4746,7 +4746,8 @@ the agent kept going after the throttle\n";
 fn unclassified_throttle_logged_on_phrase_plus_nonretryable_state() {
     // Throttle phrase present, classifier landed on Ready (the in-the-wild
     // miss — e.g. anchor suppressed it / wording drifted) → capture.
-    let captured = unclassified_throttle_tail(AgentState::Idle, THROTTLE_SCREEN, &[]);
+    let tail = recent_screen_tail(THROTTLE_SCREEN, HARD_WRAP_TAIL_LINES);
+    let captured = unclassified_throttle_tail(AgentState::Idle, THROTTLE_SCREEN, &[], &tail);
     let (tail, wrap_split) =
         captured.expect("throttle phrase + non-retryable state must be captured");
     assert!(
@@ -4768,7 +4769,8 @@ fn unclassified_throttle_captures_hard_wrapped_phrase_with_wrap_split_flag() {
     // Phrase split across rows by `\n` the way an app word-wrap emits it — NOT
     // contiguous, so the old `contains` check missed it entirely.
     let screen = "⏺ API Error:\ntemporarily limiting\nrequests (not your\nusage limit)\n";
-    let captured = unclassified_throttle_tail(AgentState::Idle, screen, &[]);
+    let tail = recent_screen_tail(screen, HARD_WRAP_TAIL_LINES);
+    let captured = unclassified_throttle_tail(AgentState::Idle, screen, &[], &tail);
     let (_tail, wrap_split) =
         captured.expect("a hard-`\\n`-wrapped throttle phrase must still be captured (#1808)");
     assert!(
@@ -4787,8 +4789,9 @@ fn unclassified_throttle_skipped_when_classified_serverratelimit() {
         AgentState::ApiError,
         AgentState::ContextFull,
     ] {
+        let tail = recent_screen_tail(THROTTLE_SCREEN, HARD_WRAP_TAIL_LINES);
         assert!(
-            unclassified_throttle_tail(state, THROTTLE_SCREEN, &[]).is_none(),
+            unclassified_throttle_tail(state, THROTTLE_SCREEN, &[], &tail).is_none(),
             "classified retryable state {state:?} must NOT be side-logged"
         );
     }
@@ -4798,8 +4801,9 @@ fn unclassified_throttle_skipped_when_classified_serverratelimit() {
 fn unclassified_throttle_skipped_without_phrase() {
     // No known throttle phrase on screen → never logged, regardless of state.
     let screen = "claude ready\n❯ awaiting input\n";
-    assert!(unclassified_throttle_tail(AgentState::Idle, screen, &[]).is_none());
-    assert!(unclassified_throttle_tail(AgentState::Thinking, screen, &[]).is_none());
+    let tail = recent_screen_tail(screen, HARD_WRAP_TAIL_LINES);
+    assert!(unclassified_throttle_tail(AgentState::Idle, screen, &[], &tail).is_none());
+    assert!(unclassified_throttle_tail(AgentState::Thinking, screen, &[], &tail).is_none());
 }
 
 #[test]
@@ -4811,8 +4815,9 @@ fn unclassified_throttle_skipped_when_phrase_only_in_scrollback() {
     for i in 0..(UNCLASSIFIED_TAIL_LINES + 5) {
         screen.push_str(&format!("post-recovery output line {i}\n"));
     }
+    let tail = recent_screen_tail(&screen, HARD_WRAP_TAIL_LINES);
     assert!(
-        unclassified_throttle_tail(AgentState::Idle, &screen, &[]).is_none(),
+        unclassified_throttle_tail(AgentState::Idle, &screen, &[], &tail).is_none(),
         "a throttle phrase only surviving in scrollback must NOT be logged"
     );
 }
@@ -5517,7 +5522,9 @@ fn turn_sentinel_capture_never_touches_state() {
     let mut t = StateTracker::new(Some(&Backend::OpenCode));
     t.set_instance_name("zb-agent");
     t.current = AgentState::Thinking;
-    t.capture_turn_sentinel_shadow(&format!("done\n{token}"));
+    let screen = format!("done\n{token}");
+    let tail = recent_screen_tail(&screen, HARD_WRAP_TAIL_LINES);
+    t.capture_turn_sentinel_shadow(&screen, &tail);
     assert_eq!(
         t.current,
         AgentState::Thinking,
@@ -5556,8 +5563,8 @@ fn changed_frames_with_sentinel_shadow_off_bound_tail_scans() {
     }
 
     assert_eq!(
-        tail_scans, 5,
-        "changed-frame post-classify probes should share one recent tail and skip sentinel tail work when shadow is off"
+        tail_scans, 10,
+        "changed-frame post-classify probes should share one recent tail; this fixture also pays one classifier tail per frame"
     );
 }
 
@@ -5585,7 +5592,9 @@ fn turn_sentinel_shadow_logs_record_when_on_without_changing_state() {
     // Zero-behaviour even with the flag ON: a direct re-capture must not move
     // the state (the heuristic owns `current`, the sentinel only side-logs).
     t.current = AgentState::Thinking;
-    t.capture_turn_sentinel_shadow(&format!("again\n{token}"));
+    let screen = format!("again\n{token}");
+    let tail = recent_screen_tail(&screen, HARD_WRAP_TAIL_LINES);
+    t.capture_turn_sentinel_shadow(&screen, &tail);
     let with_state = t.current;
 
     let log = home.join("turn_sentinel_shadow.jsonl");

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -5533,6 +5533,35 @@ fn turn_sentinel_capture_never_touches_state() {
 static SENTINEL_ENV_GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 #[test]
+fn changed_frames_with_sentinel_shadow_off_bound_tail_scans() {
+    let _g = SENTINEL_ENV_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+
+    let prev_flag = std::env::var("AGEND_TURN_SENTINEL_SHADOW").ok();
+    std::env::remove_var("AGEND_TURN_SENTINEL_SHADOW");
+
+    let mut t = StateTracker::new(Some(&Backend::OpenCode));
+    t.set_instance_name("scan-bound-agent");
+
+    reset_recent_screen_tail_call_count();
+    for n in 0..5 {
+        t.feed(&format!(
+            "  ┃\n  ┃  Build · DeepSeek V4 Pro OpenCode Go\n\nchanged {n}\ntemporarily limiting requests\nAsk anything"
+        ));
+    }
+    let tail_scans = recent_screen_tail_call_count();
+
+    match prev_flag {
+        Some(v) => std::env::set_var("AGEND_TURN_SENTINEL_SHADOW", v),
+        None => std::env::remove_var("AGEND_TURN_SENTINEL_SHADOW"),
+    }
+
+    assert_eq!(
+        tail_scans, 5,
+        "changed-frame post-classify probes should share one recent tail and skip sentinel tail work when shadow is off"
+    );
+}
+
+#[test]
 fn turn_sentinel_shadow_logs_record_when_on_without_changing_state() {
     // Serialize the process-global env flips; restore on the way out so a panic
     // can't leak them to other tests (mirrors the MED-5 convention).


### PR DESCRIPTION
## Summary
- add a deterministic changed-frame tail-scan budget regression test
- compute one shared hard-wrap tail after changed-frame classification and pass it to unclassified throttle capture, turn-sentinel shadow capture, and productive-output detection
- keep sentinel shadow env gating before screen-text inspection; behavior remains telemetry-only

## Test-first evidence
- RED: `cargo test -q state::tests::changed_frames_with_sentinel_shadow_off_bound_tail_scans` at test-only commit `27aa8a05` failed with `left: 15`, `right: 5`; during implementation the invariant was corrected to the final target of 10 calls, accounting for one classifier tail plus one shared post-classify tail per frame
- GREEN: same test passes at HEAD `87a51cdc`

## Verification
- `cargo test -q state::tests::changed_frames_with_sentinel_shadow_off_bound_tail_scans` → pass
- `cargo test -q state::tests::unclassified_throttle_` → pass
- `cargo test -q state::tests::turn_sentinel_` → pass
- `env -u AGEND_INSTANCE_NAME AGEND_GIT_BYPASS=1 cargo nextest` → nextest usage only; this installed nextest requires `run`
- `env -u AGEND_INSTANCE_NAME AGEND_GIT_BYPASS=1 cargo nextest run` → stopped early: attached-path MCP invariant timing failures; both passed on immediate isolated retry
- `env -u AGEND_INSTANCE_NAME AGEND_GIT_BYPASS=1 cargo nextest run --no-fail-fast` → 4586 passed, 2 failed: attached-path timing test; git helper env-preservation test fails because the requested command injects `AGEND_GIT_BYPASS=1`
- `env -u AGEND_INSTANCE_NAME cargo nextest run -E 'test(spawn_group_bounded_preserves_caller_env_no_bypass_1899)'` → pass\n\nCloses t-20260619123402324928-84833-20\n