### PR TITLE
feat(ephemeral): #1967 PR3b Slice-1 — opencode one-shot driver (inject→turn-end→capture→oracle)

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -2923,6 +2923,34 @@ impl InjectTarget {
             core: Arc::clone(&h.core),
         }
     }
+
+    /// PR3b (#1967): build an inject target for a HEADLESS ephemeral worker, which
+    /// has no registry [`AgentHandle`]. The inject params come from the worker's
+    /// backend preset (`inject_prefix` / `submit_key` / `typed_inject`) instead of a
+    /// handle; `deleted` is a fresh always-false flag (an ephemeral worker is never
+    /// registry-deleted). Clones the retained `pty_writer` + `core` (Arc) so the
+    /// returned target is independent of the [`EphemeralPtyHandle`] (which the reaper
+    /// owns in `LIVE_CHILDREN`).
+    pub(crate) fn from_ephemeral(h: &EphemeralPtyHandle, backend: crate::backend::Backend) -> Self {
+        let preset = backend.preset();
+        Self {
+            pty_writer: Arc::clone(&h.pty_writer),
+            inject_prefix: preset.inject_prefix.to_string(),
+            submit_key: preset.submit_key.to_string(),
+            typed_inject: preset.typed_inject,
+            deleted: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            core: Arc::clone(&h.core),
+        }
+    }
+}
+
+/// PR3b (#1967): drive a prompt inject into a headless ephemeral worker. The
+/// ephemeral driver lives outside this module ([`crate::ephemeral_driver`]), where
+/// [`InjectTarget`] + [`inject_with_target`] are private — this is the crate-visible
+/// entry point. Synchronous (PTY writes + the #1912 typed-inject readback-confirm),
+/// so it MUST be called off the daemon's threads (the driver's own thread).
+pub(crate) fn run_ephemeral_inject(target: &InjectTarget, text: &[u8]) -> crate::error::Result<()> {
+    inject_with_target(target, text)
 }
 
 /// Send a message to a named agent via direct registry injection.

