### PR TITLE
fix(agend-git): #2379 ② unify deny messages — context-aware remedy + in-scope binding

### DIFF
--- a/src/bin/agend-git.rs
+++ b/src/bin/agend-git.rs
@@ -1441,20 +1441,12 @@ fn enforce_agent_canonical_bypass_deny(args: &[String]) {
         return;
     }
     let sub = sub_args.first().map(|s| s.as_str()).unwrap_or("");
-    // #2379 ②: header + canonical-specific bypass are unique to this early deny
-    // (no Binding is loaded here — env+cwd only), but the "where to run instead"
-    // remedy reuses the SHARED builder so it stays in sync with the Action::Deny
-    // path. No binding in scope → the generic (unbound) remedy.
-    eprintln!(
-        "agend-git: DENIED — agent '{agent}' must not bypass-{sub} in a canonical-rooted repo."
-    );
-    eprintln!("           a stray provision here detaches the operator's canonical HEAD (#2234).");
-    for line in deny_remedy_lines(None) {
+    // #2379 ② (r6): the unique header + canonical-specific bypass live in a
+    // testable formatter (so the no-"security"-wording meta-test covers THIS prose
+    // too, not just the Action::Deny path) — it reuses the shared `deny_remedy_lines`.
+    for line in format_canonical_bypass_deny(&agent, sub) {
         eprintln!("{line}");
     }
-    eprintln!(
-        "           or, if you genuinely must: set AGEND_GIT_ALLOW_CANONICAL_MUTATE=1 for a one-shot (or ask lead)."
-    );
     std::process::exit(1);
 }
 
