### PR TITLE
Suppress ci-ready handoff for terminal PR at same head (#2502)

### DIFF
--- a/src/daemon/ci_watch/poller.rs
+++ b/src/daemon/ci_watch/poller.rs
@@ -1930,30 +1930,49 @@ fn persist_watch_state(
         {
             let targets = state.next_after_ci_targets();
             if !targets.is_empty() {
-                for next in targets {
-                    let repo_branch_key = format!("{}@{}", ctx.repo, ctx.branch);
-                    let pr_state = crate::daemon::pr_state::load(ctx.home, ctx.repo, ctx.branch);
-                    // #t-92758 P1(b): don't emit ci-ready for a merge-BLOCKED PR
-                    // (REJECTED verdict / Draft) — the chain target can't act on it,
-                    // so emitting only spawns a re-nudge loop. This handles the
-                    // reject-before-CI ordering; the evict in `pr_state::scanner`
-                    // handles the CI-green-then-reject ordering (#2297). The
-                    // predicate NEVER suppresses VERIFIED/green/None — the normal
-                    // "your turn" handoff stays live (is_ci_ready_merge_blocked iron
-                    // rule).
-                    if pr_state
-                        .as_ref()
-                        .is_some_and(crate::daemon::pr_state::is_ci_ready_merge_blocked)
-                    {
-                        tracing::info!(
-                            target: "ci_watch",
-                            repo = ctx.repo,
-                            branch = ctx.branch,
-                            "ci-ready suppressed — PR merge-blocked (REJECTED/Draft); no chain handoff, no track"
-                        );
-                    } else {
-                        let pr_number = pr_state.as_ref().map(|s| s.pr_number);
-                        let task_id = state.task_id.as_deref();
+                // The suppression decision is loop-INVARIANT (keyed on repo/branch/
+                // head, not the target), so load pr_state and decide ONCE rather than
+                // per target — multi-target (#2502) would otherwise re-load N times
+                // and log the suppression N times.
+                let repo_branch_key = format!("{}@{}", ctx.repo, ctx.branch);
+                let pr_state = crate::daemon::pr_state::load(ctx.home, ctx.repo, ctx.branch);
+                // #t-92758 P1(b): don't emit ci-ready for a merge-BLOCKED PR
+                // (REJECTED verdict / Draft) — the chain target can't act on it, so
+                // emitting only spawns a re-nudge loop. This handles the
+                // reject-before-CI ordering; the evict in `pr_state::scanner` handles
+                // the CI-green-then-reject ordering (#2297).
+                // #2502: ALSO suppress a PR already terminal (Merged / ClosedUnmerged)
+                // at the SAME head CI passed on — emitting "your turn" on a
+                // merged/closed PR is pure re-nudge noise. Head-GUARDED so a
+                // force-push / branch-reuse (terminal at a DIFFERENT head) still
+                // emits; #1314 freezes a terminal head_sha at the merge/close head,
+                // making the head match a reliable proxy.
+                // Both predicates fail OPEN (no sidecar / non-terminal / head
+                // mismatch → emit) and NEVER suppress VERIFIED/green — the normal
+                // "your turn" handoff stays live (is_ci_ready_merge_blocked iron
+                // rule).
+                let merge_blocked = pr_state
+                    .as_ref()
+                    .is_some_and(crate::daemon::pr_state::is_ci_ready_merge_blocked);
+                let terminal_at_head = pr_state.as_ref().is_some_and(|s| {
+                    crate::daemon::pr_state::is_ci_ready_terminal_at_head(s, &pr.current_sha)
+                });
+                if merge_blocked || terminal_at_head {
+                    tracing::info!(
+                        target: "ci_watch",
+                        repo = ctx.repo,
+                        branch = ctx.branch,
+                        reason = if merge_blocked {
+                            "merge_blocked"
+                        } else {
+                            "pr_terminal_same_head"
+                        },
+                        "ci-ready suppressed — PR not actionable; no chain handoff, no track"
+                    );
+                } else {
+                    let pr_number = pr_state.as_ref().map(|s| s.pr_number);
+                    let task_id = state.task_id.as_deref();
+                    for next in targets {
                         let msg = make_ci_ready_for_action_msg(
                             ctx.repo,
                             ctx.branch,

--- a/src/daemon/ci_watch/poller_tests.rs
+++ b/src/daemon/ci_watch/poller_tests.rs
@@ -2852,6 +2852,66 @@ fn ci_pass_emits_when_pr_merged_different_head_2502() {
     );
 }
 
+/// #2502 MULTI-TARGET invariant (codex review note): a Merged-at-same-head PR
+/// must suppress the chain handoff for EVERY `next_after_ci` target, not just the
+/// first — pins that the suppression decision stays loop-invariant (hoisted above
+/// the target loop). A regression that moved the decision back inside the loop, or
+/// that suppressed only one target, would fail here.
+#[test]
+fn ci_pass_multi_target_all_suppressed_when_pr_merged_same_head_2502() {
+    let dir = tmp_dir("2502-multi-suppress-merged-same-head");
+    let ci_dir = dir.join("ci-watches");
+    std::fs::create_dir_all(&ci_dir).ok();
+    let mut watch = watch_with_chain(None);
+    watch["next_after_ci"] = serde_json::json!(["reviewer-a", "reviewer-b"]);
+    let watch_path = ci_dir.join(watch_filename("o/r", "feat"));
+    std::fs::write(&watch_path, serde_json::to_string_pretty(&watch).unwrap()).unwrap();
+    seed_terminal_pr_state(
+        &dir,
+        "abc2502",
+        crate::daemon::pr_state::MergeState::Merged {
+            merge_commit: "mergecommit".into(),
+            merged_at: "2026-06-29T00:00:00Z".into(),
+        },
+    );
+    let provider = MockCiProvider::with_runs(vec![CiRun {
+        run_attempt: 1,
+        id: 2502,
+        conclusion: Some("success".to_string()),
+        head_sha: "abc2502".to_string(),
+        url: "https://example/run/2502".to_string(),
+        name: String::new(),
+    }]);
+    let registry: AgentRegistry =
+        Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new()));
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(ci_check_repo(
+        &dir,
+        &watch_path,
+        serde_json::from_value(watch.clone()).unwrap(),
+        vec!["lead".to_string(), "dev".to_string()],
+        &registry,
+        &provider,
+    ))
+    .unwrap();
+    for reviewer in ["reviewer-a", "reviewer-b"] {
+        let messages = crate::inbox::drain(&dir, reviewer);
+        assert!(
+            !messages
+                .iter()
+                .any(|m| m.text.contains("[ci-ready-for-action]")),
+            "{reviewer} must NOT receive [ci-ready-for-action] for a merged-same-head PR; got: {messages:?}"
+        );
+    }
+    assert!(
+        crate::daemon::ci_handoff_track::list(&dir).is_empty(),
+        "no ci_handoff_track may be recorded for ANY target when suppressed"
+    );
+}
+
 /// T3 (anti-regression for site 2's chain-target skip): the
 /// subscriber [ci-pass] loop must continue to SKIP an agent whose
 /// name appears in `next_after_ci`. Without this skip, the chain

--- a/src/daemon/ci_watch/poller_tests.rs
+++ b/src/daemon/ci_watch/poller_tests.rs
@@ -2717,6 +2717,141 @@ fn ci_pass_multi_next_after_ci_targets_each_get_ready_2502() {
     }
 }
 
+/// #2502: seed a pr_state file at `head` with `merge_state`, mirroring what
+/// gh-poll would persist, so the emit-site `pr_state::load` sees a terminal PR.
+#[cfg(test)]
+fn seed_terminal_pr_state(
+    dir: &std::path::Path,
+    head: &str,
+    merge_state: crate::daemon::pr_state::MergeState,
+) {
+    let mut ps = crate::daemon::pr_state::new_for_branch(
+        "o/r",
+        "feat",
+        head,
+        crate::daemon::pr_state::ReviewClass::Single,
+    );
+    ps.merge_state = merge_state;
+    crate::daemon::pr_state::save(dir, &ps).unwrap();
+}
+
+/// #2502: drive `ci_check_repo` for a `next_after_ci=reviewer` watch over a GREEN
+/// run at `ci_head`, returning the reviewer's drained inbox. Shared body for the
+/// terminal-suppression matrix below.
+#[cfg(test)]
+fn run_ci_pass_chain(dir: &std::path::Path, ci_head: &str) -> Vec<crate::inbox::InboxMessage> {
+    let ci_dir = dir.join("ci-watches");
+    std::fs::create_dir_all(&ci_dir).ok();
+    let watch = watch_with_chain(Some("reviewer"));
+    let watch_path = ci_dir.join(watch_filename("o/r", "feat"));
+    std::fs::write(&watch_path, serde_json::to_string_pretty(&watch).unwrap()).unwrap();
+    let provider = MockCiProvider::with_runs(vec![CiRun {
+        run_attempt: 1,
+        id: 2502,
+        conclusion: Some("success".to_string()),
+        head_sha: ci_head.to_string(),
+        url: "https://example/run/2502".to_string(),
+        name: String::new(),
+    }]);
+    let registry: AgentRegistry =
+        Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new()));
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(ci_check_repo(
+        dir,
+        &watch_path,
+        serde_json::from_value(watch.clone()).unwrap(),
+        vec!["lead".to_string(), "dev".to_string()],
+        &registry,
+        &provider,
+    ))
+    .unwrap();
+    crate::inbox::drain(dir, "reviewer")
+}
+
+/// #2502 CORE: a PR already Merged at the SAME head CI passed on SUPPRESSES the
+/// chain `[ci-ready-for-action]` and records NO ci_handoff_track — emitting "your
+/// turn" on a merged PR is pure re-nudge noise. (Also the anti-dead-code nail:
+/// `is_ci_ready_merge_blocked` alone — REJECTED/Draft only — would never fire for
+/// a Merged state, so a regression that reused it would FAIL this test.)
+#[test]
+fn ci_pass_suppressed_when_pr_merged_same_head_2502() {
+    let dir = tmp_dir("2502-suppress-merged-same-head");
+    seed_terminal_pr_state(
+        &dir,
+        "abc2502",
+        crate::daemon::pr_state::MergeState::Merged {
+            merge_commit: "mergecommit".into(),
+            merged_at: "2026-06-29T00:00:00Z".into(),
+        },
+    );
+    let messages = run_ci_pass_chain(&dir, "abc2502");
+    assert!(
+        !messages
+            .iter()
+            .any(|m| m.text.contains("[ci-ready-for-action]")),
+        "merged-at-same-head PR must NOT emit [ci-ready-for-action]; got: {messages:?}"
+    );
+    assert!(
+        crate::daemon::ci_handoff_track::list(&dir).is_empty(),
+        "no ci_handoff_track may be recorded for a suppressed handoff"
+    );
+}
+
+/// #2502 same as above for the ClosedUnmerged terminal variant.
+#[test]
+fn ci_pass_suppressed_when_pr_closed_unmerged_same_head_2502() {
+    let dir = tmp_dir("2502-suppress-closed-same-head");
+    seed_terminal_pr_state(
+        &dir,
+        "abc2502",
+        crate::daemon::pr_state::MergeState::ClosedUnmerged {
+            closed_at: "2026-06-29T00:00:00Z".into(),
+        },
+    );
+    let messages = run_ci_pass_chain(&dir, "abc2502");
+    assert!(
+        !messages
+            .iter()
+            .any(|m| m.text.contains("[ci-ready-for-action]")),
+        "closed-unmerged-at-same-head PR must NOT emit [ci-ready-for-action]; got: {messages:?}"
+    );
+    assert!(
+        crate::daemon::ci_handoff_track::list(&dir).is_empty(),
+        "no ci_handoff_track may be recorded for a suppressed handoff"
+    );
+}
+
+/// #2502 ANTI-FALSE-SUPPRESSION nail: a terminal pr_state at a DIFFERENT head
+/// (force-push / branch-reuse opened a fresh PR on the same branch) must STILL
+/// emit the chain `[ci-ready-for-action]`. The head-guard is what keeps the gate
+/// from degrading into "suppress every terminal-ish branch".
+#[test]
+fn ci_pass_emits_when_pr_merged_different_head_2502() {
+    let dir = tmp_dir("2502-emit-merged-different-head");
+    seed_terminal_pr_state(
+        &dir,
+        "oldhead0", // merged at an OLD head; the branch was since reused
+        crate::daemon::pr_state::MergeState::Merged {
+            merge_commit: "mergecommit".into(),
+            merged_at: "2026-06-29T00:00:00Z".into(),
+        },
+    );
+    let messages = run_ci_pass_chain(&dir, "abc2502");
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.text.contains("[ci-ready-for-action]")),
+        "terminal-at-DIFFERENT-head must STILL emit [ci-ready-for-action] (branch reuse stays live); got: {messages:?}"
+    );
+    assert!(
+        !crate::daemon::ci_handoff_track::list(&dir).is_empty(),
+        "a ci_handoff_track must be recorded for the live handoff"
+    );
+}
+
 /// T3 (anti-regression for site 2's chain-target skip): the
 /// subscriber [ci-pass] loop must continue to SKIP an agent whose
 /// name appears in `next_after_ci`. Without this skip, the chain

--- a/src/daemon/pr_state/mod.rs
+++ b/src/daemon/pr_state/mod.rs
@@ -464,6 +464,34 @@ pub fn is_ci_ready_merge_blocked(state: &PrState) -> bool {
         || matches!(state.draft_state, DraftState::Draft)
 }
 
+/// #2502: a PR whose cached terminal merge_state (Merged / ClosedUnmerged) was
+/// observed at the SAME head CI just passed on. Emitting `[ci-ready-for-action]`
+/// here hands "your turn" on a PR that is already merged/closed, spawning a
+/// re-nudge loop the chain target can't resolve — the proactive emit-time half of
+/// a suppression whose reactive half is the scanner's terminal track-evict
+/// (`pr_state::scanner`, the green-then-terminal ordering).
+///
+/// HEAD-GUARDED (load-bearing): a terminal state at a DIFFERENT head — a
+/// force-push / branch-reuse that opened a fresh PR on the same branch — returns
+/// `false`, so the live handoff still fires. This is sound because
+/// [`record_ci_result`] SKIPS `CiObserved` on terminal states (#1314), freezing a
+/// terminal file's `head_sha` at the merge/close head; `state.head_sha == ci_head`
+/// is therefore a reliable proxy for "CI ran on the head that was merged/closed",
+/// never a later reused head.
+///
+/// Distinct from [`is_ci_ready_merge_blocked`] (REJECTED/Draft, still-OPEN): that
+/// predicate is IRON-RULE-narrow and MUST NOT be widened to terminal states. The
+/// emit site ORs the two. Both fail OPEN — a missing sidecar (caller passes
+/// `None`), a non-terminal merge_state, an empty `head_sha`, or a head mismatch
+/// all return `false` and the normal emit proceeds.
+pub fn is_ci_ready_terminal_at_head(state: &PrState, ci_head: &str) -> bool {
+    matches!(
+        state.merge_state,
+        MergeState::Merged { .. } | MergeState::ClosedUnmerged { .. }
+    ) && !state.head_sha.is_empty()
+        && state.head_sha == ci_head
+}
+
 // ─── storage ───────────────────────────────────────────────────────────
 
 /// Canonical path to the PR-state directory.
@@ -1314,6 +1342,63 @@ mod tests {
         assert!(
             is_ci_ready_merge_blocked(&s),
             "Draft must block even with a VERIFIED verdict"
+        );
+    }
+
+    /// #2502: `is_ci_ready_terminal_at_head` suppresses ONLY a terminal
+    /// (Merged / ClosedUnmerged) PR observed at the SAME head CI passed on, and
+    /// is head-GUARDED — a terminal state at a different head (force-push /
+    /// branch-reuse) MUST NOT suppress, or a fresh PR on a reused branch would
+    /// silently lose its handoff. Non-terminal states never suppress.
+    #[test]
+    fn is_ci_ready_terminal_at_head_only_same_head_terminal() {
+        let mut s = new_state("sha-A", ReviewClass::Single);
+
+        // Non-terminal states never suppress, even at the matching head.
+        s.merge_state = MergeState::NotReady;
+        assert!(
+            !is_ci_ready_terminal_at_head(&s, "sha-A"),
+            "NotReady must not suppress"
+        );
+        s.merge_state = MergeState::MergeReady;
+        assert!(
+            !is_ci_ready_terminal_at_head(&s, "sha-A"),
+            "MergeReady must not suppress"
+        );
+
+        // Merged at the SAME head → suppress.
+        s.merge_state = MergeState::Merged {
+            merge_commit: "mc".into(),
+            merged_at: now(),
+        };
+        assert!(
+            is_ci_ready_terminal_at_head(&s, "sha-A"),
+            "Merged at same head must suppress"
+        );
+        // Merged at a DIFFERENT head (force-push / reuse) → fail open. This is the
+        // anti-false-suppression nail: #1314 freezes a terminal head_sha at the
+        // merge head, so a green at sha-B is a fresh PR on the reused branch.
+        assert!(
+            !is_ci_ready_terminal_at_head(&s, "sha-B"),
+            "Merged at a different head must NOT suppress (branch reuse stays live)"
+        );
+
+        // ClosedUnmerged at the SAME head → suppress; different head → fail open.
+        s.merge_state = MergeState::ClosedUnmerged { closed_at: now() };
+        assert!(
+            is_ci_ready_terminal_at_head(&s, "sha-A"),
+            "ClosedUnmerged at same head must suppress"
+        );
+        assert!(
+            !is_ci_ready_terminal_at_head(&s, "sha-B"),
+            "ClosedUnmerged at a different head must NOT suppress"
+        );
+
+        // Empty head_sha → fail open (never match an empty ci_head either).
+        s.head_sha = String::new();
+        assert!(
+            !is_ci_ready_terminal_at_head(&s, ""),
+            "empty head_sha must fail open (no spurious suppression)"
         );
     }
 

--- a/src/daemon/pr_state/mod.rs
+++ b/src/daemon/pr_state/mod.rs
@@ -49,8 +49,14 @@ use serde::{Deserialize, Serialize};
 
 pub mod auto_arm;
 pub mod gh_poll;
+pub mod ready_gate;
 mod remote_gc;
 mod scanner;
+
+// #2502: ci-ready emit-gate predicates live in `ready_gate` (extracted to keep
+// this file under its anti-monolith ceiling); re-exported so existing call sites
+// resolve unchanged.
+pub use ready_gate::{is_ci_ready_merge_blocked, is_ci_ready_terminal_at_head};
 pub(crate) mod verdict_buffer;
 // #986: the production per-tick handler drives the scanner with an explicit
 // (snapshot) poller via `scan_and_emit_with` — the old `scan_and_emit` wrapper
@@ -444,52 +450,6 @@ pub fn is_merge_ready(state: &PrState) -> bool {
     reviewers
         .iter()
         .all(|(_, reviewed)| sha_prefix_match(&state.head_sha, reviewed))
-}
-
-/// #t-92758: a PR whose `[ci-ready-for-action]` chain handoff is pointless right
-/// now because the PR cannot be merged/acted-on — a REJECTED verdict (a reviewer
-/// bounced it; it's being reworked) or a Draft PR (`gh pr merge` refuses drafts).
-/// Used to (a) SUPPRESS a new ci-ready emission and (b) EVICT an existing
-/// ci-handoff track so the re-nudge watchdog stops pinging the chain target for a
-/// PR they can't move.
-///
-/// IRON RULE (regression-pinned): this is DELIBERATELY narrow — it returns
-/// `false` for `Verified` / `Unverified` / `Pending` / `None` verdicts. A
-/// VERIFIED+green PR is exactly the "your turn to merge" case the chain exists
-/// for and MUST keep emitting + re-nudging; this predicate must never suppress
-/// it. (Unverified/Pending/None are not merge-blocked verdicts — the reviewer
-/// hasn't bounced the PR — so the chain handoff stays live.)
-pub fn is_ci_ready_merge_blocked(state: &PrState) -> bool {
-    matches!(state.verdict_state, VerdictState::Rejected { .. })
-        || matches!(state.draft_state, DraftState::Draft)
-}
-
-/// #2502: a PR whose cached terminal merge_state (Merged / ClosedUnmerged) was
-/// observed at the SAME head CI just passed on. Emitting `[ci-ready-for-action]`
-/// here hands "your turn" on a PR that is already merged/closed, spawning a
-/// re-nudge loop the chain target can't resolve — the proactive emit-time half of
-/// a suppression whose reactive half is the scanner's terminal track-evict
-/// (`pr_state::scanner`, the green-then-terminal ordering).
-///
-/// HEAD-GUARDED (load-bearing): a terminal state at a DIFFERENT head — a
-/// force-push / branch-reuse that opened a fresh PR on the same branch — returns
-/// `false`, so the live handoff still fires. This is sound because
-/// [`record_ci_result`] SKIPS `CiObserved` on terminal states (#1314), freezing a
-/// terminal file's `head_sha` at the merge/close head; `state.head_sha == ci_head`
-/// is therefore a reliable proxy for "CI ran on the head that was merged/closed",
-/// never a later reused head.
-///
-/// Distinct from [`is_ci_ready_merge_blocked`] (REJECTED/Draft, still-OPEN): that
-/// predicate is IRON-RULE-narrow and MUST NOT be widened to terminal states. The
-/// emit site ORs the two. Both fail OPEN — a missing sidecar (caller passes
-/// `None`), a non-terminal merge_state, an empty `head_sha`, or a head mismatch
-/// all return `false` and the normal emit proceeds.
-pub fn is_ci_ready_terminal_at_head(state: &PrState, ci_head: &str) -> bool {
-    matches!(
-        state.merge_state,
-        MergeState::Merged { .. } | MergeState::ClosedUnmerged { .. }
-    ) && !state.head_sha.is_empty()
-        && state.head_sha == ci_head
 }
 
 // ─── storage ───────────────────────────────────────────────────────────
@@ -1297,109 +1257,6 @@ mod tests {
             created_at: now(),
             updated_at: now(),
         }
-    }
-
-    /// #t-92758 IRON RULE: `is_ci_ready_merge_blocked` blocks ONLY a REJECTED
-    /// verdict or a Draft PR — never VERIFIED / Unverified / Pending / None. A
-    /// VERIFIED+green PR is the "your turn to merge" case the ci-ready chain
-    /// exists for and MUST keep emitting + re-nudging; a regression that made the
-    /// predicate true for VERIFIED would silently kill legitimate merge handoffs.
-    #[test]
-    fn is_ci_ready_merge_blocked_only_rejected_or_draft() {
-        let mut s = new_state("sha-A", ReviewClass::Single);
-
-        // Non-blocking verdicts (Ready draft state):
-        s.verdict_state = VerdictState::None;
-        assert!(!is_ci_ready_merge_blocked(&s), "None must not block");
-        s.verdict_state = VerdictState::Pending;
-        assert!(!is_ci_ready_merge_blocked(&s), "Pending must not block");
-        s.verdict_state = VerdictState::Unverified {
-            reviewer: "r".into(),
-            reviewed_head: "sha-A".into(),
-        };
-        assert!(!is_ci_ready_merge_blocked(&s), "Unverified must not block");
-        s.verdict_state = VerdictState::Verified {
-            reviewers: vec![("r".into(), "sha-A".into())],
-        };
-        assert!(
-            !is_ci_ready_merge_blocked(&s),
-            "IRON RULE: VERIFIED must NEVER be suppressed/evicted"
-        );
-
-        // Blocking: REJECTED verdict.
-        s.verdict_state = VerdictState::Rejected {
-            reviewer: "r".into(),
-            reviewed_head: "sha-A".into(),
-            reason: None,
-        };
-        assert!(is_ci_ready_merge_blocked(&s), "REJECTED must block");
-
-        // Blocking: Draft — even with an otherwise-mergeable VERIFIED verdict.
-        s.verdict_state = VerdictState::Verified {
-            reviewers: vec![("r".into(), "sha-A".into())],
-        };
-        s.draft_state = DraftState::Draft;
-        assert!(
-            is_ci_ready_merge_blocked(&s),
-            "Draft must block even with a VERIFIED verdict"
-        );
-    }
-
-    /// #2502: `is_ci_ready_terminal_at_head` suppresses ONLY a terminal
-    /// (Merged / ClosedUnmerged) PR observed at the SAME head CI passed on, and
-    /// is head-GUARDED — a terminal state at a different head (force-push /
-    /// branch-reuse) MUST NOT suppress, or a fresh PR on a reused branch would
-    /// silently lose its handoff. Non-terminal states never suppress.
-    #[test]
-    fn is_ci_ready_terminal_at_head_only_same_head_terminal() {
-        let mut s = new_state("sha-A", ReviewClass::Single);
-
-        // Non-terminal states never suppress, even at the matching head.
-        s.merge_state = MergeState::NotReady;
-        assert!(
-            !is_ci_ready_terminal_at_head(&s, "sha-A"),
-            "NotReady must not suppress"
-        );
-        s.merge_state = MergeState::MergeReady;
-        assert!(
-            !is_ci_ready_terminal_at_head(&s, "sha-A"),
-            "MergeReady must not suppress"
-        );
-
-        // Merged at the SAME head → suppress.
-        s.merge_state = MergeState::Merged {
-            merge_commit: "mc".into(),
-            merged_at: now(),
-        };
-        assert!(
-            is_ci_ready_terminal_at_head(&s, "sha-A"),
-            "Merged at same head must suppress"
-        );
-        // Merged at a DIFFERENT head (force-push / reuse) → fail open. This is the
-        // anti-false-suppression nail: #1314 freezes a terminal head_sha at the
-        // merge head, so a green at sha-B is a fresh PR on the reused branch.
-        assert!(
-            !is_ci_ready_terminal_at_head(&s, "sha-B"),
-            "Merged at a different head must NOT suppress (branch reuse stays live)"
-        );
-
-        // ClosedUnmerged at the SAME head → suppress; different head → fail open.
-        s.merge_state = MergeState::ClosedUnmerged { closed_at: now() };
-        assert!(
-            is_ci_ready_terminal_at_head(&s, "sha-A"),
-            "ClosedUnmerged at same head must suppress"
-        );
-        assert!(
-            !is_ci_ready_terminal_at_head(&s, "sha-B"),
-            "ClosedUnmerged at a different head must NOT suppress"
-        );
-
-        // Empty head_sha → fail open (never match an empty ci_head either).
-        s.head_sha = String::new();
-        assert!(
-            !is_ci_ready_terminal_at_head(&s, ""),
-            "empty head_sha must fail open (no spurious suppression)"
-        );
     }
 
     /// T1: CI green at head_sha + Verified at same head_sha → MergeReady.

