### PR TITLE
fix(shell): local/scratch shells spawn unmanaged — #1441 gate no longer blocks them (#t-98760-1)

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -1029,7 +1029,40 @@ fn build_command(config: &SpawnConfig) -> anyhow::Result<(CommandBuilder, Option
     Ok((cmd, detected_backend))
 }
 
-pub fn spawn_agent(config: &SpawnConfig, registry: &AgentRegistry) -> anyhow::Result<()> {
+/// Resolve the authoritative registry `InstanceId` for a spawn (#1441).
+///
+/// A *managed* spawn (`home = Some`: a fleet/inbox-backed agent) MUST resolve to
+/// its fleet.yaml UUID — a missing entry would force a random fallback that
+/// diverges from the agent's inbox identity and reintroduces the name/UUID
+/// dual-track bug, so refuse instead. An *unmanaged* spawn (`home = None`) has no
+/// second identity track to drift against: the standalone `capture` CLI (no
+/// fleet/inbox/daemon) AND TUI-local/scratch shells (never fleet members) both
+/// take this branch, so a throwaway minted id is safe. The TUI shell paths pass
+/// `home = None` here via `pane_factory::SpawnIdentity::UnmanagedLocalShell`.
+fn resolve_spawn_instance_id(
+    home: Option<&std::path::Path>,
+    name: &str,
+) -> anyhow::Result<crate::types::InstanceId> {
+    match home {
+        Some(h) => crate::fleet::resolve_uuid(h, name).ok_or_else(|| {
+            anyhow::anyhow!(
+                "spawn '{name}': cannot resolve InstanceId from fleet.yaml — \
+                 managed instances must be registered in fleet.yaml before spawn; \
+                 refusing to register the agent registry with a non-authoritative \
+                 random UUID (#1441)"
+            )
+        }),
+        None => Ok(crate::types::InstanceId::new()),
+    }
+}
+
+/// Spawn an agent process and register it. Returns the authoritative
+/// `InstanceId` it resolved/minted (#1441) so the caller can route the pane
+/// without re-resolving (which fails for unmanaged local shells not in fleet.yaml).
+pub fn spawn_agent(
+    config: &SpawnConfig,
+    registry: &AgentRegistry,
+) -> anyhow::Result<crate::types::InstanceId> {
     let SpawnConfig {
         name,
         backend_command,
@@ -1156,31 +1189,11 @@ pub fn spawn_agent(config: &SpawnConfig, registry: &AgentRegistry) -> anyhow::Re
         health: HealthTracker::new(),
     }));
 
-    // #1441: resolve instance ID via the single authoritative resolver
-    // (same source as inbox). Resolved once here and reused for the registry
-    // key, the PTY-reaper context, and the router-subscriber lookup so all
-    // three share one authoritative identity.
-    //
-    // Fail-fast for *managed* spawns (`home` set): a missing fleet.yaml entry
-    // would force a random fallback UUID that diverges from inbox identity and
-    // reintroduces the name/UUID dual-track bug — refuse instead. When `home`
-    // is `None` (standalone `capture` CLI: no fleet, no inbox, no daemon), no
-    // second identity track exists to drift against, so a throwaway minted id
-    // is safe.
-    let instance_id = match config.home {
-        Some(h) => match crate::fleet::resolve_uuid(h, name) {
-            Some(id) => id,
-            None => {
-                return Err(anyhow::anyhow!(
-                    "spawn '{name}': cannot resolve InstanceId from fleet.yaml — \
-                     managed instances must be registered in fleet.yaml before spawn; \
-                     refusing to register the agent registry with a non-authoritative \
-                     random UUID (#1441)"
-                ));
-            }
-        },
-        None => crate::types::InstanceId::new(),
-    };
+    // #1441: resolve the single authoritative instance ID (same source as inbox),
+    // reused for the registry key, the PTY-reaper context, and the router-subscriber
+    // lookup. Extracted to `resolve_spawn_instance_id` so the managed/unmanaged
+    // identity policy is unit-testable without a live PTY spawn.
+    let instance_id = resolve_spawn_instance_id(config.home, name)?;
 
     // Register in registry
     {
@@ -1337,7 +1350,7 @@ pub fn spawn_agent(config: &SpawnConfig, registry: &AgentRegistry) -> anyhow::Re
     rollback.commit();
 
     tracing::info!(agent = name, backend = backend_command, args = %config.args.join(" "), "spawned");
-    Ok(())
+    Ok(instance_id)
 }
 
 /// #CR-2026-06-14: lock the per-agent core (OFF the registry lock path) and
