### PR TITLE
fix(worktree): safe same-agent rebind repair instead of destructive fallback (#2496)

### DIFF
--- a/src/binding.rs
+++ b/src/binding.rs
@@ -131,6 +131,122 @@ pub fn bind(home: &Path, agent: &str, task_id: &str, branch: &str) {
     }
 }
 
+/// #2496: strict, same-agent-only exception to guard-b (see call site). ALL
+/// conditions below must hold for a metadata-only catch-up to be allowed —
+/// any failure keeps guard-b's existing reject.
+fn same_agent_metadata_catchup_allowed(
+    home: &Path,
+    agent: &str,
+    worktree: &Path,
+    source_repo: &Path,
+    branch: &str,
+    ex_branch: &str,
+) -> bool {
+    if !crate::worktree::is_git_repo(worktree) {
+        return false;
+    }
+    if !crate::worktree_pool::is_daemon_managed(worktree) {
+        return false;
+    }
+    // Marker present (checked above) but its recorded `agent=` doesn't match
+    // the caller: this worktree is daemon-managed for a DIFFERENT agent —
+    // reject rather than treat as this agent's own stale metadata.
+    if let Some(marker_agent) = managed_marker_agent(worktree) {
+        if marker_agent != agent {
+            return false;
+        }
+    }
+    if crate::worktree::has_uncommitted_changes(worktree) {
+        return false;
+    }
+    let actual_branch =
+        crate::git_helpers::git_cmd(worktree, &["branch", "--show-current"]).unwrap_or_default();
+    if actual_branch != branch {
+        return false;
+    }
+    let source_repo_str = source_repo.display().to_string();
+    if scan_existing_branch_binding(home, &source_repo_str, branch, agent).is_some() {
+        return false;
+    }
+    if agent_has_active_ci_watch_on_branch(home, agent, ex_branch) {
+        return false;
+    }
+    if branch_has_active_task(home, ex_branch) {
+        return false;
+    }
+    true
+}
+
+/// Parse a daemon-managed worktree's `.agend-managed` marker for its recorded
+/// `agent=` line. `None` when the marker is missing or the line isn't present
+/// — callers that require ownership certainty must already have checked
+/// `worktree_pool::is_daemon_managed` before this matters.
+///
+/// `pub(crate)` — also used by `mcp::handlers::force_release`'s #2496 safe
+/// rebind-repair path (same ownership check, different flow control).
+pub(crate) fn managed_marker_agent(worktree: &Path) -> Option<String> {
+    let content =
+        std::fs::read_to_string(worktree.join(crate::worktree_pool::MANAGED_MARKER)).ok()?;
+    content
+        .lines()
+        .find_map(|l| l.strip_prefix("agent="))
+        .map(|s| s.trim().to_string())
+}
+
+/// #2496: does `agent` hold an active CI watch on `branch`? A stale branch
+/// still being watched must not be silently abandoned by a metadata-only
+/// binding repair. `pub(crate)` — shared with `force_release`'s repair path.
+pub(crate) fn agent_has_active_ci_watch_on_branch(home: &Path, agent: &str, branch: &str) -> bool {
+    let ci_dir = crate::daemon::ci_watch::ci_watches_dir(home);
+    let Ok(entries) = std::fs::read_dir(&ci_dir) else {
+        return false;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("json") {
+            continue;
+        }
+        let Ok(content) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let Ok(watch) = serde_json::from_str::<serde_json::Value>(&content) else {
+            continue;
+        };
+        if watch["branch"].as_str() != Some(branch) {
+            continue;
+        }
+        if crate::daemon::ci_watch::parse_subscribers(&watch)
+            .iter()
+            .any(|s| s == agent)
+        {
+            return true;
+        }
+    }
+    false
+}
+
+/// #2496: is any task's STRUCTURED `branch` link still pointing at `branch`
+/// in an active status? Same active-status set
+/// `status_summary::auto_close_merged_tasks` uses for its structured-link arm
+/// (Open/Claimed/InProgress/InReview/Blocked/Verified) — a stale branch still
+/// tracked by a live task must not be silently abandoned by a metadata-only
+/// binding repair. `pub(crate)` — shared with `force_release`'s repair path.
+pub(crate) fn branch_has_active_task(home: &Path, branch: &str) -> bool {
+    use crate::task_events::TaskStatus;
+    crate::tasks::list_all(home).iter().any(|t| {
+        t.branch.as_deref() == Some(branch)
+            && matches!(
+                t.status,
+                TaskStatus::Open
+                    | TaskStatus::Claimed
+                    | TaskStatus::InProgress
+                    | TaskStatus::InReview
+                    | TaskStatus::Blocked
+                    | TaskStatus::Verified
+            )
+    })
+}
+
 /// Write a full binding including worktree + source-repo paths.
 ///
 /// `source_repo` is the parent repo that owns the worktree, persisted as a
