### PR TITLE
feat(ephemeral): #1967 PR3b Slice-2 — extend one-shot driver to claude backend

### DIFF
--- a/src/ephemeral_driver.rs
+++ b/src/ephemeral_driver.rs
@@ -28,13 +28,15 @@
 //! - **Success oracle = terminal `Idle` ∧ ¬error-class ([`AgentState::is_error`]) ∧
 //!   transcript GREW.** NOT `has_productive_output()` — that is false on a text-only
 //!   success (opencode's productive markers match only tool-use glyphs).
-//! - **Transcript "grew" = non-blank-line COUNT delta** (baseline at ready ↔ final at
-//!   turn-end). Chrome is NOT excluded from this measure: the footer's row COUNT is
-//!   identical at both samples (only its content — elapsed timer / token count —
-//!   churns), so it cancels in the delta. Counting LINES (not bytes) makes a chrome
-//!   content update invisible to "grew". The `result_summary` (cosmetic) drops the
-//!   trailing footer via a PATTERN-based strip ([`is_trailing_chrome`]) rather than a
-//!   per-backend magic row count, so it survives a backend bumping its footer.
+//! - **Transcript "grew" = an ANSWER appeared after the prompt echo** ([`transcript_grew`]):
+//!   locate the injected-prompt echo in the (chrome-stripped) transcript and require
+//!   non-blank content after it. This is MONOTONIC + term-size-independent + per-backend-
+//!   free — it does not depend on screen density. (A raw nonblank-COUNT delta only works
+//!   for ALT-SCREEN TUIs whose banner persists in both snapshots, e.g. claude/opencode
+//!   `max_scroll=0`; a SCROLLING-TUI backend would false-negative — #2408 lead vet.) The
+//!   count-delta is kept only as the echo-scrolled-off FALLBACK. The `result_summary`
+//!   (cosmetic) drops the trailing footer via a PATTERN-based strip ([`is_trailing_chrome`]),
+//!   not a per-backend magic row count, so it survives a backend bumping its footer.
 //!
 //! Scope: opencode (Slice-1) + claude (Slice-2) — each §5-smoke-validated. The gate
 //! ([`crate::ephemeral_tracking`] `driver_supported`) admits exactly this set; other
