### PR TITLE
feat(recovery): respawn-stuck watchdog — auto-Fresh restart of a hung Resume (#t-777-3)

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -82,6 +82,13 @@ pub struct AgentHandle {
     pub(crate) typed_inject: bool,
     pub(crate) spawned_at: std::time::Instant,
     pub(crate) spawned_at_epoch_ms: u64,
+    /// The `SpawnMode` this handle's process was spawned with (#t-777-3). Stamped
+    /// at construction from `SpawnConfig.spawn_mode` so the respawn-stuck watchdog
+    /// can tell a hung `Resume` (corrupt-session resume that never came up) from a
+    /// merely-slow `Fresh` boot — it only force-recovers `Resume` spawns, never a
+    /// slow `Fresh` (the load-bearing false-kill guard). Immutable for the life of
+    /// the handle; a respawn replaces the whole handle with a freshly-stamped one.
+    pub(crate) spawn_mode: crate::backend::SpawnMode,
     /// Set by DELETE handler to prevent reaper from spawning shell fallback.
     pub(crate) deleted: Arc<std::sync::atomic::AtomicBool>,
 }
@@ -1300,6 +1307,9 @@ pub fn spawn_agent(
                     .duration_since(std::time::UNIX_EPOCH)
                     .unwrap_or_default()
                     .as_millis() as u64,
+                // #t-777-3: stamp the spawn mode so the respawn-stuck watchdog
+                // distinguishes a hung Resume from a slow Fresh boot.
+                spawn_mode: config.spawn_mode,
                 deleted: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             },
         );
@@ -3129,6 +3139,7 @@ pub(crate) fn mk_test_handle(name: &str, id: crate::types::InstanceId) -> AgentH
         typed_inject: false,
         spawned_at: std::time::Instant::now(),
         spawned_at_epoch_ms: 0,
+        spawn_mode: crate::backend::SpawnMode::Fresh,
         deleted: Arc::new(std::sync::atomic::AtomicBool::new(false)),
     }
 }

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -394,6 +394,7 @@ fn sweep_child_tree_body(pid_file: &std::path::Path) {
         typed_inject: false,
         spawned_at: std::time::Instant::now(),
         spawned_at_epoch_ms: 0,
+        spawn_mode: crate::backend::SpawnMode::Fresh,
         deleted: Arc::new(std::sync::atomic::AtomicBool::new(false)),
     };
     let registry: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
@@ -1007,6 +1008,7 @@ fn write_to_agent_typed_uses_timeout() {
         typed_inject: true,
         spawned_at: std::time::Instant::now(),
         spawned_at_epoch_ms: 0,
+        spawn_mode: crate::backend::SpawnMode::Fresh,
         deleted: Arc::new(std::sync::atomic::AtomicBool::new(false)),
     };
     let result = write_to_agent_typed(&handle, b"x");
@@ -1757,6 +1759,7 @@ fn pty_read_error_triggers_cleanup() {
             typed_inject: false,
             spawned_at: std::time::Instant::now(),
             spawned_at_epoch_ms: 0,
+            spawn_mode: crate::backend::SpawnMode::Fresh,
             deleted: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         },
     );
@@ -1876,6 +1879,7 @@ fn make_crash_exit_handle(deleted: bool) -> (AgentHandle, crate::types::Instance
         typed_inject: false,
         spawned_at: std::time::Instant::now(),
         spawned_at_epoch_ms: 0,
+        spawn_mode: crate::backend::SpawnMode::Fresh,
         deleted: Arc::new(std::sync::atomic::AtomicBool::new(deleted)),
     };
     (handle, id)
@@ -2217,6 +2221,7 @@ fn mk_handle_1441(name: &str, id: crate::types::InstanceId) -> AgentHandle {
         typed_inject: false,
         spawned_at: std::time::Instant::now(),
         spawned_at_epoch_ms: 0,
+        spawn_mode: crate::backend::SpawnMode::Fresh,
         deleted: Arc::new(std::sync::atomic::AtomicBool::new(false)),
     }
 }

--- a/src/daemon/crash_respawn.rs
+++ b/src/daemon/crash_respawn.rs
@@ -490,6 +490,7 @@ mod deleted_gate_tests_1913 {
             typed_inject: false,
             spawned_at: std::time::Instant::now(),
             spawned_at_epoch_ms: 0,
+            spawn_mode: crate::backend::SpawnMode::Fresh,
             deleted: Arc::new(AtomicBool::new(deleted)),
         }
     }

