### PR TITLE
fix(inbox): auto-ack the full pr-state FYI class on drain (#2506)

### DIFF
--- a/src/inbox/storage.rs
+++ b/src/inbox/storage.rs
@@ -1225,7 +1225,21 @@ fn known_fire_and_forget_kind(msg: &InboxMessage) -> bool {
 fn auto_ack_on_drain_kind(msg: &InboxMessage) -> bool {
     matches!(
         msg.kind.as_deref(),
-        Some("ci-watch" | "ci-watch-stalled" | "ci-watch-resumed" | "poll" | "pr-merged")
+        Some(
+            "ci-watch"
+                | "ci-watch-stalled"
+                | "ci-watch-resumed"
+                | "poll"
+                // #2506: the rest of the pr-state FYI class. `pr-merged` was the
+                // only one #2493 listed; its siblings (terminal `pr-closed-unmerged`,
+                // plus `pr-ready-for-merge` / `review-verdict`) are the same
+                // fire-and-forget shape — once drained there is nothing to
+                // re-deliver — and were nagging poll-reminder for merged PRs.
+                | "pr-merged"
+                | "pr-closed-unmerged"
+                | "pr-ready-for-merge"
+                | "review-verdict"
+        )
     )
 }
 

--- a/src/inbox/tests.rs
+++ b/src/inbox/tests.rs
@@ -843,6 +843,25 @@ fn drain_auto_acks_daemon_notifications() {
             "[pr-merged] owner/repo@branch",
         ),
         ("ci-watch", "system:ci", "[ci-pass] owner/repo@branch"),
+        // #2506: the pr-state FYI class — terminal (`pr-closed-unmerged`) and
+        // ready/verdict notifications are fire-and-forget like `pr-merged`; they
+        // were omitted from the #2493 allow-list and so kept nagging poll-reminder
+        // for an already-merged PR until a manual ack.
+        (
+            "pr-ready-for-merge",
+            "system:pr-state",
+            "[pr-ready-for-merge] owner/repo@branch",
+        ),
+        (
+            "pr-closed-unmerged",
+            "system:pr-state",
+            "[pr-closed-unmerged] owner/repo@branch",
+        ),
+        (
+            "review-verdict",
+            "system:pr-state",
+            "[review-verdict] owner/repo@branch: VERIFIED",
+        ),
     ] {
         let home = tmp_home(&format!("drain-{kind}-auto-ack"));
         let id = format!("m-{kind}");


### PR DESCRIPTION
Fixes the observed half of #2506.

## Problem
`poll-reminder` keeps nagging about `system:pr-state` FYI notifications for an **already-merged** PR. Observed on PR #2505: `[review-verdict]` and `[pr-ready-for-merge]` stayed `read_at: null`, were re-delivered by the 10-min reclaim-TTL, and drove `unread=2 oldest=32m` until a manual `inbox action=ack`.

## Root cause
#2493 (`fix: auto-ack daemon inbox notifications`) introduced `auto_ack_on_drain_kind` but listed only **`pr-merged`** from the pr-state FYI family. Its siblings were omitted, so they don't settle on drain → stay `delivering` → reclaim-TTL reverts to `unread` → counted by `unread_count` → `poll-reminder` nags.

All four are emitted by the pr-state aggregator with `from = "system:pr-state"`, are non-obligations (`obligation_reason` returns `Some` only for `query`/`task`), and are pure fire-and-forget — same shape as the already-listed `pr-merged`.

## Fix
Add the rest of the class to `auto_ack_on_drain_kind` (`src/inbox/storage.rs`):
- `pr-closed-unmerged` — the other **terminal** event (sibling of `pr-merged`; emitted via the same `build_event_message` path, also omitted — caught while enumerating, not in the original #2506 report)
- `pr-ready-for-merge`
- `review-verdict`

Obligations (`query`/`task`) are untouched — still at-least-once + nagged-until-handled.

## Test (test-first, §3.10)
Extends `drain_auto_acks_daemon_notifications` to cover the three kinds. Verified RED→GREEN:
- test-only commit (`2642ac4d`) fails at the `pr-ready-for-merge` assertion;
- fix commit (`a8b35341`) → pass.
- Full `inbox::` module: 176 passed / 0 failed. `clippy --bin` clean.

## Deferred (the optional half of #2506) — producer-side supersession
The issue's optional fix 2 (pr-state retracts its own prior `review-verdict`/`pr-ready-for-merge` on the terminal `pr-merged`/`pr-closed-unmerged` transition, for offline recipients) is **intentionally NOT in this PR**. On implementation it is not a clean mirror of `mark_ci_watch_superseded`: it needs the terminal message's id stamped across a module boundary, a hook into the scanner's deferred-enqueue path (with the #1629 dedup-flag-reset + flock-drop ordering invariants), and per-recipient targeting (terminal event → author vs prior FYI → notify-recipient/merge-authority may differ). That is daemon-core surgery disproportionate to bundle here, and its marginal value is small because **this PR's auto-ack-on-drain is the correctness floor** — any recipient that drains settles the FYI regardless. Tracked as the remaining scope in #2506.

🤖 Generated with [Claude Code](https://claude.com/claude-code)