### PR TITLE
feat(monitor): out-of-path lsof API-activity probe for false-idle detection (#2413 Phase 1)

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -30,6 +30,27 @@ pub struct AgentCore {
     pub(crate) subscribers: Vec<crossbeam_channel::Sender<Vec<u8>>>,
     pub(crate) state: StateTracker,
     pub(crate) health: HealthTracker,
+    /// #2413 Phase 1: out-of-path API-activity signal, fed by the
+    /// `api_activity_probe` daemon thread (one batched `lsof` per tick). Read
+    /// alongside `state` under this same `core.lock()` so `list_instances` can
+    /// reconcile pattern-state against live LLM-socket activity (false-idle
+    /// detection) WITHOUT clobbering `agent_state`. Default = no signal yet.
+    pub(crate) api_activity: ApiActivity,
+}
+
+/// #2413 Phase 1: out-of-path "is this agent mid-LLM-call?" signal, derived by
+/// the `api_activity_probe` from the kernel socket table (never touches the
+/// agent↔LLM connection). Purely ADDITIVE — it never rewrites `agent_state`; a
+/// consumer derives false-idle as `agent_state == "idle" && in_flight`.
+#[derive(Debug, Clone, Default)]
+pub struct ApiActivity {
+    /// The agent's process tree currently holds ≥1 ESTABLISHED socket to an LLM
+    /// endpoint (precise, via the resolved LLM-IP table) — or, when DNS is
+    /// stale, to any public :443 host (graceful raw-:443 fallback).
+    pub in_flight: bool,
+    /// Epoch-ms of the most recent tick where `in_flight` was observed true.
+    /// `None` = never observed active (or no probe has run yet).
+    pub last_active_epoch_ms: Option<u64>,
 }
 
 /// Handle to interact with an agent.
@@ -1204,6 +1225,7 @@ pub fn spawn_agent(
         // detector recomputes the SAME token the agent is told to emit.
         state: StateTracker::for_agent(detected_backend.as_ref(), name),
         health: HealthTracker::new(),
+        api_activity: crate::agent::ApiActivity::default(),
     }));
 
     // #1441: resolve the single authoritative instance ID (same source as inbox),
@@ -1566,6 +1588,7 @@ pub fn spawn_ephemeral_worker(config: &SpawnConfig) -> anyhow::Result<EphemeralP
             subscribers: Vec::new(),
             state: StateTracker::for_agent(detected_backend.as_ref(), config.name),
             health: HealthTracker::new(),
+            api_activity: crate::agent::ApiActivity::default(),
         }));
 
         let dismiss: Vec<(String, Vec<u8>)> = detected_backend
@@ -3049,6 +3072,7 @@ pub(crate) fn mk_test_handle(name: &str, id: crate::types::InstanceId) -> AgentH
         subscribers: Vec::new(),
         state: StateTracker::new(None),
         health: HealthTracker::new(),
+        api_activity: crate::agent::ApiActivity::default(),
     }));
     let published_state = core.lock().state.published_handle();
     AgentHandle {

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -376,6 +376,7 @@ fn sweep_child_tree_body(pid_file: &std::path::Path) {
         subscribers: Vec::new(),
         state: StateTracker::new(None),
         health: HealthTracker::new(),
+        api_activity: crate::agent::ApiActivity::default(),
     }));
     let agent_name = format!("sweep-test-{}", pid_file.display());
     let handle = AgentHandle {
@@ -983,6 +984,7 @@ fn write_to_agent_typed_uses_timeout() {
         subscribers: Vec::new(),
         state: StateTracker::new(None),
         health: HealthTracker::new(),
+        api_activity: crate::agent::ApiActivity::default(),
     }));
     let published_state = core.lock().state.published_handle();
     let handle = AgentHandle {
@@ -1561,6 +1563,7 @@ fn readback_test_core(feed: &[u8]) -> Arc<CoreMutex<AgentCore>> {
         subscribers: Vec::new(),
         state: StateTracker::new(None),
         health: HealthTracker::new(),
+        api_activity: crate::agent::ApiActivity::default(),
     }))
 }
 
@@ -1705,6 +1708,7 @@ fn pty_read_error_triggers_cleanup() {
         subscribers: Vec::new(),
         state: StateTracker::new(None),
         health: HealthTracker::new(),
+        api_activity: crate::agent::ApiActivity::default(),
     }));
 
     let agent_name = "read-err-test";
@@ -1827,6 +1831,7 @@ fn make_crash_exit_handle(deleted: bool) -> (AgentHandle, crate::types::Instance
         subscribers: Vec::new(),
         state: StateTracker::new(None),
         health: HealthTracker::new(),
+        api_activity: crate::agent::ApiActivity::default(),
     }));
     let mut cmd = portable_pty::CommandBuilder::new("sh");
     cmd.arg("-c");
