### PR TITLE
fix(offthread): route #1944 draft-gate tail-read through snapshot (F-A)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1799,13 +1799,15 @@ where
             // plain marker probe mis-reads as typed content — route it through the
             // DIM-aware check (needs the per-char dim mask). Everyone else uses the
             // text-only probe: marker (claude/agy) → placeholder (kiro) → fallback.
-            // pane.vterm is owned (no lock).
+            // #t-97931 (F-A): route through the path-aware `Pane::tail_lines*` — off-
+            // thread the main-thread `pane.vterm` is idle/blank, so reading it directly
+            // mis-reads a real unsent draft as an empty box and the gate clobbers it.
             if let Some(marker) = b.input_dim_ghost_marker() {
-                let (text, dim) = pane.vterm.tail_lines_with_dim(DRAFT_INPUT_TAIL_ROWS);
+                let (text, dim) = pane.tail_lines_with_dim(DRAFT_INPUT_TAIL_ROWS);
                 notification_queue::input_box_dim_aware_empty(&text, &dim, marker)
             } else {
                 notification_queue::input_box_empty_probe(
-                    &pane.vterm.tail_lines(DRAFT_INPUT_TAIL_ROWS),
+                    &pane.tail_lines(DRAFT_INPUT_TAIL_ROWS),
                     b.input_prompt_marker(),
                     b.input_empty_placeholder(),
                 )

--- a/src/layout/pane.rs
+++ b/src/layout/pane.rs
@@ -234,6 +234,28 @@ impl Pane {
         }
     }
 
+    /// #t-97931 (off-thread draft-gate, F-A): the last `n` visible rows of THIS pane's
+    /// render path, for the #1944 draft-protection input-box probe. Off-thread the
+    /// main-thread `vterm` is idle (blank) → read the parser's published snapshot, so
+    /// the gate sees the REAL input box and never mis-reads an unsent draft as empty
+    /// (which would clobber it). Flag-OFF reads the live `vterm` (byte-identical).
+    pub fn tail_lines(&self, n: usize) -> String {
+        match &self.offthread {
+            Some(handle) => handle.load().tail_lines(n),
+            None => self.vterm.tail_lines(n),
+        }
+    }
+
+    /// #t-97931: text + per-char DIM mask of the last `n` visible rows, paired with
+    /// [`tail_lines`](Self::tail_lines) for the codex dim-ghost draft probe. Same
+    /// off-thread snapshot vs flag-OFF `vterm` dispatch.
+    pub fn tail_lines_with_dim(&self, n: usize) -> (String, Vec<bool>) {
+        match &self.offthread {
+            Some(handle) => handle.load().tail_lines_with_dim(n),
+            None => self.vterm.tail_lines_with_dim(n),
+        }
+    }
+
     /// Display label: display_name if set, otherwise agent_name.
     pub fn label(&self) -> &str {
         self.display_name.as_deref().unwrap_or(&self.agent_name)
@@ -476,6 +498,52 @@ mod tests {
             offthread: None,
             _fwd_cancel: None,
         }
+    }
+
+    /// #t-97931 (F-A, off-thread draft-gate) guard ③: the path-aware `Pane::tail_lines*`
+    /// must read the parser's PUBLISHED snapshot off-thread, NOT the idle main-thread
+    /// `pane.vterm` (blank). Else the #1944 draft-protection gate reads an empty input
+    /// box and clobbers a real unsent draft. NEUTER: revert the accessor body to
+    /// `self.vterm.tail_lines*` → off-thread it returns blank → this RED.
+    #[test]
+    fn tail_lines_offthread_reads_snapshot_not_idle_vterm() {
+        let (data_tx, data_rx) = crossbeam_channel::unbounded::<Vec<u8>>();
+        let (wake_tx, wake_rx) = crossbeam_channel::unbounded::<usize>();
+        let parser_vt = VTerm::new(40, 6);
+        let handle = crate::render::offthread::spawn_offthread_parser(
+            1,
+            "claude".to_string(),
+            data_rx,
+            parser_vt,
+            wake_tx,
+        )
+        .expect("parser thread spawns");
+        // The agent's input box carries an UNSENT draft + a DIM ghost above it.
+        data_tx
+            .send(b"\x1b[2J\x1b[H\x1b[2mghost\x1b[0m\r\n> draft in progress".to_vec())
+            .expect("parser data channel live");
+        wake_rx
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .expect("parser must publish the input-box snapshot");
+
+        let mut pane = leaf(1, "claude");
+        pane.offthread = Some(handle);
+        // The idle main-thread vterm is blank — the dead-gate surface the F-A bug read.
+        assert!(
+            pane.vterm.tail_lines(4).trim().is_empty(),
+            "off-thread pane.vterm is idle → tail is blank (the F-A mis-read source)"
+        );
+        // The path-aware accessor reads the parser-published snapshot → sees the draft.
+        let tail = pane.tail_lines(4);
+        assert!(
+            tail.contains("draft in progress"),
+            "off-thread tail_lines must read the snapshot's real input box, got {tail:?}"
+        );
+        let (dtext, dim) = pane.tail_lines_with_dim(4);
+        assert!(
+            dtext.contains("draft in progress") && dim.iter().any(|&d| d),
+            "off-thread tail_lines_with_dim must read snapshot text + DIM mask, got {dtext:?}"
+        );
     }
 
     /// #1432: a fixed content line keeps the same logical anchor regardless of

