### PR TITLE
feat(telemetry): explicit context_provider in LIST (#2439 redo)

### DIFF
--- a/src/api/handlers/query.rs
+++ b/src/api/handlers/query.rs
@@ -27,6 +27,7 @@ pub(crate) fn handle_list(_params: &Value, ctx: &HandlerCtx) -> Value {
                 blocked_reason,
                 blocked_note,
                 context,
+                context_provider,
                 api_in_flight,
                 last_api_activity_at,
                 observed_status,
@@ -44,6 +45,11 @@ pub(crate) fn handle_list(_params: &Value, ctx: &HandlerCtx) -> Value {
                     // ("pattern" = the agent's own statusline, "transcript" =
                     // token-usage estimate). Absent = honestly unknown.
                     c.state.resolved_context(),
+                    // #2439: the backend's context-telemetry CAPABILITY (statusline
+                    // vs unavailable), derived from statusline-pattern presence.
+                    // Always present — distinct from context_source/context_pct above,
+                    // which are absent when there's no fresh reading.
+                    c.state.context_provider(),
                     // #2413 Phase 1: out-of-path API-activity signal, read under the
                     // SAME lock as agent_state so a consumer can reconcile the two
                     // atomically (false-idle = agent_state=="idle" && api_in_flight).
@@ -66,7 +72,11 @@ pub(crate) fn handle_list(_params: &Value, ctx: &HandlerCtx) -> Value {
                 "blocked_reason": blocked_reason,
                 "blocked_note": blocked_note,
                 "context_pct": context.map(|(pct, _)| pct),
+                // CONTRACT (#2439): keep emitting "pattern" here for the existing
+                // external-dashboard consumers — the new typed capability goes in the
+                // additive `context_provider` field below, NOT by renaming this.
                 "context_source": context.map(|(_, source)| source),
+                "context_provider": context_provider.source_name(),
                 // #2413 Phase 1: live LLM-socket activity (out-of-path lsof probe).
                 // api_in_flight=true while pattern-state is "idle" ⇒ false-idle.
                 "api_in_flight": api_in_flight,

--- a/src/backend_profile.rs
+++ b/src/backend_profile.rs
@@ -27,6 +27,36 @@ use crate::behavioral::{BehavioralConfig, MarkerCacheId, ProductivityConfig};
 use crate::state::AgentState;
 use std::sync::OnceLock;
 
+/// Whether a backend can passively report context-window usage — surfaced as the
+/// LIST `context_provider` telemetry field (#2439). DERIVED at runtime from the
+/// presence of a statusline `context_pattern` (see
+/// [`crate::state::StateTracker::context_provider`]); it is NOT a separately stored
+/// per-backend field, so it can never drift from the pattern table it summarizes.
+/// Unlike `context_source`/`context_pct` (absent when there is no fresh reading),
+/// this is ALWAYS reported: it tells a consumer whether the backend CAN report
+/// context at all, distinct from "has a reading right now".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContextProvider {
+    /// The backend renders a status/footer line we can read a context% from (it
+    /// declares a `context_pattern`): Claude, Kiro.
+    StatusLine,
+    /// The backend exposes no trustworthy passive context signal: Codex, OpenCode,
+    /// Agy, and the shell/raw fallbacks. Its `context_pct` is honestly absent
+    /// rather than a guess.
+    Unavailable,
+}
+
+impl ContextProvider {
+    /// Stable LIST/telemetry string. CONTRACT: external dashboards key off these
+    /// values — do not rename without coordinating consumers.
+    pub fn source_name(self) -> &'static str {
+        match self {
+            ContextProvider::StatusLine => "statusline",
+            ContextProvider::Unavailable => "unavailable",
+        }
+    }
+}
+
 /// All per-backend detection data for one backend, co-located.
 ///
 /// #8 Phase 2 step-0: now consumed by PROD — `StatePatterns::for_backend`,

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1498,6 +1498,22 @@ impl StateTracker {
         None
     }
 
+    /// The backend's context-telemetry capability for the LIST `context_provider`
+    /// field (#2439). DERIVED from `context_regex.is_some()` — i.e. whether the
+    /// backend declared a statusline `context_pattern` — so it is never a separately
+    /// stored field that could drift from the pattern table. Unlike
+    /// [`resolved_context`](Self::resolved_context) (absent without a fresh reading),
+    /// this is ALWAYS available: `StatusLine` means the backend CAN report context
+    /// (Claude/Kiro), `Unavailable` means it has no passive signal (Codex/OpenCode/
+    /// Agy/shell) so an absent `context_pct` is honest, not a missed read.
+    pub fn context_provider(&self) -> crate::backend_profile::ContextProvider {
+        if self.context_regex.is_some() {
+            crate::backend_profile::ContextProvider::StatusLine
+        } else {
+            crate::backend_profile::ContextProvider::Unavailable
+        }
+    }
+
     /// Feed the current vterm screen text (ANSI already resolved by the
     /// terminal emulator — caller passes plain text rows).
     ///

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -6004,3 +6004,66 @@ fn codex_auth_pattern_drops_generic_api_key_token() {
         "a real codex auth error must still detect"
     );
 }
+
+// ───────────────────────── #2439 context provider telemetry ─────────────────────────
+
+/// #2439: `context_provider` is DERIVED from statusline-pattern presence (not a
+/// stored per-backend field), so backends that read a context statusline report
+/// `StatusLine` and the rest report `Unavailable`. This is the realized mapping a
+/// LIST consumer sees.
+#[test]
+fn context_provider_derived_from_statusline_pattern_presence() {
+    use crate::backend_profile::ContextProvider;
+    // Backends that declare a context_pattern (→ context_regex is_some) read a
+    // statusline percent.
+    for backend in [Backend::ClaudeCode, Backend::KiroCli] {
+        let t = StateTracker::new(Some(&backend));
+        assert_eq!(
+            t.context_provider(),
+            ContextProvider::StatusLine,
+            "{backend:?} reads a statusline context% → StatusLine"
+        );
+        assert_eq!(t.context_provider().source_name(), "statusline");
+    }
+    // Backends with no passive context signal derive Unavailable — a silent null
+    // becomes an explicit, honest "unavailable".
+    for backend in [
+        Backend::Codex,
+        Backend::OpenCode,
+        Backend::Agy,
+        Backend::Shell,
+        Backend::Raw("/opt/whatever".to_string()),
+    ] {
+        let t = StateTracker::new(Some(&backend));
+        assert_eq!(
+            t.context_provider(),
+            ContextProvider::Unavailable,
+            "{backend:?} has no statusline pattern → Unavailable"
+        );
+        assert_eq!(t.context_provider().source_name(), "unavailable");
+    }
+}
+
+/// #2439 CONTRACT: adding `context_provider` must NOT change the existing LIST
+/// `context_source` value — external dashboards key off `"pattern"`. After a real
+/// statusline reading, `resolved_context` still reports `"pattern"` while the new
+/// `context_provider` reports the typed `statusline` capability alongside it.
+#[test]
+fn context_source_stays_pattern_while_context_provider_is_statusline() {
+    use crate::backend_profile::ContextProvider;
+    let mut t = StateTracker::new(Some(&Backend::ClaudeCode));
+    t.feed("ctx used: 42%");
+    let (pct, source) = t
+        .resolved_context()
+        .expect("a fresh statusline reading resolves");
+    assert!((pct - 42.0).abs() < f32::EPSILON, "parsed percent: {pct}");
+    assert_eq!(
+        source, "pattern",
+        "context_source must stay \"pattern\" (external-dashboard contract)"
+    );
+    assert_eq!(
+        t.context_provider(),
+        ContextProvider::StatusLine,
+        "the new typed capability coexists with the unchanged context_source"
+    );
+}


### PR DESCRIPTION
Redo of external contributor @justdoit530-hub's closed PR #2439, applying fleet (r4)'s two constraints the original missed. Credit to @justdoit530-hub for the original idea + shape.

## What
Adds an always-present `context_provider` field to the LIST API so a consumer can tell whether a backend **can** report context-window usage at all — distinct from whether it has a fresh reading right now:
- `statusline` — backend renders a readable context% (Claude, Kiro)
- `unavailable` — no trustworthy passive signal (Codex, OpenCode, Agy, shell/raw)

Codex et al. already returned a silent `null` `context_pct`; making that an explicit `unavailable` is the improvement — **not** "lost numbers".

## r4's two constraints (the original PR broke both)
1. **DERIVED, not stored**: `StateTracker::context_provider()` derives from `context_regex.is_some()` (statusline-pattern presence). No new per-backend `BackendProfile` field that could drift from the pattern table.
2. **`context_source` contract preserved**: the existing LIST `context_source` value stays `"pattern"` (external dashboards key off it). The original renamed it to `"statusline"`; this keeps it and adds `context_provider` as an **additive** field. `resolved_context` / context_alert / context_handoff are untouched.

## Scope
**Purely additive (+119/-0)**: `ContextProvider {StatusLine, Unavailable}` enum + `source_name()` (backend_profile.rs), derived `StateTracker::context_provider()` (state/mod.rs), new LIST field (query.rs).

## Tests
- `context_provider_derived_from_statusline_pattern_presence` — realized per-backend mapping (Claude/Kiro→statusline; Codex/OpenCode/Agy/Shell/Raw→unavailable).
- `context_source_stays_pattern_while_context_provider_is_statusline` — locks the dashboard contract: after a real reading, `context_source` is still `"pattern"` while `context_provider` is `"statusline"`.

## Preflight (green)
fmt · tray clippy `-D warnings` · **cargo-xwin Windows clippy `-D warnings`** · state(359)/backend_profile(10) tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)