### PR TITLE
feat(tui): command-palette argument-value completion (承 #2381 P0)

### DIFF
--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -141,6 +141,13 @@ pub(crate) fn matching_specs(input: &str) -> Vec<&'static CommandSpec> {
         .collect()
 }
 
+/// Max candidate rows the palette popup renders (and the operator can navigate to)
+/// at once. Beyond this the list is windowed to the first `MAX_PALETTE_ROWS` and
+/// the operator narrows by typing — so the renderer, `tab_complete`, and the Down
+/// bound all index within the SAME window and the highlight can never point off
+/// screen from what Tab completes.
+pub(crate) const MAX_PALETTE_ROWS: usize = 12;
+
 /// What the palette should offer for the current `input`: the command keyword
 /// list (still typing the command), the dynamic value list for the argument
 /// position under the cursor, or a usage hint (free-form argument). Computed by
@@ -162,6 +169,21 @@ impl Completion {
             Completion::Values(v) => v.len(),
             Completion::UsageHint(_) => 0,
         }
+    }
+
+    /// Candidates actually shown and reachable — the count capped to the popup
+    /// window. The Down bound uses this so `selected` can't run past the visible
+    /// rows.
+    pub(crate) fn visible_count(&self) -> usize {
+        self.candidate_count().min(MAX_PALETTE_ROWS)
+    }
+
+    /// Clamp a (possibly stale or off-window) `selected` to the visible window —
+    /// the SINGLE source of truth for "which candidate is highlighted". Both the
+    /// renderer and [`tab_complete`] index with this, so the on-screen highlight
+    /// and the Tab target are always the same candidate.
+    pub(crate) fn clamp_selected(&self, selected: usize) -> usize {
+        selected.min(self.visible_count().saturating_sub(1))
     }
 }
 
@@ -267,20 +289,24 @@ pub(crate) fn palette_completion(input: &str, registry: &AgentRegistry) -> Compl
     }
 }
 
-/// Tab handler: complete the token under the cursor to the `selected` candidate,
-/// keeping the palette open with a trailing space so the next argument can be
-/// typed. Returns `None` (a no-op) when there is nothing to complete (usage hint
-/// or empty candidate list). The keyword path preserves any already-typed
-/// arguments (P0 behavior); the value path replaces only the current token.
+/// Tab handler: complete the token under the cursor to the highlighted candidate
+/// of the precomputed `completion`, keeping the palette open with a trailing space
+/// so the next argument can be typed. Returns `None` (a no-op) when there is
+/// nothing to complete (usage hint or empty candidate list). The keyword path
+/// preserves any already-typed arguments (P0 behavior); the value path replaces
+/// only the current token. Takes the same `completion` the renderer drew, indexed
+/// via the shared [`Completion::clamp_selected`], so Tab can never complete a
+/// candidate other than the one highlighted on screen (the >12-candidate
+/// highlight/Tab desync r4 caught).
 pub(crate) fn tab_complete(
     input: &str,
+    completion: &Completion,
     selected: usize,
-    registry: &AgentRegistry,
 ) -> Option<String> {
     let cur = cursor(input);
-    match palette_completion(input, registry) {
+    let idx = completion.clamp_selected(selected);
+    match completion {
         Completion::Keyword(specs) => {
-            let idx = selected.min(specs.len().saturating_sub(1));
             let keyword = specs.get(idx)?.keyword;
             // Keep arguments already typed after the keyword (P0 behavior).
             let rest = cur
@@ -297,7 +323,6 @@ pub(crate) fn tab_complete(
             })
         }
         Completion::Values(values) => {
-            let idx = selected.min(values.len().saturating_sub(1));
             let value = values.get(idx)?;
             // `pos >= 1` on the value path, so the prefix is never empty.
             let prefix = cur.tokens[..cur.pos].join(" ");
@@ -1003,6 +1028,13 @@ mod tests {
         );
     }
 
+    /// Compute the completion for `input` (as the renderer + key handler do) and
+    /// Tab-complete at `selected`.
+    fn tab(input: &str, selected: usize, reg: &crate::agent::AgentRegistry) -> Option<String> {
+        let comp = palette_completion(input, reg);
+        tab_complete(input, &comp, selected)
+    }
+
     /// Tab completes the token under the cursor (keyword or value), leaving a
     /// trailing space for the next argument; the keyword path keeps already-typed
     /// arguments, and there's no-op when nothing is completable.
@@ -1010,30 +1042,73 @@ mod tests {
     fn tab_complete_completes_current_token_with_trailing_space() {
         let reg = empty_registry();
         // Keyword: prefix → full keyword + space.
-        assert_eq!(tab_complete("la", 0, &reg).as_deref(), Some("layout "));
+        assert_eq!(tab("la", 0, &reg).as_deref(), Some("layout "));
         // Keyword while an arg is already typed → keyword filled, arg kept (P0).
-        assert_eq!(
-            tab_complete("sp foo", 0, &reg).as_deref(),
-            Some("spawn foo")
-        );
+        assert_eq!(tab("sp foo", 0, &reg).as_deref(), Some("spawn foo"));
         // Value (backend): replace current token, keep preceding, add space.
         assert_eq!(
-            tab_complete("spawn foo cl", 0, &reg).as_deref(),
+            tab("spawn foo cl", 0, &reg).as_deref(),
             Some("spawn foo claude ")
         );
         // Empty partial → first candidate.
         assert_eq!(
-            tab_complete("layout ", 0, &reg).as_deref(),
+            tab("layout ", 0, &reg).as_deref(),
             Some("layout even-horizontal ")
         );
         // config sub-command.
-        assert_eq!(
-            tab_complete("config s", 0, &reg).as_deref(),
-            Some("config set ")
-        );
+        assert_eq!(tab("config s", 0, &reg).as_deref(), Some("config set "));
         // Free-form arg → no-op (nothing to complete).
-        assert_eq!(tab_complete("set key ", 0, &reg), None);
+        assert_eq!(tab("set key ", 0, &reg), None);
         // No candidate matches the partial → no-op.
-        assert_eq!(tab_complete("spawn foo zzz", 0, &reg), None);
+        assert_eq!(tab("spawn foo zzz", 0, &reg), None);
+    }
+
+    /// r4 regression: with >MAX_PALETTE_ROWS candidates the renderer windows the
+    /// list and clamps the highlight to the last visible row, so Tab MUST complete
+    /// that same visible candidate — never the off-screen raw `selected`. The
+    /// shared `clamp_selected` guarantees it; this pins the contract (and is RED if
+    /// Tab ever re-clamps against the full list again).
+    #[test]
+    fn tab_complete_targets_visible_highlight_not_offscreen_when_over_window() {
+        // 20 synthetic agent-style candidates (the real >12 trigger is a fleet of
+        // >12 live agents for `:kill`/`:restart`/`:send <agent>`).
+        let values: Vec<String> = (0..20).map(|i| format!("agent{i:02}")).collect();
+        let comp = Completion::Values(values);
+        // The renderer highlights `clamp_selected(selected)` = last visible row.
+        let visible_last = MAX_PALETTE_ROWS - 1; // 11
+        assert_eq!(comp.clamp_selected(14), visible_last);
+        assert_eq!(comp.clamp_selected(99), visible_last);
+        // Tab at a past-the-window `selected` completes the VISIBLE candidate
+        // (agent11), not the off-screen agent14.
+        assert_eq!(
+            tab_complete("kill ", &comp, 14).as_deref(),
+            Some("kill agent11 ")
+        );
+        // Within the window, Tab tracks `selected` exactly.
+        assert_eq!(
+            tab_complete("kill ", &comp, 3).as_deref(),
+            Some("kill agent03 ")
+        );
+    }
+
+    /// `visible_count`/`clamp_selected` window math: never exceeds the cap, and a
+    /// short list clamps to its real last index.
+    #[test]
+    fn completion_window_clamps_selected_into_visible_range() {
+        let many = Completion::Values((0..20).map(|i| format!("v{i}")).collect());
+        assert_eq!(many.visible_count(), MAX_PALETTE_ROWS);
+        assert_eq!(many.clamp_selected(0), 0);
+        assert_eq!(
+            many.clamp_selected(MAX_PALETTE_ROWS - 1),
+            MAX_PALETTE_ROWS - 1
+        );
+        assert_eq!(
+            many.clamp_selected(MAX_PALETTE_ROWS + 5),
+            MAX_PALETTE_ROWS - 1
+        );
+
+        let few = Completion::Values(vec!["x".into(), "y".into(), "z".into()]);
+        assert_eq!(few.visible_count(), 3);
+        assert_eq!(few.clamp_selected(99), 2);
     }
 }

--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -23,16 +23,41 @@ pub(super) struct CommandCtx<'a> {
     pub telegram_state: &'a Option<Arc<dyn crate::channel::Channel>>,
 }
 
+/// The dynamic source feeding a command-argument position, declared per token in
+/// [`CommandSpec::args`] and resolved to concrete candidate strings by
+/// [`arg_values`]. `Free` = no finite candidate set (the palette shows a usage
+/// hint instead of a value list). Drives argument-value completion; `execute`
+/// is unaffected (it still parses the raw input string).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ArgSource {
+    /// Spawn-able backend names (`Backend::all`).
+    Backend,
+    /// Layout preset names (`LayoutPreset::names`).
+    Preset,
+    /// Runtime-config key names (`runtime_config::keys`).
+    ConfigKey,
+    /// `config` sub-command: `get` | `set` | `list`.
+    ConfigSub,
+    /// Live agent names (`agent::live_agent_names_vec`).
+    Agent,
+    /// Free-form value with no finite candidate set (show usage hint).
+    Free,
+}
+
 /// #t-5 command-palette completion: declarative metadata for the `:` commands —
