### PR TITLE
perf(monitor): build proc table once/collect + reuse System + subscriber gate (#t-84833-23)

### DIFF
--- a/src/instance_monitor.rs
+++ b/src/instance_monitor.rs
@@ -31,8 +31,33 @@ fn cache() -> &'static Arc<Mutex<Vec<InstanceMetrics>>> {
     METRICS_CACHE.get_or_init(|| Arc::new(Mutex::new(Vec::new())))
 }
 
+/// Last time a consumer read `latest_metrics()`. The only consumer is the TUI
+/// Monitor view, which reads once per frame it draws — so a recent read means a
+/// subscriber is actively watching. Drives the collection gate (`should_collect`)
+/// so a headless daemon (or a TUI not on the Monitor tab) skips the whole sysinfo
+/// sweep instead of sampling every 5s for nobody.
+static LAST_METRICS_READ: Mutex<Option<Instant>> = Mutex::new(None);
+
+/// How many tick intervals a subscriber's last read keeps collection warm. >1 so
+/// a brief render hiccup doesn't drop a frame's worth of freshness; the Monitor
+/// view reads every frame, so a live viewer keeps this perpetually fresh.
+const SUBSCRIBER_GRACE_TICKS: u32 = 3;
+
+/// Collect only when a subscriber read `latest_metrics()` within `grace`. `None`
+/// (never read → headless daemon) ⇒ skip. Pure, for deterministic testing.
+fn should_collect(last_read: Option<Instant>, now: Instant, grace: Duration) -> bool {
+    match last_read {
+        Some(t) => now.duration_since(t) <= grace,
+        None => false,
+    }
+}
+
 /// Read the latest metrics snapshot. Returns empty vec if no collection has run.
+/// Records the read so the collection tick knows a subscriber is watching (see
+/// `should_collect`); the Monitor view's "waiting for first collection" placeholder
+/// covers the ≤1-tick bootstrap window after the first view.
 pub fn latest_metrics() -> Vec<InstanceMetrics> {
+    *LAST_METRICS_READ.lock() = Some(Instant::now());
     cache().lock().clone()
 }
 
