### PR TITLE
feat(shadow): #2413 (B) operated-state via observed_status + #1720 snapshot-plane app-mode live-fix

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -158,11 +158,32 @@ pub fn run(fleet_path_override: Option<&str>) -> Result<()> {
 /// the flag on. The fix is symmetric to #1694(a): the reducer driver now runs in app mode
 /// (un-allowlisted), and `run_app` starts the hook-event socket server (`shadow::start`)
 /// alongside the api-activity probe. Flag-OFF by default ⇒ zero behaviour change.
-const APP_TICK_ALLOWLIST: &[&str] = &["snapshot_rotation", "thread_dump"];
+/// Per-tick handlers ALWAYS allowlisted out of app-standalone (unconditional skips).
+/// `thread_dump` is an env-gated diagnostic not needed in the interactive TUI.
+///
+/// #2413 PR-B (#1720-class fix): `snapshot_rotation` was REMOVED from this list — see
+/// [`app_snapshot_rotation_enabled`]. The live daemon runs `run_app`, never `run_core`, so
+/// allowlisting `snapshot_rotation` out meant the live daemon NEVER wrote `<home>/snapshot.json`
+/// (it was weeks-stale), and `dispatch_idle` / inbox / handoff / reply — which read it — all
+/// operated on stale state. Same #1720 class already fixed for `recovery_dispatcher` (#1694a)
+/// and `shadow_observe` (#2413 Phase B). It now runs in app mode by default, reversible via the
+/// `AGEND_APP_SNAPSHOT=0` kill-switch.
+const APP_TICK_ALLOWLIST: &[&str] = &["thread_dump"];
+
+/// #2413 PR-B: whether app-standalone runs `snapshot_rotation` (writes `snapshot.json` every
+/// tick). **Default ON** — the #1720-class fix so the live daemon's snapshot-reading deciders
+/// (dispatch_idle / inbox / handoff / reply) see CURRENT state. The `AGEND_APP_SNAPSHOT=0`
+/// kill-switch restores the pre-PR-B behaviour (allowlisted out — no app-mode snapshot write),
+/// a reversible escape hatch since flipping the whole snapshot plane stale→live is a behaviour
+/// change with a broad blast radius.
+fn app_snapshot_rotation_enabled() -> bool {
+    std::env::var("AGEND_APP_SNAPSHOT").as_deref() != Ok("0")
+}
 
 /// Build the per-tick handler set app-standalone runs: the shared
-/// `build_default_handlers` minus `APP_TICK_ALLOWLIST`. Extracted so the
-/// completeness invariant can compare it against the full daemon set.
+/// `build_default_handlers` minus `APP_TICK_ALLOWLIST` (and minus `snapshot_rotation` only when
+/// the `AGEND_APP_SNAPSHOT=0` kill-switch is set). Extracted so the completeness invariant can
+/// compare it against the full daemon set.
 ///
 /// #1694(a): `crash_tx` here is a throwaway sender (its receiver is dropped), so
 /// `stage2_dispatch_available = false` — `RecoveryDispatcherHandler` now RUNS
@@ -173,7 +194,18 @@ fn app_tick_handlers(
 ) -> Vec<Box<dyn crate::daemon::per_tick::PerTickHandler>> {
     let (crash_tx, _crash_rx) = crossbeam_channel::bounded(1);
     let mut handlers = crate::daemon::build_default_handlers(crash_tx, false, daemon_binary_stale);
-    handlers.retain(|h| !APP_TICK_ALLOWLIST.contains(&h.name()));
+    let skip_snapshot = !app_snapshot_rotation_enabled();
+    handlers.retain(|h| {
+        let name = h.name();
+        if APP_TICK_ALLOWLIST.contains(&name) {
+            return false;
+        }
+        // #2413 PR-B: snapshot_rotation runs by default; the kill-switch skips it.
+        if skip_snapshot && name == "snapshot_rotation" {
+            return false;
+        }
+        true
+    });
     handlers
 }
 
@@ -2177,9 +2209,14 @@ mod tests {
                 .collect();
 
         // Positive: every non-allowlisted daemon handler must run in app.
+        // #2413 PR-B: `snapshot_rotation` is CONDITIONALLY run (default-ON, kill-switched by
+        // `AGEND_APP_SNAPSHOT=0`), so it is exempt from the "must always run" check regardless
+        // of the ambient env — its default-on + reversibility is pinned separately by
+        // `snapshot_rotation_runs_in_app_mode_by_default_1720`.
         let missing: Vec<&str> = all
             .difference(&app)
             .filter(|n| !APP_TICK_ALLOWLIST.contains(n))
+            .filter(|n| **n != "snapshot_rotation")
             .copied()
             .collect();
         assert!(
@@ -2246,6 +2283,230 @@ mod tests {
             !APP_TICK_ALLOWLIST.contains(&"shadow_observe"),
             "shadow_observe must NOT be allowlisted out of app mode (#2413 live-fix)"
         );
+    }
+
+    /// #2413 PR-B (#1720-class fix): `snapshot_rotation` must RUN in app mode BY DEFAULT so
+    /// the live daemon writes `snapshot.json` every tick (it was allowlisted out → weeks-stale
+    /// → dispatch_idle/inbox/handoff/reply read stale state). Reversible: `AGEND_APP_SNAPSHOT=0`
+    /// restores the allowlisted-out behaviour. Pins both the default-on and the kill-switch.
+    #[test]
+    #[serial_test::serial(app_snapshot_killswitch)]
+    fn snapshot_rotation_runs_in_app_mode_by_default_1720() {
+        struct EnvGuard(Option<String>);
+        impl Drop for EnvGuard {
+            fn drop(&mut self) {
+                match &self.0 {
+                    Some(v) => std::env::set_var("AGEND_APP_SNAPSHOT", v),
+                    None => std::env::remove_var("AGEND_APP_SNAPSHOT"),
+                }
+            }
+        }
+        let _g = EnvGuard(std::env::var("AGEND_APP_SNAPSHOT").ok());
+        let names = |stale| {
+            app_tick_handlers(stale)
+                .iter()
+                .map(|h| h.name())
+                .collect::<Vec<_>>()
+        };
+
+        // Default (unset) → snapshot_rotation RUNS in app mode.
+        std::env::remove_var("AGEND_APP_SNAPSHOT");
+        assert!(
+            names(Arc::new(std::sync::atomic::AtomicBool::new(false)))
+                .contains(&"snapshot_rotation"),
+            "snapshot_rotation must RUN in app mode by default (#1720 live-fix)"
+        );
+        assert!(
+            !APP_TICK_ALLOWLIST.contains(&"snapshot_rotation"),
+            "snapshot_rotation must NOT be unconditionally allowlisted out (#1720 live-fix)"
+        );
+
+        // Kill-switch `=0` → reverts to the old allowlisted-out behaviour.
+        std::env::set_var("AGEND_APP_SNAPSHOT", "0");
+        assert!(
+            !names(Arc::new(std::sync::atomic::AtomicBool::new(false)))
+                .contains(&"snapshot_rotation"),
+            "AGEND_APP_SNAPSHOT=0 must restore the allowlisted-out behaviour (no app snapshot write)"
+        );
+    }
+
+    /// #2413 PR-B (#1720 live-fix) — END-TO-END verification on a /tmp home, driving the REAL
+    /// app-mode handler set + real `snapshot.json` + real `dispatch_idle` gate. The
+    /// operator-evidence proof of (a)(b)(c) with the `AGEND_APP_SNAPSHOT` on/off contrast:
+    ///   (a) app mode WRITES `snapshot.json` with the PROMOTED operated state (it was
+    ///       allowlisted out → weeks-stale → all snapshot readers saw stale state);
+    ///   (b) at a REAL false-idle (raw screen Idle + a high-confidence Active
+    ///       `observed_status`), `dispatch_idle` does NOT mis-fire — whereas a stale/raw
+    ///       `idle` snapshot WOULD — and the shared busy-gate `agent_is_busy`
+    ///       (inbox/handoff/reply) reads the agent as BUSY;
+    ///   (c) `AGEND_APP_SNAPSHOT=0` reverts (app does not write) — the reversible escape hatch.
+    #[cfg(unix)]
+    #[test]
+    #[serial_test::serial(shadow_observer)]
+    #[allow(clippy::unwrap_used, clippy::expect_used)]
+    fn pr_b_end_to_end_operated_state_app_mode_1720() {
+        use crate::daemon::dispatch_idle;
+        use crate::daemon::shadow::evidence::{Authority, Confidence};
+        use crate::daemon::shadow::reducer::{ObservedState, ObservedStatus};
+        use crate::snapshot::{agent_is_busy, agent_state_of, AgentSnapshot};
+
+        struct G(&'static str, Option<String>);
+        impl Drop for G {
+            fn drop(&mut self) {
+                match &self.1 {
+                    Some(v) => std::env::set_var(self.0, v),
+                    None => std::env::remove_var(self.0),
+                }
+            }
+        }
+        let _g = (
+            G(
+                "AGEND_SHADOW_OBSERVER",
+                std::env::var("AGEND_SHADOW_OBSERVER").ok(),
+            ),
+            G(
+                "AGEND_OBSERVED_DISPATCH",
+                std::env::var("AGEND_OBSERVED_DISPATCH").ok(),
+            ),
+            G(
+                "AGEND_APP_SNAPSHOT",
+                std::env::var("AGEND_APP_SNAPSHOT").ok(),
+            ),
+        );
+        std::env::set_var("AGEND_SHADOW_OBSERVER", "1");
+        std::env::remove_var("AGEND_OBSERVED_DISPATCH"); // default-ON
+        std::env::remove_var("AGEND_APP_SNAPSHOT"); // default-ON
+
+        let home = std::env::temp_dir().join(format!("agend-pr-b-e2e-{}", std::process::id()));
+        std::fs::create_dir_all(&home).ok();
+
+        // A false-idle agent: raw screen Idle (mk_test_handle default) + a high-confidence
+        // Active observed_status (the mid-API false-idle the reducer produces live).
+        let id = crate::types::InstanceId::default();
+        let handle = crate::agent::mk_test_handle("victim", id);
+        handle.core.lock().observed_status = Some(ObservedStatus {
+            state: ObservedState::Active,
+            authority: Authority::Hook,
+            confidence: Confidence::Strong,
+            evidence: vec![],
+            since_ms: 0,
+        });
+        let registry: crate::agent::AgentRegistry =
+            Arc::new(parking_lot::Mutex::new(std::collections::HashMap::from([
+                (id, handle),
+            ])));
+        let externals: crate::agent::ExternalRegistry =
+            Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new()));
+        let configs = Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new()));
+        let stale = || Arc::new(std::sync::atomic::AtomicBool::new(false));
+
+        // Run ONLY the app-set's snapshot_rotation handler (proves it IS in the real app set
+        // AND that running it writes snapshot.json). Returns whether the app set contained it.
+        let run_app_snapshot = || {
+            let ctx = crate::daemon::per_tick::TickContext {
+                home: &home,
+                registry: &registry,
+                externals: &externals,
+                configs: &configs,
+            };
+            let mut ran = false;
+            for h in app_tick_handlers(stale()) {
+                if h.name() == "snapshot_rotation" {
+                    h.run(&ctx);
+                    ran = true;
+                }
+            }
+            ran
+        };
+
+        // ══ (a)+(b): ON (default) — app writes snapshot.json with the PROMOTED operated state ══
+        assert!(
+            run_app_snapshot(),
+            "(a) app mode runs snapshot_rotation by default (un-allowlisted)"
+        );
+        assert_eq!(
+            agent_state_of(&home, "victim").as_deref(),
+            Some("thinking"),
+            "(a)+(b) app mode wrote snapshot.json with the PROMOTED operated state (false-idle → thinking)"
+        );
+        assert!(
+            agent_is_busy(&home, "victim"),
+            "(b) the shared busy-gate (inbox/handoff/reply) reads the false-idle agent as BUSY"
+        );
+
+        // (b) dispatch_idle: drive the real scan_and_emit on a past-threshold pending dispatch.
+        // Isolate the agent_state gate from the silence gate by holding silence > threshold, so
+        // ONLY agent_state decides suppress-vs-fire.
+        let save_snap = |state: &str| {
+            crate::snapshot::save(
+                &home,
+                &[AgentSnapshot {
+                    name: "victim".to_string(),
+                    backend_command: "claude".to_string(),
+                    args: vec![],
+                    working_dir: None,
+                    submit_key: "\r".to_string(),
+                    health_state: "healthy".to_string(),
+                    agent_state: state.to_string(),
+                    silent_secs: 9_999,
+                    output_silent_secs: 9_999,
+                }],
+            );
+        };
+        let make_overdue = |corr: &str| -> String {
+            let did =
+                dispatch_idle::record_dispatch(&home, "lead", "victim", Some(corr), "task", 60)
+                    .expect("recorded pending dispatch");
+            let p = dispatch_idle::pending_path(&home, &did);
+            let mut v: serde_json::Value =
+                serde_json::from_str(&std::fs::read_to_string(&p).unwrap()).unwrap();
+            v["issued_at"] =
+                serde_json::json!((chrono::Utc::now() - chrono::Duration::hours(1)).to_rfc3339());
+            v["status"] = serde_json::json!("pending");
+            v["not_working_streak"] = serde_json::json!(0);
+            crate::store::atomic_write(&p, serde_json::to_string(&v).unwrap().as_bytes()).unwrap();
+            did
+        };
+        let status_of = |did: &str| -> String {
+            dispatch_idle::list_pending(&home)
+                .into_iter()
+                .find(|d| d.dispatch_id == *did)
+                .map(|d| format!("{:?}", d.status))
+                .unwrap_or_else(|| "DELETED".into())
+        };
+
+        // Promoted "thinking" → SUPPRESSED across DEBOUNCE+margin scans (never mis-fires).
+        save_snap("thinking");
+        let did_ok = make_overdue("corr-suppress");
+        for _ in 0..5 {
+            dispatch_idle::scan_and_emit(&home);
+        }
+        assert_eq!(
+            status_of(&did_ok),
+            "Pending",
+            "(b) dispatch_idle SUPPRESSED on the promoted false-idle — did NOT mis-fire"
+        );
+
+        // Contrast: a stale/raw "idle" snapshot (the pre-#1720-fix behaviour) → FIRES (Exceeded).
+        save_snap("idle");
+        let did_fire = make_overdue("corr-fire");
+        for _ in 0..5 {
+            dispatch_idle::scan_and_emit(&home);
+        }
+        assert_eq!(
+            status_of(&did_fire),
+            "Exceeded",
+            "(b-baseline) a stale 'idle' snapshot MIS-FIRES (the bug PR-B fixes for the live daemon)"
+        );
+
+        // ══ (c): AGEND_APP_SNAPSHOT=0 reverts — app does NOT write the snapshot ══
+        std::env::set_var("AGEND_APP_SNAPSHOT", "0");
+        assert!(
+            !run_app_snapshot(),
+            "(c) AGEND_APP_SNAPSHOT=0 reverts: app mode does NOT run snapshot_rotation"
+        );
+
+        std::fs::remove_dir_all(&home).ok();
     }
 
     /// #2413 Phase B live-fix companion: the reducer driver is useless without the

