### PR TITLE
feat(shadow): graduate Shadow Observer to default-ON (=0 kill-switch)

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -41,8 +41,8 @@ pub struct AgentCore {
     /// with confidence/authority + decay/liveness backstop). Purely ADDITIVE —
     /// it NEVER rewrites `agent_state`; a consumer diffs the two under this same
     /// `core.lock()` (that diff IS the quantification). `None` until the first
-    /// per-tick reduce under `AGEND_SHADOW_OBSERVER=1` (flag-OFF default ⇒ stays
-    /// `None`, zero behaviour change). Written by `per_tick::shadow_observe`.
+    /// per-tick reduce (default-ON; stays `None` only under the
+    /// `AGEND_SHADOW_OBSERVER=0` kill-switch). Written by `per_tick::shadow_observe`.
     pub(crate) observed_status: Option<crate::daemon::shadow::reducer::ObservedStatus>,
 }
 
@@ -825,7 +825,7 @@ fn build_command(config: &SpawnConfig) -> anyhow::Result<(CommandBuilder, Option
         cmd.env("AGEND_HOME", h);
     }
 
-    // #2413 Shadow Observer — LOCAL plane (flag default-OFF via AGEND_SHADOW_OBSERVER).
+    // #2413 Shadow Observer — LOCAL plane (default-ON; `AGEND_SHADOW_OBSERVER=0` disables).
     // Inject a per-session unix-socket path + a freshly-minted 256-bit token scoped to
     // THIS spawned backend, so its lifecycle hooks emit token-authenticated evidence to
     // the daemon WITHOUT touching the backend's global config. Hook-bearing backends only

--- a/src/api/handlers/query.rs
+++ b/src/api/handlers/query.rs
@@ -57,8 +57,8 @@ pub(crate) fn handle_list(_params: &Value, ctx: &HandlerCtx) -> Value {
                     c.api_activity.last_active_epoch_ms,
                     // #2413 Phase B: the reducer's fused status, read under the SAME
                     // lock as agent_state so a consumer can diff them atomically (the
-                    // observed-vs-raw diff IS the quantification). None unless the
-                    // per-tick reduce ran under AGEND_SHADOW_OBSERVER=1.
+                    // observed-vs-raw diff IS the quantification). None only if the per-tick
+                    // reduce didn't run (default-ON; off under AGEND_SHADOW_OBSERVER=0).
                     c.observed_status.clone(),
                 )
             };

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -408,8 +408,8 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
         // The LIVE fleet daemon runs THIS `run_app`, never `run_core` (shadow::start's
         // only other caller), so without this the whole Shadow Observer plane was dead in
         // production (observed_status null on every agent under the flag — #1720/#685
-        // silent-dead-in-app class, mirrors recovery_dispatcher #1694(a)). No-op unless
-        // `AGEND_SHADOW_OBSERVER=1` (flag-OFF default ⇒ zero behaviour change). Owner-only
+        // silent-dead-in-app class, mirrors recovery_dispatcher #1694(a)). No-op under
+        // `AGEND_SHADOW_OBSERVER=0` (default-ON; the =0 kill-switch ⇒ zero change). Owner-only
         // (`!attached_mode`) like the probe: an attached TUI must not also bind the socket;
         // the daemon that owns the fleet started it. Lifecycle mirrors run_core — a
         // detached accept loop that exits with the process; the stale socket is cleared on

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -786,9 +786,9 @@ pub(crate) fn build_default_handlers(
         Box::new(per_tick::ReclaimHandler::new(30, work_stuck_latch)),
         // #2413 Phase B (Shadow Observer): per-tick reduce — fold each agent's buffered
         // hook Evidence + screen baseline + lsof liveness into an additive
-        // `observed_status` (never rewrites `agent_state`). Flag-OFF default
-        // (`AGEND_SHADOW_OBSERVER=1`) ⇒ a single `enabled()` check then early-return, so
-        // this is a no-op for a default fleet. Daemon-only telemetry → allowlisted out of
+        // `observed_status` (never rewrites `agent_state`). Default-ON; under the
+        // `AGEND_SHADOW_OBSERVER=0` kill-switch a single `enabled()` check then early-return
+        // makes it a no-op. Daemon-only telemetry → allowlisted out of
         // app mode (the hook socket server it consumes is started in `run_core`).
         Box::new(per_tick::ShadowObserveHandler::new()),
     ]
