### PR TITLE
Add explicit context provider telemetry

### DIFF
--- a/src/api/handlers/query.rs
+++ b/src/api/handlers/query.rs
@@ -27,6 +27,7 @@ pub(crate) fn handle_list(_params: &Value, ctx: &HandlerCtx) -> Value {
                 blocked_reason,
                 blocked_note,
                 context,
+                context_provider,
                 api_in_flight,
                 last_api_activity_at,
                 observed_status,
@@ -40,10 +41,11 @@ pub(crate) fn handle_list(_params: &Value, ctx: &HandlerCtx) -> Value {
                     // blocked and its free-text annotation (previously internal-only).
                     c.health.current_reason.as_ref().map(|r| r.to_string()),
                     c.health.current_note.clone(),
-                    // Context% telemetry: resolved usage + producing source
-                    // ("pattern" = the agent's own statusline, "transcript" =
-                    // token-usage estimate). Absent = honestly unknown.
+                    // Context% telemetry: resolved usage + producing source.
+                    // Absent = honestly unknown; context_provider says whether
+                    // the backend has a trustworthy passive signal at all.
                     c.state.resolved_context(),
+                    c.state.context_provider(),
                     // #2413 Phase 1: out-of-path API-activity signal, read under the
                     // SAME lock as agent_state so a consumer can reconcile the two
                     // atomically (false-idle = agent_state=="idle" && api_in_flight).
@@ -66,7 +68,8 @@ pub(crate) fn handle_list(_params: &Value, ctx: &HandlerCtx) -> Value {
                 "blocked_reason": blocked_reason,
                 "blocked_note": blocked_note,
                 "context_pct": context.map(|(pct, _)| pct),
-                "context_source": context.map(|(_, source)| source),
+                "context_source": context.map(|(_, source)| source.source_name()),
+                "context_provider": context_provider.source_name(),
                 // #2413 Phase 1: live LLM-socket activity (out-of-path lsof probe).
                 // api_in_flight=true while pattern-state is "idle" ⇒ false-idle.
                 "api_in_flight": api_in_flight,

--- a/src/backend_profile.rs
+++ b/src/backend_profile.rs
@@ -27,6 +27,29 @@ use crate::behavioral::{BehavioralConfig, MarkerCacheId, ProductivityConfig};
 use crate::state::AgentState;
 use std::sync::OnceLock;
 
+/// Source-of-truth capability for context% telemetry.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ContextProvider {
+    /// The backend renders a stable status/footer line that reports context use.
+    StatusLine,
+    /// Reserved for a calibrated transcript-token estimator. Callers must treat
+    /// this as lower confidence than [`ContextProvider::StatusLine`].
+    #[allow(dead_code)]
+    TranscriptEstimate { confidence: f32 },
+    /// The backend has no trustworthy passive context signal.
+    Unavailable,
+}
+
+impl ContextProvider {
+    pub fn source_name(self) -> &'static str {
+        match self {
+            ContextProvider::StatusLine => "statusline",
+            ContextProvider::TranscriptEstimate { .. } => "transcript",
+            ContextProvider::Unavailable => "unavailable",
+        }
+    }
+}
+
 /// All per-backend detection data for one backend, co-located.
 ///
 /// #8 Phase 2 step-0: now consumed by PROD — `StatePatterns::for_backend`,
@@ -45,6 +68,7 @@ pub struct BackendProfile {
     /// only over the bottom status rows — NOT the error tail window — because
     /// agents routinely DISCUSS context% in conversation text (prose-FP).
     pub context_pattern: Option<&'static str>,
+    pub context_provider: ContextProvider,
     /// #1947: prompt markers identifying the backend's INPUT line (and echoed /
     /// submitted user-message lines). An error pattern matched on a line whose
     /// trimmed start is one of these is operator-typed / quoted text, not CLI
@@ -150,6 +174,7 @@ fn agy_profile() -> BackendProfile {
             cache_id: Some(MarkerCacheId::Agy),
         },
         context_pattern: None,
+        context_provider: ContextProvider::Unavailable,
         input_line_markers: &[],
         initial_state: AgentState::Starting,
     }
@@ -210,6 +235,7 @@ fn kirocli_profile() -> BackendProfile {
             cache_id: Some(MarkerCacheId::Kiro),
         },
         context_pattern: Some(KIRO_CONTEXT_PATTERN),
+        context_provider: ContextProvider::StatusLine,
         input_line_markers: &[">"],
         initial_state: AgentState::Starting,
     }