@@ -2055,9 +2047,15 @@ fn emit_deny_error(subcmd: &str, reason: &str, agent: &str, binding: Option<&Bin
 /// at the ways to get a worktree. (Intentionally avoids "security"-flavoured
 /// wording per the operator copy rule — enforced by a meta-test.)
 fn deny_remedy_lines(binding: Option<&Binding>) -> Vec<String> {
-    match binding.and_then(|b| b.worktree.as_deref().map(|wt| (b, wt))) {
-        // Bound: the agent has a worktree — it's just running git in the wrong place.
-        Some((b, wt)) => {
+    // #2379 ② (r6): decide "bound" by the SAME predicate production uses —
+    // `is_bound` (task_id.is_some()) — AND require a worktree to name, so the
+    // remedy can never contradict classify's deny verdict. A partial binding
+    // (task_id=None, worktree=Some) is UNBOUND to classify, so it must get the
+    // generic remedy here too — never a "your assigned worktree is <stale>" line
+    // pointing at a path the caller isn't actually assigned to.
+    match binding {
+        Some(b) if is_bound(b) && b.worktree.is_some() => {
+            let wt = b.worktree.as_deref().unwrap_or_default();
             let branch = b.branch.as_deref().unwrap_or("<unknown>");
             let task = b.task_id.as_deref().unwrap_or("—");
             vec![
@@ -2067,8 +2065,8 @@ fn deny_remedy_lines(binding: Option<&Binding>) -> Vec<String> {
                 ),
             ]
         }
-        // Unbound (or no binding in scope): point at how to get a worktree.
-        None => vec![
+        // Unbound / partial binding / no binding in scope: point at how to get one.
+        _ => vec![
             "           you have no active worktree binding here:".to_string(),
             "             - if the daemon auto-bound one for this task, check `binding_state` and cd into it"
                 .to_string(),
@@ -2076,6 +2074,28 @@ fn deny_remedy_lines(binding: Option<&Binding>) -> Vec<String> {
                 .to_string(),
         ],
     }
+}
+
+/// #2379 ② (r6): the canonical-bypass deny block as a testable `Vec<String>`.
+/// The header + the canonical-specific `AGEND_GIT_ALLOW_CANONICAL_MUTATE` bypass
+/// are unique to this early deny (no `Binding` is loaded — env+cwd only, so the
+/// generic [`deny_remedy_lines`]`(None)` remedy is used). Extracted from the
+/// inline `eprintln!`s so the no-"security"-wording meta-test covers this prose
+/// too (the inline form was a meta-test blind spot — r6).
+fn format_canonical_bypass_deny(agent: &str, sub: &str) -> Vec<String> {
+    let mut lines = vec![
+        format!(
+            "agend-git: DENIED — agent '{agent}' must not bypass-{sub} in a canonical-rooted repo."
+        ),
+        "           a stray provision here detaches the operator's canonical HEAD (#2234)."
+            .to_string(),
+    ];
+    lines.extend(deny_remedy_lines(None));
+    lines.push(
+        "           or, if you genuinely must: set AGEND_GIT_ALLOW_CANONICAL_MUTATE=1 for a one-shot (or ask lead)."
+            .to_string(),
+    );
+    lines
 }
 
 /// Sprint 54 P2-4: build the deny-error block as a `Vec<String>` so the
@@ -2659,6 +2679,10 @@ mod tests {
         corpus.extend(format_deny_error("commit", "r", "dev", None));
         corpus.extend(deny_remedy_lines(Some(&bound)));
         corpus.extend(deny_remedy_lines(None));
+        // #2379 ② (r6 FIX1): the canonical-bypass deny prose has its own header —
+        // it MUST be in the corpus or "security" could slip in there undetected
+        // (the inline-eprintln form was a meta-test blind spot).
+        corpus.extend(format_canonical_bypass_deny("dev", "worktree"));
         let joined = corpus.join("\n");
         assert!(
             !joined.to_lowercase().contains("security"),
@@ -2667,6 +2691,35 @@ mod tests {
         assert!(
             !joined.contains("安全"),
             "deny copy must not use '安全' wording:\n{joined}"
+        );
+    }
+
+    /// #2379 ② (r6 FIX2): a PARTIAL binding (worktree set but task_id=None) is
+    /// UNBOUND to production `is_bound` (task_id.is_some()) → classify denies it.
+    /// The remedy must NOT then claim "your assigned worktree is <that path>" (a
+    /// self-contradiction). It must use the generic remedy and never name the stale
+    /// path. RED pre-fix (deny_remedy_lines keyed on worktree.is_some() → named
+    /// `/other/path`); GREEN after keying on `is_bound`.
+    #[test]
+    fn deny_remedy_partial_binding_uses_generic_not_stale_path_2379() {
+        let partial = Binding {
+            task_id: None,
+            branch: Some("feat/x".into()),
+            worktree: Some("/other/path".into()),
+        };
+        assert!(
+            !is_bound(&partial),
+            "precondition: task_id=None ⇒ unbound to the production is_bound predicate"
+        );
+        let joined = deny_remedy_lines(Some(&partial)).join("\n");
+        assert!(
+            !joined.contains("/other/path"),
+            "a partial binding (task_id=None) is denied as unbound — the remedy must NOT \
+             name it as 'your assigned worktree' (would contradict the deny):\n{joined}"
+        );
+        assert!(
+            joined.contains("binding_state") || joined.contains("bind_self"),
+            "partial binding must fall through to the generic 'get a worktree' remedy:\n{joined}"
         );
     }
 

--- a/src/bin/agend-git.rs
+++ b/src/bin/agend-git.rs
@@ -203,7 +203,7 @@ fn main() {
             // that runs first); the arm as a whole is now always-pass → MAY
             // exit(1). Fail-closed (see `push_trust_root_denylist_violation`).
             if let Some(reason) = push_trust_root_denylist_violation(&worktree) {
-                emit_deny_error(subcommand, &reason, &agent);
+                emit_deny_error(subcommand, &reason, &agent, Some(&binding));
                 write_git_event_typed(
                     &home,
                     &agent,
@@ -243,7 +243,7 @@ fn main() {
             std::process::exit(0);
         }
         Action::Deny(reason) => {
-            emit_deny_error(subcommand, &reason, &agent);
+            emit_deny_error(subcommand, &reason, &agent, Some(&binding));
             write_git_event_typed(&home, &agent, subcommand, "deny", None, Some(&reason));
             std::process::exit(1);
         }
@@ -1441,11 +1441,19 @@ fn enforce_agent_canonical_bypass_deny(args: &[String]) {
         return;
     }
     let sub = sub_args.first().map(|s| s.as_str()).unwrap_or("");
+    // #2379 ②: header + canonical-specific bypass are unique to this early deny
+    // (no Binding is loaded here — env+cwd only), but the "where to run instead"
+    // remedy reuses the SHARED builder so it stays in sync with the Action::Deny
+    // path. No binding in scope → the generic (unbound) remedy.
     eprintln!(
-        "agend-git: DENIED — agent '{agent}' must not bypass-{sub} in a canonical-rooted repo.\n\
-         If the daemon auto-bound a worktree for this task (check `binding_state`), cd into it and use normal git \
-         (no AGEND_GIT_BYPASS); otherwise use `bind_self` or ask lead. A stray provision here detaches the operator's canonical HEAD (#2234).\n\
-         If you genuinely must: ask lead, or set AGEND_GIT_ALLOW_CANONICAL_MUTATE=1 for a one-shot."
+        "agend-git: DENIED — agent '{agent}' must not bypass-{sub} in a canonical-rooted repo."
+    );
+    eprintln!("           a stray provision here detaches the operator's canonical HEAD (#2234).");
+    for line in deny_remedy_lines(None) {
+        eprintln!("{line}");
+    }
+    eprintln!(
+        "           or, if you genuinely must: set AGEND_GIT_ALLOW_CANONICAL_MUTATE=1 for a one-shot (or ask lead)."
     );
     std::process::exit(1);
 }
@@ -2032,9 +2040,41 @@ fn lexical_path_eq(a: &std::path::Path, b: &std::path::Path) -> bool {
 
 // ── Error + Telemetry ───────────────────────────────────────────────────
 
-fn emit_deny_error(subcmd: &str, reason: &str, agent: &str) {
-    for line in format_deny_error(subcmd, reason, agent) {
+fn emit_deny_error(subcmd: &str, reason: &str, agent: &str, binding: Option<&Binding>) {
+    for line in format_deny_error(subcmd, reason, agent, binding) {
         eprintln!("{line}");
+    }
+}
+
+/// #2379 ②: the shared, context-aware "where to run this instead" remedy block,
+/// reused by every deny exit so they stay consistent. Pure `format!`, ZERO I/O —
+/// `binding` is the IN-SCOPE binding (already loaded before `classify`) at the
+/// `Action::Deny` / push-denylist sites, and `None` at the early canonical-bypass
+/// deny (env+cwd only, no binding loaded). When the caller is bound, it names the
+/// agent's own worktree so the fix is actionable ("cd there"); otherwise it points
+/// at the ways to get a worktree. (Intentionally avoids "security"-flavoured
+/// wording per the operator copy rule — enforced by a meta-test.)
+fn deny_remedy_lines(binding: Option<&Binding>) -> Vec<String> {
+    match binding.and_then(|b| b.worktree.as_deref().map(|wt| (b, wt))) {
+        // Bound: the agent has a worktree — it's just running git in the wrong place.
+        Some((b, wt)) => {
+            let branch = b.branch.as_deref().unwrap_or("<unknown>");
+            let task = b.task_id.as_deref().unwrap_or("—");
+            vec![
+                format!("           your assigned worktree is {wt}"),
+                format!(
+                    "           (branch '{branch}', task {task}) — cd there and run git, no bypass needed"
+                ),
+            ]
+        }
+        // Unbound (or no binding in scope): point at how to get a worktree.
+        None => vec![
+            "           you have no active worktree binding here:".to_string(),
+            "             - if the daemon auto-bound one for this task, check `binding_state` and cd into it"
+                .to_string(),
+            "             - otherwise get one via the task board, `repo action=checkout bind=true`, or `bind_self`"
+                .to_string(),
+        ],
     }
 }
 
@@ -2045,15 +2085,34 @@ fn emit_deny_error(subcmd: &str, reason: &str, agent: &str) {
 /// forms exist; the hint enumerates all of them so operators don't
 /// have to grep the source to discover the agent-specific or
 /// time-limited variants.
-fn format_deny_error(subcmd: &str, reason: &str, agent: &str) -> Vec<String> {
-    vec![
+///
+/// #2379 ②: now carries the in-scope binding context via [`deny_remedy_lines`]
+/// so every deny tells the caller WHERE to run the command instead (its own
+/// worktree, or how to get one) — not just how to bypass.
+fn format_deny_error(
+    subcmd: &str,
+    reason: &str,
+    agent: &str,
+    binding: Option<&Binding>,
+) -> Vec<String> {
+    let mut lines = vec![
         format!("agend-git: ERROR git {subcmd} denied"),
         format!("           agent={agent}, reason: {reason}"),
-        "           HINT: use the task board for a worktree assignment, or bypass with one of:".to_string(),
+    ];
+    lines.extend(deny_remedy_lines(binding));
+    lines.push("           or bypass with one of:".to_string());
+    lines.push(
         "             AGEND_GIT_BYPASS=1               one-shot emergency override".to_string(),
-        "             AGEND_GIT_BYPASS_AGENT=<name>    agent-specific exemption (matches AGEND_INSTANCE_NAME)".to_string(),
-        "             AGEND_GIT_BYPASS_UNTIL=<epoch>   time-limited exemption (Unix seconds, not ISO)".to_string(),
-    ]
+    );
+    lines.push(
+        "             AGEND_GIT_BYPASS_AGENT=<name>    agent-specific exemption (matches AGEND_INSTANCE_NAME)"
+            .to_string(),
+    );
+    lines.push(
+        "             AGEND_GIT_BYPASS_UNTIL=<epoch>   time-limited exemption (Unix seconds, not ISO)"
+            .to_string(),
+    );
+    lines
 }
 
 /// Sprint 57 Wave 2 Track D: structured audit-event writer with an
@@ -2510,7 +2569,7 @@ mod tests {
 
     #[test]
     fn deny_hint_lists_all_three_bypass_forms() {
-        let lines = format_deny_error("commit", "unbound", "dev");
+        let lines = format_deny_error("commit", "unbound", "dev", None);
         let joined = lines.join("\n");
         for var in [
             "AGEND_GIT_BYPASS=1",
@@ -2525,6 +2584,89 @@ mod tests {
         assert!(
             joined.contains("epoch") && joined.contains("Unix seconds"),
             "AGEND_GIT_BYPASS_UNTIL hint must clarify epoch wording (not ISO), got:\n{joined}"
+        );
+    }
+
+    /// #2379 ②: a BOUND caller's deny names its OWN worktree (branch + task) so the
+    /// remedy is "cd there", not just "bypass" — the in-scope binding context
+    /// (zero I/O). Also retains the 3-form bypass hint.
+    #[test]
+    fn deny_message_names_bound_worktree_2379() {
+        let binding = Binding {
+            task_id: Some("t-42".into()),
+            branch: Some("feat/x".into()),
+            worktree: Some("/wt/feat-x".into()),
+        };
+        let joined =
+            format_deny_error("checkout", "cross-branch", "dev", Some(&binding)).join("\n");
+        assert!(
+            joined.contains("/wt/feat-x"),
+            "must name the bound worktree, got:\n{joined}"
+        );
+        assert!(
+            joined.contains("feat/x"),
+            "must name the bound branch, got:\n{joined}"
+        );
+        assert!(
+            joined.contains("t-42"),
+            "must name the task, got:\n{joined}"
+        );
+        assert!(
+            joined.contains("no bypass needed"),
+            "bound remedy is 'cd there', got:\n{joined}"
+        );
+        assert!(
+            joined.contains("AGEND_GIT_BYPASS=1"),
+            "3-form bypass hint retained, got:\n{joined}"
+        );
+    }
+
+    /// #2379 ②: an UNBOUND caller (empty binding) and a no-binding deny (`None`,
+    /// the early canonical-bypass path) both get the SAME generic "get a worktree"
+    /// remedy via the shared builder.
+    #[test]
+    fn deny_message_unbound_points_at_getting_a_worktree_2379() {
+        let empty = Binding::default();
+        for binding in [Some(&empty), None] {
+            let joined = format_deny_error("commit", "unbound", "dev", binding).join("\n");
+            assert!(
+                joined.contains("binding_state"),
+                "unbound remedy must mention binding_state, got:\n{joined}"
+            );
+            assert!(
+                joined.contains("bind_self") || joined.contains("repo action=checkout"),
+                "unbound remedy must point at provisioning a worktree, got:\n{joined}"
+            );
+        }
+        // The shared builder is what the canonical-bypass deny (no Binding) reuses.
+        assert!(
+            deny_remedy_lines(None).join("\n").contains("binding_state"),
+            "the shared remedy builder serves the no-binding deny too"
+        );
+    }
+
+    /// #2379 ②: operator copy rule — deny prose must NOT use "security"/"安全"
+    /// wording. Guards every shared deny-copy builder (the bulk of the deny prose).
+    #[test]
+    fn deny_copy_has_no_security_wording_2379() {
+        let bound = Binding {
+            task_id: Some("t-1".into()),
+            branch: Some("b".into()),
+            worktree: Some("/wt".into()),
+        };
+        let mut corpus: Vec<String> = Vec::new();
+        corpus.extend(format_deny_error("checkout", "r", "dev", Some(&bound)));
+        corpus.extend(format_deny_error("commit", "r", "dev", None));
+        corpus.extend(deny_remedy_lines(Some(&bound)));
+        corpus.extend(deny_remedy_lines(None));
+        let joined = corpus.join("\n");
+        assert!(
+            !joined.to_lowercase().contains("security"),
+            "deny copy must not use 'security' wording:\n{joined}"
+        );
+        assert!(
+            !joined.contains("安全"),
+            "deny copy must not use '安全' wording:\n{joined}"
         );
     }
 


### PR DESCRIPTION
EPIC #2379 build-order ② (after ③ denylist-core #2390). Copy/consistency only — **behavior byte-identical** (classify decisions unchanged; ③ fail-closed detection untouched).

## Problem
Deny messages in the agend-git shim were inconsistent: the `Action::Deny` path (and #2390's push-denylist, which shares it) rendered via `format_deny_error` with only `agent + reason + generic 3-form bypass hint` — **no in-scope binding context** and **not** the actionable #2234-style "cd into your worktree / `bind_self`" remedy. That richer remedy lived only in the hand-rolled #2234 canonical-bypass deny.

## Change (per lead VET)
- **New shared `deny_remedy_lines(Option<&Binding>)`** — the single "where to run this instead" builder, reused by every deny exit so they stay in sync:
  - **bound** (binding has a worktree): names the agent's OWN worktree — `your assigned worktree is <wt> (branch '<branch>', task <task>) — cd there and run git, no bypass needed`.
  - **unbound / no binding**: `check binding_state and cd in` / `task board` / `repo action=checkout bind=true` / `bind_self`.
- `format_deny_error` / `emit_deny_error` now take `Option<&Binding>`; threaded the **in-scope** `Some(&binding)` (loaded once before `classify`, **zero new I/O**) to both emit sites (`Action::Deny` + the #2390 push-denylist).
- The early **#2234 canonical-bypass deny** (env+cwd only — **no `Binding` loaded**, so passing `None` preserves zero-I/O) reuses the same builder for its remedy while keeping its own header + `AGEND_GIT_ALLOW_CANONICAL_MUTATE` bypass.
- 3-form `AGEND_GIT_BYPASS*` hint retained. Copy avoids "安全"/"security" wording (operator rule), guarded by a meta-test.

## Tests
- `deny_message_names_bound_worktree_2379` (bound → worktree/branch/task + "no bypass needed" + 3-form hint).
- `deny_message_unbound_points_at_getting_a_worktree_2379` (`Some(empty)` + `None` → generic provisioning remedy; shared builder reused by the no-binding deny).
- `deny_copy_has_no_security_wording_2379` (meta-test for the operator copy rule).
- Existing deny tests stay green: `deny_hint_lists_all_three_bypass_forms`, `deny_agent_canonical_bypass_decision_matrix_2234`, shim `deny_*` integration (unbound/cross-branch/worktree-mgmt).
- Full `cargo nextest --features tray --profile ci` (real git): 4682/4683 pass; the 1 failure is the pre-existing `api_port_published_…` daemon-startup **load-flake** (1.526s vs 1.5s; passes in isolation 0.72s — unrelated to this deny-string change). fmt + clippy (`--features tray -D warnings`) clean.

Design manifest on `spike/2379-deny-strings` (not merged). **DUAL** review requested (touches the git deny path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)