### PR TITLE
feat(shadow): #2413 (A) consume observed_status into pane badge (confidence-gated)

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -76,6 +76,12 @@ pub struct AgentHandle {
     /// stops contending with the PTY-feed producer that holds the core lock under
     /// the boot output flood. Aliases the same `AtomicU8` `record_set` writes.
     pub(crate) published_state: Arc<std::sync::atomic::AtomicU8>,
+    /// #2413 (A): lock-free clone of the core's badge-override mirror
+    /// (`StateTracker::published_observed_handle`). Read alongside `published_state`
+    /// in `render::build_agent_state_snapshot` so the badge can show a high-confidence
+    /// Shadow Observer correction WITHOUT `core.lock()`. Holds the no-override
+    /// sentinel ([`crate::state::OBSERVED_NONE`]) until the shadow driver publishes one.
+    pub(crate) published_observed: Arc<std::sync::atomic::AtomicU8>,
     pub(crate) child: Arc<Mutex<Box<dyn portable_pty::Child + Send>>>,
     pub(crate) submit_key: String,
     pub(crate) inject_prefix: String,
@@ -102,6 +108,15 @@ pub(crate) fn published_state_of(
     core: &Arc<CoreMutex<AgentCore>>,
 ) -> Arc<std::sync::atomic::AtomicU8> {
     core.lock().state.published_handle()
+}
+
+/// #2413 (A): clone an agent's lock-free badge-override mirror from its core (the
+/// sibling of [`published_state_of`]). Lets `render::build_agent_state_snapshot`
+/// read the Shadow Observer's gated correction without `core.lock()`.
+pub(crate) fn published_observed_of(
+    core: &Arc<CoreMutex<AgentCore>>,
+) -> Arc<std::sync::atomic::AtomicU8> {
+    core.lock().state.published_observed_handle()
 }
 
 // #1441: keyed by stable InstanceId (UUID), NOT name. Live-process identity
@@ -1311,6 +1326,7 @@ pub fn spawn_agent(
                 pty_writer: Arc::clone(&pty_writer),
                 pty_master: Arc::clone(&pty_master),
                 published_state: published_state_of(&core),
+                published_observed: published_observed_of(&core),
                 core: Arc::clone(&core),
                 child: Arc::clone(&child_arc),
                 submit_key: submit_key.to_string(),
@@ -3145,6 +3161,7 @@ pub(crate) fn mk_test_handle(name: &str, id: crate::types::InstanceId) -> AgentH
         observed_status: None,
     }));
     let published_state = core.lock().state.published_handle();
+    let published_observed = core.lock().state.published_observed_handle();
     AgentHandle {
         id,
         name: name.to_string().into(),
@@ -3153,6 +3170,7 @@ pub(crate) fn mk_test_handle(name: &str, id: crate::types::InstanceId) -> AgentH
         pty_master,
         core,
         published_state,
+        published_observed,
         child: Arc::new(Mutex::new(child)),
         submit_key: "\r".to_string(),
         inject_prefix: String::new(),

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -387,6 +387,7 @@ fn sweep_child_tree_body(pid_file: &std::path::Path) {
         pty_writer,
         pty_master,
         published_state: crate::agent::published_state_of(&core),
+        published_observed: crate::agent::published_observed_of(&core),
         core,
         child: Arc::new(Mutex::new(child)),
         submit_key: "\r".to_string(),
@@ -990,6 +991,7 @@ fn write_to_agent_typed_uses_timeout() {
         observed_status: None,
     }));
     let published_state = core.lock().state.published_handle();