@@ -284,6 +310,7 @@ fn opencode_profile() -> BackendProfile {
             cache_id: Some(MarkerCacheId::OpenCode),
         },
         context_pattern: None,
+        context_provider: ContextProvider::Unavailable,
         input_line_markers: &[],
         initial_state: AgentState::Starting,
     }
@@ -343,6 +370,7 @@ fn codex_profile() -> BackendProfile {
             cache_id: Some(MarkerCacheId::Codex),
         },
         context_pattern: None,
+        context_provider: ContextProvider::Unavailable,
         input_line_markers: &["›"],
         initial_state: AgentState::Starting,
     }
@@ -430,6 +458,7 @@ fn claudecode_profile() -> BackendProfile {
             cache_id: Some(MarkerCacheId::Claude),
         },
         context_pattern: Some(CLAUDE_CONTEXT_PATTERN),
+        context_provider: ContextProvider::StatusLine,
         input_line_markers: &["❯", ">"],
         initial_state: AgentState::Starting,
     }
@@ -448,6 +477,7 @@ fn empty_profile() -> BackendProfile {
             cache_id: Some(MarkerCacheId::Generic),
         },
         context_pattern: None,
+        context_provider: ContextProvider::Unavailable,
         input_line_markers: &[],
         initial_state: AgentState::Idle,
     }
@@ -474,6 +504,39 @@ mod context_pattern_tests {
         assert!(!has(&Backend::Agy));
         assert!(!has(&Backend::Shell));
         assert!(!has(&Backend::Raw("x".into())));
+    }
+
+    #[test]
+    fn context_provider_presence_per_backend() {
+        let provider = |b: &Backend| profile(b).context_provider;
+        assert_eq!(provider(&Backend::ClaudeCode), ContextProvider::StatusLine);
+        assert_eq!(provider(&Backend::KiroCli), ContextProvider::StatusLine);
+        assert_eq!(provider(&Backend::Codex), ContextProvider::Unavailable);
+        assert_eq!(provider(&Backend::OpenCode), ContextProvider::Unavailable);
+        assert_eq!(provider(&Backend::Agy), ContextProvider::Unavailable);
+        assert_eq!(provider(&Backend::Shell), ContextProvider::Unavailable);
+        assert_eq!(
+            provider(&Backend::Raw("x".into())),
+            ContextProvider::Unavailable
+        );
+    }
+
+    #[test]
+    fn unavailable_context_providers_do_not_claim_a_pattern() {
+        for backend in [
+            Backend::Codex,
+            Backend::OpenCode,
+            Backend::Agy,
+            Backend::Shell,
+            Backend::Raw("x".into()),
+        ] {
+            let profile = profile(&backend);
+            assert_eq!(profile.context_provider, ContextProvider::Unavailable);
+            assert!(
+                profile.context_pattern.is_none(),
+                "{backend:?} is unavailable and must not compile a statusline pattern"
+            );
+        }
     }
 
     /// Both patterns compile and extract the percent (capture group 1) from

--- a/src/daemon/per_tick/context_alert.rs
+++ b/src/daemon/per_tick/context_alert.rs
@@ -3,9 +3,9 @@
 //! alert goes to the agent's team orchestrator (and the usage is visible via
 //! LIST `context_pct`/`context_source`); nothing is auto-restarted.
 //!
-//! Source per agent (see `StateTracker::resolved_context`): the statusline
-//! `pattern` ONLY — a pane whose statusline can't be read is honestly
-//! `unknown` (no alert, `null` in LIST).
+//! Source per agent (see `StateTracker::resolved_context`): typed context
+//! providers. Today only statusline providers produce readings; unavailable
+//! backends are honestly `unknown` (no alert, `null` in LIST).
 //!
 //! #1945-disable (operator decision, 2026-06-10): the transcript-estimate
 //! fallback is DISABLED — its first live minute fired a triple false 100%
@@ -101,9 +101,9 @@ impl PerTickHandler for ContextAlertHandler {
             return;
         }
 
