### PR TITLE
docs: quickstart leads with `agend-terminal app`, not `start`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Declare your entire AI dev team in one `fleet.yaml`. AgEnD Terminal launches eac
 ```bash
 cargo install agend-terminal
 agend-terminal quickstart    # Interactive setup in 2 minutes
-agend-terminal start         # Launch the fleet
+agend-terminal app           # Launch the TUI — every agent's pane in one screen
 ```
 
 ### Unattended setup (CI / scripts)

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -29,7 +29,7 @@
 ```bash
 cargo install agend-terminal
 agend-terminal quickstart    # 互動式設定，2 分鐘完成
-agend-terminal start         # 啟動 fleet
+agend-terminal app           # 啟動 TUI — 一個畫面看所有 agent 的 pane
 ```
 
 ### 無人值守設定（CI / 腳本）

--- a/docs/FEATURE-quickstart.md
+++ b/docs/FEATURE-quickstart.md
@@ -140,9 +140,13 @@ After completion, quickstart lists what to do next:
 
 === Launch ===
 
-$ agend-terminal start        # Start the daemon
-$ agend-terminal list          # Check agent status
-$ agend-terminal attach general  # Connect to the agent terminal
+[Recommended] New to agend, or want the whole fleet at a glance:
+$ agend-terminal app           # TUI dashboard: every agent's pane + live status
+
+[Advanced] Automation / headless / scripted (CI, remote, no TUI):
+$ agend-terminal start         # launch the fleet daemon
+$ agend-terminal list          # check agent status
+$ agend-terminal attach general  # attach to one agent's pane
 ```
 
 ---

--- a/docs/FEATURE-quickstart.zh-TW.md
+++ b/docs/FEATURE-quickstart.zh-TW.md
@@ -152,9 +152,13 @@ quickstart 完成後會列出接下來需要做的事：
 
 === 啟動 ===
 
-$ agend-terminal start        # 啟動 daemon
+[推薦] 剛接觸 agend，或想一眼看完整個 fleet：
+$ agend-terminal app           # TUI 儀表板：一個畫面看所有 agent 的 pane + 即時狀態
+
+[進階] 自動化 / headless / 腳本（CI、遠端、無 TUI）：
+$ agend-terminal start         # 啟動 fleet daemon
 $ agend-terminal list          # 確認 agent 狀態
-$ agend-terminal attach general  # 連接到 agent 終端
+$ agend-terminal attach general  # 連接到某個 agent 的 pane
 ```
 
 ---


### PR DESCRIPTION
## What

The quickstart docs still point new users at `agend-terminal start`, but the shipped quickstart Next Steps (#2204) already recommends **`agend-terminal app`** (the TUI dashboard) for first-time / interactive use and demotes `start` to the headless / automation audience. This aligns the docs with what the runtime actually prints.

Operator-flagged: the `cargo install` → `quickstart` → **launch** flow in the README should hand a newcomer the TUI, not the headless daemon.

## Changes (scope B — README entry + detailed quickstart doc, EN + zh-TW)

| File | Change |
|---|---|
| `README.md` | quickstart entry: `agend-terminal start` → `agend-terminal app` |
| `README.zh-TW.md` | 同上 |
| `docs/FEATURE-quickstart.md` | Step 4 "Next Steps": lead with `app` (Recommended), demote `start`/`list`/`attach` to Advanced/headless |
| `docs/FEATURE-quickstart.zh-TW.md` | 第四步同上 |

## Verified against source

- `src/main.rs`: `App` = "Launch the TUI app" (needs a TTY); `Start` = "Start the daemon" (detached service mode).
- `src/app/mod.rs:run()`: `app` self-hosts the control surface / auto-starts the fleet in-process; its own error text tells headless users to use `start`.
- `src/quickstart.rs` (#2204): runtime Next Steps already prints `[Recommended] agend-terminal app` and `[Advanced] agend-terminal start`.

## Left intentionally unchanged

- README Fleet-as-code bullet ("`agend-terminal start` brings the whole fleet up") — accurate for the headless bring-up; not the quickstart entry point.

Docs-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)