--- a/src/vterm.rs
+++ b/src/vterm.rs
@@ -29,6 +29,137 @@ fn safe_cell(grid: &alacritty_terminal::grid::Grid<Cell>, line: Line, col: usize
     }
 }
 
+/// A minimal per-cell view for [`tail_lines_core`], decoupling the de-wrap / trim /
+/// DIM logic from the cell SOURCE so the live `VTerm` grid and an off-thread
+/// [`GridSnapshot`]'s flat `cells` share ONE implementation — parity by construction
+/// (#t-97931: the off-thread draft-gate must read the SAME text the live path would,
+/// or it mis-reads an idle pane as an empty input box and clobbers an unsent draft).
+#[derive(Clone, Copy)]
+struct CellView {
+    c: char,
+    fg: Color,
+    dim: bool,
+    wrapline: bool,
+    wide_spacer: bool,
+}
+
+/// Shared core for `VTerm::tail_lines` / `tail_lines_with_fg` / `tail_lines_with_dim`
+/// AND their [`GridSnapshot`] equivalents. `get(row, col)` yields the visible-grid
+/// cell at `(row, col)` (row 0 = visible top); the caller supplies the source — the
+/// live alacritty grid (via `safe_cell`) or a snapshot's `cells`. Knobs:
+///
+/// * `collect_fg` — when false the returned fg/dim vecs are empty (skips the per-cell
+///   `classify_fg` cost; #perf-R1).
+/// * `dewrap` — when true a `WRAPLINE`-soft-wrapped row is joined to its continuation
+///   WITHOUT a `\n` so a single logical line the terminal wrapped stays one line for
+///   the single-line detection regexes (#1808). When false, rows join verbatim with
+///   `\n` (byte-identical legacy text-only output).
+///
+/// Monomorphized per call site, so the closure indirection is zero-cost.
+fn tail_lines_core(
+    cols: usize,
+    rows: usize,
+    n: usize,
+    collect_fg: bool,
+    dewrap: bool,
+    get: impl Fn(usize, usize) -> CellView,
+) -> (String, Vec<CellFg>, Vec<bool>) {
+    let mut lines: Vec<String> = Vec::with_capacity(rows);
+    let mut line_fgs: Vec<Vec<CellFg>> = Vec::with_capacity(rows);
+    // #1948(b): per-char DIM-attribute mask, collected alongside fg (same gate, same
+    // alignment). codex renders its empty-box ghost/placeholder text DIM on the
+    // default colour, which the colour-only `CellFg` can't see — the draft-gate uses
+    // this to tell the ghost apart from the operator's normal-intensity input.
+    let mut line_dims: Vec<Vec<bool>> = Vec::with_capacity(rows);
+    // #1808: per-row soft-wrap flag (alacritty sets `WRAPLINE` on the LAST cell of a
+    // physical row whose logical line continues on the next row).
+    let mut wrapped: Vec<bool> = Vec::with_capacity(rows);
+    for row in 0..rows {
+        let mut line = String::with_capacity(cols);
+        let mut fg: Vec<CellFg> = Vec::new();
+        let mut dim: Vec<bool> = Vec::new();
+        let mut col = 0;
+        while col < cols {
+            let cell = get(row, col);
+            if cell.wide_spacer {
+                col += 1;
+                continue;
+            }
+            let ch = if cell.c == '\0' { ' ' } else { cell.c };
+            line.push(ch);
+            if collect_fg {
+                fg.push(classify_fg(cell.fg));
+                dim.push(cell.dim);
+            }
+            col += 1;
+        }
+        let row_wrapped = dewrap && cols > 0 && get(row, cols - 1).wrapline;
+        // trim_end drops trailing whitespace; truncate the parallel fg/dim vecs to the
+        // surviving char count so they stay aligned. EXCEPT a soft-wrapped row: its
+        // trailing space can be a significant inter-word space at the wrap column, and
+        // the next row is about to be concatenated WITHOUT a `\n` — trimming it would
+        // fuse two words and re-break the phrase the de-wrap exists to keep whole.
+        let trimmed = if row_wrapped {
+            line.as_str()
+        } else {
+            line.trim_end()
+        };
+        if collect_fg {
+            fg.truncate(trimmed.chars().count());
+            dim.truncate(trimmed.chars().count());
+        }
+        lines.push(trimmed.to_string());
+        line_fgs.push(fg);
+        line_dims.push(dim);
+        wrapped.push(row_wrapped);
+    }
+
+    // Trim blank lines at both ends so terse output doesn't look padded and tail-N
+    // doesn't return the scroll buffer's trailing whitespace.
+    let first = lines
+        .iter()
+        .position(|l| !l.is_empty())
+        .unwrap_or(lines.len());
+    let last = lines
+        .iter()
+        .rposition(|l| !l.is_empty())
+        .map(|i| i + 1)
+        .unwrap_or(first);
+    let visible = &lines[first..last];
+    let visible_fgs = &line_fgs[first..last];
+    let visible_dims = &line_dims[first..last];
+    let visible_wrapped = &wrapped[first..last];
+
+    let start = visible.len().saturating_sub(n);
+    let tail = &visible[start..];
+    let tail_fgs = &visible_fgs[start..];
+    let tail_dims = &visible_dims[start..];
+    let tail_wrapped = &visible_wrapped[start..];
+
+    let mut text = String::new();
+    let mut fg_out: Vec<CellFg> = Vec::new();
+    let mut dim_out: Vec<bool> = Vec::new();
+    for (i, line) in tail.iter().enumerate() {
+        if i > 0 {
+            // #1808: skip the `\n` (and its filler fg/dim cell) when the PREVIOUS row
+            // soft-wrapped into this one — they are one line.
+            if !tail_wrapped[i - 1] {
+                text.push('\n');
+                if collect_fg {
+                    fg_out.push(CellFg::Default);
+                    dim_out.push(false);
+                }
+            }
+        }
+        text.push_str(line);
+        if collect_fg {
+            fg_out.extend_from_slice(&tail_fgs[i]);
+            dim_out.extend_from_slice(&tail_dims[i]);
+        }
+    }
+    (text, fg_out, dim_out)
+}
+
 /// Alacritty emits `Event::PtyWrite` for terminal queries like DSR CPR
 /// (`\x1b[6n`), DA, and mode reports. On ConPTY (Windows), `conhost.exe`
 /// fires these during startup and **blocks the child process until a reply
