### PR TITLE
feat(shadow): #2413 Phase D — codex rollout-tail observer source (Stream plane) + reducer {Hook|Stream} generalization

### DIFF
--- a/SHADOW-OBSERVER-QUANT-CODEX-2413.md
+++ b/SHADOW-OBSERVER-QUANT-CODEX-2413.md
@@ -1,0 +1,72 @@
+# Shadow Observer — Quantification (#2413 Phase D, codex)
+
+**Question:** does the codex **rollout-tail** observer source (`authority=Stream`) make the
+fused `ObservedStatus` cleaner than raw screen-scrape for codex agents — the codex analogue
+of the claude result in `SHADOW-OBSERVER-QUANT-2413.md`?
+
+**Answer: yes.** On a real codex turn the reducer (fed by the rollout tail) reports the
+agent as actively working with **`authority=Stream`** throughout, while the raw screen-scrape
+`agent_state` false-reads **`idle`** mid-turn. The reducer corrects it. The Phase-D reducer
+generalization ({Hook|Stream} freshness/authority gate) gives codex full parity with claude.
+
+---
+
+## Setup
+Isolated real codex agent (`/tmp/svcxq`, flag-on `AGEND_SHADOW_OBSERVER=1`, live fleet
+UNTOUCHED), one daemon-spawned codex-tui agent `cq`. The codex rollout tailer started
+(`codex rollout tailer listening (stream plane) root=~/.codex/sessions`). Drove a multi-step
+turn (echo / sleep / echo …) and polled `list --json` for `(agent_state, observed_status)`.
+
+## Result — codex false-idle CAUGHT + Stream parity
+Poll trace during the turn (HH:MM:SS):
+
+```
+time      raw_agent_state   observed_status   authority
+11:38:41  thinking          responding        stream
+...       thinking          responding        stream     (11:38:41–56, 11 samples)
+11:38:58  idle              responding        stream   ← raw screen false-idle; reducer holds Responding
+11:38:59  idle              responding        stream
+11:39:01  idle              responding        stream
+11:39:02  idle              responding        stream
+11:39:04  idle              responding        stream
+11:39:05  idle              idle              screen   ← turn ended; correctly back to idle (no fresh stream → screen)
+```
+
+Two wins, both on REAL codex data:
+1. **`authority=Stream` for the whole active turn** — the reducer labels codex's status with
+   the rollout-stream plane, NOT the `Screen` fallback. This is the Phase-D reducer
+   generalization paying off (pre-source, the same daemon showed codex as
+   `raw=thinking / observed=Idle / authority=Screen` — the reducer was BLIND to the codex
+   turn; now it sees it via the rollout).
+2. **Codex false-idle caught** — from 11:38:58–11:39:04 the raw screen-scrape `agent_state`
+   read **`idle`** (≈5 of 5 polled samples in that window) while the turn was still in flight;
+   the reducer correctly reported **`Responding`** (Stream authority). The handler-cadence
+   correction log captured it too:
+   `raw_screen=idle observed=Thinking confidence=Strong authority=Stream` (the 10 s tick is
+   coarser than the 1.5 s poll, so it under-counts; the poll shows the full ≈6 s false-idle
+   window the reducer covered).
+3. **No false-active regression** — once the turn ended (`task_complete` → TurnEnded), the
+   reducer returned to `idle` (authority `screen`, no fresh stream evidence), matching the
+   screen. It did not wedge Active.
+
+## Verdict
+The codex rollout-tail observer + the {Hook|Stream} reducer generalization make codex's
+`ObservedStatus` measurably cleaner than raw screen-scrape — same headline win as claude
+(false-idle eliminated), now with `authority=Stream`. The out-of-path, read-only,
+zero-injection rollout tail is the cleanest plane yet (codex writes the file itself).
+
+Bonus over the claude hook plane: codex's `token_count` records carry `rate_limits`, so the
+parser also emits `RateLimited` from a definitive signal claude hooks lack (mapped, unit-
+tested; not exercised in this short turn).
+
+### Reproduce
+```
+ISO=/tmp/svcxq; rm -rf $ISO; mkdir -p $ISO
+printf 'instances:\n  cq:\n    backend: codex\n' > $ISO/fleet.yaml
+AGEND_HOME=$ISO AGEND_SHADOW_OBSERVER=1 RUST_LOG=info \
+  target/debug/agend-terminal start --foreground --fleet $ISO/fleet.yaml >$ISO/fg.log 2>&1 &
+AGEND_HOME=$ISO target/debug/agend-terminal inject cq "Do as separate shell steps: echo A; sleep 4; echo B"
+AGEND_HOME=$ISO target/debug/agend-terminal list --json | python3 -m json.tool   # observed_status.authority == "stream"
+grep "shadow correction" $ISO/daemon.*.log                                        # raw=idle observed=... authority=Stream
+# TEARDOWN: pkill -f "fleet /tmp/svcxq" (isolated daemon only — NEVER broad-pkill codex).
+```

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -415,6 +415,12 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
         // detached accept loop that exits with the process; the stale socket is cleared on
         // next bind (start_unix removes it before binding).
         crate::daemon::shadow::start(&home);
+        // #2413 Phase D: codex rollout-tail observer source (Stream plane). Owner-only +
+        // app-mode-wired for the SAME reason as shadow::start above (#2434): the live fleet
+        // daemon is app mode, so gating it run_core-only would leave codex agents' observer
+        // source dead in production. Read-only tail of ~/.codex/sessions; no-op unless the
+        // flag is on (flag-OFF default ⇒ zero behaviour change).
+        crate::daemon::shadow::rollout::spawn(Arc::clone(&registry), home.clone());
         // Attached mode stays unwired: that process never owns the registry,
         // and the Telegram bot (if any) runs under the other daemon which
         // already did its own attach.