@@ -197,19 +313,44 @@ pub fn bind_full(
             .map(|w| std::path::Path::new(w).exists())
             .unwrap_or(false);
         if ex_worktree_live && !ex_branch.is_empty() && ex_branch != branch {
-            crate::event_log::log(
+            // #2496 (adversarial consensus d-20260701140903334693-1): guard-b's
+            // blanket rejection can't distinguish a genuine live cross-branch
+            // bind-over (the #2158 danger this guard exists for) from "the
+            // worktree was ALREADY cleanly switched to the requested branch
+            // out-of-band (a plain `git checkout`, bypassing bind/release) and
+            // binding.json just hasn't caught up". `same_agent_metadata_catchup_allowed`
+            // is the strict, same-agent-only exception for the latter: pure
+            // metadata catch-up, zero mutation to the worktree. Any condition
+            // failing keeps the original reject — this only WIDENS what's
+            // allowed, never narrows the existing guard.
+            if same_agent_metadata_catchup_allowed(
                 home,
-                "binding_rebind_rejected",
                 agent,
-                &format!(
-                    "live binding on '{ex_branch}' — refused cross-branch rebind to '{branch}' (#2158); {}",
-                    crate::event_log::caller_process_context()
-                ),
-            );
-            return Err(format!(
-                "#2158: agent '{agent}' is bound to a LIVE worktree on branch '{ex_branch}' — \
-                 release_worktree first before binding to '{branch}' (no silent cross-branch rebind)"
-            ));
+                worktree,
+                source_repo,
+                branch,
+                ex_branch,
+            ) {
+                tracing::info!(
+                    %agent, %ex_branch, %branch,
+                    "#2496: same-agent stale binding metadata caught up to the worktree's \
+                     already-correct branch — no worktree/branch mutation"
+                );
+            } else {
+                crate::event_log::log(
+                    home,
+                    "binding_rebind_rejected",
+                    agent,
+                    &format!(
+                        "live binding on '{ex_branch}' — refused cross-branch rebind to '{branch}' (#2158); {}",
+                        crate::event_log::caller_process_context()
+                    ),
+                );
+                return Err(format!(
+                    "#2158: agent '{agent}' is bound to a LIVE worktree on branch '{ex_branch}' — \
+                     release_worktree first before binding to '{branch}' (no silent cross-branch rebind)"
+                ));
+            }
         }
     }
     let wt_str = worktree.display().to_string();
@@ -1391,6 +1532,248 @@ mod tests {
             Some("feat/y"),
         );
         std::fs::remove_dir_all(&home).ok();
