### PR TITLE
chore(shadow): #2413 remove dead agy PreTool/PostTool hook mapping (agy has no tool granularity)

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -61,9 +61,9 @@ impl Backend {
     /// **claude + agy (#2413 Phase D).** Both inject lifecycle hooks that emit
     /// token-authenticated shadow Evidence: claude via `.claude` settings;
     /// **agy via per-workspace `.agents/hooks.json`** written by `configure_agy`
-    /// — its `PreInvocation/PreTool/PostTool/Stop` command hooks POST
-    /// claude-compatible frames to the same shadow socket via `hook-event
-    /// --event`. The earlier "claude-only" gate was because Agy's hooks were
+    /// — its `PreInvocation`/`Stop` command hooks POST claude-compatible frames to
+    /// the same shadow socket via `hook-event --event` (agy fires no tool hooks —
+    /// t-…93090-0; busy/idle only, no tool granularity). The earlier "claude-only" gate was because Agy's hooks were
     /// never injected (2026-06-11: agy emitted 0 hook events); the prerequisite
     /// it named — "injection implementation AND shadow-data evidence that its
     /// hooks fire" — is now met (RE-spike t-…39100-6 proved per-workspace hooks

--- a/src/mcp_config.rs
+++ b/src/mcp_config.rs
@@ -437,26 +437,35 @@ fn configure_agy(working_dir: &Path, instance_name: Option<&str>) -> Result<()> 
 
 /// #2413 Phase D: upsert observe-only lifecycle-hook reporters into agy's
 /// per-workspace `.agents/hooks.json` (agy/Antigravity hook config; the global
-/// `~/.gemini` is NEVER touched — scope rule). Agy fires `PreInvocation` (per
-/// model step), `PreTool`/`PostTool`, and `Stop`; each command hook runs the
-/// shared `hook-event` reporter with an explicit `--event` carrying the
-/// CLAUDE-COMPATIBLE name the shadow server already maps, so Evidence + the
-/// reducer are reused UNCHANGED:
-///   PreInvocation→UserPromptSubmit(TurnStarted), PreTool→PreToolUse(ToolStarted),
-///   PostTool→PostToolUse(ToolEnded), Stop→Stop(TurnEnded→idle).
-/// Merge-preserving + idempotent: our entry is identified by the
-/// `hook-event --instance` marker and replaced on re-configure; any operator
-/// hooks under the same event are preserved. The reporter always exits 0
-/// (observe-only — never blocks agy's turn) and the socket write fast-fails when
-/// the per-session socket is absent (shadow off), so this is spawn-safe.
+/// `~/.gemini` is NEVER touched — scope rule). Each command hook runs the shared
+/// `hook-event` reporter with an explicit `--event` carrying the CLAUDE-COMPATIBLE
+/// name the shadow server already maps, so Evidence + the reducer are reused
+/// UNCHANGED:
+///   PreInvocation→UserPromptSubmit(TurnStarted), Stop→Stop(TurnEnded→idle).
+///
+/// Agy has NO tool-granularity hooks: only `PreInvocation` (per model step) and
+/// `Stop` ever fire. The earlier `PreTool→PreToolUse` / `PostTool→PostToolUse`
+/// mappings were dead and have been removed — empirically confirmed (t-…93090-0):
+/// a live probe registering EVERY candidate tool-hook key (PreTool/PostTool/
+/// PreToolUse/PostToolUse/OnToolStart/OnToolEnd/PreToolHooks/PostToolHooks) plus
+/// controls, driven through a real tool call, fired ONLY PreInvocation /
+/// PostInvocation / Stop; the live dogfood (agy-probe) likewise emitted
+/// UserPromptSubmit/Stop and ZERO tool events while the screen showed ToolUse. So
+/// only the two hooks agy actually fires are wired (busy/idle is fully covered;
+/// tool granularity is unavailable on agy, unlike kiro's session-tail observer).
+///
+/// Merge-preserving + idempotent + self-healing: our entry is identified by the
+/// `hook-event --instance` marker. Every re-configure first strips that marker
+/// from ALL events (so retiring a mapping — e.g. the old PreTool/PostTool — also
+/// removes the dead reporter it once wrote, leaving no dangling no-op behind),
+/// prunes any event left empty, then re-installs on the live map; operator hooks
+/// (no marker) are preserved. The reporter always exits 0 (observe-only — never
+/// blocks agy's turn) and the socket write fast-fails when the per-session socket
+/// is absent (shadow off), so this is spawn-safe.
 fn upsert_agy_state_hooks(path: &Path, instance_name: &str) -> Result<()> {
-    // (agy event name, claude-compatible event the shadow server maps).
-    const EVENT_MAP: &[(&str, &str)] = &[
-        ("PreInvocation", "UserPromptSubmit"),
-        ("PreTool", "PreToolUse"),
-        ("PostTool", "PostToolUse"),
-        ("Stop", "Stop"),
-    ];
+    // (agy event name, claude-compatible event the shadow server maps). Only the
+    // two hooks agy actually fires — see fn doc (t-…93090-0: no tool granularity).
+    const EVENT_MAP: &[(&str, &str)] = &[("PreInvocation", "UserPromptSubmit"), ("Stop", "Stop")];
     let exe = std::env::current_exe()
         .map(|p| p.display().to_string())
         .unwrap_or_else(|_| "agend-terminal".to_string());
@@ -502,6 +511,22 @@ fn upsert_agy_state_hooks(path: &Path, instance_name: &str) -> Result<()> {
     let hooks = config["hooks"]
         .as_object_mut()
         .expect("hooks set to object above");
+    // Idempotent + self-healing: first drop ANY prior agend-shadow entry (marker)
+    // from EVERY event — so retiring a mapping (e.g. the PreTool/PostTool tool
+    // hooks agy never fired) also removes the now-dead reporter it once wrote,
+    // instead of leaving a dangling no-op. Operator hooks (no marker) are kept.
+    for v in hooks.values_mut() {
+        if let Some(list) = v.as_array_mut() {
+            list.retain(|e| {
+                !e.get("command")
+                    .and_then(|c| c.as_str())
+                    .is_some_and(|c| c.contains(marker))
+            });
+        }
+    }
+    // Prune events left empty by the strip (an empty hook list carries no meaning);
+    // operator events keep their entries and survive untouched.
+    hooks.retain(|_, v| v.as_array().is_none_or(|a| !a.is_empty()));
     for (agy_event, claude_event) in EVENT_MAP {
         let command = format!("{exe} hook-event --instance {instance_name} --event {claude_event}");
         let our_entry = json!({ "name": "agend-shadow", "command": command });
@@ -511,14 +536,9 @@ fn upsert_agy_state_hooks(path: &Path, instance_name: &str) -> Result<()> {
         if !arr.is_array() {
             *arr = json!([]);
         }
-        let list = arr.as_array_mut().expect("event value set to array above");
-        // Idempotent: drop our prior entry (marker), preserve operator hooks.
-        list.retain(|e| {
-            !e.get("command")
-                .and_then(|c| c.as_str())
-                .is_some_and(|c| c.contains(marker))
-        });
-        list.push(our_entry);
+        arr.as_array_mut()
+            .expect("event value set to array above")
+            .push(our_entry);
     }
     let body = serde_json::to_string_pretty(&config)?;
     crate::store::atomic_write(path, body.as_bytes())?;
@@ -1562,24 +1582,33 @@ mod hook_state_poc_tests {
     }
 
     /// #2413 Phase D (agy): the agy hooks upsert writes per-workspace
-    /// `.agents/hooks.json` with agy's OWN event keys (PreInvocation/PreTool/
-    /// PostTool/Stop) mapped to the CLAUDE-compatible `--event` the shadow server
-    /// already understands (so Evidence + reducer are reused unchanged).
-    /// Merge-preserving + idempotent. Reverse-mutation: break EVENT_MAP (e.g.
-    /// PreTool→"ToolUse") → the `--event PreToolUse` assert fails; emit claude
-    /// KEYS (PreToolUse) → the agy-key lookup + the "no claude key" assert fail.
+    /// `.agents/hooks.json` with agy's OWN event keys mapped to the
+    /// CLAUDE-compatible `--event` the shadow server already understands (so
+    /// Evidence + reducer are reused unchanged). Agy has no tool-granularity hooks
+    /// (t-…93090-0: live probe + dogfood — see fn doc), so only the two it fires
+    /// are wired: PreInvocation→UserPromptSubmit, Stop→Stop. Merge-preserving,
+    /// idempotent, and self-healing (a stale agend-shadow reporter under a RETIRED
+    /// key — the old PreTool/PostTool — is stripped on re-configure). Reverse-
+    /// mutation: break EVENT_MAP (e.g. PreInvocation→"X") → the `--event
+    /// UserPromptSubmit` assert fails; emit a claude KEY (PreToolUse) → the agy-key
+    /// lookup + "no claude key" assert fail; drop the global strip/prune → the
+    /// stale-PreTool self-heal assert fails.
     #[test]
     fn upsert_agy_state_hooks_maps_events_merges_and_is_idempotent() {
         let dir = tmp("agy-hooks");
         let path = dir.join(".agents").join("hooks.json");
         std::fs::create_dir_all(path.parent().unwrap()).unwrap();
-        // Pre-existing operator hook under a shared event (Stop) + a foreign event.
+        // Pre-existing: operator hook under a shared event (Stop) + a foreign
+        // event (SessionStart) + a STALE agend-shadow reporter under a RETIRED key
+        // (PreTool, as older code wrote) that self-healing must strip away.
         std::fs::write(
             &path,
             serde_json::to_string(&json!({
                 "hooks": {
                     "Stop": [{"name": "user-bell", "command": "say done"}],
                     "SessionStart": [{"name": "user-greet", "command": "echo hi"}],
+                    "PreTool": [{"name": "agend-shadow",
+                                 "command": "/x hook-event --instance old --event PreToolUse"}],
                 }
             }))
             .unwrap(),
@@ -1592,12 +1621,7 @@ mod hook_state_poc_tests {
         let cfg: serde_json::Value =
             serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
 
-        for (agy_ev, claude_ev) in [
-            ("PreInvocation", "UserPromptSubmit"),
-            ("PreTool", "PreToolUse"),
-            ("PostTool", "PostToolUse"),
-            ("Stop", "Stop"),
-        ] {
+        for (agy_ev, claude_ev) in [("PreInvocation", "UserPromptSubmit"), ("Stop", "Stop")] {
             let arr = cfg["hooks"][agy_ev]
                 .as_array()
                 .unwrap_or_else(|| panic!("event {agy_ev} present"));
@@ -1627,11 +1651,18 @@ mod hook_state_poc_tests {
             "operator Stop hook preserved"
         );
         assert_eq!(cfg["hooks"]["SessionStart"][0]["command"], "echo hi");
+        // No tool granularity: PreTool/PostTool are not mapped, and the stale
+        // agend-shadow reporter under the retired PreTool key is self-healed away
+        // (its only entry was ours → stripped → the empty event pruned).
+        assert!(
+            cfg["hooks"].get("PreTool").is_none() && cfg["hooks"].get("PostTool").is_none(),
+            "retired tool-hook keys absent (dead mapping removed + stale entry self-healed)"
+        );
         // agy config must use AGY event KEYS, never claude's.
         assert!(
             cfg["hooks"].get("PreToolUse").is_none()
                 && cfg["hooks"].get("UserPromptSubmit").is_none(),
-            "agy hooks.json must key on agy events (PreTool/PreInvocation), not claude's"
+            "agy hooks.json must key on agy events (PreInvocation), not claude's"
         );
         std::fs::remove_dir_all(&dir).ok();
     }

--- a/src/mcp_config.rs
+++ b/src/mcp_config.rs
@@ -454,14 +454,16 @@ fn configure_agy(working_dir: &Path, instance_name: Option<&str>) -> Result<()> 
 /// only the two hooks agy actually fires are wired (busy/idle is fully covered;
 /// tool granularity is unavailable on agy, unlike kiro's session-tail observer).
 ///
-/// Merge-preserving + idempotent + self-healing: our entry is identified by the
-/// `hook-event --instance` marker. Every re-configure first strips that marker
-/// from ALL events (so retiring a mapping — e.g. the old PreTool/PostTool — also
-/// removes the dead reporter it once wrote, leaving no dangling no-op behind),
+/// Merge-preserving + idempotent + self-healing: our reporter is identified by
+/// its reserved `name` ("agend-shadow") AND command shape — NOT a bare command
+/// substring, so an operator hook that merely MENTIONS the marker text is never
+/// stripped (#2451 data-loss fix). Every re-configure first drops our prior
+/// reporter from ALL events (so retiring a mapping — e.g. the old PreTool/PostTool
+/// — also removes the dead reporter it once wrote, leaving no dangling no-op),
 /// prunes any event left empty, then re-installs on the live map; operator hooks
-/// (no marker) are preserved. The reporter always exits 0 (observe-only — never
-/// blocks agy's turn) and the socket write fast-fails when the per-session socket
-/// is absent (shadow off), so this is spawn-safe.
+/// are preserved. The reporter always exits 0 (observe-only — never blocks agy's
+/// turn) and the socket write fast-fails when the per-session socket is absent
+/// (shadow off), so this is spawn-safe.
 fn upsert_agy_state_hooks(path: &Path, instance_name: &str) -> Result<()> {
     // (agy event name, claude-compatible event the shadow server maps). Only the
     // two hooks agy actually fires — see fn doc (t-…93090-0: no tool granularity).
@@ -470,6 +472,19 @@ fn upsert_agy_state_hooks(path: &Path, instance_name: &str) -> Result<()> {
         .map(|p| p.display().to_string())
         .unwrap_or_else(|_| "agend-terminal".to_string());
     let marker = "hook-event --instance";
+    let our_name = "agend-shadow";
+    // PRECISE ownership: an entry is ours ONLY if it carries our reserved `name`
+    // AND our command shape. Using the command substring alone (the bug #2451
+    // reviewer-6 caught) would delete an operator hook whose command merely
+    // mentions the marker text — a data-loss false positive. We stamp `our_name`
+    // on every entry we write, so name-based matching cleans retired reporters
+    // (PreTool/PostTool from older code) without ever touching operator hooks.
+    let is_ours = |e: &serde_json::Value| {
+        e.get("name").and_then(|n| n.as_str()) == Some(our_name)
+            && e.get("command")
+                .and_then(|c| c.as_str())
+                .is_some_and(|c| c.contains(marker))
+    };
 
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
@@ -511,17 +526,13 @@ fn upsert_agy_state_hooks(path: &Path, instance_name: &str) -> Result<()> {
     let hooks = config["hooks"]
         .as_object_mut()
         .expect("hooks set to object above");
-    // Idempotent + self-healing: first drop ANY prior agend-shadow entry (marker)
-    // from EVERY event — so retiring a mapping (e.g. the PreTool/PostTool tool
-    // hooks agy never fired) also removes the now-dead reporter it once wrote,
-    // instead of leaving a dangling no-op. Operator hooks (no marker) are kept.
+    // Idempotent + self-healing: drop OUR prior reporter (precise `is_ours`) from
+    // EVERY event — so retiring a mapping (e.g. the PreTool/PostTool tool hooks
+    // agy never fired) also removes the now-dead reporter it once wrote, instead
+    // of leaving a dangling no-op. Operator hooks (not is_ours) are kept verbatim.
     for v in hooks.values_mut() {
         if let Some(list) = v.as_array_mut() {
-            list.retain(|e| {
-                !e.get("command")
-                    .and_then(|c| c.as_str())
-                    .is_some_and(|c| c.contains(marker))
-            });
+            list.retain(|e| !is_ours(e));
         }
     }
     // Prune events left empty by the strip (an empty hook list carries no meaning);
@@ -529,7 +540,7 @@ fn upsert_agy_state_hooks(path: &Path, instance_name: &str) -> Result<()> {
     hooks.retain(|_, v| v.as_array().is_none_or(|a| !a.is_empty()));
     for (agy_event, claude_event) in EVENT_MAP {
         let command = format!("{exe} hook-event --instance {instance_name} --event {claude_event}");
-        let our_entry = json!({ "name": "agend-shadow", "command": command });
+        let our_entry = json!({ "name": our_name, "command": command });
         let arr = hooks
             .entry((*agy_event).to_string())
             .or_insert_with(|| json!([]));
@@ -1588,25 +1599,35 @@ mod hook_state_poc_tests {
     /// (t-…93090-0: live probe + dogfood — see fn doc), so only the two it fires
     /// are wired: PreInvocation→UserPromptSubmit, Stop→Stop. Merge-preserving,
     /// idempotent, and self-healing (a stale agend-shadow reporter under a RETIRED
-    /// key — the old PreTool/PostTool — is stripped on re-configure). Reverse-
-    /// mutation: break EVENT_MAP (e.g. PreInvocation→"X") → the `--event
-    /// UserPromptSubmit` assert fails; emit a claude KEY (PreToolUse) → the agy-key
-    /// lookup + "no claude key" assert fail; drop the global strip/prune → the
-    /// stale-PreTool self-heal assert fails.
+    /// key — the old PreTool/PostTool — is stripped on re-configure) while ownership
+    /// is PRECISE (name=="agend-shadow", not a bare command substring), so an
+    /// operator hook that merely mentions the marker text in its command survives
+    /// (#2451 data-loss fix). Reverse-mutation: break EVENT_MAP (e.g.
+    /// PreInvocation→"X") → the `--event UserPromptSubmit` assert fails; emit a
+    /// claude KEY (PreToolUse) → the agy-key lookup + "no claude key" assert fail;
+    /// drop the global strip/prune → the stale-PreTool self-heal assert fails;
+    /// widen ownership back to the command substring → the operator-mentions-marker
+    /// preserve assert fails.
     #[test]
     fn upsert_agy_state_hooks_maps_events_merges_and_is_idempotent() {
         let dir = tmp("agy-hooks");
         let path = dir.join(".agents").join("hooks.json");
         std::fs::create_dir_all(path.parent().unwrap()).unwrap();
         // Pre-existing: operator hook under a shared event (Stop) + a foreign
-        // event (SessionStart) + a STALE agend-shadow reporter under a RETIRED key
-        // (PreTool, as older code wrote) that self-healing must strip away.
+        // event (SessionStart, with a 2nd operator hook whose COMMAND mentions the
+        // marker but whose NAME is not ours — reviewer-6 #2451 data-loss
+        // counterexample, MUST survive) + a STALE agend-shadow reporter under a
+        // RETIRED key (PreTool, as older code wrote) that self-healing must strip.
         std::fs::write(
             &path,
             serde_json::to_string(&json!({
                 "hooks": {
                     "Stop": [{"name": "user-bell", "command": "say done"}],
-                    "SessionStart": [{"name": "user-greet", "command": "echo hi"}],
+                    "SessionStart": [
+                        {"name": "user-greet", "command": "echo hi"},
+                        {"name": "operator-mentions-marker",
+                         "command": "printf 'hook-event --instance is documented here'"},
+                    ],
                     "PreTool": [{"name": "agend-shadow",
                                  "command": "/x hook-event --instance old --event PreToolUse"}],
                 }
@@ -1651,6 +1672,14 @@ mod hook_state_poc_tests {
             "operator Stop hook preserved"
         );
         assert_eq!(cfg["hooks"]["SessionStart"][0]["command"], "echo hi");
+        // #2451 data-loss fix: an operator hook whose COMMAND mentions the marker
+        // but whose NAME is not ours MUST survive (ownership is name-based, not a
+        // command substring). reviewer-6's counterexample, locked in.
+        let ss = cfg["hooks"]["SessionStart"].as_array().unwrap();
+        assert!(
+            ss.iter().any(|e| e["name"] == "operator-mentions-marker"),
+            "operator hook mentioning the marker text in its command must be preserved"
+        );
         // No tool granularity: PreTool/PostTool are not mapped, and the stale
         // agend-shadow reporter under the retired PreTool key is self-healed away
         // (its only entry was ours → stripped → the empty event pruned).


### PR DESCRIPTION
## What & why

#2413 Phase D follow-up (t-…93090-0). The agy lifecycle-hooks plane (#2448) wired four agy event keys into `.agents/hooks.json`, mapping `PreTool→PreToolUse` and `PostTool→PostToolUse`. The live dogfood found those tool hooks **never fire**. This PR proves *why* and cleans up the dead mapping.

## Confirm-first evidence (decisive — not a guess)

**Live probe** (isolated temp workspace, every candidate tool-hook key registered + controls, driven through a real tool call `echo HELLO_AGY_PROBE_42`):

| fired | not fired |
|---|---|
| `PreInvocation` (per step), `PostInvocation` (per step), `Stop` | `PreTool`, `PostTool`, `PreToolUse`, `PostToolUse`, `OnToolStart`, `OnToolEnd`, `PreToolHooks`, `PostToolHooks` |

**Production dogfood** (`agy-probe`, app log): emitted only `UserPromptSubmit` ×4 (from `PreInvocation`) and `Stop` ×1 — and **zero** tool events even at the moment `screen_state=ToolUse` (agy *was* running a tool).

**Binary schema** (`agy` protobuf strings): config-key convention is `<Category>` (the working `PreInvocation`↔`PreInvocationHooks`, `Stop`↔`StopHooks`). So the key names weren't wrong — **agy simply has no tool-granularity hooks** (unlike kiro's session-tail observer). agy busy/idle (the core goal) is fully covered by PreInvocation+Stop and was already live-verified.

## Change (branch (b): clean the dead mapping)

- `EVENT_MAP` drops `PreTool`/`PostTool`; wires only the two hooks agy fires (`PreInvocation→UserPromptSubmit`, `Stop→Stop`).
- `upsert_agy_state_hooks` is now **self-healing**: strips any prior `agend-shadow` reporter from *all* events + prunes emptied events before re-installing — so retiring the mapping also removes the no-op reporter older code wrote into existing configs (e.g. live `ai-scout`). Operator hooks (no marker) preserved.
- Doc comments (`mcp_config.rs`, `backend.rs`) updated with the evidence; regression test updated and **NEUTER-verified RED** (dropping the strip → idempotency/self-heal assert fails).

`PostInvocation` was observed to fire (per step) but is intentionally **not** wired — out of scope (busy/idle already covered; no clear added value). Noted for a possible follow-up.

## Guarantees
- **flag-OFF byte-identical**: `configure_agy` never calls `upsert_agy_state_hooks` when shadow is disabled — zero effect on the OFF path.
- **No global `~/.gemini` touch**: only per-workspace `.agents/hooks.json`.
- **claude plane untouched**: claude still fires/maps `PreToolUse`/`PostToolUse`; only agy's EVENT_MAP changed.

## Verification
- `cargo fmt --check` ✓
- `cargo clippy --features tray --all-targets -- -D warnings` ✓
- full `cargo nextest --bin agend-terminal --features tray` = **4529 passed / 0 failed** (clean env)

🤖 Generated with [Claude Code](https://claude.com/claude-code)