@@ -1924,7 +1937,7 @@ fn on_clean_exit_shell_fallback(
         registry,
     );
     match spawn_result {
-        Ok(()) => {
+        Ok(_) => {
             tracing::info!(agent = name, shell, "shell fallback spawned");
             if let Some(ref home) = home {
                 let rdir = crate::daemon::run_dir(home);

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -756,7 +756,7 @@ fn spawn_agent_refuses_mid_delete_1915() {
         shutdown: None,
     };
     let err = match spawn_agent(&cfg, &registry) {
-        Ok(()) => panic!("#1915: a mid-delete spawn must be refused, got Ok"),
+        Ok(_) => panic!("#1915: a mid-delete spawn must be refused, got Ok"),
         Err(e) => format!("{e}"),
     };
     assert!(
@@ -767,6 +767,75 @@ fn spawn_agent_refuses_mid_delete_1915() {
         registry.lock().is_empty(),
         "#1915: bailed before the insert — no handle, no resurrection"
     );
+}
+
+/// #t-98760-1: a local/scratch shell (unmanaged identity, `home = None`) resolves
+/// a throwaway InstanceId WITHOUT a fleet.yaml entry — the identity path that
+/// fixes the broken `Ctrl+B c → Shell` spawn. Pre-fix the shell passed
+/// `home = Some` and a name never in fleet.yaml, so it hit the #1441 guard.
+#[test]
+fn resolve_spawn_instance_id_unmanaged_mints_throwaway() {
+    let id1 = resolve_spawn_instance_id(None, "shell").expect("unmanaged shell must resolve");
+    let id2 = resolve_spawn_instance_id(None, "scratch").expect("unmanaged scratch must resolve");
+    // Each unmanaged spawn is its own ephemeral identity.
+    assert_ne!(id1, id2, "distinct throwaway ids per unmanaged spawn");
+}
+
+/// #t-98760-1 / #1441 GUARD INTACT: a *managed* spawn (`home = Some`) whose name
+/// is NOT in fleet.yaml is STILL refused. The fix must not widen the guard to
+/// admit a real managed agent with a non-authoritative random UUID (the dual-track
+/// bug #1441 closed).
+#[test]
+fn resolve_spawn_instance_id_managed_without_fleet_entry_refused() {
+    use std::sync::atomic::{AtomicU32, Ordering};
+    static C: AtomicU32 = AtomicU32::new(0);
+    let home = std::env::temp_dir().join(format!(
+        "agend-resolve-id-{}-{}",
+        std::process::id(),
+        C.fetch_add(1, Ordering::Relaxed)
+    ));
+    std::fs::create_dir_all(&home).ok();
+    // No fleet.yaml written → resolve_uuid returns None for any name.
+    let err = resolve_spawn_instance_id(Some(home.as_path()), "managed-agent")
+        .expect_err("managed spawn with no fleet.yaml entry must be refused");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("#1441") && msg.contains("fleet.yaml"),
+        "refusal must cite #1441 + fleet.yaml, got: {msg}"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// #t-98760-1: full-spawn integration — an unmanaged local shell (`home = None`)
+/// spawns successfully and registers under the returned authoritative id, WITHOUT
+/// a fleet.yaml "shell" entry (the operator-reported `Ctrl+B c → Shell` bug). The
+/// returned id is used directly (no post-spawn `resolve_uuid`, which used to fail
+/// here for the shell — the second bug layer). Mirrors the `home: None` style of
+/// `deleted_agent_reaper_no_shell_fallback`.
+#[test]
+fn unmanaged_local_shell_spawns_without_fleet_entry() {
+    let registry: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
+    let cfg = SpawnConfig {
+        name: "shell",
+        backend_command: "true", // exits immediately; we only assert it registered
+        args: &[],
+        spawn_mode: crate::backend::SpawnMode::Fresh,
+        cols: 80,
+        rows: 24,
+        env: None,
+        working_dir: None,
+        submit_key: "\r",
+        home: None, // unmanaged identity — the local-shell path
+        crash_tx: None,
+        shutdown: None,
+    };
+    let id =
+        spawn_agent(&cfg, &registry).expect("unmanaged local shell must spawn without fleet.yaml");
+    let reg = registry.lock();
+    let handle = reg
+        .get(&id)
+        .expect("registry must hold the spawned shell under its returned id");
+    assert_eq!(handle.name.as_str(), "shell");
 }
 
 /// Deleted agent: reaper should not spawn shell fallback when deleted flag is set.

--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -89,6 +89,7 @@ pub(super) fn execute(cmd: &str, ctx: &mut CommandCtx<'_>) -> bool {
                     pr,
                     ctx.wakeup_tx,
                     ctx.name_counter,
+                    super::pane_factory::SpawnIdentity::Managed,
                 )
             };
             match pane_result {
@@ -225,6 +226,7 @@ pub(super) fn execute(cmd: &str, ctx: &mut CommandCtx<'_>) -> bool {
                                 pr,
                                 ctx.wakeup_tx,
                                 ctx.name_counter,
+                                super::pane_factory::SpawnIdentity::Managed,
                             )
                         }
                     } else {
@@ -245,6 +247,7 @@ pub(super) fn execute(cmd: &str, ctx: &mut CommandCtx<'_>) -> bool {
                             pr,
                             ctx.wakeup_tx,
                             ctx.name_counter,
+                            super::pane_factory::SpawnIdentity::Managed,
                         )
                     };
                     if let Ok(new_pane) = pane_result {

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -323,6 +323,7 @@ pub(super) fn dispatch(action: Action, ctx: &mut DispatchCtx<'_>) -> DispatchRes
                 inner_h,
                 ctx.wakeup_tx,
                 ctx.name_counter,
+                super::pane_factory::SpawnIdentity::UnmanagedLocalShell,
             ) {
                 Ok(pane) => {
                     out.new_overlay = Some(Overlay::ScratchShell {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -412,6 +412,7 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
                 pane_rows,
                 &wakeup_tx,
                 &mut name_counter,
+                pane_factory::SpawnIdentity::UnmanagedLocalShell,
             )?;
         }
     }
@@ -1467,6 +1468,7 @@ fn pane_from_menu_item(
                 rows,
                 wakeup_tx,
                 name_counter,
+                pane_factory::SpawnIdentity::UnmanagedLocalShell,
             )
         }
         MenuItemKind::Backend(backend) => {
@@ -1519,6 +1521,7 @@ fn pane_from_menu_item(
                     rows,
                     wakeup_tx,
                     name_counter,
+                    pane_factory::SpawnIdentity::Managed,
                 )
             }
         }

--- a/src/app/overlay.rs
+++ b/src/app/overlay.rs
@@ -211,7 +211,7 @@ pub(super) fn handle_key(
                     if let Some(item) = items.into_iter().nth(sel) {
                         let pc = c.saturating_sub(2);
                         let pr = r.saturating_sub(4);
-                        if let Ok(pane) = super::pane_from_menu_item(
+                        match super::pane_from_menu_item(
                             item,
                             ctx.fleet_path,
                             ctx.layout,
@@ -222,15 +222,24 @@ pub(super) fn handle_key(
                             ctx.wakeup_tx,
                             ctx.name_counter,
                         ) {
-                            super::telegram_hooks::maybe_create_telegram_topic(
-                                ctx.telegram_state,
-                                ctx.registry,
-                                ctx.home,
-                                &pane,
-                            );
-                            let tab_name = pane.agent_name.clone();
-                            ctx.layout.add_tab(Tab::new(tab_name.to_string(), pane));
-                            outcome.needs_resize = true;
+                            Ok(pane) => {
+                                super::telegram_hooks::maybe_create_telegram_topic(
+                                    ctx.telegram_state,
+                                    ctx.registry,
+                                    ctx.home,
+                                    &pane,
+                                );
+                                let tab_name = pane.agent_name.clone();
+                                ctx.layout.add_tab(Tab::new(tab_name.to_string(), pane));
+                                outcome.needs_resize = true;
+                            }
+                            // #t-98760-1: surface a failed new-tab spawn instead of
+                            // silently swallowing the Err (mirrors SplitMenu's error
+                            // log) — a swallowed Err looked to the operator like
+                            // Ctrl+B c "did nothing".
+                            Err(e) => {
+                                tracing::error!(error = %e, "new-tab spawn failed");
+                            }
                         }
                     }
                 }

--- a/src/app/pane_factory.rs
+++ b/src/app/pane_factory.rs
@@ -24,6 +24,20 @@ use std::sync::Arc;
 
 /// Spawn an agent/shell via spawn_agent and add as a new tab.
 #[allow(clippy::too_many_arguments)]
+/// Whether a spawned pane is a managed fleet agent or an unmanaged local shell.
+/// Drives the #1441 identity policy in `agent::spawn_agent`: a managed agent must
+/// resolve its authoritative UUID from fleet.yaml (a missing entry is refused),
+/// while a local/scratch shell — never a fleet member, no inbox identity — has no
+/// second identity track to drift against and so mints a throwaway id (the same
+/// path as the standalone `capture` CLI). Carried explicitly so the sensitive
+/// guard is never widened to wrongly admit a real managed agent.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(super) enum SpawnIdentity {
+    Managed,
+    UnmanagedLocalShell,
+}
+
+#[allow(clippy::too_many_arguments)]
 pub(super) fn spawn_pane_tab(
     layout: &mut Layout,
     registry: &AgentRegistry,
@@ -39,6 +53,7 @@ pub(super) fn spawn_pane_tab(
     rows: u16,
     wakeup_tx: &crossbeam_channel::Sender<usize>,
     name_counter: &mut HashMap<String, usize>,
+    identity: SpawnIdentity,
 ) -> Result<()> {
     let pane = create_pane(
         layout,
@@ -55,6 +70,7 @@ pub(super) fn spawn_pane_tab(
         rows,
         wakeup_tx,
         name_counter,
+        identity,
     )?;
     let tab_name = pane.agent_name.clone();
     layout.add_tab(Tab::new(tab_name.to_string(), pane));
@@ -88,6 +104,7 @@ pub(super) fn create_pane(
     rows: u16,
     wakeup_tx: &crossbeam_channel::Sender<usize>,
     name_counter: &mut HashMap<String, usize>,
+    identity: SpawnIdentity,
 ) -> Result<Pane> {
     let (mut pane, fwd_tx) = build_pane_placeholder(
         layout,
@@ -101,7 +118,7 @@ pub(super) fn create_pane(
     );
     attach_agent_to_pane(
         &mut pane, fwd_tx, registry, home, command, args, spawn_mode, env, submit_key, cols, rows,
-        wakeup_tx,
+        wakeup_tx, identity,
     )?;
     Ok(pane)
 }
@@ -187,6 +204,7 @@ fn attach_agent_to_pane(
     cols: u16,
     rows: u16,
     wakeup_tx: &crossbeam_channel::Sender<usize>,
+    identity: SpawnIdentity,
 ) -> Result<()> {
     let name = pane.agent_name.to_string();
     let work_dir = pane
@@ -201,6 +219,7 @@ fn attach_agent_to_pane(
     // registry) while the render thread runs `apply_attachment` (pane mutation).
     let (instance_id, rx, dump) = spawn_and_subscribe(
         registry, home, &name, command, args, spawn_mode, env, submit_key, &work_dir, cols, rows,
+        identity,
     )?;
     apply_attachment(pane, instance_id, rx, dump, fwd_tx, wakeup_tx);
     Ok(())
@@ -226,6 +245,7 @@ fn spawn_and_subscribe(
     work_dir: &Path,
     cols: u16,
     rows: u16,
+    identity: SpawnIdentity,
 ) -> Result<(
     crate::types::InstanceId,
     crossbeam_channel::Receiver<Vec<u8>>,
@@ -276,7 +296,20 @@ fn spawn_and_subscribe(
     // --settings) are now injected centrally by agent::spawn_agent, so callers pass
     // raw args and spawn_agent enriches them from files under work_dir.
     let spawn_mode = spawn_mode.downgraded_for(command, Some(work_dir));
-    agent::spawn_agent(
+    // #1441 identity: a managed agent passes its real `home` so spawn_agent
+    // resolves the authoritative fleet.yaml UUID; a local/scratch shell passes
+    // `None` (it is not a fleet member) so spawn_agent mints a throwaway id —
+    // exactly like the standalone `capture` CLI. `home` is still used below for
+    // skills/cwd/work_dir; only the *identity* source is gated here.
+    let identity_home = match identity {
+        SpawnIdentity::Managed => Some(home),
+        SpawnIdentity::UnmanagedLocalShell => None,
+    };
+    // #1441: spawn_agent returns the authoritative InstanceId it used as the
+    // registry key — reuse it directly to route the pane's lookups. (Was a
+    // second `resolve_uuid(home, name)` here, which fails for a local shell with
+    // no fleet.yaml entry even after a successful spawn — the original bug.)
+    let instance_id = agent::spawn_agent(
         &agent::SpawnConfig {
             name,
             backend_command: command,
@@ -287,7 +320,7 @@ fn spawn_and_subscribe(
             env: Some(env),
             working_dir: Some(work_dir),
             submit_key,
-            home: Some(home),
+            home: identity_home,
             crash_tx: None,
             // restart-freeze 真嫌#1 (t-…55279): hand every Owned-mode agent the
             // process-global app shutdown flag so `app_teardown` can flip it and
@@ -298,13 +331,6 @@ fn spawn_and_subscribe(
         },
         registry,
     )?;
-
-    // #1441: resolve the authoritative UUID once (same source as the registry
-    // key spawn_agent just used) and route the pane's registry lookups by it.
-    // spawn_agent succeeded above, so the fleet.yaml entry — and thus the
-    // resolution — is guaranteed present.
-    let instance_id = crate::fleet::resolve_uuid(home, name)
-        .ok_or_else(|| anyhow::anyhow!("agent '{name}' has no fleet UUID after spawn"))?;
 
     // Subscribe to the agent's output
     let (rx, dump) = {
@@ -689,6 +715,7 @@ pub(super) fn run_attach(
                 &work_dir,
                 cols,
                 rows,
+                SpawnIdentity::Managed,
             ) {
                 Ok((instance_id, rx, dump)) => {
                     // Overwrite basic instructions with the fleet-aware version
@@ -747,6 +774,9 @@ pub(super) fn run_attach(
             &work_dir,
             cols,
             rows,
+            // AttachSpec::Direct is the deferred SHELL / direct-command path
+            // (see `build_deferred_direct_pane`) — unmanaged, no fleet.yaml entry.
+            SpawnIdentity::UnmanagedLocalShell,
         ) {
             Ok((instance_id, rx, dump)) => {
                 finish_attach(registry, pane_id, instance_id, rx, dump, work_dir, name)
@@ -950,6 +980,7 @@ pub(super) fn create_pane_from_resolved(
         rows,
         wakeup_tx,
         name_counter,
+        SpawnIdentity::Managed,
     )?;
 
     // Overwrite basic instructions with fleet-aware version

--- a/src/daemon/crash_respawn.rs
+++ b/src/daemon/crash_respawn.rs
@@ -321,7 +321,7 @@ fn respawn_agent_worker(
         },
         reg,
     ) {
-        Ok(()) => {
+        Ok(_) => {
             tracing::info!(agent = %config.name, "respawned");
             crate::event_log::log(home, "respawn", &config.name, "agent respawned");
             // #1441: registry is UUID-keyed; resolve the respawned name once.

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -2117,7 +2117,7 @@ fn handle_stage2_restart(
     );
 
     match spawn_result {
-        Ok(()) => {
+        Ok(_) => {
             tracing::info!(
                 target: "recovery_shadow",
                 agent = %name,

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -521,7 +521,7 @@ fn test_backend(backend: &backend::Backend, home: &Path) -> Vec<TestResult> {
     );
 
     match spawn_result {
-        Ok(()) => {
+        Ok(_) => {
             let re = regex::RegexBuilder::new(preset.ready_pattern)
                 .size_limit(1 << 20)
                 .build()


### PR DESCRIPTION
## Bug (operator-reported, HIGH)

After restart, **Ctrl+B c → Shell** can't open a local shell. The NewTabMenu spawns the shell with `home = Some` + name `"shell"`, which is never in `fleet.yaml`, so the **#1441 identity guard** in `spawn_agent` refuses it (`resolve_uuid → None → Err → rollback`). The NewTabMenu Enter handler then **swallowed the `Err` silently** (no log), so it looked like Ctrl+B c "did nothing".

**git `-S` confirms PREEXISTING**, not a recent regression: the guard landed in `2ef0e00a` (2026-05-29); before it, an unresolvable `home=Some` spawn was not refused.

## Two failure layers (both fixed)

1. `spawn_agent`'s #1441 guard (`agent/mod.rs`) demanded a fleet.yaml UUID for **any** `home=Some` spawn.
2. `attach_agent_to_pane` **re-resolved** the UUID post-spawn (`resolve_uuid` again, `pane_factory.rs`) — also `None` for a shell → "has no fleet UUID after spawn".

## Fix — route local shells through the guard's *existing* unmanaged path

`config.home` is used **only** by the guard, and the guard already mints a throwaway id for `home = None` (the standalone `capture` CLI: no fleet/inbox identity to drift against). A local/scratch shell is the same shape — not a fleet member, no inbox identity — so it should take that path.

- **New `pane_factory::SpawnIdentity { Managed, UnmanagedLocalShell }`**, carried *explicitly* through `create_pane → spawn_pane_tab → attach_agent_to_pane → spawn_and_subscribe`. The **4 shell spawn sites** — NewTabMenu (`mod.rs`), scratch shell (`dispatch.rs`), cold-start fallback tab (`mod.rs`), and the deferred `AttachSpec::Direct` attach (`run_attach`) — pass `UnmanagedLocalShell` → `SpawnConfig.home = None` → throwaway id. All **6 managed sites** stay `Managed` → resolve from fleet.yaml.
- **The #1441 guard itself is unchanged** — a real managed agent missing fleet.yaml is still refused (no widening; the enum is per-call-site explicit so a managed spawn can't be mislabeled).
- **`spawn_agent` now returns the authoritative `InstanceId`** it resolved/minted, so `attach` reuses it directly instead of re-resolving (fixes layer 2; aligns with #1441's own "resolve once, reuse" comment). Extracted `resolve_spawn_instance_id` for unit-testing.
- **`overlay.rs`** NewTabMenu handler now logs a failed spawn (`tracing::error!`) instead of swallowing it (mirrors `SplitMenu`).

## Tests (test-first)

- `resolve_spawn_instance_id_unmanaged_mints_throwaway` — `home=None` mints a throwaway id with no fleet.yaml (the shell path).
- `resolve_spawn_instance_id_managed_without_fleet_entry_refused` — **#1441 guard intact**: `home=Some` + no fleet entry is still refused (cites #1441 + fleet.yaml).
- `unmanaged_local_shell_spawns_without_fleet_entry` — full `spawn_agent` for a `home=None` shell succeeds and registers under the returned id, no fleet.yaml `"shell"` entry needed.

## Verification

- Targeted: **5/5 pass**. Full `cargo nextest`: all pass except `teardown_completeness_regression::teardown_leaves_zero_residual_after_full_exercise_1907`, which is a **local agend-git-shim artifact** (it shells git; the shim writes `fleet_events.jsonl`) — **passes with real git** (`PATH=/usr/bin`), and CI uses real git.
- `cargo clippy --all-targets --features tray -D warnings`: clean. `cargo fmt`: clean.

## Notes

- Blast: 10 files; the bulk is the `SpawnIdentity` threading + `spawn_agent`'s return type. The #1441 guard logic is untouched.
- Requested **DUAL review** (touches the #1441 identity guard).
- Live only after operator rebuild + restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)