@@ -788,118 +919,27 @@ impl VTerm {
         collect_fg: bool,
         dewrap: bool,
     ) -> (String, Vec<CellFg>, Vec<bool>) {
+        // #t-97931 (A): delegate to the source-agnostic `tail_lines_core` so the live
+        // grid and the off-thread `GridSnapshot` produce byte-identical output (parity
+        // by construction). `grid` is hoisted so the closure reads it once per cell.
         let grid = self.term.grid();
-        let cols = self.cols as usize;
-        let rows = self.rows as usize;
-
-        let mut lines: Vec<String> = Vec::with_capacity(rows);
-        let mut line_fgs: Vec<Vec<CellFg>> = Vec::with_capacity(rows);
-        // #1948(b): per-char DIM-attribute (`Flags::DIM`) mask, collected
-        // alongside the fg mask (same gate, same alignment). codex renders its
-        // empty-box ghost/placeholder text DIM on the default colour, which the
-        // colour-only `CellFg` can't see — the draft-gate uses this to tell the
-        // ghost apart from the operator's normal-intensity input.
-        let mut line_dims: Vec<Vec<bool>> = Vec::with_capacity(rows);
-        // #1808: per-row soft-wrap flag. alacritty sets `WRAPLINE` on the LAST
-        // cell of a physical row whose logical line CONTINUES on the next row
-        // (its own auto-wrap when text overflows `cols`, NOT a `\n`/cursor-moved
-        // line break). The de-wrap join below consults it so a single logical
-        // line the terminal soft-wrapped across rows is NOT split by a `\n` in
-        // the detection feed — which otherwise inserts `\n` mid-phrase and makes
-        // a single-line state-detection regex miss (the #1808/#1809 SRL bug).
-        // Only the detection path (`collect_fg`) de-wraps; the text-only
-        // `tail_lines` stays byte-identical (display/dialog callers unaffected).
-        let mut wrapped: Vec<bool> = Vec::with_capacity(rows);
-        for row in 0..rows {
-            let mut line = String::with_capacity(cols);
-            let mut fg: Vec<CellFg> = Vec::new();
-            let mut dim: Vec<bool> = Vec::new();
-            let mut col = 0;
-            while col < cols {
+        tail_lines_core(
+            self.cols as usize,
+            self.rows as usize,
+            n,
+            collect_fg,
+            dewrap,
+            |row, col| {
                 let cell = safe_cell(grid, Line(row as i32), col);
-                if cell.flags.contains(Flags::WIDE_CHAR_SPACER) {
-                    col += 1;
-                    continue;
+                CellView {
+                    c: cell.c,
+                    fg: cell.fg,
+                    dim: cell.flags.contains(Flags::DIM),
+                    wrapline: cell.flags.contains(Flags::WRAPLINE),
+                    wide_spacer: cell.flags.contains(Flags::WIDE_CHAR_SPACER),
                 }
-                let ch = if cell.c == '\0' { ' ' } else { cell.c };
-                line.push(ch);
-                if collect_fg {
-                    fg.push(classify_fg(cell.fg));
-                    dim.push(cell.flags.contains(Flags::DIM));
-                }
-                col += 1;
-            }
-            let row_wrapped = dewrap
-                && cols > 0
-                && safe_cell(grid, Line(row as i32), cols - 1)
-                    .flags
-                    .contains(Flags::WRAPLINE);
-            // trim_end drops trailing whitespace; truncate the parallel fg vec to
-            // the surviving char count so the two stay aligned. EXCEPT a
-            // soft-wrapped row: its trailing space can be a significant
-            // inter-word space at the wrap column, and the next row is about to
-            // be concatenated WITHOUT a `\n` — trimming it would fuse two words
-            // ("is" + "temporarily" → "istemporarily"), re-breaking the phrase
-            // the de-wrap exists to keep whole.
-            let trimmed = if row_wrapped {
-                line.as_str()
-            } else {
-                line.trim_end()
-            };
-            if collect_fg {
-                fg.truncate(trimmed.chars().count());
-                dim.truncate(trimmed.chars().count());
-            }
-            lines.push(trimmed.to_string());
-            line_fgs.push(fg);
-            line_dims.push(dim);
-            wrapped.push(row_wrapped);
-        }
-
-        // Trim blank lines at both ends so terse output doesn't look padded
-        // and tail-N doesn't return the scroll buffer's trailing whitespace.
-        let first = lines
-            .iter()
-            .position(|l| !l.is_empty())
-            .unwrap_or(lines.len());
-        let last = lines
-            .iter()
-            .rposition(|l| !l.is_empty())
-            .map(|i| i + 1)
-            .unwrap_or(first);
-        let visible = &lines[first..last];
-        let visible_fgs = &line_fgs[first..last];
-        let visible_dims = &line_dims[first..last];
-        let visible_wrapped = &wrapped[first..last];
-
-        let start = visible.len().saturating_sub(n);
-        let tail = &visible[start..];
-        let tail_fgs = &visible_fgs[start..];
-        let tail_dims = &visible_dims[start..];
-        let tail_wrapped = &visible_wrapped[start..];
-
-        let mut text = String::new();
-        let mut fg_out: Vec<CellFg> = Vec::new();
-        let mut dim_out: Vec<bool> = Vec::new();
-        for (i, line) in tail.iter().enumerate() {
-            if i > 0 {
-                // #1808: skip the `\n` (and its filler fg/dim cell) when the
-                // PREVIOUS row soft-wrapped into this one — they are one line.
-                if !tail_wrapped[i - 1] {
-                    text.push('\n');
-                    if collect_fg {
-                        fg_out.push(CellFg::Default);
-                        dim_out.push(false);
-                    }
-                }
-            }
-            text.push_str(line);
-            if collect_fg {
-                fg_out.extend_from_slice(&tail_fgs[i]);
-                dim_out.extend_from_slice(&tail_dims[i]);
-            }
-        }
-        (text, fg_out, dim_out)
+            },
+        )
     }
 
     /// Dump current screen as ANSI escape sequences for full redraw.
@@ -1093,6 +1133,62 @@ impl GridSnapshot {
             wants_mouse: false,
             mouse_sgr: false,
         }
+    }
+
+    /// Per-cell view over the snapshot's VISIBLE grid (`cells`, row-major, stride =
+    /// `cols`, row 0 = visible top) for [`tail_lines_core`]. Out-of-range degrades to a
+    /// blank cell, mirroring the live path's `safe_cell`.
+    fn cell_view(&self, row: usize, col: usize) -> CellView {
+        let cols = self.cols as usize;
+        match self.cells.get(row * cols + col) {
+            Some(cell) => CellView {
+                c: cell.c,
+                fg: cell.fg,
+                dim: cell.flags.contains(Flags::DIM),
+                wrapline: cell.flags.contains(Flags::WRAPLINE),
+                wide_spacer: cell.flags.contains(Flags::WIDE_CHAR_SPACER),
+            },
+            None => CellView {
+                c: ' ',
+                fg: Color::Named(NamedColor::Foreground),
+                dim: false,
+                wrapline: false,
+                wide_spacer: false,
+            },
+        }
+    }
+
+    /// #t-97931 (off-thread draft-gate, F-A): the last `n` visible rows as plain text —
+    /// the off-thread analog of [`VTerm::tail_lines`]. The #1944 draft-protection gate
+    /// reads THIS (the parser's published snapshot) instead of the idle main-thread
+    /// `pane.vterm` (blank off-thread), so it doesn't mis-read a real unsent draft as an
+    /// empty input box and clobber it. Shares `tail_lines_core` with the live path →
+    /// byte-identical for the same grid content.
+    pub fn tail_lines(&self, n: usize) -> String {
+        tail_lines_core(
+            self.cols as usize,
+            self.rows as usize,
+            n,
+            false,
+            false,
+            |row, col| self.cell_view(row, col),
+        )
+        .0
+    }
+
+    /// #t-97931: text + per-char DIM mask of the last `n` visible rows — the off-thread
+    /// analog of [`VTerm::tail_lines_with_dim`] (codex's dim ghost-text vs operator
+    /// input). Same snapshot source / parity as [`Self::tail_lines`].
+    pub fn tail_lines_with_dim(&self, n: usize) -> (String, Vec<bool>) {
+        let (text, _fg, dim) = tail_lines_core(
+            self.cols as usize,
+            self.rows as usize,
+            n,
+            true,
+            true,
+            |row, col| self.cell_view(row, col),
+        );
+        (text, dim)
     }
 
     /// Extract text from a selection range given in ABSOLUTE line ids (#offthread-