--- a/src/daemon/hook_shadow.rs
+++ b/src/daemon/hook_shadow.rs
@@ -202,51 +202,15 @@ pub fn is_promoted(backend_command: &str) -> bool {
     promotion_enabled() && crate::backend::Backend::parse_str(backend_command).has_state_hooks()
 }
 
-/// #1523 PROMOTION (phased v1): the authoritative `AgentState` written to the
-/// daemon's per-tick SNAPSHOT (`snapshot.json`).
-///
-/// When the flag is on AND `backend_command` is a STRONG (hook-instrumented)
-/// backend, a `Fresh` hook resolution WINS over the screen `heuristic`;
-/// `Stale`/`Unknown` (or flag-off / a non-hook backend) fall back to `heuristic`
-/// — **byte-identical** to pre-promotion. Hooks ENHANCE; the heuristic remains
-/// the complete fallback path, so a backend without hooks (or a stale window) is
-/// never worse off than before.
-///
-/// SCOPE (reviewer-2 #2014): this promotes the SNAPSHOT-scoped consumers — the
-/// #1985 nudge surface: `dispatch_idle`, the pane-state badge, and anything that
-/// reads `agent_state_of` / `snapshot.json`. It is NOT yet a global chokepoint.
-/// Several per-tick deciders read the RAW screen heuristic
-/// (`core.state.get_state()`) directly and are UNCHANGED in v1: supervisor
-/// reactions (#1946), hang detection, the recovery dispatcher, the idle /
-/// anti-stall watchdog, `conflict_notify`, and the `query` / `list` API (live
-/// registry read).
-/// Promoting those raw read sites is #1523 epic **phase-2** (post-soak). The
-/// worst snapshot-vs-raw divergence is independently bounded by the #1999
-/// throttle-gate and health-gating, so the phased boundary is safe for v1.
-pub fn authoritative_state(
-    backend_command: &str,
-    name: &str,
-    heuristic: crate::state::AgentState,
-) -> crate::state::AgentState {
-    authoritative_state_inner(promotion_enabled(), backend_command, name, heuristic)
-}
-
-/// Promotion core, split out so tests exercise the flag/backend/freshness logic
-/// without mutating the process-global `AGEND_HOOK_STATE_POC` env var.
-fn authoritative_state_inner(
-    enabled: bool,
-    backend_command: &str,
-    name: &str,
-    heuristic: crate::state::AgentState,
-) -> crate::state::AgentState {
-    if !enabled || !crate::backend::Backend::parse_str(backend_command).has_state_hooks() {
-        return heuristic;
-    }
-    match resolved_state_for(name) {
-        HookResolution::Fresh(state) => state,
-        HookResolution::Stale | HookResolution::Unknown => heuristic,
-    }
-}
+// #2413 (B): the #1523 `authoritative_state` SNAPSHOT promotion (claude-hook-only,
+// `AGEND_HOOK_STATE_POC`-gated POC) was REMOVED here — superseded by the multi-backend
+// Shadow Observer `observed_status` promotion at the snapshot chokepoint
+// (`per_tick/snapshot.rs`, gated by `shadow::operated_dispatch_enabled` + the shared
+// `shadow::gate`). The rest of this module's hook-shadow STORE stays LIVE: it feeds
+// supervisor hang/recovery (`fresh_active_hook_seq`/`latest_hook_seq`/`record_event`),
+// `inject_delivery` (`last_user_prompt_submit_for`), `recovery_shadow`/`divergence_telemetry`
+// (`resolved_state_for`), and `hook_event` (`is_promoted`) — so `AGEND_HOOK_STATE_POC`,
+// `promotion_enabled`, and `is_promoted` are intentionally KEPT (they are not the dead POC).
 
 fn now_ms() -> u64 {
     std::time::SystemTime::now()
@@ -493,11 +457,6 @@ mod tests {
             HookResolution::Fresh(AgentState::ToolUse),
             "a long tool stays ToolUse until PostToolUse/Stop — never freshness-stale"
         );
-        assert_eq!(
-            authoritative_state_inner(true, "claude", "longtool", AgentState::Idle),
-            AgentState::ToolUse,
-            "the still-open tool wins over a (wrong) heuristic"
-        );
         // PostToolUse closes the pair (→ Thinking; freshness applies again).
         record_event("longtool", "PostToolUse", None);
         assert_eq!(
@@ -506,104 +465,13 @@ mod tests {
         );
     }
 
-    /// §3.9: flag OFF → byte-identical to the heuristic, even with a fresh hook.
-    #[test]
-    fn flag_off_is_byte_identical_to_heuristic() {
-        record_event("flagoff", "UserPromptSubmit", None); // → Thinking, fresh
-        assert_eq!(
-            authoritative_state_inner(false, "claude", "flagoff", AgentState::Idle),
-            AgentState::Idle,
-            "flag off must return the heuristic verbatim"
-        );
-    }
-
-    /// §3.9: flag ON + STRONG backend + Fresh hook → the hook state is authoritative.
-    #[test]
-    fn claude_fresh_hook_wins_over_heuristic() {
-        record_event("claude-fresh", "UserPromptSubmit", None); // → Thinking, fresh
-        assert_eq!(
-            authoritative_state_inner(true, "claude", "claude-fresh", AgentState::Idle),
-            AgentState::Thinking,
-            "a fresh hook state wins over the heuristic"
-        );
-    }
-
-    /// §3.9: flag ON + STRONG backend but STALE hook → fall back to the heuristic.
-    #[test]
-    fn stale_hook_falls_back_to_heuristic() {
-        record_event("claude-stale", "SessionStart", None); // → Starting
-        backdate_for_test("claude-stale", HOOK_FRESHNESS.as_millis() as u64 + 1_000);
-        assert_eq!(
-            authoritative_state_inner(true, "claude", "claude-stale", AgentState::Idle),
-            AgentState::Idle,
-            "a stale hook state falls back to the heuristic (the floor)"
-        );
-    }
-
-    /// §3.9: a non-STRONG backend (no hooks fire) always uses the heuristic.
-    /// STRONG (hook) backends = claude + agy (#2413 Phase D: configure_agy now
-    /// injects `.agents/hooks.json` lifecycle hooks); their fresh hook wins over
-    /// the heuristic. Everything else (codex/opencode/kiro/shell) stays heuristic.
-    #[test]
-    fn backend_strength_gates_promotion() {
-        record_event("codex-agent", "UserPromptSubmit", None); // → Thinking, fresh
-        assert_eq!(
-            authoritative_state_inner(true, "codex", "codex-agent", AgentState::Idle),
-            AgentState::Idle,
-            "codex is not a hook backend — heuristic only"
-        );
-        // agy IS a hook backend now (#2413 Phase D) — its fresh hook wins.
-        record_event("agy-agent", "UserPromptSubmit", None);
-        assert_eq!(
-            authoritative_state_inner(true, "agy", "agy-agent", AgentState::Idle),
-            AgentState::Thinking,
-            "agy is a STRONG backend (#2413 Phase D) — its fresh hook wins"
-        );
-        // claude IS strong — its fresh hook wins.
-        record_event("claude-agent", "UserPromptSubmit", None);
-        assert_eq!(
-            authoritative_state_inner(true, "claude", "claude-agent", AgentState::Idle),
-            AgentState::Thinking,
-            "claude is the v1 STRONG backend"
-        );
-    }
-
-    /// §3.9 probe-6 (reviewer-2 #2014): the REAL env-gate wiring — the public
-    /// `authoritative_state` resolves the flag through `promotion_enabled()`
-    /// reading `AGEND_HOOK_STATE_POC`. `#[serial]` + an RAII guard handle the
-    /// process-global env var (restored even on panic).
-    #[test]
-    #[serial(hook_state_poc)] // shares the AGEND_HOOK_STATE_POC env with mcp_config's flag test
-    fn env_flag_gates_promotion_end_to_end() {
-        struct EnvGuard(Option<String>);
-        impl Drop for EnvGuard {
-            fn drop(&mut self) {
-                match &self.0 {
-                    Some(v) => std::env::set_var("AGEND_HOOK_STATE_POC", v),
-                    None => std::env::remove_var("AGEND_HOOK_STATE_POC"),
-                }
-            }
-        }
-        let _guard = EnvGuard(std::env::var("AGEND_HOOK_STATE_POC").ok());
-
-        record_event("env-claude", "UserPromptSubmit", None); // → Thinking, fresh
-
-        // Flag unset → heuristic (the byte-identical path), via the real gate.
-        std::env::remove_var("AGEND_HOOK_STATE_POC");
-        assert_eq!(
-            authoritative_state("claude", "env-claude", AgentState::Idle),
-            AgentState::Idle,
-            "flag unset → heuristic (real env gate)"
-        );
-
-        // Flag = 1 → the fresh claude hook wins, through promotion_enabled().
-        std::env::set_var("AGEND_HOOK_STATE_POC", "1");
-        assert_eq!(
-            authoritative_state("claude", "env-claude", AgentState::Idle),
-            AgentState::Thinking,
-            "flag=1 → the fresh claude hook wins via the real env gate"
-        );
-    }
+    // #2413 (B): the `authoritative_state` / `authoritative_state_inner` promotion tests
+    // (`flag_off_is_byte_identical_to_heuristic`, `claude_fresh_hook_wins_over_heuristic`,
+    // `stale_hook_falls_back_to_heuristic`, `backend_strength_gates_promotion`,
+    // `env_flag_gates_promotion_end_to_end`) were REMOVED with the functions they tested —
+    // the #1523 snapshot promotion is superseded by the Shadow Observer gate (see the
+    // removal note above `is_promoted`). The hook-shadow STORE tests (`resolved_state_for`,
+    // freshness, `record_event`, `is_promoted`) remain — that infra is still live.
 
     /// Refinement round 1: `PreCompact` is TRANSIENT — recorded (event
     /// visible) but mapped to NO persistent state (the ContextFull-vs-Thinking

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -681,6 +681,24 @@ pub(crate) fn build_default_handlers(
         Box::new(per_tick::RespawnWatchdogHandler::new()),
         Box::new(per_tick::WatchdogHandler::new(watchdog_dry_run)),
         Box::new(per_tick::ExternalLivenessHandler::new()),
+        // #2413 (B): ShadowObserve MUST run immediately BEFORE SnapshotRotation so the
+        // snapshot's operated `agent_state` promotion reads THIS tick's `observed_status`
+        // (it was previously LAST in the list → the snapshot would read last tick's). The
+        // reorder is confirm-first safe:
+        //   - ShadowObserve only WRITES `observed_status` + `published_observed`; nothing
+        //     else in this list writes those, so there is no write-write hazard, and no
+        //     handler except SnapshotRotation (below) reads them.
+        //   - Its INPUTS are order-independent of the per-tick sequence: `api_activity` is
+        //     written by a BACKGROUND thread (`api_activity_probe::spawn`), `state` /
+        //     productive-silence by the PTY-feed thread, hook Evidence by the socket
+        //     thread — none are per-tick handlers, so moving ShadowObserve earlier does not
+        //     stale them.
+        //   - The state-transition handlers (HangDetection / RecoveryDispatcher /
+        //     RespawnWatchdog / Watchdog) sit ABOVE this point in BOTH the old and new
+        //     layout, so ShadowObserve observes the same post-transition `state` either way.
+        // The only behaviour change is the intended one: the snapshot promotes from a fresh
+        // (this-tick) `observed_status`.
+        Box::new(per_tick::ShadowObserveHandler::new()),
         Box::new(per_tick::SnapshotRotationHandler::new()),
         Box::new(per_tick::CheckSchedulesHandler::new()),
         Box::new(per_tick::CiWatchPollHandler::new()),
@@ -784,13 +802,6 @@ pub(crate) fn build_default_handlers(
         // claimed/in_progress tasks back to Open + clears the work-stuck latch.
         // Runs in both run_core and app mode (live daemon is app-mode).
         Box::new(per_tick::ReclaimHandler::new(30, work_stuck_latch)),
-        // #2413 Phase B (Shadow Observer): per-tick reduce — fold each agent's buffered
-        // hook Evidence + screen baseline + lsof liveness into an additive
-        // `observed_status` (never rewrites `agent_state`). Default-ON; under the
-        // `AGEND_SHADOW_OBSERVER=0` kill-switch a single `enabled()` check then early-return
-        // makes it a no-op. Daemon-only telemetry → allowlisted out of
-        // app mode (the hook socket server it consumes is started in `run_core`).
-        Box::new(per_tick::ShadowObserveHandler::new()),
     ]
 }
 

--- a/src/daemon/per_tick/shadow_observe.rs
+++ b/src/daemon/per_tick/shadow_observe.rs
@@ -20,8 +20,8 @@
 use super::{PerTickHandler, TickContext};
 use crate::agent::AgentCore;
 use crate::daemon::shadow;
-use crate::daemon::shadow::evidence::{Authority, Confidence};
-use crate::daemon::shadow::reducer::{Liveness, ObservedState, ObservedStatus, ScreenSignal};
+use crate::daemon::shadow::gate;
+use crate::daemon::shadow::reducer::{Liveness, ScreenSignal};
 use crate::state::AgentState;
 use crate::sync_audit::CoreMutex;
 use std::sync::Arc;
@@ -78,7 +78,7 @@ impl PerTickHandler for ShadowObserveHandler {
                     productive_silent_ms: c.state.productive_silence().as_millis() as u64,
                     child_alive: *child_alive,
                 };
-                (raw_state, screen_signal(raw_state), live)
+                (raw_state, gate::screen_signal(raw_state), live)
             };
             let status = shadow::observe(name, screen, &live, now_ms);
             log_correction(name, raw_state, screen, &status, &live);
