### PR TITLE
fix: auto-ack daemon inbox notifications

### DIFF
--- a/src/inbox/storage.rs
+++ b/src/inbox/storage.rs
@@ -502,11 +502,19 @@ pub fn drain(home: &Path, name: &str) -> Vec<InboxMessage> {
                     continue;
                 }
                 budget_used += sz;
-                // #2299: unread → DELIVERING (not processed). read_at stays None
-                // until the agent acks (explicit `inbox ack` / implicit next-drain)
-                // or the reclaim-TTL resets it. A turn dying after this drain leaves
-                // the row `delivering` → reclaimed → re-delivered (no silent loss).
-                msg.delivering_at = Some(now.clone());
+                if auto_ack_on_drain_kind(&msg) {
+                    // Fire-and-forget notifications have no blocked sender and no
+                    // required reply. Return them to the agent once, but settle them
+                    // immediately so daemon restarts cannot resurrect completed
+                    // PR/CI/status chatter through the delivering reclaim path.
+                    msg.read_at = Some(now.clone());
+                } else {
+                    // #2299: unread → DELIVERING (not processed). read_at stays None
+                    // until the agent acks (explicit `inbox ack` / implicit next-drain)
+                    // or the reclaim-TTL resets it. A turn dying after this drain leaves
+                    // the row `delivering` → reclaimed → re-delivered (no silent loss).
+                    msg.delivering_at = Some(now.clone());
+                }
                 changed = true;
                 // #1888: a `ci-ready-for-action` handoff just transitioned to
                 // DELIVERING on this drain (#2299: was "read" pre-3-state). Phase-1
