### PR TITLE
fix(state): stop misflagging AuthError on reviewed authz content

### DIFF
--- a/src/backend_profile.rs
+++ b/src/backend_profile.rs
@@ -280,7 +280,13 @@ fn opencode_profile() -> BackendProfile {
 fn codex_profile() -> BackendProfile {
     BackendProfile {
         patterns: vec![
-            (AgentState::AuthError, r"OPENAI_API_KEY|api.?key"),
+            // auth_error FP fix: drop the generic `api.?key` token (matched any
+            // "api key" prose) — keep the env-var anchor + the real OpenAI
+            // auth-error forms. AuthError is also red-anchored downstream.
+            (
+                AgentState::AuthError,
+                r"OPENAI_API_KEY|Incorrect API key|invalid_api_key",
+            ),
             (AgentState::UsageLimit, r"hit your usage limit|try again at"),
             (
                 AgentState::RateLimit,
@@ -336,8 +342,13 @@ fn claudecode_profile() -> BackendProfile {
     BackendProfile {
         patterns: vec![
             (
+                // auth_error FP fix (operator-reported): the bare `API key` and
+                // `unauthorized` tokens are generic English that any pane
+                // reviewing/writing authz code (#2369) shows, so they misflagged
+                // healthy agents. Anchor on the REAL Claude/Anthropic
+                // auth-failure banners instead (+ the AuthError red-anchor below).
                 AgentState::AuthError,
-                r"API key|authentication failed|unauthorized|API Error: 40[13]\b",
+                r"Invalid API key|invalid x-api-key|authentication_error|authentication failed|OAuth token has expired|Please run /login|API Error: 40[13]\b",
             ),
             (
                 AgentState::ServerRateLimit,

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -505,9 +505,9 @@ fn oscillation_guard_window() -> Duration {
 /// / JSON dumps, so they get the extra FP defenses (the #1518 position gate + the
 /// #1769 working-marker override + an anchor gate). The ANCHOR gate splits by
 /// [`requires_red_anchor`] — RateLimit/ServerRateLimit now use a content anchor
-/// (`in_error_line_excluding_input`), only ContextFull/ModelUnsupported still require red. This
-/// predicate stays the full set because position + working-marker apply to all
-/// four regardless of which anchor regime they use.
+/// (`in_error_line_excluding_input`), while ContextFull/ModelUnsupported/AuthError
+/// require red. This predicate stays the full set because position +
+/// working-marker apply to all of them regardless of which anchor regime they use.
 /// Per #919 spike + dev-2 cross-audit:
 /// - ServerRateLimit / RateLimit: server-side throttle alternations
 ///   include `api_error|timeout_error|overloaded_error` etc which
@@ -527,6 +527,13 @@ fn is_high_fp_state(state: AgentState) -> bool {
             // hang-check, so a FP would silently disable a healthy agent — the
             // anchor is the FP boundary.
             | AgentState::ModelUnsupported
+            // auth_error FP fix (operator-reported): auth-failure phrases
+            // (`Invalid API key`, `Please run /login`, …) appear verbatim when an
+            // agent reviews/writes authz code (#2369) or this detection code, and
+            // an AuthError FP fires a false supervisor re-auth page + wastes a
+            // restart on a healthy agent — same cost profile as ModelUnsupported,
+            // so it joins the red-anchor regime below.
+            | AgentState::AuthError
     )
 }
 
@@ -534,10 +541,15 @@ fn is_high_fp_state(state: AgentState) -> bool {
 /// which HIGH_FP states still require the #1450 RED-SGR anchor vs the content
 /// anchor (`in_error_line_excluding_input`).
 ///
-/// - **`true`** — ContextFull, ModelUnsupported: keep RED. ContextFull has no
-///   fixture corpus to prove a content path; ModelUnsupported never auto-clears
-///   AND suppresses hang-check, so a verbatim-quote FP would silently disable a
-///   healthy agent (the anchor is the FP boundary, #1634).
+/// - **`true`** — ContextFull, ModelUnsupported, AuthError: keep RED. ContextFull
+///   has no fixture corpus to prove a content path; ModelUnsupported never
+///   auto-clears AND suppresses hang-check, so a verbatim-quote FP would silently
+///   disable a healthy agent (the anchor is the FP boundary, #1634). AuthError
+///   uses RED (not the content anchor) because the real banners — `Invalid API
+///   key`, `Please run /login`, `OAuth token has expired` — carry NO error-line
+///   indicator (`line_has_error_indicator`), so the content anchor would
+///   false-negative them; color is the only reliable signal that separates a real
+///   red banner from authz prose an agent is reviewing/writing.
 /// - **`false`** — RateLimit, ServerRateLimit: content anchor instead. The corpus
 ///   gate proved content+position+working-marker preserves detection (5/5 prose
 ///   suppressed, FN-covered incl. kiro via #1789), and the residual verbatim-quote
@@ -545,7 +557,7 @@ fn is_high_fp_state(state: AgentState) -> bool {
 fn requires_red_anchor(state: AgentState) -> bool {
     matches!(
         state,
-        AgentState::ContextFull | AgentState::ModelUnsupported
+        AgentState::ContextFull | AgentState::ModelUnsupported | AgentState::AuthError
     )
 }
 
@@ -1805,11 +1817,13 @@ impl StateTracker {
     /// (treated as no-match). Two regimes (t-coloranchor-remove-ratelimit,
     /// operator-approved after the corpus gate's go/no-go):
     ///
-    /// - **`requires_red_anchor`** {ContextFull, ModelUnsupported}: keep the
-    ///   #1450 RED anchor — a marker needs ≥1 red rendered cell, else it's prose
-    ///   not a state. ContextFull has no corpus to prove a content path;
+    /// - **`requires_red_anchor`** {ContextFull, ModelUnsupported, AuthError}: keep
+    ///   the #1450 RED anchor — a marker needs ≥1 red rendered cell, else it's
+    ///   prose not a state. ContextFull has no corpus to prove a content path;
     ///   ModelUnsupported never auto-clears AND suppresses hang-check, so a
     ///   verbatim-quote FP would silently disable a healthy agent (cost too high).
+    ///   AuthError's real banners carry no error-line indicator, so only color
+    ///   separates a banner from reviewed authz prose (operator-reported FP).
     /// - **content-anchor** {RateLimit, ServerRateLimit}: the marker must sit on
     ///   an error-line-shaped line (`in_error_line_excluding_input`) —
     ///   corpus-proven safe (5/5 prose suppressed via pattern-narrow + #1518

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -828,7 +828,9 @@ fn context_full_instant_transition() {
 #[test]
 fn auth_error_instant_transition() {
     let mut t = tracker_at(&Backend::ClaudeCode, AgentState::Idle, 0);
-    t.feed("API key invalid");
+    // Real Claude auth banner (was the synthetic "API key invalid" — the bare
+    // `API key` token was removed as an FP source; assertion unchanged).
+    t.feed("Invalid API key");
     assert_eq!(t.get_state(), AgentState::AuthError);
 }
 
@@ -5845,5 +5847,95 @@ fn lazy_fg_rebuilds_and_redetects_static_throttle_pane() {
         builds.get(),
         2,
         "#perf-R1: the throttle-hint re-detect override still rebuilds the fg mask"
+    );
+}
+
+// ── auth_error false-positive fix (operator-reported, dev-3 spike t-…58335-0) ──
+// claude AuthError regex matched generic tokens `unauthorized` + `API key`, and
+// AuthError had NO anchor gate (not in is_high_fp_state / requires_red_anchor), so
+// a healthy agent merely REVIEWING/WRITING authz code (#2369 telegram-authz) or
+// the auth-detection code itself was misflagged AuthError. Fix = narrow the
+// pattern off the generic words AND red-anchor AuthError (the real banners carry
+// no error-line indicator, so only color distinguishes a banner from prose).
+
+/// FP repro (text-only path): reviewing #2369 authz content (`unauthorized` /
+/// `API key`) must NOT latch AuthError. Pre-fix RED (generic tokens matched);
+/// post-fix GREEN (narrowed pattern no longer matches the prose).
+#[test]
+fn authz_review_content_does_not_false_flag_auth_error() {
+    let mut t = tracker_at(&Backend::ClaudeCode, AgentState::Idle, 0);
+    t.feed(
+        "reviewing #2369: hoist is_user_allowed so a non-allowlisted sender can't do an \
+         unauthorized write to the task board; also the ANTHROPIC API key check is fail-closed",
+    );
+    assert_ne!(
+        t.get_state(),
+        AgentState::AuthError,
+        "reviewing authz content (unauthorized / API key) must not be misflagged AuthError"
+    );
+}
+
+/// Precision: the real auth-failure banners must STILL classify (text-only feed
+/// fails the red anchor open, so this also pins the narrowed pattern's tokens).
+#[test]
+fn auth_error_precision_real_banners_still_detected() {
+    for banner in [
+        "Invalid API key",
+        "invalid x-api-key",
+        "authentication_error",
+        "authentication failed",
+        "Please run /login",
+        "API Error: 401",
+    ] {
+        let mut t = tracker_at(&Backend::ClaudeCode, AgentState::Idle, 0);
+        t.feed(banner);
+        assert_eq!(
+            t.get_state(),
+            AgentState::AuthError,
+            "real auth banner {banner:?} must still detect (text-only fail-open)"
+        );
+    }
+}
+
+/// AuthError JOINS the red-anchor regime: a plain (reviewed/typed, non-red) auth
+/// phrase must NOT latch; the SAME phrase rendered red (a real banner) does. This
+/// catches the residual FP an agent reviewing the auth-detection code itself would
+/// hit (its pane contains the literal banner strings in default color).
+#[test]
+fn auth_error_requires_red_anchor() {
+    let line = "Invalid API key";
+    let (mut vt, mut st) = claude_tracker();
+    drive_plain_line(&mut vt, &mut st, line);
+    assert_ne!(
+        st.get_state(),
+        AgentState::AuthError,
+        "plain (non-red) auth phrase must stay suppressed — AuthError now keeps the red anchor"
+    );
+    let (mut vt2, mut st2) = claude_tracker();
+    drive_colored_line(&mut vt2, &mut st2, RED_16, line);
+    assert_eq!(
+        st2.get_state(),
+        AgentState::AuthError,
+        "a real RED auth banner must fire"
+    );
+}
+
+/// Sweep: codex's AuthError pattern dropped the generic `api.?key` token (same FP
+/// class) — a benign `api key` mention must not latch; a real codex auth error does.
+#[test]
+fn codex_auth_pattern_drops_generic_api_key_token() {
+    let mut t = tracker_at(&Backend::Codex, AgentState::Idle, 0);
+    t.feed("set the codex api key in the environment before running");
+    assert_ne!(
+        t.get_state(),
+        AgentState::AuthError,
+        "generic `api key` mention must not latch AuthError on codex"
+    );
+    let mut t2 = tracker_at(&Backend::Codex, AgentState::Idle, 0);
+    t2.feed("Incorrect API key provided");
+    assert_eq!(
+        t2.get_state(),
+        AgentState::AuthError,
+        "a real codex auth error must still detect"
     );
 }


### PR DESCRIPTION
## Bug (operator-reported)

Healthy claude agents (lead / r4 / dev-2) were repeatedly flagged `auth_error` while **reviewing/writing #2369 telegram-authz** — a false supervisor re-auth page that wasted restarts on working agents. No real auth error existed.

## Root cause (dev-3 spike t-…58335-0)

- The claude `AuthError` regex (`backend_profile.rs`) matched the **generic** tokens `unauthorized` + `API key` — ordinary English that appears in any authz discussion.
- `AuthError` had **no anchor gate**: it was absent from both `is_high_fp_state` and `requires_red_anchor` (`state/mod.rs`), so a plain content substring match latched it (unlike ContextFull/ModelUnsupported/RateLimit, which all gate).
- codex had the same class via `api.?key` (matched any "api key" prose).

Repro pinned the exact tokens (`unauthorized`, `API key`) and refuted the initial guess that the literal `auth_error` string was the trigger — it's the #2369 authz vocabulary.

## Fix (both — they cover different manifestations)

1. **Narrow the patterns** off the generic words to the **real** auth-failure banners:
   - claude → `Invalid API key|invalid x-api-key|authentication_error|authentication failed|OAuth token has expired|Please run /login|API Error: 40[13]\b`
   - codex → `OPENAI_API_KEY|Incorrect API key|invalid_api_key` (drop `api.?key`)
   - kiro left as-is (its tokens `Not authenticated|AccessDenied|denied access` are already specific) — now also covered by the red anchor.
2. **Red-anchor AuthError**: add it to `is_high_fp_state` + `requires_red_anchor`. It uses the **RED** anchor (not the content anchor) because the real banners carry no error-line indicator (`line_has_error_indicator`), so `in_error_line_excluding_input` would false-negative them; **color is the only reliable banner-vs-prose signal**. Mirrors ModelUnsupported. This catches the residual FP an agent reviewing the auth-detection code itself would hit.

Narrowing fixes the text-only path (the #2369 review FP); the red anchor fixes the colored path (reviewing the literal banner strings in default color).

## Tests (test-first, RED→GREEN)

- `authz_review_content_does_not_false_flag_auth_error` — reviewing #2369 content no longer latches AuthError.
- `auth_error_precision_real_banners_still_detected` — `Invalid API key` / `Please run /login` / `API Error: 401` / … still detect.
- `auth_error_requires_red_anchor` — a plain (non-red) auth phrase is suppressed; the same phrase in RED fires.
- `codex_auth_pattern_drops_generic_api_key_token` — benign `api key` mention dropped; real codex error still detects.
- Existing 401/403/4013 + ContextFull/ModelUnsupported red-anchor assertions **unchanged** (only the synthetic `"API key invalid"` input in `auth_error_instant_transition` updated to the real `"Invalid API key"` banner; assertion intact).

## Verification

- `cargo fmt --check` clean
- `cargo nextest run -E 'test(state::)'` → 418/418, no regression
- `cargo clippy --all-targets --features tray -- -D warnings` clean

## Review note (DUAL)

State-detection sensitive. Please verify the **banner strings** are accurate for real Claude/codex auth failures (the red anchor means a wrong string only causes a false-negative, not a FP). kiro left unchanged by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)