--- a/src/daemon/pr_state/ready_gate.rs
+++ b/src/daemon/pr_state/ready_gate.rs
@@ -1,0 +1,175 @@
+//! ci-ready emit-gate predicates (#2502): pure checks over a cached `PrState`
+//! deciding whether the daemon should emit `[ci-ready-for-action]` on CI pass.
+//! Extracted from `mod.rs` to keep that grandfathered file under its
+//! anti-monolith ceiling; both predicates are re-exported from the parent module
+//! so existing call sites (`crate::daemon::pr_state::is_ci_ready_*`,
+//! `super::is_ci_ready_merge_blocked`) are unchanged.
+
+use super::{DraftState, MergeState, PrState, VerdictState};
+
+/// #t-92758: a PR whose `[ci-ready-for-action]` chain handoff is pointless right
+/// now because the PR cannot be merged/acted-on — a REJECTED verdict (a reviewer
+/// bounced it; it's being reworked) or a Draft PR (`gh pr merge` refuses drafts).
+/// Used to (a) SUPPRESS a new ci-ready emission and (b) EVICT an existing
+/// ci-handoff track so the re-nudge watchdog stops pinging the chain target for a
+/// PR they can't move.
+///
+/// IRON RULE (regression-pinned): this is DELIBERATELY narrow — it returns
+/// `false` for `Verified` / `Unverified` / `Pending` / `None` verdicts. A
+/// VERIFIED+green PR is exactly the "your turn to merge" case the chain exists
+/// for and MUST keep emitting + re-nudging; this predicate must never suppress
+/// it. (Unverified/Pending/None are not merge-blocked verdicts — the reviewer
+/// hasn't bounced the PR — so the chain handoff stays live.)
+pub fn is_ci_ready_merge_blocked(state: &PrState) -> bool {
+    matches!(state.verdict_state, VerdictState::Rejected { .. })
+        || matches!(state.draft_state, DraftState::Draft)
+}
+
+/// #2502: a PR whose cached terminal merge_state (Merged / ClosedUnmerged) was
+/// observed at the SAME head CI just passed on. Emitting `[ci-ready-for-action]`
+/// here hands "your turn" on a PR that is already merged/closed, spawning a
+/// re-nudge loop the chain target can't resolve — the proactive emit-time half of
+/// a suppression whose reactive half is the scanner's terminal track-evict
+/// (`pr_state::scanner`, the green-then-terminal ordering).
+///
+/// HEAD-GUARDED (load-bearing): a terminal state at a DIFFERENT head — a
+/// force-push / branch-reuse that opened a fresh PR on the same branch — returns
+/// `false`, so the live handoff still fires. This is sound because
+/// [`super::record_ci_result`] SKIPS `CiObserved` on terminal states (#1314),
+/// freezing a terminal file's `head_sha` at the merge/close head;
+/// `state.head_sha == ci_head` is therefore a reliable proxy for "CI ran on the
+/// head that was merged/closed", never a later reused head.
+///
+/// Distinct from [`is_ci_ready_merge_blocked`] (REJECTED/Draft, still-OPEN): that
+/// predicate is IRON-RULE-narrow and MUST NOT be widened to terminal states. The
+/// emit site ORs the two. Both fail OPEN — a missing sidecar (caller passes
+/// `None`), a non-terminal merge_state, an empty `head_sha`, or a head mismatch
+/// all return `false` and the normal emit proceeds.
+pub fn is_ci_ready_terminal_at_head(state: &PrState, ci_head: &str) -> bool {
+    matches!(
+        state.merge_state,
+        MergeState::Merged { .. } | MergeState::ClosedUnmerged { .. }
+    ) && !state.head_sha.is_empty()
+        && state.head_sha == ci_head
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::super::{
+        new_for_branch, DraftState, MergeState, PrState, ReviewClass, VerdictState,
+    };
+    use super::{is_ci_ready_merge_blocked, is_ci_ready_terminal_at_head};
+
+    /// A fresh PrState at `head` (verdict None, draft Ready, merge NotReady) —
+    /// the production constructor, so these tests never drift from the real
+    /// default shape.
+    fn state_at(head: &str) -> PrState {
+        new_for_branch("owner/repo", "feat/test", head, ReviewClass::Single)
+    }
+
+    /// #t-92758 IRON RULE: `is_ci_ready_merge_blocked` blocks ONLY a REJECTED
+    /// verdict or a Draft PR — never VERIFIED / Unverified / Pending / None. A
+    /// VERIFIED+green PR is the "your turn to merge" case the ci-ready chain
+    /// exists for and MUST keep emitting + re-nudging; a regression that made the
+    /// predicate true for VERIFIED would silently kill legitimate merge handoffs.
+    #[test]
+    fn is_ci_ready_merge_blocked_only_rejected_or_draft() {
+        let mut s = state_at("sha-A");
+
+        // Non-blocking verdicts (Ready draft state):
+        s.verdict_state = VerdictState::None;
+        assert!(!is_ci_ready_merge_blocked(&s), "None must not block");
+        s.verdict_state = VerdictState::Pending;
+        assert!(!is_ci_ready_merge_blocked(&s), "Pending must not block");
+        s.verdict_state = VerdictState::Unverified {
+            reviewer: "r".into(),
+            reviewed_head: "sha-A".into(),
+        };
+        assert!(!is_ci_ready_merge_blocked(&s), "Unverified must not block");
+        s.verdict_state = VerdictState::Verified {
+            reviewers: vec![("r".into(), "sha-A".into())],
+        };
+        assert!(
+            !is_ci_ready_merge_blocked(&s),
+            "IRON RULE: VERIFIED must NEVER be suppressed/evicted"
+        );
+
+        // Blocking: REJECTED verdict.
+        s.verdict_state = VerdictState::Rejected {
+            reviewer: "r".into(),
+            reviewed_head: "sha-A".into(),
+            reason: None,
+        };
+        assert!(is_ci_ready_merge_blocked(&s), "REJECTED must block");
+
+        // Blocking: Draft — even with an otherwise-mergeable VERIFIED verdict.
+        s.verdict_state = VerdictState::Verified {
+            reviewers: vec![("r".into(), "sha-A".into())],
+        };
+        s.draft_state = DraftState::Draft;
+        assert!(
+            is_ci_ready_merge_blocked(&s),
+            "Draft must block even with a VERIFIED verdict"
+        );
+    }
+
+    /// #2502: `is_ci_ready_terminal_at_head` suppresses ONLY a terminal
+    /// (Merged / ClosedUnmerged) PR observed at the SAME head CI passed on, and
+    /// is head-GUARDED — a terminal state at a different head (force-push /
+    /// branch-reuse) MUST NOT suppress, or a fresh PR on a reused branch would
+    /// silently lose its handoff. Non-terminal states never suppress.
+    #[test]
+    fn is_ci_ready_terminal_at_head_only_same_head_terminal() {
+        let mut s = state_at("sha-A");
+
+        // Non-terminal states never suppress, even at the matching head.
+        s.merge_state = MergeState::NotReady;
+        assert!(
+            !is_ci_ready_terminal_at_head(&s, "sha-A"),
+            "NotReady must not suppress"
+        );
+        s.merge_state = MergeState::MergeReady;
+        assert!(
+            !is_ci_ready_terminal_at_head(&s, "sha-A"),
+            "MergeReady must not suppress"
+        );
+
+        // Merged at the SAME head → suppress.
+        s.merge_state = MergeState::Merged {
+            merge_commit: "mc".into(),
+            merged_at: "t".into(),
+        };
+        assert!(
+            is_ci_ready_terminal_at_head(&s, "sha-A"),
+            "Merged at same head must suppress"
+        );
+        // Merged at a DIFFERENT head (force-push / reuse) → fail open. This is the
+        // anti-false-suppression nail: #1314 freezes a terminal head_sha at the
+        // merge head, so a green at sha-B is a fresh PR on the reused branch.
+        assert!(
+            !is_ci_ready_terminal_at_head(&s, "sha-B"),
+            "Merged at a different head must NOT suppress (branch reuse stays live)"
+        );
+
+        // ClosedUnmerged at the SAME head → suppress; different head → fail open.
+        s.merge_state = MergeState::ClosedUnmerged {
+            closed_at: "t".into(),
+        };
+        assert!(
+            is_ci_ready_terminal_at_head(&s, "sha-A"),
+            "ClosedUnmerged at same head must suppress"
+        );
+        assert!(
+            !is_ci_ready_terminal_at_head(&s, "sha-B"),
+            "ClosedUnmerged at a different head must NOT suppress"
+        );
+
+        // Empty head_sha → fail open (never match an empty ci_head either).
+        s.head_sha = String::new();
+        assert!(
+            !is_ci_ready_terminal_at_head(&s, ""),
+            "empty head_sha must fail open (no spurious suppression)"
+        );
+    }
+}