--- a/src/ephemeral_driver.rs
+++ b/src/ephemeral_driver.rs
@@ -1,0 +1,497 @@
+//! #1967 Phase-1 PR3b: the one-shot ephemeral-worker DRIVER (Route B).
+//!
+//! After [`crate::ephemeral_tracking::spawn_and_track`] finalizes a headless
+//! opencode worker, it launches a background driver thread (this module) that runs
+//! exactly ONE prompt turn to a recorded result:
+//!
+//!   wait-ready → inject prompt → turn-end (Idle-debounce) → capture → oracle → record
+//!
+//! The driver is decoupled from the worker's [`crate::agent::EphemeralPtyHandle`]
+//! (the reaper owns that in `LIVE_CHILDREN`): it holds only Arc clones of the PTY
+//! writer + core (inside its [`crate::agent::InjectTarget`]), so the reap sweep can
+//! terminate the worker process independently. On completion the driver marks the
+//! worker `done`, and the next reap sweep terminates the now-idle process + frees the
+//! cap slot.
+//!
+//! ## Empirical constants (PR3b 1a confirm-first smoke, lead-vetted — DO NOT change
+//! without re-smoking on a real backend)
+//! - **Poll `get_state()` ONLY, NEVER `state.tick()`.** The ephemeral read loop
+//!   ([`crate::agent`] `ephemeral_pty_read_loop`) never ticks, so the 30 s
+//!   `LATCHED_STATE_EXPIRY` Thinking→Idle decay is disabled and no phantom timer-Idle
+//!   fires. Calling `tick()` here would re-enable that decay → a false turn-end on a
+//!   quiet >30 s stretch. So the driver reads state, never advances the clock.
+//! - **Idle-debounce = 3 s of held Idle** before declaring the turn done. opencode
+//!   renders the Thinking marker CONTINUOUSLY while streaming (0 ms mid-turn Idle lull
+//!   observed on a fast model); 3 s cheaply covers a slower model's inter-render gaps.
+//!   A mid-turn Idle BLIP shorter than the window can never end the turn (the detector
+//!   resets the held-Idle clock when it sees work resume).
+//! - **Success oracle = terminal `Idle` ∧ ¬error-class ([`AgentState::is_error`]) ∧
+//!   transcript GREW.** NOT `has_productive_output()` — that is false on a text-only
+//!   success (opencode's productive markers match only tool-use glyphs).
+//! - **Transcript "grew" = non-blank body-line COUNT delta** (excluding the bottom
+//!   ~2 chrome rows: opencode's model/elapsed line + token/commands statusline, which
+//!   churn every render). Counting LINES (not bytes) is robust to chrome content churn
+//!   — the chrome line COUNT is stable across renders.
+//!
+//! Scope: opencode ONLY (the only backend the 1a smoke validated; other backends are
+//! Slice-2, each §5-smoke-gated). Durable telemetry (fleet_events L1/L2/L3 + task_events)
+//! is PR4; the result lands on the worker row for now.
+
+use crate::agent::InjectTarget;
+use crate::state::AgentState;
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+/// How often the driver samples `get_state()`. Tight enough to catch opencode's
+/// continuous-Thinking turn boundaries, loose enough to be near-free.
+const POLL_INTERVAL: Duration = Duration::from_millis(250);
+
+/// Held-Idle window (ms) before declaring the turn done — the lead-vetted
+/// conservative 3 s (covers a slow model's inter-render gaps; a fast model's 0 ms lull
+/// is well inside it).
+const TURN_DEBOUNCE_MS: u64 = 3_000;
+
+/// Max wait for the worker to reach its first `Idle` (ready) after spawn (capped by
+/// the worker's wall-TTL). opencode reaches ready in ~2.6 s; this is a generous cap.
+const READY_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Bottom chrome rows to exclude from the body-line measure (opencode's model/elapsed
+/// line + token/commands statusline). See the module doc's "grew" note.
+const CHROME_TAIL_LINES: usize = 2;
+
+/// Logical lines to dump from the vterm tail for the body measure + result capture.
+/// The worker's vterm is 50 rows; 80 covers the visible screen with margin for
+/// dewrapping (which merges wrapped rows into fewer logical lines).
+const CAPTURE_LINES: usize = 80;
+
+/// Cap on the persisted `result_summary` so a runaway transcript can't bloat the JSON
+/// sidecar. Coarse — PR4 routes the full transcript to durable telemetry.
+const MAX_SUMMARY_BYTES: usize = 8_192;
+
+/// Everything the driver thread needs. Built in `spawn_and_track` (which holds the
+/// handle) and moved into the thread; the [`InjectTarget`] carries Arc clones of the
+/// PTY writer + core, so the driver is independent of the handle the reaper owns.
+pub(crate) struct DriverConfig {
+    pub home: PathBuf,
+    pub worker_id: String,
+    pub prompt: String,
+    /// Inject capability + the worker's `core` (polled for state/vterm). Built via
+    /// [`InjectTarget::from_ephemeral`].
+    pub inject_target: InjectTarget,
+    /// The worker's wall-TTL (the reap sweep's cost guard); the driver's hard ceiling.
+    pub wall_ttl: Duration,
+}
+
+/// Launch the one-shot driver thread for a freshly-finalized worker.
+pub(crate) fn spawn_driver(cfg: DriverConfig) {
+    // fire-and-forget: drives the one-shot turn off the MCP `ephemeral spawn` handler,
+    // which returns worker_id+pid IMMEDIATELY (the PR1/2 async contract). The thread is
+    // self-bounding — it exits when the turn ends, an error class latches, an inject
+    // fails, or the wall-TTL lapses — and the reap sweep terminates the worker PROCESS
+    // independently, so no graceful JoinHandle is kept: a daemon shutdown simply drops
+    // the worker (its `reap_on_boot` sweeps any orphan on the next boot).
+    std::thread::spawn(move || run_turn(cfg));
+}
+
+/// The driver's body: wait-ready → inject → turn-end → capture → oracle → record.
+/// ALWAYS records a result (success or a failure reason) so the worker never hangs in
+/// `running`/`prompting` until the wall-TTL reap.
+fn run_turn(cfg: DriverConfig) {
+    let DriverConfig {
+        home,
+        worker_id,
+        prompt,
+        inject_target,
+        wall_ttl,
+    } = cfg;
+    let start = Instant::now();
+    let wall_ttl_ms = wall_ttl.as_millis() as u64;
+
+    // Phase 0 — wait for the worker to reach its first Idle (ready). Poll get_state()
+    // ONLY (never tick()). An error class before ready, or a ready timeout, fails the
+    // turn immediately.
+    let ready_cap_ms = (READY_TIMEOUT.as_millis() as u64).min(wall_ttl_ms);
+    loop {
+        let now_ms = start.elapsed().as_millis() as u64;
+        let state = inject_target.core.lock().state.get_state();
+        if state.is_error() {
+            return record_failure(&home, &worker_id, &format!("not ready: {state:?}"));
+        }
+        if state == AgentState::Idle {
+            break; // ready
+        }
+        if now_ms >= ready_cap_ms {
+            return record_failure(&home, &worker_id, "not ready: timed out before Idle");
+        }
+        std::thread::sleep(POLL_INTERVAL);
+    }
+
+    // Baseline body-line count (at ready, before inject) for the "grew" measure.
+    let baseline_dump = inject_target
+        .core
+        .lock()
+        .vterm
+        .tail_lines_dewrapped(CAPTURE_LINES);
+    let baseline_body = body_nonblank_count(&baseline_dump, CHROME_TAIL_LINES);
+
+    // Phase 1 — inject the prompt. Mark phase=prompting first so `ephemeral list`
+    // reflects the mid-turn state.
+    crate::ephemeral_tracking::mark_prompting(&home, &worker_id);
+    if let Err(e) = crate::agent::run_ephemeral_inject(&inject_target, prompt.as_bytes()) {
+        return record_failure(&home, &worker_id, &format!("inject failed: {e}"));
+    }
+
+    // Phase 2 — wait for turn end: Idle held ≥ debounce after work, an error class, or
+    // the wall-TTL. Poll get_state() ONLY (never tick()).
+    let mut detector = TurnEndDetector::new(TURN_DEBOUNCE_MS);
+    let stop_reason = loop {
+        let now_ms = start.elapsed().as_millis() as u64;
+        if now_ms >= wall_ttl_ms {
+            break "wall-TTL elapsed before turn end";
+        }
+        let state = inject_target.core.lock().state.get_state();
+        match detector.observe(state, now_ms) {
+            TurnDecision::Continue => std::thread::sleep(POLL_INTERVAL),
+            TurnDecision::TurnEnded => break "turn ended (Idle held)",
+            TurnDecision::ErrorClass => break "error-class state latched",
+        }
+    };
+
+    // Phase 3 — capture + oracle. Re-read the terminal state + dump at the end (an
+    // error banner can scroll off, so sample near turn-end), then decide success.
+    let end_dump = inject_target
+        .core
+        .lock()
+        .vterm
+        .tail_lines_dewrapped(CAPTURE_LINES);
+    let terminal_state = inject_target.core.lock().state.get_state();
+    let grew = body_nonblank_count(&end_dump, CHROME_TAIL_LINES) > baseline_body;
+    let success = oracle_success(terminal_state, grew);
+    let summary = build_summary(&end_dump, terminal_state, grew, stop_reason);
+
+    tracing::info!(
+        target: "ephemeral",
+        worker_id = %worker_id,
+        success,
+        terminal_state = ?terminal_state,
+        grew,
+        stop_reason,
+        "ephemeral driver turn complete"
+    );
+    crate::ephemeral_tracking::record_result(&home, &worker_id, summary, success);
+}
+
+/// Record a pre-turn failure (not-ready / inject error): the worker produced nothing,
+/// so success=false with the reason as the summary.
+fn record_failure(home: &std::path::Path, worker_id: &str, reason: &str) {
+    tracing::warn!(target: "ephemeral", worker_id = %worker_id, reason, "ephemeral driver turn failed");
+    crate::ephemeral_tracking::record_result(home, worker_id, format!("driver: {reason}"), false);
+}
+
+/// Success oracle (#1967 PR3b finding 2): a turn SUCCEEDED iff the worker is at a
+/// terminal `Idle` (NOT a latched error class — [`AgentState::is_error`] covers
+/// ContextFull/RateLimit/UsageLimit/AuthError/ApiError/Crashed/…), AND the transcript
+/// grew (the worker actually produced output). Deliberately NOT
+/// `has_productive_output()` (false on a text-only success).
+fn oracle_success(terminal_state: AgentState, transcript_grew: bool) -> bool {
+    terminal_state == AgentState::Idle && !terminal_state.is_error() && transcript_grew
+}
+
+/// Count non-blank "body" lines in a vterm dump, EXCLUDING the bottom `chrome_tail`
+/// rows. Counting LINES (not bytes) is robust to chrome CONTENT churn (the elapsed
+/// timer / token count tick every render but the chrome line COUNT is stable), so a
+/// statusline update is never misread as transcript growth.
+fn body_nonblank_count(dump: &str, chrome_tail: usize) -> usize {
+    let lines: Vec<&str> = dump.lines().collect();
+    let body_end = lines.len().saturating_sub(chrome_tail);
+    lines[..body_end]
+        .iter()
+        .filter(|l| !l.trim().is_empty())
+        .count()
+}
+
+/// Build the persisted `result_summary`: the body region (chrome rows dropped),
+/// trimmed of trailing blanks and capped at [`MAX_SUMMARY_BYTES`], prefixed with a
+/// one-line verdict so a reader sees the outcome without re-deriving it.
+fn build_summary(dump: &str, terminal_state: AgentState, grew: bool, stop_reason: &str) -> String {
+    let lines: Vec<&str> = dump.lines().collect();
+    let body_end = lines.len().saturating_sub(CHROME_TAIL_LINES);
+    let body = lines[..body_end].join("\n");
+    let body = body.trim_end();
+    let header = format!("[{terminal_state:?} grew={grew} stop={stop_reason}]\n");
+    let mut out = header;
+    out.push_str(body);
+    if out.len() > MAX_SUMMARY_BYTES {
+        // Truncate on a char boundary (byte slicing a multi-byte char would panic).
+        let mut cut = MAX_SUMMARY_BYTES;
+        while cut > 0 && !out.is_char_boundary(cut) {
+            cut -= 1;
+        }
+        out.truncate(cut);
+        out.push_str("…[truncated]");
+    }
+    out
+}
+
+/// Pure turn-end detector — the Idle-debounce state machine, time-injected (`now_ms`)
+/// so it is unit-testable with a synthetic state sequence (no sleeps, no real clock).
+#[derive(Debug)]
+struct TurnEndDetector {
+    debounce_ms: u64,
+    phase: DetectorPhase,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DetectorPhase {
+    /// Post-inject: waiting to SEE the worker leave Idle into work. A brief post-inject
+    /// (or pre-turn) Idle here must NOT count as the turn end.
+    AwaitingWork,
+    /// Saw work; waiting for the worker to return to Idle.
+    Working,
+    /// Idle seen at `idle_since_ms`; waiting for it to hold ≥ `debounce_ms`.
+    Settling { idle_since_ms: u64 },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TurnDecision {
+    /// Keep polling.
+    Continue,
+    /// Idle held ≥ debounce after work — the turn ended cleanly.
+    TurnEnded,
+    /// An error class latched — stop now (the turn failed).
+    ErrorClass,
+}
+
+impl TurnEndDetector {
+    fn new(debounce_ms: u64) -> Self {
+        Self {
+            debounce_ms,
+            phase: DetectorPhase::AwaitingWork,
+        }
+    }
+
+    /// Feed one `get_state()` sample at `now_ms` (ms since the driver started).
+    fn observe(&mut self, state: AgentState, now_ms: u64) -> TurnDecision {
+        if state.is_error() {
+            return TurnDecision::ErrorClass;
+        }
+        match self.phase {
+            DetectorPhase::AwaitingWork => {
+                // Any non-Idle, non-error state means work has started.
+                if state != AgentState::Idle {
+                    self.phase = DetectorPhase::Working;
+                }
+                TurnDecision::Continue
+            }
+            DetectorPhase::Working => {
+                if state == AgentState::Idle {
+                    self.phase = DetectorPhase::Settling {
+                        idle_since_ms: now_ms,
+                    };
+                }
+                TurnDecision::Continue
+            }
+            DetectorPhase::Settling { idle_since_ms } => {
+                if state == AgentState::Idle {
+                    if now_ms.saturating_sub(idle_since_ms) >= self.debounce_ms {
+                        TurnDecision::TurnEnded
+                    } else {
+                        TurnDecision::Continue
+                    }
+                } else {
+                    // A mid-turn Idle BLIP ended (work resumed) — reset the held-Idle
+                    // clock so a blip shorter than the window can never end the turn.
+                    self.phase = DetectorPhase::Working;
+                    TurnDecision::Continue
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    // ───────────────────────── oracle truth-table ──────────────────────────
+
+    #[test]
+    fn oracle_idle_and_grew_is_success() {
+        assert!(oracle_success(AgentState::Idle, true));
+    }
+
+    #[test]
+    fn oracle_idle_but_no_growth_fails() {
+        // Text-only-but-empty / no output → NOT a success (the `has_productive_output`
+        // false-negative class is avoided by requiring growth, but empty must fail).
+        assert!(!oracle_success(AgentState::Idle, false));
+    }
+
+    #[test]
+    fn oracle_error_class_fails_even_if_grew() {
+        // UsageLimit / RateLimit / ApiError / ContextFull / AuthError / Crashed are all
+        // is_error() → never a success, regardless of any output that scrolled by.
+        for s in [
+            AgentState::UsageLimit,
+            AgentState::RateLimit,
+            AgentState::ServerRateLimit,
+            AgentState::ApiError,
+            AgentState::ContextFull,
+            AgentState::AuthError,
+            AgentState::Crashed,
+        ] {
+            assert!(
+                !oracle_success(s, true),
+                "{s:?} is an error class → must fail"
+            );
+        }
+    }
+
+    #[test]
+    fn oracle_nonidle_nonerror_fails() {
+        // Stopped mid-work (e.g. wall-TTL while Thinking) → not a clean terminal Idle.
+        assert!(!oracle_success(AgentState::Thinking, true));
+    }
+
+    // ─────────────────────────── body-line measure ─────────────────────────
+
+    #[test]
+    fn body_count_excludes_chrome_and_blanks() {
+        // 3 body lines + 1 blank + 2 chrome rows → counts only the 3 non-blank body.
+        let dump = "answer line 1\nanswer line 2\nanswer line 3\n\nmodel · 2s\ntokens 42";
+        assert_eq!(body_nonblank_count(dump, CHROME_TAIL_LINES), 3);
+    }
+
+    #[test]
+    fn body_count_chrome_churn_does_not_grow() {
+        // Same body, only the chrome (elapsed timer / token count) changed → the body
+        // count is identical, so a chrome update is NOT misread as transcript growth.
+        let before = "prompt echo\nmodel · 1s\ntokens 10";
+        let after = "prompt echo\nmodel · 9s\ntokens 99";
+        assert_eq!(
+            body_nonblank_count(before, CHROME_TAIL_LINES),
+            body_nonblank_count(after, CHROME_TAIL_LINES),
+            "chrome churn must not change the body count"
+        );
+    }
+
+    #[test]
+    fn body_count_handles_dump_shorter_than_chrome_tail() {
+        // saturating_sub: a tiny dump (fewer rows than chrome_tail) yields 0, no panic.
+        assert_eq!(body_nonblank_count("x", 2), 0);
+        assert_eq!(body_nonblank_count("", 2), 0);
+    }
+
+    #[test]
+    fn transcript_growth_detected_via_body_delta() {
+        let baseline = "prompt echo\nmodel · 0s\ntokens 0";
+        let grown = "prompt echo\nassistant reply line\nmore reply\nmodel · 4s\ntokens 88";
+        let baseline_body = body_nonblank_count(baseline, CHROME_TAIL_LINES);
+        let grown_body = body_nonblank_count(grown, CHROME_TAIL_LINES);
+        assert!(
+            grown_body > baseline_body,
+            "the assistant reply must register as growth"
+        );
+    }
+
+    // ───────────────────── turn-end detector (debounce) ─────────────────────
+
+    /// A mid-turn Idle BLIP shorter than the debounce window must NOT end the turn;
+    /// only a continuously-held Idle ≥ debounce does. Deterministic synthetic timeline.
+    #[test]
+    fn debounce_ignores_midturn_idle_blip_then_ends_on_held_idle() {
+        let mut d = TurnEndDetector::new(TURN_DEBOUNCE_MS);
+        // Post-inject lull (Idle) — must not be mistaken for the end.
+        assert_eq!(d.observe(AgentState::Idle, 0), TurnDecision::Continue);
+        // Work starts.
+        assert_eq!(d.observe(AgentState::Thinking, 250), TurnDecision::Continue);
+        assert_eq!(d.observe(AgentState::Thinking, 500), TurnDecision::Continue);
+        // A mid-turn Idle BLIP at 750ms…
+        assert_eq!(d.observe(AgentState::Idle, 750), TurnDecision::Continue);
+        // …only ~1s of "held" Idle, still under the 3s window — NOT the end…
+        assert_eq!(d.observe(AgentState::Idle, 1_750), TurnDecision::Continue);
+        // …then work resumes (the blip ends) — held-Idle clock resets.
+        assert_eq!(
+            d.observe(AgentState::Thinking, 2_000),
+            TurnDecision::Continue
+        );
+        assert_eq!(
+            d.observe(AgentState::ToolUse, 2_500),
+            TurnDecision::Continue
+        );
+        // Real turn end: Idle starts at 3_000 and holds.
+        assert_eq!(d.observe(AgentState::Idle, 3_000), TurnDecision::Continue);
+        // Held < 3s → still continue (would have wrongly fired if the blip leaked).
+        assert_eq!(d.observe(AgentState::Idle, 5_000), TurnDecision::Continue);
+        // Held ≥ 3s from idle_since=3_000 → turn ended.
+        assert_eq!(d.observe(AgentState::Idle, 6_000), TurnDecision::TurnEnded);
+    }
+
+    /// The detector must not fire on the pre-turn Idle if work never started (a fast
+    /// model that finished between polls is left to the wall-TTL + the end-oracle).
+    #[test]
+    fn debounce_does_not_end_while_only_idle_seen() {
+        let mut d = TurnEndDetector::new(TURN_DEBOUNCE_MS);
+        for t in [0, 1_000, 5_000, 60_000] {
+            assert_eq!(
+                d.observe(AgentState::Idle, t),
+                TurnDecision::Continue,
+                "must never end the turn while only Idle has been seen (no work started)"
+            );
+        }
+    }
+
+    /// An error class at any phase short-circuits to ErrorClass.
+    #[test]
+    fn debounce_short_circuits_on_error_class() {
+        let mut d = TurnEndDetector::new(TURN_DEBOUNCE_MS);
+        assert_eq!(d.observe(AgentState::Thinking, 100), TurnDecision::Continue);
+        assert_eq!(
+            d.observe(AgentState::UsageLimit, 200),
+            TurnDecision::ErrorClass
+        );
+    }
+
+    /// Clean happy path: work → held Idle ≥ debounce → TurnEnded (no blip).
+    #[test]
+    fn debounce_clean_turn_ends_after_held_idle() {
+        let mut d = TurnEndDetector::new(TURN_DEBOUNCE_MS);
+        assert_eq!(d.observe(AgentState::Thinking, 0), TurnDecision::Continue);
+        assert_eq!(d.observe(AgentState::Idle, 1_000), TurnDecision::Continue);
+        assert_eq!(d.observe(AgentState::Idle, 3_999), TurnDecision::Continue);
+        assert_eq!(d.observe(AgentState::Idle, 4_000), TurnDecision::TurnEnded);
+    }
+
+    // ─────────────────────────────── summary ───────────────────────────────
+
+    #[test]
+    fn summary_drops_chrome_and_prefixes_verdict() {
+        let dump = "the answer\nmodel · 2s\ntokens 42";
+        let s = build_summary(dump, AgentState::Idle, true, "turn ended (Idle held)");
+        assert!(s.starts_with("[Idle grew=true stop=turn ended (Idle held)]"));
+        assert!(s.contains("the answer"));
+        assert!(
+            !s.contains("tokens 42"),
+            "the chrome statusline must be dropped"
+        );
+    }
+
+    #[test]
+    fn summary_caps_runaway_transcript_on_char_boundary() {
+        // A many-line body (survives the chrome-tail drop) with MULTIBYTE chars, so the
+        // MAX_SUMMARY_BYTES cut can land mid-char — the char-boundary backoff must not
+        // panic and must still append the marker.
+        let big = "café日本語テスト line\n".repeat(1_000);
+        let s = build_summary(&big, AgentState::Idle, true, "r");
+        assert!(
+            s.len() <= MAX_SUMMARY_BYTES + "…[truncated]".len() + 64,
+            "summary must be capped near MAX_SUMMARY_BYTES, got {} bytes",
+            s.len()
+        );
+        assert!(
+            s.ends_with("…[truncated]"),
+            "a capped summary must carry the marker"
+        );
+    }
+}

--- a/src/ephemeral_tracking.rs
+++ b/src/ephemeral_tracking.rs
@@ -96,8 +96,17 @@ pub struct EphemeralWorker {
     pub ttl_secs: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub token_budget: Option<u64>,
-    pub phase: String,  // "reserving" | "spawned" | "running" | "done"
+    pub phase: String, // "reserving" | "spawned" | "running" | "prompting" | "done"
     pub status: String, // "reserving" | "running" | "done"
+    /// PR3b: the driver's captured turn transcript slice (the worker's "answer").
+    /// `None` until the one-shot turn completes; absent on workers spawned without
+    /// a prompt (PR3a lifecycle-only spawn). Coarse — durable telemetry is PR4.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub result_summary: Option<String>,
+    /// PR3b: the success oracle's verdict for the turn (terminal Idle ∧ ¬error-class
+    /// ∧ transcript grew). `None` until the turn completes (or no prompt was given).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub success: Option<bool>,
 }
 
 #[derive(Debug, Default, Serialize, Deserialize)]
@@ -159,6 +168,12 @@ pub struct SpawnSpec {
     pub backend: String,
     pub ttl_secs: Option<u64>,
     pub token_budget: Option<u64>,
+    /// PR3b: the prompt the driver injects for the worker's one-shot turn. EMPTY =
+    /// PR3a lifecycle-only spawn (no driver thread launched — spawn + reap only).
+    pub prompt: String,
+    /// PR3b: optional model override (e.g. `provider/model` for opencode), passed to
+    /// the backend via its spawn argv. `None` = the backend's configured default.
+    pub model: Option<String>,
 }
 
 /// Why a spawn failed.
@@ -168,6 +183,12 @@ pub enum SpawnError {
     /// that doesn't map to a known backend) — an arbitrary-exec guard. Carries the
     /// rejected input for the operator-facing error.
     UnsupportedBackend(String),
+    /// PR3b: a `prompt` was given for a backend whose one-shot driver is not yet
+    /// smoke-validated. Slice-1 ships the opencode driver ONLY; other backends are
+    /// Slice-2 (each gated on a §5 per-backend smoke per the confirm-first iron rule).
+    /// Carries the rejected backend. A prompt-less spawn of any backend is unaffected
+    /// (the PR3a lifecycle-only spawn path).
+    DriverUnsupported(String),
     /// The hard max-live concurrency cap would be exceeded.
     CapExceeded { live: usize, cap: usize },
     /// The durable cap reservation could not be persisted (store write failed) —
@@ -184,6 +205,12 @@ impl std::fmt::Display for SpawnError {
                 f,
                 "ephemeral spawn: unsupported backend '{b}' — must be a bare backend command \
                  (no path separators), one of: claude, codex, opencode, kiro-cli, agy"
+            ),
+            SpawnError::DriverUnsupported(b) => write!(
+                f,
+                "ephemeral spawn: a prompt-driven one-shot turn is only supported for 'opencode' \
+                 (PR3b Slice-1); backend '{b}' is Slice-2 (pending a per-backend turn-detection \
+                 smoke). Spawn it without a prompt for a lifecycle-only worker."
             ),
             SpawnError::CapExceeded { live, cap } => write!(
                 f,
@@ -352,6 +379,42 @@ fn release_reservation(home: &Path, worker_id: &str) {
     );
 }
 
+/// PR3b: the driver flips a worker's phase to `"prompting"` just before it injects the
+/// prompt, so `ephemeral list` reflects the mid-turn state. Best-effort (log-on-fail) —
+/// a lost write only loses an observability nuance, not correctness. A vanished row
+/// (concurrently reaped) is a no-op.
+pub(crate) fn mark_prompting(home: &Path, worker_id: &str) {
+    persist_or_log!(
+        crate::store::mutate_versioned(&store_path(home), |s: &mut EphemeralStore| {
+            if let Some(w) = s.workers.iter_mut().find(|w| w.worker_id == worker_id) {
+                w.phase = "prompting".to_string();
+            }
+            Ok(())
+        }),
+        "ephemeral_mark_prompting"
+    );
+}
+
+/// PR3b: the driver writes the one-shot turn's outcome to the worker row and marks it
+/// terminal (`phase` + `status` = `"done"`), so the next [`reap_sweep`] terminates the
+/// now-idle worker process ([`is_due`] fires on `STATUS_DONE`) and frees the cap slot.
+/// Best-effort persist (log-on-fail) — a lost write only delays reap to the wall-TTL
+/// backstop. A vanished row (concurrently reaped) is a no-op.
+pub(crate) fn record_result(home: &Path, worker_id: &str, result_summary: String, success: bool) {
+    persist_or_log!(
+        crate::store::mutate_versioned(&store_path(home), |s: &mut EphemeralStore| {
+            if let Some(w) = s.workers.iter_mut().find(|w| w.worker_id == worker_id) {
+                w.result_summary = Some(result_summary.clone());
+                w.success = Some(success);
+                w.phase = STATUS_DONE.to_string();
+                w.status = STATUS_DONE.to_string();
+            }
+            Ok(())
+        }),
+        "ephemeral_record_result"
+    );
+}
+
 /// Spawn a real backend HEADLESSLY (Route B — a PTY child with no pane / no
 /// roster, via [`crate::agent::spawn_ephemeral_worker`]) under the hard max-live
 /// cap. Admission is BEFORE the spawn (r4 PR1 note): **reserve → spawn →
@@ -371,6 +434,18 @@ pub fn spawn_and_track(home: &Path, spec: SpawnSpec) -> Result<EphemeralWorker, 
         Ok(cmd) => cmd,
         Err(_) => return Err(SpawnError::UnsupportedBackend(spec.backend.clone())),
     };
+
+    // 0b) DRIVER GATE (PR3b) — a `prompt` launches the one-shot driver (inject →
+    //     turn-end → capture → oracle), which is smoke-validated for opencode ONLY
+    //     (Slice-1). Reject a prompt for any other backend BEFORE reserving/spawning
+    //     (confirm-first iron rule: never drive a backend whose turn-end detection
+    //     isn't proven on a real turn). A prompt-LESS spawn of any backend is the PR3a
+    //     lifecycle-only path and is unaffected. Gated in the SHARED SINK so a direct
+    //     caller, not just the MCP handler, is protected.
+    let drive_turn = !spec.prompt.is_empty();
+    if drive_turn && backend_command != crate::backend::Backend::OpenCode.preset().command {
+        return Err(SpawnError::DriverUnsupported(spec.backend.clone()));
+    }
 
     let ttl_secs = resolve_ttl(spec.ttl_secs);
     let seq = WORKER_SEQ.fetch_add(1, Ordering::Relaxed);
@@ -392,6 +467,8 @@ pub fn spawn_and_track(home: &Path, spec: SpawnSpec) -> Result<EphemeralWorker, 
         token_budget: spec.token_budget,
         phase: STATUS_RESERVING.to_string(),
         status: STATUS_RESERVING.to_string(),
+        result_summary: None,
+        success: None,
     };
     match try_reserve_slot(home, reserving) {
         Ok(()) => {}
@@ -410,10 +487,17 @@ pub fn spawn_and_track(home: &Path, spec: SpawnSpec) -> Result<EphemeralWorker, 
     //    create_dir_all err is ignored — `build_command` re-creates + re-validates.
     let cwd = home.join("backend-data").join("ephemeral").join(&worker_id);
     std::fs::create_dir_all(&cwd).ok();
+    // PR3b: an optional model override goes into the spawn argv (opencode gets a
+    // provider-prefixed `--model`; see `Backend::push_model_arg`). Empty/None = no-op,
+    // so a model-less spawn is byte-identical to the PR3a `args: &[]`.
+    let mut spawn_args: Vec<String> = Vec::new();
+    if let Some(model) = spec.model.as_deref() {
+        crate::backend::Backend::push_model_arg(&mut spawn_args, backend_command, model);
+    }
     let config = crate::agent::SpawnConfig {
         name: &worker_id,
         backend_command, // canonical (allowlist-resolved) — never the raw input
-        args: &[],
+        args: &spawn_args,
         spawn_mode: crate::backend::SpawnMode::Fresh, // ephemeral workers are always fresh
         cols: 200,
         rows: 50,
@@ -437,6 +521,24 @@ pub fn spawn_and_track(home: &Path, spec: SpawnSpec) -> Result<EphemeralWorker, 
     // 3) FINALIZE — stamp the real pid/token + flip reserving → running.
     match finalize_spawn(home, &worker_id, pid, token) {
         Ok(worker) => {
+            // PR3b: launch the one-shot driver BEFORE moving the handle into
+            // LIVE_CHILDREN, capturing the inject target (Arc clones of the retained
+            // pty_writer + core) so the driver is decoupled from the handle the reaper
+            // owns. Only when a prompt was given (opencode, gated in step 0b) — else
+            // this is the PR3a lifecycle-only spawn (no driver thread).
+            if drive_turn {
+                let inject_target = crate::agent::InjectTarget::from_ephemeral(
+                    &handle,
+                    crate::backend::Backend::OpenCode,
+                );
+                crate::ephemeral_driver::spawn_driver(crate::ephemeral_driver::DriverConfig {
+                    home: home.to_path_buf(),
+                    worker_id: worker_id.clone(),
+                    prompt: spec.prompt.clone(),
+                    inject_target,
+                    wall_ttl: std::time::Duration::from_secs(ttl_secs),
+                });
+            }
             LIVE_CHILDREN.lock().insert(worker_id, handle);
             Ok(worker)
         }
@@ -977,6 +1079,8 @@ mod tests {
             backend: "claude".to_string(),
             ttl_secs: Some(60),
             token_budget: None,
+            prompt: String::new(),
+            model: None,
         };
         let res = spawn_and_track(&home, spec);
         assert!(
@@ -1107,6 +1211,8 @@ mod tests {
             backend: "/tmp/evil.sh".to_string(),
             ttl_secs: Some(60),
             token_budget: None,
+            prompt: String::new(),
+            model: None,
         };
         let res = spawn_and_track(&home, spec);
         assert!(
@@ -1131,6 +1237,8 @@ mod tests {
             backend: "bogus".to_string(),
             ttl_secs: Some(60),
             token_budget: None,
+            prompt: String::new(),
+            model: None,
         };
         assert!(matches!(
             spawn_and_track(&home, spec),
@@ -1268,6 +1376,8 @@ mod tests {
             backend: "claude".to_string(), // valid backend so we reach the reserve step
             ttl_secs: Some(60),
             token_budget: None,
+            prompt: String::new(),
+            model: None,
         };
         let res = spawn_and_track(&file_home, spec);
         assert!(
@@ -1596,5 +1706,135 @@ mod tests {
             pid,
             "cleanup: reap the worker spawned by the disarmed-path test",
         );
+    }
+
+    // ─────────────────── PR3b: driver gate + result recording ───────────────────
+
+    /// PR3b driver GATE: a `prompt` for a NON-opencode backend is rejected as
+    /// `DriverUnsupported` BEFORE any reserve/spawn (confirm-first iron rule — only
+    /// opencode's turn-end detection is smoke-validated in Slice-1). Gated in the
+    /// SHARED SINK so a direct caller, not just the MCP handler, is protected. A
+    /// prompt-LESS spawn of any backend is unaffected (the PR3a lifecycle path).
+    #[test]
+    fn spawn_and_track_rejects_prompt_for_non_opencode_backend() {
+        let home = tmp_home("driver-gate");
+        let spec = SpawnSpec {
+            workflow_id: "wf".to_string(),
+            backend: "claude".to_string(),
+            prompt: "do the thing".to_string(),
+            ..Default::default()
+        };
+        let res = spawn_and_track(&home, spec);
+        assert!(
+            matches!(&res, Err(SpawnError::DriverUnsupported(b)) if b == "claude"),
+            "a prompt for a non-opencode backend must be DriverUnsupported: {res:?}"
+        );
+        assert_eq!(
+            list(&home, None).len(),
+            0,
+            "the driver gate rejects before reserve — no row, no process"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// PR3b: `mark_prompting` flips phase to `prompting`; `record_result` writes the
+    /// outcome and marks the worker terminal (phase + status = `done`) so the next
+    /// reap sweep ([`is_due`] on `STATUS_DONE`) terminates it + frees the cap slot.
+    #[test]
+    fn record_result_marks_done_with_outcome() {
+        let home = tmp_home("record-result");
+        // Seed a running worker row (bypass the cap gate for a pure store test).
+        persist_or_log!(
+            crate::store::mutate_versioned(&store_path(&home), |s: &mut EphemeralStore| {
+                s.workers.push(EphemeralWorker {
+                    worker_id: "w1".to_string(),
+                    pid: 1234,
+                    spawned_at: chrono::Utc::now().to_rfc3339(),
+                    ttl_secs: 100,
+                    phase: "spawned".to_string(),
+                    status: STATUS_RUNNING.to_string(),
+                    ..Default::default()
+                });
+                Ok(())
+            }),
+            "seed"
+        );
+        mark_prompting(&home, "w1");
+        assert_eq!(list(&home, None)[0].phase, "prompting");
+
+        record_result(&home, "w1", "the answer".to_string(), true);
+        let w = list(&home, None);
+        let w = &w[0];
+        assert_eq!(w.result_summary.as_deref(), Some("the answer"));
+        assert_eq!(w.success, Some(true));
+        assert_eq!(w.phase, STATUS_DONE);
+        assert_eq!(
+            w.status, STATUS_DONE,
+            "done status → reap sweep terminates it"
+        );
+        assert!(
+            is_due(w, chrono::Utc::now()),
+            "a done worker is due for the next reap sweep"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// REAL opencode end-to-end (`#[ignore]`: no binary/creds in CI). Drives a real
+    /// headless opencode worker through `spawn_and_track`'s driver path — inject →
+    /// Idle-debounce turn-end → capture → oracle — and asserts the worker records
+    /// success with a non-empty transcript. Run locally:
+    /// `cargo test --bin agend-terminal --features tray -- --ignored ephemeral_opencode_driver_e2e`.
+    /// Uses a FREE model; avoid the `omlx` stub provider (it wedges opencode).
+    /// `#[cfg(unix)]`: ephemeral spawn is fail-closed on Windows.
+    #[cfg(unix)]
+    #[test]
+    #[ignore = "requires a real opencode install + auth; run locally"]
+    fn ephemeral_opencode_driver_e2e() {
+        let home = tmp_home("opencode-e2e");
+        let spec = SpawnSpec {
+            workflow_id: "e2e".to_string(),
+            backend: "opencode".to_string(),
+            prompt: "Reply with exactly the word: pong".to_string(),
+            model: Some("opencode/deepseek-v4-flash-free".to_string()),
+            ttl_secs: Some(180),
+            ..Default::default()
+        };
+        let w = spawn_and_track(&home, spec).expect("spawn opencode worker");
+        assert_ne!(w.pid, 0, "a real pid was stamped");
+
+        // The driver runs ASYNC (matches the MCP contract). Poll the row until it
+        // records a result, or a generous cap. No reap sweep runs in-test, so the
+        // done row persists until we reap it explicitly.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(150);
+        let outcome = loop {
+            match list(&home, None)
+                .into_iter()
+                .find(|r| r.worker_id == w.worker_id)
+            {
+                Some(row) => {
+                    if let Some(success) = row.success {
+                        break Some((success, row.result_summary));
+                    }
+                }
+                None => break None, // unexpectedly reaped
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "the driver did not record a result within the deadline"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(500));
+        };
+        reap_one(&home, &w.worker_id); // terminate the worker process regardless
+
+        let (success, summary) = outcome.expect("the worker row must carry a result before reap");
+        assert!(
+            success,
+            "a simple prompt turn must succeed; summary={summary:?}"
+        );
+        assert!(
+            summary.map(|s| !s.trim().is_empty()).unwrap_or(false),
+            "result_summary must be non-empty on success"
+        );
+        std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,7 @@ mod deployments;
 mod dispatch_tracking;
 mod display_time;
 mod env_util;
+mod ephemeral_driver;
 mod ephemeral_tracking;
 mod error;
 mod event_log;

--- a/src/mcp/handlers/ephemeral.rs
+++ b/src/mcp/handlers/ephemeral.rs
@@ -46,6 +46,15 @@ pub(super) fn handle_spawn(home: &Path, args: &Value, _instance_name: &str) -> V
         Some(s) => s.to_string(),
         None => return json!({"error": "ephemeral spawn: missing required parameter 'backend'"}),
     };
+    // PR3b: an optional `prompt` launches the one-shot driver (inject → turn-end →
+    // capture → oracle), opencode ONLY (Slice-1; `spawn_and_track` rejects a prompt for
+    // any other backend). An optional `model` overrides the worker's default model
+    // (provider-prefixed for opencode). A prompt-less spawn is the PR3a lifecycle path.
+    let prompt = args["prompt"]
+        .as_str()
+        .map(str::to_string)
+        .unwrap_or_default();
+    let driven = !prompt.is_empty();
     let spec = crate::ephemeral_tracking::SpawnSpec {
         workflow_id,
         parent: args["parent"]
@@ -55,6 +64,11 @@ pub(super) fn handle_spawn(home: &Path, args: &Value, _instance_name: &str) -> V
         backend,
         ttl_secs: args["ttl_secs"].as_u64(),
         token_budget: args["token_budget"].as_u64(),
+        prompt,
+        model: args["model"]
+            .as_str()
+            .filter(|s| !s.is_empty())
+            .map(str::to_string),
     };
     match crate::ephemeral_tracking::spawn_and_track(home, spec) {
         Ok(w) => json!({
@@ -64,7 +78,14 @@ pub(super) fn handle_spawn(home: &Path, args: &Value, _instance_name: &str) -> V
             "workflow_id": w.workflow_id,
             "backend": w.backend,
             "ttl_secs": w.ttl_secs,
-            "note": "PR3a: real backend spawned headlessly via PTY (no pane, no roster); no prompt injection / capture yet (PR3b)",
+            "driven": driven,
+            "note": if driven {
+                "PR3b: spawned headlessly via PTY (no pane, no roster); a one-shot driver is \
+                 running the prompt ASYNC — poll `ephemeral list` for result_summary/success"
+            } else {
+                "PR3a: real backend spawned headlessly via PTY (no pane, no roster); no prompt \
+                 given, so lifecycle-only (spawn + reap, no driver)"
+            },
         }),
         Err(e) => json!({"error": e.to_string()}),
     }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -292,14 +292,16 @@ pub(crate) fn def_deployment() -> Value {
 }
 
 pub(crate) fn def_ephemeral() -> Value {
-    json!({"name": "ephemeral", "description": "#1967 Phase-1 (PR1 scaffold): manage short-lived cross-backend ephemeral workers OUTSIDE managed bookkeeping (no roster/binding/worktree). Actions: spawn, list, reap. NOTE: PR1 spawns a FAKE /bin/sleep child — real headless backend transport is a later PR.",
+    json!({"name": "ephemeral", "description": "#1967 Phase-1: manage short-lived cross-backend ephemeral workers OUTSIDE managed bookkeeping (no roster/binding/worktree). Actions: spawn, list, reap. PR3a spawns a REAL backend headlessly via a PTY (gated by AGEND_EPHEMERAL_REAL_BACKEND, default OFF); PR3b: a `prompt` runs a one-shot turn (inject → turn-end → capture → oracle), opencode only.",
         "inputSchema": {"type": "object", "properties": {
             "action": {"type": "string", "enum": ["spawn", "list", "reap"]},
-            "backend": {"type": "string", "description": "spawn: target backend (e.g. opencode). PR1 spawns a fake child regardless; real backends land in PR2/PR3."},
+            "backend": {"type": "string", "description": "spawn: target backend, a bare command (claude, codex, opencode, kiro-cli, agy). A path or unknown name is rejected."},
             "workflow_id": {"type": "string", "description": "spawn: the owning workflow id (required). list/reap: optional filter to one workflow."},
             "parent": {"type": "string", "description": "spawn: optional parent worker/agent id for the telemetry tree."},
             "ttl_secs": {"type": "number", "description": "spawn: max wall-clock TTL in seconds (cost guard). Default 1800, clamped to 7200. The reap sweep terminates a worker past its TTL."},
             "token_budget": {"type": "number", "description": "spawn: per-worker token budget (recorded; enforcement lands in a later PR)."},
+            "prompt": {"type": "string", "description": "spawn (PR3b): prompt for a one-shot driven turn. Present = launch the driver (opencode ONLY; other backends rejected — Slice-2). Absent = lifecycle-only spawn (no driver). Poll `ephemeral list` for result_summary/success."},
+            "model": {"type": "string", "description": "spawn (PR3b): optional model override for the worker (provider-prefixed for opencode, e.g. opencode/deepseek-v4-flash-free). Default = the backend's configured model."},
             "worker_id": {"type": "string", "description": "reap: reap a single worker by id."},
             "all_stale": {"type": "boolean", "description": "reap: reap all due/dead workers (TTL-expired, terminal, or process gone)."}
         }, "required": ["action"]}})
@@ -937,6 +939,8 @@ mod tests {
             ("ephemeral", "workflow_id", "mcp/handlers/ephemeral.rs spawn/list/reap workflow filter"),
             ("ephemeral", "parent", "mcp/handlers/ephemeral.rs handle_spawn → SpawnSpec.parent"),
             ("ephemeral", "ttl_secs", "mcp/handlers/ephemeral.rs handle_spawn → ephemeral_tracking::resolve_ttl (max-wall-TTL guard)"),
+            ("ephemeral", "prompt", "mcp/handlers/ephemeral.rs handle_spawn → SpawnSpec.prompt → ephemeral_driver one-shot turn (PR3b)"),
+            ("ephemeral", "model", "mcp/handlers/ephemeral.rs handle_spawn → SpawnSpec.model → Backend::push_model_arg spawn argv (PR3b)"),
             ("ephemeral", "worker_id", "mcp/handlers/ephemeral.rs handle_reap → reap_one"),
             ("ephemeral", "all_stale", "mcp/handlers/ephemeral.rs handle_reap → reap_sweep"),
             // ── ci ──


### PR DESCRIPTION
## #1967 Phase-1 PR3b Slice-1 — opencode ephemeral driver

Builds on PR3a (#2405, headless-PTY worker lifecycle). After `spawn_and_track` finalizes a headless **opencode** worker, a background driver runs **one prompt turn** to a recorded result:

```
wait-ready → inject → Idle-debounce turn-end → vterm capture → success oracle → record
```

`flag-OFF` (`AGEND_EPHEMERAL_REAL_BACKEND`), `cap=3`, **unix-only**, **opencode-only** (Slice-2 adds other backends, each §5-smoke-gated).

### What changed
- **`SpawnSpec`** += `prompt`, `model`; **`EphemeralWorker`** += `result_summary`, `success`.
- **`src/ephemeral_driver.rs`** (new) — the fire-and-forget driver thread + pure, unit-tested decision helpers.
- **`agent::run_ephemeral_inject` + `InjectTarget::from_ephemeral`** — crate-visible inject entry (`inject_with_target`/`InjectTarget` are private to the agent module; `from_handle` only takes an `AgentHandle`).
- **model** via `Backend::push_model_arg` (provider-prefixed `--model` for opencode).
- **opencode-only gate** in `spawn_and_track` (the SHARED SINK): a `prompt` for a non-opencode backend → `SpawnError::DriverUnsupported` **before** reserve/spawn (confirm-first iron rule). A prompt-less spawn of any backend is the unchanged PR3a lifecycle path.
- **MCP** `ephemeral spawn{prompt, model}` wired; tool schema + the `CONSUMED` arg-audit table updated.

### Empirical constants (carried from the 1a confirm-first smoke, lead-vetted)
- **Poll `get_state()` ONLY, never `state.tick()`** — the ephemeral read loop never ticks, so the 30s `LATCHED_STATE_EXPIRY` Thinking→Idle decay stays disabled (no phantom timer-Idle); ticking would re-enable it → false turn-end on a quiet stretch.
- **Idle-debounce = 3s held** before declaring done; a mid-turn Idle blip can't end the turn (the detector resets the held-Idle clock when work resumes).
- **Oracle = terminal `Idle` ∧ ¬`is_error()` ∧ transcript-grew** — deliberately NOT `has_productive_output()` (false on a text-only success).
- **transcript-grew = non-blank body-line COUNT delta** (excl. bottom ~2 chrome rows) — counts lines, not bytes, so chrome statusline churn is never misread as growth.

### Lifecycle
On turn end the driver writes `result_summary`/`success` + `phase`/`status=done`; the existing reap sweep (`is_due` on `done`) terminates the now-idle worker + frees the cap slot. Result is visible via `ephemeral list` until reap. Durable telemetry (fleet_events L1/L2/L3 + task_events) is PR4.

### Tests / gates
- Unit: oracle truth-table (Idle+grew→ok / UsageLimit→fail / empty→fail), debounce (mid-turn Idle blip must not fire before the held window), body-line measure (chrome churn ≠ growth), summary cap/char-boundary.
- Store: driver-gate (`DriverUnsupported`, no reserve), `record_result`/`mark_prompting`.
- **Real-opencode e2e** (`#[ignore]`, unix-only) — **passed locally in 9.2s** (success + non-empty transcript), the confirm-first empirical proof of the full path.
- Green: unix build + clippy + fmt; 40 `ephemeral_tracking` + driver + 12 `mcp::tools` unit; `spawn_rationale_audit` / `file_size_invariant` / `anti_pattern` / `cargo_include` / mcp-schema invariants; **cargo-xwin windows-msvc clippy** clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)