@@ -45,19 +70,51 @@ pub fn spawn_monitor_tick(home: std::path::PathBuf, registry: crate::agent::Agen
     // Track B finding (PR-AZ author = dev-impl-2).
     let _ = std::thread::Builder::new()
         .name("monitor_tick".into())
-        .spawn(move || loop {
-            std::thread::sleep(MONITOR_TICK);
-            collect(&home, &registry);
+        .spawn(move || {
+            use sysinfo::{ProcessRefreshKind, RefreshKind, System};
+            // R5: own ONE System for the thread's lifetime and refresh it in
+            // place each tick, instead of allocating a fresh process table every
+            // 5s. Bonus: reusing the System gives accurate CPU% (sysinfo derives
+            // it from the delta between consecutive refreshes).
+            let mut sys = System::new_with_specifics(
+                RefreshKind::nothing().with_processes(ProcessRefreshKind::everything()),
+            );
+            loop {
+                std::thread::sleep(MONITOR_TICK);
+                collect(&home, &registry, &mut sys);
+            }
         });
 }
 
-/// Collect metrics for all agents in the registry. Called from daemon tick.
-pub fn collect(home: &std::path::Path, registry: &crate::agent::AgentRegistry) {
-    use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, RefreshKind, System};
+/// One agent's registry-side snapshot, captured under a single registry lock.
+struct AgentSnap {
+    name: String,
+    pid: Option<u32>,
+    agent_state: String,
+    health_state: String,
+}
 
-    let mut sys = System::new_with_specifics(
-        RefreshKind::nothing().with_processes(ProcessRefreshKind::everything()),
-    );
+/// Collect metrics for all agents in the registry. Called from the monitor tick,
+/// which owns the persistent `sys` (refreshed in place each call — see R5).
+pub fn collect(
+    home: &std::path::Path,
+    registry: &crate::agent::AgentRegistry,
+    sys: &mut sysinfo::System,
+) {
+    use sysinfo::{ProcessRefreshKind, ProcessesToUpdate};
+
+    // R5 ⑤ subscriber gate: skip the whole sweep (the sysinfo refresh below is
+    // the dominant cost) when nobody has read `latest_metrics()` recently — a
+    // headless daemon, or a TUI not on the Monitor tab, has no consumer to serve.
+    if !should_collect(
+        *LAST_METRICS_READ.lock(),
+        Instant::now(),
+        MONITOR_TICK * SUBSCRIBER_GRACE_TICKS,
+    ) {
+        return;
+    }
+
+    // R5 ③: refresh the persistent System in place (no per-tick allocation).
     sys.refresh_processes_specifics(
         ProcessesToUpdate::All,
         true,
@@ -65,41 +122,41 @@ pub fn collect(home: &std::path::Path, registry: &crate::agent::AgentRegistry) {
     );
 
     let now = Instant::now();
-    // #1441: registry is UUID-keyed; carry the id for the re-lock lookup and
-    // the display name for metadata / metrics / sort.
-    let handles: Vec<(crate::types::InstanceId, String, Option<u32>)> = {
+    // R5 ④: one registry lock captures everything — id is no longer needed since
+    // state/health are read here too (was a per-agent re-lock). #1441: registry
+    // is UUID-keyed; name carries through for metadata / metrics / sort.
+    let snaps: Vec<AgentSnap> = {
         let reg = crate::agent::lock_registry(registry);
-        reg.iter()
-            .map(|(id, handle)| {
+        reg.values()
+            .map(|handle| {
                 let pid = handle.child.lock().process_id();
-                (*id, handle.name.to_string(), pid)
+                let core = handle.core.lock();
+                AgentSnap {
+                    name: handle.name.to_string(),
+                    pid,
+                    agent_state: core.state.get_state().display_name().to_string(),
+                    health_state: core.health.state.display_name().to_string(),
+                }
             })
             .collect()
     };
 
-    let mut metrics = Vec::with_capacity(handles.len());
-    for (id, name, pid) in handles {
-        let (agent_state, health_state) = {
-            let reg = crate::agent::lock_registry(registry);
-            reg.get(&id)
-                .map(|h| {
-                    let c = h.core.lock();
-                    (
-                        c.state.get_state().display_name().to_string(),
-                        c.health.state.display_name().to_string(),
-                    )
-                })
-                .unwrap_or_else(|| ("unknown".into(), "unknown".into()))
-        };
+    // R5 ①②: build the process memory table + parent→children index ONCE per
+    // collect (was rebuilt per agent inside `tree_rss`). Each agent's tree-RSS is
+    // then O(descendants) via the index, not O(all machine processes) per agent.
+    let (mem, children) = build_proc_index(sys);
 
-        let (rss_bytes, cpu_percent, uptime_secs) = if let Some(p) = pid {
+    let mut metrics = Vec::with_capacity(snaps.len());
+    for snap in snaps {
+        let (rss_bytes, cpu_percent, uptime_secs) = if let Some(p) = snap.pid {
             let spid = sysinfo::Pid::from_u32(p);
             if let Some(proc_info) = sys.process(spid) {
-                // Process tree RSS: recursive walk (main + all descendants)
-                let total_rss = tree_rss(&sys, spid);
-                let cpu = proc_info.cpu_usage();
-                let uptime = proc_info.run_time();
-                (Some(total_rss), Some(cpu), Some(uptime))
+                let total_rss = sum_tree_rss(p, &mem, &children);
+                (
+                    Some(total_rss),
+                    Some(proc_info.cpu_usage()),
+                    Some(proc_info.run_time()),
+                )
             } else {
                 (None, None, None)
             }
@@ -107,16 +164,16 @@ pub fn collect(home: &std::path::Path, registry: &crate::agent::AgentRegistry) {
             (None, None, None)
         };
 
-        let (heartbeat_lag_secs, pending_pickup_count) = read_metadata_metrics(home, &name);
+        let (heartbeat_lag_secs, pending_pickup_count) = read_metadata_metrics(home, &snap.name);
 
         metrics.push(InstanceMetrics {
-            name,
-            pid,
+            name: snap.name,
+            pid: snap.pid,
             rss_bytes,
             cpu_percent,
             uptime_secs,
-            agent_state,
-            health_state,
+            agent_state: snap.agent_state,
+            health_state: snap.health_state,
             heartbeat_lag_secs,
             pending_pickup_count,
             collected_at: now,
@@ -127,20 +184,38 @@ pub fn collect(home: &std::path::Path, registry: &crate::agent::AgentRegistry) {
     *cache().lock() = metrics;
 }
 
-/// One node of the process table used for the descendant-RSS walk.
-struct ProcNode {
-    mem: u64,
-    parent: Option<u32>,
+/// Process memory table (pid → RSS bytes).
+type ProcMem = std::collections::HashMap<u32, u64>;
+/// Parent pid → its direct child pids.
+type ChildIndex = std::collections::HashMap<u32, Vec<u32>>;
+
+/// Build the process memory table + parent→children index ONCE per collect from a
+/// refreshed `System`. The children index turns each agent's descendant walk into
+/// O(descendants) instead of the old O(all machine processes) full-table scan per
+/// popped pid (which `tree_rss` also paid to rebuild once per agent).
+fn build_proc_index(sys: &sysinfo::System) -> (ProcMem, ChildIndex) {
+    let procs = sys.processes();
+    let mut mem: ProcMem = std::collections::HashMap::with_capacity(procs.len());
+    let mut children: ChildIndex = std::collections::HashMap::new();
+    for p in procs.values() {
+        let pid = p.pid().as_u32();
+        mem.insert(pid, p.memory());
+        if let Some(parent) = p.parent() {
+            children.entry(parent.as_u32()).or_default().push(pid);
+        }
+    }
+    (mem, children)
 }
 
-/// Sum RSS for `root` and all its descendants, cycle-safe and iterative.
+/// Sum RSS for `root` and all its descendants, cycle-safe and iterative, walking
+/// the prebuilt `children` index (O(descendants), no full-table scan).
 ///
 /// Windows reuses PIDs aggressively, so the parent-PID graph can contain a
 /// cycle (A's parent is B, B's parent is A). The previous recursive walk would
 /// then recurse forever and overflow the stack (monitor_tick thread crash,
 /// 2026-06-12 15:13, ~18k frames). The `visited` set breaks cycles and also
 /// guarantees each process is counted at most once.
-fn sum_tree_rss(root: u32, table: &std::collections::HashMap<u32, ProcNode>) -> u64 {
+fn sum_tree_rss(root: u32, mem: &ProcMem, children: &ChildIndex) -> u64 {
     let mut visited = std::collections::HashSet::new();
     let mut stack = vec![root];
     let mut total = 0u64;
@@ -148,34 +223,18 @@ fn sum_tree_rss(root: u32, table: &std::collections::HashMap<u32, ProcNode>) -> 
         if !visited.insert(pid) {
             continue; // already counted / cycle guard
         }
-        if let Some(node) = table.get(&pid) {
-            total = total.saturating_add(node.mem);
+        if let Some(&m) = mem.get(&pid) {
+            total = total.saturating_add(m);
         }
-        for (&cpid, node) in table {
-            if node.parent == Some(pid) && !visited.contains(&cpid) {
-                stack.push(cpid);
+        if let Some(kids) = children.get(&pid) {
+            for &cpid in kids {
+                if !visited.contains(&cpid) {
+                    stack.push(cpid);
+                }
             }
         }
     }
     total
-}
-
-/// Process-tree RSS: total memory of a process plus all descendants.
-fn tree_rss(sys: &sysinfo::System, root: sysinfo::Pid) -> u64 {
-    let table: std::collections::HashMap<u32, ProcNode> = sys
-        .processes()
-        .values()
-        .map(|p| {
-            (
-                p.pid().as_u32(),
-                ProcNode {
-                    mem: p.memory(),
-                    parent: p.parent().map(|pp| pp.as_u32()),
-                },
-            )
-        })
-        .collect();
-    sum_tree_rss(root.as_u32(), &table)
 }
 
 /// Read heartbeat lag and pending pickup count from metadata JSON.
@@ -226,35 +285,138 @@ mod tests {
         assert!(m.len() <= m.capacity());
     }
 
-    fn node(mem: u64, parent: Option<u32>) -> ProcNode {
-        ProcNode { mem, parent }
+    /// Build a (mem, children) index from `(pid, mem, parent)` rows — mirrors
+    /// `build_proc_index` so the walk tests exercise the production index shape.
+    fn index(rows: &[(u32, u64, Option<u32>)]) -> (ProcMem, ChildIndex) {
+        let mut mem = ProcMem::new();
+        let mut children = ChildIndex::new();
+        for &(pid, m, parent) in rows {
+            mem.insert(pid, m);
+            if let Some(par) = parent {
+                children.entry(par).or_default().push(pid);
+            }
+        }
+        (mem, children)
     }
 
     #[test]
     fn sum_tree_rss_sums_root_and_descendants() {
-        let mut t = std::collections::HashMap::new();
-        t.insert(1, node(10, None));
-        t.insert(2, node(20, Some(1)));
-        t.insert(3, node(30, Some(2)));
-        t.insert(9, node(99, None)); // unrelated tree, must not be counted
-        assert_eq!(sum_tree_rss(1, &t), 60);
+        let (mem, children) = index(&[
+            (1, 10, None),
+            (2, 20, Some(1)),
+            (3, 30, Some(2)),
+            (9, 99, None), // unrelated tree, must not be counted
+        ]);
+        assert_eq!(sum_tree_rss(1, &mem, &children), 60);
     }
 
     #[test]
     fn sum_tree_rss_survives_parent_cycle() {
         // Windows PID reuse: A's parent is B, B's parent is A. The old recursive
         // walk overflowed the stack here; this must terminate and count each once.
-        let mut t = std::collections::HashMap::new();
-        t.insert(1, node(100, Some(2)));
-        t.insert(2, node(200, Some(1)));
-        assert_eq!(sum_tree_rss(1, &t), 300);
+        let (mem, children) = index(&[(1, 100, Some(2)), (2, 200, Some(1))]);
+        assert_eq!(sum_tree_rss(1, &mem, &children), 300);
     }
 
     #[test]
     fn sum_tree_rss_survives_self_parent() {
-        let mut t = std::collections::HashMap::new();
-        t.insert(1, node(50, Some(1)));
-        assert_eq!(sum_tree_rss(1, &t), 50);
+        let (mem, children) = index(&[(1, 50, Some(1))]);
+        assert_eq!(sum_tree_rss(1, &mem, &children), 50);
+    }
+
+    /// R5 ①②: the parent→children index scopes each agent's walk to its OWN
+    /// subtree. 50 agent trees embedded among 10_000 unrelated processes: each
+    /// root's tree-RSS must equal only its subtree, regardless of the machine's
+    /// total process count (proves no full-table-scan pollution).
+    #[test]
+    fn sum_tree_rss_isolates_subtree_among_many_unrelated_procs() {
+        let mut rows: Vec<(u32, u64, Option<u32>)> = Vec::new();
+        for pid in 100_000u32..110_000 {
+            rows.push((pid, 7, None)); // unrelated, unlinked to any agent root
+        }
+        let roots: Vec<u32> = (0..50u32).map(|i| i * 10 + 1).collect();
+        for &r in &roots {
+            rows.push((r, 100, None)); // root
+            rows.push((r + 1, 200, Some(r))); // child
+            rows.push((r + 2, 300, Some(r + 1))); // grandchild → 600 total
+        }
+        let (mem, children) = index(&rows);
+        for &r in &roots {
+            assert_eq!(
+                sum_tree_rss(r, &mem, &children),
+                600,
+                "root {r}: must sum its own subtree only, not the 10k unrelated procs"
+            );
+        }
+    }
+
+    /// R5 ①②③: the per-agent term is O(descendants), independent of the machine's
+    /// process count. Summing 50 agent subtrees over a 10_000-process table is
+    /// bounded work — a generous ceiling (not a tight micro-benchmark) that the old
+    /// O(agents×procs) full-table-scan-per-pid would blow past. Prints the measured
+    /// per-agent term so the "microsecond-level" claim is visible.
+    #[test]
+    fn per_agent_sum_is_bounded_independent_of_proc_count() {
+        let mut rows: Vec<(u32, u64, Option<u32>)> = Vec::new();
+        for pid in 100_000u32..110_000 {
+            rows.push((pid, 7, None));
+        }
+        let roots: Vec<u32> = (0..50u32).map(|i| i * 10 + 1).collect();
+        for &r in &roots {
+            rows.push((r, 100, None));
+            rows.push((r + 1, 200, Some(r)));
+        }
+        let (mem, children) = index(&rows); // built ONCE, outside the timed region
+        let start = Instant::now();
+        let mut sink = 0u64;
+        for &r in &roots {
+            sink = sink.wrapping_add(sum_tree_rss(r, &mem, &children));
+        }
+        let elapsed = start.elapsed();
+        assert_eq!(
+            sink,
+            300 * roots.len() as u64,
+            "sanity: each tree sums to 300"
+        );
+        let per_agent_us = elapsed.as_micros() as f64 / roots.len() as f64;
+        eprintln!("R5 per-agent tree-RSS term: {per_agent_us:.3}µs over a 10k-proc table");
+        assert!(
+            elapsed < Duration::from_millis(200),
+            "50 agent sums over a 10k-proc table must be fast (O(descendants), not \
+             O(agents×procs)); got {elapsed:?}"
+        );
+    }
+
+    /// R5 ⑤: collection gates on a recent subscriber read. Deterministic via
+    /// constructed Instants (no wall-clock dependence).
+    #[test]
+    fn should_collect_gates_on_recent_subscriber_read() {
+        let grace = Duration::from_secs(15);
+        let t0 = Instant::now();
+        assert!(
+            !should_collect(None, t0, grace),
+            "never read (headless) ⇒ skip"
+        );
+        assert!(should_collect(Some(t0), t0, grace), "just read ⇒ collect");
+        assert!(
+            should_collect(Some(t0), t0 + Duration::from_secs(10), grace),
+            "within grace ⇒ collect"
+        );
+        assert!(
+            !should_collect(Some(t0), t0 + Duration::from_secs(16), grace),
+            "past grace ⇒ skip (subscriber went away)"
+        );
+    }
+
+    /// R5 ⑤: reading `latest_metrics()` records the subscriber read that keeps
+    /// collection warm (bootstraps a freshly-opened Monitor view on the next tick).
+    #[test]
+    fn latest_metrics_records_subscriber_read() {
+        let _ = latest_metrics();
+        assert!(
+            LAST_METRICS_READ.lock().is_some(),
+            "latest_metrics() must record a subscriber read"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

`instance_monitor::collect` runs every 5s. Per agent it called `tree_rss`, which **rebuilt a `HashMap` of every process on the machine** (O(agents × procs)); `sum_tree_rss` then **scanned that whole table per descendant pid** (O(descendants × procs)). Each tick also allocated a **fresh `System`** and **re-locked the registry per agent** — and it ran **unconditionally**, even with no TUI reading the metrics. perf-audit R5.

## Change

- **① Process table built once per collect** — `build_proc_index` hoists the `pid → RSS` table out of the per-agent `tree_rss` (deleted).
- **② parent→children index** — `sum_tree_rss` now walks the index, so each agent's tree-RSS is **O(descendants)** instead of a full-table scan per pid. Cycle/visited safety preserved (Windows PID-reuse stack-overflow guard intact).
- **③ Persistent `System` reused across ticks** — the tick thread owns one `System` and `refresh`es it in place (no per-tick allocation). Bonus: accurate CPU% from consecutive-refresh deltas.
- **④ Single registry-lock snapshot** — captures `pid` + `agent_state` + `health_state` in one lock (was a per-agent re-lock).
- **⑤ Subscriber gate** — `collect` skips the whole sweep when `latest_metrics()` hasn't been read within 3 ticks (headless daemon, or TUI not on the Monitor tab). The Monitor view reads every frame so a live viewer stays warm; the existing *"waiting for first collection"* placeholder covers the ≤1-tick bootstrap after first view.

`collect`'s only caller is the internal tick loop; `spawn_monitor_tick`'s public signature is unchanged (both app + daemon call sites unaffected).

## Tests (test-first)

- **`sum_tree_rss_isolates_subtree_among_many_unrelated_procs`** — 50 agent trees embedded among **10,000 unrelated processes**; each root sums **only its own subtree** (proves the index scopes the walk to descendants — no full-table pollution — independent of machine process count).
- **`per_agent_sum_is_bounded_independent_of_proc_count`** — 50 sums over a 10k-proc table under a generous ceiling (catches an O(agents×procs) regression without a flaky tight-timing assert); prints the measured per-agent µs.
- **`should_collect_gates_on_recent_subscriber_read`** — deterministic gate predicate via constructed `Instant`s.
- **`latest_metrics_records_subscriber_read`** — a read records the subscriber bootstrap.
- Existing `sum_tree_rss` correctness / parent-cycle / self-parent tests adapted to the `(mem, children)` index.

## Verification

- `cargo nextest run instance_monitor`: **10/10**
- `cargo clippy --all-targets --features tray -D warnings`: **clean** · `cargo fmt`: clean

## Notes
- Blast: one file (`instance_monitor.rs`). The lead flagged R5 as low-ROI (the true dominant cost is the `sysinfo` refresh itself); ⑤ addresses that by skipping the refresh entirely when headless.
- Goes live only after operator restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)