### PR TITLE
feat(state): #2313 decision-board timeout+default (#2524 P2c-r1)

### DIFF
--- a/docs/FEATURE-decisions.md
+++ b/docs/FEATURE-decisions.md
@@ -281,7 +281,14 @@ The panel shows each decision's title, author, timestamp, content, and tags. The
 
 ---
 
-## Decision Timeout
+## Decision Timeout (`reply` tool)
+
+> This section is about the `reply` tool's own pending-decision sidecar
+> (`pending-decisions/{id}.json`) — a separate mechanism from the
+> decision-board timeout below. They share the "auto-resolve on timeout"
+> idea and the same daemon-tracker idiom, but different stores, data
+> models, and routing (see [Decision-Board Timeout+Default](#decision-board-timeoutdefault-2313-p2c)
+> for why they aren't the same thing).
 
 An agent can set an automatic decision in `reply`:
 
@@ -302,6 +309,39 @@ Flow:
 4. Timeout → marked as `timeout`, sends a notification with the default action to the agent's inbox
 
 The same agent can only have one pending decision at a time. A new pending decision automatically cancels the previous one.
+
+---
+
+## Decision-Board Timeout+Default (#2313 P2c)
+
+An opt-in per-decision timeout for `needs_answer` questions posted to the decision board (distinct from the `reply` tool's own timeout above — see the note there for why they're separate).
+
+```json
+{
+  "action": "post",
+  "title": "Deploy the lean config?",
+  "content": "...",
+  "needs_answer": true,
+  "options": [{"label": "proceed", "recommended": true}, {"label": "abort"}],
+  "timeout_secs": 1800
+}
+```
+
+If the operator has not answered within `timeout_secs`, the daemon auto-answers with `timeout_default` (or, if omitted, the `recommended` option's label). If neither is resolvable, `post` rejects the request up front.
+
+| Parameter | Type | Required | Description |
+|------|------|------|------|
+| `timeout_secs` | integer | no | Only valid with `needs_answer: true`. Seconds after `created_at` before auto-answer. |
+| `timeout_default` | string | no* | The answer to auto-apply on timeout. *Required unless an `options` entry has `recommended: true`, in which case it's derived from that label. |
+
+Flow:
+1. `post` validates `timeout_secs`/`timeout_default` and stores them on the decision record (no new store — same `decisions/{id}.json` file, additive fields).
+2. A daemon tracker scans pending questions roughly every 5 minutes (throttled, not real-time).
+3. Once `created_at + timeout_secs` has elapsed and the question is still `Pending`, it's answered with `answer: timeout_default`, `answered_by: "timeout-default"`.
+4. The decision's **author** (not necessarily whoever is currently working on the related task) is notified via inbox.
+5. If the operator answers first, the tracker's next scan sees `status != Pending` and skips it — no clobbering, no double notification.
+
+Out of scope (see #2524 P2b/P2c manifest for the full premise check): no daemon auto-trigger by priority/tag, no "current owner" routing — that's the separate clarify/threading feature (#2313 P2d). The timeout always notifies the `author` field as recorded at post time.
 
 ---
 

--- a/docs/FEATURE-decisions.zh-TW.md
+++ b/docs/FEATURE-decisions.zh-TW.md
@@ -281,7 +281,13 @@ retention:
 
 ---
 
-## 決策逾時（Decision Timeout）
+## 決策逾時（Decision Timeout，`reply` 工具）
+
+> 這節講的是 `reply` 工具自己的 pending-decision sidecar
+> （`pending-decisions/{id}.json`）——跟下面的決策板逾時是分開的機制。
+> 兩者共用「逾時自動採預設值」的概念與同款 daemon tracker idiom，
+> 但 store、資料模型、通知對象都不同（原因見下方
+> [決策板 Timeout+Default](#決策板-timeoutdefault2313-p2c) 一節）。
 
 Agent 可以在 `reply` 中設定自動決策：
 
@@ -302,6 +308,39 @@ Agent 可以在 `reply` 中設定自動決策：
 4. 逾時 → 標記為 `timeout`，發送帶有 default action 的通知到 agent 收件匣
 
 同一個 agent 同時只能有一個 pending decision。新的 pending 會自動取消前一個。
+
+---
+
+## 決策板 Timeout+Default（#2313 P2c）
+
+針對貼到決策板的 `needs_answer` 問題，提供選擇性（opt-in）的逾時機制——跟上面 `reply` 工具自己的逾時是分開的（原因見上方說明）。
+
+```json
+{
+  "action": "post",
+  "title": "要部署精簡版設定嗎？",
+  "content": "...",
+  "needs_answer": true,
+  "options": [{"label": "proceed", "recommended": true}, {"label": "abort"}],
+  "timeout_secs": 1800
+}
+```
+
+若操作者在 `timeout_secs` 內未回答，daemon 會用 `timeout_default` 自動回答（若未給，則取 `options` 裡 `recommended` 選項的 label）。若兩者都無法解出，`post` 會直接拒絕。
+
+| 參數 | 型態 | 必填 | 說明 |
+|------|------|------|------|
+| `timeout_secs` | integer | 否 | 只在 `needs_answer: true` 時有效。從 `created_at` 算起幾秒後自動回答。 |
+| `timeout_default` | string | 否* | 逾時要自動套用的答案。*除非 `options` 裡有 `recommended: true` 的項目可以推導，否則必填。 |
+
+流程：
+1. `post` 驗證 `timeout_secs`/`timeout_default`，存進決策記錄（不新增 store，仍是同一個 `decisions/{id}.json` 檔案，欄位純累加）。
+2. daemon tracker 大約每 5 分鐘掃一次待答問題（節流輪詢，非即時）。
+3. 一旦 `created_at + timeout_secs`已過、問題仍是 `Pending`，就用 `answer: timeout_default` 回答，`answered_by: "timeout-default"`。
+4. 通知該決策的**作者**（不一定是目前實際在處理相關工作的人）。
+5. 若操作者搶先回答，tracker 下次掃描看到 `status != Pending` 就跳過——不會覆蓋，也不會重複通知。
+
+不在此範圍內（詳見 #2524 P2b/P2c manifest 的完整前提查核）：不做 daemon 依 priority/tag 自動觸發、不做「current owner」動態 routing——那是另一個獨立的 clarify/threading 功能（#2313 P2d）。逾時通知一律用貼文當下記錄的 `author` 欄位。
 
 ---
 

--- a/src/daemon/decision_board_timeout.rs
+++ b/src/daemon/decision_board_timeout.rs
@@ -1,0 +1,254 @@
+//! #2524 P2c / #2313: daemon-side timeout+default for decision-board
+//! questions (`decision action=post needs_answer=true timeout_secs=N`).
+//!
+//! Same idiom as `daemon::decision_timeout` (per-tick `CadenceGate` scan,
+//! flock-guarded read-modify-write, emit-on-success) — deliberately NOT
+//! shared code with it. The #2524 P2b/P2c manifest
+//! (decision `d-20260702044452277394-4`) found the two mechanisms'
+//! store/data-model/routing genuinely differ (single-sender-cancels-prior
+//! sidecar vs. multi-author board; fixed fleet-wide recipient vs.
+//! per-decision author) — reusing the *idiom*, not the code, is the
+//! "new but small" resolution (matches #2249's own precedent).
+//!
+//! ## Scope (per decision `d-20260702044620796021-5`, forks C1a/C2a)
+//!
+//! - Auto-answers with `timeout_default` once `created_at + timeout_secs`
+//!   elapses. Notifies the decision's own `author` field — no
+//!   current-owner resolution (that's #2313's P2d clarify-routing scope).
+//! - Decisions without `timeout_secs` are never touched (byte-identical to
+//!   pre-#2313 behavior — the default, opt-in only).
+//! - Idempotent: a decision already answered (by the operator, or a prior
+//!   scan) is left alone — `decisions::auto_answer_timeout` re-checks
+//!   `status == Pending` under the per-decision flock before writing.
+
+use std::path::Path;
+
+/// Scheduler throttle in supervisor TICK iterations. 30 × 10 s = 5 min —
+/// matches `daemon::decision_timeout::TICKS_PER_DECISION_SCAN`.
+pub(crate) const TICKS_PER_DECISION_BOARD_SCAN: u64 = 30;
+
+pub(crate) struct DecisionBoardTimeoutTracker {
+    gate: crate::daemon::cadence_gate::CadenceGate,
+}
+
+impl Default for DecisionBoardTimeoutTracker {
+    fn default() -> Self {
+        Self {
+            gate: crate::daemon::cadence_gate::CadenceGate::new_interval(
+                TICKS_PER_DECISION_BOARD_SCAN,
+            ),
+        }
+    }
+}
+
+impl DecisionBoardTimeoutTracker {
+    pub(crate) fn maybe_scan(&mut self, home: &Path) -> bool {
+        if !self.gate.fire() {
+            return false;
+        }
+        scan_and_answer(home);
+        true
+    }
+}
+
+/// Pure scan: detect decision-board questions whose `timeout_secs` has
+/// elapsed, auto-answer them with `timeout_default`, and notify the
+/// author. Exposed for tests.
+pub(crate) fn scan_and_answer(home: &Path) {
+    let now = chrono::Utc::now();
+    for d in crate::decisions::list_pending(home) {
+        let (Some(timeout_secs), Some(default_label)) = (d.timeout_secs, d.timeout_default.clone())
+        else {
+            continue;
+        };
+        let Ok(created) = chrono::DateTime::parse_from_rfc3339(&d.created_at) else {
+            continue;
+        };
+        let created = created.with_timezone(&chrono::Utc);
+        let elapsed_secs = now.signed_duration_since(created).num_seconds();
+        if elapsed_secs <= timeout_secs as i64 {
+            continue;
+        }
+        let Some((author, title)) = crate::decisions::auto_answer_timeout(home, &d.id) else {
+            continue;
+        };
+        let text = format!(
+            "[decision_board_timeout] decision {} ('{title}') timed out after {elapsed_secs}s \
+             (threshold {timeout_secs}s). Auto-answered: '{default_label}'. Operator can still \
+             override via `decision action=answer`.",
+            d.id
+        );
+        if let Err(e) = crate::inbox::notify_system(
+            home,
+            &author,
+            "system:decision_board_timeout",
+            "decision_board_timeout",
+            text,
+            Some(&d.id),
+            None,
+        ) {
+            tracing::warn!(
+                decision_id = %d.id,
+                error = %e,
+                "decision_board_timeout: notify enqueue failed"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    fn tmp_home(tag: &str) -> std::path::PathBuf {
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "agend-decision-board-timeout-{}-{}-{}",
+            std::process::id(),
+            tag,
+            id
+        ));
+        std::fs::create_dir_all(&dir).ok();
+        dir
+    }
+
+    /// Backdate a posted decision's `created_at` in place, so timeout
+    /// scenarios don't require sleeping (mirrors `decision_timeout.rs`'s
+    /// `write_pending_at` helper — same technique, different store).
+    fn backdate_created_at(home: &Path, id: &str, created_at: chrono::DateTime<chrono::Utc>) {
+        let path = crate::decisions::decision_path(home, id);
+        let content = std::fs::read_to_string(&path).expect("read decision file");
+        let mut v: serde_json::Value = serde_json::from_str(&content).expect("parse decision");
+        v["created_at"] = serde_json::json!(created_at.to_rfc3339());
+        std::fs::write(&path, serde_json::to_string_pretty(&v).unwrap()).expect("write back");
+    }
+
+    #[test]
+    fn scan_and_answer_auto_answers_elapsed_decision_2313() {
+        let home = tmp_home("elapsed");
+        let created = crate::decisions::post(
+            &home,
+            "alice",
+            &serde_json::json!({
+                "title": "risky call", "content": "?", "needs_answer": true,
+                "timeout_secs": 60, "timeout_default": "proceed"
+            }),
+        );
+        let id = created["id"].as_str().expect("id").to_string();
+        backdate_created_at(
+            &home,
+            &id,
+            chrono::Utc::now() - chrono::Duration::seconds(120),
+        );
+
+        scan_and_answer(&home);
+
+        let listed = crate::decisions::list(&home, &serde_json::json!({"include_archived": true}));
+        let decisions = listed["decisions"].as_array().expect("array");
+        let d = decisions.iter().find(|d| d["id"] == id).expect("found");
+        assert_eq!(
+            d["answer"], "proceed",
+            "must auto-answer with timeout_default: {d}"
+        );
+        assert_eq!(d["answered_by"], "timeout-default");
+
+        let inbox = crate::inbox::drain(&home, "alice");
+        assert!(
+            inbox
+                .iter()
+                .any(|m| m.kind.as_deref() == Some("decision_board_timeout")
+                    && m.correlation_id.as_deref() == Some(id.as_str())),
+            "author must be notified: {inbox:?}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn scan_and_answer_skips_not_yet_elapsed_2313() {
+        let home = tmp_home("not-elapsed");
+        let created = crate::decisions::post(
+            &home,
+            "alice",
+            &serde_json::json!({
+                "title": "x", "content": "?", "needs_answer": true,
+                "timeout_secs": 6000, "timeout_default": "proceed"
+            }),
+        );
+        let id = created["id"].as_str().expect("id").to_string();
+        // created_at left at "now" — far from the 6000s threshold.
+
+        scan_and_answer(&home);
+
+        let listed = crate::decisions::list(&home, &serde_json::json!({}));
+        let decisions = listed["decisions"].as_array().expect("array");
+        let d = decisions.iter().find(|d| d["id"] == id).expect("found");
+        assert!(
+            d["answer"].is_null(),
+            "must not answer before timeout_secs elapses: {d}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn scan_and_answer_ignores_decisions_without_timeout_2313() {
+        let home = tmp_home("no-timeout");
+        let created = crate::decisions::post(
+            &home,
+            "alice",
+            &serde_json::json!({"title": "x", "content": "?", "needs_answer": true}),
+        );
+        let id = created["id"].as_str().expect("id").to_string();
+        backdate_created_at(
+            &home,
+            &id,
+            chrono::Utc::now() - chrono::Duration::seconds(999_999),
+        );
+
+        scan_and_answer(&home);
+
+        let listed = crate::decisions::list(&home, &serde_json::json!({}));
+        let decisions = listed["decisions"].as_array().expect("array");
+        let d = decisions.iter().find(|d| d["id"] == id).expect("found");
+        assert!(
+            d["answer"].is_null(),
+            "a decision with no timeout_secs must never be auto-answered, however old: {d}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn scan_and_answer_idempotent_single_notify_2313() {
+        let home = tmp_home("idempotent");
+        let created = crate::decisions::post(
+            &home,
+            "alice",
+            &serde_json::json!({
+                "title": "x", "content": "?", "needs_answer": true,
+                "timeout_secs": 60, "timeout_default": "proceed"
+            }),
+        );
+        let id = created["id"].as_str().expect("id").to_string();
+        backdate_created_at(
+            &home,
+            &id,
+            chrono::Utc::now() - chrono::Duration::seconds(120),
+        );
+
+        scan_and_answer(&home);
+        scan_and_answer(&home);
+
+        let inbox = crate::inbox::drain(&home, "alice");
+        let count = inbox
+            .iter()
+            .filter(|m| {
+                m.kind.as_deref() == Some("decision_board_timeout")
+                    && m.correlation_id.as_deref() == Some(id.as_str())
+            })
+            .count();
+        assert_eq!(count, 1, "second scan must not re-notify: {inbox:?}");
+        std::fs::remove_dir_all(&home).ok();
+    }
+}

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod ci_watch;
 pub(crate) mod conflict_notify;
 mod crash_respawn;
 pub(crate) mod cron_tick;
+pub(crate) mod decision_board_timeout;
 pub(crate) mod decision_timeout;
 pub(crate) mod dedup_state;
 pub(crate) mod delivery_worker;
@@ -780,6 +781,7 @@ pub(crate) fn build_default_handlers(
         Box::new(per_tick::AntiStallHandler::new()),
         Box::new(per_tick::IdleWatchdogHandler::new()),
         Box::new(per_tick::DecisionTimeoutHandler::new()),
+        Box::new(per_tick::DecisionBoardTimeoutHandler::new()),
         Box::new(per_tick::HelperStalenessHandler::new()),
         Box::new(per_tick::McpRegistryHandler::new(daemon_binary_stale)),
         Box::new(per_tick::WaitingOnStaleHandler::new()),

--- a/src/daemon/per_tick/mod.rs
+++ b/src/daemon/per_tick/mod.rs
@@ -90,8 +90,9 @@ pub(crate) use shadow_observe::ShadowObserveHandler;
 pub(crate) use snapshot::SnapshotRotationHandler;
 pub(crate) use supervisor_trackers::{
     AntiStallHandler, AutoReleaseHandler, CanonicalDriftHandler, ConflictNotifyHandler,
-    DecisionTimeoutHandler, DispatchIdleHandler, DispatchIdleNudgeHandler, HelperStalenessHandler,
-    IdleWatchdogHandler, McpRegistryHandler, RetentionHandler, WaitingOnStaleHandler,
+    DecisionBoardTimeoutHandler, DecisionTimeoutHandler, DispatchIdleHandler,
+    DispatchIdleNudgeHandler, HelperStalenessHandler, IdleWatchdogHandler, McpRegistryHandler,
+    RetentionHandler, WaitingOnStaleHandler,
 };
 pub(crate) use thread_dump::ThreadDumpHandler;
 pub(crate) use tmp_review_gc::TmpReviewGcHandler;

--- a/src/daemon/per_tick/supervisor_trackers.rs
+++ b/src/daemon/per_tick/supervisor_trackers.rs
@@ -33,6 +33,7 @@ use crate::daemon::anti_stall::AntiStallTracker;
 use crate::daemon::auto_release::AutoReleaseTracker;
 use crate::daemon::canonical_drift::CanonicalDriftTracker;
 use crate::daemon::conflict_notify::ConflictNotifyTracker;
+use crate::daemon::decision_board_timeout::DecisionBoardTimeoutTracker;
 use crate::daemon::decision_timeout::DecisionTimeoutTracker;
 use crate::daemon::dispatch_idle::team_nudge::DispatchIdleNudgeTracker;
 use crate::daemon::dispatch_idle::DispatchIdleTracker;
@@ -91,6 +92,13 @@ tracker_handler!(
     /// Sprint 59 Wave 1 PR-4-recover (B): operator-decision auto-default on
     /// timeout, 5min throttle.
     DecisionTimeoutHandler => DecisionTimeoutTracker, "decision_timeout"
+);
+
+tracker_handler!(
+    /// #2524 P2c / #2313: decision-board per-decision timeout+default,
+    /// 5min throttle. NOT the same tracker as `DecisionTimeoutHandler`
+    /// above (see `daemon::decision_board_timeout` module doc for why).
+    DecisionBoardTimeoutHandler => DecisionBoardTimeoutTracker, "decision_board_timeout"
 );
 
 tracker_handler!(

--- a/src/decisions.rs
+++ b/src/decisions.rs
@@ -602,9 +602,29 @@ pub fn answer(home: &Path, caller: &str, args: &Value) -> Value {
 /// under the lock (e.g. the operator answered it in the race window),
 /// mirroring `answer`'s own re-check-under-lock shape. Returns
 /// `(author, title)` on success, for the caller's notification text.
-pub(crate) fn auto_answer_timeout(_home: &Path, _id: &str) -> Option<(String, String)> {
-    // #2313 RED: not yet implemented.
-    None
+pub(crate) fn auto_answer_timeout(home: &Path, id: &str) -> Option<(String, String)> {
+    let locked = with_decision_lock(home, id, || -> Option<(String, String)> {
+        let path = decision_path(home, id);
+        let content = std::fs::read_to_string(&path).ok()?;
+        let mut decision: Decision = serde_json::from_str(&content).ok()?;
+        if decision.status != Some(DecisionStatus::Pending) {
+            return None;
+        }
+        let default_label = decision.timeout_default.clone()?;
+        let now = chrono::Utc::now().to_rfc3339();
+        decision.answer = Some(default_label);
+        decision.answered_by = Some("timeout-default".to_string());
+        decision.answered_at = Some(now.clone());
+        decision.status = Some(DecisionStatus::Answered);
+        decision.updated_at = now;
+        decision.schema_version = SCHEMA_VERSION;
+        if crate::store::save_atomic(&path, &decision).is_ok() {
+            Some((decision.author.clone(), decision.title.clone()))
+        } else {
+            None
+        }
+    });
+    locked.ok().flatten()
 }
 
 #[cfg(test)]

--- a/src/decisions.rs
+++ b/src/decisions.rs
@@ -605,7 +605,9 @@ pub fn answer(home: &Path, caller: &str, args: &Value) -> Value {
 pub(crate) fn auto_answer_timeout(home: &Path, id: &str) -> Option<(String, String)> {
     let locked = with_decision_lock(home, id, || -> Option<(String, String)> {
         let path = decision_path(home, id);
-        let content = std::fs::read_to_string(&path).ok()?;
+        let Ok(content) = std::fs::read_to_string(&path) else {
+            return None;
+        };
         let mut decision: Decision = serde_json::from_str(&content).ok()?;
         if decision.status != Some(DecisionStatus::Pending) {
             return None;

--- a/src/decisions.rs
+++ b/src/decisions.rs
@@ -80,6 +80,20 @@ pub struct Decision {
     /// RFC3339 time the answer was recorded.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub answered_at: Option<String>,
+
+    // ── #2524 P2c / #2313 optional per-decision timeout+default ──
+    // Additive with serde defaults: a question posted without `timeout_secs`
+    // leaves both at `None` and is untouched by `DecisionBoardTimeoutTracker`
+    // — behaves exactly as before #2313 (indefinite wait, the default).
+    /// Seconds after `created_at` before the tracker auto-answers with
+    /// `timeout_default`. `None` = wait indefinitely (default).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_secs: Option<u64>,
+    /// The option label auto-applied on timeout. Required (and validated at
+    /// `post` time) whenever `timeout_secs` is set — either given explicitly
+    /// or derived from the `recommended` option.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_default: Option<String>,
 }
 
 pub(crate) fn decisions_dir(home: &Path) -> std::path::PathBuf {
@@ -204,6 +218,38 @@ pub fn post(home: &Path, author: &str, args: &Value) -> Value {
     let allow_free_text = args["allow_free_text"].as_bool().unwrap_or(false);
     let status = needs_answer.then_some(DecisionStatus::Pending);
 
+    // #2524 P2c / #2313: optional per-decision timeout+default. Validated
+    // before any side effects (ID gen, supersede-archive) so a bad request
+    // never partially commits. `timeout_secs` absent (the default) leaves
+    // `timeout_default` at `None` too — untouched by
+    // `DecisionBoardTimeoutTracker`, byte-identical to pre-#2313 behavior.
+    let timeout_secs = args["timeout_secs"].as_u64();
+    if timeout_secs.is_some() && !needs_answer {
+        return serde_json::json!({
+            "error": "timeout_secs is only valid when needs_answer=true"
+        });
+    }
+    let timeout_default = if timeout_secs.is_some() {
+        let explicit = args["timeout_default"].as_str().map(String::from);
+        let derived = explicit.or_else(|| {
+            options
+                .iter()
+                .find(|o| o.recommended)
+                .map(|o| o.label.clone())
+        });
+        match derived {
+            Some(d) => Some(d),
+            None => {
+                return serde_json::json!({
+                    "error": "timeout_secs requires 'timeout_default' or an options \
+                              entry with recommended=true to derive it from"
+                })
+            }
+        }
+    } else {
+        None
+    };
+
     let clock = chrono::Utc::now();
     let now = clock.to_rfc3339();
     // The historical id format was seconds-precision only — two posts in the
@@ -273,6 +319,8 @@ pub fn post(home: &Path, author: &str, args: &Value) -> Value {
         answer: None,
         answered_by: None,
         answered_at: None,
+        timeout_secs,
+        timeout_default,
     };
 
     match save(home, &decision) {
@@ -548,6 +596,17 @@ pub fn answer(home: &Path, caller: &str, args: &Value) -> Value {
     }
 }
 
+/// #2524 P2c / #2313: called by `daemon::decision_board_timeout`'s tracker
+/// once a pending question's `timeout_secs` has elapsed. Idempotent —
+/// returns `None` if the decision was already answered/expired/removed
+/// under the lock (e.g. the operator answered it in the race window),
+/// mirroring `answer`'s own re-check-under-lock shape. Returns
+/// `(author, title)` on success, for the caller's notification text.
+pub(crate) fn auto_answer_timeout(_home: &Path, _id: &str) -> Option<(String, String)> {
+    // #2313 RED: not yet implemented.
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -753,6 +812,8 @@ mod tests {
             answer: None,
             answered_by: None,
             answered_at: None,
+            timeout_secs: None,
+            timeout_default: None,
         }
     }
 
@@ -1216,6 +1277,166 @@ mod tests {
             "answered question must drop out of the tally"
         );
         assert!(counts.by_author.is_empty());
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    // ── #2524 P2c / #2313 — timeout+default validation + auto_answer_timeout ──
+
+    #[test]
+    fn post_timeout_secs_without_needs_answer_rejected_2313() {
+        let home = tmp_home("timeout-needs-answer-2313");
+        let result = post(
+            &home,
+            "lead",
+            &serde_json::json!({"title": "x", "content": "?", "timeout_secs": 60}),
+        );
+        assert!(
+            result["error"]
+                .as_str()
+                .unwrap_or("")
+                .contains("needs_answer"),
+            "timeout_secs without needs_answer must error: {result}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn post_timeout_secs_without_default_or_recommended_rejected_2313() {
+        let home = tmp_home("timeout-no-default-2313");
+        let result = post(
+            &home,
+            "lead",
+            &serde_json::json!({
+                "title": "x", "content": "?", "needs_answer": true, "timeout_secs": 60
+            }),
+        );
+        assert!(
+            result["error"]
+                .as_str()
+                .unwrap_or("")
+                .contains("timeout_default"),
+            "timeout_secs without a resolvable default must error: {result}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn post_timeout_secs_derives_default_from_recommended_option_2313() {
+        let home = tmp_home("timeout-derives-default-2313");
+        let result = post(
+            &home,
+            "lead",
+            &serde_json::json!({
+                "title": "x", "content": "?", "needs_answer": true, "timeout_secs": 60,
+                "options": [{"label": "proceed", "recommended": true}, {"label": "abort"}]
+            }),
+        );
+        assert_eq!(result["status"], "posted", "post must succeed: {result}");
+        let id = result["id"].as_str().expect("id").to_string();
+        let listed = list(&home, &serde_json::json!({}));
+        let decisions = listed["decisions"].as_array().expect("array");
+        let d = decisions.iter().find(|d| d["id"] == id).expect("found");
+        assert_eq!(d["timeout_secs"], 60);
+        assert_eq!(d["timeout_default"], "proceed");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn post_timeout_secs_accepts_explicit_default_without_recommended_2313() {
+        let home = tmp_home("timeout-explicit-default-2313");
+        let result = post(
+            &home,
+            "lead",
+            &serde_json::json!({
+                "title": "x", "content": "?", "needs_answer": true, "timeout_secs": 60,
+                "timeout_default": "proceed"
+            }),
+        );
+        assert_eq!(result["status"], "posted", "post must succeed: {result}");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn auto_answer_timeout_answers_pending_decision_2313() {
+        let home = tmp_home("auto-answer-2313");
+        let created = post(
+            &home,
+            "lead",
+            &serde_json::json!({
+                "title": "x", "content": "?", "needs_answer": true, "timeout_secs": 60,
+                "timeout_default": "proceed-with-lean"
+            }),
+        );
+        let id = created["id"].as_str().expect("id").to_string();
+
+        let result = auto_answer_timeout(&home, &id);
+        let (author, title) = result.expect("must auto-answer a pending timeout decision");
+        assert_eq!(author, "lead");
+        assert_eq!(title, "x");
+
+        let listed = list(&home, &serde_json::json!({}));
+        let decisions = listed["decisions"].as_array().expect("array");
+        let d = decisions.iter().find(|d| d["id"] == id).expect("found");
+        assert_eq!(d["answer"], "proceed-with-lean");
+        assert_eq!(d["answered_by"], "timeout-default");
+        assert_eq!(d["status"], "answered");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn auto_answer_timeout_is_idempotent_2313() {
+        let home = tmp_home("auto-answer-idempotent-2313");
+        let created = post(
+            &home,
+            "lead",
+            &serde_json::json!({
+                "title": "x", "content": "?", "needs_answer": true, "timeout_secs": 60,
+                "timeout_default": "proceed"
+            }),
+        );
+        let id = created["id"].as_str().expect("id").to_string();
+
+        let first = auto_answer_timeout(&home, &id);
+        assert!(first.is_some(), "first call must answer: {first:?}");
+        let second = auto_answer_timeout(&home, &id);
+        assert!(
+            second.is_none(),
+            "already-answered decision must not be re-answered: {second:?}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn auto_answer_timeout_none_for_operator_answered_decision_2313() {
+        let home = tmp_home("auto-answer-operator-beat-2313");
+        let created = post(
+            &home,
+            "lead",
+            &serde_json::json!({
+                "title": "x", "content": "?", "needs_answer": true, "timeout_secs": 60,
+                "timeout_default": "proceed", "allow_free_text": true
+            }),
+        );
+        let id = created["id"].as_str().expect("id").to_string();
+        // Operator answers first (the race the timeout tracker must lose to).
+        answer(
+            &home,
+            "operator",
+            &serde_json::json!({"id": id, "answer": "operator-choice"}),
+        );
+
+        let result = auto_answer_timeout(&home, &id);
+        assert!(
+            result.is_none(),
+            "must not clobber an already-operator-answered decision: {result:?}"
+        );
+        let listed = list(&home, &serde_json::json!({}));
+        let decisions = listed["decisions"].as_array().expect("array");
+        let d = decisions.iter().find(|d| d["id"] == id).expect("found");
+        assert_eq!(
+            d["answer"], "operator-choice",
+            "operator's answer must survive"
+        );
         std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -211,7 +211,9 @@ pub(crate) fn def_decision() -> Value {
             "needs_answer": {"type": "boolean", "description": "#2305 post: mark this decision a pending question awaiting an operator answer."},
             "options": {"type": "array", "description": "#2305 post: suggested answer options (recommended-first). Each is `{label, recommended}` or a bare string.", "items": {"type": ["object", "string"]}},
             "allow_free_text": {"type": "boolean", "description": "#2305 post: accept a free-text answer not matching any option."},
-            "answer": {"type": "string", "description": "#2305 answer action: the chosen option label or free-text answer for decision `id`."}
+            "answer": {"type": "string", "description": "#2305 answer action: the chosen option label or free-text answer for decision `id`."},
+            "timeout_secs": {"type": "integer", "description": "#2524 P2c / #2313 post: only valid with needs_answer=true. After this many seconds unanswered, the daemon auto-answers with `timeout_default`. Omitted (default) = wait indefinitely."},
+            "timeout_default": {"type": "string", "description": "#2524 P2c / #2313 post: the answer auto-applied on timeout. Required when `timeout_secs` is set unless derivable from an `options` entry with `recommended: true`."}
         }, "required": ["action"]}})
 }
 
@@ -928,6 +930,8 @@ mod tests {
             ("decision", "options", "decisions.rs post question options (#2305)"),
             ("decision", "allow_free_text", "decisions.rs post question free-text gate (#2305)"),
             ("decision", "answer", "decisions.rs answer action (#2305)"),
+            ("decision", "timeout_secs", "decisions.rs post validation + Decision field; daemon/decision_board_timeout.rs scan_and_answer elapsed check (#2524 P2c)"),
+            ("decision", "timeout_default", "decisions.rs post validation/derivation + Decision field; daemon/decision_board_timeout.rs auto_answer_timeout (#2524 P2c)"),
             // ── team ──
             ("team", "action", "teams.rs routing"),
             ("team", "name", "teams.rs create/delete/update target"),


### PR DESCRIPTION
## Summary

Implements the #2313 P2c sub-item (operator-designed 2026-06-17, not
re-litigated here): an opt-in per-decision timeout for decision-board
questions (`decision action=post needs_answer=true timeout_secs=N`) —
after `timeout_secs` unanswered, the daemon auto-answers with
`timeout_default` and notifies the author.

**This is deliberately NOT built on `daemon::decision_timeout`** (the
`reply` tool's own pending-decision sidecar). The #2524 P2b/P2c manifest
(decision `d-20260702044452277394-4`) found the "borrow that sidecar
primitive" premise in #2313's own text was refuted on inspection — same
class of complexity trap as `second_reviewer` was for #2249: the two
mechanisms' store (`pending-decisions/{id}.json`, single-sender-cancels-
prior vs. `decisions/{id}.json`, multi-author board), data model, and
routing (fixed fleet-wide recipient vs. per-decision author) genuinely
differ. What *is* reused is the **idiom** — per-tick `CadenceGate` scan,
flock-guarded read-modify-write, emit-only-on-persisted-success — not the
code. This is the same "new but small" resolution #2249 landed on.

### What's added

- `Decision.timeout_secs: Option<u64>` / `timeout_default: Option<String>`
  — additive, serde-default, zero migration.
- `post` validation: `timeout_secs` only valid with `needs_answer: true`;
  requires a resolvable `timeout_default` (explicit, or derived from an
  `options` entry with `recommended: true`) — else rejected up front.
- New `DecisionBoardTimeoutTracker` (`src/daemon/decision_board_timeout.rs`),
  ~5min-throttled, wired into the same per-tick supervisor list as every
  other daemon tracker.
- `decisions::auto_answer_timeout`: idempotent — re-checks
  `status == Pending` under the per-decision flock, so an
  operator-answered (or already-timed-out) decision is never clobbered or
  double-notified.
- Notifies the decision's own `author` field — **no current-owner
  resolution** (per fork C2a: that's #2313's separate P2d clarify-routing
  scope, out of bounds here).
- `docs/FEATURE-decisions.md` (+ zh-TW): new section, cross-referenced
  against the existing `reply`-tool "Decision Timeout" section to head off
  the exact name-collision confusion the manifest flagged.

## Commits (test-first, §3.10)

1. `test(state): RED` — schema, validation/derivation (kept real per the
   #2249/P2a precedent — simple, not the tested "core"), tracker wiring,
   docs, and all 11 new tests land here; the two behavioral cores
   (`auto_answer_timeout`, and by extension `scan_and_answer` which calls
   it) are stubbed so 4/11 tests fail for the right reason (7/11 pass
   already — see commit message for which and why).
2. `feat(state): GREEN` — fills in `auto_answer_timeout`'s real
   read-modify-write.

## Test plan

- [x] `cargo test --bin agend-terminal 2313` → 11/11 pass
- [x] `cargo test --bin agend-terminal decisions::` → 33/33 pass
- [x] `cargo test --bin agend-terminal daemon::decision` → 27/27 pass (includes the unrelated `decision_timeout` module, unaffected)
- [x] `cargo test --bin agend-terminal per_tick::` → 147/147 pass
- [x] `cargo test --bin agend-terminal mcp::tools::` → 12/12 pass
- [x] `cargo test --test src_file_size_invariant` → pass
- [x] `cargo test --test spawn_rationale_audit` → pass
- [x] `cargo test --test review_tasks_6` → pass (unrelated review-repro gate)
- [x] `cargo clippy --bin agend-terminal -- -D warnings` → clean
- [x] `cargo fmt --check` → clean

Refs #2524 P2c-r1 (task `t-20260702044651477018-14977-22`), decisions
`d-20260702044452277394-4` (manifest) + `d-20260702044620796021-5`
(forks C1a/C2a). Single reviewer: gapfix-reviewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)