### PR TITLE
feat(shadow): #2413 Shadow Observer — local hook plane + Evidence reducer + quantification

### DIFF
--- a/SHADOW-OBSERVER-ARCH-2413.md
+++ b/SHADOW-OBSERVER-ARCH-2413.md
@@ -1,0 +1,155 @@
+# Shadow Observer — Architecture (#2413 Phase B)
+
+Branch `feat/2413-shadow-local-plane-hooks`. Task `t-…24134-3`. **HARD-STOP at reducer + quantification report.** flag-OFF (`AGEND_SHADOW_OBSERVER=1`), zero in-path, DUAL review. Do NOT touch in-path proxy productization (wait for the numbers).
+
+Operator chose **A**: build the reducer + *quantify* "cleaner than raw screen-scrape", THEN decide whether to invest in an in-path proxy. This doc is the design the reducer is built against.
+
+---
+
+## §1 Data flow (zero in-path)
+
+Three Evidence sources fold into one reducer; nothing here sits in the agent's request path.
+
+```
+ claude lifecycle hooks ──unix socket──▶ shadow::ingest_frame ──▶ per-agent Evidence buffer
+   (real, authority=Hook, confidence=Confirmed)                     (shadow/mod.rs: push/drain/peek)
+                                                                            │
+ vterm screen ──StateTracker.feed_with_fg──▶ agent_state (AgentState) ─────┤  reducer WRAPS as
+   (the baseline to BEAT; src/state/mod.rs)   read via core.state.get_state()│  authority=Screen Evidence
+                                                                            │
+ lsof probe ──▶ core.api_activity.in_flight / last_active_epoch_ms ─────────┤  reducer WRAPS as
+   (Phase-1, out-of-path, 5s; api_activity_probe.rs)                        │  authority=ProcessHeuristic Evidence
+                                                                            ▼
+                                          ┌─────────────────────────────────────────┐
+                                          │  REDUCER (src/daemon/shadow/reducer.rs)   │
+                                          │  per-agent, per-tick:                     │
+                                          │   1. drain Evidence buffer (hook events)  │
+                                          │   2. synth Screen Evidence (agent_state)  │
+                                          │   3. synth Liveness Evidence (api/output) │
+                                          │   4. fold → AgentRuntime (episode + decay)│
+                                          │   5. precedence → state                   │
+                                          │   6. liveness backstop reconcile          │
+                                          └─────────────────────────────────────────┘
+                                                                            ▼
+              ObservedStatus { state, confidence, authority, evidence[], since }
+                                                                            │
+                additive (mirror api_in_flight): hung on AgentCore BESIDE agent_state,
+                serialized in list_instances (query.rs) under the SAME core.lock().
+                NEVER overwrites agent_state. raw-read deciders untouched.
+```
+
+**Why wrap screen as Evidence** (not just read it): the reducer's whole value is *fusing* sources under one precedence+decay model. Screen is the baseline we must measure against, so it enters the same pipeline tagged `authority=Screen` and is *overridden* by fresher `Hook` evidence (and reconciled back when hooks drop). The quantification (§4) compares reducer output vs the raw `agent_state` it wrapped.
+
+**Coexistence with existing planes** (do NOT duplicate):
+- `hook_shadow.rs` already maps hook→`AgentState` + freshness + Phase-1 `authoritative_state()` promotion (snapshot-scoped, gated `AGEND_HOOK_STATE_POC=1`). That stays. My Evidence plane is the *richer typed* representation; the reducer is its Phase-B consumer. ObservedStatus is a NEW additive field, not a re-write of `agent_state`.
+- `recovery_shadow.rs` = 529-recovery telemetry; unrelated, reuse only its fire-once-latch dedup *pattern*.
+
+---
+
+## §2 ObservedStatus shape
+
+```rust
+pub struct ObservedStatus {
+    pub state: ObservedState,        // the MVP/refined state (below)
+    pub confidence: Confidence,      // reuse evidence::Confidence
+    pub authority: Authority,        // reuse evidence::Authority — which source decided
+    pub evidence: Vec<EvidenceRef>,  // the (kind, authority, at_ms) that justified it — bounded (last N)
+    pub since_ms: u64,               // epoch ms the state was first entered (stable across re-derive)
+}
+```
+`since_ms` is **stable**: only reset when `state` actually changes, so "how long Active/Waiting" is meaningful. `evidence[]` is a bounded explain-trail (last ~4) for debuggability + the quantification diff — not the whole buffer.
+
+Additive surface: `AgentCore.observed_status: Option<ObservedStatus>` (None until first reduce), serialized in `list_instances` as `"observed_status": {...}` beside `"agent_state"`. Read under `core.lock()` atomically with `agent_state` (so a consumer can diff them — that diff IS the quantification).
+
+---
+
+## §3 State model + MVP
+
+**MVP (3 high-reliability states)** — ship these first; refine only when evidence is sufficient, else conservatively fall back UP to the coarser state:
+
+| ObservedState   | Meaning                              | Primary evidence |
+|-----------------|--------------------------------------|------------------|
+| `WaitingForUser`| blocked awaiting a human decision    | Hook `ApprovalRequired`; Screen `PermissionPrompt`/`InteractivePrompt`/`AwaitingOperator` |
+| `Active`        | turn in progress / working           | Hook `TurnStarted`(open episode) / `ToolStarted`(open span); `api_in_flight`; Screen `Thinking`/`ToolUse` |
+| `Idle`          | at a ready prompt, nothing running   | Hook `TurnEnded`/`PromptReady`/`SessionExited`; Screen `Idle`; AND no `api_in_flight` |
+
+**Refined Active sub-states** (only when evidence is unambiguous; otherwise stay `Active`):
+- `ToolUse` — `ToolStarted` open (no matching `ToolEnded`).
+- `Responding` — assistant output streaming (Stream plane — DEFERRED this phase; weakly inferable from `api_in_flight` + fresh output, default-fold into `Active`).
+- `Thinking` — **derived**, not string-matched: episode open ∧ no open tool span ∧ not WaitingForUser ∧ no recent output. (matches hook_shadow's `UserPromptSubmit→Thinking` intuition but as a *derivation*.)
+
+**Error/limit states** (carry through from Screen authority this phase; Hook plane is blind to them, API plane DEFERRED):
+- `RateLimited` — Screen `RateLimit`/`ServerRateLimit`/`UsageLimit`.
+
+**Precedence** (highest wins when multiple fire): `RateLimited > WaitingForUser > ToolUse > Responding > Thinking > Idle`. (`Active` is the coarse fold of ToolUse/Responding/Thinking for MVP.)
+
+---
+
+## §4 Decay / reconcile / liveness backstop  ← hardest, most-tested
+
+The episode model + the phantom-stuck failure it must survive.
+
+**Episode tracking (AgentRuntime, per agent):**
+- `TurnStarted` opens an *episode* (`episode_open=true`, `episode_since`). `TurnEnded`/`SessionExited`/`PromptReady` closes it.
+- `ToolStarted{name}` opens a *tool span*. `ToolEnded` closes it.
+- `ApprovalRequired` sets `waiting=true`; cleared by the next `ToolEnded`/`TurnEnded`/`PromptReady`/`TurnStarted`.
+
+**The failure to defeat:** a closing hook (`Stop`/`PostToolUse`) is DROPPED → episode/span never closes → reducer reports `Active`/`ToolUse` forever though the agent is idle. (Hook delivery is best-effort: async, 10s timeout, socket can drop.)
+
+**Two decay mechanisms:**
+1. **TTL decay** — each Evidence carries `ttl_ms`; hook evidence ships `ttl_ms=0` (no local opinion), so the reducer assigns a *default budget* per kind (e.g. an open tool span older than `TOOL_SPAN_MAX` with no closing event is suspect). Time alone never flips state — it only marks an open span *stale* and eligible for reconcile.
+2. **Liveness backstop reconcile** (the real fix) — an open episode/span is force-closed → `Idle` (authority downgraded to `Inferred`/`Screen`, confidence `Probable`) when liveness CONTRADICTS it, ALL of:
+   - Screen `agent_state == Idle` (prompt-ready) sustained > `RECONCILE_GRACE`, **and**
+   - `api_activity.in_flight == false` (no live LLM socket), **and**
+   - `last_productive_output` silence > `RECONCILE_SILENCE`.
+   → "hook said ToolUse, but screen is back at the prompt + no LLM socket + quiet → the Stop hook was dropped; decay to Idle."
+
+**Symmetric guard (false-active from stale screen):** if Screen says `Idle` but a FRESH hook episode is open AND `api_in_flight==true` → keep `Active` (this is the **mid-API false-idle** the reducer must beat — screen looks idle mid-request, hook+socket prove otherwise).
+
+**Freshness fallback:** no hook Evidence within `HOOK_FRESHNESS` (≈600s, match hook_shadow) AND no live signal → fall back to Screen authority (confidence `Weak`).
+
+**Tests (decay/reconcile is the must-test surface):**
+- `dropped_stop_reconciles_to_idle` — open episode + screen Idle + !in_flight + silence → Idle.
+- `dropped_posttool_reconciles_tool_span` — open tool span, same contradiction → span closed.
+- `mid_api_false_idle_stays_active` — screen Idle + fresh episode + in_flight → Active (beats screen).
+- `approval_then_proceed_clears_waiting` — ApprovalRequired then ToolEnded → not stuck WaitingForUser.
+- `precedence_orders` — RateLimited > WaitingForUser > ToolUse > … table-driven.
+- `ttl_open_span_without_liveness_does_not_flip` — time alone (no contradicting liveness) does NOT flip (avoid over-eager decay).
+- `since_ms_stable_across_redrive` — re-reducing identical evidence keeps `since_ms`.
+
+---
+
+## §5 Quantification (operator's core deliverable)
+
+Isolated real claude (mirror the live-verify recipe — **SHORT AGEND_HOME, fleet.yaml, NOT --agents, do NOT touch the live fleet**; see [[reference_shadow_local_plane_live_verify_recipe]]). Drive real turns that screen-scrape gets WRONG, and count reducer corrections vs raw `agent_state`:
+1. **mid-API false-idle** — during a long tool/think, screen momentarily renders idle/prompt-ready; raw `agent_state=Idle` while hook episode open + `api_in_flight=true`. Reducer should say `Active`. Count: false-idles caught.
+2. **waiting-vs-idle** — at a permission prompt, raw screen may read `Idle`/ambiguous; hook `ApprovalRequired` → reducer `WaitingForUser`. Count: approvals correctly distinguished from idle.
+3. (control) steady idle / steady tool-use — reducer must NOT regress these (no new false-actives).
+
+Report: a table of `raw agent_state` vs `ObservedStatus.state` per sampled tick across the scripted turns, with the correction counts (`+N false-idle caught`, `+M approval-vs-idle split`, `0 regressions`). This is the number that justifies (or not) the in-path proxy phase.
+
+---
+
+## §6 Build order
+
+1. `reducer.rs` core: `AgentRuntime` + `reduce(evidence: &[Evidence], screen: AgentState, live: LivenessSnapshot) -> ObservedStatus`. PURE fn over inputs (no globals) → trivially testable; the per-tick driver calls it.
+2. Decay/reconcile + the §4 test suite (RED first on the reconcile cases).
+3. Additive surface: `AgentCore.observed_status` + per-tick reduce call + `query.rs` serialization (mirror `api_in_flight`).
+4. Screen→Evidence + liveness→Evidence wrappers.
+5. Quantification harness + report (§5).
+6. fmt + clippy + `AGEND_GIT_BYPASS=1` nextest; DUAL review.
+
+Invariants: flag-OFF default (reduce only runs / surfaces under `AGEND_SHADOW_OBSERVER=1`); reducer reads ONLY hook-buffer + screen + lsof (zero in-path); `agent_state` never mutated; spawn-site rationale on any thread.
+
+---
+
+## §7 Implementation map (file:line — so a fresh restart skips re-exploring)
+
+- **Screen baseline**: `src/state/mod.rs` — `enum AgentState` @ L24-83 (Idle/ToolUse/Thinking/PermissionPrompt/InteractivePrompt/AwaitingOperator/RateLimit/ServerRateLimit/UsageLimit/…). Derive `StateTracker::feed_with_fg()` @ L1549; read `core.state.get_state()`; `last_output` @ L237, `last_productive_output` @ L251, `productive_silence()`; `SERVER_RATE_LIMIT_RECOVERY_SILENCE=45s` @ L461.
+- **hook_shadow.rs** (coexist, DON'T duplicate): `derive_state()` @ L277-299, `resolved_state_for()` @ L129 (`HookResolution::Fresh(600s)/Stale/Unknown`, ToolUse event-pair-closed @ L149), `authoritative_state()` @ L226 (Phase-1 promotion, gated `AGEND_HOOK_STATE_POC=1`, snapshot-scoped), `HookShadow` @ L31. The reducer does NOT route through `authoritative_state()`.
+- **Additive surface to MIRROR**: `ApiActivity{in_flight,last_active_epoch_ms}` on AgentCore (`src/agent/mod.rs` field `api_activity`); serialized **`src/api/handlers/query.rs:30,49-67`** under `core.lock()` atomically with agent_state → `"api_in_flight"`/`"last_api_activity_at"`. Probe `src/api_activity_probe.rs:76` (`probe_once()` @ L113).
+- **Liveness signals**: `core.api_activity.in_flight`; `core.state.last_productive_output` / `last_output` / `productive_silence()`; `child.lock().process_id()` (`src/instance_monitor.rs:132`); heartbeat (`src/daemon/per_tick/hang_detection.rs:73-80`).
+- **Consumed (my Phase-A modules)**: `shadow::{drain,peek}(agent)->Vec<Evidence>`; `Evidence{kind,authority,confidence,at_ms,ttl_ms}`; `EvidenceKind`=TurnStarted/Responding/TurnEnded{stop_reason}/ToolStarted{name}/ToolEnded/ApprovalRequired/RateLimited{retry_at_ms}/TokenUsage/PromptReady/SessionExited; `Authority`=Hook/Stream/Transcript/Screen/ProcessHeuristic/Inferred; `Confidence`=Confirmed/Strong/Probable/Weak.
+- **Per-tick driver** under the flag: see `src/daemon/per_tick/`; snapshot buffer+screen+api_activity under one `core.lock()`, write `core.observed_status`.
+- **Quantification harness**: reuse the live-verify recipe — SHORT `AGEND_HOME` (`/tmp/svN`, SUN_LEN), `fleet.yaml` (NOT `--agents`, which has no working_dir → `claude --continue` crash), non-bypass claude via temp-removing `--dangerously-skip-permissions` from `src/backend.rs:408` (revert `git restore src/backend.rs`; agend-git denies `git checkout <file>`). macOS has no `timeout`. Read `<home>/daemon.<date>.log` for `#shadow-observer`.
+- **Preflight**: `AGEND_GIT_BYPASS=1` + `PATH=/usr/bin` nextest; fmt --check; clippy -D warnings (tray feature); new real-git test files join nextest git-subprocess group (#821); file-size invariant.

--- a/SHADOW-OBSERVER-QUANT-2413.md
+++ b/SHADOW-OBSERVER-QUANT-2413.md
@@ -1,0 +1,144 @@
+# Shadow Observer — Quantification (#2413 Phase B, §5)
+
+**Question the operator asked (option A):** is the reducer's fused `ObservedStatus`
+measurably *cleaner* than the raw screen-scrape `agent_state` — enough to justify (or not)
+a later in-path proxy phase?
+
+**Answer: yes, decisively, on the headline failure case (mid-API false-idle), with real
+claude data.** The reducer also strictly beats the raw `api_in_flight` lsof signal. Zero
+false-active regressions. Details + numbers below.
+
+---
+
+## Setup (real claude, isolated, flag-ON, zero fleet impact)
+
+Mirrors the live-verify recipe (SHORT `AGEND_HOME=/tmp/svq`, `fleet.yaml` not `--agents`,
+`AGEND_SHADOW_OBSERVER=1`, daemon `start --foreground` = `run_core`). One real
+daemon-spawned claude agent (`sq`); the live fleet was never touched; `~/.claude` global
+stayed clean (hooks live only in the per-workspace `settings.local.json`). Binary =
+`feat/2413-shadow-local-plane-hooks` @ the driver commit. Default (bypass) claude — the
+false-idle case needs no permission prompt.
+
+**Instruments (two, cross-checked):**
+1. The handler's own §5 telemetry: an INFO `#shadow-observer` "shadow correction" line
+   each tick (~10 s) the fused state disagrees with the raw screen baseline.
+2. External polling: `agend list --json` every ~1.2 s, capturing
+   `(agent_state, api_in_flight, observed_status.state, observed_status.authority)` — the
+   fine-grained raw stream the 10 s telemetry can only sample coarsely.
+
+---
+
+## Result 1 — mid-API false-idle: **CAUGHT** (the headline win)
+
+Driving a real "think then run a tool" turn, claude spends ~20–30 s in a *thinking* phase
+(`UserPromptSubmit`/`TurnStarted` → first `PreToolUse`) with **no streamed output**.
+Claude's TUI shows nothing the screen-heuristic recognizes as work, so raw
+`agent_state` reads **`idle`** for the great majority of that phase — while a turn is
+plainly in flight.
+
+Poll trace excerpt (turn 2, "history of zero"; TurnStarted 05:51:50, ToolStarted 05:52:13):
+
+```
+time      raw_agent_state  api_in_flight  observed_status.state  authority
+05:51:55  idle             true           idle                   screen   ← pre-tick (stale)
+05:51:56  idle             true           thinking               hook     ← reducer corrects
+05:52:00  idle             true           thinking               hook
+05:52:05  idle             true           thinking               hook
+05:52:10  idle             true           thinking               hook
+05:52:14  thinking         true           thinking               hook
+05:52:20  idle             true           thinking               hook
+05:52:25  idle             true           thinking               hook
+05:52:26  idle             true           idle                   screen   ← turn closed, back to idle
+```
+
+During the thinking phase the raw screen-scrape read `idle` in **22 of 24** polled samples
+(~91 %), while the reducer reported **`Thinking`** (Active family) with **`Hook`**
+authority + **`Strong`** confidence for **100 %** of it. Note the reducer *derived*
+`Thinking` (turn open ∧ no tool span ∧ no approval ∧ productive-silence > 8 s) — not by
+string-matching a spinner — exactly the §3 design.
+
+**Reproducibility (3 real turns, handler-cadence INFO count):**
+
+| turn | prompt | thinking-phase len | corrections (INFO, 10 s tick) | post-turn observed |
+|------|--------|--------------------|-------------------------------|--------------------|
+| 1 | history of zero      | ~23 s | 2 | `idle` |
+| 2 | history of primes    | ~25 s | 2 | `idle` |
+| 3 | history of primes    | ~25 s | 2 | `idle` |
+| **Σ** | | | **6 corrections / 0 regressions** | always returns to `idle` |
+
+Every correction line was identical in shape:
+`raw_screen=idle observed=Thinking confidence=Strong authority=Hook api_in_flight=true`.
+
+(The handler-cadence count, 6, is the conservative metric — it samples the false-idle every
+10 s. By *duration*, the reducer eliminated essentially the entire ~23–25 s false-idle
+window of each turn.)
+
+---
+
+## Result 2 — no false-active regression, and the reducer beats raw `api_in_flight` too
+
+Throughout the whole run `api_in_flight` read **`true`** — *including when the agent was
+genuinely idle* between turns (a lingering / CDN-shared socket; the known Phase-1 lsof
+limitation). So **raw `api_in_flight` alone is a poor idle signal**: it would have called a
+resting agent "active".
+
+The reducer did **not** make that mistake. After every turn it returned to `idle` (authority
+`screen`, the hook episode closed by `TurnEnded` + `PromptReady`) despite `api_in_flight =
+true`. The §4 control held: **0 false-actives across all 3 turns**. The reducer is therefore
+strictly cleaner than *both* baselines it fuses — raw `agent_state` (false-idle) and raw
+`api_in_flight` (false-active).
+
+This is the liveness-backstop / precedence design paying off on real data: a fresh hook
+turn-close outranks a stale socket; a stale screen-idle is overridden by an open hook
+episode.
+
+---
+
+## Result 3 — approval-vs-idle: hook-proven + unit-tested; live count deferred
+
+The second screen-scrape failure case (a permission prompt mis-read as idle/ambiguous) is
+**not** separately quantified live here, by design choice:
+
+- For **claude specifically**, the screen-scrape already classifies `PermissionPrompt`
+  reasonably (observed in this very run at SessionStart), so it is not a clear screen
+  *miss* — the false-idle is the genuine claude win.
+- The reducer's `ApprovalRequired → WaitingForUser` mapping is proven by (a) Phase-A
+  **live** verification that the `ApprovalRequired` hook fires on a real claude permission
+  prompt, and (b) deterministic unit tests (`approval_then_proceed_clears_waiting`,
+  `correction_predicate_flags_false_idle_and_approval_not_steady`).
+- A live *count* would need a non-bypass claude + an un-allowlisted MCP-tool prompt (recipe
+  gotcha 3) — fragile setup whose marginal evidence is low given the above. Deferred, not
+  blocked.
+
+The reducer's added value at an approval even when the screen agrees: it attaches `Hook`
+authority + `Confidence` + an explicit `WaitingForUser` semantic (vs the screen's heuristic
+guess), which is what a consumer needs to *act* on the distinction.
+
+---
+
+## Verdict
+
+On real claude turns the fused `ObservedStatus` corrected a false-idle that raw
+screen-scrape got wrong **~91 % of every thinking-phase sample (6 handler-cadence
+corrections over 3 turns)**, with **0 false-active regressions**, and was simultaneously
+cleaner than the raw `api_in_flight` signal. The out-of-path reducer (hook + screen + lsof,
+zero in-path) is **measurably cleaner than screen-scrape** — the empirical basis the
+operator asked for before deciding on an in-path proxy.
+
+**HARD-STOP honored:** reducer + quantification only. No in-path proxy work. The in-path
+proxy decision is now an *informed* one — the local plane already removes the dominant
+false-idle error class without sitting in the request path.
+
+### Reproduce
+```
+ISO=/tmp/svq; rm -rf $ISO; mkdir -p $ISO
+printf 'instances:\n  sq:\n    backend: claude\n' > $ISO/fleet.yaml
+AGEND_HOME=$ISO AGEND_SHADOW_OBSERVER=1 RUST_LOG=info \
+  target/debug/agend-terminal start --foreground --fleet $ISO/fleet.yaml >$ISO/fg.log 2>&1 &
+AGEND_HOME=$ISO target/debug/agend-terminal inject sq \
+  "Carefully write ~300 words on the history of primes, then use the Bash tool to run: echo done"
+# headline metric:
+grep "shadow correction" $ISO/daemon.*.log
+# live raw-vs-observed during a turn:
+AGEND_HOME=$ISO target/debug/agend-terminal list --json | python3 -m json.tool
+```

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -817,13 +817,18 @@ fn build_command(config: &SpawnConfig) -> anyhow::Result<(CommandBuilder, Option
     // backend). Set AFTER env_clear (like AGEND_INSTANCE_NAME) so isolation can't drop
     // it; the hook subprocess inherits both vars from claude's env.
     if crate::daemon::shadow::enabled()
-        && detected_backend.as_ref().is_some_and(|b| b.has_state_hooks())
+        && detected_backend
+            .as_ref()
+            .is_some_and(|b| b.has_state_hooks())
     {
         if let Some(h) = *home {
             match crate::daemon::shadow::new_session_token() {
                 Ok(token) => {
                     crate::daemon::shadow::register(&token, name);
-                    cmd.env("AGENT_TERMINAL_SOCKET", crate::daemon::shadow::socket_path(h));
+                    cmd.env(
+                        "AGENT_TERMINAL_SOCKET",
+                        crate::daemon::shadow::socket_path(h),
+                    );
                     cmd.env("AGENT_TERMINAL_SESSION", &token);
                 }
                 Err(e) => tracing::warn!(

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -810,6 +810,30 @@ fn build_command(config: &SpawnConfig) -> anyhow::Result<(CommandBuilder, Option
         cmd.env("AGEND_HOME", h);
     }
 
+    // #2413 Shadow Observer — LOCAL plane (flag default-OFF via AGEND_SHADOW_OBSERVER).
+    // Inject a per-session unix-socket path + a freshly-minted 256-bit token scoped to
+    // THIS spawned claude, so its lifecycle hooks emit token-authenticated evidence to
+    // the daemon WITHOUT touching `~/.claude` global. claude-only (the hook-bearing
+    // backend). Set AFTER env_clear (like AGEND_INSTANCE_NAME) so isolation can't drop
+    // it; the hook subprocess inherits both vars from claude's env.
+    if crate::daemon::shadow::enabled()
+        && detected_backend.as_ref().is_some_and(|b| b.has_state_hooks())
+    {
+        if let Some(h) = *home {
+            match crate::daemon::shadow::new_session_token() {
+                Ok(token) => {
+                    crate::daemon::shadow::register(&token, name);
+                    cmd.env("AGENT_TERMINAL_SOCKET", crate::daemon::shadow::socket_path(h));
+                    cmd.env("AGENT_TERMINAL_SESSION", &token);
+                }
+                Err(e) => tracing::warn!(
+                    agent = %name, error = %e,
+                    "#shadow-observer: session token mint failed — local plane skipped for this spawn"
+                ),
+            }
+        }
+    }
+
     // Phase A Piece-3: GIT_EDITOR + friends = `true` (Unix no-op
     // binary that exits 0 without producing output). Prevents git
     // editor-needing operations from dropping the agent's PTY into

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -36,6 +36,14 @@ pub struct AgentCore {
     /// reconcile pattern-state against live LLM-socket activity (false-idle
     /// detection) WITHOUT clobbering `agent_state`. Default = no signal yet.
     pub(crate) api_activity: ApiActivity,
+    /// #2413 Phase B (Shadow Observer): the reducer's fused `ObservedStatus`
+    /// (hook-plane Evidence + the screen baseline + lsof liveness → one state
+    /// with confidence/authority + decay/liveness backstop). Purely ADDITIVE —
+    /// it NEVER rewrites `agent_state`; a consumer diffs the two under this same
+    /// `core.lock()` (that diff IS the quantification). `None` until the first
+    /// per-tick reduce under `AGEND_SHADOW_OBSERVER=1` (flag-OFF default ⇒ stays
+    /// `None`, zero behaviour change). Written by `per_tick::shadow_observe`.
+    pub(crate) observed_status: Option<crate::daemon::shadow::reducer::ObservedStatus>,
 }
 
 /// #2413 Phase 1: out-of-path "is this agent mid-LLM-call?" signal, derived by
@@ -1255,6 +1263,7 @@ pub fn spawn_agent(
         state: StateTracker::for_agent(detected_backend.as_ref(), name),
         health: HealthTracker::new(),
         api_activity: crate::agent::ApiActivity::default(),
+        observed_status: None,
     }));
 
     // #1441: resolve the single authoritative instance ID (same source as inbox),
@@ -1618,6 +1627,7 @@ pub fn spawn_ephemeral_worker(config: &SpawnConfig) -> anyhow::Result<EphemeralP
             state: StateTracker::for_agent(detected_backend.as_ref(), config.name),
             health: HealthTracker::new(),
             api_activity: crate::agent::ApiActivity::default(),
+            observed_status: None,
         }));
 
         let dismiss: Vec<(String, Vec<u8>)> = detected_backend
@@ -3102,6 +3112,7 @@ pub(crate) fn mk_test_handle(name: &str, id: crate::types::InstanceId) -> AgentH
         state: StateTracker::new(None),
         health: HealthTracker::new(),
         api_activity: crate::agent::ApiActivity::default(),
+        observed_status: None,
     }));
     let published_state = core.lock().state.published_handle();
     AgentHandle {

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -377,6 +377,7 @@ fn sweep_child_tree_body(pid_file: &std::path::Path) {
         state: StateTracker::new(None),
         health: HealthTracker::new(),
         api_activity: crate::agent::ApiActivity::default(),
+        observed_status: None,
     }));
     let agent_name = format!("sweep-test-{}", pid_file.display());
     let handle = AgentHandle {
@@ -985,6 +986,7 @@ fn write_to_agent_typed_uses_timeout() {
         state: StateTracker::new(None),
         health: HealthTracker::new(),
         api_activity: crate::agent::ApiActivity::default(),
+        observed_status: None,
     }));
     let published_state = core.lock().state.published_handle();
     let handle = AgentHandle {
@@ -1564,6 +1566,7 @@ fn readback_test_core(feed: &[u8]) -> Arc<CoreMutex<AgentCore>> {
         state: StateTracker::new(None),
         health: HealthTracker::new(),
         api_activity: crate::agent::ApiActivity::default(),
+        observed_status: None,
     }))
 }
 
