### PR TITLE
fix(forwarder): reap output forwarder on pane close even for a quiet agent

### DIFF
--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -728,6 +728,7 @@ mod tests {
             selection: None,
             source: PaneSource::Local,
             offthread: None,
+            _fwd_cancel: None,
         }
     }
 

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -400,6 +400,7 @@ mod tests {
             selection: None,
             source: PaneSource::Local,
             offthread: None,
+            _fwd_cancel: None,
         }
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2218,6 +2218,7 @@ mod tests {
             selection: None,
             source: PaneSource::Local,
             offthread: None,
+            _fwd_cancel: None,
         }
     }
 

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -592,6 +592,7 @@ mod tests {
             selection: None,
             source: PaneSource::Local,
             offthread: None,
+            _fwd_cancel: None,
         }
     }
 

--- a/src/app/pane_factory.rs
+++ b/src/app/pane_factory.rs
@@ -200,6 +200,8 @@ fn build_pane_placeholder(
         selection: None,
         source: crate::layout::PaneSource::Local,
         offthread: None,
+        // No forwarder yet (started in `apply_attachment`); cancel is wired there.
+        _fwd_cancel: None,
     };
     (pane, fwd_tx)
 }
@@ -410,18 +412,30 @@ fn apply_attachment(
     // Forward subscriber output to wakeup channel via the placeholder's fwd_tx
     let name = pane.agent_name.to_string();
     let tx = wakeup_tx.clone();
-    // fire-and-forget: forwarder exits when fwd_tx.send() fails (pane
-    // dropped → fwd_rx dropped → send returns Err) or rx.recv() fails
-    // (agent removed → broadcast sender dropped). H1: lifecycle is
-    // correct — pane drop triggers forwarder exit via channel close.
+    // #forwarder-reap: pair the pane with a cancel receiver the forwarder watches
+    // so a pane close reaps it promptly even when the agent is QUIET. `_fwd_cancel`
+    // lives on the pane; dropping the pane drops it → `fwd_cancel_rx` disconnects →
+    // the `select!` wakes out of a blocking `rx.recv()`.
+    let (fwd_cancel_tx, fwd_cancel_rx) = crossbeam_channel::unbounded::<()>();
+    pane._fwd_cancel = Some(fwd_cancel_tx);
+    // fire-and-forget: forwarder exits when (a) fwd_tx.send() fails (pane dropped
+    // → fwd_rx dropped → send Err), (b) rx.recv() fails (agent removed → broadcast
+    // sender dropped), or (c) fwd_cancel_rx disconnects (pane dropped while the
+    // agent is quiet). H1: pane drop triggers forwarder exit on all three paths.
     std::thread::Builder::new()
         .name(format!("{name}_fwd"))
-        .spawn(move || {
-            while let Ok(data) = rx.recv() {
-                if fwd_tx.send(data).is_err() {
-                    break; // H1: pane closed, fwd_rx dropped
-                }
-                let _ = tx.send(pane_id);
+        .spawn(move || loop {
+            crossbeam_channel::select! {
+                recv(rx) -> msg => match msg {
+                    Ok(data) => {
+                        if fwd_tx.send(data).is_err() {
+                            break; // H1: pane closed, fwd_rx dropped
+                        }
+                        let _ = tx.send(pane_id);
+                    }
+                    Err(_) => break, // agent removed, broadcast sender dropped
+                },
+                recv(fwd_cancel_rx) -> _ => break, // #forwarder-reap: pane closed
             }
         })
         .ok();
@@ -932,18 +946,30 @@ pub(super) fn attach_pane(
 
     let pane_id = layout.next_pane_id();
     let tx = wakeup_tx.clone();
+    // #forwarder-reap: cancel pair so a pane close reaps the forwarder even when
+    // the agent is quiet (mirrors apply_attachment). `_fwd_cancel` goes on the
+    // returned Pane; dropping it disconnects `fwd_cancel_rx` → the `select!` exits.
+    let (fwd_cancel_tx, fwd_cancel_rx) = crossbeam_channel::unbounded::<()>();
     let pane_rx = {
         let n = name.to_string();
         let (fwd_tx, fwd_rx) = crossbeam_channel::unbounded::<Vec<u8>>();
-        // fire-and-forget: same lifecycle as create_pane forwarder (H1).
+        // fire-and-forget: same lifecycle as create_pane forwarder — exits on
+        // fwd_tx.send fail (pane dropped), rx.recv fail (agent gone), or
+        // fwd_cancel_rx disconnect (pane dropped while agent quiet) (H1).
         std::thread::Builder::new()
             .name(format!("{n}_fwd"))
-            .spawn(move || {
-                while let Ok(data) = rx.recv() {
-                    if fwd_tx.send(data).is_err() {
-                        break; // H1: pane closed, fwd_rx dropped
-                    }
-                    let _ = tx.send(pane_id);
+            .spawn(move || loop {
+                crossbeam_channel::select! {
+                    recv(rx) -> msg => match msg {
+                        Ok(data) => {
+                            if fwd_tx.send(data).is_err() {
+                                break; // H1: pane closed, fwd_rx dropped
+                            }
+                            let _ = tx.send(pane_id);
+                        }
+                        Err(_) => break, // agent removed, broadcast sender dropped
+                    },
+                    recv(fwd_cancel_rx) -> _ => break, // #forwarder-reap: pane closed
                 }
             })
             .ok();
@@ -969,6 +995,7 @@ pub(super) fn attach_pane(
         selection: None,
         source: crate::layout::PaneSource::Local,
         offthread: None,
+        _fwd_cancel: Some(fwd_cancel_tx),
     })
 }
 
@@ -1146,6 +1173,15 @@ pub(super) fn create_remote_pane(
         selection: None,
         source: crate::layout::PaneSource::Remote(Arc::new(Mutex::new(client))),
         offthread: None,
+        // Remote panes forward from a dup'd socket reader, not a crossbeam agent
+        // `rx`, so candidate-B's cancel channel does not apply here. NOTE: this
+        // does NOT mean remote is reaped — the remote forwarder
+        // (`{name}_remote_fwd`) blocks in `read_tagged_frame` and still has the
+        // SAME pre-existing quiet-close linger: a pane close drops only the writer
+        // fd while the dup'd reader holds the TCP open (no FIN). Reaping it needs
+        // `shutdown(Shutdown::Read)`, which crossbeam cancel cannot do. Tracked in
+        // follow-up t-20260622073457027138-41860-19.
+        _fwd_cancel: None,
     })
 }
 
@@ -1337,15 +1373,15 @@ mod tests {
         std::fs::remove_dir_all(&home).ok();
     }
 
-    /// #2404 r6 ② (decision C) — production-shaped: with an ACTIVE agent (the freeze
-    /// scenario), closing the pane reaps the forwarder. Built via the real
-    /// `build_deferred_direct_pane` + `apply_attach_outcome` path (not a synthetic
-    /// clone): the forwarder targets the pane's OWN output channel (`job.fwd_tx` →
-    /// `pane.rx`), so dropping the pane drops the last receiver and the agent's next
-    /// byte makes the forwarder's `fwd_tx.send` fail → it exits. (The off-thread
-    /// parser's deterministic reap is covered in `render::offthread`; the
-    /// quiet-agent forwarder linger is a PRE-EXISTING managed behavior, not
-    /// off-thread-introduced — follow-up t-20260622053855100612-41860-5.)
+    /// Production-shaped: closing a pane reaps its output forwarder for an ACTIVE
+    /// agent (the freeze scenario). Built via the real `build_deferred_direct_pane`
+    /// and `apply_attach_outcome` path (not a synthetic clone): the forwarder
+    /// targets the pane's OWN output channel (`job.fwd_tx` to `pane.rx`). The agent
+    /// emits a byte the forwarder processes, then the pane is closed while the agent
+    /// stays ALIVE; the #forwarder-reap cancel channel (dropped with the pane) makes
+    /// the forwarder's `select!` exit in bounded time. Companion test
+    /// `quiet_agent_pane_close_reaps_forwarder` covers the quiet case that lingered
+    /// pre-fix. See #2404 r6 (decision C); quiet-linger fix t-…41860-5.
     #[test]
     fn active_agent_pane_close_reaps_forwarder_freeze_scenario() {
         let home = tmp_home("rf_fwd_reap");
@@ -1386,15 +1422,16 @@ mod tests {
             job.fwd_tx,
             &wakeup_tx,
         );
+        // Active agent: emit a byte the forwarder processes while the pane is open.
+        sub_tx.send(b"x".to_vec()).expect("agent alive");
         // Drop the test's wakeup_tx so only the forwarder's clone keeps wakeup_rx
         // connected — its disconnect then observes the forwarder's exit.
         drop(wakeup_tx);
-        // Close the pane while the agent is alive: drops pane.rx (the forwarder
-        // channel's last receiver).
+        // Close the pane while the agent stays ALIVE: drops pane.rx AND
+        // pane._fwd_cancel → the forwarder's select! observes the cancel-channel
+        // disconnect and exits in bounded time (#forwarder-reap), even though the
+        // agent never dies (sub_tx held to the end).
         drop(pane);
-        // The active agent emits one more byte → the forwarder's fwd_tx.send fails
-        // (no receivers) → it exits, dropping its wakeup_tx clone.
-        sub_tx.send(b"x".to_vec()).expect("agent still alive");
         let mut reaped = false;
         for _ in 0..50 {
             if matches!(
@@ -1409,6 +1446,81 @@ mod tests {
             reaped,
             "active-agent pane close must reap the forwarder (the freeze scenario)"
         );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #forwarder-reap (t-…41860-5) — production-shaped: closing a pane reaps its
+    /// output forwarder even when the agent is QUIET and stays ALIVE. This is the
+    /// PRE-EXISTING linger the off-thread P1 review surfaced: the forwarder blocked
+    /// on `rx.recv()` for a silent agent only exited on the agent's next byte/death.
+    /// Built via the real `build_deferred_direct_pane` + `apply_attach_outcome`
+    /// path; the agent's upstream sender (`sub_tx`) is held alive and NEVER emits,
+    /// so the ONLY exit path is the cancel channel dropped with the pane. Seam =
+    /// `wakeup_rx` disconnect (the forwarder's `wakeup_tx` clone drops on exit).
+    /// Neuter-RED: revert the forwarder to `while let Ok(_) = rx.recv()` → a quiet,
+    /// live agent blocks it forever → `wakeup_rx` never disconnects → this fails.
+    #[test]
+    fn quiet_agent_pane_close_reaps_forwarder() {
+        let home = tmp_home("rf_fwd_reap_quiet");
+        let mut layout = Layout::new();
+        let mut name_counter = HashMap::new();
+        let (mut pane, job) = build_deferred_direct_pane(
+            &mut layout,
+            &home,
+            "shell",
+            "/bin/sh",
+            &[],
+            crate::backend::SpawnMode::Fresh,
+            None,
+            &HashMap::new(),
+            "\r",
+            80,
+            24,
+            &mut name_counter,
+        );
+        let pid = pane.id;
+        // Upstream agent broadcast — kept ALIVE and QUIET for the whole test.
+        let (sub_tx, sub_rx) = crossbeam_channel::unbounded::<Vec<u8>>();
+        let (wakeup_tx, wakeup_rx) = crossbeam_channel::unbounded::<usize>();
+        let registry: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
+        apply_attach_outcome(
+            &mut pane,
+            &registry,
+            AttachOutcome::Ready {
+                pane_id: pid,
+                instance_id: crate::types::InstanceId::default(),
+                rx: sub_rx,
+                dump: Vec::new(),
+                work_dir: home.clone(),
+                name: "shell".into(),
+            },
+            job.fwd_tx,
+            &wakeup_tx,
+        );
+        // Seam: drop the test's wakeup_tx so only the forwarder's clone keeps
+        // wakeup_rx connected — its disconnect then observes the forwarder's exit.
+        drop(wakeup_tx);
+        // Close the pane while the agent is alive but QUIET (no byte ever sent):
+        // pre-fix the forwarder is blocked in rx.recv() forever; the cancel channel
+        // (dropped with the pane) wakes the select! so it exits in bounded time.
+        drop(pane);
+        let mut reaped = false;
+        for _ in 0..50 {
+            if matches!(
+                wakeup_rx.recv_timeout(std::time::Duration::from_millis(100)),
+                Err(crossbeam_channel::RecvTimeoutError::Disconnected)
+            ) {
+                reaped = true;
+                break;
+            }
+        }
+        // Agent is still alive here (never emitted) → reap was via the cancel
+        // channel, NOT the pre-existing rx-disconnect path.
+        assert!(
+            reaped,
+            "quiet-agent pane close must reap the forwarder via the cancel channel"
+        );
+        drop(sub_tx);
         std::fs::remove_dir_all(&home).ok();
     }
 

--- a/src/app/session.rs
+++ b/src/app/session.rs
@@ -569,6 +569,7 @@ mod tests {
             selection: None,
             source: PaneSource::Local,
             offthread: None,
+            _fwd_cancel: None,
         }
     }
 

--- a/src/app/tui_events.rs
+++ b/src/app/tui_events.rs
@@ -633,6 +633,7 @@ mod tests {
             selection: None,
             source: PaneSource::Local,
             offthread: None,
+            _fwd_cancel: None,
         }
     }
 

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -384,6 +384,7 @@ mod tests {
             selection: None,
             source: PaneSource::Local,
             offthread: None,
+            _fwd_cancel: None,
         }
     }
 

--- a/src/layout/pane.rs
+++ b/src/layout/pane.rs
@@ -61,6 +61,15 @@ pub struct Pane {
     /// `core_render` paints `snapshot` instead). `None` (default, flag OFF) = the
     /// byte-identical main-thread drain+parse path.
     pub offthread: Option<crate::render::offthread::OffthreadHandle>,
+    /// #forwarder-reap: held ONLY for its `Drop`. The output-forwarder thread
+    /// `select!`s on the agent `rx` AND the receiver paired with this sender, so
+    /// dropping the pane (close) drops this sender → that receiver disconnects →
+    /// a forwarder blocked on a QUIET agent's `rx.recv()` wakes and exits in
+    /// bounded time, instead of lingering until the agent next speaks or dies.
+    /// `None` for panes with no crossbeam forwarder: the placeholder before
+    /// attach, remote `BridgeClient` panes (socket reader, own lifecycle), and
+    /// test panes. Set to `Some` by `apply_attachment` / `attach_pane`.
+    pub _fwd_cancel: Option<crossbeam_channel::Sender<()>>,
 }
 
 /// Text selection anchored to absolute scrollback logical coordinates so it
@@ -388,6 +397,7 @@ mod tests {
             selection: None,
             source: PaneSource::Local,
             offthread: None,
+            _fwd_cancel: None,
         }
     }
 
@@ -454,6 +464,7 @@ mod tests {
             selection: None,
             source: PaneSource::Local,
             offthread: None,
+            _fwd_cancel: None,
         }
     }
 

--- a/src/layout/split.rs
+++ b/src/layout/split.rs
@@ -316,6 +316,7 @@ mod tests {
             selection: None,
             source: PaneSource::Local,
             offthread: None,
+            _fwd_cancel: None,
         }
     }
     fn mk_leaf(id: usize, name: &str) -> PaneNode {

--- a/src/layout/tab.rs
+++ b/src/layout/tab.rs
@@ -392,6 +392,7 @@ mod tests {
             selection: None,
             source: PaneSource::Local,
             offthread: None,
+            _fwd_cancel: None,
         }
     }
     fn tab_with_pane(name: &str, id: usize, rect: (u16, u16, u16, u16)) -> Tab {

--- a/src/layout/tree.rs
+++ b/src/layout/tree.rs
@@ -506,6 +506,7 @@ mod tests {
             selection: None,
             source: PaneSource::Local,
             offthread: None,
+            _fwd_cancel: None,
         }
     }
     fn leaf_agent(id: usize, name: &str) -> Pane {

--- a/src/render/core_render.rs
+++ b/src/render/core_render.rs
@@ -884,6 +884,7 @@ mod tests {
             selection: None,
             source: PaneSource::Local,
             offthread: None,
+            _fwd_cancel: None,
         };
         let segments = pane_title_segments(&pane, Style::default(), AgentState::Idle, false);
         let joined = segments
@@ -912,6 +913,7 @@ mod tests {
             selection: None,
             source: PaneSource::Local,
             offthread: None,
+            _fwd_cancel: None,
         };
         // #1713 flag OFF (default): no state badge appended; only the base label
         // (+ the transient Restarting/Crashed tab badge, which lives elsewhere).
@@ -944,6 +946,7 @@ mod tests {
             selection: None,
             source: PaneSource::Local,
             offthread: None,
+            _fwd_cancel: None,
         };
         for (state, want) in [
             (AgentState::ServerRateLimit, "[ServerRateLimit]"),
@@ -997,6 +1000,7 @@ mod tests {
                 selection: None,
                 source: PaneSource::Local,
                 offthread: None,
+                _fwd_cancel: None,
             },
         );
         let snapshot = HashMap::new();
@@ -1032,6 +1036,7 @@ mod tests {
             selection: None,
             source: PaneSource::Local,
             offthread: None,
+            _fwd_cancel: None,
         };
         let mut layout = Layout::new();
         layout.add_tab(crate::layout::Tab::new("agent".to_string(), pane));
@@ -1108,6 +1113,7 @@ mod tests {
             selection: None,
             source: PaneSource::Local,
             offthread: Some(handle),
+            _fwd_cancel: None,
         };
         assert!(
             pane.vterm.tail_lines(16).trim().is_empty(),
@@ -1530,6 +1536,7 @@ mod tests {
             selection: None,
             source: PaneSource::Local,
             offthread: None,
+            _fwd_cancel: None,
         };
         let mut layout = Layout::new();
         layout.add_tab(crate::layout::Tab::new("agent".to_string(), pane));
@@ -1584,6 +1591,7 @@ mod tests {
             selection: None,
             source: PaneSource::Local,
             offthread: None,
+            _fwd_cancel: None,
         };
         let mut layout = Layout::new();
         layout.add_tab(crate::layout::Tab::new("agent".to_string(), pane));
@@ -1613,6 +1621,7 @@ mod tests {
             selection: None,
             source: PaneSource::Local,
             offthread: None,
+            _fwd_cancel: None,
         }
     }
 


### PR DESCRIPTION
## Problem (pre-existing; off-thread P1 #2404 r6 surfaced it)
The per-pane output forwarder (`pane_factory.rs` `apply_attachment` + `attach_pane`) blocked on `rx.recv()` and only exited when the next `fwd_tx.send` failed. For an **active** agent the next byte reaps it immediately; for a **QUIET** agent whose pane was closed, the forwarder lingered until the agent next spoke or died. Pre-existing managed (flag-off) behavior — bounded + self-healing, but a real leak. (Task t-…41860-5.)

## Fix — candidate B (explicit cancel channel), lead-vetted
- `Pane` gains `pub _fwd_cancel: Option<crossbeam_channel::Sender<()>>`, set by the two forwarder-spawn sites. Dropping the pane drops the sender → the paired receiver disconnects → a blocked forwarder's `select!` wakes and exits in **bounded time**.
- Both forwarder loops switch from `while let Ok(data) = rx.recv()` to `select! { recv(rx) → …send…, recv(fwd_cancel_rx) → break }`.
- `Option` (None for placeholder/remote/test ctors) so the cancel pair is created at the single forwarder-spawn chokepoint — no threading `cancel_rx` through the sync + deferred attach signatures.
- **Zero off-thread-parser change** (orthogonal — no dirty-flag / sentinel-through-data-path that candidate A would need). Deterministic, unix+windows.
- **Remote panes out of scope** (`:1105` socket `read_tagged_frame`, own lifecycle) → `_fwd_cancel: None`.

## Managed-safety (no regression)
`select!`'s rx-arm behavior is byte-identical to today; `cancel_rx` only disconnects on pane drop. Active-agent reap timing unchanged.

## Tests (production-shaped, real attach path)
- **NEW** `quiet_agent_pane_close_reaps_forwarder`: live + quiet agent (upstream `sub_tx` held, never emits), close pane → reap via cancel channel. Seam = `wakeup_rx` disconnect (forwarder's `wakeup_tx` clone drops on exit). **Neuter-RED verified**: reverting to the blocking `rx.recv()` makes a quiet+live agent block it forever → test FAILs after 5.26s.
- Existing `active_agent_pane_close_reaps_forwarder_freeze_scenario` updated for the cancel-reap path (the old post-close `sub_tx.send().expect()` would otherwise race the now-immediate cancel-reap).
- `cargo nextest` 2/2 green; `cargo fmt --check` + `clippy --all-targets --features tray -D warnings` clean.

LOC-EST ~167 (mostly tests + mechanical `_fwd_cancel: None` ctor additions; prod forwarder change ~30 lines).

⚠ App-lifecycle change → needs operator rebuild+restart to go live.

Base includes off-thread P1 #2404. correlation t-20260622053855100612-41860-5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)