@@ -86,106 +86,13 @@ impl PerTickHandler for ShadowObserveHandler {
             // render snapshot reads (Some ⇒ a high-confidence correction the badge shows;
             // None ⇒ render keeps the raw state). Computed BEFORE `status` moves into
             // `observed_status`. Both writes land under ONE core.lock; `publish_observed`
-            // touches only the separate atomic, NEVER `current` (cycle-proof).
-            let badge = badge_override(screen, &status);
+            // touches only the separate atomic, NEVER `current` (cycle-proof). Same shared
+            // gate the operated snapshot (B) uses, so badge + dispatch can never diverge.
+            let badge = gate::gated_override(raw_state, &status);
             let mut c = core.lock();
             c.observed_status = Some(status);
             c.state.publish_observed(badge);
         }
-    }
-}
-
-/// #2413 (A): the gated BADGE override. Returns `Some(AgentState)` — the state the
-/// pane badge should show INSTEAD of the raw screen-scrape — ONLY when the fused
-/// [`ObservedStatus`] is a HIGH-CONFIDENCE real-time observer-plane correction, i.e.
-/// ALL of: (a) `authority ∈ {Hook, Stream}` (a live lifecycle / event-stream plane,
-/// not the `Screen` baseline and not a low-confidence `Inferred` reconcile); (b)
-/// `confidence ∈ {Confirmed, Strong}` (freshness is already implied — the reducer only
-/// labels a fresh observer plane this high); and (c) it actually DISAGREES with the raw
-/// screen baseline at the coarse level (the §5 correction predicate via
-/// [`screen_as_observed`]), so an agreeing-but-vaguer observed state never DOWNGRADES a
-/// more-specific raw badge (e.g. raw `ToolUse` vs coarse `Active`).
-///
-/// `None` otherwise → render keeps the raw `published` state. This is the regression
-/// firewall the lead approved: weak / screen-only backends (agy has no Hook/Stream
-/// plane → authority is always `Screen`/`ProcessHeuristic`/`Inferred`) can NEVER satisfy
-/// (a) → zero badge regression, by construction. The `Inferred` reconcile-to-Idle is
-/// deliberately excluded — the badge flips only when we are SURE work is in flight or a
-/// human gate is up (lead open-q1: "只 Hook/Stream+Strong 才翻 badge").
-fn badge_override(screen: ScreenSignal, status: &ObservedStatus) -> Option<AgentState> {
-    let high_confidence = matches!(status.authority, Authority::Hook | Authority::Stream)
-        && matches!(
-            status.confidence,
-            Confidence::Confirmed | Confidence::Strong
-        );
-    if !high_confidence {
-        return None;
-    }
-    // Only a genuine §5 correction (coarse-level disagreement with the raw screen
-    // baseline) flips the badge — never a same-coarse refinement.
-    let baseline = screen_as_observed(screen);
-    if !baseline.is_some_and(|b| b != status.state.coarse()) {
-        return None;
-    }
-    badge_state_for(status.state)
-}
-
-/// Map a corrected [`ObservedState`] to the [`AgentState`] the badge renders (reusing
-/// the existing `state_color` / label tables). `Idle` ⇒ `None`: the badge never flips
-/// TO idle on a correction (the only idle-direction correction is the excluded
-/// `Inferred` reconcile).
-fn badge_state_for(state: ObservedState) -> Option<AgentState> {
-    Some(match state {
-        ObservedState::ToolUse => AgentState::ToolUse,
-        ObservedState::Thinking | ObservedState::Responding | ObservedState::Active => {
-            AgentState::Thinking
-        }
-        ObservedState::WaitingForUser => AgentState::AwaitingOperator,
-        ObservedState::RateLimited => AgentState::RateLimit,
-        ObservedState::Idle => return None,
-    })
-}
-
-/// Map the 18-variant screen-scrape [`AgentState`] into the reducer's coarse
-/// [`ScreenSignal`] buckets. Exhaustive (no wildcard) ON PURPOSE: a future `AgentState`
-/// variant forces a compile error here so the map can never silently miss a state.
-fn screen_signal(s: AgentState) -> ScreenSignal {
-    match s {
-        AgentState::Idle => ScreenSignal::Idle,
-        // Actively rendering work (incl. boot/respawn churn, treated as working).
-        AgentState::ToolUse
-        | AgentState::Thinking
-        | AgentState::Starting
-        | AgentState::Restarting => ScreenSignal::Working,
-        // A human gate.
-        AgentState::PermissionPrompt
-        | AgentState::InteractivePrompt
-        | AgentState::AwaitingOperator => ScreenSignal::Approval,
-        AgentState::RateLimit | AgentState::ServerRateLimit | AgentState::UsageLimit => {
-            ScreenSignal::RateLimited
-        }
-        // Non-decisive for the liveness reconcile (it only fires on `Idle`). A genuinely
-        // crashed agent is caught by `child_alive=false`, not by the screen chrome.
-        AgentState::Hang
-        | AgentState::GitConflict
-        | AgentState::ContextFull
-        | AgentState::AuthError
-        | AgentState::ApiError
-        | AgentState::ModelUnsupported
-        | AgentState::Crashed => ScreenSignal::Other,
-    }
-}
-
-/// The coarse [`ObservedState`] the raw screen-scrape ALONE would report — the baseline
-/// the reducer is measured against (§5 quantification). `None` for a non-decisive screen
-/// (`Other`), which the reducer never claims to "correct" (no meaningful baseline).
-fn screen_as_observed(screen: ScreenSignal) -> Option<ObservedState> {
-    match screen {
-        ScreenSignal::Idle => Some(ObservedState::Idle),
-        ScreenSignal::Working => Some(ObservedState::Active),
-        ScreenSignal::Approval => Some(ObservedState::WaitingForUser),
-        ScreenSignal::RateLimited => Some(ObservedState::RateLimited),
-        ScreenSignal::Other => None,
     }
 }
 