@@ -1517,6 +1613,39 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// #t-97931 (F-A parity guard ②): `GridSnapshot::tail_lines*` must be BYTE-IDENTICAL
+    /// to the live `VTerm::tail_lines*` for the same grid — both share `tail_lines_core`,
+    /// so the off-thread draft-gate reads exactly what the live path would. Exercises
+    /// the tricky paths: leading blank row, a DIM (faint) span, a normal draft row, and
+    /// a soft-wrapped long line (WRAPLINE) + trailing blank.
+    #[test]
+    fn snapshot_tail_lines_match_live_vterm() {
+        let mut vt = VTerm::new(12, 6);
+        vt.process(
+            "\x1b[2J\x1b[H\r\n\x1b[2mghost\x1b[0m\r\nhi there\r\nABCDEFGHIJKLMNO\r\n".as_bytes(),
+        );
+        let snap = vt.snapshot();
+        for n in [1usize, 2, 3, 6] {
+            assert_eq!(
+                snap.tail_lines(n),
+                vt.tail_lines(n),
+                "snapshot.tail_lines({n}) must equal live VTerm::tail_lines (parity)"
+            );
+            assert_eq!(
+                snap.tail_lines_with_dim(n),
+                vt.tail_lines_with_dim(n),
+                "snapshot.tail_lines_with_dim({n}) must equal live (text + DIM mask parity)"
+            );
+        }
+        // The DIM mask must carry a true (the faint 'ghost') — proves the snapshot
+        // actually preserves `Flags::DIM`, not a vacuously all-false mask.
+        let (_t, dim) = snap.tail_lines_with_dim(6);
+        assert!(
+            dim.iter().any(|&d| d),
+            "the faint 'ghost' row must mark DIM cells in the snapshot"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Off-thread audit finding **F-A** (HIGH, data-loss) — task t-…97931-7

Under `AGEND_OFFTHREAD_PARSE=1` the #1944 draft-protection gate read `pane.vterm.tail_lines()` to decide whether the input box held an unsent draft. **Off-thread the main-thread `pane.vterm` is idle (blank)**, so the probe read the box as EMPTY → `buffer_empty=Some(true)` → `effective_state=None` → a queued notification was injected **on top of the user's in-progress draft, silently clobbering it** (the exact data-loss #1944 prevents). Read-class sibling of #2411/#2414/#2417, but **persistent** (no per-frame self-heal).

## Fix (Option A — shared core, lead-vetted)
- Extract `tail_lines_impl`'s de-wrap/trim/DIM loop into a source-agnostic `tail_lines_core(get: Fn(row,col) -> CellView)`. `VTerm` supplies the live alacritty grid via `safe_cell`; `GridSnapshot` supplies its visible `cells` — **parity by construction** (the off-thread gate reads byte-identical text to the live path).
- `GridSnapshot.cells` are full alacritty `Cell`s (char + fg + flags incl `DIM`/`WRAPLINE`/`WIDE_CHAR_SPACER`) → **no new snapshot field** needed.
- Path-aware `Pane::tail_lines` / `tail_lines_with_dim` (`Some` → snapshot, `None` → live `vterm`); the draft-gate (`app/mod.rs`) calls them.

## Tests (DUAL — data-loss sensitive)
- `snapshot_tail_lines_match_live_vterm` — snapshot↔live parity incl DIM + WRAPLINE (the other half of parity).
- `tail_lines_offthread_reads_snapshot_not_idle_vterm` — off-thread reads the real draft; **NEUTER-verified RED** (revert accessor → idle vterm → blank).
- Existing `tail_lines` / state-detection tests green (live refactor is behavior-preserving).
- Local: `cargo fmt --check` 0; `clippy --features tray --all-targets -D warnings` 0; nextest 651/651 over affected modules.

## Notes
- Flag default OFF; needs an **operator rebuild + restart** to validate live (daemon/TUI behaviour, can't dogfood on its own PR).
- ⚠ Base `origin/main` (#2417). Overlaps `pane.rs` with **#2419** (zoom, additive `Pane` method) — rebase after #2419 merges (low conflict).

🤖 Generated with [Claude Code](https://claude.com/claude-code)