### PR TITLE
fix(freeze): cap drain_output per frame — bound main-thread CPU in terminal.draw

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -796,6 +796,14 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
                 // resize its pane's VTerm/PTY during render.
                 render_active_overlay(frame, &mut overlay, &layout, &registry, &home);
             })?;
+            // #freeze-2: a budget-capped `drain_output` may have left a backlog in
+            // a visible pane's channel. Re-arm `dirty` so the next frame continues
+            // draining (the select-timeout below already shrinks to the frame
+            // boundary when dirty) — the backlog clears over a few frames instead
+            // of one input-stalling mega-draw.
+            if render::active_tab_has_pending_output(&layout) {
+                dirty = true;
+            }
         }
 
         // #t-84833-10: wake the loop at the next frame boundary when a change is

--- a/src/layout/pane.rs
+++ b/src/layout/pane.rs
@@ -75,6 +75,20 @@ pub struct Selection {
     pub end: (i64, u16),
 }
 
+/// #freeze-2 probe (env-gated, `AGEND_FREEZE_INSTRUMENT`): per-frame `drain_output`
+/// cost threshold in microseconds, or `None` when disabled (zero overhead). Read
+/// once and cached. Lets an operator restart-repro confirm the freeze is in
+/// `drain_output` and that the budget bounds it. Off by default → no behavior
+/// change. `"1"` => the 2 ms default; `"<N>"` (N>1) => custom µs; else disabled.
+fn drain_probe_threshold_us() -> Option<u64> {
+    static PROBE: std::sync::OnceLock<Option<u64>> = std::sync::OnceLock::new();
+    *PROBE.get_or_init(|| match std::env::var("AGEND_FREEZE_INSTRUMENT") {
+        Ok(v) if v == "1" => Some(2_000),
+        Ok(v) => v.parse::<u64>().ok().filter(|n| *n > 1),
+        Err(_) => None,
+    })
+}
+
 impl Pane {
     /// Convert a viewport row (0-based within the pane interior) to an absolute
     /// scrollback logical line at the current scroll position. Inverse of
@@ -111,19 +125,57 @@ impl Pane {
         })
     }
 