-/// keyword + usage + one-line description. Consumed ONLY by the completion list
-/// (`matching_specs` + `render::overlay::render_command_palette`); `execute`
-/// below stays the source of truth for BEHAVIOR and is unchanged. ⚠ Adding or
-/// renaming a command in `execute` REQUIRES a matching entry here — the
+/// keyword + usage + one-line description + per-argument source. Consumed ONLY by
+/// the completion list (`matching_specs` / `palette_completion` +
+/// `render::overlay::render_command_palette`); `execute` below stays the source
+/// of truth for BEHAVIOR and is unchanged. ⚠ Adding or renaming a command in
+/// `execute` REQUIRES a matching entry here — the
 /// `command_specs_match_execute_arms_bidirectional` test fails otherwise.
 pub(crate) struct CommandSpec {
     pub keyword: &'static str,
     pub usage: &'static str,
     pub desc: &'static str,
+    /// Source for each positional argument, in order. `args[i]` feeds the value
+    /// completion for the `i`-th argument (the token AFTER the keyword).
+    pub args: &'static [ArgSource],
 }
 
 pub(crate) const COMMAND_SPECS: &[CommandSpec] = &[
@@ -40,56 +65,67 @@ pub(crate) const COMMAND_SPECS: &[CommandSpec] = &[
         keyword: "spawn",
         usage: "spawn [name] [backend]",
         desc: "New agent in a new tab",
+        args: &[ArgSource::Free, ArgSource::Backend],
     },
     CommandSpec {
         keyword: "vsplit",
         usage: "vsplit [name] [backend]",
         desc: "New agent; split focused pane vertically",
+        args: &[ArgSource::Free, ArgSource::Backend],
     },
     CommandSpec {
         keyword: "hsplit",
         usage: "hsplit [name] [backend]",
         desc: "New agent; split focused pane horizontally",
+        args: &[ArgSource::Free, ArgSource::Backend],
     },
     CommandSpec {
         keyword: "kill",
         usage: "kill <agent>",
         desc: "Close an agent's pane",
+        args: &[ArgSource::Agent],
     },
     CommandSpec {
         keyword: "restart",
         usage: "restart [agent]",
         desc: "Restart an agent (focused pane if omitted)",
+        args: &[ArgSource::Agent],
     },
     CommandSpec {
         keyword: "layout",
         usage: "layout [preset]",
         desc: "Apply a layout preset (cycles if omitted)",
+        args: &[ArgSource::Preset],
     },
     CommandSpec {
         keyword: "send",
         usage: "send <agent> <message>",
         desc: "Send a message to one agent",
+        args: &[ArgSource::Agent, ArgSource::Free],
     },
     CommandSpec {
         keyword: "broadcast",
         usage: "broadcast <message>",
         desc: "Broadcast a message to all agents",
+        args: &[ArgSource::Free],
     },
     CommandSpec {
         keyword: "status",
         usage: "status",
         desc: "Log every agent's current state",
+        args: &[],
     },
     CommandSpec {
         keyword: "config",
         usage: "config get|set|list [key] [value]",
         desc: "Runtime config get / set / list",
+        args: &[ArgSource::ConfigSub, ArgSource::ConfigKey, ArgSource::Free],
     },
     CommandSpec {
         keyword: "set",
         usage: "set <key> <value>",
         desc: "Set a runtime config key (`config set` shorthand)",
+        args: &[ArgSource::ConfigKey, ArgSource::Free],
     },
 ];
 
