### PR TITLE
fix(srl): override sticky-screen ServerRateLimit false-retry with a fresh claude hook

### DIFF
--- a/src/daemon/hook_shadow.rs
+++ b/src/daemon/hook_shadow.rs
@@ -124,6 +124,30 @@ pub fn resolved_state_for(name: &str) -> HookResolution {
     }
 }
 
+/// #t-26795 (SRL hook-override): the epoch-ms timestamp of the latest hook event IF
+/// it resolves to a FRESH, ACTIVE state, else `None`. The supervisor's
+/// ServerRateLimit retry uses this — a fresh active hook whose timestamp POST-DATES
+/// the rate-limit onset proves the agent is executing tool calls, so a sticky
+/// screen-scraped `ServerRateLimit` is stale and the retry must not fire.
+///
+/// ACTIVE = `{ToolUse, Thinking}` only. `Idle` is deliberately EXCLUDED: a fresh
+/// `Idle` is the turn-ENDED / prior-turn signal (ambiguous w.r.t. a brand-new SRL),
+/// and idle-recovery is already covered by the supervisor's productive-output
+/// `recovered` gate — so this stays the narrow "agent is provably mid-work" signal.
+///
+/// Flag-INDEPENDENT of `AGEND_HOOK_STATE_POC`: it reads the shadow snapshot that
+/// [`record_event`] populates unconditionally for any hook event. (The hooks only
+/// FIRE when the flag wires them into the backend — that is the data's presence, not
+/// this read's gating; a missing snapshot simply yields `None` = fail-safe.)
+pub fn fresh_active_hook_at_ms(name: &str) -> Option<u64> {
+    use crate::state::AgentState;
+    let snap = snapshot_for(name)?;
+    match resolved_state_for(name) {
+        HookResolution::Fresh(AgentState::ToolUse | AgentState::Thinking) => Some(snap.at_ms),
+        _ => None,
+    }
+}
+
 /// #1523: is the hook→authoritative promotion enabled? Gated on the same flag
 /// that injects the hooks, so promotion can never read hooks that aren't wired.
 fn promotion_enabled() -> bool {

--- a/src/daemon/hook_shadow.rs
+++ b/src/daemon/hook_shadow.rs
@@ -340,15 +340,24 @@ mod tests {
     #[serial]
     fn fresh_active_hook_at_ms_active_only() {
         record_event("fah-tooluse", "PreToolUse", None);
-        assert!(fresh_active_hook_at_ms("fah-tooluse").is_some(), "ToolUse is active");
+        assert!(
+            fresh_active_hook_at_ms("fah-tooluse").is_some(),
+            "ToolUse is active"
+        );
         record_event("fah-thinking", "PostToolUse", None);
-        assert!(fresh_active_hook_at_ms("fah-thinking").is_some(), "Thinking is active");
+        assert!(
+            fresh_active_hook_at_ms("fah-thinking").is_some(),
+            "Thinking is active"
+        );
         record_event("fah-idle", "Stop", None);
         assert!(
             fresh_active_hook_at_ms("fah-idle").is_none(),
             "Idle (turn-ended) is excluded — left to the productive-output recovery path"
         );
-        assert!(fresh_active_hook_at_ms("fah-absent").is_none(), "no hook → None");
+        assert!(
+            fresh_active_hook_at_ms("fah-absent").is_none(),
+            "no hook → None"
+        );
         record_event("fah-stale", "PostToolUse", None);
         backdate_for_test("fah-stale", HOOK_FRESHNESS.as_millis() as u64 + 1000);
         assert!(

--- a/src/daemon/hook_shadow.rs
+++ b/src/daemon/hook_shadow.rs
@@ -333,6 +333,30 @@ mod tests {
     use crate::state::AgentState;
     use serial_test::serial;
 
+    /// #t-26795: `fresh_active_hook_at_ms` returns a ts ONLY for a fresh ACTIVE hook
+    /// (ToolUse/Thinking). Idle (turn-ended) is excluded; an aged-out Thinking is
+    /// Stale → None; ToolUse never stales (event-pair). Absent → None.
+    #[test]
+    #[serial]
+    fn fresh_active_hook_at_ms_active_only() {
+        record_event("fah-tooluse", "PreToolUse", None);
+        assert!(fresh_active_hook_at_ms("fah-tooluse").is_some(), "ToolUse is active");
+        record_event("fah-thinking", "PostToolUse", None);
+        assert!(fresh_active_hook_at_ms("fah-thinking").is_some(), "Thinking is active");
+        record_event("fah-idle", "Stop", None);
+        assert!(
+            fresh_active_hook_at_ms("fah-idle").is_none(),
+            "Idle (turn-ended) is excluded — left to the productive-output recovery path"
+        );
+        assert!(fresh_active_hook_at_ms("fah-absent").is_none(), "no hook → None");
+        record_event("fah-stale", "PostToolUse", None);
+        backdate_for_test("fah-stale", HOOK_FRESHNESS.as_millis() as u64 + 1000);
+        assert!(
+            fresh_active_hook_at_ms("fah-stale").is_none(),
+            "a Thinking hook aged past freshness → Stale → None"
+        );
+    }
+
     #[test]
     fn derive_map_covers_the_fragile_band() {
         assert_eq!(derive_state("PreToolUse", None), Some(AgentState::ToolUse));

--- a/src/daemon/hook_shadow.rs
+++ b/src/daemon/hook_shadow.rs
@@ -16,6 +16,7 @@
 
 use parking_lot::Mutex;
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::OnceLock;
 
 /// One agent's latest hook-derived observation.
@@ -42,11 +43,26 @@ pub struct HookShadow {
     /// nothing → no `UserPromptSubmit`), so the inject-delivery watchdog needs
     /// it to survive the PreToolUse/Stop events that follow within its window.
     pub last_user_prompt_submit_ms: Option<u64>,
+    /// #t-26795: a process-global MONOTONIC sequence stamped on every
+    /// [`record_event`]. The SRL hook-override compares an agent's latest active-hook
+    /// seq against a per-episode FLOOR — a STRICTLY greater seq proves a NEW hook
+    /// arrived since the floor was consumed (forward progress), which an epoch-ms
+    /// timestamp cannot guarantee under wall-clock rollback. Only same-agent
+    /// latest-vs-floor is ever compared, so the global counter needs no per-agent map.
+    pub seq: u64,
 }
 
 fn store() -> &'static Mutex<HashMap<String, HookShadow>> {
     static S: OnceLock<Mutex<HashMap<String, HookShadow>>> = OnceLock::new();
     S.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// #t-26795: the next process-global monotonic hook sequence. Starts at 1 so the
+/// SRL-override floor's `unwrap_or(0)` default (an agent with no prior hook) is
+/// strictly below any real seq.
+fn next_seq() -> u64 {
+    static SEQ: AtomicU64 = AtomicU64::new(1);
+    SEQ.fetch_add(1, Ordering::Relaxed)
 }
 
 /// CR-2026-06-14: drop a deleted/redeployed agent's shadow entry. The global
@@ -111,10 +127,22 @@ pub enum HookResolution {
 /// `#hook-shadow` log keeps it operator-visible. The trade is a DEFINITELY-fixed
 /// false-nudge against a missed-nudge only on a double-drop corner — worth it.
 pub fn resolved_state_for(name: &str) -> HookResolution {
+    match snapshot_for(name) {
+        Some(snap) => resolve_snapshot(&snap),
+        None => HookResolution::Unknown,
+    }
+}
+
+/// Pure freshness/state resolution over a SINGLE, already-read snapshot.
+///
+/// #t-26795 (r6 finding-3): split out so a caller that also needs a field of the
+/// snapshot (e.g. [`fresh_active_hook_seq`]) resolves state AND that field from
+/// the SAME clone under ONE `store()` lock. Calling `snapshot_for` and then
+/// `resolved_state_for` separately re-locks and re-reads, which a concurrent
+/// [`record_event`] can tear — pairing generation-A's `at_ms` with generation-B's
+/// resolved state.
+fn resolve_snapshot(snap: &HookShadow) -> HookResolution {
     use crate::state::AgentState;
-    let Some(snap) = snapshot_for(name) else {
-        return HookResolution::Unknown;
-    };
     let age_ms = now_ms().saturating_sub(snap.at_ms);
     match snap.derived_state {
         // ToolUse: valid until the PostToolUse/Stop event overwrites it (above).
@@ -124,10 +152,11 @@ pub fn resolved_state_for(name: &str) -> HookResolution {
     }
 }
 
-/// #t-26795 (SRL hook-override): the epoch-ms timestamp of the latest hook event IF
-/// it resolves to a FRESH, ACTIVE state, else `None`. The supervisor's
-/// ServerRateLimit retry uses this — a fresh active hook whose timestamp POST-DATES
-/// the rate-limit onset proves the agent is executing tool calls, so a sticky
+/// #t-26795 (SRL hook-override): the monotonic [`HookShadow::seq`] of the latest hook
+/// event IF it resolves to a FRESH, ACTIVE state, else `None`. The supervisor's
+/// ServerRateLimit retry compares this against the per-episode floor — a seq STRICTLY
+/// greater than the floor proves a NEW tool-call/thinking hook arrived since the floor
+/// was last consumed (forward progress → the agent is executing), so a sticky
 /// screen-scraped `ServerRateLimit` is stale and the retry must not fire.
 ///
 /// ACTIVE = `{ToolUse, Thinking}` only. `Idle` is deliberately EXCLUDED: a fresh
@@ -139,13 +168,25 @@ pub fn resolved_state_for(name: &str) -> HookResolution {
 /// [`record_event`] populates unconditionally for any hook event. (The hooks only
 /// FIRE when the flag wires them into the backend — that is the data's presence, not
 /// this read's gating; a missing snapshot simply yields `None` = fail-safe.)
-pub fn fresh_active_hook_at_ms(name: &str) -> Option<u64> {
+pub fn fresh_active_hook_seq(name: &str) -> Option<u64> {
     use crate::state::AgentState;
+    // #t-26795 (r6 finding-3): ONE snapshot clone — resolve the state AND read its
+    // monotonic `seq` from the SAME generation. A second `resolved_state_for(name)`
+    // would re-lock and re-read, which a concurrent `record_event` can tear (gen-A
+    // seq paired with gen-B state).
     let snap = snapshot_for(name)?;
-    match resolved_state_for(name) {
-        HookResolution::Fresh(AgentState::ToolUse | AgentState::Thinking) => Some(snap.at_ms),
+    match resolve_snapshot(&snap) {
+        HookResolution::Fresh(AgentState::ToolUse | AgentState::Thinking) => Some(snap.seq),
         _ => None,
     }
+}
+
+/// #t-26795: the agent's latest recorded hook seq (ANY state), or 0 if none. The
+/// SRL-override seeds the per-episode floor with THIS at onset — so a hook recorded
+/// BEFORE the rate-limit began (seq ≤ floor) can't override a genuine new SRL
+/// (edge-a), while a hook recorded AFTER onset gets a strictly greater global seq.
+pub fn latest_hook_seq(name: &str) -> u64 {
+    snapshot_for(name).map(|s| s.seq).unwrap_or(0)
 }
 
 /// #1523: is the hook→authoritative promotion enabled? Gated on the same flag
@@ -281,6 +322,7 @@ pub fn record_event(
             derived_state: derived,
             at_ms: now,
             last_user_prompt_submit_ms,
+            seq: next_seq(),
         },
     );
     derived
@@ -316,6 +358,7 @@ pub(crate) fn set_user_prompt_submit_for_test(name: &str, ms: u64) {
         derived_state: Some(crate::state::AgentState::Thinking),
         at_ms: ms,
         last_user_prompt_submit_ms: Some(ms),
+        seq: next_seq(),
     });
     entry.last_user_prompt_submit_ms = Some(ms);
 }
@@ -333,36 +376,60 @@ mod tests {
     use crate::state::AgentState;
     use serial_test::serial;
 
-    /// #t-26795: `fresh_active_hook_at_ms` returns a ts ONLY for a fresh ACTIVE hook
+    /// #t-26795: `fresh_active_hook_seq` returns a seq ONLY for a fresh ACTIVE hook
     /// (ToolUse/Thinking). Idle (turn-ended) is excluded; an aged-out Thinking is
     /// Stale → None; ToolUse never stales (event-pair). Absent → None.
     #[test]
     #[serial]
-    fn fresh_active_hook_at_ms_active_only() {
+    fn fresh_active_hook_seq_active_only() {
         record_event("fah-tooluse", "PreToolUse", None);
         assert!(
-            fresh_active_hook_at_ms("fah-tooluse").is_some(),
+            fresh_active_hook_seq("fah-tooluse").is_some(),
             "ToolUse is active"
         );
         record_event("fah-thinking", "PostToolUse", None);
         assert!(
-            fresh_active_hook_at_ms("fah-thinking").is_some(),
+            fresh_active_hook_seq("fah-thinking").is_some(),
             "Thinking is active"
         );
         record_event("fah-idle", "Stop", None);
         assert!(
-            fresh_active_hook_at_ms("fah-idle").is_none(),
+            fresh_active_hook_seq("fah-idle").is_none(),
             "Idle (turn-ended) is excluded — left to the productive-output recovery path"
         );
         assert!(
-            fresh_active_hook_at_ms("fah-absent").is_none(),
+            fresh_active_hook_seq("fah-absent").is_none(),
             "no hook → None"
         );
         record_event("fah-stale", "PostToolUse", None);
         backdate_for_test("fah-stale", HOOK_FRESHNESS.as_millis() as u64 + 1000);
         assert!(
-            fresh_active_hook_at_ms("fah-stale").is_none(),
+            fresh_active_hook_seq("fah-stale").is_none(),
             "a Thinking hook aged past freshness → Stale → None"
+        );
+    }
+
+    /// #t-26795 (r6 finding-3): `fresh_active_hook_seq` resolves state and reads the
+    /// `seq` from ONE snapshot clone via the pure `resolve_snapshot` seam, so the
+    /// returned seq always belongs to the same generation whose state was resolved.
+    /// The torn double-read this replaces is timing-dependent (needs a concurrent
+    /// `record_event` to land between two locks), so this pins the seam + the
+    /// seq↔state pairing contract — the race-freedom itself rests on the structural
+    /// single-clone invariant, not on this test.
+    #[test]
+    #[serial]
+    fn fresh_active_hook_returns_its_own_snapshot_seq() {
+        record_event("f3-consistency", "PreToolUse", None);
+        let snap = snapshot_for("f3-consistency").expect("recorded");
+        assert_eq!(
+            resolve_snapshot(&snap),
+            HookResolution::Fresh(AgentState::ToolUse),
+            "pure resolver maps the cloned snapshot"
+        );
+        assert_eq!(
+            fresh_active_hook_seq("f3-consistency"),
+            Some(snap.seq),
+            "returned seq is the SAME snapshot's seq (one clone, no torn read)"
         );
     }
 

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -3933,6 +3933,119 @@ instances:
         std::fs::remove_dir_all(&home).ok();
     }
 
+    // ─────────────────── #t-26795 SRL hook-override ───────────────────
+
+    /// PURE truth-table for the hook→recovery decision.
+    #[test]
+    fn hook_recovered_for_srl_truth_table() {
+        let onset = 1000u64;
+        assert!(
+            super::hook_recovered_for_srl(true, Some(1500), Some(onset)),
+            "claude + fresh active hook POST-onset → recovered"
+        );
+        assert!(
+            !super::hook_recovered_for_srl(true, Some(500), Some(onset)),
+            "PRE-onset hook (prior turn) rejected → genuine new SRL not masked"
+        );
+        assert!(
+            !super::hook_recovered_for_srl(true, Some(1000), Some(onset)),
+            "exactly at onset is not strictly after → not recovered"
+        );
+        assert!(
+            !super::hook_recovered_for_srl(true, None, Some(onset)),
+            "no fresh ACTIVE hook (idle/stale/absent) → not recovered"
+        );
+        assert!(
+            !super::hook_recovered_for_srl(true, Some(1500), None),
+            "no onset (agent not in SRL) → not recovered"
+        );
+        assert!(
+            !super::hook_recovered_for_srl(false, Some(1500), Some(onset)),
+            "non-claude backend → never (unaffected)"
+        );
+    }
+
+    /// FLAP REGRESSION (operator's exact symptom, #t-26795). An agent latched on a
+    /// STICKY screen `ServerRateLimit` with `recovered`=false (no productive output
+    /// this instant) but a FRESH claude hook (tool calls firing) whose timestamp
+    /// POST-DATES the rate-limit onset → the retry track must stay CLEARED across
+    /// re-detect ticks (no re-arm = the `continue`-spam flap killed), and the onset
+    /// stays STABLE across the flap. NEUTER: drop `|| hook_recovered` from the clear
+    /// gate → a recovered=false tick re-arms → this RED.
+    #[test]
+    #[serial_test::serial]
+    fn srl_hook_override_kills_flap() {
+        let registry: AgentRegistry = Arc::new(parking_lot::Mutex::new(HashMap::new()));
+        let home = tmp_home("srl-hook-flap");
+        let mut tracks: HashMap<String, RateLimitRetry> = HashMap::new();
+        let mut srl_onset: HashMap<String, u64> = HashMap::new();
+        let name = "srl-flap-agent";
+        let (handle, _r) =
+            mock_agent_handle(name, crate::state::AgentState::ServerRateLimit);
+        registry.lock().insert(handle.id, handle);
+        // Stable onset in the PAST; a fresh active hook (now) POST-DATES it.
+        let onset = super::now_epoch_ms().saturating_sub(60_000);
+        srl_onset.insert(name.to_string(), onset);
+        crate::daemon::hook_shadow::record_event(name, "PreToolUse", None); // Fresh(ToolUse) @ now
+        for _ in 0..3 {
+            super::process_error_recovery(
+                &home,
+                &registry,
+                &mut tracks,
+                &mut Default::default(),
+                &mut Default::default(),
+                &mut Default::default(),
+                &mut srl_onset,
+                past_boot_grace(),
+            );
+        }
+        assert!(
+            !tracks.contains_key(name),
+            "a fresh post-onset claude hook must keep the SRL retry cleared — no re-arm flap"
+        );
+        assert_eq!(
+            srl_onset.get(name).copied(),
+            Some(onset),
+            "onset must stay STABLE across re-detect (or_insert never overwrites)"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// EDGE (#t-26795): a genuine NEW SRL must NOT be masked — a hook that PRE-DATES
+    /// the onset (a prior turn's, backdated before this episode) does not override;
+    /// the retry arms normally.
+    #[test]
+    #[serial_test::serial]
+    fn srl_genuine_not_masked_by_pre_onset_hook() {
+        let registry: AgentRegistry = Arc::new(parking_lot::Mutex::new(HashMap::new()));
+        let home = tmp_home("srl-genuine");
+        let mut tracks: HashMap<String, RateLimitRetry> = HashMap::new();
+        let mut srl_onset: HashMap<String, u64> = HashMap::new();
+        let name = "srl-genuine-agent";
+        let (handle, _r) =
+            mock_agent_handle(name, crate::state::AgentState::ServerRateLimit);
+        registry.lock().insert(handle.id, handle);
+        // A hook from a PRIOR turn: recorded then backdated to BEFORE the onset the
+        // tick stamps (now). hook(now-120s) < onset(now) → pre-onset → no override.
+        crate::daemon::hook_shadow::record_event(name, "PreToolUse", None);
+        crate::daemon::hook_shadow::backdate_for_test(name, 120_000);
+        super::process_error_recovery(
+            &home,
+            &registry,
+            &mut tracks,
+            &mut Default::default(),
+            &mut Default::default(),
+            &mut Default::default(),
+            &mut srl_onset,
+            past_boot_grace(),
+        );
+        assert!(
+            tracks.contains_key(name),
+            "a pre-onset hook must NOT mask a genuine SRL — the retry must arm"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
     /// #ratelimit-recovery (the live storm that wedged fixup-lead): an agent still
     /// LATCHED ServerRateLimit (the stale "Server is temporarily limiting" line
     /// re-matches in the tail, and `working_state_below` can't see a marker BELOW

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -302,6 +302,8 @@ fn run_loop(home: PathBuf, registry: AgentRegistry) {
     let mut apierror_nudge_counts: std::collections::HashMap<String, u32> =
         std::collections::HashMap::new();
     let mut last_continue_inject: HashMap<String, Instant> = HashMap::new();
+    // #t-26795: stable first-onset epoch-ms per agent (see `process_error_recovery`).
+    let mut srl_onset: HashMap<String, u64> = HashMap::new();
     let mut pane_input_tracks: HashMap<String, PaneInputTrack> = HashMap::new();
     // W1.1 (#2050): the 12 periodic trackers (anti_stall, idle_watchdog,
     // decision_timeout, helper_staleness, mcp_registry, waiting_on_stale,
@@ -340,6 +342,7 @@ fn run_loop(home: PathBuf, registry: AgentRegistry) {
                 &mut apierror_episodes,
                 &mut apierror_nudge_counts,
                 &mut last_continue_inject,
+                &mut srl_onset,
                 loop_started_at,
             );
             check_pane_input_not_submitted(
@@ -1882,6 +1885,30 @@ fn classify_inject_failure(consecutive_failures: u32) -> InjectFailAction {
     }
 }
 
+/// #t-26795: epoch-ms now — matches the hook snapshot's `at_ms` clock for the
+/// post-onset comparison (the rest of the supervisor uses `Instant` for backoff).
+fn now_epoch_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// #t-26795 (PURE, unit-tested): does a fresh claude hook prove the agent recovered
+/// from a STICKY screen-scraped `ServerRateLimit`? True iff the backend is claude AND
+/// a fresh ACTIVE hook event exists whose epoch-ms POST-DATES the rate-limit onset
+/// (the agent emitted a tool-call hook AFTER the throttle began → it is executing, so
+/// the screen text is stale). A pre-onset hook (a prior turn's, fired BEFORE this SRL)
+/// is rejected — the load-bearing edge against masking a genuine new-turn SRL.
+/// non-claude / no-hook / stale-hook → false → the screen-driven path is unchanged.
+fn hook_recovered_for_srl(
+    is_claude: bool,
+    hook_active_at_ms: Option<u64>,
+    srl_onset_ms: Option<u64>,
+) -> bool {
+    is_claude && matches!((hook_active_at_ms, srl_onset_ms), (Some(h), Some(o)) if h > o)
+}
+
 pub(crate) fn process_error_recovery(
     home: &std::path::Path,
     registry: &AgentRegistry,
@@ -1889,6 +1916,12 @@ pub(crate) fn process_error_recovery(
     apierror_episodes: &mut std::collections::HashSet<String>,
     apierror_nudge_counts: &mut HashMap<String, u32>,
     last_continue_inject: &mut HashMap<String, Instant>,
+    // #t-26795: per-agent epoch-ms of the FIRST ServerRateLimit detection of the
+    // current episode, STABLE across the detect→clear→re-detect flap (or_insert never
+    // overwrites; removed only on a genuine screen-state exit). The hook-override
+    // compares a fresh active hook's timestamp against THIS — a resetting onset would
+    // make a just-pre-re-detect hook look pre-onset and the flap would survive.
+    srl_onset: &mut HashMap<String, u64>,
     loop_started_at: Instant,
 ) {
     use crate::state::AgentState;
@@ -1955,6 +1988,29 @@ pub(crate) fn process_error_recovery(
                 (state, recovered, self_cleared, has_hint, productive_silence)
             };
 
+            // ── #t-26795 SRL hook-override (operator-reported sticky-screen flap) ──
+            // A sticky screen-scraped ServerRateLimit while a FRESH claude hook proves
+            // the agent is mid-tool-call = the screen text is stale. Track the STABLE
+            // first-onset (or_insert never overwrites → survives the detect→clear→
+            // re-detect flap; removed only on a genuine screen exit), then treat a fresh
+            // ACTIVE hook that POST-DATES it as a third recovery signal. ADD-ONLY —
+            // composes with recovered/self_cleared; claude-only; a non-claude / missing /
+            // stale / pre-onset hook falls through to the unchanged screen-driven path.
+            if state == AgentState::ServerRateLimit {
+                srl_onset.entry(name.to_string()).or_insert_with(now_epoch_ms);
+            } else {
+                srl_onset.remove(name);
+            }
+            let is_claude =
+                crate::backend::Backend::parse_str(handle.backend_command.as_str()).has_state_hooks();
+            let hook_active_at_ms = if is_claude {
+                crate::daemon::hook_shadow::fresh_active_hook_at_ms(name)
+            } else {
+                None
+            };
+            let hook_recovered =
+                hook_recovered_for_srl(is_claude, hook_active_at_ms, srl_onset.get(name).copied());
+
             // ── #1713 root-fix: ServerRateLimit retry — DECIDE with fresh state ──
             // The "should we inject this tick" decision lives HERE, under the lock,
             // gated on the agent being FRESHLY observed in ServerRateLimit — not on a
@@ -1963,7 +2019,7 @@ pub(crate) fn process_error_recovery(
             // only EXECUTES the lock-free PTY inject for the names decided here. So a
             // track can never blind-fire `continue` into a non-error state (e.g. a
             // PermissionPrompt the agent reached after the throttle cleared).
-            if state == AgentState::ServerRateLimit && (recovered || self_cleared) {
+            if state == AgentState::ServerRateLimit && (recovered || self_cleared || hook_recovered) {
                 // #ratelimit-recovery: still latched ServerRateLimit (the stale
                 // "Server is temporarily limiting" line re-matches in the tail and
                 // working_state_below can't see a marker BELOW the most-recent error
@@ -1985,7 +2041,13 @@ pub(crate) fn process_error_recovery(
                     tracing::info!(
                         agent = %name,
                         productive_silent_secs = productive_silence.as_secs(),
-                        recovered_via = if self_cleared { "agent_self_clear" } else { "productive_output" },
+                        recovered_via = if self_cleared {
+                            "agent_self_clear"
+                        } else if recovered {
+                            "productive_output"
+                        } else {
+                            "hook_active" // #t-26795: fresh post-onset claude hook
+                        },
                         "ServerRateLimit retry cleared — agent recovered"
                     );
                 }
@@ -3859,6 +3921,7 @@ instances:
             &mut Default::default(),
             &mut Default::default(),
             &mut Default::default(),
+            &mut Default::default(),
             past_boot_grace(),
         );
         assert!(
@@ -3911,6 +3974,7 @@ instances:
                 &mut Default::default(),
                 &mut Default::default(),
                 &mut last_inject,
+                &mut Default::default(),
                 past_boot_grace(),
             );
         }
@@ -3965,6 +4029,7 @@ instances:
                 &mut Default::default(),
                 &mut Default::default(),
                 &mut last_inject,
+                &mut Default::default(),
                 past_boot_grace(),
             );
         }
@@ -4006,6 +4071,7 @@ instances:
             &mut Default::default(),
             &mut Default::default(),
             &mut Default::default(),
+            &mut Default::default(),
             past_boot_grace(),
         );
 
@@ -4041,6 +4107,7 @@ instances:
                 &home,
                 &registry,
                 tracks,
+                &mut Default::default(),
                 &mut Default::default(),
                 &mut Default::default(),
                 &mut Default::default(),
@@ -4121,6 +4188,7 @@ instances:
             &mut Default::default(),
             &mut Default::default(),
             &mut last_inject,
+            &mut Default::default(),
             past_boot_grace(),
         );
 
@@ -4166,6 +4234,7 @@ instances:
             &home,
             &registry,
             &mut tracks,
+            &mut Default::default(),
             &mut Default::default(),
             &mut Default::default(),
             &mut Default::default(),
@@ -4228,6 +4297,7 @@ instances:
             &mut Default::default(),
             &mut Default::default(),
             &mut last_inject,
+            &mut Default::default(),
             past_boot_grace(),
         );
         {
@@ -4259,6 +4329,7 @@ instances:
             &mut Default::default(),
             &mut Default::default(),
             &mut last_inject,
+            &mut Default::default(),
             past_boot_grace(),
         );
         assert!(
@@ -4305,6 +4376,7 @@ instances:
             &mut Default::default(),
             &mut Default::default(),
             &mut last_inject,
+            &mut Default::default(),
             past_boot_grace(),
         );
         assert!(
@@ -4348,6 +4420,7 @@ instances:
             &mut Default::default(),
             &mut Default::default(),
             &mut Default::default(),
+            &mut Default::default(),
             past_boot_grace(),
         );
 
@@ -4386,6 +4459,7 @@ instances:
             &home,
             &registry,
             &mut tracks,
+            &mut Default::default(),
             &mut Default::default(),
             &mut Default::default(),
             &mut Default::default(),
@@ -4437,6 +4511,7 @@ instances:
             &mut Default::default(),
             &mut Default::default(),
             &mut last_inject,
+            &mut Default::default(),
             past_boot_grace(),
         );
         let track = tracks
@@ -4494,6 +4569,7 @@ instances:
             &mut Default::default(),
             &mut Default::default(),
             &mut Default::default(),
+            &mut Default::default(),
             past_boot_grace(),
         );
 
@@ -4539,6 +4615,7 @@ instances:
             &home,
             &registry,
             &mut tracks,
+            &mut Default::default(),
             &mut Default::default(),
             &mut Default::default(),
             &mut Default::default(),
@@ -4625,6 +4702,7 @@ instances:
             &mut Default::default(),
             &mut Default::default(),
             &mut last_inject,
+            &mut Default::default(),
             past_boot_grace(),
         );
 
@@ -4676,6 +4754,7 @@ instances:
             &mut Default::default(),
             &mut Default::default(),
             &mut Default::default(),
+            &mut Default::default(),
             past_boot_grace(),
         );
         assert!(
@@ -4724,6 +4803,7 @@ instances:
             &home,
             &registry,
             &mut tracks,
+            &mut Default::default(),
             &mut Default::default(),
             &mut Default::default(),
             &mut Default::default(),
@@ -4797,6 +4877,7 @@ instances:
             &mut Default::default(),
             &mut Default::default(),
             &mut Default::default(),
+            &mut Default::default(),
             past_boot_grace(),
         );
         assert!(
@@ -4847,6 +4928,7 @@ instances:
             &home,
             &registry,
             &mut tracks,
+            &mut Default::default(),
             &mut Default::default(),
             &mut Default::default(),
             &mut Default::default(),
@@ -4934,6 +5016,7 @@ instances:
             &mut Default::default(),
             &mut Default::default(),
             &mut last_inject,
+            &mut Default::default(),
             past_boot_grace(),
         );
 
@@ -4986,6 +5069,7 @@ instances:
             &home,
             &registry,
             &mut tracks,
+            &mut Default::default(),
             &mut Default::default(),
             &mut Default::default(),
             &mut Default::default(),
@@ -5467,6 +5551,7 @@ instances:
             &mut Default::default(),
             &mut Default::default(),
             &mut last_inject,
+            &mut Default::default(),
             past_boot_grace(),
         );
         assert!(
@@ -5504,6 +5589,7 @@ instances:
             &mut episodes,
             &mut Default::default(),
             &mut last_inject,
+            &mut Default::default(),
             past_boot_grace(),
         );
         assert!(
@@ -5527,6 +5613,7 @@ instances:
             &mut episodes,
             &mut Default::default(),
             &mut last_inject,
+            &mut Default::default(),
             past_boot_grace(),
         );
         assert_eq!(
@@ -5561,6 +5648,7 @@ instances:
                 &mut episodes,
                 &mut counts,
                 &mut last_inject,
+                &mut Default::default(),
                 past_boot_grace(),
             );
         }
@@ -5650,6 +5738,7 @@ instances:
             &mut episodes,
             &mut Default::default(),
             &mut last_inject,
+            &mut Default::default(),
             Instant::now(),
         );
         assert!(
@@ -5669,6 +5758,7 @@ instances:
             &mut episodes,
             &mut Default::default(),
             &mut last_inject,
+            &mut Default::default(),
             past_boot_grace(),
         );
         assert!(

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -302,8 +302,9 @@ fn run_loop(home: PathBuf, registry: AgentRegistry) {
     let mut apierror_nudge_counts: std::collections::HashMap<String, u32> =
         std::collections::HashMap::new();
     let mut last_continue_inject: HashMap<String, Instant> = HashMap::new();
-    // #t-26795: stable first-onset epoch-ms per agent (see `process_error_recovery`).
-    let mut srl_onset: HashMap<String, u64> = HashMap::new();
+    // #t-26795: per-agent SRL forward-progress hook-seq floor (see
+    // `process_error_recovery`).
+    let mut srl_floor: HashMap<String, u64> = HashMap::new();
     let mut pane_input_tracks: HashMap<String, PaneInputTrack> = HashMap::new();
     // W1.1 (#2050): the 12 periodic trackers (anti_stall, idle_watchdog,
     // decision_timeout, helper_staleness, mcp_registry, waiting_on_stale,
@@ -342,7 +343,7 @@ fn run_loop(home: PathBuf, registry: AgentRegistry) {
                 &mut apierror_episodes,
                 &mut apierror_nudge_counts,
                 &mut last_continue_inject,
-                &mut srl_onset,
+                &mut srl_floor,
                 loop_started_at,
             );
             check_pane_input_not_submitted(
@@ -1885,32 +1886,26 @@ fn classify_inject_failure(consecutive_failures: u32) -> InjectFailAction {
     }
 }
 
-/// #t-26795: epoch-ms now — matches the hook snapshot's `at_ms` clock for the
-/// post-onset comparison (the rest of the supervisor uses `Instant` for backoff).
-fn now_epoch_ms() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_millis() as u64)
-        .unwrap_or(0)
-}
-
 /// #t-26795 (PURE, unit-tested): does a fresh claude hook prove the agent recovered
 /// from a STICKY screen-scraped `ServerRateLimit`? True iff the backend is claude AND
-/// a fresh ACTIVE hook event exists whose epoch-ms POST-DATES the rate-limit onset
-/// (the agent emitted a tool-call hook AFTER the throttle began → it is executing, so
-/// the screen text is stale). A pre-onset hook (a prior turn's, fired BEFORE this SRL)
-/// is rejected — the load-bearing edge against masking a genuine new-turn SRL.
+/// a fresh ACTIVE hook's monotonic seq is STRICTLY GREATER than the per-episode floor
+/// — i.e. a NEW tool-call/thinking hook arrived since the floor was last consumed
+/// (forward progress → the agent is executing → the screen text is stale). The floor
+/// starts at the agent's latest hook seq at onset, so a pre-onset hook (seq ≤ floor)
+/// is rejected (the load-bearing edge against masking a genuine new SRL); once a
+/// recovery hook is consumed the floor ADVANCES to it, so a later genuine episode with
+/// NO newer hook (seq == floor) re-arms instead of being permanently masked.
 /// non-claude / no-hook / stale-hook → false → the screen-driven path is unchanged.
 fn hook_recovered_for_srl(
     is_claude: bool,
-    hook_active_at_ms: Option<u64>,
-    srl_onset_ms: Option<u64>,
+    hook_active_seq: Option<u64>,
+    floor: Option<u64>,
 ) -> bool {
-    is_claude && matches!((hook_active_at_ms, srl_onset_ms), (Some(h), Some(o)) if h > o)
+    is_claude && matches!((hook_active_seq, floor), (Some(h), Some(f)) if h > f)
 }
 
 // Threads the run_loop's long-lived per-agent error/retry state maps (retry_tracks,
-// apierror_episodes, apierror_nudge_counts, last_continue_inject, srl_onset); bundling
+// apierror_episodes, apierror_nudge_counts, last_continue_inject, srl_floor); bundling
 // them into a struct would not improve clarity here.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn process_error_recovery(
@@ -1920,12 +1915,14 @@ pub(crate) fn process_error_recovery(
     apierror_episodes: &mut std::collections::HashSet<String>,
     apierror_nudge_counts: &mut HashMap<String, u32>,
     last_continue_inject: &mut HashMap<String, Instant>,
-    // #t-26795: per-agent epoch-ms of the FIRST ServerRateLimit detection of the
-    // current episode, STABLE across the detect→clear→re-detect flap (or_insert never
-    // overwrites; removed only on a genuine screen-state exit). The hook-override
-    // compares a fresh active hook's timestamp against THIS — a resetting onset would
-    // make a just-pre-re-detect hook look pre-onset and the flap would survive.
-    srl_onset: &mut HashMap<String, u64>,
+    // #t-26795: per-agent forward-progress FLOOR = the monotonic hook seq last
+    // CONSUMED to clear this ServerRateLimit episode. Seeded at onset with the agent's
+    // latest hook seq (or_insert never overwrites → stable across the detect→clear→
+    // re-detect flap; removed on a genuine screen exit), then ADVANCED on every
+    // override. The hook-override fires only for a fresh active hook STRICTLY newer
+    // than this — so a stale recovery hook can't permanently mask a later genuine
+    // episode (r6 finding-1), and a pre-onset hook (seq ≤ floor) can't mask edge-a.
+    srl_floor: &mut HashMap<String, u64>,
     loop_started_at: Instant,
 ) {
     use crate::state::AgentState;
@@ -1994,28 +1991,38 @@ pub(crate) fn process_error_recovery(
 
             // ── #t-26795 SRL hook-override (operator-reported sticky-screen flap) ──
             // A sticky screen-scraped ServerRateLimit while a FRESH claude hook proves
-            // the agent is mid-tool-call = the screen text is stale. Track the STABLE
-            // first-onset (or_insert never overwrites → survives the detect→clear→
-            // re-detect flap; removed only on a genuine screen exit), then treat a fresh
-            // ACTIVE hook that POST-DATES it as a third recovery signal. ADD-ONLY —
-            // composes with recovered/self_cleared; claude-only; a non-claude / missing /
-            // stale / pre-onset hook falls through to the unchanged screen-driven path.
+            // the agent is mid-tool-call = the screen text is stale. Seed a per-episode
+            // FLOOR with the agent's latest hook seq at onset (or_insert never
+            // overwrites → survives the detect→clear→re-detect flap; removed only on a
+            // genuine screen exit); a fresh ACTIVE hook whose seq is STRICTLY newer
+            // than the floor is a third recovery signal. ADD-ONLY — composes with
+            // recovered/self_cleared; claude-only; a non-claude / missing / stale /
+            // pre-onset hook falls through to the unchanged screen-driven path.
             if state == AgentState::ServerRateLimit {
-                srl_onset
+                srl_floor
                     .entry(name.to_string())
-                    .or_insert_with(now_epoch_ms);
+                    .or_insert_with(|| crate::daemon::hook_shadow::latest_hook_seq(name));
             } else {
-                srl_onset.remove(name);
+                srl_floor.remove(name);
             }
             let is_claude = crate::backend::Backend::parse_str(handle.backend_command.as_str())
                 .has_state_hooks();
-            let hook_active_at_ms = if is_claude {
-                crate::daemon::hook_shadow::fresh_active_hook_at_ms(name)
+            let hook_active_seq = if is_claude {
+                crate::daemon::hook_shadow::fresh_active_hook_seq(name)
             } else {
                 None
             };
             let hook_recovered =
-                hook_recovered_for_srl(is_claude, hook_active_at_ms, srl_onset.get(name).copied());
+                hook_recovered_for_srl(is_claude, hook_active_seq, srl_floor.get(name).copied());
+            if hook_recovered {
+                // FORWARD-PROGRESS (r6 finding-1): advance the floor to the consumed
+                // hook so a LATER genuine episode — screen still sticky-SRL but the
+                // agent now truly stuck (no NEWER hook) — re-arms the retry instead of
+                // being permanently masked by this episode's stale recovery hook.
+                if let Some(seq) = hook_active_seq {
+                    srl_floor.insert(name.to_string(), seq);
+                }
+            }
 
             // ── #1713 root-fix: ServerRateLimit retry — DECIDE with fresh state ──
             // The "should we inject this tick" decision lives HERE, under the lock,
@@ -2245,6 +2252,10 @@ pub(crate) fn process_error_recovery(
     apierror_episodes.retain(|name| active_names.contains(name));
     apierror_nudge_counts.retain(|name, _| active_names.contains(name));
     last_continue_inject.retain(|name, _| active_names.contains(name));
+    // #t-26795 (r6 finding-2): the SRL forward-progress floor map must churn-prune
+    // too, or a delete/restart leaves a residual floor and a same-name replacement's
+    // `or_insert` INHERITS it — masking the new instance's genuine first SRL.
+    srl_floor.retain(|name, _| active_names.contains(name));
     // #t-81376 Phase-0 shadow: prune expectation/latch maps for churned agents
     // (no-op unless AGEND_RECOVERY_SHADOW=1). `()` → control-flow-inert.
     crate::daemon::recovery_shadow::retain_live(&|n| active_names.contains(n));
@@ -3942,58 +3953,64 @@ instances:
 
     // ─────────────────── #t-26795 SRL hook-override ───────────────────
 
-    /// PURE truth-table for the hook→recovery decision.
+    /// PURE truth-table + FORWARD-PROGRESS (test ②) for the hook→recovery decision:
+    /// a hook seq STRICTLY greater than the floor recovers; a seq equal to (consumed)
+    /// or below (pre-onset) the floor does not — so once the floor advances onto a
+    /// hook, that SAME hook no longer overrides, only a NEWER one does.
     #[test]
     fn hook_recovered_for_srl_truth_table() {
-        let onset = 1000u64;
+        let floor = 1000u64;
         assert!(
-            super::hook_recovered_for_srl(true, Some(1500), Some(onset)),
-            "claude + fresh active hook POST-onset → recovered"
+            super::hook_recovered_for_srl(true, Some(1500), Some(floor)),
+            "claude + a fresh active hook NEWER than the floor → recovered (forward progress)"
         );
         assert!(
-            !super::hook_recovered_for_srl(true, Some(500), Some(onset)),
-            "PRE-onset hook (prior turn) rejected → genuine new SRL not masked"
+            !super::hook_recovered_for_srl(true, Some(500), Some(floor)),
+            "a hook seq BELOW the floor (pre-onset / prior turn) → genuine new SRL not masked"
         );
         assert!(
-            !super::hook_recovered_for_srl(true, Some(1000), Some(onset)),
-            "exactly at onset is not strictly after → not recovered"
+            !super::hook_recovered_for_srl(true, Some(1000), Some(floor)),
+            "a hook seq EQUAL to the floor (already consumed — no newer hook) → not recovered → re-arms"
         );
         assert!(
-            !super::hook_recovered_for_srl(true, None, Some(onset)),
+            !super::hook_recovered_for_srl(true, None, Some(floor)),
             "no fresh ACTIVE hook (idle/stale/absent) → not recovered"
         );
         assert!(
             !super::hook_recovered_for_srl(true, Some(1500), None),
-            "no onset (agent not in SRL) → not recovered"
+            "no floor (agent not in SRL) → not recovered"
         );
         assert!(
-            !super::hook_recovered_for_srl(false, Some(1500), Some(onset)),
+            !super::hook_recovered_for_srl(false, Some(1500), Some(floor)),
             "non-claude backend → never (unaffected)"
         );
     }
 
     /// FLAP REGRESSION (operator's exact symptom, #t-26795). An agent latched on a
     /// STICKY screen `ServerRateLimit` with `recovered`=false (no productive output
-    /// this instant) but a FRESH claude hook (tool calls firing) whose timestamp
-    /// POST-DATES the rate-limit onset → the retry track must stay CLEARED across
-    /// re-detect ticks (no re-arm = the `continue`-spam flap killed), and the onset
-    /// stays STABLE across the flap. NEUTER: drop `|| hook_recovered` from the clear
-    /// gate → a recovered=false tick re-arms → this RED.
+    /// this instant) but ALIVE — firing a NEW tool-call hook every tick. Each fresh
+    /// hook seq exceeds the floor (forward progress) → the retry track stays CLEARED
+    /// across re-detect ticks (no re-arm = the `continue`-spam flap killed) and the
+    /// floor advances as each hook is consumed. NEUTER: drop `|| hook_recovered` from
+    /// the clear gate → a recovered=false tick re-arms → this RED.
     #[test]
     #[serial_test::serial]
     fn srl_hook_override_kills_flap() {
         let registry: AgentRegistry = Arc::new(parking_lot::Mutex::new(HashMap::new()));
         let home = tmp_home("srl-hook-flap");
         let mut tracks: HashMap<String, RateLimitRetry> = HashMap::new();
-        let mut srl_onset: HashMap<String, u64> = HashMap::new();
+        let mut srl_floor: HashMap<String, u64> = HashMap::new();
         let name = "srl-flap-agent";
         let (handle, _r) = mock_agent_handle(name, crate::state::AgentState::ServerRateLimit);
         registry.lock().insert(handle.id, handle);
-        // Stable onset in the PAST; a fresh active hook (now) POST-DATES it.
-        let onset = super::now_epoch_ms().saturating_sub(60_000);
-        srl_onset.insert(name.to_string(), onset);
-        crate::daemon::hook_shadow::record_event(name, "PreToolUse", None); // Fresh(ToolUse) @ now
+        // Onset baseline: a pre-SRL hook pins the floor BELOW the recovery hooks.
+        crate::daemon::hook_shadow::record_event(name, "Stop", None); // idle baseline
+        let floor = crate::daemon::hook_shadow::latest_hook_seq(name);
+        srl_floor.insert(name.to_string(), floor);
+        // The agent is actually ALIVE (false sticky SRL): it fires a NEW tool-call hook
+        // each tick → each seq > floor → forward progress → the retry stays cleared.
         for _ in 0..3 {
+            crate::daemon::hook_shadow::record_event(name, "PreToolUse", None);
             super::process_error_recovery(
                 &home,
                 &registry,
@@ -4001,39 +4018,129 @@ instances:
                 &mut Default::default(),
                 &mut Default::default(),
                 &mut Default::default(),
-                &mut srl_onset,
+                &mut srl_floor,
                 past_boot_grace(),
+            );
+            assert!(
+                !tracks.contains_key(name),
+                "a fresh post-floor claude hook each tick keeps the SRL retry cleared — the continue-spam flap is killed"
             );
         }
         assert!(
-            !tracks.contains_key(name),
-            "a fresh post-onset claude hook must keep the SRL retry cleared — no re-arm flap"
-        );
-        assert_eq!(
-            srl_onset.get(name).copied(),
-            Some(onset),
-            "onset must stay STABLE across re-detect (or_insert never overwrites)"
+            srl_floor.get(name).copied().expect("floor present after override") > floor,
+            "the floor ADVANCES to the latest consumed hook seq (forward progress)"
         );
         std::fs::remove_dir_all(&home).ok();
     }
 
-    /// EDGE (#t-26795): a genuine NEW SRL must NOT be masked — a hook that PRE-DATES
-    /// the onset (a prior turn's, backdated before this episode) does not override;
-    /// the retry arms normally.
+    /// FORWARD-PROGRESS (test ①, #t-26795 r6 finding-1): the multi-episode case the
+    /// stable first-onset design missed, driven end-to-end through the code. The
+    /// screen STAYS sticky-SRL the whole time (never emits a non-SRL tick → the floor
+    /// is never reset). (a) onset: an idle baseline seeds the floor, no active hook →
+    /// the retry ARMS. (b) episode A: a fresh tool-call hook (seq > floor) overrides
+    /// AND ADVANCES the floor onto it → the retry clears. (c) episode B: the agent is
+    /// now genuinely stuck — NO newer hook — so that SAME hook's seq == the advanced
+    /// floor → no override → the retry must RE-ARM. NEUTER: drop the floor-advance
+    /// (revert to the stable first-onset design) → the still-fresh episode-A hook
+    /// stays seq > the un-advanced floor → it permanently re-masks B → no re-arm → RED.
+    #[test]
+    #[serial_test::serial]
+    fn srl_forward_progress_rearms_genuine_episode_b() {
+        let registry: AgentRegistry = Arc::new(parking_lot::Mutex::new(HashMap::new()));
+        let home = tmp_home("srl-fwd-progress");
+        let mut tracks: HashMap<String, RateLimitRetry> = HashMap::new();
+        let mut srl_floor: HashMap<String, u64> = HashMap::new();
+        let name = "srl-fwd-agent";
+        let (handle, _r) = mock_agent_handle(name, crate::state::AgentState::ServerRateLimit);
+        registry.lock().insert(handle.id, handle);
+        let pe = |tracks: &mut HashMap<String, RateLimitRetry>,
+                  srl_floor: &mut HashMap<String, u64>| {
+            super::process_error_recovery(
+                &home,
+                &registry,
+                tracks,
+                &mut Default::default(),
+                &mut Default::default(),
+                &mut Default::default(),
+                srl_floor,
+                past_boot_grace(),
+            );
+        };
+        // (a) onset: an idle baseline seeds the floor; no active hook → the retry arms.
+        crate::daemon::hook_shadow::record_event(name, "Stop", None);
+        pe(&mut tracks, &mut srl_floor);
+        assert!(
+            tracks.contains_key(name),
+            "onset with no active hook arms the retry"
+        );
+        // (b) episode A: a fresh tool-call hook NEWER than the floor overrides AND the
+        // production code advances the floor onto it → the retry clears.
+        crate::daemon::hook_shadow::record_event(name, "PreToolUse", None);
+        pe(&mut tracks, &mut srl_floor);
+        assert!(
+            !tracks.contains_key(name),
+            "episode A: a fresh post-floor hook overrides — the retry clears"
+        );
+        // (c) episode B: agent genuinely stuck — NO newer hook. The same episode-A hook
+        // is still Fresh(ToolUse) but its seq == the advanced floor → no override.
+        pe(&mut tracks, &mut srl_floor);
+        assert!(
+            tracks.contains_key(name),
+            "a genuine episode B (no hook newer than the CONSUMED floor) must re-arm the retry — forward progress, not permanent mask"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// CHURN PRUNE (#t-26795 r6 finding-2): a deleted/restarted agent's SRL floor
+    /// must be dropped when it leaves the registry, or a same-name replacement's
+    /// `or_insert` INHERITS the stale floor and the new instance's genuine first SRL
+    /// is masked. NEUTER: drop the `srl_floor.retain(...)` churn-prune → RED.
+    #[test]
+    #[serial_test::serial]
+    fn srl_floor_pruned_on_agent_churn() {
+        let registry: AgentRegistry = Arc::new(parking_lot::Mutex::new(HashMap::new()));
+        let home = tmp_home("srl-floor-churn");
+        let mut srl_floor: HashMap<String, u64> = HashMap::new();
+        // A prior instance left a floor seq behind; it is NO LONGER in the registry
+        // (deleted / restarted under the same name).
+        srl_floor.insert("recycled-name".to_string(), 1);
+        super::process_error_recovery(
+            &home,
+            &registry,
+            &mut Default::default(),
+            &mut Default::default(),
+            &mut Default::default(),
+            &mut Default::default(),
+            &mut srl_floor,
+            past_boot_grace(),
+        );
+        assert!(
+            !srl_floor.contains_key("recycled-name"),
+            "a churned-out agent's SRL floor must be pruned so a same-name replacement re-arms its genuine first SRL"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// EDGE (#t-26795): a genuine NEW SRL must NOT be masked. The agent's latest hook
+    /// PRESENT at onset seeds the floor to its OWN seq, so with NO newer hook the
+    /// active seq EQUALS the floor → not strictly greater → no override → the retry
+    /// arms. (A hook present at onset is "pre-onset" w.r.t. the floor it seeds.) This
+    /// exercises the `or_insert_with(latest_hook_seq)` onset-init path — r4's blessed
+    /// edge-a, preserved under the seq model. NEUTER: relax `h > f` to `h >= f` → the
+    /// onset hook wrongly overrides → no arm → RED.
     #[test]
     #[serial_test::serial]
     fn srl_genuine_not_masked_by_pre_onset_hook() {
         let registry: AgentRegistry = Arc::new(parking_lot::Mutex::new(HashMap::new()));
         let home = tmp_home("srl-genuine");
         let mut tracks: HashMap<String, RateLimitRetry> = HashMap::new();
-        let mut srl_onset: HashMap<String, u64> = HashMap::new();
+        let mut srl_floor: HashMap<String, u64> = HashMap::new();
         let name = "srl-genuine-agent";
         let (handle, _r) = mock_agent_handle(name, crate::state::AgentState::ServerRateLimit);
         registry.lock().insert(handle.id, handle);
-        // A hook from a PRIOR turn: recorded then backdated to BEFORE the onset the
-        // tick stamps (now). hook(now-120s) < onset(now) → pre-onset → no override.
+        // A hook present at onset: the floor `or_insert`s to its seq → active seq ==
+        // floor → no override. No newer hook arrives = a genuine SRL.
         crate::daemon::hook_shadow::record_event(name, "PreToolUse", None);
-        crate::daemon::hook_shadow::backdate_for_test(name, 120_000);
         super::process_error_recovery(
             &home,
             &registry,
@@ -4041,12 +4148,12 @@ instances:
             &mut Default::default(),
             &mut Default::default(),
             &mut Default::default(),
-            &mut srl_onset,
+            &mut srl_floor,
             past_boot_grace(),
         );
         assert!(
             tracks.contains_key(name),
-            "a pre-onset hook must NOT mask a genuine SRL — the retry must arm"
+            "a hook no newer than the onset floor must NOT mask a genuine SRL — the retry must arm"
         );
         std::fs::remove_dir_all(&home).ok();
     }

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -4027,7 +4027,11 @@ instances:
             );
         }
         assert!(
-            srl_floor.get(name).copied().expect("floor present after override") > floor,
+            srl_floor
+                .get(name)
+                .copied()
+                .expect("floor present after override")
+                > floor,
             "the floor ADVANCES to the latest consumed hook seq (forward progress)"
         );
         std::fs::remove_dir_all(&home).ok();

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -1909,6 +1909,10 @@ fn hook_recovered_for_srl(
     is_claude && matches!((hook_active_at_ms, srl_onset_ms), (Some(h), Some(o)) if h > o)
 }
 
+// Threads the run_loop's long-lived per-agent error/retry state maps (retry_tracks,
+// apierror_episodes, apierror_nudge_counts, last_continue_inject, srl_onset); bundling
+// them into a struct would not improve clarity here.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn process_error_recovery(
     home: &std::path::Path,
     registry: &AgentRegistry,
@@ -1997,12 +2001,14 @@ pub(crate) fn process_error_recovery(
             // composes with recovered/self_cleared; claude-only; a non-claude / missing /
             // stale / pre-onset hook falls through to the unchanged screen-driven path.
             if state == AgentState::ServerRateLimit {
-                srl_onset.entry(name.to_string()).or_insert_with(now_epoch_ms);
+                srl_onset
+                    .entry(name.to_string())
+                    .or_insert_with(now_epoch_ms);
             } else {
                 srl_onset.remove(name);
             }
-            let is_claude =
-                crate::backend::Backend::parse_str(handle.backend_command.as_str()).has_state_hooks();
+            let is_claude = crate::backend::Backend::parse_str(handle.backend_command.as_str())
+                .has_state_hooks();
             let hook_active_at_ms = if is_claude {
                 crate::daemon::hook_shadow::fresh_active_hook_at_ms(name)
             } else {
@@ -2019,7 +2025,8 @@ pub(crate) fn process_error_recovery(
             // only EXECUTES the lock-free PTY inject for the names decided here. So a
             // track can never blind-fire `continue` into a non-error state (e.g. a
             // PermissionPrompt the agent reached after the throttle cleared).
-            if state == AgentState::ServerRateLimit && (recovered || self_cleared || hook_recovered) {
+            if state == AgentState::ServerRateLimit && (recovered || self_cleared || hook_recovered)
+            {
                 // #ratelimit-recovery: still latched ServerRateLimit (the stale
                 // "Server is temporarily limiting" line re-matches in the tail and
                 // working_state_below can't see a marker BELOW the most-recent error
@@ -3980,8 +3987,7 @@ instances:
         let mut tracks: HashMap<String, RateLimitRetry> = HashMap::new();
         let mut srl_onset: HashMap<String, u64> = HashMap::new();
         let name = "srl-flap-agent";
-        let (handle, _r) =
-            mock_agent_handle(name, crate::state::AgentState::ServerRateLimit);
+        let (handle, _r) = mock_agent_handle(name, crate::state::AgentState::ServerRateLimit);
         registry.lock().insert(handle.id, handle);
         // Stable onset in the PAST; a fresh active hook (now) POST-DATES it.
         let onset = super::now_epoch_ms().saturating_sub(60_000);
@@ -4022,8 +4028,7 @@ instances:
         let mut tracks: HashMap<String, RateLimitRetry> = HashMap::new();
         let mut srl_onset: HashMap<String, u64> = HashMap::new();
         let name = "srl-genuine-agent";
-        let (handle, _r) =
-            mock_agent_handle(name, crate::state::AgentState::ServerRateLimit);
+        let (handle, _r) = mock_agent_handle(name, crate::state::AgentState::ServerRateLimit);
         registry.lock().insert(handle.id, handle);
         // A hook from a PRIOR turn: recorded then backdated to BEFORE the onset the
         // tick stamps (now). hook(now-120s) < onset(now) → pre-onset → no override.

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -302,9 +302,10 @@ fn run_loop(home: PathBuf, registry: AgentRegistry) {
     let mut apierror_nudge_counts: std::collections::HashMap<String, u32> =
         std::collections::HashMap::new();
     let mut last_continue_inject: HashMap<String, Instant> = HashMap::new();
-    // #t-26795: per-agent SRL forward-progress hook-seq floor (see
-    // `process_error_recovery`).
-    let mut srl_floor: HashMap<String, u64> = HashMap::new();
+    // #t-26795: per-INSTANCE SRL forward-progress hook-seq floor, keyed by stable
+    // InstanceId (NOT name — a same-name replacement must not inherit the prior
+    // instance's floor; r6 finding-2). See `process_error_recovery`.
+    let mut srl_floor: HashMap<crate::types::InstanceId, u64> = HashMap::new();
     let mut pane_input_tracks: HashMap<String, PaneInputTrack> = HashMap::new();
     // W1.1 (#2050): the 12 periodic trackers (anti_stall, idle_watchdog,
     // decision_timeout, helper_staleness, mcp_registry, waiting_on_stale,
@@ -1915,14 +1916,17 @@ pub(crate) fn process_error_recovery(
     apierror_episodes: &mut std::collections::HashSet<String>,
     apierror_nudge_counts: &mut HashMap<String, u32>,
     last_continue_inject: &mut HashMap<String, Instant>,
-    // #t-26795: per-agent forward-progress FLOOR = the monotonic hook seq last
-    // CONSUMED to clear this ServerRateLimit episode. Seeded at onset with the agent's
+    // #t-26795: per-INSTANCE forward-progress FLOOR = the monotonic hook seq last
+    // CONSUMED to clear this ServerRateLimit episode. Keyed by stable `InstanceId`, NOT
+    // name (r6 finding-2): a same-name handle swapped between two ticks (delete/recreate
+    // /restart) gets a NEW uuid → a FRESH floor, so it can't inherit the prior
+    // instance's and mask its own genuine first SRL. Seeded at onset with the agent's
     // latest hook seq (or_insert never overwrites → stable across the detect→clear→
-    // re-detect flap; removed on a genuine screen exit), then ADVANCED on every
-    // override. The hook-override fires only for a fresh active hook STRICTLY newer
-    // than this — so a stale recovery hook can't permanently mask a later genuine
-    // episode (r6 finding-1), and a pre-onset hook (seq ≤ floor) can't mask edge-a.
-    srl_floor: &mut HashMap<String, u64>,
+    // re-detect flap; pruned when the instance leaves the registry), then ADVANCED on
+    // every override. The hook-override fires only for a fresh active hook STRICTLY
+    // newer than this — so a stale recovery hook can't permanently mask a later genuine
+    // episode (finding-1), and a pre-onset hook (seq ≤ floor) can't mask edge-a.
+    srl_floor: &mut HashMap<crate::types::InstanceId, u64>,
     loop_started_at: Instant,
 ) {
     use crate::state::AgentState;
@@ -1930,6 +1934,9 @@ pub(crate) fn process_error_recovery(
 
     // Phase 1: classify states under the registry lock (NO PTY writes here).
     let mut active_names = std::collections::HashSet::new();
+    // #t-26795 (r6 finding-2): live InstanceIds for the UUID-keyed srl_floor prune.
+    let mut active_ids: std::collections::HashSet<crate::types::InstanceId> =
+        std::collections::HashSet::new();
     let mut apierror_to_nudge: Vec<String> = Vec::new();
     // #1713 root-fix: names DECIDED (with fresh state, under the lock) to receive a
     // ServerRateLimit `continue` inject this tick. Phase 2 only executes these.
@@ -1941,6 +1948,7 @@ pub(crate) fn process_error_recovery(
         for handle in reg.values() {
             let name = handle.name.as_str();
             active_names.insert(name.to_string());
+            active_ids.insert(handle.id);
             // Capture current state + recovery signal under one lock. `recovered`
             // is the #ratelimit-recovery gate below: a recovered-but-still-latched
             // ServerRateLimit agent that produced output within RECOVERY_SILENCE.
@@ -1998,12 +2006,16 @@ pub(crate) fn process_error_recovery(
             // than the floor is a third recovery signal. ADD-ONLY — composes with
             // recovered/self_cleared; claude-only; a non-claude / missing / stale /
             // pre-onset hook falls through to the unchanged screen-driven path.
+            // r6 finding-2: key the floor by the STABLE InstanceId, not name, so a
+            // same-name replacement gets a fresh floor (the hook STORE is still
+            // name-keyed, so `latest_hook_seq(name)` correctly seeds from this
+            // instance's own hooks).
             if state == AgentState::ServerRateLimit {
                 srl_floor
-                    .entry(name.to_string())
+                    .entry(handle.id)
                     .or_insert_with(|| crate::daemon::hook_shadow::latest_hook_seq(name));
             } else {
-                srl_floor.remove(name);
+                srl_floor.remove(&handle.id);
             }
             let is_claude = crate::backend::Backend::parse_str(handle.backend_command.as_str())
                 .has_state_hooks();
@@ -2012,15 +2024,18 @@ pub(crate) fn process_error_recovery(
             } else {
                 None
             };
-            let hook_recovered =
-                hook_recovered_for_srl(is_claude, hook_active_seq, srl_floor.get(name).copied());
+            let hook_recovered = hook_recovered_for_srl(
+                is_claude,
+                hook_active_seq,
+                srl_floor.get(&handle.id).copied(),
+            );
             if hook_recovered {
                 // FORWARD-PROGRESS (r6 finding-1): advance the floor to the consumed
                 // hook so a LATER genuine episode — screen still sticky-SRL but the
                 // agent now truly stuck (no NEWER hook) — re-arms the retry instead of
                 // being permanently masked by this episode's stale recovery hook.
                 if let Some(seq) = hook_active_seq {
-                    srl_floor.insert(name.to_string(), seq);
+                    srl_floor.insert(handle.id, seq);
                 }
             }
 
@@ -2252,10 +2267,10 @@ pub(crate) fn process_error_recovery(
     apierror_episodes.retain(|name| active_names.contains(name));
     apierror_nudge_counts.retain(|name, _| active_names.contains(name));
     last_continue_inject.retain(|name, _| active_names.contains(name));
-    // #t-26795 (r6 finding-2): the SRL forward-progress floor map must churn-prune
-    // too, or a delete/restart leaves a residual floor and a same-name replacement's
-    // `or_insert` INHERITS it — masking the new instance's genuine first SRL.
-    srl_floor.retain(|name, _| active_names.contains(name));
+    // #t-26795 (r6 finding-2): prune the UUID-keyed floor for instances no longer in
+    // the registry. Keying by InstanceId (not name) is what actually closes the
+    // same-name-replacement inherit; this retain just bounds the map across churn.
+    srl_floor.retain(|id, _| active_ids.contains(id));
     // #t-81376 Phase-0 shadow: prune expectation/latch maps for churned agents
     // (no-op unless AGEND_RECOVERY_SHADOW=1). `()` → control-flow-inert.
     crate::daemon::recovery_shadow::retain_live(&|n| active_names.contains(n));
@@ -3999,14 +4014,15 @@ instances:
         let registry: AgentRegistry = Arc::new(parking_lot::Mutex::new(HashMap::new()));
         let home = tmp_home("srl-hook-flap");
         let mut tracks: HashMap<String, RateLimitRetry> = HashMap::new();
-        let mut srl_floor: HashMap<String, u64> = HashMap::new();
+        let mut srl_floor: HashMap<crate::types::InstanceId, u64> = HashMap::new();
         let name = "srl-flap-agent";
         let (handle, _r) = mock_agent_handle(name, crate::state::AgentState::ServerRateLimit);
+        let id = handle.id;
         registry.lock().insert(handle.id, handle);
         // Onset baseline: a pre-SRL hook pins the floor BELOW the recovery hooks.
         crate::daemon::hook_shadow::record_event(name, "Stop", None); // idle baseline
         let floor = crate::daemon::hook_shadow::latest_hook_seq(name);
-        srl_floor.insert(name.to_string(), floor);
+        srl_floor.insert(id, floor);
         // The agent is actually ALIVE (false sticky SRL): it fires a NEW tool-call hook
         // each tick → each seq > floor → forward progress → the retry stays cleared.
         for _ in 0..3 {
@@ -4028,7 +4044,7 @@ instances:
         }
         assert!(
             srl_floor
-                .get(name)
+                .get(&id)
                 .copied()
                 .expect("floor present after override")
                 > floor,
@@ -4053,12 +4069,12 @@ instances:
         let registry: AgentRegistry = Arc::new(parking_lot::Mutex::new(HashMap::new()));
         let home = tmp_home("srl-fwd-progress");
         let mut tracks: HashMap<String, RateLimitRetry> = HashMap::new();
-        let mut srl_floor: HashMap<String, u64> = HashMap::new();
+        let mut srl_floor: HashMap<crate::types::InstanceId, u64> = HashMap::new();
         let name = "srl-fwd-agent";
         let (handle, _r) = mock_agent_handle(name, crate::state::AgentState::ServerRateLimit);
         registry.lock().insert(handle.id, handle);
         let pe = |tracks: &mut HashMap<String, RateLimitRetry>,
-                  srl_floor: &mut HashMap<String, u64>| {
+                  srl_floor: &mut HashMap<crate::types::InstanceId, u64>| {
             super::process_error_recovery(
                 &home,
                 &registry,
@@ -4095,19 +4111,19 @@ instances:
         std::fs::remove_dir_all(&home).ok();
     }
 
-    /// CHURN PRUNE (#t-26795 r6 finding-2): a deleted/restarted agent's SRL floor
-    /// must be dropped when it leaves the registry, or a same-name replacement's
-    /// `or_insert` INHERITS the stale floor and the new instance's genuine first SRL
-    /// is masked. NEUTER: drop the `srl_floor.retain(...)` churn-prune → RED.
+    /// CHURN PRUNE (#t-26795 r6 finding-2): an instance's SRL floor is dropped once it
+    /// leaves the registry, so the UUID-keyed map stays bounded across agent churn.
+    /// NEUTER: drop the `srl_floor.retain(...)` churn-prune → RED.
     #[test]
     #[serial_test::serial]
     fn srl_floor_pruned_on_agent_churn() {
         let registry: AgentRegistry = Arc::new(parking_lot::Mutex::new(HashMap::new()));
         let home = tmp_home("srl-floor-churn");
-        let mut srl_floor: HashMap<String, u64> = HashMap::new();
-        // A prior instance left a floor seq behind; it is NO LONGER in the registry
-        // (deleted / restarted under the same name).
-        srl_floor.insert("recycled-name".to_string(), 1);
+        let mut srl_floor: HashMap<crate::types::InstanceId, u64> = HashMap::new();
+        // A prior instance left a floor seq behind; its uuid is NO LONGER in the
+        // registry (deleted / restarted).
+        let stale_id = crate::types::InstanceId::new();
+        srl_floor.insert(stale_id, 1);
         super::process_error_recovery(
             &home,
             &registry,
@@ -4119,8 +4135,74 @@ instances:
             past_boot_grace(),
         );
         assert!(
-            !srl_floor.contains_key("recycled-name"),
-            "a churned-out agent's SRL floor must be pruned so a same-name replacement re-arms its genuine first SRL"
+            !srl_floor.contains_key(&stale_id),
+            "a churned-out instance's SRL floor must be pruned to bound the map across churn"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// UUID-KEY (test ③, #t-26795 r6 finding-2): the floor must key on the STABLE
+    /// `InstanceId`, NOT the agent name — else a same-name handle SWAPPED between two
+    /// consecutive ticks (delete/recreate/restart, with NO intermediate absent-name
+    /// pass so the name-keyed retain never fires) lets the new instance INHERIT the old
+    /// one's advanced floor and its genuine first SRL is wrongly overridden. Drives the
+    /// old instance to advance its floor, swaps in a new same-name handle (new uuid)
+    /// that emits a pre-onset hook (global seq > the old floor), and asserts the new
+    /// instance's genuine SRL RE-ARMS. NEUTER: key the floor by name → the new instance
+    /// inherits the old floor → its hook seq > inherited floor → override → no arm → RED.
+    #[test]
+    #[serial_test::serial]
+    fn srl_floor_keyed_by_instance_id_survives_same_name_swap() {
+        let registry: AgentRegistry = Arc::new(parking_lot::Mutex::new(HashMap::new()));
+        let home = tmp_home("srl-floor-swap");
+        let mut tracks: HashMap<String, RateLimitRetry> = HashMap::new();
+        let mut srl_floor: HashMap<crate::types::InstanceId, u64> = HashMap::new();
+        let name = "swapped-agent";
+        let pe = |tracks: &mut HashMap<String, RateLimitRetry>,
+                  srl_floor: &mut HashMap<crate::types::InstanceId, u64>| {
+            super::process_error_recovery(
+                &home,
+                &registry,
+                tracks,
+                &mut Default::default(),
+                &mut Default::default(),
+                &mut Default::default(),
+                srl_floor,
+                past_boot_grace(),
+            );
+        };
+        // OLD instance: onset baseline → then a fresh hook overrides + advances its
+        // floor (so the old floor is LOW relative to later global seqs).
+        let (old, _r1) = mock_agent_handle(name, crate::state::AgentState::ServerRateLimit);
+        let old_id = old.id;
+        registry.lock().insert(old_id, old);
+        crate::daemon::hook_shadow::record_event(name, "Stop", None);
+        pe(&mut tracks, &mut srl_floor);
+        crate::daemon::hook_shadow::record_event(name, "PreToolUse", None);
+        pe(&mut tracks, &mut srl_floor);
+        assert!(!tracks.contains_key(name), "old instance recovered");
+        // SWAP: same NAME, NEW uuid — delete old (forget its hooks) + insert new, with
+        // NO intermediate process_error_recovery call where the name is absent.
+        registry.lock().clear();
+        crate::daemon::hook_shadow::forget(name);
+        let (new, _r2) = mock_agent_handle(name, crate::state::AgentState::ServerRateLimit);
+        let new_id = new.id;
+        registry.lock().insert(new_id, new);
+        // The new instance emits a pre-onset hook (global seq > the OLD floor) BEFORE
+        // its first genuine SRL.
+        crate::daemon::hook_shadow::record_event(name, "PreToolUse", None);
+        pe(&mut tracks, &mut srl_floor);
+        assert!(
+            tracks.contains_key(name),
+            "a same-name replacement's genuine first SRL must NOT be masked by the prior instance's inherited floor (UUID-keyed)"
+        );
+        assert!(
+            !srl_floor.contains_key(&old_id),
+            "the prior instance's floor is pruned (its uuid left the registry)"
+        );
+        assert!(
+            srl_floor.contains_key(&new_id),
+            "the new instance seeded its OWN floor under its own uuid"
         );
         std::fs::remove_dir_all(&home).ok();
     }
@@ -4138,7 +4220,7 @@ instances:
         let registry: AgentRegistry = Arc::new(parking_lot::Mutex::new(HashMap::new()));
         let home = tmp_home("srl-genuine");
         let mut tracks: HashMap<String, RateLimitRetry> = HashMap::new();
-        let mut srl_floor: HashMap<String, u64> = HashMap::new();
+        let mut srl_floor: HashMap<crate::types::InstanceId, u64> = HashMap::new();
         let name = "srl-genuine-agent";
         let (handle, _r) = mock_agent_handle(name, crate::state::AgentState::ServerRateLimit);
         registry.lock().insert(handle.id, handle);


### PR DESCRIPTION
## Bug (operator-reported, HIGH, #t-26795)
With `AGEND_OFFTHREAD_PARSE` off-thread aside — a claude agent that RECOVERED from a rate-limit kept getting `[AGEND-AUTO ratelimit-retry] continue` injected. RCA (lead, log-nailed; quantified in the spike): the screen-scraper stays stuck on residual "Server is temporarily limiting requests" text (`screen_state=ServerRateLimit`) while the agent is provably firing tool calls — the per-tool-call HOOK reports `ToolUse/Thinking` but is SHADOW-only and doesn't drive the per-tick SRL-retry decision. The slow productive-output `recovered` signal FLAPS (detect→clear→re-detect), so retries keep firing. Shadow data: 1996/2746 recovery records show a screen↔hook mismatch, **100% "hook active, screen stale"**; the incident had **14 consecutive ticks** of stable-active-hook vs sticky-SRL.

## Fix (narrow, lead-vetted)
A FRESH claude hook (active `ToolUse/Thinking`) whose timestamp **post-dates the SRL onset** proves the agent recovered → added as a **third disjunct** `hook_recovered` to the existing SRL clear gate (`supervisor.rs`), composing with `recovered`/`self_cleared` (ADD-ONLY, no change to the productive-output path).

- **Stable onset** (`srl_onset` map): the FIRST-detection epoch-ms, `or_insert` never overwrites → survives the detect→clear→re-detect flap (a resetting onset would let a just-pre-re-detect hook look pre-onset and the flap would survive — the load-bearing requirement).
- **post-onset** requirement: rejects a fresh-but-prior-turn hook → a genuine new-turn SRL is never masked.
- **claude-only** (`Backend::has_state_hooks`); **decoupled from `AGEND_HOOK_STATE_POC`** (reads `hook_shadow::fresh_active_hook_at_ms`, populated by the unconditional `record_event`) — an operator-facing fix must not hang on a POC flag; fail-safe (missing/stale/pre-onset hook → unchanged screen-driven retry).
- `Idle` deliberately excluded from "active" (turn-ended/ambiguous; left to the productive-output path).

This is the highest-leverage #1523 phase-2 promotion slice (the per-tick recovery dispatcher), scoped to the SRL case only.

## Tests
- `hook_recovered_for_srl_truth_table` — pure decider (post/pre/equal-onset, no-hook, no-onset, non-claude).
- `srl_hook_override_kills_flap` — **the mandatory flap regression**: SRL + `recovered=false` + a fresh post-onset hook → retry stays cleared across re-detect ticks; onset stays stable. **Neuter-verified** (drop the disjunct → RED).
- `srl_genuine_not_masked_by_pre_onset_hook` — a backdated (pre-onset) hook does NOT mask a genuine SRL → retry arms.
- `hook_shadow::fresh_active_hook_at_ms_active_only` — ToolUse/Thinking→Some; Idle/stale/absent→None.

CI parity: fmt clean; clippy --features tray -D warnings clean; targeted nextest (new + all existing SRL/server_rate_limit tests + the 28 `process_error_recovery` call sites) = 61/61.

## Validation caveat
Daemon-behaviour fix — can't validate on this PR's own run; needs an operator restart to confirm live ([[feedback_pr_is_its_own_dogfood_anti_pattern]]). Follow-up (lead-noted, out of scope): `self_cleared` is 0/2746 in the shadow data — the MCP self-clear exit is effectively dead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)