### PR TITLE
feat(#2465): route decision consumers through hook-primary operated_state (false-idle class)

### DIFF
--- a/src/api/handlers/instance.rs
+++ b/src/api/handlers/instance.rs
@@ -21,7 +21,19 @@ pub(crate) fn handle_inject(params: &Value, ctx: &HandlerCtx) -> Value {
         crate::fleet::resolve_uuid(ctx.home, name)
             .and_then(|id| reg.get(&id))
             .map(|handle| {
-                let is_restarting = handle.core.lock().state.current.is_unavailable();
+                // #2465: operated (hook-primary) state so a stale Restarting screen that a
+                // fresh hook has already moved past no longer spuriously blocks an inject.
+                // `is_unavailable` = Crashed|Restarting; Crashed is a non-decisive screen the
+                // gate keeps raw, so only a false-Restarting is corrected. Lock scoped + dropped
+                // before `from_handle` to preserve the single-acquisition ordering.
+                let is_restarting = {
+                    let core = handle.core.lock();
+                    crate::daemon::shadow::operated_state(
+                        core.state.current,
+                        core.observed_status.as_ref(),
+                    )
+                    .is_unavailable()
+                };
                 (agent::InjectTarget::from_handle(handle), is_restarting)
             })
     };

--- a/src/api/handlers/instance.rs
+++ b/src/api/handlers/instance.rs
@@ -21,11 +21,14 @@ pub(crate) fn handle_inject(params: &Value, ctx: &HandlerCtx) -> Value {
         crate::fleet::resolve_uuid(ctx.home, name)
             .and_then(|id| reg.get(&id))
             .map(|handle| {
-                // #2465: operated (hook-primary) state so a stale Restarting screen that a
-                // fresh hook has already moved past no longer spuriously blocks an inject.
-                // `is_unavailable` = Crashed|Restarting; Crashed is a non-decisive screen the
-                // gate keeps raw, so only a false-Restarting is corrected. Lock scoped + dropped
-                // before `from_handle` to preserve the single-acquisition ordering.
+                // #2465: routed through operated_state for single-source consistency with the
+                // other decision consumers (#1493) — NOT a behavioral change here today.
+                // `is_unavailable` = Crashed|Restarting; the gate keeps Crashed raw (non-decisive
+                // screen) and only overrides on a COARSE disagreement (rule d), so a fresh Active
+                // hook AGREES with Restarting's Working baseline and does NOT flip is_unavailable.
+                // This diverges from raw only for a cross-coarse Hook/Stream correction (e.g.
+                // raw=Restarting + Hook=WaitingForUser/RateLimited — more relevant after #2466).
+                // Lock scoped + dropped before `from_handle` to preserve the single-acquisition order.
                 let is_restarting = {
                     let core = handle.core.lock();
                     crate::daemon::shadow::operated_state(

--- a/src/daemon/per_tick/hang_detection.rs
+++ b/src/daemon/per_tick/hang_detection.rs
@@ -69,6 +69,9 @@ impl PerTickHandler for HangDetectionHandler {
                 let mut core = handle.core.lock();
                 core.health.maybe_decay();
                 let was_hung = core.health.state == crate::health::HealthState::Hung;
+                // KEEP-RAW (#2465): health/recovery must see the raw screen state — feeding the
+                // promoted/observed state could let a stale/false 'Active' hook MASK a genuinely
+                // stuck agent (the inverse of the SRL false-idle bug). Do NOT migrate to operated_state.
                 let agent_state = core.state.current;
                 let silent = core.state.last_output.elapsed();
                 // F9 (#685 sub-task 4): productive-silence reads the new

--- a/src/daemon/per_tick/reclaim.rs
+++ b/src/daemon/per_tick/reclaim.rs
@@ -397,10 +397,12 @@ impl PerTickHandler for ReclaimHandler {
             for handle in reg.values() {
                 let name = handle.name.as_str().to_string();
                 let core = handle.core.lock();
-                // #2465: operated (hook-primary) state. gate(c) keeps a raw rate-limit /
-                // usage-limit screen authoritative (and the observer never promotes TO
-                // UsageLimit), so the UsageLimit-reclaim trigger is unchanged in the common
-                // case; the helper only corrects a false-idle that masks a busy agent.
+                // #2465: routed through operated_state for single-source consistency (#1493) —
+                // INERT here today (no behavioral change). The observer never promotes TO
+                // UsageLimit, gate(c) keeps a raw usage / rate-limit screen authoritative, and
+                // Idle/Active share reclaim-eligibility, so the UsageLimit trigger is unchanged;
+                // it would only diverge for a cross-coarse Hook/Stream correction. (poll_reminder
+                // is the one consumer in this PR that sees a real behavioral change.)
                 let state = crate::daemon::shadow::operated_state(
                     core.state.current,
                     core.observed_status.as_ref(),

--- a/src/daemon/per_tick/reclaim.rs
+++ b/src/daemon/per_tick/reclaim.rs
@@ -397,7 +397,12 @@ impl PerTickHandler for ReclaimHandler {
             for handle in reg.values() {
                 let name = handle.name.as_str().to_string();
                 let core = handle.core.lock();
-                let state = core.state.current;
+                // #2465: operated (hook-primary) state. gate(c) keeps a raw rate-limit /
+                // usage-limit screen authoritative (and the observer never promotes TO
+                // UsageLimit), so the UsageLimit-reclaim trigger is unchanged in the common
+                // case; the helper only corrects a false-idle that masks a busy agent.
+                let state =
+                    crate::daemon::shadow::operated_state(core.state.current, core.observed_status.as_ref());
                 let quota = matches!(
                     core.health.current_reason,
                     Some(crate::health::BlockedReason::QuotaExceeded)

--- a/src/daemon/per_tick/reclaim.rs
+++ b/src/daemon/per_tick/reclaim.rs
@@ -401,8 +401,10 @@ impl PerTickHandler for ReclaimHandler {
                 // usage-limit screen authoritative (and the observer never promotes TO
                 // UsageLimit), so the UsageLimit-reclaim trigger is unchanged in the common
                 // case; the helper only corrects a false-idle that masks a busy agent.
-                let state =
-                    crate::daemon::shadow::operated_state(core.state.current, core.observed_status.as_ref());
+                let state = crate::daemon::shadow::operated_state(
+                    core.state.current,
+                    core.observed_status.as_ref(),
+                );
                 let quota = matches!(
                     core.health.current_reason,
                     Some(crate::health::BlockedReason::QuotaExceeded)

--- a/src/daemon/per_tick/recovery_dispatcher.rs
+++ b/src/daemon/per_tick/recovery_dispatcher.rs
@@ -283,6 +283,9 @@ impl PerTickHandler for RecoveryDispatcherHandler {
                     recovery_stage_state: core.health.recovery_stage_state,
                     last_stage1_fired_at: core.health.last_stage1_fired_at,
                     recovery_restart_count: core.health.recovery_restart_count,
+                    // KEEP-RAW (#2465): the recovery dispatcher is a health-state machine — feeding it
+                    // the promoted/observed state could let a stale/false 'Active' hook MASK a genuinely
+                    // stuck agent and skip its recovery escalation. Do NOT migrate to operated_state.
                     agent_state: core.state.current,
                     silent: core.state.last_output.elapsed(),
                     silent_productive: core.state.productive_silence(),

--- a/src/daemon/per_tick/respawn_watchdog.rs
+++ b/src/daemon/per_tick/respawn_watchdog.rs
@@ -214,6 +214,9 @@ impl PerTickHandler for RespawnWatchdogHandler {
                 if core.health.state == HealthState::Paused {
                     continue;
                 }
+                // KEEP-RAW (#2465): respawn-stuck detection is a recovery safety net — feeding it the
+                // promoted/observed state could let a stale/false 'Active' hook MASK a genuinely stuck
+                // (never-resumed) agent and suppress its respawn. Do NOT migrate to operated_state.
                 let state = core.state.current;
                 let since_elapsed = core.state.since.elapsed();
                 let silent = core.state.last_output.elapsed();

--- a/src/daemon/per_tick/snapshot.rs
+++ b/src/daemon/per_tick/snapshot.rs
@@ -40,25 +40,15 @@ impl PerTickHandler for SnapshotRotationHandler {
                 let (agent_state, health_state, silent_secs, output_silent_secs) = {
                     let c = handle.core.lock();
                     // #2413 (B): the OPERATED state — what dispatch_idle / inbox /
-                    // handoff / reply deciders read via snapshot.json. Promote the raw
-                    // screen heuristic to the Shadow Observer's HIGH-CONFIDENCE
-                    // correction (the SAME shared gate the pane badge uses, so badge and
-                    // dispatch can never diverge — #1493 class) when default-ON and a
-                    // correction applies; else the raw heuristic. `AGEND_OBSERVED_DISPATCH=0`
-                    // (or the observer kill-switch) → raw, byte-identical to pre-#2413.
-                    // NEVER writes `State::current` — the cycle-proof invariant (the
-                    // reducer's screen input stays vterm-only, so a promoted state can't
-                    // feed back into classification). Supersedes the #1523
-                    // `authoritative_state` claude-hook-only POC (multi-backend now).
+                    // handoff / reply deciders read via snapshot.json. #2465: the shared
+                    // `operated_state` helper promotes the raw screen heuristic to the
+                    // Shadow Observer's HIGH-CONFIDENCE correction (the SAME shared gate the
+                    // pane badge + the SRL/poll_reminder/reclaim/inject deciders use, so they
+                    // can never diverge — #1493 class) when ON and a correction applies; else
+                    // raw. Supersedes the #1523 `authoritative_state` claude-hook-only POC.
                     let raw = c.state.get_state();
-                    let agent_state = if crate::daemon::shadow::operated_dispatch_enabled() {
-                        c.observed_status
-                            .as_ref()
-                            .and_then(|s| crate::daemon::shadow::gate::gated_override(raw, s))
-                            .unwrap_or(raw)
-                    } else {
-                        raw
-                    };
+                    let agent_state =
+                        crate::daemon::shadow::operated_state(raw, c.observed_status.as_ref());
                     (
                         agent_state.display_name().to_string(),
                         c.health.state.display_name().to_string(),

--- a/src/daemon/per_tick/snapshot.rs
+++ b/src/daemon/per_tick/snapshot.rs
@@ -43,9 +43,10 @@ impl PerTickHandler for SnapshotRotationHandler {
                     // handoff / reply deciders read via snapshot.json. #2465: the shared
                     // `operated_state` helper promotes the raw screen heuristic to the
                     // Shadow Observer's HIGH-CONFIDENCE correction (the SAME shared gate the
-                    // pane badge + the SRL/poll_reminder/reclaim/inject deciders use, so they
-                    // can never diverge — #1493 class) when ON and a correction applies; else
-                    // raw. Supersedes the #1523 `authoritative_state` claude-hook-only POC.
+                    // pane badge + the poll_reminder/reclaim/inject deciders use, so they can
+                    // never diverge — #1493 class) when ON and a correction applies; else raw.
+                    // (The SRL retry arm is deliberately NOT a consumer — see `operated_state`.)
+                    // Supersedes the #1523 `authoritative_state` claude-hook-only POC.
                     let raw = c.state.get_state();
                     let agent_state =
                         crate::daemon::shadow::operated_state(raw, c.observed_status.as_ref());

--- a/src/daemon/per_tick/watchdog.rs
+++ b/src/daemon/per_tick/watchdog.rs
@@ -53,6 +53,9 @@ impl PerTickHandler for WatchdogHandler {
             let screen = core.vterm.tail_lines(rows);
             // bughunt2: pass the live AgentState so run_watchdog_pass can
             // auto-clear a stale rate-limit/quota latch on recovery.
+            // KEEP-RAW (#2465): the watchdog is a health/recovery safety net — feeding it the
+            // promoted/observed state could let a stale/false 'Active' hook MASK a genuinely
+            // stuck agent. Do NOT migrate to operated_state.
             let current_state = core.state.current;
             crate::daemon::watchdog::run_watchdog_pass(
                 ctx.home,

--- a/src/daemon/poll_reminder.rs
+++ b/src/daemon/poll_reminder.rs
@@ -341,6 +341,126 @@ mod tests {
         std::fs::remove_dir_all(&home).ok();
     }
 
+    /// Restore an env var to its pre-test value on drop. The shadow-observer tests mutate
+    /// `AGEND_SHADOW_OBSERVER` / `AGEND_OBSERVED_DISPATCH` process-globally, so they run
+    /// `#[serial_test::serial(shadow_observer)]` (same group as the snapshot operated-state
+    /// test) to avoid racing other readers of those vars.
+    struct EnvGuard(&'static str, Option<String>);
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.1 {
+                Some(v) => std::env::set_var(self.0, v),
+                None => std::env::remove_var(self.0),
+            }
+        }
+    }
+    fn guard_shadow_env() -> (EnvGuard, EnvGuard) {
+        (
+            EnvGuard(
+                "AGEND_SHADOW_OBSERVER",
+                std::env::var("AGEND_SHADOW_OBSERVER").ok(),
+            ),
+            EnvGuard(
+                "AGEND_OBSERVED_DISPATCH",
+                std::env::var("AGEND_OBSERVED_DISPATCH").ok(),
+            ),
+        )
+    }
+
+    /// #2465 regression (REAL path): an agent whose raw screen scrapes Idle but a FRESH
+    /// high-confidence Hook proves it is Active (the mid-API false-idle shape) must NOT be
+    /// poll-nudged — `collect_poll_reminders` now reads the operated (hook-primary) state via
+    /// `operated_state`, so a genuinely-busy agent mis-scraped idle is no longer pestered.
+    /// The `AGEND_OBSERVED_DISPATCH=0` kill-switch restores the raw-Idle reminder byte-for-byte.
+    ///
+    /// SCOPE (#2465): proves false-idle→consumer routing only. It deliberately does NOT model
+    /// the dev-3 ApiError-as-ratelimit stuck incident — claude hooks never emit RateLimited, so
+    /// that case has no observed signal to route and is a separate (SRL-arm) follow-up fix.
+    #[test]
+    #[serial_test::serial(shadow_observer)]
+    fn false_idle_corrected_by_hook_suppresses_poll_reminder() {
+        use crate::daemon::shadow::evidence::{Authority, Confidence};
+        use crate::daemon::shadow::reducer::{ObservedState, ObservedStatus};
+
+        let _env = guard_shadow_env();
+        let home = tmp_home("false-idle-suppress");
+        let agent = "false-idle-agent";
+        seed_unread(&home, agent, 3);
+        let registry = mock_registry(agent, AgentState::Idle);
+        // Attach a fresh high-confidence Hook=Active correction; raw screen stays Idle.
+        for handle in registry.lock().values() {
+            handle.core.lock().observed_status = Some(ObservedStatus {
+                state: ObservedState::Active,
+                authority: Authority::Hook,
+                confidence: Confidence::Strong,
+                evidence: vec![],
+                since_ms: 0,
+            });
+        }
+
+        // operated-dispatch ON (default): operated = Active ⇒ not idle ⇒ no reminder.
+        std::env::set_var("AGEND_SHADOW_OBSERVER", "1");
+        std::env::remove_var("AGEND_OBSERVED_DISPATCH");
+        reset_dedup(agent);
+        let v = collect_poll_reminders(&home, &registry);
+        assert!(
+            v.is_empty(),
+            "false-idle agent (hook=Active) must NOT be poll-nudged, got: {v:?}"
+        );
+
+        // Kill-switch: raw Idle wins ⇒ reminder returns (byte-identical to pre-#2465).
+        std::env::set_var("AGEND_OBSERVED_DISPATCH", "0");
+        reset_dedup(agent);
+        let v = collect_poll_reminders(&home, &registry);
+        assert_eq!(
+            v.len(),
+            1,
+            "AGEND_OBSERVED_DISPATCH=0 restores raw-Idle reminder"
+        );
+        assert_eq!(v[0].0, agent);
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #2465 gate firewall: a SCREEN-authority observed correction — the only plane a
+    /// hook/stream-less backend (e.g. agy) ever has — can NEVER satisfy the high-confidence
+    /// override gate, so the raw Idle stands and the agent is still nudged. Zero regression
+    /// for screen-only backends, by construction.
+    #[test]
+    #[serial_test::serial(shadow_observer)]
+    fn screen_authority_observed_does_not_suppress_poll_reminder() {
+        use crate::daemon::shadow::evidence::{Authority, Confidence};
+        use crate::daemon::shadow::reducer::{ObservedState, ObservedStatus};
+
+        let _env = guard_shadow_env();
+        std::env::set_var("AGEND_SHADOW_OBSERVER", "1");
+        std::env::remove_var("AGEND_OBSERVED_DISPATCH");
+
+        let home = tmp_home("screen-no-suppress");
+        let agent = "screen-obs-agent";
+        seed_unread(&home, agent, 2);
+        let registry = mock_registry(agent, AgentState::Idle);
+        for handle in registry.lock().values() {
+            handle.core.lock().observed_status = Some(ObservedStatus {
+                state: ObservedState::Active,
+                authority: Authority::Screen, // weak/screen-only plane — the agy shape
+                confidence: Confidence::Strong,
+                evidence: vec![],
+                since_ms: 0,
+            });
+        }
+        reset_dedup(agent);
+        let v = collect_poll_reminders(&home, &registry);
+        assert_eq!(
+            v.len(),
+            1,
+            "screen-authority observed must NOT override raw Idle (screen-only backends unaffected)"
+        );
+        assert_eq!(v[0].0, agent);
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
     #[test]
     fn test_collect_poll_reminders_dedupes_same_count() {
         let home = tmp_home("collect-dedup");

--- a/src/daemon/poll_reminder.rs
+++ b/src/daemon/poll_reminder.rs
@@ -41,7 +41,15 @@ pub fn collect_poll_reminders(home: &Path, registry: &AgentRegistry) -> Vec<(Str
     let idle_names: Vec<String> = {
         let reg = agent::lock_registry(registry);
         reg.values()
-            .filter(|handle| handle.core.lock().state.current == AgentState::Idle)
+            // #2465: operated (hook-primary) state — a screen that mis-scrapes Idle while
+            // a fresh hook proves the agent is mid-turn no longer gets a poll nudge it
+            // shouldn't. A correction never flips TO idle, so a genuinely idle agent is
+            // unaffected; raw==operated ⇒ byte-identical to pre-#2465.
+            .filter(|handle| {
+                let c = handle.core.lock();
+                crate::daemon::shadow::operated_state(c.state.current, c.observed_status.as_ref())
+                    == AgentState::Idle
+            })
             .map(|handle| handle.name.to_string())
             .collect()
     };

--- a/src/daemon/shadow/mod.rs
+++ b/src/daemon/shadow/mod.rs
@@ -83,6 +83,32 @@ pub fn operated_dispatch_enabled() -> bool {
     enabled() && std::env::var("AGEND_OBSERVED_DISPATCH").as_deref() != Ok("0")
 }
 
+/// #2465: the OPERATED state a daemon DECISION consumer should act on — the Shadow
+/// Observer's high-confidence correction of the raw screen heuristic when
+/// operated-dispatch is ON and a §5 correction applies (the SAME shared
+/// [`gate::gated_override`] the pane badge and the snapshot writer use, so deciders can
+/// never diverge — #1493 class), else `raw`. `AGEND_OBSERVED_DISPATCH=0` (or the observer
+/// kill-switch) ⇒ `raw`, byte-identical to pre-#2413. The single source of precedence for
+/// every (B) decision consumer (SRL retry arm/clear, poll_reminder idle filter, reclaim
+/// eligibility, API inject guard) so a hook-confirmed state that the screen mis-scrapes
+/// (e.g. ApiError-as-RateLimited read as Idle) is no longer ignored. NEVER reads or writes
+/// `State::current`: callers pass the raw heuristic in, so the reducer's screen input stays
+/// vterm-only and a promoted state can't feed back into classification (the #2413
+/// cycle-proof invariant). Health/recovery deciders deliberately do NOT use this — they must
+/// see raw to catch a stuck agent a stale 'Active' hook would mask (the inverse failure).
+pub fn operated_state(
+    raw: crate::state::AgentState,
+    observed: Option<&reducer::ObservedStatus>,
+) -> crate::state::AgentState {
+    if operated_dispatch_enabled() {
+        observed
+            .and_then(|s| gate::gated_override(raw, s))
+            .unwrap_or(raw)
+    } else {
+        raw
+    }
+}
+
 /// The per-daemon unix socket the hooks emit to. One socket for the daemon; the
 /// token attributes each frame to its agent.
 pub fn socket_path(home: &Path) -> PathBuf {

--- a/src/daemon/shadow/mod.rs
+++ b/src/daemon/shadow/mod.rs
@@ -89,13 +89,22 @@ pub fn operated_dispatch_enabled() -> bool {
 /// [`gate::gated_override`] the pane badge and the snapshot writer use, so deciders can
 /// never diverge — #1493 class), else `raw`. `AGEND_OBSERVED_DISPATCH=0` (or the observer
 /// kill-switch) ⇒ `raw`, byte-identical to pre-#2413. The single source of precedence for
-/// every (B) decision consumer (SRL retry arm/clear, poll_reminder idle filter, reclaim
-/// eligibility, API inject guard) so a hook-confirmed state that the screen mis-scrapes
-/// (e.g. ApiError-as-RateLimited read as Idle) is no longer ignored. NEVER reads or writes
-/// `State::current`: callers pass the raw heuristic in, so the reducer's screen input stays
-/// vterm-only and a promoted state can't feed back into classification (the #2413
-/// cycle-proof invariant). Health/recovery deciders deliberately do NOT use this — they must
-/// see raw to catch a stuck agent a stale 'Active' hook would mask (the inverse failure).
+/// the (B) decision consumers that DO route through it — the snapshot writer, the
+/// `poll_reminder` idle filter, `reclaim` eligibility, and the API inject guard — so a fresh
+/// high-confidence Hook/Stream correction (e.g. a screen mis-scraped Idle while the agent is
+/// actually mid-turn) is no longer ignored. NEVER reads or writes `State::current`: callers
+/// pass the raw heuristic in, so the reducer's screen input stays vterm-only and a promoted
+/// state can't feed back into classification (the #2413 cycle-proof invariant).
+///
+/// Deliberately NOT used by (so this list is the auditable scope of the routing):
+/// - **the SRL retry arm/clear** (`supervisor.rs`) — it still gates on raw `core.state.current`.
+///   claude hooks never emit `RateLimited` (`evidence.rs` — a `StopFailure` maps to
+///   `TurnEnded`/`ApiError`, the API plane owns rate-limit), so `observed` carries NO rate-limit
+///   signal to route there; migrating it would be inert for the ApiError-as-rate-limit stuck
+///   case (operated stays Idle). That real fix is the follow-up #2466.
+/// - **the health/recovery deciders** (hang_detection / watchdog / recovery_dispatcher /
+///   respawn_watchdog) — they must see raw to catch a stuck agent a stale 'Active' hook would
+///   mask (the inverse failure; each carries a `// KEEP-RAW (#2465)` rationale at its call site).
 pub fn operated_state(
     raw: crate::state::AgentState,
     observed: Option<&reducer::ObservedStatus>,

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -1330,6 +1330,10 @@ fn tick(
             // lock drops (CR-2026-06-14 concurrency).
             waiting_on_heartbeat_stale = !core.state.is_heartbeat_fresh();
 
+            // KEEP-RAW (#2465): the AuthError stability / escalation gate reads raw
+            // core.state.current. operated_state is inert here anyway (AuthError maps to the
+            // gate's non-decisive 'Other' screen, which is never overridden), and this is a
+            // recovery/escalation decider that must see raw. See `operated_state` docstring.
             let agent_state = core.state.current;
             // #1523: capture how long AuthError has been continuously held (state
             // age) for the post-lock stability gate. `Some` iff currently in
@@ -1958,6 +1962,10 @@ pub(crate) fn process_error_recovery(
             // used to mis-suppress). `productive_silence` is for the log only.
             let (state, recovered, self_cleared, has_throttle_hint, productive_silence) = {
                 let mut core = handle.core.lock();
+                // KEEP-RAW (#2465): the SRL retry arm reads raw core.state.current. claude hooks
+                // never emit RateLimited (a StopFailure → ApiError, the API plane owns rate-limit),
+                // so operated_state would be inert here; the true ApiError-as-rate-limit SRL fix is
+                // tracked in #2466, out of this PR's scope.
                 let state = core.state.current;
                 let recovered = core.state.recovered_within(RECOVERY_SILENCE);
                 // #2232: ground-truth recovery latch the agent set by self-clearing


### PR DESCRIPTION
## What

Routes the daemon's **decision consumers** through a single hook-primary "operated" state instead of the raw screen-scrape, so a high-confidence Hook/Stream correction of a mis-scraped screen reaches the deciders (the #2413 Shadow Observer plane).

- **New shared helper** `crate::daemon::shadow::operated_state(raw, observed)` = `gated_override(raw, observed).unwrap_or(raw)`, gated by the `AGEND_OBSERVED_DISPATCH` / `AGEND_SHADOW_OBSERVER` kill-switches — the single source of precedence (the SAME gate the pane badge + snapshot writer use, so deciders can't diverge — #1493 class). Never reads/writes `State::current` (the #2413 cycle-proof invariant holds: callers pass raw in).
- **`per_tick/snapshot.rs`** refactored to call the helper (the inline block it was extracted from).
- **A — migrated** (3 decision consumers): `poll_reminder` idle filter, `per_tick/reclaim` eligibility, API `inject` guard (`is_unavailable`).
- **B — KEEP-RAW (documented, NOT migrated)**: the health/recovery state machine — `hang_detection`, `per_tick/watchdog`, `recovery_dispatcher`, `respawn_watchdog`. Each carries a `// KEEP-RAW (#2465): …` rationale: feeding these a promoted state could let a stale/false 'Active' hook **mask a genuinely stuck agent** (the inverse failure). They must see raw.

## Scope (read this)

This PR fixes the **false-idle → decision-consumer** class: when a fresh high-confidence Hook proves an agent is Active but the screen mis-scrapes Idle, the migrated consumers now act on the corrected state.

It does **NOT** fix the dev-3 `ApiError`-as-rate-limit stuck incident that motivated the issue. Verified against code + the real `recovery_shadow.jsonl` entry: a claude `StopFailure → ApiError` produces `EvidenceKind::TurnEnded`, and **claude hooks never emit `RateLimited`** (`evidence.rs:139` — "the API plane owns RateLimited"). So for that incident `observed = Idle` and `operated_state = Idle` — there is no observed rate-limit signal to route, and migrating the SRL retry arm would be **inert**. The SRL-arm real fix (a `StopFailure`/throttle-hint arm trigger) is a separate follow-up, coordinated with the 529-recovery owner. The SRL arm is deliberately left reading raw here.

## Tests (real path, not synthetic)

- `false_idle_corrected_by_hook_suppresses_poll_reminder` — drives the real `collect_poll_reminders`: a raw-Idle agent with a fresh Hook=Active correction is no longer poll-nudged; `AGEND_OBSERVED_DISPATCH=0` restores the raw-Idle reminder byte-for-byte.
- `screen_authority_observed_does_not_suppress_poll_reminder` — gate firewall: a Screen-authority observed (the only plane a hook/stream-less backend like **agy** ever has) never overrides raw → zero regression for screen-only backends, by construction.

Behavior is identical whenever `observed == raw` (the common case). Gates: `fmt --check`, `clippy --all-targets --features tray -D warnings`, full `nextest` — all green locally.

Part of #2465 (false-idle→consumer routing slice; SRL-arm fix is a follow-up). Relates to #2413.