--- a/src/daemon/lifecycle.rs
+++ b/src/daemon/lifecycle.rs
@@ -357,6 +357,7 @@ mod tests {
             typed_inject: false,
             spawned_at: std::time::Instant::now(),
             spawned_at_epoch_ms: 0,
+            spawn_mode: crate::backend::SpawnMode::Fresh,
             deleted: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         }
     }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -672,6 +672,13 @@ pub(crate) fn build_default_handlers(
             std::sync::Arc::new(crash_tx),
             stage2_dispatch_available,
         )),
+        // #t-777-3: respawn-stuck watchdog — auto-Fresh-restart an agent whose
+        // Resume spawn hung (corrupt-session `resume --last`), bounded by a
+        // retry cap that escalates a P0 + pause. Recovers via the proven API
+        // restart path so it works in BOTH run_core and the live app-mode daemon
+        // (where the crash_tx→respawn machinery is inert). Disjoint state class
+        // from the Hung ladder above (no crash_tx needed).
+        Box::new(per_tick::RespawnWatchdogHandler::new()),
         Box::new(per_tick::WatchdogHandler::new(watchdog_dry_run)),
         Box::new(per_tick::ExternalLivenessHandler::new()),
         Box::new(per_tick::SnapshotRotationHandler::new()),

--- a/src/daemon/per_tick/mod.rs
+++ b/src/daemon/per_tick/mod.rs
@@ -54,6 +54,7 @@ pub(crate) mod progress_mirror;
 pub(crate) mod reclaim;
 pub(crate) mod reconcile_backups_gc;
 pub(crate) mod recovery_dispatcher;
+pub(crate) mod respawn_watchdog;
 pub(crate) mod shadow_observe;
 pub(crate) mod snapshot;
 pub(crate) mod supervisor_trackers;
@@ -84,6 +85,7 @@ pub(crate) use progress_mirror::ProgressMirrorHandler;
 pub(crate) use reclaim::ReclaimHandler;
 pub(crate) use reconcile_backups_gc::ReconcileBackupsGcHandler;
 pub(crate) use recovery_dispatcher::RecoveryDispatcherHandler;
