### PR TITLE
fix(offthread): restore pane scrolling under AGEND_OFFTHREAD_PARSE=1

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1851,7 +1851,9 @@ fn scroll_focused(layout: &mut Layout, delta: i32) {
     if let Some(tab) = layout.active_tab_mut() {
         let fid = tab.focus_id;
         if let Some(pane) = tab.root_mut().find_pane_mut(fid) {
-            let max = pane.vterm.max_scroll();
+            // #offthread-scroll: off-thread mode leaves `pane.vterm` idle, so use the
+            // path-aware max (snapshot history when off-thread, else live vterm).
+            let max = pane.scroll_max();
             if delta > 0 {
                 pane.scroll_offset = (pane.scroll_offset + delta as usize).min(max);
             } else {

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -465,8 +465,8 @@ fn handle_selection(layout: &mut Layout, mouse: &MouseEvent) {
                 // distance sets the scroll step (drag further → scroll faster).
                 let row = if mouse.row < inner_y {
                     let overshoot = (inner_y - mouse.row) as usize;
-                    pane.scroll_offset =
-                        (pane.scroll_offset + overshoot).min(pane.vterm.max_scroll());
+                    // #offthread-scroll: path-aware max (off-thread vterm is idle).
+                    pane.scroll_offset = (pane.scroll_offset + overshoot).min(pane.scroll_max());
                     0
                 } else if mouse.row >= inner_y + inner_h {
                     let overshoot = (mouse.row - (inner_y + inner_h - 1)) as usize;

--- a/src/layout/pane.rs
+++ b/src/layout/pane.rs
@@ -138,6 +138,19 @@ fn thread_cpu_time_us() -> Option<u64> {
 }
 
 impl Pane {
+    /// Max scroll-back offset for THIS pane's render path. Off-thread mode
+    /// (`AGEND_OFFTHREAD_PARSE`) renders the parser thread's published snapshot and
+    /// leaves the main-thread `vterm` idle (drain no-ops), so its `max_scroll()` is 0
+    /// and clamping scroll to it would pin every off-thread pane to the bottom
+    /// (#offthread-scroll regression). Use the snapshot's captured scrollback depth
+    /// when off-thread, else the live vterm's full history.
+    pub fn scroll_max(&self) -> usize {
+        match &self.offthread {
+            Some(handle) => handle.scroll_max(),
+            None => self.vterm.max_scroll(),
+        }
+    }
+
     /// Convert a viewport row (0-based within the pane interior) to an absolute
     /// scrollback logical line at the current scroll position. Inverse of
     /// [`Self::logical_line_to_viewport`].

--- a/src/render/core_render.rs
+++ b/src/render/core_render.rs
@@ -648,8 +648,9 @@ fn render_pane(
         // Option X (off-thread parse, flag AGEND_OFFTHREAD_PARSE): the parser
         // thread owns the VTerm and publishes an immutable snapshot. The main
         // thread does ZERO parse here — it loads the latest snapshot, paints it,
-        // and routes any resize to the parser thread (which owns the VTerm). P1
-        // renders the live offset-0 grid; off-thread scrollback is a P2 follow-up.
+        // and routes any resize to the parser thread (which owns the VTerm). The
+        // snapshot carries a bounded scrollback window, so `render_offset` scrolls
+        // it like the live path (#offthread-scroll; depth = SNAPSHOT_SCROLLBACK_ROWS).
         let snap = handle.load();
         if let Some(d) = crate::render::resize::ResizeDecision::needed(inner, snap.cols, snap.rows)
         {

--- a/src/render/offthread.rs
+++ b/src/render/offthread.rs
@@ -333,13 +333,19 @@ fn parser_loop(
 /// flood/restore workload off-thread exists to fix. This keeps the captured rows as
 /// shared `Arc`s and updates them MINIMALLY per burst:
 /// - scrollback UNCHANGED → reuse the last published `Arc` (O(1));
-/// - GREW by `k` rows → capture ONLY the `k` new rows, append, trim to the cap
-///   (old rows stay shared, not re-copied);
+/// - GREW by `k` rows → capture ONLY the `k` new ROWS (`k` row clones), reusing every
+///   retained row `Arc`, then rebuild the outer pointer slice (`O(cap)` Arc-ptr clones,
+///   NOT `O(cap)` cell copies — the dominant per-cell cost is avoided);
 /// - cols changed (resize → reflow) or scrollback SHRANK (`\x1b[3J` / clear) → full
-///   recapture (rare; the safety net for any non-append history change).
-///
-/// Tracks the UNCAPPED `max_scroll` so growth is still detected once the captured
-/// window is pinned at the cap (older rows then scroll out of the front).
+///   recapture (rare; the safety net for any non-append history change);
+/// - alacritty scrollback SATURATED ([`VTerm::history_saturated`], ≥ `HISTORY_LIMIT`):
+///   `max_scroll` is then PINNED while content keeps evicting+adding, so the grow-delta
+///   below goes blind to the shift (the #2411 r6 stale-window bug). Recapture the tail
+///   every burst there — CORRECT, no stale window. Confined to a pane with ≥10k
+///   scrollback lines + active output (uncommon); below saturation the cheap
+///   incremental path runs. (alacritty 0.26 exposes no monotonic scroll counter that
+///   would let us keep the cheap path past saturation — an exact-counter follow-up
+///   would need upstream support.)
 struct ScrollbackCache {
     /// Newest `min(max_scroll, cap)` rows, OLDEST front — published as the snapshot's
     /// `history` (index 0 = oldest = `Line(-len)`, back = `Line(-1)`).
@@ -371,6 +377,11 @@ impl ScrollbackCache {
         if cols != self.last_cols || max_scroll < self.last_max_scroll {
             // Resize (history reflowed to new width) or scrollback shrank → recapture.
             self.rows = vterm.capture_history_tail(max_scroll.min(cap)).into();
+        } else if vterm.history_saturated() {
+            // alacritty's scrollback is FULL: `max_scroll` is pinned at HISTORY_LIMIT
+            // while content keeps shifting, so the grow-delta below would miss the
+            // shift and serve a STALE window (#2411 r6). Recapture the tail — correct.
+            self.rows = vterm.capture_history_tail(cap).into();
         } else if max_scroll > self.last_max_scroll {
             let grew = max_scroll - self.last_max_scroll;
             if grew >= cap {
@@ -609,6 +620,55 @@ mod tests {
             cache.rows.iter().any(|r| Arc::ptr_eq(r, &kept)),
             "an old scrollback row must be REUSED (shared Arc), not re-cloned on growth"
         );
+    }
+
+    /// #2411 r6 BLOCKER regression — the 10k history-CAP stale-window bug. alacritty's
+    /// scrollback caps at `HISTORY_LIMIT` (10000): past that, `max_scroll` is PINNED
+    /// while content keeps evicting-oldest + adding-newest, so the old `max_scroll`-delta
+    /// detector saw "unchanged" → served a PERMANENTLY STALE window after 10k lines.
+    /// Drive the cache per-burst across >10000 UNIQUE lines (so any stale row mismatches)
+    /// and assert the incremental history renders IDENTICALLY to a fresh full capture at
+    /// every offset. Offset 0 (visible screen) is the control (always fresh); offsets >0
+    /// (scrollback) are where the stale window would show. NEUTER: drop the
+    /// `history_saturated` recapture branch in `update` → the post-10k window freezes →
+    /// the >0 offsets diverge → RED.
+    #[test]
+    fn scrollback_cache_correct_past_10k_history_cap() {
+        use ratatui::buffer::Buffer;
+        use ratatui::layout::Rect;
+        let mut vt = VTerm::new(40, 5);
+        vt.process(b"\x1b[2J\x1b[H");
+        let mut cache = ScrollbackCache::new();
+        // Fill PAST the 10k cap with UNIQUE lines (cheap incremental until ~10k, then
+        // the saturated recapture path for the tail).
+        for i in 0..10_100u32 {
+            vt.process(format!("uniq-line-{i:05}\r\n").as_bytes());
+            cache.update(&vt);
+        }
+        assert!(
+            vt.history_saturated(),
+            "10.1k lines must saturate alacritty's history cap"
+        );
+        let mut incr = vt.snapshot_visible();
+        incr.history = cache.update(&vt);
+        let full = vt.snapshot();
+        assert_eq!(
+            incr.history.len(),
+            full.history.len(),
+            "captured depth must match the fresh full capture at saturation"
+        );
+        let area = Rect::new(0, 0, 40, 5);
+        for off in [0usize, 1, 3, 500, 999] {
+            let mut a = Buffer::empty(area);
+            let mut b = Buffer::empty(area);
+            incr.render_to_buffer(&mut a, area, off, false);
+            full.render_to_buffer(&mut b, area, off, false);
+            assert_eq!(
+                a, b,
+                "past the 10k cap, incremental must match a fresh full capture at offset={off} \
+                 (a stale window — the r6 bug — diverges at offsets >0)"
+            );
+        }
     }
 
     /// BENCHMARK (#[ignore]: timing, run locally) — quantifies the r6 fix: per-publish

--- a/src/render/offthread.rs
+++ b/src/render/offthread.rs
@@ -386,7 +386,11 @@ mod tests {
         let vt = VTerm::new(20, 4);
         let h = spawn_offthread_parser(5, "scroll".to_string(), data_rx, vt, wake_tx)
             .expect("parser thread spawns");
-        assert_eq!(h.scroll_max(), 0, "blank initial snapshot has no scrollback");
+        assert_eq!(
+            h.scroll_max(),
+            0,
+            "blank initial snapshot has no scrollback"
+        );
 
         // Feed more lines than the 4-row screen so content scrolls into history.
         let mut payload = String::from("\x1b[2J\x1b[H");

--- a/src/render/offthread.rs
+++ b/src/render/offthread.rs
@@ -16,10 +16,11 @@
 //! not reintroduce `core.lock` contention. The snapshot is immutable, so render
 //! loads a whole `Arc` and never observes a torn grid.
 
-use crate::vterm::{GridSnapshot, VTerm};
+use crate::vterm::{GridSnapshot, ScrollbackRows, VTerm, SNAPSHOT_SCROLLBACK_ROWS};
 use arc_swap::ArcSwap;
 use crossbeam_channel::{select, Receiver, Sender};
 use std::cell::Cell;
+use std::collections::VecDeque;
 use std::sync::Arc;
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
@@ -81,10 +82,10 @@ impl OffthreadHandle {
     /// `pane.scroll_offset` to this: in off-thread mode the main-thread `pane.vterm`
     /// is idle (drain no-ops), so its `max_scroll()` is 0 and would pin scrolling to
     /// the bottom — the scrollback lives in the parser thread's VTerm, surfaced here
-    /// via the snapshot's `history_rows` (#offthread-scroll). Cheap `load()` (Guard,
-    /// no `Arc` clone).
+    /// via the snapshot's captured `history` depth (#offthread-scroll). Cheap `load()`
+    /// (Guard, no `Arc` clone).
     pub fn scroll_max(&self) -> usize {
-        self.snapshot.load().history_rows as usize
+        self.snapshot.load().history.len()
     }
 
     /// Route a resize to the parser thread (which owns the `VTerm`). Deduped:
@@ -237,6 +238,7 @@ fn parser_loop(
     wakeup_tx: Sender<usize>,
 ) {
     let coalesce = Duration::from_millis(SNAPSHOT_COALESCE_MS);
+    let mut scrollback = ScrollbackCache::new();
 
     loop {
         // Cancel has deterministic priority over a continuously-ready data arm
@@ -293,7 +295,7 @@ fn parser_loop(
                 Some(Event::Data(Ok(d))) => vterm.process(&d),
                 Some(Event::Data(Err(_))) => {
                     // pane gone mid-burst: publish what we have, then exit.
-                    publish(&vterm, &publisher, &wakeup_tx, pane_id, name);
+                    publish(&vterm, &mut scrollback, &publisher, &wakeup_tx, pane_id, name);
                     return;
                 }
                 Some(Event::Resize(Ok((c, r)))) => {
@@ -307,21 +309,98 @@ fn parser_loop(
         }
 
         // Phase 3 — one snapshot per coalesced burst.
-        publish(&vterm, &publisher, &wakeup_tx, pane_id, name);
+        publish(&vterm, &mut scrollback, &publisher, &wakeup_tx, pane_id, name);
     }
 }
 
-/// Build + publish an immutable snapshot and wake the render loop once.
+/// Parser-thread INCREMENTAL scrollback cache (#2411 r4/r6). The original
+/// `vterm.snapshot()` deep-cloned all ≤1000 history rows EVERY burst — even when the
+/// scrollback was unchanged or merely growing — wasting parser CPU+alloc in the exact
+/// flood/restore workload off-thread exists to fix. This keeps the captured rows as
+/// shared `Arc`s and updates them MINIMALLY per burst:
+/// - scrollback UNCHANGED → reuse the last published `Arc` (O(1));
+/// - GREW by `k` rows → capture ONLY the `k` new rows, append, trim to the cap
+///   (old rows stay shared, not re-copied);
+/// - cols changed (resize → reflow) or scrollback SHRANK (`\x1b[3J` / clear) → full
+///   recapture (rare; the safety net for any non-append history change).
+///
+/// Tracks the UNCAPPED `max_scroll` so growth is still detected once the captured
+/// window is pinned at the cap (older rows then scroll out of the front).
+struct ScrollbackCache {
+    /// Newest `min(max_scroll, cap)` rows, OLDEST front — published as the snapshot's
+    /// `history` (index 0 = oldest = `Line(-len)`, back = `Line(-1)`).
+    rows: VecDeque<crate::vterm::ScrollbackRow>,
+    last_max_scroll: usize,
+    last_cols: u16,
+    /// The last published slice, reused verbatim when nothing changed.
+    published: ScrollbackRows,
+}
+
+impl ScrollbackCache {
+    fn new() -> Self {
+        Self {
+            rows: VecDeque::new(),
+            last_max_scroll: 0,
+            // 0 forces the first update to (re)capture, matching the real cols.
+            last_cols: 0,
+            published: crate::vterm::empty_scrollback(),
+        }
+    }
+
+    /// Update from the parser's `vterm` and return the history to publish (a cheap
+    /// `Arc` clone). See the struct doc for the per-case cost.
+    fn update(&mut self, vterm: &VTerm) -> ScrollbackRows {
+        let cols = vterm.cols();
+        let max_scroll = vterm.max_scroll();
+        let cap = SNAPSHOT_SCROLLBACK_ROWS;
+        let mut changed = true;
+        if cols != self.last_cols || max_scroll < self.last_max_scroll {
+            // Resize (history reflowed to new width) or scrollback shrank → recapture.
+            self.rows = vterm.capture_history_tail(max_scroll.min(cap)).into();
+        } else if max_scroll > self.last_max_scroll {
+            let grew = max_scroll - self.last_max_scroll;
+            if grew >= cap {
+                self.rows = vterm.capture_history_tail(cap).into();
+            } else {
+                // Only the `grew` newest rows are new (scrollback is append-only absent
+                // a resize/clear, both handled above); the rest stay shared.
+                for row in vterm.capture_history_tail(grew) {
+                    self.rows.push_back(row);
+                }
+                while self.rows.len() > cap {
+                    self.rows.pop_front();
+                }
+            }
+        } else {
+            changed = false; // max_scroll == last && cols == last → unchanged.
+        }
+        self.last_cols = cols;
+        self.last_max_scroll = max_scroll;
+        if changed {
+            self.published = self.rows.iter().cloned().collect::<Vec<_>>().into();
+        }
+        self.published.clone()
+    }
+}
+
+/// Build + publish an immutable snapshot and wake the render loop once. The visible
+/// grid is captured fresh; the scrollback comes from the incremental `cache`.
 fn publish(
     vterm: &VTerm,
+    cache: &mut ScrollbackCache,
     publisher: &Arc<ArcSwap<GridSnapshot>>,
     wakeup_tx: &Sender<usize>,
     pane_id: usize,
     name: &str,
 ) {
     let probe = instrument_enabled().then(Instant::now);
-    let snap = vterm.snapshot();
-    let bytes = snap.cells.len() * std::mem::size_of::<alacritty_terminal::term::cell::Cell>();
+    let mut snap = vterm.snapshot_visible();
+    snap.history = cache.update(vterm);
+    let cell_bytes = std::mem::size_of::<alacritty_terminal::term::cell::Cell>();
+    // #2411: bytes MUST include history (was under-reported ~21x), so the
+    // `#offthread-snapshot` probe reflects the real per-publish footprint.
+    let history_cells: usize = snap.history.iter().map(|r| r.len()).sum();
+    let bytes = (snap.cells.len() + history_cells) * cell_bytes;
     publisher.store(Arc::new(snap));
     if let Some(start) = probe {
         tracing::info!(

--- a/src/render/offthread.rs
+++ b/src/render/offthread.rs
@@ -374,6 +374,45 @@ mod tests {
         );
     }
 
+    /// #offthread-scroll: the handle's `scroll_max` reflects the published
+    /// snapshot's captured scrollback depth, so the scroll clamp isn't pinned to 0.
+    /// The bug was the scroll handlers clamping `scroll_offset` on the IDLE main
+    /// `pane.vterm` (drain no-ops in off-thread mode → its `max_scroll()` is 0),
+    /// pinning every off-thread pane to the bottom. `Pane::scroll_max` now reads this.
+    #[test]
+    fn handle_scroll_max_reflects_published_scrollback() {
+        let (data_tx, data_rx) = crossbeam_channel::unbounded::<Vec<u8>>();
+        let (wake_tx, wake_rx) = crossbeam_channel::unbounded::<usize>();
+        let vt = VTerm::new(20, 4);
+        let h = spawn_offthread_parser(5, "scroll".to_string(), data_rx, vt, wake_tx)
+            .expect("parser thread spawns");
+        assert_eq!(h.scroll_max(), 0, "blank initial snapshot has no scrollback");
+
+        // Feed more lines than the 4-row screen so content scrolls into history.
+        let mut payload = String::from("\x1b[2J\x1b[H");
+        for i in 1..=10 {
+            payload.push_str(&format!("line{i:02}\r\n"));
+        }
+        data_tx.send(payload.into_bytes()).unwrap();
+
+        // Wait for a publish, then for scroll_max to reflect the captured scrollback.
+        let mut got = false;
+        for _ in 0..10 {
+            if wake_rx.recv_timeout(Duration::from_secs(2)).is_err() {
+                break;
+            }
+            if h.scroll_max() > 0 {
+                got = true;
+                break;
+            }
+        }
+        assert!(
+            got,
+            "after >screen output, the handle must report a positive scroll_max"
+        );
+        drop(data_tx);
+    }
+
     /// A resize routed through the handle reaches the parser thread (which owns the
     /// VTerm) and the next snapshot carries the new dims.
     #[test]

--- a/src/render/offthread.rs
+++ b/src/render/offthread.rs
@@ -76,6 +76,17 @@ impl OffthreadHandle {
         self.snapshot.load_full()
     }
 
+    /// Max scroll-back offset the off-thread render path can honor = the captured
+    /// scrollback depth of the latest snapshot. The scroll handlers clamp
+    /// `pane.scroll_offset` to this: in off-thread mode the main-thread `pane.vterm`
+    /// is idle (drain no-ops), so its `max_scroll()` is 0 and would pin scrolling to
+    /// the bottom — the scrollback lives in the parser thread's VTerm, surfaced here
+    /// via the snapshot's `history_rows` (#offthread-scroll). Cheap `load()` (Guard,
+    /// no `Arc` clone).
+    pub fn scroll_max(&self) -> usize {
+        self.snapshot.load().history_rows as usize
+    }
+
     /// Route a resize to the parser thread (which owns the `VTerm`). Deduped:
     /// returns `false` (no send) when dims are unchanged since the last send.
     /// A closed channel (parser thread gone) is treated as a no-op.

--- a/src/render/offthread.rs
+++ b/src/render/offthread.rs
@@ -496,6 +496,151 @@ mod tests {
         drop(data_tx);
     }
 
+    // ───────────── ScrollbackCache (#2411 r4/r6 incremental rework) ─────────────
+
+    /// CORRECTNESS: the INCREMENTAL `ScrollbackCache` (drive it per burst, the way
+    /// `parser_loop` does) must produce a history that renders IDENTICALLY to the
+    /// full one-shot `vterm.snapshot()` (the r4-verified reference) at every offset —
+    /// across growth past the visible screen + a resize (reflow → recapture). This is
+    /// the guard that the per-burst incremental append never diverges from a full copy.
+    #[test]
+    fn scrollback_cache_renders_identically_to_full_capture() {
+        use ratatui::buffer::Buffer;
+        use ratatui::layout::Rect;
+        let mut vt = VTerm::new(20, 5);
+        vt.process(b"\x1b[2J\x1b[H");
+        let mut cache = ScrollbackCache::new();
+        // Drive the cache exactly like the parser: update after each burst, incl a
+        // mid-run resize (exercises the cols-change recapture path).
+        for i in 1..=40 {
+            vt.process(format!("line{i:02}\r\n").as_bytes());
+            cache.update(&vt);
+            if i == 25 {
+                vt.resize(12, 5);
+                cache.update(&vt);
+            }
+        }
+        let mut incr = vt.snapshot_visible();
+        incr.history = cache.update(&vt);
+        let full = vt.snapshot(); // full one-shot reference (r4-verified render)
+        assert_eq!(
+            incr.history.len(),
+            full.history.len(),
+            "incremental + full must capture the same depth"
+        );
+        let area = Rect::new(0, 0, 12, 5);
+        let max_scroll = vt.max_scroll();
+        for off in [0usize, 1, 3, max_scroll.saturating_sub(1), max_scroll, max_scroll + 5] {
+            let mut a = Buffer::empty(area);
+            let mut b = Buffer::empty(area);
+            incr.render_to_buffer(&mut a, area, off, false);
+            full.render_to_buffer(&mut b, area, off, false);
+            assert_eq!(
+                a, b,
+                "incremental cache must render identically to the full capture at offset={off}"
+            );
+        }
+    }
+
+    /// DIRTY-SKIP (r4 fix): when the scrollback is UNCHANGED between bursts, the cache
+    /// returns the SAME `Arc` — no re-clone (the original bug was deep-cloning every
+    /// burst even when nothing scrolled).
+    #[test]
+    fn scrollback_cache_reuses_arc_when_unchanged() {
+        let mut vt = VTerm::new(20, 4);
+        vt.process(b"\x1b[2J\x1b[H");
+        for i in 1..=8 {
+            vt.process(format!("l{i}\r\n").as_bytes());
+        }
+        let mut cache = ScrollbackCache::new();
+        cache.update(&vt); // populate
+        let a = cache.update(&vt); // no new output since last
+        let b = cache.update(&vt); // still none
+        assert!(
+            Arc::ptr_eq(&a, &b),
+            "unchanged scrollback must reuse the same Arc (no per-burst re-clone)"
+        );
+    }
+
+    /// PERF MECHANISM (r6 fix): on growth the cache ALLOCATES ONLY the new rows and
+    /// SHARES the old ones — a previously-captured row is the SAME `Arc` after more
+    /// output, not a re-copy. This is what makes the flood/restore publish cheap.
+    #[test]
+    fn scrollback_cache_shares_old_rows_on_growth() {
+        let mut vt = VTerm::new(20, 4);
+        vt.process(b"\x1b[2J\x1b[H");
+        let mut cache = ScrollbackCache::new();
+        for i in 1..=10 {
+            vt.process(format!("l{i:02}\r\n").as_bytes());
+            cache.update(&vt);
+        }
+        assert!(!cache.rows.is_empty(), "must have scrollback to test sharing");
+        let kept = Arc::clone(&cache.rows[0]); // an existing (older) row
+        // Grow further (well under the cap, so the front is not trimmed).
+        for i in 11..=15 {
+            vt.process(format!("l{i:02}\r\n").as_bytes());
+            cache.update(&vt);
+        }
+        assert!(
+            cache.rows.iter().any(|r| Arc::ptr_eq(r, &kept)),
+            "an old scrollback row must be REUSED (shared Arc), not re-cloned on growth"
+        );
+    }
+
+    /// BENCHMARK (#[ignore]: timing, run locally) — quantifies the r6 fix: per-publish
+    /// cost of the OLD full-recapture (`vterm.snapshot()`) vs the NEW incremental
+    /// `ScrollbackCache` under a sustained flood that scrolls rows into history every
+    /// burst (the restart/restore workload). Run:
+    /// `cargo test --bin agend-terminal -- --ignored --nocapture scrollback_bench`.
+    #[test]
+    #[ignore = "timing benchmark; run locally with --nocapture"]
+    fn scrollback_bench_incremental_vs_full_recapture() {
+        let cols = 200u16;
+        let mut vt = VTerm::new(cols, 50);
+        vt.process(b"\x1b[2J\x1b[H");
+        // Pre-fill history to the cap so both paths work the worst case.
+        for i in 0..1200 {
+            vt.process(format!("seed line {i} ........................\r\n").as_bytes());
+        }
+        let bursts = 500;
+        // OLD: full recapture every burst.
+        let t_full = {
+            let start = Instant::now();
+            for i in 0..bursts {
+                vt.process(format!("flood {i} ........................\r\n").as_bytes());
+                let _ = vt.snapshot(); // deep-clones all ≤1000 history rows
+            }
+            start.elapsed()
+        };
+        // NEW: incremental cache every burst.
+        let t_incr = {
+            let mut cache = ScrollbackCache::new();
+            cache.update(&vt);
+            let start = Instant::now();
+            for i in 0..bursts {
+                vt.process(format!("flood {i} ........................\r\n").as_bytes());
+                let mut snap = vt.snapshot_visible();
+                snap.history = cache.update(&vt);
+                std::hint::black_box(&snap);
+            }
+            start.elapsed()
+        };
+        println!(
+            "scrollback_bench (cols={cols}, cap={SNAPSHOT_SCROLLBACK_ROWS}, {bursts} bursts):\n  \
+             FULL recapture : {t_full:?} ({:?}/burst)\n  \
+             INCREMENTAL    : {t_incr:?} ({:?}/burst)\n  \
+             speedup        : {:.1}x",
+            t_full / bursts,
+            t_incr / bursts,
+            t_full.as_secs_f64() / t_incr.as_secs_f64().max(1e-9),
+        );
+        assert!(
+            t_incr * 3 < t_full,
+            "incremental must be materially cheaper than full recapture under flood \
+             (full={t_full:?}, incr={t_incr:?})"
+        );
+    }
+
     /// A resize routed through the handle reaches the parser thread (which owns the
     /// VTerm) and the next snapshot carries the new dims.
     #[test]

--- a/src/render/offthread.rs
+++ b/src/render/offthread.rs
@@ -295,7 +295,14 @@ fn parser_loop(
                 Some(Event::Data(Ok(d))) => vterm.process(&d),
                 Some(Event::Data(Err(_))) => {
                     // pane gone mid-burst: publish what we have, then exit.
-                    publish(&vterm, &mut scrollback, &publisher, &wakeup_tx, pane_id, name);
+                    publish(
+                        &vterm,
+                        &mut scrollback,
+                        &publisher,
+                        &wakeup_tx,
+                        pane_id,
+                        name,
+                    );
                     return;
                 }
                 Some(Event::Resize(Ok((c, r)))) => {
@@ -309,7 +316,14 @@ fn parser_loop(
         }
 
         // Phase 3 — one snapshot per coalesced burst.
-        publish(&vterm, &mut scrollback, &publisher, &wakeup_tx, pane_id, name);
+        publish(
+            &vterm,
+            &mut scrollback,
+            &publisher,
+            &wakeup_tx,
+            pane_id,
+            name,
+        );
     }
 }
 
@@ -530,7 +544,14 @@ mod tests {
         );
         let area = Rect::new(0, 0, 12, 5);
         let max_scroll = vt.max_scroll();
-        for off in [0usize, 1, 3, max_scroll.saturating_sub(1), max_scroll, max_scroll + 5] {
+        for off in [
+            0usize,
+            1,
+            3,
+            max_scroll.saturating_sub(1),
+            max_scroll,
+            max_scroll + 5,
+        ] {
             let mut a = Buffer::empty(area);
             let mut b = Buffer::empty(area);
             incr.render_to_buffer(&mut a, area, off, false);
@@ -574,9 +595,12 @@ mod tests {
             vt.process(format!("l{i:02}\r\n").as_bytes());
             cache.update(&vt);
         }
-        assert!(!cache.rows.is_empty(), "must have scrollback to test sharing");
+        assert!(
+            !cache.rows.is_empty(),
+            "must have scrollback to test sharing"
+        );
         let kept = Arc::clone(&cache.rows[0]); // an existing (older) row
-        // Grow further (well under the cap, so the front is not trimmed).
+                                               // Grow further (well under the cap, so the front is not trimmed).
         for i in 11..=15 {
             vt.process(format!("l{i:02}\r\n").as_bytes());
             cache.update(&vt);

--- a/src/vterm.rs
+++ b/src/vterm.rs
@@ -235,6 +235,11 @@ pub struct VTerm {
     snapshot_scratch: std::cell::RefCell<Vec<Cell>>,
 }
 
+/// alacritty scrollback cap for every [`VTerm`] (its `Config::scrolling_history`).
+/// Bounds memory; also the point past which `max_scroll` stops growing (see
+/// [`VTerm::history_saturated`]).
+pub(crate) const HISTORY_LIMIT: usize = 10000;
+
 impl VTerm {
     pub fn new(cols: u16, rows: u16) -> Self {
         Self::with_listener(cols, rows, PtyWriteListener::noop())
@@ -255,7 +260,7 @@ impl VTerm {
     fn with_listener(cols: u16, rows: u16, listener: PtyWriteListener) -> Self {
         let size = VTermSize { cols, rows };
         let config = Config {
-            scrolling_history: 10000,
+            scrolling_history: HISTORY_LIMIT,
             ..Default::default()
         };
         let term = term::Term::new(config, &size, listener);
@@ -582,6 +587,17 @@ impl VTerm {
         let total = self.term.grid().total_lines();
         let screen = self.term.grid().screen_lines();
         total.saturating_sub(screen)
+    }
+
+    /// True once alacritty's scrollback is FULL (`max_scroll` pinned at
+    /// [`HISTORY_LIMIT`]). Past this point `max_scroll` stays constant while content
+    /// keeps evicting-oldest + adding-newest, so a `max_scroll`-delta change detector
+    /// goes blind to the shift (#2411 r6). The off-thread `ScrollbackCache` uses this
+    /// to switch from cheap incremental-append to a per-burst tail recapture (correct,
+    /// no stale window). alacritty 0.26 exposes no monotonic scroll counter that would
+    /// let us keep the cheap path here.
+    pub fn history_saturated(&self) -> bool {
+        self.max_scroll() >= HISTORY_LIMIT
     }
 
     /// Get cursor position (line, column).

--- a/src/vterm.rs
+++ b/src/vterm.rs
@@ -326,25 +326,31 @@ impl VTerm {
         let grid = self.term.grid();
         let cols = self.cols.min(grid.columns() as u16);
         let rows = self.rows.min(grid.screen_lines() as u16);
-        // Bounded scrollback: at most the actual history, capped. Reading negative
-        // `Line`s pulls scrollback; `safe_cell` yields blanks past the buffer end.
-        let history = self.max_scroll().min(SNAPSHOT_SCROLLBACK_ROWS) as u16;
-        let total = history as usize + rows as usize;
-        let mut cells = Vec::with_capacity(total * cols as usize);
-        for r in 0..total {
-            // cells row r ↔ alacritty Line(r - history): rows [0, history) are the
-            // oldest→newest scrollback, then [history, history+rows) the visible grid.
-            let grid_line = Line(r as i32 - history as i32);
+        // Visible grid (offset 0) — unchanged layout/contract.
+        let mut cells = Vec::with_capacity(rows as usize * cols as usize);
+        for row in 0..rows {
             for c in 0..cols {
-                cells.push(safe_cell(grid, grid_line, c as usize).clone());
+                cells.push(safe_cell(grid, Line(row as i32), c as usize).clone());
+            }
+        }
+        // Bounded scrollback ABOVE the screen, oldest first: row 0 = Line(-h), row
+        // h-1 = Line(-1). Reading negative `Line`s pulls scrollback; `safe_cell`
+        // yields blanks past the buffer end. Capped so the copy + memory stay bounded.
+        let history_rows = self.max_scroll().min(SNAPSHOT_SCROLLBACK_ROWS) as u16;
+        let mut history = Vec::with_capacity(history_rows as usize * cols as usize);
+        for h in 0..history_rows {
+            let grid_line = Line(h as i32 - history_rows as i32);
+            for c in 0..cols {
+                history.push(safe_cell(grid, grid_line, c as usize).clone());
             }
         }
         let cur = grid.cursor.point;
         GridSnapshot {
             cols,
             rows,
-            history_rows: history,
             cells,
+            history,
+            history_rows,
             cursor: (cur.line.0 as u16, cur.column.0 as u16),
         }
     }
@@ -955,13 +961,17 @@ impl VTerm {
 pub struct GridSnapshot {
     pub cols: u16,
     pub rows: u16,
-    /// Captured scrollback rows ABOVE the visible screen (0 = none). `cells` is
-    /// laid out as `(history_rows + rows) × cols`: the first `history_rows` rows
-    /// are history (oldest first), then the `rows` visible-grid rows. So `cells`
-    /// row `r` corresponds to alacritty `Line(r - history_rows)`.
-    pub history_rows: u16,
-    /// `(history_rows + rows) * cols` cells, row-major, stride = `cols`.
+    /// `rows * cols` cells, row-major, stride = `cols` — the VISIBLE (offset-0)
+    /// grid, unchanged. Row 0 is the visible top of screen.
     pub cells: Vec<Cell>,
+    /// Captured scrollback ABOVE the visible screen, kept SEPARATE from `cells` so
+    /// the visible-grid layout/contract is unchanged. `history_rows * cols` cells,
+    /// row-major, OLDEST first: row `history_rows-1` is the line just above the
+    /// visible top (alacritty `Line(-1)`), row 0 the oldest (`Line(-history_rows)`).
+    /// Empty when there is no scrollback. Bounded by [`SNAPSHOT_SCROLLBACK_ROWS`].
+    pub history: Vec<Cell>,
+    /// Number of captured scrollback rows (`history.len() / cols`; 0 = none).
+    pub history_rows: u16,
     /// Cursor `(line, col)` in visible coordinates.
     pub cursor: (u16, u16),
 }
@@ -984,8 +994,9 @@ impl GridSnapshot {
         Self {
             cols,
             rows,
-            history_rows: 0,
             cells: vec![Cell::default(); cols as usize * rows as usize],
+            history: Vec::new(),
+            history_rows: 0,
             cursor: (0, 0),
         }
     }
@@ -1071,26 +1082,34 @@ impl GridSnapshot {
             }
         }
 
-        // Apply the scroll offset by mapping each view row to a captured snapshot
-        // row, mirroring the live `render_to_buffer_inner`'s `Line(row - offset)`.
-        // The visible grid sits at snapshot rows `[history_rows, history_rows+rows)`,
-        // so view row `row` at offset `off` reads snapshot row `row + history_rows -
-        // off`. Out of the captured `[0, total_rows)` window → blank (same degrade as
-        // the live path's `safe_cell` beyond the scrollback buffer). `off` is clamped
-        // like the live path so an absurd offset can't wrap the `i32` arithmetic.
+        // Apply the scroll offset by mapping each view row to an alacritty-relative
+        // line `line = row - off`, mirroring the live `render_to_buffer_inner`'s
+        // `Line(row - offset)`: `line >= 0` reads the visible grid (`cells`), `line <
+        // 0` reads captured scrollback (`history`, oldest at index 0), and anything
+        // beyond the captured window blanks — the same degrade as the live path's
+        // `safe_cell` past the scrollback buffer. `off` is clamped like the live path
+        // so an absurd offset can't wrap the `i32` arithmetic.
         let off: i32 = scroll_offset.min(i32::MAX as usize) as i32;
-        let total_rows = self.history_rows as i32 + self.rows as i32;
+        let default_cell = || DEFAULT_CELL.get_or_init(Cell::default);
         for row in 0..rows {
-            let snap_row = row as i32 + self.history_rows as i32 - off;
+            let line = row as i32 - off;
             let mut col = 0u16;
             while col < cols {
-                let cell = if snap_row >= 0 && snap_row < total_rows {
-                    let idx = (snap_row as usize) * stride + (col as usize);
+                let cell = if line >= 0 {
+                    // Visible grid row `line` (always < rows since row < rows, off ≥ 0).
                     self.cells
-                        .get(idx)
-                        .unwrap_or_else(|| DEFAULT_CELL.get_or_init(Cell::default))
+                        .get((line as usize) * stride + (col as usize))
+                        .unwrap_or_else(default_cell)
                 } else {
-                    DEFAULT_CELL.get_or_init(Cell::default)
+                    // Scrollback: alacritty Line(-k) → history row `history_rows - k`.
+                    let hidx = self.history_rows as i32 + line;
+                    if hidx >= 0 {
+                        self.history
+                            .get((hidx as usize) * stride + (col as usize))
+                            .unwrap_or_else(default_cell)
+                    } else {
+                        default_cell()
+                    }
                 };
                 if cell.flags.contains(Flags::WIDE_CHAR_SPACER) {
                     let x = area.x + col;
@@ -1331,9 +1350,62 @@ mod tests {
         vt.process(b"\x1b[2J\x1b[Hab\r\ncd");
         let snap = vt.snapshot();
         assert_eq!((snap.cols, snap.rows), (10, 3));
+        // `cells` is the VISIBLE grid only (3×10) — unchanged by the scrollback split
+        // (history, if any, lives in the separate `history` Vec).
         assert_eq!(snap.cells.len(), 30);
         // cursor sits after "cd" on row 1 (0-based), col 2.
         assert_eq!(snap.cursor, (1, 2));
+    }
+
+    /// #offthread-scroll REGRESSION: the off-thread snapshot render must match the
+    /// flag-OFF live `VTerm` render AT A SCROLL OFFSET — not only at offset 0. The
+    /// bug (operator 2026-06-22: off-thread panes could not scroll) was the snapshot
+    /// capturing ONLY the offset-0 visible grid and `render_inner` ignoring the
+    /// offset. With real scrollback (≤ the cap, so the snapshot captures ALL of it)
+    /// the two paths are now byte-identical at every offset, incl. beyond history
+    /// (both blank). Neuter check: revert `snapshot()` to visible-only or
+    /// `render_inner` to the offset-0 `idx` → the off>0 cases diverge → RED.
+    #[test]
+    fn snapshot_render_matches_vterm_at_scroll_offset() {
+        use ratatui::buffer::Buffer;
+        use ratatui::layout::Rect;
+        let mut vt = VTerm::new(20, 5);
+        vt.process(b"\x1b[2J\x1b[H");
+        for i in 1..=12 {
+            // 12 lines on a 5-row screen → ≥7 scroll into history.
+            vt.process(format!("line{i:02}\r\n").as_bytes());
+        }
+        let snap = vt.snapshot();
+        let max_scroll = vt.max_scroll();
+        assert!(
+            max_scroll > 0,
+            "12 lines in a 5-row term must produce scrollback"
+        );
+        assert_eq!(
+            snap.history_rows as usize, max_scroll,
+            "history ≤ cap → the snapshot captures the FULL scrollback"
+        );
+        let area = Rect::new(0, 0, 20, 5);
+        for off in [
+            0usize,
+            1,
+            3,
+            max_scroll.saturating_sub(1),
+            max_scroll,
+            max_scroll + 10, // beyond history → both paths blank identically
+        ] {
+            for cursor in [false, true] {
+                let mut live = Buffer::empty(area);
+                let mut snapshot = Buffer::empty(area);
+                vt.render_to_buffer(&mut live, area, off, cursor);
+                snap.render_to_buffer(&mut snapshot, area, off, cursor);
+                assert_eq!(
+                    live, snapshot,
+                    "off-thread snapshot must render identically to the live vterm at \
+                     scroll_offset={off} cursor={cursor}"
+                );
+            }
+        }
     }
 
     // ── CR-2026-06-14: PTY-writer raw-lock hardening (t-30) ──────────────

--- a/src/vterm.rs
+++ b/src/vterm.rs
@@ -313,35 +313,21 @@ impl VTerm {
         }
     }
 
-    /// Option X (off-thread parse, `AGEND_OFFTHREAD_PARSE`): copy the visible grid
-    /// PLUS a bounded scrollback window + cursor into an owned, immutable
-    /// [`GridSnapshot`] that the per-pane parser thread publishes via `ArcSwap`.
-    /// Same per-cell copy as `render_to_buffer_inner`'s L1 scratch (via `safe_cell`,
-    /// clamped to grid dims), but owned (not a borrowed `RefCell`) so it can cross
-    /// the thread boundary. Captures up to [`SNAPSHOT_SCROLLBACK_ROWS`] history rows
-    /// (alacritty negative `Line`s) above the visible screen so the off-thread render
-    /// path can honor a scroll offset (#offthread-scroll). `cells` row `r` ↔
-    /// `Line(r - history_rows)`; row `history_rows` is the live top of screen.
-    pub fn snapshot(&self) -> GridSnapshot {
+    /// Option X (off-thread parse, `AGEND_OFFTHREAD_PARSE`): copy the VISIBLE grid +
+    /// cursor into an owned, immutable [`GridSnapshot`] with NO scrollback (history
+    /// empty). The parser thread publishes via `ArcSwap`. Same per-cell copy as
+    /// `render_to_buffer_inner`'s L1 scratch (via `safe_cell`, clamped to grid dims),
+    /// but owned (not a borrowed `RefCell`) so it can cross the thread boundary. The
+    /// parser injects an incrementally-maintained `history` after this (see
+    /// `ScrollbackCache` in `crate::render::offthread`); tests use [`Self::snapshot`].
+    pub fn snapshot_visible(&self) -> GridSnapshot {
         let grid = self.term.grid();
         let cols = self.cols.min(grid.columns() as u16);
         let rows = self.rows.min(grid.screen_lines() as u16);
-        // Visible grid (offset 0) — unchanged layout/contract.
         let mut cells = Vec::with_capacity(rows as usize * cols as usize);
         for row in 0..rows {
             for c in 0..cols {
                 cells.push(safe_cell(grid, Line(row as i32), c as usize).clone());
-            }
-        }
-        // Bounded scrollback ABOVE the screen, oldest first: row 0 = Line(-h), row
-        // h-1 = Line(-1). Reading negative `Line`s pulls scrollback; `safe_cell`
-        // yields blanks past the buffer end. Capped so the copy + memory stay bounded.
-        let history_rows = self.max_scroll().min(SNAPSHOT_SCROLLBACK_ROWS) as u16;
-        let mut history = Vec::with_capacity(history_rows as usize * cols as usize);
-        for h in 0..history_rows {
-            let grid_line = Line(h as i32 - history_rows as i32);
-            for c in 0..cols {
-                history.push(safe_cell(grid, grid_line, c as usize).clone());
             }
         }
         let cur = grid.cursor.point;
@@ -349,10 +335,41 @@ impl VTerm {
             cols,
             rows,
             cells,
-            history,
-            history_rows,
+            history: empty_scrollback(),
             cursor: (cur.line.0 as u16, cur.column.0 as u16),
         }
+    }
+
+    /// A full one-shot snapshot: the visible grid PLUS the whole bounded scrollback
+    /// (≤ [`SNAPSHOT_SCROLLBACK_ROWS`]) captured fresh. The NON-incremental reference
+    /// path — TEST-ONLY (the parser uses `snapshot_visible` + an incremental
+    /// `ScrollbackCache` to avoid re-capturing unchanged scrollback every burst; the
+    /// `render==live` regression test renders THIS full capture to validate both).
+    #[cfg(test)]
+    pub(crate) fn snapshot(&self) -> GridSnapshot {
+        let mut snap = self.snapshot_visible();
+        let depth = self.max_scroll().min(SNAPSHOT_SCROLLBACK_ROWS);
+        snap.history = std::sync::Arc::from(self.capture_history_tail(depth));
+        snap
+    }
+
+    /// Capture the `count` NEWEST scrollback rows as per-row `Arc`s, OLDEST first:
+    /// index 0 = `Line(-count)`, index `count-1` = `Line(-1)` (the line just above the
+    /// visible top). Reading negative `Line`s pulls scrollback; `safe_cell` yields
+    /// blanks past the buffer end. Each row is `cols` cells. Used by [`Self::snapshot`]
+    /// (full) and the parser's `ScrollbackCache` (incremental append of new rows).
+    pub fn capture_history_tail(&self, count: usize) -> Vec<ScrollbackRow> {
+        let grid = self.term.grid();
+        let cols = self.cols.min(grid.columns() as u16) as usize;
+        (1..=count)
+            .rev()
+            .map(|k| {
+                let line = Line(-(k as i32));
+                (0..cols)
+                    .map(|c| safe_cell(grid, line, c).clone())
+                    .collect::<ScrollbackRow>()
+            })
+            .collect()
     }
 
     fn render_to_buffer_inner(
@@ -952,8 +969,8 @@ impl VTerm {
 /// drain burst via [`VTerm::snapshot`] and publishes it through `ArcSwap`; the
 /// render loop loads the latest and paints it WITHOUT touching the VTerm (which,
 /// in off-thread mode, lives on the parser thread). Holds the visible grid PLUS a
-/// bounded scrollback window ([`history_rows`](GridSnapshot::history_rows) rows
-/// above the visible screen) so the off-thread render path can honor a scroll
+/// bounded scrollback window ([`history`](GridSnapshot::history), `history.len()`
+/// rows above the visible screen) so the off-thread render path can honor a scroll
 /// offset — matching the flag-OFF live path up to [`SNAPSHOT_SCROLLBACK_ROWS`]
 /// rows of history (deeper than that clamps; the live path keeps the full
 /// `scrolling_history`).
@@ -964,27 +981,41 @@ pub struct GridSnapshot {
     /// `rows * cols` cells, row-major, stride = `cols` — the VISIBLE (offset-0)
     /// grid, unchanged. Row 0 is the visible top of screen.
     pub cells: Vec<Cell>,
-    /// Captured scrollback ABOVE the visible screen, kept SEPARATE from `cells` so
-    /// the visible-grid layout/contract is unchanged. `history_rows * cols` cells,
-    /// row-major, OLDEST first: row `history_rows-1` is the line just above the
-    /// visible top (alacritty `Line(-1)`), row 0 the oldest (`Line(-history_rows)`).
-    /// Empty when there is no scrollback. Bounded by [`SNAPSHOT_SCROLLBACK_ROWS`].
-    pub history: Vec<Cell>,
-    /// Number of captured scrollback rows (`history.len() / cols`; 0 = none).
-    pub history_rows: u16,
+    /// Bounded scrollback ABOVE the visible screen as PER-ROW `Arc`s, kept SEPARATE
+    /// from `cells` so the visible-grid layout/contract is unchanged. OLDEST first:
+    /// `history[len-1]` is the line just above the visible top (alacritty `Line(-1)`),
+    /// `history[0]` the oldest (`Line(-len)`); each row is `cols` cells. Empty = no
+    /// scrollback. Bounded by [`SNAPSHOT_SCROLLBACK_ROWS`]. Per-row `Arc`s let the
+    /// parser maintain this INCREMENTALLY (#2411 r4/r6): an unchanged burst reuses
+    /// the whole slice (`Arc` refcount, no copy) and a growing one allocates only the
+    /// NEW rows while sharing the rest — vs the original per-burst deep clone.
+    pub history: ScrollbackRows,
     /// Cursor `(line, col)` in visible coordinates.
     pub cursor: (u16, u16),
 }
 
+/// One scrollback row — `cols` cells, shared via `Arc` so the parser can reuse it
+/// across bursts without copying (see [`GridSnapshot::history`]).
+pub type ScrollbackRow = std::sync::Arc<[Cell]>;
+
+/// Scrollback history as per-row `Arc`s. Cloning the outer `Arc` is O(1); each row
+/// `Arc` is shared, not copied.
+pub type ScrollbackRows = std::sync::Arc<[ScrollbackRow]>;
+
+/// An empty scrollback (no history) — `blank` snapshots and the no-scrollback case.
+pub(crate) fn empty_scrollback() -> ScrollbackRows {
+    std::sync::Arc::from(Vec::<ScrollbackRow>::new())
+}
+
 /// Max scrollback rows captured into a [`GridSnapshot`] for the off-thread render
-/// path (#offthread-scroll). Bounds the per-snapshot copy + memory: a snapshot is
-/// built per coalesced burst on the PARSER thread, so this is off the render/main
-/// thread (it does NOT reintroduce the main-thread freeze Option X removed), but it
-/// still costs ~`(history+rows)×cols` `Cell` copies + holds that much per live
-/// `Arc`. 1000 rows (~20 screens) gives ample interactive scroll-back at a bounded
-/// cost; the flag-OFF live path keeps the full `scrolling_history` (10000). Tunable;
-/// `#offthread-snapshot` logs the real `snapshot_bytes`.
-const SNAPSHOT_SCROLLBACK_ROWS: usize = 1000;
+/// path (#offthread-scroll). Bounds memory + the worst-case (resize/clear) recapture:
+/// the snapshot is built per coalesced burst on the PARSER thread (off the
+/// render/main thread — does NOT reintroduce the main-thread freeze Option X
+/// removed), and per-row `Arc`s make the STEADY-STATE publish cheap (reuse unchanged
+/// rows; allocate only newly-scrolled ones). 1000 rows (~20 screens) gives ample
+/// interactive scroll-back; the flag-OFF live path keeps the full `scrolling_history`
+/// (10000). Tunable; `#offthread-snapshot` logs the real `snapshot_bytes`.
+pub(crate) const SNAPSHOT_SCROLLBACK_ROWS: usize = 1000;
 
 impl GridSnapshot {
     /// A blank snapshot — the initial `ArcSwap` value before the parser thread
@@ -995,8 +1026,7 @@ impl GridSnapshot {
             cols,
             rows,
             cells: vec![Cell::default(); cols as usize * rows as usize],
-            history: Vec::new(),
-            history_rows: 0,
+            history: empty_scrollback(),
             cursor: (0, 0),
         }
     }
@@ -1011,8 +1041,8 @@ impl GridSnapshot {
     /// (`render_to_buffer_inner`) stays byte-identical and untouched; the two
     /// MUST be kept in sync (a P2 cleanup may DRY them once the flag stabilizes).
     /// `scroll_offset` selects the visible window over the captured scrollback
-    /// ([`history_rows`](GridSnapshot::history_rows)) — same semantics as the live
-    /// path, up to the captured depth — and (at offset 0) gates the block cursor.
+    /// ([`history`](GridSnapshot::history)) — same semantics as the live path, up to
+    /// the captured depth — and (at offset 0) gates the block cursor.
     pub fn render_to_buffer(
         &self,
         buf: &mut ratatui::buffer::Buffer,
@@ -1091,6 +1121,7 @@ impl GridSnapshot {
         // so an absurd offset can't wrap the `i32` arithmetic.
         let off: i32 = scroll_offset.min(i32::MAX as usize) as i32;
         let default_cell = || DEFAULT_CELL.get_or_init(Cell::default);
+        let history_rows = self.history.len() as i32;
         for row in 0..rows {
             let line = row as i32 - off;
             let mut col = 0u16;
@@ -1102,10 +1133,11 @@ impl GridSnapshot {
                         .unwrap_or_else(default_cell)
                 } else {
                     // Scrollback: alacritty Line(-k) → history row `history_rows - k`.
-                    let hidx = self.history_rows as i32 + line;
+                    let hidx = history_rows + line;
                     if hidx >= 0 {
                         self.history
-                            .get((hidx as usize) * stride + (col as usize))
+                            .get(hidx as usize)
+                            .and_then(|r| r.get(col as usize))
                             .unwrap_or_else(default_cell)
                     } else {
                         default_cell()
@@ -1382,7 +1414,8 @@ mod tests {
             "12 lines in a 5-row term must produce scrollback"
         );
         assert_eq!(
-            snap.history_rows as usize, max_scroll,
+            snap.history.len(),
+            max_scroll,
             "history ≤ cap → the snapshot captures the FULL scrollback"
         );
         let area = Rect::new(0, 0, 20, 5);

--- a/src/vterm.rs
+++ b/src/vterm.rs
@@ -313,27 +313,37 @@ impl VTerm {
         }
     }
 
-    /// Option X (off-thread parse, `AGEND_OFFTHREAD_PARSE`): copy the live
-    /// (offset-0) visible grid + cursor into an owned, immutable [`GridSnapshot`]
-    /// that the per-pane parser thread publishes via `ArcSwap`. Same visible-cell
-    /// copy as `render_to_buffer_inner`'s L1 scratch (clamped to the grid dims),
-    /// but owned (not a borrowed `RefCell`) so it can cross the thread boundary.
-    /// Scrollback is NOT captured (P1: off-thread mode renders the live view;
-    /// scroll-back is a P2 follow-up).
+    /// Option X (off-thread parse, `AGEND_OFFTHREAD_PARSE`): copy the visible grid
+    /// PLUS a bounded scrollback window + cursor into an owned, immutable
+    /// [`GridSnapshot`] that the per-pane parser thread publishes via `ArcSwap`.
+    /// Same per-cell copy as `render_to_buffer_inner`'s L1 scratch (via `safe_cell`,
+    /// clamped to grid dims), but owned (not a borrowed `RefCell`) so it can cross
+    /// the thread boundary. Captures up to [`SNAPSHOT_SCROLLBACK_ROWS`] history rows
+    /// (alacritty negative `Line`s) above the visible screen so the off-thread render
+    /// path can honor a scroll offset (#offthread-scroll). `cells` row `r` ↔
+    /// `Line(r - history_rows)`; row `history_rows` is the live top of screen.
     pub fn snapshot(&self) -> GridSnapshot {
         let grid = self.term.grid();
         let cols = self.cols.min(grid.columns() as u16);
         let rows = self.rows.min(grid.screen_lines() as u16);
-        let mut cells = Vec::with_capacity(rows as usize * cols as usize);
-        for row in 0..rows {
+        // Bounded scrollback: at most the actual history, capped. Reading negative
+        // `Line`s pulls scrollback; `safe_cell` yields blanks past the buffer end.
+        let history = self.max_scroll().min(SNAPSHOT_SCROLLBACK_ROWS) as u16;
+        let total = history as usize + rows as usize;
+        let mut cells = Vec::with_capacity(total * cols as usize);
+        for r in 0..total {
+            // cells row r ↔ alacritty Line(r - history): rows [0, history) are the
+            // oldest→newest scrollback, then [history, history+rows) the visible grid.
+            let grid_line = Line(r as i32 - history as i32);
             for c in 0..cols {
-                cells.push(safe_cell(grid, Line(row as i32), c as usize).clone());
+                cells.push(safe_cell(grid, grid_line, c as usize).clone());
             }
         }
         let cur = grid.cursor.point;
         GridSnapshot {
             cols,
             rows,
+            history_rows: history,
             cells,
             cursor: (cur.line.0 as u16, cur.column.0 as u16),
         }
@@ -935,18 +945,36 @@ impl VTerm {
 /// (`AGEND_OFFTHREAD_PARSE`). The per-pane parser thread builds one after each
 /// drain burst via [`VTerm::snapshot`] and publishes it through `ArcSwap`; the
 /// render loop loads the latest and paints it WITHOUT touching the VTerm (which,
-/// in off-thread mode, lives on the parser thread). Holds the live (offset-0)
-/// visible cells + cursor only — scrollback is a P1 limitation (off-thread mode
-/// renders the live view).
+/// in off-thread mode, lives on the parser thread). Holds the visible grid PLUS a
+/// bounded scrollback window ([`history_rows`](GridSnapshot::history_rows) rows
+/// above the visible screen) so the off-thread render path can honor a scroll
+/// offset — matching the flag-OFF live path up to [`SNAPSHOT_SCROLLBACK_ROWS`]
+/// rows of history (deeper than that clamps; the live path keeps the full
+/// `scrolling_history`).
 #[derive(Clone)]
 pub struct GridSnapshot {
     pub cols: u16,
     pub rows: u16,
-    /// `rows * cols` cells, row-major, stride = `cols`.
+    /// Captured scrollback rows ABOVE the visible screen (0 = none). `cells` is
+    /// laid out as `(history_rows + rows) × cols`: the first `history_rows` rows
+    /// are history (oldest first), then the `rows` visible-grid rows. So `cells`
+    /// row `r` corresponds to alacritty `Line(r - history_rows)`.
+    pub history_rows: u16,
+    /// `(history_rows + rows) * cols` cells, row-major, stride = `cols`.
     pub cells: Vec<Cell>,
     /// Cursor `(line, col)` in visible coordinates.
     pub cursor: (u16, u16),
 }
+
+/// Max scrollback rows captured into a [`GridSnapshot`] for the off-thread render
+/// path (#offthread-scroll). Bounds the per-snapshot copy + memory: a snapshot is
+/// built per coalesced burst on the PARSER thread, so this is off the render/main
+/// thread (it does NOT reintroduce the main-thread freeze Option X removed), but it
+/// still costs ~`(history+rows)×cols` `Cell` copies + holds that much per live
+/// `Arc`. 1000 rows (~20 screens) gives ample interactive scroll-back at a bounded
+/// cost; the flag-OFF live path keeps the full `scrolling_history` (10000). Tunable;
+/// `#offthread-snapshot` logs the real `snapshot_bytes`.
+const SNAPSHOT_SCROLLBACK_ROWS: usize = 1000;
 
 impl GridSnapshot {
     /// A blank snapshot — the initial `ArcSwap` value before the parser thread
@@ -956,6 +984,7 @@ impl GridSnapshot {
         Self {
             cols,
             rows,
+            history_rows: 0,
             cells: vec![Cell::default(); cols as usize * rows as usize],
             cursor: (0, 0),
         }
@@ -970,7 +999,9 @@ impl GridSnapshot {
     /// instead of the live grid. Kept deliberately separate so the flag-OFF path
     /// (`render_to_buffer_inner`) stays byte-identical and untouched; the two
     /// MUST be kept in sync (a P2 cleanup may DRY them once the flag stabilizes).
-    /// `scroll_offset` only gates the block cursor (P1 snapshot is offset-0 live).
+    /// `scroll_offset` selects the visible window over the captured scrollback
+    /// ([`history_rows`](GridSnapshot::history_rows)) — same semantics as the live
+    /// path, up to the captured depth — and (at offset 0) gates the block cursor.
     pub fn render_to_buffer(
         &self,
         buf: &mut ratatui::buffer::Buffer,
@@ -1040,14 +1071,27 @@ impl GridSnapshot {
             }
         }
 
+        // Apply the scroll offset by mapping each view row to a captured snapshot
+        // row, mirroring the live `render_to_buffer_inner`'s `Line(row - offset)`.
+        // The visible grid sits at snapshot rows `[history_rows, history_rows+rows)`,
+        // so view row `row` at offset `off` reads snapshot row `row + history_rows -
+        // off`. Out of the captured `[0, total_rows)` window → blank (same degrade as
+        // the live path's `safe_cell` beyond the scrollback buffer). `off` is clamped
+        // like the live path so an absurd offset can't wrap the `i32` arithmetic.
+        let off: i32 = scroll_offset.min(i32::MAX as usize) as i32;
+        let total_rows = self.history_rows as i32 + self.rows as i32;
         for row in 0..rows {
+            let snap_row = row as i32 + self.history_rows as i32 - off;
             let mut col = 0u16;
             while col < cols {
-                let idx = (row as usize) * stride + (col as usize);
-                let cell = self
-                    .cells
-                    .get(idx)
-                    .unwrap_or_else(|| DEFAULT_CELL.get_or_init(Cell::default));
+                let cell = if snap_row >= 0 && snap_row < total_rows {
+                    let idx = (snap_row as usize) * stride + (col as usize);
+                    self.cells
+                        .get(idx)
+                        .unwrap_or_else(|| DEFAULT_CELL.get_or_init(Cell::default))
+                } else {
+                    DEFAULT_CELL.get_or_init(Cell::default)
+                };
                 if cell.flags.contains(Flags::WIDE_CHAR_SPACER) {
                     let x = area.x + col;
                     let y = area.y + row;


### PR DESCRIPTION
## Bug (operator-reported, 2026-06-22, HIGH)
With \`AGEND_OFFTHREAD_PARSE=1\`, **all panes could not scroll**. Flag-OFF (default) scrolls fine → an off-thread render-path regression introduced by #2404 (Option X P1, which deferred off-thread scrollback to "P2"). Operator unset the flag to recover.

## Root cause (two-part)
1. **Scroll clamp pinned to 0**: \`scroll_focused\` (app/mod.rs) and the mouse drag-autoscroll (app/mouse.rs) clamp \`scroll_offset\` against \`pane.vterm.max_scroll()\`. In off-thread mode \`pane.vterm\` is IDLE (the main-thread drain no-ops; the parser thread owns the real VTerm), so its \`max_scroll()\` is **0** → \`scroll_offset\` is pinned to 0.
2. **Snapshot had no scrollback + render ignored the offset**: \`GridSnapshot\` captured only the offset-0 visible grid, and \`GridSnapshot::render_inner\` ignored \`scroll_offset\` for content ("P1 snapshot is offset-0 live").

So even with a non-zero offset nothing scrolled, and the offset could never become non-zero anyway.

## Fix
- **\`GridSnapshot\`** gains a SEPARATE \`history: Vec<Cell>\` + \`history_rows\` (the visible \`cells\` layout/contract is **unchanged**). \`VTerm::snapshot()\` captures up to \`SNAPSHOT_SCROLLBACK_ROWS\` (1000) rows of scrollback (alacritty negative \`Line\`s) into it — on the **parser thread**, so it does NOT reintroduce the main-thread parse freeze Option X removed.
- **\`GridSnapshot::render_inner\`** now maps each view row to \`line = row - offset\`: \`line ≥ 0\` reads the visible \`cells\`, \`line < 0\` reads \`history\`, beyond the captured window blanks — mirroring the live path's \`Line(row - offset)\` exactly.
- **Path-aware scroll max**: new \`OffthreadHandle::scroll_max()\` (snapshot \`history_rows\`) + \`Pane::scroll_max()\` (off-thread → handle, else \`vterm.max_scroll()\`); both scroll-clamp sites use it.

Flag-OFF path is **byte-identical/untouched** (\`render_to_buffer_inner\` unchanged; offset-0 snapshot render still equals the live render).

### Deliberate trade
Off-thread scroll depth is bounded to \`SNAPSHOT_SCROLLBACK_ROWS\` = 1000 rows (~20 screens) vs the live path's full \`scrolling_history\` (10000), to bound the per-snapshot copy + memory (the \`#offthread-snapshot\` instrument logs \`snapshot_bytes\`). Tunable const. Fixes the "can't scroll at all" regression; full-depth parity is a cheap follow-up if wanted.

## Tests
- \`vterm::snapshot_render_matches_vterm_at_scroll_offset\` — the regression test: off-thread snapshot render == live VTerm render at offsets {0,1,3,max,max+10} with real scrollback. **Neuter-verified**: reverting \`render_inner\` to ignore the offset → RED.
- \`offthread::handle_scroll_max_reflects_published_scrollback\` — the clamp source is non-zero after >screen output.
- Existing \`snapshot_renders_identically_to_vterm\` (offset-0 byte-identity) still green.

## Out of scope (pre-existing, not regressed)
Text SELECTION in off-thread mode (\`logical_line_to_viewport\` uses the idle \`pane.vterm\`; copy reads idle vterm) — broken before this PR too; a separate follow-up.

**\`AGEND_OFFTHREAD_PARSE\` stays default-OFF and is unusable-without-this-merge; default is NOT flipped (P3).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)