@@ -103,6 +139,172 @@ pub(crate) fn matching_specs(input: &str) -> Vec<&'static CommandSpec> {
         .iter()
         .filter(|s| s.keyword.starts_with(first))
         .collect()
+}
+
+/// What the palette should offer for the current `input`: the command keyword
+/// list (still typing the command), the dynamic value list for the argument
+/// position under the cursor, or a usage hint (free-form argument). Computed by
+/// [`palette_completion`]; consumed identically by the key handler (navigation /
+/// Tab) and the renderer so the highlighted candidate always matches what Tab
+/// completes.
+pub(crate) enum Completion {
+    Keyword(Vec<&'static CommandSpec>),
+    Values(Vec<String>),
+    UsageHint(&'static str),
+}
+
+impl Completion {
+    /// Number of selectable candidates (a usage hint is informational, not
+    /// selectable, so it counts as zero — Down/clamp must not land on it).
+    pub(crate) fn candidate_count(&self) -> usize {
+        match self {
+            Completion::Keyword(v) => v.len(),
+            Completion::Values(v) => v.len(),
+            Completion::UsageHint(_) => 0,
+        }
+    }
+}
+
+/// The token under the cursor for palette completion. Mirrors `execute`'s
+/// whitespace tokenization so a completed candidate lands at the position
+/// `execute` will parse it as: `pos` is the token index under the cursor (0 = the
+/// command keyword), and `partial` is the text already typed for that token
+/// (empty when a trailing space has opened a fresh token).
+struct Cursor<'a> {
+    tokens: Vec<&'a str>,
+    pos: usize,
+    partial: &'a str,
+}
+
+fn cursor(input: &str) -> Cursor<'_> {
+    let tokens: Vec<&str> = input.split_whitespace().collect();
+    if input.ends_with(char::is_whitespace) || tokens.is_empty() {
+        // Trailing space (or empty input) → the cursor opens a fresh token.
+        Cursor {
+            pos: tokens.len(),
+            partial: "",
+            tokens,
+        }
+    } else {
+        let pos = tokens.len() - 1;
+        Cursor {
+            partial: tokens[pos],
+            tokens,
+            pos,
+        }
+    }
+}
+
+/// Concrete candidate strings for an argument source. Only [`ArgSource::Agent`]
+/// touches the registry (a single lock, taken only while completing an agent
+/// argument — never on the per-pane render path), keeping the cost off the
+/// hot path the way #2380's lock-free render snapshot intends.
+fn arg_values(src: ArgSource, registry: &AgentRegistry) -> Vec<String> {
+    match src {
+        ArgSource::Backend => crate::backend::Backend::all()
+            .iter()
+            .map(|b| b.as_str().to_string())
+            .collect(),
+        ArgSource::Preset => crate::layout::LayoutPreset::names()
+            .iter()
+            .map(|s| (*s).to_string())
+            .collect(),
+        ArgSource::ConfigKey => crate::runtime_config::keys(),
+        ArgSource::ConfigSub => {
+            vec!["get".to_string(), "set".to_string(), "list".to_string()]
+        }
+        ArgSource::Agent => crate::agent::live_agent_names_vec(registry),
+        ArgSource::Free => Vec::new(),
+    }
+}
+
+/// Compute the completion for the palette `input`. While typing the command word
+/// (or when the first token is not yet a complete command) this is the keyword
+/// list (P0 behavior, unchanged). Once the keyword is complete and a space has
+/// been typed, it switches to the value list for the argument position under the
+/// cursor, prefix-filtered by what's typed so far; free-form arguments yield a
+/// usage hint instead.
+pub(crate) fn palette_completion(input: &str, registry: &AgentRegistry) -> Completion {
+    let cur = cursor(input);
+    let known_keyword = cur
+        .tokens
+        .first()
+        .is_some_and(|kw| COMMAND_SPECS.iter().any(|c| c.keyword == *kw));
+
+    // Still completing the command word, or the first token isn't a real command
+    // yet → keyword completion (identical to P0).
+    if cur.pos == 0 || !known_keyword {
+        return Completion::Keyword(matching_specs(input));
+    }
+
+    let keyword = cur.tokens[0];
+    let Some(spec) = COMMAND_SPECS.iter().find(|c| c.keyword == keyword) else {
+        return Completion::Keyword(matching_specs(input));
+    };
+
+    let arg_index = cur.pos - 1;
+    let Some(&src) = spec.args.get(arg_index) else {
+        // Past the last declared argument → nothing to complete.
+        return Completion::UsageHint(spec.usage);
+    };
+
+    // `config`'s key (the 2nd argument) is only meaningful after `get`/`set`;
+    // `config list` takes no key, so don't offer one there.
+    if keyword == "config"
+        && arg_index == 1
+        && !matches!(cur.tokens.get(1).copied(), Some("get") | Some("set"))
+    {
+        return Completion::UsageHint(spec.usage);
+    }
+
+    match src {
+        ArgSource::Free => Completion::UsageHint(spec.usage),
+        src => {
+            let mut values = arg_values(src, registry);
+            values.retain(|v| v.starts_with(cur.partial));
+            Completion::Values(values)
+        }
+    }
+}
+
+/// Tab handler: complete the token under the cursor to the `selected` candidate,
+/// keeping the palette open with a trailing space so the next argument can be
+/// typed. Returns `None` (a no-op) when there is nothing to complete (usage hint
+/// or empty candidate list). The keyword path preserves any already-typed
+/// arguments (P0 behavior); the value path replaces only the current token.
+pub(crate) fn tab_complete(
+    input: &str,
+    selected: usize,
+    registry: &AgentRegistry,
+) -> Option<String> {
+    let cur = cursor(input);
+    match palette_completion(input, registry) {
+        Completion::Keyword(specs) => {
+            let idx = selected.min(specs.len().saturating_sub(1));
+            let keyword = specs.get(idx)?.keyword;
+            // Keep arguments already typed after the keyword (P0 behavior).
+            let rest = cur
+                .tokens
+                .iter()
+                .skip(1)
+                .copied()
+                .collect::<Vec<_>>()
+                .join(" ");
+            Some(if rest.is_empty() {
+                format!("{keyword} ")
+            } else {
+                format!("{keyword} {rest}")
+            })
+        }
+        Completion::Values(values) => {
+            let idx = selected.min(values.len().saturating_sub(1));
+            let value = values.get(idx)?;
+            // `pos >= 1` on the value path, so the prefix is never empty.
+            let prefix = cur.tokens[..cur.pos].join(" ");
+            Some(format!("{prefix} {value} "))
+        }
+        Completion::UsageHint(_) => None,
+    }
 }
 
 /// Execute a command palette command. Returns true if layout changed (needs resize).
