### PR TITLE
fix(tab-bar): remove transient-state badge that misaligned tab clicks

### DIFF
--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -354,7 +354,9 @@ enum TabBarClick {
 }
 
 /// Hit-test the tab bar at the given column.
-/// SYNC: layout math must match render_tab_bar() in render.rs.
+/// SYNC: per-tab width must match `render_tab_bar()` in render/core_render.rs. Both
+/// derive the label from `Tab::tab_bar_label`; the other widths are the `*` dot (1),
+/// the inter-tab separator (1), and the trailing ` [+] ` (5).
 /// M4: This is O(n_tabs) string-width scan, not a full layout re-render.
 /// Caching tab positions would save ~5 iterations but adds invalidation
 /// complexity. Kept as-is — n_tabs is typically 1-5.
@@ -366,10 +368,8 @@ fn tab_bar_hit_test(layout: &Layout, col: u16) -> Option<TabBarClick> {
             x += 1;
         } // separator space
         let is_active = i == layout.active;
-        let has_notif = tab.root().has_notification();
-        let badge = if has_notif && !is_active { " !" } else { "" };
-        let label = format!(" {}{badge} ", tab.name);
-        let tab_w = 1 + label.width() as u16; // "*" + label
+        let label = tab.tab_bar_label(is_active);
+        let tab_w = 1 + label.width() as u16; // "*" dot + label
         if col >= x && col < x + tab_w {
             return Some(TabBarClick::Tab(i));
         }
@@ -961,6 +961,68 @@ mod tests {
         // No tabs → only [+] button at col 0
         let result = tab_bar_hit_test(&layout, 0);
         assert_eq!(result, Some(TabBarClick::NewTab));
+    }
+
+    /// #777: `Tab::tab_bar_label` (the shared render/hit-test source of truth) wraps the
+    /// name in spaces and appends the `" !"` unread badge ONLY on inactive tabs.
+    #[test]
+    fn tab_bar_label_notif_badge_is_inactive_only() {
+        let mut p = leaf(1, "a");
+        p.has_notification = true;
+        let tab = Tab::new("work".to_string(), p);
+        assert_eq!(
+            tab.tab_bar_label(false),
+            " work ! ",
+            "inactive + notif → badge"
+        );
+        assert_eq!(
+            tab.tab_bar_label(true),
+            " work ",
+            "active → no badge even with notif"
+        );
+        let plain = Tab::new("x".to_string(), leaf(2, "b"));
+        assert_eq!(plain.tab_bar_label(false), " x ", "no notif → no badge");
+    }
+
+    /// #777 regression: render and `tab_bar_hit_test` must agree on per-tab widths so a
+    /// click never lands on the wrong tab. The old `[respawning]`/`[crashed]` badge
+    /// widened a tab in render ONLY — the hit-test didn't count it, shifting every later
+    /// tab's hit range. Both sides now derive the label from `Tab::tab_bar_label`, so each
+    /// tab's hit boundary equals its rendered width (`*` dot + label), with the separator
+    /// between tabs and ` [+] ` after. Walk varied-width tabs: each tab's first AND last
+    /// column must hit it, and the column right after the last tab must hit `[+]`.
+    #[test]
+    fn tab_bar_hit_test_boundaries_match_shared_label_widths() {
+        use unicode_width::UnicodeWidthStr;
+        let mut layout = Layout::new();
+        layout.add_tab(Tab::new("alpha".to_string(), leaf(1, "a")));
+        layout.add_tab(Tab::new("b".to_string(), leaf(2, "b")));
+        layout.add_tab(Tab::new("gamma-3".to_string(), leaf(3, "c")));
+
+        let mut x = 0u16;
+        for (i, tab) in layout.tabs.iter().enumerate() {
+            if i > 0 {
+                x += 1; // inter-tab separator column
+            }
+            let w = 1 + tab.tab_bar_label(i == layout.active).width() as u16; // dot + label
+            assert_eq!(
+                tab_bar_hit_test(&layout, x),
+                Some(TabBarClick::Tab(i)),
+                "tab {i} first col {x}"
+            );
+            let last = x + w - 1;
+            assert_eq!(
+                tab_bar_hit_test(&layout, last),
+                Some(TabBarClick::Tab(i)),
+                "tab {i} last col {last}"
+            );
+            x += w;
+        }
+        assert_eq!(
+            tab_bar_hit_test(&layout, x),
+            Some(TabBarClick::NewTab),
+            "col {x} right after the last tab must be the [+] button"
+        );
     }
 
     // --- Sprint 41 T-3 r2: drag state machine tests ---

--- a/src/layout/tab.rs
+++ b/src/layout/tab.rs
@@ -77,6 +77,20 @@ impl Tab {
         self.root.as_mut().expect("root is always Some")
     }
 
+    /// The tab-bar label for this tab: `" <name>[ !] "` — leading/trailing spaces
+    /// plus a `" !"` unread-notification badge shown only on INACTIVE tabs. SHARED by
+    /// `render_tab_bar` (the rendered span) and `tab_bar_hit_test` (its width) so the
+    /// two can never drift on the label — a render-only widener the hit-test didn't
+    /// count was the #777 misaligned-click bug.
+    pub fn tab_bar_label(&self, is_active: bool) -> String {
+        let notif_badge = if self.root().has_notification() && !is_active {
+            " !"
+        } else {
+            ""
+        };
+        format!(" {}{notif_badge} ", self.name)
+    }
+
     pub fn focused_pane(&self) -> Option<&Pane> {
         self.root().find_pane(self.focus_id)
     }

--- a/src/render/core_render.rs
+++ b/src/render/core_render.rs
@@ -14,22 +14,6 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Clear, Paragraph};
 use ratatui::Frame;
 
