### PR TITLE
fix(render): #freeze-4 absorb the restart flood in a bounded boot/loading phase

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -205,6 +205,21 @@ fn trace_tty_size(enabled: bool, phase: &str) {
 /// 33 ms ≈ 30 fps is plenty for a TUI and halves the render CPU vs 60 fps.
 const FRAME_INTERVAL: std::time::Duration = std::time::Duration::from_millis(33);
 
+/// #freeze-4 (t-…2324) per-frame TIME budget for the BOOT catch-up drain
+/// ([`render::drain_all_panes_until`]). Load-bearing safety: each boot frame yields
+/// to `select!` (input) after this much draining, so a restart flood can never
+/// hard-freeze input — worst case the loading phase lasts a few more frames. ~80 ms
+/// keeps input serviced ~12×/s while clearing the flood far faster than the
+/// steady-state 64 KiB/frame. Provisional (conservative); tune from `#freeze-*`
+/// restart data if needed.
+const BOOT_FRAME_TIME_CAP: std::time::Duration = std::time::Duration::from_millis(80);
+
+/// #freeze-4 hard ceiling on the boot catch-up phase: after this the loop reverts
+/// to the steady-state cap regardless of remaining backlog (which then drains under
+/// the normal bounded path). Guarantees boot can't hang unbounded on a pathological
+/// backlog. Provisional (conservative).
+const MAX_BOOT_CATCHUP: std::time::Duration = std::time::Duration::from_millis(1500);
+
 /// Pure frame-cap decision (the test seam): may we draw now? `None` = never drawn
 /// (always draw the first frame); otherwise only once `FRAME_INTERVAL` has elapsed
 /// since the last draw. Independent of *what* changed — coalescing/dirtiness is
@@ -682,6 +697,18 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
     // `should_sync_notifications`). Mirrors `last_draw`'s frame-cap state.
     let mut last_notif_sync: Option<std::time::Instant> = None;
 
+    // #freeze-4 (t-…2324) restart-flood boot phase: at restart every pane carries a
+    // pre-restart backlog (its dump enqueues via #freeze-4 A1, plus the post-subscribe
+    // burst). Until that flood is drained, the loop runs a bounded "loading" phase —
+    // a TIME-capped drain ([`render::drain_all_panes_until`]) that clears the flood
+    // fast while still yielding to input every frame, shown as a loading indicator —
+    // instead of letting the steady-state 64 KiB/frame cap trickle it out over ~1s of
+    // interactive freeze. Exits to the steady path once all deferred attaches are
+    // applied AND every pane's rx is drained, or after `MAX_BOOT_CATCHUP`.
+    let boot_start = std::time::Instant::now();
+    let attaches_expected = pending_fwd.len();
+    let mut booting = true;
+
     loop {
         if crate::bootstrap::signals::term_requested() {
             tracing::info!("app: SIGTERM received, exiting main loop");
@@ -770,13 +797,35 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
         if dirty && should_draw(last_draw, frame_now, FRAME_INTERVAL) {
             last_draw = Some(frame_now);
             dirty = false;
-            // #freeze-3: drain queued PTY output for EVERY pane (active +
-            // background) into its VTerm BEFORE drawing, within one shared
-            // per-frame byte budget. `render_pane` no longer drains, so a
-            // backgrounded busy tab's `rx` stays bounded instead of replaying a
-            // multi-second catch-up when switched to. Background panes are drained
-            // but not redrawn; only the active tab is painted below.
-            render::drain_all_panes(&mut layout);
+            // #freeze-4: during the bounded boot catch-up phase, drain the restart
+            // flood with a per-frame TIME-capped drain — it clears the backlog fast
+            // as a "loading" phase while still yielding to input every frame. Exit
+            // to the steady path once all deferred attaches are applied AND every
+            // pane's rx is drained, or after MAX_BOOT_CATCHUP (so boot can't hang).
+            if booting {
+                let backlog_remains =
+                    render::drain_all_panes_until(&mut layout, BOOT_FRAME_TIME_CAP);
+                let timed_out = boot_start.elapsed() >= MAX_BOOT_CATCHUP;
+                if (pending_fwd.is_empty() && !backlog_remains) || timed_out {
+                    booting = false;
+                    tracing::info!(
+                        phase = "boot-catchup-complete",
+                        elapsed_ms = boot_start.elapsed().as_millis() as u64,
+                        attaches_expected = attaches_expected,
+                        attaches_pending = pending_fwd.len(),
+                        timed_out = timed_out,
+                        "#freeze-4: restart-flood boot catch-up drained"
+                    );
+                }
+            } else {
+                // #freeze-3: drain queued PTY output for EVERY pane (active +
+                // background) into its VTerm BEFORE drawing, within one shared
+                // per-frame byte budget. `render_pane` no longer drains, so a
+                // backgrounded busy tab's `rx` stays bounded instead of replaying a
+                // multi-second catch-up when switched to. Background panes are drained
+                // but not redrawn; only the active tab is painted below.
+                render::drain_all_panes(&mut layout);
+            }
             terminal.draw(|frame| {
                 // #1027: snapshot the shared daemon-binary-stale flag once
                 // per frame so the render path sees a consistent value.
@@ -807,15 +856,26 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
                 // &mut because ScratchShell needs to drain output and maybe
                 // resize its pane's VTerm/PTY during render.
                 render_active_overlay(frame, &mut overlay, &layout, &registry, &home);
+                // #freeze-4: loading indicator while the boot catch-up phase absorbs
+                // the restart flood (so it reads as loading-with-progress, not a freeze).
+                if booting {
+                    render::render_boot_indicator(
+                        frame,
+                        attaches_expected.saturating_sub(pending_fwd.len()),
+                        attaches_expected,
+                    );
+                }
             })?;
-            // #freeze-2/#freeze-3: the budget-capped `drain_all_panes` above may
-            // have left a backlog in a VISIBLE pane's channel. Re-arm `dirty` so
-            // the next frame continues the active tab's catch-up (the select-timeout
-            // below shrinks to the frame boundary when dirty) — it clears over a few
-            // frames instead of one input-stalling mega-draw. Background backlog
-            // needs no redraw: the loop's ≤50ms idle cadence + per-output wakeups
-            // guarantee `drain_all_panes` runs again to bound every pane's `rx`.
-            if render::active_tab_has_pending_output(&layout) {
+            // #freeze-4: while booting, keep cycling at frame cadence so the
+            // time-capped catch-up runs every frame until the restart flood clears.
+            // #freeze-2/#freeze-3: otherwise the budget-capped `drain_all_panes`
+            // above may have left a backlog in a VISIBLE pane's channel — re-arm
+            // `dirty` so the next frame continues the active tab's catch-up (the
+            // select-timeout below shrinks to the frame boundary when dirty), clearing
+            // over a few frames instead of one input-stalling mega-draw. Background
+            // backlog needs no redraw: the loop's ≤50ms idle cadence + per-output
+            // wakeups guarantee `drain_all_panes` runs again to bound every pane's `rx`.
+            if booting || render::active_tab_has_pending_output(&layout) {
                 dirty = true;
             }
         }

--- a/src/app/pane_factory.rs
+++ b/src/app/pane_factory.rs
@@ -22,6 +22,24 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 
+/// #freeze-4 A1: chunk size the initial screen dump is split into when fed through
+/// the pane's rx (instead of one unbounded `vterm.process(&dump)`). Matches the
+/// PTY read size so the render loop's boot/steady drain treats dump bytes exactly
+/// like live output — keeps the boot-phase per-frame TIME cap tight (a single
+/// chunk can't blow it) and removes the last unbounded process on the restart path.
+const DUMP_CHUNK_BYTES: usize = 8 * 1024;
+
+/// #freeze-4 probe (env-gated, `AGEND_FREEZE_INSTRUMENT`): log the initial screen
+/// dump size per pane at attach, so an operator restart-repro can size the
+/// restart-flood (the `vterm.process(&dump)` cost was previously uninstrumented —
+/// `#freeze-backlog` only sees the rx stream). Off by default → zero overhead.
+fn freeze_dump_probe_enabled() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| {
+        std::env::var("AGEND_FREEZE_INSTRUMENT").is_ok_and(|v| !v.is_empty() && v != "0")
+    })
+}
+
 /// Spawn an agent/shell via spawn_agent and add as a new tab.
 #[allow(clippy::too_many_arguments)]
 /// Whether a spawned pane is a managed fleet agent or an unmanaged local shell.
@@ -347,10 +365,17 @@ fn spawn_and_subscribe(
 /// Cheap, **main-thread** half of an attach (#render-first phase-(b)): apply the
 /// [`spawn_and_subscribe`] result to the placeholder pane and start the output
 /// forwarder. MUST run on the render thread — it mutates the `Pane` (which lives
-/// in the main-thread-owned `Layout`) and processes the dump BEFORE the forwarder
-/// is started, so the initial screen is seeded ahead of any post-subscribe stream
-/// (the render loop's `drain_output` only ever sees post-dump bytes → no
-/// out-of-order first frame).
+/// in the main-thread-owned `Layout`).
+///
+/// #freeze-4 A1: the initial screen dump is pushed into the pane's rx (chunked,
+/// AHEAD of the forwarder) instead of an unbounded one-shot `vterm.process(&dump)`.
+/// The forwarder is started only after the whole dump is enqueued, so FIFO
+/// preserves the seed-before-stream order (dump bytes are drained before any
+/// post-subscribe byte). This routes the dump through the SAME bounded drain path
+/// as live output — the render loop's boot-phase (time-capped) / steady-state
+/// (byte-capped) `drain_all_panes` bounds the per-frame cost, removing the last
+/// unbounded process on the restart path. (At restart, every pane's dump enqueues
+/// at once → the boot phase absorbs the flood instead of an interactive freeze.)
 fn apply_attachment(
     pane: &mut Pane,
     instance_id: crate::types::InstanceId,
@@ -360,11 +385,28 @@ fn apply_attachment(
     wakeup_tx: &crossbeam_channel::Sender<usize>,
 ) {
     pane.instance_id = instance_id;
-    // Feed the screen dump into the placeholder's local VTerm
-    pane.vterm.process(&dump);
+    let pane_id = pane.id;
+    // #freeze-4 A1: enqueue the dump through rx (chunked, FIFO before the forwarder)
+    // rather than processing it unbounded into the VTerm here.
+    if freeze_dump_probe_enabled() && !dump.is_empty() {
+        tracing::info!(
+            tag = "#freeze-dump",
+            pane_id = pane_id,
+            dump_bytes = dump.len(),
+            chunks = dump.len().div_ceil(DUMP_CHUNK_BYTES),
+            "attach screen dump enqueued to rx"
+        );
+    }
+    for chunk in dump.chunks(DUMP_CHUNK_BYTES) {
+        if fwd_tx.send(chunk.to_vec()).is_err() {
+            return; // pane already dropped → nothing to forward
+        }
+    }
+    // Wake the loop so the just-enqueued dump is drained (the boot phase / drain
+    // re-arm catches it; the forwarder also wakes on each subsequent live chunk).
+    let _ = wakeup_tx.send(pane_id);
 
     // Forward subscriber output to wakeup channel via the placeholder's fwd_tx
-    let pane_id = pane.id;
     let name = pane.agent_name.to_string();
     let tx = wakeup_tx.clone();
     // fire-and-forget: forwarder exits when fwd_tx.send() fails (pane
@@ -1205,10 +1247,14 @@ mod tests {
         std::fs::remove_dir_all(&home).ok();
     }
 
-    /// must-resolve: a worker `Ready` outcome seeds the dump into the pane and
-    /// starts the forwarder (subscriber bytes reach the pane's output channel).
+    /// must-resolve: a worker `Ready` outcome enqueues the dump and starts the
+    /// forwarder. #freeze-4 A1: the dump is no longer processed directly into the
+    /// VTerm — it is pushed (chunked, FIFO) through the pane's output channel AHEAD
+    /// of the forwarder, so the render loop's bounded drain handles it like live
+    /// output. So the dump must arrive on the output channel FIRST, then
+    /// post-subscribe stream bytes.
     #[test]
-    fn apply_ready_outcome_seeds_dump_and_starts_forwarder() {
+    fn apply_ready_outcome_enqueues_dump_then_forwards_freeze4() {
         let home = tmp_home("rf_ready");
         let mut layout = Layout::new();
         let mut name_counter = HashMap::new();
@@ -1245,11 +1291,18 @@ mod tests {
             fwd_tx,
             &wakeup_tx,
         );
-        assert!(
-            screen_of(&pane).contains("DUMP-XYZ"),
-            "the worker's dump must be seeded into the pane vterm"
+        // #freeze-4 A1: the dump is enqueued through the output channel (chunked,
+        // FIFO) ahead of the forwarder — NOT seeded directly into the VTerm. It
+        // must arrive FIRST (here "DUMP-XYZ" < one chunk → one message).
+        let dumped = fwd_rx
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .expect("dump enqueued to the output channel");
+        assert_eq!(
+            dumped, b"DUMP-XYZ",
+            "the dump must be enqueued to rx (ahead of the stream), not processed \
+             unbounded into the vterm"
         );
-        // Forwarder is live: a subscriber byte reaches the (passed) fwd channel.
+        // Forwarder is live + FIFO: a subscriber byte arrives AFTER the dump.
         sub_tx
             .send(b"hello".to_vec())
             .expect("send on an open channel");

--- a/src/render/core_render.rs
+++ b/src/render/core_render.rs
@@ -1,6 +1,7 @@
 //! Core rendering: main entry point, tab bar, status bar, pane tree.
 
 use std::collections::HashMap;
+use std::time::{Duration, Instant};
 
 use super::border::{render_border_grid, render_pane_titles};
 use crate::agent::{self, AgentRegistry};
@@ -169,6 +170,82 @@ fn freeze_backlog_probe_enabled() -> bool {
     *ON.get_or_init(|| {
         std::env::var("AGEND_FREEZE_INSTRUMENT").is_ok_and(|v| !v.is_empty() && v != "0")
     })
+}
+
+/// #freeze-4: per-pane byte budget for the BOOT-phase drain. Generous (8× the
+/// steady per-pane budget) so a restart flood clears in few loading frames; the
+/// real limiter is the per-frame TIME cap below, this just bounds how far a single
+/// pane can run past that cap (≈ one pane's worth of `DUMP_CHUNK_BYTES` chunks).
+const DRAIN_BOOT_PER_PANE_BUDGET_BYTES: usize = 8 * DRAIN_OUTPUT_BUDGET_BYTES;
+
+/// #freeze-4 (t-…2324) BOOT-phase drain: drain panes active-first until everything
+/// is empty OR `time_cap` elapses; returns `true` if any backlog remains. Unlike
+/// the steady-state byte-capped [`drain_all_panes`] (#2385/#2393, left untouched),
+/// this uses a per-frame TIME budget — the clock is checked between panes and the
+/// pass stops once `time_cap` is spent.
+///
+/// The TIME cap is the load-bearing safety: it GUARANTEES the render loop returns
+/// to `select!` to service input every frame, so a restart flood can NEVER hard-
+/// freeze input regardless of backlog size — worst case the bounded boot/loading
+/// phase just lasts a few more frames. Used only inside the bounded boot window
+/// (see the render loop's `booting` state); steady state is unchanged.
+pub fn drain_all_panes_until(layout: &mut Layout, time_cap: Duration) -> bool {
+    let start = Instant::now();
+    let active = layout.active;
+    let mut more = false;
+    let order = std::iter::once(active).chain((0..layout.tabs.len()).filter(move |&i| i != active));
+    for tab_idx in order {
+        let Some(tab) = layout.tabs.get_mut(tab_idx) else {
+            continue;
+        };
+        for id in tab.root().pane_ids() {
+            let Some(pane) = tab.root_mut().find_pane_mut(id) else {
+                continue;
+            };
+            pane.drain_output(DRAIN_BOOT_PER_PANE_BUDGET_BYTES);
+            if !pane.rx.is_empty() {
+                more = true;
+            }
+            // Yield after each pane once the per-frame time budget is spent so the
+            // loop services input; remaining panes/backlog drain next boot frame.
+            if start.elapsed() >= time_cap {
+                return true;
+            }
+        }
+    }
+    more
+}
+
+/// #freeze-4: a small top-centered "loading" notice shown during the bounded boot
+/// catch-up phase, so the restart flood reads as a load (with progress) rather than
+/// a freeze. `applied`/`expected` = attaches completed / total deferred attaches.
+pub fn render_boot_indicator(frame: &mut Frame, applied: usize, expected: usize) {
+    let area = frame.area();
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
+    let text = if expected > 0 {
+        format!(" loading — attaching {applied}/{expected} agents… ")
+    } else {
+        " loading… ".to_string()
+    };
+    let w = (text.chars().count() as u16).min(area.width);
+    let rect = Rect {
+        x: area.x + area.width.saturating_sub(w) / 2,
+        y: area.y,
+        width: w,
+        height: 1,
+    };
+    frame.render_widget(Clear, rect);
+    frame.render_widget(
+        Paragraph::new(text).alignment(Alignment::Center).style(
+            Style::default()
+                .fg(Color::Black)
+                .bg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ),
+        rect,
+    );
 }
 
 fn build_agent_state_snapshot(
@@ -1545,5 +1622,96 @@ mod tests {
              the per-pane budget (the backlog itself is now bounded because draining \
              runs every frame for background tabs too)"
         );
+    }
+
+    // ── #freeze-4 restart-flood boot-phase drain ──────────────────────────
+
+    /// Build N tabs, each pane flooded with `chunks_per_pane` × 4 KiB (a restart
+    /// flood). Senders are returned so the caller keeps them alive (rx stays
+    /// connected). Tab 0 is active.
+    fn flooded_layout(
+        n: usize,
+        chunks_per_pane: usize,
+    ) -> (Layout, Vec<crossbeam_channel::Sender<Vec<u8>>>) {
+        const CHUNK: usize = 4 * 1024;
+        let mut layout = Layout::new();
+        let mut txs = Vec::new();
+        for id in 1..=n {
+            let (tx, rx) = crossbeam_channel::unbounded::<Vec<u8>>();
+            for _ in 0..chunks_per_pane {
+                tx.send(vec![b'x'; CHUNK]).unwrap();
+            }
+            layout.add_tab(crate::layout::Tab::new(
+                format!("t{id}"),
+                pane_with_rx(id, rx),
+            ));
+            txs.push(tx);
+        }
+        layout.goto_tab(0);
+        (layout, txs)
+    }
+
+    fn rx_len_of(layout: &Layout, tab_idx: usize, pane_id: usize) -> usize {
+        layout.tabs[tab_idx]
+            .root()
+            .find_pane(pane_id)
+            .map(|p| p.rx.len())
+            .unwrap_or(0)
+    }
+
+    /// #freeze-4 LOAD-BEARING SAFETY: the per-frame TIME cap MUST stop the boot
+    /// drain mid-pass so the render loop returns to `select!` to service input every
+    /// frame — a restart flood can never hard-freeze input regardless of backlog.
+    /// A `Duration::ZERO` cap must yield after the FIRST pane, leaving later panes
+    /// UNTOUCHED. RED if the time-cap check is removed (neutered): the pass would
+    /// drain every pane in one call and the untouched assertion fails. Cross-platform.
+    #[test]
+    fn drain_all_panes_until_time_cap_yields_after_bounded_work_freeze4() {
+        // 100 × 4 KiB = 400 KiB/pane, larger than the boot per-pane budget so a pane
+        // can't be drained to empty "for free" in a single visit.
+        let (mut layout, txs) = flooded_layout(3, 100);
+
+        let more = drain_all_panes_until(&mut layout, Duration::ZERO);
+        assert!(
+            more,
+            "a ZERO time-cap with backlog remaining must report more pending"
+        );
+        // The LAST pane in drain order (tab 2, id 3) must still hold its FULL backlog
+        // — the ZERO cap stopped the pass long before reaching it.
+        assert_eq!(
+            rx_len_of(&layout, 2, 3),
+            100,
+            "ZERO time-cap must yield before draining every pane (without the cap, \
+             all panes drain in one call → input would be starved)"
+        );
+        drop(txs);
+    }
+
+    /// #freeze-4: given time (a generous cap, as the bounded boot window provides),
+    /// the boot drain clears the WHOLE restart flood across active + background tabs
+    /// in a bounded number of frames → after the boot phase no pane carries backlog
+    /// into interactive use.
+    #[test]
+    fn drain_all_panes_until_clears_whole_flood_when_uncapped_freeze4() {
+        let (mut layout, txs) = flooded_layout(3, 100);
+
+        let mut frames = 0usize;
+        loop {
+            let more = drain_all_panes_until(&mut layout, Duration::from_secs(30));
+            frames += 1;
+            assert!(frames < 1000, "boot catch-up must converge");
+            if !more {
+                break;
+            }
+        }
+        for (tab_idx, pane_id) in [(0usize, 1usize), (1, 2), (2, 3)] {
+            assert_eq!(
+                rx_len_of(&layout, tab_idx, pane_id),
+                0,
+                "every pane's restart backlog must be fully drained in the boot phase \
+                 (tab {tab_idx} pane {pane_id})"
+            );
+        }
+        drop(txs);
     }
 }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -8,7 +8,10 @@ pub mod panels_fleet;
 pub mod resize;
 pub mod scratch;
 
-pub use core_render::{active_tab_has_pending_output, drain_all_panes, render};
+pub use core_render::{
+    active_tab_has_pending_output, drain_all_panes, drain_all_panes_until, render,
+    render_boot_indicator,
+};
 pub use overlay::{
     render_command_palette, render_confirm, render_help, render_menu, render_move_pane_target,
     render_rename, render_scroll_indicator, render_tab_list,


### PR DESCRIPTION
## Problem (freeze-4 restart-flood — task t-…2324-0, operator-confirmed on a #2393 build)

Even after #2393, the **restart moment still freezes ~1s** (input + tab-switch lag), reproducible every restart.

**RCA** (the daemon runs in **owned/app mode** → render-first #2343 defers attach *into* the loop): at re-attach every pane carries a pre-restart flood that was processed in the **interactive** loop:
- **(A) the screen dump** was processed **unbounded, one-shot** in `apply_attachment` (`pane.vterm.process(&dump)`) — uninstrumented (the `#freeze-backlog` probe only saw rx).
- **(B) the post-subscribe burst** drained 64 KiB/frame over ~15 frames (`#freeze-backlog`: `max_rx_chunks` 132 → 4).

Both run on the main thread over the first ~15 interactive frames → input + tab-switch queue behind them → the ~1s freeze. #2393 *bounded* (B) per-frame but the catch-up still ran in the interactive loop.

A literal "drain before the loop" was rejected at VET: render-first (#2343) deliberately defers attach into the loop to show the shell fast — a pre-loop drain would force pre-loop attach and undo #2343.

## Fix — absorb the flood as a bounded **loading phase** in the early loop

- **A1 — dump→rx (simplification, regardless of size)**: `apply_attachment` now enqueues the dump through the pane's `rx` (chunked at `DUMP_CHUNK_BYTES` = 8 KiB, FIFO **ahead of** the forwarder) instead of an unbounded `vterm.process(&dump)`. FIFO preserves seed-before-stream; the bounded drain handles the dump exactly like live output — **removing the last unbounded process on the restart path**.
- **Boot phase**: a `booting` state from loop entry drains with **`render::drain_all_panes_until(layout, BOOT_FRAME_TIME_CAP)`** — a **per-frame TIME cap (~80 ms)** that is the **load-bearing safety**: every boot frame yields back to `select!`, so a restart flood can **never hard-freeze input** regardless of backlog (worst case the loading phase lasts a few more frames). It clears the flood far faster than the steady 64 KiB/frame. Exits to the steady path once **all deferred attaches are applied AND every pane's rx is drained**, or after **`MAX_BOOT_CATCHUP` (~1.5 s)** so boot can't hang. A `loading — attaching M/N agents…` indicator shows progress.
- **Steady-state #2385/#2393 cap is UNTOUCHED** — the bigger budget is confined to the bounded boot window.
- **Probes** (env-gated `AGEND_FREEZE_INSTRUMENT`, zero behavior off): `#freeze-dump` (dump size/pane) + a one-shot `boot-catchup-complete` phase log for the boot timeline.

Constants are **conservative provisional** (per VET); the operator's validation restart (with the probes) confirms sizing — small follow-up only if tuning is needed.

## Tests
- `drain_all_panes_until_time_cap_yields_after_bounded_work_freeze4` — a `Duration::ZERO` cap must yield after the first pane, leaving later panes untouched. **RED-verified**: neutering the time-cap check fails it (`left 36, right 100`).
- `drain_all_panes_until_clears_whole_flood_when_uncapped_freeze4` — a generous cap clears every tab's backlog in bounded frames.
- `apply_ready_outcome_enqueues_dump_then_forwards_freeze4` — A1: the dump arrives on the output channel FIFO **ahead of** the post-subscribe stream (updated from the old "dump→vterm direct" contract).
- #2393 steady-state test untouched (proves the interactive cap is unchanged).
- Full `cargo nextest --features tray --profile ci`: **4680 passed, 0 failed, 37 skipped**. fmt + clippy (`--features tray -D warnings`) clean.

## Notes
Design manifest (for VET) is on `spike/freeze-4-restart-flood` (not merged — manifests don't land in main). **DUAL** review requested (render-sensitive). Merge needs an operator rebuild + restart to validate live (and to collect `#freeze-dump`/timeline data for constant sizing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)