-        // Phase 1 (cheap, locks only): snapshot each agent's resolved context
-        // — statusline pattern only (#1945-disable: no transcript estimate;
-        // an unreadable pane is unknown and never alerts).
+        // Phase 1 (cheap, locks only): snapshot each agent's resolved context.
+        // Unavailable providers return None, so they stay unknown and never
+        // alert as a guessed 100%.
         let mut resolved: Vec<(String, f32, &'static str)> = Vec::new();
         // #latch-prune (cleanup-on-delete, #1923 G5 class): capture ALL live
         // agent names — not just those with a context reading — so the per-agent
@@ -115,7 +115,7 @@ impl PerTickHandler for ContextAlertHandler {
             for handle in reg.values() {
                 live.insert(handle.name.as_str().to_string());
                 if let Some((pct, source)) = handle.core.lock().state.resolved_context() {
-                    resolved.push((handle.name.as_str().to_string(), pct, source));
+                    resolved.push((handle.name.as_str().to_string(), pct, source.source_name()));
                 }
             }
             live

--- a/src/daemon/per_tick/context_handoff.rs
+++ b/src/daemon/per_tick/context_handoff.rs
@@ -5,12 +5,12 @@
 //! safety net against the 6/10 97%-stall incident shape, not seamless
 //! succession (Plan B, deferred until the #1523 hook track stabilizes).
 //!
-//! Signal: `StateTracker::resolved_context` — statusline `pattern` ONLY.
-//! Per-backend honesty: today only the claude backend renders a readable
-//! context statusline, so only claude agents ever produce a reading; kiro
-//! (pie icon, pattern TBD), codex (hidden by default), opencode/agy (no
-//! passive signal) yield `None` and are NEVER injected — the fallback is
-//! "do nothing", documented, not "guess" (multi-backend principle).
+//! Signal: `StateTracker::resolved_context`.
+//! Per-backend honesty: Claude and Kiro currently render readable status/footer
+//! context percentages (`ContextProvider::StatusLine`). Codex, OpenCode, and
+//! Agy declare `ContextProvider::Unavailable`, yield `None`, and are NEVER
+//! injected from a guessed value — the fallback is "do nothing", documented,
+//! not "guess" (multi-backend principle).
 //!
 //! NOISE BUDGET (hard requirement, per operator) — the #2008 four
 //! principles apply:
@@ -225,8 +225,8 @@ impl PerTickHandler for ContextHandoffHandler {
         }
 
         // Phase 1 (cheap, locks only): snapshot resolved context + idleness.
-        // Agents without a pattern reading (every non-claude backend today)
-        // produce nothing here and are never injected.
+        // Agents whose provider is unavailable produce nothing here and are
+        // never injected from a guessed value.
         let mut snapshot: Vec<(String, f32, bool)> = Vec::new();
         // #latch-prune (cleanup-on-delete, #1923 G5 class): capture ALL live
         // agent names so the per-agent `states` episode-latch can drop deleted

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -283,6 +283,7 @@ pub struct StateTracker {
     /// truncate the statusline mid-session; the timestamp lets consumers
     /// judge staleness instead of treating "can't read" as "safe".
     context_pct: Option<(f32, Instant)>,
+    context_provider: crate::backend_profile::ContextProvider,
     /// Set to true the moment we enter `InteractivePrompt`; cleared by
     /// `take_interactive_prompt_notice()` once the supervisor has forwarded a
     /// Telegram notice. This deduplicates per-entry: re-entry (e.g. dismissed
@@ -1315,6 +1316,10 @@ impl StateTracker {
                 .and_then(|p| p.context_pattern)
                 .and_then(|p| regex::Regex::new(p).ok()),
             context_pct: None,
+            context_provider: backend
+                .map(crate::backend_profile::profile)
+                .map(|p| p.context_provider)
+                .unwrap_or(crate::backend_profile::ContextProvider::Unavailable),
             interactive_prompt_pending_notice: false,
             interactive_recovery_pending_notice: false,
             blocked_since: None,
@@ -1478,9 +1483,9 @@ impl StateTracker {
         }
     }
 
-    /// Resolved context usage as `(percent, source)` — PATTERN ONLY (the
-    /// agent's own statusline). Readings older than [`CONTEXT_FRESH`] are
-    /// dropped rather than trusted — `None` = honestly unknown, no alert.
+    /// Resolved context usage as `(percent, provider)` — currently statusline
+    /// only. Readings older than [`CONTEXT_FRESH`] are dropped rather than
+    /// trusted — `None` = honestly unknown, no alert.
     ///
     /// #1945-disable (operator decision, 2026-06-10): the transcript-estimate
     /// fallback ("transcript" source) is DISABLED — its first live minute
@@ -1489,13 +1494,17 @@ impl StateTracker {
     /// corrected estimator + its root-cause record live on in
     /// `token_cost::estimate_context_pct` (tested, uncalled); re-enable ONLY
     /// after validating its readings against statusline ground truth.
-    pub fn resolved_context(&self) -> Option<(f32, &'static str)> {
+    pub fn resolved_context(&self) -> Option<(f32, crate::backend_profile::ContextProvider)> {
         if let Some((pct, at)) = self.context_pct {
             if at.elapsed() < CONTEXT_FRESH {
-                return Some((pct, "pattern"));
+                return Some((pct, self.context_provider));
             }
         }
         None
+    }
+
+    pub fn context_provider(&self) -> crate::backend_profile::ContextProvider {
+        self.context_provider
     }
 
     /// Feed the current vterm screen text (ANSI already resolved by the

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -1,5 +1,6 @@
 use super::patterns::is_generic_startup_prompt;
 use super::*;
+use crate::backend_profile::ContextProvider;
 use crate::health::HealthTracker;
 use crate::vterm::CellFg;
 
@@ -4990,7 +4991,7 @@ fn claude_context_pct_extracted_from_statusline() {
     t.feed(CLAUDE_STATUSLINE_FRAME);
     let (pct, source) = t.resolved_context().expect("statusline percent extracted");
     assert!((pct - 61.0).abs() < f32::EPSILON);
-    assert_eq!(source, "pattern");
+    assert_eq!(source, ContextProvider::StatusLine);
 }
 
 /// A stale frame can leave an OLD statusline copy above the live one (seen in
@@ -5029,7 +5030,7 @@ fn kiro_context_pct_extracted_from_footer() {
     );
     let (pct, source) = t.resolved_context().expect("footer percent extracted");
     assert!((pct - 10.0).abs() < f32::EPSILON);
-    assert_eq!(source, "pattern");
+    assert_eq!(source, ContextProvider::StatusLine);
 }
 
 /// Prose-FP guard: agents routinely DISCUSS context% in conversation text.
@@ -5067,10 +5068,10 @@ fn context_pct_truncated_statusline_keeps_previous_reading() {
     assert!((pct - 61.0).abs() < f32::EPSILON);
 }
 
-/// #1945-disable: context resolution is PATTERN ONLY — the transcript
-/// estimate is disabled (its first live minute fired a triple false 100%
-/// alert), so an unreadable statusline is honestly unknown (no alert) and a
-/// readable one reports source "pattern". The estimate plumbing
+/// #1945-disable: context resolution is statusline-provider only — the
+/// transcript estimate is disabled (its first live minute fired a triple false
+/// 100% alert), so an unreadable statusline is honestly unknown (no alert) and
+/// a readable one reports `ContextProvider::StatusLine`. The estimate plumbing
 /// (`set_context_estimate` / the "transcript" source) is REMOVED from the
 /// tracker — this test pins that the disabled path stays disabled.
 #[test]
@@ -5083,8 +5084,8 @@ fn context_resolution_is_pattern_only_estimate_disabled_1945() {
     t.feed(CLAUDE_STATUSLINE_FRAME);
     assert_eq!(
         t.resolved_context().map(|(p, s)| (p as u32, s)),
-        Some((61, "pattern")),
-        "pattern reading reports with source \"pattern\""
+        Some((61, ContextProvider::StatusLine)),
+        "pattern reading reports with source ContextProvider::StatusLine"
     );
 }
 
@@ -5099,10 +5100,11 @@ fn context_pct_unknown_for_backends_without_pattern() {
         Backend::Shell,
     ] {
         let mut t = StateTracker::new(Some(&backend));
+        assert_eq!(t.context_provider(), ContextProvider::Unavailable);
         t.feed("  Model: X | Ctx Used: 61.0% | done\n❯");
         assert!(
             t.resolved_context().is_none(),
-            "{backend:?} has no context_pattern → unknown"
+            "{backend:?} has ContextProvider::Unavailable → unknown"
         );
     }
 }


### PR DESCRIPTION
## Summary
- add ContextProvider to backend profiles, with StatusLine for Claude/Kiro and Unavailable for Codex/OpenCode/Agy/Shell/Raw
- return typed context provider information from StateTracker::resolved_context and expose context_provider in list output
- update context alert/handoff comments so unavailable providers stay honestly unknown, not guessed
- add tests pinning backend provider capability and unavailable-provider behavior

## Verification
- cargo fmt --check
- cargo check
- cargo test context_