### PR TITLE
fix(teams): explicit project_id override for fragile source_repo slug derivation (#2509)

### DIFF
--- a/src/fleet/mod.rs
+++ b/src/fleet/mod.rs
@@ -520,6 +520,16 @@ pub struct TeamConfig {
     pub created_at: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_repo: Option<std::path::PathBuf>,
+    /// #2509: explicit project-board id override. `project_id_from_source_repo`
+    /// guesses `owner/repo` from `source_repo`'s last two path segments, which
+    /// mis-slugs when the local clone sits under an intermediate directory
+    /// (e.g. `~/Projects/x` → `Projects_x` instead of `x`). Set this to align
+    /// the team's resolved board with wherever its tasks actually live, without
+    /// touching `source_repo` (worktree/dispatch identity) or any existing
+    /// event history. `None` (default) preserves the source_repo-derived guess
+    /// exactly — byte-identical for every deployment that doesn't set it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub accept_from: Vec<String>,
 }

--- a/src/fleet/persist.rs
+++ b/src/fleet/persist.rs
@@ -261,6 +261,12 @@ fn team_config_to_mapping(config: &TeamConfig) -> serde_yaml_ng::Mapping {
             serde_yaml_ng::Value::String(sr.display().to_string()),
         );
     }
+    if let Some(ref pid) = config.project_id {
+        team.insert(
+            "project_id".into(),
+            serde_yaml_ng::Value::String(pid.clone()),
+        );
+    }
     if !config.accept_from.is_empty() {
         let seq: Vec<serde_yaml_ng::Value> = config
             .accept_from
@@ -471,6 +477,7 @@ pub fn migrate_teams_json_to_yaml(home: &Path) -> Result<()> {
             description: team.description.clone(),
             created_at: team.created_at.clone(),
             source_repo: None,
+            project_id: None,
             accept_from: Vec::new(),
         };
         match add_team_to_yaml(home, &team.name, &cfg) {

--- a/src/fleet/persist/review_repro_deployments_health_teams.rs
+++ b/src/fleet/persist/review_repro_deployments_health_teams.rs
@@ -42,6 +42,7 @@ fn team_with_member(member: &str) -> TeamConfig {
         description: None,
         created_at: Some("2026-06-14T00:00:00Z".to_string()),
         source_repo: None,
+        project_id: None,
         accept_from: Vec::new(),
     }
 }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -268,6 +268,7 @@ pub(crate) fn def_team() -> Value {
             "orchestrator": {"type": "string", "description": "Team orchestrator — must be a member."},
             "description": {"type": "string"},
             "repository_path": {"type": "string", "description": "Local filesystem path to the source repository for the team."},
+            "project_id": {"type": "string", "description": "#2509: explicit project-board id override. Set when `repository_path` sits under an intermediate directory (e.g. ~/Projects/x), which mis-derives the board slug from the last two path segments — this overrides that guess without touching repository_path/worktree identity."},
             "accept_from": {"type": "array", "items": {"type": "string"}, "description": "External agent names allowed to send directly to this team's orchestrator (cross-team allowlist). Empty = deny all cross-team sends (default)."},
             "add": {"type": "array", "items": {"type": "string"}},
             "remove": {"type": "array", "items": {"type": "string"}}
@@ -926,6 +927,7 @@ mod tests {
             ("team", "orchestrator", "teams.rs create/update validated member"),
             ("team", "description", "teams.rs create/update"),
             ("team", "repository_path", "teams.rs create/update source_repo"),
+            ("team", "project_id", "teams.rs create/update project_id override (#2509)"),
             ("team", "accept_from", "teams.rs create/update cross-team allowlist"),
             ("team", "add", "teams.rs update add-members"),
             ("team", "remove", "teams.rs update remove-members"),

--- a/src/tasks/board_router.rs
+++ b/src/tasks/board_router.rs
@@ -303,13 +303,31 @@ pub(crate) fn project_id_from_source_repo(repo: &Path) -> String {
     project_slug(&raw)
 }
 
-/// The project a caller currently acts in: its team's `source_repo`, else the
-/// fleet-wide [`DEFAULT_PROJECT`]. (No team / no `source_repo` → default → the
-/// `home` board → byte-identical for single-project deployments.)
+/// #2509: a team's resolved project id — explicit `project_id` override
+/// (slugged for the same filesystem/path-escape safety as the source_repo
+/// derivation) takes priority over the `source_repo`-derived guess.
+/// `project_id_from_source_repo` guesses `owner/repo` from the last two path
+/// segments, which mis-slugs when the local clone sits under an intermediate
+/// directory (e.g. `~/Projects/x` → `Projects_x`); the override lets an
+/// operator align the team with wherever its tasks actually live without
+/// touching `source_repo` (worktree/dispatch identity) or any event history.
+/// `None` when the team has set neither, so the caller falls back to
+/// [`DEFAULT_PROJECT`] — byte-identical to pre-#2509 for every team that
+/// doesn't set `project_id`.
+fn project_id_for_team(team: &crate::teams::Team) -> Option<String> {
+    team.project_id
+        .as_ref()
+        .map(|pid| project_slug(pid))
+        .or_else(|| team.source_repo.as_deref().map(project_id_from_source_repo))
+}
+
+/// The project a caller currently acts in: its team's `project_id` override or
+/// `source_repo`-derived guess, else the fleet-wide [`DEFAULT_PROJECT`]. (No
+/// team / neither set → default → the `home` board → byte-identical for
+/// single-project deployments.)
 pub(super) fn resolve_current_project(home: &Path, caller: &str) -> String {
     crate::teams::find_team_for(home, caller)
-        .and_then(|t| t.source_repo)
-        .map(|repo| project_id_from_source_repo(&repo))
+        .and_then(|t| project_id_for_team(&t))
         .unwrap_or_else(|| DEFAULT_PROJECT.to_string())
 }
 
@@ -330,8 +348,7 @@ pub(super) fn resolve_current_project(home: &Path, caller: &str) -> String {
 pub(super) fn resolve_current_project_checked(home: &Path, caller: &str) -> anyhow::Result<String> {
     let fleet = crate::teams::try_load_fleet(home)?;
     Ok(crate::teams::find_team_for_in(&fleet, caller)
-        .and_then(|t| t.source_repo)
-        .map(|repo| project_id_from_source_repo(&repo))
+        .and_then(|t| project_id_for_team(&t))
         .unwrap_or_else(|| DEFAULT_PROJECT.to_string()))
 }
 

--- a/src/tasks/tests.rs
+++ b/src/tasks/tests.rs
@@ -1290,6 +1290,96 @@ teams:
     std::fs::write(crate::fleet::fleet_yaml_path(home), yaml).unwrap();
 }
 
+// ── #2509: explicit project_id override at the resolver level ──
+
+/// A team whose `source_repo` sits under an intermediate directory — the
+/// exact reported friction (`~/Projects/simple-edge-tts` mis-derives to
+/// `Projects_simple-edge-tts` instead of `simple-edge-tts`).
+fn fragile_source_repo_fleet(home: &std::path::Path, project_id_line: &str) {
+    let yaml = format!(
+        "instances:\n  dev:\n    backend: claude\nteams:\n  edge:\n    members:\n      - dev\n    source_repo: /Users/me/Projects/simple-edge-tts\n{project_id_line}"
+    );
+    std::fs::write(crate::fleet::fleet_yaml_path(home), yaml).unwrap();
+}
+
+/// `resolve_current_project`/`resolve_current_project_checked` prefer an
+/// explicit `project_id` override over the fragile `source_repo`-derived
+/// guess; with no override, the fallback is byte-identical to pre-#2509
+/// (still the fragile slug — pinned here so a future change can't silently
+/// alter the fallback derivation itself, only add the override on top).
+#[test]
+fn resolve_current_project_prefers_explicit_project_id_2509() {
+    let home = tmp_home("2509-resolver-fallback");
+    fragile_source_repo_fleet(&home, "");
+    assert_eq!(
+        super::board_router::resolve_current_project(&home, "dev"),
+        "Projects_simple-edge-tts",
+        "byte-identical fallback: no project_id set, fragile derivation unchanged"
+    );
+    assert_eq!(
+        super::board_router::resolve_current_project_checked(&home, "dev").unwrap(),
+        "Projects_simple-edge-tts"
+    );
+    std::fs::remove_dir_all(&home).ok();
+
+    let home = tmp_home("2509-resolver-override");
+    fragile_source_repo_fleet(&home, "    project_id: simple-edge-tts\n");
+    assert_eq!(
+        super::board_router::resolve_current_project(&home, "dev"),
+        "simple-edge-tts",
+        "explicit project_id must win over the fragile source_repo derivation"
+    );
+    assert_eq!(
+        super::board_router::resolve_current_project_checked(&home, "dev").unwrap(),
+        "simple-edge-tts"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// `resolve_target_project` (the comms auto-create dispatch-routing path)
+/// inherits the same override — it's a direct passthrough to
+/// `resolve_current_project`, so a task auto-created for `dev` as dispatch
+/// target lands on the operator-intended board too, not just claim/done/update.
+#[test]
+fn resolve_target_project_prefers_explicit_project_id_2509() {
+    let home = tmp_home("2509-target-project");
+    fragile_source_repo_fleet(&home, "    project_id: simple-edge-tts\n");
+    assert_eq!(
+        super::resolve_target_project(&home, "dev"),
+        "simple-edge-tts"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// Slug safety: an operator-supplied `project_id` goes through the SAME
+/// `project_slug` sanitization as the `source_repo` derivation — no path
+/// escape (`../`), no collapse to `.`/`..`/empty (CR-2026-06-14).
+#[test]
+fn resolve_current_project_sanitizes_malicious_project_id_2509() {
+    let home = tmp_home("2509-slug-safety");
+    fragile_source_repo_fleet(&home, "    project_id: \"../escape\"\n");
+    let resolved = super::board_router::resolve_current_project(&home, "dev");
+    assert_eq!(
+        resolved,
+        crate::task_events::project_slug("../escape"),
+        "project_id must be sanitized via project_slug, not raw-used"
+    );
+    assert!(
+        !resolved.contains('/') && resolved != ".." && resolved != ".",
+        "sanitized project_id must not be a path-escaping component: {resolved}"
+    );
+    std::fs::remove_dir_all(&home).ok();
+
+    let home = tmp_home("2509-slug-safety-alldots");
+    fragile_source_repo_fleet(&home, "    project_id: \"...\"\n");
+    let resolved = super::board_router::resolve_current_project(&home, "dev");
+    assert_eq!(
+        resolved, "_",
+        "an all-dots project_id must defang to the safe sentinel, not '..'-collapse"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
 fn create_on(home: &std::path::Path, caller: &str, title: &str, deps: &[String]) -> String {
     handle(
         home,

--- a/src/teams.rs
+++ b/src/teams.rs
@@ -31,6 +31,9 @@ pub struct Team {
     /// teams needing remediation.
     #[serde(default)]
     pub source_repo: Option<std::path::PathBuf>,
+    /// #2509: explicit project-board id override — see `TeamConfig::project_id`.
+    #[serde(default)]
+    pub project_id: Option<String>,
     /// #785: team members that are registered in the team metadata but
     /// missing from the runtime registry (no live instance). Surfaces
     /// the desync state — operator can enumerate which members need a
@@ -123,6 +126,7 @@ fn project_team(name: &str, cfg: &crate::fleet::TeamConfig) -> Team {
         description: cfg.description.clone(),
         created_at: cfg.created_at.clone().unwrap_or_default(),
         source_repo: cfg.source_repo.clone(),
+        project_id: cfg.project_id.clone(),
         stale_members: Vec::new(),
         accept_from: cfg.accept_from.clone(),
     }
@@ -163,6 +167,9 @@ pub fn create(home: &Path, args: &Value) -> Value {
     let source_repo = args["repository_path"]
         .as_str()
         .map(std::path::PathBuf::from);
+    // #2509: independent of `source_repo` — lets the operator fix board-ACL
+    // routing without touching worktree/dispatch identity.
+    let project_id = args["project_id"].as_str().map(String::from);
 
     // Validate orchestrator
     if let Some(ref orch) = orchestrator {
@@ -212,6 +219,7 @@ pub fn create(home: &Path, args: &Value) -> Value {
         description,
         created_at: Some(chrono::Utc::now().to_rfc3339()),
         source_repo,
+        project_id,
         accept_from,
     };
     match crate::fleet::add_team_to_yaml(home, &name, &cfg) {
@@ -489,6 +497,14 @@ pub fn update(home: &Path, args: &Value) -> Value {
         .map(std::path::PathBuf::from)
         .or_else(|| current.source_repo.clone());
 
+    // #2509: same set-or-preserve pattern as `source_repo` — no clear support
+    // (an omitted arg preserves the current value; `as_str()` can't
+    // distinguish `null` from absent anyway).
+    let new_project_id = args["project_id"]
+        .as_str()
+        .map(String::from)
+        .or_else(|| current.project_id.clone());
+
     let new_accept_from: Vec<String> = args["accept_from"]
         .as_array()
         .map(|a| {
@@ -503,6 +519,7 @@ pub fn update(home: &Path, args: &Value) -> Value {
         description: current.description.clone(),
         created_at: current.created_at.clone(),
         source_repo: new_source_repo,
+        project_id: new_project_id,
         accept_from: new_accept_from,
     };
     match crate::fleet::update_team_in_yaml(home, &name, &cfg) {
@@ -562,6 +579,7 @@ pub fn remove_member_from_all(home: &Path, instance_name: &str) {
             description: cfg.description.clone(),
             created_at: cfg.created_at.clone(),
             source_repo: cfg.source_repo.clone(),
+            project_id: cfg.project_id.clone(),
             accept_from: cfg.accept_from.clone(),
         };
         let _ = crate::fleet::update_team_in_yaml(home, team_name, &new_cfg);
@@ -686,6 +704,116 @@ mod tests {
             "orphan must NOT double-fire on the already-Cancelled task (cancel-before-cascade), got {auto_orphan}"
         );
         std::fs::remove_dir_all(home).ok();
+    }
+
+    // ── #2509: explicit project_id override ──
+
+    /// `project_id` create/update/list round-trip: absent by default (renders
+    /// `null`, matching `source_repo`'s existing absent-field convention),
+    /// settable at create time independent of `repository_path`, and
+    /// settable/updatable later via `update` without needing to touch
+    /// `repository_path`.
+    #[test]
+    fn project_id_create_update_list_round_trip_2509() {
+        let home = tmp_home("2509-round-trip");
+        let created = create(&home, &serde_json::json!({"name": "t", "members": ["dev"]}));
+        assert_eq!(created["status"], "created", "{created}");
+        let listed = list(&home);
+        let t = listed["teams"]
+            .as_array()
+            .expect("teams array")
+            .iter()
+            .find(|t| t["name"] == "t")
+            .expect("team 't' present");
+        assert!(
+            t["project_id"].is_null(),
+            "project_id must be absent/null by default: {t}"
+        );
+
+        let updated = update(
+            &home,
+            &serde_json::json!({"name": "t", "project_id": "simple-edge-tts"}),
+        );
+        assert_eq!(updated["status"], "updated", "{updated}");
+        let listed = list(&home);
+        let t = listed["teams"]
+            .as_array()
+            .expect("teams array")
+            .iter()
+            .find(|t| t["name"] == "t")
+            .expect("team 't' present");
+        assert_eq!(t["project_id"], "simple-edge-tts");
+
+        // A second team can set project_id at create time, independent of
+        // repository_path (no repository_path at all here).
+        let created2 = create(
+            &home,
+            &serde_json::json!({"name": "t2", "members": ["dev2"], "project_id": "explicit-only"}),
+        );
+        assert_eq!(created2["status"], "created", "{created2}");
+        let listed = list(&home);
+        let t2 = listed["teams"]
+            .as_array()
+            .expect("teams array")
+            .iter()
+            .find(|t| t["name"] == "t2")
+            .expect("team 't2' present");
+        assert_eq!(t2["project_id"], "explicit-only");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #2509 regression: the exact reported friction. Team's `source_repo` sits
+    /// under an intermediate directory (`~/Projects/simple-edge-tts`), so
+    /// `project_id_from_source_repo` mis-derives `Projects_simple-edge-tts`. A
+    /// task explicitly created on the `simple-edge-tts` board (e.g. via
+    /// `send repository=...`, modeled here with `create`'s `project` arg) is
+    /// then unclaimable by the team's own member — until `project_id` aligns
+    /// the team's resolved board with where the task actually lives.
+    #[test]
+    fn project_id_override_fixes_cross_board_denial_regression_2509() {
+        let home = tmp_home("2509-regression");
+        std::fs::write(
+            crate::fleet::fleet_yaml_path(&home),
+            "instances:\n  dev:\n    backend: claude\nteams:\n  edge:\n    members:\n      - dev\n    source_repo: /Users/me/Projects/simple-edge-tts\n",
+        )
+        .unwrap();
+        let created = crate::tasks::handle(
+            &home,
+            "dev",
+            &serde_json::json!({"action": "create", "title": "t", "project": "simple-edge-tts"}),
+        );
+        let task_id = created["id"].as_str().expect("task id").to_string();
+
+        // Pre-fix: dev's team resolves to the mis-derived slug, so this claim
+        // is denied — reproduces the reported bug.
+        let denied = crate::tasks::handle(
+            &home,
+            "dev",
+            &serde_json::json!({"action": "claim", "id": task_id}),
+        );
+        assert!(
+            denied["error"]
+                .as_str()
+                .is_some_and(|e| e.contains("cross-board mutation denied")),
+            "must reproduce the reported false denial pre-fix: {denied}"
+        );
+
+        let updated = update(
+            &home,
+            &serde_json::json!({"name": "edge", "project_id": "simple-edge-tts"}),
+        );
+        assert_eq!(updated["status"], "updated", "{updated}");
+
+        let claimed = crate::tasks::handle(
+            &home,
+            "dev",
+            &serde_json::json!({"action": "claim", "id": task_id}),
+        );
+        assert!(
+            claimed["error"].is_null(),
+            "project_id override must fix the claim: {claimed}"
+        );
+        std::fs::remove_dir_all(&home).ok();
     }
 
     // ── #1744-M7: deterministic + fail-closed self-orch verdict ──
@@ -1484,6 +1612,7 @@ mod tests {
             description: None,
             created_at: "2026-01-01T00:00:00Z".to_string(),
             source_repo: None,
+            project_id: None,
             stale_members: Vec::new(),
             accept_from: Vec::new(),
         };
@@ -1518,6 +1647,7 @@ mod tests {
             description: None,
             created_at: "2026-01-01T00:00:00Z".to_string(),
             source_repo: None,
+            project_id: None,
             stale_members: vec!["stale-2".to_string()],
             accept_from: Vec::new(),
         };


### PR DESCRIPTION
## Summary
Fixes #2509: `project_id_from_source_repo` guesses `owner/repo` from `source_repo`'s last two path segments, which mis-derives the board slug when the local clone sits under an intermediate directory (e.g. `~/Projects/simple-edge-tts` → `Projects_simple-edge-tts`). The team's tasks may actually live on a different board (`simple-edge-tts`), so `resolve_current_project`/`resolve_current_project_checked` resolve the caller to the wrong project and `can_mutate_on_board` denies legitimate `claim`/`done`/`update`.

- Adds an explicit, purely-additive `project_id` field to team config (`TeamConfig`/`Team`), settable via `team create`/`team update` independent of `repository_path`.
- `resolve_current_project`/`resolve_current_project_checked` prefer the override over the `source_repo`-derived guess; `resolve_target_project` inherits the fix for free (it's a direct passthrough).
- `None` (default) is byte-identical to pre-#2509 for every team that doesn't set it — no data migration needed, and the automatic derivation algorithm itself is unchanged (deliberately **not** doing a git-remote fallback or a parent-dir blacklist — see the locked adversarial-consensus decision `d-20260701132947564849-0`).
- Caught along the way: the hand-written YAML mapping serializer (`team_config_to_mapping`) silently drops any `TeamConfig` field not explicitly listed — needed a matching fix for `project_id` to actually persist through `team update`.

Design reached via adversarial consensus with codex-reviewer.

## Test plan
- [x] `cargo test --bin agend-terminal` — 4618 passed, 0 failed
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test --test src_file_size_invariant` — clean
- [x] New tests: `project_id_create_update_list_round_trip_2509`, `project_id_override_fixes_cross_board_denial_regression_2509` (reproduces the exact reported bug, then confirms the fix), `resolve_current_project_prefers_explicit_project_id_2509`, `resolve_target_project_prefers_explicit_project_id_2509`, `resolve_current_project_sanitizes_malicious_project_id_2509`

🤖 Generated with [Claude Code](https://claude.com/claude-code)