+    let published_observed = core.lock().state.published_observed_handle();
     let handle = AgentHandle {
         id: crate::types::InstanceId::default(),
         name: "typed-test".into(),
@@ -998,6 +1000,7 @@ fn write_to_agent_typed_uses_timeout() {
         pty_master: Arc::new(Mutex::new(pair.master)),
         core,
         published_state,
+        published_observed,
         child: Arc::new(Mutex::new(
             pair.slave
                 .spawn_command(portable_pty::CommandBuilder::new("true"))
@@ -1740,6 +1743,7 @@ fn pty_read_error_triggers_cleanup() {
                     .master,
             )),
             published_state: crate::agent::published_state_of(&core),
+            published_observed: crate::agent::published_observed_of(&core),
             core: Arc::clone(&core),
             child: Arc::new(Mutex::new(
                 portable_pty::native_pty_system()
@@ -1872,6 +1876,7 @@ fn make_crash_exit_handle(deleted: bool) -> (AgentHandle, crate::types::Instance
                 .master,
         )),
         published_state: crate::agent::published_state_of(&core),
+        published_observed: crate::agent::published_observed_of(&core),
         core,
         child: Arc::new(Mutex::new(child)),
         submit_key: "\r".to_string(),
@@ -2214,6 +2219,7 @@ fn mk_handle_1441(name: &str, id: crate::types::InstanceId) -> AgentHandle {
         pty_writer,
         pty_master,
         published_state: crate::agent::published_state_of(&core),
+        published_observed: crate::agent::published_observed_of(&core),
         core,
         child: Arc::new(Mutex::new(child)),
         submit_key: "\r".to_string(),

--- a/src/daemon/crash_respawn.rs
+++ b/src/daemon/crash_respawn.rs
@@ -483,6 +483,7 @@ mod deleted_gate_tests_1913 {
             pty_writer,
             pty_master,
             published_state: crate::agent::published_state_of(&core),
+            published_observed: crate::agent::published_observed_of(&core),
             core,
             child: Arc::new(Mutex::new(child)),
             submit_key: "\r".to_string(),

--- a/src/daemon/lifecycle.rs
+++ b/src/daemon/lifecycle.rs
@@ -350,6 +350,7 @@ mod tests {
             pty_writer,
             pty_master,
             published_state: crate::agent::published_state_of(&core),
+            published_observed: crate::agent::published_observed_of(&core),
             core,
             child: Arc::new(Mutex::new(child)),
             submit_key: "\r".to_string(),

--- a/src/daemon/per_tick/mod.rs
+++ b/src/daemon/per_tick/mod.rs
@@ -311,6 +311,7 @@ pub(crate) fn mock_live_agent_no_context(
         pty_writer,
         pty_master: Arc::new(parking_lot::Mutex::new(pair.master)),
         published_state: crate::agent::published_state_of(&core),
+        published_observed: crate::agent::published_observed_of(&core),
         core,
         child: Arc::new(parking_lot::Mutex::new(child)),
         submit_key: "\r".to_string(),

--- a/src/daemon/per_tick/shadow_observe.rs
+++ b/src/daemon/per_tick/shadow_observe.rs
@@ -20,7 +20,8 @@
 use super::{PerTickHandler, TickContext};
 use crate::agent::AgentCore;
 use crate::daemon::shadow;
-use crate::daemon::shadow::reducer::{Liveness, ObservedState, ScreenSignal};
+use crate::daemon::shadow::evidence::{Authority, Confidence};
+use crate::daemon::shadow::reducer::{Liveness, ObservedState, ObservedStatus, ScreenSignal};
 use crate::state::AgentState;
 use crate::sync_audit::CoreMutex;
 use std::sync::Arc;
@@ -81,9 +82,68 @@ impl PerTickHandler for ShadowObserveHandler {
             };
             let status = shadow::observe(name, screen, &live, now_ms);
             log_correction(name, raw_state, screen, &status, &live);
-            core.lock().observed_status = Some(status);
+            // #2413 (A): publish the GATED badge override into the lock-free mirror the
+            // render snapshot reads (Some ⇒ a high-confidence correction the badge shows;
+            // None ⇒ render keeps the raw state). Computed BEFORE `status` moves into
+            // `observed_status`. Both writes land under ONE core.lock; `publish_observed`
+            // touches only the separate atomic, NEVER `current` (cycle-proof).
+            let badge = badge_override(screen, &status);
+            let mut c = core.lock();
+            c.observed_status = Some(status);
+            c.state.publish_observed(badge);
         }
     }
+}
+
+/// #2413 (A): the gated BADGE override. Returns `Some(AgentState)` — the state the
+/// pane badge should show INSTEAD of the raw screen-scrape — ONLY when the fused
+/// [`ObservedStatus`] is a HIGH-CONFIDENCE real-time observer-plane correction, i.e.
+/// ALL of: (a) `authority ∈ {Hook, Stream}` (a live lifecycle / event-stream plane,
+/// not the `Screen` baseline and not a low-confidence `Inferred` reconcile); (b)
+/// `confidence ∈ {Confirmed, Strong}` (freshness is already implied — the reducer only
+/// labels a fresh observer plane this high); and (c) it actually DISAGREES with the raw
+/// screen baseline at the coarse level (the §5 correction predicate via
+/// [`screen_as_observed`]), so an agreeing-but-vaguer observed state never DOWNGRADES a
+/// more-specific raw badge (e.g. raw `ToolUse` vs coarse `Active`).
+///
+/// `None` otherwise → render keeps the raw `published` state. This is the regression
+/// firewall the lead approved: weak / screen-only backends (agy has no Hook/Stream
+/// plane → authority is always `Screen`/`ProcessHeuristic`/`Inferred`) can NEVER satisfy
+/// (a) → zero badge regression, by construction. The `Inferred` reconcile-to-Idle is
+/// deliberately excluded — the badge flips only when we are SURE work is in flight or a
+/// human gate is up (lead open-q1: "只 Hook/Stream+Strong 才翻 badge").
+fn badge_override(screen: ScreenSignal, status: &ObservedStatus) -> Option<AgentState> {
+    let high_confidence = matches!(status.authority, Authority::Hook | Authority::Stream)
+        && matches!(
+            status.confidence,
+            Confidence::Confirmed | Confidence::Strong
+        );
+    if !high_confidence {
+        return None;
+    }
+    // Only a genuine §5 correction (coarse-level disagreement with the raw screen
+    // baseline) flips the badge — never a same-coarse refinement.
+    let baseline = screen_as_observed(screen);
+    if !baseline.is_some_and(|b| b != status.state.coarse()) {
+        return None;
+    }
+    badge_state_for(status.state)
+}
+
+/// Map a corrected [`ObservedState`] to the [`AgentState`] the badge renders (reusing
+/// the existing `state_color` / label tables). `Idle` ⇒ `None`: the badge never flips
+/// TO idle on a correction (the only idle-direction correction is the excluded
+/// `Inferred` reconcile).
+fn badge_state_for(state: ObservedState) -> Option<AgentState> {
+    Some(match state {
+        ObservedState::ToolUse => AgentState::ToolUse,
+        ObservedState::Thinking | ObservedState::Responding | ObservedState::Active => {
+            AgentState::Thinking
+        }
+        ObservedState::WaitingForUser => AgentState::AwaitingOperator,
+        ObservedState::RateLimited => AgentState::RateLimit,
+        ObservedState::Idle => return None,
+    })
 }
 
 /// Map the 18-variant screen-scrape [`AgentState`] into the reducer's coarse
@@ -381,5 +441,204 @@ mod tests {
             ScreenSignal::Approval,
             ObservedState::WaitingForUser
         ));
+    }
+
+    // ── #2413 (A): the gated BADGE override ──────────────────────────────────────
+
+    fn status(
+        state: ObservedState,
+        authority: Authority,
+        confidence: Confidence,
+    ) -> ObservedStatus {
+        ObservedStatus {
+            state,
+            confidence,
+            authority,
+            evidence: vec![],
+            since_ms: 0,
+        }
+    }
+
+    /// The headline win: screen renders Idle mid-request, but a fresh Hook (or Stream)
+    /// episode proves Active ⇒ the badge flips to a working state.
+    #[test]
+    fn badge_override_flips_on_high_confidence_false_idle() {
+        let s = status(ObservedState::Active, Authority::Hook, Confidence::Strong);
+        assert_eq!(
+            badge_override(ScreenSignal::Idle, &s),
+            Some(AgentState::Thinking)
+        );
+        // Stream plane (codex) parity.
+        let s = status(
+            ObservedState::ToolUse,
+            Authority::Stream,
+            Confidence::Strong,
+        );
+        assert_eq!(
+            badge_override(ScreenSignal::Idle, &s),
+            Some(AgentState::ToolUse)
+        );
+    }
+
+    /// A hook `ApprovalRequired` (Confirmed) splits WaitingForUser out of an idle/ambiguous
+    /// screen ⇒ the badge shows AwaitingOperator.
+    #[test]
+    fn badge_override_flips_approval_out_of_idle() {
+        let s = status(
+            ObservedState::WaitingForUser,
+            Authority::Hook,
+            Confidence::Confirmed,
+        );
+        assert_eq!(
+            badge_override(ScreenSignal::Idle, &s),
+            Some(AgentState::AwaitingOperator)
+        );
+    }
+
+    /// Regression firewall (1): a screen-only backend (agy — authority always `Screen`)
+    /// can NEVER satisfy the Hook/Stream gate, so the badge keeps the raw state even at
+    /// Strong confidence and a coarse disagreement. Zero regression for weak backends.
+    #[test]
+    fn badge_override_screen_only_backend_keeps_raw() {
+        let s = status(
+            ObservedState::WaitingForUser,
+            Authority::Screen,
+            Confidence::Strong,
+        );
+        assert_eq!(badge_override(ScreenSignal::Idle, &s), None);
+    }
+
+    /// Regression firewall (2): a low-confidence (stale-plane `Probable`) status does not
+    /// flip the badge even with a Hook authority.
+    #[test]
+    fn badge_override_excludes_low_confidence() {
+        let s = status(ObservedState::Active, Authority::Hook, Confidence::Probable);
+        assert_eq!(badge_override(ScreenSignal::Idle, &s), None);
+    }
+
+    /// Lead open-q1: the dropped-hook reconcile-to-Idle (`Inferred`/`Probable`) is
+    /// excluded — the badge only flips when SURE work is in flight / a gate is up.
+    #[test]
+    fn badge_override_excludes_inferred_reconcile() {
+        let s = status(
+            ObservedState::Idle,
+            Authority::Inferred,
+            Confidence::Probable,
+        );
+        assert_eq!(badge_override(ScreenSignal::Working, &s), None);
+    }
+
+    /// No downgrade: a Hook+Strong status that AGREES coarsely with the raw screen
+    /// (both Working) does not flip, so a more-specific raw `ToolUse` is never traded
+    /// for a vaguer observed `Active`.
+    #[test]
+    fn badge_override_no_downgrade_on_coarse_agreement() {
+        let s = status(ObservedState::Active, Authority::Hook, Confidence::Strong);
+        assert_eq!(badge_override(ScreenSignal::Working, &s), None);
+    }
+
+    #[test]
+    fn badge_state_for_maps_active_family_and_excludes_idle() {
+        assert_eq!(
+            badge_state_for(ObservedState::ToolUse),
+            Some(AgentState::ToolUse)
+        );
+        assert_eq!(
+            badge_state_for(ObservedState::Thinking),
+            Some(AgentState::Thinking)
+        );
+        assert_eq!(
+            badge_state_for(ObservedState::Responding),
+            Some(AgentState::Thinking)
+        );
+        assert_eq!(
+            badge_state_for(ObservedState::Active),
+            Some(AgentState::Thinking)
+        );
+        assert_eq!(
+            badge_state_for(ObservedState::WaitingForUser),
+            Some(AgentState::AwaitingOperator)
+        );
+        assert_eq!(
+            badge_state_for(ObservedState::RateLimited),
+            Some(AgentState::RateLimit)
+        );
+        assert_eq!(badge_state_for(ObservedState::Idle), None);
+    }
+
+    /// Representative confirm-first: flag-ON, a buffered `TurnStarted` (episode open) +
+    /// a live child + an Idle screen ⇒ the mid-API false-idle correction is GATED and
+    /// PUBLISHED into the lock-free `published_observed` mirror the render badge reads.
+    /// This is the end-to-end pin that the correction actually reaches render, not just
+    /// `observed_status`.
+    #[test]
+    #[serial(shadow_observer)]
+    fn flag_on_publishes_badge_override_to_mirror() {
+        let home = std::env::temp_dir();
+        let externals: ExternalRegistry = Arc::new(PLMutex::new(HashMap::new()));
+        let configs = Arc::new(PLMutex::new(HashMap::new()));
+        let (registry, core, name, _reader) = one_agent_registry("shadow-badge-on");
+
+        let token = shadow::new_session_token().unwrap();
+        shadow::register(&token, &name);
+        shadow::push(
+            &name,
+            Evidence::hook(
+                EvidenceKind::TurnStarted,
+                chrono::Utc::now().timestamp_millis().max(0) as u64,
+            ),
+        );
+
+        with_flag(true, || {
+            let ctx = ctx_for(&home, &registry, &externals, &configs);
+            ShadowObserveHandler::new().run(&ctx);
+        });
+
+        let byte = core
+            .lock()
+            .state
+            .published_observed_handle()
+            .load(std::sync::atomic::Ordering::Relaxed);
+        let badge = AgentState::from_observed_u8(byte);
+        assert!(
+            matches!(
+                badge,
+                Some(AgentState::Thinking) | Some(AgentState::ToolUse)
+            ),
+            "mid-API false-idle correction must reach the lock-free badge mirror, got {badge:?}"
+        );
+        shadow::forget_agent(&name);
+    }
+
+    /// Flag-OFF: the handler early-returns, so the badge mirror stays at the no-override
+    /// sentinel (render falls back to the raw state) — byte-identical to pre-#2413.
+    #[test]
+    #[serial(shadow_observer)]
+    fn flag_off_leaves_badge_mirror_at_sentinel() {
+        let home = std::env::temp_dir();
+        let externals: ExternalRegistry = Arc::new(PLMutex::new(HashMap::new()));
+        let configs = Arc::new(PLMutex::new(HashMap::new()));
+        let (registry, core, name, _reader) = one_agent_registry("shadow-badge-off");
+
+        let token = shadow::new_session_token().unwrap();
+        shadow::register(&token, &name);
+        shadow::push(&name, Evidence::hook(EvidenceKind::TurnStarted, 1_000));
+
+        with_flag(false, || {
+            let ctx = ctx_for(&home, &registry, &externals, &configs);
+            ShadowObserveHandler::new().run(&ctx);
+        });
+
+        let byte = core
+            .lock()
+            .state
+            .published_observed_handle()
+            .load(std::sync::atomic::Ordering::Relaxed);
+        assert_eq!(
+            AgentState::from_observed_u8(byte),
+            None,
+            "flag-OFF ⇒ no badge override published ⇒ mirror stays at the sentinel"
+        );
+        shadow::forget_agent(&name);
     }
 }

--- a/src/daemon/poll_reminder.rs
+++ b/src/daemon/poll_reminder.rs
@@ -279,6 +279,7 @@ mod tests {
         };
         let core = Arc::new(crate::sync_audit::CoreMutex::new(core));
         let published_state = core.lock().state.published_handle();
+        let published_observed = core.lock().state.published_observed_handle();
         // `st.current` was set directly (bypasses record_set), so sync the
         // lock-free mirror to match.
         published_state.store(state as u8, std::sync::atomic::Ordering::Relaxed);
@@ -290,6 +291,7 @@ mod tests {
             pty_master: Arc::new(Mutex::new(pair.master)),
             core,
             published_state,
+            published_observed,
             child: Arc::new(Mutex::new(child)),
             submit_key: "\r".to_string(),
             inject_prefix: String::new(),

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -3917,6 +3917,7 @@ instances:
         core.lock().state.current = state;
         // Direct `.current` write bypasses record_set, so sync the lock-free mirror.
         let published_state = core.lock().state.published_handle();
+        let published_observed = core.lock().state.published_observed_handle();
         published_state.store(state as u8, std::sync::atomic::Ordering::Relaxed);
         let handle = crate::agent::AgentHandle {
             id: crate::types::InstanceId::default(),
@@ -3926,6 +3927,7 @@ instances:
             pty_master: Arc::new(parking_lot::Mutex::new(pair.master)),
             core,
             published_state,
+            published_observed,
             child: Arc::new(parking_lot::Mutex::new(child)),
             submit_key: "\r".to_string(),
             inject_prefix: String::new(),

--- a/src/render/core_render.rs
+++ b/src/render/core_render.rs
@@ -362,6 +362,12 @@ fn build_agent_state_snapshot(
     registry: &AgentRegistry,
 ) -> HashMap<String, AgentState> {
     let reg = agent::lock_registry(registry);
+    // #2413 (A): show the Shadow Observer's high-confidence badge correction in place
+    // of the raw screen state, unless the operator turned it off (`:set observed_badge
+    // off`) or the whole observer is killed (`AGEND_SHADOW_OBSERVER=0`). Computed ONCE
+    // per frame (not per pane); both reads are cheap but neither belongs in the loop.
+    let show_observed =
+        crate::runtime_config::get().observed_badge && crate::daemon::shadow::enabled();
     let mut snapshot = HashMap::new();
     for tab in &layout.tabs {
         for id in tab.root().pane_ids() {
@@ -370,19 +376,8 @@ fn build_agent_state_snapshot(
                     snapshot
                         .entry(pane.agent_name.to_string())
                         .or_insert_with(|| {
-                            // Read the lock-free published mirror — NO core.lock().
-                            // Under the boot PTY flood the per-agent core lock is
-                            // held 2–6 ms by each `pty_read_loop` feed; taking it
-                            // here (once per pane, every frame) made the render
-                            // snapshot wait up to ~10 ms and starved input. The
-                            // AtomicU8 is written in lockstep by `record_set`.
                             reg.get(&pane.instance_id)
-                                .map(|h| {
-                                    AgentState::from_u8(
-                                        h.published_state
-                                            .load(std::sync::atomic::Ordering::Relaxed),
-                                    )
-                                })
+                                .map(|h| observed_or_raw_state(h, show_observed))
                                 .unwrap_or(AgentState::Idle)
                         });
                 }
@@ -390,6 +385,26 @@ fn build_agent_state_snapshot(
         }
     }
     snapshot
+}
+
+/// #2413 (A): the badge state for one agent — the Shadow Observer's high-confidence
+/// correction (`published_observed`) when `show_observed` AND a correction is published,
+/// else the raw screen-scrape state (`published_state`).
+///
+/// Both reads are lock-free `Relaxed` `AtomicU8` loads — NO `core.lock()`. Under the
+/// boot PTY flood the per-agent core lock is held 2–6 ms by each `pty_read_loop` feed;
+/// taking it here (once per pane, every frame) made the render snapshot wait up to
+/// ~10 ms and starved input. Both atomics are written in lockstep by their writers
+/// (`record_set` for `published_state`; the per-tick `shadow_observe` driver for
+/// `published_observed`), so the render path stays contention-free.
+fn observed_or_raw_state(h: &agent::AgentHandle, show_observed: bool) -> AgentState {
+    use std::sync::atomic::Ordering::Relaxed;
+    if show_observed {
+        if let Some(corrected) = AgentState::from_observed_u8(h.published_observed.load(Relaxed)) {
+            return corrected;
+        }
+    }
+    AgentState::from_u8(h.published_state.load(Relaxed))
 }
 
 pub fn render(
@@ -1592,6 +1607,36 @@ mod tests {
         // separate concern. This test documents the protocol for future
         // wiring; runs only with `cargo test -- --ignored` against a daemon
         // spun up with the env set.
+    }
+
+    /// #2413 (A): the badge picks the Shadow Observer correction over the raw state
+    /// ONLY when `show_observed` AND a correction is published; otherwise the raw
+    /// `published_state` wins. Pins all three branches of `observed_or_raw_state` —
+    /// the lock-free read the render snapshot uses. `#[cfg(unix)]` (mk_test_handle).
+    #[cfg(unix)]
+    #[test]
+    fn observed_or_raw_state_prefers_correction_only_when_enabled() {
+        let id = crate::types::InstanceId::default();
+        let handle = crate::agent::mk_test_handle("agent", id);
+        // Raw screen state = Restarting (via record_set); a published badge override.
+        handle.core.lock().state.set_restarting();
+        handle
+            .core
+            .lock()
+            .state
+            .publish_observed(Some(AgentState::ToolUse));
+
+        // Toggle ON ⇒ the high-confidence correction wins.
+        assert_eq!(observed_or_raw_state(&handle, true), AgentState::ToolUse);
+        // Toggle OFF ⇒ the raw state wins (operator opted out / observer killed).
+        assert_eq!(
+            observed_or_raw_state(&handle, false),
+            AgentState::Restarting
+        );
+
+        // No correction published (sentinel) ⇒ raw state even when enabled.
+        handle.core.lock().state.publish_observed(None);
+        assert_eq!(observed_or_raw_state(&handle, true), AgentState::Restarting);
     }
 
     /// Regression for the post-#2346 residual freeze: the per-frame render state

--- a/src/runtime_config.rs
+++ b/src/runtime_config.rs
@@ -64,6 +64,18 @@ pub struct RuntimeConfig {
     /// before it existed (additive — no schema bump).
     #[serde(default = "default_true")]
     pub dim_unfocused_panes: bool,
+    /// #2413 (A): when true (DEFAULT), the pane state badge shows the Shadow
+    /// Observer's HIGH-CONFIDENCE correction (`observed_status`, gated to
+    /// Hook/Stream + Confirmed/Strong) in place of the raw screen-scrape — e.g. an
+    /// agent mid-API-call that renders `[Idle]` shows `[Thinking]`, an approval gate
+    /// shows `[AwaitingOperator]`. Weak / screen-only backends keep the raw state
+    /// (the gate can't fire), so this never regresses them. `false` keeps every
+    /// badge on the raw screen state. The `AGEND_SHADOW_OBSERVER=0` kill-switch
+    /// disables the whole observer (and so this) regardless. Read live by
+    /// `render::build_agent_state_snapshot`; toggle via `:set observed_badge on|off`.
+    /// `default_true` also fills the field for configs written before it existed.
+    #[serde(default = "default_true")]
+    pub observed_badge: bool,
     /// #2090: origin-aware long-task progress reporting mode. `0` = off
     /// (DEFAULT — zero behaviour change).
     ///
@@ -126,6 +138,7 @@ impl Default for RuntimeConfig {
             show_pane_state: true,
             copy_on_select: true,
             dim_unfocused_panes: true,
+            observed_badge: true,
             progress_mode: 0,
             schema_version: RuntimeConfig::CURRENT,
         }
@@ -280,6 +293,15 @@ pub fn set(home: &Path, key: &str, value: &str) -> Result<String, String> {
                 _ => return Err(format!("invalid boolean: {value} (use on/off)")),
             };
         }
+        "observed_badge" => {
+            // #2413 (A): operator-facing badge-correction toggle — accept on/off
+            // alongside true/false/1/0.
+            config.observed_badge = match value {
+                "true" | "1" | "on" => true,
+                "false" | "0" | "off" => false,
+                _ => return Err(format!("invalid boolean: {value} (use on/off)")),
+            };
+        }
         "progress_mode" => {
             let m: i64 = value
                 .parse()
@@ -334,6 +356,7 @@ pub fn get_key(key: &str) -> Result<String, String> {
         "show_pane_state" => Ok(config.show_pane_state.to_string()),
         "copy_on_select" => Ok(config.copy_on_select.to_string()),
         "dim_unfocused_panes" => Ok(config.dim_unfocused_panes.to_string()),
+        "observed_badge" => Ok(config.observed_badge.to_string()),
         "progress_mode" => Ok(config.progress_mode.to_string()),
         _ => Err(format!("unknown config key: {key}")),
     }
@@ -485,6 +508,28 @@ mod tests {
         assert_eq!(get_key("copy_on_select").unwrap(), "true");
         // Garbage value rejected (not silently coerced).
         assert!(set(&dir, "copy_on_select", "maybe").is_err());
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// #2413 (A): `observed_badge` defaults ON (the operator sees observer-corrected
+    /// badges by default) and toggles via on/off (and true/false/1/0), persisting
+    /// across reload. Garbage rejected.
+    #[test]
+    #[serial(runtime_config)]
+    fn observed_badge_default_on_and_toggleable_via_on_off() {
+        assert!(
+            RuntimeConfig::default().observed_badge,
+            "observed_badge must default ON"
+        );
+        let dir = std::env::temp_dir().join("agend-test-runtime-config-obsbadge");
+        std::fs::create_dir_all(&dir).ok();
+        set(&dir, "observed_badge", "off").unwrap();
+        reload(&dir);
+        assert_eq!(get_key("observed_badge").unwrap(), "false");
+        set(&dir, "observed_badge", "on").unwrap();
+        reload(&dir);
+        assert_eq!(get_key("observed_badge").unwrap(), "true");
+        assert!(set(&dir, "observed_badge", "maybe").is_err());
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -82,6 +82,13 @@ pub enum AgentState {
     Restarting,
 }
 
+/// #2413 (A): the "no badge override" sentinel for the Shadow Observer's lock-free
+/// badge-override mirror (`StateTracker::published_observed`). NOT a valid
+/// `AgentState` discriminant (the enum has 18 variants, 0–17), so it can never
+/// collide with a real state byte. When the mirror holds this, the render snapshot
+/// falls back to the raw `published` state.
+pub const OBSERVED_NONE: u8 = u8::MAX;
+
 impl AgentState {
     /// Inverse of the `#[repr(u8)]` discriminant: reconstruct the state from the
     /// byte published into the lock-free `AtomicU8` mirror. Unknown bytes (never
@@ -110,6 +117,16 @@ impl AgentState {
             17 => Self::Restarting,
             _ => Self::Idle,
         }
+    }
+
+    /// #2413 (A): decode the Shadow Observer BADGE-override mirror byte. The
+    /// per-tick `shadow_observe` driver stores [`OBSERVED_NONE`] when no
+    /// high-confidence correction applies (→ `None`, render falls back to the raw
+    /// `published` state) or a real `AgentState` discriminant when a correction
+    /// should override the badge. Checked against the sentinel BEFORE `from_u8` so
+    /// the sentinel can never be misread as `Idle`.
+    pub fn from_observed_u8(v: u8) -> Option<AgentState> {
+        (v != OBSERVED_NONE).then(|| AgentState::from_u8(v))
     }
 
     /// GO-NARROW 6 states that trigger orchestrator notify on transition.
@@ -233,6 +250,17 @@ pub struct StateTracker {
     /// ordering is sufficient: it carries no other memory, and the render path
     /// already tolerates ≤1-frame staleness (it re-snapshots every draw).
     published: Arc<AtomicU8>,
+    /// #2413 (A): lock-free mirror of the Shadow Observer's gated BADGE override —
+    /// the coarse `AgentState` the render snapshot should show INSTEAD of `published`,
+    /// but ONLY when a high-confidence observer-plane correction applies (gated by
+    /// the per-tick `shadow_observe` driver — see `badge_override`). Holds
+    /// [`OBSERVED_NONE`] (no override → render uses raw `published`) until a
+    /// correction is published, and is reset to it whenever the correction lapses.
+    /// SEPARATE from `published` ON PURPOSE: the reducer's screen input is `current`
+    /// (vterm-only) and is NEVER read from this mirror, so a corrected badge can
+    /// never feed back into classification (#2413 cycle-proof). Read lock-free via
+    /// [`StateTracker::published_observed_handle`]; written only by `publish_observed`.
+    published_observed: Arc<AtomicU8>,
     pub(crate) since: Instant,
     pub last_output: Instant,
     /// F9 (#685 sub-task 4): `Some(t)` only when `infer_productivity()` returned
@@ -1302,6 +1330,10 @@ impl StateTracker {
             // Seed the lock-free mirror with the same initial state (record_set
             // keeps it in lockstep thereafter).
             published: Arc::new(AtomicU8::new(initial_state as u8)),
+            // #2413 (A): badge-override mirror starts with no correction; the render
+            // snapshot uses the raw `published` state until the shadow driver
+            // publishes a high-confidence correction.
+            published_observed: Arc::new(AtomicU8::new(OBSERVED_NONE)),
             since: Instant::now(),
             last_output: Instant::now(),
             last_productive_output: None,
@@ -2684,6 +2716,27 @@ impl StateTracker {
     /// atomic `record_set` writes, so reads always observe the latest transition.
     pub fn published_handle(&self) -> Arc<AtomicU8> {
         Arc::clone(&self.published)
+    }
+
+    /// #2413 (A): clone the lock-free badge-override handle (sibling of
+    /// [`published_handle`]). The render snapshot reads it without `core.lock()` to
+    /// show a high-confidence Shadow Observer correction in place of the raw state.
+    pub fn published_observed_handle(&self) -> Arc<AtomicU8> {
+        Arc::clone(&self.published_observed)
+    }
+
+    /// #2413 (A): publish the Shadow Observer's gated BADGE override into the
+    /// lock-free mirror the render snapshot reads. `Some(state)` ⇒ a high-confidence
+    /// observer correction the badge should show; `None` ⇒ no override (stores
+    /// [`OBSERVED_NONE`] so render falls back to the raw `published` state). The
+    /// per-tick driver calls this EVERY tick so a lapsed correction is cleared.
+    /// Takes `&self` (the atomic is interior-mutable) and NEVER touches `current` —
+    /// the cycle-proof invariant: a corrected badge can't feed back into the
+    /// reducer's screen input (which reads `current`, not this mirror). Relaxed: a
+    /// standalone value, ≤1-frame render staleness is already tolerated.
+    pub fn publish_observed(&self, badge: Option<AgentState>) {
+        let byte = badge.map_or(OBSERVED_NONE, |s| s as u8);
+        self.published_observed.store(byte, Ordering::Relaxed);
     }
 
     /// Time since the agent last produced PRODUCTIVE output, for the silence-based

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -5915,6 +5915,72 @@ fn published_mirror_tracks_current_through_record_set() {
     );
 }
 
+/// #2413 (A): the badge-override mirror encode/decode. `publish_observed(Some(s))`
+/// stores `s`'s discriminant (decodes back to `Some(s)`); `publish_observed(None)`
+/// stores the [`crate::state::OBSERVED_NONE`] sentinel (decodes to `None` → render
+/// uses the raw state). The sentinel is NOT a real discriminant, so it can never be
+/// misread as a state.
+#[test]
+fn observed_mirror_encode_decode_roundtrip() {
+    use std::sync::atomic::Ordering;
+    let t = StateTracker::new(None);
+    let observed = t.published_observed_handle();
+    // Default: no correction published yet ⇒ sentinel ⇒ None.
+    assert_eq!(
+        AgentState::from_observed_u8(observed.load(Ordering::Relaxed)),
+        None,
+        "fresh tracker has no badge override"
+    );
+    // A published correction roundtrips.
+    for s in [
+        AgentState::Thinking,
+        AgentState::ToolUse,
+        AgentState::AwaitingOperator,
+        AgentState::RateLimit,
+    ] {
+        t.publish_observed(Some(s));
+        assert_eq!(
+            AgentState::from_observed_u8(observed.load(Ordering::Relaxed)),
+            Some(s),
+            "publish_observed(Some({s:?})) must roundtrip"
+        );
+    }
+    // Clearing the correction returns to the sentinel.
+    t.publish_observed(None);
+    assert_eq!(
+        AgentState::from_observed_u8(observed.load(Ordering::Relaxed)),
+        None,
+        "publish_observed(None) clears the override"
+    );
+}
+
+/// #2413 (A) cycle-proof invariant: `publish_observed` writes ONLY the separate
+/// badge mirror and NEVER `current` — so a corrected badge can never feed back into
+/// the reducer's screen input (which reads `current`). Drive a correction far from
+/// the real state and assert `current` (and its own published mirror) are untouched.
+#[test]
+fn publish_observed_never_mutates_current() {
+    use std::sync::atomic::Ordering;
+    let mut t = StateTracker::new(None); // Idle
+    t.set_restarting(); // current = Restarting (via record_set)
+    let current_before = t.get_state();
+    let published_before = t.published_handle().load(Ordering::Relaxed);
+
+    // Publish a wildly different badge override.
+    t.publish_observed(Some(AgentState::ToolUse));
+
+    assert_eq!(
+        t.get_state(),
+        current_before,
+        "publish_observed must not change `current`"
+    );
+    assert_eq!(
+        t.published_handle().load(Ordering::Relaxed),
+        published_before,
+        "publish_observed must not touch the raw `published` mirror"
+    );
+}
+
 // ── auth_error false-positive fix (operator-reported, dev-3 spike t-…58335-0) ──
 // claude AuthError regex matched generic tokens `unauthorized` + `API key`, and
 // AuthError had NO anchor gate (not in is_high_fp_state / requires_red_anchor), so


### PR DESCRIPTION
**PR-A of #2413 A+B** (operator-approved 2026-06-25; lead-vetted Phase-1 design note). Consumes the Shadow Observer's `observed_status` into the operator-visible pane state badge, confidence-gated so weak / screen-only backends never regress. **PR-B (operated state / dispatch_idle + supersede #1523) follows after this merges.**

## What
- **New lock-free `StateTracker::published_observed` AtomicU8 mirror** (sibling of `published`), cloned onto `AgentHandle.published_observed`. Render reads it WITHOUT `core.lock()` (perf-parity with the raw mirror). `OBSERVED_NONE` sentinel = "no override → use the raw state".
- **Gated badge override** published by the per-tick `shadow_observe` driver: `authority ∈ {Hook,Stream}` ∧ `confidence ∈ {Confirmed,Strong}` ∧ a genuine §5 coarse correction vs the raw screen (never downgrades a more-specific raw state). The `Inferred` reconcile-to-Idle is excluded (lead open-q1).
- **`render::build_agent_state_snapshot`** prefers the correction when the new `:set observed_badge on|off` toggle (default ON) is set AND the observer is enabled. `AGEND_SHADOW_OBSERVER=0` kill-switch disables both.

## Cycle-proof (the load-bearing invariant)
Corrected state is written ONLY to the separate `published_observed` mirror, **NEVER** to `State::current` (the reducer's screen input) — so it can't feed back into classification. Pinned by `publish_observed_never_mutates_current`.

## Zero regression for weak backends
Screen-only backends (agy) have no Hook/Stream plane → `authority` is never Hook/Stream → the gate can't fire → the badge stays on the raw state, by construction. Pinned by `badge_override_screen_only_backend_keeps_raw`.

## Tests
badge_override gating firewall (false-idle flip, approval split, screen-only keep-raw, low-confidence + Inferred excluded, no coarse downgrade), encode/decode + sentinel roundtrip, render-snapshot preference (all 3 branches), representative driver test (correction reaches the lock-free mirror via the REAL per-tick path), flag-OFF mirror stays sentinel, observed_badge toggle.

Local: `fmt --check`, `clippy --all-targets --features tray -D warnings`, and the **Windows cross-check** all green; full `--tests` green except 6 pre-existing `agend-git`-shim worktree-creation artifacts (confirmed failing identically on clean origin/main — CI's clean env is the backstop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)