### PR TITLE
feat(state): #2524 P3a PR-1 — observation-plane coverage for ephemeral workers

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -1491,6 +1491,14 @@ pub struct EphemeralPtyHandle {
     /// alone to hold the master side open).
     #[allow(dead_code)]
     pub pty_master: Box<dyn portable_pty::MasterPty + Send>,
+    /// #2524 P3a PR-1: the detected backend, so the shadow-observer's rollout-tail
+    /// candidate merge (`daemon::shadow::rollout`) can filter ephemeral workers down
+    /// to codex ones — mirrors how a managed `AgentHandle` carries `backend_command`.
+    pub backend: Option<crate::backend::Backend>,
+    /// #2524 P3a PR-1: the worker's spawn cwd, so the rollout tailer can attribute a
+    /// codex session file to this worker directly (ephemeral workers have no fixed
+    /// `<home>/workspace/<name>` convention to derive it from, unlike managed agents).
+    pub cwd: Option<PathBuf>,
 }
 
 impl std::fmt::Debug for EphemeralPtyHandle {
@@ -1709,6 +1717,8 @@ pub fn spawn_ephemeral_worker(config: &SpawnConfig) -> anyhow::Result<EphemeralP
             pty_writer,
             core,
             pty_master,
+            backend: detected_backend,
+            cwd: config.working_dir.map(std::path::Path::to_path_buf),
         })
     }
 }

