### PR TITLE
AUDIT2-006 (A+B): offload event-bus delivery off the tick thread

### DIFF
--- a/src/channel/telegram/notify.rs
+++ b/src/channel/telegram/notify.rs
@@ -32,17 +32,19 @@ pub fn notify_telegram_silent(home: &std::path::Path, instance_name: &str, text:
     let _ = notify_telegram_inner(home, instance_name, text, true);
 }
 
-/// Drives the Telegram send to completion synchronously, returning `Some(())`
-/// when a send was attempted or `None` when nothing was sent (no telegram
-/// channel / dedup-suppressed).
+/// Claims the per-(instance, topic, content) dedup slot and ENQUEUES the Telegram
+/// send onto the bounded delivery worker (AUDIT2-006), so the tick / main-loop
+/// caller never blocks on the network round-trip. Returns `Some(())` when the send
+/// was accepted for delivery, or `None` when nothing was enqueued (no telegram
+/// channel / dedup-suppressed / delivery queue full → dedup claim evicted).
 ///
-/// H8 (channel-HIGH-1): this MUST drive the send rather than schedule it with
-/// `telegram_runtime().spawn(...)` and drop the `JoinHandle`. `telegram_runtime()`
-/// is a `new_current_thread` runtime with no persistent driver thread, so a
-/// spawned task makes no progress unless some later sync-context `block_on`
-/// happens to cooperatively poll it — otherwise the notification is queued
-/// forever while the dedup claim suppresses a re-emit for the whole TTL. We use
-/// the Handle-guarded `block_on_value` (#1476), mirroring `reply.rs::send_reply`.
+/// The actual send runs in [`send_telegram_job`] on the worker thread, which still
+/// drives it to completion via the Handle-guarded `block_on_value` (#1476) — never
+/// a fire-and-forget `telegram_runtime().spawn(...)` whose `JoinHandle` is dropped
+/// onto the driver-less `new_current_thread` runtime (the H8 / channel-HIGH-1
+/// invariant; `tests/notify_undriven_runtime_invariant_channel.rs` statically pins
+/// it). Moving delivery to the worker thread does not weaken H8: the send is still
+/// driven to completion, just off the caller's thread.
 fn notify_telegram_inner(
     home: &std::path::Path,
     instance_name: &str,
@@ -82,17 +84,70 @@ fn notify_telegram_inner(
         return None;
     }
 
-    let text = text.to_string();
-    let home_owned = home.to_path_buf();
-    let instance_owned = instance_name.to_string();
-    // H8: drive the send to completion on the Telegram runtime via the
-    // Handle-guarded `block_on_value` (#1476) — never fire-and-forget onto the
-    // undriven current_thread runtime (see fn doc). Blocks the caller for one
-    // send, exactly as `reply.rs::send_reply` does.
+    // AUDIT2-006: offload the blocking Telegram send (the network round-trip) off
+    // the tick / main-loop thread onto the bounded delivery worker. The dedup
+    // claim above already ran synchronously, so a concurrent duplicate is still
+    // suppressed; if the bounded queue is full the send never happens, so we evict
+    // the claim — otherwise a never-delivered notify would suppress a legitimate
+    // same-text re-emit for the whole TTL (the queue-full twin of the MED-1
+    // send-failure evict below).
+    let job = crate::daemon::delivery_worker::TelegramSendJob {
+        home: home.to_path_buf(),
+        instance: instance_name.to_string(),
+        text: text.to_string(),
+        disable_notification,
+        token,
+        group_id,
+        topic_id,
+        dedup_key: dedup_key.clone(),
+    };
+    if crate::daemon::delivery_worker::enqueue_telegram_send(job).is_err() {
+        crate::channel::dedup::global(home).evict(&dedup_key);
+        tracing::warn!(
+            instance = %instance_name,
+            "AUDIT2-006: telegram notify dropped — delivery queue full; dedup claim evicted"
+        );
+        return None;
+    }
+    Some(())
+}
+
+/// AUDIT2-006: the actual blocking Telegram send, run on the delivery worker
+/// thread (see `daemon::delivery_worker`). The dedup / retry / topic-recreate
+/// semantics are unchanged from the former inline `notify_telegram_inner` send —
+/// the only behavioural change is the THREAD it runs on. It still drives the send
+/// to completion via the Handle-guarded `block_on_value` (#1476) — never a fire-
+/// and-forget `spawn` onto the undriven current_thread runtime (the H8 invariant).
+pub(crate) fn send_telegram_job(job: crate::daemon::delivery_worker::TelegramSendJob) {
+    let crate::daemon::delivery_worker::TelegramSendJob {
+        home: home_owned,
+        instance: instance_owned,
+        text,
+        disable_notification,
+        token,
+        group_id,
+        topic_id,
+        dedup_key,
+    } = job;
     block_on_value(async move {
         use teloxide::payloads::SendMessageSetters;
         use teloxide::prelude::Requester;
-        let bot = teloxide::Bot::new(&token);
+        // AUDIT2-006 (A): give the Telegram client an explicit request timeout so
+        // a black-holed API connection can't park this delivery indefinitely. We
+        // start from teloxide's recommended settings (keep-alive etc.) and only
+        // add the timeout. On the (effectively impossible) builder failure, fall
+        // back to teloxide's default client — losing the timeout but never the
+        // send.
+        let bot = match teloxide::net::default_reqwest_settings()
+            .timeout(std::time::Duration::from_secs(10))
+            .build()
+        {
+            Ok(client) => teloxide::Bot::with_client(&token, client),
+            Err(e) => {
+                tracing::warn!(error = %e, "AUDIT2-006: telegram client builder failed — using default (no request timeout)");
+                teloxide::Bot::new(&token)
+            }
+        };
         let chat_id = teloxide::types::ChatId(group_id);
         let result: anyhow::Result<()> = async {
             // Test seam: force the first send to fail without a network call.
@@ -178,7 +233,6 @@ fn notify_telegram_inner(
             tracing::warn!(error = %e, "telegram notify failed");
         }
     });
-    Some(())
 }
 
 #[cfg(test)]
@@ -227,13 +281,53 @@ mod tests {
         )
     }
 