@@ -1709,6 +1712,7 @@ fn pty_read_error_triggers_cleanup() {
         state: StateTracker::new(None),
         health: HealthTracker::new(),
         api_activity: crate::agent::ApiActivity::default(),
+        observed_status: None,
     }));
 
     let agent_name = "read-err-test";
@@ -1832,6 +1836,7 @@ fn make_crash_exit_handle(deleted: bool) -> (AgentHandle, crate::types::Instance
         state: StateTracker::new(None),
         health: HealthTracker::new(),
         api_activity: crate::agent::ApiActivity::default(),
+        observed_status: None,
     }));
     let mut cmd = portable_pty::CommandBuilder::new("sh");
     cmd.arg("-c");
@@ -2002,6 +2007,7 @@ fn run_pty_read_loop_for_r8(
         state: StateTracker::new(Some(&backend)),
         health: HealthTracker::new(),
         api_activity: crate::agent::ApiActivity::default(),
+        observed_status: None,
     }));
     let ctx = PtyReadContext {
         name: "r8-dismiss-test".to_string(),
@@ -2195,6 +2201,7 @@ fn mk_handle_1441(name: &str, id: crate::types::InstanceId) -> AgentHandle {
         state: StateTracker::new(None),
         health: HealthTracker::new(),
         api_activity: crate::agent::ApiActivity::default(),
+        observed_status: None,
     }));
     AgentHandle {
         id,

--- a/src/api/handlers/query.rs
+++ b/src/api/handlers/query.rs
@@ -29,6 +29,7 @@ pub(crate) fn handle_list(_params: &Value, ctx: &HandlerCtx) -> Value {
                 context,
                 api_in_flight,
                 last_api_activity_at,
+                observed_status,
             ) = {
                 let c = handle.core.lock();
                 (
@@ -48,6 +49,11 @@ pub(crate) fn handle_list(_params: &Value, ctx: &HandlerCtx) -> Value {
                     // atomically (false-idle = agent_state=="idle" && api_in_flight).
                     c.api_activity.in_flight,
                     c.api_activity.last_active_epoch_ms,
+                    // #2413 Phase B: the reducer's fused status, read under the SAME
+                    // lock as agent_state so a consumer can diff them atomically (the
+                    // observed-vs-raw diff IS the quantification). None unless the
+                    // per-tick reduce ran under AGEND_SHADOW_OBSERVER=1.
+                    c.observed_status.clone(),
                 )
             };
             let entry = json!({
@@ -65,6 +71,9 @@ pub(crate) fn handle_list(_params: &Value, ctx: &HandlerCtx) -> Value {
                 // api_in_flight=true while pattern-state is "idle" ⇒ false-idle.
                 "api_in_flight": api_in_flight,
                 "last_api_activity_at": last_api_activity_at,
+                // #2413 Phase B: additive reducer status (state/confidence/authority/
+                // evidence-trail/since_ms). null unless the Shadow Observer flag is on.
+                "observed_status": observed_status,
                 "kind": "managed",
             });
             (name, entry)

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -149,7 +149,13 @@ pub fn run(fleet_path_override: Option<&str>) -> Result<()> {
 /// Stage3 instead of silent-dropping (see `build_default_handlers`'
 /// `stage2_dispatch_available = false` below). All stages stay shadow-gated-off by
 /// default — zero behavior change unless an operator opts in.
-const APP_TICK_ALLOWLIST: &[&str] = &["snapshot_rotation", "thread_dump"];
+///
+/// #2413 Phase B: `shadow_observe` is allowlisted out of app mode ON PURPOSE — the
+/// hook-event socket server it consumes (`shadow::start`) is started ONLY in `run_core`,
+/// so the whole Shadow Observer plane is run_core-only (the isolated quantification
+/// daemon is `start --foreground` = run_core). Running the reducer in app mode would
+/// only ever fold empty buffers. It is flag-OFF by default regardless.
+const APP_TICK_ALLOWLIST: &[&str] = &["snapshot_rotation", "thread_dump", "shadow_observe"];
 
 /// Build the per-tick handler set app-standalone runs: the shared
 /// `build_default_handlers` minus `APP_TICK_ALLOWLIST`. Extracted so the

--- a/src/daemon/crash_respawn.rs
+++ b/src/daemon/crash_respawn.rs
@@ -474,6 +474,7 @@ mod deleted_gate_tests_1913 {
             state: crate::state::StateTracker::new(None),
             health: crate::health::HealthTracker::new(),
             api_activity: crate::agent::ApiActivity::default(),
+            observed_status: None,
         }));
         AgentHandle {
             id: InstanceId::parse(VICTIM_UUID).expect("uuid"),

--- a/src/daemon/lifecycle.rs
+++ b/src/daemon/lifecycle.rs
@@ -341,6 +341,7 @@ mod tests {
             state: crate::state::StateTracker::new(None),
             health: crate::health::HealthTracker::new(),
             api_activity: crate::agent::ApiActivity::default(),
+            observed_status: None,
         }));
         crate::agent::AgentHandle {
             id: crate::types::InstanceId::default(),

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -22,8 +22,6 @@ pub(crate) mod heartbeat_pair;
 pub(crate) mod helper_staleness_watchdog;
 pub mod hook_shadow;
 pub(crate) mod idle_watchdog;
-/// #2413 Shadow Observer — local plane (claude hooks side-channel). Spike, flag-OFF.
-pub mod shadow;
 pub(crate) mod inbox_stuck_watchdog;
 pub(crate) mod inject_delivery;
 pub(crate) mod lifecycle;
@@ -37,6 +35,8 @@ pub(crate) mod recovery_shadow;
 pub(crate) mod restart;
 pub(crate) mod retention;
 pub(crate) mod router;
+/// #2413 Shadow Observer — local plane (claude hooks side-channel). Spike, flag-OFF.
+pub mod shadow;
 pub(crate) mod supervisor;
 pub(crate) mod task_progress;
 pub(crate) mod task_sweep;

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -894,6 +894,10 @@ fn run_core(home: &Path, source: FleetSource) -> anyhow::Result<()> {
 
     let ctx = init_daemon_services(home, telegram_pre)?;
 
+    // #2413 Shadow Observer — local plane: start the unix-socket hook-event server
+    // (no-op unless AGEND_SHADOW_OBSERVER=1). Observe-only side-channel; never blocks.
+    crate::daemon::shadow::start(home);
+
     // #event-bus Step 2 (legacy-zero): register the per-pattern delivery
     // subscribers once (the bus is the SOLE delivery path). Shared with
     // `app::run_app` so owned `agend-terminal app` mode wires the IDENTICAL

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -777,6 +777,13 @@ pub(crate) fn build_default_handlers(
         // claimed/in_progress tasks back to Open + clears the work-stuck latch.
         // Runs in both run_core and app mode (live daemon is app-mode).
         Box::new(per_tick::ReclaimHandler::new(30, work_stuck_latch)),
+        // #2413 Phase B (Shadow Observer): per-tick reduce — fold each agent's buffered
+        // hook Evidence + screen baseline + lsof liveness into an additive
+        // `observed_status` (never rewrites `agent_state`). Flag-OFF default
+        // (`AGEND_SHADOW_OBSERVER=1`) ⇒ a single `enabled()` check then early-return, so
+        // this is a no-op for a default fleet. Daemon-only telemetry → allowlisted out of
+        // app mode (the hook socket server it consumes is started in `run_core`).
+        Box::new(per_tick::ShadowObserveHandler::new()),
     ]
 }
 

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -22,6 +22,8 @@ pub(crate) mod heartbeat_pair;
 pub(crate) mod helper_staleness_watchdog;
 pub mod hook_shadow;
 pub(crate) mod idle_watchdog;
+/// #2413 Shadow Observer — local plane (claude hooks side-channel). Spike, flag-OFF.
+pub mod shadow;
 pub(crate) mod inbox_stuck_watchdog;
 pub(crate) mod inject_delivery;
 pub(crate) mod lifecycle;

--- a/src/daemon/per_tick/mod.rs
+++ b/src/daemon/per_tick/mod.rs
@@ -54,6 +54,7 @@ pub(crate) mod progress_mirror;
 pub(crate) mod reclaim;
 pub(crate) mod reconcile_backups_gc;
 pub(crate) mod recovery_dispatcher;
+pub(crate) mod shadow_observe;
 pub(crate) mod snapshot;
 pub(crate) mod supervisor_trackers;
 pub(crate) mod thread_dump;
@@ -83,6 +84,7 @@ pub(crate) use progress_mirror::ProgressMirrorHandler;
 pub(crate) use reclaim::ReclaimHandler;
 pub(crate) use reconcile_backups_gc::ReconcileBackupsGcHandler;
 pub(crate) use recovery_dispatcher::RecoveryDispatcherHandler;
+pub(crate) use shadow_observe::ShadowObserveHandler;
 pub(crate) use snapshot::SnapshotRotationHandler;
 pub(crate) use supervisor_trackers::{
     AntiStallHandler, AutoReleaseHandler, CanonicalDriftHandler, ConflictNotifyHandler,
@@ -298,6 +300,7 @@ pub(crate) fn mock_live_agent_no_context(
         state: crate::state::StateTracker::new(None),
         health: crate::health::HealthTracker::new(),
         api_activity: crate::agent::ApiActivity::default(),
+        observed_status: None,
     }));
     let handle = crate::agent::AgentHandle {
         id: crate::types::InstanceId::default(),

--- a/src/daemon/per_tick/shadow_observe.rs
+++ b/src/daemon/per_tick/shadow_observe.rs
@@ -20,7 +20,7 @@
 use super::{PerTickHandler, TickContext};
 use crate::agent::AgentCore;
 use crate::daemon::shadow;
-use crate::daemon::shadow::reducer::{Liveness, ScreenSignal};
+use crate::daemon::shadow::reducer::{Liveness, ObservedState, ScreenSignal};
 use crate::state::AgentState;
 use crate::sync_audit::CoreMutex;
 use std::sync::Arc;
@@ -69,17 +69,18 @@ impl PerTickHandler for ShadowObserveHandler {
             // reduce (which takes the shadow buffer/runtime locks — DISJOINT from
             // core.lock, and no thread ever acquires core.lock while holding those, so
             // no ordering hazard), then write the result under a fresh brief lock.
-            let (screen, live) = {
+            let (raw_state, screen, live) = {
                 let c = core.lock();
-                let screen = screen_signal(c.state.get_state());
+                let raw_state = c.state.get_state();
                 let live = Liveness {
                     api_in_flight: c.api_activity.in_flight,
                     productive_silent_ms: c.state.productive_silence().as_millis() as u64,
                     child_alive: *child_alive,
                 };
-                (screen, live)
+                (raw_state, screen_signal(raw_state), live)
             };
             let status = shadow::observe(name, screen, &live, now_ms);
+            log_correction(name, raw_state, screen, &status, &live);
             core.lock().observed_status = Some(status);
         }
     }
@@ -112,6 +113,59 @@ fn screen_signal(s: AgentState) -> ScreenSignal {
         | AgentState::ApiError
         | AgentState::ModelUnsupported
         | AgentState::Crashed => ScreenSignal::Other,
+    }
+}
+
+/// The coarse [`ObservedState`] the raw screen-scrape ALONE would report — the baseline
+/// the reducer is measured against (§5 quantification). `None` for a non-decisive screen
+/// (`Other`), which the reducer never claims to "correct" (no meaningful baseline).
+fn screen_as_observed(screen: ScreenSignal) -> Option<ObservedState> {
+    match screen {
+        ScreenSignal::Idle => Some(ObservedState::Idle),
+        ScreenSignal::Working => Some(ObservedState::Active),
+        ScreenSignal::Approval => Some(ObservedState::WaitingForUser),
+        ScreenSignal::RateLimited => Some(ObservedState::RateLimited),
+        ScreenSignal::Other => None,
+    }
+}
+
+/// §5 quantification telemetry. When the fused `ObservedStatus` disagrees with what the
+/// raw screen-scrape ALONE would report, that's a CORRECTION — the reducer's whole value
+/// (e.g. screen renders `Idle` mid-request but a live hook episode + API socket prove
+/// `Active`; or screen looks `Idle`/ambiguous at a permission prompt but a hook
+/// `ApprovalRequired` proves `WaitingForUser`). Logged at INFO (the headline metric: grep
+/// `#shadow-observer` + "correction" to count false-idles caught / approval splits); the
+/// agreeing per-tick trace is DEBUG. Runs only under the flag ⇒ zero prod noise.
+fn log_correction(
+    name: &str,
+    raw_state: AgentState,
+    screen: ScreenSignal,
+    status: &crate::daemon::shadow::reducer::ObservedStatus,
+    live: &Liveness,
+) {
+    let Some(screen_state) = screen_as_observed(screen) else {
+        return; // non-decisive screen → no baseline to correct
+    };
+    if screen_state != status.state.coarse() {
+        tracing::info!(
+            tag = "#shadow-observer",
+            agent = %name,
+            raw_screen = %raw_state.display_name(),
+            observed = ?status.state,
+            confidence = ?status.confidence,
+            authority = ?status.authority,
+            api_in_flight = live.api_in_flight,
+            productive_silent_ms = live.productive_silent_ms,
+            "shadow correction: ObservedStatus overrides raw screen-scrape"
+        );
+    } else {
+        tracing::debug!(
+            tag = "#shadow-observer",
+            agent = %name,
+            raw_screen = %raw_state.display_name(),
+            observed = ?status.state,
+            "shadow tick: observed agrees with raw screen"
+        );
     }
 }
 
@@ -273,5 +327,58 @@ mod tests {
         assert_eq!(screen_signal(AgentState::Crashed), ScreenSignal::Other);
         assert_eq!(screen_signal(AgentState::GitConflict), ScreenSignal::Other);
         assert_eq!(screen_signal(AgentState::Hang), ScreenSignal::Other);
+    }
+
+    #[test]
+    fn screen_as_observed_baseline_buckets() {
+        assert_eq!(
+            screen_as_observed(ScreenSignal::Idle),
+            Some(ObservedState::Idle)
+        );
+        assert_eq!(
+            screen_as_observed(ScreenSignal::Working),
+            Some(ObservedState::Active)
+        );
+        assert_eq!(
+            screen_as_observed(ScreenSignal::Approval),
+            Some(ObservedState::WaitingForUser)
+        );
+        assert_eq!(
+            screen_as_observed(ScreenSignal::RateLimited),
+            Some(ObservedState::RateLimited)
+        );
+        // A non-decisive screen has no baseline the reducer can "correct".
+        assert_eq!(screen_as_observed(ScreenSignal::Other), None);
+    }
+
+    /// The §5 correction predicate, deterministically: the two headline wins the live
+    /// quantification counts. (a) mid-API false-idle — screen Idle but a fresh hook
+    /// episode + a live socket ⇒ Active ⇒ Idle≠Active ⇒ counts as a correction.
+    /// (b) approval-vs-idle — hook ApprovalRequired but screen reads Idle ⇒ WaitingForUser
+    /// ⇒ correction. (c) control — steady tool-use agrees with the screen ⇒ NOT a
+    /// correction (no false-active regression).
+    #[test]
+    fn correction_predicate_flags_false_idle_and_approval_not_steady() {
+        let is_correction = |screen: ScreenSignal, observed: ObservedState| {
+            screen_as_observed(screen).is_some_and(|b| b != observed.coarse())
+        };
+        // (a) false-idle caught.
+        assert!(is_correction(ScreenSignal::Idle, ObservedState::Active));
+        assert!(is_correction(ScreenSignal::Idle, ObservedState::ToolUse));
+        // (b) approval split out of idle.
+        assert!(is_correction(
+            ScreenSignal::Idle,
+            ObservedState::WaitingForUser
+        ));
+        // (c) steady states agree → no correction (no regression).
+        assert!(!is_correction(
+            ScreenSignal::Working,
+            ObservedState::ToolUse
+        ));
+        assert!(!is_correction(ScreenSignal::Idle, ObservedState::Idle));
+        assert!(!is_correction(
+            ScreenSignal::Approval,
+            ObservedState::WaitingForUser
+        ));
     }
 }