--- a/src/daemon/per_tick/shadow_observe.rs
+++ b/src/daemon/per_tick/shadow_observe.rs
@@ -52,7 +52,7 @@ impl PerTickHandler for ShadowObserveHandler {
         // it before touching any per-agent core lock (never hold the registry lock
         // across another lock — mirrors `api_activity_probe::probe_once`). child_alive
         // is read here (its own `child.lock()`) so the reduce loop needs only core.lock.
-        let agents: Vec<(String, Arc<CoreMutex<AgentCore>>, bool)> = {
+        let mut agents: Vec<(String, Arc<CoreMutex<AgentCore>>, bool)> = {
             let reg = crate::agent::lock_registry(ctx.registry);
             reg.values()
                 .map(|h| {
@@ -61,6 +61,19 @@ impl PerTickHandler for ShadowObserveHandler {
                 })
                 .collect()
         };
+        // #2524 P3a PR-1: ephemeral workers bypass the managed `AgentRegistry` by
+        // design (#1967 "avoid managed bookkeeping"), so without this merge the
+        // reduce below NEVER runs on their `core` and `observed_status` stays `None`
+        // forever (not just laggy). `live_children_snapshot()` takes its OWN brief
+        // `LIVE_CHILDREN` lock, already released by the time this line runs — the
+        // registry lock above is ALSO already released (its block ended) — so
+        // neither lock is ever held nested with the other (lock-ordering note: see
+        // PR body).
+        agents.extend(
+            crate::ephemeral_tracking::live_children_snapshot()
+                .into_iter()
+                .map(|w| (w.worker_id, w.core, w.child_alive)),
+        );
         if agents.is_empty() {
             return;
         }

--- a/src/daemon/shadow/rollout.rs
+++ b/src/daemon/shadow/rollout.rs
@@ -147,20 +147,45 @@ pub(crate) fn session_cwd(line: &str) -> Option<String> {
     Some(rec.payload.get("cwd")?.as_str()?.to_string())
 }
 
-/// Map a session cwd → the agend codex agent that owns it. SCOPED + separator-agnostic:
-/// the cwd must EQUAL `<home>/workspace/<name>` for a LIVE codex agent, compared by path
-/// COMPONENTS (`Path` eq handles `\` vs `/`, so it works on Windows — #2437 round-1) AND
-/// rooted at THIS daemon's `home`, so a stray `*/workspace/<name>` OUTSIDE the fleet (a
-/// same-named operator codex, another daemon's home) is NOT attributed (#2437 round-3 r6).
-/// codex canonicalizes `/tmp`→`/private/tmp` on macOS; [`strip_private`] (unix-only)
-/// reconciles that before the comparison.
-fn agent_for_cwd(cwd: &str, home: &Path, codex_agents: &[String]) -> Option<String> {
+/// Map a session cwd → the agend codex agent that owns it. `candidates` is a
+/// (name, expected-cwd) list: for a MANAGED agent, `expected-cwd` is the fixed
+/// `<home>/workspace/<name>` convention; for an EPHEMERAL codex worker (#2524 P3a
+/// PR-1 — they bypass the registry by design, #1967, and have no fixed workspace
+/// convention), it's the worker's own recorded spawn cwd. Compared by path
+/// COMPONENTS (`Path` eq handles `\` vs `/`, so it works on Windows — #2437
+/// round-1). codex canonicalizes `/tmp`→`/private/tmp` on macOS; [`strip_private`]
+/// (unix-only) reconciles that before the comparison.
+///
+/// #2524 P3a PR-1 RED: not yet fail-closed on ambiguity — first match wins, same as
+/// the pre-PR behavior. GREEN commit makes this fail-closed instead.
+fn agent_for_cwd(cwd: &str, candidates: &[(String, PathBuf)]) -> Option<String> {
     let cwd_path = Path::new(strip_private(cwd));
-    let ws = home.join("workspace");
-    codex_agents
+    candidates
         .iter()
-        .find(|name| cwd_path == ws.join(name))
-        .cloned()
+        .find(|(_, expected)| cwd_path == expected.as_path())
+        .map(|(name, _)| name.clone())
+}
+
+/// Build the (name, expected-cwd) candidate list `agent_for_cwd` matches against:
+/// managed codex agents (from the registry, `<home>/workspace/<name>` convention)
+/// PLUS live ephemeral codex workers (#2524 P3a PR-1, their own recorded spawn
+/// cwd — read-only `LIVE_CHILDREN` snapshot, doesn't register them anywhere).
+fn codex_candidates(registry: &crate::agent::AgentRegistry, home: &Path) -> Vec<(String, PathBuf)> {
+    let ws = home.join("workspace");
+    let mut out: Vec<(String, PathBuf)> = live_codex_agents(registry)
+        .into_iter()
+        .map(|name| {
+            let expected = ws.join(&name);
+            (name, expected)
+        })
+        .collect();
+    out.extend(
+        crate::ephemeral_tracking::live_children_snapshot()
+            .into_iter()
+            .filter(|w| matches!(w.backend, Some(crate::backend::Backend::Codex)))
+            .filter_map(|w| w.cwd.map(|cwd| (w.worker_id, cwd))),
+    );
+    out
 }
 
 /// Strip codex's macOS `/private` canonicalization prefix (`/private/tmp/...` → `/tmp/...`)
@@ -235,8 +260,8 @@ fn tail_once(
     home: &Path,
     cursors: &mut HashMap<PathBuf, Cursor>,
 ) {
-    let codex_agents = live_codex_agents(registry);
-    if codex_agents.is_empty() {
+    let candidates = codex_candidates(registry, home);
+    if candidates.is_empty() {
         return;
     }
     for file in discover_rollouts(root) {
@@ -244,7 +269,7 @@ fn tail_once(
             offset: 0,
             agent: None,
         });
-        drain_file(&file, cur, home, &codex_agents);
+        drain_file(&file, cur, &candidates);
     }
 }
 
@@ -308,7 +333,7 @@ fn discover_rollouts(root: &Path) -> Vec<PathBuf> {
 /// the first `session_meta` line) to an agend codex agent, and push each transition as
 /// Evidence. A file not owned by any live codex agent is consumed-and-ignored (cursor
 /// advances so we don't re-scan it).
-fn drain_file(file: &Path, cur: &mut Cursor, home: &Path, codex_agents: &[String]) {
+fn drain_file(file: &Path, cur: &mut Cursor, candidates: &[(String, PathBuf)]) {
     use std::io::{BufRead, BufReader, Seek, SeekFrom};
     let Ok(f) = std::fs::File::open(file) else {
         return;
@@ -348,7 +373,7 @@ fn drain_file(file: &Path, cur: &mut Cursor, home: &Path, codex_agents: &[String
         // Resolve the owning agent from the session_meta header (first line).
         if cur.agent.is_none() {
             if let Some(cwd) = session_cwd(&line) {
-                cur.agent = agent_for_cwd(&cwd, home, codex_agents);
+                cur.agent = agent_for_cwd(&cwd, candidates);
             }
             // Either way the header line itself is not a transition.
             continue;
@@ -371,6 +396,15 @@ mod tests {
 
     fn kind_of(line: &str) -> Option<EvidenceKind> {
         record_to_evidence(line, 1_000).map(|e| e.kind)
+    }
+
+    /// Build the (name, expected-cwd) candidate list for a set of MANAGED agent
+    /// names under `home` — the `<home>/workspace/<name>` convention `codex_candidates`
+    /// derives for registry members. Test-only shorthand so existing fixtures don't
+    /// need to spell out the join at every call site.
+    fn ws_candidates(home: &Path, names: &[&str]) -> Vec<(String, PathBuf)> {
+        let ws = home.join("workspace");
+        names.iter().map(|n| (n.to_string(), ws.join(n))).collect()
     }
 
     #[test]
@@ -500,34 +534,60 @@ mod tests {
     #[test]
     fn agent_for_cwd_matches_only_fleet_codex_workspace() {
         let home = std::env::temp_dir().join("svcx_test_home");
-        let agents = vec!["cx".to_string(), "cx2".to_string()];
+        let candidates = ws_candidates(&home, &["cx", "cx2"]);
         // The agent's own workspace (built like production) → match, on any platform.
         let ws_cx = home.join("workspace").join("cx");
         assert_eq!(
-            agent_for_cwd(&ws_cx.to_string_lossy(), &home, &agents).as_deref(),
+            agent_for_cwd(&ws_cx.to_string_lossy(), &candidates).as_deref(),
             Some("cx")
         );
         // Unknown agent name UNDER the fleet workspace → None.
         let ghost = home.join("workspace").join("ghost");
-        assert_eq!(
-            agent_for_cwd(&ghost.to_string_lossy(), &home, &agents),
-            None
-        );
+        assert_eq!(agent_for_cwd(&ghost.to_string_lossy(), &candidates), None);
         // A cwd not ending in `workspace/<name>` → None.
-        assert_eq!(agent_for_cwd("/some/other/dir", &home, &agents), None);
+        assert_eq!(agent_for_cwd("/some/other/dir", &candidates), None);
+    }
+
+    /// #2524 P3a PR-1: an ephemeral codex worker's OWN recorded cwd (not the
+    /// `<home>/workspace/<name>` convention) also attributes correctly — it's just
+    /// another candidate in the merged list.
+    #[test]
+    fn agent_for_cwd_matches_ephemeral_worker_explicit_cwd() {
+        let candidates = vec![(
+            "eph-1".to_string(),
+            PathBuf::from("/tmp/some/ephemeral/dir"),
+        )];
+        assert_eq!(
+            agent_for_cwd("/tmp/some/ephemeral/dir", &candidates).as_deref(),
+            Some("eph-1")
+        );
+        assert_eq!(agent_for_cwd("/tmp/some/other/dir", &candidates), None);
+    }
+
+    /// #2524 P3a PR-1: two candidates (e.g. two ephemeral workers, or an ephemeral
+    /// worker colliding with a managed agent's workspace) sharing the SAME expected
+    /// cwd is FAIL-CLOSED — attribute to neither rather than guess.
+    #[test]
+    fn agent_for_cwd_ambiguous_when_two_candidates_share_a_cwd() {
+        let shared = PathBuf::from("/tmp/shared/workdir");
+        let candidates = vec![
+            ("eph-1".to_string(), shared.clone()),
+            ("eph-2".to_string(), shared.clone()),
+        ];
+        assert_eq!(
+            agent_for_cwd(&shared.to_string_lossy(), &candidates),
+            None,
+            "an ambiguous cwd must not attribute to either candidate"
+        );
     }
 
     /// #2437 r6 (regression, verbatim): a SAME-NAMED `workspace/<name>` OUTSIDE this daemon's
     /// home must NOT attribute — the tail-component-only match (round-3) wrongly did.
     #[test]
     fn agent_for_cwd_does_not_attribute_same_named_stray_workspace() {
-        let agents = vec!["cx".to_string()];
+        let candidates = ws_candidates(Path::new("/tmp/svcx"), &["cx"]);
         assert_eq!(
-            agent_for_cwd(
-                "/tmp/operator/workspace/cx",
-                Path::new("/tmp/svcx"),
-                &agents
-            ),
+            agent_for_cwd("/tmp/operator/workspace/cx", &candidates),
             None
         );
     }
@@ -537,14 +597,9 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn agent_for_cwd_reconciles_macos_private_prefix() {
-        let agents = vec!["cx".to_string()];
+        let candidates = ws_candidates(Path::new("/tmp/svcx"), &["cx"]);
         assert_eq!(
-            agent_for_cwd(
-                "/private/tmp/svcx/workspace/cx",
-                Path::new("/tmp/svcx"),
-                &agents
-            )
-            .as_deref(),
+            agent_for_cwd("/private/tmp/svcx/workspace/cx", &candidates).as_deref(),
             Some("cx")
         );
     }
@@ -593,8 +648,8 @@ mod tests {
             offset: 0,
             agent: None,
         };
-        let agents = vec!["cxt".to_string()];
-        drain_file(&roll, &mut cur, &home, &agents);
+        let candidates = ws_candidates(&home, &["cxt"]);
+        drain_file(&roll, &mut cur, &candidates);
 
         assert_eq!(
             cur.agent.as_deref(),
@@ -632,7 +687,7 @@ mod tests {
         )
         .unwrap();
         f2.flush().unwrap();
-        drain_file(&roll, &mut cur, &home, &agents);
+        drain_file(&roll, &mut cur, &candidates);
         assert_eq!(
             cur.offset, off_after,
             "partial line must not advance the cursor"
@@ -683,8 +738,8 @@ mod tests {
             offset: 0,
             agent: None,
         };
-        let agents = vec!["cxr".to_string()];
-        drain_file(&roll, &mut cur, &home, &agents);
+        let candidates = ws_candidates(&home, &["cxr"]);
+        drain_file(&roll, &mut cur, &candidates);
         assert!(
             cur.offset > 0 && cur.agent.is_some(),
             "first drain advanced"
@@ -712,7 +767,7 @@ mod tests {
             "rebuilt session is shorter than the prior cursor"
         );
 
-        drain_file(&roll, &mut cur, &home, &agents);
+        drain_file(&roll, &mut cur, &candidates);
         // Recovered: agent re-resolved from the new header + the new ToolStarted seen (the
         // pre-fix code would have left the cursor past EOF → observer DEAF → empty).
         let evs = super::super::peek("cxr");

--- a/src/daemon/shadow/rollout.rs
+++ b/src/daemon/shadow/rollout.rs
@@ -156,14 +156,25 @@ pub(crate) fn session_cwd(line: &str) -> Option<String> {
 /// round-1). codex canonicalizes `/tmp`→`/private/tmp` on macOS; [`strip_private`]
 /// (unix-only) reconciles that before the comparison.
 ///
-/// #2524 P3a PR-1 RED: not yet fail-closed on ambiguity — first match wins, same as
-/// the pre-PR behavior. GREEN commit makes this fail-closed instead.
+/// #2524 P3a PR-1: FAIL-CLOSED on an ambiguous cwd (≥2 candidates share the same
+/// expected cwd — e.g. two ephemeral workers spawned in the same directory, or an
+/// ephemeral worker's cwd colliding with a managed agent's workspace path). Do NOT
+/// guess: attribute to neither rather than silently mis-crediting Evidence.
 fn agent_for_cwd(cwd: &str, candidates: &[(String, PathBuf)]) -> Option<String> {
     let cwd_path = Path::new(strip_private(cwd));
-    candidates
+    let mut matches = candidates
         .iter()
-        .find(|(_, expected)| cwd_path == expected.as_path())
-        .map(|(name, _)| name.clone())
+        .filter(|(_, expected)| cwd_path == expected.as_path());
+    let first = matches.next()?;
+    if matches.next().is_some() {
+        tracing::warn!(
+            tag = "#shadow-observer",
+            cwd = %cwd_path.display(),
+            "codex rollout: cwd matches MULTIPLE candidate agents — ambiguous, not attributing"
+        );
+        return None;
+    }
+    Some(first.0.clone())
 }
 
 /// Build the (name, expected-cwd) candidate list `agent_for_cwd` matches against:

--- a/src/ephemeral_tracking.rs
+++ b/src/ephemeral_tracking.rs
@@ -140,9 +140,6 @@ static WORKER_SEQ: AtomicU64 = AtomicU64::new(0);
 /// READ-ONLY — this is an observation feed, not a registration: it doesn't add the
 /// worker to `AgentRegistry`/`fleet.yaml`/binding, so it doesn't reintroduce the
 /// "managed bookkeeping" #1967 deliberately avoids for ephemeral workers.
-// #2524 P3a PR-1 RED: `core`/`child_alive` aren't read yet — `shadow_observe.rs`
-// wires them in GREEN. Drop this once that caller lands.
-#[allow(dead_code)]
 pub(crate) struct LiveEphemeralSnapshot {
     pub worker_id: String,
     pub core: Arc<crate::sync_audit::CoreMutex<crate::agent::AgentCore>>,

--- a/src/ephemeral_tracking.rs
+++ b/src/ephemeral_tracking.rs
@@ -29,7 +29,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{LazyLock, OnceLock};
+use std::sync::{Arc, LazyLock, OnceLock};
 
 /// Cost-guard default: hard ceiling on simultaneously-live ephemeral workers when
 /// `AGEND_EPHEMERAL_MAX_LIVE` is unset/invalid. Spawn admission rejects once the
@@ -134,6 +134,40 @@ static LIVE_CHILDREN: LazyLock<Mutex<HashMap<String, crate::agent::EphemeralPtyH
 
 /// Process-local monotonic counter for unique worker ids within a daemon life.
 static WORKER_SEQ: AtomicU64 = AtomicU64::new(0);
+
+/// #2524 P3a PR-1: one live ephemeral worker, as exposed to the shadow-observer's
+/// observation plane (`daemon::per_tick::shadow_observe` + `daemon::shadow::rollout`).
+/// READ-ONLY — this is an observation feed, not a registration: it doesn't add the
+/// worker to `AgentRegistry`/`fleet.yaml`/binding, so it doesn't reintroduce the
+/// "managed bookkeeping" #1967 deliberately avoids for ephemeral workers.
+// #2524 P3a PR-1 RED: `core`/`child_alive` aren't read yet — `shadow_observe.rs`
+// wires them in GREEN. Drop this once that caller lands.
+#[allow(dead_code)]
+pub(crate) struct LiveEphemeralSnapshot {
+    pub worker_id: String,
+    pub core: Arc<crate::sync_audit::CoreMutex<crate::agent::AgentCore>>,
+    pub child_alive: bool,
+    pub backend: Option<crate::backend::Backend>,
+    pub cwd: Option<PathBuf>,
+}
+
+/// Snapshot all live ephemeral workers under ONE brief `LIVE_CHILDREN` lock,
+/// released before this returns — so a caller (e.g. `shadow_observe`'s per-tick
+/// handler) never holds this lock nested with any other (the registry lock in
+/// particular; see that caller's own lock-ordering note).
+pub(crate) fn live_children_snapshot() -> Vec<LiveEphemeralSnapshot> {
+    LIVE_CHILDREN
+        .lock()
+        .iter()
+        .map(|(worker_id, h)| LiveEphemeralSnapshot {
+            worker_id: worker_id.clone(),
+            core: Arc::clone(&h.core),
+            child_alive: h.child.lock().process_id().is_some(),
+            backend: h.backend.clone(),
+            cwd: h.cwd.clone(),
+        })
+        .collect()
+}
 
 fn store_path(home: &Path) -> PathBuf {
     crate::store::store_path(home, "ephemeral_workers.json")
@@ -1059,6 +1093,80 @@ mod tests {
             "reaped worker removed from store"
         );
         assert_dead_within(w.pid, "reap must terminate the real ephemeral process");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #2524 P3a PR-1 — THE wiring pin: a real ephemeral worker (registered ONLY in
+    /// `LIVE_CHILDREN`, never in the `AgentRegistry` this test deliberately leaves
+    /// EMPTY) still gets `observed_status` populated by running the REAL
+    /// `ShadowObserveHandler::run()` entry point. Before this PR the per-tick reduce
+    /// iterated the registry only, so an ephemeral worker's `observed_status` stayed
+    /// `None` forever — not laggy, NEVER SET. `#[cfg(unix)]`: ephemeral spawn is
+    /// fail-closed on Windows.
+    #[cfg(unix)]
+    #[test]
+    #[serial_test::serial(shadow_observer)]
+    fn ephemeral_worker_gets_observed_status_via_shadow_observe_2524_p3a() {
+        use crate::agent::{AgentRegistry, ExternalRegistry};
+        use crate::daemon::per_tick::{PerTickHandler, ShadowObserveHandler, TickContext};
+        use crate::daemon::shadow;
+        use crate::daemon::shadow::evidence::{Evidence, EvidenceKind};
+        use crate::daemon::shadow::reducer::ObservedState;
+        use parking_lot::Mutex as PLMutex;
+
+        let prev = std::env::var("AGEND_SHADOW_OBSERVER").ok();
+        std::env::set_var("AGEND_SHADOW_OBSERVER", "1");
+
+        let home = tmp_home("shadow-ephemeral-wiring");
+        let w = track_real_worker(&home, "wf1", 3600);
+        let core = LIVE_CHILDREN
+            .lock()
+            .get(&w.worker_id)
+            .map(|h| Arc::clone(&h.core))
+            .expect("worker just inserted into LIVE_CHILDREN");
+
+        let token = shadow::new_session_token().unwrap();
+        shadow::register(&token, &w.worker_id);
+        shadow::push(
+            &w.worker_id,
+            Evidence::hook(
+                EvidenceKind::TurnStarted,
+                chrono::Utc::now().timestamp_millis().max(0) as u64,
+            ),
+        );
+
+        // Deliberately EMPTY registry — proves this is the LIVE_CHILDREN path, not
+        // the pre-existing managed-agent path (already covered by
+        // `shadow_observe::tests::flag_on_reduce_writes_observed_status`).
+        let registry: AgentRegistry = Arc::new(PLMutex::new(HashMap::new()));
+        let externals: ExternalRegistry = Arc::new(PLMutex::new(HashMap::new()));
+        let configs = Arc::new(PLMutex::new(HashMap::new()));
+        let ctx = TickContext {
+            home: &home,
+            registry: &registry,
+            externals: &externals,
+            configs: &configs,
+        };
+        ShadowObserveHandler::new().run(&ctx);
+
+        let status = core
+            .lock()
+            .observed_status
+            .clone()
+            .expect("ephemeral worker must ALSO get observed_status — #2524 P3a PR-1");
+        assert_ne!(
+            status.state,
+            ObservedState::Idle,
+            "an open episode + a live child ⇒ Active family, not Idle"
+        );
+
+        shadow::forget_agent(&w.worker_id);
+        reap_one(&home, &w.worker_id).expect("reap_one");
+        assert_dead_within(w.pid, "cleanup must terminate the real process");
+        match prev {
+            Some(v) => std::env::set_var("AGEND_SHADOW_OBSERVER", v),
+            None => std::env::remove_var("AGEND_SHADOW_OBSERVER"),
+        }
         std::fs::remove_dir_all(&home).ok();
     }
 


### PR DESCRIPTION
## Summary

PR-1 of a two-PR split (PR-2 = `t-20260702062136166045-14977-27`, waits
for this to merge before starting). Per decisions
`d-20260702062543495557-8` and `d-20260702063047100813-9`: ephemeral
workers bypass the managed `AgentRegistry` by design (#1967 "avoid
managed bookkeeping"), which means today `core.observed_status`
**never** populates for an ephemeral worker — not laggy, never set —
because `ShadowObserveHandler::run()` only iterates the registry, and
the codex rollout-tailer's `agent_for_cwd` only knows the registry's
`<home>/workspace/<name>` convention. This PR extends both to also see
ephemeral workers, read-only.

### What's added

- `src/agent/mod.rs`: `EphemeralPtyHandle` gains `backend: Option<Backend>`
  + `cwd: Option<PathBuf>`, populated at the single construction site
  (`spawn_ephemeral_worker`) from `detected_backend` + `config.working_dir`.
- `src/ephemeral_tracking.rs`: new `LiveEphemeralSnapshot` +
  `live_children_snapshot()` — a **read-only** `LIVE_CHILDREN` accessor.
  No registration, no mutation, doesn't reintroduce #1967's "avoid
  managed bookkeeping".
- `src/daemon/per_tick/shadow_observe.rs`: `run()` merges the ephemeral
  snapshot into its per-tick agent list before the existing reduce loop,
  which is otherwise **unchanged** — managed-agent path is byte-identical.
- `src/daemon/shadow/rollout.rs`: `agent_for_cwd` now takes a
  `(name, expected-cwd)` candidate list instead of deriving
  `<home>/workspace/<name>` from bare names, and is **fail-closed** on
  ambiguity — if ≥2 candidates share the same expected cwd, attribute to
  **neither** (log a warning) rather than guess. `codex_candidates()`
  merges registry-derived candidates (unchanged convention) with live
  ephemeral codex workers' own recorded `cwd`.

### Lock ordering (hard requirement)

Both new call sites take the registry lock and the `LIVE_CHILDREN` lock
**separately, never nested**:

- `shadow_observe.rs::run()`: `lock_registry(ctx.registry)` is scoped to
  its own block and dropped before `live_children_snapshot()` is called
  (which takes and releases its own `LIVE_CHILDREN` lock internally).
- `rollout.rs::codex_candidates()`: `live_codex_agents(registry)` takes
  and releases the registry lock, *then* `live_children_snapshot()` is
  called. Neither function ever holds both locks at once.

### Not in scope (PR-2, or excluded per task spec)

- Driver consumption of `observed_status` (`driver_supported()`, the
  `observed_status` veto in `ephemeral_driver.rs`) — PR-2.
- QUANT-CODEX fixture replay, isolated-codex smoke — PR-2.
- kiro/agy extension.

## Commits (RED/GREEN, §3.10)

1. `test(state): RED` — two failing tests pin the gap: the real-entry-
   point wiring test (`ephemeral_worker_gets_observed_status_via_shadow_
   observe_2524_p3a`, registers a real ephemeral worker ONLY in
   `LIVE_CHILDREN`, registry deliberately empty, runs the REAL
   `ShadowObserveHandler::run()`) fails because `shadow_observe.rs` is
   left at the pre-PR baseline; the ambiguity test
   (`agent_for_cwd_ambiguous_when_two_candidates_share_a_cwd`) fails
   because `agent_for_cwd` is still first-match-wins. Everything else —
   including `codex_candidates()`'s ephemeral merge, which has no
   dedicated end-to-end test, only `agent_for_cwd`'s matching logic
   directly — compiles and passes already (documented in the commit
   message).
2. `feat(state): GREEN` — wires `shadow_observe.rs`'s merge line and
   flips `agent_for_cwd` to fail-closed; both RED tests pass.

## Test plan

- [x] `cargo test --bin agend-terminal daemon::shadow::rollout::` → 13/13 pass
- [x] `cargo test --bin agend-terminal ephemeral_tracking::` → 27/27 pass (+2 ignored, pre-existing, require real installs)
- [x] `cargo test --bin agend-terminal daemon::per_tick::shadow_observe::` → 4/4 pass (managed-agent path unaffected)
- [x] `cargo test --bin agend-terminal daemon::` → 1212/1212 pass
- [x] `cargo test --test src_file_size_invariant` → pass
- [x] `cargo test --test spawn_rationale_audit` → pass
- [x] all 34 `review_*.rs` static-grep regression tests → pass, no literal collisions with the new code
- [x] `cargo clippy --all-targets -- -D warnings` → clean
- [x] `cargo fmt --check` → clean
- [ ] Un-scoped full `cargo test --bin agend-terminal` (all ~4670 tests, no filter) shows 246 failures in `worktree_pool::`/`worktree_cleanup::` and similar — confirmed **pre-existing environment parallelism flakiness, unrelated to this PR**: both modules pass 100% (102/102, 16/16) when run in isolation, and grep confirms zero references from those modules to any file this PR touches.

Refs #2524 P3a-r1 (task `t-20260702064236685306-14977-28`), decisions
`d-20260702062543495557-8` + `d-20260702063047100813-9`. Single
reviewer: gapfix-reviewer — focus: lock ordering, managed-agent
invariance, the real-entry-point wiring test, read-only-ness of the
snapshot accessor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)