### PR TITLE
Route MCP list_instances through runtime state

### DIFF
--- a/src/api/handlers/mcp_proxy.rs
+++ b/src/api/handlers/mcp_proxy.rs
@@ -135,7 +135,19 @@ pub(crate) fn handle_mcp_tool(params: &Value, ctx: &HandlerCtx) -> Value {
         });
     }
     let timeout = tool_timeout(tool);
-    handle_mcp_tool_inner(tool, args, instance, timeout, crate::mcp::execute_tool)
+    let runtime = crate::mcp::handlers::dispatch::RuntimeContext {
+        registry: ctx.registry.clone(),
+        externals: ctx.externals.clone(),
+    };
+    handle_mcp_tool_inner(
+        tool,
+        args,
+        instance,
+        timeout,
+        move |tool, args, instance| {
+            crate::mcp::execute_tool_with_runtime(tool, args, instance, runtime)
+        },
+    )
 }
 
 /// Inner proxy with an injectable executor + explicit timeout — the §3.9 test

--- a/src/api/handlers/query.rs
+++ b/src/api/handlers/query.rs
@@ -4,10 +4,18 @@
 //! without mutating state.
 
 use super::HandlerCtx;
-use crate::agent;
+use crate::agent::{self, AgentRegistry, ExternalRegistry};
 use serde_json::{json, Value};
 
 pub(crate) fn handle_list(_params: &Value, ctx: &HandlerCtx) -> Value {
+    list_response(ctx.home, ctx.registry, ctx.externals)
+}
+
+pub(crate) fn list_response(
+    home: &std::path::Path,
+    registry: &AgentRegistry,
+    externals: &ExternalRegistry,
+) -> Value {
     // H9: snapshot each managed agent's fields UNDER the tier-1 registry lock,
     // then drop(reg) BEFORE the per-agent dispatch_idle disk I/O. The original
     // called `pending_for_instance` (→ `read_dir` + a `read_to_string` +
@@ -16,7 +24,7 @@ pub(crate) fn handle_list(_params: &Value, ctx: &HandlerCtx) -> Value {
     // N*M file reads/parses entirely under the lock — blocking every other API
     // handler, the supervisor tick, crash-respawn, hang-detection and the TUI
     // render path on disk contention. Mirrors the external-agent loop below.
-    let reg = agent::lock_registry(ctx.registry);
+    let reg = agent::lock_registry(registry);
     let snapshot: Vec<(String, Value)> = reg
         .values()
         .map(|handle| {
@@ -95,7 +103,7 @@ pub(crate) fn handle_list(_params: &Value, ctx: &HandlerCtx) -> Value {
     let mut agents: Vec<Value> = Vec::with_capacity(snapshot.len());
     for (name, mut entry) in snapshot {
         let (dispatched_waiting_for, pending_response_to) =
-            crate::daemon::dispatch_idle::pending_for_instance(ctx.home, &name);
+            crate::daemon::dispatch_idle::pending_for_instance(home, &name);
         if let Some(obj) = entry.as_object_mut() {
             obj.insert(
                 "dispatched_waiting_for".into(),
@@ -105,10 +113,10 @@ pub(crate) fn handle_list(_params: &Value, ctx: &HandlerCtx) -> Value {
         }
         agents.push(entry);
     }
-    let ext = agent::lock_external(ctx.externals);
+    let ext = agent::lock_external(externals);
     for (name, handle) in ext.iter() {
         let (dispatched_waiting_for, pending_response_to) =
-            crate::daemon::dispatch_idle::pending_for_instance(ctx.home, name);
+            crate::daemon::dispatch_idle::pending_for_instance(home, name);
         agents.push(json!({
             "name": name,
             "backend": handle.backend_command,

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -21,6 +21,14 @@ pub mod request_dedup;
 
 pub type ConfigRegistry = Arc<Mutex<HashMap<String, crate::daemon::AgentConfig>>>;
 
+pub(crate) fn list_response(
+    home: &std::path::Path,
+    registry: &crate::agent::AgentRegistry,
+    externals: &crate::agent::ExternalRegistry,
+) -> serde_json::Value {
+    handlers::query::list_response(home, registry, externals)
+}
+
 // ---------------------------------------------------------------------------
 // ApiNotifier — decouples api.rs from the TUI layer
 // ---------------------------------------------------------------------------

--- a/src/mcp/handlers/ci/review_repro_mcp_ci_worktree.rs
+++ b/src/mcp/handlers/ci/review_repro_mcp_ci_worktree.rs
@@ -87,6 +87,7 @@ fn unwatch_uses_validated_caller_not_clear_all_mcp_ci_worktree() {
         args: &unwatch_args,
         instance_name: "lead",
         sender: &no_sender,
+        runtime: None,
     };
     let resp = crate::mcp::handlers::dispatch::try_dispatch("ci", &ctx)
         .expect("ci tool must be registered in the dispatch table");

--- a/src/mcp/handlers/dispatch.rs
+++ b/src/mcp/handlers/dispatch.rs
@@ -41,6 +41,16 @@ pub(crate) struct HandlerCtx<'a> {
     pub args: &'a Value,
     pub instance_name: &'a str,
     pub sender: &'a Option<Sender>,
+    pub runtime: Option<&'a RuntimeContext>,
+}
+
+/// Optional daemon runtime state available only when MCP tools are executed
+/// through the in-process API `mcp_tool` path. Standalone bridge calls leave it
+/// absent and keep the legacy socket/fallback behavior.
+#[derive(Clone)]
+pub(crate) struct RuntimeContext {
+    pub registry: crate::agent::AgentRegistry,
+    pub externals: crate::agent::ExternalRegistry,
 }
 
 /// One MCP tool's dispatcher. Function pointer (not `Box<dyn …>`) so
@@ -184,11 +194,9 @@ macro_rules! action_adapter {
 // Flat adapters — one per simple (non-action-based) tool.
 // ---------------------------------------------------------------------
 
-adapter!(
-    dispatch_list_instances,
-    hai,
-    instance::handle_list_instances
-);
+pub(crate) fn dispatch_list_instances(ctx: &HandlerCtx<'_>) -> Value {
+    instance::handle_list_instances_with_runtime(ctx.home, ctx.args, ctx.instance_name, ctx.runtime)
+}
 adapter!(
     dispatch_create_instance,
     hai,
@@ -566,6 +574,7 @@ mod tests {
             args,
             instance_name: instance,
             sender: &EMPTY_SENDER,
+            runtime: None,
         }
     }
 

--- a/src/mcp/handlers/instance_queries.rs
+++ b/src/mcp/handlers/instance_queries.rs
@@ -1,8 +1,14 @@
 use crate::agent_ops::{list_agents, merge_metadata};
+use crate::mcp::handlers::dispatch::RuntimeContext;
 use serde_json::{json, Value};
 use std::path::Path;
 
-pub(super) fn handle_list_instances(home: &Path, args: &Value, instance_name: &str) -> Value {
+pub(super) fn handle_list_instances_with_runtime(
+    home: &Path,
+    args: &Value,
+    instance_name: &str,
+    runtime: Option<&RuntimeContext>,
+) -> Value {
     // If `instance` param is provided, return detailed info for that instance (replaces describe_instance)
     if let Some(target) = args["instance"].as_str().filter(|s| !s.is_empty()) {
         return handle_describe_instance(home, &json!({"name": target}));
@@ -14,34 +20,33 @@ pub(super) fn handle_list_instances(home: &Path, args: &Value, instance_name: &s
     // context ballast. Set `verbose:true` or `include_evidence:true` for detail.
     let include_evidence = args["verbose"].as_bool().unwrap_or(false)
         || args["include_evidence"].as_bool().unwrap_or(false);
-    match crate::api::call(home, &json!({"method": crate::api::method::LIST})) {
-        Ok(resp) => {
-            if let Some(agents) = resp["result"]["agents"].as_array() {
-                let instances: Vec<Value> = agents
-                    .iter()
-                    .filter(|a| {
-                        let backend = a["backend"].as_str().unwrap_or("");
-                        crate::backend::Backend::from_command(backend).is_some()
-                    })
-                    .map(|a| {
-                        let mut info = a.clone();
-                        let name = a["name"].as_str().unwrap_or("");
-                        merge_metadata(home, name, &mut info);
-                        if name == instance_name {
-                            info["is_self"] = json!(true);
-                        }
-                        if !include_evidence {
-                            strip_observed_evidence(&mut info);
-                        }
-                        info
-                    })
-                    .collect();
-                json!({"instances": instances, "compact": !include_evidence})
-            } else {
-                json!({"instances": list_agents(), "compact": true})
-            }
-        }
-        Err(_) => json!({"instances": list_agents(), "compact": true}),
+    let Some(runtime) = runtime else {
+        return json!({"instances": list_agents(), "compact": true});
+    };
+    let resp = crate::api::list_response(home, &runtime.registry, &runtime.externals);
+    if let Some(agents) = resp["result"]["agents"].as_array() {
+        let instances: Vec<Value> = agents
+            .iter()
+            .filter(|a| {
+                let backend = a["backend"].as_str().unwrap_or("");
+                crate::backend::Backend::from_command(backend).is_some()
+            })
+            .map(|a| {
+                let mut info = a.clone();
+                let name = a["name"].as_str().unwrap_or("");
+                merge_metadata(home, name, &mut info);
+                if name == instance_name {
+                    info["is_self"] = json!(true);
+                }
+                if !include_evidence {
+                    strip_observed_evidence(&mut info);
+                }
+                info
+            })
+            .collect();
+        json!({"instances": instances, "compact": !include_evidence})
+    } else {
+        json!({"instances": list_agents(), "compact": true})
     }
 }
 
@@ -96,6 +101,8 @@ pub(super) fn handle_describe_instance(home: &Path, args: &Value) -> Value {
 mod tests {
     use super::*;
     use serde_json::json;
+    use std::collections::HashMap;
+    use std::sync::Arc;
 
     #[test]
     fn strip_observed_evidence_drops_only_evidence_2475() {
@@ -120,5 +127,34 @@ mod tests {
         let mut info = json!({"name": "dev-2", "agent_state": "idle"});
         strip_observed_evidence(&mut info); // must not panic / must be inert
         assert_eq!(info["name"], "dev-2");
+    }
+
+    #[test]
+    fn list_instances_uses_runtime_registry_without_api_loopback_2454() {
+        let home = std::env::temp_dir().join(format!("agend-list-runtime-{}", std::process::id()));
+        let registry = Arc::new(parking_lot::Mutex::new(HashMap::new()));
+        let externals = Arc::new(parking_lot::Mutex::new(HashMap::from([(
+            "external-one".to_string(),
+            crate::agent::ExternalAgentHandle {
+                backend_command: "codex".to_string(),
+                pid: 4242,
+            },
+        )])));
+        let runtime = RuntimeContext {
+            registry,
+            externals,
+        };
+
+        let result =
+            handle_list_instances_with_runtime(&home, &json!({}), "caller", Some(&runtime));
+        let instances = result["instances"]
+            .as_array()
+            .expect("instances array from runtime path");
+        assert!(
+            instances
+                .iter()
+                .any(|agent| agent["name"].as_str() == Some("external-one")),
+            "runtime registry result should be returned without depending on the API socket: {result}"
+        );
     }
 }

--- a/src/mcp/handlers/mod.rs
+++ b/src/mcp/handlers/mod.rs
@@ -87,7 +87,17 @@ pub fn interrupt_esc_params(target: &str) -> Value {
 #[cfg(test)]
 use instance::resolve_team_layout;
 
+#[cfg(test)]
 pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
+    handle_tool_with_runtime(tool, args, instance_name, None)
+}
+
+pub(crate) fn handle_tool_with_runtime(
+    tool: &str,
+    args: &Value,
+    instance_name: &str,
+    runtime: Option<dispatch::RuntimeContext>,
+) -> Value {
     let home = crate::home_dir();
     // arch F5 (t-…47102): a read-only tool (pure query, no state change) skips the
     // two per-call DISK side-effects below — the usage append and the heartbeat RMW
@@ -150,6 +160,7 @@ pub fn handle_tool(tool: &str, args: &Value, instance_name: &str) -> Value {
         args,
         instance_name,
         sender: &sender,
+        runtime: runtime.as_ref(),
     };
     if let Some(value) = dispatch::try_dispatch(tool, &dispatch_ctx) {
         return value;

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -13,9 +13,11 @@ pub mod usage_stats;
 
 use serde_json::Value;
 
-/// Service boundary: single public entry point for MCP tool execution.
-/// API layer calls this instead of reaching into `handlers::handle_tool`
-/// directly, keeping timeout policy in API and execution in MCP.
-pub fn execute_tool(tool_name: &str, args: &Value, instance_name: &str) -> Value {
-    handlers::handle_tool(tool_name, args, instance_name)
+pub(crate) fn execute_tool_with_runtime(
+    tool_name: &str,
+    args: &Value,
+    instance_name: &str,
+    runtime: handlers::dispatch::RuntimeContext,
+) -> Value {
+    handlers::handle_tool_with_runtime(tool_name, args, instance_name, Some(runtime))
 }

--- a/tests/review_api_query_lock_io_api.rs
+++ b/tests/review_api_query_lock_io_api.rs
@@ -5,7 +5,7 @@
 //! Finding: "handle_list holds the global registry mutex across per-agent
 //! blocking disk I/O."
 //!
-//! `handle_list` (src/api/handlers/query.rs) takes the tier-1 registry lock
+//! `list_response` (src/api/handlers/query.rs) takes the tier-1 registry lock
 //! (`agent::lock_registry`) and then, INSIDE the `.map()` over
 //! `reg.values()`, calls
 //! `crate::daemon::dispatch_idle::pending_for_instance(ctx.home, name)` for
@@ -21,7 +21,7 @@
 //! race, so this is a SOURCE-SCANNING invariant (the codebase's first-class
 //! method for held-lock invariants, mirroring tests/core_mutex_invariant.rs
 //! and tests/anti_pattern_invariant.rs). It asserts that within
-//! `handle_list`, NO `pending_for_instance` call appears between the
+//! `list_response`, NO `pending_for_instance` call appears between the
 //! `lock_registry` acquisition and the matching `drop(reg)`.
 //!
 //! RED now: `pending_for_instance` is called inside the `.map()` closure
@@ -39,18 +39,18 @@ fn query_rs() -> PathBuf {
         .join("query.rs")
 }
 
-/// Extract the body lines of `handle_list` (from its `fn` signature to the
+/// Extract the body lines of `list_response` (from its `fn` signature to the
 /// next top-level `fn ` at the same indentation). Returns 1-based line
 /// numbers paired with the line text, comment/doc lines stripped.
-fn handle_list_body(src: &str) -> Vec<(usize, String)> {
+fn list_response_body(src: &str) -> Vec<(usize, String)> {
     let mut out = Vec::new();
     let mut in_fn = false;
     for (i, raw) in src.lines().enumerate() {
         let trimmed = raw.trim_start();
         if !in_fn {
-            if trimmed.starts_with("pub(crate) fn handle_list(")
-                || trimmed.starts_with("fn handle_list(")
-                || trimmed.starts_with("pub fn handle_list(")
+            if trimmed.starts_with("pub(crate) fn list_response(")
+                || trimmed.starts_with("fn list_response(")
+                || trimmed.starts_with("pub fn list_response(")
             {
                 in_fn = true;
                 out.push((i + 1, raw.to_string()));
@@ -78,13 +78,13 @@ fn handle_list_body(src: &str) -> Vec<(usize, String)> {
 }
 
 #[test]
-fn handle_list_does_not_hold_registry_lock_across_dispatch_idle_io_api() {
+fn list_response_does_not_hold_registry_lock_across_dispatch_idle_io_api() {
     let path = query_rs();
     let src = std::fs::read_to_string(&path).expect("read query.rs");
-    let body = handle_list_body(&src);
+    let body = list_response_body(&src);
     assert!(
         !body.is_empty(),
-        "could not locate handle_list in {}",
+        "could not locate list_response in {}",
         path.display()
     );
 
@@ -93,13 +93,13 @@ fn handle_list_does_not_hold_registry_lock_across_dispatch_idle_io_api() {
     let lock_idx = body
         .iter()
         .position(|(_, l)| l.contains("lock_registry("))
-        .expect("handle_list must acquire the registry lock");
+        .expect("list_response must acquire the registry lock");
     let drop_idx = body
         .iter()
         .skip(lock_idx)
         .position(|(_, l)| l.contains("drop(reg)"))
         .map(|p| p + lock_idx)
-        .expect("handle_list must release the registry lock with drop(reg)");
+        .expect("list_response must release the registry lock with drop(reg)");
 
     // Any pending_for_instance (or list_pending) call BETWEEN the lock and
     // the drop is the bug: per-agent blocking disk I/O under the tier-1
@@ -113,7 +113,7 @@ fn handle_list_does_not_hold_registry_lock_across_dispatch_idle_io_api() {
 
     assert!(
         offenders.is_empty(),
-        "handle_list calls dispatch_idle disk I/O WHILE holding the tier-1 \
+        "list_response calls dispatch_idle disk I/O WHILE holding the tier-1 \
          registry lock (between lock_registry and drop(reg)). This blocks \
          every other API handler, the supervisor tick, crash-respawn, \
          hang-detection, and the TUI render path under disk contention. \


### PR DESCRIPTION
## Summary

- Extract API LIST response construction into a crate-local helper shared by API and MCP.
- Pass cloned daemon registry/external runtime state into MCP tool execution when invoked through the API `mcp_tool` proxy.
- Route `list_instances` through that runtime state instead of socket-looping back to API LIST; no-runtime callers keep compact fallback.
- Add regression coverage proving runtime-backed `list_instances` works without depending on the API socket.

## Scope

Second incremental slice for #2454. This removes the `list_instances` MCP handler's production API LIST loopback. `describe_instance` and other MCP handlers still have loopbacks and are intentionally left for later slices.

## Tests

- `cargo fmt --check`
- `cargo test -q list_instances_uses_runtime_registry_without_api_loopback_2454`
- `cargo test -q mcp_proxy`
- `git diff --check`
