### PR TITLE
feat(#2435): TUI image paste (Ctrl+B i) — clipboard → PNG → agent Read, attach + app

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,6 +43,7 @@ dependencies = [
  "memchr",
  "parking_lot",
  "plist",
+ "png",
  "portable-pty",
  "predicates",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,6 +138,12 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "local-time"] 
 # `crate::logging`; CLI commands keep stderr.
 tracing-appender = "0.2"
 arboard = "3.6.1"
+# #2435 TUI image paste: encode clipboard RGBA → PNG. Pinned to "0.18" to UNIFY
+# with the `png 0.18.1` already in the tree (transitively via arboard's own
+# backends + the `image` crate), so this adds NO second png version. Do NOT use
+# the heavyweight `image` crate here (see the `tray` note below) — `png` alone
+# is the lightweight encoder we need.
+png = "0.18"
 unicode-width = "0.2"
 which = "8"
 # #2288 re-bumped sysinfo 0.38→0.39.3, which requires rustc 1.95 and broke the

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -373,8 +373,38 @@ pub(super) fn dispatch(action: Action, ctx: &mut DispatchCtx<'_>) -> DispatchRes
                 Err(e) => tracing::warn!(error = %e, "toggle copy-on-select failed"),
             }
         }
+        // #2435: paste a clipboard image into the focused pane's agent. This arm
+        // is COMPILE-FORCED — the match is exhaustive (no `_` catch-all), so the
+        // app surface cannot silently drop the feature (#2434/#2438 mode-mismatch
+        // class). Production passes the real clipboard capture; tests inject a
+        // synthetic one (see `paste_image`).
+        Action::PasteImage => paste_image(ctx, crate::image_paste::capture_clipboard_image),
     }
     out
