### PR TITLE
AUDIT2-006 C: offload cron PTY inject off the tick thread

### DIFF
--- a/src/agent/inject_offload.rs
+++ b/src/agent/inject_offload.rs
@@ -1,0 +1,137 @@
+//! AUDIT2-006 C: cron PTY-inject offload.
+//!
+//! `inject_with_target_gated` historically did three things inline on the caller's
+//! (tick) thread: prepend the #1769 daemon-auto marker, run the #1513 defer gate
+//! (a *durable* `notification_queue` enqueue when the agent is busy/typing), and —
+//! if not deferred — perform the blocking physical PTY write (typed-inject
+//! readback, ≤5s per write, possibly several writes).
+//!
+//! This module splits the SYNCHRONOUS prepare/gate phase ([`prepare_inject`]) from
+//! the physical delivery, so cron can offload ONLY the physical write to the
+//! bounded delivery worker (AUDIT2-006 A+B) while the durable defer-gate stays on
+//! the caller's thread. `inject_with_target_gated` (the inline variant) is
+//! unchanged for every existing caller — API / supervisor / per-tick / replay all
+//! keep byte-equivalent synchronous delivery. Only cron opts into
+//! [`inject_with_target_gated_offload`].
+//!
+//! [`prepare_inject`] is the SOLE implementation of the marker + #1513 gate; the
+//! offload path must never re-prepend the marker or re-check the gate.
+
+/// Result of the synchronous prepare/gate phase shared by the inline and offload
+/// inject paths.
+pub(crate) enum InjectPrep {
+    /// The #1513 gate fired: the wake was durably enqueued (synchronously) to the
+    /// `notification_queue` for the per-tick flush. Carries the enqueue `Result`,
+    /// which the caller surfaces unchanged.
+    Deferred(crate::error::Result<()>),
+    /// Not deferred — proceed to the physical inject with these (marker-prepended,
+    /// owned) bytes. The caller chooses inline vs offloaded delivery.
+    Proceed(Vec<u8>),
+}
+
+/// The synchronous prepare/gate phase: #1769 marker prepend + #1513 env-conditional
+/// defer gate. SOLE implementation of both — callers must not duplicate either.
+/// `force` skips the gate (operator relay / api INJECT / recovery); `auto_kind`
+/// adds the daemon-auto marker (and routes a busy-agent defer through the
+/// coalescing enqueue, keep-latest per #t-3558).
+pub(crate) fn prepare_inject(
+    name: &str,
+    text: &[u8],
+    force: bool,
+    auto_kind: Option<&str>,
+) -> InjectPrep {
+    // #1769: daemon self-originated auto-injects carry an identifying marker so an
+    // orchestrator can distinguish them from real operator/peer input. Prepended
+    // HERE so the tag survives whichever delivery path runs. `None` (operator relay
+    // / api INJECT / inbox — already carrying their own headers) is verbatim.
+    let marked: Vec<u8> = match auto_kind {
+        Some(kind) => [super::daemon_auto_prefix(kind).as_bytes(), text].concat(),
+        None => text.to_vec(),
+    };
+    // #1513 PR-2: gate direct PTY injects like the notification path. Self-contained
+    // via AGEND_HOME; AGEND_HOME absent (non-daemon / unit test) → gate skipped.
+    if !force {
+        if let Ok(home) = std::env::var("AGEND_HOME") {
+            let home = std::path::Path::new(&home);
+            if crate::inbox::notify::should_defer_direct_inject(home, name) {
+                // Gated direct injects (cron / replay) are UTF-8 text wakes; enqueue
+                // ambient-class for the per-tick flush to drain once the pane settles
+                // (the flush re-injects via the api INJECT path with force=true —
+                // byte-equivalent). #1630: this enqueue IS the deferred-delivery path
+                // — if it fails the wake is lost, so the Result is propagated, not
+                // swallowed. #t-3558 P2: an AGEND-AUTO nudge (auto_kind set) routes
+                // through the coalescing enqueue (keep-latest) so a non-draining agent
+                // can't stack identical same-kind retry nudges.
+                let text_str = String::from_utf8_lossy(&marked);
+                let enq = if auto_kind.is_some() {
+                    crate::notification_queue::enqueue_coalesced_auto(home, name, &text_str)
+                } else {
+                    crate::notification_queue::enqueue_classified(home, name, &text_str, false)
+                };
+                return InjectPrep::Deferred(enq.map_err(|e| {
+                    crate::error::AgendError::ApiError(format!("deferred enqueue: {e}"))
+                }));
+            }
+        }
+    }
+    InjectPrep::Proceed(marked)
+}
+
+/// Outcome of [`inject_with_target_gated_offload`]. `Queued` means "accepted by the
+/// bounded delivery queue", NOT "physically delivered": if the target agent is
+/// deleted before the worker dispatches, the physical inject no-ops (the captured
+/// `InjectTarget.deleted` flag) and the recorded status stays at the queued value —
+/// queue-accept is the durability boundary by design.
+pub(crate) enum InjectDispatch {
+    /// The #1513 gate fired — durably enqueued (synchronous). Carries the enqueue
+    /// `Result` so the caller maps Ok/Err exactly as the inline path would.
+    Deferred(crate::error::Result<()>),
+    /// The physical write was accepted by the bounded delivery worker (not yet
+    /// delivered).
+    Queued,
+    /// The bounded delivery queue was full — the wake was dropped. The caller
+    /// records a drop status and WARNs.
+    QueueFull,
+}
+
+/// AUDIT2-006 C: cron-only variant of [`super::inject_with_target_gated`] that
+/// OFFLOADS the physical PTY write to the bounded delivery worker, so the tick
+/// thread never blocks on the typed-inject readback. The #1513 defer gate runs
+/// SYNCHRONOUSLY here (its enqueue is a durable source-of-truth write); only the
+/// physical inject moves off-thread.
+///
+/// The worker uses the CAPTURED `InjectTarget`, never re-resolving the name — a
+/// same-name redeploy must not receive a stale cron fire. `Queued` is NOT
+/// "delivered" (see [`InjectDispatch`]).
+///
+/// CRON ONLY. Recovery / force / API paths need synchronous delivery and must keep
+/// using `inject_with_target_gated`; `tests/cron_offload_caller_invariant.rs` pins
+/// this fn to its single cron call site.
+pub(crate) fn inject_with_target_gated_offload(
+    target: &super::InjectTarget,
+    name: &str,
+    text: &[u8],
+) -> InjectDispatch {
+    match prepare_inject(name, text, false, None) {
+        InjectPrep::Deferred(r) => InjectDispatch::Deferred(r),
+        InjectPrep::Proceed(marked) => {
+            match crate::daemon::delivery_worker::enqueue_cron_inject(target.clone(), name, marked)
+            {
+                Ok(()) => InjectDispatch::Queued,
+                Err(()) => InjectDispatch::QueueFull,
+            }
+        }
+    }
+}
+
+/// Physical-only inject for the delivery worker. The caller MUST have already run
+/// the prepare/gate phase (marker + #1513 gate) — this performs ONLY the physical
+/// PTY write, on the worker thread. Distinct from `run_ephemeral_inject` (which is
+/// bound to the headless ephemeral driver); reusing that would pollute its
+/// semantics.
+pub(crate) fn inject_target_physical(
+    target: &super::InjectTarget,
+    text: &[u8],
+) -> crate::error::Result<()> {
+    super::inject_with_target(target, text)
+}

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -155,6 +155,15 @@ pub fn lock_external(
 mod sensitive_env;
 use sensitive_env::SENSITIVE_ENV_KEYS;
 
+// AUDIT2-006 C: cron PTY-inject offload — prepare/gate split + bounded-worker
+// offload sibling. Kept out of this (grandfathered) file to respect its LOC
+// ceiling; the child module reaches the private `inject_with_target` /
+// `daemon_auto_prefix` via `super::`.
+mod inject_offload;
+pub(crate) use inject_offload::{
+    inject_target_physical, inject_with_target_gated_offload, InjectDispatch,
+};
+
 /// Returns true if the env-var name is on the spawn-time deny-list.
 pub fn is_sensitive_env_key(key: &str) -> bool {
     SENSITIVE_ENV_KEYS
@@ -2763,55 +2772,14 @@ pub(crate) fn inject_with_target_gated(
     force: bool,
     auto_kind: Option<&str>,
 ) -> crate::error::Result<()> {
-    // #1769: daemon self-originated auto-injects carry an identifying marker so
-    // an orchestrator can distinguish them from real operator/peer input. The
-    // marker is prepended HERE (before both the deferred-enqueue and the direct
-    // inject) so the tag survives whichever delivery path runs. Worker semantics
-    // are unchanged — the inner payload + submit are preserved; only a leading
-    // text tag is added. `None` (operator relay / api INJECT / inbox — which
-    // already carry their own headers) injects verbatim.
-    let marked: Vec<u8>;
-    let text: &[u8] = match auto_kind {
-        Some(kind) => {
-            marked = [daemon_auto_prefix(kind).as_bytes(), text].concat();
-            &marked
-        }
-        None => text,
-    };
-    // #1513 PR-2: gate direct PTY injects like the notification path. Self-
-    // contained via AGEND_HOME; AGEND_HOME absent (non-daemon / unit test) →
-    // gate skipped.
-    if !force {
-        if let Ok(home) = std::env::var("AGEND_HOME") {
-            let home = std::path::Path::new(&home);
-            if crate::inbox::notify::should_defer_direct_inject(home, name) {
-                // Gated direct injects (cron / replay) are UTF-8 text wakes;
-                // enqueue ambient-class for the per-tick flush to drain once the
-                // pane settles (the flush re-injects via the api INJECT path,
-                // landing back here with force=true — byte-equivalent delivery).
-                // #1630: this enqueue IS the deferred-delivery path — if it
-                // fails the wake is lost outright. The fn returns Result and the
-                // callers handle it (e.g. daemon::replay logs "replay inject
-                // failed"), so propagate rather than swallow. anyhow→AgendError
-                // has no generic variant, so map through ApiError (message
-                // preserved via Display).
-                // #t-3558 P2: an AGEND-AUTO nudge (auto_kind set) routes through
-                // the coalescing enqueue so a non-draining agent can't stack
-                // identical same-kind retry nudges (keep-latest). Everything else
-                // keeps the plain ambient enqueue.
-                let text_str = String::from_utf8_lossy(text);
-                let enq = if auto_kind.is_some() {
-                    crate::notification_queue::enqueue_coalesced_auto(home, name, &text_str)
-                } else {
-                    crate::notification_queue::enqueue_classified(home, name, &text_str, false)
-                };
-                return enq.map_err(|e| {
-                    crate::error::AgendError::ApiError(format!("deferred enqueue: {e}"))
-                });
-            }
-        }
+    // AUDIT2-006 C: prepare/gate (marker + #1513 defer) is the shared synchronous
+    // phase (sole impl in `inject_offload`); this inline variant then does the
+    // physical write directly, byte-equivalent to before. Cron uses
+    // `inject_with_target_gated_offload` to offload that physical write instead.
+    match inject_offload::prepare_inject(name, text, force, auto_kind) {
+        inject_offload::InjectPrep::Deferred(result) => result,
+        inject_offload::InjectPrep::Proceed(marked) => inject_with_target(target, &marked),
     }
-    inject_with_target(target, text)
 }
 
 /// #1146: inner inject that works on a snapshot of fields rather than a

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -1564,6 +1564,45 @@ fn inject_with_target_skips_deleted_agent_1146() {
     assert!(inject_with_target(&target, b"should be skipped").is_ok());
 }
 
+/// AUDIT2-006 C: the cron offload variant runs the prepare/gate phase
+/// synchronously (gate not triggered — `"agentA"` is never busy in a unit test, so
+/// it Proceeds) and offloads the physical write to the bounded delivery worker: a
+/// healthy queue → `Queued`, a full queue → `QueueFull`.
+#[test]
+fn inject_offload_queues_then_drops_on_full() {
+    let _ff = crate::daemon::delivery_worker::test_support::force_full_guard();
+    let writer: PtyWriter = Arc::new(parking_lot::Mutex::new(
+        Box::new(std::io::sink()) as Box<dyn Write + Send>
+    ));
+    let target = InjectTarget {
+        pty_writer: writer,
+        inject_prefix: String::new(),
+        submit_key: "\r".to_string(),
+        typed_inject: false,
+        deleted: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        core: readback_test_core(b""),
+    };
+
+    crate::daemon::delivery_worker::test_support::set_force_full(false);
+    assert!(
+        matches!(
+            inject_with_target_gated_offload(&target, "agentA", b"hi"),
+            InjectDispatch::Queued
+        ),
+        "a healthy delivery queue must accept the cron inject (Queued)"
+    );
+
+    crate::daemon::delivery_worker::test_support::set_force_full(true);
+    assert!(
+        matches!(
+            inject_with_target_gated_offload(&target, "agentA", b"hi"),
+            InjectDispatch::QueueFull
+        ),
+        "a full delivery queue must drop the cron inject (QueueFull)"
+    );
+    crate::daemon::delivery_worker::test_support::set_force_full(false);
+}
+
 // ── #1912 readback-confirm inject (hermetic, VTerm-driven) ──────────────────
 
 /// #1912: build a throwaway core with a vterm pre-seeded with `feed` (simulating

--- a/src/channel/telegram/notify.rs
+++ b/src/channel/telegram/notify.rs
@@ -327,6 +327,7 @@ mod tests {
     #[test]
     fn telegram_queue_full_evicts_dedup_audit2_006() {
         let _g = guard();
+        let _ff = crate::daemon::delivery_worker::test_support::force_full_guard();
         let home = tmp_home("qfull");
         std::fs::write(
             crate::fleet::fleet_yaml_path(&home),

--- a/src/daemon/cron_tick.rs
+++ b/src/daemon/cron_tick.rs
@@ -205,6 +205,20 @@ fn note_unhandled_cron_fire(home: &Path, sched_id: &str, target: &str, handled: 
 /// orphaned target), then records the run and auto-disables one-shots.
 /// `message`/`label` are the static schedule strings (frozen by the producer —
 /// non-time-sensitive, so no rebuild-drift concern).
+/// AUDIT2-006 C: map an offloaded-inject outcome to a `record_run` status. Pure so
+/// it is unit-tested without seeding a live registry. `ok_queued` means "accepted
+/// by the bounded delivery queue", NOT physically delivered (see `InjectDispatch`);
+/// the deferred-gate path keeps today's `ok`/`inject_failed` mapping because its
+/// durable enqueue already completed synchronously.
+fn cron_inject_status(dispatch: &agent::InjectDispatch) -> &'static str {
+    match dispatch {
+        agent::InjectDispatch::Deferred(Ok(())) => "ok",
+        agent::InjectDispatch::Deferred(Err(_)) => "inject_failed",
+        agent::InjectDispatch::Queued => "ok_queued",
+        agent::InjectDispatch::QueueFull => "drop_queue_full",
+    }
+}
+
 fn deliver_cron_fire(
     home: &Path,
     registry: &AgentRegistry,
@@ -245,14 +259,17 @@ fn deliver_cron_fire(
         // in run_history, and let the auto-disable below retire it.
         "missed"
     } else if let Some((tgt, name)) = inject_snap.as_ref() {
-        // #1769: cron is an operator-scheduled action, not a daemon auto-nudge → no marker.
-        match agent::inject_with_target_gated(tgt, name, message.as_bytes(), false, None) {
-            Ok(()) => "ok",
-            Err(e) => {
-                tracing::warn!(error = %e, "schedule inject failed");
-                "inject_failed"
-            }
+        // #1769: cron is an operator-scheduled action, not a daemon auto-nudge → no
+        // marker. AUDIT2-006 C: offload the physical PTY write to the bounded
+        // delivery worker so this tick never blocks on the typed-inject readback.
+        // The prepare/gate phase still runs synchronously inside `_offload`.
+        let dispatch = agent::inject_with_target_gated_offload(tgt, name, message.as_bytes());
+        if let agent::InjectDispatch::Deferred(Err(e)) = &dispatch {
+            tracing::warn!(error = %e, "schedule inject failed");
+        } else if matches!(dispatch, agent::InjectDispatch::QueueFull) {
+            tracing::warn!(target = %name, "schedule inject dropped: delivery queue full");
         }
+        cron_inject_status(&dispatch)
     } else if crate::fleet::instance_is_known(home, target) {
         // Known fleet instance that simply isn't running right now. Defer
         // the self-IPC enqueue past the lock (see the `deferred_inbox`
@@ -781,6 +798,33 @@ mod tests {
             .last()
             .map(|r| r.status.clone())
             .unwrap_or_default()
+    }
+
+    /// AUDIT2-006 C: the offloaded-inject → run-status mapping. `ok_queued` =
+    /// accepted by the bounded delivery queue (not physically delivered);
+    /// `drop_queue_full` = dropped; the deferred-gate path keeps today's
+    /// `ok`/`inject_failed` because its durable enqueue already completed.
+    #[test]
+    fn cron_inject_status_maps_dispatch() {
+        use crate::agent::InjectDispatch;
+        assert_eq!(
+            super::cron_inject_status(&InjectDispatch::Deferred(Ok(()))),
+            "ok"
+        );
+        assert_eq!(
+            super::cron_inject_status(&InjectDispatch::Deferred(Err(
+                crate::error::AgendError::ApiError("boom".into())
+            ))),
+            "inject_failed"
+        );
+        assert_eq!(
+            super::cron_inject_status(&InjectDispatch::Queued),
+            "ok_queued"
+        );
+        assert_eq!(
+            super::cron_inject_status(&InjectDispatch::QueueFull),
+            "drop_queue_full"
+        );
     }
 
     #[test]

--- a/src/daemon/delivery_worker.rs
+++ b/src/daemon/delivery_worker.rs
@@ -53,6 +53,16 @@ enum DeliveryJob {
     /// thread (see `channel::telegram::notify`). On terminal send failure the
     /// worker evicts that claim.
     TelegramSend(TelegramSendJob),
+    /// AUDIT2-006 C: a cron physical PTY inject. The prepare/gate phase (marker +
+    /// #1513 defer) already ran synchronously on the tick thread; the worker does
+    /// ONLY the physical write via the CAPTURED `InjectTarget`. It NEVER re-resolves
+    /// `agent` (a same-name redeploy must not receive a stale fire — `agent` is for
+    /// logging only).
+    CronInject {
+        target: crate::agent::InjectTarget,
+        agent: String,
+        text: Vec<u8>,
+    },
 }
 
 /// Payload for an offloaded Telegram send. Carries the already-resolved channel
@@ -119,6 +129,15 @@ fn dispatch(job: DeliveryJob) {
         DeliveryJob::TelegramSend(job) => {
             crate::channel::telegram::notify::send_telegram_job(job);
         }
+        DeliveryJob::CronInject {
+            target,
+            agent,
+            text,
+        } => {
+            if let Err(e) = crate::agent::inject_target_physical(&target, &text) {
+                tracing::debug!(agent = %agent, error = %e, "delivery_worker: cron inject failed");
+            }
+        }
     }
 }
 
@@ -142,6 +161,22 @@ pub(crate) fn enqueue_pty_wake(
 /// dedup claim so a later identical emit isn't suppressed for the whole TTL.
 pub(crate) fn enqueue_telegram_send(job: TelegramSendJob) -> Result<(), ()> {
     try_enqueue(DeliveryJob::TelegramSend(job))
+}
+
+/// AUDIT2-006 C: offload a cron physical PTY inject. The caller (cron) has already
+/// run the prepare/gate phase synchronously; `target` is the CAPTURED inject
+/// snapshot — the worker never re-resolves `agent` (logging only). Returns `Err(())`
+/// when the bounded queue is full, so the caller records `drop_queue_full`.
+pub(crate) fn enqueue_cron_inject(
+    target: crate::agent::InjectTarget,
+    agent: &str,
+    text: Vec<u8>,
+) -> Result<(), ()> {
+    try_enqueue(DeliveryJob::CronInject {
+        target,
+        agent: agent.to_string(),
+        text,
+    })
 }
 
 fn try_enqueue(job: DeliveryJob) -> Result<(), ()> {
@@ -169,12 +204,21 @@ pub(crate) mod test_support {
     use std::sync::atomic::{AtomicBool, Ordering};
 
     static FORCE_FULL: AtomicBool = AtomicBool::new(false);
+    static FF_LOCK: parking_lot::Mutex<()> = parking_lot::Mutex::new(());
 
     /// Force every `try_enqueue` to behave as if the bounded queue were full,
     /// WITHOUT actually filling 256 slots — lets callers unit-test the drop /
     /// dedup-rollback paths deterministically.
     pub(crate) fn set_force_full(on: bool) {
         FORCE_FULL.store(on, Ordering::Relaxed);
+    }
+
+    /// Serialize tests that toggle [`set_force_full`]: `FORCE_FULL` is process-
+    /// global, so parallel test threads would otherwise corrupt each other's
+    /// expected queue state. Hold the returned guard across the whole
+    /// toggle→assert→reset window. Every force-full test MUST hold it.
+    pub(crate) fn force_full_guard() -> parking_lot::MutexGuard<'static, ()> {
+        FF_LOCK.lock()
     }
 
     pub(super) fn force_full() -> bool {
@@ -191,6 +235,7 @@ mod tests {
     /// drop (`Err`) rather than a stall.
     #[test]
     fn enqueue_is_nonblocking_and_drops_when_full() {
+        let _ff = test_support::force_full_guard();
         // Healthy queue: a PTY wake enqueues without blocking.
         test_support::set_force_full(false);
         assert!(

--- a/tests/cron_offload_caller_invariant.rs
+++ b/tests/cron_offload_caller_invariant.rs
@@ -1,0 +1,57 @@
+//! AUDIT2-006 C invariant: `inject_with_target_gated_offload` — the cron-only PTY
+//! offload that records `ok_queued` BEFORE physical delivery — must NOT be called
+//! from recovery / force / API / per-tick paths, which need synchronous delivery
+//! (they keep using `inject_with_target_gated`). The only production call site is
+//! cron (`src/daemon/cron_tick.rs`); the definition lives in
+//! `src/agent/inject_offload.rs` and its unit tests in `src/agent/tests.rs`.
+//!
+//! This is a static source-scan guard so the next person can't quietly wire the
+//! offload (and its weaker "queued != delivered" semantics) into a recovery/force
+//! path where synchronous delivery is expected.
+#![allow(clippy::unwrap_used)]
+
+use std::path::{Path, PathBuf};
+
+fn rs_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    for entry in std::fs::read_dir(dir).unwrap() {
+        let p = entry.unwrap().path();
+        if p.is_dir() {
+            rs_files(&p, out);
+        } else if p.extension().is_some_and(|x| x == "rs") {
+            out.push(p);
+        }
+    }
+}
+
+#[test]
+fn offload_inject_only_called_from_cron() {
+    let src = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut files = Vec::new();
+    rs_files(&src, &mut files);
+
+    // (definition, the sole production cron caller, the fn's unit tests)
+    const ALLOWED: &[&str] = &[
+        "src/agent/inject_offload.rs",
+        "src/daemon/cron_tick.rs",
+        "src/agent/tests.rs",
+    ];
+
+    let mut offenders = Vec::new();
+    for f in &files {
+        let content = std::fs::read_to_string(f).unwrap();
+        if !content.contains("inject_with_target_gated_offload(") {
+            continue;
+        }
+        let rel = format!("src/{}", f.strip_prefix(&src).unwrap().display()).replace('\\', "/");
+        if !ALLOWED.contains(&rel.as_str()) {
+            offenders.push(rel);
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "AUDIT2-006 C: `inject_with_target_gated_offload(` may only appear in {ALLOWED:?} \
+         (cron-only; recovery/force/API/per-tick must use the synchronous \
+         `inject_with_target_gated`). Offending files: {offenders:?}"
+    );
+}


### PR DESCRIPTION
## What & why

The cron subscriber (`deliver_cron_fire`) blocked the daemon tick thread on `agent::inject_with_target_gated` → the physical PTY write (typed-inject readback, ≤5s per write, possibly several). This is the **bounded residual** deferred from AUDIT2-006 A+B (#2511). The delivery worker now exists, so cron offloads its physical write while the durable defer-gate stays synchronous.

Consensus design with `codex-reviewer` (decision `d-20260630115207560361-2`).

## Design — prepare/gate split + per-caller opt-in offload

New `src/agent/inject_offload.rs` (a child module, so the grandfathered `agent/mod.rs` doesn't grow past its LOC ceiling — it actually **shrinks** 3191 → 3159):

- **`prepare_inject`** is now the SOLE impl of the #1769 marker + #1513 env-conditional defer-gate (a durable `notification_queue` enqueue), returning `InjectPrep::{Deferred(Result), Proceed(bytes)}`.
- **`inject_with_target_gated`** keeps its signature and does the inline physical write for the `Proceed` case — **byte-equivalent** for API / supervisor / per-tick / replay callers.
- **`inject_with_target_gated_offload`** (cron ONLY) runs prepare/gate synchronously, then enqueues the physical write to the delivery worker → `InjectDispatch::{Deferred, Queued, QueueFull}`. The worker uses the **CAPTURED `InjectTarget`** and **never re-resolves the name** (a same-name redeploy must not get a stale fire). `Queued` ≠ delivered.
- **`inject_target_physical`** — the physical-only entry the worker calls (distinct from `run_ephemeral_inject`).
- `delivery_worker`: new `CronInject` job + `enqueue_cron_inject`; dispatch calls `inject_target_physical` (no gate, no registry resolve).
- cron `deliver_cron_fire` records **synchronously**: `ok`/`inject_failed` (deferred-gate path), `ok_queued` (accepted), `drop_queue_full`+WARN (full queue); one-shot disable unchanged.

## Safety / semantics (codex)
- **Memory-safe**: `InjectTarget` is Arc clones; delete sets `deleted=true`, the physical inject no-ops — no use-after-free.
- **Observability boundary**: queue-accept is the durability boundary, so an agent deleted before dispatch leaves run_history at `ok_queued` (`ok_queued` is documented as "accepted, not delivered").
- **Head-of-line**: cron shares the single FIFO worker with notify/telegram; PTY/Telegram lane-split is a future option, not this PR.

## Out of scope
Lane-splitting the worker; any change to the inline (API/supervisor/per-tick/replay) callers.

## Tests
- offload `Queued` / `QueueFull`; `cron_inject_status` dispatch→status mapping; `tests/cron_offload_caller_invariant.rs` pins `_offload` to its single cron call site (recovery/force/API must use the synchronous variant); force-full tests serialized via a shared guard to remove a cross-test race.
- Green: bin **4601/0**, lib **25/0**; `cargo fmt --check` + `cargo clippy --all-targets -D warnings`; `src_file_size` (LOC) / `atomic_write` / `spawn_rationale` / `anti_pattern` invariants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)