### PR TITLE
fix(inbox): mark_ci_watch_superseded matches correlation_id equality, not text substring (bug-audit Rank3)

### DIFF
--- a/src/inbox/storage.rs
+++ b/src/inbox/storage.rs
@@ -348,11 +348,20 @@ pub fn mark_ci_watch_superseded(
                 continue;
             }
             if let Ok(mut msg) = serde_json::from_str::<InboxMessage>(line) {
+                // Authoritative match is `correlation_id` EQUALITY, not a
+                // `text.contains` substring. ci-watch enqueues set
+                // `correlation_id = "<repo>@<branch>"` (see `ci_watch::poller` /
+                // `ci_watch::sweep`). A substring match supersedes a
+                // prefix-colliding branch: a new `repo@feat/x` event would wrongly
+                // supersede an unread `repo@feat/x-2` notice (its key CONTAINS
+                // `repo@feat/x`), silently dropping feat/x-2's CI-ready signal. The
+                // `line.contains` pre-filter above stays as a cheap screen (it
+                // over-includes; this equality is the authoritative decision).
                 if msg.read_at.is_none()
                     && msg.superseded_by.is_none()
                     && msg.kind.as_deref() == Some("ci-watch")
                     && msg.from == "system:ci"
-                    && msg.text.contains(repo_branch_key)
+                    && msg.correlation_id.as_deref() == Some(repo_branch_key)
                 {
                     msg.superseded_by = Some(new_msg_id.to_string());
                     changed = true;

--- a/src/inbox/storage/perf_r3_equiv.rs
+++ b/src/inbox/storage/perf_r3_equiv.rs
@@ -219,6 +219,7 @@ fn cross_mutator_consistency() {
     // 5. enqueue a ci-watch E, then supersede it → E unread+superseded (excluded).
     let mut e = InboxMessage::new_system("system:ci", "ci-watch", "ci-watch owner/repo@main built");
     e.id = Some("E".to_string());
+    e.correlation_id = Some("owner/repo@main".to_string());
     enqueue(&home, name, e).expect("enqueue E");
     assert_eq!(unread_count(&home, name).0, 2, "D + E unread");
     mark_ci_watch_superseded(&home, name, "owner/repo@main", "m-newer");

--- a/src/inbox/tests.rs
+++ b/src/inbox/tests.rs
@@ -2440,7 +2440,7 @@ fn superseded_by_field_backward_compat() {
 fn mark_ci_watch_superseded_tags_prior_messages() {
     let home = tmp_home("supersede_tag");
     let agent = "test-agent";
-    let msg1 = msg()
+    let mut msg1 = msg()
         .schema_version(0)
         .id("old-1")
         .sender("system:ci")
@@ -2448,12 +2448,71 @@ fn mark_ci_watch_superseded_tags_prior_messages() {
         .kind("ci-watch")
         .timestamp("2026-01-01T00:00:00Z")
         .build();
+    // Real ci-watch enqueues set `correlation_id = "<repo>@<branch>"` (the key
+    // the supersede match keys on); mirror that in the fixture.
+    msg1.correlation_id = Some("owner/repo@main".to_string());
     enqueue(&home, agent, msg1).unwrap();
     mark_ci_watch_superseded(&home, agent, "owner/repo@main", "new-msg-id");
     let msgs = drain(&home, agent);
     assert!(
         msgs.is_empty(),
         "superseded message should be filtered: {msgs:?}"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// bug-audit Rank3 regression: `mark_ci_watch_superseded` must match on
+/// `correlation_id` EQUALITY, not a `text.contains` substring. Two unread
+/// ci-watch notices — A=`owner/repo@feat/x` and B=`owner/repo@feat/x-2`, where
+/// B's key CONTAINS A's — superseding for A must mark ONLY A; the
+/// prefix-colliding B must survive (pre-fix the substring match wrongly
+/// superseded B, silently dropping feat/x-2's CI-ready signal).
+#[test]
+fn mark_ci_watch_superseded_does_not_supersede_prefix_colliding_branch() {
+    let home = tmp_home("supersede_prefix_collision");
+    let agent = "test-agent";
+
+    let mut a = msg()
+        .schema_version(0)
+        .id("A")
+        .sender("system:ci")
+        .text("[ci-pass] owner/repo@feat/x (abc1234): passed ✓")
+        .kind("ci-watch")
+        .timestamp("2026-01-01T00:00:00Z")
+        .build();
+    a.correlation_id = Some("owner/repo@feat/x".to_string());
+    enqueue(&home, agent, a).unwrap();
+
+    let mut b = msg()
+        .schema_version(0)
+        .id("B")
+        .sender("system:ci")
+        .text("[ci-pass] owner/repo@feat/x-2 (def5678): passed ✓")
+        .kind("ci-watch")
+        .timestamp("2026-01-01T00:00:00Z")
+        .build();
+    b.correlation_id = Some("owner/repo@feat/x-2".to_string());
+    enqueue(&home, agent, b).unwrap();
+
+    mark_ci_watch_superseded(&home, agent, "owner/repo@feat/x", "new-x");
+
+    // Read back without draining so we can inspect `superseded_by` per id.
+    let path = home.join("inbox").join(format!("{agent}.jsonl"));
+    let content = std::fs::read_to_string(&path).unwrap();
+    let msgs: Vec<InboxMessage> = content
+        .lines()
+        .filter_map(|l| serde_json::from_str(l).ok())
+        .collect();
+    let a = msgs.iter().find(|m| m.id.as_deref() == Some("A")).unwrap();
+    let b = msgs.iter().find(|m| m.id.as_deref() == Some("B")).unwrap();
+    assert!(
+        a.superseded_by.is_some(),
+        "A (exact key match) must be superseded"
+    );
+    assert!(
+        b.superseded_by.is_none(),
+        "B (owner/repo@feat/x-2) must NOT be superseded — prefix collision with \
+         owner/repo@feat/x"
     );
     std::fs::remove_dir_all(&home).ok();
 }
@@ -3414,6 +3473,7 @@ fn m1_supersede_preserves_non_matching_messages() {
     enqueue(&home, agent, make_msg("from:lead", "task dispatch")).unwrap();
     let mut ci = make_msg("system:ci", "[ci-pass] owner/repo@main: passed");
     ci.kind = Some("ci-watch".to_string());
+    ci.correlation_id = Some("owner/repo@main".to_string());
     enqueue(&home, agent, ci).unwrap();
 
     super::storage::mark_ci_watch_superseded(&home, agent, "owner/repo@main", "new-id");


### PR DESCRIPTION
## Bug (lead-verified)

`mark_ci_watch_superseded` (`src/inbox/storage.rs`) decided which prior unread ci-watch notices to mark superseded with **`msg.text.contains(repo_branch_key)`** — a substring match. So a new event for `repo@feat/x` wrongly supersedes an unread notice for **`repo@feat/x-2`** (whose key *contains* `repo@feat/x`), **silently dropping feat/x-2's legitimate CI-ready signal** — a branch-name prefix collision.

## Fix

Authoritative match → **`correlation_id` equality**: `msg.correlation_id.as_deref() == Some(repo_branch_key)`.

Verified every ci-watch enqueue already sets `correlation_id = "<repo>@<branch>"` (`ci_watch::poller` :1077/:1105/:1228/:1868, `ci_watch::sweep` :225), so equality matches exactly — no prefix collision and no missed supersedes. The cheap `line.contains(repo_branch_key)` pre-filter stays as a fast screen (it over-includes; the equality is now the authoritative decision).

## Tests (deterministic, RED→GREEN verified)

- New `mark_ci_watch_superseded_does_not_supersede_prefix_colliding_branch`: seeds A=`owner/repo@feat/x` + B=`owner/repo@feat/x-2` (both unread ci-watch), supersedes for A, asserts **only A** is `superseded_by`-tagged and **B survives**.
- **RED→GREEN confirmed locally**: with the old `text.contains`, the new test fails (`B must NOT be superseded`); with `correlation_id` equality it passes.
- Existing supersede fixtures (`mark_ci_watch_superseded_tags_prior_messages`, `m1_supersede_preserves_non_matching_messages`, `perf_r3_equiv::cross_mutator_consistency`) updated to set `correlation_id` — mirroring real ci-watch messages, which the substring-era fixtures omitted. **No assertions changed.**

`clippy --tests --features tray -D warnings` + all supersede/ci_watch tests (262) green. Merge needs operator rebuild + restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)