+}
+
+/// Capture a clipboard image (via `capture`) and inject its `[AGEND-IMAGE-PASTE]`
+/// marker into the focused pane — the `app`-mode half of #2435.
+///
+/// `capture` is a dependency-injection seam: production passes
+/// [`crate::image_paste::capture_clipboard_image`] (reads the real GUI
+/// clipboard); tests pass a synthetic capture so the keybind → marker →
+/// focused-pane wiring is provable through this REAL `app` path WITHOUT a GUI
+/// clipboard (which headless CI lacks). A capture `Err` (no image / unreachable
+/// clipboard) logs and no-ops, so a mis-paste never disrupts the session.
+fn paste_image<F>(ctx: &mut DispatchCtx<'_>, capture: F)
+where
+    F: FnOnce() -> anyhow::Result<(std::path::PathBuf, String)>,
+{
+    match capture() {
+        Ok((path, marker)) => {
+            tracing::info!(target: "image_paste", path = %path.display(), "image paste → focused pane (app)");
+            super::write_to_focused(ctx.home, ctx.layout, ctx.registry, marker.as_bytes());
+        }
+        Err(e) => {
+            tracing::warn!(target: "image_paste", error = %e, "image paste failed (no clipboard image?)");
+        }
+    }
 }
 
 #[cfg(test)]
@@ -573,6 +603,85 @@ mod tests {
         assert!(
             pane.selection.is_some(),
             "#84662: nothing-to-copy is not a completed copy → highlight unchanged"
+        );
+    }
+
+    // #2435: representative app-mode WIRING test — the focused pane's
+    // `last_input_at` (set by Pane::write_input) is the observable proving the
+    // marker flowed through the REAL app path (paste_image → write_to_focused →
+    // write_input), not just attach. The clipboard read is mocked via the
+    // injected capture so this runs in headless CI; the full real-clipboard
+    // dispatch is covered by an #[ignore] manual test.
+    fn focused_last_input_some(ctx: &DispatchCtx<'_>) -> bool {
+        ctx.layout
+            .active_tab()
+            .expect("active tab")
+            .root()
+            .find_pane(1)
+            .expect("focused pane")
+            .last_input_at
+            .is_some()
+    }
+
+    #[test]
+    fn paste_image_injects_marker_into_focused_pane() {
+        let registry: AgentRegistry = std::sync::Arc::new(parking_lot::Mutex::new(HashMap::new()));
+        let home = std::env::temp_dir();
+        let (tx, _rx) = crossbeam_channel::bounded(1);
+        let mut layout = Layout::new();
+        layout.add_tab(Tab::new("a".to_string(), test_pane(1, "a")));
+        layout.active = 0;
+        let mut last_tab = 0;
+        let mut names = HashMap::new();
+        let mut ctx = make_ctx(
+            &mut layout,
+            &registry,
+            &home,
+            &mut last_tab,
+            &tx,
+            &mut names,
+        );
+        assert!(!focused_last_input_some(&ctx), "precondition: no input yet");
+
+        // Drive the REAL app paste path with a synthetic capture (clipboard mocked).
+        paste_image(&mut ctx, || {
+            Ok((
+                std::path::PathBuf::from("/tmp/agend_paste_test.png"),
+                "[AGEND-IMAGE-PASTE: /tmp/agend_paste_test.png]\n".to_string(),
+            ))
+        });
+
+        assert!(
+            focused_last_input_some(&ctx),
+            "#2435: paste_image must inject the marker into the focused pane (app-mode wiring live)"
+        );
+    }
+
+    #[test]
+    fn paste_image_capture_err_is_graceful_noop() {
+        let registry: AgentRegistry = std::sync::Arc::new(parking_lot::Mutex::new(HashMap::new()));
+        let home = std::env::temp_dir();
+        let (tx, _rx) = crossbeam_channel::bounded(1);
+        let mut layout = Layout::new();
+        layout.add_tab(Tab::new("a".to_string(), test_pane(1, "a")));
+        layout.active = 0;
+        let mut last_tab = 0;
+        let mut names = HashMap::new();
+        let mut ctx = make_ctx(
+            &mut layout,
+            &registry,
+            &home,
+            &mut last_tab,
+            &tx,
+            &mut names,
+        );
+
+        // A capture failure (no clipboard image) must NOT inject and must NOT panic.
+        paste_image(&mut ctx, || Err(anyhow::anyhow!("no image in clipboard")));
+
+        assert!(
+            !focused_last_input_some(&ctx),
+            "#2435: a failed clipboard capture injects nothing"
         );
     }
 }

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -610,8 +610,10 @@ mod tests {
     // `last_input_at` (set by Pane::write_input) is the observable proving the
     // marker flowed through the REAL app path (paste_image → write_to_focused →
     // write_input), not just attach. The clipboard read is mocked via the
-    // injected capture so this runs in headless CI; the full real-clipboard
-    // dispatch is covered by an #[ignore] manual test.
+    // injected capture so this runs in headless CI. The full real-clipboard path
+    // (arboard get_image on an actual GUI clipboard image) has NO committed test —
+    // headless CI has no clipboard — and is verified manually on a real desktop
+    // (see the `crate::image_paste` module doc).
     fn focused_last_input_some(ctx: &DispatchCtx<'_>) -> bool {
         ctx.layout
             .active_tab()

--- a/src/image_paste.rs
+++ b/src/image_paste.rs
@@ -7,13 +7,15 @@
 //! text + a PNG file, so any backend with a `Read`-style tool works.
 //!
 //! ## Surface-agnostic by design
-//! This module owns ONLY the clipboard→png→temp→marker logic — it does NOT bind
-//! a keystroke or pick a TUI entry point. The keybind wiring (attach CLI vs the
-//! `app` multi-pane TUI) is added by a caller once the operator confirms the
-//! surface (#2435); we have been burned by app-mode vs run_core/attach mode
-//! mismatches before (#2434/#2438), so the entry point is deliberately deferred
-//! while the reusable core ships + is tested now. `#![allow(dead_code)]` covers
-//! the not-yet-wired public entry until that caller lands.
+//! This module owns ONLY the clipboard→png→temp→marker logic — it binds NO
+//! keystroke and picks NO TUI entry. `Ctrl+B i` is wired to BOTH surfaces by
+//! their own dispatchers (operator chose both): the attach CLI (`crate::tui`,
+//! via `BridgeClient`) and the `app` multi-pane TUI (`app::dispatch`, via
+//! `write_to_focused`). Keeping the core here — not in either surface — is what
+//! avoids the app-mode vs run_core/attach mode-mismatch class (#2434/#2438): the
+//! same `capture_clipboard_image` serves both, and `app::dispatch`'s exhaustive
+//! match compile-forces the app arm so the feature can't be live-in-attach-but-
+//! dead-in-app.
 //!
 //! ## Cross-platform testing boundary ([xwin compile ≠ windows runtime])
 //! `arboard` + the `png` encoder are cross-platform and compile for
@@ -24,7 +26,6 @@
 //! Everything else here — PNG encode, temp write, the stale-file sweep, and the
 //! marker chain — is pure/deterministic and unit-tested below, so the
 //! windows-latest CI runtime gates it on Windows too.
-#![allow(dead_code)] // public entry wired to a TUI surface in a #2435 follow-up
 
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};

--- a/src/image_paste.rs
+++ b/src/image_paste.rs
@@ -1,0 +1,264 @@
+//! #2435 TUI image paste — surface-agnostic core.
+//!
+//! Captures an image from the operator's clipboard, encodes it to a PNG in the
+//! system temp dir, and produces an `[AGEND-IMAGE-PASTE: <path>]` marker to
+//! inject into an agent's input. The agent (taught by `crate::instructions`)
+//! then `Read`s that path. Backend-agnostic: the agent only ever sees marker
+//! text + a PNG file, so any backend with a `Read`-style tool works.
+//!
+//! ## Surface-agnostic by design
+//! This module owns ONLY the clipboard→png→temp→marker logic — it does NOT bind
+//! a keystroke or pick a TUI entry point. The keybind wiring (attach CLI vs the
+//! `app` multi-pane TUI) is added by a caller once the operator confirms the
+//! surface (#2435); we have been burned by app-mode vs run_core/attach mode
+//! mismatches before (#2434/#2438), so the entry point is deliberately deferred
+//! while the reusable core ships + is tested now. `#![allow(dead_code)]` covers
+//! the not-yet-wired public entry until that caller lands.
+//!
+//! ## Cross-platform testing boundary ([xwin compile ≠ windows runtime])
+//! `arboard` + the `png` encoder are cross-platform and compile for
+//! windows-msvc (cargo-xwin verified). But the clipboard-READ step
+//! (`arboard::get_image`) needs a real GUI clipboard holding an image, so it is
+//! NOT reachable from headless CI — it is verified by a human paste on a real
+//! desktop (a macOS arboard set→get→encode round-trip was run as manual proof).
+//! Everything else here — PNG encode, temp write, the stale-file sweep, and the
+//! marker chain — is pure/deterministic and unit-tested below, so the
+//! windows-latest CI runtime gates it on Windows too.
+#![allow(dead_code)] // public entry wired to a TUI surface in a #2435 follow-up
+
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+/// Filename prefix for temp PNGs this feature writes — also what the cleanup
+/// sweep matches. One constant so a rename can't desync writer and sweeper.
+const PASTE_FILE_PREFIX: &str = "agend_paste_";
+
+/// How long a pasted temp PNG lives before a later paste sweeps it. Generous —
+/// the agent reads the file within seconds; this just bounds temp-dir growth
+/// without risking the just-written file (age ≈ 0).
+const PASTE_FILE_TTL: Duration = Duration::from_secs(3600);
+
+/// The marker prefix the agent is taught to recognize (see `crate::instructions`).
+const MARKER_PREFIX: &str = "[AGEND-IMAGE-PASTE: ";
+
+/// Build the input marker for a pasted image. One function so the wire format
+/// stays in lockstep with the `[AGEND-IMAGE-PASTE]` contract documented to
+/// agents in `crate::instructions`.
+fn image_paste_marker(path: &Path) -> String {
+    format!("{MARKER_PREFIX}{}]\n", path.display())
+}
+
+/// Encode raw 8-bit RGBA bytes (`width*height*4` long) as a PNG in the system
+/// temp dir; returns the absolute path. Uses the `png` crate directly — the
+/// heavyweight `image` crate is deliberately NOT pulled (see Cargo.toml).
+fn save_rgba_as_png(bytes: &[u8], width: usize, height: usize) -> anyhow::Result<PathBuf> {
+    let ts = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!("{PASTE_FILE_PREFIX}{ts}.png"));
+    let file = std::fs::File::create(&path)?;
+    let mut enc = png::Encoder::new(file, width as u32, height as u32);
+    enc.set_color(png::ColorType::Rgba);
+    enc.set_depth(png::BitDepth::Eight);
+    enc.write_header()?.write_image_data(bytes)?;
+    Ok(path)
+}
+
+/// Pure staleness decision, extracted so the TTL logic is unit-testable without
+/// touching the filesystem or sleeping. A file is stale iff its age exceeds
+/// `ttl`; a `modified` in the future (clock skew) → `duration_since` errs → not
+/// stale (fail-safe: never delete a file that looks newer than now).
+fn is_stale(modified: SystemTime, now: SystemTime, ttl: Duration) -> bool {
+    now.duration_since(modified)
+        .map(|age| age > ttl)
+        .unwrap_or(false)
+}
+
+/// Best-effort sweep of stale paste PNGs in `dir` older than `ttl`. Never errors
+/// (missing dir / unreadable entry / failed remove is silently skipped) — temp
+/// hygiene must never break the paste path.
+fn cleanup_old_paste_images_in(dir: &Path, ttl: Duration) {
+    let now = SystemTime::now();
+    let Ok(rd) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in rd.flatten() {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+        if !(name.starts_with(PASTE_FILE_PREFIX) && name.ends_with(".png")) {
+            continue;
+        }
+        let modified = entry.metadata().and_then(|m| m.modified()).ok();
+        if modified.is_some_and(|m| is_stale(m, now, ttl)) {
+            let _ = std::fs::remove_file(entry.path());
+        }
+    }
+}
+
+/// Surface-agnostic core: encode `width*height` RGBA `bytes` to a temp PNG and
+/// return `(path, marker)` — the marker is what a caller injects into the
+/// agent's input. Clipboard-independent (the bytes are passed in), so this is
+/// the seam the representative wiring test drives with a synthetic image (the
+/// real clipboard read is mocked out). Sweeps stale prior pastes first.
+fn encode_and_mark(bytes: &[u8], width: usize, height: usize) -> anyhow::Result<(PathBuf, String)> {
+    cleanup_old_paste_images_in(&std::env::temp_dir(), PASTE_FILE_TTL);
+    let path = save_rgba_as_png(bytes, width, height)?;
+    let marker = image_paste_marker(&path);
+    Ok((path, marker))
+}
+
+/// Read an image from the system clipboard, save it as a PNG, and return
+/// `(path, marker)` for the caller to inject into the attached agent. This is
+/// the one not-headless-testable seam — `arboard::get_image` needs a real GUI
+/// clipboard image (verified manually). Errors (no image / unreachable
+/// clipboard) propagate so the caller can log + no-op rather than break the
+/// session.
+pub(crate) fn capture_clipboard_image() -> anyhow::Result<(PathBuf, String)> {
+    let mut cb = arboard::Clipboard::new()?;
+    let img = cb.get_image()?;
+    encode_and_mark(&img.bytes, img.width, img.height)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    /// 2x2 RGBA (red, green, blue, white) — minimal synthetic image.
+    fn synthetic_rgba() -> (usize, usize, Vec<u8>) {
+        let px: [[u8; 4]; 4] = [
+            [255, 0, 0, 255],
+            [0, 255, 0, 255],
+            [0, 0, 255, 255],
+            [255, 255, 255, 255],
+        ];
+        (2, 2, px.concat())
+    }
+
+    fn unique_tmp_dir(tag: &str) -> PathBuf {
+        let d = std::env::temp_dir().join(format!(
+            "agend-imgpaste-{tag}-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&d).unwrap();
+        d
+    }
+
+    /// Decode a PNG file's dimensions (png 0.18 needs `BufRead + Seek`).
+    fn png_dims(path: &Path) -> (u32, u32) {
+        let dec = png::Decoder::new(std::io::BufReader::new(std::fs::File::open(path).unwrap()));
+        let reader = dec.read_info().unwrap();
+        let info = reader.info();
+        (info.width, info.height)
+    }
+
+    #[test]
+    fn save_rgba_writes_valid_png_in_temp() {
+        let (w, h, rgba) = synthetic_rgba();
+        let path = save_rgba_as_png(&rgba, w, h).expect("encode");
+        assert!(path.exists());
+        assert!(
+            path.starts_with(std::env::temp_dir()),
+            "writes into temp dir"
+        );
+        assert!(path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|n| n.starts_with(PASTE_FILE_PREFIX) && n.ends_with(".png")));
+        let raw = std::fs::read(&path).unwrap();
+        assert_eq!(&raw[..8], b"\x89PNG\r\n\x1a\n", "valid PNG signature");
+        assert_eq!(png_dims(&path), (w as u32, h as u32));
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn marker_matches_documented_contract() {
+        let p = Path::new("/tmp/agend_paste_123.png");
+        let m = image_paste_marker(p);
+        // Must match the `[AGEND-IMAGE-PASTE: <path>]` form instructions.rs
+        // teaches the agent, and end in a newline so it submits as one line.
+        assert!(m.starts_with("[AGEND-IMAGE-PASTE: "));
+        assert!(m.ends_with("]\n"));
+        assert!(m.contains("/tmp/agend_paste_123.png"));
+    }
+
+    #[test]
+    fn is_stale_decision_both_directions() {
+        let now = SystemTime::UNIX_EPOCH + Duration::from_secs(10_000);
+        let ttl = Duration::from_secs(3600);
+        // 2h old → stale.
+        assert!(is_stale(now - Duration::from_secs(7200), now, ttl));
+        // 1min old → fresh.
+        assert!(!is_stale(now - Duration::from_secs(60), now, ttl));
+        // future mtime (clock skew) → fail-safe not-stale.
+        assert!(!is_stale(now + Duration::from_secs(60), now, ttl));
+    }
+
+    #[test]
+    fn cleanup_removes_matching_stale_keeps_others() {
+        let dir = unique_tmp_dir("cleanup");
+        let stale = dir.join("agend_paste_old.png");
+        let other_png = dir.join("unrelated.png"); // wrong prefix
+        let other_ext = dir.join("agend_paste_note.txt"); // wrong ext
+        for f in [&stale, &other_png, &other_ext] {
+            std::fs::write(f, b"x").unwrap();
+        }
+        // ttl=0 → any matching file (age > 0) is stale. A brief pause makes the
+        // age unambiguously > 0 without depending on clock granularity.
+        std::thread::sleep(Duration::from_millis(15));
+        cleanup_old_paste_images_in(&dir, Duration::ZERO);
+        assert!(!stale.exists(), "matching stale PNG removed");
+        assert!(other_png.exists(), "non-prefixed PNG untouched");
+        assert!(other_ext.exists(), "non-PNG untouched");
+
+        // With a generous ttl, a fresh matching file is kept.
+        let fresh = dir.join("agend_paste_fresh.png");
+        std::fs::write(&fresh, b"x").unwrap();
+        cleanup_old_paste_images_in(&dir, Duration::from_secs(3600));
+        assert!(fresh.exists(), "fresh matching PNG kept");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn cleanup_on_missing_dir_is_noop() {
+        // Never errors on a dir that doesn't exist.
+        cleanup_old_paste_images_in(Path::new("/nonexistent/agend/imgpaste/xyz"), Duration::ZERO);
+    }
+
+    /// Representative WIRING test (lead reinforcement): drive the whole chain a
+    /// real paste traverses — synthetic clipboard image → `encode_and_mark` →
+    /// the injected marker → the path an agent would `Read` — with the
+    /// clipboard read mocked (synthetic bytes stand in for `arboard::get_image`).
+    /// Proves the pieces are actually wired together, not just individually
+    /// correct: the marker the agent receives points at a real, readable PNG of
+    /// the captured image.
+    #[test]
+    fn chain_synthetic_image_to_agent_readable_marker() {
+        let (w, h, rgba) = synthetic_rgba();
+        let (path, marker) = encode_and_mark(&rgba, w, h).expect("encode_and_mark");
+
+        // The marker an agent receives must carry exactly this file's path.
+        assert!(marker.starts_with("[AGEND-IMAGE-PASTE: "));
+        assert!(marker.contains(&path.display().to_string()));
+
+        // What the agent does: parse the path out of the marker and Read it.
+        let parsed = marker
+            .strip_prefix("[AGEND-IMAGE-PASTE: ")
+            .and_then(|s| s.strip_suffix("]\n"))
+            .expect("marker parses to a path");
+        let agent_path = Path::new(parsed);
+        assert_eq!(agent_path, path, "agent-visible path == written file");
+
+        // That path must be a real, readable PNG of the captured image.
+        let raw = std::fs::read(agent_path).expect("agent can read the file");
+        assert_eq!(&raw[..8], b"\x89PNG\r\n\x1a\n", "agent reads a valid PNG");
+        assert_eq!(png_dims(agent_path), (w as u32, h as u32));
+
+        std::fs::remove_file(&path).ok();
+    }
+}

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -338,6 +338,23 @@ pub(crate) fn build_instructions_body(
     // "continue" was mistaken by an orchestrator for an operator command and a
     // task was dispatched from it. The daemon now tags such nudges; teach agents
     // to recognize the tag (same trust model as [AGEND-MSG]).
+    // #2435: TUI image paste. Ctrl+B i in the TUI (the attach client OR the app
+    // multi-pane view) reads an image from the operator's clipboard, saves it as
+    // a PNG, and injects this marker. Platform-neutral — the clipboard read works
+    // on macOS/Windows/Linux; the agent only ever sees the marker + a PNG path.
+    content.push_str("\n## TUI image paste (`[AGEND-IMAGE-PASTE]`)\n\n");
+    content
+        .push_str("When you see input beginning with `[AGEND-IMAGE-PASTE: /path/to/file.png]`:\n");
+    content.push_str(
+        "- The operator pressed `Ctrl+B i` in the TUI to paste an image from their clipboard.\n",
+    );
+    content.push_str("- The image was saved to the given path as a PNG file.\n");
+    content.push_str(
+        "- Immediately use your `Read` tool on that path to view the image, then respond based on \
+         what you see.\n",
+    );
+    content.push_str("- Do NOT ask the operator to describe the image — read it directly.\n\n");
+
     content.push_str("\n## Daemon auto-inject (`[AGEND-AUTO]`)\n\n");
     content.push_str("When you see input beginning with `[AGEND-AUTO kind=...]` (e.g. `[AGEND-AUTO kind=ratelimit-retry] continue`):\n");
     content.push_str("- This is an AUTOMATIC nudge the daemon injected to resume you (e.g. after a transient rate-limit auto-retry) — NOT a real operator or peer instruction.\n");

--- a/src/keybinds.rs
+++ b/src/keybinds.rs
@@ -56,6 +56,11 @@ pub enum Action {
     /// #2325: toggle the text-selection copy mode (Mode B copy-on-select ↔
     /// Mode A explicit-copy), persisting the choice. Bound to `Ctrl+B e`.
     ToggleCopyOnSelect,
+    /// #2435: paste an image from the clipboard into the focused pane's agent as
+    /// an `[AGEND-IMAGE-PASTE: <path>]` marker. Bound to `Ctrl+B i`. The exhaustive
+    /// `app::dispatch` match makes adding this variant compile-force its app arm —
+    /// so the feature cannot be live-in-attach-but-dead-in-app (#2434/#2438 class).
+    PasteImage,
     None,
 }
 
@@ -220,6 +225,8 @@ fn dispatch_prefix(key: KeyEvent) -> Action {
         KeyCode::Char('d') if !key.modifiers.contains(KeyModifiers::SHIFT) => Action::Detach,
         KeyCode::Char('?') => Action::ShowHelp,
         KeyCode::Char('~') => Action::ScratchShell,
+        // #2435: paste clipboard image into the focused pane's agent.
+        KeyCode::Char('i') => Action::PasteImage,
 
         _ => Action::None,
     }
@@ -321,6 +328,16 @@ mod tests {
         assert_eq!(
             prefix_action(KeyCode::Char('e'), KeyModifiers::empty()),
             Action::ToggleCopyOnSelect
+        );
+    }
+
+    // --- i: PasteImage (#2435) ---
+
+    #[test]
+    fn keybind_ctrl_b_i_pastes_image() {
+        assert_eq!(
+            prefix_action(KeyCode::Char('i'), KeyModifiers::empty()),
+            Action::PasteImage
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,7 @@ mod github_token;
 mod headless;
 mod health;
 mod identity;
+mod image_paste;
 mod inbox;
 mod instance_monitor;
 mod instructions;

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -83,6 +83,22 @@ pub fn attach(home: &Path, name: &str) -> anyhow::Result<()> {
                         tracing::info!("detached");
                         break;
                     }
+                    // Ctrl+B i — paste a clipboard image into the attached agent
+                    // (#2435). Shares the surface-agnostic core with app mode.
+                    if code == KeyCode::Char('i') && modifiers.is_empty() {
+                        match crate::image_paste::capture_clipboard_image() {
+                            Ok((path, marker)) => {
+                                tracing::info!(target: "image_paste", path = %path.display(), "image paste → agent (attach)");
+                                if bridge.send_input(marker.as_bytes()).is_err() {
+                                    break;
+                                }
+                            }
+                            Err(e) => {
+                                tracing::warn!(target: "image_paste", error = %e, "image paste failed (no clipboard image?)");
+                            }
+                        }
+                        continue;
+                    }
                     // Not 'd' — send Ctrl+B + current key
                     let mut bytes = vec![0x02];
                     bytes.extend(key_to_bytes(code, modifiers));


### PR DESCRIPTION
Reworks external closed PR #2435 (justdoit530-hub, `feature/tui-image-paste`) per fixup-lead/r6/operator. **Ctrl+B i** reads an image from the operator's clipboard, encodes it to a temp PNG, and injects an `[AGEND-IMAGE-PASTE: <path>]` marker; the agent (taught by `instructions.rs`) `Read`s that path. Backend-agnostic.

## Structure
- **`src/image_paste.rs`** — surface-agnostic core: `capture_clipboard_image()` → arboard `get_image` → `save_rgba_as_png` (png 0.18) → `(path, marker)`; stale-file sweep bounds temp growth.
- **attach CLI** (`src/tui.rs`) — Ctrl+B i → core → inject via `BridgeClient`.
- **app multi-pane TUI** (`src/app/dispatch.rs`) — new `keybinds::Action::PasteImage` → `paste_image()` → `write_to_focused` (focused pane).
- **`src/instructions.rs`** — platform-neutral `[AGEND-IMAGE-PASTE]` agent doc.

operator chose scope **(c) = both surfaces**.

## Mode-mismatch guard (#2434/#2438 class)
`app::dispatch`'s match over `keybinds::Action` is **exhaustive** (no `_` catch-all), so adding `Action::PasteImage` **compile-forces** the app arm — the feature *structurally cannot* be live-in-attach-but-dead-in-app. The core lives in its own module (not a surface), so one capture serves both.

## r6 must-fixes
- `png` pinned `"0.18"` to **unify** with the existing transitive `png 0.18.1` → zero new version (the original PR added `png 0.17` alongside `0.18.1` = a version conflict). `image` crate deliberately NOT pulled (Cargo.toml note).
- temp-file cleanup sweep (the original leaked every paste).
- tests added; clipboard instructions platform-neutral.

## Tests
- Core: png encode/temp, marker contract, pure `is_stale` both directions, cleanup (stale-removed / fresh+non-matching kept / missing-dir no-op), and a representative **chain** test (synthetic image → marker → parse → Read → valid PNG).
- Keybind: `Ctrl+B i → Action::PasteImage`.
- **App-mode representative wiring test** (`paste_image_injects_marker_into_focused_pane`): drives the REAL `app` dispatch path with a synthetic capture (clipboard mocked) and asserts the marker reached the focused pane via `write_to_focused`. + graceful-noop on capture Err.

## Cross-platform ([xwin compile ≠ windows runtime])
cargo-xwin cross-compiles the full feature for windows-msvc; CI (incl. windows-latest runtime) gates the encode/temp/cleanup/marker paths. The clipboard-**read** (`arboard::get_image`) needs a real GUI clipboard image → inherently un-CI-able headless; verified by a manual macOS arboard set→get→encode round-trip (and a manual paste on a real desktop is the final check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)