@@ -1176,30 +1184,48 @@ fn reclaim_renudge_worthy(home: &Path, msg: &InboxMessage) -> bool {
 /// every recognised non-obligation kind to `None`, so without this helper an
 /// unrecognised future kind would be indistinguishable from a non-obligation and
 /// silently dropped from the reclaim re-nudge. The known set mirrors the kinds the
-/// daemon emits today: `query` / `task` (obligations) + `report` / `update` /
-/// `ci-watch` / `poll` (non-obligations), plus a plain `kind=None`. Anything else →
-/// `true` (unknown → conservatively re-arm; failure mode = noise, never silent loss).
+/// daemon emits today: `query` / `task` (obligations) plus the
+/// [`known_fire_and_forget_kind`] set, plus a plain `kind=None`. Anything else
+/// → `true` (unknown → conservatively re-arm; failure mode = noise, never silent
+/// loss).
 fn kind_is_unknown(msg: &InboxMessage) -> bool {
     match msg.kind.as_deref() {
         None => false, // a plain message is a recognised non-obligation
-        Some(k) => !matches!(
-            k,
-            "query" | "task" | "report" | "update" | "ci-watch" | "poll"
-        ),
+        Some("query" | "task") => false,
+        Some(_) => !known_fire_and_forget_kind(msg),
     }
 }
 
 /// Recognised fire-and-forget *kinds* have no outstanding obligation once they
-/// were delivered once. If their turn never explicitly acked them, reclaim must
-/// settle them to `processed` instead of making them unread again; otherwise old
-/// `report`/`update` rows can loop forever through poll-reminder (#2482).
+/// were delivered once. Reclaim uses this for rows left in `delivering`;
+/// otherwise old `report`/`update`/`pr-merged` rows can loop forever through
+/// poll-reminder (#2482 / ghost pr-merged).
 ///
 /// Plain `kind=None` rows intentionally stay outside this set: #2299's core
 /// anti-silent-loss guarantee still redelivers generic messages after a dead turn.
-fn known_non_obligation_kind(msg: &InboxMessage) -> bool {
+fn known_fire_and_forget_kind(msg: &InboxMessage) -> bool {
     matches!(
         msg.kind.as_deref(),
-        Some("report" | "update" | "ci-watch" | "poll")
+        Some(
+            "report"
+                | "update"
+                | "ci-watch"
+                | "ci-watch-stalled"
+                | "ci-watch-resumed"
+                | "poll"
+                | "pr-merged"
+        )
+    )
+}
+
+/// Daemon-originated notification kinds that are safe to settle on first drain.
+/// This is narrower than [`known_fire_and_forget_kind`]: peer `report`/`update`
+/// messages keep #2299's delivering/ack behavior on first drain, while pure
+/// daemon notifications avoid the restart/reclaim loop entirely.
+fn auto_ack_on_drain_kind(msg: &InboxMessage) -> bool {
+    matches!(
+        msg.kind.as_deref(),
+        Some("ci-watch" | "ci-watch-stalled" | "ci-watch-resumed" | "poll" | "pr-merged")
     )
 }
 
@@ -1401,11 +1427,11 @@ pub fn reclaim_stale_delivering(home: &Path) {
                             })
                             .unwrap_or(true); // unparseable timestamp → reclaim (fail-safe)
                         if stale {
-                            if known_non_obligation_kind(&msg) {
-                                // #2482: fire-and-forget rows (report/update/ci-watch/poll)
-                                // were already delivered once and have no actor blocked on them.
-                                // Reverting them to unread lets poll-reminder/drain resurrect old
-                                // completed-task chatter forever. Terminally settle instead.
+                            if known_fire_and_forget_kind(&msg) {
+                                // #2482: fire-and-forget rows were already delivered once
+                                // and have no actor blocked on them. Reverting them to
+                                // unread lets poll-reminder/drain resurrect old completed
+                                // PR/CI/status chatter forever. Terminally settle instead.
                                 msg.read_at = Some(now.to_rfc3339());
                                 settled_non_obligations += 1;
                             } else {

--- a/src/inbox/tests.rs
+++ b/src/inbox/tests.rs
@@ -834,6 +834,57 @@ fn test_drain_marks_delivering_then_implicit_ack_keeps_message() {
     fs::remove_dir_all(&home).ok();
 }
 
+#[test]
+fn drain_auto_acks_daemon_notifications() {
+    for (kind, from, body) in [
+        (
+            "pr-merged",
+            "system:pr-state",
+            "[pr-merged] owner/repo@branch",
+        ),
+        ("ci-watch", "system:ci", "[ci-pass] owner/repo@branch"),
+    ] {
+        let home = tmp_home(&format!("drain-{kind}-auto-ack"));
+        let id = format!("m-{kind}");
+        enqueue(
+            &home,
+            "agent1",
+            msg().sender(from).text(body).kind(kind).id(&id).build(),
+        )
+        .ok();
+
+        let msgs = drain(&home, "agent1");
+        assert_eq!(msgs.len(), 1, "{kind} still surfaces to the agent");
+        assert_eq!(msgs[0].id.as_deref(), Some(id.as_str()));
+        assert!(
+            msgs[0].read_at.is_some(),
+            "fire-and-forget {kind} must be processed on first drain"
+        );
+        assert!(
+            msgs[0].delivering_at.is_none(),
+            "{kind} must not wait in delivering for a later ack"
+        );
+
+        let content = fs::read_to_string(inbox_path(&home, "agent1")).unwrap();
+        let persisted: InboxMessage =
+            serde_json::from_str(content.lines().next().unwrap()).unwrap();
+        assert!(persisted.read_at.is_some());
+        assert!(persisted.delivering_at.is_none());
+        assert_eq!(
+            unread_count(&home, "agent1").0,
+            0,
+            "auto-acked notification must not drive poll-reminder unread count"
+        );
+
+        let second = drain(&home, "agent1");
+        assert!(
+            second.is_empty(),
+            "auto-acked {kind} must not be returned again"
+        );
+        fs::remove_dir_all(&home).ok();
+    }
+}
+
 // ─────────────────────────────────────────────────────────────────────────
 // #2299 three-state delivery: unread → delivering → processed + reclaim-TTL.
 // ─────────────────────────────────────────────────────────────────────────
@@ -875,6 +926,39 @@ fn reclaim_redelivers_after_turn_death() {
     assert_eq!(redelivered[0].id.as_deref(), Some("m-stale"));
     assert!(redelivered[0].delivering_at.is_some());
     assert!(redelivered[0].read_at.is_none());
+    fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn reclaim_settles_legacy_stale_pr_merged_delivering_row() {
+    let home = tmp_home("reclaim-pr-merged-settle");
+    enqueue(
+        &home,
+        "a",
+        msg()
+            .sender("system:pr-state")
+            .text("[pr-merged] owner/repo@branch")
+            .kind("pr-merged")
+            .id("m-pr-merged-stale")
+            .delivering_at(&secs_ago(660))
+            .build(),
+    )
+    .unwrap();
+
+    reclaim_stale_delivering(&home);
+
+    let post = drain(&home, "a");
+    assert!(
+        post.is_empty(),
+        "stale pr-merged notification must be settled, not re-delivered"
+    );
+    let content = fs::read_to_string(inbox_path(&home, "a")).unwrap();
+    let persisted: InboxMessage = serde_json::from_str(content.lines().next().unwrap()).unwrap();
+    assert!(persisted.read_at.is_some());
+    assert!(
+        persisted.delivering_at.is_some(),
+        "settle stamps read_at; delivering_at may remain as historical audit"
+    );
     fs::remove_dir_all(&home).ok();
 }
 


### PR DESCRIPTION
## Summary
- Auto-ack daemon-generated fire-and-forget inbox notifications on first drain, so `pr-merged` / `ci-watch` rows do not sit in `delivering` waiting for a later implicit or explicit ACK.
- Add `pr-merged` and CI health notifications to the known fire-and-forget set used by reclaim, so legacy stale `delivering` rows settle instead of returning to unread.
- Keep peer `report` / `update` first-drain behavior unchanged; they only use the existing reclaim settle fallback.

## Root Cause
`pr-merged` messages were neither auto-acked on drain nor recognized as a known non-obligation kind. If the daemon restarted while the row was `delivering`, reclaim could turn it back into `unread`; because `pr-merged` looked unknown, it could keep re-arming poll reminders and reappearing.

## Tests
- `cargo fmt --check`
- `git diff --check`
- `cargo test -q inbox::tests`
- `cargo test -q drain_auto_acks_daemon_notifications`
- `cargo test -q reclaim_settles_legacy_stale_pr_merged_delivering_row`

Closes no issue (operator-reported live bug).
