### PR TITLE
test(teardown): allowlist fleet_events.jsonl — append-only shim audit, not residual

### DIFF
--- a/tests/teardown_completeness_regression.rs
+++ b/tests/teardown_completeness_regression.rs
@@ -40,6 +40,17 @@ const ALLOWLIST: &[(&str, &str)] = &[
     ("daemon.", "daemon.<date>.log — tracing legitimately names the deleted instance"),
     ("event-log.jsonl", "append-only audit trail — create/delete events name the instance by design"),
     ("task_events.jsonl", "append-only task-event log — owner/assignee history named by design"),
+    // #t-…34628-8 RCA: same append-only-audit class as event-log.jsonl. Written by
+    // the agend-git shim (src/bin/agend-git.rs — #2158 bypass-audit / #2234 cwd-drift)
+    // whenever a daemon git op runs through the shim (git_helpers.rs::git_cmd sets
+    // AGEND_GIT_BYPASS=1). Home-level forensic trail that names instances by design →
+    // teardown must NOT scrub it (would corrupt the audit chain). Only created when
+    // PATH `git` is the operator's shim (local dev machine); CI's real /usr/bin/git
+    // never writes it — which is why this entry was missing yet CI stayed green while
+    // two devs hit a local red. (The test inherits the operator git binary, i.e. is
+    // not fully hermetic w.r.t. `git`; forcing real git in the harness is an optional
+    // future hardening, intentionally NOT done here — A2/KISS.)
+    ("fleet_events.jsonl", "append-only agend-git shim forensic audit (#2158/#2234) — home-level, names instances by design; same class as event-log.jsonl, teardown must not scrub"),
     // ── intentional retention (audit-confirmed; see #1907 spike) ──
     ("schedules.json", "INTENTIONAL: orphan-disabled, never deleted — operator may re-target a cron"),
     ("tasks.json", "INTENTIONAL: owner cleared but the task row is kept for surviving agents"),


### PR DESCRIPTION
## Problem
`teardown_completeness_regression::teardown_leaves_zero_residual_after_full_exercise_1907` is **red in-worktree but green in CI** — two devs forced `--no-verify` (masks real failures). (RCA spike, task t-…34628-8.)

## Root cause (3 experiments, isolated /tmp homes)
The operator's `git` on PATH is the **agend-git shim** (`~/.agend-terminal/bin/git`), not real git. The test's own booted daemon runs git via `git_helpers::git_cmd` (which sets `AGEND_GIT_BYPASS=1`), so the shim appends a #2158 bypass-audit line — naming the agent — to `home/fleet_events.jsonl`. CI's real `/usr/bin/git` ignores the bypass and never creates the file, so the missing allowlist entry never bit there.

| run | env | result |
|---|---|---|
| EXP1 | shim on PATH + bypass | RED |
| EXP2 | `PATH=/usr/bin:$PATH` real git, no bypass | GREEN |
| EXP3 | shim on PATH, no env bypass | RED (daemon sets its own bypass) |

→ sole variable = the `git` binary on PATH. Not `AGEND_HOME` (the test isolates `temp_dir()/…-{pid}-{nanos}`), not the operator's env bypass.

## Fix (test-only, zero prod)
`fleet_events.jsonl` is a home-level **append-only forensic audit log** that names instances by design — the SAME class as the already-allowlisted `event-log.jsonl` / `task_events.jsonl`. `full_delete_instance` correctly does NOT scrub it (that would corrupt the audit chain). So this is an **ALLOWLIST omission, not a prod teardown gap** — add the entry with a rationale comment.

## Verification (dual env)
- Shim env (was RED) → **GREEN**; real-git env → GREEN.
- Other ALLOWLIST entries + assertion logic unchanged (diff = +11 lines: one entry + comment).
- `clippy --all-targets --features tray -- -D warnings` clean; 36 source-scan/invariant tests pass.

**This removes the footgun that pushed devs to `--no-verify`.**

correlation_id=t-20260620200941970440-34628-8

🤖 Generated with [Claude Code](https://claude.com/claude-code)