@@ -909,7 +909,7 @@ fn run_core(home: &Path, source: FleetSource) -> anyhow::Result<()> {
     let ctx = init_daemon_services(home, telegram_pre)?;
 
     // #2413 Shadow Observer — local plane: start the unix-socket hook-event server
-    // (no-op unless AGEND_SHADOW_OBSERVER=1). Observe-only side-channel; never blocks.
+    // (no-op under AGEND_SHADOW_OBSERVER=0; default-ON). Observe-only side-channel; never blocks.
     crate::daemon::shadow::start(home);
 
     // #event-bus Step 2 (legacy-zero): register the per-pattern delivery
@@ -1386,16 +1386,16 @@ fn build_tick_infrastructure(
     crate::api_activity_probe::spawn(Arc::clone(&ctx.registry));
     // #2413 Phase D: codex rollout-tail observer source (Stream plane) — read-only tail of
     // ~/.codex/sessions/.../rollout-*.jsonl → Evidence → the shared buffer the reducer
-    // consumes. No-op unless AGEND_SHADOW_OBSERVER=1 (flag-OFF default ⇒ zero change).
+    // consumes. No-op under the AGEND_SHADOW_OBSERVER=0 kill-switch (default-ON).
     // ALSO wired into run_app (the live fleet daemon is app mode — #2434 lesson).
     crate::daemon::shadow::rollout::spawn(Arc::clone(&ctx.registry), home.to_path_buf());
     // #2413 opencode plane: SSE `/event` observer source (Stream plane). Subscribes to each
     // opencode agent's embedded server (port injected at spawn) → Evidence → shared buffer.
-    // No-op unless AGEND_SHADOW_OBSERVER=1. ALSO wired into run_app (#2434 lesson).
+    // No-op under AGEND_SHADOW_OBSERVER=0 (default-ON). ALSO wired into run_app (#2434).
     crate::daemon::shadow::opencode::spawn(Arc::clone(&ctx.registry), home.to_path_buf());
     // #2413 kiro plane: read-only tail of ~/.kiro/sessions/cli/<uuid>.jsonl → Evidence →
-    // shared buffer (attribution via the <uuid>.json sidecar cwd). No-op unless
-    // AGEND_SHADOW_OBSERVER=1. ALSO wired into run_app (#2434 lesson).
+    // shared buffer (attribution via the <uuid>.json sidecar cwd). No-op under
+    // AGEND_SHADOW_OBSERVER=0 (default-ON). ALSO wired into run_app (#2434 lesson).
     crate::daemon::shadow::kiro::spawn(Arc::clone(&ctx.registry), home.to_path_buf());
 
     crate::inbox::recover_half_writes(home);

--- a/src/daemon/per_tick/shadow_observe.rs
+++ b/src/daemon/per_tick/shadow_observe.rs
@@ -1,8 +1,8 @@
 //! #2413 Shadow Observer — Phase B per-tick driver.
 //!
 //! The reducer ([`crate::daemon::shadow::reducer`]) is a pure state machine; this
-//! handler is the per-tick glue that feeds it. Each tick (when
-//! `AGEND_SHADOW_OBSERVER=1`) it, per managed agent:
+//! handler is the per-tick glue that feeds it. Each tick (default-ON; skipped only under
+//! the `AGEND_SHADOW_OBSERVER=0` kill-switch) it, per managed agent:
 //!   1. snapshots the screen baseline (`agent_state` → [`ScreenSignal`]) + the cheap
 //!      out-of-path liveness ([`Liveness`]: `api_in_flight` / productive-silence /
 //!      child-alive) under one `core.lock()`;
@@ -182,13 +182,14 @@ mod tests {
 
     /// Set `AGEND_SHADOW_OBSERVER`, run a closure, then restore the prior value. Paired
     /// with `#[serial(shadow_observer)]` so the process-global env flip can't leak into a
-    /// parallel test reading `shadow::enabled()`.
+    /// parallel test reading `shadow::enabled()`. Since the plane is now **default-ON**, the
+    /// OFF case must set the explicit `=0` kill-switch (an unset/removed var is now ON).
     fn with_flag<T>(on: bool, f: impl FnOnce() -> T) -> T {
         let prev = std::env::var("AGEND_SHADOW_OBSERVER").ok();
         if on {
             std::env::set_var("AGEND_SHADOW_OBSERVER", "1");
         } else {
-            std::env::remove_var("AGEND_SHADOW_OBSERVER");
+            std::env::set_var("AGEND_SHADOW_OBSERVER", "0");
         }
         let out = f();
         match prev {

--- a/src/daemon/shadow/mod.rs
+++ b/src/daemon/shadow/mod.rs
@@ -13,8 +13,9 @@
 //!    consumes;
 //! 4. runs the socket event server ([`start`]).
 //!
-//! Spike discipline: prove hook→evidence under the native TUI + no global touch. No
-//! reducer. `flag default OFF` via `AGEND_SHADOW_OBSERVER=1`.
+//! Now **default ON** (graduated after all 5 backends live-verified) — additive only
+//! (`observed_status` is written beside, never drives, `agent_state`). Disable with the
+//! `AGEND_SHADOW_OBSERVER=0` kill-switch.
 
 pub mod evidence;
 pub mod kiro;
@@ -59,10 +60,15 @@ pub struct ShadowFrame {
     pub tool_name: Option<String>,
 }
 
-/// `true` when the Shadow Observer local plane is enabled (`AGEND_SHADOW_OBSERVER=1`).
-/// Default OFF — zero behavior change for every existing spawn.
+/// `true` when the Shadow Observer is enabled. **Default ON** — graduated after all 5
+/// backends (claude/codex/opencode/kiro hook-or-stream, agy screen) were live-verified.
+/// Disabled ONLY by the explicit `AGEND_SHADOW_OBSERVER=0` kill-switch; an absent var,
+/// `=1`, or any other value ⇒ ON. The plane stays purely additive (`observed_status` is
+/// written beside `agent_state`, never drives fleet behaviour), so default-ON is safe; the
+/// `=0` kill-switch is byte-identical to the old default-OFF (no observer tick, no observer
+/// thread spawns, no spawn-env injection).
 pub fn enabled() -> bool {
-    std::env::var("AGEND_SHADOW_OBSERVER").as_deref() == Ok("1")
+    std::env::var("AGEND_SHADOW_OBSERVER").as_deref() != Ok("0")
 }
 
 /// The per-daemon unix socket the hooks emit to. One socket for the daemon; the
@@ -322,6 +328,30 @@ mod tests {
     use super::evidence::EvidenceKind;
     use super::*;
     use serial_test::serial;
+
+    /// The Shadow Observer graduated to **default-ON**: `enabled()` is true unless the
+    /// explicit `AGEND_SHADOW_OBSERVER=0` kill-switch is set. Pins BOTH the default-ON
+    /// behaviour (confirm-first ①) and the `=0`-only opt-out (confirm-first ②) — an absent
+    /// var, `=1`, or any other value ⇒ ON; only `=0` ⇒ OFF.
+    #[test]
+    #[serial(shadow_observer)]
+    fn enabled_is_default_on_with_zero_kill_switch() {
+        let prev = std::env::var("AGEND_SHADOW_OBSERVER").ok();
+        std::env::remove_var("AGEND_SHADOW_OBSERVER");
+        assert!(enabled(), "absent var ⇒ default-ON");
+        std::env::set_var("AGEND_SHADOW_OBSERVER", "1");
+        assert!(enabled(), "=1 ⇒ ON");
+        std::env::set_var("AGEND_SHADOW_OBSERVER", "");
+        assert!(enabled(), "empty value ⇒ ON (only =0 disables)");
+        std::env::set_var("AGEND_SHADOW_OBSERVER", "yes");
+        assert!(enabled(), "arbitrary value ⇒ ON");
+        std::env::set_var("AGEND_SHADOW_OBSERVER", "0");
+        assert!(!enabled(), "=0 kill-switch ⇒ OFF");
+        match prev {
+            Some(v) => std::env::set_var("AGEND_SHADOW_OBSERVER", v),
+            None => std::env::remove_var("AGEND_SHADOW_OBSERVER"),
+        }
+    }
 
     /// End-to-end over the REAL unix socket transport: a client (the hook emit) writes
     /// one token-authenticated frame line; the server's `handle_conn` reads it, ingests,

--- a/src/daemon/shadow/opencode.rs
+++ b/src/daemon/shadow/opencode.rs
@@ -1,8 +1,9 @@
 //! #2413 — opencode HTTP `/event` SSE observer source (Stream plane).
 //!
 //! opencode is client-server: its native TUI EMBEDS an HTTP server (the same binary /
-//! event-bus as `opencode serve`) and is itself a client of it. When
-//! `AGEND_SHADOW_OBSERVER=1`, [`build_command`](crate::agent) injects `--port N` (an
+//! event-bus as `opencode serve`) and is itself a client of it. When the Shadow Observer
+//! is enabled (default-ON; `AGEND_SHADOW_OBSERVER=0` disables),
+//! [`build_command`](crate::agent) injects `--port N` (an
 //! OS-allocated free port, [`alloc_port`]) into the opencode launch so that embedded
 //! server is reachable on a KNOWN port; this module subscribes to
 //! `http://127.0.0.1:N/event` (Server-Sent Events) and maps opencode's NATIVE session

--- a/src/daemon/shadow/reducer.rs
+++ b/src/daemon/shadow/reducer.rs
@@ -17,7 +17,8 @@
 //! Evidence and [`AgentRuntime::observe`] derives the status from the current screen +
 //! liveness snapshot. Both are pure over their inputs (no globals) so the whole state
 //! machine is unit-testable without a daemon; the per-tick driver (OUT OF SCOPE here)
-//! supplies the snapshot under one `core.lock()`. Runs only under `AGEND_SHADOW_OBSERVER`.
+//! supplies the snapshot under one `core.lock()`. Runs whenever the Shadow Observer is
+//! enabled (default-ON; gated off by the `AGEND_SHADOW_OBSERVER=0` kill-switch).
 
 // The whole reducer surface (ObservedStatus / AgentRuntime / ScreenSignal / Liveness +
 // ObservedState::coarse) is now consumed by the Phase-B per-tick driver

--- a/src/mcp_config.rs
+++ b/src/mcp_config.rs
@@ -1643,22 +1643,34 @@ mod hook_state_poc_tests {
     /// AGEND_RESTART_HANDOFF fix in #1964 (a fleet agent's inherited env must
     /// not flip the contract under test).
     #[test]
-    #[serial_test::serial(hook_state_poc)] // #2014: shares AGEND_HOOK_STATE_POC with hook_shadow's env test
+    // #2014: shares AGEND_HOOK_STATE_POC with hook_shadow's env test. Also serialized
+    // against `shadow_observer` because this test now drives the AGEND_SHADOW_OBSERVER=0
+    // kill-switch (the plane is default-ON since the graduate), which other shadow tests
+    // also flip.
+    #[serial_test::serial(hook_state_poc, shadow_observer)]
     fn hooks_not_injected_without_flag() {
-        // Serialize the process-global env flip; restore before asserting so
-        // a panic can't leak the cleared flag to other tests. The named serial
-        // group above coordinates this with hook_shadow's promotion env test
-        // (which mutates the SAME var); the local mutex is the in-module backstop.
+        // Serialize the process-global env flips; restore before asserting so a panic can't
+        // leak them to other tests. The serial groups + local mutex coordinate the shared
+        // AGEND_HOOK_STATE_POC / AGEND_SHADOW_OBSERVER vars across tests.
         static GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
         let _g = GUARD.lock().unwrap_or_else(|e| e.into_inner());
         let prev = std::env::var("AGEND_HOOK_STATE_POC").ok();
         std::env::remove_var("AGEND_HOOK_STATE_POC");
+        // The Shadow Observer is now default-ON, and its `|| shadow::enabled()` gate also
+        // drives hook injection — so prove the no-hooks path with BOTH flags off: the
+        // explicit `=0` kill-switch (an absent var would now mean ON).
+        let prev_shadow = std::env::var("AGEND_SHADOW_OBSERVER").ok();
+        std::env::set_var("AGEND_SHADOW_OBSERVER", "0");
 
         let dir = tmp("flag-off");
         // configure_claude needs a git repo; it git-inits itself.
         let result = configure_claude(&dir, Some("agent-y"));
         if let Some(v) = prev {
             std::env::set_var("AGEND_HOOK_STATE_POC", v);
+        }
+        match prev_shadow {
+            Some(v) => std::env::set_var("AGEND_SHADOW_OBSERVER", v),
+            None => std::env::remove_var("AGEND_SHADOW_OBSERVER"),
         }
         result.unwrap();
         let cfg: serde_json::Value = serde_json::from_str(


### PR DESCRIPTION
## Graduate the Shadow Observer to default-ON (`AGEND_SHADOW_OBSERVER=0` kill-switch)

All 5 backends are live-verified (claude=hook, codex=rollout-tail, opencode=SSE, kiro=session-tail; agy=screen) — detection no longer needs an opt-in flag. Per operator decision, flip the framework to default-ON, keeping the flag as an opt-out kill-switch.

### Core change (single chokepoint)
`src/daemon/shadow/mod.rs` `enabled()`: `== Ok("1")` (opt-in) → `!= Ok("0")` (opt-out). An absent var / `=1` / any other value ⇒ **ON**; only `AGEND_SHADOW_OBSERVER=0` ⇒ OFF. Every gated path (per-tick reduce, rollout/opencode/kiro observer spawns, claude socket-env + opencode `--port` injection, claude/agy hook config) flows through `enabled()`, so they all graduate together.

### Safety
- **Additive guarantee intact**: `observed_status` is written *beside* `agent_state`, never drives fleet behaviour — so default-ON changes no fleet decisions.
- **`=0` byte-identical to the old default-OFF, by construction**: both produce `enabled()==false` → the same early-returns at every gate. Only the *unset* case flipped (false→true). No path differs under `=0`.
- flag NOT removed — retained as the kill-switch.

### Tests / docs
- New `enabled_is_default_on_with_zero_kill_switch` pins default-ON (absent/`=1`/empty/arbitrary ⇒ ON) + the `=0`-only opt-out (confirm-first ①+②).
- Tests that assumed *unset = OFF* re-keyed on the explicit `=0` kill-switch: `per_tick::shadow_observe::with_flag` OFF branch now sets `=0` (was `remove_var`); `mcp_config::hooks_not_injected_without_flag` sets `AGEND_SHADOW_OBSERVER=0` (+ serialized against the `shadow_observer` group).
- doc comments across mod.rs / reducer.rs / opencode.rs / shadow_observe.rs / daemon mod.rs / app/mod.rs / agent/mod.rs / query.rs updated ("default OFF / =1 enable" → "default ON / =0 disable").

### CI parity
fmt; clippy `--features tray --all-targets -D warnings`; full `nextest --bin`; **Windows `cargo xwin clippy` clean**. Needs operator rebuild+restart to take effect live (the running daemon will then observe by default; `AGEND_SHADOW_OBSERVER=0` to opt out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
