### PR TITLE
feat: guard fresh restarts against uncommitted work

### DIFF
--- a/docs/MCP-TOOLS.md
+++ b/docs/MCP-TOOLS.md
@@ -94,7 +94,8 @@ Replace an instance with a fresh one.
 ### `restart_instance`
 Kill and restart an instance. Default mode `resume` preserves conversation state; `fresh` starts clean (like `replace_instance`).
 - **instance**: instance to restart
-- mode (resume / fresh), reason
+- mode (resume / fresh), reason, force
+- `fresh` refuses by default if the bound worktree has uncommitted changes (#2476); commit/push or leave a task-board handoff first, or pass `force: true`.
 
 ### `list_instances`
 List all active agent instances. Pass optional `instance` for detailed info on a single instance.

--- a/docs/MCP-TOOLS.zh-TW.md
+++ b/docs/MCP-TOOLS.zh-TW.md
@@ -94,7 +94,8 @@
 ### `restart_instance`
 終止並重啟一個 instance。預設模式 `resume` 會保留對話狀態；`fresh` 則從乾淨狀態啟動（等同 `replace_instance`）。
 - **instance**: 要重啟的 instance
-- mode (resume / fresh), reason
+- mode (resume / fresh), reason, force
+- `fresh` 預設會在 bound worktree 有未提交變更時拒絕（#2476）；請先 commit/push 或留下 task-board handoff，或傳 `force: true`。
 
 ### `list_instances`
 列出所有作用中的 agent instance。可選擇性傳入 `instance` 以取得單一 instance 的詳細資訊。

--- a/src/mcp/handlers/instance_state/mod.rs
+++ b/src/mcp/handlers/instance_state/mod.rs
@@ -405,6 +405,30 @@ pub(super) fn handle_restart_instance(home: &Path, args: &Value) -> Value {
     let reason = args["reason"].as_str().unwrap_or("manual restart");
     let mode = args["mode"].as_str().unwrap_or("resume");
 
+    // #2476: a `fresh` restart DROPS the agent's in-memory context (that is its
+    // value — it releases a stale prompt cache while a dev idles waiting on
+    // review/CI). But fresh-restart-as-routine must not silently discard
+    // UNCOMMITTED groundwork in the agent's bound worktree. Pre-flight: if the
+    // bound worktree has uncommitted changes, refuse unless `force:true`, telling
+    // the caller to push / leave a board handoff first. `resume` is unaffected
+    // (it keeps context), and an unbound agent has no worktree to protect.
+    if mode != "resume" && !args["force"].as_bool().unwrap_or(false) {
+        if let Some(wt) = crate::binding::read(home, name)
+            .and_then(|b| b["worktree"].as_str().map(std::path::PathBuf::from))
+        {
+            if wt.exists() && crate::worktree::has_uncommitted_changes(&wt) {
+                return json!({
+                    "error": "refusing fresh restart: bound worktree has uncommitted changes \
+                              that a context drop would strand. Commit/push (or leave a task-board \
+                              handoff) first, then retry — or pass force:true to drop context anyway.",
+                    "name": name,
+                    "worktree": wt.display().to_string(),
+                    "code": "uncommitted_work_at_risk",
+                });
+            }
+        }
+    }
+
     let fleet_path = crate::fleet::fleet_yaml_path(home);
     let config = match crate::fleet::FleetConfig::load(&fleet_path) {
         Ok(c) => c,
@@ -510,6 +534,94 @@ pub(super) fn resolve_team_layout(
 mod tests {
     use super::*;
     use std::collections::HashMap;
+
+    #[allow(clippy::unwrap_used, clippy::expect_used)]
+    fn dirty_worktree(tag: &str) -> std::path::PathBuf {
+        let wt = std::env::temp_dir().join(format!(
+            "agend-2476-{tag}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&wt).unwrap();
+        let git = |args: &[&str]| {
+            std::process::Command::new("git")
+                .args(args)
+                .current_dir(&wt)
+                .env("AGEND_GIT_BYPASS", "1")
+                .output()
+                .expect("git");
+        };
+        git(&["init", "-b", "main"]);
+        // Untracked file → `git status --porcelain` non-empty → work-at-risk.
+        std::fs::write(wt.join("wip.txt"), "uncommitted groundwork").unwrap();
+        wt
+    }
+
+    #[allow(clippy::unwrap_used, clippy::expect_used)]
+    fn bind_worktree(home: &std::path::Path, agent: &str, wt: &std::path::Path) {
+        let dir = crate::paths::runtime_dir(home).join(agent);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("binding.json"),
+            serde_json::json!({"worktree": wt.display().to_string()}).to_string(),
+        )
+        .unwrap();
+    }
+
+    /// #2476: a `fresh` restart must refuse when the bound worktree has
+    /// uncommitted changes (context drop would strand them), unless `force`.
+    /// `resume` keeps context so it is never guarded.
+    #[test]
+    #[allow(clippy::unwrap_used, clippy::expect_used)]
+    fn fresh_restart_guards_uncommitted_worktree_2476() {
+        let home = std::env::temp_dir().join(format!(
+            "agend-2476-home-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&home).unwrap();
+        let wt = dirty_worktree("wt");
+        bind_worktree(&home, "dev", &wt);
+
+        // fresh + dirty + no force → refused at the guard (before any spawn).
+        let refused = handle_restart_instance(
+            &home,
+            &serde_json::json!({"instance": "dev", "mode": "fresh"}),
+        );
+        assert_eq!(
+            refused["code"], "uncommitted_work_at_risk",
+            "got: {refused}"
+        );
+
+        // force bypasses the guard (proceeds past it — a later error is NOT the guard).
+        let forced = handle_restart_instance(
+            &home,
+            &serde_json::json!({"instance": "dev", "mode": "fresh", "force": true}),
+        );
+        assert_ne!(
+            forced["code"], "uncommitted_work_at_risk",
+            "force must bypass: {forced}"
+        );
+
+        // resume keeps context → never guarded.
+        let resumed = handle_restart_instance(
+            &home,
+            &serde_json::json!({"instance": "dev", "mode": "resume"}),
+        );
+        assert_ne!(
+            resumed["code"], "uncommitted_work_at_risk",
+            "resume must not guard: {resumed}"
+        );
+
+        std::fs::remove_dir_all(&home).ok();
+        std::fs::remove_dir_all(&wt).ok();
+    }
 
     // #1625: every restart, regardless of mode, must carry the same-tab layout
     // hint so the respawned pane returns to its original tab (the fresh path

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -132,7 +132,8 @@ pub(crate) fn def_restart_instance() -> Value {
         "inputSchema": {"type": "object", "properties": {
             "instance": {"type": "string", "description": "Name of the existing instance to restart"},
             "mode": {"type": "string", "enum": ["resume", "fresh"], "default": "resume", "description": "resume = keep conversation (--continue/--resume); fresh = clean start"},
-            "reason": {"type": "string"}
+            "reason": {"type": "string"},
+            "force": {"type": "boolean", "description": "#2476: allow a `fresh` restart even when the bound worktree has uncommitted changes (default false refuses, to avoid stranding un-pushed groundwork)."}
         }, "required": ["instance"]}})
 }
 
@@ -1019,6 +1020,11 @@ mod tests {
             ("restart_instance", "instance", "mcp/handlers/instance.rs restart target"),
             ("restart_instance", "mode", "mcp/handlers/instance.rs restart_spawn_params --continue/--resume"),
             ("restart_instance", "reason", "mcp/handlers/instance.rs restart event"),
+            (
+                "restart_instance",
+                "force",
+                "instance_state/mod.rs fresh-restart uncommitted-work guard bypass (#2476)",
+            ),
             // ── watchdog / config / mode ──
             ("watchdog", "action", "mcp/handlers/dispatch.rs snooze/resume/status/ack"),
             ("watchdog", "duration", "mcp/handlers/dispatch.rs parse_duration_secs (snooze)"),

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -625,6 +625,7 @@ pub(crate) use gc::{
 
 mod target_sweep;
 #[cfg(test)]
+#[allow(unused_imports)] // Unix-only target_sweep tests use these seams; Windows may not.
 pub(crate) use target_sweep::{
     safe_managed_root, target_sweep_candidates_with_roster, target_sweep_run_with_roster,
     validate_target_for_delete,


### PR DESCRIPTION
## What & why

Implements the safe, low-risk first step for #2476: make `restart_instance(mode=fresh)` safe enough to use as a routine context-release mechanism after a dev has pushed / handed off work.

A fresh restart deliberately drops in-memory LLM context. That is useful for avoiding cold prompt-cache re-reads while a dev waits on review/CI, but it must not strand uncommitted groundwork in the bound worktree. This PR adds a pre-flight guard:

- `fresh` restart checks the agent's bound worktree for uncommitted changes and refuses with `code: "uncommitted_work_at_risk"` unless `force:true` is set.
- `resume` restart is unchanged.
- unbound agents are unchanged.
- schema/docs mention the new `force` opt-out.

## Verification

- `cargo test --bin agend-terminal fresh_restart_guards_uncommitted_worktree_2476 -- --test-threads=1`
- `cargo test --bin agend-terminal mcp::tools::tests::coordination_tool_schema_fields_are_consumed_or_deferred`
- `cargo test --bin agend-terminal mcp::registry::tests::docs_match_registry_tool_set`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`

## Notes

This PR intentionally does **not** auto-park or auto-restart agents. It adds the safety guard required before making fresh-restart a standard workflow/daemon-assisted step.

Closes #2476
