### PR TITLE
AUDIT2-009: per-workflow CI notify cursor — fix silently-dropped low-id rerun-to-green

### DIFF
--- a/src/daemon/ci_watch/poller.rs
+++ b/src/daemon/ci_watch/poller.rs
@@ -89,7 +89,7 @@ use super::registry::{ci_watches_dir, flush_watch_state, remove_watch};
 use super::sweep::{
     bump_repo_stall_and_maybe_notify, clear_repo_stall_and_maybe_resume, clear_stall_state,
 };
-use super::watch_state::WatchState;
+use super::watch_state::{WatchState, WorkflowNotifyCursor};
 use super::WATCH_TTL_HOURS;
 
 // Test-only re-exports so the existing test module (moved verbatim from
@@ -687,6 +687,101 @@ pub(crate) fn select_runs_to_notify(
     // Sort oldest-first by run_id
     selected.sort_by_key(|&(_, id)| id);
     selected.into_iter().map(|(i, _)| i).collect()
+}
+
+/// AUDIT2-009: the per-workflow notify key. Named workflows key by `name`; unnamed
+/// runs (degraded provider / parse) get a synthetic per-id key so two unnamed runs
+/// are never collapsed into one cursor (mirrors `latest_run_per_workflow`).
+fn workflow_cursor_key(run: &CiRun) -> String {
+    if run.name.is_empty() {
+        format!("#run:{}", run.id)
+    } else {
+        run.name.clone()
+    }
+}
+
+/// AUDIT2-009: per-workflow notify gate (used once the cursor map is seeded; the
+/// empty-map migration / fresh-watch path stays on the legacy
+/// [`select_runs_to_notify`]). For each latest-per-workflow TERMINAL run at the
+/// CURRENT head, select it (its index into `runs`) when its workflow has no cursor
+/// or its `(id, run_attempt, conclusion)` differs from the recorded cursor. This is
+/// what rescues a lower-id workflow's rerun-to-green that the single-`last_run_id`
+/// threshold silently dropped (the AUDIT2-009 handoff break).
+fn select_runs_to_notify_per_workflow(
+    runs: &[CiRun],
+    current_sha: &str,
+    last_notified_by_workflow: &std::collections::BTreeMap<String, WorkflowNotifyCursor>,
+) -> Vec<usize> {
+    // One terminal run per workflow at the current head — max `(id, run_attempt)`,
+    // keeping the index into `runs`.
+    let mut best: std::collections::HashMap<String, (usize, u64, u64)> =
+        std::collections::HashMap::new();
+    for (i, run) in runs.iter().enumerate() {
+        if run.head_sha != current_sha || run.conclusion.is_none() {
+            continue;
+        }
+        let key = workflow_cursor_key(run);
+        best.entry(key)
+            .and_modify(|e| {
+                if (run.id, run.run_attempt) > (e.1, e.2) {
+                    *e = (i, run.id, run.run_attempt);
+                }
+            })
+            .or_insert((i, run.id, run.run_attempt));
+    }
+    let mut selected: Vec<(usize, u64)> = best
+        .into_iter()
+        .filter_map(|(key, (i, _, _))| {
+            let run = &runs[i];
+            let conclusion = run.conclusion.as_deref()?;
+            let fresh = match last_notified_by_workflow.get(&key) {
+                None => true,
+                Some(c) => {
+                    c.run_id != run.id
+                        || c.run_attempt != run.run_attempt
+                        || c.conclusion != conclusion
+                }
+            };
+            fresh.then_some((i, run.id))
+        })
+        .collect();
+    selected.sort_by_key(|&(_, id)| id);
+    selected.into_iter().map(|(i, _)| i).collect()
+}
+
+/// AUDIT2-009: the per-workflow notify cursors for ALL latest-per-workflow TERMINAL
+/// runs at the current head. Persisted after every notify cycle (and on the
+/// migration / seeding poll, even when nothing was selected) so a high-id
+/// representative never leaves a sibling workflow unseeded — an unseeded sibling
+/// would later re-notify a stable state.
+fn compute_workflow_cursors(
+    runs: &[CiRun],
+    current_sha: &str,
+) -> std::collections::BTreeMap<String, WorkflowNotifyCursor> {
+    let mut best: std::collections::BTreeMap<String, WorkflowNotifyCursor> =
+        std::collections::BTreeMap::new();
+    for run in runs.iter() {
+        if run.head_sha != current_sha {
+            continue;
+        }
+        let Some(conclusion) = run.conclusion.as_deref() else {
+            continue;
+        };
+        let key = workflow_cursor_key(run);
+        let cursor = WorkflowNotifyCursor {
+            run_id: run.id,
+            run_attempt: run.run_attempt,
+            conclusion: conclusion.to_string(),
+        };
+        best.entry(key)
+            .and_modify(|e| {
+                if (run.id, run.run_attempt) > (e.run_id, e.run_attempt) {
+                    *e = cursor.clone();
+                }
+            })
+            .or_insert(cursor);
+    }
+    best
 }
 
 /// Pure function: deduplicate terminal runs by head_sha.
