### PR TITLE
fix(offthread): forward mouse to mouse-capture panes off-thread (snapshot mode)

### DIFF
--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -549,7 +549,11 @@ fn pane_for_mouse_forward(layout: &Layout, mouse: &MouseEvent) -> Option<(usize,
     // the wants_mouse pane (opencode) was not focused.
     let pane_id = tab.pane_at(mouse.column, mouse.row)?;
     let pane = tab.root().find_pane(pane_id)?;
-    if !pane.vterm.wants_mouse() || !pane.vterm.mouse_sgr() {
+    // #offthread-mouse: read the pane's path-aware mouse mode (parser-stamped snapshot
+    // off-thread, live `vterm` flag-OFF) — NOT `pane.vterm` directly, which is idle
+    // off-thread → mode default → this gate would never fire (dead-gate bug: a
+    // fullscreen claude-code never gets its forwarded wheel/click).
+    if !pane.wants_mouse() || !pane.mouse_sgr() {
         return None;
     }
     let &(px, py, pw, ph) = tab.pane_rects.get(&pane_id)?;
@@ -696,6 +700,63 @@ mod tests {
             routed.map(|(id, _, _)| id),
             Some(1),
             "single-pane opencode tab must still route mouse to that pane"
+        );
+    }
+
+    /// #offthread-mouse (operator 2026-06-23: fullscreen claude-code couldn't wheel-
+    /// scroll). Off-thread the main-thread `pane.vterm` is idle, so the forward gate
+    /// must read the PARSER-stamped mouse mode on the published snapshot — else it
+    /// never fires and a fullscreen claude-code (mouse-capture, self-scrolls) never
+    /// receives its forwarded wheel/click. Drives the real parser through a mouse-
+    /// enable startup, then asserts the gate routes a wheel event to the pane.
+    /// NEUTER-RED: revert the gate to `pane.vterm.wants_mouse()/mouse_sgr()` → the
+    /// idle off-thread vterm has no mouse mode → `None` → the wheel is not forwarded.
+    #[test]
+    fn pane_for_mouse_forward_offthread_reads_snapshot_mouse_mode() {
+        let (data_tx, data_rx) = crossbeam_channel::unbounded::<Vec<u8>>();
+        let (wake_tx, wake_rx) = crossbeam_channel::unbounded::<usize>();
+        let parser_vt = crate::vterm::VTerm::new(20, 6);
+        let handle = crate::render::offthread::spawn_offthread_parser(
+            1,
+            "claude".to_string(),
+            data_rx,
+            parser_vt,
+            wake_tx,
+        )
+        .expect("parser thread spawns");
+        // Fullscreen claude-code startup: enable mouse tracking (1000) + SGR (1006).
+        data_tx
+            .send(b"\x1b[?1000h\x1b[?1006h".to_vec())
+            .expect("parser data channel live");
+        wake_rx
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .expect("parser must publish the mouse-mode snapshot");
+
+        let mut pane = leaf(1, "claude");
+        pane.offthread = Some(handle);
+        // The idle main-thread vterm has NO mouse mode (the dead-gate surface) ...
+        assert!(
+            !pane.vterm.wants_mouse(),
+            "off-thread pane.vterm is idle → no mouse mode"
+        );
+        // ... but the path-aware accessors read the parser-stamped snapshot.
+        assert!(
+            pane.wants_mouse() && pane.mouse_sgr(),
+            "off-thread mouse mode must come from the published snapshot"
+        );
+
+        let mut layout = Layout::new();
+        layout.add_tab(Tab::new("single".to_string(), pane));
+        layout.active = 0;
+        layout.tabs[0].focus_id = 1;
+        layout.tabs[0].pane_rects.insert(1, (0, 1, 20, 10));
+
+        let mouse = scroll_up_at(10, 5);
+        let routed = super::pane_for_mouse_forward(&layout, &mouse);
+        assert_eq!(
+            routed.map(|(id, _, _)| id),
+            Some(1),
+            "off-thread mouse-capture pane must route the wheel for forwarding (so claude-code self-scrolls)"
         );
     }
 

--- a/src/layout/pane.rs
+++ b/src/layout/pane.rs
@@ -159,6 +159,30 @@ impl Pane {
         }
     }
 
+    /// #offthread-mouse: whether the child terminal has enabled mouse reporting, for
+    /// the mouse-forward gate. Off-thread the main-thread `vterm` is idle (processes
+    /// no bytes → mode default → mouse OFF), so this reads the PARSER-stamped mode on
+    /// the published snapshot, NOT `pane.vterm`. Reading `pane.vterm` off-thread is the
+    /// dead-gate bug: a fullscreen claude-code (alt-screen + mouse-capture, self-
+    /// scrolls) would never receive its forwarded wheel/click. Flag-OFF reads the live
+    /// `vterm` (byte-identical to before).
+    pub fn wants_mouse(&self) -> bool {
+        match &self.offthread {
+            Some(handle) => handle.load().wants_mouse,
+            None => self.vterm.wants_mouse(),
+        }
+    }
+
+    /// #offthread-mouse: whether SGR mouse encoding is active, paired with
+    /// [`wants_mouse`](Self::wants_mouse) for the forward gate. Same off-thread
+    /// snapshot vs flag-OFF `vterm` dispatch.
+    pub fn mouse_sgr(&self) -> bool {
+        match &self.offthread {
+            Some(handle) => handle.load().mouse_sgr,
+            None => self.vterm.mouse_sgr(),
+        }
+    }
+
     /// #offthread-selection: the ABSOLUTE-line base a selection endpoint is measured
     /// from. Off-thread it is the published snapshot's visible-top absolute id
     /// (`history_origin + history.len()`), read from the snapshot — NOT `pane.vterm`,

