### PR TITLE
refactor(#2050 simplify PR-A): tracker_handler! macro + live_agent_names() helper (zero behavior change)

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -361,6 +361,27 @@ pub fn lock_registry(reg: &AgentRegistry) -> RegistryGuard<'_> {
     RegistryGuard { inner }
 }
 
+/// #2050 simplify: the live-agent-name registry-snapshot idiom — a `HashSet`
+/// of the current handle names taken under the registry lock — centralized
+/// from the 4 daemon-lane copies (`supervisor` + `supervisor_trackers`). The 3
+/// app-lane sites build the set inline before a `.filter` and are left as-is
+/// (outside this lane).
+pub(crate) fn live_agent_names(registry: &AgentRegistry) -> std::collections::HashSet<String> {
+    lock_registry(registry)
+        .values()
+        .map(|h| h.name.to_string())
+        .collect()
+}
+
+/// `Vec` sibling of [`live_agent_names`] for the one caller
+/// (`check_pane_input_not_submitted`) that needs an ordered `&[String]` slice.
+pub(crate) fn live_agent_names_vec(registry: &AgentRegistry) -> Vec<String> {
+    lock_registry(registry)
+        .values()
+        .map(|h| h.name.to_string())
+        .collect()
+}
+
 // ── #945 Phase 1: pending-registry slot for deferred attach ────────────
 //
 // `bootstrap::telegram_init` runs in a background thread (~6s of HTTP

