### PR TITLE
perf(mcp): read-only tools skip per-call usage append + heartbeat RMW

### DIFF
--- a/src/mcp/handlers/mod.rs
+++ b/src/mcp/handlers/mod.rs
@@ -86,12 +86,19 @@ use instance::resolve_team_layout;
 
 pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
     let home = crate::home_dir();
+    // arch F5 (t-…47102): a read-only tool (pure query, no state change) skips the
+    // two per-call DISK side-effects below — the usage append and the heartbeat RMW
+    // — so a polling agent doesn't pay disk on every `list_instances`/`binding_state`.
+    // The in-mem heartbeat (the authoritative liveness signal) still fires; see below.
+    let read_only = is_read_only_tool(tool);
     // #2055 step 1: instrument-only usage stats — record THAT this tool was
     // called + which optional params it carried, into <home>/mcp-usage-stats.jsonl.
     // Best-effort, zero behaviour change: it never touches `args` or the result
     // and swallows all errors. This is the single dispatch chokepoint, so every
-    // tool call is observed exactly once.
-    crate::mcp::usage_stats::record(&home, tool, args);
+    // (non-read-only) tool call is observed exactly once.
+    if !read_only {
+        crate::mcp::usage_stats::record(&home, tool, args);
+    }
     // Explicit arg beats env var. Cross-instance arms require `Some`;
     // anonymous/standalone arms tolerate the empty `&str` view.
     let sender: Option<Sender> = Sender::new(instance_name).or_else(Sender::from_env);
@@ -104,15 +111,31 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
     // ordering: pair lock acquired BEFORE disk I/O, released AFTER (lock
     // is leaf-level per docs/DAEMON-LOCK-ORDERING.md).
     if !instance_name.is_empty() {
+        // The in-mem pair heartbeat is the AUTHORITATIVE liveness source
+        // (supervisor/router/dispatch_idle all read `heartbeat_pair`). It is cheap
+        // (no disk), so it fires for EVERY tool call incl. read-only — a read-only
+        // poll still proves the agent is alive.
+        let cold_start =
+            crate::daemon::heartbeat_pair::snapshot_for(instance_name).heartbeat_at_ms == 0;
         crate::daemon::heartbeat_pair::update_with(instance_name, |p| {
             p.heartbeat_at_ms = crate::daemon::heartbeat_pair::now_ms();
         });
-        save_metadata(
-            &home,
-            instance_name,
-            "last_heartbeat",
-            json!(chrono::Utc::now().to_rfc3339()),
-        );
+        // Disk `last_heartbeat` RMW: skip for a read-only tool (the perf win) EXCEPT
+        // on the cold→warm first call after a (re)start. The supervisor reads disk
+        // `last_heartbeat` ONLY as the crash-recovery fallback while the in-mem pair
+        // is still cold (`heartbeat_at_ms == 0`, supervisor.rs ~1248); refreshing it
+        // on that one transition keeps the post-restart fallback fresh, so a
+        // read-only-only agent can't be falsely stale-escalated. Once the pair is
+        // warm the fallback is never consulted, so subsequent read-only polls skip
+        // the disk write.
+        if !read_only || cold_start {
+            save_metadata(
+                &home,
+                instance_name,
+                "last_heartbeat",
+                json!(chrono::Utc::now().to_rfc3339()),
+            );
+        }
     }
 
     // #694 BLOCK 2 — dispatch table lookup. Returns `Some` for migrated
@@ -136,6 +159,29 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
     // dispatch.rs::tests pins that every tool in `tool_definitions()`
     // is routed by `dispatch.rs`.)
     json!({"error": format!("unknown tool: {tool}")})
+}
+
+/// arch F5 (t-…47102): MCP tools that are PURE QUERIES — no state change, no
+/// outbound effect. `handle_tool` skips its two per-call disk side-effects (the
+/// usage append + the heartbeat RMW) for these so a polling agent doesn't pay
+/// disk on every call; the in-mem heartbeat still fires, so liveness is preserved.
+///
+/// Conservative allowlist — only tools that NEVER mutate. Deliberately NOT here:
+/// `inbox` (drain transitions unread→delivering), `download_attachment` (writes a
+/// file), and every action-based tool (`task`/`decision`/`team`/`schedule`/
+/// `deployment`/`ci`/`health`/`repo`/`mode`) whose read-vs-write splits by
+/// `action` — those keep the full path rather than coupling this chokepoint to
+/// each tool's per-action semantics (the minority of read actions pay the IO).
+fn is_read_only_tool(tool: &str) -> bool {
+    matches!(
+        tool,
+        "list_instances"
+            | "binding_state"
+            | "gc_dry_run"
+            | "tokens"
+            | "pane_snapshot"
+            | "tui_screenshot"
+    )
 }
 
 #[cfg(test)]