@@ -167,7 +169,7 @@ fn run_turn(cfg: DriverConfig) {
         .vterm
         .tail_lines_dewrapped(CAPTURE_LINES);
     let terminal_state = inject_target.core.lock().state.get_state();
-    let grew = nonblank_count(&end_dump) > baseline_body;
+    let grew = transcript_grew(&end_dump, &prompt, baseline_body);
     let success = oracle_success(terminal_state, grew);
     let summary = build_summary(&end_dump, terminal_state, grew, stop_reason);
 
@@ -199,13 +201,66 @@ fn oracle_success(terminal_state: AgentState, transcript_grew: bool) -> bool {
     terminal_state == AgentState::Idle && !terminal_state.is_error() && transcript_grew
 }
 
-/// Count non-blank lines in a vterm dump. Used for the "grew" measure as a
-/// baseline↔final DELTA, so chrome is NOT excluded here: the footer's row COUNT is
-/// identical at baseline and at turn-end (only its CONTENT churns — elapsed timer,
-/// token count), so it cancels in the delta. Counting LINES (not bytes) makes a chrome
-/// content update invisible to "grew". Backend-agnostic — no per-backend tuning.
+/// Count non-blank lines in a vterm dump. Used as the FALLBACK "grew" signal (see
+/// [`transcript_grew`]): a baseline↔final DELTA. Chrome is NOT excluded — the footer row
+/// COUNT is identical at both samples (only its content churns), so it cancels in the
+/// delta; counting LINES (not bytes) makes a chrome update invisible.
 fn nonblank_count(dump: &str) -> usize {
     dump.lines().filter(|l| !l.trim().is_empty()).count()
+}
+
+/// Did the worker produce an ANSWER this turn? PR3b Slice-2 (lead vet) — a MONOTONIC,
+/// term-size-independent, per-backend-free signal: locate the injected-prompt echo in
+/// the (chrome-stripped) transcript and require non-blank content AFTER it (= the
+/// assistant's reply).
+///
+/// Why not the raw nonblank-COUNT delta: that only works for an ALT-SCREEN TUI whose
+/// startup banner persists in BOTH the baseline and final snapshots (claude/opencode —
+/// empirically `max_scroll=0`), so `final = banner + answer > baseline = banner`. A
+/// SCROLLING-TUI backend (a future slice) would FALSE-NEGATIVE when a dense ready screen
+/// scrolls off behind a short answer (`nonblank(final) ≤ nonblank(baseline)`). Anchoring
+/// on the prompt echo sidesteps screen density entirely — content after the echo is the
+/// answer regardless of how the screen scrolled.
+///
+/// FALLBACK: if the echo is not found (a long turn scrolled it off the captured window),
+/// fall back to the conservative nonblank-COUNT delta (`final > baseline`) so a
+/// genuinely-grown transcript whose echo is no longer visible is not wrongly judged empty.
+fn transcript_grew(end_dump: &str, prompt: &str, baseline_nonblank: usize) -> bool {
+    let body = strip_trailing_chrome(end_dump);
+    let body_lines: Vec<&str> = body.lines().collect();
+    match locate_prompt_echo(&body_lines, prompt) {
+        // Answer = any non-blank line after the echo (trailing chrome already stripped).
+        Some(echo_idx) => body_lines[echo_idx + 1..]
+            .iter()
+            .any(|l| !l.trim().is_empty()),
+        // Echo scrolled off → conservative count-delta fallback.
+        None => nonblank_count(end_dump) > baseline_nonblank,
+    }
+}
+
+/// A stable prefix of the prompt to match the echo on — first ~40 chars (or the whole
+/// prompt if shorter). A prefix (not the full text) so a TUI that WRAPS or truncates a
+/// long echo still anchors on its first rendered line.
+fn prompt_echo_needle(prompt: &str) -> &str {
+    let trimmed = prompt.trim();
+    let end = trimmed
+        .char_indices()
+        .nth(40)
+        .map(|(i, _)| i)
+        .unwrap_or(trimmed.len());
+    &trimmed[..end]
+}
+
+/// Find the transcript line echoing the injected prompt, by matching its prefix
+/// ([`prompt_echo_needle`]). Returns the LAST match (the most recent turn's echo, so a
+/// prompt that also appears earlier in scrollback doesn't mis-anchor). `None` if the
+/// prompt is empty or its echo isn't present (scrolled off / not yet rendered).
+fn locate_prompt_echo(lines: &[&str], prompt: &str) -> Option<usize> {
+    let needle = prompt_echo_needle(prompt);
+    if needle.is_empty() {
+        return None;
+    }
+    lines.iter().rposition(|l| l.contains(needle))
 }
 
 /// True if `line` is trailing CHROME (a footer / statusline row), not transcript body.
@@ -426,16 +481,83 @@ mod tests {
     }
 
     #[test]
-    fn transcript_growth_detected_via_nonblank_delta() {
-        // Baseline (ready, before inject) vs final (after a reply) — the assistant's new
-        // lines register as growth even though the footer rows are unchanged.
+    fn nonblank_delta_fallback_detects_growth() {
+        // The FALLBACK signal (echo scrolled off): baseline vs final nonblank delta.
         let baseline = "❯ prompt\n─────\n❯\nModel: Opus | Ctx Used: 0%";
         let grown =
             "❯ prompt\n⏺ assistant reply\n⏺ more reply\n─────\n❯\nModel: Opus | Ctx Used: 3%";
+        assert!(nonblank_count(grown) > nonblank_count(baseline));
+    }
+
+    // ───────────── grew = prompt-echo anchor (#2408 root fix) ─────────────
+
+    /// THE root-fix test (replaces fixup-dev's `grew_false_negative_when_dense_baseline_
+    /// exceeds_sparse_end`): a DENSE baseline (huge ready banner) + a SPARSE end (short
+    /// answer) — the raw count-delta FALSE-NEGATIVES, but the prompt-echo anchor finds the
+    /// answer after the echo → grew=TRUE. This is the scrolling-TUI failure the new signal
+    /// fixes.
+    #[test]
+    fn grew_true_even_when_sparse_end_is_denser_baseline() {
+        let prompt = "Summarize the file";
+        // Dense baseline: a big ready banner (would be in scrollback for a scrolling TUI).
+        let dense_baseline_nonblank = 50;
+        // Sparse end: the prompt echo + a one-line answer + chrome. nonblank ≈ 3 < 50, so
+        // the count-delta would judge grew=false (the reviewers' false-negative).
+        let sparse_end =
+            "❯ Summarize the file\n⏺ It is a config file.\n─────\n❯\n  Model: Opus | Ctx Used: 2%";
         assert!(
-            nonblank_count(grown) > nonblank_count(baseline),
-            "the assistant reply must register as growth"
+            nonblank_count(sparse_end) < dense_baseline_nonblank,
+            "precondition: this IS the count-delta false-negative shape"
         );
+        assert!(
+            transcript_grew(sparse_end, prompt, dense_baseline_nonblank),
+            "prompt-echo anchor must see the answer after the echo → grew=true"
+        );
+    }
+
+    /// Echo present but NO content after it (worker produced nothing) → grew=false.
+    #[test]
+    fn grew_false_when_no_answer_after_echo() {
+        let prompt = "do the thing";
+        let end = "❯ do the thing\n─────\n❯\n  Model: Opus | Ctx Used: 0%";
+        assert!(
+            !transcript_grew(end, prompt, 0),
+            "only the echo + chrome, no answer → grew=false"
+        );
+    }
+
+    /// Echo NOT found (scrolled off a long turn) → fall back to the nonblank count-delta.
+    #[test]
+    fn grew_falls_back_to_count_delta_when_echo_absent() {
+        let prompt = "a prompt that scrolled off the captured window";
+        // No echo line present; end is denser than baseline → fallback says grew.
+        let end = "⏺ line1\n⏺ line2\n⏺ line3\n─────\n❯";
+        assert!(
+            transcript_grew(end, prompt, 1),
+            "fallback: end denser than baseline → grew"
+        );
+        assert!(
+            !transcript_grew(end, prompt, 99),
+            "fallback: end NOT denser than a huge baseline → not grew"
+        );
+    }
+
+    /// The anchor matches a PREFIX (a wrapped/truncated echo still anchors) and uses the
+    /// LAST occurrence (a prompt repeated in scrollback doesn't mis-anchor to the old one).
+    #[test]
+    fn locate_prompt_echo_prefix_and_last_match() {
+        let prompt = "Reply with exactly the word: pong and nothing else at all";
+        let lines = vec![
+            "❯ Reply with exactly the word: pong and nothing el", // wrapped/truncated echo
+            "⏺ pong",
+        ];
+        // Prefix (first ~40 chars) still matches the truncated echo line.
+        assert_eq!(locate_prompt_echo(&lines, prompt), Some(0));
+        // Last occurrence wins.
+        let repeated = vec!["❯ do x", "⏺ ok", "❯ do x", "⏺ done"];
+        assert_eq!(locate_prompt_echo(&repeated, "do x"), Some(2));
+        // Empty prompt → no anchor.
+        assert_eq!(locate_prompt_echo(&lines, ""), None);
     }
 
     /// Pattern-based chrome strip drops claude's footer (rules / empty `❯` box / Model

--- a/src/ephemeral_driver.rs
+++ b/src/ephemeral_driver.rs
@@ -1,8 +1,8 @@
 //! #1967 Phase-1 PR3b: the one-shot ephemeral-worker DRIVER (Route B).
 //!
 //! After [`crate::ephemeral_tracking::spawn_and_track`] finalizes a headless
-//! opencode worker, it launches a background driver thread (this module) that runs
-//! exactly ONE prompt turn to a recorded result:
+//! opencode/claude worker, it launches a background driver thread (this module) that
+//! runs exactly ONE prompt turn to a recorded result:
 //!
 //!   wait-ready → inject prompt → turn-end (Idle-debounce) → capture → oracle → record
 //!
@@ -28,14 +28,19 @@
 //! - **Success oracle = terminal `Idle` ∧ ¬error-class ([`AgentState::is_error`]) ∧
 //!   transcript GREW.** NOT `has_productive_output()` — that is false on a text-only
 //!   success (opencode's productive markers match only tool-use glyphs).
-//! - **Transcript "grew" = non-blank body-line COUNT delta** (excluding the bottom
-//!   ~2 chrome rows: opencode's model/elapsed line + token/commands statusline, which
-//!   churn every render). Counting LINES (not bytes) is robust to chrome content churn
-//!   — the chrome line COUNT is stable across renders.
+//! - **Transcript "grew" = non-blank-line COUNT delta** (baseline at ready ↔ final at
+//!   turn-end). Chrome is NOT excluded from this measure: the footer's row COUNT is
+//!   identical at both samples (only its content — elapsed timer / token count —
+//!   churns), so it cancels in the delta. Counting LINES (not bytes) makes a chrome
+//!   content update invisible to "grew". The `result_summary` (cosmetic) drops the
+//!   trailing footer via a PATTERN-based strip ([`is_trailing_chrome`]) rather than a
+//!   per-backend magic row count, so it survives a backend bumping its footer.
 //!
-//! Scope: opencode ONLY (the only backend the 1a smoke validated; other backends are
-//! Slice-2, each §5-smoke-gated). Durable telemetry (fleet_events L1/L2/L3 + task_events)
-//! is PR4; the result lands on the worker row for now.
+//! Scope: opencode (Slice-1) + claude (Slice-2) — each §5-smoke-validated. The gate
+//! ([`crate::ephemeral_tracking`] `driver_supported`) admits exactly this set; other
+//! backends are later slices. Both proven to render a continuous work marker so the
+//! Idle-debounce isn't fooled by a mid-turn idle. Durable telemetry (fleet_events
+//! L1/L2/L3 + task_events) is PR4; the result lands on the worker row for now.
 
 use crate::agent::InjectTarget;
 use crate::state::AgentState;
@@ -52,12 +57,9 @@ const POLL_INTERVAL: Duration = Duration::from_millis(250);
 const TURN_DEBOUNCE_MS: u64 = 3_000;
 
 /// Max wait for the worker to reach its first `Idle` (ready) after spawn (capped by
-/// the worker's wall-TTL). opencode reaches ready in ~2.6 s; this is a generous cap.
+/// the worker's wall-TTL). opencode reaches ready in ~2.6 s, claude in ~11 s; this is a
+/// generous cap for both.
 const READY_TIMEOUT: Duration = Duration::from_secs(60);
-
-/// Bottom chrome rows to exclude from the body-line measure (opencode's model/elapsed
-/// line + token/commands statusline). See the module doc's "grew" note.
-const CHROME_TAIL_LINES: usize = 2;
 
 /// Logical lines to dump from the vterm tail for the body measure + result capture.
 /// The worker's vterm is 50 rows; 80 covers the visible screen with margin for
@@ -126,13 +128,13 @@ fn run_turn(cfg: DriverConfig) {
         std::thread::sleep(POLL_INTERVAL);
     }
 
-    // Baseline body-line count (at ready, before inject) for the "grew" measure.
+    // Baseline non-blank-line count (at ready, before inject) for the "grew" measure.
     let baseline_dump = inject_target
         .core
         .lock()
         .vterm
         .tail_lines_dewrapped(CAPTURE_LINES);
-    let baseline_body = body_nonblank_count(&baseline_dump, CHROME_TAIL_LINES);
+    let baseline_body = nonblank_count(&baseline_dump);
 
     // Phase 1 — inject the prompt. Mark phase=prompting first so `ephemeral list`
     // reflects the mid-turn state.
@@ -165,7 +167,7 @@ fn run_turn(cfg: DriverConfig) {
         .vterm
         .tail_lines_dewrapped(CAPTURE_LINES);
     let terminal_state = inject_target.core.lock().state.get_state();
-    let grew = body_nonblank_count(&end_dump, CHROME_TAIL_LINES) > baseline_body;
+    let grew = nonblank_count(&end_dump) > baseline_body;
     let success = oracle_success(terminal_state, grew);
     let summary = build_summary(&end_dump, terminal_state, grew, stop_reason);
 
@@ -197,26 +199,77 @@ fn oracle_success(terminal_state: AgentState, transcript_grew: bool) -> bool {
     terminal_state == AgentState::Idle && !terminal_state.is_error() && transcript_grew
 }
 
-/// Count non-blank "body" lines in a vterm dump, EXCLUDING the bottom `chrome_tail`
-/// rows. Counting LINES (not bytes) is robust to chrome CONTENT churn (the elapsed
-/// timer / token count tick every render but the chrome line COUNT is stable), so a
-/// statusline update is never misread as transcript growth.
-fn body_nonblank_count(dump: &str, chrome_tail: usize) -> usize {
-    let lines: Vec<&str> = dump.lines().collect();
-    let body_end = lines.len().saturating_sub(chrome_tail);
-    lines[..body_end]
-        .iter()
-        .filter(|l| !l.trim().is_empty())
-        .count()
+/// Count non-blank lines in a vterm dump. Used for the "grew" measure as a
+/// baseline↔final DELTA, so chrome is NOT excluded here: the footer's row COUNT is
+/// identical at baseline and at turn-end (only its CONTENT churns — elapsed timer,
+/// token count), so it cancels in the delta. Counting LINES (not bytes) makes a chrome
+/// content update invisible to "grew". Backend-agnostic — no per-backend tuning.
+fn nonblank_count(dump: &str) -> usize {
+    dump.lines().filter(|l| !l.trim().is_empty()).count()
 }
 
-/// Build the persisted `result_summary`: the body region (chrome rows dropped),
+/// True if `line` is trailing CHROME (a footer / statusline row), not transcript body.
+/// PATTERN-based (PR3b Slice-2 lead vet) rather than a per-backend magic row count, so
+/// it survives a backend bumping its footer's row count. Covers opencode + claude
+/// footers; an unrecognized footer line simply isn't stripped — purely COSMETIC (the
+/// "grew" oracle never uses this; it's chrome-cancelling). Used only to clean the
+/// persisted `result_summary`.
+fn is_trailing_chrome(line: &str) -> bool {
+    let t = line.trim();
+    if t.is_empty() {
+        return true; // trailing blank rows
+    }
+    // A separator / box-drawing-frame-only row (claude's `───` rules + box borders).
+    if t.chars().all(|c| {
+        matches!(
+            c,
+            '─' | '━'
+                | '│'
+                | '┃'
+                | '╭'
+                | '╮'
+                | '╰'
+                | '╯'
+                | '├'
+                | '┤'
+                | '┬'
+                | '┴'
+                | ' '
+        )
+    }) {
+        return true;
+    }
+    // A lone input-prompt glyph = an EMPTY input box (NOT `❯ <prompt>`, which is body).
+    if matches!(t, "❯" | "›" | ">" | "┃") {
+        return true;
+    }
+    // Known backend footer statuslines (claude + opencode).
+    let lower = t.to_ascii_lowercase();
+    lower.contains("bypass permissions")        // claude: `⏵⏵ bypass permissions …`
+        || lower.contains("ctx used")           // claude: `Model: … | Ctx Used: …`
+        || lower.starts_with("model:")          // claude statusline
+        || lower.starts_with("▣ build")         // opencode completion line
+        || lower.contains("esc to interrupt") // any working footer (safety; not at Idle)
+}
+
+/// The transcript body = the dump with its trailing chrome rows stripped (pattern-
+/// based). Walks from the bottom dropping chrome rows, stops at the first body row.
+fn strip_trailing_chrome(dump: &str) -> String {
+    let lines: Vec<&str> = dump.lines().collect();
+    let keep = lines.len()
+        - lines
+            .iter()
+            .rev()
+            .take_while(|l| is_trailing_chrome(l))
+            .count();
+    lines[..keep].join("\n")
+}
+
+/// Build the persisted `result_summary`: the body region (trailing chrome stripped),
 /// trimmed of trailing blanks and capped at [`MAX_SUMMARY_BYTES`], prefixed with a
 /// one-line verdict so a reader sees the outcome without re-deriving it.
 fn build_summary(dump: &str, terminal_state: AgentState, grew: bool, stop_reason: &str) -> String {
-    let lines: Vec<&str> = dump.lines().collect();
-    let body_end = lines.len().saturating_sub(CHROME_TAIL_LINES);
-    let body = lines[..body_end].join("\n");
+    let body = strip_trailing_chrome(dump);
     let body = body.trim_end();
     let header = format!("[{terminal_state:?} grew={grew} stop={stop_reason}]\n");
     let mut out = header;
@@ -354,45 +407,72 @@ mod tests {
         assert!(!oracle_success(AgentState::Thinking, true));
     }
 
-    // ─────────────────────────── body-line measure ─────────────────────────
+    // ─────────────── grew measure (nonblank delta) + chrome strip ───────────────
 
     #[test]
-    fn body_count_excludes_chrome_and_blanks() {
-        // 3 body lines + 1 blank + 2 chrome rows → counts only the 3 non-blank body.
-        let dump = "answer line 1\nanswer line 2\nanswer line 3\n\nmodel · 2s\ntokens 42";
-        assert_eq!(body_nonblank_count(dump, CHROME_TAIL_LINES), 3);
+    fn nonblank_count_ignores_blank_lines() {
+        assert_eq!(nonblank_count("a\n\nb\n   \nc"), 3);
+        assert_eq!(nonblank_count(""), 0);
     }
 
     #[test]
-    fn body_count_chrome_churn_does_not_grow() {
-        // Same body, only the chrome (elapsed timer / token count) changed → the body
-        // count is identical, so a chrome update is NOT misread as transcript growth.
-        let before = "prompt echo\nmodel · 1s\ntokens 10";
-        let after = "prompt echo\nmodel · 9s\ntokens 99";
-        assert_eq!(
-            body_nonblank_count(before, CHROME_TAIL_LINES),
-            body_nonblank_count(after, CHROME_TAIL_LINES),
-            "chrome churn must not change the body count"
-        );
+    fn nonblank_count_stable_under_chrome_churn() {
+        // The "grew" measure is a baseline↔final DELTA; the footer's row COUNT is
+        // constant (only its content — elapsed timer / token count — churns), so a
+        // chrome update never changes the count → never misread as growth.
+        let before = "prompt echo\nModel: Opus | Ctx Used: 1.0%\n⏵⏵ bypass permissions on";
+        let after = "prompt echo\nModel: Opus | Ctx Used: 9.0%\n⏵⏵ bypass permissions on";
+        assert_eq!(nonblank_count(before), nonblank_count(after));
     }
 
     #[test]
-    fn body_count_handles_dump_shorter_than_chrome_tail() {
-        // saturating_sub: a tiny dump (fewer rows than chrome_tail) yields 0, no panic.
-        assert_eq!(body_nonblank_count("x", 2), 0);
-        assert_eq!(body_nonblank_count("", 2), 0);
-    }
-
-    #[test]
-    fn transcript_growth_detected_via_body_delta() {
-        let baseline = "prompt echo\nmodel · 0s\ntokens 0";
-        let grown = "prompt echo\nassistant reply line\nmore reply\nmodel · 4s\ntokens 88";
-        let baseline_body = body_nonblank_count(baseline, CHROME_TAIL_LINES);
-        let grown_body = body_nonblank_count(grown, CHROME_TAIL_LINES);
+    fn transcript_growth_detected_via_nonblank_delta() {
+        // Baseline (ready, before inject) vs final (after a reply) — the assistant's new
+        // lines register as growth even though the footer rows are unchanged.
+        let baseline = "❯ prompt\n─────\n❯\nModel: Opus | Ctx Used: 0%";
+        let grown =
+            "❯ prompt\n⏺ assistant reply\n⏺ more reply\n─────\n❯\nModel: Opus | Ctx Used: 3%";
         assert!(
-            grown_body > baseline_body,
+            nonblank_count(grown) > nonblank_count(baseline),
             "the assistant reply must register as growth"
         );
+    }
+
+    /// Pattern-based chrome strip drops claude's footer (rules / empty `❯` box / Model
+    /// statusline / bypass line) but keeps the answer + the `✻ Worked` completion line.
+    #[test]
+    fn strip_trailing_chrome_drops_claude_footer() {
+        let dump = "the answer\n✻ Worked for 6s\n\n──────────\n❯\n──────────\n  Model: Opus 4.8 | Ctx Used: 3.0%\n  ⏵⏵ bypass permissions on (shift+tab to cycle)";
+        let body = strip_trailing_chrome(dump);
+        assert!(body.contains("the answer"), "body answer kept");
+        assert!(body.contains("✻ Worked for 6s"), "completion marker kept");
+        assert!(
+            !body.contains("bypass permissions"),
+            "claude footer dropped"
+        );
+        assert!(!body.contains("Model:"), "claude statusline dropped");
+        assert!(!body.contains('❯'), "empty input box dropped");
+    }
+
+    /// A `❯ <prompt>` echo (content after the glyph) is BODY, not chrome — only a LONE
+    /// `❯` (empty input box) is stripped.
+    #[test]
+    fn strip_trailing_chrome_keeps_prompt_echo() {
+        let dump = "❯ do the thing\nresult here\n❯";
+        let body = strip_trailing_chrome(dump);
+        assert!(body.contains("❯ do the thing"), "the prompt echo is body");
+        assert!(body.contains("result here"));
+        assert!(
+            body.ends_with("result here"),
+            "the trailing empty ❯ box is stripped"
+        );
+    }
+
+    #[test]
+    fn strip_trailing_chrome_handles_all_chrome_and_empty() {
+        // All-chrome / empty dumps return empty, no panic (the `len - take_while` math).
+        assert_eq!(strip_trailing_chrome(""), "");
+        assert_eq!(strip_trailing_chrome("──────\n❯\n\n"), "");
     }
 
     // ───────────────────── turn-end detector (debounce) ─────────────────────
@@ -467,13 +547,14 @@ mod tests {
 
     #[test]
     fn summary_drops_chrome_and_prefixes_verdict() {
-        let dump = "the answer\nmodel · 2s\ntokens 42";
+        let dump =
+            "the answer\n─────\n❯\n  Model: Opus | Ctx Used: 3.0%\n  ⏵⏵ bypass permissions on";
         let s = build_summary(dump, AgentState::Idle, true, "turn ended (Idle held)");
         assert!(s.starts_with("[Idle grew=true stop=turn ended (Idle held)]"));
         assert!(s.contains("the answer"));
         assert!(
-            !s.contains("tokens 42"),
-            "the chrome statusline must be dropped"
+            !s.contains("bypass permissions") && !s.contains("Model:"),
+            "the chrome footer must be dropped from the summary"
         );
     }
 

--- a/src/ephemeral_tracking.rs
+++ b/src/ephemeral_tracking.rs
@@ -208,9 +208,10 @@ impl std::fmt::Display for SpawnError {
             ),
             SpawnError::DriverUnsupported(b) => write!(
                 f,
-                "ephemeral spawn: a prompt-driven one-shot turn is only supported for 'opencode' \
-                 (PR3b Slice-1); backend '{b}' is Slice-2 (pending a per-backend turn-detection \
-                 smoke). Spawn it without a prompt for a lifecycle-only worker."
+                "ephemeral spawn: a prompt-driven one-shot turn is only supported for \
+                 'opencode' and 'claude' (PR3b Slice-1/2); backend '{b}' is pending its own \
+                 per-backend turn-detection smoke. Spawn it without a prompt for a \
+                 lifecycle-only worker."
             ),
             SpawnError::CapExceeded { live, cap } => write!(
                 f,
@@ -250,6 +251,19 @@ pub fn resolve_supported_backend(backend: &str) -> Result<&'static str, String> 
         Some(b) => Ok(b.preset().command),
         None => Err(format!("backend '{backend}' is not a supported backend")),
     }
+}
+
+/// PR3b: backends whose one-shot DRIVER (inject → turn-end → capture → oracle) is
+/// §5-smoke-validated, so a `prompt` may be driven on them. Slice-1 added opencode;
+/// Slice-2 added claude (both proven to render a continuous work marker so the
+/// Idle-debounce isn't fooled by a mid-turn idle — confirm-first iron rule). A prompt
+/// for any other backend is rejected ([`SpawnError::DriverUnsupported`]) until its own
+/// §5 smoke lands. `backend_command` is the canonical, allowlist-resolved command.
+fn driver_supported(backend_command: &str) -> bool {
+    matches!(
+        crate::backend::Backend::from_command(backend_command),
+        Some(crate::backend::Backend::OpenCode | crate::backend::Backend::ClaudeCode)
+    )
 }
 
 /// Why a slot reservation failed.
@@ -436,14 +450,14 @@ pub fn spawn_and_track(home: &Path, spec: SpawnSpec) -> Result<EphemeralWorker, 
     };
 
     // 0b) DRIVER GATE (PR3b) — a `prompt` launches the one-shot driver (inject →
-    //     turn-end → capture → oracle), which is smoke-validated for opencode ONLY
-    //     (Slice-1). Reject a prompt for any other backend BEFORE reserving/spawning
-    //     (confirm-first iron rule: never drive a backend whose turn-end detection
-    //     isn't proven on a real turn). A prompt-LESS spawn of any backend is the PR3a
-    //     lifecycle-only path and is unaffected. Gated in the SHARED SINK so a direct
-    //     caller, not just the MCP handler, is protected.
+    //     turn-end → capture → oracle), §5-smoke-validated for the [`driver_supported`]
+    //     backend set (Slice-1 opencode, Slice-2 claude). Reject a prompt for any other
+    //     backend BEFORE reserving/spawning (confirm-first iron rule: never drive a
+    //     backend whose turn-end detection isn't proven on a real turn). A prompt-LESS
+    //     spawn of any backend is the PR3a lifecycle-only path and is unaffected. Gated
+    //     in the SHARED SINK so a direct caller, not just the MCP handler, is protected.
     let drive_turn = !spec.prompt.is_empty();
-    if drive_turn && backend_command != crate::backend::Backend::OpenCode.preset().command {
+    if drive_turn && !driver_supported(backend_command) {
         return Err(SpawnError::DriverUnsupported(spec.backend.clone()));
     }
 
@@ -524,13 +538,16 @@ pub fn spawn_and_track(home: &Path, spec: SpawnSpec) -> Result<EphemeralWorker, 
             // PR3b: launch the one-shot driver BEFORE moving the handle into
             // LIVE_CHILDREN, capturing the inject target (Arc clones of the retained
             // pty_writer + core) so the driver is decoupled from the handle the reaper
-            // owns. Only when a prompt was given (opencode, gated in step 0b) — else
-            // this is the PR3a lifecycle-only spawn (no driver thread).
-            if drive_turn {
-                let inject_target = crate::agent::InjectTarget::from_ephemeral(
-                    &handle,
-                    crate::backend::Backend::OpenCode,
-                );
+            // owns. Only when a prompt was given (a driver_supported backend, gated in
+            // step 0b) — else this is the PR3a lifecycle-only spawn (no driver thread).
+            // The real backend (opencode/claude) drives the inject preset + capture, so
+            // `from_ephemeral` gets it (never a hardcode). `from_command` is `Some` here
+            // because step 0b's `driver_supported` already confirmed the canonical command.
+            if let (true, Some(backend)) = (
+                drive_turn,
+                crate::backend::Backend::from_command(backend_command),
+            ) {
+                let inject_target = crate::agent::InjectTarget::from_ephemeral(&handle, backend);
                 crate::ephemeral_driver::spawn_driver(crate::ephemeral_driver::DriverConfig {
                     home: home.to_path_buf(),
                     worker_id: worker_id.clone(),
@@ -1710,24 +1727,25 @@ mod tests {
 
     // ─────────────────── PR3b: driver gate + result recording ───────────────────
 
-    /// PR3b driver GATE: a `prompt` for a NON-opencode backend is rejected as
-    /// `DriverUnsupported` BEFORE any reserve/spawn (confirm-first iron rule — only
-    /// opencode's turn-end detection is smoke-validated in Slice-1). Gated in the
-    /// SHARED SINK so a direct caller, not just the MCP handler, is protected. A
-    /// prompt-LESS spawn of any backend is unaffected (the PR3a lifecycle path).
+    /// PR3b driver GATE: a `prompt` for a backend NOT in [`driver_supported`] is
+    /// rejected as `DriverUnsupported` BEFORE any reserve/spawn (confirm-first iron rule
+    /// — never drive a backend whose turn-detection isn't §5-smoke-proven). codex is the
+    /// canonical still-unsupported backend (Slice-3+). Gated in the SHARED SINK so a
+    /// direct caller, not just the MCP handler, is protected. A prompt-LESS spawn of any
+    /// backend is unaffected (the PR3a lifecycle path).
     #[test]
-    fn spawn_and_track_rejects_prompt_for_non_opencode_backend() {
+    fn spawn_and_track_rejects_prompt_for_unsupported_backend() {
         let home = tmp_home("driver-gate");
         let spec = SpawnSpec {
             workflow_id: "wf".to_string(),
-            backend: "claude".to_string(),
+            backend: "codex".to_string(),
             prompt: "do the thing".to_string(),
             ..Default::default()
         };
         let res = spawn_and_track(&home, spec);
         assert!(
-            matches!(&res, Err(SpawnError::DriverUnsupported(b)) if b == "claude"),
-            "a prompt for a non-opencode backend must be DriverUnsupported: {res:?}"
+            matches!(&res, Err(SpawnError::DriverUnsupported(b)) if b == "codex"),
+            "a prompt for a driver-unsupported backend must be DriverUnsupported: {res:?}"
         );
         assert_eq!(
             list(&home, None).len(),
@@ -1735,6 +1753,32 @@ mod tests {
             "the driver gate rejects before reserve — no row, no process"
         );
         std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// PR3b Slice-2: the [`driver_supported`] set is exactly {opencode, claude} — the
+    /// §5-smoke-validated backends. Regression-guards the gate generalization: opencode
+    /// (Slice-1) MUST stay supported, claude (Slice-2) is added, and codex/kiro/agy stay
+    /// rejected (their per-backend smoke hasn't landed). Canonical commands + aliases.
+    #[test]
+    fn driver_supported_is_opencode_and_claude_only() {
+        assert!(
+            driver_supported("opencode"),
+            "opencode (Slice-1) must stay supported"
+        );
+        assert!(
+            driver_supported("claude"),
+            "claude (Slice-2) is now supported"
+        );
+        assert!(
+            driver_supported("claude-2.1"),
+            "a claude-prefixed alias maps to ClaudeCode → supported"
+        );
+        for unsupported in ["codex", "kiro-cli", "kiro", "agy"] {
+            assert!(
+                !driver_supported(unsupported),
+                "{unsupported} has no §5 smoke yet → driver unsupported"
+            );
+        }
     }
 
     /// PR3b: `mark_prompting` flips phase to `prompting`; `record_result` writes the
@@ -1830,6 +1874,62 @@ mod tests {
         assert!(
             success,
             "a simple prompt turn must succeed; summary={summary:?}"
+        );
+        assert!(
+            summary.map(|s| !s.trim().is_empty()).unwrap_or(false),
+            "result_summary must be non-empty on success"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// REAL claude end-to-end (`#[ignore]`: no binary/creds in CI) — PR3b Slice-2.
+    /// Drives a real headless claude worker through the SAME driver path (turn-detect /
+    /// oracle / capture reuse, per the §5 smoke) and asserts success with a non-empty
+    /// transcript. Uses the inherited model (no override). Run locally:
+    /// `cargo test --bin agend-terminal --features tray -- --ignored ephemeral_claude_driver_e2e`.
+    /// claude ready is ~11s + a short turn, so the budget is generous.
+    /// `#[cfg(unix)]`: ephemeral spawn is fail-closed on Windows.
+    #[cfg(unix)]
+    #[test]
+    #[ignore = "requires a real claude install + auth; run locally"]
+    fn ephemeral_claude_driver_e2e() {
+        let home = tmp_home("claude-e2e");
+        let spec = SpawnSpec {
+            workflow_id: "e2e".to_string(),
+            backend: "claude".to_string(),
+            prompt: "Reply with exactly the word: pong".to_string(),
+            ttl_secs: Some(240),
+            ..Default::default()
+        };
+        let w = spawn_and_track(&home, spec).expect("spawn claude worker");
+        assert_ne!(w.pid, 0, "a real pid was stamped");
+
+        // Driver runs ASYNC; poll the row until it records a result (claude ready ~11s).
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(210);
+        let outcome = loop {
+            match list(&home, None)
+                .into_iter()
+                .find(|r| r.worker_id == w.worker_id)
+            {
+                Some(row) => {
+                    if let Some(success) = row.success {
+                        break Some((success, row.result_summary));
+                    }
+                }
+                None => break None,
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "the driver did not record a result within the deadline"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(500));
+        };
+        reap_one(&home, &w.worker_id);
+
+        let (success, summary) = outcome.expect("the worker row must carry a result before reap");
+        assert!(
+            success,
+            "a simple claude prompt turn must succeed; summary={summary:?}"
         );
         assert!(
             summary.map(|s| !s.trim().is_empty()).unwrap_or(false),


### PR DESCRIPTION
## #1967 Phase-1 PR3b Slice-2 — claude ephemeral driver

Builds on Slice-1 (#2407, opencode driver). Adds **claude** to the one-shot driver — `flag-OFF`, `cap=3`, **unix-only**. Driver reuses ~100%; only the backend gate + chrome-strip changed.

### §5 confirm-first smoke (gate — done before impl, lead-vetted)
Drove a **real headless claude worker**. Timeline: `Starting → PermissionPrompt`(transient) `→ Idle`(~11s ready) `→ inject → Thinking → Idle`(end) — **one unbroken Thinking stretch, no mid-turn Idle blip**. Verdicts:
- **turn-detect SOUND** — claude renders a continuous work marker; `detect()` is first-match-wins with `ToolUse`/`Thinking` listed *before* `Idle(❯)`, so a work marker beats the persistent `❯` input box. 3s debounce carries over.
- **oracle SOUND** — claude's error patterns are all `is_error()`; the existing oracle works unchanged.
- **never-tick HOLDS** — `silence_idle_ms` is shadow-only (`record_shadow_telemetry`, zero state change); state is regex-driven.
- **only diff = chrome footer shape** (claude ≈5 rows vs opencode ~2).

Findings doc: `workspace/fixup-dev-2/PR3B-SLICE2-CLAUDE-SMOKE-FINDINGS.md`.

### What changed
- **Gate**: opencode-only check → `driver_supported(backend)` set `{opencode, claude}` (other backends still → `SpawnError::DriverUnsupported` = later slices).
- **`spawn_and_track`** passes the **real backend** to `InjectTarget::from_ephemeral` (was a hardcoded `OpenCode`) so claude gets its own inject preset.
- **Chrome handling — pattern-based** (lead vet: robust to a backend bumping its footer rows, vs a magic per-backend count):
  - **GREW** no longer excludes chrome — it's a baseline↔final non-blank-line **COUNT delta**, and the footer row count is constant at both samples → cancels. Backend-agnostic; removes the per-backend `CHROME_TAIL` constant from the correctness path.
  - **`result_summary`** (cosmetic) strips the trailing footer via `is_trailing_chrome` (separator/box rows, lone `❯` input box, claude `Model`/`Ctx`/`bypass` statuslines, opencode `▣ Build`).
- debounce 3s / poll-not-tick / oracle / `READY_TIMEOUT` (60s covers claude's ~11s ready) all reuse unchanged.

### Tests / gates
- `driver_supported` = {opencode, claude} regression; gate rejects codex (unsupported-backend).
- Pattern chrome-strip: claude footer dropped, prompt-echo + `✻ Worked` completion kept, all-chrome dump safe; non-blank-delta grew; churn-stable count.
- **opencode e2e KEPT as regression** + **new claude e2e** (both `#[ignore]`) — **both PASS locally** (opencode 10s, claude ~17s incl ~11s ready), proving the gate generalization + GREW refactor don't break opencode and claude works end-to-end.
- Green: unix build + clippy + fmt; 43 ephemeral unit; `spawn_rationale_audit` / `file_size_invariant` / `anti_pattern_invariant`; **cargo-xwin windows-msvc clippy** clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)