### PR TITLE
feat: task get + minimal list projection (#2475 Phase 2)

### DIFF
--- a/docs/MCP-TOOLS.md
+++ b/docs/MCP-TOOLS.md
@@ -5,10 +5,12 @@
 ## Action-based Tools
 
 ### `task`
-Manage task board. Actions: create, list, claim, done, update.
-- **action**: create / list / claim / done / update
-- title, description, id, assignee, priority, status, branch, depends_on, filter_status, filter_assignee, result, due_at, duration
+Manage task board. Actions: create, list, get, claim, done, update.
+- **action**: create / list / get / claim / done / update
+- title, description, id, assignee, priority, status, branch, depends_on, filter_status, filter_assignee, result, due_at, duration, fields
 - `list` is **terse by default** (#2475): `description` / `result` are length-capped (~200 chars). Pass `verbose: true` for full text; response carries `terse: true` when capping fired.
+- `list` accepts `fields: "minimal"` (#2475) to project rows down to id/title/status/assignee/priority; response carries `fields: "minimal"|"full"`.
+- `get` (#2475) returns ONE task's FULL record by `id` (alias `task_id`) — the companion to the terse `list` when you need one task's full text.
 
 ### `decision`
 Manage decisions. Actions: post, list, update.

--- a/docs/MCP-TOOLS.zh-TW.md
+++ b/docs/MCP-TOOLS.zh-TW.md
@@ -5,10 +5,12 @@
 ## 動作型工具（Action-based Tools）
 
 ### `task`
-管理 task board。動作：create、list、claim、done、update。
-- **action**: create / list / claim / done / update
-- title, description, id, assignee, priority, status, branch, depends_on, filter_status, filter_assignee, result, due_at, duration
+管理 task board。動作：create、list、get、claim、done、update。
+- **action**: create / list / get / claim / done / update
+- title, description, id, assignee, priority, status, branch, depends_on, filter_status, filter_assignee, result, due_at, duration, fields
 - `list` 預設為**精簡模式**（#2475）：`description`／`result` 會限制長度（約 200 字）。傳 `verbose: true` 可取回完整文字；回應中的 `terse: true` 表示已套用精簡。
+- `list` 可傳 `fields: "minimal"`（#2475）只投影 id/title/status/assignee/priority；回應帶 `fields: "minimal"|"full"`。
+- `get`（#2475）以 `id`（別名 `task_id`）回傳單一任務的**完整**記錄 —— 搭配精簡 `list`，需要單筆完整內容時使用。
 
 ### `decision`
 管理 decision。動作：post、list、update。

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -214,9 +214,9 @@ pub(crate) fn def_decision() -> Value {
 }
 
 pub(crate) fn def_task() -> Value {
-    json!({"name": "task", "description": "Manage task board. Actions: create, list, claim, done, update, sweep, health, activity, metadata_set, metadata_get. #806: default list trims to actionable statuses (open/claimed/in_progress/blocked); pass include_history=true to surface done/cancelled. `sweep` is operator-triggered manual hygiene (5 stale-task categories with dry-run + confirm_ids round-trip). #830: `health` is a one-shot board-hygiene snapshot — totals + by_status + ghost_owners + stale_claims + age aggregates + recommendations array.",
+    json!({"name": "task", "description": "Manage task board. Actions: create, list, get, claim, done, update, sweep, health, activity, metadata_set, metadata_get. #2475: `get` returns ONE task's FULL record by `id` (companion to the terse-by-default `list`); `list` accepts `fields:\"minimal\"` to project rows down to id/title/status/assignee/priority. #806: default list trims to actionable statuses (open/claimed/in_progress/blocked); pass include_history=true to surface done/cancelled. `sweep` is operator-triggered manual hygiene (5 stale-task categories with dry-run + confirm_ids round-trip). #830: `health` is a one-shot board-hygiene snapshot — totals + by_status + ghost_owners + stale_claims + age aggregates + recommendations array.",
         "inputSchema": {"type": "object", "properties": {
-            "action": {"type": "string", "enum": ["create", "list", "claim", "done", "update", "sweep", "health", "activity", "metadata_set", "metadata_get"]},
+            "action": {"type": "string", "enum": ["create", "list", "get", "claim", "done", "update", "sweep", "health", "activity", "metadata_set", "metadata_get"]},
             "title": {"type": "string"}, "description": {"type": "string"},
             "priority": {"type": "string", "enum": ["low", "normal", "high", "urgent"]},
             "assignee": {"type": "string"}, "depends_on": {"type": "array", "items": {"type": "string"}}, "parent_id": {"type": "string", "description": "Parent task ID for subtask composition (A is composed of B,C,D). Complementary to depends_on (execution order)."},
@@ -225,6 +225,7 @@ pub(crate) fn def_task() -> Value {
             "filter_assignee": {"type": "string", "description": "list: filter by assignee (alias: assignee)."}, "filter_status": {"type": "string", "description": "list: filter by status (alias: status)."}, "filter_tag": {"type": "string", "description": "Filter by tag (alias: tag)"}, "tag": {"type": "string", "description": "Alias of filter_tag (#2037)."}, "tags": {"type": "array", "items": {"type": "string"}, "description": "Task tags (for create/update)"},
             "include_history": {"type": "boolean", "description": "#806: opt in to done/cancelled in `list` response (default trims to actionable)."},
             "verbose": {"type": "boolean", "description": "#2475 list: default is TERSE — `description`/`result` are length-capped (~200 chars) to keep routine list calls small. Set true for the full text (or fetch a single task's detail). Response carries `terse: true` when capping fired."},
+            "fields": {"type": "string", "enum": ["full", "minimal"], "description": "#2475 list: column projection. `minimal` keeps only id/title/status/assignee/priority (drops every other field) for the lightest routine poll; default `full` is unchanged. Response carries `fields: \"minimal\"|\"full\"`."},
             "limit": {"type": "integer", "description": "#806: cap `list` response to N newest-first entries (sort by updated_at desc)."},
             "due_at": {"type": "string", "description": "ISO 8601 deadline for the task"},
             "branch": {"type": "string", "description": "Git branch the implementer should work on"},
@@ -887,6 +888,7 @@ mod tests {
             ("task", "tags", "tasks/handler.rs create/update"),
             ("task", "include_history", "tasks/handler.rs list opt-in"),
             ("task", "verbose", "tasks/handler.rs list full-text opt-in (#2475)"),
+            ("task", "fields", "tasks/handler.rs list minimal projection (#2475 Phase 2)"),
             ("task", "limit", "tasks/handler.rs list cap"),
             ("task", "due_at", "tasks/handler.rs create deadline"),
             ("task", "branch", "tasks/handler.rs create event"),

--- a/src/tasks/handler.rs
+++ b/src/tasks/handler.rs
@@ -43,6 +43,7 @@ pub fn handle(home: &Path, instance_name: &str, args: &Value) -> Value {
     match action {
         "create" => handle_create(home, emitter, args),
         "list" => handle_list(home, instance_name, args),
+        "get" => handle_get(home, instance_name, args),
         "claim" => handle_claim(home, instance_name, emitter, args),
         "done" => handle_done(home, instance_name, emitter, args),
         "update" => handle_update(home, instance_name, emitter, args),
@@ -292,6 +293,11 @@ fn handle_list(home: &Path, caller: &str, args: &Value) -> Value {
     // `description`/`result` fields; truncate them by default and let callers
     // opt into the full text with `verbose: true` (or fetch one task's detail).
     let verbose = args["verbose"].as_bool().unwrap_or(false);
+    // #2475 Phase 2: opt-in column projection. `fields:"minimal"` keeps only the
+    // routing-relevant columns (id/title/status/assignee/priority) so a lead can
+    // poll the board for state without pulling every structured field into
+    // context. Default ("full") is unchanged — additive, non-breaking shape.
+    let minimal = args["fields"].as_str() == Some("minimal");
     if fleet_scope {
         let mut tagged: Vec<Value> = filtered
             .iter()
@@ -308,11 +314,17 @@ fn handle_list(home: &Path, caller: &str, args: &Value) -> Value {
                 terse_task_value(v);
             }
         }
+        if minimal {
+            for v in &mut tagged {
+                minimal_task_value(v);
+            }
+        }
         return serde_json::json!({
             "tasks": tagged,
             "filtered_default": filtered_default,
             "scope": "fleet",
             "terse": !verbose,
+            "fields": if minimal { "minimal" } else { "full" },
         });
     }
     let mut tasks: Vec<Value> = filtered
@@ -324,10 +336,16 @@ fn handle_list(home: &Path, caller: &str, args: &Value) -> Value {
             terse_task_value(v);
         }
     }
+    if minimal {
+        for v in &mut tasks {
+            minimal_task_value(v);
+        }
+    }
     serde_json::json!({
         "tasks": tasks,
         "filtered_default": filtered_default,
         "terse": !verbose,
+        "fields": if minimal { "minimal" } else { "full" },
     })
 }
 
@@ -347,6 +365,60 @@ fn terse_task_value(v: &mut Value) {
                 *s = format!("{kept}… (+{dropped} chars; verbose=true for full)");
             }
         }
+    }
+}
+
+/// #2475 Phase 2: project a serialized task down to the minimal routing columns
+/// for `fields:"minimal"` list calls. Whitelists id/title/status/assignee/
+/// priority (plus the fleet-scope `project` tag when present) and drops every
+/// other field. Opt-in only — the default list shape is unchanged, so existing
+/// callers that deserialize full `Task` rows are unaffected.
+fn minimal_task_value(v: &mut Value) {
+    const KEEP: &[&str] = &["id", "title", "status", "assignee", "priority", "project"];
+    let Some(obj) = v.as_object_mut() else { return };
+    obj.retain(|k, _| KEEP.contains(&k.as_str()));
+}
+
+/// #2475 Phase 2: single-task detail fetch. The terse-by-default `list` caps
+/// `description`/`result`; `get` is the companion that returns ONE task's FULL
+/// record by id, so a caller can pull the full text of just the task it cares
+/// about instead of re-listing the whole board with `verbose:true`. Resolves the
+/// task on the caller's current project board first, then falls back to scanning
+/// every board (the id may live elsewhere). Returns `{ "task": {...} }` or an
+/// `{ "error": ... }` when the id is absent.
+fn handle_get(home: &Path, caller: &str, args: &Value) -> Value {
+    let Some(id) = id_arg(args).map(str::to_string) else {
+        return serde_json::json!({"error": "missing 'id' (or 'task_id')"});
+    };
+    // Primary board: explicit `project`, else the caller's current project.
+    let project = args["project"]
+        .as_str()
+        .map(String::from)
+        .unwrap_or_else(|| super::board_router::resolve_current_project(home, caller));
+    let board = crate::task_events::board_root(home, &project);
+    let mut found = super::list_all_at(home, &board)
+        .into_iter()
+        .find(|t| t.id == id);
+    let mut found_project = found.as_ref().map(|_| project);
+    // Cross-board fallback: the id may live on another project's board.
+    if found.is_none() {
+        for (p, ts) in super::board_router::list_all_boards(home) {
+            if let Some(t) = ts.into_iter().find(|t| t.id == id) {
+                found_project = Some(p);
+                found = Some(t);
+                break;
+            }
+        }
+    }
+    match found {
+        Some(t) => {
+            let mut v = serde_json::to_value(&t).unwrap_or(Value::Null);
+            if let (Some(obj), Some(p)) = (v.as_object_mut(), found_project) {
+                obj.insert("project".to_string(), Value::String(p));
+            }
+            serde_json::json!({ "task": v })
+        }
+        None => serde_json::json!({"error": format!("task not found: {id}")}),
     }
 }
 

--- a/src/tasks/tests.rs
+++ b/src/tasks/tests.rs
@@ -708,6 +708,108 @@ fn task_list_truncates_heavy_text_by_default_2475() {
 }
 
 #[test]
+fn task_get_returns_single_full_task_2475() {
+    let home = tmp_home("get-2475");
+    let long_description = "d".repeat(260);
+    let created = handle(
+        &home,
+        "agent1",
+        &serde_json::json!({
+            "action": "create",
+            "title": "detailed task",
+            "description": long_description,
+        }),
+    );
+    let id = created["id"].as_str().expect("id").to_string();
+
+    let got = handle(
+        &home,
+        "agent1",
+        &serde_json::json!({"action": "get", "id": id}),
+    );
+    let t = &got["task"];
+    assert_eq!(t["id"], id);
+    assert_eq!(t["title"], "detailed task");
+    // get is FULL by design — the heavy field is NOT capped.
+    assert_eq!(t["description"], long_description);
+
+    // task_id alias works too.
+    let via_alias = handle(
+        &home,
+        "agent1",
+        &serde_json::json!({"action": "get", "task_id": id}),
+    );
+    assert_eq!(via_alias["task"]["id"], id);
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn task_get_missing_id_and_not_found_errors_2475() {
+    let home = tmp_home("get-missing-2475");
+    let no_id = handle(&home, "agent1", &serde_json::json!({"action": "get"}));
+    assert!(
+        no_id["error"].as_str().unwrap().contains("missing"),
+        "missing id must error: {no_id}"
+    );
+
+    let absent = handle(
+        &home,
+        "agent1",
+        &serde_json::json!({"action": "get", "id": "t-does-not-exist"}),
+    );
+    assert!(
+        absent["error"].as_str().unwrap().contains("not found"),
+        "absent id must error: {absent}"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn task_list_fields_minimal_projects_rows_2475() {
+    let home = tmp_home("list-minimal-2475");
+    let created = handle(
+        &home,
+        "agent1",
+        &serde_json::json!({
+            "action": "create",
+            "title": "projected task",
+            "description": "some description text",
+            "assignee": "agent1",
+        }),
+    );
+    let id = created["id"].as_str().expect("id").to_string();
+
+    let listed = handle(
+        &home,
+        "agent1",
+        &serde_json::json!({"action": "list", "fields": "minimal"}),
+    );
+    assert_eq!(listed["fields"], "minimal");
+    let row = &listed["tasks"][0];
+    // Kept columns.
+    assert_eq!(row["id"], id);
+    assert_eq!(row["title"], "projected task");
+    assert!(row.get("status").is_some());
+    assert_eq!(row["assignee"], "agent1");
+    assert!(row.get("priority").is_some());
+    // Dropped columns.
+    assert!(
+        row.get("description").is_none(),
+        "minimal projection must drop description: {row}"
+    );
+    assert!(
+        row.get("created_at").is_none(),
+        "minimal projection must drop created_at: {row}"
+    );
+
+    // Default list keeps the full shape.
+    let full = handle(&home, "agent1", &serde_json::json!({"action": "list"}));
+    assert_eq!(full["fields"], "full");
+    assert!(full["tasks"][0].get("description").is_some());
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
 fn test_create_list_claim_done() {
     let home = tmp_home("crud");
     let r = handle(


### PR DESCRIPTION
## Summary
Phase 2 of #2475 — additive, non-breaking MCP read-volume cuts (Phase 1 terse/compact already landed in f31d9f76).

- **`task action=get`**: returns ONE task's FULL record by `id` (alias `task_id`). Companion to the terse-by-default `list` — pull one task's full text instead of re-listing the whole board with `verbose:true`. Resolves the caller's project board first, then falls back to scanning all boards.
- **`task list` `fields:\"minimal\"`**: projects rows down to id/title/status/assignee/priority (drops every other field) for the lightest routine poll. Default `full` shape is unchanged.
- Schema (action enum + `fields`), `#1933` CONSUMED audit entry, and `MCP-TOOLS.md` (+ zh-TW) updated.

Why non-breaking: existing callers/tests deserialize full `Task` rows on the default `list`; projection and `get` are strictly opt-in, so no response shape changes by default (the reason Phase 1 left the aggressive projection for a separate phase).

## Tests
- `cargo fmt --check`
- `cargo test --bin agend-terminal tasks::tests::` (106 pass; +3 new: get full/alias, get missing/not-found, minimal projection)
- `cargo test --bin agend-terminal coordination_tool_schema_fields_are_consumed_or_deferred`
- `cargo test --bin agend-terminal docs_match_registry_tool_set`
- `cargo test --test src_file_size_invariant`
- `cargo clippy --all-targets --features tray -- -D warnings`

Refs #2475