### PR TITLE
feat(palette): Ctrl+B `:` command completion — prefix-match keyword hints

### DIFF
--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -23,7 +23,92 @@ pub(super) struct CommandCtx<'a> {
     pub telegram_state: &'a Option<Arc<dyn crate::channel::Channel>>,
 }
 
+/// #t-5 command-palette completion: declarative metadata for the `:` commands —
+/// keyword + usage + one-line description. Consumed ONLY by the completion list
+/// (`matching_specs` + `render::overlay::render_command_palette`); `execute`
+/// below stays the source of truth for BEHAVIOR and is unchanged. ⚠ Adding or
+/// renaming a command in `execute` REQUIRES a matching entry here — the
+/// `command_specs_cover_execute_arms` test fails otherwise.
+pub(crate) struct CommandSpec {
+    pub keyword: &'static str,
+    pub usage: &'static str,
+    pub desc: &'static str,
+}
+
+pub(crate) const COMMAND_SPECS: &[CommandSpec] = &[
+    CommandSpec {
+        keyword: "spawn",
+        usage: "spawn [name] [backend]",
+        desc: "New agent in a new tab",
+    },
+    CommandSpec {
+        keyword: "vsplit",
+        usage: "vsplit [name] [backend]",
+        desc: "New agent; split focused pane vertically",
+    },
+    CommandSpec {
+        keyword: "hsplit",
+        usage: "hsplit [name] [backend]",
+        desc: "New agent; split focused pane horizontally",
+    },
+    CommandSpec {
+        keyword: "kill",
+        usage: "kill <agent>",
+        desc: "Close an agent's pane",
+    },
+    CommandSpec {
+        keyword: "restart",
+        usage: "restart [agent]",
+        desc: "Restart an agent (focused pane if omitted)",
+    },
+    CommandSpec {
+        keyword: "layout",
+        usage: "layout [preset]",
+        desc: "Apply a layout preset (cycles if omitted)",
+    },
+    CommandSpec {
+        keyword: "send",
+        usage: "send <agent> <message>",
+        desc: "Send a message to one agent",
+    },
+    CommandSpec {
+        keyword: "broadcast",
+        usage: "broadcast <message>",
+        desc: "Broadcast a message to all agents",
+    },
+    CommandSpec {
+        keyword: "status",
+        usage: "status",
+        desc: "Log every agent's current state",
+    },
+    CommandSpec {
+        keyword: "config",
+        usage: "config get|set|list [key] [value]",
+        desc: "Runtime config get / set / list",
+    },
+    CommandSpec {
+        keyword: "set",
+        usage: "set <key> <value>",
+        desc: "Set a runtime config key (`config set` shorthand)",
+    },
+];
+
+/// The command specs whose keyword (first token) starts with `input`'s first
+/// token — the palette's prefix-match completion candidates. Empty/whitespace
+/// input matches ALL (list-on-open). Keyword-only (P0); argument-value completion
+/// (backend / agent / config-key / preset names) is a follow-up.
+pub(crate) fn matching_specs(input: &str) -> Vec<&'static CommandSpec> {
+    let first = input.split_whitespace().next().unwrap_or("");
+    COMMAND_SPECS
+        .iter()
+        .filter(|s| s.keyword.starts_with(first))
+        .collect()
+}
+
 /// Execute a command palette command. Returns true if layout changed (needs resize).
