### PR TITLE
fix(#2470): stale ServerRateLimit badge yields to fresh post-SRL hook activity

### DIFF
--- a/src/daemon/shadow/gate.rs
+++ b/src/daemon/shadow/gate.rs
@@ -12,9 +12,12 @@
 //! ALL of: (a) `authority ∈ {Hook, Stream}` — a live lifecycle / event-stream plane, not
 //! the `Screen` baseline and not a low-confidence `Inferred` reconcile; (b) `confidence ∈
 //! {Confirmed, Strong}` — freshness is already implied (the reducer only labels a fresh
-//! observer plane this high); (c) the raw screen is NOT itself a GATE screen (`Approval` /
-//! `RateLimited`) — a human approval prompt or a rate-limit banner is authoritative and must
-//! NEVER be masked by an observed override (the operator/daemon must always see it); and
+//! observer plane this high); (c) the raw screen is not a HARD gate screen — `Approval`
+//! (human prompt), `UsageLimit` (user quota), and user `RateLimit` are authoritative and must
+//! NEVER be masked (the operator/daemon must always see them). #2470 narrowed this: a raw
+//! `ServerRateLimit` MAY be superseded, because a stale SRL banner that lingers in the tail while
+//! the agent has provably resumed (the reducer's `resumed_post_srl`) otherwise pins the badge —
+//! so it falls through to (d) and is overridden only by a fresh post-SRL Hook/Stream Active; and
 //! (d) the observed state genuinely DISAGREES with the raw screen baseline at the coarse
 //! level (the §5 correction predicate via [`screen_as_observed`]), so an agreeing-but-vaguer
 //! observed state never DOWNGRADES a more-specific raw state. `None` otherwise → the consumer
@@ -258,7 +261,11 @@ mod tests {
             Some(AgentState::Active),
             "a fresh post-SRL Hook Active must supersede a stale ServerRateLimit badge"
         );
-        let stream_tool = status(ObservedState::ToolUse, Authority::Stream, Confidence::Strong);
+        let stream_tool = status(
+            ObservedState::ToolUse,
+            Authority::Stream,
+            Confidence::Strong,
+        );
         assert_eq!(
             gated_override(AgentState::ServerRateLimit, &stream_tool),
             Some(AgentState::Active),
@@ -273,7 +280,11 @@ mod tests {
         );
         // A still-RateLimited observed (current limit, e.g. open hook window) → (d) coarse-agreement
         // → keep SRL (never mis-clear a genuine current limit).
-        let still_rl = status(ObservedState::RateLimited, Authority::Hook, Confidence::Strong);
+        let still_rl = status(
+            ObservedState::RateLimited,
+            Authority::Hook,
+            Confidence::Strong,
+        );
         assert_eq!(
             gated_override(AgentState::ServerRateLimit, &still_rl),
             None,

--- a/src/daemon/shadow/gate.rs
+++ b/src/daemon/shadow/gate.rs
@@ -87,10 +87,22 @@ fn observed_to_agent_state(state: ObservedState) -> Option<AgentState> {
 /// sites, but the gate itself reads nothing mutable).
 pub(crate) fn gated_override(raw: AgentState, status: &ObservedStatus) -> Option<AgentState> {
     let screen = screen_signal(raw);
-    // (c) A raw GATE screen is authoritative — never let an observed override mask a human
-    // approval prompt or a rate-limit banner (also blocks a stale observed=Active from
-    // hiding a raw that just transitioned to Approval under the reducer's snapshot).
-    if matches!(screen, ScreenSignal::Approval | ScreenSignal::RateLimited) {
+    // (c) A raw Approval screen is ALWAYS authoritative — a human approval gate must never be
+    // masked by an observed override (also blocks a stale observed=Active from hiding a raw that
+    // just transitioned to Approval under the reducer's snapshot). Approval-hook reliability is
+    // unverifiable in-fleet (claude runs --dangerously-skip-permissions → prompts never occur), and
+    // hiding a pending approval is worse than over-reporting it, so this stays hard (#2470).
+    if matches!(screen, ScreenSignal::Approval) {
+        return None;
+    }
+    // (c') #2470: a RateLimited screen is authoritative too, EXCEPT a STALE `ServerRateLimit` banner
+    // the agent has provably moved past. ONLY the `ServerRateLimit` raw may be superseded — UsageLimit
+    // (user quota) and user `RateLimit` stay authoritative (operator must see them; not a "resumed"
+    // semantic). Even for ServerRateLimit the override still requires the (a)/(b)/(d) checks below:
+    // a CURRENT hook rate-limit window or a no-fresh-episode banner stays `RateLimited` in `status`
+    // → fails the (d) coarse-disagreement check → kept; only the reducer's #2470 `resumed_post_srl`
+    // (a fresh post-SRL Hook/Stream episode) yields an Active `status` that passes and overrides.
+    if matches!(screen, ScreenSignal::RateLimited) && !matches!(raw, AgentState::ServerRateLimit) {
         return None;
     }
     // (a) + (b) high-confidence real-time observer plane only.
@@ -205,10 +217,12 @@ mod tests {
         assert_eq!(gated_override(AgentState::Active, &s), None);
     }
 
-    /// P2 composition invariant (t-…5060-11): a raw GATE screen (`Approval` / `RateLimited`)
-    /// is NEVER masked by an override — for EVERY gate-class raw state, even a maximally
-    /// confident Hook status pointing elsewhere returns `None` (keep the raw gate). This is
-    /// the pin that the dispatch/operator can always see a pending approval or rate-limit.
+    /// P2 composition invariant (t-…5060-11), narrowed by #2470: these gate-class raws are NEVER
+    /// masked — even a maximally confident Hook Active returns `None`. `ServerRateLimit` was REMOVED
+    /// from this set (#2470: a stale SRL banner may be superseded by a fresh post-SRL Hook/Stream
+    /// Active — see `server_rate_limit_overridden_only_by_fresh_hook_active`); Approval family +
+    /// user `RateLimit` + `UsageLimit` stay hard so dispatch/operator always sees a pending
+    /// approval or a genuine quota/rate limit.
     #[test]
     fn gate_screen_is_never_overridden() {
         let gate_raws = [
@@ -216,7 +230,6 @@ mod tests {
             AgentState::InteractivePrompt,
             AgentState::AwaitingOperator,
             AgentState::RateLimit,
-            AgentState::ServerRateLimit,
             AgentState::UsageLimit,
         ];
         // The most "override-prone" status: highest confidence, active-family, disagreeing.
@@ -228,6 +241,44 @@ mod tests {
                 "a gate screen ({raw:?}) must never be masked by an observed override"
             );
         }
+    }
+
+    /// #2470: `ServerRateLimit` is the ONE gate-class raw a fresh high-confidence post-SRL
+    /// Hook/Stream Active MAY supersede (the reducer's `resumed_post_srl` yields that Active when a
+    /// new turn opened after a stale banner) — so the badge stops pinning [ServerRateLimit]. But a
+    /// screen-authority / still-RateLimited observed must NOT override → a genuinely-current limit
+    /// stays visible. NEUTER: revert the gate (c') split (RateLimited returns None for all raws) and
+    /// the first assert goes RED.
+    #[test]
+    fn server_rate_limit_overridden_only_by_fresh_hook_active() {
+        // Resumed: a fresh high-confidence Hook/Stream Active supersedes the stale SRL banner.
+        let hook_active = status(ObservedState::Active, Authority::Hook, Confidence::Strong);
+        assert_eq!(
+            gated_override(AgentState::ServerRateLimit, &hook_active),
+            Some(AgentState::Active),
+            "a fresh post-SRL Hook Active must supersede a stale ServerRateLimit badge"
+        );
+        let stream_tool = status(ObservedState::ToolUse, Authority::Stream, Confidence::Strong);
+        assert_eq!(
+            gated_override(AgentState::ServerRateLimit, &stream_tool),
+            Some(AgentState::Active),
+            "Stream-plane parity (codex)"
+        );
+        // Screen-authority observed (no real-time observer plane, e.g. agy) → keep SRL.
+        let screen_active = status(ObservedState::Active, Authority::Screen, Confidence::Strong);
+        assert_eq!(
+            gated_override(AgentState::ServerRateLimit, &screen_active),
+            None,
+            "a screen-authority observed must NOT clear a ServerRateLimit"
+        );
+        // A still-RateLimited observed (current limit, e.g. open hook window) → (d) coarse-agreement
+        // → keep SRL (never mis-clear a genuine current limit).
+        let still_rl = status(ObservedState::RateLimited, Authority::Hook, Confidence::Strong);
+        assert_eq!(
+            gated_override(AgentState::ServerRateLimit, &still_rl),
+            None,
+            "a current (RateLimited) observed must NOT clear the ServerRateLimit"
+        );
     }
 
     /// #1493 composition: drive the REAL reducer (not a hand-built status) and confirm the
@@ -263,6 +314,92 @@ mod tests {
         assert!(
             gated_override(AgentState::Idle, &s).is_some(),
             "a real mid-API false-idle must promote at an idle raw"
+        );
+    }
+
+    /// #2470 load-bearing (REAL reducer + gate end-to-end): the stale-ServerRateLimit-badge fix.
+    /// Drives `AgentRuntime` so the reducer's `resumed_post_srl` and the gate's (c') split are both
+    /// exercised on real `observe()` output — not hand-built statuses.
+    #[test]
+    fn stale_server_rate_limit_reconcile_real_reducer_2470() {
+        let live = crate::daemon::shadow::reducer::Liveness {
+            api_in_flight: true,
+            productive_silent_ms: 0,
+            child_alive: true,
+        };
+
+        // (1) RESUMED: turn hit a 529 (StopFailure → episode closed), then a NEW turn started —
+        //     agent is working again while the SRL banner is still in the tail. Reducer yields the
+        //     stale RateLimited → Active; gate promotes it at a ServerRateLimit raw → badge=Active.
+        let mut rt = AgentRuntime::default();
+        rt.ingest(&Evidence::hook(EvidenceKind::TurnStarted, 1_000));
+        rt.ingest(&Evidence::hook(
+            EvidenceKind::TurnEnded {
+                stop_reason: Some("failure".into()),
+            },
+            1_100,
+        ));
+        rt.ingest(&Evidence::hook(EvidenceKind::TurnStarted, 1_200)); // resumed
+        let s = rt.observe(ScreenSignal::RateLimited, &live, 1_300);
+        assert_ne!(
+            s.state,
+            ObservedState::RateLimited,
+            "a fresh post-SRL turn must yield the stale RateLimited screen"
+        );
+        assert_eq!(
+            gated_override(AgentState::ServerRateLimit, &s),
+            Some(AgentState::Active),
+            "#2470: resumed agent's badge must show Active, not the stale ServerRateLimit"
+        );
+
+        // (2) STUCK (no fresh episode): turn failed and never resumed (episode_open == false).
+        //     Reducer keeps RateLimited; gate keeps the raw ServerRateLimit (no mis-clear).
+        let mut rt = AgentRuntime::default();
+        rt.ingest(&Evidence::hook(EvidenceKind::TurnStarted, 1_000));
+        rt.ingest(&Evidence::hook(
+            EvidenceKind::TurnEnded {
+                stop_reason: Some("failure".into()),
+            },
+            1_100,
+        ));
+        let s = rt.observe(ScreenSignal::RateLimited, &live, 1_200);
+        assert_eq!(
+            s.state,
+            ObservedState::RateLimited,
+            "a failed turn with no resume must stay RateLimited"
+        );
+        assert_eq!(
+            gated_override(AgentState::ServerRateLimit, &s),
+            None,
+            "#2470: a genuinely-stuck SRL must NOT be cleared"
+        );
+
+        // (3) CURRENT hook rate-limit window open + an episode → still RateLimited (NOT cleared by
+        //     a resumed episode, because the hook itself confirms a live limit).
+        let mut rt = AgentRuntime::default();
+        rt.ingest(&Evidence::hook(
+            EvidenceKind::RateLimited {
+                retry_at_ms: Some(9_000),
+            },
+            1_000,
+        ));
+        rt.ingest(&Evidence::hook(EvidenceKind::TurnStarted, 1_100));
+        let s = rt.observe(ScreenSignal::RateLimited, &live, 1_200);
+        assert_eq!(
+            s.state,
+            ObservedState::RateLimited,
+            "an open hook rate-limit window stays RateLimited even with an episode"
+        );
+
+        // (4) UsageLimit raw (user quota): even though the reducer yields Active (it only sees the
+        //     collapsed RateLimited signal), the gate keeps UsageLimit authoritative → badge stays.
+        let mut rt = AgentRuntime::default();
+        rt.ingest(&Evidence::hook(EvidenceKind::TurnStarted, 1_200));
+        let s = rt.observe(ScreenSignal::RateLimited, &live, 1_300);
+        assert_eq!(
+            gated_override(AgentState::UsageLimit, &s),
+            None,
+            "#2470: UsageLimit (user quota) must NEVER be superseded — operator must see it"
         );
     }
 

--- a/src/daemon/shadow/reducer.rs
+++ b/src/daemon/shadow/reducer.rs
@@ -394,8 +394,8 @@ impl AgentRuntime {
         // which would mis-clear a still-rate-limited agent once the latch expires. `last_progress_ms`
         // is advanced only by lifecycle/progress evidence (see `ingest`), so a banner with only stale
         // progress + late TokenUsage stays RateLimited.
-        let progress_fresh =
-            self.last_progress_ms > 0 && now_ms.saturating_sub(self.last_progress_ms) <= HOOK_FRESHNESS_MS;
+        let progress_fresh = self.last_progress_ms > 0
+            && now_ms.saturating_sub(self.last_progress_ms) <= HOOK_FRESHNESS_MS;
         let resumed_post_srl = progress_fresh && self.episode_open && !hook_rate_limit_current;
         let rate_limited =
             hook_rate_limit_current || (screen == ScreenSignal::RateLimited && !resumed_post_srl);
@@ -932,8 +932,8 @@ mod tests {
             EvidenceKind::RateLimited { retry_at_ms: None },
             2_000,
         )); // latch set @ 2_000
-        // A LATE accounting-only TokenUsage advances last_observer_ms (props observer_fresh) but
-        // is NOT progress and does NOT clear the latch.
+            // A LATE accounting-only TokenUsage advances last_observer_ms (props observer_fresh) but
+            // is NOT progress and does NOT clear the latch.
         rt.ingest(&Evidence::stream(
             EvidenceKind::TokenUsage {
                 input: 10,

--- a/src/daemon/shadow/reducer.rs
+++ b/src/daemon/shadow/reducer.rs
@@ -160,6 +160,16 @@ pub struct AgentRuntime {
     waiting_since_ms: u64,
     /// Absolute epoch-ms the rate-limit clears (from `RateLimited.retry_at_ms`), if any.
     rate_limited_until_ms: Option<u64>,
+    /// #2470 (r6): "currently rate-limited" latch from a `RateLimited` EVIDENCE, independent of the
+    /// `retry_at_ms` timestamp. opencode emits `RateLimited{retry_at_ms: None}` per retry
+    /// (opencode.rs `session.status{retry}`), so the `rate_limited_until_ms > now` window alone
+    /// MISSES a live opencode rate-limit. Set on any `RateLimited` evidence, CLEARED by any newer
+    /// lifecycle/progress evidence (turn/tool/responding/idle) — i.e. a rate-limit stays "current"
+    /// until a fresh recovery signal supersedes it, so a mid-retry agent is NEVER mis-cleared.
+    rate_limit_active: bool,
+    /// Epoch-ms of the newest `RateLimited` evidence — bounds `rate_limit_active` to the observer
+    /// freshness window (a long-silent latch expires → screen baseline takes over, as elsewhere).
+    last_rate_limit_evidence_ms: u64,
     /// Newest real-time OBSERVER-plane evidence timestamp (`Hook` for claude, `Stream` for
     /// codex) — drives the freshness fallback. #2413 Phase D generalized this from Hook-only
     /// so the codex rollout (`Stream`) plane gets parity; claude has ONLY `Hook`, so its
@@ -193,6 +203,16 @@ impl AgentRuntime {
         {
             self.last_observer_ms = ev.at_ms;
             self.last_observer_authority = Some(ev.authority);
+        }
+        // #2470 (r6): a `RateLimited` evidence latches "currently rate-limited"; ANY other
+        // lifecycle/progress evidence (turn/tool/responding/idle/approval) is a NEWER recovery
+        // signal that supersedes it. `TokenUsage` is accounting-only (no lifecycle meaning) and
+        // must NOT count as recovery.
+        if !matches!(
+            ev.kind,
+            EvidenceKind::RateLimited { .. } | EvidenceKind::TokenUsage { .. }
+        ) {
+            self.rate_limit_active = false;
         }
         match &ev.kind {
             EvidenceKind::TurnStarted => {
@@ -229,6 +249,10 @@ impl AgentRuntime {
             }
             EvidenceKind::RateLimited { retry_at_ms } => {
                 self.rate_limited_until_ms = *retry_at_ms;
+                // #2470 (r6): latch "currently rate-limited" even when `retry_at_ms` is None
+                // (opencode's retry status) — the window check alone would miss it.
+                self.rate_limit_active = true;
+                self.last_rate_limit_evidence_ms = ev.at_ms;
             }
             EvidenceKind::Responding => {
                 self.last_responding_ms = ev.at_ms;
@@ -333,15 +357,24 @@ impl AgentRuntime {
         // `episode_open == false` since StopFailure→close_episode) stays RateLimited. The gate
         // (shadow::gate) keeps UsageLimit / Approval authoritative regardless — only the
         // ServerRateLimit *raw* is allowed to be superseded by this resumed-active observed.
-        let hook_rate_limit_current = self
+        let hook_rate_limit_window = self
             .rate_limited_until_ms
             .is_some_and(|until| until > now_ms);
+        // #2470 (r6): a fresh `RateLimited` EVIDENCE latch is ALSO a current limit — covers
+        // opencode's `retry_at_ms: None` retry status the window check misses. Bounded to the
+        // observer freshness window AND cleared by any newer recovery signal (see `ingest`), so a
+        // mid-retry agent stays RateLimited but a genuinely-resumed one (newer turn/output) does not.
+        let rate_limit_evidence_current = self.rate_limit_active
+            && now_ms.saturating_sub(self.last_rate_limit_evidence_ms) <= HOOK_FRESHNESS_MS;
+        let hook_rate_limit_current = hook_rate_limit_window || rate_limit_evidence_current;
         let resumed_post_srl = observer_fresh && self.episode_open && !hook_rate_limit_current;
         let rate_limited =
             hook_rate_limit_current || (screen == ScreenSignal::RateLimited && !resumed_post_srl);
         if rate_limited {
+            // A hook/stream-confirmed limit is labeled with its observer plane; a screen-only
+            // banner is `Screen`.
             let auth = if hook_rate_limit_current {
-                Authority::Hook
+                self.last_observer_authority.unwrap_or(Authority::Hook)
             } else {
                 Authority::Screen
             };
@@ -822,6 +855,38 @@ mod tests {
         rt.ingest(&hook(EvidenceKind::ApprovalRequired, 1_050));
         let s = rt.observe(ScreenSignal::Working, &live_busy(), 1_100);
         assert_eq!(s.state, ObservedState::WaitingForUser);
+    }
+
+    /// #2470 (r6 finding): an opencode mid-retry emits `RateLimited{retry_at_ms: None}`
+    /// (session.status{retry}) while a turn is still open — a CURRENT limit that must NOT be
+    /// mis-cleared as a "stale SRL the agent moved past". The window check
+    /// (`rate_limited_until_ms > now`) alone misses the None case; the `rate_limit_active` latch
+    /// catches it, and only a NEWER recovery signal supersedes it. NEUTER: drop the latch from
+    /// `hook_rate_limit_current` and the first assert flips to Active (mis-clear) → RED.
+    #[test]
+    fn opencode_retry_rate_limit_not_mis_cleared_2470() {
+        // Turn opened (Stream plane), then rate-limited and RETRYING (retry_at None); episode open.
+        let mut rt = AgentRuntime::default();
+        rt.ingest(&Evidence::stream(EvidenceKind::TurnStarted, 1_000));
+        rt.ingest(&Evidence::stream(
+            EvidenceKind::RateLimited { retry_at_ms: None },
+            1_100,
+        ));
+        let s = rt.observe(ScreenSignal::RateLimited, &live_busy(), 1_200);
+        assert_eq!(
+            s.state,
+            ObservedState::RateLimited,
+            "#2470 r6: a mid-retry opencode (RateLimited retry_at=None + open episode) must NOT be mis-cleared"
+        );
+
+        // Recovery: a NEWER progress signal (Responding) supersedes the latch → reconciles to active.
+        rt.ingest(&Evidence::stream(EvidenceKind::Responding, 1_300));
+        let s = rt.observe(ScreenSignal::RateLimited, &live_busy(), 1_400);
+        assert_ne!(
+            s.state,
+            ObservedState::RateLimited,
+            "#2470: a NEWER recovery signal supersedes the rate-limit latch (no longer current)"
+        );
     }
 
     /// `since_ms` is stable while the state holds, and resets when it changes.

--- a/src/daemon/shadow/reducer.rs
+++ b/src/daemon/shadow/reducer.rs
@@ -182,6 +182,13 @@ pub struct AgentRuntime {
     last_observer_authority: Option<Authority>,
     /// Newest `Responding` evidence — distinguishes the `Responding` refinement.
     last_responding_ms: u64,
+    /// #2470 (r6 round-3): newest REAL-PROGRESS evidence — a lifecycle signal that proves the
+    /// agent actually advanced (TurnStarted / ToolStarted / ToolEnded / Responding / PromptReady /
+    /// TurnEnded). EXCLUDES `TokenUsage` (accounting-only) and `RateLimited` (the thing we're
+    /// reconciling against). `resumed_post_srl` keys on THIS, not the generic `last_observer_ms`:
+    /// a `TokenUsage` props `last_observer_ms` without any real progress, which would otherwise
+    /// mis-clear a still-rate-limited agent once the rate-limit latch expires (r6 repro).
+    last_progress_ms: u64,
     /// Stable-`since` bookkeeping: the last derived state + when it was entered.
     last_state: Option<ObservedState>,
     last_state_since_ms: u64,
@@ -213,6 +220,21 @@ impl AgentRuntime {
             EvidenceKind::RateLimited { .. } | EvidenceKind::TokenUsage { .. }
         ) {
             self.rate_limit_active = false;
+        }
+        // #2470 (r6 round-3): track REAL-PROGRESS freshness separately from `last_observer_ms`.
+        // Only a genuine lifecycle/progress signal advances it — NOT `TokenUsage` (accounting,
+        // which would otherwise prop `observer_fresh` and mis-clear a still-rate-limited agent
+        // after the latch expires) and NOT `RateLimited` (the state we reconcile against).
+        if matches!(
+            ev.kind,
+            EvidenceKind::TurnStarted
+                | EvidenceKind::ToolStarted { .. }
+                | EvidenceKind::ToolEnded
+                | EvidenceKind::Responding
+                | EvidenceKind::PromptReady
+                | EvidenceKind::TurnEnded { .. }
+        ) {
+            self.last_progress_ms = ev.at_ms;
         }
         match &ev.kind {
             EvidenceKind::TurnStarted => {
@@ -367,7 +389,14 @@ impl AgentRuntime {
         let rate_limit_evidence_current = self.rate_limit_active
             && now_ms.saturating_sub(self.last_rate_limit_evidence_ms) <= HOOK_FRESHNESS_MS;
         let hook_rate_limit_current = hook_rate_limit_window || rate_limit_evidence_current;
-        let resumed_post_srl = observer_fresh && self.episode_open && !hook_rate_limit_current;
+        // #2470 (r6 round-3): "resumed" requires REAL-PROGRESS freshness, NOT the generic observer
+        // freshness — a `TokenUsage` props `last_observer_ms` (accounting) without any real progress,
+        // which would mis-clear a still-rate-limited agent once the latch expires. `last_progress_ms`
+        // is advanced only by lifecycle/progress evidence (see `ingest`), so a banner with only stale
+        // progress + late TokenUsage stays RateLimited.
+        let progress_fresh =
+            self.last_progress_ms > 0 && now_ms.saturating_sub(self.last_progress_ms) <= HOOK_FRESHNESS_MS;
+        let resumed_post_srl = progress_fresh && self.episode_open && !hook_rate_limit_current;
         let rate_limited =
             hook_rate_limit_current || (screen == ScreenSignal::RateLimited && !resumed_post_srl);
         if rate_limited {
@@ -886,6 +915,39 @@ mod tests {
             s.state,
             ObservedState::RateLimited,
             "#2470: a NEWER recovery signal supersedes the rate-limit latch (no longer current)"
+        );
+    }
+
+    /// #2470 (r6 round-3 repro): a LATE `TokenUsage` (accounting-only) props `observer_fresh` but is
+    /// NOT real progress. After the rate-limit latch's freshness window expires, a still-rate-limited
+    /// agent emitting only TokenUsage must STAY RateLimited — not be mis-cleared to Active. The fix
+    /// keys `resumed_post_srl` on `last_progress_ms` (lifecycle-only): here the only progress was the
+    /// stale TurnStarted, so progress is NOT fresh → kept. NEUTER: key resume on `observer_fresh`
+    /// again → the late TokenUsage props it → flips to Active → RED.
+    #[test]
+    fn token_usage_does_not_prop_resume_after_latch_expiry_2470() {
+        let mut rt = AgentRuntime::default();
+        rt.ingest(&Evidence::stream(EvidenceKind::TurnStarted, 1_000)); // last_progress_ms = 1_000
+        rt.ingest(&Evidence::stream(
+            EvidenceKind::RateLimited { retry_at_ms: None },
+            2_000,
+        )); // latch set @ 2_000
+        // A LATE accounting-only TokenUsage advances last_observer_ms (props observer_fresh) but
+        // is NOT progress and does NOT clear the latch.
+        rt.ingest(&Evidence::stream(
+            EvidenceKind::TokenUsage {
+                input: 10,
+                output: 20,
+            },
+            500_000,
+        ));
+        // Observe JUST after the rate-limit latch's freshness window expires.
+        let now = 2_000 + HOOK_FRESHNESS_MS + 1;
+        let s = rt.observe(ScreenSignal::RateLimited, &live_busy(), now);
+        assert_eq!(
+            s.state,
+            ObservedState::RateLimited,
+            "#2470 r6: a late TokenUsage must NOT prop a resume — a still-rate-limited agent stays RateLimited"
         );
     }
 

--- a/src/daemon/shadow/reducer.rs
+++ b/src/daemon/shadow/reducer.rs
@@ -316,13 +316,31 @@ impl AgentRuntime {
             );
         }
 
-        // (P1) Rate-limited: hook `RateLimited` window still open, or the screen says so.
-        let rate_limited = self
+        // Observer-plane freshness: a Hook/Stream episode within the window is the real-time
+        // signal. Computed here (ahead of P1) because the #2470 stale-SRL reconcile needs it.
+        // If no Hook/Stream evidence is fresh, the observer plane is stale and the screen
+        // baseline wins downstream. (#2413 Phase D: generalized from Hook-only to {Hook|Stream}.)
+        let observer_fresh = now_ms.saturating_sub(self.last_observer_ms) <= HOOK_FRESHNESS_MS
+            && self.last_observer_ms > 0;
+
+        // (P1) Rate-limited: a HOOK-confirmed retry window still open, or the screen says so —
+        // EXCEPT a STALE ServerRateLimit banner the agent has already moved past. #2470:
+        // `resumed_post_srl` = a fresh OPEN observer episode proves a NEW turn started after the
+        // (screen-only) banner, so the banner is stale → yield so the Active family (P3) reports the
+        // real thinking/active and the badge stops lying [ServerRateLimit]. NOT cleared: a
+        // HOOK-confirmed window (`rate_limited_until_ms` in the future) is a CURRENT limit; and a
+        // screen banner with NO fresh episode (a genuinely stuck/failed turn has
+        // `episode_open == false` since StopFailure→close_episode) stays RateLimited. The gate
+        // (shadow::gate) keeps UsageLimit / Approval authoritative regardless — only the
+        // ServerRateLimit *raw* is allowed to be superseded by this resumed-active observed.
+        let hook_rate_limit_current = self
             .rate_limited_until_ms
-            .is_some_and(|until| until > now_ms)
-            || screen == ScreenSignal::RateLimited;
+            .is_some_and(|until| until > now_ms);
+        let resumed_post_srl = observer_fresh && self.episode_open && !hook_rate_limit_current;
+        let rate_limited =
+            hook_rate_limit_current || (screen == ScreenSignal::RateLimited && !resumed_post_srl);
         if rate_limited {
-            let auth = if matches!(self.rate_limited_until_ms, Some(u) if u > now_ms) {
+            let auth = if hook_rate_limit_current {
                 Authority::Hook
             } else {
                 Authority::Screen
@@ -342,12 +360,6 @@ impl AgentRuntime {
             };
             return (ObservedState::WaitingForUser, auth, conf);
         }
-
-        // Observer-plane freshness: if no Hook/Stream evidence in the window, the real-time
-        // observer plane is stale — defer to the screen baseline (Weak), the conservative
-        // fallback. (#2413 Phase D: generalized from Hook-only to {Hook|Stream}.)
-        let observer_fresh = now_ms.saturating_sub(self.last_observer_ms) <= HOOK_FRESHNESS_MS
-            && self.last_observer_ms > 0;
 
         // (P3/P4/P5) Active family — only if an episode/tool is open AND liveness does
         // NOT contradict it (the phantom-stuck decay). If it DOES contradict, fall to Idle.
@@ -766,14 +778,38 @@ mod tests {
         );
     }
 
-    /// Precedence: rate-limit outranks an open episode; approval outranks tool-use.
+    /// Precedence (#2470-updated): a HOOK-confirmed rate-limit window outranks an open episode
+    /// (a CURRENT limit), but a SCREEN-only rate-limit banner YIELDS to a fresh post-SRL episode
+    /// (a stale banner the resumed agent moved past); approval outranks tool-use.
     #[test]
     fn precedence_orders() {
-        // RateLimited > everything: open episode + screen rate-limited.
+        // HOOK rate-limit window > open episode: a confirmed window (retry_at in the future) is a
+        // CURRENT limit and is NOT cleared by a fresh turn.
+        let mut rt = AgentRuntime::default();
+        rt.ingest(&hook(
+            EvidenceKind::RateLimited {
+                retry_at_ms: Some(9_000),
+            },
+            1_000,
+        ));
+        rt.ingest(&hook(EvidenceKind::TurnStarted, 1_050));
+        let s = rt.observe(ScreenSignal::RateLimited, &live_busy(), 1_100);
+        assert_eq!(
+            s.state,
+            ObservedState::RateLimited,
+            "a current hook rate-limit window outranks an open episode"
+        );
+
+        // #2470: a SCREEN-only rate-limit banner with a fresh open episode (no hook window) is
+        // STALE — the agent resumed — so it yields to the Active family (stops the stuck badge).
         let mut rt = AgentRuntime::default();
         rt.ingest(&hook(EvidenceKind::TurnStarted, 1_000));
         let s = rt.observe(ScreenSignal::RateLimited, &live_busy(), 1_100);
-        assert_eq!(s.state, ObservedState::RateLimited);
+        assert_ne!(
+            s.state,
+            ObservedState::RateLimited,
+            "#2470: a stale screen-only SRL banner yields to a fresh post-SRL episode"
+        );
 
         // WaitingForUser > ToolUse: a tool span is open but an approval is pending.
         let mut rt = AgentRuntime::default();


### PR DESCRIPTION
## Problem (operator-reported)

Fleet-view badge stays pinned `[ServerRateLimit]` while the agent is actually working (screenshot:
dev-2 shows "Sublimating… thinking with xhigh effort" but the badge reads ServerRateLimit). The SRL
banner lingers in the vterm tail (level-triggered, refreshed by the throttle wave), so the screen
keeps classifying ServerRateLimit even after the agent resumed.

## Root cause — two layers, not one

1. **Reducer (P1)** (`shadow/reducer.rs`): the rate-limited precedence returns `RateLimited` whenever
   `screen == RateLimited`, and it sits ABOVE the Active family — so even a fresh post-SRL hook turn
   is masked → `observed.state` stays RateLimited.
2. **Gate (c)** (`shadow/gate.rs`): a RateLimited raw screen is never overridden → badge = raw.

So gate(c) alone can't fix it (observed is also RateLimited → nothing Active to show). The fix is
two coordinated layers (lead-vetted spike, A–D).

## Fix

- **Reducer P1**: a SCREEN-only RateLimited yields to
  `resumed_post_srl = observer_fresh && episode_open && !hook_rate_limit_current` → the stale banner
  falls through to the Active family, so `observed` becomes Active/Thinking. A HOOK-confirmed window
  (`rate_limited_until_ms` in the future) is a CURRENT limit and stays RateLimited; a banner with no
  fresh episode (a genuinely failed/stuck turn — `StopFailure` closes the episode) also stays.
- **Gate (c')**: split the gate-screen rule. `Approval` is ALWAYS authoritative; a RateLimited raw is
  authoritative EXCEPT `raw == ServerRateLimit`, which falls through to the existing (a)/(b)/(d)
  high-confidence checks — so only a fresh Hook/Stream Active (the reducer's `resumed_post_srl`)
  overrides it; a current/screen-authority/RateLimited `status` fails (d) and is kept. **UsageLimit
  (user quota) and user `RateLimit` stay never-override** (operator must see them).

### Approval stays hard (gating verification)
Operator initially wanted to also drop Approval's never-override. Verification found the Approval-hook
is **unverifiable in-fleet**: claude is spawned with `--dangerously-skip-permissions`
(backend.rs:416/614) so permission prompts never occur, and the `Notification(permission_prompt)`
mapping is docs-sourced/never-observed. Hiding a pending approval (badge lies "active") is worse than
over-reporting one, so Approval's guard is kept. (Out-of-fleet live test deferred per operator.)

### No measure-only-shadow coupling (#2466 lesson)
The discriminator uses only production reducer state derived from hook/stream evidence
(`episode_open` / `observer_fresh` / `rate_limited_until_ms`) — never an `AGEND_*_SHADOW` flag.
agy (no Hook/Stream plane) → `observer_fresh = false` → never relaxes → unaffected by construction.

## Tests
- gate invariant `gate_screen_is_never_overridden` narrowed (ServerRateLimit removed; Approval +
  UsageLimit + user RateLimit stay hard) + new `server_rate_limit_overridden_only_by_fresh_hook_active`
  (Hook/Stream Active overrides; screen-authority / still-RateLimited does not).
- real-reducer end-to-end `stale_server_rate_limit_reconcile_real_reducer_2470`: resumed→Active badge;
  stuck (no episode)→stays SRL; open hook window→stays RateLimited; UsageLimit raw→stays UsageLimit.
- `precedence_orders` updated to the new precedence (hook window > episode > stale screen banner).

Retry path untouched (over-retry handled by #2466). Gates: fmt, `clippy --all-targets --features tray
-D warnings`, full `nextest` — green locally. Closes #2470. Follows #2465/#2466. Cross-model DUAL.