+pub(crate) use respawn_watchdog::RespawnWatchdogHandler;
 pub(crate) use shadow_observe::ShadowObserveHandler;
 pub(crate) use snapshot::SnapshotRotationHandler;
 pub(crate) use supervisor_trackers::{
@@ -316,6 +318,7 @@ pub(crate) fn mock_live_agent_no_context(
         typed_inject: false,
         spawned_at: std::time::Instant::now(),
         spawned_at_epoch_ms: 0,
+        spawn_mode: crate::backend::SpawnMode::Fresh,
         deleted: Arc::new(std::sync::atomic::AtomicBool::new(false)),
     };
     (handle, reader)

--- a/src/daemon/per_tick/respawn_watchdog.rs
+++ b/src/daemon/per_tick/respawn_watchdog.rs
@@ -1,0 +1,602 @@
+//! #t-777-3: respawn-stuck watchdog — auto-recover an agent whose `Resume`
+//! spawn hung and never came up.
+//!
+//! ## The incident (RCA `workspace/fixup-dev-2/RESPAWN-WATCHDOG-RCA-777-3.md`)
+//! A broad `pkill` killed codex agents mid-session-write; the daemon then
+//! re-spawned them via the `Resume` path (`daemon/mod.rs:1850`
+//! `SpawnMode::Resume.downgraded_for` / app session-restore `app/session.rs:238`).
+//! `resume --last` on a half-written (corrupt) session **hung**, and the agent
+//! sat in `AgentState::Restarting` ~45 min with no watchdog covering it — the
+//! Hung recovery ladder keys on `HealthState::Hung`, never on a respawn that is
+//! itself stuck. Manual `restart_instance(fresh)` was the only fix.
+//!
+//! ## What this handler does
+//! Each tick it flags any agent that (a) was spawned via `Resume`, (b) is still
+//! in a not-yet-ready state (`Starting`/`Restarting`), (c) has been there past a
+//! timeout, AND (d) has emitted no output for that timeout — then auto-recovers
+//! via a **Fresh** restart through the PROVEN API path
+//! (`restart_instance_autonomic` → direct `DELETE`+`SPAWN` →
+//! `ApiEvent::InstanceCreated` → a fresh pane). That path works in BOTH the
+//! `run_core` daemon and the **live app-mode daemon** (`run_app`), where the
+//! `crash_tx`→respawn machinery is inert (agents spawn with `crash_tx: None`,
+//! `pane_factory.rs`) — which is exactly why this watchdog drives recovery via
+//! `api::call` instead of emitting an `AgentExitEvent`.
+//!
+//! ## Why `Resume`-only (the load-bearing false-kill guard)
+//! Firing ONLY on `SpawnMode::Resume` is what lets the watchdog ship
+//! ON-by-default safely: a slow-but-healthy *Fresh* boot is NEVER force-killed
+//! (its `spawn_mode != Resume`). The Fresh respawn this watchdog itself triggers
+//! is therefore never re-detected → the Resume-gate is the structural
+//! loop-breaker; the K-retry cap is the explicit belt for a recurring
+//! stuck-Resume pathology (e.g. a daemon that keeps restarting + re-resuming a
+//! corrupt session). After K failed auto-Fresh attempts within the stability
+//! window it stops retrying and escalates a P0 to the operator + pauses (the
+//! terminal "auto when possible, page when auto fails" escalation).
+//!
+//! ## Disjoint from the Hung ladder (no double-fire)
+//! `hang_detection` → `recovery_dispatcher` key on `HealthState::Hung`. This
+//! watchdog keys on `AgentState::{Starting,Restarting}` + `SpawnMode::Resume`
+//! and skips any agent already `HealthState::Paused` — a disjoint state class,
+//! so the two never act on the same agent in the same tick.
+//!
+//! ## Gate-exempt by construction (operator authority)
+//! The recovery goes through `restart_instance_autonomic`, whose inner
+//! `DELETE`/`SPAWN` are DIRECT api methods (operator-transport — `operator_gate`
+//! returns `Ok` before `classify`). It is reached ONLY from this internal
+//! hang-detection tick (never agent-invocable), so it is gate-exempt by the same
+//! daemon-autonomic-self-heal rationale as crash-respawn / hang-recovery: a
+//! stuck resume must self-heal even while the operator is away/asleep.
+
+use super::{PerTickHandler, TickContext};
+use crate::agent;
+use crate::backend::SpawnMode;
+use crate::health::HealthState;
+use crate::state::AgentState;
+use parking_lot::Mutex;
+use std::collections::{HashMap, HashSet};
+use std::sync::atomic::Ordering;
+use std::time::{Duration, Instant};
+
+/// `tracing` target for the watchdog's telemetry, so dashboards can aggregate
+/// its decisions alongside the `recovery_shadow` recovery-ladder surface.
+const TARGET: &str = "respawn_watchdog";
+
+/// Time an agent must sit in a not-yet-ready state — with NO output — after a
+/// `Resume` spawn before the watchdog judges the resume stuck. Generous vs a
+/// normal resume (which completes in seconds) so a slow-but-legit resume is
+/// never force-killed, while a hung one self-heals within ~1 min instead of the
+/// 45-min incident. Lead-set (#t-777-3 msg m-…100): ~60s.
+const RESPAWN_STUCK_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Anti-thrash: once the watchdog fires an auto-Fresh for an agent it will not
+/// re-fire for this long. Covers the async window between firing and the
+/// `DELETE`+`SPAWN` actually replacing the (still-`Resume`) handle, so a slow
+/// restart never queues a second fire. > `RESPAWN_STUCK_TIMEOUT` by design.
+const RESPAWN_RETRY_COOLDOWN: Duration = Duration::from_secs(90);
+
+/// Max auto-Fresh attempts per agent within the stability window before the
+/// watchdog gives up and escalates (terminal). Mirrors `STAGE2_MAX_RESTARTS`.
+const RESPAWN_MAX_RETRIES: u32 = 3;
+
+/// A retry record for an agent that is no longer stuck is forgiven (cleared)
+/// once this much stability elapses — mirrors `HealthTracker`'s
+/// `STABILITY_WINDOW` decay discipline so a long-recovered agent does not carry
+/// retry attribution forever.
+const RESPAWN_STABILITY_WINDOW: Duration = Duration::from_secs(1800);
+
+/// Kill-switch env var. The watchdog is ON by default (it is the missing safety
+/// floor); set `AGEND_RESPAWN_WATCHDOG=0` to disable without a daemon restart
+/// (read each tick, like the recovery-ladder gates).
+const DISABLE_ENV_VAR: &str = "AGEND_RESPAWN_WATCHDOG";
+
+/// Per-agent retry bookkeeping. Lives on the HANDLER (daemon-lifetime), NOT the
+/// agent handle, so it SURVIVES the `DELETE`+`SPAWN` that the auto-Fresh
+/// performs — a handle-local counter would reset to 0 on every fresh handle,
+/// making the K-cap unreachable. This is what lets the cap bound repeated
+/// stuck-Resume episodes across respawns.
+struct RetryRecord {
+    /// Auto-Fresh attempts fired for this agent in the current stability window.
+    count: u32,
+    /// When the last auto-Fresh fired (`None` = never) — drives both the
+    /// anti-thrash cooldown and the stability-window forgiveness.
+    last_retry_at: Option<Instant>,
+    /// Fire-once latch for the terminal P0 escalation, so a persistently-stuck
+    /// agent pages the operator at most once per cap cycle.
+    escalated: bool,
+}
+
+impl RetryRecord {
+    fn new() -> Self {
+        Self {
+            count: 0,
+            last_retry_at: None,
+            escalated: false,
+        }
+    }
+}
+
+/// What `decide` says to do with one stuck-Resume detection this tick.
+#[derive(Debug, PartialEq, Eq)]
+enum Action {
+    /// In cooldown, or already-escalated — do nothing this tick.
+    None,
+    /// Fire an auto-Fresh restart; carries the (1-based) attempt number.
+    Fire(u32),
+    /// Cap reached — pause + page the operator (terminal).
+    Escalate,
+}
+
+/// Pure decision + record mutation for one stuck detection, extracted so the
+/// bounded-retry / cooldown / fire-once-escalate state machine is unit-testable
+/// without a registry or the api round-trip. Takes `&mut RetryRecord` so a test
+/// can assert both the returned `Action` AND the resulting record state.
+fn decide(rec: &mut RetryRecord, now: Instant, cooldown: Duration, max: u32) -> Action {
+    if let Some(t) = rec.last_retry_at {
+        if now.saturating_duration_since(t) < cooldown {
+            return Action::None;
+        }
+    }
+    if rec.count >= max {
+        if rec.escalated {
+            return Action::None;
+        }
+        rec.escalated = true;
+        return Action::Escalate;
+    }
+    rec.count += 1;
+    rec.last_retry_at = Some(now);
+    Action::Fire(rec.count)
+}
+
+/// The stuck-Resume predicate, pure for unit tests. `true` ⟺ this spawn was a
+/// `Resume`, the agent is still in a not-yet-ready state, it has been there past
+/// `timeout`, AND it has produced no output for `timeout` (the conservative
+/// no-productive-output gate that spares a slow-but-emitting resume).
+fn is_stuck_resume(
+    spawn_mode: SpawnMode,
+    state: AgentState,
+    since_elapsed: Duration,
+    silent: Duration,
+    timeout: Duration,
+) -> bool {
+    spawn_mode == SpawnMode::Resume
+        && matches!(state, AgentState::Starting | AgentState::Restarting)
+        && since_elapsed > timeout
+        && silent > timeout
+}
+
+pub(crate) struct RespawnWatchdogHandler {
+    retries: Mutex<HashMap<String, RetryRecord>>,
+}
+
+impl RespawnWatchdogHandler {
+    pub(crate) fn new() -> Self {
+        Self {
+            retries: Mutex::new(HashMap::new()),
+        }
+    }
+}
+
+impl PerTickHandler for RespawnWatchdogHandler {
+    fn name(&self) -> &'static str {
+        "respawn_watchdog"
+    }
+
+    fn run(&self, ctx: &TickContext<'_>) {
+        // ON by default; operator kill-switch read each tick.
+        if std::env::var(DISABLE_ENV_VAR)
+            .map(|v| v == "0")
+            .unwrap_or(false)
+        {
+            return;
+        }
+
+        // Phase 1 (under the registry lock): collect the stuck-Resume names and
+        // the full live name-set. No I/O / api::call under the lock — the
+        // recovery work runs in phase 2 after the guard drops (lock-ordering /
+        // #1593 deadlock-class discipline, mirroring recovery_dispatcher).
+        let (stuck, live): (Vec<String>, HashSet<String>) = {
+            let reg = agent::lock_registry_tracked(ctx.registry, "respawn_watchdog");
+            let mut stuck = Vec::new();
+            let mut live = HashSet::new();
+            for handle in reg.values() {
+                let name = handle.name.to_string();
+                live.insert(name.clone());
+                // Skip an instance mid-teardown (deleted flag) — don't fight a
+                // delete with a respawn.
+                if handle.deleted.load(Ordering::Acquire) {
+                    continue;
+                }
+                let spawn_mode = handle.spawn_mode;
+                let core = handle.core.lock();
+                // Already operator/Stage3-paused → terminal, leave it alone
+                // (keeps this disjoint from the Hung ladder's Paused class).
+                if core.health.state == HealthState::Paused {
+                    continue;
+                }
+                let state = core.state.current;
+                let since_elapsed = core.state.since.elapsed();
+                let silent = core.state.last_output.elapsed();
+                drop(core);
+                if is_stuck_resume(
+                    spawn_mode,
+                    state,
+                    since_elapsed,
+                    silent,
+                    RESPAWN_STUCK_TIMEOUT,
+                ) {
+                    stuck.push(name);
+                }
+            }
+            (stuck, live)
+        };
+
+        // Forgive/evict stale retry records (agent recovered or left).
+        self.gc_records(&stuck, &live);
+
+        // Phase 2 (lock dropped): decide + act per stuck agent.
+        for name in &stuck {
+            self.handle_stuck(ctx, name);
+        }
+    }
+}
+
+impl RespawnWatchdogHandler {
+    /// Drop retry records for agents that left the registry, and forgive records
+    /// for agents that are no longer stuck once they've been stable for the
+    /// window (so a transient stuck-Resume that auto-recovered doesn't keep
+    /// counting toward the cap forever).
+    fn gc_records(&self, stuck: &[String], live: &HashSet<String>) {
+        let stuck_set: HashSet<&str> = stuck.iter().map(String::as_str).collect();
+        let now = Instant::now();
+        let mut retries = self.retries.lock();
+        retries.retain(|name, rec| {
+            if !live.contains(name) {
+                return false; // agent gone
+            }
+            if stuck_set.contains(name.as_str()) {
+                return true; // still stuck → keep counting
+            }
+            // Not stuck now: keep the record (so a quick re-stuck still counts)
+            // until it has been stable for the window, then forgive.
+            match rec.last_retry_at {
+                Some(t) => now.saturating_duration_since(t) < RESPAWN_STABILITY_WINDOW,
+                None => false,
+            }
+        });
+    }
+
+    /// Decide + act on one stuck-Resume agent. One lock acquisition mutates the
+    /// retry record and yields an `Action`; the I/O (thread spawn / notify /
+    /// enter_paused) runs AFTER the lock drops.
+    fn handle_stuck(&self, ctx: &TickContext<'_>, name: &str) {
+        let now = Instant::now();
+        let action = {
+            let mut retries = self.retries.lock();
+            let rec = retries
+                .entry(name.to_string())
+                .or_insert_with(RetryRecord::new);
+            decide(rec, now, RESPAWN_RETRY_COOLDOWN, RESPAWN_MAX_RETRIES)
+        };
+        match action {
+            Action::None => {}
+            Action::Fire(attempt) => self.fire_auto_fresh(ctx, name, attempt),
+            Action::Escalate => self.escalate_terminal(ctx, name),
+        }
+    }
+
+    /// (B) Trigger an auto-Fresh restart via the proven API path, off the tick.
+    fn fire_auto_fresh(&self, ctx: &TickContext<'_>, name: &str, attempt: u32) {
+        tracing::warn!(
+            target: TARGET,
+            agent = %name,
+            attempt,
+            max = RESPAWN_MAX_RETRIES,
+            "respawn-stuck watchdog: stuck Resume detected — triggering auto-Fresh restart"
+        );
+        crate::event_log::log(
+            ctx.home,
+            "respawn_watchdog_fresh",
+            name,
+            &format!("auto-Fresh restart attempt {attempt}/{RESPAWN_MAX_RETRIES}"),
+        );
+        let home = ctx.home.to_path_buf();
+        let name_owned = name.to_string();
+        // fire-and-forget: the restart round-trips DELETE+SPAWN over the api
+        // socket (~100ms+) and must not block the supervisor tick. No JoinHandle
+        // is kept — the restart is self-contained, its outcome is reported via
+        // tracing + the operator notify on failure, and progress is re-observed
+        // by next-tick re-detection (the cap handles a persistent failure).
+        std::thread::spawn(move || {
+            let reason =
+                format!("respawn-stuck watchdog auto-Fresh (#t-777-3, attempt {attempt}/{RESPAWN_MAX_RETRIES})");
+            let spawned = crate::mcp::handlers::instance_state::restart_instance_autonomic(
+                &home,
+                &name_owned,
+                &reason,
+            );
+            if spawned {
+                tracing::info!(
+                    target: TARGET,
+                    agent = %name_owned,
+                    attempt,
+                    "respawn-stuck watchdog: auto-Fresh restart issued"
+                );
+            } else {
+                tracing::error!(
+                    target: TARGET,
+                    agent = %name_owned,
+                    attempt,
+                    "respawn-stuck watchdog: auto-Fresh restart FAILED to spawn"
+                );
+                notify_restart_failed(&name_owned);
+            }
+        });
+    }
+
+    /// (A) Terminal escalation after the retry cap: pause the agent
+    /// (`enter_paused`) and page the operator P0 (fire-once via the `escalated`
+    /// latch set in `decide`).
+    fn escalate_terminal(&self, ctx: &TickContext<'_>, name: &str) {
+        let now = Instant::now();
+        {
+            let reg = agent::lock_registry(ctx.registry);
+            if let Some(h) = reg.values().find(|h| h.name.as_str() == name) {
+                h.core.lock().health.enter_paused(now);
+            }
+        }
+        crate::event_log::log(
+            ctx.home,
+            "respawn_watchdog_escalate",
+            name,
+            &format!("auto-Fresh exhausted after {RESPAWN_MAX_RETRIES} attempts — paused + P0"),
+        );
+        notify_escalation(name, RESPAWN_MAX_RETRIES);
+    }
+}
+
+/// Page the operator P0 that auto-recovery is exhausted. Mirrors
+/// `hang_detection::notify_self_orch_hung` — same `notify_all_escalation_channels`
+/// Error-severity, Sleep-penetrating path.
+fn notify_escalation(name: &str, attempts: u32) {
+    tracing::error!(
+        target: TARGET,
+        agent = %name,
+        attempts,
+        "respawn-stuck watchdog: auto-Fresh retries exhausted — escalating P0 + pausing"
+    );
+    let msg = format!(
+        "🛑 {name}: stuck on a `resume` that never came up. Auto-Fresh restart was attempted \
+         {attempts}× and it kept coming up stuck — giving up auto-recovery and PAUSING it. Manual \
+         intervention required: investigate the (likely corrupt) session, then `restart_instance` \
+         fresh / unpause."
+    );
+    crate::channel::notify_all_escalation_channels(
+        name,
+        crate::channel::NotifySeverity::Error,
+        &msg,
+        false,
+    );
+}
+
+/// Page the operator that a single auto-Fresh restart's SPAWN failed (agent
+/// likely gone), so a failed recovery is surfaced, not silently dropped.
+fn notify_restart_failed(name: &str) {
+    let msg = format!(
+        "⚠️ {name}: respawn-stuck watchdog attempted an auto-Fresh restart but the SPAWN failed — \
+         the agent may be gone. Manual operator check needed."
+    );
+    crate::channel::notify_all_escalation_channels(
+        name,
+        crate::channel::NotifySeverity::Error,
+        &msg,
+        false,
+    );
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::agent::{AgentRegistry, ExternalRegistry};
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    // ── detection predicate ──────────────────────────────────────────────
+
+    #[test]
+    fn stuck_resume_fires_on_resume_starting_past_both_timeouts() {
+        assert!(is_stuck_resume(
+            SpawnMode::Resume,
+            AgentState::Starting,
+            Duration::from_secs(61),
+            Duration::from_secs(61),
+            RESPAWN_STUCK_TIMEOUT,
+        ));
+    }
+
+    #[test]
+    fn stuck_resume_fires_on_restarting_too() {
+        assert!(is_stuck_resume(
+            SpawnMode::Resume,
+            AgentState::Restarting,
+            Duration::from_secs(120),
+            Duration::from_secs(120),
+            RESPAWN_STUCK_TIMEOUT,
+        ));
+    }
+
+    #[test]
+    fn fresh_spawn_never_fires_even_when_stuck() {
+        // The load-bearing false-kill guard: a slow Fresh boot is NEVER
+        // force-restarted, no matter how long it sits in Starting.
+        assert!(!is_stuck_resume(
+            SpawnMode::Fresh,
+            AgentState::Starting,
+            Duration::from_secs(600),
+            Duration::from_secs(600),
+            RESPAWN_STUCK_TIMEOUT,
+        ));
+    }
+
+    #[test]
+    fn ready_state_never_fires() {
+        // An agent that reached a ready state (Idle) is not stuck, even on a
+        // Resume spawn — `since`/`silence` are irrelevant.
+        assert!(!is_stuck_resume(
+            SpawnMode::Resume,
+            AgentState::Idle,
+            Duration::from_secs(600),
+            Duration::from_secs(600),
+            RESPAWN_STUCK_TIMEOUT,
+        ));
+    }
+
+    #[test]
+    fn slow_but_emitting_resume_is_spared() {
+        // In Starting past the time-in-state threshold, BUT still emitting output
+        // (silence below threshold) → a slow-but-alive resume, NOT stuck. The
+        // dual-elapsed gate is exactly the "no productive output" requirement.
+        assert!(!is_stuck_resume(
+            SpawnMode::Resume,
+            AgentState::Starting,
+            Duration::from_secs(120),
+            Duration::from_secs(5),
+            RESPAWN_STUCK_TIMEOUT,
+        ));
+    }
+
+    #[test]
+    fn within_timeout_never_fires() {
+        assert!(!is_stuck_resume(
+            SpawnMode::Resume,
+            AgentState::Starting,
+            Duration::from_secs(30),
+            Duration::from_secs(30),
+            RESPAWN_STUCK_TIMEOUT,
+        ));
+    }
+
+    // ── bounded-retry / cooldown / fire-once-escalate state machine ──────
+
+    #[test]
+    fn decide_first_detection_fires() {
+        let mut rec = RetryRecord::new();
+        let now = Instant::now();
+        let action = decide(&mut rec, now, RESPAWN_RETRY_COOLDOWN, RESPAWN_MAX_RETRIES);
+        assert_eq!(action, Action::Fire(1));
+        assert_eq!(rec.count, 1);
+        assert_eq!(rec.last_retry_at, Some(now));
+    }
+
+    #[test]
+    fn decide_skips_within_cooldown() {
+        let base = Instant::now();
+        let mut rec = RetryRecord {
+            count: 1,
+            last_retry_at: Some(base),
+            escalated: false,
+        };
+        // 30s after a fire, cooldown (90s) still active → no re-fire, no mutation.
+        let action = decide(
+            &mut rec,
+            base + Duration::from_secs(30),
+            RESPAWN_RETRY_COOLDOWN,
+            RESPAWN_MAX_RETRIES,
+        );
+        assert_eq!(action, Action::None);
+        assert_eq!(rec.count, 1);
+    }
+
+    #[test]
+    fn decide_fires_again_past_cooldown_under_cap() {
+        let base = Instant::now();
+        let mut rec = RetryRecord {
+            count: 1,
+            last_retry_at: Some(base),
+            escalated: false,
+        };
+        let later = base + RESPAWN_RETRY_COOLDOWN + Duration::from_secs(1);
+        let action = decide(&mut rec, later, RESPAWN_RETRY_COOLDOWN, RESPAWN_MAX_RETRIES);
+        assert_eq!(action, Action::Fire(2));
+        assert_eq!(rec.count, 2);
+        assert_eq!(rec.last_retry_at, Some(later));
+    }
+
+    #[test]
+    fn decide_escalates_once_at_cap_then_latches() {
+        let base = Instant::now();
+        let mut rec = RetryRecord {
+            count: RESPAWN_MAX_RETRIES,
+            last_retry_at: Some(base),
+            escalated: false,
+        };
+        let later = base + RESPAWN_RETRY_COOLDOWN + Duration::from_secs(1);
+        // Cap reached + past cooldown → Escalate, and latch.
+        assert_eq!(
+            decide(&mut rec, later, RESPAWN_RETRY_COOLDOWN, RESPAWN_MAX_RETRIES),
+            Action::Escalate
+        );
+        assert!(rec.escalated);
+        // Subsequent detections are silent (fire-once page).
+        let later2 = later + RESPAWN_RETRY_COOLDOWN + Duration::from_secs(1);
+        assert_eq!(
+            decide(
+                &mut rec,
+                later2,
+                RESPAWN_RETRY_COOLDOWN,
+                RESPAWN_MAX_RETRIES
+            ),
+            Action::None
+        );
+    }
+
+    // ── handler plumbing ────────────────────────────────────────────────
+
+    #[test]
+    fn name_matches_module() {
+        assert_eq!(RespawnWatchdogHandler::new().name(), "respawn_watchdog");
+    }
+
+    #[test]
+    fn run_is_noop_on_empty_registry() {
+        let home = std::env::temp_dir().join(format!(
+            "agend-respawn-wd-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&home).ok();
+        let registry: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let externals: ExternalRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let configs = Arc::new(Mutex::new(HashMap::new()));
+        let ctx = TickContext {
+            home: &home,
+            registry: &registry,
+            externals: &externals,
+            configs: &configs,
+        };
+        RespawnWatchdogHandler::new().run(&ctx);
+        assert!(registry.lock().is_empty());
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn gc_drops_records_for_absent_agents() {
+        let wd = RespawnWatchdogHandler::new();
+        {
+            let mut r = wd.retries.lock();
+            r.insert("gone".to_string(), RetryRecord::new());
+            r.insert("still-stuck".to_string(), RetryRecord::new());
+        }
+        let stuck = vec!["still-stuck".to_string()];
+        let mut live = HashSet::new();
+        live.insert("still-stuck".to_string()); // "gone" is no longer live
+        wd.gc_records(&stuck, &live);
+        let r = wd.retries.lock();
+        assert!(!r.contains_key("gone"), "absent agent's record evicted");
+        assert!(r.contains_key("still-stuck"), "stuck agent's record kept");
+    }
+}

--- a/src/daemon/poll_reminder.rs
+++ b/src/daemon/poll_reminder.rs
@@ -296,6 +296,7 @@ mod tests {
             typed_inject: false,
             spawned_at: std::time::Instant::now(),
             spawned_at_epoch_ms: 0,
+            spawn_mode: crate::backend::SpawnMode::Fresh,
             deleted: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         };
         let reg: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -3932,6 +3932,7 @@ instances:
             typed_inject: false,
             spawned_at: std::time::Instant::now(),
             spawned_at_epoch_ms: 0,
+            spawn_mode: crate::backend::SpawnMode::Fresh,
             deleted: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         };
         (handle, reader)

--- a/src/mcp/handlers/instance_state/mod.rs
+++ b/src/mcp/handlers/instance_state/mod.rs
@@ -451,6 +451,31 @@ pub(super) fn handle_restart_instance(home: &Path, args: &Value) -> Value {
     json!({"name": name, "reason": reason, "mode": mode, "spawned": spawned})
 }
 
+/// #t-777-3: daemon-autonomic self-heal entry — the respawn-stuck watchdog's
+/// narrow path to a **Fresh** restart. Wraps `handle_restart_instance(mode=fresh)`,
+/// which round-trips the PROVEN direct `DELETE`(no_wait)+`SPAWN` api::calls →
+/// `ApiEvent::InstanceCreated` → app pane Fresh respawn (the same path the
+/// operator's manual `restart_instance fresh` takes, working in the live
+/// app-mode daemon where the crash_tx→respawn machinery is inert).
+///
+/// **Gate-exempt BY CONSTRUCTION** (no new operator-gate surface): the inner
+/// `DELETE`/`SPAWN` are DIRECT api methods — operator-transport, which
+/// `operator_gate::check_operation_allowed` returns `Ok` for before `classify`
+/// is consulted. Reached ONLY from the per-tick hang-detection watchdog (never
+/// agent-invocable), so the narrowness is enforced by the trigger, exactly like
+/// crash-respawn / hang-recovery (`operator_gate` module scope note). Returns
+/// whether the SPAWN succeeded so the caller can escalate a failed recovery.
+pub(crate) fn restart_instance_autonomic(home: &Path, name: &str, reason: &str) -> bool {
+    let result = handle_restart_instance(
+        home,
+        &json!({"name": name, "mode": "fresh", "reason": reason}),
+    );
+    result
+        .get("spawned")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false)
+}
+
 pub(super) fn resolve_team_layout(
     home: &Path,
     name: &str,


### PR DESCRIPTION
## Problem (RCA: task t-…777-3)
A broad `pkill` killed codex agents mid-session-write; the daemon re-spawned them via the **Resume** path (`daemon/mod.rs:1850` `downgraded_for` / app session-restore `session.rs:238`). `resume --last` on the half-written (corrupt) session **hung**, and the agent sat in `AgentState::Restarting` **~45 min** with **no watchdog** — the Hung recovery ladder keys only on `HealthState::Hung`, never on a respawn that is itself stuck. Manual `restart_instance(fresh)` was the only fix. (Codex `has_resumable_session()` always returns `true`, so the corrupt Resume is never pre-downgraded to Fresh.)

## Fix — new per-tick `RespawnWatchdogHandler`
- **Detect:** `spawn_mode==Resume && state ∈ {Starting,Restarting} && in-state >60s && no output >60s`. **Resume-only** is the load-bearing false-kill guard (a slow *Fresh* boot is never force-restarted) and the structural loop-breaker (a Fresh respawn is never re-detected).
- **Recover (B):** auto-Fresh via the **proven API path** — `restart_instance_autonomic` → direct `DELETE`+`SPAWN` → `ApiEvent::InstanceCreated` → fresh pane. Works in **both** `run_core` and the **live app-mode daemon** (`run_app`), where the `crash_tx`→respawn machinery is inert (`pane_factory` spawns with `crash_tx: None`) — which is why recovery drives via `api::call`, not an `AgentExitEvent`.
- **Bound + escalate (A):** a **handler-local** retry map (survives the `DELETE`+`SPAWN` that resets a handle-local counter) caps at **3** attempts/stability-window; on exhaustion → `enter_paused` + operator **P0 page** (terminal). Anti-thrash cooldown covers the async restart window. "Auto when possible, page when auto fails."
- **Disjoint** from the Hung ladder (keys on `AgentState`+`SpawnMode`, skips `Paused`) → no double-fire. **ON by default** (`AGEND_RESPAWN_WATCHDOG=0` kill-switch).

## Enabling change
Stamp `SpawnMode` onto `AgentHandle` so the watchdog can tell a hung Resume from a slow Fresh boot (not previously recorded).

## operator authority
**No new gate surface.** The inner `DELETE`/`SPAWN` are DIRECT api methods (operator-transport — `check_operation_allowed` returns `Ok` before `classify`), reached ONLY from this internal hang-detection tick (never agent-invocable) → gate-exempt **by construction**, same trust model as crash-respawn / hang-recovery.

## Tests
13 unit tests: predicate truth-table (incl. Fresh-never-fires + slow-but-emitting-spared), bounded-retry/cooldown/fire-once-escalate state machine, gc, smoke. App-completeness + recovery + spawn-rationale + file-size + state-mutation invariants green. v1 = watchdog only; codex `has_resumable_session()` corrupt-session detection = follow-up.

⚠ **Dogfood note:** this changes recovery and is its own dogfood (binary-lag) — verify via merge + daemon restart, not only in-worktree tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)