### PR TITLE
chore(gitignore): ignore agent-ephemeral scratch (SESSION-HANDOFF.md et al)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,12 @@ statusline.sh
 mcp-config.json
 *.json.lock
 .agend-managed
+
+# Agent-ephemeral scratch (per-agent, not for version control)
+SESSION-HANDOFF.md
+PRODUCTION-READINESS.md
+CR-*.md
+arch-survey/
+.codex/
+.gemini/
+.opencode/


### PR DESCRIPTION
## What

Add a `.gitignore` block for agent-ephemeral scratch files so `git add -A` in a worktree no longer sweeps them into PRs.

## Why

Freeze fix #2380 was REJECTed (2nd blocker) because an untracked `SESSION-HANDOFF.md` at the worktree root got swept in by `git add -A` and needed a manual `git rm`. The repo's committed `.gitignore` did not cover it — a recurring scope-sprawl footgun that wastes review rounds.

## Scope (lead-vetted spike manifest, [A]+[B])

Added (all verified `tracked-hits=0` — no committed file shadowed; `.gitignore` never untracks existing files):

```
# Agent-ephemeral scratch (per-agent, not for version control)
SESSION-HANDOFF.md
PRODUCTION-READINESS.md
CR-*.md
arch-survey/
.codex/
.gemini/
.opencode/
```

- Root scratch files: **unanchored** (matches existing `CODE_REVIEW_*.md` convention).
- Per-agent tool dirs: **trailing slash** (matches existing `.claude/`).
- `.codex/ .gemini/ .opencode/` are siblings of the already-ignored `.claude/ .continue/ .factory/ .kiro/`.

## Held / out of scope

- **HELD** `SCOPE-*.md` / `SPIKE-*.md`: broad glob, do not currently leak from worktrees, mild risk of colliding with a future intentional design doc → left to operator.
- **Not touched** `docs/*.md` WIP, `graphify-out/`, `positive-threshold`: real/unknown canonical-tree files (operator's call), not agent ephemeral.

## Verification

- `git status --porcelain` → only ` M .gitignore` (no tracked file mutated).
- `git check-ignore -v` confirms each new rule active for its target; negative control confirms `SCOPE-*`/`SPIKE-*` remain un-ignored.
- Zero code; `.gitignore`-only diff (+9 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