+    }
+
+    // ── #2496: same-agent metadata-catchup exception to guard-b ──────────────
+
+    /// A real git-repo dir standing in for a worktree (plain repo — every
+    /// check the #2496 exception performs, `is_git_repo`/`has_uncommitted_changes`/
+    /// `branch --show-current`/`switch`, works identically on a plain repo or an
+    /// actual `git worktree add` checkout).
+    fn tmp_git_repo(tag: &str) -> std::path::PathBuf {
+        let dir = tmp_home(tag);
+        std::process::Command::new("git")
+            .env("AGEND_GIT_BYPASS", "1")
+            .args(["init", "-q", "-b", "main"])
+            .current_dir(&dir)
+            .output()
+            .ok();
+        // Every REAL source repo gitignores `.agend-managed` (this repo's own
+        // .gitignore does — see `worktree.rs::commit_marker_gitignore`'s test
+        // precedent) so the lease marker never makes a clean worktree look
+        // dirty. Commit it here so `write_managed_marker` doesn't trip
+        // `has_uncommitted_changes` in these tests.
+        std::fs::write(dir.join(".gitignore"), ".agend-managed\n").unwrap();
+        std::process::Command::new("git")
+            .env("AGEND_GIT_BYPASS", "1")
+            .args(["add", ".gitignore"])
+            .current_dir(&dir)
+            .output()
+            .ok();
+        std::process::Command::new("git")
+            .env("AGEND_GIT_BYPASS", "1")
+            .args([
+                "-c",
+                "user.name=test",
+                "-c",
+                "user.email=test@test",
+                "commit",
+                "-q",
+                "-m",
+                "init",
+            ])
+            .current_dir(&dir)
+            .output()
+            .ok();
+        dir
+    }
+
+    fn git_switch(repo: &Path, branch: &str) {
+        std::process::Command::new("git")
+            .env("AGEND_GIT_BYPASS", "1")
+            .args(["switch", "-c", branch])
+            .current_dir(repo)
+            .output()
+            .ok();
+    }
+
+    fn write_managed_marker(worktree: &Path, agent: &str) {
+        std::fs::write(
+            worktree.join(crate::worktree_pool::MANAGED_MARKER),
+            format!("agent={agent}\nbranch=irrelevant\n"),
+        )
+        .unwrap();
+    }
+
+    /// #2496 (consensus test 1 + 8): a worktree that was cleanly `git
+    /// checkout`'d to the requested branch out-of-band (bind/release bypassed
+    /// entirely) — daemon-managed, owned by this agent, clean — gets its
+    /// STALE binding metadata caught up instead of rejected. No worktree
+    /// mutation happens (it was already on the right branch).
+    #[test]
+    fn guard_b_allows_metadata_catchup_when_worktree_already_on_requested_branch_2496() {
+        let home = tmp_home("2496-catchup-allow");
+        let wt = tmp_git_repo("2496-catchup-allow-wt");
+        write_managed_marker(&wt, "agentA");
+        let src = home.join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        bind_full(&home, "agentA", "", "feat/x", &wt, &src, false).expect("first bind ok");
+
+        // Out-of-band: the worktree is switched to feat/y directly (bypassing
+        // bind/release) — binding.json still says feat/x.
+        git_switch(&wt, "feat/y");
+
+        bind_full(&home, "agentA", "", "feat/y", &wt, &src, false).expect(
+            "same-agent metadata catchup must be allowed: worktree is already on feat/y, clean, managed",
+        );
+        assert_eq!(
+            read(&home, "agentA")
+                .and_then(|b| b.get("branch").and_then(|v| v.as_str()).map(String::from))
+                .as_deref(),
+            Some("feat/y"),
+            "binding.json must catch up to the worktree's actual branch"
+        );
+        std::fs::remove_dir_all(&home).ok();
+        std::fs::remove_dir_all(&wt).ok();
+    }
+
+    /// #2496 (consensus test 2): same scenario, but the worktree is DIRTY —
+    /// guard-b's original reject stands; metadata is untouched.
+    #[test]
+    fn guard_b_rejects_metadata_catchup_when_worktree_dirty_2496() {
+        let home = tmp_home("2496-catchup-dirty");
+        let wt = tmp_git_repo("2496-catchup-dirty-wt");
+        write_managed_marker(&wt, "agentA");
+        let src = home.join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        bind_full(&home, "agentA", "", "feat/x", &wt, &src, false).expect("first bind ok");
+        git_switch(&wt, "feat/y");
+        std::fs::write(wt.join("dirty.txt"), "uncommitted").unwrap();
+
+        let err = bind_full(&home, "agentA", "", "feat/y", &wt, &src, false)
+            .expect_err("dirty worktree must NOT get the metadata-catchup exception");
+        assert!(
+            err.contains("#2158"),
+            "must be the original guard-b reject: {err}"
+        );
+        assert_eq!(
+            read(&home, "agentA")
+                .and_then(|b| b.get("branch").and_then(|v| v.as_str()).map(String::from))
+                .as_deref(),
+            Some("feat/x"),
+            "rejected catchup must not mutate the binding"
+        );
+        std::fs::remove_dir_all(&home).ok();
+        std::fs::remove_dir_all(&wt).ok();
+    }
+
+    /// #2496 (consensus test 3): missing `.agend-managed` marker, and a marker
+    /// present but recording a DIFFERENT agent, both reject.
+    #[test]
+    fn guard_b_rejects_metadata_catchup_when_marker_missing_or_mismatched_2496() {
+        let home = tmp_home("2496-catchup-marker");
+        let src = home.join("src");
+        std::fs::create_dir_all(&src).unwrap();
+
+        // Sub-case: marker missing entirely.
+        let wt1 = tmp_git_repo("2496-catchup-marker-missing");
+        bind_full(&home, "agentA", "", "feat/x", &wt1, &src, false).expect("first bind ok");
+        git_switch(&wt1, "feat/y");
+        assert!(
+            bind_full(&home, "agentA", "", "feat/y", &wt1, &src, false).is_err(),
+            "no .agend-managed marker → not daemon-managed → reject"
+        );
+        std::fs::remove_dir_all(&wt1).ok();
+
+        // Sub-case: marker present but for a DIFFERENT agent.
+        let wt2 = tmp_git_repo("2496-catchup-marker-mismatch");
+        write_managed_marker(&wt2, "someone-else");
+        bind_full(&home, "agentB", "", "feat/x", &wt2, &src, false).expect("first bind ok");
+        git_switch(&wt2, "feat/y");
+        assert!(
+            bind_full(&home, "agentB", "", "feat/y", &wt2, &src, false).is_err(),
+            "marker agent mismatch → reject, not treated as this agent's own stale metadata"
+        );
+        std::fs::remove_dir_all(&wt2).ok();
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #2496 (consensus test 4): the requested branch is already held by a
+    /// DIFFERENT agent — reject even though this agent's own worktree is
+    /// clean and genuinely on that branch (two worktrees can't both claim the
+    /// same (source_repo, branch)).
+    #[test]
+    fn guard_b_rejects_metadata_catchup_when_branch_held_by_another_agent_2496() {
+        let home = tmp_home("2496-catchup-other-agent");
+        let src = home.join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        let other_wt = home.join("other-wt");
+        std::fs::create_dir_all(&other_wt).unwrap();
+        bind_full(&home, "other-agent", "", "feat/y", &other_wt, &src, false)
+            .expect("other agent holds feat/y");
+
+        let wt = tmp_git_repo("2496-catchup-other-agent-wt");
+        write_managed_marker(&wt, "agentA");
+        bind_full(&home, "agentA", "", "feat/x", &wt, &src, false).expect("first bind ok");
+        git_switch(&wt, "feat/y");
+
+        let err = bind_full(&home, "agentA", "", "feat/y", &wt, &src, false)
+            .expect_err("feat/y is held by another agent on the same source_repo — must reject");
+        assert!(err.contains("#2158"), "{err}");
+        std::fs::remove_dir_all(&home).ok();
+        std::fs::remove_dir_all(&wt).ok();
+    }
+
+    /// #2496 (consensus test 5): the stale branch (`feat/x`, being abandoned)
+    /// has an active CI watch for this agent — must not silently orphan it.
+    #[test]
+    fn guard_b_rejects_metadata_catchup_when_stale_branch_has_active_ci_watch_2496() {
+        let home = tmp_home("2496-catchup-ci-watch");
+        let wt = tmp_git_repo("2496-catchup-ci-watch-wt");
+        write_managed_marker(&wt, "agentA");
+        let src = home.join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        bind_full(&home, "agentA", "", "feat/x", &wt, &src, false).expect("first bind ok");
+        git_switch(&wt, "feat/y");
+
+        let ci_dir = home.join("ci-watches");
+        std::fs::create_dir_all(&ci_dir).unwrap();
+        std::fs::write(
+            ci_dir.join("w.json"),
+            serde_json::to_string(&serde_json::json!({
+                "repo": "o/r",
+                "branch": "feat/x",
+                "subscribers": [{"instance": "agentA"}],
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let err = bind_full(&home, "agentA", "", "feat/y", &wt, &src, false)
+            .expect_err("active CI watch on the abandoned stale branch must block catchup");
+        assert!(err.contains("#2158"), "{err}");
+        std::fs::remove_dir_all(&home).ok();
+        std::fs::remove_dir_all(&wt).ok();
+    }
+
+    /// #2496 (consensus test 6): the stale branch has an active
+    /// branch-linked task — must not silently orphan it.
+    #[test]
+    fn guard_b_rejects_metadata_catchup_when_stale_branch_has_active_task_2496() {
+        let home = tmp_home("2496-catchup-task");
+        let wt = tmp_git_repo("2496-catchup-task-wt");
+        write_managed_marker(&wt, "agentA");
+        let src = home.join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        bind_full(&home, "agentA", "", "feat/x", &wt, &src, false).expect("first bind ok");
+        git_switch(&wt, "feat/y");
+
+        crate::tasks::handle(
+            &home,
+            "agentA",
+            &serde_json::json!({
+                "action": "create",
+                "title": "work on feat/x",
+                "assignee": "agentA",
+                "branch": "feat/x",
+            }),
+        );
+
+        let err = bind_full(&home, "agentA", "", "feat/y", &wt, &src, false)
+            .expect_err("active task linked to the abandoned stale branch must block catchup");
+        assert!(err.contains("#2158"), "{err}");
+        std::fs::remove_dir_all(&home).ok();
+        std::fs::remove_dir_all(&wt).ok();
     }
 
     /// (ii) binding-change audit: a bind emits `binding_changed` and an unbind emits

--- a/src/mcp/handlers/force_release/mod.rs
+++ b/src/mcp/handlers/force_release/mod.rs
@@ -20,6 +20,9 @@ use serde_json::{json, Value};
 use std::path::{Path, PathBuf};
 
 mod gc;
+mod repair;
+
+pub(crate) use repair::attempt_safe_rebind_repair;
 
 /// MCP tool: `force_release_worktree`.
 ///
@@ -145,9 +148,13 @@ pub(super) struct RebaseCleanOutcome {
     pub(super) binding_outcome: Value,
 }
 
-/// Sprint 60 W1 PR-1: shared cleanup helper used by both
-/// `force_release_worktree` (operator/agent-callable) and
-/// `bind_self(rebase_mode=true)` (atomic recover-and-bind).
+/// Sprint 60 W1 PR-1: cleanup helper for the EXPLICIT, operator-callable
+/// `force_release_worktree` tool (destructive by design — see its docstring).
+///
+/// #2496: no longer used by `bind_self(rebase_mode=true)` — that path now
+/// tries [`attempt_safe_rebind_repair`] FIRST and fails closed rather than
+/// silently landing here (this function's fallthrough to `release_full` is
+/// exactly the "as destructive as `release_worktree`" behavior #2496 reported).
 ///
 /// Validates path safety against the daemon worktree pool, removes
 /// the stale on-disk dir if present, and clears any lingering binding

--- a/src/mcp/handlers/force_release/repair.rs
+++ b/src/mcp/handlers/force_release/repair.rs
@@ -126,15 +126,33 @@ pub(crate) fn attempt_safe_rebind_repair(
     let Some(binding) = crate::binding::read(home, agent) else {
         return Ok(RepairAction::NoOp);
     };
+    // codex-reviewer (PR #2523 review): the recorded binding branch can have
+    // its own live dependents (CI watch / task) INDEPENDENT of the worktree's
+    // actual branch — a "double-stale" binding (binding.branch=A, worktree
+    // actually on B, requested C) must not silently abandon A's tracking just
+    // because the mutation touches B→C. Preflight EVERY branch this call is
+    // about to abandon — recorded_branch always, actual_branch too once known
+    // — BEFORE any mutation (switch or the destructive fallback below).
+    let recorded_branch = binding
+        .get("branch")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
     let wt_str = binding
         .get("worktree")
         .and_then(|v| v.as_str())
         .unwrap_or("");
     let worktree = Path::new(wt_str);
     if wt_str.is_empty() || !worktree.exists() || !crate::worktree::is_git_repo(worktree) {
-        // No LIVE worktree at the recorded path — nothing to protect. Safe to
-        // fall back to the legacy stale-state cleanup (rebase_clean_self's
-        // original, still-legitimate purpose).
+        // No LIVE worktree at the recorded path — nothing to protect from
+        // mutation, but the binding we're about to CLEAR can still be the
+        // only thing tracking `recorded_branch` for a live CI watch/task.
+        if let Some(blocked) =
+            reject_if_branch_has_dependents(home, agent, &recorded_branch, branch)
+        {
+            return Err(blocked);
+        }
         return match rebase_clean_self(home, agent, branch) {
             Ok(_) => Ok(RepairAction::StaleStateCleared),
             Err(e) => Err(RepairBlocked::PathUnsafe(e)),
@@ -162,16 +180,24 @@ pub(crate) fn attempt_safe_rebind_repair(
     }
     let actual_branch =
         crate::git_helpers::git_cmd(worktree, &["branch", "--show-current"]).unwrap_or_default();
+
+    // Preflight BOTH candidate abandoned branches before any mutation —
+    // recorded_branch (the binding we're about to overwrite) and, if it
+    // differs, actual_branch (the branch the switch below would move away
+    // from). Order doesn't matter: either blocking either one must happen
+    // strictly before the `git switch` call.
+    if let Some(blocked) = reject_if_branch_has_dependents(home, agent, &recorded_branch, branch) {
+        return Err(blocked);
+    }
+    if actual_branch != recorded_branch {
+        if let Some(blocked) = reject_if_branch_has_dependents(home, agent, &actual_branch, branch)
+        {
+            return Err(blocked);
+        }
+    }
+
     if actual_branch == branch {
         return Ok(RepairAction::MetadataOnly);
-    }
-    // About to abandon `actual_branch` in-place — must not silently orphan a
-    // live dependent still tracking it.
-    if crate::binding::agent_has_active_ci_watch_on_branch(home, agent, &actual_branch) {
-        return Err(RepairBlocked::ActiveCiWatch);
-    }
-    if crate::binding::branch_has_active_task(home, &actual_branch) {
-        return Err(RepairBlocked::ActiveTask);
     }
     // Plain `git switch` — NOT `worktree::checkout_branch` (that falls back
     // to `git switch -c`, silently CREATING a branch; a repair path must
@@ -182,6 +208,29 @@ pub(crate) fn attempt_safe_rebind_repair(
         Err(GitError::NonZero { stderr, .. }) => Err(RepairBlocked::SwitchFailed(stderr)),
         Err(GitError::Spawn(e)) => Err(RepairBlocked::SwitchFailed(e.to_string())),
     }
+}
+
+/// `Some(blocked)` iff `candidate` is a real branch being abandoned (non-empty
+/// and different from the `target` we're moving TO) that still has a live
+/// dependent (this agent's CI watch, or any active task linked to it).
+/// `target` itself is never checked — it's where we're going, not what's
+/// being abandoned.
+fn reject_if_branch_has_dependents(
+    home: &Path,
+    agent: &str,
+    candidate: &str,
+    target: &str,
+) -> Option<RepairBlocked> {
+    if candidate.is_empty() || candidate == target {
+        return None;
+    }
+    if crate::binding::agent_has_active_ci_watch_on_branch(home, agent, candidate) {
+        return Some(RepairBlocked::ActiveCiWatch);
+    }
+    if crate::binding::branch_has_active_task(home, candidate) {
+        return Some(RepairBlocked::ActiveTask);
+    }
+    None
 }
 
 #[cfg(test)]
@@ -320,6 +369,90 @@ mod tests {
         assert!(
             crate::binding::read(&home, "agentA").is_some(),
             "binding must survive the switch (no release_full call)"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// codex-reviewer (PR #2523 review, finding 1): the "double-stale
+    /// ordering" bug — binding.branch=A, worktree ACTUALLY on B, requested C.
+    /// A has a live dependent. Pre-fix, the repair checked dependents only on
+    /// B, then switched the worktree to C — mutating live state before
+    /// `bind_full`'s later guard-b check on A could ever reject. Must now
+    /// block on A's dependent BEFORE any `git switch`, leaving the worktree
+    /// on B untouched.
+    #[test]
+    fn attempt_safe_rebind_repair_blocks_on_recorded_branch_dependent_before_switching_2496() {
+        let home = tmp_home("2496-repair-double-stale");
+        let wt = tmp_git_repo(&home, "agentA");
+        write_managed_marker(&wt, "agentA");
+        let src = home.join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        // binding.branch = "A".
+        crate::binding::bind_full(&home, "agentA", "", "A", &wt, &src, false)
+            .expect("first bind ok");
+        // Worktree drifts to B out-of-band (bind/release bypassed).
+        git_switch(&wt, "B");
+        // A (the STALE recorded branch, not B) has an active task.
+        crate::tasks::handle(
+            &home,
+            "agentA",
+            &serde_json::json!({
+                "action": "create",
+                "title": "work on A",
+                "assignee": "agentA",
+                "branch": "A",
+            }),
+        );
+
+        let result = attempt_safe_rebind_repair(&home, "agentA", "C");
+        assert!(
+            matches!(result, Err(RepairBlocked::ActiveTask)),
+            "expected ActiveTask block on the recorded branch A, got {result:?}"
+        );
+        let actual = crate::git_helpers::git_cmd(&wt, &["branch", "--show-current"]).unwrap();
+        assert_eq!(
+            actual, "B",
+            "worktree must NOT have been switched — the block must land before any mutation"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// codex-reviewer (PR #2523 review, finding 2): the dead-worktree
+    /// fallback must also preflight the recorded branch's dependents before
+    /// falling through to the destructive `rebase_clean_self` — a missing
+    /// worktree doesn't make a live CI watch/task on the recorded branch
+    /// disappear.
+    #[test]
+    fn attempt_safe_rebind_repair_blocks_stale_state_cleanup_when_recorded_branch_has_dependent_2496(
+    ) {
+        let home = tmp_home("2496-repair-dead-with-dependent");
+        let wt = tmp_git_repo(&home, "agentA");
+        write_managed_marker(&wt, "agentA");
+        let src = home.join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        crate::binding::bind_full(&home, "agentA", "", "A", &wt, &src, false)
+            .expect("first bind ok");
+        // Worktree is now GONE — the incident-recovery scenario.
+        std::fs::remove_dir_all(&wt).ok();
+        crate::tasks::handle(
+            &home,
+            "agentA",
+            &serde_json::json!({
+                "action": "create",
+                "title": "work on A",
+                "assignee": "agentA",
+                "branch": "A",
+            }),
+        );
+
+        let result = attempt_safe_rebind_repair(&home, "agentA", "C");
+        assert!(
+            matches!(result, Err(RepairBlocked::ActiveTask)),
+            "expected ActiveTask block, got {result:?}"
+        );
+        assert!(
+            crate::binding::read(&home, "agentA").is_some(),
+            "binding must survive — rebase_clean_self/release_full must NOT have run"
         );
         std::fs::remove_dir_all(&home).ok();
     }

--- a/src/mcp/handlers/force_release/repair.rs
+++ b/src/mcp/handlers/force_release/repair.rs
@@ -1,0 +1,326 @@
+//! #2496 (adversarial consensus d-20260701140903334693-1): the SAFE same-agent
+//! rebind-repair path for `bind_self(rebase_mode=true)`.
+//!
+//! Split out of `force_release/mod.rs` to keep that file under the
+//! `src/mcp/handlers` 750-LOC handler invariant (`tests/file_size_invariant.rs`)
+//! — same reason `gc.rs` is its own file.
+
+use super::rebase_clean_self;
+use std::path::Path;
+
+/// What (if anything) [`attempt_safe_rebind_repair`] changed. The issue's
+/// acceptance criteria requires callers to know exactly which of these
+/// happened — never a bare boolean.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum RepairAction {
+    /// No existing binding for this agent — nothing to repair; the normal
+    /// bind proceeds untouched (fresh first-bind semantics).
+    NoOp,
+    /// A binding existed but its recorded worktree is dead (missing / not a
+    /// git repo) — there is no LIVE protected worktree to endanger, so this
+    /// is exactly the original `rebase_clean_self` incident-recovery case
+    /// (stale/corrupt binding + any leftover dir at the legacy path
+    /// formula): legacy cleanup ran (`destructive_release` semantics, but
+    /// safe here because nothing live was touched).
+    StaleStateCleared,
+    /// The worktree was already on the requested branch; no worktree
+    /// mutation was needed — `bind_full`'s own #2496 guard-b exception lets
+    /// the immediately-following bind write binding.json to match reality.
+    MetadataOnly,
+    /// The worktree was clean but on a different branch; an in-place
+    /// `git switch` (never `-c` — no branch creation in a repair path)
+    /// moved it to the requested branch.
+    SwitchedBranch,
+}
+
+/// Why [`attempt_safe_rebind_repair`] refused to repair. The acceptance
+/// criteria requires fail-closed behavior with a clear, specific reason —
+/// callers MUST surface this as a blocked error, never silently fall through
+/// to a destructive release.
+#[derive(Debug, Clone)]
+pub(crate) enum RepairBlocked {
+    Dirty,
+    NotDaemonManaged,
+    MarkerAgentMismatch(String),
+    OtherAgentHoldsBranch(String),
+    ActiveCiWatch,
+    ActiveTask,
+    SwitchFailed(String),
+    /// The legacy stale-state cleanup ([`rebase_clean_self`]) itself refused
+    /// (path-safety violation) — defense-in-depth; `agent_ops::validate_branch`
+    /// should already have caught this upstream.
+    PathUnsafe(String),
+}
+
+impl std::fmt::Display for RepairBlocked {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RepairBlocked::Dirty => write!(f, "worktree has uncommitted changes"),
+            RepairBlocked::NotDaemonManaged => {
+                write!(
+                    f,
+                    "worktree is not daemon-managed (.agend-managed marker missing)"
+                )
+            }
+            RepairBlocked::MarkerAgentMismatch(a) => write!(
+                f,
+                "worktree's .agend-managed marker belongs to a different agent ('{a}')"
+            ),
+            RepairBlocked::OtherAgentHoldsBranch(a) => {
+                write!(f, "branch is already held by another agent ('{a}')")
+            }
+            RepairBlocked::ActiveCiWatch => write!(
+                f,
+                "the worktree's current branch has an active CI watch for this agent"
+            ),
+            RepairBlocked::ActiveTask => write!(
+                f,
+                "the worktree's current branch has an active task linked to it"
+            ),
+            RepairBlocked::SwitchFailed(e) => write!(f, "git switch failed: {e}"),
+            RepairBlocked::PathUnsafe(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+/// Attempt a SAFE same-agent rebind repair — tried FIRST by
+/// `bind_self(rebase_mode=true)`, in place of the old unconditional
+/// `rebase_clean_self` (which was exactly as destructive as
+/// `release_worktree`, defeating the whole point of `rebase_mode`).
+///
+/// Reads the agent's ACTUAL bound worktree via `binding::read` (the #2496
+/// root-cause fix — NOT a recomputed `worktrees/<agent>/<branch>` path
+/// formula, which never matches the flat `worktrees/<agent>-<source>` layout
+/// `repo action=checkout bind:true` actually uses). Only if that worktree is
+/// daemon-managed, owned by THIS agent, and clean does it proceed:
+/// - already on `branch` → [`RepairAction::MetadataOnly`] (nothing to mutate;
+///   the caller's subsequent `bind_full` picks this up via its own #2496
+///   guard-b exception).
+/// - on a different branch → in-place `git switch` (plain, no `-c` — this is
+///   a repair path, it must never silently create a branch) →
+///   [`RepairAction::SwitchedBranch`].
+///
+/// [`RepairAction::NoOp`] when there's no existing binding at all — nothing
+/// live to protect, the caller's normal bind proceeds as a fresh first-bind.
+///
+/// [`RepairAction::StaleStateCleared`] when a binding exists but its recorded
+/// worktree is dead (missing, or not a git repo) — there's no LIVE protected
+/// worktree here, so falling back to the legacy [`rebase_clean_self`] cleanup
+/// (clear the corrupt binding + any leftover dir at the pre-#2496 path
+/// formula) is safe; this is the ORIGINAL incident-recovery purpose
+/// `rebase_mode` shipped for, and it's preserved unchanged.
+///
+/// Every other case — dirty, unmanaged, marker-agent mismatch, the requested
+/// branch already held by another agent, an active CI watch or task still
+/// tied to the worktree's CURRENT (about-to-be-abandoned) branch, or the
+/// `git switch` itself failing — returns [`RepairBlocked`]. Callers MUST
+/// treat this as fail-closed and must NOT fall through to a destructive
+/// release: these are all cases where a LIVE worktree WAS found but touching
+/// it isn't safe.
+pub(crate) fn attempt_safe_rebind_repair(
+    home: &Path,
+    agent: &str,
+    branch: &str,
+) -> Result<RepairAction, RepairBlocked> {
+    let Some(binding) = crate::binding::read(home, agent) else {
+        return Ok(RepairAction::NoOp);
+    };
+    let wt_str = binding
+        .get("worktree")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let worktree = Path::new(wt_str);
+    if wt_str.is_empty() || !worktree.exists() || !crate::worktree::is_git_repo(worktree) {
+        // No LIVE worktree at the recorded path — nothing to protect. Safe to
+        // fall back to the legacy stale-state cleanup (rebase_clean_self's
+        // original, still-legitimate purpose).
+        return match rebase_clean_self(home, agent, branch) {
+            Ok(_) => Ok(RepairAction::StaleStateCleared),
+            Err(e) => Err(RepairBlocked::PathUnsafe(e)),
+        };
+    }
+    if !crate::worktree_pool::is_daemon_managed(worktree) {
+        return Err(RepairBlocked::NotDaemonManaged);
+    }
+    if let Some(marker_agent) = crate::binding::managed_marker_agent(worktree) {
+        if marker_agent != agent {
+            return Err(RepairBlocked::MarkerAgentMismatch(marker_agent));
+        }
+    }
+    if crate::worktree::has_uncommitted_changes(worktree) {
+        return Err(RepairBlocked::Dirty);
+    }
+    let source_repo_str = binding
+        .get("source_repo")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    if let Some(other) =
+        crate::binding::scan_existing_branch_binding(home, source_repo_str, branch, agent)
+    {
+        return Err(RepairBlocked::OtherAgentHoldsBranch(other));
+    }
+    let actual_branch =
+        crate::git_helpers::git_cmd(worktree, &["branch", "--show-current"]).unwrap_or_default();
+    if actual_branch == branch {
+        return Ok(RepairAction::MetadataOnly);
+    }
+    // About to abandon `actual_branch` in-place — must not silently orphan a
+    // live dependent still tracking it.
+    if crate::binding::agent_has_active_ci_watch_on_branch(home, agent, &actual_branch) {
+        return Err(RepairBlocked::ActiveCiWatch);
+    }
+    if crate::binding::branch_has_active_task(home, &actual_branch) {
+        return Err(RepairBlocked::ActiveTask);
+    }
+    // Plain `git switch` — NOT `worktree::checkout_branch` (that falls back
+    // to `git switch -c`, silently CREATING a branch; a repair path must
+    // never do that as a side effect).
+    use crate::git_helpers::{git_cmd, GitError};
+    match git_cmd(worktree, &["switch", branch]) {
+        Ok(_) => Ok(RepairAction::SwitchedBranch),
+        Err(GitError::NonZero { stderr, .. }) => Err(RepairBlocked::SwitchFailed(stderr)),
+        Err(GitError::Spawn(e)) => Err(RepairBlocked::SwitchFailed(e.to_string())),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    fn tmp_home(suffix: &str) -> std::path::PathBuf {
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let h = std::env::temp_dir().join(format!(
+            "agend-force-release-repair-{}-{}-{}",
+            std::process::id(),
+            suffix,
+            id,
+        ));
+        std::fs::create_dir_all(&h).ok();
+        h
+    }
+
+    /// A REAL git-repo dir, deliberately at a FLAT (`<home>/live/<agent>`)
+    /// path — NOT the legacy `<home>/worktrees/<agent>/<branch>` formula — so
+    /// tests prove `attempt_safe_rebind_repair` resolves the worktree via
+    /// `binding::read` (the actual #2496 fix) rather than any path formula.
+    fn tmp_git_repo(home: &Path, agent: &str) -> std::path::PathBuf {
+        let dir = home.join("live").join(agent);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::process::Command::new("git")
+            .env("AGEND_GIT_BYPASS", "1")
+            .args(["init", "-q", "-b", "main"])
+            .current_dir(&dir)
+            .output()
+            .ok();
+        std::fs::write(dir.join(".gitignore"), ".agend-managed\n").unwrap();
+        std::process::Command::new("git")
+            .env("AGEND_GIT_BYPASS", "1")
+            .args(["add", ".gitignore"])
+            .current_dir(&dir)
+            .output()
+            .ok();
+        std::process::Command::new("git")
+            .env("AGEND_GIT_BYPASS", "1")
+            .args([
+                "-c",
+                "user.name=test",
+                "-c",
+                "user.email=test@test",
+                "commit",
+                "-q",
+                "-m",
+                "init",
+            ])
+            .current_dir(&dir)
+            .output()
+            .ok();
+        dir
+    }
+
+    fn git_switch(repo: &Path, branch: &str) {
+        std::process::Command::new("git")
+            .env("AGEND_GIT_BYPASS", "1")
+            .args(["switch", "-c", branch])
+            .current_dir(repo)
+            .output()
+            .ok();
+    }
+
+    fn write_managed_marker(worktree: &Path, agent: &str) {
+        std::fs::write(
+            worktree.join(crate::worktree_pool::MANAGED_MARKER),
+            format!("agent={agent}\nbranch=irrelevant\n"),
+        )
+        .unwrap();
+    }
+
+    /// #2496 (consensus test 7): the worktree lives at a FLAT path (not the
+    /// legacy `<agent>/<branch>` formula `rebase_clean_self` computes) and is
+    /// already on the requested branch — `attempt_safe_rebind_repair` must
+    /// find it via `binding::read`, report `MetadataOnly`, and touch NEITHER
+    /// the worktree NOR call any destructive release.
+    #[test]
+    fn attempt_safe_rebind_repair_finds_real_worktree_via_binding_metadata_only_2496() {
+        let home = tmp_home("2496-repair-metadata-only");
+        let wt = tmp_git_repo(&home, "agentA");
+        write_managed_marker(&wt, "agentA");
+        let src = home.join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        crate::binding::bind_full(&home, "agentA", "", "feat/x", &wt, &src, false)
+            .expect("first bind ok");
+        // Worktree is genuinely on `main` right now (never switched) —
+        // request the branch it's ALREADY on.
+        let result = attempt_safe_rebind_repair(&home, "agentA", "main");
+        assert!(
+            matches!(result, Ok(RepairAction::MetadataOnly)),
+            "expected MetadataOnly, got {result:?}"
+        );
+        assert!(wt.exists(), "worktree must be untouched: {result:?}");
+        assert!(
+            crate::binding::read(&home, "agentA").is_some(),
+            "binding must be untouched (no release_full call)"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #2496 (consensus test 8): the worktree is clean but on a DIFFERENT
+    /// branch than requested, with no stale-branch dependents —
+    /// `attempt_safe_rebind_repair` performs an in-place `git switch` and
+    /// reports `SwitchedBranch`.
+    #[test]
+    fn attempt_safe_rebind_repair_switches_branch_in_place_when_clean_2496() {
+        let home = tmp_home("2496-repair-switch");
+        let wt = tmp_git_repo(&home, "agentA");
+        write_managed_marker(&wt, "agentA");
+        let src = home.join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        crate::binding::bind_full(&home, "agentA", "", "main", &wt, &src, false)
+            .expect("first bind ok");
+        // `feat/y` must already exist as a local ref — the repair's plain
+        // `git switch` (no `-c`) deliberately never creates a branch.
+        git_switch(&wt, "feat/y");
+        std::process::Command::new("git")
+            .env("AGEND_GIT_BYPASS", "1")
+            .args(["switch", "main"])
+            .current_dir(&wt)
+            .output()
+            .ok();
+
+        let result = attempt_safe_rebind_repair(&home, "agentA", "feat/y");
+        assert!(
+            matches!(result, Ok(RepairAction::SwitchedBranch)),
+            "expected SwitchedBranch, got {result:?}"
+        );
+        let actual = crate::git_helpers::git_cmd(&wt, &["branch", "--show-current"]).unwrap();
+        assert_eq!(actual, "feat/y", "worktree must be switched in place");
+        assert!(
+            crate::binding::read(&home, "agentA").is_some(),
+            "binding must survive the switch (no release_full call)"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+}

--- a/src/mcp/handlers/worktree.rs
+++ b/src/mcp/handlers/worktree.rs
@@ -81,10 +81,24 @@ pub(crate) fn handle_bind_self(home: &Path, args: &Value, sender: &Option<Sender
         }
     }
 
+    // #2496: rebase_mode tries a SAFE same-agent repair FIRST — reads the
+    // agent's actual bound worktree and either finds it already on `branch`
+    // (metadata-only, no mutation) or in-place `git switch`es a clean
+    // worktree to it. Any condition that isn't safe (dirty, not
+    // daemon-managed, held by another agent, an active CI watch/task on the
+    // branch being abandoned, or the switch itself failing) is a fail-closed
+    // BLOCKED error — no more silent fallthrough to a full destructive
+    // release (that defeated the entire point of `rebase_mode`).
+    let mut repair_action = None;
     if args["rebase_mode"].as_bool().unwrap_or(false) {
-        if let Err(e) = crate::mcp::handlers::force_release::rebase_clean_self(home, agent, branch)
-        {
-            return json!({"error": e, "code": "path_outside_pool"});
+        match crate::mcp::handlers::force_release::attempt_safe_rebind_repair(home, agent, branch) {
+            Ok(action) => repair_action = Some(action),
+            Err(reason) => {
+                return json!({
+                    "error": format!("rebase_mode repair blocked: {reason}"),
+                    "code": "rebind_repair_blocked"
+                });
+            }
         }
     }
 
@@ -113,11 +127,19 @@ pub(crate) fn handle_bind_self(home: &Path, args: &Value, sender: &Option<Sender
                 .and_then(|s| serde_json::from_str::<Value>(&s).ok())
                 .and_then(|v| v["worktree"].as_str().map(String::from))
                 .unwrap_or_default();
-            json!({
+            let mut resp = json!({
                 "bound": true,
                 "worktree_path": worktree_path,
                 "branch": branch,
-            })
+            });
+            // #2496: surface exactly what the safe repair did (or that it
+            // wasn't invoked at all) — the acceptance criteria requires
+            // callers to know whether metadata-only, a branch switch, or
+            // nothing happened.
+            if let Some(action) = repair_action {
+                resp["repair_action"] = serde_json::to_value(action).unwrap_or(Value::Null);
+            }
+            resp
         }
         Err(err) => {
             // Map `DispatchError` to the pre-#781 string-code response shape, but


### PR DESCRIPTION
## Summary
Fixes #2496: a stale daemon binding blocked normal branch rebinding after a completed task, even when the on-disk worktree was clean and already switched to the intended branch.

Two root causes:
- `bind_full`'s guard-b (`src/binding.rs`) rejects a live-worktree cross-branch rebind using only the STALE recorded branch, never re-deriving the worktree's actual current git branch — a worktree cleanly `git checkout`'d to the requested branch out-of-band (bypassing bind/release) is wrongly treated as a dangerous cross-branch bind-over.
- The only "recovery" path (`bind_self(rebase_mode=true)` → `rebase_clean_self`) computed its target via the superseded `worktrees/<agent>/<branch>/` layout, which never matches the flat `worktrees/<agent>-<source>/` scheme `repo action=checkout bind:true` actually uses — so it unconditionally fell through to a full `worktree_pool::release_full`, making `rebase_mode` exactly as destructive as `release_worktree` and defeating its whole purpose.

**Piece 1** — `bind_full`'s guard-b gets a strict, same-agent-only exception: allows metadata-only catch-up ONLY when the worktree is a valid git repo, daemon-managed with a matching (or absent) `.agend-managed` marker agent, clean, and its ACTUAL current branch already equals the requested one, with no other agent holding the same `(source_repo, branch)` and no active CI watch or task still tied to the branch being abandoned.

**Piece 2** — `bind_self(rebase_mode=true)` now tries `attempt_safe_rebind_repair` FIRST: reads the agent's real bound worktree via `binding::read` (not a path formula) and either finds it already on the requested branch (metadata-only), in-place `git switch`es a clean worktree on a different branch (never `-c` — a repair path must never create a branch), or fails closed with a specific reason — never silently falling through to a destructive release anymore. When there's no live worktree at all (the original incident-recovery case), it still safely falls back to the legacy `rebase_clean_self` cleanup, since nothing live is at risk there.

`repair.rs` is split out of `force_release/mod.rs` to stay under the `src/mcp/handlers` 750-LOC file-size invariant (same reason `gc.rs` is its own file).

Design reached via adversarial consensus with codex-reviewer.

## Test plan
- [x] `cargo test --bin agend-terminal` — 4626 passed, 0 failed
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test --test src_file_size_invariant --test file_size_invariant` — clean
- [x] New tests cover all 8 consensus scenarios: metadata catch-up allowed/dirty/marker-mismatch/other-agent-held/active-CI-watch/active-task rejections (binding.rs), plus real-worktree-via-binding metadata-only and in-place branch switch (repair.rs)
- [x] All pre-existing guard-b and `rebase_clean_self`/`bind_self(rebase_mode)` tests still pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)