### PR TITLE
feat(tui): add Ctrl+B i image paste via clipboard (arboard + png)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,6 +43,7 @@ dependencies = [
  "memchr",
  "parking_lot",
  "plist",
+ "png 0.17.16",
  "portable-pty",
  "predicates",
  "proptest",
@@ -2079,7 +2080,7 @@ dependencies = [
  "byteorder-lite",
  "moxcms",
  "num-traits",
- "png",
+ "png 0.18.1",
  "tiff",
 ]
 
@@ -2558,7 +2559,7 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-foundation",
  "once_cell",
- "png",
+ "png 0.18.1",
  "thiserror 2.0.18",
  "windows-sys 0.61.2",
 ]
@@ -3178,6 +3179,19 @@ dependencies = [
  "quick-xml",
  "serde",
  "time",
+]
+
+[[package]]
+name = "png"
+version = "0.17.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
+dependencies = [
+ "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -5107,7 +5121,7 @@ dependencies = [
  "objc2-core-graphics",
  "objc2-foundation",
  "once_cell",
- "png",
+ "png 0.18.1",
  "thiserror 2.0.18",
  "windows-sys 0.61.2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,6 +138,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "local-time"] 
 # `crate::logging`; CLI commands keep stderr.
 tracing-appender = "0.2"
 arboard = "3.6.1"
+png = "0.17"
 unicode-width = "0.2"
 which = "8"
 # #2288 re-bumped sysinfo 0.38→0.39.3, which requires rustc 1.95 and broke the

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -338,6 +338,17 @@ pub(crate) fn build_instructions_body(
     // "continue" was mistaken by an orchestrator for an operator command and a
     // task was dispatched from it. The daemon now tags such nudges; teach agents
     // to recognize the tag (same trust model as [AGEND-MSG]).
+    // Image paste: Ctrl+B i in TUI saves clipboard image to /tmp and injects this marker.
+    content.push_str("\n## TUI image paste (`[AGEND-IMAGE-PASTE]`)\n\n");
+    content
+        .push_str("When you see input beginning with `[AGEND-IMAGE-PASTE: /path/to/file.png]`:\n");
+    content.push_str(
+        "- The operator pressed Ctrl+B i in the TUI to paste an image from their clipboard.\n",
+    );
+    content.push_str("- The image has been saved to the given path as a PNG file.\n");
+    content.push_str("- Immediately use your `Read` tool on that path to view the image, then respond based on what you see.\n");
+    content.push_str("- Do NOT ask the operator to describe the image — read it directly.\n\n");
+
     content.push_str("\n## Daemon auto-inject (`[AGEND-AUTO]`)\n\n");
     content.push_str("When you see input beginning with `[AGEND-AUTO kind=...]` (e.g. `[AGEND-AUTO kind=ratelimit-retry] continue`):\n");
     content.push_str("- This is an AUTOMATIC nudge the daemon injected to resume you (e.g. after a transient rate-limit auto-retry) — NOT a real operator or peer instruction.\n");

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -11,6 +11,32 @@ use crossterm::terminal;
 use std::io::Write;
 use std::path::Path;
 
+/// Save raw RGBA bytes as a PNG file in the system temp directory.
+fn save_rgba_as_png(
+    bytes: &[u8],
+    width: usize,
+    height: usize,
+) -> anyhow::Result<std::path::PathBuf> {
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+    let path = std::env::temp_dir().join(format!("agend_paste_{ts}.png"));
+    let file = std::fs::File::create(&path)?;
+    let mut enc = png::Encoder::new(file, width as u32, height as u32);
+    enc.set_color(png::ColorType::Rgba);
+    enc.set_depth(png::BitDepth::Eight);
+    enc.write_header()?.write_image_data(bytes)?;
+    Ok(path)
+}
+
+/// Read image from system clipboard and save as PNG. Returns the file path.
+fn paste_image_from_clipboard() -> anyhow::Result<std::path::PathBuf> {
+    let mut cb = arboard::Clipboard::new()?;
+    let img = cb.get_image()?;
+    save_rgba_as_png(&img.bytes, img.width, img.height)
+}
+
 /// RAII guard for crossterm raw mode.
 struct RawModeGuard;
 impl Drop for RawModeGuard {
@@ -83,7 +109,23 @@ pub fn attach(home: &Path, name: &str) -> anyhow::Result<()> {
                         tracing::info!("detached");
                         break;
                     }
-                    // Not 'd' — send Ctrl+B + current key
+                    // Ctrl+B i — paste image from clipboard
+                    if code == KeyCode::Char('i') && modifiers.is_empty() {
+                        match paste_image_from_clipboard() {
+                            Ok(path) => {
+                                let msg = format!("[AGEND-IMAGE-PASTE: {}]\n", path.display());
+                                tracing::info!(path = %path.display(), "image paste injected");
+                                if bridge.send_input(msg.as_bytes()).is_err() {
+                                    break;
+                                }
+                            }
+                            Err(e) => {
+                                tracing::warn!(error = %e, "image paste failed — no image in clipboard?");
+                            }
+                        }
+                        continue;
+                    }
+                    // Not 'd' or 'i' — send Ctrl+B + current key
                     let mut bytes = vec![0x02];
                     bytes.extend(key_to_bytes(code, modifiers));
                     if bridge.send_input(&bytes).is_err() {


### PR DESCRIPTION
## Summary
- Add Ctrl+B i handling in the TUI to paste an image from the clipboard.
- Read clipboard RGBA data with arboard, encode it as PNG with the png crate, save it under /tmp, and inject an `[AGEND-IMAGE-PASTE: /path]` marker into the agent input stream.
- Document the marker in agent instructions so agents read the saved image directly.

## Usage
1. Copy an image.
2. In the TUI, press Ctrl+B i.
3. The agent receives the saved PNG path and reads it automatically.

## Verification
- cargo fmt --check
- cargo check