### PR TITLE
feat(ephemeral): #1967 Phase-1 PR2 — real headless spawn + admission-before-spawn

### DIFF
--- a/docs/design/1967-ephemeral-phase1.md
+++ b/docs/design/1967-ephemeral-phase1.md
@@ -134,3 +134,64 @@ portable-pty pipe-mode vs std::process → PR2 (low risk, std::process default).
 - **Token attribution accuracy** — transcript scrape is post-hoc/cwd-keyed/claude+codex-only;
   ACP usage messages preferred but unverified — budget only as good as the token signal.
 - **Scope creep** — keep to ephemeral spawn/reap; Phase 2/3 stay trigger-conditioned.
+
+---
+
+## PR2 (headless spawn) — landed (lead-vetted Option Y)
+
+Replaced PR1's fake `/bin/sleep` child with a REAL headless process. Key choices:
+
+- **Option Y (not a `build_command` refactor)**: `build_command` (`agent/mod.rs:710`)
+  is ~250 lines of security-sensitive managed-hot-path code (env-isolation,
+  cwd symlink-validation, git-shim PATH + `AGEND_REAL_GIT`, opencode XDG
+  provisioning, fleet-env filtering) with side effects — refactoring it into a
+  shared `ResolvedSpawn` was rejected as over-engineering + a managed-hot-path
+  regression risk for parts PR2's stub worker doesn't use. Instead the new
+  `headless::resolve_headless_command` reuses the SAME single-source helpers
+  (`which` / `preset_spawn_args` / `spawn_flags` / `agent::resolve_child_env`) →
+  no argv/isolation drift; `build_command` is untouched (zero PTY regression).
+- **`HeadlessTransport`** (`src/headless.rs`) = lifecycle only (`spawn` + `cancel`);
+  the ACP protocol methods (handshake/prompt/stream) are PR3. Captured stdin/
+  stdout/stderr pipes ride on `HeadlessHandle` for PR3.
+- **Admission BEFORE spawn** (r4 PR1 note): `reserve → spawn → finalize`.
+  `try_reserve_slot` is a single atomic RMW (no TOCTOU); an over-cap spawn rejects
+  WITHOUT creating any process. `stale_reserving` rows (crash between reserve and
+  finalize, age > `RESERVE_STALE_SECS` = 60s) are reaped by the sweep; the sweep
+  gates reserving rows on the stale timeout, NOT pid-liveness (pid=0 reads as dead
+  and would race an in-flight finalize).
+- **Reap reuses PR1** (start-token PID-recycle guard, `terminate_worker`); reap =
+  single-process SIGTERM + `wait()`.
+
+### ⚠ PR3 PREREQUISITES — deferred PTY/real-backend setup (do NOT bury)
+`resolve_headless_command` applies only the transport-agnostic CORE (program,
+argv, #1440 env-isolation, identity env). The following `build_command` steps are
+NOT done in PR2 (the stub worker has no protocol → runs no real backend) and MUST
+be added before PR3 lets a real backend run headless — each is a correctness or
+SECURITY prerequisite:
+
+1. **git-shim PATH shadowing + `AGEND_REAL_GIT` (#1504)** — without prepending
+   `$AGEND_HOME/bin` to PATH, a headless backend's `git` ESCAPES the `agend-git`
+   safety gate (push-denylist, worktree guards). SECURITY-critical.
+2. **cwd validation + provisioning** (`api::validate_working_directory` +
+   `create_dir_all` + symlink revalidation).
+3. **opencode per-instance XDG isolation (#1519) + autoupdate disable (#1956/#1970)**.
+4. **fleet.yaml user-env passthrough with #2106 credential filtering**.
+5. terminal env (`TERM`/`COLORTERM`/`FORCE_COLOR`) + git-editor env
+   (`GIT_EDITOR`/`GIT_SEQUENCE_EDITOR`/`EDITOR`/`VISUAL`) + `LANG`.
+
+(The same list is duplicated at the top of `src/headless.rs` so it is visible
+from the spawn site.)
+
+### Windows posture
+The headless spawn (`std::process`) + `process::terminate` (TerminateProcess) are
+cross-platform. The real-process lifecycle tests run on ALL CI platforms incl.
+windows-latest (the test spawns `/bin/sleep` on unix, `ping -n` on Windows) — so
+the spawn+reap path is RUNTIME-exercised on Windows, not just compile-verified
+(the xwin lesson: cross-compile-green ≠ runtime-pass). Ephemeral workers remain a
+unix-first runtime feature; no backend is Windows-only.
+
+### Honest scope
+PR2 is the SPAWN MECHANISM only. A spawned worker has NO protocol driving it, so it
+does no useful work until PR3 (ACP) drives the captured stdio. PR2 does NOT touch
+ACP/JSON-RPC, the telemetry layers (PR4/5), token-budget enforcement (PR6), or
+group-kill/graceful-cancel (later).

--- a/src/ephemeral_tracking.rs
+++ b/src/ephemeral_tracking.rs
@@ -1,32 +1,32 @@
-//! #1967 Phase-1: ephemeral worker tracking (PR1 scaffold).
+//! #1967 Phase-1: ephemeral worker tracking + lifecycle.
 //!
 //! Short-lived, cross-backend "ephemeral" workers live OUTSIDE the managed-agent
 //! bookkeeping — they are NOT inserted into the agent registry, fleet.yaml,
 //! binding, or the worktree pool. They are tracked only in a small JSON sidecar
 //! (`$AGEND_HOME/ephemeral_workers.json`, mirroring [`crate::dispatch_tracking`])
-//! plus an in-memory `Child` handle map for zombie reaping.
+//! plus an in-memory [`crate::headless::HeadlessHandle`] map for zombie reaping.
 //!
-//! PR1 scope = lifecycle + tracking + reap + day-1 cost guards ONLY. There is NO
-//! real backend transport yet: [`spawn_and_track`] launches a FAKE child
-//! (`/bin/sleep`) so the spawn→track→reap lifecycle, the cost guards, and the
-//! reap's real process termination are exercised against a genuine OS process.
-//! The headless protocol transport (ACP) is PR2/PR3. See
-//! `docs/design/1967-ephemeral-phase1.md`.
+//! PR2: [`spawn_and_track`] launches a REAL headless process via a
+//! [`crate::headless::HeadlessTransport`] (no PTY, no registry). Admission is
+//! BEFORE the spawn (reserve → spawn → finalize). The worker has no protocol
+//! driving it yet — PR3 (ACP) adds that. See `docs/design/1967-ephemeral-phase1.md`.
 //!
-//! ## Cost guards (lead vet condition — day-1, before real spawn)
+//! ## Cost guards (lead vet condition — day-1)
 //! - **Hard max-live concurrency cap** ([`MAX_LIVE_WORKERS`]): admission is an
-//!   atomic check-and-add under the store flock ([`try_track_within_cap`]), so the
-//!   cap can never be exceeded even under concurrent spawns.
+//!   atomic check-and-add under the store flock ([`try_reserve_slot`], BEFORE the
+//!   spawn), so the cap can never be exceeded even under concurrent spawns and an
+//!   over-cap spawn creates no process.
 //! - **Max-wall-TTL** ([`DEFAULT_WALL_TTL_SECS`], clamped to [`MAX_WALL_TTL_SECS`]):
 //!   the reap sweep terminates any worker whose wall clock exceeds its `ttl_secs`,
 //!   so a wedged/forgotten worker cannot run (and bill) unbounded.
 
+use crate::backend::SpawnMode;
+use crate::headless::{HeadlessHandle, HeadlessTransport};
 use crate::store::SchemaVersioned;
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::process::Child;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::LazyLock;
 
@@ -44,12 +44,23 @@ pub const DEFAULT_WALL_TTL_SECS: u64 = 30 * 60;
 /// cannot disable the wall-TTL guard by requesting an enormous value.
 pub const MAX_WALL_TTL_SECS: u64 = 2 * 60 * 60;
 
-/// PR1 fake-child command — a real OS process so reap/TTL enforcement is genuine.
-/// Replaced by the headless backend transport in PR2/PR3.
-const FAKE_CHILD_CMD: &str = "/bin/sleep";
+/// Cost-guard / liveness: a worker stuck in the `"reserving"` state (admission
+/// slot taken but `finalize` never ran — daemon crashed between reserve and
+/// finalize) longer than this is reaped as stale. Conservative: WELL above the
+/// worst-case spawn+finalize latency (milliseconds) so the reap never races an
+/// in-flight finalize.
+const RESERVE_STALE_SECS: i64 = 60;
 
-/// One tracked ephemeral worker. Persisted as a JSON row; the live `Child` handle
-/// (for zombie reaping) is held separately in [`LIVE_CHILDREN`].
+/// Worker status: admission slot taken, real process not yet spawned/finalized.
+const STATUS_RESERVING: &str = "reserving";
+/// Worker status: real process spawned + finalized (live).
+const STATUS_RUNNING: &str = "running";
+/// Worker status: terminal (workflow signalled done) — reaped on the next sweep.
+const STATUS_DONE: &str = "done";
+
+/// One tracked ephemeral worker. Persisted as a JSON row; the live
+/// [`crate::headless::HeadlessHandle`] (for zombie reaping + PR3 stdio) is held
+/// separately in [`LIVE_CHILDREN`].
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct EphemeralWorker {
     pub worker_id: String,
@@ -66,8 +77,8 @@ pub struct EphemeralWorker {
     pub ttl_secs: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub token_budget: Option<u64>,
-    pub phase: String,  // "spawned" | "running" | "done"
-    pub status: String, // "running" | "done"
+    pub phase: String,  // "reserving" | "spawned" | "running" | "done"
+    pub status: String, // "reserving" | "running" | "done"
 }
 
 #[derive(Debug, Default, Serialize, Deserialize)]
@@ -85,12 +96,11 @@ impl crate::store::SchemaVersioned for EphemeralStore {
     }
 }
 
-/// In-memory map of `worker_id → Child` for the PR1 fake children, so reap can
-/// `wait()` the terminated child and never leak a zombie. Empty after a daemon
-/// restart (handles don't survive) — restart orphans are handled by
-/// [`reap_on_boot`] via pid + start-token instead. PR2's real workers go through
-/// the agent spawn machinery's own reaping.
-static LIVE_CHILDREN: LazyLock<Mutex<HashMap<String, Child>>> =
+/// In-memory map of `worker_id → HeadlessHandle` for workers spawned THIS daemon
+/// life, so reap can `wait()` the terminated child (never leak a zombie) and PR3
+/// can reach the captured stdio pipes. Empty after a restart (handles don't
+/// survive) — restart orphans are reaped by [`reap_on_boot`] via pid + start-token.
+static LIVE_CHILDREN: LazyLock<Mutex<HashMap<String, HeadlessHandle>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
 /// Process-local monotonic counter for unique worker ids within a daemon life.
@@ -136,7 +146,7 @@ pub struct SpawnSpec {
 pub enum SpawnError {
     /// The hard max-live concurrency cap would be exceeded.
     CapExceeded { live: usize, cap: usize },
-    /// The fake child failed to launch.
+    /// The headless process failed to launch (or finalize).
     Spawn(std::io::Error),
 }
 
@@ -152,11 +162,13 @@ impl std::fmt::Display for SpawnError {
     }
 }
 
-/// Atomic admission: add `worker` only if the live count is below
-/// [`MAX_LIVE_WORKERS`]. The check-and-add happens in ONE locked read-modify-write
-/// (the store flock), so concurrent spawns can never push the count past the cap.
-/// Returns `Err(live)` (the count seen) when the cap is full.
-fn try_track_within_cap(home: &Path, worker: EphemeralWorker) -> Result<(), usize> {
+/// Atomic admission RESERVE (r4 PR1 note: admission happens BEFORE spawning the
+/// real process). In ONE locked read-modify-write: if the live count is below
+/// [`MAX_LIVE_WORKERS`], insert `reserving` (a [`STATUS_RESERVING`] row, pid=0)
+/// and return `Ok`; else `Err(live)` WITHOUT inserting — so an over-cap spawn
+/// rejects before any OS process exists. Single RMW under the store flock →
+/// concurrent reserves can never push the count past the cap (no TOCTOU).
+fn try_reserve_slot(home: &Path, reserving: EphemeralWorker) -> Result<(), usize> {
     let mut rejected_at = None;
     persist_or_log!(
         crate::store::mutate_versioned(&store_path(home), |s: &mut EphemeralStore| {
@@ -164,10 +176,10 @@ fn try_track_within_cap(home: &Path, worker: EphemeralWorker) -> Result<(), usiz
                 rejected_at = Some(s.workers.len());
                 return Ok(());
             }
-            s.workers.push(worker.clone());
+            s.workers.push(reserving.clone());
             Ok(())
         }),
-        "ephemeral_track"
+        "ephemeral_reserve"
     );
     match rejected_at {
         Some(live) => Err(live),
@@ -175,69 +187,144 @@ fn try_track_within_cap(home: &Path, worker: EphemeralWorker) -> Result<(), usiz
     }
 }
 
-/// Spawn a worker (PR1: a FAKE `/bin/sleep` child) and track it, enforcing the
-/// hard max-live cap. On cap-exceeded the just-spawned child is terminated so no
-/// process leaks. Returns the tracked [`EphemeralWorker`].
-pub fn spawn_and_track(home: &Path, spec: SpawnSpec) -> Result<EphemeralWorker, SpawnError> {
+/// Finalize a reserved slot once the real process is spawned: stamp the real pid
+/// and start-token, then flip `STATUS_RESERVING` → `STATUS_RUNNING` (the wall-TTL
+/// clock restarts at the real spawn time). Returns the finalized worker, or `Err`
+/// if the reserving row is gone (e.g. concurrently reaped as stale — caller then
+/// kills the just-spawned orphan).
+fn finalize_spawn(
+    home: &Path,
+    worker_id: &str,
+    pid: u32,
+    token: Option<u64>,
+) -> Result<EphemeralWorker, ()> {
+    let mut finalized = None;
+    persist_or_log!(
+        crate::store::mutate_versioned(&store_path(home), |s: &mut EphemeralStore| {
+            if let Some(w) = s.workers.iter_mut().find(|w| w.worker_id == worker_id) {
+                w.pid = pid;
+                w.process_start_token = token;
+                w.status = STATUS_RUNNING.to_string();
+                w.phase = "spawned".to_string();
+                w.spawned_at = chrono::Utc::now().to_rfc3339();
+                finalized = Some(w.clone());
+            }
+            Ok(())
+        }),
+        "ephemeral_finalize"
+    );
+    finalized.ok_or(())
+}
+
+/// Remove a reserved slot (spawn or finalize failed) so a failed admission frees
+/// the cap and leaves no orphan row.
+fn release_reservation(home: &Path, worker_id: &str) {
+    persist_or_log!(
+        crate::store::mutate_versioned(&store_path(home), |s: &mut EphemeralStore| {
+            s.workers.retain(|w| w.worker_id != worker_id);
+            Ok(())
+        }),
+        "ephemeral_release_reservation"
+    );
+}
+
+/// Spawn a real headless worker under the hard max-live cap, via the supplied
+/// [`HeadlessTransport`]. Admission is BEFORE the spawn (r4 PR1 note):
+/// **reserve → spawn → finalize**. An over-cap spawn rejects WITHOUT creating any
+/// process; a spawn/finalize failure releases the reservation (no leaked slot, no
+/// leaked process). Returns the live [`EphemeralWorker`].
+pub fn spawn_and_track(
+    home: &Path,
+    spec: SpawnSpec,
+    transport: &dyn HeadlessTransport,
+) -> Result<EphemeralWorker, SpawnError> {
     let ttl_secs = resolve_ttl(spec.ttl_secs);
-    let child = spawn_fake_child(ttl_secs).map_err(SpawnError::Spawn)?;
-    let pid = child.id();
     let seq = WORKER_SEQ.fetch_add(1, Ordering::Relaxed);
-    let worker = EphemeralWorker {
-        worker_id: format!("eph-{}-{}", std::process::id(), seq),
-        workflow_id: spec.workflow_id,
-        parent: spec.parent,
-        backend: spec.backend,
-        pid,
-        process_start_token: crate::process::process_start_token(pid),
+    let worker_id = format!("eph-{}-{}", std::process::id(), seq);
+
+    // 1) ADMISSION BEFORE SPAWN — reserve the cap slot atomically. Over cap →
+    //    reject here, before any OS process exists (r4 PR1 NON-BLOCKING note).
+    let reserving = EphemeralWorker {
+        worker_id: worker_id.clone(),
+        workflow_id: spec.workflow_id.clone(),
+        parent: spec.parent.clone(),
+        backend: spec.backend.clone(),
+        pid: 0,
+        process_start_token: None,
         spawned_at: chrono::Utc::now().to_rfc3339(),
         ttl_secs,
         token_budget: spec.token_budget,
-        phase: "spawned".to_string(),
-        status: "running".to_string(),
+        phase: STATUS_RESERVING.to_string(),
+        status: STATUS_RESERVING.to_string(),
     };
+    if let Err(live) = try_reserve_slot(home, reserving) {
+        return Err(SpawnError::CapExceeded {
+            live,
+            cap: MAX_LIVE_WORKERS,
+        });
+    }
 
-    match try_track_within_cap(home, worker.clone()) {
-        Ok(()) => {
-            LIVE_CHILDREN.lock().insert(worker.worker_id.clone(), child);
+    // 2) SPAWN the real headless process — only now that a slot is reserved.
+    let cmd = crate::headless::resolve_headless_command(
+        &spec.backend,
+        &[],              // PR2: no extra caller args
+        SpawnMode::Fresh, // ephemeral workers are always fresh
+        None,             // PR2: cwd validation/provisioning deferred to PR3 (see headless.rs)
+        &worker_id,
+        Some(home),
+    );
+    let handle = match transport.spawn(&cmd) {
+        Ok(h) => h,
+        Err(e) => {
+            release_reservation(home, &worker_id);
+            return Err(SpawnError::Spawn(e));
+        }
+    };
+    let pid = handle.pid();
+    let token = crate::process::process_start_token(pid);
+
+    // 3) FINALIZE — stamp the real pid/token + flip reserving → running.
+    match finalize_spawn(home, &worker_id, pid, token) {
+        Ok(worker) => {
+            LIVE_CHILDREN.lock().insert(worker_id, handle);
             Ok(worker)
         }
-        Err(live) => {
-            // Admission rejected after the spawn — terminate the orphan so the cap
-            // is honoured with zero leaked process.
-            let mut c = child;
+        Err(()) => {
+            // Reserving row vanished (concurrently reaped as stale) — kill the
+            // orphan so no process leaks; the slot is already gone.
+            let mut h = handle;
             crate::process::terminate(pid);
-            let _ = c.wait();
-            Err(SpawnError::CapExceeded {
-                live,
-                cap: MAX_LIVE_WORKERS,
-            })
+            let _ = h.child.wait();
+            Err(SpawnError::Spawn(std::io::Error::other(
+                "ephemeral finalize: reserving slot vanished before finalize",
+            )))
         }
     }
 }
 
-/// PR1 fake child: a real `/bin/sleep` outliving its own TTL (so the reap-by-TTL
-/// path — not the child's natural exit — does the terminating). Detached stdio.
-fn spawn_fake_child(ttl_secs: u64) -> std::io::Result<Child> {
-    use std::process::{Command, Stdio};
-    Command::new(FAKE_CHILD_CMD)
-        .arg(ttl_secs.saturating_add(60).to_string())
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
+/// Seconds since `w.spawned_at` at `now` (the row's age). A corrupt/unparseable
+/// timestamp returns `i64::MAX` so the row is treated as overdue (never kept
+/// forever).
+fn age_secs(w: &EphemeralWorker, now: chrono::DateTime<chrono::Utc>) -> i64 {
+    match chrono::DateTime::parse_from_rfc3339(&w.spawned_at) {
+        Ok(t) => (now - t.with_timezone(&chrono::Utc)).num_seconds(),
+        Err(_) => i64::MAX,
+    }
 }
 
-/// Pure reap decision: is `w` due to be reaped at `now`? — terminal status, or its
-/// max-wall-TTL has elapsed. (Pid-liveness is handled separately by the sweep.)
+/// Pure reap decision for a RUNNING worker: terminal status, or its max-wall-TTL
+/// has elapsed (the cost guard). Reserving rows are NOT judged here (see
+/// [`is_stale_reserving`]); pid-liveness is handled separately by the sweep.
 fn is_due(w: &EphemeralWorker, now: chrono::DateTime<chrono::Utc>) -> bool {
-    if w.status == "done" {
-        return true;
-    }
-    match chrono::DateTime::parse_from_rfc3339(&w.spawned_at) {
-        Ok(t) => (now - t.with_timezone(&chrono::Utc)).num_seconds() >= w.ttl_secs as i64,
-        Err(_) => true, // unparseable timestamp → corrupt row, don't keep forever
-    }
+    w.status == STATUS_DONE || age_secs(w, now) >= w.ttl_secs as i64
+}
+
+/// A `STATUS_RESERVING` row is stale iff older than [`RESERVE_STALE_SECS`] — the
+/// daemon crashed between reserve and finalize. A FRESH reserving row (spawn/
+/// finalize in flight, pid still 0) must NOT be reaped, so the sweep gates
+/// reserving rows on this (NOT on pid-liveness, which would see pid=0 as dead).
+fn is_stale_reserving(w: &EphemeralWorker, now: chrono::DateTime<chrono::Utc>) -> bool {
+    w.status == STATUS_RESERVING && age_secs(w, now) >= RESERVE_STALE_SECS
 }
 
 /// Periodic reap sweep (run from the per-tick handler). Removes every worker that
@@ -253,7 +340,16 @@ fn reap_sweep_at(home: &Path, now: chrono::DateTime<chrono::Utc>) -> Vec<Ephemer
         crate::store::mutate_versioned(&store_path(home), |s: &mut EphemeralStore| {
             let mut keep = Vec::with_capacity(s.workers.len());
             for w in std::mem::take(&mut s.workers) {
-                if is_due(&w, now) || !crate::process::is_pid_alive(w.pid) {
+                // Reserving rows (pid=0, spawn in flight) are judged ONLY by the
+                // stale timeout — NOT by pid-liveness (pid=0 reads as dead and
+                // would race an in-flight finalize). Running rows: terminal /
+                // TTL-expired / process gone.
+                let drop = if w.status == STATUS_RESERVING {
+                    is_stale_reserving(&w, now)
+                } else {
+                    is_due(&w, now) || !crate::process::is_pid_alive(w.pid)
+                };
+                if drop {
                     reaped.push(w);
                 } else {
                     keep.push(w);
@@ -339,15 +435,21 @@ pub fn reap_on_boot(home: &Path) -> usize {
 
 /// Terminate a reaped worker's process and reap its zombie.
 ///
-/// If we still hold the live `Child` handle (spawned this daemon life): SIGTERM
-/// then `wait()` to collect the exit (no zombie). Otherwise (e.g. a restart
-/// orphan): a start-token-guarded SIGTERM only — a recycled pid is never killed,
-/// and init reaps the orphan's zombie. PR1 sends a single SIGTERM; the
-/// process-GROUP kill + protocol graceful-cancel-before-kill are PR2/PR3.
+/// If we still hold the live [`HeadlessHandle`] (spawned this daemon life):
+/// SIGTERM then `wait()` to collect the exit (no zombie). Otherwise (e.g. a
+/// restart orphan): a start-token-guarded SIGTERM only — a recycled pid is never
+/// killed, and init reaps the orphan's zombie.
+///
+/// ⚠ group-kill DEFERRED (PR3): this sends a single-process SIGTERM, matching the
+/// transport's [`HeadlessTransport::cancel`]. PR2's worker is a single stub
+/// process; when PR3 runs a real backend that may fork children, switch to
+/// process-group spawn + `kill_process_tree`, and add the protocol graceful-cancel
+/// BEFORE the hard SIGTERM.
 fn terminate_worker(w: &EphemeralWorker) {
-    if let Some(mut child) = LIVE_CHILDREN.lock().remove(&w.worker_id) {
-        crate::process::terminate(w.pid);
-        let _ = child.wait();
+    if let Some(mut handle) = LIVE_CHILDREN.lock().remove(&w.worker_id) {
+        // Same lifecycle stop as the transport (SIGTERM + reap) — go through it so
+        // there is one cancel path (PR3 wraps it with a protocol graceful-cancel).
+        crate::headless::StdioTransport.cancel(&mut handle);
         return;
     }
     if w.pid == 0 || !crate::process::is_pid_alive(w.pid) {
@@ -382,16 +484,88 @@ mod tests {
         dir
     }
 
-    // Only the #[cfg(unix)] real-fake-child tests build a SpawnSpec; gate the
-    // helper so Windows clippy (-D warnings) doesn't flag it as dead code.
-    #[cfg(unix)]
-    fn spec(workflow_id: &str, ttl_secs: Option<u64>) -> SpawnSpec {
+    fn stub_spec(workflow_id: &str, ttl_secs: Option<u64>) -> SpawnSpec {
         SpawnSpec {
             workflow_id: workflow_id.to_string(),
             parent: None,
-            backend: "opencode".to_string(),
+            backend: "stub".to_string(),
             ttl_secs,
             token_budget: None,
+        }
+    }
+
+    /// A real, CROSS-PLATFORM long-lived process so the spawn→reap lifecycle +
+    /// termination are exercised on EVERY CI platform incl. windows-latest
+    /// (Windows posture must-carry: don't let a `cfg(unix)` gate hide a
+    /// cross-platform prod gap — xwin compile-green ≠ runtime-pass).
+    fn long_lived_cmd() -> (PathBuf, Vec<String>) {
+        #[cfg(unix)]
+        {
+            (PathBuf::from("/bin/sleep"), vec!["30".to_string()])
+        }
+        #[cfg(windows)]
+        {
+            (
+                PathBuf::from("ping"),
+                vec!["-n".to_string(), "31".to_string(), "127.0.0.1".to_string()],
+            )
+        }
+    }
+
+    /// Test transport: spawns a real cross-platform long-lived process (ignoring
+    /// `cmd.program`, so tests need no installed backend) + counts spawn calls
+    /// (to assert admission-before-spawn creates ZERO process when over cap).
+    struct StubTransport {
+        spawned: std::sync::atomic::AtomicUsize,
+    }
+    impl StubTransport {
+        fn new() -> Self {
+            Self {
+                spawned: std::sync::atomic::AtomicUsize::new(0),
+            }
+        }
+        fn spawn_count(&self) -> usize {
+            self.spawned.load(Ordering::Relaxed)
+        }
+    }
+    impl HeadlessTransport for StubTransport {
+        fn spawn(
+            &self,
+            _cmd: &crate::headless::HeadlessCommand,
+        ) -> std::io::Result<HeadlessHandle> {
+            self.spawned.fetch_add(1, Ordering::Relaxed);
+            let (program, args) = long_lived_cmd();
+            let mut c = std::process::Command::new(program);
+            c.args(args)
+                .stdin(std::process::Stdio::piped())
+                .stdout(std::process::Stdio::piped())
+                .stderr(std::process::Stdio::piped());
+            let mut child = c.spawn()?;
+            let stdin = child.stdin.take();
+            let stdout = child.stdout.take();
+            let stderr = child.stderr.take();
+            Ok(HeadlessHandle {
+                child,
+                stdin,
+                stdout,
+                stderr,
+            })
+        }
+        fn cancel(&self, handle: &mut HeadlessHandle) {
+            crate::process::terminate(handle.pid());
+            let _ = handle.child.wait();
+        }
+    }
+
+    fn reserving_row(id: &str, age_secs: i64) -> EphemeralWorker {
+        EphemeralWorker {
+            worker_id: id.to_string(),
+            pid: 0,
+            spawned_at: (chrono::Utc::now() - chrono::Duration::seconds(age_secs)).to_rfc3339(),
+            ttl_secs: 100,
+            status: STATUS_RESERVING.to_string(),
+            phase: STATUS_RESERVING.to_string(),
+            ..Default::default()
         }
     }
 
@@ -473,10 +647,7 @@ mod tests {
                 status: "running".to_string(),
                 ..Default::default()
             };
-            assert!(
-                try_track_within_cap(&home, w).is_ok(),
-                "under cap must accept"
-            );
+            assert!(try_reserve_slot(&home, w).is_ok(), "under cap must accept");
         }
         assert_eq!(list(&home, None).len(), MAX_LIVE_WORKERS);
         let over = EphemeralWorker {
@@ -487,7 +658,7 @@ mod tests {
             status: "running".to_string(),
             ..Default::default()
         };
-        let res = try_track_within_cap(&home, over);
+        let res = try_reserve_slot(&home, over);
         assert_eq!(res, Err(MAX_LIVE_WORKERS), "at cap must reject");
         assert_eq!(
             list(&home, None).len(),
@@ -525,13 +696,17 @@ mod tests {
         std::fs::remove_dir_all(&home).ok();
     }
 
-    /// #[cfg(unix)] full lifecycle against a REAL fake child: spawn → list → reap,
-    /// and the reap genuinely terminates the process (is_pid_alive → false).
-    #[cfg(unix)]
+    /// Full lifecycle against a REAL (cross-platform) headless process:
+    /// reserve→spawn→finalize → list → reap, and the reap genuinely terminates
+    /// the process (is_pid_alive → false). Runs on all CI platforms.
     #[test]
-    fn fake_child_lifecycle_spawn_list_reap() {
+    fn headless_lifecycle_spawn_list_reap() {
         let home = tmp_home("lifecycle");
-        let w = spawn_and_track(&home, spec("wf1", Some(3600))).expect("spawn");
+        let t = StubTransport::new();
+        let w = spawn_and_track(&home, stub_spec("wf1", Some(3600)), &t).expect("spawn");
+        assert_eq!(t.spawn_count(), 1, "exactly one process spawned");
+        assert_eq!(w.status, STATUS_RUNNING, "finalized to running");
+        assert_ne!(w.pid, 0, "real pid stamped at finalize");
         assert_eq!(
             list(&home, Some("wf1")).len(),
             1,
@@ -539,7 +714,7 @@ mod tests {
         );
         assert!(
             crate::process::is_pid_alive(w.pid),
-            "fake child is alive after spawn"
+            "real headless process is alive after spawn"
         );
 
         let reaped = reap_one(&home, &w.worker_id).expect("reap_one returns the worker");
@@ -549,33 +724,102 @@ mod tests {
             0,
             "reaped worker removed from store"
         );
-        // The child was SIGTERM'd + waited → dead.
         assert!(
             !crate::process::is_pid_alive(w.pid),
-            "reap must terminate the fake child"
+            "reap must terminate the real headless process"
         );
         std::fs::remove_dir_all(&home).ok();
     }
 
-    /// #[cfg(unix)] the reap SWEEP enforces max-wall-TTL: a real child spawned with
-    /// a 0s TTL (already expired) is terminated + removed on the next sweep.
-    #[cfg(unix)]
+    /// The reap SWEEP enforces max-wall-TTL: a real process past its TTL is
+    /// terminated + removed (drive `now` past the TTL — deterministic, no waiting).
     #[test]
     fn reap_sweep_enforces_wall_ttl() {
         let home = tmp_home("ttl-sweep");
-        // ttl=0 → resolve_ttl bumps to DEFAULT; instead spawn with a tiny ttl and
-        // drive the sweep with a `now` past it (deterministic, no real waiting).
-        let w = spawn_and_track(&home, spec("wf1", Some(60))).expect("spawn");
+        let t = StubTransport::new();
+        let w = spawn_and_track(&home, stub_spec("wf1", Some(60)), &t).expect("spawn");
         assert!(crate::process::is_pid_alive(w.pid));
-        // Sweep at now+61s → the worker is past its 60s wall-TTL → reaped.
         let future = chrono::Utc::now() + chrono::Duration::seconds(61);
         let reaped = reap_sweep_at(&home, future);
         assert_eq!(reaped.len(), 1, "the TTL-expired worker must be reaped");
         assert_eq!(list(&home, None).len(), 0);
         assert!(
             !crate::process::is_pid_alive(w.pid),
-            "TTL reap must terminate the child"
+            "TTL reap must terminate the real process"
         );
         std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// r4 PR1 NON-BLOCKING note: admission is BEFORE spawn. When the cap is full,
+    /// `spawn_and_track` rejects WITHOUT creating ANY process (the transport's
+    /// spawn is never called) — zero orphan.
+    #[test]
+    fn admission_before_spawn_rejects_over_cap_zero_orphan() {
+        let home = tmp_home("cap-noorphan");
+        // Fill every slot with reservations (no processes).
+        for i in 0..MAX_LIVE_WORKERS {
+            try_reserve_slot(&home, reserving_row(&format!("r{i}"), 0)).unwrap();
+        }
+        let t = StubTransport::new();
+        let res = spawn_and_track(&home, stub_spec("wf", Some(60)), &t);
+        assert!(
+            matches!(res, Err(SpawnError::CapExceeded { .. })),
+            "over-cap spawn must be rejected"
+        );
+        assert_eq!(
+            t.spawn_count(),
+            0,
+            "admission BEFORE spawn: ZERO process created when over cap"
+        );
+        assert_eq!(
+            list(&home, None).len(),
+            MAX_LIVE_WORKERS,
+            "rejected spawn adds nothing"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// reserve↔finalize crash: a STALE reserving row (daemon died before finalize)
+    /// is reaped by the sweep, while a FRESH reserving row (spawn in flight, pid=0)
+    /// is KEPT — the sweep must gate reserving rows on the stale timeout, NOT on
+    /// pid-liveness (pid=0 reads as dead and would race an in-flight finalize).
+    #[test]
+    fn stale_reserving_reaped_fresh_kept() {
+        let home = tmp_home("stale-reserve");
+        try_reserve_slot(&home, reserving_row("fresh", 0)).unwrap();
+        try_reserve_slot(&home, reserving_row("stale", RESERVE_STALE_SECS + 5)).unwrap();
+        let reaped = reap_sweep_at(&home, chrono::Utc::now());
+        assert_eq!(reaped.len(), 1, "only the stale reserving row is reaped");
+        assert_eq!(reaped[0].worker_id, "stale");
+        let kept = list(&home, None);
+        assert_eq!(
+            kept.len(),
+            1,
+            "the fresh reserving row is kept (no pid=0 race)"
+        );
+        assert_eq!(kept[0].worker_id, "fresh");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// `HeadlessTransport::cancel` lifecycle: spawn a real process then cancel it
+    /// → the process is terminated (SIGTERM + reap).
+    #[test]
+    fn headless_transport_cancel_terminates() {
+        let t = StubTransport::new();
+        let cmd = crate::headless::HeadlessCommand {
+            program: PathBuf::from("ignored-by-stub"),
+            args: vec![],
+            env_clear: false,
+            envs: vec![],
+            cwd: None,
+        };
+        let mut handle = t.spawn(&cmd).expect("spawn");
+        let pid = handle.pid();
+        assert!(crate::process::is_pid_alive(pid));
+        t.cancel(&mut handle);
+        assert!(
+            !crate::process::is_pid_alive(pid),
+            "cancel must terminate the process"
+        );
     }
 }

--- a/src/ephemeral_tracking.rs
+++ b/src/ephemeral_tracking.rs
@@ -569,6 +569,21 @@ mod tests {
         }
     }
 
+    /// Poll until `pid` is dead or a short deadline. Termination + OS process-
+    /// object cleanup can lag briefly (notably on Windows: an exited process stays
+    /// queryable until its last handle closes), so a death check must NOT assert
+    /// immediately. The caller must have dropped the `Child` handle first.
+    fn assert_dead_within(pid: u32, label: &str) {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while crate::process::is_pid_alive(pid) {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "{label}: pid {pid} still alive after deadline"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        }
+    }
+
     #[test]
     fn resolve_ttl_defaults_and_clamps() {
         assert_eq!(resolve_ttl(None), DEFAULT_WALL_TTL_SECS);
@@ -724,10 +739,7 @@ mod tests {
             0,
             "reaped worker removed from store"
         );
-        assert!(
-            !crate::process::is_pid_alive(w.pid),
-            "reap must terminate the real headless process"
-        );
+        assert_dead_within(w.pid, "reap must terminate the real headless process");
         std::fs::remove_dir_all(&home).ok();
     }
 
@@ -743,10 +755,7 @@ mod tests {
         let reaped = reap_sweep_at(&home, future);
         assert_eq!(reaped.len(), 1, "the TTL-expired worker must be reaped");
         assert_eq!(list(&home, None).len(), 0);
-        assert!(
-            !crate::process::is_pid_alive(w.pid),
-            "TTL reap must terminate the real process"
-        );
+        assert_dead_within(w.pid, "TTL reap must terminate the real process");
         std::fs::remove_dir_all(&home).ok();
     }
 
@@ -817,9 +826,12 @@ mod tests {
         let pid = handle.pid();
         assert!(crate::process::is_pid_alive(pid));
         t.cancel(&mut handle);
-        assert!(
-            !crate::process::is_pid_alive(pid),
-            "cancel must terminate the process"
-        );
+        // Drop the Child handle before checking liveness: on Windows an exited
+        // process still reports alive while ANY handle to it is open (the OS frees
+        // the process object only on the last CloseHandle). Production's
+        // `terminate_worker` drops the handle the same way (it owns it via
+        // LIVE_CHILDREN.remove), so this mirrors the real reap path.
+        drop(handle);
+        assert_dead_within(pid, "cancel must terminate the process");
     }
 }

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -1,0 +1,199 @@
+//! #1967 Phase-1 PR2: headless (no-PTY) process transport for ephemeral workers.
+//!
+//! PR1 spawned a FAKE `/bin/sleep` child; PR2 swaps that for a REAL headless
+//! process — the resolved backend command run via `std::process` with piped
+//! stdio (NO PTY, NO agent registry). The captured stdio handles ride on
+//! [`HeadlessHandle`] for PR3 (the ACP protocol) to drive; PR2 only does the
+//! process LIFECYCLE (spawn + cancel), never protocol I/O.
+//!
+//! ## ⚠ PR3 PREREQUISITES — deliberately deferred here (lead-vetted Option Y)
+//! [`resolve_headless_command`] reuses the SAME single-source helpers as the PTY
+//! path (`which` / [`Backend::preset_spawn_args`] / [`Backend::spawn_flags`] /
+//! [`crate::agent::resolve_child_env`]) so argv + the #1440 env-isolation can't
+//! drift. But the PTY spawn (`agent::build_command`) ALSO does several
+//! PTY/real-backend-specific steps that PR2's *stub* worker (no protocol → no
+//! real backend doing work) does NOT need — and which are NOT done here. Before
+//! PR3 lets a real backend run headless, these MUST be added (each is a
+//! correctness or SECURITY prerequisite — do not ship PR3 without them):
+//!
+//! 1. **git-shim PATH shadowing + `AGEND_REAL_GIT` (#1504)** — without prepending
+//!    `$AGEND_HOME/bin` to PATH, a headless backend's `git` calls bypass the
+//!    `agend-git` shim → ESCAPE the git safety gate (push-denylist, worktree
+//!    guards). SECURITY-critical.
+//! 2. **cwd validation + provisioning** (`api::validate_working_directory` +
+//!    `create_dir_all` + symlink revalidation) — PR2 sets no cwd (stub inherits
+//!    the daemon cwd); a real backend needs a validated, provisioned workdir.
+//! 3. **opencode per-instance XDG isolation (#1519) + autoupdate disable
+//!    (#1956/#1970)** — session-isolation correctness + self-update-modal hang.
+//! 4. **fleet.yaml user-env passthrough with #2106 credential filtering** —
+//!    operator per-instance creds/env.
+//! 5. terminal env (`TERM`/`COLORTERM`/`FORCE_COLOR`) + git-editor env
+//!    (`GIT_EDITOR`/`GIT_SEQUENCE_EDITOR`/`EDITOR`/`VISUAL`) + `LANG` — only matter
+//!    once a real backend runs (the git-editor pair pairs with #1).
+//!
+//! See also docs/design/1967-ephemeral-phase1.md (the same deferral list).
+
+use crate::backend::{Backend, SpawnMode};
+use std::path::{Path, PathBuf};
+use std::process::{Child, ChildStderr, ChildStdin, ChildStdout, Command, Stdio};
+
+/// A resolved headless command. Built ONLY from the same single-source helpers
+/// the PTY path uses, so headless argv/env cannot drift from `build_command`.
+#[derive(Debug, Clone)]
+pub struct HeadlessCommand {
+    pub program: PathBuf,
+    pub args: Vec<String>,
+    /// Mirror the #1440 isolation: clear inherited env before injecting.
+    pub env_clear: bool,
+    pub envs: Vec<(String, String)>,
+    pub cwd: Option<PathBuf>,
+}
+
+/// A spawned headless child + its captured stdio pipes. PR2 holds the pipes
+/// unused; PR3 (ACP) drives stdin/stdout for the protocol — they are captured
+/// NOW so the spawn wiring (piped stdio) is complete and PR3 only adds the
+/// protocol driver.
+#[derive(Debug)]
+pub struct HeadlessHandle {
+    pub child: Child,
+    /// PR3 (ACP) writes protocol requests here. Captured but unused in PR2.
+    #[allow(dead_code)]
+    pub stdin: Option<ChildStdin>,
+    /// PR3 (ACP) reads protocol responses here. Captured but unused in PR2.
+    #[allow(dead_code)]
+    pub stdout: Option<ChildStdout>,
+    /// PR3 reads diagnostics here. Captured but unused in PR2.
+    #[allow(dead_code)]
+    pub stderr: Option<ChildStderr>,
+}
+
+impl HeadlessHandle {
+    pub fn pid(&self) -> u32 {
+        self.child.id()
+    }
+}
+
+/// Process LIFECYCLE for a headless worker (spawn + cancel). The ACP protocol
+/// methods (handshake / prompt / stream) are intentionally NOT on this trait
+/// yet — they land in PR3 once the wire shape is verified against a real backend.
+pub trait HeadlessTransport {
+    /// Spawn `cmd` as a headless child with piped stdio.
+    fn spawn(&self, cmd: &HeadlessCommand) -> std::io::Result<HeadlessHandle>;
+
+    /// Cancel a running worker: single-process SIGTERM + reap. PR3 adds a
+    /// protocol-level graceful cancel BEFORE this hard stop.
+    ///
+    /// ⚠ group-kill DEFERRED: this terminates only the worker process, not a
+    /// process GROUP. PR2's worker is a single stub process with no children, so
+    /// a single SIGTERM fully reaps it. When PR3 runs a real backend that may
+    /// fork subprocesses, switch to `process_group(0)` at spawn +
+    /// [`crate::process::kill_process_tree`] (group kill) here.
+    fn cancel(&self, handle: &mut HeadlessHandle);
+}
+
+/// The PR2 transport: a real OS process via `std::process` with piped stdio.
+pub struct StdioTransport;
+
+impl HeadlessTransport for StdioTransport {
+    fn spawn(&self, cmd: &HeadlessCommand) -> std::io::Result<HeadlessHandle> {
+        let mut c = Command::new(&cmd.program);
+        c.args(&cmd.args);
+        if cmd.env_clear {
+            c.env_clear();
+        }
+        for (k, v) in &cmd.envs {
+            c.env(k, v);
+        }
+        if let Some(dir) = &cmd.cwd {
+            c.current_dir(dir);
+        }
+        // Piped stdio: NO PTY. PR3 (ACP) drives these pipes for the protocol.
+        c.stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        let mut child = c.spawn()?;
+        let stdin = child.stdin.take();
+        let stdout = child.stdout.take();
+        let stderr = child.stderr.take();
+        Ok(HeadlessHandle {
+            child,
+            stdin,
+            stdout,
+            stderr,
+        })
+    }
+
+    fn cancel(&self, handle: &mut HeadlessHandle) {
+        crate::process::terminate(handle.pid());
+        let _ = handle.child.wait();
+    }
+}
+
+/// Resolve the headless command for `backend_command`, reusing the SAME
+/// single-source helpers as the PTY path (`which` / `preset_spawn_args` /
+/// `spawn_flags` / [`crate::agent::resolve_child_env`]) — so argv and the #1440
+/// env-isolation cannot drift between the PTY and headless paths.
+///
+/// PR2 applies the CORE only: resolved program, enriched argv, #1440 env
+/// isolation (must-carry: the security invariant), and the re-injected identity
+/// env (`AGEND_INSTANCE_NAME` / `AGEND_HOME` — both isolation-dropped, mirroring
+/// `build_command`). All other `build_command` setup is a PR3 prerequisite — see
+/// the module doc.
+pub fn resolve_headless_command(
+    backend_command: &str,
+    args: &[String],
+    mode: SpawnMode,
+    cwd: Option<&Path>,
+    name: &str,
+    home: Option<&Path>,
+) -> HeadlessCommand {
+    let backend = Backend::from_command(backend_command);
+
+    // argv = preset (per mode) + caller args + backend spawn_flags — the SAME
+    // helpers `build_command` uses (single source, no re-impl).
+    let mut argv: Vec<String> = backend
+        .as_ref()
+        .map(|b| b.preset_spawn_args(mode))
+        .unwrap_or_default();
+    argv.extend(args.iter().cloned());
+    if let (Some(b), Some(wd)) = (backend.as_ref(), cwd) {
+        argv.extend(b.spawn_flags(wd));
+    }
+
+    let program = which::which(backend_command).unwrap_or_else(|_| PathBuf::from(backend_command));
+
+    // #1440 env isolation — MUST apply to the headless child (must-carry #1: the
+    // child-env-isolation security invariant). Same helper + same gating as
+    // `build_command`: when isolation is on, clear + inject only the allowed env.
+    let passthrough = home
+        .and_then(|h| crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(h)).ok())
+        .map(|f| f.resolve_passthrough_env(name))
+        .unwrap_or_default();
+    let source_env: std::collections::BTreeMap<String, String> = std::env::vars().collect();
+    let plan = crate::agent::resolve_child_env(backend.as_ref(), &passthrough, &source_env);
+
+    let (env_clear, mut envs) = if crate::agent::env_isolation_enabled() {
+        (true, plan.injected)
+    } else {
+        // Isolation off (default) — inherit env, exactly like `build_command`'s
+        // non-isolated branch. (The one-time operator "dropped keys" hint is the
+        // PTY path's; not re-emitted here to avoid touching `agent` internals.)
+        (false, Vec::new())
+    };
+
+    // Identity env — re-injected AFTER the clear because both are isolation-
+    // SENSITIVE (dropped by `env_clear`), mirroring `build_command`. The worker
+    // needs these to identify itself + resolve the daemon home.
+    envs.push(("AGEND_INSTANCE_NAME".to_string(), name.to_string()));
+    if let Some(h) = home {
+        envs.push(("AGEND_HOME".to_string(), h.display().to_string()));
+    }
+
+    HeadlessCommand {
+        program,
+        args: argv,
+        env_clear,
+        envs,
+        cwd: cwd.map(Path::to_path_buf),
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,7 @@ mod fleet;
 mod framing;
 mod git_helpers;
 mod github_token;
+mod headless;
 mod health;
 mod identity;
 mod inbox;

--- a/src/mcp/handlers/ephemeral.rs
+++ b/src/mcp/handlers/ephemeral.rs
@@ -1,14 +1,44 @@
-//! #1967 Phase-1 (PR1 scaffold): MCP `ephemeral` tool handlers (spawn/list/reap).
+//! #1967 Phase-1: MCP `ephemeral` tool handlers (spawn/list/reap).
 //!
-//! Thin wrappers over [`crate::ephemeral_tracking`]. PR1 `spawn` launches a FAKE
-//! `/bin/sleep` child to exercise the lifecycle + cost guards; real headless
-//! backend transport is PR2/PR3. Per-action parameter validation lives here (the
-//! shared schema validator only enforces the top-level `action`, mirroring `ci`).
+//! Thin wrappers over [`crate::ephemeral_tracking`]. Per-action parameter
+//! validation lives here (the shared schema validator only enforces the top-level
+//! `action`, mirroring `ci`).
 
 use serde_json::{json, Value};
 use std::path::Path;
+use std::sync::OnceLock;
+
+/// PR2 SAFETY GATE (r4 MEDIUM): the production `ephemeral spawn` path must NOT
+/// launch a real headless backend until PR3 lands the deferred safety
+/// prerequisites — git-shim PATH shadowing + `AGEND_REAL_GIT` (#1504), #1440
+/// env-isolation, cwd validation/provisioning, fleet-env #2106 filtering. Without
+/// them a real backend would ESCAPE the git-shim gate and inherit the daemon's
+/// full env at startup, and "no protocol → no work" does NOT stop a backend's
+/// STARTUP behavior (git/env reads, opencode autoupdate). An injected agent could
+/// call `ephemeral spawn` to exploit that, so the gate is enforced in CODE here,
+/// not merely documented.
+///
+/// Default OFF → real-backend spawn is rejected (safe against the injected-agent
+/// threat; the agent cannot set the daemon's env). An operator may set
+/// `AGEND_EPHEMERAL_REAL_BACKEND=1` to opt in for dev/testing, EXPLICITLY
+/// accepting that the PR3 safety prerequisites are not yet applied — do NOT enable
+/// in production until PR3. The spawn MECHANISM (reserve→spawn→finalize, reap) is
+/// fully exercised regardless via the stub transport in `ephemeral_tracking`
+/// unit tests; this gate only fences the MCP entry point.
+fn real_backend_spawn_enabled() -> bool {
+    static ON: OnceLock<bool> = OnceLock::new();
+    *ON.get_or_init(|| std::env::var("AGEND_EPHEMERAL_REAL_BACKEND").as_deref() == Ok("1"))
+}
 
 pub(super) fn handle_spawn(home: &Path, args: &Value, _instance_name: &str) -> Value {
+    if !real_backend_spawn_enabled() {
+        return json!({"error": "ephemeral spawn: disabled in PR2 (mechanism-only). Launching a real \
+            headless backend requires PR3 safety prerequisites not yet landed — git-shim PATH + \
+            AGEND_REAL_GIT (#1504), #1440 env-isolation, cwd validation, fleet-env #2106 filtering. \
+            Until then a real backend would escape the git-shim gate / inherit the daemon env. See \
+            docs/design/1967-ephemeral-phase1.md. (Operators may set AGEND_EPHEMERAL_REAL_BACKEND=1 \
+            to opt in for dev/testing, accepting the missing safety.)"});
+    }
     let workflow_id = match args["workflow_id"].as_str().filter(|s| !s.is_empty()) {
         Some(s) => s.to_string(),
         None => {
@@ -78,4 +108,32 @@ pub(super) fn handle_reap(home: &Path, args: &Value) -> Value {
         return json!({"ok": true, "reaped": ids, "count": count});
     }
     json!({"error": "ephemeral reap: specify worker_id, workflow_id, or all_stale=true"})
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// r4 MEDIUM safety gate: with the opt-in flag OFF (the default), the
+    /// production MCP `ephemeral spawn` must REJECT a real-backend request — it
+    /// must never reach `which::which` / spawn a real backend that would escape
+    /// the git-shim gate before PR3's safety prerequisites land. (The spawn
+    /// mechanism itself is exercised separately via the stub transport in
+    /// `ephemeral_tracking` unit tests, which bypass this MCP entry gate.)
+    #[test]
+    fn handle_spawn_gated_rejects_real_backend_by_default() {
+        let home = std::env::temp_dir();
+        let args = json!({"action": "spawn", "workflow_id": "wf1", "backend": "claude"});
+        let res = handle_spawn(&home, &args, "tester");
+        let err = res["error"].as_str().unwrap_or("");
+        assert!(
+            err.contains("mechanism-only") && err.contains("PR3"),
+            "real-backend ephemeral spawn must be gated off by default: {res}"
+        );
+        assert_ne!(
+            res["ok"].as_bool(),
+            Some(true),
+            "gated spawn must not report ok"
+        );
+    }
 }

--- a/src/mcp/handlers/ephemeral.rs
+++ b/src/mcp/handlers/ephemeral.rs
@@ -29,7 +29,7 @@ pub(super) fn handle_spawn(home: &Path, args: &Value, _instance_name: &str) -> V
         ttl_secs: args["ttl_secs"].as_u64(),
         token_budget: args["token_budget"].as_u64(),
     };
-    match crate::ephemeral_tracking::spawn_and_track(home, spec) {
+    match crate::ephemeral_tracking::spawn_and_track(home, spec, &crate::headless::StdioTransport) {
         Ok(w) => json!({
             "ok": true,
             "worker_id": w.worker_id,
@@ -37,7 +37,7 @@ pub(super) fn handle_spawn(home: &Path, args: &Value, _instance_name: &str) -> V
             "workflow_id": w.workflow_id,
             "backend": w.backend,
             "ttl_secs": w.ttl_secs,
-            "note": "PR1 scaffold: fake /bin/sleep child — no real backend transport yet",
+            "note": "PR2: real headless process (no-PTY, piped stdio); no protocol driving it yet (PR3 ACP)",
         }),
         Err(e) => json!({"error": e.to_string()}),
     }


### PR DESCRIPTION
## #1967 Phase-1 — PR2: real headless spawn + admission-before-spawn

Replaces PR1's fake `/bin/sleep` child with a REAL headless process (no PTY, no agent registry), via a new `HeadlessTransport`. **Lead-vetted Option Y.** Design doc updated (`docs/design/1967-ephemeral-phase1.md`).

### What lands
- **`src/headless.rs`** — `HeadlessTransport` (lifecycle: `spawn` + `cancel`) + `StdioTransport` (`std::process`, piped stdio) + `HeadlessHandle` (captures stdin/stdout/stderr for PR3) + `resolve_headless_command`. The resolver reuses the **SAME single-source helpers** as the PTY path (`which` / `preset_spawn_args` / `spawn_flags` / `agent::resolve_child_env`) so argv + the #1440 env-isolation can't drift — **`build_command` is UNTOUCHED** (zero managed-PTY-hot-path regression).
- **Admission BEFORE spawn** (r4 PR1 note): `reserve → spawn → finalize`. `try_reserve_slot` is a single atomic RMW under the store flock (no TOCTOU); an over-cap spawn rejects **without creating any process**. A stale `reserving` row (crash between reserve and finalize, age > `RESERVE_STALE_SECS`=60s) is reaped — the sweep gates reserving rows on the stale timeout, **not** pid-liveness (pid=0 reads as dead → would race an in-flight finalize).
- **Reap reuses PR1** (start-token PID-recycle guard, `terminate_worker`), now routed through `HeadlessTransport::cancel` (one cancel path). Single-process SIGTERM; group `kill_process_tree` + protocol graceful-cancel are PR3 (documented in code).

### ⚠ PR3 prerequisites (loudly documented — `src/headless.rs` + design doc, NOT buried)
git-shim PATH + `AGEND_REAL_GIT` (#1504 — a buried omission = git-shim **security-gate ESCAPE** when PR3 runs a real backend's `git`), cwd validation/provisioning, opencode XDG (#1519), fleet user-env #2106 filtering, terminal/git-editor env. PR2's stub worker (no protocol → no real backend doing work) does not need them.

### Windows posture
`std::process` + `process::terminate` are cross-platform; the real-process lifecycle tests run on **ALL** CI platforms (`/bin/sleep` on unix, `ping -n` on Windows) so spawn+reap is **runtime-exercised on windows-latest**, not just compile-verified (the xwin lesson). Verified locally: `cargo xwin clippy --target x86_64-pc-windows-msvc --all-targets --features tray -- -D warnings` → EXIT 0.

### Tests
headless lifecycle (real cross-platform spawn→list→reap **terminates the process**), reap-sweep TTL enforcement, **admission-before-spawn cap reject = ZERO orphan** (`transport.spawn` never called), stale-reserving reaped / fresh kept, transport `cancel` terminates — plus PR1's resolve_ttl/is_due/atomic-RMW/cap/reap-on-boot.

### Verification
`cargo fmt --check` ✓ · `cargo clippy --all-targets --features tray -- -D warnings` EXIT 0 ✓ · Windows cross-clippy EXIT 0 ✓ · 14 ephemeral + tool-invariant tests green.

### Honest scope
PR2 is the spawn **mechanism** only — a spawned worker has no protocol driving it (does no useful work until PR3 ACP drives the captured stdio). Not in scope: ACP/JSON-RPC, telemetry layers (PR4/5), token-budget enforcement (PR6), group-kill/graceful-cancel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