--- a/src/daemon/per_tick/supervisor_trackers.rs
+++ b/src/daemon/per_tick/supervisor_trackers.rs
@@ -42,88 +42,61 @@ use crate::daemon::mcp_registry_watcher::{DaemonBinaryStale, McpRegistryWatcherT
 use crate::daemon::retention::RetentionSupervisor;
 use crate::daemon::waiting_on_stale::WaitingOnStaleTracker;
 use parking_lot::Mutex;
-use std::collections::HashSet;
 
-/// Sprint 59 Wave 1 PR-1 (#9): per-task ETA stall scan, throttled to 5min.
-pub(crate) struct AntiStallHandler {
-    tracker: Mutex<AntiStallTracker>,
-}
-impl AntiStallHandler {
-    pub(crate) fn new() -> Self {
-        Self {
-            tracker: Mutex::new(AntiStallTracker::default()),
+/// #2050 simplify: collapse the truly-uniform `maybe_scan`-over-`ctx.home`
+/// tracker wrappers. Each is `struct H { tracker: Mutex<T> }` + an arg-less
+/// `new()` + a [`PerTickHandler`] impl whose `run` calls
+/// `self.tracker.lock().maybe_scan(ctx.home)`; only the type, the `name`
+/// literal, and the per-wrapper doc differ. The 4 NON-uniform handlers
+/// (McpRegistry's extra `binary_stale`, WaitingOnStale's and ConflictNotify's
+/// `retain_active` prunes, Retention's `maybe_sweep`) stay hand-written below.
+/// Behaviour-identical: `<$T>::default()` ≡ the original `T::default()`, same
+/// `name()`, same per-tick `maybe_scan(ctx.home)`. The doc on each invocation is
+/// re-emitted onto the generated struct so the issue history survives.
+macro_rules! tracker_handler {
+    ($(#[$doc:meta])* $H:ident => $T:ty, $name:literal) => {
+        $(#[$doc])*
+        pub(crate) struct $H {
+            tracker: Mutex<$T>,
         }
-    }
-}
-impl PerTickHandler for AntiStallHandler {
-    fn name(&self) -> &'static str {
-        "anti_stall"
-    }
-    fn run(&self, ctx: &TickContext<'_>) {
-        self.tracker.lock().maybe_scan(ctx.home);
-    }
-}
-
-/// Sprint 59 Wave 1 PR-2 (#10+#12): per-agent + fleet idle thresholds, 5min.
-pub(crate) struct IdleWatchdogHandler {
-    tracker: Mutex<IdleWatchdogTracker>,
-}
-impl IdleWatchdogHandler {
-    pub(crate) fn new() -> Self {
-        Self {
-            tracker: Mutex::new(IdleWatchdogTracker::default()),
+        impl $H {
+            pub(crate) fn new() -> Self {
+                Self {
+                    tracker: Mutex::new(<$T>::default()),
+                }
+            }
         }
-    }
-}
-impl PerTickHandler for IdleWatchdogHandler {
-    fn name(&self) -> &'static str {
-        "idle_watchdog"
-    }
-    fn run(&self, ctx: &TickContext<'_>) {
-        self.tracker.lock().maybe_scan(ctx.home);
-    }
+        impl PerTickHandler for $H {
+            fn name(&self) -> &'static str {
+                $name
+            }
+            fn run(&self, ctx: &TickContext<'_>) {
+                self.tracker.lock().maybe_scan(ctx.home);
+            }
+        }
+    };
 }
 
-/// Sprint 59 Wave 1 PR-4-recover (B): operator-decision auto-default on
-/// timeout, 5min throttle.
-pub(crate) struct DecisionTimeoutHandler {
-    tracker: Mutex<DecisionTimeoutTracker>,
-}
-impl DecisionTimeoutHandler {
-    pub(crate) fn new() -> Self {
-        Self {
-            tracker: Mutex::new(DecisionTimeoutTracker::default()),
-        }
-    }
-}
-impl PerTickHandler for DecisionTimeoutHandler {
-    fn name(&self) -> &'static str {
-        "decision_timeout"
-    }
-    fn run(&self, ctx: &TickContext<'_>) {
-        self.tracker.lock().maybe_scan(ctx.home);
-    }
-}
+tracker_handler!(
+    /// Sprint 59 Wave 1 PR-1 (#9): per-task ETA stall scan, throttled to 5min.
+    AntiStallHandler => AntiStallTracker, "anti_stall"
+);
 
-/// Sprint 59 Wave 2 PR-3 (#13): deployment-cadence helper-staleness ping.
-pub(crate) struct HelperStalenessHandler {
-    tracker: Mutex<HelperStalenessWatchdogTracker>,
-}
-impl HelperStalenessHandler {
-    pub(crate) fn new() -> Self {
-        Self {
-            tracker: Mutex::new(HelperStalenessWatchdogTracker::default()),
-        }
-    }
-}
-impl PerTickHandler for HelperStalenessHandler {
-    fn name(&self) -> &'static str {
-        "helper_staleness"
-    }
-    fn run(&self, ctx: &TickContext<'_>) {
-        self.tracker.lock().maybe_scan(ctx.home);
-    }
-}
+tracker_handler!(
+    /// Sprint 59 Wave 1 PR-2 (#10+#12): per-agent + fleet idle thresholds, 5min.
+    IdleWatchdogHandler => IdleWatchdogTracker, "idle_watchdog"
+);
+
+tracker_handler!(
+    /// Sprint 59 Wave 1 PR-4-recover (B): operator-decision auto-default on
+    /// timeout, 5min throttle.
+    DecisionTimeoutHandler => DecisionTimeoutTracker, "decision_timeout"
+);
+
+tracker_handler!(
+    /// Sprint 59 Wave 2 PR-3 (#13): deployment-cadence helper-staleness ping.
+    HelperStalenessHandler => HelperStalenessWatchdogTracker, "helper_staleness"
+);
 
 /// Sprint 60 W1 PR-2 (#P0-2): daemon-binary hot-reload detector. Flips the
 /// shared TUI status-bar flag (`DaemonBinaryStale`) the render loop reads —
@@ -174,10 +147,7 @@ impl PerTickHandler for WaitingOnStaleHandler {
         // doesn't leak one permanent entry per ever-stale agent, and a same-name
         // redeploy can't inherit a stale dedup timestamp that false-suppresses a
         // real alert.
-        let live: HashSet<String> = {
-            let reg = crate::agent::lock_registry(ctx.registry);
-            reg.values().map(|h| h.name.to_string()).collect()
-        };
+        let live = crate::agent::live_agent_names(ctx.registry);
         self.tracker.lock().retain_active(&live);
     }
 }
