### PR TITLE
feat(#2409): agy_profile ApiError pattern for Gemini "high traffic" server error

### DIFF
--- a/src/backend_profile.rs
+++ b/src/backend_profile.rs
@@ -111,6 +111,16 @@ fn agy_profile() -> BackendProfile {
                 AgentState::UsageLimit,
                 r"Individual quota reached|Contact your administrator to enable overages",
             ),
+            // #2409: Gemini transient "high traffic" server error. ApiError (not
+            // ServerRateLimit) because SRL is `is_high_fp_state` → content anchor
+            // requires an error-line indicator (`Error:` / `429` / …) which this
+            // message lacks; ApiError has no anchor/position gate → pattern match
+            // = immediate transition → the #1697 quick-nudge injects `continue`
+            // once per episode, appropriate for a "try again in a minute" error.
+            (
+                AgentState::ApiError,
+                r"servers are experiencing high traffic|try again in a minute",
+            ),
             (
                 AgentState::PermissionPrompt,
                 r"Requesting permission for:|Do you trust the contents of this project|tab Amend · e edit command",

--- a/src/backend_profile.rs
+++ b/src/backend_profile.rs
@@ -111,15 +111,24 @@ fn agy_profile() -> BackendProfile {
                 AgentState::UsageLimit,
                 r"Individual quota reached|Contact your administrator to enable overages",
             ),
-            // #2409: Gemini transient "high traffic" server error. ApiError (not
-            // ServerRateLimit) because SRL is `is_high_fp_state` → content anchor
-            // requires an error-line indicator (`Error:` / `429` / …) which this
-            // message lacks; ApiError has no anchor/position gate → pattern match
-            // = immediate transition → the #1697 quick-nudge injects `continue`
-            // once per episode, appropriate for a "try again in a minute" error.
+            // #2409: Gemini transient "high traffic" server error (agy/Antigravity).
+            // ApiError (not ServerRateLimit): SRL is `is_high_fp_state` and needs a
+            // content/red anchor (an error-line indicator like `Error:` / `429`),
+            // which this banner lacks → SRL would false-negative. ApiError has no
+            // anchor/position gate → a pattern match transitions immediately and the
+            // #1697 quick-nudge injects `continue` once per episode — right for a
+            // transient, retryable error.
+            //
+            // Match ONLY the specific "high traffic" phrase, NOT the generic
+            // "try again in a minute" tail: ApiError is un-gated (and agy has no
+            // `input_line_markers`), so a broad phrase would FP on an agent's own
+            // prose (e.g. "I'll try again in a minute"). The real banner ("...are
+            // experiencing high traffic right now, please try again in a minute.")
+            // contains the specific phrase, so this matches it with zero detection
+            // loss. (PR #2410 review.)
             (
                 AgentState::ApiError,
-                r"servers are experiencing high traffic|try again in a minute",
+                r"servers are experiencing high traffic",
             ),
             (
                 AgentState::PermissionPrompt,
@@ -590,6 +599,47 @@ mod agy_quota_2236 {
             patterns.detect(idle),
             Some(AgentState::Idle),
             "#2236: ordinary agy idle pane must NOT be misread as UsageLimit"
+        );
+    }
+}
+
+#[cfg(test)]
+mod agy_apierror_2409 {
+    use super::*;
+
+    /// #2409: Gemini's transient "high traffic" banner must classify as `ApiError`
+    /// so `process_error_recovery` fires the #1697 quick-nudge (`continue`) instead
+    /// of leaving the agy agent wedged. Verbatim shape from the issue, WITH the agy
+    /// Idle chrome ("Type your message" / "? for shortcuts") that co-renders — so
+    /// this also proves ApiError outranks Idle (first-match priority; the pattern is
+    /// ordered before Idle in `agy_profile`).
+    const AGY_HIGH_TRAFFIC_PANE: &str = "  Our servers are experiencing high traffic right now, please try again in a minute.\n\n  Type your message\n  ? for shortcuts";
+
+    #[test]
+    fn agy_high_traffic_detects_api_error() {
+        let patterns = crate::state::StatePatterns::for_backend(&Backend::Agy);
+        assert_eq!(
+            patterns.detect(AGY_HIGH_TRAFFIC_PANE),
+            Some(AgentState::ApiError),
+            "#2409: agy 'high traffic' banner must read ApiError (not Idle), feeding the #1697 quick-nudge"
+        );
+    }
+
+    /// FP guard (PR #2410 review): the pattern matches ONLY the specific "high
+    /// traffic" phrase, NOT the generic "try again in a minute" tail. ApiError is
+    /// un-gated (not `is_high_fp_state`, no anchor/position gate, agy has no
+    /// `input_line_markers`), so an agent's OWN prose mentioning "try again in a
+    /// minute" must NOT trip a false ApiError + spurious `continue` nudge. This
+    /// test is RED against the original broad `...|try again in a minute` alternation.
+    const AGY_RETRY_PROSE_PANE: &str = "  I hit a transient upstream error, so I'll try again in a minute once it clears.\n\n  Type your message\n  ? for shortcuts";
+
+    #[test]
+    fn agy_retry_prose_not_misread_as_api_error() {
+        let patterns = crate::state::StatePatterns::for_backend(&Backend::Agy);
+        assert_eq!(
+            patterns.detect(AGY_RETRY_PROSE_PANE),
+            Some(AgentState::Idle),
+            "#2409/PR2410: an agent's own 'try again in a minute' prose must NOT be misread as ApiError"
         );
     }
 }


### PR DESCRIPTION
## What

Add an `ApiError` detection pattern to `agy_profile()` in `backend_profile.rs` so the daemon can auto-recover agy instances stuck on a Gemini transient server error.

## How

Single pattern addition in `agy_profile().patterns`:

```rust
(
    AgentState::ApiError,
    r"servers are experiencing high traffic|try again in a minute",
)
```

Placed after `UsageLimit` (which must outrank Idle chrome) and before `PermissionPrompt`.

## Why `ApiError` and not `ServerRateLimit`

- `ServerRateLimit` is `is_high_fp_state` → requires `in_error_line_excluding_input` content anchor
- The Gemini message **"Our servers are experiencing high traffic right now, please try again in a minute."** contains **no error-line indicator** (`Error:`, `429`, `exception:`, etc.)
- Content anchor would reject the detection → `ServerRateLimit` retry would never fire
- `ApiError` has **no anchor or position gate** → pattern match = immediate state transition
- The `#1697` quick-nudge (single per-episode `continue` inject, `APIERROR_NUDGE_MAX=12` cap) is the right behavior for a "try again in a minute" transient error

## Scope

- `src/backend_profile.rs`: 10-line addition (pattern + comment)
- No behavioral change to other backends
- No new dependencies

## Missing (follow-up)

- `tests/fixtures/state-replay/agy-apierror.raw` — needs a real PTY capture of the error to add a fixture-replay test. I do not have one on hand; will supply when the error next occurs.

## Lessons

- agy is the only backend with zero error-state detection — all other backends (claude/kiro/codex/opencode) have `ServerRateLimit` + net-error patterns. This was a gap inherited from the original agy corpus (#1579) which only covered Thinking/ToolUse/Idle/Permission.

Closes #2409