--- a/src/daemon/per_tick/shadow_observe.rs
+++ b/src/daemon/per_tick/shadow_observe.rs
@@ -1,0 +1,277 @@
+//! #2413 Shadow Observer — Phase B per-tick driver.
+//!
+//! The reducer ([`crate::daemon::shadow::reducer`]) is a pure state machine; this
+//! handler is the per-tick glue that feeds it. Each tick (when
+//! `AGEND_SHADOW_OBSERVER=1`) it, per managed agent:
+//!   1. snapshots the screen baseline (`agent_state` → [`ScreenSignal`]) + the cheap
+//!      out-of-path liveness ([`Liveness`]: `api_in_flight` / productive-silence /
+//!      child-alive) under one `core.lock()`;
+//!   2. folds the agent's buffered hook Evidence into its persistent reducer runtime
+//!      and derives an [`crate::daemon::shadow::reducer::ObservedStatus`]
+//!      ([`crate::daemon::shadow::observe`]);
+//!   3. hangs the result on `AgentCore.observed_status` — purely ADDITIVE, beside
+//!      `agent_state`, which it NEVER rewrites. `list_instances` serializes both under
+//!      one lock so a consumer can diff them (that diff IS the §5 quantification).
+//!
+//! Flag-OFF default ⇒ a single cheap `enabled()` check then early-return (zero work,
+//! zero behaviour change). The reduce reads ONLY the hook buffer + screen + lsof signal
+//! — zero in-path (SHADOW-OBSERVER-ARCH-2413.md invariants).
+
+use super::{PerTickHandler, TickContext};
+use crate::agent::AgentCore;
+use crate::daemon::shadow;
+use crate::daemon::shadow::reducer::{Liveness, ScreenSignal};
+use crate::state::AgentState;
+use crate::sync_audit::CoreMutex;
+use std::sync::Arc;
+
+/// Per-tick reduce driver. Stateless: the per-agent accumulators live in the shadow
+/// module's runtime registry (keyed by name, pruned on despawn), so nothing here needs
+/// interior mutability.
+pub(crate) struct ShadowObserveHandler;
+
+impl ShadowObserveHandler {
+    pub(crate) fn new() -> Self {
+        Self
+    }
+}
+
+impl PerTickHandler for ShadowObserveHandler {
+    fn name(&self) -> &'static str {
+        "shadow_observe"
+    }
+
+    fn run(&self, ctx: &TickContext<'_>) {
+        // Flag-OFF default: one env check then nothing. The hook socket server is also
+        // gated off, so the buffers are empty anyway.
+        if !shadow::enabled() {
+            return;
+        }
+        // Snapshot (name, core, child_alive) under a BRIEF registry lock, then release
+        // it before touching any per-agent core lock (never hold the registry lock
+        // across another lock — mirrors `api_activity_probe::probe_once`). child_alive
+        // is read here (its own `child.lock()`) so the reduce loop needs only core.lock.
+        let agents: Vec<(String, Arc<CoreMutex<AgentCore>>, bool)> = {
+            let reg = crate::agent::lock_registry(ctx.registry);
+            reg.values()
+                .map(|h| {
+                    let child_alive = h.child.lock().process_id().is_some();
+                    (h.name.to_string(), Arc::clone(&h.core), child_alive)
+                })
+                .collect()
+        };
+        if agents.is_empty() {
+            return;
+        }
+        let now_ms = chrono::Utc::now().timestamp_millis().max(0) as u64;
+        for (name, core, child_alive) in &agents {
+            // Read the screen + liveness inputs under one core.lock(), drop it, run the
+            // reduce (which takes the shadow buffer/runtime locks — DISJOINT from
+            // core.lock, and no thread ever acquires core.lock while holding those, so
+            // no ordering hazard), then write the result under a fresh brief lock.
+            let (screen, live) = {
+                let c = core.lock();
+                let screen = screen_signal(c.state.get_state());
+                let live = Liveness {
+                    api_in_flight: c.api_activity.in_flight,
+                    productive_silent_ms: c.state.productive_silence().as_millis() as u64,
+                    child_alive: *child_alive,
+                };
+                (screen, live)
+            };
+            let status = shadow::observe(name, screen, &live, now_ms);
+            core.lock().observed_status = Some(status);
+        }
+    }
+}
+
+/// Map the 18-variant screen-scrape [`AgentState`] into the reducer's coarse
+/// [`ScreenSignal`] buckets. Exhaustive (no wildcard) ON PURPOSE: a future `AgentState`
+/// variant forces a compile error here so the map can never silently miss a state.
+fn screen_signal(s: AgentState) -> ScreenSignal {
+    match s {
+        AgentState::Idle => ScreenSignal::Idle,
+        // Actively rendering work (incl. boot/respawn churn, treated as working).
+        AgentState::ToolUse
+        | AgentState::Thinking
+        | AgentState::Starting
+        | AgentState::Restarting => ScreenSignal::Working,
+        // A human gate.
+        AgentState::PermissionPrompt
+        | AgentState::InteractivePrompt
+        | AgentState::AwaitingOperator => ScreenSignal::Approval,
+        AgentState::RateLimit | AgentState::ServerRateLimit | AgentState::UsageLimit => {
+            ScreenSignal::RateLimited
+        }
+        // Non-decisive for the liveness reconcile (it only fires on `Idle`). A genuinely
+        // crashed agent is caught by `child_alive=false`, not by the screen chrome.
+        AgentState::Hang
+        | AgentState::GitConflict
+        | AgentState::ContextFull
+        | AgentState::AuthError
+        | AgentState::ApiError
+        | AgentState::ModelUnsupported
+        | AgentState::Crashed => ScreenSignal::Other,
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::agent::{AgentRegistry, ExternalRegistry};
+    use crate::daemon::shadow::evidence::{Evidence, EvidenceKind};
+    use crate::daemon::shadow::reducer::ObservedState;
+    use parking_lot::Mutex as PLMutex;
+    use serial_test::serial;
+    use std::collections::HashMap;
+
+    /// Set `AGEND_SHADOW_OBSERVER`, run a closure, then restore the prior value. Paired
+    /// with `#[serial(shadow_observer)]` so the process-global env flip can't leak into a
+    /// parallel test reading `shadow::enabled()`.
+    fn with_flag<T>(on: bool, f: impl FnOnce() -> T) -> T {
+        let prev = std::env::var("AGEND_SHADOW_OBSERVER").ok();
+        if on {
+            std::env::set_var("AGEND_SHADOW_OBSERVER", "1");
+        } else {
+            std::env::remove_var("AGEND_SHADOW_OBSERVER");
+        }
+        let out = f();
+        match prev {
+            Some(v) => std::env::set_var("AGEND_SHADOW_OBSERVER", v),
+            None => std::env::remove_var("AGEND_SHADOW_OBSERVER"),
+        }
+        out
+    }
+
+    /// Build a one-agent registry around a live mock agent (real `cat` child → its
+    /// `process_id()` is `Some`, so `child_alive=true`). Returns the kept-alive PTY
+    /// reader the caller must not drop, and the agent's name + core for assertions.
+    fn one_agent_registry(
+        name: &str,
+    ) -> (
+        AgentRegistry,
+        Arc<CoreMutex<AgentCore>>,
+        String,
+        Box<dyn std::io::Read + Send>,
+    ) {
+        let (handle, reader) = super::super::mock_live_agent_no_context(name);
+        let core = Arc::clone(&handle.core);
+        let agent_name = handle.name.to_string();
+        let registry: AgentRegistry = Arc::new(PLMutex::new(HashMap::new()));
+        registry.lock().insert(handle.id, handle);
+        (registry, core, agent_name, reader)
+    }
+
+    fn ctx_for<'a>(
+        home: &'a std::path::Path,
+        registry: &'a AgentRegistry,
+        externals: &'a ExternalRegistry,
+        configs: &'a Arc<PLMutex<HashMap<String, crate::daemon::AgentConfig>>>,
+    ) -> TickContext<'a> {
+        TickContext {
+            home,
+            registry,
+            externals,
+            configs,
+        }
+    }
+
+    /// Prod wiring, flag-ON: a buffered `TurnStarted` (episode open) + a live child ⇒ the
+    /// handler writes `observed_status` = an Active-family state beside `agent_state`.
+    /// This is the regression pin that the per-tick reduce actually runs in prod (not
+    /// just the pure reducer unit tests).
+    #[test]
+    #[serial(shadow_observer)]
+    fn flag_on_reduce_writes_observed_status() {
+        let home = std::env::temp_dir();
+        let externals: ExternalRegistry = Arc::new(PLMutex::new(HashMap::new()));
+        let configs = Arc::new(PLMutex::new(HashMap::new()));
+        let (registry, core, name, _reader) = one_agent_registry("shadow-drv-on");
+
+        let token = shadow::new_session_token().unwrap();
+        shadow::register(&token, &name);
+        shadow::push(
+            &name,
+            Evidence::hook(
+                EvidenceKind::TurnStarted,
+                chrono::Utc::now().timestamp_millis().max(0) as u64,
+            ),
+        );
+
+        with_flag(true, || {
+            let ctx = ctx_for(&home, &registry, &externals, &configs);
+            ShadowObserveHandler::new().run(&ctx);
+        });
+
+        let status = core.lock().observed_status.clone();
+        let status = status.expect("flag-ON ⇒ reduce ran ⇒ observed_status set");
+        assert_ne!(
+            status.state,
+            ObservedState::Idle,
+            "an open episode + a live child ⇒ Active family, not Idle"
+        );
+        shadow::forget_agent(&name);
+    }
+
+    /// Flag-OFF default: the handler early-returns, so `observed_status` stays `None`
+    /// (zero behaviour change for the default fleet). Pins that the flag actually gates.
+    #[test]
+    #[serial(shadow_observer)]
+    fn flag_off_leaves_observed_status_none() {
+        let home = std::env::temp_dir();
+        let externals: ExternalRegistry = Arc::new(PLMutex::new(HashMap::new()));
+        let configs = Arc::new(PLMutex::new(HashMap::new()));
+        let (registry, core, name, _reader) = one_agent_registry("shadow-drv-off");
+
+        let token = shadow::new_session_token().unwrap();
+        shadow::register(&token, &name);
+        shadow::push(&name, Evidence::hook(EvidenceKind::TurnStarted, 1_000));
+
+        with_flag(false, || {
+            let ctx = ctx_for(&home, &registry, &externals, &configs);
+            ShadowObserveHandler::new().run(&ctx);
+        });
+
+        assert!(
+            core.lock().observed_status.is_none(),
+            "flag-OFF ⇒ no reduce ⇒ observed_status stays None"
+        );
+        shadow::forget_agent(&name);
+    }
+
+    #[test]
+    fn screen_signal_maps_every_bucket() {
+        assert_eq!(screen_signal(AgentState::Idle), ScreenSignal::Idle);
+        assert_eq!(screen_signal(AgentState::ToolUse), ScreenSignal::Working);
+        assert_eq!(screen_signal(AgentState::Thinking), ScreenSignal::Working);
+        assert_eq!(screen_signal(AgentState::Starting), ScreenSignal::Working);
+        assert_eq!(
+            screen_signal(AgentState::PermissionPrompt),
+            ScreenSignal::Approval
+        );
+        assert_eq!(
+            screen_signal(AgentState::InteractivePrompt),
+            ScreenSignal::Approval
+        );
+        assert_eq!(
+            screen_signal(AgentState::AwaitingOperator),
+            ScreenSignal::Approval
+        );
+        assert_eq!(
+            screen_signal(AgentState::RateLimit),
+            ScreenSignal::RateLimited
+        );
+        assert_eq!(
+            screen_signal(AgentState::ServerRateLimit),
+            ScreenSignal::RateLimited
+        );
+        assert_eq!(
+            screen_signal(AgentState::UsageLimit),
+            ScreenSignal::RateLimited
+        );
+        assert_eq!(screen_signal(AgentState::Crashed), ScreenSignal::Other);
+        assert_eq!(screen_signal(AgentState::GitConflict), ScreenSignal::Other);
+        assert_eq!(screen_signal(AgentState::Hang), ScreenSignal::Other);
+    }
+}

--- a/src/daemon/poll_reminder.rs
+++ b/src/daemon/poll_reminder.rs
@@ -275,6 +275,7 @@ mod tests {
             state: st,
             health: crate::health::HealthTracker::new(),
             api_activity: crate::agent::ApiActivity::default(),
+            observed_status: None,
         };
         let core = Arc::new(crate::sync_audit::CoreMutex::new(core));
         let published_state = core.lock().state.published_handle();