-    /// Drain pending output into the local VTerm.
-    pub fn drain_output(&mut self) {
-        while let Ok(data) = self.rx.try_recv() {
-            self.vterm.process(&data);
-            if self.backend.is_some() {
-                let text = String::from_utf8_lossy(&data);
-                if text.contains("[from:") {
-                    self.has_notification = true;
+    /// Drain up to `budget_bytes` of pending PTY output into the local VTerm,
+    /// leaving any remainder queued in the (unbounded) channel. Returns `true` if
+    /// output still remains — the render loop re-arms a redraw on this so the
+    /// backlog finishes draining over subsequent frames.
+    ///
+    /// #freeze-2 (t-…74503): this `vterm.process` loop runs on the MAIN thread
+    /// inside `terminal.draw`. Un-bounded, a boot/restart backlog (every agent
+    /// re-attaching + dumping its screen) made one draw take ~100 ms+ → the loop
+    /// couldn't service input → freeze. (CPU, not a lock — #2380's lock-free
+    /// snapshot addressed a different, smaller consumer.) Bounding the per-frame
+    /// work keeps `terminal.draw` short so input stays responsive while the pane
+    /// visually catches up across a few frames. Lossless + FIFO: chunks are
+    /// processed in receive order; unprocessed chunks stay queued.
+    #[must_use = "re-arm a redraw when output remains, or the backlog stalls"]
+    pub fn drain_output(&mut self, budget_bytes: usize) -> bool {
+        let probe_threshold = drain_probe_threshold_us();
+        let probe_start = probe_threshold.map(|_| Instant::now());
+        let mut drained = 0usize;
+        // Process whole chunks until the byte budget is met (per-chunk granularity:
+        // the last chunk may carry us slightly over — chunks are PTY-read-bounded).
+        while drained < budget_bytes {
+            match self.rx.try_recv() {
+                Ok(data) => {
+                    drained += data.len();
+                    self.vterm.process(&data);
+                    if self.backend.is_some() {
+                        let text = String::from_utf8_lossy(&data);
+                        if text.contains("[from:") {
+                            self.has_notification = true;
+                        }
+                    }
                 }
+                Err(_) => break, // channel empty (or disconnected)
             }
         }
         // Don't auto-scroll if user has scrolled back (they're reading history).
         // User scrolls back to bottom manually via mouse or Ctrl+B [ → j.
+        let more = !self.rx.is_empty();
+        if let (Some(threshold), Some(start)) = (probe_threshold, probe_start) {
+            let us = start.elapsed().as_micros() as u64;
+            if us >= threshold {
+                tracing::info!(
+                    tag = "#freeze-drain",
+                    drain_us = us,
+                    bytes = drained,
+                    more = more,
+                    "drain_output budget cycle"
+                );
+            }
+        }
+        more
     }
 
     /// Write bytes (keystrokes, paste) to this pane's underlying process.
@@ -341,6 +393,50 @@ mod tests {
             selection: None,
             source: PaneSource::Local,
         }
+    }
+
+    /// #freeze-2: `drain_output` must (a) cap per call at the byte budget, (b)
+    /// report "more remaining" so the loop re-arms, (c) over repeated calls drain
+    /// the WHOLE backlog, (d) losslessly and in FIFO order.
+    #[test]
+    fn drain_output_budget_caps_and_drains_losslessly_in_fifo_order() {
+        let (tx, rx) = crossbeam_channel::unbounded::<Vec<u8>>();
+        let mut pane = test_pane(rx, 80, 4);
+        // 10 distinct single-byte chunks: '0'..='9' (1 byte each).
+        for c in b'0'..=b'9' {
+            let _ = tx.send(vec![c]); // unbounded + live rx → never fails
+        }
+        drop(tx); // disconnect so try_recv ends the loop once the queue is empty
+
+        // First call, 3-byte budget: processes exactly chunks '0','1','2' (the
+        // while-budget check trips at drained==3), leaving '3'..='9' queued.
+        let more = pane.drain_output(3);
+        assert!(
+            more,
+            "a 3-byte budget over 10 queued bytes must leave a remainder"
+        );
+        let after_first = pane.vterm.tail_lines(4);
+        assert!(
+            after_first.contains("012"),
+            "budgeted prefix processed: {after_first:?}"
+        );
+        assert!(
+            !after_first.contains('3'),
+            "budget cap: the 4th chunk must NOT be processed yet: {after_first:?}"
+        );
+
+        // Drain the rest over subsequent "frames" until dry.
+        let mut frames = 0;
+        while pane.drain_output(3) {
+            frames += 1;
+            assert!(frames < 50, "must converge to drained");
+        }
+        // Lossless + FIFO: every chunk processed, in order.
+        let final_lines = pane.vterm.tail_lines(4);
+        assert!(
+            final_lines.contains("0123456789"),
+            "all chunks must be drained in FIFO order: {final_lines:?}"
+        );
     }
 
     #[test]

--- a/src/render/core_render.rs
+++ b/src/render/core_render.rs
@@ -54,6 +54,35 @@ pub fn state_color(state: AgentState) -> Color {
     }
 }
 
+/// #freeze-2 (t-…74503): max bytes of queued PTY output a pane drains into its
+/// VTerm per frame, inside `terminal.draw` on the main thread (see
+/// `Pane::drain_output`). Caps per-frame CPU so a boot/restart backlog can't stall
+/// the draw (and thus input); the remainder drains over the next frames. Tunable —
+/// smaller = snappier input under flood / slower visual catch-up. Calibrated to
+/// keep `terminal.draw` responsive (a few ms); verify with the `#freeze-drain`
+/// probe (`AGEND_FREEZE_INSTRUMENT`).
+const DRAIN_OUTPUT_BUDGET_BYTES: usize = 32 * 1024;
+
+/// #freeze-2: does any pane the render path actually DRAINS in the active tab
+/// still have queued PTY output? The render loop re-arms `dirty` on this so a
+/// budget-capped `drain_output` finishes draining over subsequent frames. Mirrors
+/// `render_pane_tree`'s pane selection (zoom = only the focused pane is drawn).
+pub fn active_tab_has_pending_output(layout: &Layout) -> bool {
+    let Some(tab) = layout.tabs.get(layout.active) else {
+        return false;
+    };
+    if tab.zoomed {
+        tab.root()
+            .find_pane(tab.focus_id)
+            .is_some_and(|p| !p.rx.is_empty())
+    } else {
+        tab.root()
+            .pane_ids()
+            .iter()
+            .any(|id| tab.root().find_pane(*id).is_some_and(|p| !p.rx.is_empty()))
+    }
+}
+
 fn build_agent_state_snapshot(
     layout: &Layout,
     registry: &AgentRegistry,
@@ -375,7 +404,10 @@ fn render_pane(
     is_drag_source: bool,
     is_drag_target: bool,
 ) -> PaneBorderInfo {
-    pane.drain_output();
+    // #freeze-2: budget-capped — the render loop re-arms `dirty` via
+    // `active_tab_has_pending_output` when a backlog remains, so this can't stall
+    // the draw. The returned "more" is observed there, not here.
+    let _ = pane.drain_output(DRAIN_OUTPUT_BUDGET_BYTES);
 
     if focused {
         pane.has_notification = false;
@@ -1251,5 +1283,38 @@ mod tests {
              lock-free published mirror, not take core.lock()"
         );
         holder.join().unwrap();
+    }
+
+    /// #freeze-2: the render loop re-arms `dirty` on this when a budget-capped
+    /// `drain_output` leaves a backlog — so it MUST report a visible pane's queued
+    /// rx (else the backlog stalls; correctness rule ①). Cross-platform (no PTY).
+    #[test]
+    fn active_tab_has_pending_output_reflects_visible_pane_queue() {
+        let (tx, rx) = crossbeam_channel::unbounded::<Vec<u8>>();
+        let pane = Pane {
+            agent_name: "agent".into(),
+            instance_id: crate::types::InstanceId::default(),
+            vterm: VTerm::new(38, 11),
+            rx,
+            id: 1,
+            backend: Some(crate::backend::Backend::ClaudeCode),
+            working_dir: None,
+            display_name: None,
+            scroll_offset: 0,
+            has_notification: false,
+            fleet_instance_name: None,
+            last_input_at: None,
+            pending_notification_count: 0,
+            selection: None,
+            source: PaneSource::Local,
+        };
+        let mut layout = Layout::new();
+        layout.add_tab(crate::layout::Tab::new("agent".to_string(), pane));
+
+        // Empty channel → nothing to re-arm.
+        assert!(!active_tab_has_pending_output(&layout));
+        // Queued output on the visible pane → re-arm so the next frame drains it.
+        tx.send(b"backlog".to_vec()).unwrap();
+        assert!(active_tab_has_pending_output(&layout));
     }
 }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -8,7 +8,7 @@ pub mod panels_fleet;
 pub mod resize;
 pub mod scratch;
 
-pub use core_render::render;
+pub use core_render::{active_tab_has_pending_output, render};
 pub use overlay::{
     render_command_palette, render_confirm, render_help, render_menu, render_move_pane_target,
     render_rename, render_scroll_indicator, render_tab_list,

--- a/src/render/scratch.rs
+++ b/src/render/scratch.rs
@@ -43,7 +43,10 @@ pub fn render_scratch_shell(
         return;
     }
 
-    pane.drain_output();
+    // #freeze-2: the scratch-shell is a single user-opened overlay pane, not the
+    // boot-flood many-agent render path, so it keeps draining fully each frame
+    // (unbounded) — behavior unchanged. The budget-cap targets `render_pane`.
+    let _ = pane.drain_output(usize::MAX);
 
     // W2.6: the same render-authoritative resize as `core_render::render_pane`.
     // `block.inner(oa)` here equals `PaneContentRect::from_bordered_area(oa)`


### PR DESCRIPTION
## Root cause (instrument-confirmed — #2380 didn't fix this)
The residual restart freeze (operator: ~10s stuck on first input after restart). `pane.drain_output()` is an **unbounded** `while rx.try_recv { vterm.process }` that runs on the **main thread inside `terminal.draw`**. A boot/restart backlog (every agent re-attaching + dumping its screen) made one draw take **~108 ms** (`#freeze-loop` draw_us=107809; normal ~2 ms) → the loop couldn't service input → freeze.

It is **CPU, not a lock**:
- No `thread="main"` `#freeze-corelock` wait at the 107 ms draw (the main thread isn't blocked on core.lock).
- `render_pane` reads the pane-**local** vterm; #2380's lock-free agent-state snapshot fixed a *different, smaller* consumer.
- supervisor:1235 / agent:1649 are **producer** core.lock holds that don't gate the lock-free draw.

draw time ∝ backlog → restart (all agents at once) is the worst case → multi-second.

## Fix (lead-vetted candidate 1)
- `drain_output(budget_bytes) -> bool`: process whole chunks until the byte budget, leave the remainder queued (`rx` is unbounded → **lossless**, FIFO), return "more remains".
- `render_pane` passes `DRAIN_OUTPUT_BUDGET_BYTES` (32 KiB, tunable).
- The render loop re-arms `dirty` via `active_tab_has_pending_output` (mirrors `render_pane_tree`'s zoom/normal pane selection) so the backlog drains over a few frames; the existing #2346 frame-cap select-timeout already shrinks to the frame boundary when dirty. **Input stays responsive; the pane catches up over ~frames.**
- Scratch-shell overlay left unbounded (single user-opened pane, not the boot-flood path — behavior unchanged).
- env-gated `#freeze-drain` probe (`AGEND_FREEZE_INSTRUMENT`) so the operator restart-repro confirms the cost is in `drain_output` and is bounded after the fix.

## Tests (deterministic, cross-platform)
- `drain_output_budget_caps_and_drains_losslessly_in_fifo_order` — budget cap + reports-remaining + loop-to-dry + lossless + FIFO.
- `active_tab_has_pending_output_reflects_visible_pane_queue` — the `dirty` re-arm trigger (correctness rule: never stall the backlog).

## Verification
`cargo fmt --check` + `clippy --all-targets --features tray -- -D warnings` clean; 83 touched-module tests + the 2 new tests green. Diff ~50 LOC prod + tests.

supervisor:1235 lock-shrink = separate low-priority task (orthogonal). Merge → operator rebuild+restart to verify the freeze is gone + collect `#freeze-drain` data.

correlation_id=t-20260621005233596507-74503-0

🤖 Generated with [Claude Code](https://claude.com/claude-code)