+///
+/// ⚠ Adding/renaming a command keyword here? Sync `COMMAND_SPECS` above (the
+/// completion list) — `command_specs_cover_execute_arms` enforces coverage.
 pub(super) fn execute(cmd: &str, ctx: &mut CommandCtx<'_>) -> bool {
     let parts: Vec<&str> = cmd.trim().splitn(3, ' ').collect();
     if parts.is_empty() {
@@ -512,5 +597,53 @@ mod tests {
             "palette :set copy_on_select off must persist to runtime-config.json"
         );
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    // ── #t-5 command-palette completion ──────────────────────────────────────
+
+    #[test]
+    fn matching_specs_prefix_filters_first_token() {
+        // Empty / whitespace input → ALL specs (list-on-open, the operator's
+        // "what commands exist?" entry point).
+        assert_eq!(matching_specs("").len(), COMMAND_SPECS.len());
+        assert_eq!(matching_specs("   ").len(), COMMAND_SPECS.len());
+        // Prefix narrows; only `config` starts with "co".
+        let co = matching_specs("co");
+        assert!(co.iter().any(|s| s.keyword == "config"));
+        assert!(co.iter().all(|s| s.keyword.starts_with("co")));
+        // First token only: trailing args don't drop the keyword match.
+        assert!(matching_specs("config get foo")
+            .iter()
+            .any(|s| s.keyword == "config"));
+        // No match → empty (so Tab-complete is a no-op).
+        assert!(matching_specs("zzz").is_empty());
+    }
+
+    /// Structural sync guard: every `COMMAND_SPECS` keyword must appear as a
+    /// string literal inside `execute`, so a typo'd/stale spec can't ship a
+    /// completion the dispatcher doesn't handle. Source-scan (NOT live `execute`
+    /// calls — `spawn`/`restart` fork real PTY processes); pure + cross-platform.
+    /// Scan only the slice from `fn execute(` to the test module, so the
+    /// `COMMAND_SPECS` definition above and these tests below can't self-satisfy it.
+    #[test]
+    fn command_specs_cover_execute_arms() {
+        let src = include_str!("commands.rs");
+        let from_execute = src
+            .split_once("fn execute(cmd:")
+            .map(|(_, rest)| rest)
+            .expect("execute fn must exist");
+        let exec_body = from_execute
+            .split_once("#[cfg(test)]")
+            .map(|(body, _)| body)
+            .unwrap_or(from_execute);
+        for spec in COMMAND_SPECS {
+            let arm = format!("\"{}\"", spec.keyword);
+            assert!(
+                exec_body.contains(&arm),
+                "COMMAND_SPECS keyword {:?} has no {} arm in execute — add the arm or remove the spec",
+                spec.keyword,
+                arm
+            );
+        }
     }
 }

--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -28,7 +28,7 @@ pub(super) struct CommandCtx<'a> {
 /// (`matching_specs` + `render::overlay::render_command_palette`); `execute`
 /// below stays the source of truth for BEHAVIOR and is unchanged. ⚠ Adding or
 /// renaming a command in `execute` REQUIRES a matching entry here — the
-/// `command_specs_cover_execute_arms` test fails otherwise.
+/// `command_specs_match_execute_arms_bidirectional` test fails otherwise.
 pub(crate) struct CommandSpec {
     pub keyword: &'static str,
     pub usage: &'static str,
@@ -108,7 +108,8 @@ pub(crate) fn matching_specs(input: &str) -> Vec<&'static CommandSpec> {
 /// Execute a command palette command. Returns true if layout changed (needs resize).
 ///
 /// ⚠ Adding/renaming a command keyword here? Sync `COMMAND_SPECS` above (the
-/// completion list) — `command_specs_cover_execute_arms` enforces coverage.
+/// completion list) — `command_specs_match_execute_arms_bidirectional` asserts the
+/// two sets are exactly equal (both directions).
 pub(super) fn execute(cmd: &str, ctx: &mut CommandCtx<'_>) -> bool {
     let parts: Vec<&str> = cmd.trim().splitn(3, ' ').collect();
     if parts.is_empty() {
@@ -619,31 +620,47 @@ mod tests {
         assert!(matching_specs("zzz").is_empty());
     }
 
-    /// Structural sync guard: every `COMMAND_SPECS` keyword must appear as a
-    /// string literal inside `execute`, so a typo'd/stale spec can't ship a
-    /// completion the dispatcher doesn't handle. Source-scan (NOT live `execute`
-    /// calls — `spawn`/`restart` fork real PTY processes); pure + cross-platform.
-    /// Scan only the slice from `fn execute(` to the test module, so the
-    /// `COMMAND_SPECS` definition above and these tests below can't self-satisfy it.
+    /// Bidirectional sync guard: the `COMMAND_SPECS` keyword set must EXACTLY
+    /// equal the set of `execute` command arms — so a stale/typo'd spec can't
+    /// offer a completion the dispatcher won't handle (forward), AND a newly added
+    /// command can't be missing from the palette (reverse).
+    ///
+    /// Source-scan, NOT live `execute` calls (`spawn`/`restart` fork real PTY
+    /// processes); pure + cross-platform. Two precision measures vs a naive
+    /// substring scan:
+    /// 1. Bound to the `execute` fn body (`fn execute(` → next top-level `fn`), so
+    ///    `handle_config_command`'s `Some("get")`/`Some("set")` sub-arms and the
+    ///    test module don't leak in.
+    /// 2. Match a quoted keyword ONLY when immediately followed by `|` (group arm)
+    ///    or `=>` (arm body). This excludes non-arm literals like
+    ///    `unwrap_or(&"agent")` and `Some("get")` (both followed by `)`), which a
+    ///    bare `contains("\"agent\"")` false-matched.
     #[test]
-    fn command_specs_cover_execute_arms() {
+    fn command_specs_match_execute_arms_bidirectional() {
+        use std::collections::BTreeSet;
         let src = include_str!("commands.rs");
         let from_execute = src
             .split_once("fn execute(cmd:")
             .map(|(_, rest)| rest)
             .expect("execute fn must exist");
         let exec_body = from_execute
-            .split_once("#[cfg(test)]")
+            .split_once("\nfn ")
             .map(|(body, _)| body)
             .unwrap_or(from_execute);
-        for spec in COMMAND_SPECS {
-            let arm = format!("\"{}\"", spec.keyword);
-            assert!(
-                exec_body.contains(&arm),
-                "COMMAND_SPECS keyword {:?} has no {} arm in execute — add the arm or remove the spec",
-                spec.keyword,
-                arm
-            );
-        }
+        let arm_re = regex::Regex::new(r#""([a-z_]+)"\s*(?:\||=>)"#).expect("valid regex");
+        let arm_keywords: BTreeSet<&str> = arm_re
+            .captures_iter(exec_body)
+            .map(|c| c.get(1).expect("group 1").as_str())
+            .collect();
+        let spec_keywords: BTreeSet<&str> = COMMAND_SPECS.iter().map(|s| s.keyword).collect();
+        assert_eq!(
+            spec_keywords,
+            arm_keywords,
+            "COMMAND_SPECS must EXACTLY match execute's command arms.\n  \
+             in specs only (offered but unhandled): {:?}\n  \
+             in execute only (handled but not in palette): {:?}",
+            spec_keywords.difference(&arm_keywords).collect::<Vec<_>>(),
+            arm_keywords.difference(&spec_keywords).collect::<Vec<_>>(),
+        );
     }
 }

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -190,6 +190,7 @@ pub(super) fn dispatch(action: Action, ctx: &mut DispatchCtx<'_>) -> DispatchRes
         Action::CommandPalette => {
             out.new_overlay = Some(Overlay::Command {
                 input: String::new(),
+                selected: 0,
             });
         }
         Action::ShowDecisions => {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4,7 +4,10 @@
 //! same PTY lifecycle as the daemon: auto-dismiss, state tracking, broadcast.
 
 mod api_server;
-mod commands;
+// #t-5: `pub(crate)` so `render::overlay` can read the completion specs
+// (`CommandSpec` / `COMMAND_SPECS` / `matching_specs`). `execute` stays
+// `pub(super)` = app-only, so command EXECUTION is not widened.
+pub(crate) mod commands;
 mod dispatch;
 mod mouse;
 mod overlay;
@@ -290,8 +293,11 @@ fn render_active_overlay(
                 .unwrap_or(0);
             render::render_scroll_indicator(frame, so);
         }
-        Overlay::Command { ref input } => {
-            render::render_command_palette(frame, input);
+        Overlay::Command {
+            ref input,
+            selected,
+        } => {
+            render::render_command_palette(frame, input, *selected);
         }
         Overlay::Decisions {
             ref items,
@@ -886,7 +892,7 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
                         match &mut overlay {
                             Overlay::RenameTab { ref mut input }
                             | Overlay::RenamePane { ref mut input }
-                            | Overlay::Command { ref mut input } => {
+                            | Overlay::Command { ref mut input, .. } => {
                                 input.push_str(&text);
                             }
                             Overlay::ScratchShell { pane } => {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -891,9 +891,19 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
                     Event::Paste(text) => {
                         match &mut overlay {
                             Overlay::RenameTab { ref mut input }
-                            | Overlay::RenamePane { ref mut input }
-                            | Overlay::Command { ref mut input, .. } => {
+                            | Overlay::RenamePane { ref mut input } => {
                                 input.push_str(&text);
+                            }
+                            // #t-5: paste grows `input` → the candidate set changes,
+                            // so reset the completion highlight (same as Char /
+                            // Backspace) — otherwise a stale `selected` past the new
+                            // (shorter) list left Tab silently no-op.
+                            Overlay::Command {
+                                ref mut input,
+                                ref mut selected,
+                            } => {
+                                input.push_str(&text);
+                                *selected = 0;
                             }
                             Overlay::ScratchShell { pane } => {
                                 pane.write_input(&registry, text.as_bytes());

--- a/src/app/overlay.rs
+++ b/src/app/overlay.rs
@@ -607,9 +607,13 @@ pub(super) fn handle_key(
             // palette open (and a trailing space) so the operator types args next.
             // No-op when the prefix matches nothing.
             KeyCode::Tab => {
-                let keyword = super::commands::matching_specs(input)
-                    .get(*selected)
-                    .map(|s| s.keyword.to_string());
+                let matches = super::commands::matching_specs(input);
+                // Clamp `selected` at the use-site (same as render): it may be
+                // stale — e.g. a paste shrank the candidate list below it — and
+                // Tab must complete the candidate the operator actually sees
+                // highlighted, not silently no-op on an out-of-range index.
+                let idx = (*selected).min(matches.len().saturating_sub(1));
+                let keyword = matches.get(idx).map(|s| s.keyword.to_string());
                 if let Some(keyword) = keyword {
                     let rest: String = input
                         .split_whitespace()
@@ -1667,6 +1671,31 @@ mod tests {
         match &overlay {
             Overlay::Decisions { selected, .. } => assert_eq!(*selected, 1, "k moves up"),
             _ => panic!("expected Decisions overlay"),
+        }
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #t-5 BLOCKER 2 (r6): a paste can leave `selected` past the now-shorter
+    /// candidate list; Tab must still complete the highlighted keyword instead of
+    /// silently no-op'ing on an out-of-range index. Drive the exact stale state
+    /// (selected=5, input "co" → only `config` matches) through `handle_key`.
+    #[test]
+    fn tab_completes_keyword_when_selected_is_stale() {
+        let home = dec_home("cmd_tab_stale");
+        let mut overlay = Overlay::Command {
+            input: "co".to_string(),
+            selected: 5,
+        };
+        run_keys(&home, &mut overlay, &[KeyCode::Tab]);
+        match overlay {
+            Overlay::Command { input, selected } => {
+                assert_eq!(
+                    input, "config ",
+                    "Tab completes the matched keyword + trailing space"
+                );
+                assert_eq!(selected, 0, "Tab resets the highlight");
+            }
+            _ => panic!("palette must stay open after Tab"),
         }
         std::fs::remove_dir_all(&home).ok();
     }

--- a/src/app/overlay.rs
+++ b/src/app/overlay.rs
@@ -114,6 +114,11 @@ pub(super) enum Overlay {
     /// Command palette (:command input).
     Command {
         input: String,
+        /// #t-5 completion: highlighted index into the prefix-matched candidate
+        /// list (`commands::matching_specs(input)`). Recomputed on each edit; the
+        /// candidate list itself is derived from `input` (not stored) so the enum
+        /// holds no borrowed `&'static` specs.
+        selected: usize,
     },
     /// #2305: pending-decision answer board (Ctrl+B D). Lists questions awaiting
     /// an operator answer; Browse to pick one, then Answer (select an option or
@@ -563,7 +568,13 @@ pub(super) fn handle_key(
             }
             _ => {}
         },
-        Overlay::Command { ref mut input } => match key.code {
+        Overlay::Command {
+            ref mut input,
+            ref mut selected,
+        } => match key.code {
+            // Enter: execute the CURRENT input — semantics unchanged from before
+            // completion existed (completion is opt-in via Tab; Enter never picks a
+            // candidate, so muscle memory / scripts behave identically).
             KeyCode::Enter => {
                 let cmd = input.clone();
                 *overlay = Overlay::None;
@@ -582,11 +593,44 @@ pub(super) fn handle_key(
             KeyCode::Esc => {
                 *overlay = Overlay::None;
             }
+            // #t-5 completion nav: move the highlight within the candidate list.
+            KeyCode::Up => {
+                *selected = selected.saturating_sub(1);
+            }
+            KeyCode::Down => {
+                let n = super::commands::matching_specs(input).len();
+                if *selected + 1 < n {
+                    *selected += 1;
+                }
+            }
+            // Tab: complete the FIRST token to the highlighted keyword, keep the
+            // palette open (and a trailing space) so the operator types args next.
+            // No-op when the prefix matches nothing.
+            KeyCode::Tab => {
+                let keyword = super::commands::matching_specs(input)
+                    .get(*selected)
+                    .map(|s| s.keyword.to_string());
+                if let Some(keyword) = keyword {
+                    let rest: String = input
+                        .split_whitespace()
+                        .skip(1)
+                        .collect::<Vec<_>>()
+                        .join(" ");
+                    *input = if rest.is_empty() {
+                        format!("{keyword} ")
+                    } else {
+                        format!("{keyword} {rest}")
+                    };
+                    *selected = 0;
+                }
+            }
             KeyCode::Backspace => {
                 input.pop();
+                *selected = 0; // candidate set changed → reset highlight
             }
             KeyCode::Char(c) => {
                 input.push(c);
+                *selected = 0; // candidate set changed → reset highlight
             }
             _ => {}
         },

--- a/src/render/overlay.rs
+++ b/src/render/overlay.rs
@@ -327,17 +327,50 @@ pub fn render_scroll_indicator(frame: &mut Frame, offset: usize) {
     );
 }
 
-pub fn render_command_palette(frame: &mut Frame, input: &str) {
+/// #t-5: command palette with prefix-match completion. Renders the `:input` line
+/// plus a candidate list — `commands::matching_specs(input)`, derived live from the
+/// input (empty input lists all, the "what commands exist?" entry point) — with the
+/// `selected` candidate highlighted, modeled on [`render_menu`]. Keyword-only (P0).
+pub fn render_command_palette(frame: &mut Frame, input: &str, selected: usize) {
     let area = frame.area();
-    let w = 60u16.min(area.width.saturating_sub(4));
+    let matches = crate::app::commands::matching_specs(input);
+    // Cap rows so the popup can't outgrow the screen; the full set (11) fits.
+    let shown = matches.len().min(12);
+    let sel = selected.min(shown.saturating_sub(1));
+
+    let w = 64u16.min(area.width.saturating_sub(4));
     let x = (area.width.saturating_sub(w)) / 2;
     let y = area.height / 3;
-    let ra = Rect::new(x, y, w, 3);
-    let inner = render_titled_popup(frame, ra, Color::Cyan, " : Command (Enter, Esc) ");
-    frame.render_widget(
-        Paragraph::new(format!(":{input}")).style(Style::default().fg(Color::White)),
-        inner,
-    );
+    // 1 input line + `shown` candidate rows + 2 border rows, clamped to the screen.
+    let height = u16::try_from(shown + 3)
+        .unwrap_or(u16::MAX)
+        .min(area.height);
+    let ra = Rect::new(x, y, w, height);
+    let inner = render_titled_popup(frame, ra, Color::Cyan, " : Command — Tab ↑↓ Enter Esc ");
+
+    let mut lines: Vec<Line> = Vec::with_capacity(shown + 1);
+    lines.push(Line::from(Span::styled(
+        format!(":{input}"),
+        Style::default().fg(Color::White),
+    )));
+    for (i, spec) in matches.iter().take(shown).enumerate() {
+        let style = if i == sel {
+            Style::default()
+                .fg(Color::Black)
+                .bg(Color::Cyan)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(Color::Gray)
+        };
+        let prefix = if i == sel { "> " } else { "  " };
+        lines.push(Line::from(Span::styled(
+            format!("{prefix}{:<26} {}", spec.usage, spec.desc),
+            style,
+        )));
+    }
+    frame.render_widget(Paragraph::new(lines), inner);
+
+    // Cursor on the input line, just after `:input`.
     let cursor_x = inner.x + 1 + input.width() as u16;
     if cursor_x < inner.x + inner.width {
         frame.set_cursor_position(ratatui::layout::Position::new(cursor_x, inner.y));
@@ -387,5 +420,40 @@ mod tests {
     fn centered_overlay_rect_centers_within_area() {
         let r = centered_overlay_rect(Rect::new(0, 0, 100, 40), 10, 50, 2, 4);
         assert_eq!((r.x, r.y, r.width, r.height), (25, 15, 50, 10));
+    }
+
+    /// #t-5 UX smoke: the palette lists ALL commands on empty input (the operator's
+    /// "what commands exist?" discovery), and prefix-filters to matching keywords.
+    #[test]
+    fn command_palette_lists_all_on_open_and_prefix_filters() {
+        fn palette_text(input: &str) -> String {
+            let backend = ratatui::backend::TestBackend::new(80, 20);
+            let mut terminal = ratatui::Terminal::new(backend).unwrap();
+            terminal
+                .draw(|frame| render_command_palette(frame, input, 0))
+                .unwrap();
+            let buf = terminal.backend().buffer().clone();
+            let mut out = String::new();
+            for y in 0..buf.area.height {
+                for x in 0..buf.area.width {
+                    out.push_str(buf.cell((x, y)).map(|c| c.symbol()).unwrap_or(" "));
+                }
+                out.push('\n');
+            }
+            out
+        }
+        // Empty input → list every command.
+        let all = palette_text("");
+        assert!(
+            all.contains("spawn") && all.contains("config") && all.contains("layout"),
+            "empty input must list all commands:\n{all}"
+        );
+        // Prefix narrows to matching keyword(s) only.
+        let co = palette_text("co");
+        assert!(co.contains("config"), "`co` must show config:\n{co}");
+        assert!(
+            !co.contains("spawn") && !co.contains("layout"),
+            "`co` must hide non-matching commands:\n{co}"
+        );
     }
 }


### PR DESCRIPTION
## Problem
The `:` command palette (`Overlay::Command`) was a blank text box — operators couldn't discover which commands exist. (operator-requested, lead-vetted spike → impl, task t-…98760-5.)

## UX (P0, keyword prefix-match)
- **Ctrl+B `:` lists ALL commands** (the "what commands exist?" entry point).
- Typing **prefix-filters** the first token; **↑/↓** move the highlight.
- **Tab** completes the highlighted keyword into the input (keeps the palette open + a trailing space for args).
- **Enter still executes the CURRENT input — semantics unchanged.** Completion is purely additive (no muscle-memory/script break).

## Implementation — command EXECUTION untouched
- `commands.rs`: additive `COMMAND_SPECS` table (`{keyword, usage, desc}`, 11 commands) + `matching_specs(prefix)`. **`execute` is byte-for-byte unchanged** (only a reminder comment to keep the table in sync). `mod commands` widened to `pub(crate)` so render reads the specs; `execute` stays `pub(super)` = app-only, so command execution is not widened.
- `Overlay::Command` gains `selected`; the candidate list is derived live from `input` (no `&'static` stored in the enum). Up/Down/Tab added; Backspace/Char reset the highlight. Confirmed Up/Down/Tab were previously unbound in this overlay.
- `render_command_palette` renders the candidate list (`usage` / `desc`, selected highlighted), modeled on the existing `render_menu`.

## Tests (cross-platform, no PTY)
- `matching_specs_prefix_filters_first_token` — empty→all, prefix narrows, no-match→empty.
- `command_specs_cover_execute_arms` — source-scan guard: every spec keyword has an `execute` arm (a stale/typo'd spec can't offer a completion the dispatcher won't handle). Source-scan because `execute` can't be called live (spawn/restart fork real processes).
- `command_palette_lists_all_on_open_and_prefix_filters` — TestBackend render smoke.

## Verification
`cargo fmt --check` + `clippy --all-targets --features tray -- -D warnings` clean; 3 new tests + 58 touched-module regression tests green.

Keyword-only is P0; **argument-value completion** (backend / agent / config-key / preset names — dynamic sources noted in the spike) is a deliberate follow-up. Merge needs operator restart to go live.

correlation_id=t-20260620083915795311-98760-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)