--- a/src/vterm.rs
+++ b/src/vterm.rs
@@ -345,6 +345,13 @@ impl VTerm {
             // No history here → origin is the visible top's absolute id (`max_scroll`).
             // The parser overwrites this after injecting `history` (see `publish`).
             history_origin: self.max_scroll() as u64,
+            // #offthread-mouse: stamp the live mouse-mode from THIS (real) VTerm so the
+            // off-thread forward gate reads it instead of the idle `pane.vterm`. mode is
+            // independent of history, so no `publish`-time fixup is needed (unlike
+            // `history_origin`). Only the parser publish path builds snapshots from a
+            // live VTerm; `pane.vterm` never calls this off-thread.
+            wants_mouse: self.wants_mouse(),
+            mouse_sgr: self.mouse_sgr(),
         }
     }
 
@@ -1032,6 +1039,18 @@ pub struct GridSnapshot {
     /// window is shallower than that; rows scrolled out of the window decode to
     /// blanks (clamped), NOT wrong content.
     pub history_origin: u64,
+    /// #offthread-mouse: whether the terminal application has enabled mouse
+    /// reporting (any of SGR mouse modes 1000/1002/1003) — i.e. `VTerm::wants_mouse`
+    /// captured by the PARSER from the real VTerm at publish. Off-thread the
+    /// main-thread `pane.vterm` is idle (processes no bytes → mode default → mouse
+    /// OFF), so the mouse-forward gate must read THIS, not `pane.vterm`, or it would
+    /// never forward (the dead-gate bug: e.g. a fullscreen claude-code never receives
+    /// its own wheel/click). See `Pane::wants_mouse`.
+    pub wants_mouse: bool,
+    /// #offthread-mouse: whether SGR mouse encoding (1006) is active, paired with
+    /// `wants_mouse` for the forward gate. Parser-captured from the real VTerm at
+    /// publish (same idle-`pane.vterm` reason as `wants_mouse`).
+    pub mouse_sgr: bool,
 }
 
 /// One scrollback row — `cols` cells, shared via `Arc` so the parser can reuse it
@@ -1069,6 +1088,10 @@ impl GridSnapshot {
             history: empty_scrollback(),
             cursor: (0, 0),
             history_origin: 0,
+            // Pre-first-publish: no mouse mode known yet → don't forward (fall through
+            // to agend scroll). The first real publish stamps the live mode.
+            wants_mouse: false,
+            mouse_sgr: false,
         }
     }
 


### PR DESCRIPTION
## Bug (operator-reported, HIGH)
Under `AGEND_OFFTHREAD_PARSE=1`, a **fullscreen claude-code** pane could not mouse-wheel scroll (codex/agy panes could).

## RCA (confirm-first — two corrections before any code)
- The mouse-forward gate `pane_for_mouse_forward` reads `pane.vterm.wants_mouse()/mouse_sgr()` (the sole reader). But off-thread, `pane.vterm` is **idle** (#2414 established this; drain no-ops, the parser owns the real VTerm), so its mode is default → **mouse OFF** → the gate **never fires off-thread for any pane**. So claude's wheel was *not* being forwarded (the opposite of the first hypothesis), and off-thread click/drag forwarding was silently dead too.
- Operator's `~/.claude/settings.json` has `"tui": "fullscreen"` → claude-code is **alt-screen + self-enables mouse-capture + has its own wheel-scroll**. So it relies on receiving the forwarded wheel; with the gate dead it never does, and agend can't pane-scroll it (alt-screen has no scrollback, `snapshot_bytes`≈56k visible-only) → it can't scroll at all. Same **idle-`pane.vterm` staleness class as #2414**, introduced by off-thread (#2404).

## Fix (the #2414 pattern; minimal/KISS)
- The parser stamps the **live mouse mode** (`wants_mouse`, `mouse_sgr`) from the real VTerm into `GridSnapshot` at publish — in `snapshot_visible()` (mode is history-independent, so no publish-time fixup unlike `history_origin`). Only the parser publish path builds snapshots from a live VTerm; `pane.vterm` never calls it off-thread (vet condition verified).
- `Pane::wants_mouse()`/`mouse_sgr()` dispatch off-thread → snapshot, flag-OFF → `pane.vterm` (byte-identical).
- `pane_for_mouse_forward` reads the accessors → revives wheel forwarding so fullscreen claude-code self-scrolls, and **incidentally revives off-thread click/drag forwarding** for any mouse-capture app (opencode, etc.).
- No alt-screen-aware main-screen wheel routing (rare; out of scope — KISS).
- Crux respected: mode is parser-stamped at publish; the gate never reads the idle `pane.vterm` off-thread.

## Tests
- `pane_for_mouse_forward_offthread_reads_snapshot_mouse_mode`: drives the real parser through a mouse-enable startup, asserts the gate routes a wheel event to the off-thread pane while `pane.vterm` stays mode-off. **Neuter-RED verified**: reverting the gate to `pane.vterm.*` → `None` (not forwarded) → fails.
- Existing `pane_for_mouse_forward_*` tests (offthread:None) pin **flag-OFF byte-identity**. All 28 adjacent mouse/offthread/vterm tests green; fmt + `clippy --all-targets --features tray -D warnings` clean.

⚠ App-lifecycle/render change → needs operator rebuild+restart to go live. base origin/main `84278d13`. correlation t-20260622233350659277-15962-0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)