### PR TITLE
fix(render): #freeze-3 drain background tabs' panes each frame (bound bg rx, kill switch catch-up)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -770,6 +770,13 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
         if dirty && should_draw(last_draw, frame_now, FRAME_INTERVAL) {
             last_draw = Some(frame_now);
             dirty = false;
+            // #freeze-3: drain queued PTY output for EVERY pane (active +
+            // background) into its VTerm BEFORE drawing, within one shared
+            // per-frame byte budget. `render_pane` no longer drains, so a
+            // backgrounded busy tab's `rx` stays bounded instead of replaying a
+            // multi-second catch-up when switched to. Background panes are drained
+            // but not redrawn; only the active tab is painted below.
+            render::drain_all_panes(&mut layout);
             terminal.draw(|frame| {
                 // #1027: snapshot the shared daemon-binary-stale flag once
                 // per frame so the render path sees a consistent value.
@@ -801,11 +808,13 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
                 // resize its pane's VTerm/PTY during render.
                 render_active_overlay(frame, &mut overlay, &layout, &registry, &home);
             })?;
-            // #freeze-2: a budget-capped `drain_output` may have left a backlog in
-            // a visible pane's channel. Re-arm `dirty` so the next frame continues
-            // draining (the select-timeout below already shrinks to the frame
-            // boundary when dirty) — the backlog clears over a few frames instead
-            // of one input-stalling mega-draw.
+            // #freeze-2/#freeze-3: the budget-capped `drain_all_panes` above may
+            // have left a backlog in a VISIBLE pane's channel. Re-arm `dirty` so
+            // the next frame continues the active tab's catch-up (the select-timeout
+            // below shrinks to the frame boundary when dirty) — it clears over a few
+            // frames instead of one input-stalling mega-draw. Background backlog
+            // needs no redraw: the loop's ≤50ms idle cadence + per-output wakeups
+            // guarantee `drain_all_panes` runs again to bound every pane's `rx`.
             if render::active_tab_has_pending_output(&layout) {
                 dirty = true;
             }

--- a/src/layout/pane.rs
+++ b/src/layout/pane.rs
@@ -126,9 +126,10 @@ impl Pane {
     }
 
     /// Drain up to `budget_bytes` of pending PTY output into the local VTerm,
-    /// leaving any remainder queued in the (unbounded) channel. Returns `true` if
-    /// output still remains — the render loop re-arms a redraw on this so the
-    /// backlog finishes draining over subsequent frames.
+    /// leaving any remainder queued in the (unbounded) channel. Returns the number
+    /// of BYTES drained this call. Callers that share one per-frame budget across
+    /// many panes (`render::drain_all_panes`) subtract it from the remaining budget;
+    /// whether output still remains is `!pane.rx.is_empty()`.
     ///
     /// #freeze-2 (t-…74503): this `vterm.process` loop runs on the MAIN thread
     /// inside `terminal.draw`. Un-bounded, a boot/restart backlog (every agent
@@ -138,8 +139,7 @@ impl Pane {
     /// work keeps `terminal.draw` short so input stays responsive while the pane
     /// visually catches up across a few frames. Lossless + FIFO: chunks are
     /// processed in receive order; unprocessed chunks stay queued.
-    #[must_use = "re-arm a redraw when output remains, or the backlog stalls"]
-    pub fn drain_output(&mut self, budget_bytes: usize) -> bool {
+    pub fn drain_output(&mut self, budget_bytes: usize) -> usize {
         let probe_threshold = drain_probe_threshold_us();
         let probe_start = probe_threshold.map(|_| Instant::now());
         let mut drained = 0usize;
@@ -162,7 +162,6 @@ impl Pane {
         }
         // Don't auto-scroll if user has scrolled back (they're reading history).
         // User scrolls back to bottom manually via mouse or Ctrl+B [ → j.
-        let more = !self.rx.is_empty();
         if let (Some(threshold), Some(start)) = (probe_threshold, probe_start) {
             let us = start.elapsed().as_micros() as u64;
             if us >= threshold {
@@ -170,12 +169,12 @@ impl Pane {
                     tag = "#freeze-drain",
                     drain_us = us,
                     bytes = drained,
-                    more = more,
+                    more = !self.rx.is_empty(),
                     "drain_output budget cycle"
                 );
             }
         }
-        more
+        drained
     }
 
     /// Write bytes (keystrokes, paste) to this pane's underlying process.
@@ -395,9 +394,10 @@ mod tests {
         }
     }
 
-    /// #freeze-2: `drain_output` must (a) cap per call at the byte budget, (b)
-    /// report "more remaining" so the loop re-arms, (c) over repeated calls drain
-    /// the WHOLE backlog, (d) losslessly and in FIFO order.
+    /// #freeze-2: `drain_output` must (a) cap per call at the byte budget and
+    /// return the bytes drained, (b) leave the remainder queued (`!rx.is_empty()`)
+    /// so the loop re-arms, (c) over repeated calls drain the WHOLE backlog, (d)
+    /// losslessly and in FIFO order.
     #[test]
     fn drain_output_budget_caps_and_drains_losslessly_in_fifo_order() {
         let (tx, rx) = crossbeam_channel::unbounded::<Vec<u8>>();
@@ -408,11 +408,15 @@ mod tests {
         }
         drop(tx); // disconnect so try_recv ends the loop once the queue is empty
 
-        // First call, 3-byte budget: processes exactly chunks '0','1','2' (the
-        // while-budget check trips at drained==3), leaving '3'..='9' queued.
-        let more = pane.drain_output(3);
+        // First call, 3-byte budget: processes exactly chunks '0','1','2' (3 bytes,
+        // the while-budget check trips at drained==3), leaving '3'..='9' queued.
+        let drained = pane.drain_output(3);
+        assert_eq!(
+            drained, 3,
+            "a 3-byte budget drains exactly 3 one-byte chunks"
+        );
         assert!(
-            more,
+            !pane.rx.is_empty(),
             "a 3-byte budget over 10 queued bytes must leave a remainder"
         );
         let after_first = pane.vterm.tail_lines(4);
@@ -425,9 +429,10 @@ mod tests {
             "budget cap: the 4th chunk must NOT be processed yet: {after_first:?}"
         );
 
-        // Drain the rest over subsequent "frames" until dry.
+        // Drain the rest over subsequent "frames" until dry (a call drains 0 once
+        // the queue is empty).
         let mut frames = 0;
-        while pane.drain_output(3) {
+        while pane.drain_output(3) > 0 {
             frames += 1;
             assert!(frames < 50, "must converge to drained");
         }
@@ -437,6 +442,67 @@ mod tests {
             final_lines.contains("0123456789"),
             "all chunks must be drained in FIFO order: {final_lines:?}"
         );
+    }
+
+    // ── #freeze-3 H2 (background-tab catch-up) deterministic proofs ────────
+
+    /// #freeze-3 H2 MEMORY: the pane's `rx` is an UNBOUNDED channel — left undrained
+    /// (the pre-fix background-tab case) it queues EVERY chunk, growing ∝ the
+    /// agent's output. This pins the hazard the render loop's `drain_all_panes` must
+    /// bound: it now drains every pane every frame, so a backgrounded pane's `rx`
+    /// never reaches this state in practice (see
+    /// `core_render::tests::drain_all_panes_bounds_background_rx_freeze3`).
+    #[test]
+    fn backgrounded_pane_rx_accumulates_unbounded_freeze3() {
+        let (tx, rx) = crossbeam_channel::unbounded::<Vec<u8>>();
+        let pane = test_pane(rx, 80, 24);
+        for _ in 0..1000 {
+            let _ = tx.send(vec![b'y'; 1024]); // live unbounded rx → never fails
+        }
+        assert_eq!(
+            pane.rx.len(),
+            1000,
+            "an un-drained pane queues every chunk — unbounded memory (~1 MiB here; \
+             grows without limit). The fix is to drain it every frame regardless of \
+             which tab is active."
+        );
+    }
+
+    /// #freeze-3 H2 SIZING: a budget-capped drain processes
+    /// `DRAIN_OUTPUT_BUDGET_BYTES` (32 KiB) per frame, so draining a backlog takes
+    /// `ceil(backlog / 32KiB)` frames — LINEAR in the backlog. At `FRAME_INTERVAL`
+    /// = 33 ms: 1 MiB ≈ 32 frames ≈ 1 s, 16 MiB ≈ 512 ≈ 17 s. This is exactly the
+    /// residual #2385 left: it turned "one 107 ms input-stall" into a non-blocking
+    /// but UNBOUNDED-LENGTH catch-up — unbounded because the *backlog* was unbounded
+    /// (background tabs never drained). The #freeze-3 fix bounds the backlog by
+    /// draining every pane every frame; this test sizes the per-frame budget.
+    #[test]
+    fn drain_catchup_frames_scale_linearly_with_backlog_h2_freeze3() {
+        const BUDGET: usize = 32 * 1024; // mirror DRAIN_OUTPUT_BUDGET_BYTES
+        const CHUNK: usize = 4 * 1024; // PTY-read-sized chunk
+        for &(kib, want_frames) in &[(128usize, 4usize), (256, 8), (512, 16)] {
+            let (tx, rx) = crossbeam_channel::unbounded::<Vec<u8>>();
+            let mut pane = test_pane(rx, 80, 24);
+            let total = kib * 1024;
+            for _ in 0..(total / CHUNK) {
+                let _ = tx.send(vec![b'x'; CHUNK]); // live unbounded rx → never fails
+            }
+            // Count per-frame bounded drains until dry (the render loop's re-arm).
+            let mut frames = 0usize;
+            loop {
+                frames += 1;
+                assert!(frames < 100_000, "must converge to drained");
+                pane.drain_output(BUDGET);
+                if pane.rx.is_empty() {
+                    break;
+                }
+            }
+            assert_eq!(
+                frames, want_frames,
+                "{kib} KiB backlog must take ceil({kib}KiB / 32KiB) = {want_frames} \
+                 bounded-drain frames (catch-up is LINEAR in backlog)"
+            );
+        }
     }
 
     #[test]

--- a/src/render/core_render.rs
+++ b/src/render/core_render.rs
@@ -83,6 +83,94 @@ pub fn active_tab_has_pending_output(layout: &Layout) -> bool {
     }
 }
 
+/// #freeze-3 (t-…50793): total bytes drained across ALL panes per frame, shared
+/// active-tab-first. Caps per-frame main-thread VTerm work regardless of pane
+/// count — the boot/restart flood is every pane dumping its screen at once, so a
+/// naive per-pane budget would scale to `N × DRAIN_OUTPUT_BUDGET_BYTES` and
+/// re-create the #freeze-2 long-draw that #2385 bounded for the active pane alone.
+/// Sized at 2× the per-pane budget: the active tab keeps its full snappy budget
+/// (zero draw-time regression when the background is idle) and the background
+/// panes share the remainder.
+const DRAIN_ALL_TOTAL_BUDGET_BYTES: usize = 2 * DRAIN_OUTPUT_BUDGET_BYTES;
+
+/// #freeze-3 (t-…50793) ROOT FIX: drain queued PTY output for EVERY pane (both the
+/// active tab's and the background tabs') into its own `Pane.vterm`, within the
+/// single shared per-frame `DRAIN_ALL_TOTAL_BUDGET_BYTES`, spending the ACTIVE
+/// tab's panes first so the visible catch-up keeps priority. Returns `true` if any
+/// pane still has queued output after this pass.
+///
+/// This fixes the residual freeze #2385 left: `render_pane` only ever drained the
+/// ACTIVE tab, so a backgrounded busy tab's `pane.rx` grew UNBOUNDED and switching
+/// to it replayed `ceil(backlog / budget)` frames of catch-up — proportional to
+/// how long the tab was backgrounded (the operator's multi-second "一直刷新").
+/// Draining every pane every frame keeps each `rx` bounded → the switch is
+/// instant and memory is bounded.
+///
+/// All work is on the MAIN thread against `Pane.vterm` (owned, NOT behind
+/// core.lock — the PTY read loops feed the SEPARATE `AgentCore.vterm`), so there
+/// is zero contention with the per-agent core locks (perf-R1 safe).
+///
+/// Re-arm: the render loop re-arms its redraw on the ACTIVE tab's backlog only
+/// (`active_tab_has_pending_output`) — background draining needs no redraw and is
+/// guaranteed a next pass by the loop's ≤50ms idle cadence plus per-output
+/// wakeups (both set `dirty` → frame-due → this runs again).
+///
+/// Limitation: a single background agent sustaining > one pane's drain rate
+/// (~`DRAIN_OUTPUT_BUDGET_BYTES`/frame) indefinitely can delay OTHER background
+/// panes' drain (active-first + the shared cap) — they still drain once it pauses,
+/// and the active tab plus that agent are never starved. KISS: no cross-frame
+/// round-robin cursor.
+pub fn drain_all_panes(layout: &mut Layout) -> bool {
+    let active = layout.active;
+    let mut remaining = DRAIN_ALL_TOTAL_BUDGET_BYTES;
+    let mut more = false;
+    let mut probe_panes_with_backlog = 0usize;
+    let mut probe_max_rx_chunks = 0usize;
+    // Active tab first (visible catch-up priority), then the rest in tab order.
+    let order = std::iter::once(active).chain((0..layout.tabs.len()).filter(move |&i| i != active));
+    for tab_idx in order {
+        let Some(tab) = layout.tabs.get_mut(tab_idx) else {
+            continue;
+        };
+        for id in tab.root().pane_ids() {
+            let Some(pane) = tab.root_mut().find_pane_mut(id) else {
+                continue;
+            };
+            let budget = DRAIN_OUTPUT_BUDGET_BYTES.min(remaining);
+            remaining = remaining.saturating_sub(pane.drain_output(budget));
+            let rx_chunks = pane.rx.len();
+            if rx_chunks > 0 {
+                more = true;
+                probe_panes_with_backlog += 1;
+                probe_max_rx_chunks = probe_max_rx_chunks.max(rx_chunks);
+            }
+        }
+    }
+    // #freeze-3 probe (env-gated, `AGEND_FREEZE_INSTRUMENT`): summarize residual
+    // backlog so an operator restart-repro can confirm background rx stays bounded.
+    // Off by default → zero behavior change.
+    if probe_panes_with_backlog > 0 && freeze_backlog_probe_enabled() {
+        tracing::info!(
+            tag = "#freeze-backlog",
+            panes_with_backlog = probe_panes_with_backlog,
+            max_rx_chunks = probe_max_rx_chunks,
+            budget_spent = DRAIN_ALL_TOTAL_BUDGET_BYTES - remaining,
+            "drain_all_panes residual backlog"
+        );
+    }
+    more
+}
+
+/// #freeze-3 probe gate: the `#freeze-backlog` summary in `drain_all_panes` fires
+/// only when `AGEND_FREEZE_INSTRUMENT` is set (any non-empty, non-`"0"` value),
+/// mirroring `Pane::drain_output`'s `#freeze-drain` probe. Read once, cached.
+fn freeze_backlog_probe_enabled() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| {
+        std::env::var("AGEND_FREEZE_INSTRUMENT").is_ok_and(|v| !v.is_empty() && v != "0")
+    })
+}
+
 fn build_agent_state_snapshot(
     layout: &Layout,
     registry: &AgentRegistry,
@@ -404,11 +492,11 @@ fn render_pane(
     is_drag_source: bool,
     is_drag_target: bool,
 ) -> PaneBorderInfo {
-    // #freeze-2: budget-capped — the render loop re-arms `dirty` via
-    // `active_tab_has_pending_output` when a backlog remains, so this can't stall
-    // the draw. The returned "more" is observed there, not here.
-    let _ = pane.drain_output(DRAIN_OUTPUT_BUDGET_BYTES);
-
+    // #freeze-3: draining moved OUT of the render path into the render loop's
+    // `drain_all_panes`, which drains EVERY tab's panes (not just the active one)
+    // so a backgrounded tab's `rx` stays bounded. `render_pane` is now a pure
+    // VTerm read; the active tab's catch-up re-arm still rides on
+    // `active_tab_has_pending_output` in the loop.
     if focused {
         pane.has_notification = false;
     }
@@ -1316,5 +1404,146 @@ mod tests {
         // Queued output on the visible pane → re-arm so the next frame drains it.
         tx.send(b"backlog".to_vec()).unwrap();
         assert!(active_tab_has_pending_output(&layout));
+    }
+
+    fn pane_with_rx(id: usize, rx: crossbeam_channel::Receiver<Vec<u8>>) -> Pane {
+        Pane {
+            agent_name: "agent".into(),
+            instance_id: crate::types::InstanceId::default(),
+            vterm: VTerm::new(38, 11),
+            rx,
+            id,
+            backend: Some(crate::backend::Backend::ClaudeCode),
+            working_dir: None,
+            display_name: None,
+            scroll_offset: 0,
+            has_notification: false,
+            fleet_instance_name: None,
+            last_input_at: None,
+            pending_notification_count: 0,
+            selection: None,
+            source: PaneSource::Local,
+        }
+    }
+
+    /// #freeze-3 H2 MECHANISM: the per-frame drain re-arm
+    /// (`active_tab_has_pending_output`, the render loop's signal to keep the
+    /// VISIBLE catch-up going) only sees the ACTIVE tab. A backgrounded tab's
+    /// backlog therefore never re-arms a *redraw* — correct, since hidden tabs need
+    /// no redraw. (Background draining is the job of `drain_all_panes`, gated below;
+    /// this test pins the re-arm's active-only scope so the two stay decoupled.)
+    /// Cross-platform.
+    #[test]
+    fn rearm_ignores_backgrounded_tab_backlog_freeze3() {
+        let (_tx0, rx0) = crossbeam_channel::unbounded::<Vec<u8>>();
+        let (tx1, rx1) = crossbeam_channel::unbounded::<Vec<u8>>();
+        let mut layout = Layout::new();
+        layout.add_tab(crate::layout::Tab::new(
+            "t0".to_string(),
+            pane_with_rx(1, rx0),
+        ));
+        layout.add_tab(crate::layout::Tab::new(
+            "t1".to_string(),
+            pane_with_rx(2, rx1),
+        ));
+        layout.goto_tab(0); // add_tab focuses the new tab; make t0 the active one.
+
+        // active = 0 (t0). Backlog ONLY on the BACKGROUND tab (t1).
+        tx1.send(b"backlog".to_vec()).unwrap();
+        assert!(
+            !active_tab_has_pending_output(&layout),
+            "a backgrounded tab's backlog must NOT re-arm a redraw — its catch-up is \
+             invisible; it is drained by `drain_all_panes`, not the redraw re-arm"
+        );
+
+        // Switch to t1 → its backlog is now the active tab's → the re-arm fires.
+        layout.goto_tab(1);
+        assert!(
+            active_tab_has_pending_output(&layout),
+            "switching to the backlogged tab makes it active → re-arm fires (redraw)"
+        );
+    }
+
+    /// #freeze-3 ROOT-FIX GATE: `drain_all_panes` must drain a BACKGROUND tab's
+    /// pane too (not just the active tab), so a backgrounded busy pane's `rx`
+    /// converges to EMPTY over a BOUNDED number of frames instead of accumulating
+    /// unbounded. This is the fix for the residual switch-time catch-up #2385 left:
+    /// pre-fix only the active tab drained, so switching to a long-backgrounded tab
+    /// replayed `ceil(backlog / budget)` frames (∝ background duration). RED if
+    /// `drain_all_panes` skipped background tabs (the bug): the background `rx`
+    /// would never drain and the loop below would not converge. Cross-platform.
+    #[test]
+    fn drain_all_panes_bounds_background_rx_freeze3() {
+        const CHUNK: usize = 4 * 1024; // PTY-read-sized chunk
+
+        let (_tx0, rx0) = crossbeam_channel::unbounded::<Vec<u8>>();
+        let (tx1, rx1) = crossbeam_channel::unbounded::<Vec<u8>>();
+        let mut layout = Layout::new();
+        layout.add_tab(crate::layout::Tab::new(
+            "t0".to_string(),
+            pane_with_rx(1, rx0),
+        ));
+        layout.add_tab(crate::layout::Tab::new(
+            "t1".to_string(),
+            pane_with_rx(2, rx1),
+        ));
+        layout.goto_tab(0); // t0 ACTIVE (idle), t1 BACKGROUND (flooded).
+
+        // Flood the BACKGROUND tab with a backlog the active render path never sees.
+        let backlog = 512 * 1024;
+        let chunks = backlog / CHUNK; // 128 chunks
+        for _ in 0..chunks {
+            tx1.send(vec![b'x'; CHUNK]).unwrap();
+        }
+        let bg_rx_len = |layout: &Layout| -> usize {
+            layout.tabs[1]
+                .root()
+                .find_pane(2)
+                .map(|p| p.rx.len())
+                .unwrap_or(0)
+        };
+        assert_eq!(
+            bg_rx_len(&layout),
+            chunks,
+            "precondition: the whole backlog is queued on the background pane"
+        );
+
+        // Each `drain_all_panes` call == one render frame. The background pane MUST
+        // drain down to empty over a bounded number of frames (the fix), not stay
+        // queued (the bug). The active tab is idle and leaves the shared budget, so
+        // t1 drains DRAIN_OUTPUT_BUDGET_BYTES (32 KiB = 8 chunks) per frame.
+        let mut frames = 0usize;
+        let mut prev = bg_rx_len(&layout);
+        loop {
+            let more = drain_all_panes(&mut layout);
+            frames += 1;
+            assert!(
+                frames < 1_000,
+                "background backlog must converge to drained (it did not — the bug: \
+                 a background tab is never drained, so its rx grows unbounded)"
+            );
+            let now = bg_rx_len(&layout);
+            assert!(
+                now < prev,
+                "each frame must make progress draining the background pane \
+                 (prev={prev} now={now})"
+            );
+            prev = now;
+            if !more {
+                break;
+            }
+        }
+        assert_eq!(
+            bg_rx_len(&layout),
+            0,
+            "after convergence the background rx is empty → switching to it shows \
+             no catch-up"
+        );
+        assert_eq!(
+            frames, 16,
+            "512 KiB backlog drains in ceil(512KiB / 32KiB) = 16 bounded frames at \
+             the per-pane budget (the backlog itself is now bounded because draining \
+             runs every frame for background tabs too)"
+        );
     }
 }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -8,7 +8,7 @@ pub mod panels_fleet;
 pub mod resize;
 pub mod scratch;
 
-pub use core_render::{active_tab_has_pending_output, render};
+pub use core_render::{active_tab_has_pending_output, drain_all_panes, render};
 pub use overlay::{
     render_command_palette, render_confirm, render_help, render_menu, render_move_pane_target,
     render_rename, render_scroll_indicator, render_tab_list,


### PR DESCRIPTION
## Problem (freeze-3 RCA — task t-…50793-0)

Operator still hit a residual render freeze after #2380 + #2385 (pre-#2386, **not** an input-method issue): switching to a tab that had been busy in the background "一直刷新" for a long time, multi-second.

**RCA (H2, proven by deterministic tests)**: the render path drained only the **active** tab's panes (`render_pane` → `drain_output`, 32 KiB/frame), and the re-arm `active_tab_has_pending_output` only checked the active tab. So a **backgrounded** busy tab's `pane.rx` accumulated **UNBOUNDED**; switching to it then replayed `ceil(backlog / 32KiB)` frames of catch-up — proportional to how long the tab was backgrounded (1 MiB ≈ 1 s, 16 MiB ≈ 17 s @ 33 ms frames). #2385 made the per-frame drain non-blocking but left the total catch-up length unbounded.

## Fix (A) — root-fix

Drain **every** tab's panes every frame into their own `Pane.vterm`, via new `render::drain_all_panes(layout)`, called in the render loop **before** `terminal.draw`:

- `render_pane` **no longer drains** — the draw is now a pure VTerm read.
- Background panes are drained but **not redrawn**, so every `rx` stays bounded and switching is **instant** (no catch-up, no memory growth).
- All work is **main-thread** against `Pane.vterm` (owned, **NOT** behind `core.lock` — the PTY read loops feed the *separate* `AgentCore.vterm`), so zero lock contention (perf-R1 safe).

### Bounded per-frame work (lead impl-note ①)
A single shared per-frame byte budget `DRAIN_ALL_TOTAL_BUDGET_BYTES` (= 2× the per-pane 32 KiB), spent **active-tab-first**. The boot/restart flood is every pane at once, so a naive per-pane budget would scale to `N × 32 KiB` and re-create the #freeze-2 long-draw; the shared cap keeps the active tab's full snappy budget while background panes share the remainder. `drain_output` now returns **bytes drained** so the budget can be shared across panes; `more` is derived from `!rx.is_empty()`.

### Re-arm / background cadence
The redraw re-arm stays **active-only** (`active_tab_has_pending_output`) — background draining needs no redraw and is guaranteed a next pass by the loop's ≤50 ms idle `default(select_timeout)` arm + per-output wakeups (both set `dirty` → frame-due → `drain_all_panes` runs again).

### Limitation (documented)
A single background agent sustaining `> ~970 KiB/s` indefinitely can delay *other* background panes' drain (active-first + shared cap); they still drain once it pauses, and the active tab + that agent are never starved. KISS: no cross-frame round-robin cursor.

### Probe
env-gated `#freeze-backlog` summary in `drain_all_panes` (`AGEND_FREEZE_INSTRUMENT`), zero behavior when off.

## Tests
- 3 spike H2 proofs ported (`pane.rs` ×2, `core_render.rs` ×1).
- **New gate** `drain_all_panes_bounds_background_rx_freeze3`: a 512 KiB background backlog converges to **empty in a bounded 16 frames**. **RED-verified** — fails (`prev=128 now=128`) against an active-only drain; GREEN with the fix.
- Full `cargo nextest --features tray --profile ci`: **4673 passed, 0 failed, 39 skipped**. fmt + clippy (`--features tray -D warnings`) clean.

## Review
**DUAL** review requested (render-sensitive). Merge needs an operator rebuild + restart to validate live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)