-    /// §3.9 (MED-1): a notify whose send FAILS must evict its dedup claim, so a
-    /// retry of the same text within the TTL actually sends instead of being
-    /// suppressed into a no-op. The twin of the reply.rs HIGH-2 fix.
+    /// §3.9 (MED-1): a send that FAILS must evict its dedup claim, so a retry of
+    /// the same text within the TTL actually sends instead of being suppressed
+    /// into a no-op. The twin of the reply.rs HIGH-2 fix. AUDIT2-006 relocated the
+    /// send (and this evict) into `send_telegram_job` on the delivery worker, so
+    /// the test now drives that primitive directly (the caller already claimed the
+    /// dedup slot, exactly as `notify_telegram_inner` does before enqueueing).
     #[test]
-    fn notify_failed_send_evicts_dedup_med1() {
+    fn send_failed_evicts_dedup_med1() {
         let _g = guard();
         let home = tmp_home("evict");
+        std::env::set_var("NOTIFY_MED1_TOKEN", "fake");
+
+        // Claim the dedup slot as the synchronous caller would, then run the
+        // (forced-failing) send: it must roll the claim back.
+        let key = notify_key(&home, "C", "hello operator");
+        assert!(crate::channel::dedup::global(&home).record_and_check(key.clone()));
+
+        set_forced_send_error(anyhow::anyhow!("transient network error"));
+        super::send_telegram_job(crate::daemon::delivery_worker::TelegramSendJob {
+            home: home.clone(),
+            instance: "C".to_string(),
+            text: "hello operator".to_string(),
+            disable_notification: false,
+            token: "fake".to_string(),
+            group_id: -100_777,
+            topic_id: crate::channel::telegram::lookup_topic_for_instance(&home, "C"),
+            dedup_key: key.clone(),
+        });
+
+        // record_and_check is fresh again (would be `false`/suppressed w/o evict).
+        assert!(
+            crate::channel::dedup::global(&home).record_and_check(key),
+            "MED-1: a failed send must evict its dedup claim so a retry can send"
+        );
+
+        std::env::remove_var("NOTIFY_MED1_TOKEN");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// AUDIT2-006 (codex edit 2): when the bounded delivery queue is FULL the send
+    /// never happens, so `notify_telegram_inner` must evict the dedup claim it just
+    /// recorded — otherwise a never-delivered notify would suppress a legitimate
+    /// same-text re-emit for the whole TTL (a new silent-drop class).
+    #[test]
+    fn telegram_queue_full_evicts_dedup_audit2_006() {
+        let _g = guard();
+        let home = tmp_home("qfull");
         std::fs::write(
             crate::fleet::fleet_yaml_path(&home),
             "channel:\n  type: telegram\n  bot_token_env: NOTIFY_MED1_TOKEN\n  group_id: -100777\n  mode: topic\ninstances:\n  C:\n    backend: claude\n",
@@ -241,19 +335,20 @@ mod tests {
         .unwrap();
         std::env::set_var("NOTIFY_MED1_TOKEN", "fake");
 
-        // First notify: records the dedup claim, then the (forced-failing) send.
-        // H8: `notify_telegram_inner` now drives the send synchronously
-        // (block_on_value), so by the time it returns the failed send has already
-        // evicted the claim — no JoinHandle to drive.
-        set_forced_send_error(anyhow::anyhow!("transient network error"));
-        notify_telegram_inner(&home, "C", "hello operator", false).expect("send driven");
+        // Force the delivery queue to report full: claim recorded, enqueue fails,
+        // claim must be evicted; nothing was sent so the call returns None.
+        crate::daemon::delivery_worker::test_support::set_force_full(true);
+        let sent = notify_telegram_inner(&home, "C", "hello operator", false);
+        crate::daemon::delivery_worker::test_support::set_force_full(false);
+        assert!(
+            sent.is_none(),
+            "a full delivery queue means nothing was sent"
+        );
 
-        // The failed send must have rolled back the claim: record_and_check is
-        // fresh again (would be `false`/suppressed without the evict).
         let key = notify_key(&home, "C", "hello operator");
         assert!(
             crate::channel::dedup::global(&home).record_and_check(key),
-            "MED-1: a failed notify must evict its dedup claim so a retry can send"
+            "AUDIT2-006: a queue-full drop must evict the dedup claim so a retry can send"
         );
 
         std::env::remove_var("NOTIFY_MED1_TOKEN");

--- a/src/daemon/delivery_worker.rs
+++ b/src/daemon/delivery_worker.rs
@@ -1,0 +1,210 @@
+//! AUDIT2-006: bounded delivery worker.
+//!
+//! The daemon's main tick / `run_core` loop emits events and, via the event bus
+//! subscribers, delivers notifications by injecting into agent PTYs and sending
+//! Telegram messages. Both are BLOCKING I/O: a Telegram network black-hole (no
+//! local request timeout) or a slow PTY readback would otherwise park the tick
+//! thread — stalling the hang-detection, recovery-dispatcher and crash handling
+//! that share that one thread.
+//!
+//! This module offloads ONLY the blocking *wake* effect (the physical PTY poke
+//! and the Telegram send) onto a single bounded background worker. Durable
+//! source-of-truth writes (inbox JSONL, `notification_queue`, schedule
+//! `run_history`) stay SYNCHRONOUS on the caller — a notification is a wakeup,
+//! not a commit barrier. `event_bus::emit`'s handled-count is unaffected: it is
+//! decided by the synchronous kind-match inside each subscriber, BEFORE any
+//! delivery is enqueued (see `event_bus.rs`).
+//!
+//! Backpressure: a bounded `sync_channel(QUEUE_CAP)`; [`enqueue_pty_wake`] /
+//! [`enqueue_telegram_send`] use `try_send` and NEVER block. On a full queue the
+//! job is dropped and the caller is told (`Err(())`) so it can record the drop
+//! where it owns a durable status (cron → `drop_queue_full`; Telegram → evict the
+//! dedup claim so a later identical emit isn't suppressed for the whole TTL).
+//!
+//! Shutdown is best-effort by design: the worker is a daemon-lifetime thread
+//! reaped by the OS at process exit. There is no graceful join (Rust std threads
+//! can't be safely cancelled mid-`block_on`); a queued-but-undrained job is
+//! explained by its synchronous record (e.g. cron's `ok_queued`).
+//!
+//! Single worker (not a pool) on purpose: FIFO keeps Telegram retry / topic-
+//! recreation / dedup and per-agent inject ordering trivially serial. If head-of-
+//! line latency becomes real after the Telegram request timeout lands, split into
+//! lanes (one Telegram, one PTY) later — not now.
+
+use std::sync::mpsc::{sync_channel, Receiver, SyncSender, TrySendError};
+use std::sync::OnceLock;
+
+/// Queue depth. Large enough to absorb a burst of watchdog / cron / crash
+/// notifications, small enough that a wedged delivery path (post request-timeout)
+/// surfaces as drops quickly rather than unbounded memory growth.
+const QUEUE_CAP: usize = 256;
+
+/// A unit of blocking delivery work offloaded off the tick / main-loop thread.
+enum DeliveryJob {
+    /// Physical submit-aware PTY inject — the `inbox::notify::inject_with_submit`
+    /// primitive (an `api::call(INJECT)` loopback). The worker calls the `_direct`
+    /// primitive, NEVER the offload wrapper, so there is no recursive re-enqueue.
+    PtyWake {
+        home: std::path::PathBuf,
+        agent: String,
+        notification: String,
+    },
+    /// A Telegram send whose dedup claim was already recorded on the caller
+    /// thread (see `channel::telegram::notify`). On terminal send failure the
+    /// worker evicts that claim.
+    TelegramSend(TelegramSendJob),
+}
+
+/// Payload for an offloaded Telegram send. Carries the already-resolved channel
+/// coordinates and the dedup key claimed on the caller thread, so the worker
+/// reproduces exactly what the synchronous path would have sent.
+pub(crate) struct TelegramSendJob {
+    pub home: std::path::PathBuf,
+    pub instance: String,
+    pub text: String,
+    pub disable_notification: bool,
+    pub token: String,
+    pub group_id: i64,
+    pub topic_id: Option<i32>,
+    pub dedup_key: crate::channel::dedup::DedupKey,
+}
+
+struct DeliveryWorker {
+    tx: SyncSender<DeliveryJob>,
+}
+
+fn global() -> &'static DeliveryWorker {
+    static WORKER: OnceLock<DeliveryWorker> = OnceLock::new();
+    WORKER.get_or_init(|| {
+        let (tx, rx) = sync_channel::<DeliveryJob>(QUEUE_CAP);
+        // fire-and-forget: the delivery worker drains for the whole daemon
+        // lifetime; there is no graceful join — shutdown is best-effort by design
+        // (AUDIT2-006). The OS reaps the thread at process exit, and any queued-
+        // but-undrained job is explained by its synchronous record.
+        if let Err(e) = std::thread::Builder::new()
+            .name("agend-delivery".into())
+            .spawn(move || worker_loop(rx))
+        {
+            // Spawn failure is exceptional (OS thread exhaustion). Without the
+            // worker the queue would silently fill; log loudly so the operator
+            // sees why deliveries stop. The `tx` is still returned, so callers get
+            // `Err(())` on every enqueue (queue never drained) and record drops.
+            tracing::error!(error = %e, "AUDIT2-006: failed to spawn delivery worker thread");
+        }
+        DeliveryWorker { tx }
+    })
+}
+
+fn worker_loop(rx: Receiver<DeliveryJob>) {
+    while let Ok(job) = rx.recv() {
+        // Isolate each job: one panicking delivery must not kill the worker
+        // (mirrors the event_bus #1745 per-subscriber panic isolation).
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| dispatch(job)));
+    }
+}
+
+fn dispatch(job: DeliveryJob) {
+    match job {
+        DeliveryJob::PtyWake {
+            home,
+            agent,
+            notification,
+        } => {
+            if let Err(e) =
+                crate::inbox::notify::inject_with_submit_direct(&home, &agent, &notification)
+            {
+                tracing::debug!(agent = %agent, error = %e, "delivery_worker: PTY wake inject failed");
+            }
+        }
+        DeliveryJob::TelegramSend(job) => {
+            crate::channel::telegram::notify::send_telegram_job(job);
+        }
+    }
+}
+
+/// Offload a physical submit-aware PTY wake. Returns `Err(())` when the bounded
+/// queue is full — the wake is dropped and the caller owns whether/how to record
+/// that (most notify callers discard the result; a WARN is emitted internally).
+pub(crate) fn enqueue_pty_wake(
+    home: &std::path::Path,
+    agent: &str,
+    notification: &str,
+) -> Result<(), ()> {
+    try_enqueue(DeliveryJob::PtyWake {
+        home: home.to_path_buf(),
+        agent: agent.to_string(),
+        notification: notification.to_string(),
+    })
+}
+
+/// Offload a Telegram send whose dedup claim was already recorded on the caller
+/// thread. Returns `Err(())` when the queue is full — the caller MUST evict the
+/// dedup claim so a later identical emit isn't suppressed for the whole TTL.
+pub(crate) fn enqueue_telegram_send(job: TelegramSendJob) -> Result<(), ()> {
+    try_enqueue(DeliveryJob::TelegramSend(job))
+}
+
+fn try_enqueue(job: DeliveryJob) -> Result<(), ()> {
+    #[cfg(test)]
+    if test_support::force_full() {
+        return Err(());
+    }
+    match global().tx.try_send(job) {
+        Ok(()) => Ok(()),
+        Err(TrySendError::Full(_)) => {
+            tracing::warn!(
+                cap = QUEUE_CAP,
+                "AUDIT2-006: delivery queue full — dropping a delivery job (caller records its own drop status)"
+            );
+            Err(())
+        }
+        // The worker is daemon-lifetime; disconnection only happens at process
+        // teardown. Treat as a drop.
+        Err(TrySendError::Disconnected(_)) => Err(()),
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test_support {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    static FORCE_FULL: AtomicBool = AtomicBool::new(false);
+
+    /// Force every `try_enqueue` to behave as if the bounded queue were full,
+    /// WITHOUT actually filling 256 slots — lets callers unit-test the drop /
+    /// dedup-rollback paths deterministically.
+    pub(crate) fn set_force_full(on: bool) {
+        FORCE_FULL.store(on, Ordering::Relaxed);
+    }
+
+    pub(super) fn force_full() -> bool {
+        FORCE_FULL.load(Ordering::Relaxed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The hot path is `try_send`: a delivery enqueue must return immediately and
+    /// never block the caller (tick) thread, and a full queue must surface as a
+    /// drop (`Err`) rather than a stall.
+    #[test]
+    fn enqueue_is_nonblocking_and_drops_when_full() {
+        // Healthy queue: a PTY wake enqueues without blocking.
+        test_support::set_force_full(false);
+        assert!(
+            enqueue_pty_wake(std::path::Path::new("/tmp/aw"), "agentA", "ping").is_ok(),
+            "a non-full delivery queue must accept the wake without blocking"
+        );
+
+        // Full queue: the enqueue is dropped (Err) — the caller, not the worker,
+        // owns recording the drop. No block, no panic.
+        test_support::set_force_full(true);
+        assert!(
+            enqueue_pty_wake(std::path::Path::new("/tmp/aw"), "agentA", "ping").is_err(),
+            "AUDIT2-006: a full delivery queue must drop (Err), never block the tick thread"
+        );
+        test_support::set_force_full(false);
+    }
+}

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -13,6 +13,7 @@ mod crash_respawn;
 pub(crate) mod cron_tick;
 pub(crate) mod decision_timeout;
 pub(crate) mod dedup_state;
+pub(crate) mod delivery_worker;
 pub(crate) mod dispatch_idle;
 pub(crate) mod escalation_persist;
 pub(crate) mod event_bus;

--- a/src/inbox/notify.rs
+++ b/src/inbox/notify.rs
@@ -628,7 +628,30 @@ where
     Ok(())
 }
 
+/// AUDIT2-006: offload the physical PTY wake (the blocking `api::call(INJECT)`
+/// loopback) to the bounded delivery worker so the tick / main-loop thread never
+/// blocks on the inject readback. Every upstream durable decision — the #911
+/// dedup gate, the #1513 defer→`enqueue_classified`, the #2044 verification arm —
+/// has already run synchronously on the caller; only the physical wake moves off-
+/// thread. The worker calls [`inject_with_submit_direct`] (NOT this wrapper), so
+/// there is no recursive re-enqueue.
+///
+/// Returns `Ok(())` once the wake is accepted by the bounded queue; `Err` only
+/// when the queue is full (the wake is dropped — the worker module logs a WARN).
 fn inject_with_submit(home: &Path, agent_name: &str, message: &str) -> anyhow::Result<()> {
+    crate::daemon::delivery_worker::enqueue_pty_wake(home, agent_name, message)
+        .map_err(|()| anyhow::anyhow!("delivery queue full — PTY wake dropped"))
+}
+
+/// The physical submit-aware inject primitive: a self-IPC `api::call(INJECT)`
+/// loopback that drives the actual PTY write. Runs on the delivery worker thread
+/// (see [`inject_with_submit`]); callers on the tick / main-loop thread MUST go
+/// through the offload wrapper instead of calling this directly.
+pub(crate) fn inject_with_submit_direct(
+    home: &Path,
+    agent_name: &str,
+    message: &str,
+) -> anyhow::Result<()> {
     let resp = crate::api::call(
         home,
         &serde_json::json!({


### PR DESCRIPTION
## What & why

The daemon tick / `run_core` loop fanned out event-bus notifications by injecting into agent PTYs and sending Telegram messages **synchronously on that one thread**. A black-holed Telegram API (no request timeout) or a slow PTY readback parked the tick — stalling hang-detection, the recovery dispatcher and crash handling that share it (AUDIT2-006).

Scope of this PR is **A + B** (consensus with codex-reviewer, decision `d-20260630031131176065-0`, VERIFIED). Cron's direct `inject_with_target_gated` PTY branch is a **bounded residual** split to a follow-up (see below).

## Changes

**A — Telegram request timeout.** `send_telegram_job` builds the teloxide `Bot` from `default_reqwest_settings().timeout(10s)` so a black-holed connection can no longer park a delivery indefinitely.

**B — bounded delivery worker** (`src/daemon/delivery_worker.rs`, `sync_channel(256)`, single FIFO worker, `try_send` → drop+WARN on full). Offloads **only the blocking wake effect**; durable writes stay synchronous.
- *notify-path PTY wake*: `inbox::notify::inject_with_submit` split into `inject_with_submit_direct` (physical `api::call(INJECT)`, worker-only) + an offload wrapper. All `notify_agent` / `compose_aware_inject` / `renudge` / `#2044` re-deliver paths now funnel through one offload point; the worker calls `_direct`, never the wrapper (no recursive re-enqueue).
- *Telegram send*: `notify_telegram_inner` claims dedup **synchronously**, then enqueues; the send runs in `send_telegram_job` on the worker. **Queue-full evicts the dedup claim** (codex edit 2) so a never-delivered notify can't suppress a legitimate same-text retry for the whole TTL.

## Invariants preserved
- `event_bus::emit()` and its handled-count (#1720 cron silent-drop guard) **unchanged** — decided by synchronous kind-match before any enqueue.
- Durable source-of-truth writes (inbox JSONL, `notification_queue`) stay **synchronous** on the caller — a notification is a wakeup, not a commit barrier.
- H8 / channel-HIGH-1: `send_telegram_job` still drives the send via `block_on_value` (no fire-and-forget `spawn`); the static invariant test stays green.
- Shutdown best-effort: daemon-lifetime worker reaped at process exit; `thread::spawn` carries a `// fire-and-forget:` rationale (spawn-rationale invariant).

## Deferred (follow-up task `t-20260630032743117105-137-1`)
Cron's `deliver_cron_fire` blocks on `agent::inject_with_target_gated`, which internally does an `AGEND_HOME`-conditional #1513 defer-gate (a durable `notification_queue` write) before the physical write. A clean offload (keep the gate synchronous, offload only the physical write) requires splitting that primitive without breaking its synchronous API/supervisor/per_tick/replay callers. Cron inject is **bounded** (per-write ≤5s), not the unbounded Telegram black-hole, so it is a tracked residual rather than a blocker.

## Tests
- New: `delivery_worker` non-blocking enqueue + drop-on-full; telegram `send_failed_evicts_dedup_med1` (relocated to `send_telegram_job`); telegram `queue_full_evicts_dedup_audit2_006`.
- Green: bin **4597/0**, lib **25/0**; `src_file_size_invariant` (LOC ceiling), `spawn_rationale_audit`, `block_on_runtime_guard_invariant`, `notify_undriven_runtime_invariant_channel` (H8), `anti_pattern` / `atomic_write` / `core_mutex` / `enqueue_drop` invariants; `cargo fmt --check` + `cargo clippy --all-targets -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)