-/// Sprint 20.5 Track 7 transient state badge (per dev-reviewer
-/// cross-validation B↔C peer-pass): for tab-bar agents in transient
-/// lifecycle states (Restarting / Crashed), surface a short text badge
-/// alongside the colour dot so the registry-vs-process divergence window
-/// is visually announced rather than silent.
-///
-/// Returns `None` for terminal / steady states — most ticks emit no badge,
-/// keeping the tab bar uncluttered.
-pub(super) fn transient_state_badge(state: AgentState) -> Option<&'static str> {
-    match state {
-        AgentState::Restarting => Some(" [respawning]"),
-        AgentState::Crashed => Some(" [crashed]"),
-        _ => None,
-    }
-}
-
 pub fn state_color(state: AgentState) -> Color {
     match state {
         AgentState::Starting => Color::White,
@@ -328,7 +312,9 @@ pub fn highest_priority_state(
     best
 }
 
-/// SYNC: layout math (label width, spacing) must match tab_bar_hit_test() in app.rs.
+/// SYNC: per-tab width must match `tab_bar_hit_test()` in app/mouse.rs. Both derive
+/// the label from `Tab::tab_bar_label`; the only other widths are the `*` dot (1), the
+/// inter-tab separator (1), and the trailing ` [+] ` (5).
 fn render_tab_bar(
     frame: &mut Frame,
     area: Rect,
@@ -386,16 +372,10 @@ fn render_tab_bar(
             Span::styled("*", Style::default().fg(sc))
         };
 
-        let has_notif = tab.root().has_notification();
-        let notif_badge = if has_notif && !is_active { " !" } else { "" };
-        let label = format!(" {}{notif_badge} ", tab.name);
+        let label = tab.tab_bar_label(is_active);
 
         spans.push(dot);
         spans.push(Span::styled(label, style));
-
-        if let Some(b) = transient_state_badge(state) {
-            spans.push(Span::styled(b, Style::default().fg(Color::Yellow)));
-        }
     }
 
     let new_tab_style = if matches!(drag_tab_target, Some(DragTabTarget::NewTab)) {
@@ -761,8 +741,7 @@ pub(super) fn pane_title_segments(
     // a `[<State>]` text badge of the DETECTED AgentState so the operator can
     // eyeball-verify detection against the live pane. Extra text only — the
     // pane's colour (state_color) is untouched, and it uses the same
-    // `title_style` so it introduces no new colour. The transient
-    // Restarting/Crashed tab-bar badge (`transient_state_badge`) is unaffected.
+    // `title_style` so it introduces no new colour.
     if show_state_badge {
         segments.push((format!(" [{state:?}]"), title_style));
     }
@@ -1317,23 +1296,6 @@ mod tests {
             !text.contains("daemon binary stale"),
             "binary_stale=false must NOT surface warning, got: {text}"
         );
-    }
-
-    #[test]
-    fn transient_state_badge_emits_for_restarting_and_crashed_only() {
-        assert_eq!(
-            transient_state_badge(AgentState::Restarting),
-            Some(" [respawning]")
-        );
-        assert_eq!(
-            transient_state_badge(AgentState::Crashed),
-            Some(" [crashed]")
-        );
-        assert_eq!(transient_state_badge(AgentState::Idle), None);
-        assert_eq!(transient_state_badge(AgentState::Idle), None);
-        assert_eq!(transient_state_badge(AgentState::ToolUse), None);
-        assert_eq!(transient_state_badge(AgentState::Hang), None);
-        assert_eq!(transient_state_badge(AgentState::PermissionPrompt), None);
     }
 
     #[test]


### PR DESCRIPTION
## Bug (operator-reported, #777)
The tab bar's `[respawning]`/`[crashed]` text badge ① widened a tab in render but `tab_bar_hit_test` didn't count its width → clicks on later tabs landed on the **wrong tab**; ② was redundant (the colored dot already conveys state).

## RCA (lead-confirmed)
- **render** `render_tab_bar` (core_render.rs) pushed `transient_state_badge(state)` = ` [respawning]`/` [crashed]`, widening the tab.
- **hit-test** `tab_bar_hit_test` (mouse.rs) used `tab_w = 1 + label.width()` — **omitting the badge** → render wider than hit-test → later tabs shift right → misclick.

## Fix (KISS — solves both)
- Remove the `transient_state_badge` push from `render_tab_bar`; **delete the orphaned `transient_state_badge` fn + its unit test** (grep-confirmed no other caller) + a dangling doc ref. State is still shown by the colored dot (`state_color` + Restarting `SLOW_BLINK`).
- **Share the label**: new `Tab::tab_bar_label(is_active)` used by BOTH render and hit-test, so their widths can't drift on the label again. Other widths are constants in both: `*` dot (1), separator (1), ` [+] ` (5).

## Tests (app/mouse.rs)
- `tab_bar_hit_test_boundaries_match_shared_label_widths` — walks varied-width tabs; asserts each tab's first/last column hits it + the column after the last tab hits `[+]` (the col→idx alignment the bug broke).
- `tab_bar_label_notif_badge_is_inactive_only` — guards the shared label (spacing + inactive-only ` !` unread badge).

## Scope / gates
Surgical: tab bar only (mouse.rs +tests, tab.rs helper, core_render.rs −orphan). fmt clean · tray clippy `--features tray -D warnings` clean · core_render(23)/tab(15)/mouse(27) + new tests all green. **Visual/click behavior = operator dogfood after restart**; CI covers hit-test layout math.

🤖 Generated with [Claude Code](https://claude.com/claude-code)