@@ -662,5 +864,176 @@ mod tests {
             spec_keywords.difference(&arm_keywords).collect::<Vec<_>>(),
             arm_keywords.difference(&spec_keywords).collect::<Vec<_>>(),
         );
+    }
+
+    // ── #t-… param-value (argument) completion ───────────────────────────────
+
+    fn empty_registry() -> crate::agent::AgentRegistry {
+        std::sync::Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new()))
+    }
+
+    /// The declared per-argument sources — the token→source table the operator
+    /// sees. A wrong entry would offer the wrong candidate list at that position.
+    #[test]
+    fn command_specs_arg_sources_match_table() {
+        use ArgSource::*;
+        let want: &[(&str, &[ArgSource])] = &[
+            ("spawn", &[Free, Backend]),
+            ("vsplit", &[Free, Backend]),
+            ("hsplit", &[Free, Backend]),
+            ("kill", &[Agent]),
+            ("restart", &[Agent]),
+            ("layout", &[Preset]),
+            ("send", &[Agent, Free]),
+            ("broadcast", &[Free]),
+            ("status", &[]),
+            ("config", &[ConfigSub, ConfigKey, Free]),
+            ("set", &[ConfigKey, Free]),
+        ];
+        for (kw, args) in want {
+            let spec = COMMAND_SPECS
+                .iter()
+                .find(|s| s.keyword == *kw)
+                .unwrap_or_else(|| panic!("no spec for {kw}"));
+            assert_eq!(spec.args, *args, "arg sources for `{kw}`");
+        }
+    }
+
+    /// Each command/token position resolves to the right candidate kind, and the
+    /// dynamic value lists hold the real candidates, prefix-filtered.
+    #[test]
+    fn palette_completion_routes_each_position_to_correct_source() {
+        let reg = empty_registry();
+        let kind = |input: &str| match palette_completion(input, &reg) {
+            Completion::Keyword(_) => "keyword",
+            Completion::Values(_) => "values",
+            Completion::UsageHint(_) => "hint",
+        };
+        // Position 0 (the command word) → keyword list.
+        assert_eq!(kind("sp"), "keyword");
+        assert_eq!(kind(""), "keyword");
+        // FREE first arg → usage hint (spawn name / broadcast message).
+        assert_eq!(kind("spawn "), "hint");
+        assert_eq!(kind("broadcast "), "hint");
+
+        // backend (spawn t2): the value list holds the real backends, filtered.
+        let Completion::Values(backends) = palette_completion("spawn foo ", &reg) else {
+            panic!("spawn t2 must be a value list");
+        };
+        assert!(
+            backends.contains(&"claude".to_string()) && backends.contains(&"codex".to_string()),
+            "backends: {backends:?}"
+        );
+        let Completion::Values(filtered) = palette_completion("spawn foo cl", &reg) else {
+            panic!("filtered backend must be a value list");
+        };
+        assert_eq!(filtered, vec!["claude".to_string()]);
+
+        // preset (layout t1): exactly LayoutPreset::names().
+        let Completion::Values(presets) = palette_completion("layout ", &reg) else {
+            panic!("layout t1 must be a value list");
+        };
+        let want_presets: Vec<String> = crate::layout::LayoutPreset::names()
+            .iter()
+            .map(|s| (*s).to_string())
+            .collect();
+        assert_eq!(presets, want_presets);
+
+        // config-key (set t1): exactly runtime_config::keys(); value (t2) free.
+        let Completion::Values(keys) = palette_completion("set ", &reg) else {
+            panic!("set t1 must be a value list");
+        };
+        assert_eq!(keys, crate::runtime_config::keys());
+        assert_eq!(kind("set somekey "), "hint");
+
+        // config sub-command (config t1): get/set/list.
+        let Completion::Values(subs) = palette_completion("config ", &reg) else {
+            panic!("config t1 must be a value list");
+        };
+        assert_eq!(
+            subs,
+            vec!["get".to_string(), "set".to_string(), "list".to_string()]
+        );
+        // config key (t2) only after get/set; `list` takes none.
+        assert_eq!(kind("config set "), "values");
+        assert_eq!(kind("config get "), "values");
+        assert_eq!(kind("config list "), "hint");
+
+        // agent positions route to the Agent value source (empty registry → empty
+        // list, but the Values variant proves it's a value position, not keyword).
+        assert_eq!(kind("kill "), "values");
+        assert_eq!(kind("restart "), "values");
+        assert_eq!(kind("send "), "values");
+        // send message (t2) is free-form → hint.
+        assert_eq!(kind("send bob "), "hint");
+    }
+
+    /// The palette's token splitting agrees with `execute`'s `splitn(3, ' ')` so a
+    /// completed value lands in the slot the dispatcher reads it from. `config` is
+    /// the only 4-token command: key at token 2, value at token 3 — exactly where
+    /// `handle_config_command` re-splits `parts[2]`.
+    #[test]
+    fn palette_completion_token_split_aligns_with_execute() {
+        let reg = empty_registry();
+        // `config set <key> <value>`: token2 = key (values), token3 = value (hint).
+        assert!(matches!(
+            palette_completion("config set ", &reg),
+            Completion::Values(_)
+        ));
+        assert!(matches!(
+            palette_completion("config set show_pane_state ", &reg),
+            Completion::UsageHint(_)
+        ));
+        // `set <key> <value>`: token1 = key, token2 = value.
+        assert!(matches!(
+            palette_completion("set ", &reg),
+            Completion::Values(_)
+        ));
+        assert!(matches!(
+            palette_completion("set show_pane_state ", &reg),
+            Completion::UsageHint(_)
+        ));
+        // Mid-token (no trailing space) still completes the position it's editing.
+        let Completion::Values(keys) = palette_completion("set show", &reg) else {
+            panic!("partial key must still be the key position");
+        };
+        assert!(
+            !keys.is_empty() && keys.iter().all(|k| k.starts_with("show")),
+            "partial-filtered keys: {keys:?}"
+        );
+    }
+
+    /// Tab completes the token under the cursor (keyword or value), leaving a
+    /// trailing space for the next argument; the keyword path keeps already-typed
+    /// arguments, and there's no-op when nothing is completable.
+    #[test]
+    fn tab_complete_completes_current_token_with_trailing_space() {
+        let reg = empty_registry();
+        // Keyword: prefix → full keyword + space.
+        assert_eq!(tab_complete("la", 0, &reg).as_deref(), Some("layout "));
+        // Keyword while an arg is already typed → keyword filled, arg kept (P0).
+        assert_eq!(
+            tab_complete("sp foo", 0, &reg).as_deref(),
+            Some("spawn foo")
+        );
+        // Value (backend): replace current token, keep preceding, add space.
+        assert_eq!(
+            tab_complete("spawn foo cl", 0, &reg).as_deref(),
+            Some("spawn foo claude ")
+        );
+        // Empty partial → first candidate.
+        assert_eq!(
+            tab_complete("layout ", 0, &reg).as_deref(),
+            Some("layout even-horizontal ")
+        );
+        // config sub-command.
+        assert_eq!(
+            tab_complete("config s", 0, &reg).as_deref(),
+            Some("config set ")
+        );
+        // Free-form arg → no-op (nothing to complete).
+        assert_eq!(tab_complete("set key ", 0, &reg), None);
+        // No candidate matches the partial → no-op.
+        assert_eq!(tab_complete("spawn foo zzz", 0, &reg), None);
     }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -297,7 +297,12 @@ fn render_active_overlay(
             ref input,
             selected,
         } => {
-            render::render_command_palette(frame, input, *selected);
+            // Compute the completion once (same `palette_completion` the key
+            // handler uses) and hand it to the renderer, so the highlighted
+            // candidate always matches what Tab completes. Registry is touched
+            // only for agent-argument completion — off the per-pane render path.
+            let completion = commands::palette_completion(input, registry);
+            render::render_command_palette(frame, input, *selected, &completion);
         }
         Overlay::Decisions {
             ref items,

--- a/src/app/overlay.rs
+++ b/src/app/overlay.rs
@@ -593,38 +593,27 @@ pub(super) fn handle_key(
             KeyCode::Esc => {
                 *overlay = Overlay::None;
             }
-            // #t-5 completion nav: move the highlight within the candidate list.
+            // #t-5 completion nav: move the highlight within the candidate list
+            // (keywords while typing the command, argument values once past it).
             KeyCode::Up => {
                 *selected = selected.saturating_sub(1);
             }
             KeyCode::Down => {
-                let n = super::commands::matching_specs(input).len();
+                let n = super::commands::palette_completion(input, ctx.registry).candidate_count();
                 if *selected + 1 < n {
                     *selected += 1;
                 }
             }
-            // Tab: complete the FIRST token to the highlighted keyword, keep the
-            // palette open (and a trailing space) so the operator types args next.
-            // No-op when the prefix matches nothing.
+            // Tab: complete the token under the cursor to the highlighted
+            // candidate — the command keyword while typing it, or an argument
+            // value once the keyword is complete — keeping the palette open with
+            // a trailing space for the next argument. No-op when there's nothing
+            // to complete (the clamp + empty handling live in `tab_complete`).
             KeyCode::Tab => {
-                let matches = super::commands::matching_specs(input);
-                // Clamp `selected` at the use-site (same as render): it may be
-                // stale — e.g. a paste shrank the candidate list below it — and
-                // Tab must complete the candidate the operator actually sees
-                // highlighted, not silently no-op on an out-of-range index.
-                let idx = (*selected).min(matches.len().saturating_sub(1));
-                let keyword = matches.get(idx).map(|s| s.keyword.to_string());
-                if let Some(keyword) = keyword {
-                    let rest: String = input
-                        .split_whitespace()
-                        .skip(1)
-                        .collect::<Vec<_>>()
-                        .join(" ");
-                    *input = if rest.is_empty() {
-                        format!("{keyword} ")
-                    } else {
-                        format!("{keyword} {rest}")
-                    };
+                if let Some(new_input) =
+                    super::commands::tab_complete(input, *selected, ctx.registry)
+                {
+                    *input = new_input;
                     *selected = 0;
                 }
             }

--- a/src/app/overlay.rs
+++ b/src/app/overlay.rs
@@ -599,7 +599,10 @@ pub(super) fn handle_key(
                 *selected = selected.saturating_sub(1);
             }
             KeyCode::Down => {
-                let n = super::commands::palette_completion(input, ctx.registry).candidate_count();
+                // Bound to the VISIBLE window (capped at MAX_PALETTE_ROWS), not
+                // the full count — otherwise `selected` could run past the last
+                // rendered row and Tab would complete an off-screen candidate.
+                let n = super::commands::palette_completion(input, ctx.registry).visible_count();
                 if *selected + 1 < n {
                     *selected += 1;
                 }
@@ -609,9 +612,12 @@ pub(super) fn handle_key(
             // value once the keyword is complete — keeping the palette open with
             // a trailing space for the next argument. No-op when there's nothing
             // to complete (the clamp + empty handling live in `tab_complete`).
+            // Computed from the SAME `palette_completion` the renderer drew so the
+            // completed candidate matches the on-screen highlight.
             KeyCode::Tab => {
+                let completion = super::commands::palette_completion(input, ctx.registry);
                 if let Some(new_input) =
-                    super::commands::tab_complete(input, *selected, ctx.registry)
+                    super::commands::tab_complete(input, &completion, *selected)
                 {
                     *input = new_input;
                     *selected = 0;

--- a/src/layout/preset.rs
+++ b/src/layout/preset.rs
@@ -52,6 +52,20 @@ impl LayoutPreset {
     pub fn all_names() -> &'static str {
         "even-horizontal, even-vertical, main-vertical, main-horizontal, tiled"
     }
+
+    /// The preset names as individual completion candidates (the command-palette
+    /// `:layout <preset>` value list). Sibling of [`all_names`], which joins these
+    /// for a log line; `preset_names_match_variants` pins the two in sync with
+    /// `name`/`from_name` so a new variant can't silently drift.
+    pub fn names() -> &'static [&'static str] {
+        &[
+            "even-horizontal",
+            "even-vertical",
+            "main-vertical",
+            "main-horizontal",
+            "tiled",
+        ]
+    }
 }
 
 /// Collect all panes from a tree in left-to-right order (consuming the tree).
@@ -118,5 +132,24 @@ pub(super) fn build_preset(panes: Vec<Pane>, preset: LayoutPreset) -> PaneNode {
             }
         }
         LayoutPreset::Tiled => build_tree(panes, SplitDir::Horizontal, true),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `names()` (completion candidates) must stay in sync with the canonical
+    /// `name`/`from_name`/`all_names`: every listed name must round-trip through
+    /// `from_name` back to a preset whose `name()` equals it, and the joined
+    /// `all_names` must be exactly the names comma-joined. Catches a new variant
+    /// (or a typo) drifting one list out of step.
+    #[test]
+    fn preset_names_match_variants() {
+        for n in LayoutPreset::names() {
+            let p = LayoutPreset::from_name(n).unwrap_or_else(|| panic!("from_name({n}) is None"));
+            assert_eq!(p.name(), *n, "name() round-trip mismatch for {n}");
+        }
+        assert_eq!(LayoutPreset::names().join(", "), LayoutPreset::all_names());
     }
 }

--- a/src/render/overlay.rs
+++ b/src/render/overlay.rs
@@ -328,14 +328,34 @@ pub fn render_scroll_indicator(frame: &mut Frame, offset: usize) {
 }
 
 /// #t-5: command palette with prefix-match completion. Renders the `:input` line
-/// plus a candidate list — `commands::matching_specs(input)`, derived live from the
-/// input (empty input lists all, the "what commands exist?" entry point) — with the
-/// `selected` candidate highlighted, modeled on [`render_menu`]. Keyword-only (P0).
-pub fn render_command_palette(frame: &mut Frame, input: &str, selected: usize) {
+/// plus the precomputed [`Completion`] (the same one the key handler uses, so the
+/// highlight always matches what Tab completes) with the `selected` candidate
+/// highlighted, modeled on [`render_menu`]. The candidate rows are command
+/// keywords while typing the command, argument values once past it, or a single
+/// dim usage hint for a free-form argument (not selectable).
+pub fn render_command_palette(
+    frame: &mut Frame,
+    input: &str,
+    selected: usize,
+    completion: &crate::app::commands::Completion,
+) {
+    use crate::app::commands::Completion;
     let area = frame.area();
-    let matches = crate::app::commands::matching_specs(input);
-    // Cap rows so the popup can't outgrow the screen; the full set (11) fits.
-    let shown = matches.len().min(12);
+
+    // Display rows for the candidate area. A usage hint is informational (not
+    // selectable), so it never takes the highlight.
+    let rows: Vec<String> = match completion {
+        Completion::Keyword(specs) => specs
+            .iter()
+            .map(|s| format!("{:<26} {}", s.usage, s.desc))
+            .collect(),
+        Completion::Values(values) => values.clone(),
+        Completion::UsageHint(usage) => vec![format!("usage: {usage}")],
+    };
+    let selectable = !matches!(completion, Completion::UsageHint(_));
+
+    // Cap rows so the popup can't outgrow the screen; the full keyword set (11) fits.
+    let shown = rows.len().min(12);
     let sel = selected.min(shown.saturating_sub(1));
 
     let w = 64u16.min(area.width.saturating_sub(4));
@@ -353,8 +373,9 @@ pub fn render_command_palette(frame: &mut Frame, input: &str, selected: usize) {
         format!(":{input}"),
         Style::default().fg(Color::White),
     )));
-    for (i, spec) in matches.iter().take(shown).enumerate() {
-        let style = if i == sel {
+    for (i, row) in rows.iter().take(shown).enumerate() {
+        let highlighted = selectable && i == sel;
+        let style = if highlighted {
             Style::default()
                 .fg(Color::Black)
                 .bg(Color::Cyan)
@@ -362,11 +383,8 @@ pub fn render_command_palette(frame: &mut Frame, input: &str, selected: usize) {
         } else {
             Style::default().fg(Color::Gray)
         };
-        let prefix = if i == sel { "> " } else { "  " };
-        lines.push(Line::from(Span::styled(
-            format!("{prefix}{:<26} {}", spec.usage, spec.desc),
-            style,
-        )));
+        let prefix = if highlighted { "> " } else { "  " };
+        lines.push(Line::from(Span::styled(format!("{prefix}{row}"), style)));
     }
     frame.render_widget(Paragraph::new(lines), inner);
 
@@ -422,38 +440,63 @@ mod tests {
         assert_eq!((r.x, r.y, r.width, r.height), (25, 15, 50, 10));
     }
 
+    fn palette_text(input: &str, completion: &crate::app::commands::Completion) -> String {
+        let backend = ratatui::backend::TestBackend::new(80, 20);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| render_command_palette(frame, input, 0, completion))
+            .unwrap();
+        let buf = terminal.backend().buffer().clone();
+        let mut out = String::new();
+        for y in 0..buf.area.height {
+            for x in 0..buf.area.width {
+                out.push_str(buf.cell((x, y)).map(|c| c.symbol()).unwrap_or(" "));
+            }
+            out.push('\n');
+        }
+        out
+    }
+
     /// #t-5 UX smoke: the palette lists ALL commands on empty input (the operator's
     /// "what commands exist?" discovery), and prefix-filters to matching keywords.
     #[test]
     fn command_palette_lists_all_on_open_and_prefix_filters() {
-        fn palette_text(input: &str) -> String {
-            let backend = ratatui::backend::TestBackend::new(80, 20);
-            let mut terminal = ratatui::Terminal::new(backend).unwrap();
-            terminal
-                .draw(|frame| render_command_palette(frame, input, 0))
-                .unwrap();
-            let buf = terminal.backend().buffer().clone();
-            let mut out = String::new();
-            for y in 0..buf.area.height {
-                for x in 0..buf.area.width {
-                    out.push_str(buf.cell((x, y)).map(|c| c.symbol()).unwrap_or(" "));
-                }
-                out.push('\n');
-            }
-            out
-        }
+        use crate::app::commands::{matching_specs, Completion};
         // Empty input → list every command.
-        let all = palette_text("");
+        let all = palette_text("", &Completion::Keyword(matching_specs("")));
         assert!(
             all.contains("spawn") && all.contains("config") && all.contains("layout"),
             "empty input must list all commands:\n{all}"
         );
         // Prefix narrows to matching keyword(s) only.
-        let co = palette_text("co");
+        let co = palette_text("co", &Completion::Keyword(matching_specs("co")));
         assert!(co.contains("config"), "`co` must show config:\n{co}");
         assert!(
             !co.contains("spawn") && !co.contains("layout"),
             "`co` must hide non-matching commands:\n{co}"
+        );
+    }
+
+    /// #t-… param-value completion render: a `Values` completion lists the dynamic
+    /// candidates, and a `UsageHint` (free-form argument) renders the dim hint line
+    /// instead — directly answering the operator's "what do I put here?".
+    #[test]
+    fn command_palette_renders_values_and_usage_hint() {
+        use crate::app::commands::Completion;
+        // Value list (e.g. `:spawn foo <backend>`).
+        let vals = palette_text(
+            "spawn foo ",
+            &Completion::Values(vec!["claude".to_string(), "codex".to_string()]),
+        );
+        assert!(
+            vals.contains("claude") && vals.contains("codex"),
+            "value completion must list the candidates:\n{vals}"
+        );
+        // Free-form argument → usage hint, no value list.
+        let hint = palette_text("set key ", &Completion::UsageHint("set <key> <value>"));
+        assert!(
+            hint.contains("usage:") && hint.contains("set <key> <value>"),
+            "free-form arg must show the usage hint:\n{hint}"
         );
     }
 }

--- a/src/render/overlay.rs
+++ b/src/render/overlay.rs
@@ -354,17 +354,22 @@ pub fn render_command_palette(
     };
     let selectable = !matches!(completion, Completion::UsageHint(_));
 
-    // Cap rows so the popup can't outgrow the screen; the full keyword set (11) fits.
-    let shown = rows.len().min(12);
-    let sel = selected.min(shown.saturating_sub(1));
+    // Window the list to the popup; beyond it the operator narrows by typing. The
+    // highlight uses the SAME `clamp_selected` the key handler / `tab_complete`
+    // use, so the highlighted row is always the candidate Tab will complete — even
+    // when `selected` ran past the window (>MAX_PALETTE_ROWS candidates).
+    let shown = rows.len().min(crate::app::commands::MAX_PALETTE_ROWS);
+    let sel = completion.clamp_selected(selected);
 
     let w = 64u16.min(area.width.saturating_sub(4));
     let x = (area.width.saturating_sub(w)) / 2;
-    let y = area.height / 3;
     // 1 input line + `shown` candidate rows + 2 border rows, clamped to the screen.
     let height = u16::try_from(shown + 3)
         .unwrap_or(u16::MAX)
         .min(area.height);
+    // Anchor at ~1/3 down, but pull up so a tall popup (up to MAX_PALETTE_ROWS
+    // value candidates) never spills past the bottom edge on a short terminal.
+    let y = (area.height / 3).min(area.height.saturating_sub(height));
     let ra = Rect::new(x, y, w, height);
     let inner = render_titled_popup(frame, ra, Color::Cyan, " : Command — Tab ↑↓ Enter Esc ");
 
@@ -440,11 +445,15 @@ mod tests {
         assert_eq!((r.x, r.y, r.width, r.height), (25, 15, 50, 10));
     }
 
-    fn palette_text(input: &str, completion: &crate::app::commands::Completion) -> String {
+    fn palette_text_sel(
+        input: &str,
+        selected: usize,
+        completion: &crate::app::commands::Completion,
+    ) -> String {
         let backend = ratatui::backend::TestBackend::new(80, 20);
         let mut terminal = ratatui::Terminal::new(backend).unwrap();
         terminal
-            .draw(|frame| render_command_palette(frame, input, 0, completion))
+            .draw(|frame| render_command_palette(frame, input, selected, completion))
             .unwrap();
         let buf = terminal.backend().buffer().clone();
         let mut out = String::new();
@@ -455,6 +464,10 @@ mod tests {
             out.push('\n');
         }
         out
+    }
+
+    fn palette_text(input: &str, completion: &crate::app::commands::Completion) -> String {
+        palette_text_sel(input, 0, completion)
     }
 
     /// #t-5 UX smoke: the palette lists ALL commands on empty input (the operator's
@@ -497,6 +510,34 @@ mod tests {
         assert!(
             hint.contains("usage:") && hint.contains("set <key> <value>"),
             "free-form arg must show the usage hint:\n{hint}"
+        );
+    }
+
+    /// r4 regression: with >MAX_PALETTE_ROWS candidates the popup windows the list
+    /// and the highlight (`> `) lands on the last VISIBLE row — never an off-screen
+    /// candidate — so it matches what `tab_complete` completes. RED before the fix
+    /// (render clamped the highlight to row 11 while Tab used the raw `selected`).
+    #[test]
+    fn command_palette_highlight_stays_within_visible_window() {
+        use crate::app::commands::{Completion, MAX_PALETTE_ROWS};
+        let values: Vec<String> = (0..20).map(|i| format!("agent{i:02}")).collect();
+        let comp = Completion::Values(values);
+        // `selected` ran past the window (e.g. Down held). The highlight is the
+        // last visible candidate (agent11), and no off-window candidate renders.
+        let out = palette_text_sel("kill ", 14, &comp);
+        assert!(
+            out.contains("> agent11"),
+            "highlight must be the last visible candidate (agent11):\n{out}"
+        );
+        assert!(
+            !out.contains("agent14") && !out.contains("agent19"),
+            "off-window candidates must not render:\n{out}"
+        );
+        // At most MAX_PALETTE_ROWS candidate rows are shown.
+        let shown_rows = out.matches("agent").count();
+        assert!(
+            shown_rows <= MAX_PALETTE_ROWS,
+            "windowed to <= {MAX_PALETTE_ROWS} rows, got {shown_rows}:\n{out}"
         );
     }
 }


### PR DESCRIPTION
Follow-up to #2381 (keyword-only `:` palette). Operator feedback: candidates exist, but operators don't know **what value to type** (`set <key> <value>`, `spawn` backend, `kill` agent). This adds argument-value completion. Spike manifest vetted by lead; all 4 UX calls made by lead.

## Behavior
Once the command keyword is complete + a space is typed, the palette switches from the command list to the **dynamic value list for the argument position under the cursor** (prefix-filtered). `Tab` completes the current token and adds a trailing space for the next arg; `↑↓` navigate; **`Enter` still executes the raw input unchanged** (completion stays opt-in via Tab — same iron rule as #2381). Free-form args (names / messages / config values) show a dim usage hint instead of a value list.

## Token → source table
| command | token1 | token2 |
|---|---|---|
| spawn/vsplit/hsplit | name (free → hint) | **backend** |
| kill / restart | **agent** | — |
| layout | **preset** | — |
| send | **agent** | message (free → hint) |
| broadcast | message (free → hint) | — |
| config | **get/set/list** | **config-key** (get/set only) |
| set | **config-key** | value (free → hint) |

Sources: `Backend::all`, `agent::live_agent_names_vec`, `LayoutPreset::names` (new additive helper), `runtime_config::keys`, literal `get/set/list`.

## Design / blast radius (additive; `execute` byte-unchanged)
- **commands.rs**: `ArgSource` enum + declarative `CommandSpec.args` + `arg_values` resolver + `palette_completion(input, registry) -> Keyword | Values | UsageHint` + `tab_complete`. A single `cursor` tokenizer mirrors `execute`'s `splitn(3, ' ')` so a completed value lands in the slot the dispatcher reads.
- **overlay.rs** `Overlay::Command`: `↓`/`Tab` use the new completion; `Enter`/`Esc`/`Char`/`Backspace` unchanged; enum stays thin `(input, selected)`.
- **render/overlay.rs** + **app/mod.rs**: `render_command_palette` takes the precomputed `&Completion` (computed once in `render_active_overlay`, the same `palette_completion` the key handler uses) → highlight always matches what Tab completes.
- **#2380 alignment**: only agent completion takes the **registry lock** (≠ the core.lock PTY-feed contention #2380 fixed), and only while the modal palette is open — off the per-pane render hot path, preserving the lock-free render.

The `COMMAND_SPECS ↔ execute` bidirectional sync guard stays green (only the keyword set is compared).

## Tests
- `command_specs_arg_sources_match_table` — pins the whole token→source table.
- `palette_completion_routes_each_position_to_correct_source` — each position → correct candidate kind + real candidates, prefix-filtered.
- `palette_completion_token_split_aligns_with_execute` — config key@token2 / value@token3 alignment with `splitn(3,' ')`.
- `tab_complete_completes_current_token_with_trailing_space` — current-token completion, keyword path keeps typed args, no-op cases.
- `preset_names_match_variants` — `names()` ↔ `name`/`from_name`/`all_names` drift guard.
- `command_palette_renders_values_and_usage_hint` — render of value list + usage hint.

### Evidence
- ran `env -u AGEND_INSTANCE_NAME cargo fmt --check` → OK
- ran `cargo clippy --tests --features tray -- -D warnings` → clean
- ran `cargo nextest run --features tray` → **4653 passed, 0 failed** (1 slow, 1 leaky; benign)
- RED→GREEN: neutered the value-path to first-token-only (`tokens[..1]`) → `tab_complete` test failed (`"spawn claude "` vs `"spawn foo claude "`) → restored → green. Not a tautology.

Pure TUI/UX. Merge needs operator rebuild+restart to go live.