### PR TITLE
fix(offthread): read snapshot for text selection so off-thread panes can copy

### DIFF
--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -340,7 +340,9 @@ pub(super) fn dispatch(action: Action, ctx: &mut DispatchCtx<'_>) -> DispatchRes
                 if let Some(pane) = tab.root_mut().find_pane_mut(focus_id) {
                     let mut copied = false;
                     if let Some(ref sel) = pane.selection {
-                        let text = pane.vterm.extract_text(sel.start, sel.end);
+                        // #offthread-selection: off-thread reads the snapshot, not
+                        // the idle `vterm` (which would copy blank).
+                        let text = pane.extract_selection_text(sel.start, sel.end);
                         if !text.is_empty() {
                             super::mouse::copy_to_clipboard(&text);
                             copied = true;

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -497,7 +497,9 @@ fn handle_selection(layout: &mut Layout, mouse: &MouseEvent) {
                     if start == end {
                         pane.selection = None;
                     } else if crate::runtime_config::get().copy_on_select {
-                        let text = pane.vterm.extract_text(start, end);
+                        // #offthread-selection: off-thread reads the snapshot, not
+                        // the idle `vterm` (which would copy blank).
+                        let text = pane.extract_selection_text(start, end);
                         if !text.is_empty() {
                             copy_to_clipboard(&text);
                         }

--- a/src/layout/pane.rs
+++ b/src/layout/pane.rs
@@ -72,17 +72,25 @@ pub struct Pane {
     pub _fwd_cancel: Option<crossbeam_channel::Sender<()>>,
 }
 
-/// Text selection anchored to absolute scrollback logical coordinates so it
-/// stays pinned to its content under both new output and user scrolling.
+/// Text selection anchored to absolute scrollback line ids so it stays pinned to
+/// its content under both new output and user scrolling.
 ///
-/// `.0` is the logical line index counted from the oldest line currently in
-/// the buffer (`grid_line + max_scroll()`); `.1` is the column. Endpoints are
-/// converted to viewport rows at render / extract time via
-/// [`Pane::logical_line_to_viewport`].
+/// `.0` is an ABSOLUTE line id (`grid_line + `[`selection_base`](Pane::selection_base));
+/// `.1` is the column. Endpoints are produced by [`Pane::viewport_to_logical_line`]
+/// and resolved at render / extract time via [`Pane::logical_line_to_viewport`] /
+/// [`Pane::extract_selection_text`].
 ///
-/// Edge case: a line evicted from the 10000-line history cap loses its anchor
-/// and the selection drifts. Unreachable within a single gesture (would need
-/// ~10000 lines of output in the seconds a drag takes), so left unhandled.
+/// Edge cases (#offthread-selection):
+/// - Live (flag-OFF): the id derives from the live `vterm.max_scroll()`, capped at
+///   alacritty's 10000-row scrollback — a line evicted past that cap loses its anchor
+///   and drifts. Unreachable within a single gesture (~10000 lines in the seconds a
+///   drag takes), so left unhandled.
+/// - Off-thread: the id is monotonic via the published snapshot's `history_origin`
+///   (parser-stamped), so it tracks content across the snapshot window's
+///   evict+append — the >1000-row drift r6 caught. The snapshot window is only
+///   `SNAPSHOT_SCROLLBACK_ROWS` (1000) deep; an endpoint scrolled OUT of that window
+///   resolves to blanks (clamped), NOT wrong content. The same 10000-cap saturation
+///   limit applies (parity-with-live; alacritty exposes no monotonic counter, #2411).
 #[derive(Clone)]
 pub struct Selection {
     /// Start: (logical line, column). May be before or after `end`.
@@ -151,23 +159,55 @@ impl Pane {
         }
     }
 
-    /// Convert a viewport row (0-based within the pane interior) to an absolute
-    /// scrollback logical line at the current scroll position. Inverse of
+    /// #offthread-selection: the ABSOLUTE-line base a selection endpoint is measured
+    /// from. Off-thread it is the published snapshot's visible-top absolute id
+    /// (`history_origin + history.len()`), read from the snapshot — NOT `pane.vterm`,
+    /// which is idle off-thread (`max_scroll()` = 0, the bug root). Flag-OFF it is the
+    /// live `vterm.max_scroll()`. Encoding an endpoint as `row - scroll_offset + base`
+    /// makes it an absolute, monotonic line id (see `GridSnapshot::history_origin`)
+    /// that stays pinned to its content as the snapshot window evicts+appends rows —
+    /// fixing the >1000-row drift a relative depth had. Under-cap off-thread
+    /// `history_origin == 0` so `base == history.len() == scroll_max()` and flag-OFF
+    /// `base == vterm.max_scroll()` → both byte-identical to the pre-anchor form.
+    fn selection_base(&self) -> i64 {
+        match &self.offthread {
+            Some(handle) => {
+                let snap = handle.load();
+                snap.history_origin as i64 + snap.history.len() as i64
+            }
+            None => self.vterm.max_scroll() as i64,
+        }
+    }
+
+    /// Convert a viewport row (0-based within the pane interior) to an ABSOLUTE
+    /// scrollback line id at the current scroll position. Inverse of
     /// [`Self::logical_line_to_viewport`].
     ///
     /// Derivation: render maps viewport row → `grid_line = row - scroll_offset`
-    /// (see `VTerm::render_to_buffer`), and the oldest buffer line sits at
-    /// `grid_line = -max_scroll()`. Counting from that oldest line gives a
-    /// reference stable under append: `logical = grid_line + max_scroll()`.
+    /// (see `VTerm::render_to_buffer`); adding [`selection_base`](Self::selection_base)
+    /// (the absolute id of the visible top) yields an absolute id stable under append
+    /// AND across snapshot-window eviction (#offthread-selection).
     pub fn viewport_to_logical_line(&self, row: u16) -> i64 {
-        row as i64 - self.scroll_offset as i64 + self.vterm.max_scroll() as i64
+        row as i64 - self.scroll_offset as i64 + self.selection_base()
     }
 
-    /// Convert an absolute scrollback logical line back to a viewport row at
-    /// the current scroll position. The result may be negative or `>=` viewport
-    /// height when the anchored content has scrolled off-screen; callers clip.
+    /// Convert an absolute scrollback line id back to a viewport row at the current
+    /// scroll position. The result may be negative or `>=` viewport height when the
+    /// anchored content has scrolled off-screen; callers clip.
     pub fn logical_line_to_viewport(&self, logical: i64) -> i64 {
-        logical + self.scroll_offset as i64 - self.vterm.max_scroll() as i64
+        logical + self.scroll_offset as i64 - self.selection_base()
+    }
+
+    /// Extract the selected text for THIS pane's render path (#offthread-selection).
+    /// Off-thread mode (`offthread = Some`) reads the parser's published
+    /// `GridSnapshot` — the live `vterm` is idle/blank there, so reading it would
+    /// copy nothing. Flag-OFF reads the live `vterm` (byte-identical to before).
+    /// Coordinates are absolute scrollback logical coords from `viewport_to_logical_line`.
+    pub fn extract_selection_text(&self, start: (i64, u16), end: (i64, u16)) -> String {
+        match &self.offthread {
+            Some(handle) => handle.load().extract_text(start, end),
+            None => self.vterm.extract_text(start, end),
+        }
     }
 
     /// Display label: display_name if set, otherwise agent_name.
@@ -479,6 +519,214 @@ mod tests {
             offthread: None,
             _fwd_cancel: None,
         }
+    }
+
+    /// #offthread-selection END-TO-END: an off-thread pane's live `vterm` is idle/
+    /// blank (drain no-ops; the parser thread owns the real grid), so text selection
+    /// must read the published snapshot. Drives the REAL parser, builds an off-thread
+    /// Pane, and asserts `extract_selection_text` (the path mouse copy-on-select +
+    /// Cmd+C use) returns the on-screen content via the snapshot — NOT the empty live
+    /// vterm. Neuter: route `extract_selection_text` back to `pane.vterm` → empty → RED.
+    #[test]
+    fn offthread_pane_extracts_selection_from_snapshot_not_idle_vterm() {
+        let (data_tx, data_rx) = crossbeam_channel::unbounded::<Vec<u8>>();
+        let (wake_tx, wake_rx) = crossbeam_channel::unbounded::<usize>();
+        let parser_vt = VTerm::new(20, 4);
+        let handle = crate::render::offthread::spawn_offthread_parser(
+            9,
+            "sel".to_string(),
+            data_rx,
+            parser_vt,
+            wake_tx,
+        )
+        .expect("parser thread spawns");
+
+        // 8 lines into a 4-row screen → 4 rows scroll into the captured history.
+        let mut payload = String::from("\x1b[2J\x1b[H");
+        for i in 1..=8 {
+            payload.push_str(&format!("row{i:02}\r\n"));
+        }
+        data_tx
+            .send(payload.into_bytes())
+            .expect("parser data channel is live");
+        assert_eq!(
+            wake_rx.recv_timeout(std::time::Duration::from_secs(2)),
+            Ok(9),
+            "parser must publish a snapshot"
+        );
+
+        // Off-thread pane: the parser owns the content; the pane's own vterm is idle.
+        let mut pane = test_pane(crossbeam_channel::bounded(1).1, 20, 4);
+        pane.offthread = Some(handle);
+        pane.scroll_offset = 0;
+
+        // The bug: the OLD path (idle vterm) copies nothing.
+        assert!(
+            pane.vterm.extract_text((0, 0), (3, 19)).trim().is_empty(),
+            "precondition: an off-thread pane's live vterm is blank"
+        );
+
+        // Full content (oldest history row .. bottom visible) via the off-thread-aware
+        // depth: must contain the FIRST (scrolled into history) + LAST (visible) lines.
+        let depth = pane.scroll_max() as i64;
+        assert!(
+            depth > 0,
+            "8 lines / 4 rows must produce captured scrollback"
+        );
+        let full = pane.extract_selection_text((0, 0), (depth + 3, 19));
+        assert!(
+            full.contains("row01") && full.contains("row08"),
+            "off-thread selection must copy history + visible content; got {full:?}"
+        );
+
+        // Viewport-mapped selection (the path the mouse uses): the visible screen
+        // rows 0..3 extract real on-screen content, not blanks.
+        let start = (pane.viewport_to_logical_line(0), 0u16);
+        let end = (pane.viewport_to_logical_line(3), 19u16);
+        let visible = pane.extract_selection_text(start, end);
+        assert!(
+            visible.contains("row") && !visible.trim().is_empty(),
+            "viewport selection must copy on-screen content; got {visible:?}"
+        );
+    }
+
+    /// Wait for the parser's first publish, then drain any further publishes until
+    /// quiet, so the loaded snapshot reflects the WHOLE fed burst (not a mid-burst one).
+    fn wait_settled(wake_rx: &crossbeam_channel::Receiver<usize>) {
+        wake_rx
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .expect("parser must publish at least once");
+        while wake_rx
+            .recv_timeout(std::time::Duration::from_millis(150))
+            .is_ok()
+        {}
+    }
+
+    /// #offthread-selection ANCHOR STABILITY (r6 REJECT @03bf21af). A selection
+    /// endpoint must stay pinned to its content AFTER the snapshot's 1000-row history
+    /// window saturates and shifts — the rejected impl used a RELATIVE depth
+    /// (`grid_line + history.len()`) which drifts there because `history.len()` pins at
+    /// 1000 while content evicts+appends. The absolute `history_origin` fix tracks it.
+    /// Neuter (the rejected coord): drop the `- history_origin` in `extract_text` AND
+    /// the origin in `selection_base` → after the window shift the endpoint drifts →
+    /// `after != before` → RED.
+    #[test]
+    fn offthread_selection_anchor_stable_past_snapshot_window() {
+        let (data_tx, data_rx) = crossbeam_channel::unbounded::<Vec<u8>>();
+        let (wake_tx, wake_rx) = crossbeam_channel::unbounded::<usize>();
+        let parser_vt = VTerm::new(20, 4);
+        let handle = crate::render::offthread::spawn_offthread_parser(
+            2,
+            "anchor".to_string(),
+            data_rx,
+            parser_vt,
+            wake_tx,
+        )
+        .expect("parser thread spawns");
+
+        // 1100 distinct lines → the 1000-row window SATURATES + shifts, and the parser
+        // max_scroll (~1096) ≫ window → history_origin advances past 0.
+        let mut p = String::from("\x1b[2J\x1b[H");
+        for i in 1..=1100 {
+            p.push_str(&format!("L{i:05}\r\n"));
+        }
+        data_tx.send(p.into_bytes()).expect("send burst");
+        wait_settled(&wake_rx);
+
+        let mut pane = test_pane(crossbeam_channel::bounded(1).1, 20, 4);
+        pane.offthread = Some(handle);
+        pane.scroll_offset = 0;
+
+        // The regime r6 flagged: window saturated + origin advanced.
+        let snap0 = pane.offthread.as_ref().expect("offthread set").load();
+        assert_eq!(
+            snap0.history.len(),
+            1000,
+            "1100 lines must saturate the 1000-row snapshot window"
+        );
+        assert!(
+            snap0.history_origin > 0,
+            "history_origin must advance past the window: {}",
+            snap0.history_origin
+        );
+        drop(snap0);
+
+        // Capture the absolute id of the TOP visible row + its content NOW.
+        let cap_top = pane.viewport_to_logical_line(0);
+        let before = pane.extract_selection_text((cap_top, 0), (cap_top, 19));
+        assert!(
+            before.starts_with('L'),
+            "captured a content line: {before:?}"
+        );
+
+        // Publish 10 MORE lines: the captured content scrolls back 10 rows (still in
+        // the 1000-row window). The absolute id is fixed; origin advances by 10.
+        let mut p2 = String::new();
+        for i in 1101..=1110 {
+            p2.push_str(&format!("L{i:05}\r\n"));
+        }
+        data_tx.send(p2.into_bytes()).expect("send more");
+        wait_settled(&wake_rx);
+
+        let after = pane.extract_selection_text((cap_top, 0), (cap_top, 19));
+        assert_eq!(
+            after, before,
+            "absolute anchor must track content across a window shift past the cap (the r6 drift)"
+        );
+    }
+
+    /// #offthread-selection: a resize BETWEEN selection capture and copy must not
+    /// drift the anchor (r6 required). A rows-only resize (cols unchanged → history
+    /// does NOT reflow) shifts the screen/scrollback split → both `max_scroll` and
+    /// `history_origin` move, but the absolute id stays pinned to the same content.
+    #[test]
+    fn offthread_selection_anchor_survives_resize_between_capture_and_copy() {
+        let (data_tx, data_rx) = crossbeam_channel::unbounded::<Vec<u8>>();
+        let (wake_tx, wake_rx) = crossbeam_channel::unbounded::<usize>();
+        let parser_vt = VTerm::new(20, 6);
+        let handle = crate::render::offthread::spawn_offthread_parser(
+            3,
+            "resize".to_string(),
+            data_rx,
+            parser_vt,
+            wake_tx,
+        )
+        .expect("parser thread spawns");
+
+        let mut p = String::from("\x1b[2J\x1b[H");
+        for i in 1..=40 {
+            p.push_str(&format!("R{i:04}\r\n"));
+        }
+        data_tx.send(p.into_bytes()).expect("send burst");
+        wait_settled(&wake_rx);
+
+        let mut pane = test_pane(crossbeam_channel::bounded(1).1, 20, 6);
+        pane.offthread = Some(handle);
+        pane.scroll_offset = 0;
+
+        let cap = pane.viewport_to_logical_line(1); // a visible content row
+        let before = pane.extract_selection_text((cap, 0), (cap, 19));
+        assert!(
+            before.starts_with('R'),
+            "captured a content line: {before:?}"
+        );
+
+        // Resize rows only (cols stay 20 → no history reflow), via the real handle →
+        // the parser re-publishes a fresh snapshot at the new dims with a new origin.
+        assert!(
+            pane.offthread
+                .as_ref()
+                .expect("offthread set")
+                .request_resize(20, 10),
+            "resize must be routed to the parser"
+        );
+        wait_settled(&wake_rx);
+
+        let after = pane.extract_selection_text((cap, 0), (cap, 19));
+        assert_eq!(
+            after, before,
+            "absolute anchor must survive a resize between capture and copy"
+        );
     }
 
     /// #freeze-2: `drain_output` must (a) cap per call at the byte budget and

--- a/src/render/offthread.rs
+++ b/src/render/offthread.rs
@@ -421,6 +421,12 @@ fn publish(
     let probe = instrument_enabled().then(Instant::now);
     let mut snap = vterm.snapshot_visible();
     snap.history = cache.update(vterm);
+    // #offthread-selection: stamp the snapshot's absolute origin from the REAL parser
+    // VTerm (`max_scroll - history.len()`). MUST be computed here, not at selection
+    // encode/decode time — off-thread the main-thread `pane.vterm` is idle so its
+    // `max_scroll()` is 0. Each published snapshot carries its own origin so an
+    // absolute endpoint stays pinned across publishes. See `GridSnapshot::history_origin`.
+    snap.history_origin = vterm.max_scroll().saturating_sub(snap.history.len()) as u64;
     let cell_bytes = std::mem::size_of::<alacritty_terminal::term::cell::Cell>();
     // #2411: bytes MUST include history (was under-reported ~21x), so the
     // `#offthread-snapshot` probe reflects the real per-publish footprint.

--- a/src/vterm.rs
+++ b/src/vterm.rs
@@ -342,6 +342,9 @@ impl VTerm {
             cells,
             history: empty_scrollback(),
             cursor: (cur.line.0 as u16, cur.column.0 as u16),
+            // No history here → origin is the visible top's absolute id (`max_scroll`).
+            // The parser overwrites this after injecting `history` (see `publish`).
+            history_origin: self.max_scroll() as u64,
         }
     }
 
@@ -355,6 +358,8 @@ impl VTerm {
         let mut snap = self.snapshot_visible();
         let depth = self.max_scroll().min(SNAPSHOT_SCROLLBACK_ROWS);
         snap.history = std::sync::Arc::from(self.capture_history_tail(depth));
+        // origin = base_scroll - captured depth (the rows above this window).
+        snap.history_origin = self.max_scroll().saturating_sub(snap.history.len()) as u64;
         snap
     }
 
@@ -1008,6 +1013,25 @@ pub struct GridSnapshot {
     pub history: ScrollbackRows,
     /// Cursor `(line, col)` in visible coordinates.
     pub cursor: (u16, u16),
+    /// #offthread-selection: absolute line id of `history[0]` (the oldest captured
+    /// row) — the count of lines that have scrolled ABOVE this snapshot's history
+    /// window over the parser VTerm's life (`max_scroll - history.len()` at capture).
+    /// MONOTONIC (until alacritty's 10000 scrollback cap saturates — see below), so a
+    /// selection endpoint can be stored as an ABSOLUTE line id (`history_origin +
+    /// index`) that stays pinned to its content as new output evicts+appends rows,
+    /// even after the `history.len()` window saturates at `SNAPSHOT_SCROLLBACK_ROWS`
+    /// (1000). Decoding against the CURRENT snapshot's `history_origin` (not the
+    /// capture-time one) is what tracks the content across publishes/generations.
+    ///
+    /// Computed by the PARSER from the real VTerm at publish time (the main-thread
+    /// `pane.vterm` is idle off-thread → its `max_scroll()` is 0, useless here).
+    /// PARITY-WITH-LIVE limitation (same as #2411): once `max_scroll` saturates at
+    /// alacritty's 10000-row cap, `history_origin` stops advancing, so a selection
+    /// older than 10000 scrolled lines drifts — exactly the live `VTerm` path's limit
+    /// (alacritty 0.26 exposes no monotonic scroll counter). The 1000-row snapshot
+    /// window is shallower than that; rows scrolled out of the window decode to
+    /// blanks (clamped), NOT wrong content.
+    pub history_origin: u64,
 }
 
 /// One scrollback row — `cols` cells, shared via `Arc` so the parser can reuse it
@@ -1044,7 +1068,87 @@ impl GridSnapshot {
             cells: vec![Cell::default(); cols as usize * rows as usize],
             history: empty_scrollback(),
             cursor: (0, 0),
+            history_origin: 0,
         }
+    }
+
+    /// Extract text from a selection range given in ABSOLUTE line ids (#offthread-
+    /// selection) — the off-thread analog of [`VTerm::extract_text`]. Off-thread mode
+    /// leaves the pane's live `VTerm` idle, so selection reads the published snapshot
+    /// here. An endpoint's `.0` is an absolute line id (`history_origin + index`, see
+    /// [`GridSnapshot::history_origin`]); decoding against THIS snapshot's
+    /// `history_origin` maps it to the alacritty-relative line
+    /// `line = id - history_origin - history.len()` — the SAME cell layout
+    /// `render_inner` paints (`line >= 0` → `cells` row `line`; `line < 0` →
+    /// `history[history.len() + line]`, oldest at index 0). Because the id is
+    /// ABSOLUTE, a selection captured against an OLDER snapshot still resolves to its
+    /// content after the window has evicted+appended rows (the drift r6 caught with a
+    /// relative index). Ids outside the captured window resolve to blanks (clamped),
+    /// NOT wrong content, mirroring the live path's `safe_cell` degrade. Trailing
+    /// spaces trimmed per line.
+    pub fn extract_text(&self, start: (i64, u16), end: (i64, u16)) -> String {
+        let history_rows = self.history.len() as i64;
+        let origin = self.history_origin as i64;
+        let stride = self.cols as usize;
+
+        // Normalize so `s` precedes `e` by (logical line, col) — mirrors VTerm.
+        let (s, e) = if start <= end {
+            (start, end)
+        } else {
+            (end, start)
+        };
+        let (s_line, s_col) = s;
+        let (e_line, e_col) = e;
+
+        let mut text = String::new();
+        for logical in s_line..=e_line {
+            // absolute id → alacritty-relative line (render's `row - off`). Under-cap
+            // `origin == 0` so this is identical to the relative form; over-cap the
+            // `- origin` is what keeps the anchor pinned as the window shifts.
+            let line = logical - origin - history_rows;
+            let col_start = if logical == s_line { s_col } else { 0 };
+            let col_end = if logical == e_line {
+                e_col
+            } else {
+                self.cols.saturating_sub(1)
+            };
+
+            let mut row_text = String::new();
+            for col in col_start..=col_end {
+                if col as usize >= self.cols as usize {
+                    break;
+                }
+                let cell = if line >= 0 {
+                    if (line as usize) < self.rows as usize {
+                        self.cells.get(line as usize * stride + col as usize)
+                    } else {
+                        None
+                    }
+                } else {
+                    let hidx = history_rows + line;
+                    if hidx >= 0 {
+                        self.history
+                            .get(hidx as usize)
+                            .and_then(|r| r.get(col as usize))
+                    } else {
+                        None
+                    }
+                };
+                match cell {
+                    // A wide char's trailing spacer carries no glyph (its char was
+                    // pushed at the lead cell) — skip it, matching VTerm.
+                    Some(c) if c.flags.contains(Flags::WIDE_CHAR_SPACER) => continue,
+                    Some(c) => row_text.push(if c.c == '\0' { ' ' } else { c.c }),
+                    // Out of the captured window → blank, like `safe_cell`.
+                    None => row_text.push(' '),
+                }
+            }
+            if !text.is_empty() {
+                text.push('\n');
+            }
+            text.push_str(row_text.trim_end());
+        }
+        text
     }
 
     /// Paint this snapshot into a ratatui buffer. Mirrors
@@ -1455,6 +1559,59 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// #offthread-selection REGRESSION (operator 2026-06-23: off-thread panes could
+    /// not copy). Text selection reads `pane.vterm` (idle/blank off-thread); the fix
+    /// routes it to the published `GridSnapshot`. This pins
+    /// `GridSnapshot::extract_text` byte-identical to the live `VTerm::extract_text`
+    /// across history + visible + partial-column + multi-line ranges, so mouse
+    /// copy-on-select and Cmd+C copy the SAME content the flag-OFF path would.
+    /// Neuter: have `extract_text` read `cells` only (ignore history) / use the wrong
+    /// history index / return blank → the equality fails on the history ranges.
+    #[test]
+    fn snapshot_extract_text_matches_vterm() {
+        let mut vt = VTerm::new(20, 5);
+        vt.process(b"\x1b[2J\x1b[H");
+        for i in 1..=12 {
+            // 12 lines on a 5-row screen → ≥7 scroll into history (incl. a wide char).
+            vt.process(format!("line{i:02}日\r\n").as_bytes());
+        }
+        let snap = vt.snapshot();
+        let max_scroll = vt.max_scroll() as i64;
+        assert!(
+            max_scroll > 0,
+            "12 lines in a 5-row term must scroll into history"
+        );
+        assert_eq!(
+            snap.history.len() as i64,
+            max_scroll,
+            "history ≤ cap → the snapshot captures the FULL scrollback"
+        );
+        let last = max_scroll + 5 - 1; // bottom visible logical line
+        let cols = 19u16;
+        let ranges = [
+            ((0i64, 0u16), (last, cols)),    // everything: history + visible
+            ((0, 0), (2, cols)),             // fully in history
+            ((max_scroll, 0), (last, cols)), // fully in the visible screen
+            ((1, 3), (4, 6)),                // partial cols, multi-line, history
+            ((last, 0), (last, cols)),       // single bottom line
+            ((0, 5), (last, 2)),             // reversed-ish col span across all
+        ];
+        for (s, e) in ranges {
+            assert_eq!(
+                snap.extract_text(s, e),
+                vt.extract_text(s, e),
+                "GridSnapshot::extract_text must equal VTerm::extract_text for {s:?}..{e:?}"
+            );
+        }
+        // Sanity: a visible content row extracts REAL text, not blanks (guards
+        // against a silently-empty extract passing the equality vacuously).
+        let content = snap.extract_text((max_scroll, 0), (last, cols));
+        assert!(
+            content.contains("line"),
+            "visible-row extract must contain real content, got: {content:?}"
+        );
     }
 
     // ── CR-2026-06-14: PTY-writer raw-lock hardening (t-30) ──────────────


### PR DESCRIPTION
## Bug (operator-reported, HIGH)
Under `AGEND_OFFTHREAD_PARSE=1`, text copy/selection was broken: copy returned blank/whitespace.

## RCA (confirm-first — disproves the dispatched assumption)
The dispatch assumed "only the lead pane works because it's `offthread:None`". **Live evidence disproves this**: all 15 panes including fixup-lead (pane_id=2, 43k+ `#offthread-snapshot` publishes) are `offthread: Some`. So:
- Both selection paths read `pane.vterm.extract_text()` — mouse copy-on-select (`mouse.rs`) + Cmd+C (`dispatch.rs`).
- Off-thread, `pane.vterm` is **permanently blank**: `drain_output` no-ops when `offthread = Some` (pane.rs), and the render path paints the parser's published `GridSnapshot` directly (`core_render.rs` `snap.render_to_buffer`) — there is **no snapshot→vterm sync**. `viewport_to_logical_line` also used `vterm.max_scroll()` = 0.
- #2411 fixed `scroll_max` (scroll) but not the selection path → selection broke **uniformly for every off-thread pane**.
- The "only lead works" anomaly has **no code-level cause** (all panes are uniformly off-thread); it's being pinned with the operator separately (likely a zoom/terminal-native-selection usage artifact). The app-internal fix here is correct regardless and makes **all** panes selectable.

## Fix (snapshot-based selection; flag-OFF byte-identical)
- `GridSnapshot::extract_text` — off-thread analog of `VTerm::extract_text`, reading the snapshot's `cells` + captured `history` with the SAME `logical → line = logical - history.len()` mapping `render_inner` paints.
- `Pane::extract_selection_text` dispatches: off-thread → snapshot, flag-OFF → live vterm (unchanged).
- `viewport_to_logical_line` / `logical_line_to_viewport` use `scroll_max()` (render-path depth) instead of `vterm.max_scroll()`, so the selection anchor **and** the highlight overlay share the snapshot's history depth off-thread. Flag-OFF: `scroll_max() == vterm.max_scroll()` → byte-identical.
- Both copy paths call the dispatcher.

## Tests
- `vterm::snapshot_extract_text_matches_vterm`: `GridSnapshot::extract_text` == `VTerm::extract_text` across history / visible / partial-column / multi-line ranges (incl. a wide char) — proves the off-thread copy yields the SAME content as the live path.
- `layout::pane::offthread_pane_extracts_selection_from_snapshot_not_idle_vterm`: end-to-end — drives the real parser, builds an off-thread Pane, asserts `extract_selection_text` returns on-screen content (history + visible) not the blank vterm. **Neuter-RED verified**: routing the dispatcher back to `pane.vterm` → `got ""` → fails.
- All adjacent selection/off-thread/render tests green (flag-OFF byte-identity: `snapshot_renders_identically_to_vterm`, `render_paints_offthread_snapshot_not_main_vterm`, `logical_anchor_*`, drag tests). fmt + `clippy --all-targets --features tray -D warnings` clean.

⚠ App-lifecycle/render change → needs operator rebuild+restart to go live. base includes #2411/#2412. correlation t-20260622123046192818-61487-4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)