### PR DESCRIPTION
## What

When CI passes on a branch with a `next_after_ci` chain, the daemon emits `[ci-ready-for-action]` ("your turn") to each chain target and records a `ci_handoff_track`. This suppresses that emission (and skips the track) when the locally-cached `pr_state` sidecar shows the PR is already **terminal** (`Merged` / `ClosedUnmerged`) at the **same head** CI passed on — emitting "your turn" on a merged/closed PR is pure re-nudge noise.

It is the **proactive emit-time** complement to the scanner's existing **reactive** terminal track-evict: the scanner handles the green-then-terminal ordering; this handles the terminal-then-green ordering. No fresh GitHub API, no loop merge, no debounce — it reads the sidecar that already exists.

## Design

- **New predicate** `is_ci_ready_terminal_at_head(state, ci_head)` in `pr_state`, deliberately SEPARATE from the iron-rule-narrow `is_ci_ready_merge_blocked` (REJECTED/Draft only). Widening that predicate would break its regression pin AND make the suppression dead code — it never returns true for terminal states.
- **Head-guarded**: suppress only when `merge_state ∈ {Merged, ClosedUnmerged}` AND `sidecar.head_sha == ci_head`. A terminal state at a *different* head (force-push / branch reuse opening a fresh PR on the same branch) still emits. Sound because `record_ci_result` skips `CiObserved` on terminal states (#1314), freezing a terminal file's `head_sha` at the merge/close head.
- **Fail-open**: no sidecar / non-terminal state / empty head / head mismatch → normal emit + track.
- The decision is **hoisted above the `next_after_ci` target loop** (it's loop-invariant), so multi-target chains suppress all targets uniformly and load `pr_state` once.
- The subscriber `[ci-pass]` informational path is untouched — only the actionable chain signal is gated.

## Tests

`pr_state` unit test (head-guard semantics) + 4 `ci_watch` integration tests:
- Merged @ same head → suppress (also the anti-dead-code pin)
- ClosedUnmerged @ same head → suppress
- Merged @ different head → STILL emit + track (anti-false-suppression)
- Multi-target Merged @ same head → all targets suppressed

Local: target suite green, `clippy --all-targets --features tray -D warnings` clean, `fmt --check` clean.

## Residual risk (known)

A closed-then-reopened PR at the *same* head has a small fail-closed window before the scanner removes the stale sidecar. Bounded and rare; the scanner already evicted the handoff track on close, so it is not a regression. Root-fixing would need the reducer to refuse head advance on terminal states (or store `merged_head_sha`) — out of scope.

## Review

Adversarially reviewed by a peer reviewer: **VERIFIED, no findings** — independently re-ran the test matrix, clippy, fmt, and `git diff --check`. The multi-target suppression test was added in response to its non-blocking coverage note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)