@@ -1996,6 +2001,7 @@ fn run_pty_read_loop_for_r8(
         subscribers: Vec::new(),
         state: StateTracker::new(Some(&backend)),
         health: HealthTracker::new(),
+        api_activity: crate::agent::ApiActivity::default(),
     }));
     let ctx = PtyReadContext {
         name: "r8-dismiss-test".to_string(),
@@ -2188,6 +2194,7 @@ fn mk_handle_1441(name: &str, id: crate::types::InstanceId) -> AgentHandle {
         subscribers: Vec::new(),
         state: StateTracker::new(None),
         health: HealthTracker::new(),
+        api_activity: crate::agent::ApiActivity::default(),
     }));
     AgentHandle {
         id,

--- a/src/api/handlers/query.rs
+++ b/src/api/handlers/query.rs
@@ -21,7 +21,15 @@ pub(crate) fn handle_list(_params: &Value, ctx: &HandlerCtx) -> Value {
         .values()
         .map(|handle| {
             let name = handle.name.to_string();
-            let (agent_state, health_state, blocked_reason, blocked_note, context) = {
+            let (
+                agent_state,
+                health_state,
+                blocked_reason,
+                blocked_note,
+                context,
+                api_in_flight,
+                last_api_activity_at,
+            ) = {
                 let c = handle.core.lock();
                 (
                     c.state.get_state().display_name().to_string(),
@@ -35,6 +43,11 @@ pub(crate) fn handle_list(_params: &Value, ctx: &HandlerCtx) -> Value {
                     // ("pattern" = the agent's own statusline, "transcript" =
                     // token-usage estimate). Absent = honestly unknown.
                     c.state.resolved_context(),
+                    // #2413 Phase 1: out-of-path API-activity signal, read under the
+                    // SAME lock as agent_state so a consumer can reconcile the two
+                    // atomically (false-idle = agent_state=="idle" && api_in_flight).
+                    c.api_activity.in_flight,
+                    c.api_activity.last_active_epoch_ms,
                 )
             };
             let entry = json!({
@@ -48,6 +61,10 @@ pub(crate) fn handle_list(_params: &Value, ctx: &HandlerCtx) -> Value {
                 "blocked_note": blocked_note,
                 "context_pct": context.map(|(pct, _)| pct),
                 "context_source": context.map(|(_, source)| source),
+                // #2413 Phase 1: live LLM-socket activity (out-of-path lsof probe).
+                // api_in_flight=true while pattern-state is "idle" ⇒ false-idle.
+                "api_in_flight": api_in_flight,
+                "last_api_activity_at": last_api_activity_at,
                 "kind": "managed",
             });
             (name, entry)

--- a/src/api_activity_probe.rs
+++ b/src/api_activity_probe.rs
@@ -1,0 +1,532 @@
+//! #2413 Phase 1 — out-of-path API-activity probe.
+//!
+//! Answers "is this agent actually mid-LLM-call, or genuinely idle?" by reading
+//! the kernel socket table (`lsof`) once per tick — it **never touches** the
+//! agent↔LLM connection (no proxy, no decrypt, zero in-path risk). The signal
+//! feeds `AgentCore::api_activity`, which `list_instances` surfaces so an
+//! operator (or the daemon) can spot a *false-idle*: pattern-state says `idle`
+//! but a live LLM socket proves the agent is mid-turn.
+//!
+//! ## Why a socket probe works (empirically, 2026-06-23, this fleet)
+//! An idle managed agent holds **zero** ESTABLISHED `:443` sockets (verified
+//! claude / codex / agy, whole PID-tree). A turn opens a socket to the LLM at
+//! turn-start, holds it through the turn, closes on idle. So socket-to-LLM
+//! present ⟺ mid-turn.
+//!
+//! ## Precise vs graceful (the LLM-IP table)
+//! `lsof -nP` yields raw IPs, not hostnames (reverse-DNS fails — Anthropic /
+//! OpenAI are CDN-fronted, PTR = NXDOMAIN). So we forward-resolve a small table
+//! of LLM hostnames → IP set and match by IP (precise: ignores npm / git-https /
+//! telemetry). When DNS is stale/unavailable the match **degrades** to "any
+//! public `:443`" (raw-:443 fallback) — never worse than the simple signal.
+//!
+//! ## Known limitation (accepted, #2413)
+//! When an LLM endpoint shares a CDN IP range with non-LLM telemetry (e.g.
+//! Statsig/Sentry over the same Cloudflare block), pure IP-match cannot perfectly
+//! separate them. For false-idle this errs **toward "active"** — the safe
+//! direction (we never wrongly call a busy agent idle).
+//!
+//! ## Platform
+//! macOS/Linux (operator runs darwin). Windows / any host without `lsof` →
+//! the probe thread no-ops once and exits; `api_activity` stays default (`None`/
+//! `false`), the daemon is never broken (best-effort + graceful).
+
+use crate::agent::{AgentCore, AgentRegistry};
+use crate::sync_audit::CoreMutex;
+use std::collections::{HashMap, HashSet};
+use std::net::{IpAddr, ToSocketAddrs};
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Probe cadence. Aligned with the instance-monitor tick (5 s). LLM turns
+/// typically run >5 s, so a 5 s probe catches them; a brief sub-tick turn that
+/// is missed is, by definition, not a stall — false-idle is about *long* idles.
+const PROBE_TICK: Duration = Duration::from_secs(5);
+
+/// Re-resolve the LLM-IP table every N ticks (60 s). CDN IPs rotate slowly; a
+/// minute of staleness is harmless (a stale-but-nonempty table stays precise on
+/// the IPs it knows, and any miss just degrades that one socket to the public
+/// `:443` rule, not to wrong-attribution).
+const REFRESH_TICKS: u64 = 12;
+
+/// Timeout for one `lsof`/`ps` spawn. Generous (a batched `lsof` measures
+/// ~0.07 s) — the bound only guards the rare `lsof`-wedged-on-a-stale-mount
+/// failure mode so the probe thread can never hang the process.
+const SPAWN_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// LLM API endpoints, by backend (empirically observed remote hosts, #2413 spike).
+/// Everything NOT on this list (npm / github / datadog telemetry / auth) is noise.
+const LLM_HOSTS: &[&str] = &[
+    "api.anthropic.com",                 // claude
+    "chatgpt.com",                       // codex (observed)
+    "api.openai.com",                    // codex / openai
+    "cloudcode-pa.googleapis.com",       // agy
+    "daily-cloudcode-pa.googleapis.com", // agy (observed)
+];
+
+/// One ESTABLISHED outbound socket: the owning PID and its remote endpoint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Socket {
+    pid: u32,
+    remote_ip: IpAddr,
+    remote_port: u16,
+}
+
+/// Spawn the daemon-owned probe thread. Fire-and-forget.
+pub fn spawn(registry: AgentRegistry) {
+    // fire-and-forget: the probe loop is a read-only sampler that terminates on
+    // process exit. Losing the thread on shutdown is harmless (next boot
+    // re-samples); it owns no state another thread must join. (§10.5)
+    let _ = std::thread::Builder::new()
+        .name("api_activity_probe".into())
+        .spawn(move || {
+            if !tool_available("lsof") {
+                tracing::info!(
+                    "api_activity_probe: `lsof` not found — out-of-path API-activity \
+                     probe disabled (api_activity stays None/false). Daemon unaffected."
+                );
+                return;
+            }
+            let mut llm_ips: HashSet<IpAddr> = HashSet::new();
+            let mut tick: u64 = 0;
+            loop {
+                if tick.is_multiple_of(REFRESH_TICKS) {
+                    let fresh = resolve_llm_ips(LLM_HOSTS);
+                    // Keep the last good table on a failed/empty refresh — only an
+                    // empty table (never resolved) drops us to the raw-:443 rule.
+                    if !fresh.is_empty() {
+                        llm_ips = fresh;
+                    }
+                }
+                probe_once(&registry, &llm_ips);
+                tick = tick.wrapping_add(1);
+                std::thread::sleep(PROBE_TICK);
+            }
+        });
+}
+
+/// One probe cycle: snapshot agent roots (brief registry lock) → run `lsof`/`ps`
+/// OUT of the lock → attribute sockets to agents → write each agent's
+/// `api_activity`. On a tool failure this cycle is skipped (no write), so a
+/// transient `lsof` hiccup leaves the prior signal intact rather than flipping
+/// every agent to "idle".
+fn probe_once(registry: &AgentRegistry, llm_ips: &HashSet<IpAddr>) {
+    // Snapshot (name, root_pid, core) under the registry lock, then release it
+    // BEFORE the subprocess spawns — the lock must never be held across I/O.
+    let agents: Vec<(String, Arc<CoreMutex<AgentCore>>)> = {
+        let reg = crate::agent::lock_registry(registry);
+        reg.values()
+            .map(|h| (h.name.to_string(), Arc::clone(&h.core)))
+            .collect()
+    };
+    if agents.is_empty() {
+        return;
+    }
+    // root_pid → agent name. A PID read failure (process gone) just drops that
+    // agent from attribution this tick.
+    let roots: HashMap<u32, String> = {
+        let reg = crate::agent::lock_registry(registry);
+        reg.values()
+            .filter_map(|h| {
+                h.child
+                    .lock()
+                    .process_id()
+                    .map(|pid| (pid, h.name.to_string()))
+            })
+            .collect()
+    };
+
+    let sockets = match probe_sockets() {
+        Some(s) => s,
+        None => return, // lsof failed/timed out — keep the prior signal.
+    };
+    let ppid = probe_ppid_map(); // empty on failure → only pid==root attributes.
+
+    let active = active_agents(&roots, &ppid, &sockets, llm_ips);
+
+    let now_ms = chrono::Utc::now().timestamp_millis().max(0) as u64;
+    for (name, core) in &agents {
+        let in_flight = active.contains(name.as_str());
+        let mut c = core.lock();
+        c.api_activity.in_flight = in_flight;
+        if in_flight {
+            c.api_activity.last_active_epoch_ms = Some(now_ms);
+        }
+    }
+}
+
+/// Run `lsof` and parse its ESTABLISHED-TCP sockets. `None` on spawn failure /
+/// non-zero exit (graceful — caller skips the tick).
+fn probe_sockets() -> Option<Vec<Socket>> {
+    let mut cmd = std::process::Command::new("lsof");
+    // -nP: no DNS / port-name resolution (fast, raw IPs). -i/-s: only ESTABLISHED
+    // TCP. -Fpn: machine-readable field output — `p<pid>` then `n<addr>` lines.
+    cmd.args(["-nP", "-iTCP", "-sTCP:ESTABLISHED", "-Fpn"]);
+    let out = crate::git_helpers::spawn_group_bounded(cmd, "api_probe_lsof", SPAWN_TIMEOUT).ok()?;
+    // lsof exits non-zero when *some* fds are unreadable even though it printed
+    // usable output — so parse stdout regardless of status (don't gate on exit).
+    Some(parse_lsof(&String::from_utf8_lossy(&out.stdout)))
+}
+
+/// Build a pid → ppid map from `ps`. Empty on failure (walk-up then only matches
+/// a socket owned directly by an agent root PID).
+fn probe_ppid_map() -> HashMap<u32, u32> {
+    let mut cmd = std::process::Command::new("ps");
+    cmd.args(["-axo", "pid=,ppid="]);
+    match crate::git_helpers::spawn_group_bounded(cmd, "api_probe_ps", SPAWN_TIMEOUT) {
+        Ok(out) => parse_ps_ppid(&String::from_utf8_lossy(&out.stdout)),
+        Err(_) => HashMap::new(),
+    }
+}
+
+/// Is `tool` runnable? (`<tool> -v`/exit). Used once to gate the whole probe.
+fn tool_available(tool: &str) -> bool {
+    std::process::Command::new(tool)
+        .arg("-v")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .is_ok()
+}
+
+/// Forward-resolve the LLM hostnames to their current IP set via the system
+/// resolver (no extra crate). Best-effort: hosts that fail to resolve are skipped.
+fn resolve_llm_ips(hosts: &[&str]) -> HashSet<IpAddr> {
+    let mut ips = HashSet::new();
+    for host in hosts {
+        if let Ok(addrs) = (*host, 443u16).to_socket_addrs() {
+            for a in addrs {
+                ips.insert(a.ip());
+            }
+        }
+    }
+    ips
+}
+
+// ── pure helpers (unit-tested) ──────────────────────────────────────────────
+
+/// Parse `lsof -Fpn` output → sockets. Format: a `p<pid>` line opens a process,
+/// then `f<fd>` (ignored) + `n<local>-><remote>` lines for its files.
+fn parse_lsof(stdout: &str) -> Vec<Socket> {
+    let mut out = Vec::new();
+    let mut cur_pid: Option<u32> = None;
+    for line in stdout.lines() {
+        let Some((tag, rest)) = line.split_at_checked(1) else {
+            continue;
+        };
+        match tag {
+            "p" => cur_pid = rest.trim().parse().ok(),
+            "n" => {
+                if let (Some(pid), Some((ip, port))) = (cur_pid, parse_name_remote(rest)) {
+                    out.push(Socket {
+                        pid,
+                        remote_ip: ip,
+                        remote_port: port,
+                    });
+                }
+            }
+            _ => {} // f<fd>, etc. — ignored
+        }
+    }
+    out
+}
+
+/// Extract `(remote_ip, remote_port)` from an lsof `n` address `LOCAL->REMOTE`.
+/// Only ESTABLISHED sockets (which carry `->`) yield a value.
+fn parse_name_remote(name: &str) -> Option<(IpAddr, u16)> {
+    let (_local, remote) = name.split_once("->")?;
+    parse_endpoint(remote)
+}
+
+/// Parse `ip:port`, handling bracketed IPv6 (`[2001:db8::1]:443`) vs bare IPv4.
+fn parse_endpoint(addr: &str) -> Option<(IpAddr, u16)> {
+    let (ip_str, port_str) = if let Some(rest) = addr.strip_prefix('[') {
+        rest.split_once("]:")? // "2001:db8::1", "443"
+    } else {
+        addr.rsplit_once(':')? // "1.2.3.4", "443"
+    };
+    Some((ip_str.parse().ok()?, port_str.parse().ok()?))
+}
+
+/// Parse `ps -axo pid=,ppid=` (whitespace-padded `<pid> <ppid>` per line).
+fn parse_ps_ppid(stdout: &str) -> HashMap<u32, u32> {
+    let mut map = HashMap::new();
+    for line in stdout.lines() {
+        let mut it = line.split_whitespace();
+        if let (Some(pid), Some(ppid)) = (it.next(), it.next()) {
+            if let (Ok(pid), Ok(ppid)) = (pid.parse(), ppid.parse()) {
+                map.insert(pid, ppid);
+            }
+        }
+    }
+    map
+}
+
+/// Set of agent names with an in-flight API socket. For each socket that counts
+/// as API activity, walk its PID up the parent chain to the owning agent root.
+fn active_agents(
+    roots: &HashMap<u32, String>,
+    ppid: &HashMap<u32, u32>,
+    sockets: &[Socket],
+    llm_ips: &HashSet<IpAddr>,
+) -> HashSet<String> {
+    let mut active = HashSet::new();
+    for s in sockets {
+        if !counts_as_api(s.remote_ip, s.remote_port, llm_ips) {
+            continue;
+        }
+        if let Some(name) = owning_agent(s.pid, ppid, roots) {
+            active.insert(name.to_string());
+        }
+    }
+    active
+}
+
+/// Does this socket count as LLM API activity?
+/// - precise (table non-empty): remote `:443` AND remote IP ∈ LLM-IP table.
+/// - degraded (table empty — DNS failed): any remote `:443` to a public IP.
+fn counts_as_api(remote: IpAddr, port: u16, llm_ips: &HashSet<IpAddr>) -> bool {
+    if port != 443 {
+        return false;
+    }
+    if llm_ips.is_empty() {
+        is_public_remote(remote) // raw-:443 fallback
+    } else {
+        llm_ips.contains(&remote)
+    }
+}
+
+/// Walk `pid` up the parent chain; return the first ancestor (incl. itself) that
+/// is an agent root. Depth-capped (cycle / PID-reuse guard).
+fn owning_agent<'a>(
+    pid: u32,
+    ppid: &HashMap<u32, u32>,
+    roots: &'a HashMap<u32, String>,
+) -> Option<&'a str> {
+    let mut cur = pid;
+    for _ in 0..64 {
+        if let Some(name) = roots.get(&cur) {
+            return Some(name.as_str());
+        }
+        match ppid.get(&cur) {
+            Some(&p) if p != cur && p != 0 => cur = p,
+            _ => return None,
+        }
+    }
+    None
+}
+
+/// Public (internet-routable) remote? Excludes loopback / private / link-local /
+/// ULA so the raw-:443 fallback never counts loopback IPC or LAN traffic.
+fn is_public_remote(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(a) => {
+            !a.is_loopback()
+                && !a.is_private()
+                && !a.is_link_local()
+                && !a.is_unspecified()
+                && !a.is_broadcast()
+        }
+        IpAddr::V6(a) => {
+            let seg0 = a.segments()[0];
+            let link_local = (seg0 & 0xffc0) == 0xfe80; // fe80::/10
+            let ula = (seg0 & 0xfe00) == 0xfc00; // fc00::/7
+            !a.is_loopback() && !a.is_unspecified() && !link_local && !ula
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
+    fn v4(s: &str) -> IpAddr {
+        IpAddr::V4(s.parse::<Ipv4Addr>().expect("test ipv4 literal"))
+    }
+
+    // Real-shaped `lsof -Fpn` output (see the live capture in the PR notes):
+    // `p<pid>` opens a process; `f<fd>` delimits files; `n<local>-><remote>`.
+    // pid 100 = a claude root (socket to api.anthropic.com + a Cloudflare
+    // telemetry IP); pid 200 = a codex Rust child (socket to chatgpt.com), its
+    // parent 150 is the codex agent root; pid 999 = unrelated noise on :443.
+    const LSOF_FIXTURE: &str = "\
+p100
+f14
+n192.168.1.5:54321->160.79.104.10:443
+f15
+n192.168.1.5:54322->104.16.9.34:443
+p200
+f33
+n192.168.1.5:60001->104.18.32.47:443
+p300
+f9
+n[fe80:e::1c12:5a10:30e:a686]:54592->[fe80:e::47a:ee1f]:50231
+p999
+f7
+n192.168.1.5:51000->93.184.216.34:443
+";
+
+    #[test]
+    fn parse_lsof_extracts_pid_and_remote_endpoints() {
+        let socks = parse_lsof(LSOF_FIXTURE);
+        // 100: two :443 sockets; 200: one; 300: one (link-local, non-443); 999: one.
+        assert_eq!(socks.len(), 5);
+        assert!(socks.contains(&Socket {
+            pid: 100,
+            remote_ip: v4("160.79.104.10"),
+            remote_port: 443
+        }));
+        assert!(socks.contains(&Socket {
+            pid: 200,
+            remote_ip: v4("104.18.32.47"),
+            remote_port: 443
+        }));
+        // IPv6 bracketed remote parsed; its port is the link-local 50231.
+        assert!(socks.iter().any(|s| s.pid == 300
+            && s.remote_port == 50231
+            && matches!(s.remote_ip, IpAddr::V6(_))));
+    }
+
+    #[test]
+    fn parse_endpoint_handles_ipv4_and_bracketed_ipv6() {
+        assert_eq!(
+            parse_endpoint("160.79.104.10:443"),
+            Some((v4("160.79.104.10"), 443))
+        );
+        assert_eq!(
+            parse_endpoint("[2001:db8::1]:443"),
+            Some((
+                IpAddr::V6(
+                    "2001:db8::1"
+                        .parse::<Ipv6Addr>()
+                        .expect("test ipv6 literal")
+                ),
+                443
+            ))
+        );
+        assert_eq!(parse_endpoint("garbage"), None);
+    }
+
+    #[test]
+    fn parse_ps_ppid_parses_padded_pairs() {
+        let map = parse_ps_ppid("    1     0\n  150     1\n  200   150\n  100     1\nbad line\n");
+        assert_eq!(map.get(&200), Some(&150));
+        assert_eq!(map.get(&150), Some(&1));
+        assert_eq!(map.len(), 4); // "bad line" (single token) skipped
+    }
+
+    fn roots() -> HashMap<u32, String> {
+        // claude root owns its socket directly (pid 100); codex root is the node
+        // wrapper (150) whose Rust child (200) owns the socket.
+        HashMap::from([(100, "claude".to_string()), (150, "codex".to_string())])
+    }
+    fn ppid() -> HashMap<u32, u32> {
+        HashMap::from([(100, 1), (150, 1), (200, 150), (999, 1)])
+    }
+
+    #[test]
+    fn precise_mode_matches_only_llm_ips_and_attributes_via_pid_tree() {
+        // Table = the two LLM IPs in the fixture; the Cloudflare telemetry IP
+        // (104.16.9.34) and the noise host (93.184.216.34) are NOT in it.
+        let llm: HashSet<IpAddr> = HashSet::from([v4("160.79.104.10"), v4("104.18.32.47")]);
+        let socks = parse_lsof(LSOF_FIXTURE);
+        let active = active_agents(&roots(), &ppid(), &socks, &llm);
+        // claude: direct LLM socket on its root. codex: LLM socket on child 200 →
+        // walked up to root 150. Noise pid 999 (not an agent) ignored.
+        assert!(active.contains("claude"));
+        assert!(
+            active.contains("codex"),
+            "child socket must attribute to the root via ppid walk-up"
+        );
+        assert_eq!(active.len(), 2);
+    }
+
+    #[test]
+    fn precise_mode_ignores_non_llm_443() {
+        // A claude root holding ONLY a Cloudflare-telemetry :443 socket (not in
+        // the LLM table) is NOT flagged active — the whole point of precise mode.
+        let llm: HashSet<IpAddr> = HashSet::from([v4("160.79.104.10")]);
+        let socks = vec![Socket {
+            pid: 100,
+            remote_ip: v4("104.16.9.34"),
+            remote_port: 443,
+        }];
+        let active = active_agents(&roots(), &ppid(), &socks, &llm);
+        assert!(active.is_empty());
+    }
+
+    #[test]
+    fn degraded_mode_counts_any_public_443_but_not_private_or_loopback() {
+        let empty: HashSet<IpAddr> = HashSet::new(); // DNS failed → raw-:443 fallback
+        let socks = vec![
+            Socket {
+                pid: 100,
+                remote_ip: v4("93.184.216.34"),
+                remote_port: 443,
+            }, // public
+            Socket {
+                pid: 150,
+                remote_ip: v4("127.0.0.1"),
+                remote_port: 443,
+            }, // loopback IPC
+            Socket {
+                pid: 150,
+                remote_ip: v4("192.168.1.9"),
+                remote_port: 443,
+            }, // LAN
+        ];
+        let active = active_agents(&roots(), &ppid(), &socks, &empty);
+        assert!(
+            active.contains("claude"),
+            "public :443 counts in degraded mode"
+        );
+        assert!(
+            !active.contains("codex"),
+            "loopback/LAN :443 must NOT count"
+        );
+    }
+
+    #[test]
+    fn non_443_never_counts() {
+        let empty = HashSet::new();
+        assert!(!counts_as_api(v4("160.79.104.10"), 80, &empty));
+        assert!(!counts_as_api(v4("160.79.104.10"), 50231, &empty));
+    }
+
+    #[test]
+    fn owning_agent_caps_depth_on_parent_cycle() {
+        // PID-reuse cycle 5↔6 with no agent root above → must terminate (not hang).
+        let cyclic = HashMap::from([(5u32, 6u32), (6u32, 5u32)]);
+        let r = HashMap::from([(1u32, "a".to_string())]);
+        assert_eq!(owning_agent(5, &cyclic, &r), None);
+    }
+
+    #[test]
+    fn owning_agent_matches_self_and_ancestor() {
+        let r = roots();
+        let p = ppid();
+        assert_eq!(owning_agent(100, &p, &r), Some("claude")); // self is a root
+        assert_eq!(owning_agent(200, &p, &r), Some("codex")); // parent is a root
+        assert_eq!(owning_agent(999, &p, &r), None); // unrelated
+    }
+
+    #[test]
+    fn is_public_remote_classifies_ranges() {
+        assert!(is_public_remote(v4("160.79.104.10")));
+        assert!(!is_public_remote(v4("127.0.0.1")));
+        assert!(!is_public_remote(v4("10.0.0.1")));
+        assert!(!is_public_remote(v4("192.168.1.1")));
+        assert!(!is_public_remote(IpAddr::V6(
+            "fe80::1".parse::<Ipv6Addr>().expect("test ipv6 literal")
+        )));
+        assert!(!is_public_remote(IpAddr::V6(
+            "::1".parse::<Ipv6Addr>().expect("test ipv6 literal")
+        )));
+        assert!(is_public_remote(IpAddr::V6(
+            "2606:4700::1"
+                .parse::<Ipv6Addr>()
+                .expect("test ipv6 literal")
+        )));
+    }
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -391,6 +391,10 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
     if !attached_mode {
         crate::daemon::supervisor::spawn(home.clone(), Arc::clone(&registry));
         crate::instance_monitor::spawn_monitor_tick(home.clone(), Arc::clone(&registry));
+        // #2413 Phase 1: out-of-path lsof API-activity probe (feeds
+        // AgentCore::api_activity for false-idle detection). Self-disables if
+        // `lsof` is absent.
+        crate::api_activity_probe::spawn(Arc::clone(&registry));
         // Attached mode stays unwired: that process never owns the registry,
         // and the Telegram bot (if any) runs under the other daemon which
         // already did its own attach.

--- a/src/daemon/crash_respawn.rs
+++ b/src/daemon/crash_respawn.rs
@@ -473,6 +473,7 @@ mod deleted_gate_tests_1913 {
             subscribers: Vec::new(),
             state: crate::state::StateTracker::new(None),
             health: crate::health::HealthTracker::new(),
+            api_activity: crate::agent::ApiActivity::default(),
         }));
         AgentHandle {
             id: InstanceId::parse(VICTIM_UUID).expect("uuid"),

--- a/src/daemon/lifecycle.rs
+++ b/src/daemon/lifecycle.rs
@@ -340,6 +340,7 @@ mod tests {
             subscribers: Vec::new(),
             state: crate::state::StateTracker::new(None),
             health: crate::health::HealthTracker::new(),
+            api_activity: crate::agent::ApiActivity::default(),
         }));
         crate::agent::AgentHandle {
             id: crate::types::InstanceId::default(),

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1360,6 +1360,10 @@ fn build_tick_infrastructure(
     }
     router::spawn(home.to_path_buf(), Arc::clone(&ctx.registry));
     crate::instance_monitor::spawn_monitor_tick(home.to_path_buf(), Arc::clone(&ctx.registry));
+    // #2413 Phase 1: out-of-path lsof API-activity probe (feeds
+    // AgentCore::api_activity for false-idle detection). Self-disables if
+    // `lsof` is absent.
+    crate::api_activity_probe::spawn(Arc::clone(&ctx.registry));
 
     crate::inbox::recover_half_writes(home);
     // #1988: same half-write recovery for the task-event log — quarantine a

--- a/src/daemon/per_tick/mod.rs
+++ b/src/daemon/per_tick/mod.rs
@@ -297,6 +297,7 @@ pub(crate) fn mock_live_agent_no_context(
         subscribers: Vec::new(),
         state: crate::state::StateTracker::new(None),
         health: crate::health::HealthTracker::new(),
+        api_activity: crate::agent::ApiActivity::default(),
     }));
     let handle = crate::agent::AgentHandle {
         id: crate::types::InstanceId::default(),

--- a/src/daemon/poll_reminder.rs
+++ b/src/daemon/poll_reminder.rs
@@ -274,6 +274,7 @@ mod tests {
             subscribers: Vec::new(),
             state: st,
             health: crate::health::HealthTracker::new(),
+            api_activity: crate::agent::ApiActivity::default(),
         };
         let core = Arc::new(crate::sync_audit::CoreMutex::new(core));
         let published_state = core.lock().state.published_handle();

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -3911,6 +3911,7 @@ instances:
             subscribers: Vec::new(),
             state: crate::state::StateTracker::new(None),
             health: crate::health::HealthTracker::new(),
+            api_activity: crate::agent::ApiActivity::default(),
         }));
         core.lock().state.current = state;
         // Direct `.current` write bypasses record_set, so sync the lock-free mirror.

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod agent;
 mod agent_ops;
 mod agy_workspace;
 mod api;
+mod api_activity_probe;
 mod app;
 mod auth_cookie;
 mod backend;


### PR DESCRIPTION
## #2413 Phase 1 — out-of-path lsof API-activity probe (false-idle detection)

Daemon-owned probe that reads the kernel socket table (`lsof`) once per tick to tell whether a *pattern-idle* agent is genuinely idle or mid-LLM-call — **out-of-path, never touches the agent↔LLM connection** (zero in-path risk). This is the A1-first path the operator picked over the in-path A2 proxy.

### What it does
- **`src/api_activity_probe.rs`** (new): one batched `lsof -nP -iTCP -sTCP:ESTABLISHED` per 5s tick + a `ps` PID-tree walk-up to attribute LLM sockets to managed agents (handles codex's node-wrapper → Rust-child). LLM endpoints matched against a **forward-resolved IP table** (`std::net::ToSocketAddrs`, refreshed ~60s) — `lsof -nP` gives IPs not hostnames and reverse-DNS NXDOMAINs for the CDNs. **Graceful degrade** to "any public `:443`" when DNS is stale (never worse than raw-:443). **Self-disables** to a no-op if `lsof` is absent (Windows / no-lsof never breaks the daemon).
- **`AgentCore`**: additive `api_activity: ApiActivity { in_flight, last_active_epoch_ms }`. **Never rewrites `agent_state`.**
- **`list_instances` / `describe_instance`**: surface `api_in_flight` + `last_api_activity_at`, read under the **same `core.lock()`** as `agent_state` so a consumer reconciles atomically (false-idle = `agent_state=="idle" && api_in_flight`).
- Probe thread spawned next to `spawn_monitor_tick` in both daemon + app paths, **independent of the monitor's TUI-subscriber gate** (so it runs headless — `list_instances` always needs it).

### Empirical "ceiling" (macOS, live fleet)
- Idle managed agent holds **ZERO** ESTABLISHED `:443` sockets; a turn opens a socket to the LLM (`api.anthropic.com` 160.79.104.10) and holds it through the turn → **socket-present ⟺ mid-turn**. Clean binary signal for false-idle.
- **Known limitation (accepted):** when an LLM endpoint shares a CDN block with non-LLM telemetry (Statsig/Sentry on Cloudflare), IP-match can't perfectly separate them; it errs **toward "active"** — the safe direction for false-idle.

### Tests / gates
- `cargo fmt` + `cargo clippy --all-targets --features tray -- -D warnings`: clean.
- New unit tests **10/10** pass (parsers + attribution + precise/degraded/depth-cap), fixtures built from real-shaped `lsof -Fpn` / `ps` output.
- Full `cargo test --tests`: 4415 pass; the only 6 failures are `auto_release`/`messaging` integration tests dying on the **agend-git #2158 in-worktree shim** (stray-worktree rejection of their own `/tmp` `git worktree add`). **Verified pre-existing**: identical failures on clean `origin/main` with this change fully stashed. CI on real git (no shim) is authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