@@ -1384,13 +1479,37 @@ async fn ci_check_repo(
     // the terminal-only notification gates below.
     check_early_job_failures(&ctx, &mut state, &pr, provider).await;
 
-    let to_notify = select_runs_to_notify(
-        &pr.runs,
-        pr.effective_last_run_id,
-        tracking.last_notified_conclusion,
-        tracking.last_notified_run_attempt,
-        tracking.last_notified_run_conclusion,
-    );
+    // AUDIT2-009: on a head move the per-workflow cursors describe the OLD head —
+    // clear them so the new head is treated fresh (mirrors `effective_last_run_id`
+    // resetting `last_run_id`). Selection then falls to the legacy gate until the
+    // new head's cursors are seeded below.
+    let head_moved = tracking
+        .prev_head_sha
+        .is_some_and(|prev| prev != pr.current_sha.as_str());
+    if head_moved {
+        state.last_notified_by_workflow.clear();
+    }
+    // AUDIT2-009: once the per-workflow cursor map is seeded, it is the authoritative
+    // notify gate (one cursor per workflow `name`, so a low-id workflow's rerun-to-
+    // green is no longer hard-dropped by the single global `last_run_id` threshold).
+    // An EMPTY map (fresh watch or pre-upgrade legacy state) falls back to the legacy
+    // threshold gate — no behavior change, no post-upgrade storm — and is seeded
+    // below from this poll's latest-per-workflow runs.
+    let to_notify = if state.last_notified_by_workflow.is_empty() {
+        select_runs_to_notify(
+            &pr.runs,
+            pr.effective_last_run_id,
+            tracking.last_notified_conclusion,
+            tracking.last_notified_run_attempt,
+            tracking.last_notified_run_conclusion,
+        )
+    } else {
+        select_runs_to_notify_per_workflow(
+            &pr.runs,
+            &pr.current_sha,
+            &state.last_notified_by_workflow,
+        )
+    };
     if to_notify.is_empty() {
         // #1991: did anything actually change this cycle? A branch whose runs
         // are all terminal and all already-notified produces an UNCHANGED
@@ -1413,6 +1532,15 @@ async fn ci_check_repo(
             if activity {
                 state.last_terminal_seen_at = Some(chrono::Utc::now().to_rfc3339());
             }
+        }
+        // AUDIT2-009: seed/refresh per-workflow cursors even when nothing was
+        // selected — migration's first post-upgrade poll may notify nothing under
+        // the legacy gate, but the map must populate so later polls use the
+        // per-workflow gate. Only when there ARE current-head terminal runs, so a
+        // stale-only / all-in-progress poll preserves the existing map.
+        let cursors = compute_workflow_cursors(&pr.runs, &pr.current_sha);
+        if !cursors.is_empty() {
+            state.last_notified_by_workflow = cursors;
         }
         if state != snapshot {
             flush_watch_state(watch_path, &state);
@@ -2060,6 +2188,15 @@ fn persist_watch_state(
         state.last_stale_emitted_sha = Some(s.clone());
     }
     state.last_terminal_seen_at = Some(chrono::Utc::now().to_rfc3339());
+    // AUDIT2-009: record the per-workflow cursors for ALL latest-per-workflow
+    // terminal runs at the current head (not just the notified representative), so
+    // an unnotified sibling workflow never re-triggers a stable-state notification
+    // next poll. Only overwrite when there ARE current-head terminal runs — a
+    // stale-only emit preserves the existing map.
+    let cursors = compute_workflow_cursors(&pr.runs, &pr.current_sha);
+    if !cursors.is_empty() {
+        state.last_notified_by_workflow = cursors;
+    }
 }
 
 /// Refresh `expires_at` to now + 72h after a successful poll (#1267).

--- a/src/daemon/ci_watch/poller_tests.rs
+++ b/src/daemon/ci_watch/poller_tests.rs
@@ -703,6 +703,177 @@ fn test_1307_rerun_pass_same_sha_fires_notification() {
     );
 }
 
+// ── AUDIT2-009: per-workflow notify cursor ──────────────────────────────────
+
+fn wf_run(name: &str, id: u64, attempt: u64, conclusion: Option<&str>, sha: &str) -> CiRun {
+    CiRun {
+        id,
+        run_attempt: attempt,
+        conclusion: conclusion.map(String::from),
+        head_sha: sha.into(),
+        url: String::new(),
+        name: name.into(),
+    }
+}
+
+fn cursor(
+    id: u64,
+    attempt: u64,
+    conclusion: &str,
+) -> crate::daemon::ci_watch::watch_state::WorkflowNotifyCursor {
+    crate::daemon::ci_watch::watch_state::WorkflowNotifyCursor {
+        run_id: id,
+        run_attempt: attempt,
+        conclusion: conclusion.into(),
+    }
+}
+
+/// The bug: workflow A (low id) failed and workflow B (high id) passed → both
+/// notified; the legacy single high-water threshold (= B.id) then HARD-dropped A's
+/// rerun-to-green because `A.id < threshold`. Per-workflow cursors rescue it.
+#[test]
+fn per_workflow_rescues_low_id_workflow_rerun_audit2_009() {
+    use std::collections::BTreeMap;
+    let runs = vec![
+        wf_run("A", 100, 2, Some("success"), "head"), // A reran: attempt 1→2, fail→success
+        wf_run("B", 200, 1, Some("success"), "head"),
+    ];
+    let mut map = BTreeMap::new();
+    map.insert("A".to_string(), cursor(100, 1, "failure"));
+    map.insert("B".to_string(), cursor(200, 1, "success"));
+    assert_eq!(
+        select_runs_to_notify_per_workflow(&runs, "head", &map),
+        vec![0],
+        "A's rerun-to-green (id 100 < B's 200) MUST be selected (AUDIT2-009)"
+    );
+}
+
+/// A provider without an attempt concept reruns by minting a NEW run_id with
+/// `run_attempt == 1`. Keying only on (attempt, conclusion) would swallow it; the
+/// cursor's `run_id` catches it.
+#[test]
+fn per_workflow_provider_retry_new_id_notifies_audit2_009() {
+    use std::collections::BTreeMap;
+    let runs = vec![wf_run("A", 150, 1, Some("success"), "head")];
+    let mut map = BTreeMap::new();
+    map.insert("A".to_string(), cursor(100, 1, "failure"));
+    assert_eq!(
+        select_runs_to_notify_per_workflow(&runs, "head", &map),
+        vec![0],
+        "a retry as a NEW run_id at attempt 1 must notify (run_id is part of the cursor)"
+    );
+}
+
+/// An unchanged latest-per-workflow terminal set on the same head selects nothing
+/// (the #1991 storm guard, subsumed per-workflow).
+#[test]
+fn per_workflow_stable_state_selects_nothing_audit2_009() {
+    use std::collections::BTreeMap;
+    let runs = vec![
+        wf_run("A", 100, 2, Some("success"), "head"),
+        wf_run("B", 200, 1, Some("success"), "head"),
+    ];
+    let mut map = BTreeMap::new();
+    map.insert("A".to_string(), cursor(100, 2, "success"));
+    map.insert("B".to_string(), cursor(200, 1, "success"));
+    assert!(
+        select_runs_to_notify_per_workflow(&runs, "head", &map).is_empty(),
+        "an unchanged latest-per-workflow terminal set must select nothing"
+    );
+}
+
+/// Two UNNAMED runs at the same head must NOT collapse into one cursor (synthetic
+/// `#run:<id>` keys), so one going terminal never masks the other.
+#[test]
+fn per_workflow_empty_name_runs_do_not_collapse_audit2_009() {
+    use std::collections::BTreeMap;
+    let runs = vec![
+        wf_run("", 100, 1, Some("success"), "head"),
+        wf_run("", 200, 1, Some("failure"), "head"),
+    ];
+    let cursors = compute_workflow_cursors(&runs, "head");
+    assert_eq!(cursors.len(), 2, "two unnamed runs → two #run:<id> cursors");
+    assert!(cursors.contains_key("#run:100") && cursors.contains_key("#run:200"));
+    let mut map = BTreeMap::new();
+    map.insert("#run:100".to_string(), cursor(100, 1, "success"));
+    assert_eq!(
+        select_runs_to_notify_per_workflow(&runs, "head", &map),
+        vec![1],
+        "the unseeded unnamed run must be selected independently"
+    );
+}
+
+/// `compute_workflow_cursors` records one cursor per workflow = its LATEST attempt,
+/// for TERMINAL runs at the CURRENT head only (stale-sha + in-progress excluded).
+#[test]
+fn compute_workflow_cursors_latest_per_workflow_current_head_audit2_009() {
+    let runs = vec![
+        wf_run("A", 99, 1, Some("failure"), "head"), // superseded older attempt
+        wf_run("A", 100, 2, Some("success"), "head"), // latest A
+        wf_run("B", 200, 1, Some("success"), "head"),
+        wf_run("A", 50, 1, Some("success"), "oldsha"), // stale sha → excluded
+        wf_run("C", 300, 1, None, "head"),             // in-progress → excluded
+    ];
+    let cursors = compute_workflow_cursors(&runs, "head");
+    assert_eq!(
+        cursors.len(),
+        2,
+        "only terminal latest A + B at current head"
+    );
+    assert_eq!(cursors.get("A"), Some(&cursor(100, 2, "success")));
+    assert_eq!(cursors.get("B"), Some(&cursor(200, 1, "success")));
+}
+
+/// AUDIT2-009 end-to-end (true regression): two workflows at the same head — A
+/// (low id) fails, B (high id) passes → aggregate failure notified + per-workflow
+/// cursors seeded. Then A is rerun to green (same id, attempt 2). The legacy single
+/// high-water threshold (= B.id) would HARD-drop A's rerun (`A.id < threshold`) and
+/// the watch would stay at `failure` (handoff silently broken). With per-workflow
+/// cursors the rerun is selected → aggregate success → the watch transitions to
+/// `success` (the same select→fan_out→persist chain that fires `[ci-pass]` /
+/// `[ci-ready-for-action]` + `record_ci_result`).
+#[test]
+fn e2e_low_id_workflow_rerun_green_notifies_handoff_audit2_009() {
+    let dir = tmp_dir("audit2-009-e2e");
+    let mut watch = base_watch();
+    watch["next_after_ci"] = serde_json::json!(["reviewer"]);
+
+    // Cycle 1: A (id 100) failure + B (id 200) success at "head".
+    let p1 = MockCiProvider::with_runs(vec![
+        wf_run("A", 100, 1, Some("failure"), "head"),
+        wf_run("B", 200, 1, Some("success"), "head"),
+    ]);
+    run_ci_check(&dir, &watch, &p1).unwrap();
+    let watch_path = dir.join("ci-watches").join(watch_filename("o/r", "feat"));
+    let after1: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&watch_path).unwrap()).unwrap();
+    assert_eq!(
+        after1["last_notified_conclusion"].as_str(),
+        Some("failure"),
+        "cycle 1: aggregate failure must be notified"
+    );
+
+    // Cycle 2: A rerun to green (same id 100, attempt 2). B unchanged.
+    let p2 = MockCiProvider::with_runs(vec![
+        wf_run("A", 100, 2, Some("success"), "head"),
+        wf_run("B", 200, 1, Some("success"), "head"),
+    ]);
+    run_ci_check(&dir, &after1, &p2).unwrap();
+    let after2: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&watch_path).unwrap()).unwrap();
+    assert_eq!(
+        after2["last_notified_conclusion"].as_str(),
+        Some("success"),
+        "AUDIT2-009: A's low-id rerun-to-green MUST notify (aggregate success), not be \
+         hard-dropped by the high-water threshold — else the handoff is silently broken"
+    );
+    assert_eq!(
+        after2["last_notified_by_workflow"]["A"]["conclusion"].as_str(),
+        Some("success"),
+        "A's per-workflow cursor must advance to success"
+    );
+}
+
 #[test]
 fn test_different_head_sha_triggers_new_notification() {
     let runs = vec![

--- a/src/daemon/ci_watch/registry.rs
+++ b/src/daemon/ci_watch/registry.rs
@@ -353,6 +353,11 @@ pub(super) fn flush_watch_state(watch_path: &Path, state: &super::watch_state::W
     merged.last_notified_conclusion = state.last_notified_conclusion.clone();
     merged.last_notified_run_attempt = state.last_notified_run_attempt;
     merged.last_notified_run_conclusion = state.last_notified_run_conclusion.clone();
+    // AUDIT2-009: the per-workflow notify cursors are poll-owned (like the
+    // last_notified_* fields above) — without this they'd never persist, so every
+    // poll would see an empty map, fall back to the legacy threshold gate, and the
+    // fix would be inert.
+    merged.last_notified_by_workflow = state.last_notified_by_workflow.clone();
     merged.last_stale_emitted_sha = state.last_stale_emitted_sha.clone();
     merged.last_mergeable_state = state.last_mergeable_state.clone();
     merged.last_mergeable_check_at = state.last_mergeable_check_at.clone();

--- a/src/daemon/ci_watch/watch_state.rs
+++ b/src/daemon/ci_watch/watch_state.rs
@@ -8,6 +8,29 @@ pub struct Subscriber {
     pub subscribed_at: Option<String>,
 }
 
+/// AUDIT2-009: per-workflow notify cursor. CI runs from N workflows form N parallel
+/// `run_id` streams; the legacy single `last_run_id` high-water threshold silently
+/// dropped a lower-id workflow's rerun-to-green (`run.id < threshold`) BEFORE the
+/// attempt/conclusion check, breaking the `next_after_ci` reviewer handoff. Keyed by
+/// workflow name (unnamed runs use a synthetic `#run:<id>` key), this records the
+/// last-notified `(run_id, run_attempt, conclusion)` PER WORKFLOW, so a fresh
+/// terminal event in any workflow is selected regardless of its id relative to
+/// siblings. `run_id` is part of the cursor because a provider without an attempt
+/// concept reports a rerun as a NEW id with `run_attempt == 1` — keying on
+/// attempt+conclusion alone would swallow it.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct WorkflowNotifyCursor {
+    pub run_id: u64,
+    pub run_attempt: u64,
+    pub conclusion: String,
+}
+
+fn workflow_cursor_map_is_empty(
+    m: &std::collections::BTreeMap<String, WorkflowNotifyCursor>,
+) -> bool {
+    m.is_empty()
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct WatchState {
     #[serde(default)]
@@ -59,6 +82,13 @@ pub struct WatchState {
     /// `None` on a legacy watch → gate 1 falls back to the aggregate field.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_notified_run_conclusion: Option<String>,
+    /// AUDIT2-009: per-workflow notify cursors (keyed by workflow name; unnamed →
+    /// `#run:<id>`). The authoritative notify gate — supersedes the single
+    /// `last_run_id` threshold (kept above with reduced authority for migration /
+    /// observability). Reset on head move. Absent on a legacy watch → seeded on
+    /// the first post-upgrade poll from the current head's latest-per-workflow runs.
+    #[serde(default, skip_serializing_if = "workflow_cursor_map_is_empty")]
+    pub last_notified_by_workflow: std::collections::BTreeMap<String, WorkflowNotifyCursor>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_stale_emitted_sha: Option<String>,
 


### PR DESCRIPTION
## What & why (High, silent)

CI runs from N workflows form **N parallel `run_id` streams**, but the notify dedup gated on a SINGLE global `last_run_id` high-water threshold: `select_runs_to_notify` hard-dropped `run.id < threshold` **before** the attempt/conclusion check (the #1859 attempt rescue only applied at `run.id == threshold`). So when a lower-id workflow failed while a higher-id sibling passed, a later `gh run rerun` of the failing workflow (id unchanged) was **silently dropped** → no `[ci-pass]`/`[ci-ready-for-action]`, `record_ci_result` never ran → the `next_after_ci` reviewer handoff broke. ~half the time with ≥2 workflows (run-id ordering is arbitrary).

Consensus design **A'** with `codex-reviewer` (decision `d-20260630180257849779-3`).

## Fix — per-workflow notify cursor
- `WatchState.last_notified_by_workflow: BTreeMap<String, WorkflowNotifyCursor>`, cursor = `(run_id, run_attempt, conclusion)`. **`run_id` is part of the cursor** because a provider without an attempt concept reports a rerun as a NEW id with `run_attempt == 1`.
- **Selection**: once seeded, the map is the notify gate — for each latest-per-workflow terminal run at the current head, select it when its workflow has no cursor or its `(id, attempt, conclusion)` differs. Keyed by workflow `name` (unnamed → synthetic `#run:<id>`, never collapsed). An **empty map** (fresh watch / pre-upgrade legacy state) falls back to the legacy threshold gate — no behavior change, no post-upgrade storm — and is seeded from this poll.
- The map only decides *"is there a fresh terminal event worth running the aggregate path"*; the **aggregate verdict / `[ci-pass]` / `[ci-ready-for-action]` / `record_ci_result` logic is UNCHANGED**. Cursors for **all** latest-per-workflow runs are persisted (not just the representative) so an unseeded sibling never re-notifies a stable state. Reset on head move.
- **`flush_watch_state`**: added `last_notified_by_workflow` to the poll-owned merge allowlist (flush re-reads the file + overwrites only poll-owned fields) — **without this the map never persists and the fix is inert**. The e2e test below caught exactly this omission.
- Legacy `last_run_id` / `last_notified_*` kept (reduced authority) for migration / UI.

## Tests
- `per_workflow_rescues_low_id_workflow_rerun` (the bug); `provider_retry_new_id_notifies` (cursor includes id); `stable_state_selects_nothing` (#1991 storm subsumed); `empty_name_runs_do_not_collapse`; `compute_workflow_cursors_latest_per_workflow_current_head`.
- **e2e `e2e_low_id_workflow_rerun_green_notifies_handoff`** — two cycles (A fails + B passes → A rerun green) asserting the watch transitions `failure → success`; a **true regression test** (fails without the fix *or* without the flush persistence).
- Existing **193** poller tests unchanged (legacy gate intact; two-cycle tests now exercise the per-workflow path on their 2nd cycle).
- Green: bin **4608/0**, lib **25/0**; `cargo fmt --check` + `cargo clippy --all-targets -D warnings`; `src_file_size` / `atomic_write` / `anti_pattern` invariants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)