@@ -206,93 +176,30 @@ impl PerTickHandler for ConflictNotifyHandler {
         // #1923 G5 cleanup-on-delete (was supervisor.rs:425-430): prune
         // per-agent conflict state for agents no longer in the registry. Runs
         // every tick, unconditionally, exactly as the supervisor `.retain` did.
-        let live: HashSet<String> = {
-            let reg = crate::agent::lock_registry(ctx.registry);
-            reg.values().map(|h| h.name.to_string()).collect()
-        };
+        let live = crate::agent::live_agent_names(ctx.registry);
         self.tracker.lock().retain_active(&live);
     }
 }
 
-/// #852 residual PR-B: per-tick canonical-drift (detached-HEAD residue) scan.
-pub(crate) struct CanonicalDriftHandler {
-    tracker: Mutex<CanonicalDriftTracker>,
-}
-impl CanonicalDriftHandler {
-    pub(crate) fn new() -> Self {
-        Self {
-            tracker: Mutex::new(CanonicalDriftTracker::default()),
-        }
-    }
-}
-impl PerTickHandler for CanonicalDriftHandler {
-    fn name(&self) -> &'static str {
-        "canonical_drift"
-    }
-    fn run(&self, ctx: &TickContext<'_>) {
-        self.tracker.lock().maybe_scan(ctx.home);
-    }
-}
+tracker_handler!(
+    /// #852 residual PR-B: per-tick canonical-drift (detached-HEAD residue) scan.
+    CanonicalDriftHandler => CanonicalDriftTracker, "canonical_drift"
+);
 
-/// #870: per-tick auto-release scan (faster ~30s cadence, internal).
-pub(crate) struct AutoReleaseHandler {
-    tracker: Mutex<AutoReleaseTracker>,
-}
-impl AutoReleaseHandler {
-    pub(crate) fn new() -> Self {
-        Self {
-            tracker: Mutex::new(AutoReleaseTracker::default()),
-        }
-    }
-}
-impl PerTickHandler for AutoReleaseHandler {
-    fn name(&self) -> &'static str {
-        "auto_release"
-    }
-    fn run(&self, ctx: &TickContext<'_>) {
-        self.tracker.lock().maybe_scan(ctx.home);
-    }
-}
+tracker_handler!(
+    /// #870: per-tick auto-release scan (faster ~30s cadence, internal).
+    AutoReleaseHandler => AutoReleaseTracker, "auto_release"
+);
 
-/// PR1 watchdog L1: cross-team-safe dispatch-idle scan (~60s, internal).
-pub(crate) struct DispatchIdleHandler {
-    tracker: Mutex<DispatchIdleTracker>,
-}
-impl DispatchIdleHandler {
-    pub(crate) fn new() -> Self {
-        Self {
-            tracker: Mutex::new(DispatchIdleTracker::default()),
-        }
-    }
-}
-impl PerTickHandler for DispatchIdleHandler {
-    fn name(&self) -> &'static str {
-        "dispatch_idle"
-    }
-    fn run(&self, ctx: &TickContext<'_>) {
-        self.tracker.lock().maybe_scan(ctx.home);
-    }
-}
+tracker_handler!(
+    /// PR1 watchdog L1: cross-team-safe dispatch-idle scan (~60s, internal).
+    DispatchIdleHandler => DispatchIdleTracker, "dispatch_idle"
+);
 