@@ -2256,6 +2262,28 @@ mod tests {
              region (#2413 live-fix) — gating it to run_core left the whole plane dead in \
              the app-mode live daemon. No 'crate::daemon::shadow::start(&home)' before the \
              #[cfg(test)] cutoff"
+        );
+    }
+
+    /// #2413 Phase D: the codex rollout-tail observer source (Stream plane) must be started
+    /// in app mode too — same #1720/#685 reasoning as the hook socket above. The live fleet
+    /// daemon is `run_app`, so gating `rollout::spawn` to run_core-only would leave codex
+    /// agents' observer source dead in production (their `observed_status` would never get
+    /// Stream evidence). Production-region scan only (the assert literal lives in the test
+    /// module below — #2434's vacuous-pin lesson). REVERSE-MUTATION verified: deleting the
+    /// real `rollout::spawn(...)` call from run_app turns this RED.
+    #[test]
+    fn run_app_wires_codex_rollout_tailer_2413() {
+        let source = std::fs::read_to_string("src/app/mod.rs")
+            .or_else(|_| std::fs::read_to_string("agend-terminal/src/app/mod.rs"))
+            .expect("source file must be readable from test cwd");
+        let prod = &source[..source.find("#[cfg(test)]").unwrap_or(source.len())];
+        assert!(
+            prod.contains("crate::daemon::shadow::rollout::spawn("),
+            "run_app must spawn the codex rollout-tail observer in the PRODUCTION region \
+             (#2413 Phase D) — gating it run_core-only would leave codex agents' Stream \
+             observer dead in the app-mode live daemon. No \
+             'crate::daemon::shadow::rollout::spawn(' before the #[cfg(test)] cutoff"
         );
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -420,7 +420,7 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
         // daemon is app mode, so gating it run_core-only would leave codex agents' observer
         // source dead in production. Read-only tail of ~/.codex/sessions; no-op unless the
         // flag is on (flag-OFF default ⇒ zero behaviour change).
-        crate::daemon::shadow::rollout::spawn(Arc::clone(&registry), home.clone());
+        crate::daemon::shadow::rollout::spawn(Arc::clone(&registry));
         // Attached mode stays unwired: that process never owns the registry,
         // and the Telegram bot (if any) runs under the other daemon which
         // already did its own attach.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -420,7 +420,7 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
         // daemon is app mode, so gating it run_core-only would leave codex agents' observer
         // source dead in production. Read-only tail of ~/.codex/sessions; no-op unless the
         // flag is on (flag-OFF default ⇒ zero behaviour change).
-        crate::daemon::shadow::rollout::spawn(Arc::clone(&registry));
+        crate::daemon::shadow::rollout::spawn(Arc::clone(&registry), home.clone());
         // Attached mode stays unwired: that process never owns the registry,
         // and the Telegram bot (if any) runs under the other daemon which
         // already did its own attach.

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1377,6 +1377,11 @@ fn build_tick_infrastructure(
     // AgentCore::api_activity for false-idle detection). Self-disables if
     // `lsof` is absent.
     crate::api_activity_probe::spawn(Arc::clone(&ctx.registry));
+    // #2413 Phase D: codex rollout-tail observer source (Stream plane) — read-only tail of
+    // ~/.codex/sessions/.../rollout-*.jsonl → Evidence → the shared buffer the reducer
+    // consumes. No-op unless AGEND_SHADOW_OBSERVER=1 (flag-OFF default ⇒ zero change).
+    // ALSO wired into run_app (the live fleet daemon is app mode — #2434 lesson).
+    crate::daemon::shadow::rollout::spawn(Arc::clone(&ctx.registry), home.to_path_buf());
 
     crate::inbox::recover_half_writes(home);
     // #1988: same half-write recovery for the task-event log — quarantine a

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1381,7 +1381,7 @@ fn build_tick_infrastructure(
     // ~/.codex/sessions/.../rollout-*.jsonl → Evidence → the shared buffer the reducer
     // consumes. No-op unless AGEND_SHADOW_OBSERVER=1 (flag-OFF default ⇒ zero change).
     // ALSO wired into run_app (the live fleet daemon is app mode — #2434 lesson).
-    crate::daemon::shadow::rollout::spawn(Arc::clone(&ctx.registry));
+    crate::daemon::shadow::rollout::spawn(Arc::clone(&ctx.registry), home.to_path_buf());
 
     crate::inbox::recover_half_writes(home);
     // #1988: same half-write recovery for the task-event log — quarantine a

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1381,7 +1381,7 @@ fn build_tick_infrastructure(
     // ~/.codex/sessions/.../rollout-*.jsonl → Evidence → the shared buffer the reducer
     // consumes. No-op unless AGEND_SHADOW_OBSERVER=1 (flag-OFF default ⇒ zero change).
     // ALSO wired into run_app (the live fleet daemon is app mode — #2434 lesson).
-    crate::daemon::shadow::rollout::spawn(Arc::clone(&ctx.registry), home.to_path_buf());
+    crate::daemon::shadow::rollout::spawn(Arc::clone(&ctx.registry));
 
     crate::inbox::recover_half_writes(home);
     // #1988: same half-write recovery for the task-event log — quarantine a

--- a/src/daemon/shadow/evidence.rs
+++ b/src/daemon/shadow/evidence.rs
@@ -107,6 +107,23 @@ impl Evidence {
             ttl_ms: 0,
         }
     }
+
+    /// A `Stream`-authority, `Strong` observation stamped at the rollout record time —
+    /// the codex rollout-tail plane's constructor (#2413 Phase D). Codex (TUI) live-flushes
+    /// its `~/.codex/sessions/.../rollout-*.jsonl` DURING a turn (confirm-first verified:
+    /// function_call/response_item records appear mid-turn), so a tailed event is a strong
+    /// real-time truth — one notch below `Hook`/`Confirmed` only because it is an
+    /// after-the-fact append-tail, not a synchronous lifecycle callback. Cross-platform
+    /// (std::fs tail, unlike the unix-socket hook plane) ⇒ no cfg gate.
+    pub fn stream(kind: EvidenceKind, at_ms: u64) -> Self {
+        Self {
+            kind,
+            authority: Authority::Stream,
+            confidence: Confidence::Strong,
+            at_ms,
+            ttl_ms: 0,
+        }
+    }
 }
 
 /// Map a claude lifecycle hook to the `EvidenceKind` it evidences, or `None` for a

--- a/src/daemon/shadow/mod.rs
+++ b/src/daemon/shadow/mod.rs
@@ -18,6 +18,7 @@
 
 pub mod evidence;
 pub mod reducer;
+pub mod rollout;
 
 use evidence::Evidence;
 // #2433: only the unix-gated ingest path uses these — gate the imports to match so they
@@ -33,14 +34,12 @@ use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
 /// Per-agent evidence buffer cap — drop-oldest beyond this. A spike bound; the
-/// reducer drains far faster than hooks fire, so this only guards a never-drained
+/// reducer drains far faster than evidence fires, so this only guards a never-drained
 /// agent from unbounded growth.
-// #2433: the whole hook-INGESTION plane (socket frame → buffer push) feeds the
-// `#[cfg(unix)]` AF_UNIX server, so on a non-unix PROD build it is unreachable and would
-// trip `-D warnings` dead_code. `any(unix, test)` keeps it for unix prod + EVERY test
-// build (the platform-independent reducer/evidence tests construct hook Evidence), while
-// dropping it from non-unix prod. The reducer/driver/buffer-drain are platform-agnostic.
-#[cfg(any(unix, test))]
+// #2413 Phase D: now used cross-platform — the codex `rollout` plane (std::fs tail) pushes
+// here too, not just the `#[cfg(unix)]` hook socket. So `push`/`BUFFER_CAP` are no longer
+// unix-only and the #2433 `cfg(any(unix, test))` gate is removed (genuinely live on all
+// platforms via the rollout tailer).
 const BUFFER_CAP: usize = 256;
 
 /// One wire frame the hook emit writes to the socket (a single JSON line). Mirrors
@@ -118,10 +117,9 @@ fn buffer() -> &'static Mutex<HashMap<String, VecDeque<Evidence>>> {
     B.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
-/// Append one observation for `agent`, bounded drop-oldest at [`BUFFER_CAP`]. #2433:
-/// only the unix ingest path (+ tests) PUSHES; on non-unix prod the buffer is only ever
-/// drained (empty) by the platform-agnostic reducer, so this is gated like the plumbing.
-#[cfg(any(unix, test))]
+/// Append one observation for `agent`, bounded drop-oldest at [`BUFFER_CAP`]. #2413
+/// Phase D: pushed by BOTH the unix hook-ingest path (claude) AND the cross-platform
+/// `rollout` tailer (codex), so it is no longer unix-gated.
 pub fn push(agent: &str, ev: Evidence) {
     let mut b = buffer().lock();
     let q = b.entry(agent.to_string()).or_default();

--- a/src/daemon/shadow/reducer.rs
+++ b/src/daemon/shadow/reducer.rs
@@ -462,11 +462,11 @@ impl AgentRuntime {
         //      STAYS Active no matter how long (#2433 r6 round-2) — productive-silence is
         //      the `Thinking` signature, so reconciling on it alone would re-create the
         //      very false-idle this plane exists to beat.
-        let hook_stale = self.last_observer_ms > 0
+        let observer_stale = self.last_observer_ms > 0
             && now_ms.saturating_sub(self.last_observer_ms) >= EPISODE_STALE_MS;
         let last_output_ms = now_ms.saturating_sub(live.productive_silent_ms);
         let episode_produced_output = last_output_ms >= self.episode_since_ms;
-        self.tool_open.is_none() && hook_stale && episode_produced_output
+        self.tool_open.is_none() && observer_stale && episode_produced_output
     }
 }
 

--- a/src/daemon/shadow/reducer.rs
+++ b/src/daemon/shadow/reducer.rs
@@ -159,8 +159,16 @@ pub struct AgentRuntime {
     waiting_since_ms: u64,
     /// Absolute epoch-ms the rate-limit clears (from `RateLimited.retry_at_ms`), if any.
     rate_limited_until_ms: Option<u64>,
-    /// Newest Hook-authority evidence timestamp — drives the freshness fallback.
-    last_hook_ms: u64,
+    /// Newest real-time OBSERVER-plane evidence timestamp (`Hook` for claude, `Stream` for
+    /// codex) — drives the freshness fallback. #2413 Phase D generalized this from Hook-only
+    /// so the codex rollout (`Stream`) plane gets parity; claude has ONLY `Hook`, so its
+    /// behavior is unchanged (this is `max` of Hook timestamps exactly as before).
+    last_observer_ms: u64,
+    /// Which observer plane produced that newest evidence — the authority the active-family
+    /// status is LABELED with when the observer plane is fresh (`Hook`→claude, `Stream`→
+    /// codex). `None` until any Hook/Stream evidence arrives (then the Idle/Screen fallback
+    /// labels apply). Screen/lsof/Inferred are NOT observer planes and never set this.
+    last_observer_authority: Option<Authority>,
     /// Newest `Responding` evidence — distinguishes the `Responding` refinement.
     last_responding_ms: u64,
     /// Stable-`since` bookkeeping: the last derived state + when it was entered.
@@ -174,8 +182,16 @@ impl AgentRuntime {
     /// Fold one piece of Evidence into the accumulator. Idempotent-ish: replaying the
     /// same terminal event twice is harmless (close is monotone).
     pub fn ingest(&mut self, ev: &Evidence) {
-        if ev.authority == Authority::Hook {
-            self.last_hook_ms = self.last_hook_ms.max(ev.at_ms);
+        // #2413 Phase D: track the newest REAL-TIME observer evidence + which plane it came
+        // from (`Hook`=claude lifecycle hooks, `Stream`=codex rollout tail). Generalized from
+        // the prior Hook-only `last_hook_ms.max(at_ms)`; for a claude (Hook-only) agent this
+        // is byte-identical (same max, authority always `Hook`). Screen/lsof/Inferred are not
+        // observer planes and never advance the freshness clock.
+        if matches!(ev.authority, Authority::Hook | Authority::Stream)
+            && ev.at_ms >= self.last_observer_ms
+        {
+            self.last_observer_ms = ev.at_ms;
+            self.last_observer_authority = Some(ev.authority);
         }
         match &ev.kind {
             EvidenceKind::TurnStarted => {
@@ -326,27 +342,31 @@ impl AgentRuntime {
             return (ObservedState::WaitingForUser, auth, conf);
         }
 
-        // Hook freshness: if no hook evidence in the window, the hook plane is stale —
-        // defer to the screen baseline (Weak), the conservative fallback.
-        let hook_fresh =
-            now_ms.saturating_sub(self.last_hook_ms) <= HOOK_FRESHNESS_MS && self.last_hook_ms > 0;
+        // Observer-plane freshness: if no Hook/Stream evidence in the window, the real-time
+        // observer plane is stale — defer to the screen baseline (Weak), the conservative
+        // fallback. (#2413 Phase D: generalized from Hook-only to {Hook|Stream}.)
+        let observer_fresh = now_ms.saturating_sub(self.last_observer_ms) <= HOOK_FRESHNESS_MS
+            && self.last_observer_ms > 0;
 
         // (P3/P4/P5) Active family — only if an episode/tool is open AND liveness does
         // NOT contradict it (the phantom-stuck decay). If it DOES contradict, fall to Idle.
         let active_open = self.episode_open || self.tool_open.is_some();
         if active_open && !self.reconcile_to_idle(screen, live, now_ms) {
-            // Mid-API false-idle beat: screen looks idle but a fresh hook episode + a
-            // live socket prove work in flight → keep Active. This is the headline win
-            // over raw screen-scrape.
+            // Mid-API false-idle beat: screen looks idle but a fresh observer episode (hook
+            // or stream) + a live socket prove work in flight → keep Active. This is the
+            // headline win over raw screen-scrape (now claude AND codex — #2413 Phase D).
             let mid_api_false_idle =
-                screen == ScreenSignal::Idle && hook_fresh && live.api_in_flight;
+                screen == ScreenSignal::Idle && observer_fresh && live.api_in_flight;
 
-            let authority = if hook_fresh {
-                Authority::Hook
+            let authority = if observer_fresh {
+                // Label with the plane that produced the fresh evidence: `Hook` for claude,
+                // `Stream` for codex (#2413 Phase D). Falls back to `Hook` only in the
+                // can't-happen case of observer_fresh with no recorded authority.
+                self.last_observer_authority.unwrap_or(Authority::Hook)
             } else {
                 Authority::Screen
             };
-            let confidence = if hook_fresh {
+            let confidence = if observer_fresh {
                 Confidence::Strong
             } else {
                 Confidence::Probable
@@ -387,7 +407,7 @@ impl AgentRuntime {
         }
         // Genuinely idle. Authority is the screen unless a hook PromptReady/TurnEnded
         // is what closed us — either way Idle is well-supported.
-        let conf = if hook_fresh {
+        let conf = if observer_fresh {
             Confidence::Strong
         } else {
             Confidence::Weak
@@ -442,8 +462,8 @@ impl AgentRuntime {
         //      STAYS Active no matter how long (#2433 r6 round-2) — productive-silence is
         //      the `Thinking` signature, so reconciling on it alone would re-create the
         //      very false-idle this plane exists to beat.
-        let hook_stale =
-            self.last_hook_ms > 0 && now_ms.saturating_sub(self.last_hook_ms) >= EPISODE_STALE_MS;
+        let hook_stale = self.last_observer_ms > 0
+            && now_ms.saturating_sub(self.last_observer_ms) >= EPISODE_STALE_MS;
         let last_output_ms = now_ms.saturating_sub(live.productive_silent_ms);
         let episode_produced_output = last_output_ms >= self.episode_since_ms;
         self.tool_open.is_none() && hook_stale && episode_produced_output
@@ -565,6 +585,43 @@ mod tests {
             "live socket beats idle screen"
         );
         assert_eq!(s.authority, Authority::Hook);
+    }
+
+    /// #2413 Phase D: a codex agent observed via the `Stream` plane gets PARITY with claude
+    /// — the freshness/authority gate is generalized to {Hook|Stream}, so the active-family
+    /// status is labeled `authority=Stream` (NOT the `Screen` fallback) and the mid-API
+    /// false-idle beat fires for it too. The codex analogue of `mid_api_false_idle_stays_active`.
+    #[test]
+    fn codex_stream_evidence_gets_stream_authority_and_mid_api_beat() {
+        let mut rt = AgentRuntime::default();
+        rt.ingest(&Evidence::stream(EvidenceKind::TurnStarted, 1_000));
+        let s = rt.observe(ScreenSignal::Idle, &live_busy(), 1_500);
+        assert_ne!(
+            s.state,
+            ObservedState::Idle,
+            "fresh Stream episode + live socket beats idle screen (codex mid-API beat)"
+        );
+        assert_eq!(
+            s.authority,
+            Authority::Stream,
+            "codex active status is labeled Stream, not the Screen fallback"
+        );
+    }
+
+    /// #2413 Phase D guardrail: generalizing the freshness gate to {Hook|Stream} must leave
+    /// a HOOK-ONLY (claude) agent BYTE-IDENTICAL — its active status stays `authority=Hook`.
+    /// (The whole existing claude reducer suite also pins this; this is the explicit
+    /// Phase-D no-regression anchor the lead asked for.)
+    #[test]
+    fn hook_only_agent_unchanged_after_phase_d_generalization() {
+        let mut rt = AgentRuntime::default();
+        rt.ingest(&hook(EvidenceKind::TurnStarted, 1_000));
+        let s = rt.observe(ScreenSignal::Idle, &live_busy(), 1_500);
+        assert_eq!(
+            s.authority,
+            Authority::Hook,
+            "claude (Hook-only) authority unaffected by the {{Hook|Stream}} generalization"
+        );
     }
 
     /// #2433 r6 REJECT (verbatim reviewer test): a dropped terminal hook + a STUCK

--- a/src/daemon/shadow/rollout.rs
+++ b/src/daemon/shadow/rollout.rs
@@ -1,0 +1,568 @@
+//! #2413 Phase D — codex rollout-tail observer source.
+//!
+//! Codex (TUI mode) live-flushes its session to
+//! `~/.codex/sessions/<Y>/<M>/<D>/rollout-<ts>-<uuid>.jsonl` DURING a turn (confirm-first
+//! verified: `function_call`/`response_item` records appear mid-turn, before
+//! `task_complete`). This module is a strictly **READ-ONLY tail** of those files: each
+//! appended JSONL record → [`Evidence`] (`authority=Stream`) → the SAME per-agent buffer
+//! the reducer already consumes ([`super::push`]). It NEVER writes `~/.codex` and never
+//! injects anything — codex produces the file itself, so this is the cleanest plane yet.
+//!
+//! Parallel to the claude hook plane in `mod.rs`: claude = unix-socket hook ingest
+//! (`Authority::Hook`), codex = rollout tail (`Authority::Stream`). The reducer is
+//! unchanged — both planes just fill the buffer.
+//!
+//! Cross-platform (`std::fs` tail; no unix socket), so nothing here is cfg-gated.
+
+use super::evidence::{Evidence, EvidenceKind};
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+/// Poll cadence for the tail loop. Codex live-flushes within a turn, so ~1 s gives
+/// near-real-time state without busy-spinning the disk.
+const TAIL_TICK: std::time::Duration = std::time::Duration::from_secs(1);
+
+/// One codex rollout JSONL record — only the fields we consume (codex emits more).
+#[derive(Debug, Deserialize)]
+struct RolloutRecord {
+    /// ISO-8601 Z record-write time. We prefer it over wall-clock so replayed/lagged
+    /// reads still stamp Evidence at the true event time.
+    timestamp: Option<String>,
+    #[serde(rename = "type")]
+    rtype: String,
+    #[serde(default)]
+    payload: serde_json::Value,
+}
+
+/// Map one codex rollout JSONL line → [`Evidence`] (`authority=Stream`). `now_ms` is the
+/// fallback stamp when the record carries no parseable timestamp. `None` for records that
+/// are not an agent-state transition (`session_meta` / `turn_context` / `user_message` /
+/// `developer`+`user` messages / a `token_count` with no rate-limit). PURE — unit-tested
+/// against real record shapes, no I/O.
+pub(crate) fn record_to_evidence(line: &str, now_ms: u64) -> Option<Evidence> {
+    let rec: RolloutRecord = serde_json::from_str(line.trim()).ok()?;
+    let at_ms = rec
+        .timestamp
+        .as_deref()
+        .and_then(parse_iso_ms)
+        .unwrap_or(now_ms);
+    let p = &rec.payload;
+    let ptype = p.get("type").and_then(|v| v.as_str());
+    let kind = match (rec.rtype.as_str(), ptype) {
+        // A turn began / ended.
+        ("event_msg", Some("task_started")) => EvidenceKind::TurnStarted,
+        ("event_msg", Some("task_complete")) => EvidenceKind::TurnEnded { stop_reason: None },
+        // Assistant output is streaming (event-level notification).
+        ("event_msg", Some("agent_message")) => EvidenceKind::Responding,
+        // A tool (codex `exec_command` / MCP call) started / ended.
+        ("response_item", Some("function_call")) => EvidenceKind::ToolStarted {
+            name: p.get("name").and_then(|v| v.as_str()).map(str::to_string),
+        },
+        ("response_item", Some("function_call_output")) => EvidenceKind::ToolEnded,
+        // A structured assistant message = responding; user/developer messages are the
+        // PROMPT side, not agent state (they fall through to the `_` arm below).
+        ("response_item", Some("message"))
+            if p.get("role").and_then(|v| v.as_str()) == Some("assistant") =>
+        {
+            EvidenceKind::Responding
+        }
+        // Token accounting — also the carrier of codex's `rate_limits` (the bonus claude
+        // hooks lack). Surface RateLimited only when a window is actually exhausted;
+        // otherwise it's just usage accounting.
+        ("event_msg", Some("token_count")) => {
+            if let Some(retry_at_ms) = rate_limit_retry_at(p, at_ms) {
+                EvidenceKind::RateLimited {
+                    retry_at_ms: Some(retry_at_ms),
+                }
+            } else {
+                let (input, output) = token_usage(p);
+                EvidenceKind::TokenUsage { input, output }
+            }
+        }
+        _ => return None,
+    };
+    Some(Evidence::stream(kind, at_ms))
+}
+
+/// Extract `(input, output)` token totals from a `token_count` payload's `info`.
+fn token_usage(payload: &serde_json::Value) -> (u64, u64) {
+    let last = payload.get("info").and_then(|i| i.get("last_token_usage"));
+    let g = |k: &str| {
+        last.and_then(|u| u.get(k))
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0)
+    };
+    (g("input_tokens"), g("output_tokens"))
+}
+
+/// If a `token_count` payload's `rate_limits` shows a window at/over capacity, return the
+/// absolute epoch-ms instant it resets (best-effort). `None` = not currently throttled.
+/// Codex reports `rate_limits.{primary,secondary}.{used_percent,resets_in_seconds}`.
+fn rate_limit_retry_at(payload: &serde_json::Value, at_ms: u64) -> Option<u64> {
+    let rl = payload.get("info").and_then(|i| i.get("rate_limits"))?;
+    for win in ["primary", "secondary"] {
+        let w = match rl.get(win) {
+            Some(w) => w,
+            None => continue,
+        };
+        let used = w
+            .get("used_percent")
+            .and_then(|v| v.as_f64())
+            .unwrap_or(0.0);
+        if used >= 100.0 {
+            let resets = w
+                .get("resets_in_seconds")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+            return Some(at_ms + resets * 1000);
+        }
+    }
+    None
+}
+
+/// Parse an ISO-8601 / RFC-3339 instant (e.g. `2026-06-24T02:59:08.844Z`) → epoch ms.
+fn parse_iso_ms(s: &str) -> Option<u64> {
+    chrono::DateTime::parse_from_rfc3339(s)
+        .ok()
+        .map(|dt| dt.timestamp_millis().max(0) as u64)
+}
+
+/// Extract the session cwd from a `session_meta` record (rollout line 1), normalized for
+/// the macOS `/tmp`↔`/private/tmp` symlink so it matches an agend workspace path. `None`
+/// if the line isn't a `session_meta` or carries no cwd.
+pub(crate) fn session_cwd(line: &str) -> Option<String> {
+    let rec: RolloutRecord = serde_json::from_str(line.trim()).ok()?;
+    if rec.rtype != "session_meta" {
+        return None;
+    }
+    let cwd = rec.payload.get("cwd")?.as_str()?;
+    Some(normalize_path(cwd))
+}
+
+/// Normalize a path for cwd↔workspace comparison: strip the macOS `/private` prefix that
+/// codex records for `/tmp` paths (`/private/tmp/...` → `/tmp/...`). A no-op elsewhere.
+fn normalize_path(p: &str) -> String {
+    p.strip_prefix("/private")
+        .filter(|rest| rest.starts_with('/'))
+        .map(str::to_string)
+        .unwrap_or_else(|| p.to_string())
+}
+
+/// Map a normalized session cwd → the agend agent that owns it, given the daemon home and
+/// the live (name, is_codex) set. An agend agent's workspace is `<home>/workspace/<name>`;
+/// we only attribute rollouts whose cwd matches a CODEX agent's workspace (never a stray
+/// codex the operator launched outside the fleet).
+fn agent_for_cwd(cwd: &str, home: &Path, codex_agents: &[String]) -> Option<String> {
+    let ws_root = normalize_path(&home.join("workspace").to_string_lossy());
+    for name in codex_agents {
+        let ws = format!("{ws_root}/{name}");
+        if cwd == ws {
+            return Some(name.clone());
+        }
+    }
+    None
+}
+
+/// Today's codex rollout directory root (`<CODEX_HOME|~/.codex>/sessions`).
+fn codex_sessions_root() -> Option<PathBuf> {
+    if let Ok(h) = std::env::var("CODEX_HOME") {
+        return Some(PathBuf::from(h).join("sessions"));
+    }
+    std::env::var("HOME")
+        .ok()
+        .map(|h| PathBuf::from(h).join(".codex").join("sessions"))
+}
+
+/// Per-file tail cursor: byte offset consumed + the agent the rollout is attributed to
+/// (resolved once from the session_meta header; `None` until resolved / if not ours).
+struct Cursor {
+    offset: u64,
+    agent: Option<String>,
+}
+
+/// Spawn the codex rollout tailer — a fire-and-forget daemon thread (mirrors
+/// `api_activity_probe::spawn`). No-op unless [`super::enabled`]. Wired into BOTH
+/// `run_core` AND `run_app` (the #2434 lesson: the live fleet daemon is app mode).
+pub fn spawn(registry: crate::agent::AgentRegistry, home: PathBuf) {
+    if !super::enabled() {
+        return;
+    }
+    // fire-and-forget: a detached read-only tail of codex's own session files. It owns no
+    // daemon state, holds no lock across I/O, and exits when the process does. Losing it on
+    // shutdown is harmless (next boot re-discovers from the live rollout tail). (§10.5)
+    let _ = std::thread::Builder::new()
+        .name("shadow-codex-rollout".into())
+        .spawn(move || {
+            let Some(root) = codex_sessions_root() else {
+                tracing::info!(
+                    tag = "#shadow-observer",
+                    "codex rollout tailer: no HOME/CODEX_HOME — disabled"
+                );
+                return;
+            };
+            tracing::info!(tag = "#shadow-observer", root = %root.display(),
+                "codex rollout tailer listening (stream plane)");
+            let mut cursors: HashMap<PathBuf, Cursor> = HashMap::new();
+            loop {
+                tail_once(&root, &registry, &home, &mut cursors);
+                std::thread::sleep(TAIL_TICK);
+            }
+        });
+}
+
+/// One tail cycle: (re)discover today's rollout files, attribute each to a codex agent via
+/// its session_meta cwd, and drain newly-appended records → Evidence → the per-agent
+/// buffer. Bounded work; reads only, never under a held lock.
+fn tail_once(
+    root: &Path,
+    registry: &crate::agent::AgentRegistry,
+    home: &Path,
+    cursors: &mut HashMap<PathBuf, Cursor>,
+) {
+    let codex_agents = live_codex_agents(registry);
+    if codex_agents.is_empty() {
+        return;
+    }
+    for file in discover_rollouts(root) {
+        let cur = cursors.entry(file.clone()).or_insert(Cursor {
+            offset: 0,
+            agent: None,
+        });
+        drain_file(&file, cur, home, &codex_agents);
+    }
+}
+
+/// Snapshot the live CODEX agent names (brief registry lock, released before any I/O).
+fn live_codex_agents(registry: &crate::agent::AgentRegistry) -> Vec<String> {
+    let reg = crate::agent::lock_registry(registry);
+    reg.values()
+        .filter(|h| h.backend_command.contains("codex"))
+        .map(|h| h.name.to_string())
+        .collect()
+}
+
+/// Today's rollout files under `<root>/<Y>/<M>/<D>/`. (Today only — a long-lived session
+/// crossing midnight is rare for an agent and re-discovered as the next day's dir fills;
+/// keeping it to today bounds the scan.)
+fn discover_rollouts(root: &Path) -> Vec<PathBuf> {
+    let now = chrono::Utc::now();
+    let dir = root
+        .join(now.format("%Y").to_string())
+        .join(now.format("%m").to_string())
+        .join(now.format("%d").to_string());
+    let Ok(rd) = std::fs::read_dir(&dir) else {
+        return Vec::new();
+    };
+    rd.filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.starts_with("rollout-") && n.ends_with(".jsonl"))
+        })
+        .collect()
+}
+
+/// Read newly-appended bytes of one rollout file from the cursor offset, attribute it (via
+/// the first `session_meta` line) to an agend codex agent, and push each transition as
+/// Evidence. A file not owned by any live codex agent is consumed-and-ignored (cursor
+/// advances so we don't re-scan it).
+fn drain_file(file: &Path, cur: &mut Cursor, home: &Path, codex_agents: &[String]) {
+    use std::io::{BufRead, BufReader, Seek, SeekFrom};
+    let Ok(f) = std::fs::File::open(file) else {
+        return;
+    };
+    let len = f.metadata().map(|m| m.len()).unwrap_or(0);
+    if len <= cur.offset {
+        return; // nothing new (or truncated/rotated — leave for re-discovery)
+    }
+    let mut reader = BufReader::new(f);
+    if reader.seek(SeekFrom::Start(cur.offset)).is_err() {
+        return;
+    }
+    let now_ms = chrono::Utc::now().timestamp_millis().max(0) as u64;
+    let mut consumed = cur.offset;
+    let mut line = String::new();
+    loop {
+        line.clear();
+        let n = match reader.read_line(&mut line) {
+            Ok(0) => break,
+            Ok(n) => n,
+            Err(_) => break,
+        };
+        // Only act on a COMPLETE line (ends with '\n'); a partial trailing write is left
+        // for the next tick (don't advance the cursor past it).
+        if !line.ends_with('\n') {
+            break;
+        }
+        consumed += n as u64;
+        // Resolve the owning agent from the session_meta header (first line).
+        if cur.agent.is_none() {
+            if let Some(cwd) = session_cwd(&line) {
+                cur.agent = agent_for_cwd(&cwd, home, codex_agents);
+            }
+            // Either way the header line itself is not a transition.
+            continue;
+        }
+        if let Some(agent) = cur.agent.as_deref() {
+            if let Some(ev) = record_to_evidence(&line, now_ms) {
+                super::push(agent, ev);
+            }
+        }
+    }
+    cur.offset = consumed;
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::super::evidence::{Authority, EvidenceKind};
+    use super::*;
+    use serial_test::serial;
+
+    fn kind_of(line: &str) -> Option<EvidenceKind> {
+        record_to_evidence(line, 1_000).map(|e| e.kind)
+    }
+
+    #[test]
+    fn maps_turn_lifecycle_and_tools() {
+        assert_eq!(
+            kind_of(
+                r#"{"timestamp":"2026-06-24T02:59:00.000Z","type":"event_msg","payload":{"type":"task_started"}}"#
+            ),
+            Some(EvidenceKind::TurnStarted)
+        );
+        assert_eq!(
+            kind_of(
+                r#"{"type":"event_msg","payload":{"type":"task_complete","turn_id":"t1","duration_ms":1200}}"#
+            ),
+            Some(EvidenceKind::TurnEnded { stop_reason: None })
+        );
+        assert_eq!(
+            kind_of(
+                r#"{"type":"response_item","payload":{"type":"function_call","name":"exec_command","call_id":"c1"}}"#
+            ),
+            Some(EvidenceKind::ToolStarted {
+                name: Some("exec_command".into())
+            })
+        );
+        assert_eq!(
+            kind_of(
+                r#"{"type":"response_item","payload":{"type":"function_call_output","call_id":"c1"}}"#
+            ),
+            Some(EvidenceKind::ToolEnded)
+        );
+    }
+
+    #[test]
+    fn assistant_message_is_responding_user_is_not() {
+        assert_eq!(
+            kind_of(
+                r#"{"type":"response_item","payload":{"type":"message","role":"assistant","content":[]}}"#
+            ),
+            Some(EvidenceKind::Responding)
+        );
+        assert_eq!(
+            kind_of(r#"{"type":"event_msg","payload":{"type":"agent_message","message":"hi"}}"#),
+            Some(EvidenceKind::Responding)
+        );
+        // User / developer prompt side is NOT agent state.
+        assert_eq!(
+            kind_of(
+                r#"{"type":"response_item","payload":{"type":"message","role":"user","content":[]}}"#
+            ),
+            None
+        );
+        // session_meta / turn_context / user_message → not a transition.
+        assert_eq!(kind_of(r#"{"type":"turn_context","payload":{}}"#), None);
+        assert_eq!(
+            kind_of(r#"{"type":"event_msg","payload":{"type":"user_message","message":"go"}}"#),
+            None
+        );
+    }
+
+    #[test]
+    fn token_count_yields_usage_then_ratelimit_when_exhausted() {
+        // Normal token_count → TokenUsage with the last-turn totals.
+        let u = kind_of(
+            r#"{"type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":15797,"output_tokens":36}}}}"#,
+        );
+        assert_eq!(
+            u,
+            Some(EvidenceKind::TokenUsage {
+                input: 15797,
+                output: 36
+            })
+        );
+        // A window at 100% used → RateLimited (the codex-only bonus).
+        let r = kind_of(
+            r#"{"timestamp":"2026-06-24T03:00:00.000Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":1,"output_tokens":1},"rate_limits":{"primary":{"used_percent":100.0,"resets_in_seconds":60}}}}}"#,
+        );
+        match r {
+            Some(EvidenceKind::RateLimited {
+                retry_at_ms: Some(ms),
+            }) => {
+                // 03:00:00.000Z + 60s
+                assert_eq!(
+                    ms,
+                    parse_iso_ms("2026-06-24T03:00:00.000Z").unwrap() + 60_000
+                );
+            }
+            other => panic!("expected RateLimited, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn evidence_is_stream_authority_with_record_timestamp() {
+        let ev = record_to_evidence(
+            r#"{"timestamp":"2026-06-24T02:59:08.844Z","type":"event_msg","payload":{"type":"task_started"}}"#,
+            9_999,
+        )
+        .unwrap();
+        assert_eq!(ev.authority, Authority::Stream);
+        // Stamped at the RECORD time, not the fallback now_ms.
+        assert_eq!(ev.at_ms, parse_iso_ms("2026-06-24T02:59:08.844Z").unwrap());
+        assert_ne!(ev.at_ms, 9_999);
+    }
+
+    #[test]
+    fn malformed_or_partial_line_is_none() {
+        assert_eq!(record_to_evidence("not json", 1), None);
+        assert_eq!(record_to_evidence("", 1), None);
+        assert_eq!(record_to_evidence("{}", 1), None);
+    }
+
+    #[test]
+    fn session_cwd_extracts_and_normalizes_private_tmp() {
+        let line = r#"{"type":"session_meta","payload":{"id":"u1","cwd":"/private/tmp/svcx/workspace/cx","originator":"codex-tui"}}"#;
+        assert_eq!(session_cwd(line).as_deref(), Some("/tmp/svcx/workspace/cx"));
+        // Non-/private paths pass through unchanged.
+        let live = r#"{"type":"session_meta","payload":{"cwd":"/Users/x/.agend-terminal/workspace/codex-challenger"}}"#;
+        assert_eq!(
+            session_cwd(live).as_deref(),
+            Some("/Users/x/.agend-terminal/workspace/codex-challenger")
+        );
+        // A non-session_meta line yields no cwd.
+        assert_eq!(session_cwd(r#"{"type":"event_msg","payload":{}}"#), None);
+    }
+
+    #[test]
+    fn agent_for_cwd_matches_only_fleet_codex_workspace() {
+        let home = Path::new("/tmp/svcx");
+        let agents = vec!["cx".to_string(), "cx2".to_string()];
+        assert_eq!(
+            agent_for_cwd("/tmp/svcx/workspace/cx", home, &agents).as_deref(),
+            Some("cx")
+        );
+        // /private-normalized cwd matches the /tmp workspace.
+        assert_eq!(
+            agent_for_cwd(
+                &normalize_path("/private/tmp/svcx/workspace/cx2"),
+                home,
+                &agents
+            )
+            .as_deref(),
+            Some("cx2")
+        );
+        // A stray codex outside the fleet workspace is not attributed.
+        assert_eq!(
+            agent_for_cwd("/Users/x/some/other/dir", home, &agents),
+            None
+        );
+        // An unknown agent name under the workspace root is not attributed.
+        assert_eq!(
+            agent_for_cwd("/tmp/svcx/workspace/ghost", home, &agents),
+            None
+        );
+    }
+
+    /// Integration: a real on-disk rollout file (session_meta header + a turn) tailed by
+    /// `drain_file` resolves the owning agent from the cwd and pushes each transition as
+    /// Stream Evidence into the shared buffer. Also pins the partial-trailing-line safety
+    /// (a line without a newline is NOT consumed until completed).
+    #[test]
+    #[serial(shadow_observer)]
+    fn drain_file_tails_real_rollout_into_buffer() {
+        use std::io::Write;
+        let home = std::env::temp_dir().join(format!("agend_rollout_{}", std::process::id()));
+        let ws = home.join("workspace").join("cxt");
+        std::fs::create_dir_all(&ws).unwrap();
+        let cwd = ws.to_string_lossy().to_string();
+        let roll = home.join("rollout-test.jsonl");
+        let mut f = std::fs::File::create(&roll).unwrap();
+        writeln!(
+            f,
+            r#"{{"type":"session_meta","payload":{{"cwd":"{cwd}","originator":"codex-tui"}}}}"#
+        )
+        .unwrap();
+        writeln!(
+            f,
+            r#"{{"type":"event_msg","payload":{{"type":"task_started"}}}}"#
+        )
+        .unwrap();
+        writeln!(
+            f,
+            r#"{{"type":"response_item","payload":{{"type":"function_call","name":"exec_command"}}}}"#
+        )
+        .unwrap();
+        writeln!(
+            f,
+            r#"{{"type":"event_msg","payload":{{"type":"task_complete","turn_id":"t1"}}}}"#
+        )
+        .unwrap();
+        f.flush().unwrap();
+
+        let mut cur = Cursor {
+            offset: 0,
+            agent: None,
+        };
+        let agents = vec!["cxt".to_string()];
+        drain_file(&roll, &mut cur, &home, &agents);
+
+        assert_eq!(
+            cur.agent.as_deref(),
+            Some("cxt"),
+            "cwd resolved to the agent"
+        );
+        let evs = super::super::peek("cxt");
+        let kinds: Vec<&EvidenceKind> = evs.iter().map(|e| &e.kind).collect();
+        assert!(kinds.contains(&&EvidenceKind::TurnStarted), "{kinds:?}");
+        assert!(
+            kinds.iter().any(|k| matches!(
+                k,
+                EvidenceKind::ToolStarted { name } if name.as_deref() == Some("exec_command")
+            )),
+            "{kinds:?}"
+        );
+        assert!(
+            kinds.contains(&&EvidenceKind::TurnEnded { stop_reason: None }),
+            "{kinds:?}"
+        );
+        assert!(
+            evs.iter().all(|e| e.authority == Authority::Stream),
+            "all Stream authority"
+        );
+        let off_after = cur.offset;
+
+        // Partial-trailing-line safety: append bytes WITHOUT a newline → not consumed.
+        let mut f2 = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&roll)
+            .unwrap();
+        write!(
+            f2,
+            r#"{{"type":"event_msg","payload":{{"type":"task_started"#
+        )
+        .unwrap();
+        f2.flush().unwrap();
+        drain_file(&roll, &mut cur, &home, &agents);
+        assert_eq!(
+            cur.offset, off_after,
+            "partial line must not advance the cursor"
+        );
+
+        super::super::drain("cxt");
+        super::super::forget_agent("cxt");
+        let _ = std::fs::remove_dir_all(&home);
+    }
+}

--- a/src/daemon/shadow/rollout.rs
+++ b/src/daemon/shadow/rollout.rs
@@ -136,10 +136,9 @@ fn parse_iso_ms(s: &str) -> Option<u64> {
         .map(|dt| dt.timestamp_millis().max(0) as u64)
 }
 
-/// Extract the session cwd from a `session_meta` record (rollout line 1). `None` if the
-/// line isn't a `session_meta` or carries no cwd. Returned verbatim — attribution
-/// ([`agent_for_cwd`]) matches by trailing path COMPONENTS, so no string normalization
-/// (the old macOS-only `/private` strip) is needed or applied.
+/// Extract the session cwd from a `session_meta` record (rollout line 1), verbatim. `None`
+/// if the line isn't a `session_meta` or carries no cwd. Any macOS `/private` reconciliation
+/// happens in [`agent_for_cwd`] at comparison time, so the raw cwd is returned here.
 pub(crate) fn session_cwd(line: &str) -> Option<String> {
     let rec: RolloutRecord = serde_json::from_str(line.trim()).ok()?;
     if rec.rtype != "session_meta" {
@@ -148,22 +147,36 @@ pub(crate) fn session_cwd(line: &str) -> Option<String> {
     Some(rec.payload.get("cwd")?.as_str()?.to_string())
 }
 
-/// Map a session cwd → the agend codex agent that owns it. An agend agent's workspace is
-/// `<home>/workspace/<name>`, so we attribute by the cwd's TRAILING TWO path components:
-/// `workspace/<name>` for a LIVE codex agent. #2437 round-3: this is platform-robust where
-/// full-path equality against `home` was NOT — `Path::components` is separator-agnostic
-/// (handles `\` vs `/`), and it sidesteps every cross-platform cwd-format quirk (macOS
-/// `/private/tmp`, drive-letter case, symlink canonicalization, codex's own formatting).
-/// The exact `<name>` must be a live fleet codex agent, so a stray `*/workspace/<name>`
-/// outside the fleet is not attributed.
-fn agent_for_cwd(cwd: &str, codex_agents: &[String]) -> Option<String> {
-    let mut tail = Path::new(cwd).components().rev();
-    let name = tail.next()?.as_os_str().to_str()?; // <name>
-    let parent = tail.next()?.as_os_str().to_str()?; // must be "workspace"
-    if parent != "workspace" {
-        return None;
+/// Map a session cwd → the agend codex agent that owns it. SCOPED + separator-agnostic:
+/// the cwd must EQUAL `<home>/workspace/<name>` for a LIVE codex agent, compared by path
+/// COMPONENTS (`Path` eq handles `\` vs `/`, so it works on Windows — #2437 round-1) AND
+/// rooted at THIS daemon's `home`, so a stray `*/workspace/<name>` OUTSIDE the fleet (a
+/// same-named operator codex, another daemon's home) is NOT attributed (#2437 round-3 r6).
+/// codex canonicalizes `/tmp`→`/private/tmp` on macOS; [`strip_private`] (unix-only)
+/// reconciles that before the comparison.
+fn agent_for_cwd(cwd: &str, home: &Path, codex_agents: &[String]) -> Option<String> {
+    let cwd_path = Path::new(strip_private(cwd));
+    let ws = home.join("workspace");
+    codex_agents
+        .iter()
+        .find(|name| cwd_path == ws.join(name))
+        .cloned()
+}
+
+/// Strip codex's macOS `/private` canonicalization prefix (`/private/tmp/...` → `/tmp/...`)
+/// so a `/tmp`-rooted daemon home matches. cfg-guarded to unix — Windows has no such prefix
+/// and must not have `/private` semantics applied to its paths (#2437 review). No-op
+/// otherwise.
+#[cfg(unix)]
+fn strip_private(p: &str) -> &str {
+    match p.strip_prefix("/private") {
+        Some(rest) if rest.starts_with('/') => rest,
+        _ => p,
     }
-    codex_agents.iter().find(|n| n.as_str() == name).cloned()
+}
+#[cfg(not(unix))]
+fn strip_private(p: &str) -> &str {
+    p
 }
 
 /// Today's codex rollout directory root (`<CODEX_HOME|~/.codex>/sessions`).
@@ -186,7 +199,7 @@ struct Cursor {
 /// Spawn the codex rollout tailer — a fire-and-forget daemon thread (mirrors
 /// `api_activity_probe::spawn`). No-op unless [`super::enabled`]. Wired into BOTH
 /// `run_core` AND `run_app` (the #2434 lesson: the live fleet daemon is app mode).
-pub fn spawn(registry: crate::agent::AgentRegistry) {
+pub fn spawn(registry: crate::agent::AgentRegistry, home: PathBuf) {
     if !super::enabled() {
         return;
     }
@@ -207,7 +220,7 @@ pub fn spawn(registry: crate::agent::AgentRegistry) {
                 "codex rollout tailer listening (stream plane)");
             let mut cursors: HashMap<PathBuf, Cursor> = HashMap::new();
             loop {
-                tail_once(&root, &registry, &mut cursors);
+                tail_once(&root, &registry, &home, &mut cursors);
                 std::thread::sleep(TAIL_TICK);
             }
         });
@@ -219,6 +232,7 @@ pub fn spawn(registry: crate::agent::AgentRegistry) {
 fn tail_once(
     root: &Path,
     registry: &crate::agent::AgentRegistry,
+    home: &Path,
     cursors: &mut HashMap<PathBuf, Cursor>,
 ) {
     let codex_agents = live_codex_agents(registry);
@@ -230,7 +244,7 @@ fn tail_once(
             offset: 0,
             agent: None,
         });
-        drain_file(&file, cur, &codex_agents);
+        drain_file(&file, cur, home, &codex_agents);
     }
 }
 
@@ -294,7 +308,7 @@ fn discover_rollouts(root: &Path) -> Vec<PathBuf> {
 /// the first `session_meta` line) to an agend codex agent, and push each transition as
 /// Evidence. A file not owned by any live codex agent is consumed-and-ignored (cursor
 /// advances so we don't re-scan it).
-fn drain_file(file: &Path, cur: &mut Cursor, codex_agents: &[String]) {
+fn drain_file(file: &Path, cur: &mut Cursor, home: &Path, codex_agents: &[String]) {
     use std::io::{BufRead, BufReader, Seek, SeekFrom};
     let Ok(f) = std::fs::File::open(file) else {
         return;
@@ -334,7 +348,7 @@ fn drain_file(file: &Path, cur: &mut Cursor, codex_agents: &[String]) {
         // Resolve the owning agent from the session_meta header (first line).
         if cur.agent.is_none() {
             if let Some(cwd) = session_cwd(&line) {
-                cur.agent = agent_for_cwd(&cwd, codex_agents);
+                cur.agent = agent_for_cwd(&cwd, home, codex_agents);
             }
             // Either way the header line itself is not a transition.
             continue;
@@ -479,35 +493,60 @@ mod tests {
         assert_eq!(session_cwd(r#"{"type":"event_msg","payload":{}}"#), None);
     }
 
-    /// Attribution by trailing `workspace/<name>` components — separator-agnostic, robust on
-    /// macOS AND Windows (#2437 round-3). Fixtures built with the platform `Path` API + raw
-    /// forms; the macOS `/private` prefix no longer needs special handling (tail-only match).
+    /// Attribution is SCOPED to this daemon's `home` AND separator-agnostic (#2437): a cwd
+    /// attributes only if it equals `<home>/workspace/<live-name>`. Fixtures are built with
+    /// the platform `Path` API (the cwd the SAME way production derives it), so the assert
+    /// holds on macOS AND Windows (`\` separators).
     #[test]
     fn agent_for_cwd_matches_only_fleet_codex_workspace() {
+        let home = std::env::temp_dir().join("svcx_test_home");
         let agents = vec!["cx".to_string(), "cx2".to_string()];
-        // Unix-shaped fleet workspace.
+        // The agent's own workspace (built like production) → match, on any platform.
+        let ws_cx = home.join("workspace").join("cx");
         assert_eq!(
-            agent_for_cwd("/tmp/svcx/workspace/cx", &agents).as_deref(),
+            agent_for_cwd(&ws_cx.to_string_lossy(), &home, &agents).as_deref(),
             Some("cx")
         );
-        // macOS /private form matches WITHOUT any normalization (tail components only).
+        // Unknown agent name UNDER the fleet workspace → None.
+        let ghost = home.join("workspace").join("ghost");
         assert_eq!(
-            agent_for_cwd("/private/tmp/svcx/workspace/cx2", &agents).as_deref(),
-            Some("cx2")
+            agent_for_cwd(&ghost.to_string_lossy(), &home, &agents),
+            None
         );
-        // A real platform path built via the Path API (Windows → `\` separators).
-        let plat = std::path::Path::new("/some/root")
-            .join("workspace")
-            .join("cx");
+        // A cwd not ending in `workspace/<name>` → None.
+        assert_eq!(agent_for_cwd("/some/other/dir", &home, &agents), None);
+    }
+
+    /// #2437 r6 (regression, verbatim): a SAME-NAMED `workspace/<name>` OUTSIDE this daemon's
+    /// home must NOT attribute — the tail-component-only match (round-3) wrongly did.
+    #[test]
+    fn agent_for_cwd_does_not_attribute_same_named_stray_workspace() {
+        let agents = vec!["cx".to_string()];
         assert_eq!(
-            agent_for_cwd(&plat.to_string_lossy(), &agents).as_deref(),
-            Some("cx"),
-            "platform-separator path must still match"
+            agent_for_cwd(
+                "/tmp/operator/workspace/cx",
+                Path::new("/tmp/svcx"),
+                &agents
+            ),
+            None
         );
-        // A stray codex outside any `workspace/<name>` is not attributed.
-        assert_eq!(agent_for_cwd("/Users/x/some/other/dir", &agents), None);
-        // An unknown agent name under a `workspace` dir is not attributed.
-        assert_eq!(agent_for_cwd("/tmp/svcx/workspace/ghost", &agents), None);
+    }
+
+    /// codex canonicalizes `/tmp`→`/private/tmp` on macOS; `strip_private` (unix-only)
+    /// reconciles it so a `/tmp`-rooted home still matches. (Windows has no such prefix.)
+    #[cfg(unix)]
+    #[test]
+    fn agent_for_cwd_reconciles_macos_private_prefix() {
+        let agents = vec!["cx".to_string()];
+        assert_eq!(
+            agent_for_cwd(
+                "/private/tmp/svcx/workspace/cx",
+                Path::new("/tmp/svcx"),
+                &agents
+            )
+            .as_deref(),
+            Some("cx")
+        );
     }
 
     /// Integration: a real on-disk rollout file (session_meta header + a turn) tailed by
@@ -555,7 +594,7 @@ mod tests {
             agent: None,
         };
         let agents = vec!["cxt".to_string()];
-        drain_file(&roll, &mut cur, &agents);
+        drain_file(&roll, &mut cur, &home, &agents);
 
         assert_eq!(
             cur.agent.as_deref(),
@@ -593,7 +632,7 @@ mod tests {
         )
         .unwrap();
         f2.flush().unwrap();
-        drain_file(&roll, &mut cur, &agents);
+        drain_file(&roll, &mut cur, &home, &agents);
         assert_eq!(
             cur.offset, off_after,
             "partial line must not advance the cursor"
@@ -645,7 +684,7 @@ mod tests {
             agent: None,
         };
         let agents = vec!["cxr".to_string()];
-        drain_file(&roll, &mut cur, &agents);
+        drain_file(&roll, &mut cur, &home, &agents);
         assert!(
             cur.offset > 0 && cur.agent.is_some(),
             "first drain advanced"
@@ -673,7 +712,7 @@ mod tests {
             "rebuilt session is shorter than the prior cursor"
         );
 
-        drain_file(&roll, &mut cur, &agents);
+        drain_file(&roll, &mut cur, &home, &agents);
         // Recovered: agent re-resolved from the new header + the new ToolStarted seen (the
         // pre-fix code would have left the cursor past EOF → observer DEAF → empty).
         let evs = super::super::peek("cxr");

--- a/src/daemon/shadow/rollout.rs
+++ b/src/daemon/shadow/rollout.rs
@@ -136,42 +136,34 @@ fn parse_iso_ms(s: &str) -> Option<u64> {
         .map(|dt| dt.timestamp_millis().max(0) as u64)
 }
 
-/// Extract the session cwd from a `session_meta` record (rollout line 1), normalized for
-/// the macOS `/tmp`↔`/private/tmp` symlink so it matches an agend workspace path. `None`
-/// if the line isn't a `session_meta` or carries no cwd.
+/// Extract the session cwd from a `session_meta` record (rollout line 1). `None` if the
+/// line isn't a `session_meta` or carries no cwd. Returned verbatim — attribution
+/// ([`agent_for_cwd`]) matches by trailing path COMPONENTS, so no string normalization
+/// (the old macOS-only `/private` strip) is needed or applied.
 pub(crate) fn session_cwd(line: &str) -> Option<String> {
     let rec: RolloutRecord = serde_json::from_str(line.trim()).ok()?;
     if rec.rtype != "session_meta" {
         return None;
     }
-    let cwd = rec.payload.get("cwd")?.as_str()?;
-    Some(normalize_path(cwd))
+    Some(rec.payload.get("cwd")?.as_str()?.to_string())
 }
 
-/// Normalize a path for cwd↔workspace comparison: strip the macOS `/private` prefix that
-/// codex records for `/tmp` paths (`/private/tmp/...` → `/tmp/...`). A no-op elsewhere.
-fn normalize_path(p: &str) -> String {
-    p.strip_prefix("/private")
-        .filter(|rest| rest.starts_with('/'))
-        .map(str::to_string)
-        .unwrap_or_else(|| p.to_string())
-}
-
-/// Map a normalized session cwd → the agend agent that owns it, given the daemon home and
-/// the live (name, is_codex) set. An agend agent's workspace is `<home>/workspace/<name>`;
-/// we only attribute rollouts whose cwd matches a CODEX agent's workspace (never a stray
-/// codex the operator launched outside the fleet).
-fn agent_for_cwd(cwd: &str, home: &Path, codex_agents: &[String]) -> Option<String> {
-    // Compare as PATHS, not formatted strings. `home.join("workspace")` uses the platform
-    // separator (`\` on Windows), so a hardcoded `/` join would MIX separators and never
-    // match on Windows (it didn't — #2437 windows-latest). `Path` equality is
-    // separator-agnostic. `cwd` is already normalized (session_cwd strips the macOS
-    // `/private` prefix) so it shares the home's root form.
-    let cwd_path = Path::new(cwd);
-    codex_agents
-        .iter()
-        .find(|name| cwd_path == home.join("workspace").join(name))
-        .cloned()
+/// Map a session cwd → the agend codex agent that owns it. An agend agent's workspace is
+/// `<home>/workspace/<name>`, so we attribute by the cwd's TRAILING TWO path components:
+/// `workspace/<name>` for a LIVE codex agent. #2437 round-3: this is platform-robust where
+/// full-path equality against `home` was NOT — `Path::components` is separator-agnostic
+/// (handles `\` vs `/`), and it sidesteps every cross-platform cwd-format quirk (macOS
+/// `/private/tmp`, drive-letter case, symlink canonicalization, codex's own formatting).
+/// The exact `<name>` must be a live fleet codex agent, so a stray `*/workspace/<name>`
+/// outside the fleet is not attributed.
+fn agent_for_cwd(cwd: &str, codex_agents: &[String]) -> Option<String> {
+    let mut tail = Path::new(cwd).components().rev();
+    let name = tail.next()?.as_os_str().to_str()?; // <name>
+    let parent = tail.next()?.as_os_str().to_str()?; // must be "workspace"
+    if parent != "workspace" {
+        return None;
+    }
+    codex_agents.iter().find(|n| n.as_str() == name).cloned()
 }
 
 /// Today's codex rollout directory root (`<CODEX_HOME|~/.codex>/sessions`).
@@ -194,7 +186,7 @@ struct Cursor {
 /// Spawn the codex rollout tailer — a fire-and-forget daemon thread (mirrors
 /// `api_activity_probe::spawn`). No-op unless [`super::enabled`]. Wired into BOTH
 /// `run_core` AND `run_app` (the #2434 lesson: the live fleet daemon is app mode).
-pub fn spawn(registry: crate::agent::AgentRegistry, home: PathBuf) {
+pub fn spawn(registry: crate::agent::AgentRegistry) {
     if !super::enabled() {
         return;
     }
@@ -215,7 +207,7 @@ pub fn spawn(registry: crate::agent::AgentRegistry, home: PathBuf) {
                 "codex rollout tailer listening (stream plane)");
             let mut cursors: HashMap<PathBuf, Cursor> = HashMap::new();
             loop {
-                tail_once(&root, &registry, &home, &mut cursors);
+                tail_once(&root, &registry, &mut cursors);
                 std::thread::sleep(TAIL_TICK);
             }
         });
@@ -227,7 +219,6 @@ pub fn spawn(registry: crate::agent::AgentRegistry, home: PathBuf) {
 fn tail_once(
     root: &Path,
     registry: &crate::agent::AgentRegistry,
-    home: &Path,
     cursors: &mut HashMap<PathBuf, Cursor>,
 ) {
     let codex_agents = live_codex_agents(registry);
@@ -239,7 +230,7 @@ fn tail_once(
             offset: 0,
             agent: None,
         });
-        drain_file(&file, cur, home, &codex_agents);
+        drain_file(&file, cur, &codex_agents);
     }
 }
 
@@ -303,7 +294,7 @@ fn discover_rollouts(root: &Path) -> Vec<PathBuf> {
 /// the first `session_meta` line) to an agend codex agent, and push each transition as
 /// Evidence. A file not owned by any live codex agent is consumed-and-ignored (cursor
 /// advances so we don't re-scan it).
-fn drain_file(file: &Path, cur: &mut Cursor, home: &Path, codex_agents: &[String]) {
+fn drain_file(file: &Path, cur: &mut Cursor, codex_agents: &[String]) {
     use std::io::{BufRead, BufReader, Seek, SeekFrom};
     let Ok(f) = std::fs::File::open(file) else {
         return;
@@ -343,7 +334,7 @@ fn drain_file(file: &Path, cur: &mut Cursor, home: &Path, codex_agents: &[String
         // Resolve the owning agent from the session_meta header (first line).
         if cur.agent.is_none() {
             if let Some(cwd) = session_cwd(&line) {
-                cur.agent = agent_for_cwd(&cwd, home, codex_agents);
+                cur.agent = agent_for_cwd(&cwd, codex_agents);
             }
             // Either way the header line itself is not a transition.
             continue;
@@ -477,47 +468,46 @@ mod tests {
     }
 
     #[test]
-    fn session_cwd_extracts_and_normalizes_private_tmp() {
+    fn session_cwd_extracts_verbatim() {
         let line = r#"{"type":"session_meta","payload":{"id":"u1","cwd":"/private/tmp/svcx/workspace/cx","originator":"codex-tui"}}"#;
-        assert_eq!(session_cwd(line).as_deref(), Some("/tmp/svcx/workspace/cx"));
-        // Non-/private paths pass through unchanged.
-        let live = r#"{"type":"session_meta","payload":{"cwd":"/Users/x/.agend-terminal/workspace/codex-challenger"}}"#;
+        // Returned verbatim — no normalization (attribution is by trailing components).
         assert_eq!(
-            session_cwd(live).as_deref(),
-            Some("/Users/x/.agend-terminal/workspace/codex-challenger")
+            session_cwd(line).as_deref(),
+            Some("/private/tmp/svcx/workspace/cx")
         );
         // A non-session_meta line yields no cwd.
         assert_eq!(session_cwd(r#"{"type":"event_msg","payload":{}}"#), None);
     }
 
+    /// Attribution by trailing `workspace/<name>` components — separator-agnostic, robust on
+    /// macOS AND Windows (#2437 round-3). Fixtures built with the platform `Path` API + raw
+    /// forms; the macOS `/private` prefix no longer needs special handling (tail-only match).
     #[test]
     fn agent_for_cwd_matches_only_fleet_codex_workspace() {
-        let home = Path::new("/tmp/svcx");
         let agents = vec!["cx".to_string(), "cx2".to_string()];
+        // Unix-shaped fleet workspace.
         assert_eq!(
-            agent_for_cwd("/tmp/svcx/workspace/cx", home, &agents).as_deref(),
+            agent_for_cwd("/tmp/svcx/workspace/cx", &agents).as_deref(),
             Some("cx")
         );
-        // /private-normalized cwd matches the /tmp workspace.
+        // macOS /private form matches WITHOUT any normalization (tail components only).
         assert_eq!(
-            agent_for_cwd(
-                &normalize_path("/private/tmp/svcx/workspace/cx2"),
-                home,
-                &agents
-            )
-            .as_deref(),
+            agent_for_cwd("/private/tmp/svcx/workspace/cx2", &agents).as_deref(),
             Some("cx2")
         );
-        // A stray codex outside the fleet workspace is not attributed.
+        // A real platform path built via the Path API (Windows → `\` separators).
+        let plat = std::path::Path::new("/some/root")
+            .join("workspace")
+            .join("cx");
         assert_eq!(
-            agent_for_cwd("/Users/x/some/other/dir", home, &agents),
-            None
+            agent_for_cwd(&plat.to_string_lossy(), &agents).as_deref(),
+            Some("cx"),
+            "platform-separator path must still match"
         );
-        // An unknown agent name under the workspace root is not attributed.
-        assert_eq!(
-            agent_for_cwd("/tmp/svcx/workspace/ghost", home, &agents),
-            None
-        );
+        // A stray codex outside any `workspace/<name>` is not attributed.
+        assert_eq!(agent_for_cwd("/Users/x/some/other/dir", &agents), None);
+        // An unknown agent name under a `workspace` dir is not attributed.
+        assert_eq!(agent_for_cwd("/tmp/svcx/workspace/ghost", &agents), None);
     }
 
     /// Integration: a real on-disk rollout file (session_meta header + a turn) tailed by
@@ -534,9 +524,13 @@ mod tests {
         let cwd = ws.to_string_lossy().to_string();
         let roll = home.join("rollout-test.jsonl");
         let mut f = std::fs::File::create(&roll).unwrap();
+        // serde_json so the cwd is JSON-escaped — a real path has `\` on Windows, which is
+        // an invalid raw JSON escape (#2437 windows-latest). Production codex writes valid
+        // escaped JSON; the test must too.
         writeln!(
             f,
-            r#"{{"type":"session_meta","payload":{{"cwd":"{cwd}","originator":"codex-tui"}}}}"#
+            "{}",
+            serde_json::json!({"type":"session_meta","payload":{"cwd": &cwd, "originator":"codex-tui"}})
         )
         .unwrap();
         writeln!(
@@ -561,7 +555,7 @@ mod tests {
             agent: None,
         };
         let agents = vec!["cxt".to_string()];
-        drain_file(&roll, &mut cur, &home, &agents);
+        drain_file(&roll, &mut cur, &agents);
 
         assert_eq!(
             cur.agent.as_deref(),
@@ -599,7 +593,7 @@ mod tests {
         )
         .unwrap();
         f2.flush().unwrap();
-        drain_file(&roll, &mut cur, &home, &agents);
+        drain_file(&roll, &mut cur, &agents);
         assert_eq!(
             cur.offset, off_after,
             "partial line must not advance the cursor"
@@ -628,7 +622,8 @@ mod tests {
         let mut f = std::fs::File::create(&roll).unwrap();
         writeln!(
             f,
-            r#"{{"type":"session_meta","payload":{{"cwd":"{cwd}"}}}}"#
+            "{}",
+            serde_json::json!({"type":"session_meta","payload":{"cwd": &cwd}})
         )
         .unwrap();
         writeln!(
@@ -650,7 +645,7 @@ mod tests {
             agent: None,
         };
         let agents = vec!["cxr".to_string()];
-        drain_file(&roll, &mut cur, &home, &agents);
+        drain_file(&roll, &mut cur, &agents);
         assert!(
             cur.offset > 0 && cur.agent.is_some(),
             "first drain advanced"
@@ -662,7 +657,8 @@ mod tests {
         let mut f2 = std::fs::File::create(&roll).unwrap();
         writeln!(
             f2,
-            r#"{{"type":"session_meta","payload":{{"cwd":"{cwd}"}}}}"#
+            "{}",
+            serde_json::json!({"type":"session_meta","payload":{"cwd": &cwd}})
         )
         .unwrap();
         writeln!(
@@ -677,7 +673,7 @@ mod tests {
             "rebuilt session is shorter than the prior cursor"
         );
 
-        drain_file(&roll, &mut cur, &home, &agents);
+        drain_file(&roll, &mut cur, &agents);
         // Recovered: agent re-resolved from the new header + the new ToolStarted seen (the
         // pre-fix code would have left the cursor past EOF → observer DEAF → empty).
         let evs = super::super::peek("cxr");

--- a/src/daemon/shadow/rollout.rs
+++ b/src/daemon/shadow/rollout.rs
@@ -23,6 +23,14 @@ use std::path::{Path, PathBuf};
 /// near-real-time state without busy-spinning the disk.
 const TAIL_TICK: std::time::Duration = std::time::Duration::from_secs(1);
 
+/// How many LOCAL day-dirs back `discover_rollouts` scans (today + 2 prior). Covers a
+/// session that crosses one or two midnights (its file stays in its START-day dir). #2437 r4.
+const DISCOVER_DAYS: u32 = 3;
+
+/// Only tail rollout files modified within this window — skips dormant old sessions while
+/// still catching a long-running one that crossed midnight (whose file keeps being appended).
+const DISCOVER_RECENT: std::time::Duration = std::time::Duration::from_secs(26 * 3600);
+
 /// One codex rollout JSONL record — only the fields we consume (codex emits more).
 #[derive(Debug, Deserialize)]
 struct RolloutRecord {
@@ -154,14 +162,16 @@ fn normalize_path(p: &str) -> String {
 /// we only attribute rollouts whose cwd matches a CODEX agent's workspace (never a stray
 /// codex the operator launched outside the fleet).
 fn agent_for_cwd(cwd: &str, home: &Path, codex_agents: &[String]) -> Option<String> {
-    let ws_root = normalize_path(&home.join("workspace").to_string_lossy());
-    for name in codex_agents {
-        let ws = format!("{ws_root}/{name}");
-        if cwd == ws {
-            return Some(name.clone());
-        }
-    }
-    None
+    // Compare as PATHS, not formatted strings. `home.join("workspace")` uses the platform
+    // separator (`\` on Windows), so a hardcoded `/` join would MIX separators and never
+    // match on Windows (it didn't — #2437 windows-latest). `Path` equality is
+    // separator-agnostic. `cwd` is already normalized (session_cwd strips the macOS
+    // `/private` prefix) so it shares the home's root form.
+    let cwd_path = Path::new(cwd);
+    codex_agents
+        .iter()
+        .find(|name| cwd_path == home.join("workspace").join(name))
+        .cloned()
 }
 
 /// Today's codex rollout directory root (`<CODEX_HOME|~/.codex>/sessions`).
@@ -242,25 +252,51 @@ fn live_codex_agents(registry: &crate::agent::AgentRegistry) -> Vec<String> {
         .collect()
 }
 
-/// Today's rollout files under `<root>/<Y>/<M>/<D>/`. (Today only — a long-lived session
-/// crossing midnight is rare for an agent and re-discovered as the next day's dir fills;
-/// keeping it to today bounds the scan.)
+/// Recently-modified rollout files under the last [`DISCOVER_DAYS`] day-dirs
+/// (`<root>/<Y>/<M>/<D>/`). #2437 r4: a codex session is named by — and filed under — its
+/// START day (LOCAL date, matching the `rollout-<local-ts>` filename, NOT the UTC `Z`
+/// session_meta stamp). A long-running fleet agent's session crosses midnight and keeps
+/// appending to YESTERDAY's file, which a today-only scan would miss — leaving that agent
+/// OBSERVE-BLIND after every midnight until it restarts. So scan the last few LOCAL
+/// day-dirs and keep only files touched within [`DISCOVER_RECENT`] (bounds the set + skips
+/// dormant prior-day sessions).
 fn discover_rollouts(root: &Path) -> Vec<PathBuf> {
-    let now = chrono::Utc::now();
-    let dir = root
-        .join(now.format("%Y").to_string())
-        .join(now.format("%m").to_string())
-        .join(now.format("%d").to_string());
-    let Ok(rd) = std::fs::read_dir(&dir) else {
-        return Vec::new();
-    };
-    rd.filter_map(|e| e.ok().map(|e| e.path()))
-        .filter(|p| {
-            p.file_name()
+    let now = chrono::Local::now();
+    let recent_cutoff = std::time::SystemTime::now()
+        .checked_sub(DISCOVER_RECENT)
+        .unwrap_or(std::time::UNIX_EPOCH);
+    let mut out = Vec::new();
+    for back in 0..DISCOVER_DAYS {
+        let day = now - chrono::Duration::days(i64::from(back));
+        let dir = root
+            .join(day.format("%Y").to_string())
+            .join(day.format("%m").to_string())
+            .join(day.format("%d").to_string());
+        let Ok(rd) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for e in rd.flatten() {
+            let p = e.path();
+            let is_rollout = p
+                .file_name()
                 .and_then(|n| n.to_str())
-                .is_some_and(|n| n.starts_with("rollout-") && n.ends_with(".jsonl"))
-        })
-        .collect()
+                .is_some_and(|n| n.starts_with("rollout-") && n.ends_with(".jsonl"));
+            if !is_rollout {
+                continue;
+            }
+            // Recency: skip dormant old sessions; keep a long-running one still being
+            // written (its file mtime stays fresh even though its day-dir is older).
+            let fresh = e
+                .metadata()
+                .and_then(|m| m.modified())
+                .map(|m| m >= recent_cutoff)
+                .unwrap_or(true);
+            if fresh {
+                out.push(p);
+            }
+        }
+    }
+    out
 }
 
 /// Read newly-appended bytes of one rollout file from the cursor offset, attribute it (via
@@ -273,8 +309,16 @@ fn drain_file(file: &Path, cur: &mut Cursor, home: &Path, codex_agents: &[String
         return;
     };
     let len = f.metadata().map(|m| m.len()).unwrap_or(0);
+    // #2437 r6: a same-path REBUILD (codex reusing a path, or any truncation) shrinks the
+    // file below our cursor. Detect it and RESET — re-resolve the agent from the new header
+    // and re-drain from 0. Otherwise a shorter rewrite is never read (the observer goes
+    // DEAF for that agent) and a longer one would seek into the middle of a record.
+    if len < cur.offset {
+        cur.offset = 0;
+        cur.agent = None;
+    }
     if len <= cur.offset {
-        return; // nothing new (or truncated/rotated — leave for re-discovery)
+        return; // nothing new
     }
     let mut reader = BufReader::new(f);
     if reader.seek(SeekFrom::Start(cur.offset)).is_err() {
@@ -563,6 +607,87 @@ mod tests {
 
         super::super::drain("cxt");
         super::super::forget_agent("cxt");
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    /// #2437 r6 (regression): a same-path REBUILD (codex truncates/reuses a rollout path)
+    /// must REWIND the cursor so the observer keeps seeing the new session — not go DEAF
+    /// because the rebuilt file is shorter than the prior cursor offset.
+    #[test]
+    #[serial(shadow_observer)]
+    fn truncated_rollout_same_path_rewinds_cursor() {
+        use std::io::Write;
+        let home = std::env::temp_dir().join(format!("agend_roll_trunc_{}", std::process::id()));
+        let ws = home.join("workspace").join("cxr");
+        std::fs::create_dir_all(&ws).unwrap();
+        let cwd = ws.to_string_lossy().to_string();
+        let roll = home.join("rollout-trunc.jsonl");
+
+        // First session: header + a turn + padding so the cursor advances well past a short
+        // rebuild. Drain it.
+        let mut f = std::fs::File::create(&roll).unwrap();
+        writeln!(
+            f,
+            r#"{{"type":"session_meta","payload":{{"cwd":"{cwd}"}}}}"#
+        )
+        .unwrap();
+        writeln!(
+            f,
+            r#"{{"type":"event_msg","payload":{{"type":"task_started"}}}}"#
+        )
+        .unwrap();
+        for _ in 0..6 {
+            writeln!(
+                f,
+                r#"{{"type":"event_msg","payload":{{"type":"token_count","info":{{"last_token_usage":{{"input_tokens":1,"output_tokens":1}}}}}}}}"#
+            )
+            .unwrap();
+        }
+        f.flush().unwrap();
+        drop(f);
+        let mut cur = Cursor {
+            offset: 0,
+            agent: None,
+        };
+        let agents = vec!["cxr".to_string()];
+        drain_file(&roll, &mut cur, &home, &agents);
+        assert!(
+            cur.offset > 0 && cur.agent.is_some(),
+            "first drain advanced"
+        );
+        let big_offset = cur.offset;
+        super::super::drain("cxr"); // clear the buffer
+
+        // REBUILD: truncate (File::create) + a SHORTER new session. File now < big_offset.
+        let mut f2 = std::fs::File::create(&roll).unwrap();
+        writeln!(
+            f2,
+            r#"{{"type":"session_meta","payload":{{"cwd":"{cwd}"}}}}"#
+        )
+        .unwrap();
+        writeln!(
+            f2,
+            r#"{{"type":"response_item","payload":{{"type":"function_call","name":"exec_command"}}}}"#
+        )
+        .unwrap();
+        f2.flush().unwrap();
+        drop(f2);
+        assert!(
+            std::fs::metadata(&roll).unwrap().len() < big_offset,
+            "rebuilt session is shorter than the prior cursor"
+        );
+
+        drain_file(&roll, &mut cur, &home, &agents);
+        // Recovered: agent re-resolved from the new header + the new ToolStarted seen (the
+        // pre-fix code would have left the cursor past EOF → observer DEAF → empty).
+        let evs = super::super::peek("cxr");
+        assert!(
+            evs.iter()
+                .any(|e| matches!(&e.kind, EvidenceKind::ToolStarted { .. })),
+            "after truncation the observer must re-drain the rebuilt session, got {evs:?}"
+        );
+        super::super::drain("cxr");
+        super::super::forget_agent("cxr");
         let _ = std::fs::remove_dir_all(&home);
     }
 }


### PR DESCRIPTION
## #2413 Phase D — extend the Shadow Observer to codex agents

Reuse the Evidence schema + reducer; swap the observer SOURCE from claude's hook-socket to a strictly **read-only tail** of codex's own `~/.codex/sessions/.../rollout-*.jsonl`. flag-OFF default (`AGEND_SHADOW_OBSERVER`) ⇒ zero behaviour change; additive (never rewrites `agent_state`); never writes `~/.codex`, never injects — codex produces the file itself (the cleanest plane yet). **HARD-STOP at observer source + quantification** (no in-path proxy).

### Confirm-first (the hard gate) — PASSED
An isolated codex agent's rollout grew **18→43 lines during a 22s turn** — `function_call`/`response_item` records mid-turn, last record not `task_complete`. Codex live-flushes real-time state (not an end-of-turn batch).

### Observer source (`src/daemon/shadow/rollout.rs`)
Pure parser `record_to_evidence` (`task_started`→TurnStarted, `function_call{name}`→ToolStarted, `function_call_output`→ToolEnded, `message/assistant`+`agent_message`→Responding, `task_complete`→TurnEnded, `token_count`→TokenUsage + `rate_limits`→**RateLimited** — the bonus claude hooks lack) + `session_cwd` (normalizes macOS `/private/tmp`↔`/tmp`) + `agent_for_cwd` (fleet codex workspaces only) + a fire-and-forget tailer (discover today's rollouts, per-file byte-offset cursor, drain complete lines → `Evidence(Stream)` → the shared buffer the reducer consumes). Cross-platform `std::fs`. `Evidence::stream` added; `push`/`BUFFER_CAP` un-gated (cross-platform now). `rollout::spawn` wired into **both** `run_core` AND `run_app` owner block (the #2434 lesson — the live fleet daemon is app mode).

### Reducer generalization (lead-approved, surgical)
The freshness/authority gate was Hook-only, so codex Stream evidence came out `authority=Screen`. Generalized `{Hook|Stream}`: `last_hook_ms`→`last_observer_ms` + `last_observer_authority`; the active-family authority is labeled by the fresh plane (Hook→claude, Stream→codex); the mid-API beat + Path-2 reconcile recognize Stream. **Precedence + the 3-condition reconcile semantics are UNTOUCHED** (r4/r6's verified core). Claude (Hook-only) is **byte-identical** — the 18 existing reducer tests are the proof, plus an explicit `hook_only_agent_unchanged_after_phase_d_generalization` anchor.

### Quantification (`SHADOW-OBSERVER-QUANT-CODEX-2413.md`)
Real isolated codex, flag-on: the reducer reports `authority=Stream` for the whole active turn and **catches the codex false-idle** (raw screen-scrape read `idle` mid-turn while the reducer correctly held `Responding`/Stream); no false-active regression (back to idle on `task_complete`). Same headline win as claude.

### Tests / gating
- 8 parser unit tests + a real-file `drain_file` integration test.
- `run_app_wires_codex_rollout_tailer_2413` (app-mode-entry, production-region scan, **reverse-mutation verified RED**) — the #2434 vacuous-pin lesson.
- `codex_stream_evidence_gets_stream_authority_and_mid_api_beat` (Stream parity) + `hook_only_agent_unchanged_after_phase_d_generalization` (no-regression).
- macOS fmt + clippy(tray, all-targets) + Windows **cargo-xwin** clippy GREEN.

DUAL cross-model requested (reducer touched + new observer source → focus: claude no-regression + codex Stream parity + tailer lifecycle). Minor nit flagged: the P1 rate-limit / P2 waiting authority labels stay Hook-specific (left as precedence semantics; codex rate-limit-authority cosmetic — the rate-limit STATE still derives correctly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)