--- a/src/mcp/handlers/tests.rs
+++ b/src/mcp/handlers/tests.rs
@@ -3374,3 +3374,136 @@ fn fallback_send_preserves_query_kind_survives_clear_med5() {
     std::env::remove_var("AGEND_HOME");
     std::fs::remove_dir_all(&home).ok();
 }
+
+// ── arch F5 (t-…47102): read-only tools skip the two per-call disk IOs ──────
+// (usage append + heartbeat RMW) while KEEPING the cheap in-mem heartbeat
+// (the authoritative liveness signal). Cold-start still refreshes disk so the
+// supervisor's crash-recovery fallback can't falsely stale-escalate.
+
+/// Warm read-only call: skips usage append + disk last_heartbeat RMW, but the
+/// in-mem `heartbeat_pair` is STILL bumped (load-bearing — liveness preserved).
+#[test]
+fn read_only_tool_skips_disk_io_but_bumps_inmem_heartbeat() {
+    let _g = fleet_test_guard();
+    let home = tmp_home("ro_warm");
+    std::env::set_var("AGEND_HOME", &home);
+    let agent = "ro-warm-agent";
+    // Warm the pair (heartbeat_at_ms = 1 > 0) so the cold-start refresh is NOT taken.
+    crate::daemon::heartbeat_pair::update_with(agent, |p| p.heartbeat_at_ms = 1);
+    // Pre-seed a sentinel disk last_heartbeat so we can detect a (skipped) rewrite.
+    save_metadata(&home, agent, "last_heartbeat", json!("SENTINEL"));
+
+    let _ = handle_tool("binding_state", &json!({"instance": agent}), agent);
+
+    // (a) in-mem heartbeat bumped 1 → ~now (liveness preserved for a read-only poll).
+    let after = crate::daemon::heartbeat_pair::snapshot_for(agent).heartbeat_at_ms;
+    assert!(
+        after > 1,
+        "read-only call must bump the in-mem heartbeat (got {after})"
+    );
+    // (b) disk last_heartbeat NOT rewritten (warm read-only skips the RMW).
+    let mut info = json!({});
+    merge_metadata(&home, agent, &mut info);
+    assert_eq!(
+        info["last_heartbeat"], "SENTINEL",
+        "warm read-only must NOT rewrite disk last_heartbeat"
+    );
+    // (c) no usage-stats line for the read-only tool.
+    let stats = std::fs::read_to_string(home.join("mcp-usage-stats.jsonl")).unwrap_or_default();
+    assert!(
+        !stats.contains("binding_state"),
+        "read-only tool must not append usage stats: {stats:?}"
+    );
+
+    std::env::remove_var("AGEND_HOME");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// Cold-start (in-mem pair == 0, i.e. first call after a daemon (re)start): a
+/// read-only call DOES refresh disk last_heartbeat — the supervisor reads it as
+/// the crash-recovery fallback while the pair is cold, so this keeps it fresh.
+#[test]
+fn read_only_cold_start_refreshes_disk_heartbeat() {
+    let _g = fleet_test_guard();
+    let home = tmp_home("ro_cold");
+    std::env::set_var("AGEND_HOME", &home);
+    let agent = "ro-cold-agent";
+    // Force the pair cold.
+    crate::daemon::heartbeat_pair::update_with(agent, |p| p.heartbeat_at_ms = 0);
+
+    let _ = handle_tool("binding_state", &json!({"instance": agent}), agent);
+
+    let mut info = json!({});
+    merge_metadata(&home, agent, &mut info);
+    assert!(
+        info["last_heartbeat"].is_string(),
+        "cold-start read-only MUST refresh disk last_heartbeat (supervisor fallback)"
+    );
+    assert!(
+        crate::daemon::heartbeat_pair::snapshot_for(agent).heartbeat_at_ms > 0,
+        "cold-start call warms the in-mem pair"
+    );
+
+    std::env::remove_var("AGEND_HOME");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// A non-read-only tool (here `mode`, action-based → NOT in the allowlist) keeps
+/// the full path: usage append + disk last_heartbeat both fire (unchanged).
+#[test]
+fn non_read_only_tool_still_writes_usage_and_disk_heartbeat() {
+    let _g = fleet_test_guard();
+    let home = tmp_home("rw_full");
+    std::env::set_var("AGEND_HOME", &home);
+    let agent = "rw-full-agent";
+    crate::daemon::heartbeat_pair::update_with(agent, |p| p.heartbeat_at_ms = 1);
+    save_metadata(&home, agent, "last_heartbeat", json!("OLD"));
+
+    let _ = handle_tool("mode", &json!({"action": "get"}), agent);
+
+    let mut info = json!({});
+    merge_metadata(&home, agent, &mut info);
+    assert_ne!(
+        info["last_heartbeat"], "OLD",
+        "non-read-only tool must refresh disk last_heartbeat"
+    );
+    let stats = std::fs::read_to_string(home.join("mcp-usage-stats.jsonl")).unwrap_or_default();
+    assert!(
+        stats.contains("\"mode\""),
+        "non-read-only tool must append usage stats: {stats:?}"
+    );
+
+    std::env::remove_var("AGEND_HOME");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// The allowlist is exactly the six pure-query tools; mutating + action-based
+/// tools are excluded (they keep the full path).
+#[test]
+fn is_read_only_tool_allowlist() {
+    for t in [
+        "list_instances",
+        "binding_state",
+        "gc_dry_run",
+        "tokens",
+        "pane_snapshot",
+        "tui_screenshot",
+    ] {
+        assert!(is_read_only_tool(t), "{t} must be classified read-only");
+    }
+    for t in [
+        "send",
+        "inbox",
+        "task",
+        "decision",
+        "bind_self",
+        "mode",
+        "download_attachment",
+        "restart_instance",
+    ] {
+        assert!(
+            !is_read_only_tool(t),
+            "{t} must NOT be classified read-only"
+        );
+    }
+}


### PR DESCRIPTION
## What (arch F5 — de2eb8 review, r4-confirmed-real; operator chose to do-now)

`handle_tool` paid **two disk IOs on every tool call** — the #2055 usage-stats append + the flocked `last_heartbeat` metadata RMW — even for pure-query tools (`list_instances`/`binding_state`/…) an agent polls in a loop. This skips both for a static allowlist of read-only tools.

## Design (spike-vetted by lead)

- **`is_read_only_tool` allowlist (6 pure queries)**: `list_instances`, `binding_state`, `gc_dry_run`, `tokens`, `pane_snapshot`, `tui_screenshot`. For these, skip the usage append **and** the disk `last_heartbeat` RMW.
- **KEEP the in-mem `heartbeat_pair` update for every call** (incl. read-only). It is the **authoritative liveness source** — `supervisor`/`router`/`dispatch_idle` all read the in-mem pair — and is cheap (no disk), so a read-only poll still proves liveness.
- **Liveness safety (the one real, non-cosmetic risk, folded in per vet):** the supervisor reads disk `last_heartbeat` **only** as the crash-recovery fallback while the in-mem pair is *cold* (`heartbeat_at_ms == 0`, before the first call after a (re)start — `supervisor.rs ~1248`). So the disk write is skipped for read-only **except on that cold→warm first call**, which refreshes the fallback. This bounds any stale window to "before first call" (same as the in-mem pair) — a read-only-only agent **cannot** be falsely stale-escalated.

### Deliberately NOT skipped
- `inbox` (drain transitions unread→delivering — mutates), `download_attachment` (writes a file).
- Action-based tools (`task`/`decision`/`team`/`schedule`/`deployment`/`ci`/`health`/`repo`/`mode`) whose read-vs-write splits by `action` — kept on the full path (no per-action coupling at this chokepoint; the minority of read actions pay the IO).
- **Not bundled** (per scope): list_instances' displayed `last_heartbeat` may lag for a read-only-only agent — cosmetic only (supervisor uses in-mem); left for a separate change if the operator cares.

## Tests (test-first)

- `read_only_tool_skips_disk_io_but_bumps_inmem_heartbeat` — warm read-only: no usage append, no disk RMW, **but in-mem heartbeat IS bumped** (load-bearing liveness invariant).
- `read_only_cold_start_refreshes_disk_heartbeat` — cold pair: disk refreshed (fallback freshness).
- `non_read_only_tool_still_writes_usage_and_disk_heartbeat` — full path unchanged.
- `is_read_only_tool_allowlist` — membership.

## Verification
- `cargo nextest run -E 'test(mcp::handlers)'` → **456/456**, no regression.
- `cargo fmt --check` clean · `cargo clippy --all-targets --features tray -- -D warnings` clean.

Blast: `src/mcp/handlers/mod.rs` only (handle_tool + `is_read_only_tool`) + tests. No change to dispatch/registry/heartbeat_pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)