-/// PR1 watchdog L2: generic per-team auto-nudge on exceeded dispatches.
-pub(crate) struct DispatchIdleNudgeHandler {
-    tracker: Mutex<DispatchIdleNudgeTracker>,
-}
-impl DispatchIdleNudgeHandler {
-    pub(crate) fn new() -> Self {
-        Self {
-            tracker: Mutex::new(DispatchIdleNudgeTracker::default()),
-        }
-    }
-}
-impl PerTickHandler for DispatchIdleNudgeHandler {
-    fn name(&self) -> &'static str {
-        "dispatch_idle_nudge"
-    }
-    fn run(&self, ctx: &TickContext<'_>) {
-        self.tracker.lock().maybe_scan(ctx.home);
-    }
-}
+tracker_handler!(
+    /// PR1 watchdog L2: generic per-team auto-nudge on exceeded dispatches.
+    DispatchIdleNudgeHandler => DispatchIdleNudgeTracker, "dispatch_idle_nudge"
+);
 
 /// Retention sweep (review-task / tmp GC supervisor).
 pub(crate) struct RetentionHandler {

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -384,10 +384,7 @@ fn run_loop(home: PathBuf, registry: AgentRegistry) {
             // W1.1 (#2050): the sibling `conflict_notify_tracker.retain_active`
             // prune moved into `ConflictNotifyHandler::run` alongside the
             // tracker it cleans (its state now lives in that handler).
-            let live_agents: std::collections::HashSet<String> = {
-                let reg = agent::lock_registry(&registry);
-                reg.values().map(|h| h.name.to_string()).collect()
-            };
+            let live_agents = agent::live_agent_names(&registry);
             notify_tracks.retain(|name, _| live_agents.contains(name));
             // CR-2026-06-14 (resource-leak): `pending_auth` has NO
             // cleanup-on-delete path of its own — entries are only removed inside
@@ -433,10 +430,7 @@ pub(crate) fn check_pane_input_not_submitted(
     tracks: &mut HashMap<String, PaneInputTrack>,
     loop_started_at: Instant,
 ) {
-    let agent_names: Vec<String> = {
-        let reg = agent::lock_registry(registry);
-        reg.values().map(|h| h.name.to_string()).collect()
-    };
+    let agent_names = agent::live_agent_names_vec(registry);
     check_pane_input_not_submitted_for_agents(home, &agent_names, tracks, loop_started_at);
 }
 


### PR DESCRIPTION
## What
**PR-A of the 5-PR simplify epic** (#2050, parent t-…84833-24). Two mechanical dedup items from the simplify-audit's daemon lane, **strictly scoped per the audit fix_sketch** — dedup only, **zero behavior change**.

### 1. `tracker_handler!` macro (supervisor_trackers.rs) — ~120 LOC boilerplate
Collapse the **8 truly-uniform** `PerTickHandler` wrappers (`anti_stall`, `idle_watchdog`, `decision_timeout`, `helper_staleness`, `canonical_drift`, `auto_release`, `dispatch_idle`, `dispatch_idle_nudge`). Each was `struct{tracker:Mutex<T>}` + arg-less `new()` + `impl PerTickHandler{name, run→maybe_scan(ctx.home)}`, differing only by type, name literal, and doc. The macro captures each per-wrapper doc (`$(#[$doc:meta])*`) and **re-emits it onto the generated struct**, so issue history survives as a real doc comment.

**Kept hand-written** (the audit's "do NOT shoehorn" guards): `McpRegistry` (extra `binary_stale` field+arg), `WaitingOnStale` & `ConflictNotify` (extra `retain_active` prunes), `Retention` (`maybe_sweep`, not `maybe_scan`). **Unchanged**: the re-exports (`mod.rs`) and `build_default_handlers` construction order.

### 2. `live_agent_names()` / `live_agent_names_vec()` (agent module) — ~5 LOC
Centralize the `lock_registry(reg).values().map(|h| h.name.to_string()).collect()` snapshot idiom from the **4 daemon-lane sites** (`supervisor.rs:387`/`436`, `supervisor_trackers.rs` ×2). The `_vec` sibling preserves the `&[String]` slice fed into `check_pane_input_not_submitted`. Surrounding `#1923`/CR prune comments + `.retain` calls kept verbatim. The **3 app-lane sites left as-is** (out of scope).

## Byte-identical proof
- **`all_twelve_supervisor_trackers_registered_in_order`** (the load-bearing order-guard — pins all 12 handler names + relative order) passes **unedited** (no test assertion touched).
- 887 daemon/supervisor/agent/handler/per_tick tests pass.
- `cargo fmt --check` ✓ · `cargo clippy --tests --features tray -D warnings` ✓.

Net **−78 LOC**. Behaviour-identical; merge needs an operator **rebuild + restart** to go live. → single review (verify byte-identical + scoping respected). PR-B follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)