### PR TITLE
feat(shadow): agy lifecycle-hooks plane → Evidence (authority=Hook, #2413 Phase D)

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -827,10 +827,11 @@ fn build_command(config: &SpawnConfig) -> anyhow::Result<(CommandBuilder, Option
 
     // #2413 Shadow Observer — LOCAL plane (flag default-OFF via AGEND_SHADOW_OBSERVER).
     // Inject a per-session unix-socket path + a freshly-minted 256-bit token scoped to
-    // THIS spawned claude, so its lifecycle hooks emit token-authenticated evidence to
-    // the daemon WITHOUT touching `~/.claude` global. claude-only (the hook-bearing
-    // backend). Set AFTER env_clear (like AGEND_INSTANCE_NAME) so isolation can't drop
-    // it; the hook subprocess inherits both vars from claude's env.
+    // THIS spawned backend, so its lifecycle hooks emit token-authenticated evidence to
+    // the daemon WITHOUT touching the backend's global config. Hook-bearing backends only
+    // (`has_state_hooks()` = claude + agy #2413 Phase D). Set AFTER env_clear (like
+    // AGEND_INSTANCE_NAME) so isolation can't drop it; the hook subprocess inherits both
+    // vars from the backend's env (claude `.claude` hooks / agy `.agents/hooks.json`).
     if crate::daemon::shadow::enabled()
         && detected_backend
             .as_ref()

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -58,13 +58,21 @@ impl Backend {
     /// backend always uses the heuristic (no hooks fire, so `resolved_state_for`
     /// stays `Unknown` → heuristic fallback).
     ///
-    /// **claude-only in v1.** `configure_agy` does NOT inject the hooks, and
-    /// production data confirmed it (2026-06-11: ai-scout/agy emitted **0** hook
-    /// events all day, including during a real 16:14 task run; all 3,490 events
-    /// came from claude). Re-adding Agy requires the injection implementation AND
-    /// shadow-data evidence that its hooks fire — not just the enum membership.
+    /// **claude + agy (#2413 Phase D).** Both inject lifecycle hooks that emit
+    /// token-authenticated shadow Evidence: claude via `.claude` settings;
+    /// **agy via per-workspace `.agents/hooks.json`** written by `configure_agy`
+    /// — its `PreInvocation/PreTool/PostTool/Stop` command hooks POST
+    /// claude-compatible frames to the same shadow socket via `hook-event
+    /// --event`. The earlier "claude-only" gate was because Agy's hooks were
+    /// never injected (2026-06-11: agy emitted 0 hook events); the prerequisite
+    /// it named — "injection implementation AND shadow-data evidence that its
+    /// hooks fire" — is now met (RE-spike t-…39100-6 proved per-workspace hooks
+    /// fire live; injection added below). Other backends have no hooks (heuristic
+    /// fallback). Gates: socket-env injection (agent/mod.rs), hook→authoritative
+    /// promotion (hook_shadow.rs, also `AGEND_HOOK_STATE_POC`-gated), divergence
+    /// telemetry, supervisor SRL hook-recovery.
     pub fn has_state_hooks(&self) -> bool {
-        matches!(self, Backend::ClaudeCode)
+        matches!(self, Backend::ClaudeCode | Backend::Agy)
     }
 
     /// #2090: does this backend expose a subagent / sub-task mechanism an agent
@@ -1299,6 +1307,27 @@ impl BackendBehavior for Backend {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+
+    /// #2413 Phase D: agy joins claude as a hook backend (its `.agents/hooks.json`
+    /// lifecycle hooks emit shadow Evidence). This gates socket-env injection +
+    /// hook promotion. Every other backend stays heuristic-only.
+    #[test]
+    fn agy_and_claude_have_state_hooks_others_do_not() {
+        assert!(
+            Backend::Agy.has_state_hooks(),
+            "agy is a hook backend (#2413 Phase D)"
+        );
+        assert!(Backend::ClaudeCode.has_state_hooks());
+        for b in [
+            Backend::Codex,
+            Backend::OpenCode,
+            Backend::KiroCli,
+            Backend::Shell,
+            Backend::Raw("x".into()),
+        ] {
+            assert!(!b.has_state_hooks(), "{b:?} must stay heuristic-only");
+        }
+    }
 
     /// #8 Phase 1 parity proof: the `BackendBehavior` facade returns EXACTLY
     /// what the existing inherent methods / free fn return for every variant —

--- a/src/daemon/hook_shadow.rs
+++ b/src/daemon/hook_shadow.rs
@@ -540,9 +540,10 @@ mod tests {
         );
     }
 
-    /// §3.9: a non-STRONG backend (no hooks fire) always uses the heuristic. In
-    /// v1 only claude is strong — agy is heuristic-only (configure_agy injects no
-    /// hooks; production-verified 0 events).
+    /// §3.9: a non-STRONG backend (no hooks fire) always uses the heuristic.
+    /// STRONG (hook) backends = claude + agy (#2413 Phase D: configure_agy now
+    /// injects `.agents/hooks.json` lifecycle hooks); their fresh hook wins over
+    /// the heuristic. Everything else (codex/opencode/kiro/shell) stays heuristic.
     #[test]
     fn backend_strength_gates_promotion() {
         record_event("codex-agent", "UserPromptSubmit", None); // → Thinking, fresh
@@ -551,12 +552,12 @@ mod tests {
             AgentState::Idle,
             "codex is not a hook backend — heuristic only"
         );
-        // agy is NOT strong in v1 — even a (manually-injected) hook is ignored.
+        // agy IS a hook backend now (#2413 Phase D) — its fresh hook wins.
         record_event("agy-agent", "UserPromptSubmit", None);
         assert_eq!(
             authoritative_state_inner(true, "agy", "agy-agent", AgentState::Idle),
-            AgentState::Idle,
-            "agy is heuristic-only in v1 (no hook injection)"
+            AgentState::Thinking,
+            "agy is a STRONG backend (#2413 Phase D) — its fresh hook wins"
         );
         // claude IS strong — its fresh hook wins.
         record_event("claude-agent", "UserPromptSubmit", None);

--- a/src/main.rs
+++ b/src/main.rs
@@ -170,6 +170,26 @@ fn emit_shadow_frame(payload: &serde_json::Value) {
 #[cfg(not(unix))]
 fn emit_shadow_frame(_payload: &serde_json::Value) {}
 
+/// #2413 Phase D: resolve the hook event name for backends whose hook payload
+/// omits `hook_event_name`. agy's `.agents/hooks.json` command hooks pass the
+/// (claude-compatible) event via `--event`; claude carries it in stdin and
+/// passes no `--event`. The override fills the field ONLY when stdin omits a
+/// non-empty `hook_event_name`, so claude is byte-identical. Pure (no I/O) for
+/// unit-testability.
+fn apply_hook_event_override(v: &mut serde_json::Value, event: Option<String>) {
+    let Some(ev) = event else { return };
+    if v.get("hook_event_name")
+        .and_then(|x| x.as_str())
+        .is_some_and(|s| !s.is_empty())
+    {
+        return; // stdin already carries the event (claude) — leave it.
+    }
+    if !v.is_object() {
+        *v = serde_json::json!({});
+    }
+    v["hook_event_name"] = serde_json::Value::String(ev);
+}
+
 fn load_dotenv() {
     let env_path = home_dir().join(".env");
     if !env_path.exists() {
@@ -290,6 +310,14 @@ enum Commands {
         /// session↔agent attribution without a session-id map).
         #[arg(long)]
         instance: String,
+        /// #2413 Phase D (agy): explicit claude-compatible event name for
+        /// backends whose hook payload does NOT carry `hook_event_name`
+        /// (agy/Antigravity `.agents/hooks.json` command hooks). When set, it
+        /// SUPPLIES `hook_event_name` only if stdin lacks it — so the socket
+        /// server's existing event→Evidence mapping is reused unchanged. Claude
+        /// omits this flag (its stdin payload already carries the event).
+        #[arg(long)]
+        event: Option<String>,
     },
     /// Send input to an agent
     Inject {
@@ -856,7 +884,7 @@ fn main() -> anyhow::Result<()> {
                 }
             }
         }
-        Some(Commands::HookEvent { instance }) => {
+        Some(Commands::HookEvent { instance, event }) => {
             // Observe-only contract: NEVER block the agent — exit 0 on every
             // path, keep stdout empty (stderr is fine; hooks ignore it on 0).
             let mut payload = String::new();
@@ -866,7 +894,10 @@ fn main() -> anyhow::Result<()> {
             let _ = std::io::stdin()
                 .take(64 * 1024)
                 .read_to_string(&mut payload);
-            let v: serde_json::Value = serde_json::from_str(&payload).unwrap_or_default();
+            let mut v: serde_json::Value = serde_json::from_str(&payload).unwrap_or_default();
+            // #2413 Phase D (agy): agy's `.agents/hooks.json` command hooks carry
+            // the event via `--event` (their stdin payload has no `hook_event_name`).
+            apply_hook_event_override(&mut v, event);
             let req = serde_json::json!({
                 "method": api::method::HOOK_EVENT,
                 "params": {
@@ -1388,6 +1419,40 @@ fn list_running_agents(home: &std::path::Path) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #2413 Phase D (agy): `--event` supplies `hook_event_name` ONLY when the
+    /// stdin payload omits a non-empty one — so agy (payload lacks it) gets the
+    /// claude-compatible event, while claude (carries it in stdin, no `--event`)
+    /// is byte-identical. Reverse-mutation: drop the absence-guard → claude's v3
+    /// would be overwritten to "PreToolUse" and the assert fails.
+    #[test]
+    fn apply_hook_event_override_fills_only_when_absent() {
+        use serde_json::json;
+        // agy: stdin lacks hook_event_name → --event supplies it.
+        let mut v = json!({"conversationId": "abc", "invocationNum": 1});
+        apply_hook_event_override(&mut v, Some("PreToolUse".into()));
+        assert_eq!(v["hook_event_name"], "PreToolUse");
+        // claude: stdin has it, no --event → unchanged.
+        let mut v2 = json!({"hook_event_name": "Stop"});
+        apply_hook_event_override(&mut v2, None);
+        assert_eq!(v2["hook_event_name"], "Stop");
+        // stdin event WINS even if --event is somehow present (claude unaffected).
+        let mut v3 = json!({"hook_event_name": "Stop"});
+        apply_hook_event_override(&mut v3, Some("PreToolUse".into()));
+        assert_eq!(v3["hook_event_name"], "Stop");
+        // empty stdin event == absent → filled.
+        let mut v4 = json!({"hook_event_name": ""});
+        apply_hook_event_override(&mut v4, Some("Stop".into()));
+        assert_eq!(v4["hook_event_name"], "Stop");
+        // non-object stdin (null/garbage) → coerced to object carrying the event.
+        let mut v5 = json!(null);
+        apply_hook_event_override(&mut v5, Some("Stop".into()));
+        assert_eq!(v5["hook_event_name"], "Stop");
+        // no override + no stdin event → stays absent (no-op).
+        let mut v6 = json!({"x": 1});
+        apply_hook_event_override(&mut v6, None);
+        assert!(v6.get("hook_event_name").is_none());
+    }
 
     #[test]
     fn home_dir_default() {

--- a/src/mcp_config.rs
+++ b/src/mcp_config.rs
@@ -416,7 +416,112 @@ fn configure_agy(working_dir: &Path, instance_name: Option<&str>) -> Result<()> 
     // re-discovers from the config just written.
     clear_agy_mcp_cache();
 
+    // #2413 Phase D (agy shadow plane): inject per-workspace lifecycle hooks into
+    // `.agents/hooks.json` — agy/Antigravity's hook config (NEVER touches the
+    // global `~/.gemini`, scope rule honored). Same flag gate as claude
+    // (`configure_claude`); needs an instance name for the session↔agent
+    // attribution embedded in the hook command. RE-spike (t-…39100-6) proved these
+    // per-workspace hooks fire live mid-turn.
+    if std::env::var("AGEND_HOOK_STATE_POC").as_deref() == Ok("1")
+        || crate::daemon::shadow::enabled()
+    {
+        if let Some(name) = instance_name {
+            let hooks_path = working_dir.join(".agents").join("hooks.json");
+            upsert_agy_state_hooks(&hooks_path, name)?;
+        }
+    }
+
     tracing::debug!(path = %path.display(), "configured agy MCP (.agents/)");
+    Ok(())
+}
+
+/// #2413 Phase D: upsert observe-only lifecycle-hook reporters into agy's
+/// per-workspace `.agents/hooks.json` (agy/Antigravity hook config; the global
+/// `~/.gemini` is NEVER touched — scope rule). Agy fires `PreInvocation` (per
+/// model step), `PreTool`/`PostTool`, and `Stop`; each command hook runs the
+/// shared `hook-event` reporter with an explicit `--event` carrying the
+/// CLAUDE-COMPATIBLE name the shadow server already maps, so Evidence + the
+/// reducer are reused UNCHANGED:
+///   PreInvocation→UserPromptSubmit(TurnStarted), PreTool→PreToolUse(ToolStarted),
+///   PostTool→PostToolUse(ToolEnded), Stop→Stop(TurnEnded→idle).
+/// Merge-preserving + idempotent: our entry is identified by the
+/// `hook-event --instance` marker and replaced on re-configure; any operator
+/// hooks under the same event are preserved. The reporter always exits 0
+/// (observe-only — never blocks agy's turn) and the socket write fast-fails when
+/// the per-session socket is absent (shadow off), so this is spawn-safe.
+fn upsert_agy_state_hooks(path: &Path, instance_name: &str) -> Result<()> {
+    // (agy event name, claude-compatible event the shadow server maps).
+    const EVENT_MAP: &[(&str, &str)] = &[
+        ("PreInvocation", "UserPromptSubmit"),
+        ("PreTool", "PreToolUse"),
+        ("PostTool", "PostToolUse"),
+        ("Stop", "Stop"),
+    ];
+    let exe = std::env::current_exe()
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|_| "agend-terminal".to_string());
+    let marker = "hook-event --instance";
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let _lock = crate::store::acquire_file_lock(&config_lock_path(path))?;
+    let mut config: serde_json::Value = if path.exists() {
+        let content = std::fs::read_to_string(path)?;
+        match serde_json::from_str(&content) {
+            Ok(v) => v,
+            Err(e) => {
+                // Fail-CLOSED (same contract as upsert_state_hooks): back up the
+                // corrupt file (rename-first) and refuse to silently clobber it.
+                let backup = path.with_extension(format!(
+                    "corrupt.{}",
+                    chrono::Utc::now().format("%Y%m%d%H%M%S")
+                ));
+                if !crate::store::backup_corrupt_file(path, &backup) {
+                    anyhow::bail!(
+                        "malformed agy hooks at {} and its backup failed; refusing to overwrite (original preserved)",
+                        path.display()
+                    );
+                }
+                tracing::warn!(
+                    path = %path.display(), backup = %backup.display(), error = %e,
+                    "malformed agy hooks.json, backed up corrupt file and starting fresh"
+                );
+                json!({})
+            }
+        }
+    } else {
+        json!({})
+    };
+    if !config.is_object() {
+        config = json!({});
+    }
+    if !config.get("hooks").map(|h| h.is_object()).unwrap_or(false) {
+        config["hooks"] = json!({});
+    }
+    let hooks = config["hooks"]
+        .as_object_mut()
+        .expect("hooks set to object above");
+    for (agy_event, claude_event) in EVENT_MAP {
+        let command = format!("{exe} hook-event --instance {instance_name} --event {claude_event}");
+        let our_entry = json!({ "name": "agend-shadow", "command": command });
+        let arr = hooks
+            .entry((*agy_event).to_string())
+            .or_insert_with(|| json!([]));
+        if !arr.is_array() {
+            *arr = json!([]);
+        }
+        let list = arr.as_array_mut().expect("event value set to array above");
+        // Idempotent: drop our prior entry (marker), preserve operator hooks.
+        list.retain(|e| {
+            !e.get("command")
+                .and_then(|c| c.as_str())
+                .is_some_and(|c| c.contains(marker))
+        });
+        list.push(our_entry);
+    }
+    let body = serde_json::to_string_pretty(&config)?;
+    crate::store::atomic_write(path, body.as_bytes())?;
     Ok(())
 }
 
@@ -1453,6 +1558,81 @@ mod hook_state_poc_tests {
                 "instance embedded for attribution"
             );
         }
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// #2413 Phase D (agy): the agy hooks upsert writes per-workspace
+    /// `.agents/hooks.json` with agy's OWN event keys (PreInvocation/PreTool/
+    /// PostTool/Stop) mapped to the CLAUDE-compatible `--event` the shadow server
+    /// already understands (so Evidence + reducer are reused unchanged).
+    /// Merge-preserving + idempotent. Reverse-mutation: break EVENT_MAP (e.g.
+    /// PreTool→"ToolUse") → the `--event PreToolUse` assert fails; emit claude
+    /// KEYS (PreToolUse) → the agy-key lookup + the "no claude key" assert fail.
+    #[test]
+    fn upsert_agy_state_hooks_maps_events_merges_and_is_idempotent() {
+        let dir = tmp("agy-hooks");
+        let path = dir.join(".agents").join("hooks.json");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        // Pre-existing operator hook under a shared event (Stop) + a foreign event.
+        std::fs::write(
+            &path,
+            serde_json::to_string(&json!({
+                "hooks": {
+                    "Stop": [{"name": "user-bell", "command": "say done"}],
+                    "SessionStart": [{"name": "user-greet", "command": "echo hi"}],
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        upsert_agy_state_hooks(&path, "agent-x").unwrap();
+        upsert_agy_state_hooks(&path, "agent-x").unwrap(); // idempotent re-run
+
+        let cfg: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+
+        for (agy_ev, claude_ev) in [
+            ("PreInvocation", "UserPromptSubmit"),
+            ("PreTool", "PreToolUse"),
+            ("PostTool", "PostToolUse"),
+            ("Stop", "Stop"),
+        ] {
+            let arr = cfg["hooks"][agy_ev]
+                .as_array()
+                .unwrap_or_else(|| panic!("event {agy_ev} present"));
+            let ours: Vec<_> = arr
+                .iter()
+                .filter(|e| {
+                    e["command"]
+                        .as_str()
+                        .is_some_and(|c| c.contains("hook-event --instance"))
+                })
+                .collect();
+            assert_eq!(ours.len(), 1, "{agy_ev}: exactly one of ours after re-run");
+            let cmd = ours[0]["command"].as_str().unwrap();
+            assert!(
+                cmd.contains("--instance agent-x"),
+                "{agy_ev}: instance embedded"
+            );
+            assert!(
+                cmd.contains(&format!("--event {claude_ev}")),
+                "{agy_ev} → --event {claude_ev}; got {cmd}"
+            );
+        }
+        // Merge-preserving: operator + foreign entries survive.
+        let stop = cfg["hooks"]["Stop"].as_array().unwrap();
+        assert!(
+            stop.iter().any(|e| e["command"] == "say done"),
+            "operator Stop hook preserved"
+        );
+        assert_eq!(cfg["hooks"]["SessionStart"][0]["command"], "echo hi");
+        // agy config must use AGY event KEYS, never claude's.
+        assert!(
+            cfg["hooks"].get("PreToolUse").is_none()
+                && cfg["hooks"].get("UserPromptSubmit").is_none(),
+            "agy hooks.json must key on agy events (PreTool/PreInvocation), not claude's"
+        );
         std::fs::remove_dir_all(&dir).ok();
     }
 


### PR DESCRIPTION
## What
agy becomes the **2nd Hook backend** (after claude), reusing the claude #2433 hook→socket→Evidence local plane verbatim. From the RE-spike (t-…39100-6) that proved agy's per-workspace `.agents/hooks.json` lifecycle hooks fire live mid-turn.

- **`configure_agy`** now also writes per-workspace `.agents/hooks.json` (**NEVER** touches global `~/.gemini`), same flag gate as claude (`AGEND_HOOK_STATE_POC=1 || shadow::enabled()` + an instance name). Merge-preserving + idempotent (`upsert_agy_state_hooks`).
- agy command hooks run the shared `hook-event` reporter with an explicit **`--event`** carrying the **claude-compatible** event the shadow server already maps → **Evidence + reducer reused UNCHANGED**:
  - `PreInvocation`→`UserPromptSubmit` (TurnStarted/busy, per model step)
  - `PreTool`→`PreToolUse` (ToolStarted)
  - `PostTool`→`PostToolUse` (ToolEnded)
  - `Stop`→`Stop` (TurnEnded→idle)
  - (agy's stdin payload lacks `hook_event_name`; `--event` fills it **only when absent** → claude byte-identical.)

## HARD vet points
**#1 (make-or-break) — CLOSED**: socket-env injection (`AGENT_TERMINAL_SOCKET`/`SESSION`, agent/mod.rs) was gated on `has_state_hooks()` = **claude-only** (so daemon-spawned agy got NO socket env — my RE-spike only saw it via inherited shell env). Extended `has_state_hooks()` to `Agy` (backend.rs) → daemon-spawned agy now gets the per-session socket+token, AND hook-state promotion turns on (hook_shadow, `AGEND_HOOK_STATE_POC`-gated). Both gates default-OFF → byte-identical when off.

**#2 (PreTool/PostTool fire) — evidence + deferred-to-dogfood**: the binary registry confirms `NewPreToolHookFn`/`NewPostToolHookFn` are valid command-hook events, and the RE-spike proved the hook mechanism fires live (PreInvocation/PostInvocation/Stop). An isolated `agy --print` re-confirmation was **flaky (cold-start hang)** — but `--print` is NOT the real path. **Authoritative confirmation = the operator live-dogfood** (real daemon-spawned agy → `observed_status authority=Hook` with tool spans), which needs operator rebuild+restart regardless.

## Unchanged / safety
Evidence + reducer + socket server **unchanged**. Spawn-safe: reporter always exits 0 (never blocks agy's turn); socket write fast-fails when no per-session socket (shadow off). Scope: per-workspace only; global `~/.gemini` never touched.

## Tests
`upsert_agy_state_hooks` (event mapping + merge-preserving + idempotent + agy-not-claude event keys) · `apply_hook_event_override` (fill-only-when-absent; claude byte-identical) · `has_state_hooks` (agy+claude on, others off).

## Preflight (green, clean env)
fmt · tray clippy `-D warnings` · **cargo-xwin Windows clippy `-D warnings`** · agent(108)/backend(39)/mcp_config(35)/shadow(54)/+3 new. (Note: `hooks_not_injected_without_flag` false-fails under the fleet shell env `AGEND_SHADOW_OBSERVER=1`; passes clean — run tests with both flags unset.)

⚠ Needs operator rebuild+restart to go live (+ the live agy dogfood for authority=Hook). This + kiro = Phase D done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)