### PR TITLE
chore(deps): bump quinn-proto 0.11.14 → 0.11.15 (RUSTSEC-2026-0185)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3479,9 +3479,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## CI-blocker fix — RUSTSEC-2026-0185

RUSTSEC-2026-0185 (published 2026-06-22): quinn-proto 0.11.14 remote memory exhaustion / DoS (unbounded out-of-order stream reassembly), patched in 0.11.15. The advisory-db update made `cargo audit` (a required check) hard-fail **fleet-wide** → blocks `main` + all PR merges (incl SRL #2415).

## Change
Drop-in patch bump of a **transitive** dep (via quinn 0.11.9). **Cargo.lock-only** — version + checksum, no source change.

## Verified locally
- `cargo audit` → clean, RUSTSEC-2026-0185 cleared, no other advisories (633 deps scanned)
- `cargo +1.88 check --locked --features tray` → green (MSRV 1.88 intact, #2288 lesson)
- `cargo check --locked --all-targets --features tray` → green (lib+bin+tests compile)

Full test suite runs in CI. Single-review fast track (trivial dep-bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)