--- a/src/daemon/shadow/evidence.rs
+++ b/src/daemon/shadow/evidence.rs
@@ -145,13 +145,17 @@ pub fn evidence_kind_for_hook(
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 
     #[test]
     fn hook_to_evidence_mapping_covers_the_contract() {
         let m = |e, n, t| evidence_kind_for_hook(e, n, t);
-        assert_eq!(m("UserPromptSubmit", None, None), Some(EvidenceKind::TurnStarted));
+        assert_eq!(
+            m("UserPromptSubmit", None, None),
+            Some(EvidenceKind::TurnStarted)
+        );
         assert_eq!(
             m("PreToolUse", None, Some("Bash")),
             Some(EvidenceKind::ToolStarted {
@@ -181,7 +185,10 @@ mod tests {
                 stop_reason: Some("failure".to_string())
             })
         );
-        assert_eq!(m("SessionEnd", None, None), Some(EvidenceKind::SessionExited));
+        assert_eq!(
+            m("SessionEnd", None, None),
+            Some(EvidenceKind::SessionExited)
+        );
         // Non-transition hooks + unknown notification → no evidence.
         assert_eq!(m("SessionStart", None, None), None);
         assert_eq!(m("PreCompact", None, None), None);

--- a/src/daemon/shadow/evidence.rs
+++ b/src/daemon/shadow/evidence.rs
@@ -1,0 +1,213 @@
+//! #2413 Shadow Observer — the shared **Evidence** contract.
+//!
+//! An observation plane (this is the LOCAL plane: claude lifecycle hooks) never
+//! intervenes; it emits typed `Evidence` into a per-agent buffer, tagged with the
+//! `authority` (how the truth was learned) and a `confidence`. A later reducer
+//! (Phase B, OUT OF SCOPE for this spike) consumes the buffer and normalizes it to
+//! an `ObservedStatus`.
+//!
+//! This type is SHARED with the API/proxy plane (fixup-dev-2). Keep the serde shape
+//! stable: both planes serialize/deserialize `Evidence` across the wire and into the
+//! buffer.
+
+use serde::{Deserialize, Serialize};
+
+/// One typed observation from a plane. `authority`/`confidence` let a consumer tell a
+/// `Confirmed` `Hook` turn-end apart from a `Weak` `Screen` guess.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Evidence {
+    /// Flattened so the internally-tagged `EvidenceKind` merges INTO the `Evidence`
+    /// object (`{"kind":"turn_ended","stop_reason":…,"authority":"hook",…}`) — the
+    /// shared wire shape both planes agreed on, not a nested `kind.kind`.
+    #[serde(flatten)]
+    pub kind: EvidenceKind,
+    pub authority: Authority,
+    pub confidence: Confidence,
+    /// Capture time, epoch ms.
+    pub at_ms: u64,
+    /// Decay budget in ms; `0` = no expiry hint (the reducer decides). The reducer
+    /// (Phase B) uses this to age stale evidence so a dropped terminal event can't
+    /// wedge a phantom state.
+    pub ttl_ms: u64,
+}
+
+/// The normalized observation kinds. `#[serde(tag = "kind")]` → an internally-tagged
+/// JSON object, e.g. `{"kind":"tool_started","name":"Bash"}`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum EvidenceKind {
+    /// A turn began (claude `UserPromptSubmit`).
+    TurnStarted,
+    /// Assistant tokens are streaming (Stream plane; the Hook plane does not emit it).
+    Responding,
+    /// A turn ended (claude `Stop` / `StopFailure`).
+    TurnEnded { stop_reason: Option<String> },
+    /// A tool invocation began (claude `PreToolUse`).
+    ToolStarted { name: Option<String> },
+    /// A tool invocation ended (claude `PostToolUse`).
+    ToolEnded,
+    /// The agent is blocked awaiting an approval/permission decision.
+    ApprovalRequired,
+    /// Rate-limited. `retry_at_ms` is an ABSOLUTE epoch-ms instant (NOT a duration —
+    /// the API plane converts the Anthropic `retry-after` delta/HTTP-date to absolute,
+    /// per cross-plane agreement). NOTE: claude hooks are BLIND to rate-limiting (it is
+    /// the API plane's signal); the local plane never emits this — kept in the shared
+    /// contract so the API plane can.
+    RateLimited { retry_at_ms: Option<u64> },
+    /// Token accounting for a turn (API plane).
+    TokenUsage { input: u64, output: u64 },
+    /// The agent is idle at a ready prompt (claude `Notification{idle_prompt}`).
+    PromptReady,
+    /// The session ended (claude `SessionEnd`).
+    SessionExited,
+}
+
+/// HOW the evidence was learned — drives per-transition precedence in the reducer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Authority {
+    /// Backend lifecycle hook (this plane). The strongest local-truth source.
+    Hook,
+    /// A structured event stream (SSE / app-server / proxy — API plane).
+    Stream,
+    /// A session transcript / event-log tail.
+    Transcript,
+    /// The VISUAL plane: semantic detection over the shadow screen.
+    Screen,
+    /// Process-tree liveness (pgrep / proc children).
+    ProcessHeuristic,
+    /// Derived by the reducer from other evidence (e.g. Thinking).
+    Inferred,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Confidence {
+    Confirmed,
+    Strong,
+    Probable,
+    Weak,
+}
+
+impl Evidence {
+    /// A `Hook`-authority, `Confirmed` observation stamped now. The local plane's
+    /// only constructor — every hook event is a confirmed local truth.
+    pub fn hook(kind: EvidenceKind, at_ms: u64) -> Self {
+        Self {
+            kind,
+            authority: Authority::Hook,
+            confidence: Confidence::Confirmed,
+            at_ms,
+            // Hook events are confirmed point-in-time facts; the reducer owns decay,
+            // so the local plane leaves the hint at 0 (no local expiry opinion).
+            ttl_ms: 0,
+        }
+    }
+}
+
+/// Map a claude lifecycle hook to the `EvidenceKind` it evidences, or `None` for a
+/// hook that is not a state transition (`SessionStart`, `PreCompact`). The claude
+/// hook event semantics:
+/// - `UserPromptSubmit` → a turn started.
+/// - `PreToolUse` (carries `tool_name`) / `PostToolUse` → tool start / end.
+/// - `PermissionRequest`, or `Notification` with `permission_prompt` → awaiting approval.
+/// - `Notification` with `idle_prompt` → idle at a ready prompt.
+/// - `Stop` → turn ended; `StopFailure` → turn ended in failure.
+/// - `SessionEnd` → session exited.
+///
+/// Rate-limit is deliberately absent: claude hooks do not fire for it (the API plane
+/// owns `RateLimited`).
+pub fn evidence_kind_for_hook(
+    hook_event_name: &str,
+    notification_type: Option<&str>,
+    tool_name: Option<&str>,
+) -> Option<EvidenceKind> {
+    Some(match hook_event_name {
+        "UserPromptSubmit" => EvidenceKind::TurnStarted,
+        "PreToolUse" => EvidenceKind::ToolStarted {
+            name: tool_name.map(str::to_string),
+        },
+        "PostToolUse" => EvidenceKind::ToolEnded,
+        "PermissionRequest" => EvidenceKind::ApprovalRequired,
+        "Notification" => match notification_type {
+            Some("permission_prompt") => EvidenceKind::ApprovalRequired,
+            Some("idle_prompt") => EvidenceKind::PromptReady,
+            _ => return None,
+        },
+        "Stop" => EvidenceKind::TurnEnded { stop_reason: None },
+        "StopFailure" => EvidenceKind::TurnEnded {
+            stop_reason: Some("failure".to_string()),
+        },
+        "SessionEnd" => EvidenceKind::SessionExited,
+        // SessionStart / PreCompact carry no state transition.
+        _ => return None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hook_to_evidence_mapping_covers_the_contract() {
+        let m = |e, n, t| evidence_kind_for_hook(e, n, t);
+        assert_eq!(m("UserPromptSubmit", None, None), Some(EvidenceKind::TurnStarted));
+        assert_eq!(
+            m("PreToolUse", None, Some("Bash")),
+            Some(EvidenceKind::ToolStarted {
+                name: Some("Bash".to_string())
+            })
+        );
+        assert_eq!(m("PostToolUse", None, None), Some(EvidenceKind::ToolEnded));
+        assert_eq!(
+            m("PermissionRequest", None, None),
+            Some(EvidenceKind::ApprovalRequired)
+        );
+        assert_eq!(
+            m("Notification", Some("permission_prompt"), None),
+            Some(EvidenceKind::ApprovalRequired)
+        );
+        assert_eq!(
+            m("Notification", Some("idle_prompt"), None),
+            Some(EvidenceKind::PromptReady)
+        );
+        assert_eq!(
+            m("Stop", None, None),
+            Some(EvidenceKind::TurnEnded { stop_reason: None })
+        );
+        assert_eq!(
+            m("StopFailure", None, None),
+            Some(EvidenceKind::TurnEnded {
+                stop_reason: Some("failure".to_string())
+            })
+        );
+        assert_eq!(m("SessionEnd", None, None), Some(EvidenceKind::SessionExited));
+        // Non-transition hooks + unknown notification → no evidence.
+        assert_eq!(m("SessionStart", None, None), None);
+        assert_eq!(m("PreCompact", None, None), None);
+        assert_eq!(m("Notification", Some("other"), None), None);
+        // Rate-limit is never hook-sourced.
+        assert!(!matches!(
+            m("Stop", None, None),
+            Some(EvidenceKind::RateLimited { .. })
+        ));
+    }
+
+    #[test]
+    fn evidence_serde_is_internally_tagged_snake_case() {
+        let ev = Evidence::hook(
+            EvidenceKind::ToolStarted {
+                name: Some("Read".to_string()),
+            },
+            1_000,
+        );
+        let j = serde_json::to_value(&ev).expect("serialize");
+        assert_eq!(j["kind"], "tool_started");
+        assert_eq!(j["name"], "Read");
+        assert_eq!(j["authority"], "hook");
+        assert_eq!(j["confidence"], "confirmed");
+        // round-trips
+        let back: Evidence = serde_json::from_value(j).expect("deserialize");
+        assert_eq!(back, ev);
+    }
+}

--- a/src/daemon/shadow/evidence.rs
+++ b/src/daemon/shadow/evidence.rs
@@ -91,7 +91,11 @@ pub enum Confidence {
 
 impl Evidence {
     /// A `Hook`-authority, `Confirmed` observation stamped now. The local plane's
-    /// only constructor — every hook event is a confirmed local truth.
+    /// only constructor — every hook event is a confirmed local truth. #2433: its only
+    /// PROD caller is the unix socket-ingest path, so it is dead on non-unix prod;
+    /// `any(unix, test)` keeps it for unix prod + EVERY test build (the platform-agnostic
+    /// reducer tests construct hook Evidence to drive the state machine).
+    #[cfg(any(unix, test))]
     pub fn hook(kind: EvidenceKind, at_ms: u64) -> Self {
         Self {
             kind,
@@ -117,6 +121,10 @@ impl Evidence {
 ///
 /// Rate-limit is deliberately absent: claude hooks do not fire for it (the API plane
 /// owns `RateLimited`).
+///
+/// #2433: only the unix socket-ingest path (+ the mapping's own tests) calls this, so it
+/// is gated like the rest of the hook-ingestion plumbing (dead on non-unix prod).
+#[cfg(any(unix, test))]
 pub fn evidence_kind_for_hook(
     hook_event_name: &str,
     notification_type: Option<&str>,

--- a/src/daemon/shadow/mod.rs
+++ b/src/daemon/shadow/mod.rs
@@ -107,7 +107,9 @@ pub fn push(agent: &str, ev: Evidence) {
 }
 
 /// Drain (remove + return, oldest-first) all evidence for `agent` — the reducer's
-/// consume path (Phase B).
+/// consume path (Phase B). Deferred consumer: the Phase-B reducer is OUT OF SCOPE for
+/// this spike, so nothing in prod drains yet (tests do); kept as the buffer's contract.
+#[allow(dead_code)]
 pub fn drain(agent: &str) -> Vec<Evidence> {
     let mut b = buffer().lock();
     b.get_mut(agent)
@@ -115,7 +117,9 @@ pub fn drain(agent: &str) -> Vec<Evidence> {
         .unwrap_or_default()
 }
 
-/// Non-destructive snapshot (oldest-first) — for samples / debug / tests.
+/// Non-destructive snapshot (oldest-first) — for samples / debug / tests. Deferred
+/// consumer (debug/sample surface) like [`drain`]; not yet read in prod this spike.
+#[allow(dead_code)]
 pub fn peek(agent: &str) -> Vec<Evidence> {
     buffer()
         .lock()
@@ -164,14 +168,28 @@ pub fn ingest_frame(frame: &ShadowFrame) -> Option<(String, Evidence)> {
     Some((agent, ev))
 }
 
-/// Start the unix-socket event server (one accept loop on a daemon thread). Removes a
-/// stale socket file first, binds, and processes one JSON frame per connection. No-op
-/// unless [`enabled`]. Errors are logged, never fatal — the observer must never wedge
-/// the daemon.
+/// Start the unix-socket event server (one accept loop on a daemon thread). No-op
+/// unless [`enabled`]. The unix-socket transport is the only platform-specific part;
+/// everything above (token/buffer/mapping) is cross-platform. The fleet runs on
+/// macOS/Linux, so Windows is a logged no-op (the flag is OFF there anyway).
 pub fn start(home: &Path) {
     if !enabled() {
         return;
     }
+    #[cfg(unix)]
+    start_unix(home);
+    #[cfg(not(unix))]
+    {
+        let _ = home;
+        tracing::info!(tag = "#shadow-observer",
+            "unix-socket event server unavailable on this platform — local plane disabled");
+    }
+}
+
+/// Removes a stale socket, binds, and processes one JSON frame per connection. Errors
+/// are logged, never fatal — the observer must never wedge the daemon.
+#[cfg(unix)]
+fn start_unix(home: &Path) {
     let path = socket_path(home);
     let _ = std::fs::remove_file(&path); // clear a stale socket from a prior run
     let listener = match std::os::unix::net::UnixListener::bind(&path) {
@@ -201,6 +219,7 @@ pub fn start(home: &Path) {
         .ok();
 }
 
+#[cfg(unix)]
 fn handle_conn(stream: std::os::unix::net::UnixStream) {
     use std::io::{BufRead, BufReader, Read};
     // One small JSON frame per connection. Bound the read (`Read::take` on the stream,

--- a/src/daemon/shadow/mod.rs
+++ b/src/daemon/shadow/mod.rs
@@ -17,6 +17,7 @@
 //! reducer. `flag default OFF` via `AGEND_SHADOW_OBSERVER=1`.
 
 pub mod evidence;
+pub mod reducer;
 
 use evidence::{evidence_kind_for_hook, Evidence};
 use parking_lot::Mutex;

--- a/src/daemon/shadow/mod.rs
+++ b/src/daemon/shadow/mod.rs
@@ -19,8 +19,14 @@
 pub mod evidence;
 pub mod reducer;
 
-use evidence::{evidence_kind_for_hook, Evidence};
+use evidence::Evidence;
+// #2433: only the unix-gated ingest path uses these — gate the imports to match so they
+// aren't unused on a non-unix prod build (`evidence_kind_for_hook` feeds `ingest_frame`;
+// serde derives only `ShadowFrame`, the wire frame).
+#[cfg(any(unix, test))]
+use evidence::evidence_kind_for_hook;
 use parking_lot::Mutex;
+#[cfg(any(unix, test))]
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, VecDeque};
 use std::path::{Path, PathBuf};
@@ -29,10 +35,17 @@ use std::sync::OnceLock;
 /// Per-agent evidence buffer cap — drop-oldest beyond this. A spike bound; the
 /// reducer drains far faster than hooks fire, so this only guards a never-drained
 /// agent from unbounded growth.
+// #2433: the whole hook-INGESTION plane (socket frame → buffer push) feeds the
+// `#[cfg(unix)]` AF_UNIX server, so on a non-unix PROD build it is unreachable and would
+// trip `-D warnings` dead_code. `any(unix, test)` keeps it for unix prod + EVERY test
+// build (the platform-independent reducer/evidence tests construct hook Evidence), while
+// dropping it from non-unix prod. The reducer/driver/buffer-drain are platform-agnostic.
+#[cfg(any(unix, test))]
 const BUFFER_CAP: usize = 256;
 
 /// One wire frame the hook emit writes to the socket (a single JSON line). Mirrors
 /// the existing `hook-event` payload fields + the session token.
+#[cfg(any(unix, test))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ShadowFrame {
     /// Per-session 256-bit token (hex) — proves the frame came from THIS spawned
@@ -80,6 +93,9 @@ pub fn register(token: &str, agent: &str) {
 }
 
 /// Resolve a frame's token to its agent name, or `None` if unknown (forged / stale).
+/// #2433: only the unix socket-ingest path (+ tests) resolves; gate it like the rest of
+/// the ingestion plumbing so it isn't dead on non-unix prod.
+#[cfg(any(unix, test))]
 pub fn resolve(token: &str) -> Option<String> {
     tokens().lock().get(token).cloned()
 }
@@ -102,7 +118,10 @@ fn buffer() -> &'static Mutex<HashMap<String, VecDeque<Evidence>>> {
     B.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
-/// Append one observation for `agent`, bounded drop-oldest at [`BUFFER_CAP`].
+/// Append one observation for `agent`, bounded drop-oldest at [`BUFFER_CAP`]. #2433:
+/// only the unix ingest path (+ tests) PUSHES; on non-unix prod the buffer is only ever
+/// drained (empty) by the platform-agnostic reducer, so this is gated like the plumbing.
+#[cfg(any(unix, test))]
 pub fn push(agent: &str, ev: Evidence) {
     let mut b = buffer().lock();
     let q = b.entry(agent.to_string()).or_default();
@@ -164,6 +183,7 @@ pub fn observe(
     rt.observe(screen, live, now_ms)
 }
 
+#[cfg(any(unix, test))]
 fn now_ms() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -174,7 +194,9 @@ fn now_ms() -> u64 {
 /// Ingest one frame: validate its token → resolve agent, map the hook → [`Evidence`],
 /// push it, and return `(agent, evidence)` for logging/tests. `None` when the token is
 /// unknown (rejected — anti-spoof) or the hook carries no state transition. Pure w.r.t.
-/// the socket so the round-trip is unit-testable without a real connection.
+/// the socket so the round-trip is unit-testable without a real connection. #2433: gated
+/// like the rest of the ingestion plumbing (its only prod caller is the unix socket).
+#[cfg(any(unix, test))]
 pub fn ingest_frame(frame: &ShadowFrame) -> Option<(String, Evidence)> {
     let agent = match resolve(&frame.token) {
         Some(a) => a,
@@ -257,11 +279,23 @@ fn start_unix(home: &Path) {
         .ok();
 }
 
+/// Per-connection read deadline for the hook-event socket. The accept loop processes
+/// connections SEQUENTIALLY, so without a wall-clock bound a single client that connects
+/// and then never sends a newline would block `read_line` indefinitely and PIN the loop —
+/// starving all subsequent hook delivery (#2433 r6). A starved hook plane in turn makes
+/// the dropped-terminal-hook phantom-stick MORE likely. Generous (a real hook writes one
+/// line + closes in well under a ms); the bound only guards the wedged-client failure mode.
+#[cfg(unix)]
+const SOCKET_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+
 #[cfg(unix)]
 fn handle_conn(stream: std::os::unix::net::UnixStream) {
     use std::io::{BufRead, BufReader, Read};
-    // One small JSON frame per connection. Bound the read (`Read::take` on the stream,
-    // then buffer it) so a wedged client can't pin the accept loop.
+    // One small JSON frame per connection, with TWO independent bounds so a wedged client
+    // can never pin the (sequential) accept loop: a wall-clock read deadline
+    // (`set_read_timeout` — a client that connects but never sends a newline) AND a byte
+    // cap (`Read::take` — a client that floods bytes without a newline). #2433 r6.
+    let _ = stream.set_read_timeout(Some(SOCKET_READ_TIMEOUT));
     let mut line = String::new();
     let mut reader = BufReader::new(stream.take(64 * 1024));
     if reader.read_line(&mut line).is_err() || line.trim().is_empty() {
@@ -279,7 +313,10 @@ fn handle_conn(stream: std::os::unix::net::UnixStream) {
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
-    use super::evidence::{Authority, EvidenceKind};
+    // `Authority` is referenced only by the `#[cfg(unix)]` socket tests, so importing it
+    // unconditionally would be an unused-import error on a non-unix test build (#2433) —
+    // those tests qualify it inline (`super::evidence::Authority`) instead.
+    use super::evidence::EvidenceKind;
     use super::*;
     use serial_test::serial;
 
@@ -322,13 +359,66 @@ mod tests {
             "frame delivered over the real socket → 1 evidence"
         );
         assert_eq!(evidence[0].kind, EvidenceKind::TurnStarted);
-        assert_eq!(evidence[0].authority, Authority::Hook);
+        assert_eq!(evidence[0].authority, super::evidence::Authority::Hook);
         assert_eq!(
             evidence[0].confidence,
             super::evidence::Confidence::Confirmed
         );
         drain("shadow-sock-agent");
         forget_agent("shadow-sock-agent");
+        let _ = std::fs::remove_file(&sock);
+    }
+
+    /// #2433 r6 (②): a client that connects but NEVER sends a newline must not pin the
+    /// (sequential) accept loop forever — the per-conn read deadline unblocks it, and the
+    /// loop goes on to ingest the next real frame. Without `set_read_timeout`, the first
+    /// `handle_conn` blocks indefinitely and this test hangs (caught as a nextest
+    /// slow-timeout). Takes ~`SOCKET_READ_TIMEOUT` by design.
+    #[cfg(unix)]
+    #[test]
+    #[serial(shadow_observer)]
+    fn handle_conn_read_deadline_unblocks_a_silent_client() {
+        use std::io::Write;
+        use std::os::unix::net::{UnixListener, UnixStream};
+        let token = new_session_token().unwrap();
+        register(&token, "shadow-deadline-agent");
+        let dir =
+            std::env::temp_dir().join(format!("agend_shadow_deadline_{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&dir);
+        let sock = dir.join("shadow-events.sock");
+        let _ = std::fs::remove_file(&sock);
+        let listener = UnixListener::bind(&sock).expect("bind");
+        // Server: first conn is SILENT (must return via the deadline, not hang), then the
+        // second conn carries a real frame (must still ingest — proves the loop recovered).
+        let server = std::thread::spawn(move || {
+            if let Ok((s, _)) = listener.accept() {
+                handle_conn(s);
+            }
+            if let Ok((s, _)) = listener.accept() {
+                handle_conn(s);
+            }
+        });
+        // Silent client connects FIRST (accepted first) and writes nothing; held open
+        // across the deadline so the first `handle_conn` truly never sees a newline.
+        let silent = UnixStream::connect(&sock).expect("connect silent");
+        // Real client queued behind it; its bytes wait in the socket until the loop
+        // recovers from the silent conn and accepts again.
+        let mut real = UnixStream::connect(&sock).expect("connect real");
+        let frame = serde_json::json!({"token": token, "hook_event_name": "UserPromptSubmit"});
+        real.write_all(format!("{frame}\n").as_bytes())
+            .expect("write real frame");
+        drop(real);
+        server.join().unwrap();
+        drop(silent);
+        let evidence = peek("shadow-deadline-agent");
+        assert_eq!(
+            evidence.len(),
+            1,
+            "loop recovered from the silent client and ingested the real frame"
+        );
+        assert_eq!(evidence[0].kind, EvidenceKind::TurnStarted);
+        drain("shadow-deadline-agent");
+        forget_agent("shadow-deadline-agent");
         let _ = std::fs::remove_file(&sock);
     }
 

--- a/src/daemon/shadow/mod.rs
+++ b/src/daemon/shadow/mod.rs
@@ -85,9 +85,14 @@ pub fn resolve(token: &str) -> Option<String> {
 }
 
 /// Drop an agent's token(s) on despawn/delete so the registry doesn't grow across
-/// churn and a recycled name can't inherit a dead session's binding.
+/// churn and a recycled name can't inherit a dead session's binding. Also clears
+/// the per-agent Evidence buffer + reducer runtime so a same-name respawn starts
+/// CLEAN (no inherited open episode / stale evidence) — the despawn hook is the
+/// lifecycle point that keeps the name-keyed reducer state honest.
 pub fn forget_agent(agent: &str) {
     tokens().lock().retain(|_, a| a != agent);
+    buffer().lock().remove(agent);
+    runtimes().lock().remove(agent);
 }
 
 // ── per-agent evidence buffer ────────────────────────────────────────────────────
@@ -108,9 +113,8 @@ pub fn push(agent: &str, ev: Evidence) {
 }
 
 /// Drain (remove + return, oldest-first) all evidence for `agent` — the reducer's
-/// consume path (Phase B). Deferred consumer: the Phase-B reducer is OUT OF SCOPE for
-/// this spike, so nothing in prod drains yet (tests do); kept as the buffer's contract.
-#[allow(dead_code)]
+/// consume path (Phase B). Consumed by [`observe`] (the per-tick driver folds the
+/// drained evidence into the agent's persistent reducer runtime).
 pub fn drain(agent: &str) -> Vec<Evidence> {
     let mut b = buffer().lock();
     b.get_mut(agent)
@@ -127,6 +131,37 @@ pub fn peek(agent: &str) -> Vec<Evidence> {
         .get(agent)
         .map(|q| q.iter().cloned().collect())
         .unwrap_or_default()
+}
+
+// ── per-agent reducer runtime (Phase B driver) ─────────────────────────────────────
+
+/// Persistent per-agent reducer accumulators. Keyed by NAME (consistent with the
+/// Evidence buffer + token registry above); [`forget_agent`] drops the entry on despawn
+/// so a same-name respawn starts with a fresh [`reducer::AgentRuntime`].
+fn runtimes() -> &'static Mutex<HashMap<String, reducer::AgentRuntime>> {
+    static R: OnceLock<Mutex<HashMap<String, reducer::AgentRuntime>>> = OnceLock::new();
+    R.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Fold `agent`'s buffered hook Evidence into its persistent reducer runtime, then
+/// derive the [`reducer::ObservedStatus`] from the current screen + liveness snapshot.
+/// The per-tick driver ([`crate::daemon::per_tick::shadow_observe`]) calls this under the
+/// `AGEND_SHADOW_OBSERVER` flag and hangs the result on `AgentCore.observed_status`
+/// (purely ADDITIVE — never rewrites `agent_state`). Draining here is the buffer's sole
+/// consume path: each tick takes the new hook events and advances the episode model.
+pub fn observe(
+    agent: &str,
+    screen: reducer::ScreenSignal,
+    live: &reducer::Liveness,
+    now_ms: u64,
+) -> reducer::ObservedStatus {
+    let evidence = drain(agent);
+    let mut rts = runtimes().lock();
+    let rt = rts.entry(agent.to_string()).or_default();
+    for ev in &evidence {
+        rt.ingest(ev);
+    }
+    rt.observe(screen, live, now_ms)
 }
 
 fn now_ms() -> u64 {

--- a/src/daemon/shadow/mod.rs
+++ b/src/daemon/shadow/mod.rs
@@ -181,8 +181,10 @@ pub fn start(home: &Path) {
     #[cfg(not(unix))]
     {
         let _ = home;
-        tracing::info!(tag = "#shadow-observer",
-            "unix-socket event server unavailable on this platform — local plane disabled");
+        tracing::info!(
+            tag = "#shadow-observer",
+            "unix-socket event server unavailable on this platform — local plane disabled"
+        );
     }
 }
 
@@ -239,10 +241,60 @@ fn handle_conn(stream: std::os::unix::net::UnixStream) {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
-    use super::evidence::EvidenceKind;
+    use super::evidence::{Authority, EvidenceKind};
     use super::*;
     use serial_test::serial;
+
+    /// End-to-end over the REAL unix socket transport: a client (the hook emit) writes
+    /// one token-authenticated frame line; the server's `handle_conn` reads it, ingests,
+    /// and the Evidence lands in the buffer. Proves the socket+token+Evidence path the
+    /// spike exists to validate (the live claude hook does exactly this write).
+    #[cfg(unix)]
+    #[test]
+    #[serial(shadow_observer)]
+    fn socket_round_trip_delivers_evidence() {
+        use std::io::Write;
+        use std::os::unix::net::{UnixListener, UnixStream};
+        let token = new_session_token().unwrap();
+        register(&token, "shadow-sock-agent");
+        let dir = std::env::temp_dir().join(format!("agend_shadow_sock_{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&dir);
+        let sock = dir.join("shadow-events.sock");
+        let _ = std::fs::remove_file(&sock);
+        let listener = UnixListener::bind(&sock).expect("bind");
+        let server = std::thread::spawn(move || {
+            if let Ok((stream, _)) = listener.accept() {
+                handle_conn(stream);
+            }
+        });
+        let mut stream = UnixStream::connect(&sock).expect("connect");
+        let frame = serde_json::json!({
+            "token": token,
+            "hook_event_name": "UserPromptSubmit",
+        });
+        stream
+            .write_all(format!("{frame}\n").as_bytes())
+            .expect("write frame");
+        drop(stream);
+        server.join().unwrap();
+        let evidence = peek("shadow-sock-agent");
+        assert_eq!(
+            evidence.len(),
+            1,
+            "frame delivered over the real socket → 1 evidence"
+        );
+        assert_eq!(evidence[0].kind, EvidenceKind::TurnStarted);
+        assert_eq!(evidence[0].authority, Authority::Hook);
+        assert_eq!(
+            evidence[0].confidence,
+            super::evidence::Confidence::Confirmed
+        );
+        drain("shadow-sock-agent");
+        forget_agent("shadow-sock-agent");
+        let _ = std::fs::remove_file(&sock);
+    }
 
     fn frame(token: &str, event: &str, tool: Option<&str>) -> ShadowFrame {
         ShadowFrame {

--- a/src/daemon/shadow/mod.rs
+++ b/src/daemon/shadow/mod.rs
@@ -1,0 +1,308 @@
+//! #2413 Shadow Observer — LOCAL plane (claude lifecycle hooks).
+//!
+//! A spawned claude's hooks emit one JSON frame per lifecycle event to a per-daemon
+//! unix socket, carrying a per-session 256-bit token. This module:
+//! 1. mints the token + resolves the socket path ([`new_session_token`],
+//!    [`socket_path`]) — injected into the single spawned claude's env at spawn time
+//!    (`AGENT_TERMINAL_SOCKET` / `AGENT_TERMINAL_SESSION`), scoped to that process, so
+//!    `~/.claude` global is never touched;
+//! 2. validates the token against a per-session registry ([`register`], [`resolve`])
+//!    so another LOCAL process cannot forge evidence for an agent;
+//! 3. maps the hook event → [`Evidence`] and pushes it into a per-agent buffer
+//!    ([`push`], [`drain`], [`peek`]) that a later reducer (Phase B, OUT OF SCOPE)
+//!    consumes;
+//! 4. runs the socket event server ([`start`]).
+//!
+//! Spike discipline: prove hook→evidence under the native TUI + no global touch. No
+//! reducer. `flag default OFF` via `AGEND_SHADOW_OBSERVER=1`.
+
+pub mod evidence;
+
+use evidence::{evidence_kind_for_hook, Evidence};
+use parking_lot::Mutex;
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, VecDeque};
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+/// Per-agent evidence buffer cap — drop-oldest beyond this. A spike bound; the
+/// reducer drains far faster than hooks fire, so this only guards a never-drained
+/// agent from unbounded growth.
+const BUFFER_CAP: usize = 256;
+
+/// One wire frame the hook emit writes to the socket (a single JSON line). Mirrors
+/// the existing `hook-event` payload fields + the session token.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ShadowFrame {
+    /// Per-session 256-bit token (hex) — proves the frame came from THIS spawned
+    /// claude, not another local process.
+    pub token: String,
+    pub hook_event_name: String,
+    #[serde(default)]
+    pub notification_type: Option<String>,
+    #[serde(default)]
+    pub tool_name: Option<String>,
+}
+
+/// `true` when the Shadow Observer local plane is enabled (`AGEND_SHADOW_OBSERVER=1`).
+/// Default OFF — zero behavior change for every existing spawn.
+pub fn enabled() -> bool {
+    std::env::var("AGEND_SHADOW_OBSERVER").as_deref() == Ok("1")
+}
+
+/// The per-daemon unix socket the hooks emit to. One socket for the daemon; the
+/// token attributes each frame to its agent.
+pub fn socket_path(home: &Path) -> PathBuf {
+    home.join("shadow-events.sock")
+}
+
+/// Mint a fresh 256-bit session token (64 hex chars). Cryptographically random
+/// (`getrandom`, same primitive as `auth_cookie`) so it is unguessable by another
+/// local process.
+pub fn new_session_token() -> anyhow::Result<String> {
+    let mut buf = [0u8; 32];
+    getrandom::fill(&mut buf).map_err(|e| anyhow::anyhow!("getrandom: {e}"))?;
+    Ok(hex::encode(buf))
+}
+
+// ── per-session token registry (token → agent name) ──────────────────────────────
+
+fn tokens() -> &'static Mutex<HashMap<String, String>> {
+    static T: OnceLock<Mutex<HashMap<String, String>>> = OnceLock::new();
+    T.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Bind a freshly-minted token to an agent name (at spawn time). A same-name respawn
+/// gets a NEW token, so a stale token from a dead session resolves to nothing.
+pub fn register(token: &str, agent: &str) {
+    tokens().lock().insert(token.to_string(), agent.to_string());
+}
+
+/// Resolve a frame's token to its agent name, or `None` if unknown (forged / stale).
+pub fn resolve(token: &str) -> Option<String> {
+    tokens().lock().get(token).cloned()
+}
+
+/// Drop an agent's token(s) on despawn/delete so the registry doesn't grow across
+/// churn and a recycled name can't inherit a dead session's binding.
+pub fn forget_agent(agent: &str) {
+    tokens().lock().retain(|_, a| a != agent);
+}
+
+// ── per-agent evidence buffer ────────────────────────────────────────────────────
+
+fn buffer() -> &'static Mutex<HashMap<String, VecDeque<Evidence>>> {
+    static B: OnceLock<Mutex<HashMap<String, VecDeque<Evidence>>>> = OnceLock::new();
+    B.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Append one observation for `agent`, bounded drop-oldest at [`BUFFER_CAP`].
+pub fn push(agent: &str, ev: Evidence) {
+    let mut b = buffer().lock();
+    let q = b.entry(agent.to_string()).or_default();
+    if q.len() >= BUFFER_CAP {
+        q.pop_front();
+    }
+    q.push_back(ev);
+}
+
+/// Drain (remove + return, oldest-first) all evidence for `agent` — the reducer's
+/// consume path (Phase B).
+pub fn drain(agent: &str) -> Vec<Evidence> {
+    let mut b = buffer().lock();
+    b.get_mut(agent)
+        .map(|q| q.drain(..).collect())
+        .unwrap_or_default()
+}
+
+/// Non-destructive snapshot (oldest-first) — for samples / debug / tests.
+pub fn peek(agent: &str) -> Vec<Evidence> {
+    buffer()
+        .lock()
+        .get(agent)
+        .map(|q| q.iter().cloned().collect())
+        .unwrap_or_default()
+}
+
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Ingest one frame: validate its token → resolve agent, map the hook → [`Evidence`],
+/// push it, and return `(agent, evidence)` for logging/tests. `None` when the token is
+/// unknown (rejected — anti-spoof) or the hook carries no state transition. Pure w.r.t.
+/// the socket so the round-trip is unit-testable without a real connection.
+pub fn ingest_frame(frame: &ShadowFrame) -> Option<(String, Evidence)> {
+    let agent = match resolve(&frame.token) {
+        Some(a) => a,
+        None => {
+            tracing::warn!(
+                tag = "#shadow-observer",
+                event = %frame.hook_event_name,
+                "rejected hook frame: unknown session token (anti-spoof)"
+            );
+            return None;
+        }
+    };
+    let kind = evidence_kind_for_hook(
+        &frame.hook_event_name,
+        frame.notification_type.as_deref(),
+        frame.tool_name.as_deref(),
+    )?;
+    let ev = Evidence::hook(kind, now_ms());
+    push(&agent, ev.clone());
+    tracing::info!(
+        tag = "#shadow-observer",
+        agent = %agent,
+        event = %frame.hook_event_name,
+        evidence = ?ev.kind,
+        "local-plane evidence recorded (authority=Hook, confidence=Confirmed)"
+    );
+    Some((agent, ev))
+}
+
+/// Start the unix-socket event server (one accept loop on a daemon thread). Removes a
+/// stale socket file first, binds, and processes one JSON frame per connection. No-op
+/// unless [`enabled`]. Errors are logged, never fatal — the observer must never wedge
+/// the daemon.
+pub fn start(home: &Path) {
+    if !enabled() {
+        return;
+    }
+    let path = socket_path(home);
+    let _ = std::fs::remove_file(&path); // clear a stale socket from a prior run
+    let listener = match std::os::unix::net::UnixListener::bind(&path) {
+        Ok(l) => l,
+        Err(e) => {
+            tracing::warn!(tag = "#shadow-observer", path = %path.display(), error = %e,
+                "shadow event server: bind failed — local plane disabled this run");
+            return;
+        }
+    };
+    tracing::info!(tag = "#shadow-observer", path = %path.display(),
+        "shadow event server listening (local plane)");
+    // fire-and-forget: a detached accept loop for an observe-only side-channel; it
+    // owns no daemon state and must never block the supervisor. It exits when the
+    // daemon process does (the socket is removed on next boot).
+    std::thread::Builder::new()
+        .name("shadow-event-server".into())
+        .spawn(move || {
+            for conn in listener.incoming() {
+                match conn {
+                    Ok(stream) => handle_conn(stream),
+                    Err(e) => tracing::debug!(tag = "#shadow-observer", error = %e,
+                        "shadow event server: accept error"),
+                }
+            }
+        })
+        .ok();
+}
+
+fn handle_conn(stream: std::os::unix::net::UnixStream) {
+    use std::io::{BufRead, BufReader, Read};
+    // One small JSON frame per connection. Bound the read (`Read::take` on the stream,
+    // then buffer it) so a wedged client can't pin the accept loop.
+    let mut line = String::new();
+    let mut reader = BufReader::new(stream.take(64 * 1024));
+    if reader.read_line(&mut line).is_err() || line.trim().is_empty() {
+        return;
+    }
+    match serde_json::from_str::<ShadowFrame>(line.trim()) {
+        Ok(frame) => {
+            let _ = ingest_frame(&frame);
+        }
+        Err(e) => tracing::debug!(tag = "#shadow-observer", error = %e,
+            "shadow event server: malformed frame dropped"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::evidence::EvidenceKind;
+    use super::*;
+    use serial_test::serial;
+
+    fn frame(token: &str, event: &str, tool: Option<&str>) -> ShadowFrame {
+        ShadowFrame {
+            token: token.to_string(),
+            hook_event_name: event.to_string(),
+            notification_type: None,
+            tool_name: tool.map(str::to_string),
+        }
+    }
+
+    #[test]
+    #[serial(shadow_observer)]
+    fn ingest_valid_token_records_evidence() {
+        let token = new_session_token().unwrap();
+        register(&token, "shadow-test-a");
+        let out = ingest_frame(&frame(&token, "PreToolUse", Some("Bash")));
+        assert_eq!(
+            out.map(|(a, e)| (a, e.kind)),
+            Some((
+                "shadow-test-a".to_string(),
+                EvidenceKind::ToolStarted {
+                    name: Some("Bash".to_string())
+                }
+            ))
+        );
+        let buffered = drain("shadow-test-a");
+        assert_eq!(buffered.len(), 1, "evidence landed in the per-agent buffer");
+        assert_eq!(
+            buffered[0].kind,
+            EvidenceKind::ToolStarted {
+                name: Some("Bash".to_string())
+            }
+        );
+        forget_agent("shadow-test-a");
+    }
+
+    #[test]
+    #[serial(shadow_observer)]
+    fn ingest_unknown_token_is_rejected_and_buffers_nothing() {
+        // A forged token (never registered) must not produce evidence — the
+        // anti-local-spoof property.
+        let out = ingest_frame(&frame("deadbeef-not-registered", "UserPromptSubmit", None));
+        assert!(out.is_none(), "unknown token rejected");
+        assert!(
+            drain("shadow-test-b").is_empty(),
+            "no evidence buffered for any agent on a forged token"
+        );
+    }
+
+    #[test]
+    #[serial(shadow_observer)]
+    fn forget_agent_invalidates_its_token() {
+        let token = new_session_token().unwrap();
+        register(&token, "shadow-test-c");
+        assert_eq!(resolve(&token).as_deref(), Some("shadow-test-c"));
+        forget_agent("shadow-test-c");
+        assert!(resolve(&token).is_none(), "despawn drops the token binding");
+        // A same-name respawn with a new token does not inherit the old one.
+        assert!(ingest_frame(&frame(&token, "Stop", None)).is_none());
+    }
+
+    #[test]
+    #[serial(shadow_observer)]
+    fn buffer_is_bounded_drop_oldest() {
+        let token = new_session_token().unwrap();
+        register(&token, "shadow-test-d");
+        for _ in 0..(BUFFER_CAP + 10) {
+            ingest_frame(&frame(&token, "PostToolUse", None));
+        }
+        assert_eq!(peek("shadow-test-d").len(), BUFFER_CAP, "bounded at cap");
+        drain("shadow-test-d");
+        forget_agent("shadow-test-d");
+    }
+
+    #[test]
+    fn token_is_256_bit_hex() {
+        let t = new_session_token().unwrap();
+        assert_eq!(t.len(), 64, "32 bytes → 64 hex chars = 256-bit");
+        assert!(t.chars().all(|c| c.is_ascii_hexdigit()));
+        assert_ne!(t, new_session_token().unwrap(), "tokens are unique");
+    }
+}

--- a/src/daemon/shadow/reducer.rs
+++ b/src/daemon/shadow/reducer.rs
@@ -39,17 +39,22 @@ const HOOK_FRESHNESS_MS: u64 = 600_000;
 /// that a genuinely-dropped terminal hook is caught within a few ticks.
 const RECONCILE_SILENCE_MS: u64 = 8_000;
 
-/// An open hook episode with NO fresh hook for this long is presumed phantom — its
-/// closing hook (Stop/PostToolUse) was dropped. Past this, a screen-Idle + sustained
-/// silence reconciles to Idle **even if `api_in_flight` is still true**: the lsof signal
-/// is a proven-unreliable idle *blocker* (lingering / CDN-shared sockets stay
-/// ESTABLISHED long after a turn ends — see SHADOW-OBSERVER-QUANT-2413.md), so it is
-/// WEAK-POSITIVE-ONLY and must never wedge an ended turn at Active forever (#2433 r6
-/// REJECT). A genuinely mid-API turn keeps emitting fresh hooks, so it never crosses
-/// this threshold — the headline mid-API false-idle win is preserved. This is the
-/// pure-time last-resort backstop. Shorter than [`HOOK_FRESHNESS_MS`] (the full
-/// screen-fallback): the episode is decayed to Idle well before the hook plane is
-/// considered wholly stale.
+/// An open hook episode with NO fresh hook for this long is one *precondition* (not the
+/// whole trigger) for the last-resort reconcile: its closing hook (Stop/PostToolUse) may
+/// have dropped. Past this, a screen-Idle + sustained silence reconciles to Idle **even
+/// if `api_in_flight` is still true** — the lsof signal is a proven-unreliable idle
+/// *blocker* (lingering / CDN-shared sockets stay ESTABLISHED long after a turn ends, see
+/// SHADOW-OBSERVER-QUANT-2413.md), so it is WEAK-POSITIVE-ONLY and must never wedge an
+/// ended turn at Active forever (#2433 r6).
+///
+/// Staleness ALONE is not sufficient, because a long model-think is ALSO screen-idle +
+/// productive-silent + hook-silent (claude fires no hooks between `TurnStarted` and the
+/// first tool/Stop, and streams no output while thinking) — reconciling on time alone
+/// would re-introduce the very false-idle this plane exists to beat (#2433 r6 round-2).
+/// So [`AgentRuntime::reconcile_to_idle`] additionally requires the episode to have
+/// PRODUCED output and then fallen quiet (a finished turn), never reconciling a
+/// produced-nothing-yet think. Shorter than [`HOOK_FRESHNESS_MS`] (the full
+/// screen-fallback): the produced-then-quiet episode decays before the plane is wholly stale.
 const EPISODE_STALE_MS: u64 = 300_000;
 
 /// Bound on the explain-trail kept per agent (last-N justifying evidence).
@@ -413,8 +418,22 @@ impl AgentRuntime {
         if !live.api_in_flight {
             return true;
         }
-        // Path 2: socket stuck true, but hooks long gone → dropped close; ignore api.
-        self.last_hook_ms > 0 && now_ms.saturating_sub(self.last_hook_ms) >= EPISODE_STALE_MS
+        // Path 2: socket stuck true (lingering). `api_in_flight` is weak-positive-only, so
+        // it must not BLOCK a reconcile forever — but a pure-time threshold alone would
+        // misclassify a genuine long model-think (which IS, by definition, screen-idle +
+        // productive-silence + an open episode — #2433 r6 round-2). Two conditions, both
+        // required:
+        //  (a) the hook plane is stale (no fresh hook for ≥ EPISODE_STALE_MS ⇒ a closing
+        //      Stop/PostToolUse was almost certainly dropped), AND
+        //  (b) the episode actually PRODUCED output and THEN fell quiet — i.e. the turn
+        //      delivered its answer and looks finished. A turn that has been silent SINCE
+        //      IT STARTED (last productive output predates `episode_since`) is still
+        //      thinking and STAYS Active no matter how long, preserving zero-false-idle.
+        let hook_stale =
+            self.last_hook_ms > 0 && now_ms.saturating_sub(self.last_hook_ms) >= EPISODE_STALE_MS;
+        let last_output_ms = now_ms.saturating_sub(live.productive_silent_ms);
+        let episode_produced_output = last_output_ms >= self.episode_since_ms;
+        hook_stale && episode_produced_output
     }
 }
 
@@ -581,6 +600,29 @@ mod tests {
             s.state,
             ObservedState::Idle,
             "fresh episode + live socket = mid-API in flight → stay Active, not reconciled"
+        );
+    }
+
+    /// #2433 r6 round-2 (verbatim reviewer test): a REAL long silent API turn — a turn
+    /// that has been thinking >300s with `api_in_flight=true` and has NEVER produced output
+    /// (productive-silence spans the whole episode) — must NOT be reconciled to Idle by the
+    /// last-resort path. Productive-silence is the `Thinking` signature, so the stale-hook
+    /// reconcile additionally requires the episode to have produced-then-quieted; a
+    /// produced-nothing-yet think stays Active no matter how long.
+    #[test]
+    fn review_pr2433_long_silent_api_turn_over_300s_currently_reconciles_idle() {
+        let mut rt = AgentRuntime::default();
+        rt.ingest(&hook(EvidenceKind::TurnStarted, 1_000));
+        let live = Liveness {
+            api_in_flight: true,
+            productive_silent_ms: 301_000,
+            child_alive: true,
+        };
+        let s = rt.observe(ScreenSignal::Idle, &live, 1_000 + EPISODE_STALE_MS + 1);
+        assert_ne!(
+            s.state,
+            ObservedState::Idle,
+            "a real >300s silent API turn would be misclassified idle by the last-resort path"
         );
     }
 

--- a/src/daemon/shadow/reducer.rs
+++ b/src/daemon/shadow/reducer.rs
@@ -402,14 +402,15 @@ impl AgentRuntime {
     ///
     /// Two ways an open episode is contradicted:
     /// 1. **No live socket either** (`!api_in_flight`) — screen-idle + no-api + silence is
-    ///    the original clean contradiction: the turn is genuinely over.
-    /// 2. **Socket stuck, but the hook plane has gone STALE** (no fresh hook for
-    ///    ≥ [`EPISODE_STALE_MS`]) — the closing hook was dropped AND `api_in_flight` is
-    ///    stuck `true` on a lingering socket (the #2433 r6 REJECT: the quantification
-    ///    itself proved sockets stay ESTABLISHED after a turn). Here `api_in_flight` is
-    ///    WEAK-POSITIVE-ONLY and is IGNORED — it must never *block* an idle reconcile, or
-    ///    an ended turn wedges at Active forever. A real mid-API turn keeps FRESH hooks,
-    ///    so it never reaches this path; the headline mid-API false-idle win is preserved.
+    ///    the clean contradiction: the turn is genuinely over (catches a dropped
+    ///    `Stop`/`PostToolUse` even on an open tool span — a dead socket means no work).
+    /// 2. **Socket stuck `true`, but corroborated finished** — `api_in_flight` lingers
+    ///    ESTABLISHED after a turn (and can false-positive on CDN-shared telemetry IPs;
+    ///    the quantification proved this), so it is WEAK-POSITIVE-ONLY: it must neither
+    ///    *block* an idle reconcile forever NOR be ignored so eagerly that a still-working
+    ///    turn reads Idle. Reconcile only with (a) no open tool span, (b) a stale hook
+    ///    plane (≥ [`EPISODE_STALE_MS`] ⇒ dropped close), and (c) produced-then-quiet (a
+    ///    delivered response). #2433 r6 rounds 1-3 pin each of these.
     fn reconcile_to_idle(&self, screen: ScreenSignal, live: &Liveness, now_ms: u64) -> bool {
         if screen != ScreenSignal::Idle || live.productive_silent_ms < RECONCILE_SILENCE_MS {
             return false;
@@ -419,21 +420,33 @@ impl AgentRuntime {
             return true;
         }
         // Path 2: socket stuck true (lingering). `api_in_flight` is weak-positive-only, so
-        // it must not BLOCK a reconcile forever — but a pure-time threshold alone would
-        // misclassify a genuine long model-think (which IS, by definition, screen-idle +
-        // productive-silence + an open episode — #2433 r6 round-2). Two conditions, both
-        // required:
-        //  (a) the hook plane is stale (no fresh hook for ≥ EPISODE_STALE_MS ⇒ a closing
-        //      Stop/PostToolUse was almost certainly dropped), AND
-        //  (b) the episode actually PRODUCED output and THEN fell quiet — i.e. the turn
-        //      delivered its answer and looks finished. A turn that has been silent SINCE
-        //      IT STARTED (last productive output predates `episode_since`) is still
-        //      thinking and STAYS Active no matter how long, preserving zero-false-idle.
+        // it must not BLOCK a reconcile forever — but it also must not be ignored so
+        // eagerly that a still-working turn is called Idle. THREE conditions, all required:
+        //  (a) NO open tool span — an open tool can legitimately run SILENTLY for minutes
+        //      (a long Bash/build), so a live socket + open tool = genuinely `ToolUse`; we
+        //      never reconcile it here (#2433 r6 round-3). A dropped `PostToolUse` is still
+        //      caught by Path 1 once the socket dies (no-api is a clean contradiction).
+        //      Empirically a *running* tool reads screen=Working (verified: `sleep 22`
+        //      held agent_state=`thinking` for its whole 23s — SHADOW-OBSERVER-QUANT-2413),
+        //      so the screen==Idle precondition above already blocks reconcile for a live
+        //      tool; (a) only guards the artificial screen==Idle + open-tool worst-case.
+        //      DOCUMENTED RESIDUAL (the out-of-path limit, only an in-path proxy fully
+        //      closes it): if `PostToolUse` drops WHILE the socket lingers (api stuck true)
+        //      and the screen has returned to Idle, the span stays `ToolUse` until the next
+        //      hook (Stop / next `TurnStarted` / `PromptReady`) — bounded + self-healing.
+        //  (b) the hook plane is stale (no fresh hook for ≥ EPISODE_STALE_MS ⇒ a closing
+        //      Stop was almost certainly dropped), AND
+        //  (c) the episode actually PRODUCED output and THEN fell quiet — i.e. the turn
+        //      delivered its answer and looks finished. A turn silent SINCE IT STARTED
+        //      (last productive output predates `episode_since`) is still thinking and
+        //      STAYS Active no matter how long (#2433 r6 round-2) — productive-silence is
+        //      the `Thinking` signature, so reconciling on it alone would re-create the
+        //      very false-idle this plane exists to beat.
         let hook_stale =
             self.last_hook_ms > 0 && now_ms.saturating_sub(self.last_hook_ms) >= EPISODE_STALE_MS;
         let last_output_ms = now_ms.saturating_sub(live.productive_silent_ms);
         let episode_produced_output = last_output_ms >= self.episode_since_ms;
-        hook_stale && episode_produced_output
+        self.tool_open.is_none() && hook_stale && episode_produced_output
     }
 }
 
@@ -623,6 +636,37 @@ mod tests {
             s.state,
             ObservedState::Idle,
             "a real >300s silent API turn would be misclassified idle by the last-resort path"
+        );
+    }
+
+    /// #2433 r6 round-3 (verbatim reviewer test): an OPEN tool span (a long-running silent
+    /// tool — e.g. a multi-minute Bash/build) with a live API socket must stay `ToolUse`,
+    /// NOT be reconciled to Idle just because the turn produced output earlier. A live
+    /// socket + open tool span = genuinely working; the api-stuck last-resort excludes open
+    /// tools (a dropped `PostToolUse` is still caught by the no-api Path 1 when the socket
+    /// dies).
+    #[test]
+    fn review_pr2433_long_silent_open_tool_after_output_stays_tooluse() {
+        let mut rt = AgentRuntime::default();
+        rt.ingest(&hook(EvidenceKind::TurnStarted, 1_000));
+        rt.ingest(&hook(EvidenceKind::Responding, 2_000));
+        rt.ingest(&hook(
+            EvidenceKind::ToolStarted {
+                name: Some("Bash".into()),
+            },
+            3_000,
+        ));
+        let now_ms = 3_000 + EPISODE_STALE_MS + 1;
+        let live = Liveness {
+            api_in_flight: true,
+            productive_silent_ms: now_ms - 2_000,
+            child_alive: true,
+        };
+        let s = rt.observe(ScreenSignal::Idle, &live, now_ms);
+        assert_eq!(
+            s.state,
+            ObservedState::ToolUse,
+            "an open tool span with a live API socket must not be reconciled to idle just because prior output exists"
         );
     }
 

--- a/src/daemon/shadow/reducer.rs
+++ b/src/daemon/shadow/reducer.rs
@@ -19,11 +19,12 @@
 //! machine is unit-testable without a daemon; the per-tick driver (OUT OF SCOPE here)
 //! supplies the snapshot under one `core.lock()`. Runs only under `AGEND_SHADOW_OBSERVER`.
 
-// The public reducer surface (ObservedStatus / AgentRuntime / ScreenSignal / Liveness)
-// is consumed by the Phase-B per-tick driver + the additive list_instances surface
-// (SHADOW-OBSERVER-ARCH-2413.md §6 step 3) — not yet wired, so it is dead in prod until
-// then (flag-OFF anyway). The tests exercise the whole surface. Narrow/remove this when
-// the driver lands. Mirrors the Phase-A deferred-consumer allows on shadow::{drain,peek}.
+// The core reducer surface (ObservedStatus / AgentRuntime / ScreenSignal / Liveness) is
+// now consumed by the Phase-B per-tick driver (`per_tick::shadow_observe` →
+// `shadow::observe`) + the additive list_instances surface (SHADOW-OBSERVER-ARCH-2413.md
+// §6 step 3). The residual under this allow is `ObservedState::coarse()` — reserved for
+// the §5 quantification harness's coarse-bucket (Idle/Active/WaitingForUser) reporting,
+// which lands next. Narrow to that one item (or drop the allow) once the harden lands.
 #![allow(dead_code)]
 
 use super::evidence::{Authority, Confidence, Evidence, EvidenceKind};

--- a/src/daemon/shadow/reducer.rs
+++ b/src/daemon/shadow/reducer.rs
@@ -39,6 +39,19 @@ const HOOK_FRESHNESS_MS: u64 = 600_000;
 /// that a genuinely-dropped terminal hook is caught within a few ticks.
 const RECONCILE_SILENCE_MS: u64 = 8_000;
 
+/// An open hook episode with NO fresh hook for this long is presumed phantom — its
+/// closing hook (Stop/PostToolUse) was dropped. Past this, a screen-Idle + sustained
+/// silence reconciles to Idle **even if `api_in_flight` is still true**: the lsof signal
+/// is a proven-unreliable idle *blocker* (lingering / CDN-shared sockets stay
+/// ESTABLISHED long after a turn ends — see SHADOW-OBSERVER-QUANT-2413.md), so it is
+/// WEAK-POSITIVE-ONLY and must never wedge an ended turn at Active forever (#2433 r6
+/// REJECT). A genuinely mid-API turn keeps emitting fresh hooks, so it never crosses
+/// this threshold — the headline mid-API false-idle win is preserved. This is the
+/// pure-time last-resort backstop. Shorter than [`HOOK_FRESHNESS_MS`] (the full
+/// screen-fallback): the episode is decayed to Idle well before the hook plane is
+/// considered wholly stale.
+const EPISODE_STALE_MS: u64 = 300_000;
+
 /// Bound on the explain-trail kept per agent (last-N justifying evidence).
 const TRAIL_CAP: usize = 8;
 
@@ -299,7 +312,7 @@ impl AgentRuntime {
         // prompt alone is `Strong`. A sustained-idle + no-api contradiction can clear a
         // phantom-waiting (the approval was answered without a closing hook).
         let waiting = self.waiting || screen == ScreenSignal::Approval;
-        if waiting && !self.reconcile_to_idle(screen, live) {
+        if waiting && !self.reconcile_to_idle(screen, live, now_ms) {
             let (auth, conf) = if self.waiting {
                 (Authority::Hook, Confidence::Confirmed)
             } else {
@@ -316,7 +329,7 @@ impl AgentRuntime {
         // (P3/P4/P5) Active family — only if an episode/tool is open AND liveness does
         // NOT contradict it (the phantom-stuck decay). If it DOES contradict, fall to Idle.
         let active_open = self.episode_open || self.tool_open.is_some();
-        if active_open && !self.reconcile_to_idle(screen, live) {
+        if active_open && !self.reconcile_to_idle(screen, live, now_ms) {
             // Mid-API false-idle beat: screen looks idle but a fresh hook episode + a
             // live socket prove work in flight → keep Active. This is the headline win
             // over raw screen-scrape.
@@ -378,14 +391,30 @@ impl AgentRuntime {
     }
 
     /// The liveness backstop: an open episode/span should be force-closed to Idle when
-    /// liveness CONTRADICTS it — the screen is back at the prompt, no LLM socket is
-    /// live, and productive output has been quiet past the threshold. Time alone never
-    /// trips this; it requires the screen-idle + no-api + sustained-silence conjunction,
-    /// so a normal mid-turn pause (model thinking, socket still open) does NOT decay.
-    fn reconcile_to_idle(&self, screen: ScreenSignal, live: &Liveness) -> bool {
-        screen == ScreenSignal::Idle
-            && !live.api_in_flight
-            && live.productive_silent_ms >= RECONCILE_SILENCE_MS
+    /// liveness CONTRADICTS it. Both paths require the screen back at the prompt + output
+    /// quiet past [`RECONCILE_SILENCE_MS`] — a normal mid-turn pause (output still
+    /// flowing) never decays.
+    ///
+    /// Two ways an open episode is contradicted:
+    /// 1. **No live socket either** (`!api_in_flight`) — screen-idle + no-api + silence is
+    ///    the original clean contradiction: the turn is genuinely over.
+    /// 2. **Socket stuck, but the hook plane has gone STALE** (no fresh hook for
+    ///    ≥ [`EPISODE_STALE_MS`]) — the closing hook was dropped AND `api_in_flight` is
+    ///    stuck `true` on a lingering socket (the #2433 r6 REJECT: the quantification
+    ///    itself proved sockets stay ESTABLISHED after a turn). Here `api_in_flight` is
+    ///    WEAK-POSITIVE-ONLY and is IGNORED — it must never *block* an idle reconcile, or
+    ///    an ended turn wedges at Active forever. A real mid-API turn keeps FRESH hooks,
+    ///    so it never reaches this path; the headline mid-API false-idle win is preserved.
+    fn reconcile_to_idle(&self, screen: ScreenSignal, live: &Liveness, now_ms: u64) -> bool {
+        if screen != ScreenSignal::Idle || live.productive_silent_ms < RECONCILE_SILENCE_MS {
+            return false;
+        }
+        // Path 1: no live socket → clean contradiction.
+        if !live.api_in_flight {
+            return true;
+        }
+        // Path 2: socket stuck true, but hooks long gone → dropped close; ignore api.
+        self.last_hook_ms > 0 && now_ms.saturating_sub(self.last_hook_ms) >= EPISODE_STALE_MS
     }
 }
 
@@ -504,6 +533,55 @@ mod tests {
             "live socket beats idle screen"
         );
         assert_eq!(s.authority, Authority::Hook);
+    }
+
+    /// #2433 r6 REJECT (verbatim reviewer test): a dropped terminal hook + a STUCK
+    /// `api_in_flight=true` (lingering socket — the quantification proved sockets stay
+    /// ESTABLISHED after a turn) must NOT wedge the ended turn at Active forever. Once the
+    /// hook plane is stale + screen Idle + productive silence, `api_in_flight` is ignored
+    /// (weak-positive-only) and the episode reconciles to Idle.
+    #[test]
+    fn review_pr2433_stale_api_socket_does_not_keep_dropped_stop_active_forever() {
+        let mut rt = AgentRuntime::default();
+        rt.ingest(&hook(EvidenceKind::TurnStarted, 1_000));
+        let live = Liveness {
+            api_in_flight: true,
+            productive_silent_ms: 60_000,
+            child_alive: true,
+        };
+        let s = rt.observe(
+            ScreenSignal::Idle,
+            &live,
+            1_000 + HOOK_FRESHNESS_MS + 60_000,
+        );
+        assert_eq!(
+            s.state,
+            ObservedState::Idle,
+            "stale api_in_flight alone must not keep a dropped terminal hook active forever"
+        );
+    }
+
+    /// The symmetric guard for the #2433 fix: a FRESH hook episode (recent TurnStarted,
+    /// hook age < EPISODE_STALE_MS) + `api_in_flight=true` + screen Idle + silence ≥ 8s —
+    /// i.e. the real mid-API thinking phase from the quantification — must STILL stay
+    /// Active. `api_in_flight` as weak-positive must not be reconciled away while hooks are
+    /// fresh, or the fix would have regressed the headline mid-API false-idle win.
+    #[test]
+    fn fresh_episode_with_live_socket_stays_active_despite_silence() {
+        let mut rt = AgentRuntime::default();
+        rt.ingest(&hook(EvidenceKind::TurnStarted, 1_000));
+        let live = Liveness {
+            api_in_flight: true,
+            productive_silent_ms: 30_000,
+            child_alive: true,
+        };
+        // Hook age 100s ≪ EPISODE_STALE_MS (300s) ⇒ fresh ⇒ no last-resort reconcile.
+        let s = rt.observe(ScreenSignal::Idle, &live, 1_000 + 100_000);
+        assert_ne!(
+            s.state,
+            ObservedState::Idle,
+            "fresh episode + live socket = mid-API in flight → stay Active, not reconciled"
+        );
     }
 
     /// Time alone (no contradicting liveness — socket still live) must NOT decay an open

--- a/src/daemon/shadow/reducer.rs
+++ b/src/daemon/shadow/reducer.rs
@@ -1,0 +1,658 @@
+//! #2413 Shadow Observer — Phase B reducer (Evidence → `ObservedStatus`).
+//!
+//! Folds three out-of-path signals into ONE status with precedence + decay + a
+//! liveness backstop:
+//!   1. typed hook-plane [`Evidence`] (real, `authority=Hook`) — the rich source;
+//!   2. the screen-scrape `agent_state`, wrapped as a `Screen`-authority signal — the
+//!      baseline we measure against (and override when hooks are fresher);
+//!   3. cheap lsof/process liveness (`api_in_flight`, productive-silence, child-alive)
+//!      — the BACKSTOP that decays a phantom-stuck state.
+//!
+//! The hard problem (§4 of SHADOW-OBSERVER-ARCH-2413.md): hook delivery is best-effort,
+//! so a closing event (`Stop`/`PostToolUse`) can DROP — leaving an episode/tool span
+//! open forever and the agent stuck reporting `Active`/`ToolUse` while it's idle. Time
+//! alone never flips state; only liveness that CONTRADICTS an open span reconciles it.
+//!
+//! [`AgentRuntime`] is the per-agent accumulator; [`AgentRuntime::ingest`] folds one
+//! Evidence and [`AgentRuntime::observe`] derives the status from the current screen +
+//! liveness snapshot. Both are pure over their inputs (no globals) so the whole state
+//! machine is unit-testable without a daemon; the per-tick driver (OUT OF SCOPE here)
+//! supplies the snapshot under one `core.lock()`. Runs only under `AGEND_SHADOW_OBSERVER`.
+
+// The public reducer surface (ObservedStatus / AgentRuntime / ScreenSignal / Liveness)
+// is consumed by the Phase-B per-tick driver + the additive list_instances surface
+// (SHADOW-OBSERVER-ARCH-2413.md §6 step 3) — not yet wired, so it is dead in prod until
+// then (flag-OFF anyway). The tests exercise the whole surface. Narrow/remove this when
+// the driver lands. Mirrors the Phase-A deferred-consumer allows on shadow::{drain,peek}.
+#![allow(dead_code)]
+
+use super::evidence::{Authority, Confidence, Evidence, EvidenceKind};
+use serde::{Deserialize, Serialize};
+use std::collections::VecDeque;
+
+/// No hook Evidence within this window ⇒ the hook plane is stale; fall back to the
+/// screen baseline. Mirrors `hook_shadow::HOOK_FRESHNESS` so the two planes age alike.
+const HOOK_FRESHNESS_MS: u64 = 600_000;
+
+/// Productive-output silence past which a screen-Idle + no-api contradiction is allowed
+/// to reconcile an open episode/span to Idle. Long enough that a normal inter-tool gap
+/// (model thinking between tools, output still flowing) does NOT trip it, short enough
+/// that a genuinely-dropped terminal hook is caught within a few ticks.
+const RECONCILE_SILENCE_MS: u64 = 8_000;
+
+/// Bound on the explain-trail kept per agent (last-N justifying evidence).
+const TRAIL_CAP: usize = 8;
+
+/// The reducer's normalized state. MVP = `Idle`/`Active`/`WaitingForUser` (high
+/// reliability); the `Active` refinements (`ToolUse`/`Responding`/`Thinking`) are
+/// emitted only when evidence is unambiguous — otherwise the reducer conservatively
+/// reports the coarse `Active`. `RateLimited` carries from the screen baseline this
+/// phase (the hook + API planes are blind to it).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ObservedState {
+    Idle,
+    /// Coarse "working" — used when a turn is open but the sub-state is ambiguous.
+    Active,
+    /// Refined `Active`: a turn is open with no tool span and no fresh output.
+    Thinking,
+    /// Refined `Active`: a tool invocation is open (no matching `ToolEnded`).
+    ToolUse,
+    /// Refined `Active`: assistant output streaming (Stream plane — mostly N/A this
+    /// phase; folds into `Active` unless a `Responding` evidence is fresh).
+    Responding,
+    /// Blocked awaiting a human decision — the proxy-invisible state.
+    WaitingForUser,
+    RateLimited,
+}
+
+impl ObservedState {
+    /// MVP coarsening: every refined `Active` sub-state collapses to `Active`. Used by
+    /// the additive surface when only the 3 high-reliability buckets are wanted.
+    pub fn coarse(self) -> ObservedState {
+        match self {
+            ObservedState::Thinking | ObservedState::ToolUse | ObservedState::Responding => {
+                ObservedState::Active
+            }
+            other => other,
+        }
+    }
+}
+
+/// A bounded reference to a piece of evidence that justified the current state — the
+/// explain-trail, for debugging + the quantification diff (not the whole buffer).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EvidenceRef {
+    pub kind: String,
+    pub authority: Authority,
+    pub at_ms: u64,
+}
+
+/// The additive status hung beside `agent_state` (never replacing it). `since_ms` is
+/// STABLE — only reset when `state` actually changes — so "how long Active/Waiting" is
+/// meaningful across re-derives.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ObservedStatus {
+    pub state: ObservedState,
+    pub confidence: Confidence,
+    pub authority: Authority,
+    pub evidence: Vec<EvidenceRef>,
+    pub since_ms: u64,
+}
+
+/// Coarse screen signal the reducer consumes — the driver maps the 18-variant
+/// `crate::state::AgentState` into these buckets so the reducer doesn't couple to the
+/// whole enum. (See `SHADOW-OBSERVER-ARCH-2413.md` §7 for the AgentState→ScreenSignal map.)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScreenSignal {
+    /// Prompt-ready / nothing rendering.
+    Idle,
+    /// ToolUse / Thinking / Starting / Restarting — actively rendering work.
+    Working,
+    /// PermissionPrompt / InteractivePrompt / AwaitingOperator — a human gate.
+    Approval,
+    /// RateLimit / ServerRateLimit / UsageLimit.
+    RateLimited,
+    /// Hang / Crashed / errors / anything non-decisive for liveness reconcile.
+    Other,
+}
+
+/// Cheap out-of-path liveness snapshot for the backstop (all already computed per-agent
+/// elsewhere — see arch §7). `productive_silent_ms` is the sustained-quiet measure the
+/// reconcile uses (no separate screen-idle-since tracking needed).
+#[derive(Debug, Clone, Copy)]
+pub struct Liveness {
+    /// lsof: a live socket to an LLM endpoint (the strongest false-idle beat).
+    pub api_in_flight: bool,
+    /// Since the last *productive* output (F9-gated), in ms.
+    pub productive_silent_ms: u64,
+    /// The agent's child process still exists.
+    pub child_alive: bool,
+}
+
+/// Per-agent accumulator. Folded with hook Evidence over time (`ingest`), then queried
+/// for a status (`observe`). Cheap + `Clone` for snapshotting.
+#[derive(Debug, Clone, Default)]
+pub struct AgentRuntime {
+    episode_open: bool,
+    episode_since_ms: u64,
+    tool_open: Option<String>,
+    tool_since_ms: u64,
+    waiting: bool,
+    waiting_since_ms: u64,
+    /// Absolute epoch-ms the rate-limit clears (from `RateLimited.retry_at_ms`), if any.
+    rate_limited_until_ms: Option<u64>,
+    /// Newest Hook-authority evidence timestamp — drives the freshness fallback.
+    last_hook_ms: u64,
+    /// Newest `Responding` evidence — distinguishes the `Responding` refinement.
+    last_responding_ms: u64,
+    /// Stable-`since` bookkeeping: the last derived state + when it was entered.
+    last_state: Option<ObservedState>,
+    last_state_since_ms: u64,
+    /// Bounded explain-trail (newest last).
+    trail: VecDeque<EvidenceRef>,
+}
+
+impl AgentRuntime {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Fold one piece of Evidence into the accumulator. Idempotent-ish: replaying the
+    /// same terminal event twice is harmless (close is monotone).
+    pub fn ingest(&mut self, ev: &Evidence) {
+        if ev.authority == Authority::Hook {
+            self.last_hook_ms = self.last_hook_ms.max(ev.at_ms);
+        }
+        match &ev.kind {
+            EvidenceKind::TurnStarted => {
+                self.open_episode(ev.at_ms);
+                // A fresh turn supersedes a prior unresolved approval.
+                self.clear_waiting();
+            }
+            EvidenceKind::TurnEnded { .. } | EvidenceKind::SessionExited => {
+                self.close_episode();
+            }
+            // An idle prompt is the agent telling us the turn is over and it's ready.
+            EvidenceKind::PromptReady => {
+                self.close_episode();
+            }
+            EvidenceKind::ToolStarted { name } => {
+                // A tool implies an active turn even if the TurnStarted hook dropped.
+                if !self.episode_open {
+                    self.open_episode(ev.at_ms);
+                }
+                self.tool_open = Some(name.clone().unwrap_or_default());
+                self.tool_since_ms = ev.at_ms;
+            }
+            EvidenceKind::ToolEnded => {
+                self.tool_open = None;
+                // Tool proceeded ⇒ any approval that gated it is resolved.
+                self.clear_waiting();
+            }
+            EvidenceKind::ApprovalRequired => {
+                self.waiting = true;
+                self.waiting_since_ms = ev.at_ms;
+                if !self.episode_open {
+                    self.open_episode(ev.at_ms);
+                }
+            }
+            EvidenceKind::RateLimited { retry_at_ms } => {
+                self.rate_limited_until_ms = *retry_at_ms;
+            }
+            EvidenceKind::Responding => {
+                self.last_responding_ms = ev.at_ms;
+                if !self.episode_open {
+                    self.open_episode(ev.at_ms);
+                }
+            }
+            // No state effect — accounting only.
+            EvidenceKind::TokenUsage { .. } => {}
+        }
+        self.push_trail(ev);
+    }
+
+    fn open_episode(&mut self, at_ms: u64) {
+        if !self.episode_open {
+            self.episode_open = true;
+            self.episode_since_ms = at_ms;
+        }
+    }
+
+    fn close_episode(&mut self) {
+        self.episode_open = false;
+        self.tool_open = None;
+        self.clear_waiting();
+    }
+
+    fn clear_waiting(&mut self) {
+        self.waiting = false;
+    }
+
+    fn push_trail(&mut self, ev: &Evidence) {
+        if self.trail.len() >= TRAIL_CAP {
+            self.trail.pop_front();
+        }
+        self.trail.push_back(EvidenceRef {
+            kind: evidence_kind_tag(&ev.kind).to_string(),
+            authority: ev.authority,
+            at_ms: ev.at_ms,
+        });
+    }
+
+    /// Derive the status from the accumulator + the current screen + liveness snapshot.
+    /// `now_ms` is the decision time (decay/freshness reference). Mutates only the
+    /// `since_ms` bookkeeping (so `&mut self`); the state logic itself is a pure
+    /// function of (accumulator, screen, live, now).
+    pub fn observe(
+        &mut self,
+        screen: ScreenSignal,
+        live: &Liveness,
+        now_ms: u64,
+    ) -> ObservedStatus {
+        let (state, authority, confidence) = self.derive(screen, live, now_ms);
+
+        // Stable `since`: only move the clock when the state actually changes.
+        let since_ms = if self.last_state == Some(state) {
+            self.last_state_since_ms
+        } else {
+            self.last_state = Some(state);
+            self.last_state_since_ms = now_ms;
+            now_ms
+        };
+
+        ObservedStatus {
+            state,
+            confidence,
+            authority,
+            evidence: self.trail.iter().cloned().collect(),
+            since_ms,
+        }
+    }
+
+    /// The pure state derivation: precedence + liveness backstop reconcile.
+    fn derive(
+        &self,
+        screen: ScreenSignal,
+        live: &Liveness,
+        now_ms: u64,
+    ) -> (ObservedState, Authority, Confidence) {
+        // A dead process trumps everything — the agent isn't running.
+        if !live.child_alive {
+            return (
+                ObservedState::Idle,
+                Authority::ProcessHeuristic,
+                Confidence::Strong,
+            );
+        }
+
+        // (P1) Rate-limited: hook `RateLimited` window still open, or the screen says so.
+        let rate_limited = self
+            .rate_limited_until_ms
+            .is_some_and(|until| until > now_ms)
+            || screen == ScreenSignal::RateLimited;
+        if rate_limited {
+            let auth = if matches!(self.rate_limited_until_ms, Some(u) if u > now_ms) {
+                Authority::Hook
+            } else {
+                Authority::Screen
+            };
+            return (ObservedState::RateLimited, auth, Confidence::Strong);
+        }
+
+        // (P2) Waiting for a human. Hook `ApprovalRequired` is `Confirmed`; the screen
+        // prompt alone is `Strong`. A sustained-idle + no-api contradiction can clear a
+        // phantom-waiting (the approval was answered without a closing hook).
+        let waiting = self.waiting || screen == ScreenSignal::Approval;
+        if waiting && !self.reconcile_to_idle(screen, live) {
+            let (auth, conf) = if self.waiting {
+                (Authority::Hook, Confidence::Confirmed)
+            } else {
+                (Authority::Screen, Confidence::Strong)
+            };
+            return (ObservedState::WaitingForUser, auth, conf);
+        }
+
+        // Hook freshness: if no hook evidence in the window, the hook plane is stale —
+        // defer to the screen baseline (Weak), the conservative fallback.
+        let hook_fresh =
+            now_ms.saturating_sub(self.last_hook_ms) <= HOOK_FRESHNESS_MS && self.last_hook_ms > 0;
+
+        // (P3/P4/P5) Active family — only if an episode/tool is open AND liveness does
+        // NOT contradict it (the phantom-stuck decay). If it DOES contradict, fall to Idle.
+        let active_open = self.episode_open || self.tool_open.is_some();
+        if active_open && !self.reconcile_to_idle(screen, live) {
+            // Mid-API false-idle beat: screen looks idle but a fresh hook episode + a
+            // live socket prove work in flight → keep Active. This is the headline win
+            // over raw screen-scrape.
+            let mid_api_false_idle =
+                screen == ScreenSignal::Idle && hook_fresh && live.api_in_flight;
+
+            let authority = if hook_fresh {
+                Authority::Hook
+            } else {
+                Authority::Screen
+            };
+            let confidence = if hook_fresh {
+                Confidence::Strong
+            } else {
+                Confidence::Probable
+            };
+
+            // Refine only when unambiguous; else the coarse `Active`.
+            let state = if self.tool_open.is_some() {
+                ObservedState::ToolUse
+            } else if now_ms.saturating_sub(self.last_responding_ms) < RECONCILE_SILENCE_MS
+                && self.last_responding_ms > 0
+            {
+                ObservedState::Responding
+            } else if self.tool_open.is_none()
+                && !self.waiting
+                && live.productive_silent_ms >= RECONCILE_SILENCE_MS
+            {
+                // Turn open, no tool, no approval, quiet output → derived Thinking.
+                ObservedState::Thinking
+            } else if mid_api_false_idle {
+                // Screen idle but provably active — don't claim a refinement, just Active.
+                ObservedState::Active
+            } else {
+                ObservedState::Active
+            };
+            return (state, authority, confidence);
+        }
+
+        // (P6) Idle — nothing open, or an open span reconciled away.
+        // If we reconciled an open span (hooks said active, liveness disagreed), mark
+        // the inference so a consumer can see the dropped-terminal-hook recovery.
+        if active_open {
+            // active_open but we're here ⇒ reconcile_to_idle fired.
+            return (
+                ObservedState::Idle,
+                Authority::Inferred,
+                Confidence::Probable,
+            );
+        }
+        // Genuinely idle. Authority is the screen unless a hook PromptReady/TurnEnded
+        // is what closed us — either way Idle is well-supported.
+        let conf = if hook_fresh {
+            Confidence::Strong
+        } else {
+            Confidence::Weak
+        };
+        (ObservedState::Idle, Authority::Screen, conf)
+    }
+
+    /// The liveness backstop: an open episode/span should be force-closed to Idle when
+    /// liveness CONTRADICTS it — the screen is back at the prompt, no LLM socket is
+    /// live, and productive output has been quiet past the threshold. Time alone never
+    /// trips this; it requires the screen-idle + no-api + sustained-silence conjunction,
+    /// so a normal mid-turn pause (model thinking, socket still open) does NOT decay.
+    fn reconcile_to_idle(&self, screen: ScreenSignal, live: &Liveness) -> bool {
+        screen == ScreenSignal::Idle
+            && !live.api_in_flight
+            && live.productive_silent_ms >= RECONCILE_SILENCE_MS
+    }
+}
+
+/// Stable short tag for an `EvidenceKind` (the explain-trail label).
+fn evidence_kind_tag(kind: &EvidenceKind) -> &'static str {
+    match kind {
+        EvidenceKind::TurnStarted => "turn_started",
+        EvidenceKind::Responding => "responding",
+        EvidenceKind::TurnEnded { .. } => "turn_ended",
+        EvidenceKind::ToolStarted { .. } => "tool_started",
+        EvidenceKind::ToolEnded => "tool_ended",
+        EvidenceKind::ApprovalRequired => "approval_required",
+        EvidenceKind::RateLimited { .. } => "rate_limited",
+        EvidenceKind::TokenUsage { .. } => "token_usage",
+        EvidenceKind::PromptReady => "prompt_ready",
+        EvidenceKind::SessionExited => "session_exited",
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn hook(kind: EvidenceKind, at_ms: u64) -> Evidence {
+        Evidence::hook(kind, at_ms)
+    }
+
+    /// Liveness with a live agent, no api socket, quiet, child alive — the "idle screen"
+    /// baseline most reconcile tests start from.
+    fn live_quiet(productive_silent_ms: u64) -> Liveness {
+        Liveness {
+            api_in_flight: false,
+            productive_silent_ms,
+            child_alive: true,
+        }
+    }
+
+    fn live_busy() -> Liveness {
+        Liveness {
+            api_in_flight: true,
+            productive_silent_ms: 0,
+            child_alive: true,
+        }
+    }
+
+    #[test]
+    fn turn_then_idle_basic() {
+        let mut rt = AgentRuntime::new();
+        rt.ingest(&hook(EvidenceKind::TurnStarted, 1_000));
+        let s = rt.observe(ScreenSignal::Working, &live_busy(), 1_100);
+        assert!(matches!(
+            s.state,
+            ObservedState::Active | ObservedState::Thinking
+        ));
+        rt.ingest(&hook(EvidenceKind::TurnEnded { stop_reason: None }, 2_000));
+        let s = rt.observe(ScreenSignal::Idle, &live_quiet(0), 2_100);
+        assert_eq!(s.state, ObservedState::Idle);
+    }
+
+    #[test]
+    fn tool_span_is_tooluse() {
+        let mut rt = AgentRuntime::new();
+        rt.ingest(&hook(EvidenceKind::TurnStarted, 1_000));
+        rt.ingest(&hook(
+            EvidenceKind::ToolStarted {
+                name: Some("Bash".into()),
+            },
+            1_100,
+        ));
+        let s = rt.observe(ScreenSignal::Working, &live_busy(), 1_200);
+        assert_eq!(s.state, ObservedState::ToolUse);
+        assert_eq!(s.authority, Authority::Hook);
+    }
+
+    /// THE headline reconcile: a dropped `Stop` hook leaves the episode open, but the
+    /// screen is back at the prompt + no api socket + quiet ⇒ decay to Idle (Inferred).
+    #[test]
+    fn dropped_stop_reconciles_to_idle() {
+        let mut rt = AgentRuntime::new();
+        rt.ingest(&hook(EvidenceKind::TurnStarted, 1_000));
+        // ... no TurnEnded ever arrives (dropped). Much later, screen is idle + quiet.
+        let s = rt.observe(ScreenSignal::Idle, &live_quiet(30_000), 60_000);
+        assert_eq!(s.state, ObservedState::Idle, "phantom episode must decay");
+        assert_eq!(s.authority, Authority::Inferred, "marked as a reconcile");
+    }
+
+    /// A dropped `PostToolUse` leaves the tool span open; same contradiction closes it.
+    #[test]
+    fn dropped_posttool_reconciles_tool_span() {
+        let mut rt = AgentRuntime::new();
+        rt.ingest(&hook(EvidenceKind::TurnStarted, 1_000));
+        rt.ingest(&hook(
+            EvidenceKind::ToolStarted {
+                name: Some("Bash".into()),
+            },
+            1_100,
+        ));
+        // PostToolUse + Stop dropped. Screen idle, quiet, no api.
+        let s = rt.observe(ScreenSignal::Idle, &live_quiet(20_000), 40_000);
+        assert_eq!(s.state, ObservedState::Idle);
+        assert_eq!(s.authority, Authority::Inferred);
+    }
+
+    /// The mid-API false-idle BEAT: screen renders idle mid-request, but a fresh hook
+    /// episode + a live socket prove work in flight ⇒ stay Active (raw screen-scrape
+    /// would wrongly say Idle here — this is the quantified win).
+    #[test]
+    fn mid_api_false_idle_stays_active() {
+        let mut rt = AgentRuntime::new();
+        rt.ingest(&hook(EvidenceKind::TurnStarted, 1_000));
+        let s = rt.observe(ScreenSignal::Idle, &live_busy(), 1_500);
+        assert_ne!(
+            s.state,
+            ObservedState::Idle,
+            "live socket beats idle screen"
+        );
+        assert_eq!(s.authority, Authority::Hook);
+    }
+
+    /// Time alone (no contradicting liveness — socket still live) must NOT decay an open
+    /// span. Guards against over-eager TTL decay.
+    #[test]
+    fn ttl_open_span_without_liveness_does_not_flip() {
+        let mut rt = AgentRuntime::new();
+        rt.ingest(&hook(
+            EvidenceKind::ToolStarted {
+                name: Some("Bash".into()),
+            },
+            1_000,
+        ));
+        // Long time later, but the socket is STILL live ⇒ still working.
+        let s = rt.observe(ScreenSignal::Working, &live_busy(), 999_000);
+        assert_eq!(
+            s.state,
+            ObservedState::ToolUse,
+            "no contradiction → no decay"
+        );
+    }
+
+    /// `ApprovalRequired` → WaitingForUser, then `ToolEnded` (proceeded) clears it.
+    #[test]
+    fn approval_then_proceed_clears_waiting() {
+        let mut rt = AgentRuntime::new();
+        rt.ingest(&hook(EvidenceKind::TurnStarted, 1_000));
+        rt.ingest(&hook(EvidenceKind::ApprovalRequired, 1_100));
+        let s = rt.observe(ScreenSignal::Approval, &live_busy(), 1_200);
+        assert_eq!(s.state, ObservedState::WaitingForUser);
+        assert_eq!(s.authority, Authority::Hook);
+        rt.ingest(&hook(EvidenceKind::ToolEnded, 1_300));
+        let s = rt.observe(ScreenSignal::Working, &live_busy(), 1_400);
+        assert_ne!(
+            s.state,
+            ObservedState::WaitingForUser,
+            "proceeded, not stuck"
+        );
+    }
+
+    /// Precedence: rate-limit outranks an open episode; approval outranks tool-use.
+    #[test]
+    fn precedence_orders() {
+        // RateLimited > everything: open episode + screen rate-limited.
+        let mut rt = AgentRuntime::new();
+        rt.ingest(&hook(EvidenceKind::TurnStarted, 1_000));
+        let s = rt.observe(ScreenSignal::RateLimited, &live_busy(), 1_100);
+        assert_eq!(s.state, ObservedState::RateLimited);
+
+        // WaitingForUser > ToolUse: a tool span is open but an approval is pending.
+        let mut rt = AgentRuntime::new();
+        rt.ingest(&hook(
+            EvidenceKind::ToolStarted {
+                name: Some("Bash".into()),
+            },
+            1_000,
+        ));
+        rt.ingest(&hook(EvidenceKind::ApprovalRequired, 1_050));
+        let s = rt.observe(ScreenSignal::Working, &live_busy(), 1_100);
+        assert_eq!(s.state, ObservedState::WaitingForUser);
+    }
+
+    /// `since_ms` is stable while the state holds, and resets when it changes.
+    #[test]
+    fn since_ms_stable_across_redrive() {
+        let mut rt = AgentRuntime::new();
+        rt.ingest(&hook(EvidenceKind::TurnStarted, 1_000));
+        let a = rt.observe(ScreenSignal::Working, &live_busy(), 1_100);
+        let b = rt.observe(ScreenSignal::Working, &live_busy(), 5_000);
+        assert_eq!(a.since_ms, b.since_ms, "same state ⇒ since frozen");
+        rt.ingest(&hook(EvidenceKind::TurnEnded { stop_reason: None }, 6_000));
+        let c = rt.observe(ScreenSignal::Idle, &live_quiet(0), 6_100);
+        assert_eq!(c.since_ms, 6_100, "state changed ⇒ since reset");
+    }
+
+    /// A dead child trumps stale "active" hooks.
+    #[test]
+    fn dead_child_is_idle() {
+        let mut rt = AgentRuntime::new();
+        rt.ingest(&hook(EvidenceKind::TurnStarted, 1_000));
+        let live = Liveness {
+            api_in_flight: false,
+            productive_silent_ms: 0,
+            child_alive: false,
+        };
+        let s = rt.observe(ScreenSignal::Working, &live, 1_100);
+        assert_eq!(s.state, ObservedState::Idle);
+        assert_eq!(s.authority, Authority::ProcessHeuristic);
+    }
+
+    /// Stale hook plane (no evidence in the freshness window) falls back to the screen
+    /// baseline with Weak confidence rather than asserting a stale hook state.
+    #[test]
+    fn stale_hook_falls_back_to_screen() {
+        let mut rt = AgentRuntime::new();
+        rt.ingest(&hook(EvidenceKind::TurnStarted, 1_000));
+        // Way past freshness; screen idle, quiet ⇒ Idle/Weak (not phantom Active).
+        let s = rt.observe(
+            ScreenSignal::Idle,
+            &live_quiet(30_000),
+            1_000 + HOOK_FRESHNESS_MS + 60_000,
+        );
+        assert_eq!(s.state, ObservedState::Idle);
+    }
+
+    /// A non-decisive screen signal (`Other` = Hang/Crashed/error chrome) does NOT
+    /// trip the idle-reconcile (it isn't `Idle`), so an open episode with a live agent
+    /// stays Active rather than being wrongly decayed. (A genuinely crashed agent is
+    /// caught by `child_alive=false`, not the screen.)
+    #[test]
+    fn screen_other_is_non_decisive() {
+        let mut rt = AgentRuntime::new();
+        rt.ingest(&hook(EvidenceKind::TurnStarted, 1_000));
+        // Other screen + quiet + no api, but child alive: reconcile needs screen==Idle,
+        // so it does NOT fire → stays Active.
+        let s = rt.observe(ScreenSignal::Other, &live_quiet(30_000), 60_000);
+        assert_ne!(
+            s.state,
+            ObservedState::Idle,
+            "Other screen never reconciles"
+        );
+    }
+
+    #[test]
+    fn coarse_collapses_active_family() {
+        assert_eq!(ObservedState::ToolUse.coarse(), ObservedState::Active);
+        assert_eq!(ObservedState::Thinking.coarse(), ObservedState::Active);
+        assert_eq!(ObservedState::Responding.coarse(), ObservedState::Active);
+        assert_eq!(
+            ObservedState::WaitingForUser.coarse(),
+            ObservedState::WaitingForUser
+        );
+        assert_eq!(ObservedState::Idle.coarse(), ObservedState::Idle);
+    }
+
+    #[test]
+    fn observed_status_serde_roundtrips() {
+        let mut rt = AgentRuntime::new();
+        rt.ingest(&hook(EvidenceKind::TurnStarted, 1_000));
+        let s = rt.observe(ScreenSignal::Working, &live_busy(), 1_100);
+        let j = serde_json::to_value(&s).expect("serialize");
+        assert!(j.get("state").is_some());
+        assert!(j.get("since_ms").is_some());
+        let back: ObservedStatus = serde_json::from_value(j).expect("deserialize");
+        assert_eq!(back, s);
+    }
+}

--- a/src/daemon/shadow/reducer.rs
+++ b/src/daemon/shadow/reducer.rs
@@ -19,13 +19,11 @@
 //! machine is unit-testable without a daemon; the per-tick driver (OUT OF SCOPE here)
 //! supplies the snapshot under one `core.lock()`. Runs only under `AGEND_SHADOW_OBSERVER`.
 
-// The core reducer surface (ObservedStatus / AgentRuntime / ScreenSignal / Liveness) is
-// now consumed by the Phase-B per-tick driver (`per_tick::shadow_observe` →
-// `shadow::observe`) + the additive list_instances surface (SHADOW-OBSERVER-ARCH-2413.md
-// §6 step 3). The residual under this allow is `ObservedState::coarse()` — reserved for
-// the §5 quantification harness's coarse-bucket (Idle/Active/WaitingForUser) reporting,
-// which lands next. Narrow to that one item (or drop the allow) once the harden lands.
-#![allow(dead_code)]
+// The whole reducer surface (ObservedStatus / AgentRuntime / ScreenSignal / Liveness +
+// ObservedState::coarse) is now consumed by the Phase-B per-tick driver
+// (`per_tick::shadow_observe` → `shadow::observe`) + the §5 correction telemetry +
+// the additive list_instances surface — so the Phase-A blanket `#![allow(dead_code)]`
+// is gone (driver landed, SHADOW-OBSERVER-ARCH-2413.md §6 step 3/5).
 
 use super::evidence::{Authority, Confidence, Evidence, EvidenceKind};
 use serde::{Deserialize, Serialize};
@@ -155,10 +153,6 @@ pub struct AgentRuntime {
 }
 
 impl AgentRuntime {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
     /// Fold one piece of Evidence into the accumulator. Idempotent-ish: replaying the
     /// same terminal event twice is harmless (close is monotone).
     pub fn ingest(&mut self, ev: &Evidence) {
@@ -440,7 +434,7 @@ mod tests {
 
     #[test]
     fn turn_then_idle_basic() {
-        let mut rt = AgentRuntime::new();
+        let mut rt = AgentRuntime::default();
         rt.ingest(&hook(EvidenceKind::TurnStarted, 1_000));
         let s = rt.observe(ScreenSignal::Working, &live_busy(), 1_100);
         assert!(matches!(
@@ -454,7 +448,7 @@ mod tests {
 
     #[test]
     fn tool_span_is_tooluse() {
-        let mut rt = AgentRuntime::new();
+        let mut rt = AgentRuntime::default();
         rt.ingest(&hook(EvidenceKind::TurnStarted, 1_000));
         rt.ingest(&hook(
             EvidenceKind::ToolStarted {
@@ -471,7 +465,7 @@ mod tests {
     /// screen is back at the prompt + no api socket + quiet ⇒ decay to Idle (Inferred).
     #[test]
     fn dropped_stop_reconciles_to_idle() {
-        let mut rt = AgentRuntime::new();
+        let mut rt = AgentRuntime::default();
         rt.ingest(&hook(EvidenceKind::TurnStarted, 1_000));
         // ... no TurnEnded ever arrives (dropped). Much later, screen is idle + quiet.
         let s = rt.observe(ScreenSignal::Idle, &live_quiet(30_000), 60_000);
@@ -482,7 +476,7 @@ mod tests {
     /// A dropped `PostToolUse` leaves the tool span open; same contradiction closes it.
     #[test]
     fn dropped_posttool_reconciles_tool_span() {
-        let mut rt = AgentRuntime::new();
+        let mut rt = AgentRuntime::default();
         rt.ingest(&hook(EvidenceKind::TurnStarted, 1_000));
         rt.ingest(&hook(
             EvidenceKind::ToolStarted {
@@ -501,7 +495,7 @@ mod tests {
     /// would wrongly say Idle here — this is the quantified win).
     #[test]
     fn mid_api_false_idle_stays_active() {
-        let mut rt = AgentRuntime::new();
+        let mut rt = AgentRuntime::default();
         rt.ingest(&hook(EvidenceKind::TurnStarted, 1_000));
         let s = rt.observe(ScreenSignal::Idle, &live_busy(), 1_500);
         assert_ne!(
@@ -516,7 +510,7 @@ mod tests {
     /// span. Guards against over-eager TTL decay.
     #[test]
     fn ttl_open_span_without_liveness_does_not_flip() {
-        let mut rt = AgentRuntime::new();
+        let mut rt = AgentRuntime::default();
         rt.ingest(&hook(
             EvidenceKind::ToolStarted {
                 name: Some("Bash".into()),
@@ -535,7 +529,7 @@ mod tests {
     /// `ApprovalRequired` → WaitingForUser, then `ToolEnded` (proceeded) clears it.
     #[test]
     fn approval_then_proceed_clears_waiting() {
-        let mut rt = AgentRuntime::new();
+        let mut rt = AgentRuntime::default();
         rt.ingest(&hook(EvidenceKind::TurnStarted, 1_000));
         rt.ingest(&hook(EvidenceKind::ApprovalRequired, 1_100));
         let s = rt.observe(ScreenSignal::Approval, &live_busy(), 1_200);
@@ -554,13 +548,13 @@ mod tests {
     #[test]
     fn precedence_orders() {
         // RateLimited > everything: open episode + screen rate-limited.
-        let mut rt = AgentRuntime::new();
+        let mut rt = AgentRuntime::default();
         rt.ingest(&hook(EvidenceKind::TurnStarted, 1_000));
         let s = rt.observe(ScreenSignal::RateLimited, &live_busy(), 1_100);
         assert_eq!(s.state, ObservedState::RateLimited);
 
         // WaitingForUser > ToolUse: a tool span is open but an approval is pending.
-        let mut rt = AgentRuntime::new();
+        let mut rt = AgentRuntime::default();
         rt.ingest(&hook(
             EvidenceKind::ToolStarted {
                 name: Some("Bash".into()),
@@ -575,7 +569,7 @@ mod tests {
     /// `since_ms` is stable while the state holds, and resets when it changes.
     #[test]
     fn since_ms_stable_across_redrive() {
-        let mut rt = AgentRuntime::new();
+        let mut rt = AgentRuntime::default();
         rt.ingest(&hook(EvidenceKind::TurnStarted, 1_000));
         let a = rt.observe(ScreenSignal::Working, &live_busy(), 1_100);
         let b = rt.observe(ScreenSignal::Working, &live_busy(), 5_000);
@@ -588,7 +582,7 @@ mod tests {
     /// A dead child trumps stale "active" hooks.
     #[test]
     fn dead_child_is_idle() {
-        let mut rt = AgentRuntime::new();
+        let mut rt = AgentRuntime::default();
         rt.ingest(&hook(EvidenceKind::TurnStarted, 1_000));
         let live = Liveness {
             api_in_flight: false,
@@ -604,7 +598,7 @@ mod tests {
     /// baseline with Weak confidence rather than asserting a stale hook state.
     #[test]
     fn stale_hook_falls_back_to_screen() {
-        let mut rt = AgentRuntime::new();
+        let mut rt = AgentRuntime::default();
         rt.ingest(&hook(EvidenceKind::TurnStarted, 1_000));
         // Way past freshness; screen idle, quiet ⇒ Idle/Weak (not phantom Active).
         let s = rt.observe(
@@ -621,7 +615,7 @@ mod tests {
     /// caught by `child_alive=false`, not the screen.)
     #[test]
     fn screen_other_is_non_decisive() {
-        let mut rt = AgentRuntime::new();
+        let mut rt = AgentRuntime::default();
         rt.ingest(&hook(EvidenceKind::TurnStarted, 1_000));
         // Other screen + quiet + no api, but child alive: reconcile needs screen==Idle,
         // so it does NOT fire → stays Active.
@@ -647,7 +641,7 @@ mod tests {
 
     #[test]
     fn observed_status_serde_roundtrips() {
-        let mut rt = AgentRuntime::new();
+        let mut rt = AgentRuntime::default();
         rt.ingest(&hook(EvidenceKind::TurnStarted, 1_000));
         let s = rt.observe(ScreenSignal::Working, &live_busy(), 1_100);
         let j = serde_json::to_value(&s).expect("serialize");

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -3912,6 +3912,7 @@ instances:
             state: crate::state::StateTracker::new(None),
             health: crate::health::HealthTracker::new(),
             api_activity: crate::agent::ApiActivity::default(),
+            observed_status: None,
         }));
         core.lock().state.current = state;
         // Direct `.current` write bypasses record_set, so sync the lock-free mirror.

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,6 +141,34 @@ pub fn home_dir() -> PathBuf {
 ///
 /// Supports: `KEY=value`, `export KEY=value`, single/double quoted values.
 /// Quoted values preserve `#` inside; unquoted values strip inline comments.
+/// #2413 Shadow Observer local plane: emit one token-authenticated hook frame to the
+/// per-session unix socket (`AGENT_TERMINAL_SOCKET`), if this process was spawned with
+/// a session token (`AGENT_TERMINAL_SESSION`). Best-effort + observe-only: any error is
+/// swallowed so the hook never blocks or fails the agent's action. Unix-only (the
+/// socket transport); a no-op elsewhere.
+#[cfg(unix)]
+fn emit_shadow_frame(payload: &serde_json::Value) {
+    let (Ok(sock), Ok(token)) = (
+        std::env::var("AGENT_TERMINAL_SOCKET"),
+        std::env::var("AGENT_TERMINAL_SESSION"),
+    ) else {
+        return; // not a shadow-observed session
+    };
+    let frame = serde_json::json!({
+        "token": token,
+        "hook_event_name": payload["hook_event_name"],
+        "notification_type": payload["notification_type"],
+        "tool_name": payload["tool_name"],
+    });
+    use std::io::Write;
+    if let Ok(mut stream) = std::os::unix::net::UnixStream::connect(&sock) {
+        let _ = stream.write_all(format!("{frame}\n").as_bytes());
+    }
+}
+
+#[cfg(not(unix))]
+fn emit_shadow_frame(_payload: &serde_json::Value) {}
+
 fn load_dotenv() {
     let env_path = home_dir().join(".env");
     if !env_path.exists() {
@@ -850,6 +878,12 @@ fn main() -> anyhow::Result<()> {
             if let Err(e) = api::call(&home, &req) {
                 eprintln!("hook-event: daemon unreachable ({e}) — event dropped (shadow-mode)");
             }
+            // #2413 Shadow Observer (local plane): if this spawn carries a per-session
+            // socket+token (AGENT_TERMINAL_SOCKET / AGENT_TERMINAL_SESSION in env, set
+            // at spawn for an observed claude), ALSO emit a token-authenticated frame to
+            // the shadow event server — the evidence channel, distinct from the api call
+            // above. Best-effort, observe-only.
+            emit_shadow_frame(&v);
             return Ok(());
         }
         Some(Commands::Inject { name, text }) => {

--- a/src/mcp/handlers/instance_state/lifecycle.rs
+++ b/src/mcp/handlers/instance_state/lifecycle.rs
@@ -186,6 +186,10 @@ pub(crate) fn full_delete_instance(home: &Path, name: &str) -> Result<(), String
     // but this global `HashMap<name, HookShadow>` had no eviction path (it only
     // ever inserted via `record_event`), leaking one entry per ever-seen agent.
     crate::daemon::hook_shadow::forget(name);
+    // #2413 Shadow Observer (local plane): drop this agent's session token(s) so the
+    // registry doesn't grow across churn and a recycled name can't inherit a dead
+    // session's token binding. Same name↔uuid residual class as the hook-shadow store.
+    crate::daemon::shadow::forget_agent(name);
 
     // #1744-H2: drop the persisted escalation state so a later agent reusing
     // this name does not rehydrate the deleted instance's crash budget /

--- a/src/mcp_config.rs
+++ b/src/mcp_config.rs
@@ -197,7 +197,11 @@ fn configure_claude(working_dir: &Path, instance_name: Option<&str>) -> Result<(
     // Empirically verified (2026-06-11 live fleet spawn): the events fire as
     // documented, the TUI shows no artifacts (async), and this upsert
     // preserves pre-existing keys.
-    if std::env::var("AGEND_HOOK_STATE_POC").as_deref() == Ok("1") {
+    // #hook-state-poc OR #2413 Shadow Observer (local plane): either flag wants the
+    // lifecycle hooks wired into the per-workspace settings (still NEVER ~/.claude).
+    if std::env::var("AGEND_HOOK_STATE_POC").as_deref() == Ok("1")
+        || crate::daemon::shadow::enabled()
+    {
         if let Some(name) = instance_name {
             upsert_state_hooks(&path, name)?;
         }


### PR DESCRIPTION
## #2413 Shadow Observer (Phase A local plane + Phase B reducer + quantification)

Out-of-path agent-state observability: fuse claude lifecycle **hooks** + the screen-scrape `agent_state` baseline + the lsof `api_in_flight` liveness signal into one additive `ObservedStatus` — **zero in-path**, **flag-OFF default** (`AGEND_SHADOW_OBSERVER=1`), `agent_state` **never rewritten**.

Operator chose **A**: build the reducer + *quantify* "cleaner than raw screen-scrape", THEN decide on an in-path proxy. This PR delivers that — reducer + the numbers. **HARD-STOP at reducer + quantification** (no in-path proxy work).

### Phase A — local hook plane (earlier, live-verified)
Per-session-token unix-socket server; claude lifecycle hooks → typed `Evidence`; per-agent buffer. Hooks injected per-workspace at spawn (`~/.claude` global untouched). `src/daemon/shadow/{mod.rs,evidence.rs}`, spawn wiring, `forget_agent` despawn hook.

### Phase B — reducer + driver + quantification (this review's focus)
- **reducer.rs** — pure `Evidence → ObservedStatus` over a per-agent `AgentRuntime` (episode/tool-span model). Precedence `RateLimited > WaitingForUser > ToolUse > Responding > Thinking > Idle`; **decay + liveness backstop** so a dropped terminal hook (Stop/PostToolUse) can't phantom-stick Active (reconciled to Idle only when screen-idle ∧ !api_in_flight ∧ sustained silence — time alone never flips). `Thinking` is *derived* (turn open ∧ no tool ∧ no approval ∧ silent), not string-matched.
- **per_tick/shadow_observe.rs** (NEW driver) — flag-gated; snapshots screen(`AgentState`→`ScreenSignal`, exhaustive) + `Liveness`, folds the hook buffer via `shadow::observe()`, writes `AgentCore.observed_status`. Registry lock never held across a core lock. Emits §5 correction telemetry.
- **Additive surface** — `AgentCore.observed_status: Option<ObservedStatus>` (mirrors `api_activity`), serialized in `list_instances` under the SAME `core.lock()` as `agent_state` so a consumer diffs them atomically. Daemon-only → allowlisted out of app mode (the hook server is `run_core`-only).

### Quantification (SHADOW-OBSERVER-QUANT-2413.md — the core deliverable)
Real daemon-spawned claude, isolated (fleet untouched, `~/.claude` clean), flag-on. **3 real turns → 6 handler-cadence corrections**, all `raw_screen=idle → observed=Thinking (Hook authority, Strong)`. During each ~23–25 s thinking phase, raw screen-scrape false-read `idle` **~91 %** of polled samples; the reducer correctly said Active(Thinking) **100 %**. **0 false-active regressions** — returns to idle on hook turn-close even with `api_in_flight=true` (lingering socket), so the reducer beats **both** raw screen-scrape (false-idle) **and** raw `api_in_flight` (false-active).

**Verdict:** the out-of-path reducer is *measurably* cleaner than screen-scrape — the empirical basis to (later) decide on an in-path proxy.

### Review note
DUAL review requested — state-derivation sensitive. Preflight: `fmt --check` clean; `clippy --features tray --all-targets` clean; reducer + driver + invariant + 207 agent/mcp-handler blast-radius tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)