### PR TITLE
docs(fleet): sync #2344 role_kind to zh-TW + note fail-closed in EN

### DIFF
--- a/docs/FEATURE-fleet.md
+++ b/docs/FEATURE-fleet.md
@@ -102,7 +102,7 @@ Each key is the agent's name (must match `[a-zA-Z0-9_-]`); the value is its conf
 | Field | Type | Description |
 |-------|------|-------------|
 | `role` | string | Agent role description, free text (alias: `description`) |
-| `role_kind` | enum | **Optional, opt-in.** Typed role selector that trims the MCP tool surface this agent advertises (defense-in-depth, #2300). One of `reviewer` / `planner` / `explorer` (read/report — drops instance/worktree lifecycle + orchestration tools) or `orchestrator` / `implementer` / `utility` / `proxy` (full surface). **Absent → all tools** (no existing fleet changes). Distinct from the free-text `role` above; an unknown value fails fleet load. |
+| `role_kind` | enum | **Optional, opt-in.** Typed role selector that trims the MCP tool surface this agent advertises (defense-in-depth, #2300). One of `reviewer` / `planner` / `explorer` (read/report — drops instance/worktree lifecycle + orchestration tools) or `orchestrator` / `implementer` / `utility` / `proxy` (full surface). **Absent → all tools** (no existing fleet changes). Distinct from the free-text `role` above. Strict + fail-closed: an unknown value fails fleet load, and a malformed fleet never silently widens the advertised tool surface (#2367). |
 | `backend` | string | Override defaults backend |
 | `command` | string | Override defaults command |
 | `args` | [string] | Additional CLI arguments (merged with defaults) |

--- a/docs/FEATURE-fleet.zh-TW.md
+++ b/docs/FEATURE-fleet.zh-TW.md
@@ -68,6 +68,7 @@ instances:
 
   reviewer:
     role: "Code reviewer"
+    role_kind: reviewer   # 具型別的角色 → 裁切對外公告的 MCP 工具面（opt-in；詳見下方）
     backend: kiro-cli
     working_directory: ~/Projects/my-app
     source_repo: ~/Projects/my-app
@@ -104,7 +105,8 @@ teams:
 
 | 欄位 | 型別 | 說明 |
 |------|------|------|
-| `role` | string | Agent 的角色描述（別名：`description`） |
+| `role` | string | Agent 的角色描述，自由文字（別名：`description`） |
+| `role_kind` | enum | **選用、opt-in。** 具型別的角色選擇器，用來裁切此 agent 對外公告的 MCP 工具面（縱深防禦，#2300）。可為 `reviewer` / `planner` / `explorer`（讀取/回報類——移除 instance/worktree 生命週期與協調類工具）或 `orchestrator` / `implementer` / `utility` / `proxy`（完整工具面）。**未設定 → 全部工具**（不更動既有 fleet 行為）。與上方自由文字的 `role` 不同。strict 且 fail-closed：未知值會使 fleet 載入失敗，格式錯誤的 fleet 也絕不會悄悄放寬對外公告的工具面（#2367）。 |
 | `backend` | string | 覆蓋 defaults 的 backend |
 | `command` | string | 覆蓋 defaults 的命令 |
 | `args` | [string] | 附加的 CLI 參數（與 defaults 合併） |


### PR DESCRIPTION
## What

Docs-only sync of the #2344 `role_kind` feature (docs collaboration chunk B). Touches **only** `docs/FEATURE-fleet.md` + `docs/FEATURE-fleet.zh-TW.md` (no overlap with other doc chunks).

`FEATURE-fleet.md` documented `role_kind` in 2 places (example + field table); the zh-TW mirror had it in **0**. This brings the 繁中 version to parity.

## Changes

**`FEATURE-fleet.zh-TW.md`** (sync to EN):
- Add `role_kind: reviewer` to the `reviewer` instance in the fleet.yaml example (mirrors EN).
- Add the `role_kind` row to the `instances` field table — 繁中, structure/values aligned with EN (7 RoleKind variants, opt-in, absent → all tools, strict + fail-closed).
- Add "自由文字" to the `role` row to match EN's "free text" (and so the `role_kind` row's "與上方自由文字的 `role` 不同" reference reads correctly).

**`FEATURE-fleet.md`** (complete the EN row):
- The field-table row said an unknown value "fails fleet load" but omitted the #2367 rework guarantee. Extended to "Strict + fail-closed: an unknown value fails fleet load, and a malformed fleet never silently widens the advertised tool surface (#2367)."

## Notes

- `FEATURE-configuration.md` (+zh-TW) **intentionally not touched**: its fleet.yaml lists are curated "common"/"typical operator-edited" subsets (already omitting `display_name`/`cols`/`rows`/`git_branch`/…), not an exhaustive field reference. `role_kind` is niche opt-in; its canonical reference is `FEATURE-fleet.md`. (Task allowed "沒有則略" — flag if you'd prefer it added.)
- Pure markdown, no rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)