### PR TITLE
feat(#2344): typed RoleKind enum drives per-role MCP tool subsetting

### DIFF
--- a/docs/FEATURE-fleet.md
+++ b/docs/FEATURE-fleet.md
@@ -64,6 +64,7 @@ instances:
 
   reviewer:
     role: "Code reviewer"
+    role_kind: reviewer   # typed role → trims the MCP tool surface (opt-in; see below)
     backend: kiro-cli
     working_directory: ~/Projects/my-app
     source_repo: ~/Projects/my-app
@@ -100,7 +101,8 @@ Each key is the agent's name (must match `[a-zA-Z0-9_-]`); the value is its conf
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `role` | string | Agent role description (alias: `description`) |
+| `role` | string | Agent role description, free text (alias: `description`) |
+| `role_kind` | enum | **Optional, opt-in.** Typed role selector that trims the MCP tool surface this agent advertises (defense-in-depth, #2300). One of `reviewer` / `planner` / `explorer` (read/report — drops instance/worktree lifecycle + orchestration tools) or `orchestrator` / `implementer` / `utility` / `proxy` (full surface). **Absent → all tools** (no existing fleet changes). Distinct from the free-text `role` above; an unknown value fails fleet load. |
 | `backend` | string | Override defaults backend |
 | `command` | string | Override defaults command |
 | `args` | [string] | Additional CLI arguments (merged with defaults) |

--- a/src/api/handlers/mcp_proxy.rs
+++ b/src/api/handlers/mcp_proxy.rs
@@ -236,22 +236,52 @@ fn handle_mcp_tool_inner(
 pub(crate) fn handle_mcp_tools_list(params: &Value, ctx: &HandlerCtx) -> Value {
     // #2344: subset off the typed `role_kind` (operator-declared), NOT the
     // free-text `role` description — the old exact-match against the prose role
-    // never hit, so every agent saw all 36 tools. `.ok()` here is a per-request
-    // best-effort read; a malformed `role_kind` is caught loudly at the
-    // authoritative fleet load (#2344 D2 strict), so this path only ever sees a
-    // valid (or absent) value.
-    let role_kind = params
+    // never hit, so every agent saw all 36 tools.
+    let inst = params
         .get("instance")
         .and_then(|v| v.as_str())
-        .filter(|s| !s.is_empty())
-        .and_then(|inst| {
-            crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(ctx.home))
-                .ok()
-                .and_then(|fleet| fleet.instances.get(inst).and_then(|i| i.role_kind))
-        });
-    // Default-all-open hot path: no instance / undeclared role_kind → the canonical
-    // full surface (also keeps `tool_definitions` the single unfiltered builder
-    // the count-invariant pins). A role only narrows via the capability registry.
+        .filter(|s| !s.is_empty());
+    let role_kind = match inst {
+        // No instance (old bridge / non-agent caller) → default-all-open.
+        None => None,
+        Some(inst) => {
+            // #2344 (r6 #2367 reject + lead nuance): distinguish a MISSING fleet.yaml
+            // from a present-but-malformed one. The old `FleetConfig::load(..).ok()`
+            // collapsed BOTH to `None` → the full 36-tool surface, which let a typo'd
+            // `role_kind: supervisor` FAIL strict parse yet still advertise every tool
+            // — the D2 strict-deny hole r6 found.
+            let fleet_path = crate::fleet::fleet_yaml_path(ctx.home);
+            if !fleet_path.exists() {
+                // (1) No fleet.yaml at all — a common setup (dev / fresh / local
+                // shell). Stay ALL-OPEN; a blanket fail-closed would regress every
+                // no-fleet daemon.
+                None
+            } else {
+                match crate::fleet::FleetConfig::load(&fleet_path) {
+                    // (2) Present but FAILS to load (parse error / malformed
+                    // role_kind) → FAIL CLOSED. Surface the error loudly (operator
+                    // fixes the config); never silently advertise the full surface.
+                    Err(e) => {
+                        return json!({
+                            "ok": false,
+                            "error": format!(
+                                "tools/list: fleet.yaml is present but failed to load \
+                                 (refusing to advertise the full tool surface — fix the \
+                                 config): {e:#}"
+                            ),
+                        });
+                    }
+                    // (3) Loaded OK → the instance's role_kind. An unknown instance OR
+                    // an absent role_kind → all-open (the unchanged opt-in contract).
+                    Ok(fleet) => fleet.instances.get(inst).and_then(|i| i.role_kind),
+                }
+            }
+        }
+    };
+    // Default-all-open hot path: no instance / no fleet.yaml / undeclared role_kind
+    // → the canonical full surface (also keeps `tool_definitions` the single
+    // unfiltered builder the count-invariant pins). A role only narrows via the
+    // capability registry.
     let result = match role_kind {
         None => crate::mcp::tools::tool_definitions(),
         Some(rk) => crate::mcp::tools::tool_definitions_for_role(Some(rk)),
@@ -487,6 +517,96 @@ mod tests {
             .map(|a| a.len())
             .unwrap_or(0);
         assert_eq!(n_full, full, "no instance → all-open full surface");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    fn toollist_ctx_home(tag: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!("agend-mcp-toollist-{tag}-{}", std::process::id()))
+    }
+
+    /// #2344 D2 STRICT on the live bridge path (r6 #2367 reject): a fleet.yaml that
+    /// is PRESENT but malformed (e.g. an unknown `role_kind`) must FAIL CLOSED in
+    /// `handle_mcp_tools_list` — NOT silently fall back to the full 36-tool surface
+    /// (the old `.ok()` swallowed the parse error). Returns `ok: false` + an
+    /// explanatory error, no `result.tools`, and does not panic.
+    #[test]
+    fn tools_list_fails_closed_on_malformed_role_kind() {
+        let dir = toollist_ctx_home("bad");
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        std::fs::write(
+            dir.join("fleet.yaml"),
+            "instances:\n  bad:\n    role_kind: supervisor\n    command: claude\n",
+        )
+        .expect("write fleet.yaml");
+
+        let registry: crate::agent::AgentRegistry = Default::default();
+        let configs: crate::api::ConfigRegistry = Default::default();
+        let externals: crate::agent::ExternalRegistry = Default::default();
+        let ctx = HandlerCtx {
+            registry: &registry,
+            configs: &configs,
+            externals: &externals,
+            notifier: None,
+            home: &dir,
+        };
+
+        let resp = handle_mcp_tools_list(&json!({"instance": "bad"}), &ctx);
+        assert_eq!(
+            resp["ok"], false,
+            "present-but-malformed fleet.yaml must fail closed, got: {resp}"
+        );
+        let err = resp["error"].as_str().unwrap_or("");
+        assert!(
+            err.contains("supervisor") || err.contains("role_kind") || err.contains("fleet"),
+            "error must explain the failure (bad value / role_kind / fleet), got: {err}"
+        );
+        assert!(
+            resp.get("result").and_then(|r| r.get("tools")).is_none(),
+            "fail-closed must NOT return a full tool list, got: {resp}"
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// #2344 (lead nuance): a MISSING fleet.yaml must stay ALL-OPEN — a no-fleet
+    /// daemon (dev / fresh / local-shell setups) must NOT be fail-closed just
+    /// because an instance name is passed. Only a PRESENT-but-malformed fleet.yaml
+    /// fails closed (above); absence is not an error.
+    #[test]
+    fn tools_list_all_open_when_no_fleet_yaml() {
+        let dir = toollist_ctx_home("nofleet");
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        // Deliberately NO fleet.yaml written.
+
+        let registry: crate::agent::AgentRegistry = Default::default();
+        let configs: crate::api::ConfigRegistry = Default::default();
+        let externals: crate::agent::ExternalRegistry = Default::default();
+        let ctx = HandlerCtx {
+            registry: &registry,
+            configs: &configs,
+            externals: &externals,
+            notifier: None,
+            home: &dir,
+        };
+
+        let full = crate::mcp::tools::tool_definitions()["tools"]
+            .as_array()
+            .map(|a| a.len())
+            .unwrap_or(0);
+        let resp = handle_mcp_tools_list(&json!({"instance": "anyone"}), &ctx);
+        assert_eq!(
+            resp["ok"], true,
+            "no fleet.yaml must NOT fail closed, got: {resp}"
+        );
+        let n = resp["result"]["tools"]
+            .as_array()
+            .map(|a| a.len())
+            .unwrap_or(0);
+        assert_eq!(
+            n, full,
+            "no fleet.yaml → all-open full surface (no-fleet setups not regressed)"
+        );
 
         std::fs::remove_dir_all(&dir).ok();
     }

--- a/src/api/handlers/mcp_proxy.rs
+++ b/src/api/handlers/mcp_proxy.rs
@@ -234,21 +234,27 @@ fn handle_mcp_tool_inner(
 /// no instance (old bridge / non-agent caller), unknown instance, or a role not
 /// in the capability registry (dev / lead / orchestrator / …) → the full surface.
 pub(crate) fn handle_mcp_tools_list(params: &Value, ctx: &HandlerCtx) -> Value {
-    let role = params
+    // #2344: subset off the typed `role_kind` (operator-declared), NOT the
+    // free-text `role` description — the old exact-match against the prose role
+    // never hit, so every agent saw all 36 tools. `.ok()` here is a per-request
+    // best-effort read; a malformed `role_kind` is caught loudly at the
+    // authoritative fleet load (#2344 D2 strict), so this path only ever sees a
+    // valid (or absent) value.
+    let role_kind = params
         .get("instance")
         .and_then(|v| v.as_str())
         .filter(|s| !s.is_empty())
         .and_then(|inst| {
             crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(ctx.home))
                 .ok()
-                .and_then(|fleet| fleet.instances.get(inst).and_then(|i| i.role.clone()))
+                .and_then(|fleet| fleet.instances.get(inst).and_then(|i| i.role_kind))
         });
-    // Default-all-open hot path: no instance / unlabeled instance → the canonical
+    // Default-all-open hot path: no instance / undeclared role_kind → the canonical
     // full surface (also keeps `tool_definitions` the single unfiltered builder
     // the count-invariant pins). A role only narrows via the capability registry.
-    let result = match role.as_deref() {
+    let result = match role_kind {
         None => crate::mcp::tools::tool_definitions(),
-        Some(r) => crate::mcp::tools::tool_definitions_for_role(Some(r)),
+        Some(rk) => crate::mcp::tools::tool_definitions_for_role(Some(rk)),
     };
     json!({ "ok": true, "result": result })
 }
@@ -430,5 +436,58 @@ mod tests {
             resp.get("status").is_none(),
             "no accepted_in_progress on success: {resp}"
         );
+    }
+
+    /// #2344 e2e: `handle_mcp_tools_list` subsets the surface for a fleet instance
+    /// whose `role_kind` is a read/report role — the live path the MCP bridge hits.
+    /// A reviewer sees fewer than the full 36 tools; no instance → all-open.
+    #[test]
+    fn tools_list_subsets_for_role_kind_reviewer() {
+        let dir =
+            std::env::temp_dir().join(format!("agend-mcp-toolslist-rk-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        std::fs::write(
+            dir.join("fleet.yaml"),
+            "instances:\n  rev:\n    role: \"Code reviewer\"\n    role_kind: reviewer\n    command: claude\n",
+        )
+        .expect("write fleet.yaml");
+
+        let registry: crate::agent::AgentRegistry = Default::default();
+        let configs: crate::api::ConfigRegistry = Default::default();
+        let externals: crate::agent::ExternalRegistry = Default::default();
+        let ctx = HandlerCtx {
+            registry: &registry,
+            configs: &configs,
+            externals: &externals,
+            notifier: None,
+            home: &dir,
+        };
+
+        let full = crate::mcp::tools::tool_definitions()["tools"]
+            .as_array()
+            .map(|a| a.len())
+            .unwrap_or(0);
+
+        // role_kind=reviewer → subsetted surface.
+        let resp = handle_mcp_tools_list(&json!({"instance": "rev"}), &ctx);
+        assert_eq!(resp["ok"], true);
+        let n = resp["result"]["tools"]
+            .as_array()
+            .map(|a| a.len())
+            .unwrap_or(0);
+        assert!(
+            n > 0 && n < full,
+            "tools_list for role_kind=reviewer must be subsetted ({n} < {full})"
+        );
+
+        // No instance → all-open (the default hot path).
+        let resp_full = handle_mcp_tools_list(&json!({}), &ctx);
+        let n_full = resp_full["result"]["tools"]
+            .as_array()
+            .map(|a| a.len())
+            .unwrap_or(0);
+        assert_eq!(n_full, full, "no instance → all-open full surface");
+
+        std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/src/fleet/mod.rs
+++ b/src/fleet/mod.rs
@@ -342,11 +342,45 @@ pub enum IdleExpectation {
     OnDemand,
 }
 
+/// #2344: typed agent-role selector. Drives the per-role MCP tool subset
+/// (`crate::mcp::registry::tool_subset_for_role`). Distinct from the free-text
+/// `role` description below: the operator DECLARES this typed value (no brittle
+/// prose-parsing — see archived plan PLAN-role-enum-default-by-role-2026-04).
+///
+/// `#[serde(rename_all = "snake_case")]` → fleet.yaml values: `reviewer`,
+/// `planner`, `explorer`, `orchestrator`, `implementer`, `utility`, `proxy`.
+/// STRICT (#2344 D2): a `role_kind:` present with any other value FAILS
+/// fleet.yaml load (serde unknown-variant error naming the offending instance +
+/// value); an ABSENT `role_kind` is legal and resolves to the all-open default
+/// (opt-in — no existing fleet breaks, no real agent loses tools).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RoleKind {
+    /// Restricted read/report subset — no instance/worktree lifecycle (#2158).
+    Reviewer,
+    /// Restricted read/report — same subset surface as `Reviewer`.
+    Planner,
+    /// Strictest read-only — also drops `repo` (checkout) + `ci` (run/dispatch).
+    Explorer,
+    /// Full capability — fleet orchestration/dispatch (lead).
+    Orchestrator,
+    /// Full capability — implements changes (dev).
+    Implementer,
+    /// Full capability — general/utility agent.
+    Utility,
+    /// Full capability — bridges an external/proxy backend.
+    Proxy,
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct InstanceConfig {
     /// Role description. TS version uses "description", accepted as alias.
     #[serde(alias = "description")]
     pub role: Option<String>,
+    /// #2344: typed role selector driving the per-role MCP tool subset (opt-in;
+    /// absent → all-open). Distinct from the free-text `role` description above.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub role_kind: Option<RoleKind>,
     /// Unique instance ID (UUIDv4). Auto-assigned on first load if absent.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
@@ -993,6 +1027,115 @@ instances:
             resolved.args
         );
 
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    // ── #2344: typed role_kind drives the per-role MCP tool subset ──
+
+    fn tool_count(defs: &serde_json::Value) -> usize {
+        defs.get("tools")
+            .and_then(|t| t.as_array())
+            .map(|a| a.len())
+            .unwrap_or(0)
+    }
+
+    /// #2344: a typed `role_kind: reviewer` parses to the enum AND drives the MCP
+    /// tool subset (narrower than full) — the per-role subsetting that was inert.
+    /// The prose `role` description coexists unchanged.
+    #[test]
+    fn role_kind_reviewer_parses_and_subsets_tools() {
+        let dir = std::env::temp_dir().join(format!("agend-fleet-rk-rev-{}", std::process::id()));
+        let path = write_fleet(
+            &dir,
+            r#"
+instances:
+  rev:
+    role: "Senior code reviewer"
+    role_kind: reviewer
+    command: claude
+"#,
+        );
+        let config = FleetConfig::load(&path).expect("load");
+        let inst = config.instances.get("rev").expect("instance");
+        assert_eq!(inst.role_kind, Some(RoleKind::Reviewer));
+        assert_eq!(
+            inst.role.as_deref(),
+            Some("Senior code reviewer"),
+            "prose role description coexists with the typed role_kind"
+        );
+
+        let full = tool_count(&crate::mcp::tools::tool_definitions());
+        let subset = tool_count(&crate::mcp::tools::tool_definitions_for_role(
+            inst.role_kind,
+        ));
+        assert!(
+            subset < full,
+            "role_kind=reviewer must narrow the tool surface ({subset} < {full})"
+        );
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    /// #2344 REGRESSION PIN: a free-text `role` description with NO `role_kind`
+    /// stays ALL-OPEN (opt-in) — the original bug class. Prose like "Code reviewer"
+    /// never matched a subset key, so it must surface the full 36 tools; only an
+    /// operator-declared typed `role_kind` narrows.
+    #[test]
+    fn prose_role_without_role_kind_stays_all_open() {
+        let dir = std::env::temp_dir().join(format!("agend-fleet-rk-prose-{}", std::process::id()));
+        let path = write_fleet(
+            &dir,
+            r#"
+instances:
+  rev:
+    role: "Code reviewer"
+    command: claude
+"#,
+        );
+        let config = FleetConfig::load(&path).expect("load");
+        let inst = config.instances.get("rev").expect("instance");
+        assert_eq!(
+            inst.role_kind, None,
+            "no role_kind declared → None (opt-in)"
+        );
+
+        let full = tool_count(&crate::mcp::tools::tool_definitions());
+        let surface = tool_count(&crate::mcp::tools::tool_definitions_for_role(
+            inst.role_kind,
+        ));
+        assert_eq!(
+            surface, full,
+            "prose role without role_kind must stay all-open (the #2344 bug: prose never subsets)"
+        );
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    /// #2344 D2 STRICT: a `role_kind:` present with a value outside the seven
+    /// variants FAILS fleet.yaml load (returns Err, does NOT panic), naming the bad
+    /// value + the valid options. A field-ABSENT role_kind is legal (covered
+    /// above), so existing fleets (no role_kind) are never wrongly blocked.
+    #[test]
+    fn unknown_role_kind_value_fails_load_strict() {
+        let dir = std::env::temp_dir().join(format!("agend-fleet-rk-bad-{}", std::process::id()));
+        let path = write_fleet(
+            &dir,
+            r#"
+instances:
+  badagent:
+    role_kind: supervisor
+    command: claude
+"#,
+        );
+        let err =
+            FleetConfig::load(&path).expect_err("unknown role_kind must fail load (D2 strict)");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("supervisor"),
+            "error must name the bad value, got: {msg}"
+        );
+        assert!(
+            msg.contains("reviewer"),
+            "error must list the valid role_kind options, got: {msg}"
+        );
         fs::remove_dir_all(&dir).ok();
     }
 

--- a/src/mcp/registry.rs
+++ b/src/mcp/registry.rs
@@ -19,7 +19,9 @@ pub(crate) fn all() -> &'static [ToolEntry] {
 
 /// #2300 P0: declarative per-role MCP tool subsets (capability registry).
 ///
-/// Maps a free-form fleet.yaml `role` label → the tool names that role may SEE.
+/// Keyed by a typed [`crate::fleet::RoleKind`]'s canonical (snake_case) name →
+/// the tool names that role may SEE (#2344: was a free-text `role` label that
+/// never matched real prose, so the subsetting was inert).
 /// **Default-all-open**: a role NOT listed here — including dev / lead /
 /// orchestrator / unlabeled — gets the full `all()` surface, byte-identical to
 /// pre-#2300. Only the listed read/report roles are trimmed, hiding footgun
@@ -103,13 +105,33 @@ const ROLE_TOOL_SUBSETS: &[(&str, &[&str])] = &[
     ),
 ];
 
-/// #2300 P0: the MCP tool entries a given `role` may SEE. Default-all-open:
-/// `None`, an unlisted role (dev / lead / orchestrator / …), or an unknown label
-/// → the full `all()` surface (byte-identical, registry order). A listed role is
-/// narrowed to its subset; a subset name not in the registry is ignored (never
-/// widens). Order always follows the registry, not the subset list.
-pub(crate) fn tool_subset_for_role(role: Option<&str>) -> Vec<&'static ToolEntry> {
-    let subset = role.and_then(|r| {
+/// #2300 P0 / #2344: the MCP tool entries a given typed [`crate::fleet::RoleKind`]
+/// may SEE. Default-all-open: `None` (no `role_kind` declared — opt-in) or a
+/// full-capability role (`Orchestrator` / `Implementer` / `Utility` / `Proxy`) →
+/// the full `all()` surface (byte-identical, registry order). The three read/report
+/// roles narrow to their curated subset; a subset name not in the registry is
+/// ignored (never widens). Order always follows the registry, not the subset list.
+///
+/// #2344: the match on `RoleKind` is EXHAUSTIVE on purpose — adding a variant
+/// forces a deliberate subset-vs-all-open decision here at compile time. (Was a
+/// free-text `role` string exact-match that no real prose role ever hit → the
+/// per-role subsetting was silently inert.)
+pub(crate) fn tool_subset_for_role(
+    role_kind: Option<crate::fleet::RoleKind>,
+) -> Vec<&'static ToolEntry> {
+    use crate::fleet::RoleKind;
+    let subset_key: Option<&str> = match role_kind {
+        Some(RoleKind::Reviewer) => Some("reviewer"),
+        Some(RoleKind::Planner) => Some("planner"),
+        Some(RoleKind::Explorer) => Some("explorer"),
+        // Full-capability roles + undeclared (opt-in) → all-open.
+        Some(RoleKind::Orchestrator)
+        | Some(RoleKind::Implementer)
+        | Some(RoleKind::Utility)
+        | Some(RoleKind::Proxy)
+        | None => None,
+    };
+    let subset = subset_key.and_then(|r| {
         ROLE_TOOL_SUBSETS
             .iter()
             .find(|(name, _)| *name == r)
@@ -323,24 +345,26 @@ static ALL_TOOLS: [ToolEntry; 36] = [
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::fleet::RoleKind;
 
-    fn names(role: Option<&str>) -> Vec<&'static str> {
+    fn names(role: Option<RoleKind>) -> Vec<&'static str> {
         tool_subset_for_role(role).iter().map(|e| e.name).collect()
     }
 
-    /// #2300 P0 byte-identical invariant: full-capability roles (dev / lead),
-    /// `None`, and any UNKNOWN role surface the ENTIRE registry in registry order
-    /// — zero behavior change. If this breaks, default-all-open regressed.
+    /// #2300 P0 byte-identical invariant: full-capability roles (orchestrator /
+    /// implementer / utility / proxy) and `None` (undeclared role_kind) surface the
+    /// ENTIRE registry in registry order — zero behavior change. If this breaks,
+    /// default-all-open regressed.
     #[test]
     fn full_capability_roles_surface_all_36_byte_identical() {
         let all_names: Vec<&str> = all().iter().map(|e| e.name).collect();
         assert_eq!(all_names.len(), 36, "registry baseline is 36 tools");
         for role in [
             None,
-            Some("dev"),
-            Some("lead"),
-            Some("orchestrator"),
-            Some("totally-unknown-role"),
+            Some(RoleKind::Orchestrator),
+            Some(RoleKind::Implementer),
+            Some(RoleKind::Utility),
+            Some(RoleKind::Proxy),
         ] {
             assert_eq!(
                 names(role),
@@ -354,7 +378,7 @@ mod tests {
     /// tools its workflow needs. Pins the conservative subset contract.
     #[test]
     fn reviewer_drops_lifecycle_keeps_review_tools() {
-        let r = names(Some("reviewer"));
+        let r = names(Some(RoleKind::Reviewer));
         // Dropped: instance/worktree lifecycle (the #2158 vector) + orchestration.
         for cut in [
             "bind_self",
@@ -404,7 +428,7 @@ mod tests {
     /// and `ci` (run/dispatch) that reviewer/planner keep.
     #[test]
     fn explorer_is_strictest_read_only() {
-        let e = names(Some("explorer"));
+        let e = names(Some(RoleKind::Explorer));
         for cut in ["repo", "ci", "bind_self", "create_instance"] {
             assert!(
                 !e.contains(&cut),

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -10,13 +10,13 @@ pub fn tool_definitions() -> Value {
     json!({"tools": tools})
 }
 
-/// #2300 P0: tool definitions VISIBLE to `role` (per
-/// [`crate::mcp::registry::tool_subset_for_role`]). Default-all-open — `None` /
-/// dev / lead / unknown role → the full set, byte-identical to
-/// [`tool_definitions`]. Used by the daemon `tools/list` handler to subset the
-/// surface a read/report role advertises.
-pub fn tool_definitions_for_role(role: Option<&str>) -> Value {
-    let tools: Vec<Value> = crate::mcp::registry::tool_subset_for_role(role)
+/// #2300 P0 / #2344: tool definitions VISIBLE to a typed [`crate::fleet::RoleKind`]
+/// (per [`crate::mcp::registry::tool_subset_for_role`]). Default-all-open — `None`
+/// (no `role_kind` declared) or a full-capability role → the full set,
+/// byte-identical to [`tool_definitions`]. Used by the daemon `tools/list` handler
+/// to subset the surface a read/report role advertises.
+pub fn tool_definitions_for_role(role_kind: Option<crate::fleet::RoleKind>) -> Value {
+    let tools: Vec<Value> = crate::mcp::registry::tool_subset_for_role(role_kind)
         .iter()
         .map(|entry| (entry.definition)())
         .collect();


### PR DESCRIPTION
## Bug (#2344)

Per-role MCP tool subsetting (#2300) was **inert**: `tool_subset_for_role` exact-matched the free-text fleet.yaml `role:` description against the subset keys (`reviewer`/`planner`/`explorer`), but every real role is **prose** ("Code reviewer", "Team lead — …", "審查者…"). Zero ever matched → every agent saw all 36 tools. (Confirmed in the read-only spike — no real `role:` value equals a subset key.)

## Change (per the approved spike design; operator decisions D1 = 7 variants, D2 = strict)

Add a typed, **operator-declared** `role_kind: Option<RoleKind>` on `InstanceConfig` that drives the subset — the archived `PLAN-role-enum` approach (declare a typed value; do **not** parse the brittle prose).

- **`RoleKind`** (`#[serde(rename_all="snake_case")]`, 7 variants): `reviewer` / `planner` / `explorer` (read/report subsets) + `orchestrator` / `implementer` / `utility` / `proxy` (full surface).
- **`tool_subset_for_role(Option<RoleKind>)`** with an **EXHAUSTIVE match** — adding a variant forces a deliberate subset-vs-all-open decision at compile time. The dead prose exact-match is removed.
- **mcp_proxy** `tools_list` handler sources the typed `role_kind`, not the prose `role`.
- **Pure OPT-IN**: absent `role_kind` → all-open. No existing fleet breaks; no real agent loses tools. The free-text `role` description coexists unchanged.
- **D2 STRICT**: a `role_kind:` present with a value outside the seven **fails fleet.yaml load** (`Option<RoleKind>` deserialize error naming the bad value + valid options), no panic. A **field-absent** `role_kind` is legal — existing fleets are never wrongly rejected.
- Preserves the **#2300 defense-in-depth** intent (now actually realized for declared roles; still P0 visibility-only, hard DENY remains P1/#2158).

## Tests

- `prose_role_without_role_kind_stays_all_open` — **#2344 regression pin**: prose `role` + no `role_kind` → all 36 tools.
- `role_kind_reviewer_parses_and_subsets_tools` — fleet-load chain: `role_kind: reviewer` parses + narrows the surface (prose `role` coexists).
- `unknown_role_kind_value_fails_load_strict` — D2: `role_kind: supervisor` → `FleetConfig::load` Err naming the bad value + options (no panic).
- `tools_list_subsets_for_role_kind_reviewer` — **e2e**: `handle_mcp_tools_list` (the live bridge path) returns a subsetted surface for `role_kind=reviewer`; no instance → all-open.
- Existing registry subset tests migrated to the typed enum (`full_capability_…`, `reviewer_…`, `explorer_…`, `subset_names_…`).

## Verification

- `cargo nextest` (role_kind + registry + e2e): **8/8**. `cargo clippy --all-targets --features tray -D warnings`: clean. `cargo fmt`: clean.
- `docs/FEATURE-fleet.md` documents the `role_kind` field + example.

## Notes
- Blast: 5 files (fleet, registry, tools, mcp_proxy, docs). The #2300 subset lists themselves are unchanged; only the *keying* moves from inert prose to typed `RoleKind`.
- single review. Live after operator restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)