@@ -203,7 +110,7 @@ fn log_correction(
     status: &crate::daemon::shadow::reducer::ObservedStatus,
     live: &Liveness,
 ) {
-    let Some(screen_state) = screen_as_observed(screen) else {
+    let Some(screen_state) = gate::screen_as_observed(screen) else {
         return; // non-decisive screen → no baseline to correct
     };
     if screen_state != status.state.coarse() {
@@ -353,217 +260,6 @@ mod tests {
             "flag-OFF ⇒ no reduce ⇒ observed_status stays None"
         );
         shadow::forget_agent(&name);
-    }
-
-    #[test]
-    fn screen_signal_maps_every_bucket() {
-        assert_eq!(screen_signal(AgentState::Idle), ScreenSignal::Idle);
-        assert_eq!(screen_signal(AgentState::ToolUse), ScreenSignal::Working);
-        assert_eq!(screen_signal(AgentState::Thinking), ScreenSignal::Working);
-        assert_eq!(screen_signal(AgentState::Starting), ScreenSignal::Working);
-        assert_eq!(
-            screen_signal(AgentState::PermissionPrompt),
-            ScreenSignal::Approval
-        );
-        assert_eq!(
-            screen_signal(AgentState::InteractivePrompt),
-            ScreenSignal::Approval
-        );
-        assert_eq!(
-            screen_signal(AgentState::AwaitingOperator),
-            ScreenSignal::Approval
-        );
-        assert_eq!(
-            screen_signal(AgentState::RateLimit),
-            ScreenSignal::RateLimited
-        );
-        assert_eq!(
-            screen_signal(AgentState::ServerRateLimit),
-            ScreenSignal::RateLimited
-        );
-        assert_eq!(
-            screen_signal(AgentState::UsageLimit),
-            ScreenSignal::RateLimited
-        );
-        assert_eq!(screen_signal(AgentState::Crashed), ScreenSignal::Other);
-        assert_eq!(screen_signal(AgentState::GitConflict), ScreenSignal::Other);
-        assert_eq!(screen_signal(AgentState::Hang), ScreenSignal::Other);
-    }
-
-    #[test]
-    fn screen_as_observed_baseline_buckets() {
-        assert_eq!(
-            screen_as_observed(ScreenSignal::Idle),
-            Some(ObservedState::Idle)
-        );
-        assert_eq!(
-            screen_as_observed(ScreenSignal::Working),
-            Some(ObservedState::Active)
-        );
-        assert_eq!(
-            screen_as_observed(ScreenSignal::Approval),
-            Some(ObservedState::WaitingForUser)
-        );
-        assert_eq!(
-            screen_as_observed(ScreenSignal::RateLimited),
-            Some(ObservedState::RateLimited)
-        );
-        // A non-decisive screen has no baseline the reducer can "correct".
-        assert_eq!(screen_as_observed(ScreenSignal::Other), None);
-    }
-
-    /// The §5 correction predicate, deterministically: the two headline wins the live
-    /// quantification counts. (a) mid-API false-idle — screen Idle but a fresh hook
-    /// episode + a live socket ⇒ Active ⇒ Idle≠Active ⇒ counts as a correction.
-    /// (b) approval-vs-idle — hook ApprovalRequired but screen reads Idle ⇒ WaitingForUser
-    /// ⇒ correction. (c) control — steady tool-use agrees with the screen ⇒ NOT a
-    /// correction (no false-active regression).
-    #[test]
-    fn correction_predicate_flags_false_idle_and_approval_not_steady() {
-        let is_correction = |screen: ScreenSignal, observed: ObservedState| {
-            screen_as_observed(screen).is_some_and(|b| b != observed.coarse())
-        };
-        // (a) false-idle caught.
-        assert!(is_correction(ScreenSignal::Idle, ObservedState::Active));
-        assert!(is_correction(ScreenSignal::Idle, ObservedState::ToolUse));
-        // (b) approval split out of idle.
-        assert!(is_correction(
-            ScreenSignal::Idle,
-            ObservedState::WaitingForUser
-        ));
-        // (c) steady states agree → no correction (no regression).
-        assert!(!is_correction(
-            ScreenSignal::Working,
-            ObservedState::ToolUse
-        ));
-        assert!(!is_correction(ScreenSignal::Idle, ObservedState::Idle));
-        assert!(!is_correction(
-            ScreenSignal::Approval,
-            ObservedState::WaitingForUser
-        ));
-    }
-
-    // ── #2413 (A): the gated BADGE override ──────────────────────────────────────
-
-    fn status(
-        state: ObservedState,
-        authority: Authority,
-        confidence: Confidence,
-    ) -> ObservedStatus {
-        ObservedStatus {
-            state,
-            confidence,
-            authority,
-            evidence: vec![],
-            since_ms: 0,
-        }
-    }
-
-    /// The headline win: screen renders Idle mid-request, but a fresh Hook (or Stream)
-    /// episode proves Active ⇒ the badge flips to a working state.
-    #[test]
-    fn badge_override_flips_on_high_confidence_false_idle() {
-        let s = status(ObservedState::Active, Authority::Hook, Confidence::Strong);
-        assert_eq!(
-            badge_override(ScreenSignal::Idle, &s),
-            Some(AgentState::Thinking)
-        );
-        // Stream plane (codex) parity.
-        let s = status(
-            ObservedState::ToolUse,
-            Authority::Stream,
-            Confidence::Strong,
-        );
-        assert_eq!(
-            badge_override(ScreenSignal::Idle, &s),
-            Some(AgentState::ToolUse)
-        );
-    }
-
-    /// A hook `ApprovalRequired` (Confirmed) splits WaitingForUser out of an idle/ambiguous
-    /// screen ⇒ the badge shows AwaitingOperator.
-    #[test]
-    fn badge_override_flips_approval_out_of_idle() {
-        let s = status(
-            ObservedState::WaitingForUser,
-            Authority::Hook,
-            Confidence::Confirmed,
-        );
-        assert_eq!(
-            badge_override(ScreenSignal::Idle, &s),
-            Some(AgentState::AwaitingOperator)
-        );
-    }
-
-    /// Regression firewall (1): a screen-only backend (agy — authority always `Screen`)
-    /// can NEVER satisfy the Hook/Stream gate, so the badge keeps the raw state even at
-    /// Strong confidence and a coarse disagreement. Zero regression for weak backends.
-    #[test]
-    fn badge_override_screen_only_backend_keeps_raw() {
-        let s = status(
-            ObservedState::WaitingForUser,
-            Authority::Screen,
-            Confidence::Strong,
-        );
-        assert_eq!(badge_override(ScreenSignal::Idle, &s), None);
-    }
-
-    /// Regression firewall (2): a low-confidence (stale-plane `Probable`) status does not
-    /// flip the badge even with a Hook authority.
-    #[test]
-    fn badge_override_excludes_low_confidence() {
-        let s = status(ObservedState::Active, Authority::Hook, Confidence::Probable);
-        assert_eq!(badge_override(ScreenSignal::Idle, &s), None);
-    }
-
-    /// Lead open-q1: the dropped-hook reconcile-to-Idle (`Inferred`/`Probable`) is
-    /// excluded — the badge only flips when SURE work is in flight / a gate is up.
-    #[test]
-    fn badge_override_excludes_inferred_reconcile() {
-        let s = status(
-            ObservedState::Idle,
-            Authority::Inferred,
-            Confidence::Probable,
-        );
-        assert_eq!(badge_override(ScreenSignal::Working, &s), None);
-    }
-
-    /// No downgrade: a Hook+Strong status that AGREES coarsely with the raw screen
-    /// (both Working) does not flip, so a more-specific raw `ToolUse` is never traded
-    /// for a vaguer observed `Active`.
-    #[test]
-    fn badge_override_no_downgrade_on_coarse_agreement() {
-        let s = status(ObservedState::Active, Authority::Hook, Confidence::Strong);
-        assert_eq!(badge_override(ScreenSignal::Working, &s), None);
-    }
-
-    #[test]
-    fn badge_state_for_maps_active_family_and_excludes_idle() {
-        assert_eq!(
-            badge_state_for(ObservedState::ToolUse),
-            Some(AgentState::ToolUse)
-        );
-        assert_eq!(
-            badge_state_for(ObservedState::Thinking),
-            Some(AgentState::Thinking)
-        );
-        assert_eq!(
-            badge_state_for(ObservedState::Responding),
-            Some(AgentState::Thinking)
-        );
-        assert_eq!(
-            badge_state_for(ObservedState::Active),
-            Some(AgentState::Thinking)
-        );
-        assert_eq!(
-            badge_state_for(ObservedState::WaitingForUser),
-            Some(AgentState::AwaitingOperator)
-        );
-        assert_eq!(
-            badge_state_for(ObservedState::RateLimited),
-            Some(AgentState::RateLimit)
-        );
-        assert_eq!(badge_state_for(ObservedState::Idle), None);
     }
 
     /// Representative confirm-first: flag-ON, a buffered `TurnStarted` (episode open) +

--- a/src/daemon/per_tick/snapshot.rs
+++ b/src/daemon/per_tick/snapshot.rs
@@ -39,20 +39,26 @@ impl PerTickHandler for SnapshotRotationHandler {
             .map(|handle| {
                 let (agent_state, health_state, silent_secs, output_silent_secs) = {
                     let c = handle.core.lock();
-                    // #1523: hook→authoritative promotion (phased v1). For a
-                    // STRONG backend with a Fresh hook resolution this returns the
-                    // hook state; otherwise (flag off / non-hook backend / stale
-                    // window) it returns the screen heuristic unchanged —
-                    // byte-identical. Scope is the SNAPSHOT and its consumers
-                    // (dispatch_idle / pane badge / agent_state_of — the #1985
-                    // surface); per-tick deciders that read the raw heuristic
-                    // directly (supervisor/hang/recovery/watchdog/conflict_notify/
-                    // query API) are unchanged in v1 — see authoritative_state.
-                    let agent_state = crate::daemon::hook_shadow::authoritative_state(
-                        &handle.backend_command,
-                        &handle.name,
-                        c.state.get_state(),
-                    );
+                    // #2413 (B): the OPERATED state — what dispatch_idle / inbox /
+                    // handoff / reply deciders read via snapshot.json. Promote the raw
+                    // screen heuristic to the Shadow Observer's HIGH-CONFIDENCE
+                    // correction (the SAME shared gate the pane badge uses, so badge and
+                    // dispatch can never diverge — #1493 class) when default-ON and a
+                    // correction applies; else the raw heuristic. `AGEND_OBSERVED_DISPATCH=0`
+                    // (or the observer kill-switch) → raw, byte-identical to pre-#2413.
+                    // NEVER writes `State::current` — the cycle-proof invariant (the
+                    // reducer's screen input stays vterm-only, so a promoted state can't
+                    // feed back into classification). Supersedes the #1523
+                    // `authoritative_state` claude-hook-only POC (multi-backend now).
+                    let raw = c.state.get_state();
+                    let agent_state = if crate::daemon::shadow::operated_dispatch_enabled() {
+                        c.observed_status
+                            .as_ref()
+                            .and_then(|s| crate::daemon::shadow::gate::gated_override(raw, s))
+                            .unwrap_or(raw)
+                    } else {
+                        raw
+                    };
                     (
                         agent_state.display_name().to_string(),
                         c.health.state.display_name().to_string(),
@@ -157,5 +163,89 @@ mod tests {
             mtime1, mtime2,
             "second run with unchanged state must skip the on-disk write"
         );
+    }
+
+    /// #2413 (B): the operated `agent_state` written to `snapshot.json` (what dispatch_idle
+    /// / inbox / handoff / reply read) is the GATED `observed_status` promotion when
+    /// enabled (default-ON), and the raw screen heuristic when the `AGEND_OBSERVED_DISPATCH=0`
+    /// kill-switch is set (byte-identical to pre-#2413). Drives the REAL handler through
+    /// `crate::snapshot::load`. `#[cfg(unix)]` — `mk_test_handle` is unix-only.
+    #[cfg(unix)]
+    #[test]
+    #[serial_test::serial(shadow_observer)]
+    fn operated_state_promotes_observed_or_falls_back_on_kill_switch() {
+        use crate::daemon::shadow::evidence::{Authority, Confidence};
+        use crate::daemon::shadow::reducer::{ObservedState, ObservedStatus};
+
+        struct EnvGuard(&'static str, Option<String>);
+        impl Drop for EnvGuard {
+            fn drop(&mut self) {
+                match &self.1 {
+                    Some(v) => std::env::set_var(self.0, v),
+                    None => std::env::remove_var(self.0),
+                }
+            }
+        }
+        let _g1 = EnvGuard(
+            "AGEND_SHADOW_OBSERVER",
+            std::env::var("AGEND_SHADOW_OBSERVER").ok(),
+        );
+        let _g2 = EnvGuard(
+            "AGEND_OBSERVED_DISPATCH",
+            std::env::var("AGEND_OBSERVED_DISPATCH").ok(),
+        );
+
+        let home = tmp_home("operated");
+        let id = crate::types::InstanceId::default();
+        let handle = crate::agent::mk_test_handle("opagent", id);
+        // Raw screen state stays Idle (StateTracker::new default); attach a high-confidence
+        // Active correction (the mid-API false-idle shape).
+        handle.core.lock().observed_status = Some(ObservedStatus {
+            state: ObservedState::Active,
+            authority: Authority::Hook,
+            confidence: Confidence::Strong,
+            evidence: vec![],
+            since_ms: 0,
+        });
+        let registry: AgentRegistry = Arc::new(Mutex::new(HashMap::from([(id, handle)])));
+        let externals: ExternalRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let configs = Arc::new(Mutex::new(HashMap::new()));
+        let ctx = TickContext {
+            home: &home,
+            registry: &registry,
+            externals: &externals,
+            configs: &configs,
+        };
+        let agent_state = |home: &std::path::Path| -> String {
+            crate::snapshot::load(home)
+                .unwrap()
+                .agents
+                .into_iter()
+                .find(|a| a.name == "opagent")
+                .unwrap()
+                .agent_state
+        };
+
+        // Default-ON: the high-confidence false-idle correction is promoted → "thinking".
+        std::env::set_var("AGEND_SHADOW_OBSERVER", "1");
+        std::env::remove_var("AGEND_OBSERVED_DISPATCH");
+        SnapshotRotationHandler::new().run(&ctx);
+        assert_eq!(
+            agent_state(&home),
+            "thinking",
+            "operated state promotes the high-confidence observed correction"
+        );
+
+        // Kill-switch: raw heuristic only → "idle" (byte-identical to pre-#2413). A fresh
+        // handler avoids the unchanged-state dedup skip.
+        std::env::set_var("AGEND_OBSERVED_DISPATCH", "0");
+        SnapshotRotationHandler::new().run(&ctx);
+        assert_eq!(
+            agent_state(&home),
+            "idle",
+            "AGEND_OBSERVED_DISPATCH=0 falls back to the raw heuristic"
+        );
+
+        std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/daemon/shadow/gate.rs
+++ b/src/daemon/shadow/gate.rs
@@ -1,0 +1,315 @@
+//! #2413 — the SHARED `observed_status` consumption gate.
+//!
+//! Both consumers of the Shadow Observer's fused [`ObservedStatus`] decide IDENTICALLY
+//! whether it should OVERRIDE the raw screen-scrape state: the pane badge ((A) —
+//! `per_tick::shadow_observe`, the lock-free `published_observed` mirror render reads) and
+//! the operated snapshot state ((B) — `per_tick::snapshot`, the `agent_state` string that
+//! `dispatch_idle` / inbox / handoff / reply deciders read). Factored here so the two can
+//! never drift (#1493 class) and so the gate — including the P2 composition invariant — is
+//! unit-tested in ONE place.
+//!
+//! [`gated_override`] fires ONLY for a HIGH-CONFIDENCE real-time observer correction, i.e.
+//! ALL of: (a) `authority ∈ {Hook, Stream}` — a live lifecycle / event-stream plane, not
+//! the `Screen` baseline and not a low-confidence `Inferred` reconcile; (b) `confidence ∈
+//! {Confirmed, Strong}` — freshness is already implied (the reducer only labels a fresh
+//! observer plane this high); (c) the raw screen is NOT itself a GATE screen (`Approval` /
+//! `RateLimited`) — a human approval prompt or a rate-limit banner is authoritative and must
+//! NEVER be masked by an observed override (the operator/daemon must always see it); and
+//! (d) the observed state genuinely DISAGREES with the raw screen baseline at the coarse
+//! level (the §5 correction predicate via [`screen_as_observed`]), so an agreeing-but-vaguer
+//! observed state never DOWNGRADES a more-specific raw state. `None` otherwise → the consumer
+//! keeps the raw state. Weak / screen-only backends (agy has no Hook/Stream plane →
+//! `authority` is always `Screen`/`ProcessHeuristic`/`Inferred`) can NEVER satisfy (a) → zero
+//! regression for them, by construction.
+
+use super::evidence::{Authority, Confidence};
+use super::reducer::{ObservedState, ObservedStatus, ScreenSignal};
+use crate::state::AgentState;
+
+/// Map the 18-variant screen-scrape [`AgentState`] into the reducer's coarse
+/// [`ScreenSignal`] buckets. Exhaustive (no wildcard) ON PURPOSE: a future `AgentState`
+/// variant forces a compile error here so the map can never silently miss a state.
+pub(crate) fn screen_signal(s: AgentState) -> ScreenSignal {
+    match s {
+        AgentState::Idle => ScreenSignal::Idle,
+        // Actively rendering work (incl. boot/respawn churn, treated as working).
+        AgentState::ToolUse
+        | AgentState::Thinking
+        | AgentState::Starting
+        | AgentState::Restarting => ScreenSignal::Working,
+        // A human gate.
+        AgentState::PermissionPrompt
+        | AgentState::InteractivePrompt
+        | AgentState::AwaitingOperator => ScreenSignal::Approval,
+        AgentState::RateLimit | AgentState::ServerRateLimit | AgentState::UsageLimit => {
+            ScreenSignal::RateLimited
+        }
+        // Non-decisive for the liveness reconcile (it only fires on `Idle`). A genuinely
+        // crashed agent is caught by `child_alive=false`, not by the screen chrome.
+        AgentState::Hang
+        | AgentState::GitConflict
+        | AgentState::ContextFull
+        | AgentState::AuthError
+        | AgentState::ApiError
+        | AgentState::ModelUnsupported
+        | AgentState::Crashed => ScreenSignal::Other,
+    }
+}
+
+/// The coarse [`ObservedState`] the raw screen-scrape ALONE would report — the baseline
+/// the reducer is measured against (§5 quantification). `None` for a non-decisive screen
+/// (`Other`), which the reducer never claims to "correct" (no meaningful baseline).
+pub(crate) fn screen_as_observed(screen: ScreenSignal) -> Option<ObservedState> {
+    match screen {
+        ScreenSignal::Idle => Some(ObservedState::Idle),
+        ScreenSignal::Working => Some(ObservedState::Active),
+        ScreenSignal::Approval => Some(ObservedState::WaitingForUser),
+        ScreenSignal::RateLimited => Some(ObservedState::RateLimited),
+        ScreenSignal::Other => None,
+    }
+}
+
+/// Map a corrected [`ObservedState`] to the [`AgentState`] a consumer shows (reusing the
+/// existing `state_color` / `display_name` tables). `Idle` ⇒ `None`: a correction never
+/// flips TO idle (the only idle-direction correction is the excluded `Inferred` reconcile).
+fn observed_to_agent_state(state: ObservedState) -> Option<AgentState> {
+    Some(match state {
+        ObservedState::ToolUse => AgentState::ToolUse,
+        ObservedState::Thinking | ObservedState::Responding | ObservedState::Active => {
+            AgentState::Thinking
+        }
+        ObservedState::WaitingForUser => AgentState::AwaitingOperator,
+        ObservedState::RateLimited => AgentState::RateLimit,
+        ObservedState::Idle => return None,
+    })
+}
+
+/// The shared gate (see module docs). `Some(state)` ⇒ both the badge AND the operated
+/// snapshot should show `state` instead of `raw`; `None` ⇒ keep `raw`. Pure over its
+/// inputs — never touches `State::current` (the cycle-proof invariant lives at the call
+/// sites, but the gate itself reads nothing mutable).
+pub(crate) fn gated_override(raw: AgentState, status: &ObservedStatus) -> Option<AgentState> {
+    let screen = screen_signal(raw);
+    // (c) A raw GATE screen is authoritative — never let an observed override mask a human
+    // approval prompt or a rate-limit banner (also blocks a stale observed=Active from
+    // hiding a raw that just transitioned to Approval under the reducer's snapshot).
+    if matches!(screen, ScreenSignal::Approval | ScreenSignal::RateLimited) {
+        return None;
+    }
+    // (a) + (b) high-confidence real-time observer plane only.
+    let high_confidence = matches!(status.authority, Authority::Hook | Authority::Stream)
+        && matches!(
+            status.confidence,
+            Confidence::Confirmed | Confidence::Strong
+        );
+    if !high_confidence {
+        return None;
+    }
+    // (d) a genuine §5 coarse correction vs the raw screen baseline.
+    let baseline = screen_as_observed(screen);
+    if !baseline.is_some_and(|b| b != status.state.coarse()) {
+        return None;
+    }
+    observed_to_agent_state(status.state)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::daemon::shadow::evidence::{Evidence, EvidenceKind};
+    use crate::daemon::shadow::reducer::AgentRuntime;
+
+    fn status(
+        state: ObservedState,
+        authority: Authority,
+        confidence: Confidence,
+    ) -> ObservedStatus {
+        ObservedStatus {
+            state,
+            confidence,
+            authority,
+            evidence: vec![],
+            since_ms: 0,
+        }
+    }
+
+    /// The headline win: raw screen reads Idle mid-request, but a fresh Hook (or Stream)
+    /// episode proves Active ⇒ override to a working state.
+    #[test]
+    fn flips_on_high_confidence_false_idle() {
+        let s = status(ObservedState::Active, Authority::Hook, Confidence::Strong);
+        assert_eq!(
+            gated_override(AgentState::Idle, &s),
+            Some(AgentState::Thinking)
+        );
+        // Stream plane (codex) parity.
+        let s = status(
+            ObservedState::ToolUse,
+            Authority::Stream,
+            Confidence::Strong,
+        );
+        assert_eq!(
+            gated_override(AgentState::Idle, &s),
+            Some(AgentState::ToolUse)
+        );
+    }
+
+    /// A hook `ApprovalRequired` (Confirmed) splits WaitingForUser out of an idle raw
+    /// screen ⇒ override to AwaitingOperator (the approval-out-of-idle correction).
+    #[test]
+    fn flips_approval_out_of_idle() {
+        let s = status(
+            ObservedState::WaitingForUser,
+            Authority::Hook,
+            Confidence::Confirmed,
+        );
+        assert_eq!(
+            gated_override(AgentState::Idle, &s),
+            Some(AgentState::AwaitingOperator)
+        );
+    }
+
+    /// Firewall (1): a screen-only backend (agy — authority always `Screen`) can NEVER
+    /// satisfy the Hook/Stream gate → raw kept even at Strong confidence + disagreement.
+    #[test]
+    fn screen_only_backend_keeps_raw() {
+        let s = status(
+            ObservedState::WaitingForUser,
+            Authority::Screen,
+            Confidence::Strong,
+        );
+        assert_eq!(gated_override(AgentState::Idle, &s), None);
+    }
+
+    /// Firewall (2): a low-confidence (`Probable`) status does not override even with Hook.
+    #[test]
+    fn excludes_low_confidence() {
+        let s = status(ObservedState::Active, Authority::Hook, Confidence::Probable);
+        assert_eq!(gated_override(AgentState::Idle, &s), None);
+    }
+
+    /// The dropped-hook reconcile-to-Idle (`Inferred`/`Probable`) is excluded (lead open-q1).
+    #[test]
+    fn excludes_inferred_reconcile() {
+        let s = status(
+            ObservedState::Idle,
+            Authority::Inferred,
+            Confidence::Probable,
+        );
+        assert_eq!(gated_override(AgentState::ToolUse, &s), None);
+    }
+
+    /// No downgrade: a Hook+Strong status that AGREES coarsely with the raw working screen
+    /// does not override, so a more-specific raw `ToolUse` is never traded for vaguer `Active`.
+    #[test]
+    fn no_downgrade_on_coarse_agreement() {
+        let s = status(ObservedState::Active, Authority::Hook, Confidence::Strong);
+        assert_eq!(gated_override(AgentState::ToolUse, &s), None);
+    }
+
+    /// P2 composition invariant (t-…5060-11): a raw GATE screen (`Approval` / `RateLimited`)
+    /// is NEVER masked by an override — for EVERY gate-class raw state, even a maximally
+    /// confident Hook status pointing elsewhere returns `None` (keep the raw gate). This is
+    /// the pin that the dispatch/operator can always see a pending approval or rate-limit.
+    #[test]
+    fn gate_screen_is_never_overridden() {
+        let gate_raws = [
+            AgentState::PermissionPrompt,
+            AgentState::InteractivePrompt,
+            AgentState::AwaitingOperator,
+            AgentState::RateLimit,
+            AgentState::ServerRateLimit,
+            AgentState::UsageLimit,
+        ];
+        // The most "override-prone" status: highest confidence, active-family, disagreeing.
+        let aggressive = status(ObservedState::Active, Authority::Hook, Confidence::Strong);
+        for raw in gate_raws {
+            assert_eq!(
+                gated_override(raw, &aggressive),
+                None,
+                "a gate screen ({raw:?}) must never be masked by an observed override"
+            );
+        }
+    }
+
+    /// #1493 composition: drive the REAL reducer (not a hand-built status) and confirm the
+    /// gate's end-to-end contract. A real `observe()` at an Approval screen yields
+    /// WaitingForUser; promoting it back at an Approval raw is a no-op (gate screen kept),
+    /// and a real mid-API false-idle (Idle screen + open hook episode + live socket) yields
+    /// an Active status that the gate DOES promote at an Idle raw.
+    #[test]
+    fn composition_with_real_reducer_output() {
+        // (1) Real approval at an approval screen → WaitingForUser; gate keeps the raw gate.
+        let mut rt = AgentRuntime::default();
+        rt.ingest(&Evidence::hook(EvidenceKind::TurnStarted, 1_000));
+        rt.ingest(&Evidence::hook(EvidenceKind::ApprovalRequired, 1_100));
+        let live = crate::daemon::shadow::reducer::Liveness {
+            api_in_flight: true,
+            productive_silent_ms: 0,
+            child_alive: true,
+        };
+        let s = rt.observe(ScreenSignal::Approval, &live, 1_200);
+        assert_eq!(s.state, ObservedState::WaitingForUser);
+        assert_eq!(
+            gated_override(AgentState::PermissionPrompt, &s),
+            None,
+            "an approval screen must stay raw, not be masked"
+        );
+
+        // (2) Real mid-API false-idle (Idle screen, fresh hook episode, live socket) →
+        // Active; the gate promotes it at an Idle raw.
+        let mut rt = AgentRuntime::default();
+        rt.ingest(&Evidence::hook(EvidenceKind::TurnStarted, 1_000));
+        let s = rt.observe(ScreenSignal::Idle, &live, 1_500);
+        assert_ne!(s.state, ObservedState::Idle);
+        assert!(
+            gated_override(AgentState::Idle, &s).is_some(),
+            "a real mid-API false-idle must promote at an idle raw"
+        );
+    }
+
+    #[test]
+    fn observed_to_agent_state_maps_active_family_and_excludes_idle() {
+        assert_eq!(
+            observed_to_agent_state(ObservedState::ToolUse),
+            Some(AgentState::ToolUse)
+        );
+        assert_eq!(
+            observed_to_agent_state(ObservedState::Thinking),
+            Some(AgentState::Thinking)
+        );
+        assert_eq!(
+            observed_to_agent_state(ObservedState::Responding),
+            Some(AgentState::Thinking)
+        );
+        assert_eq!(
+            observed_to_agent_state(ObservedState::Active),
+            Some(AgentState::Thinking)
+        );
+        assert_eq!(
+            observed_to_agent_state(ObservedState::WaitingForUser),
+            Some(AgentState::AwaitingOperator)
+        );
+        assert_eq!(
+            observed_to_agent_state(ObservedState::RateLimited),
+            Some(AgentState::RateLimit)
+        );
+        assert_eq!(observed_to_agent_state(ObservedState::Idle), None);
+    }
+
+    #[test]
+    fn screen_signal_maps_gate_classes() {
+        assert_eq!(screen_signal(AgentState::Idle), ScreenSignal::Idle);
+        assert_eq!(screen_signal(AgentState::ToolUse), ScreenSignal::Working);
+        assert_eq!(
+            screen_signal(AgentState::PermissionPrompt),
+            ScreenSignal::Approval
+        );
+        assert_eq!(
+            screen_signal(AgentState::UsageLimit),
+            ScreenSignal::RateLimited
+        );
+        assert_eq!(screen_signal(AgentState::Crashed), ScreenSignal::Other);
+    }
+}

--- a/src/daemon/shadow/mod.rs
+++ b/src/daemon/shadow/mod.rs
@@ -18,6 +18,7 @@
 //! `AGEND_SHADOW_OBSERVER=0` kill-switch.
 
 pub mod evidence;
+pub(crate) mod gate;
 pub mod kiro;
 pub mod opencode;
 pub mod reducer;
@@ -69,6 +70,17 @@ pub struct ShadowFrame {
 /// thread spawns, no spawn-env injection).
 pub fn enabled() -> bool {
     std::env::var("AGEND_SHADOW_OBSERVER").as_deref() != Ok("0")
+}
+
+/// #2413 (B): `true` when the observer's correction may drive the OPERATED snapshot state
+/// (`agent_state` in `snapshot.json` → the dispatch_idle / inbox / handoff / reply
+/// deciders). **Default ON**, disabled by the explicit `AGEND_OBSERVED_DISPATCH=0`
+/// kill-switch — independent of the badge (A): B changes daemon BEHAVIOUR, A only pixels,
+/// so they must be separately reversible. The promotion ALSO requires [`enabled`] (no
+/// observer ⇒ no `observed_status` to promote), so flipping `AGEND_SHADOW_OBSERVER=0`
+/// disables B too. `=0` is byte-identical to pre-#2413 (snapshot writes the raw heuristic).
+pub fn operated_dispatch_enabled() -> bool {
+    enabled() && std::env::var("AGEND_OBSERVED_DISPATCH").as_deref() != Ok("0")
 }
 
 /// The per-daemon unix socket the hooks emit to. One socket for the daemon; the


### PR DESCRIPTION
**PR-B of #2413 A+B** (operator GO 2026-06-25; PR-A badge merged in #2456). Makes the Shadow Observer's high-confidence `observed_status` correction drive the **OPERATED snapshot state** (dispatch_idle / inbox / handoff / reply), superseding the #1523 claude-hook-only POC — and **fixes a #1720-class bug** that left the live app-mode daemon's `snapshot.json` weeks-stale.

## What
- **NEW `src/daemon/shadow/gate.rs`** — the SHARED `observed_status` consumption gate (`gated_override`) used by **both** the pane badge (A, merged) and the operated snapshot (B), so they can never drift (#1493). Adds the **P2 invariant**: a raw GATE screen (Approval / RateLimited) is NEVER masked by an override.
- **`per_tick/snapshot.rs:51` chokepoint**: `authoritative_state(...)` → the gated `observed_status` promotion (multi-backend). Gated by `AGEND_OBSERVED_DISPATCH=0` kill-switch (default-ON). **NEVER writes `State::current`** — the cycle-proof invariant.
- **Handler reorder**: `ShadowObserve` now runs immediately before `SnapshotRotation` so the snapshot reads THIS tick's `observed_status`. Confirm-first reorder-safety proof in-code (api_activity is a background thread; transition handlers sit above both positions; nothing else reads observed_status).
- **#1720 live-fix**: un-allowlist `snapshot_rotation` from app mode so the live `run_app` daemon **writes `snapshot.json` every tick** (it was stale for weeks → dispatch_idle/inbox/handoff/reply read stale state). Reversible via `AGEND_APP_SNAPSHOT=0`. Same class as #1694a (recovery_dispatcher) and #2413-PhaseB (shadow_observe).
- **#1523**: removed the now-dead `authoritative_state` (+5 tests). **Kept** `is_promoted`/`promotion_enabled`/`AGEND_HOOK_STATE_POC` + the hook-shadow STORE — live infra (supervisor hang/recovery, inject_delivery, divergence_telemetry, hook_event), not dead POC.

## ⚠ Blast radius (for DUAL): the snapshot plane goes stale→live in the app daemon
Un-allowlisting `snapshot_rotation` makes the **whole** snapshot plane (dispatch_idle suppression + inbox defer/inject/drain + handoff + reply gates) operate on CURRENT state in the live daemon, where they previously read weeks-stale data. This is a behaviour change broader than "operated state" — reviewers should weigh it. Reversible via `AGEND_APP_SNAPSHOT=0`.

## Isolated /tmp verification — (a)(b)(c), deterministic
`app::tests::pr_b_end_to_end_operated_state_app_mode_1720` drives the **real** `app_tick_handlers` set + real `snapshot.json` + real `dispatch_idle::scan_and_emit` + `agent_is_busy` on a /tmp home (run_app is a TUI → drove the identical prod code paths deterministically):
- **(a)** app mode writes `snapshot.json` with the promoted operated state (`agent_state="thinking"` for the false-idle agent).
- **(b)** `agent_is_busy=true` (inbox/handoff/reply see BUSY); dispatch_idle **suppressed** (Pending) on the promoted false-idle, but **fired** (Exceeded) on a stale "idle" snapshot — the exact misjudge the bug causes. No regression (both directions correct).
- **(c)** `AGEND_APP_SNAPSHOT=0` reverts (app doesn't write).

## Two independent kill-switches (operator confirms final defaults at merge)
- `AGEND_OBSERVED_DISPATCH=0` — disable the operated promotion (snapshot writes the raw heuristic, byte-identical to pre-#2413).
- `AGEND_APP_SNAPSHOT=0` — disable the app-mode snapshot write (restores the pre-PR-B allowlisted-out behaviour).

Local: fmt + clippy `--all-targets --features tray -D warnings` + **Windows cross-check** green; PR-B test suite green; `--tests` only 6 pre-existing `agend-git`-shim worktree-creation artifacts (CI clean env is the backstop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)