### PR TITLE
Fail closed on stale dispatch checkout binding

### DIFF
--- a/src/mcp/handlers/ci/checkout.rs
+++ b/src/mcp/handlers/ci/checkout.rs
@@ -202,6 +202,19 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
                         "fetch_attempted": fetch_attempted,
                     });
                 }
+                let existing_task_id = existing
+                    .get("task_id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default();
+                if !existing_task_id.is_empty() {
+                    return json!({
+                        "error": format!(
+                            "stale binding for branch '{branch}' points at a missing worktree - release first before checkout"
+                        ),
+                        "code": "stale_binding",
+                        "branch": branch,
+                    });
+                }
             }
         }
     }

--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -967,6 +967,56 @@ fn checkout_bind_true_idempotent_when_already_bound_1494() {
 
 #[test]
 #[cfg(unix)]
+fn checkout_bind_true_rejects_stale_dispatch_binding_2499() {
+    let home = p778_tmp_home("2499-stale");
+    let parent = p778_tmp_home("2499-stale-src");
+    let source = p778_setup_source_repo(&parent, "feat/2499");
+    let agent = "stale-dev";
+    let task_id = "t-2499";
+
+    let lease = crate::worktree_pool::lease(&home, &source, agent, "feat/2499")
+        .expect("dispatch pre-build lease must succeed");
+    crate::binding::bind_full(
+        &home,
+        agent,
+        task_id,
+        "feat/2499",
+        &lease.path,
+        &source,
+        false,
+    )
+    .expect("dispatch pre-build bind_full");
+
+    std::fs::remove_dir_all(&lease.path).expect("simulate missing dispatch worktree");
+
+    let resp = super::handle_checkout_repo(
+        &home,
+        &serde_json::json!({
+            "repository_path": source.display().to_string(),
+            "branch": "feat/2499",
+            "bind": true,
+        }),
+        agent,
+    );
+
+    assert_eq!(
+        resp["code"].as_str(),
+        Some("stale_binding"),
+        "#2499: stale dispatch binding must fail closed instead of rebinding with empty task_id: {resp}"
+    );
+    let binding = crate::binding::read(&home, agent).expect("binding remains for explicit release");
+    assert_eq!(
+        binding["task_id"].as_str(),
+        Some(task_id),
+        "#2499: failed checkout must not overwrite the dispatch task_id"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&parent).ok();
+}
+
+#[test]
+#[cfg(unix)]
 fn checkout_writes_event_log_success_and_error_1466() {
     // #1466: every checkout outcome — success AND error — must leave a
     // `worktree_checkout` event-log trace (observability for silent


### PR DESCRIPTION
## Summary
- Treat same-branch dispatch bindings with a missing worktree and non-empty task_id as stale_binding during repo checkout bind:true.
- Fail closed before repo checkout can rebind with an empty task_id, preserving auto-release provenance.
- Add regression coverage for #2499 stale-binding hardening while keeping the normal live same-branch idempotent path intact.

## Verification
- cargo fmt --check
- git diff --check
- cargo test -q -p agend-terminal checkout_bind_true_rejects_stale_dispatch_binding_2499
- cargo test -q -p agend-terminal checkout_bind_true_idempotent_when_already_bound_1494

Review: opencode-reviewer-2499 returned VERIFIED with evidence from the same two targeted tests and the checkout guard placement.

Fixes the narrow stale-binding hardening case from #2499.