### PR TITLE
feat(state): #2524 P3a PR-2 — ephemeral driver codex enablement (observed_status turn-end + latch-expiry self-heal)

### DIFF
--- a/src/ephemeral_driver.rs
+++ b/src/ephemeral_driver.rs
@@ -20,9 +20,13 @@
 //!   the full `tick()` here would blanket-enable the 30 s `LATCHED_STATE_EXPIRY`
 //!   decay for every backend → a false turn-end on a quiet >30 s stretch. #2524 P3a
 //!   PR-2 (decision `d-20260702075424735619-11`) adds a NARROWER, throttled
-//!   exception in Phase 0 ONLY — [`StateTracker::expire_stale_latch_if_due`] — so a
-//!   mis-latched ready-screen state (confirm-first finding on a real backend spawn)
-//!   can self-heal without reopening the quiet->30s false-turn-end risk for Phase 2.
+//!   exception — [`StateTracker::expire_stale_latch_if_due`] — called in Phase 0 for
+//!   every backend (nothing is in-progress yet, so an early unblock costs nothing)
+//!   and in Phase 2 for codex ONLY (which alone has the `observed_status` veto below
+//!   as a safety net against that same false-turn-end risk — decision
+//!   `d-20260702081055743388-12`). See the Phase 0/Phase 2 comments in `run_turn` for
+//!   the full per-phase rationale — do NOT collapse this asymmetry into one
+//!   unconditional call without re-deriving that veto for every other backend first.
 //! - **Idle-debounce = 3 s of held Idle** before declaring the turn done. opencode
 //!   renders the Thinking marker CONTINUOUSLY while streaming (0 ms mid-turn Idle lull
 //!   observed on a fast model); 3 s cheaply covers a slower model's inter-render gaps.
@@ -41,13 +45,30 @@
 //!   (cosmetic) drops the trailing footer via a PATTERN-based strip ([`is_trailing_chrome`]),
 //!   not a per-backend magic row count, so it survives a backend bumping its footer.
 //!
-//! Scope: opencode (Slice-1) + claude (Slice-2) — each §5-smoke-validated. The gate
-//! ([`crate::ephemeral_tracking`] `driver_supported`) admits exactly this set; other
-//! backends are later slices. Both proven to render a continuous work marker so the
-//! Idle-debounce isn't fooled by a mid-turn idle. Durable telemetry (fleet_events
-//! L1/L2/L3 + task_events) is PR4; the result lands on the worker row for now.
+//! Scope: opencode (Slice-1) + claude (Slice-2) + codex (#2524 P3a PR-2) — each
+//! §5-smoke-validated. The gate ([`crate::ephemeral_tracking`] `driver_supported`)
+//! admits exactly this set; other backends are later slices. opencode/claude are
+//! proven to render a continuous work marker so the Idle-debounce isn't fooled by a
+//! mid-turn idle — their turn-end reads raw `get_state()` UNCHANGED. codex is
+//! different: its raw screen goes idle for several seconds mid-turn
+//! (SHADOW-OBSERVER-QUANT-CODEX-2413.md — longer than [`TURN_DEBOUNCE_MS`]), so its
+//! turn-end detection additionally consults `core.observed_status` (the Shadow
+//! Observer's Stream-authority-corrected status, populated by the codex rollout tail —
+//! #2524 P3a PR-1) and VETOES a raw-Idle sample when Stream evidence says the turn is
+//! still active ([`effective_turn_state`]). This is a per-backend veto, not a plane
+//! swap: opencode/claude never consult `observed_status` (zero behavior change), and
+//! codex still falls back to raw `get_state()` once Stream evidence goes stale or
+//! agrees with Idle. Durable telemetry (fleet_events L1/L2/L3 + task_events) is PR4;
+//! the result lands on the worker row for now.
 
 use crate::agent::InjectTarget;
+use crate::backend::Backend;
+// RED (#2524 P3a PR-2): `effective_turn_state` doesn't consult these yet — the
+// GREEN commit's real veto body uses both. Only referenced by tests until then.
+#[allow(unused_imports)]
+use crate::daemon::shadow::evidence::Authority;
+#[allow(unused_imports)]
+use crate::daemon::shadow::reducer::{ObservedState, ObservedStatus};
 use crate::state::AgentState;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
@@ -87,6 +108,10 @@ pub(crate) struct DriverConfig {
     pub inject_target: InjectTarget,
     /// The worker's wall-TTL (the reap sweep's cost guard); the driver's hard ceiling.
     pub wall_ttl: Duration,
+    /// #2524 P3a PR-2: which backend this worker runs, so turn-end detection can branch
+    /// (codex consults `observed_status`; every other backend is unaffected — see
+    /// [`effective_turn_state`]).
+    pub backend: Backend,
 }
 
 /// Launch the one-shot driver thread for a freshly-finalized worker.
@@ -110,6 +135,7 @@ fn run_turn(cfg: DriverConfig) {
         prompt,
         inject_target,
         wall_ttl,
+        backend,
     } = cfg;
     let start = Instant::now();
     let wall_ttl_ms = wall_ttl.as_millis() as u64;
@@ -159,14 +185,43 @@ fn run_turn(cfg: DriverConfig) {
     }
 
     // Phase 2 — wait for turn end: Idle held ≥ debounce after work, an error class, or
-    // the wall-TTL. Poll get_state() ONLY (never tick()).
+    // the wall-TTL. Poll get_state() ONLY (never the general tick()).
+    //
+    // #2524 P3a PR-2 (decision d-20260702081055743388-12): the Phase 0 latch-expiry
+    // check does NOT extend here for opencode/claude — DELIBERATELY, not an oversight.
+    // `expire_stale_latch_if_due` transitions on ELAPSED TIME alone, without
+    // re-evaluating the current screen (`record_set`'s same-state early-return never
+    // refreshes `since` on a repeat Active match, however often the screen re-renders
+    // — see `StateTracker::record_set`). Calling it here for a backend with no
+    // turn-end-authority fallback would re-derive EXACTLY the risk this module's own
+    // top doc already flags ("Calling `tick()` here would re-enable that decay → a
+    // false turn-end on a quiet >30s stretch"): a genuinely-still-running turn past
+    // 30s continuously classified Active could get force-flipped to Idle and read as
+    // a real TurnEnded 3s later. opencode/claude are §5-smoke-validated on the
+    // OPPOSITE premise — a real turn-end always produces a final render burst (new
+    // pty bytes ⇒ `detect()` naturally re-evaluates and transitions), so they have
+    // no latent ready-style mis-latch to fix here, and adding the check would be a
+    // new, un-smoked risk for no benefit. codex is different ONLY because it has the
+    // `observed_status` veto below as a safety net: even if `expire_stale_latch_if_due`
+    // wrongly forces Idle on a still-active codex turn, fresh Stream-authority
+    // evidence overrides it back to `Active` before `TurnEndDetector` ever sees it
+    // (see `codex_expiry_forced_idle_is_vetoed_back_to_active` below) — a protection
+    // opencode/claude do not have. Do NOT "simplify" this to an unconditional call for
+    // all backends without re-adding that veto first.
     let mut detector = TurnEndDetector::new(TURN_DEBOUNCE_MS);
     let stop_reason = loop {
         let now_ms = start.elapsed().as_millis() as u64;
         if now_ms >= wall_ttl_ms {
             break "wall-TTL elapsed before turn end";
         }
-        let state = inject_target.core.lock().state.get_state();
+        let (raw, observed) = {
+            let mut c = inject_target.core.lock();
+            if backend == Backend::Codex {
+                c.state.expire_stale_latch_if_due(now_ms);
+            }
+            (c.state.get_state(), c.observed_status.clone())
+        };
+        let state = effective_turn_state(&backend, raw, observed.as_ref());
         match detector.observe(state, now_ms) {
             TurnDecision::Continue => std::thread::sleep(POLL_INTERVAL),
             TurnDecision::TurnEnded => break "turn ended (Idle held)",
@@ -352,6 +407,35 @@ fn build_summary(dump: &str, terminal_state: AgentState, grew: bool, stop_reason
         out.push_str("…[truncated]");
     }
     out
+}
+
+/// #2524 P3a PR-2: the state actually fed to [`TurnEndDetector`] for this poll sample.
+/// PURE (no lock, no I/O) — takes the raw screen state and the worker's current
+/// `observed_status` already read under one `core.lock()` by the caller — so it's
+/// unit-testable with synthetic inputs (see the `codex_survives_quant_2413_*` test,
+/// fed the REAL SHADOW-OBSERVER-QUANT-CODEX-2413.md trace).
+///
+/// opencode/claude: always the raw state, unchanged — zero behavior change, per the
+/// §5-smoke precedent (this function is a no-op for them).
+///
+/// codex: a raw `Idle` sample is VETOED (treated as still `Active`) when
+/// `observed_status` carries FRESH `Stream`-authority evidence that says otherwise —
+/// SHADOW-OBSERVER-QUANT-CODEX-2413.md shows codex's raw screen false-idling for
+/// several seconds mid-turn (longer than [`TURN_DEBOUNCE_MS`]) while the rollout-tail
+/// Stream evidence correctly holds `Responding`. Once Stream evidence goes stale or
+/// itself agrees with Idle (the reducer falls back to `Screen` authority — the real
+/// turn has ended), the raw state passes through unchanged, so the debounce still
+/// applies normally at the REAL end. A non-`Idle` raw sample is never touched — the
+/// veto only ever suppresses a false idle, never invents one.
+///
+/// RED (#2524 P3a PR-2): not yet vetoing anything — always the raw state, for every
+/// backend. The GREEN commit adds the codex Stream-authority veto.
+fn effective_turn_state(
+    _backend: &Backend,
+    raw: AgentState,
+    _observed: Option<&ObservedStatus>,
+) -> AgentState {
+    raw
 }
 
 /// Pure turn-end detector — the Idle-debounce state machine, time-injected (`now_ms`)
@@ -589,6 +673,24 @@ mod tests {
         assert!(!body.contains('❯'), "empty input box dropped");
     }
 
+    /// #2524 P3a PR-2: codex's bottom statusline, verbatim off a real isolated smoke
+    /// (`gpt-5.5 medium · /private/var/…/backend-data/ephemeral/eph-53468-0`) —
+    /// dropped structurally (path after " · "), not by the model name.
+    #[test]
+    fn strip_trailing_chrome_drops_codex_footer() {
+        let dump = "• pong\n\n  gpt-5.5 medium · /private/var/folders/wn/T/agend-ephemeral-53468-codex-e2e-0/backend-data/ephemeral/eph-53468-0";
+        let body = strip_trailing_chrome(dump);
+        assert!(body.contains("pong"), "body answer kept");
+        assert!(!body.contains("gpt-5.5 medium"), "codex statusline dropped");
+    }
+
+    /// A body line that happens to contain " · " but NOT followed by an absolute
+    /// path must NOT be mistaken for the codex statusline.
+    #[test]
+    fn is_trailing_chrome_requires_a_path_after_the_middle_dot() {
+        assert!(!is_trailing_chrome("today's agenda · groceries, laundry"));
+    }
+
     /// A `❯ <prompt>` echo (content after the glyph) is BODY, not chrome — only a LONE
     /// `❯` (empty input box) is stripped.
     #[test]
@@ -670,6 +772,294 @@ mod tests {
         assert_eq!(d.observe(AgentState::Idle, 1_000), TurnDecision::Continue);
         assert_eq!(d.observe(AgentState::Idle, 3_999), TurnDecision::Continue);
         assert_eq!(d.observe(AgentState::Idle, 4_000), TurnDecision::TurnEnded);
+    }
+
+    // ──────────────────── effective_turn_state (#2524 P3a PR-2) ────────────────────
+
+    fn observed(state: ObservedState, authority: Authority) -> ObservedStatus {
+        ObservedStatus {
+            state,
+            confidence: crate::daemon::shadow::evidence::Confidence::Strong,
+            authority,
+            evidence: Vec::new(),
+            since_ms: 0,
+        }
+    }
+
+    /// opencode/claude MUST be a no-op regardless of raw state or observed_status —
+    /// the veto is codex-only (zero behavior change for the §5-smoke-validated
+    /// backends, per the module doc).
+    #[test]
+    fn effective_turn_state_is_noop_for_opencode_and_claude() {
+        for backend in [Backend::OpenCode, Backend::ClaudeCode] {
+            for raw in [AgentState::Idle, AgentState::Active] {
+                assert_eq!(
+                    effective_turn_state(&backend, raw, None),
+                    raw,
+                    "{backend:?}/{raw:?} with no observed_status must pass through"
+                );
+                assert_eq!(
+                    effective_turn_state(
+                        &backend,
+                        raw,
+                        Some(&observed(ObservedState::Responding, Authority::Stream))
+                    ),
+                    raw,
+                    "{backend:?}/{raw:?} must ignore observed_status entirely"
+                );
+            }
+        }
+    }
+
+    /// codex: a non-Idle raw sample is never touched — the veto only ever suppresses
+    /// a false Idle, it never invents activity out of an already-active sample.
+    #[test]
+    fn effective_turn_state_codex_leaves_non_idle_raw_alone() {
+        assert_eq!(
+            effective_turn_state(&Backend::Codex, AgentState::Active, None),
+            AgentState::Active
+        );
+        assert_eq!(
+            effective_turn_state(
+                &Backend::Codex,
+                AgentState::Active,
+                Some(&observed(ObservedState::Idle, Authority::Screen))
+            ),
+            AgentState::Active
+        );
+    }
+
+    /// codex: raw Idle + no observed_status yet (e.g. the shadow-observer tick hasn't
+    /// run) → passes through unchanged. Never invents a veto from nothing.
+    #[test]
+    fn effective_turn_state_codex_no_observed_status_passes_through() {
+        assert_eq!(
+            effective_turn_state(&Backend::Codex, AgentState::Idle, None),
+            AgentState::Idle
+        );
+    }
+
+    /// codex: raw Idle + observed_status ALSO Idle (any authority) → the two planes
+    /// agree, no veto — the debounce proceeds normally at a REAL idle.
+    #[test]
+    fn effective_turn_state_codex_agreeing_idle_passes_through() {
+        assert_eq!(
+            effective_turn_state(
+                &Backend::Codex,
+                AgentState::Idle,
+                Some(&observed(ObservedState::Idle, Authority::Stream))
+            ),
+            AgentState::Idle
+        );
+        assert_eq!(
+            effective_turn_state(
+                &Backend::Codex,
+                AgentState::Idle,
+                Some(&observed(ObservedState::Idle, Authority::Screen))
+            ),
+            AgentState::Idle
+        );
+    }
+
+    /// codex: raw Idle + observed_status says active but via `Screen` authority (not
+    /// `Stream`) → NOT vetoed. `Screen` authority is the same plane as the raw sample
+    /// itself (no independent correction), so there is nothing to veto WITH.
+    #[test]
+    fn effective_turn_state_codex_screen_authority_does_not_veto() {
+        assert_eq!(
+            effective_turn_state(
+                &Backend::Codex,
+                AgentState::Idle,
+                Some(&observed(ObservedState::Responding, Authority::Screen))
+            ),
+            AgentState::Idle
+        );
+    }
+
+    /// codex: raw Idle + FRESH Stream-authority evidence saying the turn is still
+    /// active (Responding/Thinking/ToolUse/Active — anything that doesn't coarsen to
+    /// Idle) → VETOED to `Active`. This is the exact false-idle shape
+    /// SHADOW-OBSERVER-QUANT-CODEX-2413.md documents on a real turn.
+    #[test]
+    fn effective_turn_state_codex_stream_active_vetoes_false_idle() {
+        for state in [
+            ObservedState::Responding,
+            ObservedState::Thinking,
+            ObservedState::ToolUse,
+            ObservedState::Active,
+        ] {
+            assert_eq!(
+                effective_turn_state(
+                    &Backend::Codex,
+                    AgentState::Idle,
+                    Some(&observed(state, Authority::Stream))
+                ),
+                AgentState::Active,
+                "{state:?}/Stream must veto a raw-Idle sample"
+            );
+        }
+    }
+
+    /// #2524 P3a PR-2 — THE fixture-replay pin: the REAL raw/observed/authority trace
+    /// from SHADOW-OBSERVER-QUANT-CODEX-2413.md (§"Result" table, verbatim timestamps
+    /// converted to relative ms from the first sample), fed through
+    /// `effective_turn_state` into a REAL `TurnEndDetector`. Proves the false-idle
+    /// window (11:38:58–11:39:04, raw=Idle/observed=Responding/Stream — ~6 s, LONGER
+    /// than the 3 s debounce) does not end the turn, and the REAL end (11:39:05,
+    /// raw=Idle/observed=Idle/Screen — Stream evidence went stale, reducer fell back
+    /// to Screen) does, once held for the debounce. No real codex binary, no sleep —
+    /// pure data replay.
+    #[test]
+    fn codex_survives_quant_2413_false_idle_trace() {
+        let trace: &[(u64, AgentState, ObservedState, Authority)] = &[
+            // 11:38:41–56: continuous work, Stream authority throughout (11 samples in
+            // the doc; 4 representative ones suffice to establish Working).
+            (
+                0,
+                AgentState::Active,
+                ObservedState::Responding,
+                Authority::Stream,
+            ),
+            (
+                5_000,
+                AgentState::Active,
+                ObservedState::Responding,
+                Authority::Stream,
+            ),
+            (
+                10_000,
+                AgentState::Active,
+                ObservedState::Responding,
+                Authority::Stream,
+            ),
+            (
+                15_000,
+                AgentState::Active,
+                ObservedState::Responding,
+                Authority::Stream,
+            ),
+            // 11:38:58–11:39:04: raw screen false-idles for ~6s; Stream evidence still
+            // says Responding — this is the window a naive raw-state feed would
+            // wrongly end the turn in (3s debounce < 6s window).
+            (
+                17_000,
+                AgentState::Idle,
+                ObservedState::Responding,
+                Authority::Stream,
+            ),
+            (
+                18_000,
+                AgentState::Idle,
+                ObservedState::Responding,
+                Authority::Stream,
+            ),
+            (
+                20_000,
+                AgentState::Idle,
+                ObservedState::Responding,
+                Authority::Stream,
+            ),
+            (
+                21_000,
+                AgentState::Idle,
+                ObservedState::Responding,
+                Authority::Stream,
+            ),
+            (
+                23_000,
+                AgentState::Idle,
+                ObservedState::Responding,
+                Authority::Stream,
+            ),
+            // 11:39:05: the turn REALLY ends — no fresh Stream evidence, reducer falls
+            // back to Screen authority, agreeing with raw Idle.
+            (
+                24_000,
+                AgentState::Idle,
+                ObservedState::Idle,
+                Authority::Screen,
+            ),
+            // Hold the real Idle for the debounce window so TurnEnded actually fires.
+            (
+                27_000,
+                AgentState::Idle,
+                ObservedState::Idle,
+                Authority::Screen,
+            ),
+        ];
+
+        let mut detector = TurnEndDetector::new(TURN_DEBOUNCE_MS);
+        let mut turn_ended_at: Option<u64> = None;
+        for &(now_ms, raw, obs_state, authority) in trace {
+            let observed_status = observed(obs_state, authority);
+            let effective = effective_turn_state(&Backend::Codex, raw, Some(&observed_status));
+            if detector.observe(effective, now_ms) == TurnDecision::TurnEnded {
+                turn_ended_at.get_or_insert(now_ms);
+            }
+        }
+        assert_eq!(
+            turn_ended_at,
+            Some(27_000),
+            "must not false-fire during the 17s-23s false-idle window; must fire only \
+             once the REAL end (24s) has held the debounce"
+        );
+    }
+
+    /// #2524 P3a PR-2 (decision `d-20260702081055743388-12`) — THE decisive
+    /// interaction pin between the two codex-only Phase 2 safety nets:
+    /// `expire_stale_latch_if_due` transitions on ELAPSED TIME alone (never
+    /// re-reading the actual screen), so it CAN wrongly force a genuinely-still-
+    /// running codex turn's raw state to `Idle` after 30s of no state CHANGE (even
+    /// if the screen keeps re-rendering the SAME classification — `record_set`'s
+    /// same-state early-return never refreshes `since`). This is exactly the risk
+    /// the decision flagged. It's safe ONLY because `effective_turn_state`'s
+    /// `observed_status` veto catches it: fresh Stream-authority evidence saying the
+    /// turn is still `Responding` (the QUANT-CODEX-2413.md shape) overrides the
+    /// wrongly-forced `Idle` back to `Active` BEFORE `TurnEndDetector` ever sees it —
+    /// so the two mechanisms together never produce a false `TurnEnded`. This is
+    /// exactly why Phase 2's `expire_stale_latch_if_due` call is codex-ONLY (see
+    /// `run_turn`'s Phase 2 comment): opencode/claude have no such veto, so the same
+    /// risk would NOT be caught for them.
+    #[test]
+    fn codex_expiry_forced_idle_is_vetoed_back_to_active() {
+        let mut tracker = crate::state::StateTracker::new(Some(&Backend::Codex));
+        // A genuinely-still-running codex turn, classified `Active` for >30s straight
+        // (a slow model — real, not stale).
+        tracker.current = AgentState::Active;
+        tracker.since = std::time::Instant::now() - std::time::Duration::from_secs(31);
+
+        // The throttle is due → `expire_stale_latch_if_due` blindly force-transitions
+        // to `Idle` without re-checking the screen. This alone WOULD be wrong.
+        tracker.expire_stale_latch_if_due(1_000);
+        let raw = tracker.get_state();
+        assert_eq!(
+            raw,
+            AgentState::Idle,
+            "expiry force-transitions on elapsed time alone, with no screen re-check"
+        );
+
+        // Fresh Stream-authority evidence says the turn is genuinely still active —
+        // the veto must override the wrongly-forced Idle before TurnEndDetector sees it.
+        let observed_status = observed(ObservedState::Responding, Authority::Stream);
+        let effective = effective_turn_state(&Backend::Codex, raw, Some(&observed_status));
+        assert_eq!(
+            effective,
+            AgentState::Active,
+            "the observed_status veto must override the wrongly-forced Idle"
+        );
+
+        // Feed the ALREADY-Working detector the effective (vetoed) state — must NOT
+        // end the turn.
+        let mut detector = TurnEndDetector::new(TURN_DEBOUNCE_MS);
+        assert_eq!(
+            detector.observe(AgentState::Active, 0),
+            TurnDecision::Continue
+        ); // enter Working
+        assert_eq!(
+            detector.observe(effective, 1_000),
+            TurnDecision::Continue,
+            "the vetoed-back-to-Active sample must not end the turn"
+        );
     }
 
     // ─────────────────────────────── summary ───────────────────────────────

--- a/src/ephemeral_driver.rs
+++ b/src/ephemeral_driver.rs
@@ -63,11 +63,7 @@
 
 use crate::agent::InjectTarget;
 use crate::backend::Backend;
-// RED (#2524 P3a PR-2): `effective_turn_state` doesn't consult these yet — the
-// GREEN commit's real veto body uses both. Only referenced by tests until then.
-#[allow(unused_imports)]
 use crate::daemon::shadow::evidence::Authority;
-#[allow(unused_imports)]
 use crate::daemon::shadow::reducer::{ObservedState, ObservedStatus};
 use crate::state::AgentState;
 use std::path::PathBuf;
@@ -366,6 +362,15 @@ fn is_trailing_chrome(line: &str) -> bool {
     if matches!(t, "❯" | "›" | ">" | "┃") {
         return true;
     }
+    // codex (#2524 P3a PR-2): persistent bottom statusline `<model> · <cwd path>` —
+    // real capture off an isolated codex smoke: `gpt-5.5 medium · /private/var/
+    // .../backend-data/ephemeral/eph-53468-0`. Matched STRUCTURALLY (the segment
+    // after " · " is an absolute path) rather than the model name, which varies
+    // per-session/config — same pattern-not-magic-string principle as the rest of
+    // this function.
+    if t.split(" · ").nth(1).is_some_and(|s| s.starts_with('/')) {
+        return true;
+    }
     // Known backend footer statuslines (claude + opencode).
     let lower = t.to_ascii_lowercase();
     lower.contains("bypass permissions")        // claude: `⏵⏵ bypass permissions …`
@@ -428,14 +433,23 @@ fn build_summary(dump: &str, terminal_state: AgentState, grew: bool, stop_reason
 /// applies normally at the REAL end. A non-`Idle` raw sample is never touched — the
 /// veto only ever suppresses a false idle, never invents one.
 ///
-/// RED (#2524 P3a PR-2): not yet vetoing anything — always the raw state, for every
-/// backend. The GREEN commit adds the codex Stream-authority veto.
 fn effective_turn_state(
-    _backend: &Backend,
+    backend: &Backend,
     raw: AgentState,
-    _observed: Option<&ObservedStatus>,
+    observed: Option<&ObservedStatus>,
 ) -> AgentState {
-    raw
+    if *backend != Backend::Codex || raw != AgentState::Idle {
+        return raw;
+    }
+    match observed {
+        Some(status)
+            if status.authority == Authority::Stream
+                && status.state.coarse() != ObservedState::Idle =>
+        {
+            AgentState::Active
+        }
+        _ => raw,
+    }
 }
 
 /// Pure turn-end detector — the Idle-debounce state machine, time-injected (`now_ms`)

--- a/src/ephemeral_driver.rs
+++ b/src/ephemeral_driver.rs
@@ -15,11 +15,14 @@
 //!
 //! ## Empirical constants (PR3b 1a confirm-first smoke, lead-vetted — DO NOT change
 //! without re-smoking on a real backend)
-//! - **Poll `get_state()` ONLY, NEVER `state.tick()`.** The ephemeral read loop
-//!   ([`crate::agent`] `ephemeral_pty_read_loop`) never ticks, so the 30 s
-//!   `LATCHED_STATE_EXPIRY` Thinking→Idle decay is disabled and no phantom timer-Idle
-//!   fires. Calling `tick()` here would re-enable that decay → a false turn-end on a
-//!   quiet >30 s stretch. So the driver reads state, never advances the clock.
+//! - **Poll `get_state()` ONLY, NEVER the general `state.tick()`.** The ephemeral
+//!   read loop ([`crate::agent`] `ephemeral_pty_read_loop`) never ticks, so calling
+//!   the full `tick()` here would blanket-enable the 30 s `LATCHED_STATE_EXPIRY`
+//!   decay for every backend → a false turn-end on a quiet >30 s stretch. #2524 P3a
+//!   PR-2 (decision `d-20260702075424735619-11`) adds a NARROWER, throttled
+//!   exception in Phase 0 ONLY — [`StateTracker::expire_stale_latch_if_due`] — so a
+//!   mis-latched ready-screen state (confirm-first finding on a real backend spawn)
+//!   can self-heal without reopening the quiet->30s false-turn-end risk for Phase 2.
 //! - **Idle-debounce = 3 s of held Idle** before declaring the turn done. opencode
 //!   renders the Thinking marker CONTINUOUSLY while streaming (0 ms mid-turn Idle lull
 //!   observed on a fast model); 3 s cheaply covers a slower model's inter-render gaps.
@@ -112,12 +115,22 @@ fn run_turn(cfg: DriverConfig) {
     let wall_ttl_ms = wall_ttl.as_millis() as u64;
 
     // Phase 0 — wait for the worker to reach its first Idle (ready). Poll get_state()
-    // ONLY (never tick()). An error class before ready, or a ready timeout, fails the
-    // turn immediately.
+    // ONLY (never the general tick()) — but DO run the throttled latch-expiry check,
+    // for ALL backends here (#2524 P3a PR-2, decision `d-20260702075424735619-11`):
+    // without it, a screen-classifier state that mis-latches Active on the ready
+    // screen and then goes fully static (no further pty bytes ⇒ no `detect()`
+    // re-evaluation either) can NEVER self-heal, and Phase 0 would wait out the full
+    // `READY_TIMEOUT` on an already-ready worker. Safe for EVERY backend here
+    // specifically because nothing is "in progress" yet to falsely cut short — the
+    // worst case is Phase 0 unblocking slightly early, never a truncated turn.
     let ready_cap_ms = (READY_TIMEOUT.as_millis() as u64).min(wall_ttl_ms);
     loop {
         let now_ms = start.elapsed().as_millis() as u64;
-        let state = inject_target.core.lock().state.get_state();
+        let state = {
+            let mut c = inject_target.core.lock();
+            c.state.expire_stale_latch_if_due(now_ms);
+            c.state.get_state()
+        };
         if state.is_error() {
             return record_failure(&home, &worker_id, &format!("not ready: {state:?}"));
         }

--- a/src/ephemeral_tracking.rs
+++ b/src/ephemeral_tracking.rs
@@ -287,13 +287,21 @@ pub fn resolve_supported_backend(backend: &str) -> Result<&'static str, String> 
 /// PR3b: backends whose one-shot DRIVER (inject → turn-end → capture → oracle) is
 /// §5-smoke-validated, so a `prompt` may be driven on them. Slice-1 added opencode;
 /// Slice-2 added claude (both proven to render a continuous work marker so the
-/// Idle-debounce isn't fooled by a mid-turn idle — confirm-first iron rule). A prompt
-/// for any other backend is rejected ([`SpawnError::DriverUnsupported`]) until its own
-/// §5 smoke lands. `backend_command` is the canonical, allowlist-resolved command.
+/// Idle-debounce isn't fooled by a mid-turn idle — confirm-first iron rule). #2524
+/// P3a PR-2 adds codex — its raw screen false-idles mid-turn for several seconds
+/// (SHADOW-OBSERVER-QUANT-CODEX-2413.md), longer than the Idle-debounce window, so its
+/// turn-end detection is routed through `core.observed_status` (Stream authority) — see
+/// `ephemeral_driver::effective_turn_state`. A prompt for any other backend is rejected
+/// ([`SpawnError::DriverUnsupported`]) until its own §5 smoke lands. `backend_command`
+/// is the canonical, allowlist-resolved command.
 fn driver_supported(backend_command: &str) -> bool {
     matches!(
         crate::backend::Backend::from_command(backend_command),
-        Some(crate::backend::Backend::OpenCode | crate::backend::Backend::ClaudeCode)
+        Some(
+            crate::backend::Backend::OpenCode
+                | crate::backend::Backend::ClaudeCode
+                | crate::backend::Backend::Codex
+        )
     )
 }
 
@@ -578,13 +586,15 @@ pub fn spawn_and_track(home: &Path, spec: SpawnSpec) -> Result<EphemeralWorker, 
                 drive_turn,
                 crate::backend::Backend::from_command(backend_command),
             ) {
-                let inject_target = crate::agent::InjectTarget::from_ephemeral(&handle, backend);
+                let inject_target =
+                    crate::agent::InjectTarget::from_ephemeral(&handle, backend.clone());
                 crate::ephemeral_driver::spawn_driver(crate::ephemeral_driver::DriverConfig {
                     home: home.to_path_buf(),
                     worker_id: worker_id.clone(),
                     prompt: spec.prompt.clone(),
                     inject_target,
                     wall_ttl: std::time::Duration::from_secs(ttl_secs),
+                    backend,
                 });
             }
             LIVE_CHILDREN.lock().insert(worker_id, handle);
@@ -1834,22 +1844,23 @@ mod tests {
 
     /// PR3b driver GATE: a `prompt` for a backend NOT in [`driver_supported`] is
     /// rejected as `DriverUnsupported` BEFORE any reserve/spawn (confirm-first iron rule
-    /// — never drive a backend whose turn-detection isn't §5-smoke-proven). codex is the
-    /// canonical still-unsupported backend (Slice-3+). Gated in the SHARED SINK so a
-    /// direct caller, not just the MCP handler, is protected. A prompt-LESS spawn of any
-    /// backend is unaffected (the PR3a lifecycle path).
+    /// — never drive a backend whose turn-detection isn't §5-smoke-proven). kiro-cli is
+    /// the canonical still-unsupported backend (codex joined the supported set in #2524
+    /// P3a PR-2 — see `driver_supported_is_opencode_claude_and_codex_only`). Gated in the
+    /// SHARED SINK so a direct caller, not just the MCP handler, is protected. A
+    /// prompt-LESS spawn of any backend is unaffected (the PR3a lifecycle path).
     #[test]
     fn spawn_and_track_rejects_prompt_for_unsupported_backend() {
         let home = tmp_home("driver-gate");
         let spec = SpawnSpec {
             workflow_id: "wf".to_string(),
-            backend: "codex".to_string(),
+            backend: "kiro-cli".to_string(),
             prompt: "do the thing".to_string(),
             ..Default::default()
         };
         let res = spawn_and_track(&home, spec);
         assert!(
-            matches!(&res, Err(SpawnError::DriverUnsupported(b)) if b == "codex"),
+            matches!(&res, Err(SpawnError::DriverUnsupported(b)) if b == "kiro-cli"),
             "a prompt for a driver-unsupported backend must be DriverUnsupported: {res:?}"
         );
         assert_eq!(
@@ -1860,25 +1871,30 @@ mod tests {
         std::fs::remove_dir_all(&home).ok();
     }
 
-    /// PR3b Slice-2: the [`driver_supported`] set is exactly {opencode, claude} — the
-    /// §5-smoke-validated backends. Regression-guards the gate generalization: opencode
-    /// (Slice-1) MUST stay supported, claude (Slice-2) is added, and codex/kiro/agy stay
-    /// rejected (their per-backend smoke hasn't landed). Canonical commands + aliases.
+    /// #2524 P3a PR-2: the [`driver_supported`] set is exactly {opencode, claude,
+    /// codex} — the §5-smoke-validated backends. Regression-guards the gate
+    /// generalization: opencode (Slice-1) and claude (Slice-2) MUST stay supported,
+    /// codex (PR-2) is added, and kiro/agy stay rejected (their per-backend smoke
+    /// hasn't landed). Canonical commands + aliases.
     #[test]
-    fn driver_supported_is_opencode_and_claude_only() {
+    fn driver_supported_is_opencode_claude_and_codex_only() {
         assert!(
             driver_supported("opencode"),
             "opencode (Slice-1) must stay supported"
         );
         assert!(
             driver_supported("claude"),
-            "claude (Slice-2) is now supported"
+            "claude (Slice-2) must stay supported"
         );
         assert!(
             driver_supported("claude-2.1"),
             "a claude-prefixed alias maps to ClaudeCode → supported"
         );
-        for unsupported in ["codex", "kiro-cli", "kiro", "agy"] {
+        assert!(
+            driver_supported("codex"),
+            "codex (#2524 P3a PR-2) is now supported"
+        );
+        for unsupported in ["kiro-cli", "kiro", "agy"] {
             assert!(
                 !driver_supported(unsupported),
                 "{unsupported} has no §5 smoke yet → driver unsupported"
@@ -2040,6 +2056,115 @@ mod tests {
             summary.map(|s| !s.trim().is_empty()).unwrap_or(false),
             "result_summary must be non-empty on success"
         );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// REAL codex end-to-end (`#[ignore]`: no binary/creds in CI) — #2524 P3a PR-2.
+    /// Drives a real headless codex worker through the SAME driver path as
+    /// claude/opencode, but ALSO exercises the `observed_status` wiring this PR's
+    /// turn-end veto depends on (unlike claude/opencode, whose driver never touches
+    /// it): starts the REAL rollout tailer ([`crate::daemon::shadow::rollout::spawn`],
+    /// read-only against `~/.codex/sessions`) and manually drives
+    /// `ShadowObserveHandler::run()` on a tight loop — standing in for the daemon's
+    /// per-tick supervisor, which isn't running in-test — so `core.observed_status`
+    /// actually gets populated from this worker's REAL rollout file, the same wiring
+    /// #2524 P3a PR-1 built. Asserts the worker records success with a non-empty
+    /// transcript. Run locally:
+    /// `cargo test --bin agend-terminal --features tray -- --ignored ephemeral_codex_driver_e2e`.
+    /// `#[cfg(unix)]`: ephemeral spawn is fail-closed on Windows.
+    #[cfg(unix)]
+    #[test]
+    #[ignore = "requires a real codex install + auth; run locally"]
+    fn ephemeral_codex_driver_e2e() {
+        use crate::agent::{AgentRegistry, ExternalRegistry};
+        use crate::daemon::per_tick::{PerTickHandler, ShadowObserveHandler, TickContext};
+        use parking_lot::Mutex as PLMutex;
+        use std::sync::atomic::AtomicBool;
+
+        let prev = std::env::var("AGEND_SHADOW_OBSERVER").ok();
+        std::env::set_var("AGEND_SHADOW_OBSERVER", "1");
+
+        let home = tmp_home("codex-e2e");
+        let registry: AgentRegistry = Arc::new(PLMutex::new(HashMap::new()));
+        let externals: ExternalRegistry = Arc::new(PLMutex::new(HashMap::new()));
+        let configs = Arc::new(PLMutex::new(HashMap::new()));
+
+        // Real rollout tailer thread (#2524 P3a PR-1) — read-only against the REAL
+        // `~/.codex/sessions`; attribution is scoped to THIS worker's own recorded
+        // cwd, so the live fleet (if any) is untouched.
+        crate::daemon::shadow::rollout::spawn(Arc::clone(&registry), home.clone());
+
+        // Manually drive the per-tick reduce (standing in for the daemon's tick loop,
+        // which isn't running in-test) so `observed_status` is actually populated.
+        let stop = Arc::new(AtomicBool::new(false));
+        let ticker = {
+            let stop = Arc::clone(&stop);
+            let registry = Arc::clone(&registry);
+            let externals = Arc::clone(&externals);
+            let configs = Arc::clone(&configs);
+            let home = home.clone();
+            std::thread::spawn(move || {
+                let ctx = TickContext {
+                    home: &home,
+                    registry: &registry,
+                    externals: &externals,
+                    configs: &configs,
+                };
+                while !stop.load(Ordering::Relaxed) {
+                    ShadowObserveHandler::new().run(&ctx);
+                    std::thread::sleep(std::time::Duration::from_millis(300));
+                }
+            })
+        };
+
+        let spec = SpawnSpec {
+            workflow_id: "e2e".to_string(),
+            backend: "codex".to_string(),
+            prompt: "Reply with exactly the word: pong".to_string(),
+            ttl_secs: Some(180),
+            ..Default::default()
+        };
+        let w = spawn_and_track(&home, spec).expect("spawn codex worker");
+        assert_ne!(w.pid, 0, "a real pid was stamped");
+
+        // Driver runs ASYNC; poll the row until it records a result.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(150);
+        let outcome = loop {
+            match list(&home, None)
+                .into_iter()
+                .find(|r| r.worker_id == w.worker_id)
+            {
+                Some(row) => {
+                    if let Some(success) = row.success {
+                        break Some((success, row.result_summary));
+                    }
+                }
+                None => break None,
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "the driver did not record a result within the deadline"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(500));
+        };
+        stop.store(true, Ordering::Relaxed);
+        let _ = ticker.join();
+        reap_one(&home, &w.worker_id);
+
+        let (success, summary) = outcome.expect("the worker row must carry a result before reap");
+        assert!(
+            success,
+            "a simple codex prompt turn must succeed; summary={summary:?}"
+        );
+        assert!(
+            summary.map(|s| !s.trim().is_empty()).unwrap_or(false),
+            "result_summary must be non-empty on success"
+        );
+
+        match prev {
+            Some(v) => std::env::set_var("AGEND_SHADOW_OBSERVER", v),
+            None => std::env::remove_var("AGEND_SHADOW_OBSERVER"),
+        }
         std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -261,6 +261,13 @@ pub struct StateTracker {
     /// [`StateTracker::published_observed_handle`]; written only by `publish_observed`.
     published_observed: Arc<AtomicU8>,
     pub(crate) since: Instant,
+    /// #2524 P3a PR-2: last caller-supplied `now_ms` [`expire_stale_latch_if_due`]
+    /// actually ran on — caller-clock-relative (e.g. the ephemeral driver's own
+    /// turn-elapsed-ms), not wall-clock; only needs to be monotonic per caller.
+    // RED: no caller wires this in yet — the GREEN commit adds the ephemeral
+    // driver's Phase 0 call site.
+    #[allow(dead_code)]
+    pub(crate) last_latch_check_ms: u64,
     pub last_output: Instant,
     /// F9 (#685 sub-task 4): `Some(t)` only when `infer_productivity()` returned
     /// a `Productive` signal (heartbeat refresh or structural marker match) at
@@ -976,6 +983,12 @@ impl StateTracker {
     /// stalls.
     const PENDING_TRANSITIONS_CAP: usize = 256;
     const LATCHED_STATE_EXPIRY: Duration = Duration::from_secs(30);
+    /// #2524 P3a PR-2: throttle window for `expire_stale_latch_if_due` — cheap
+    /// enough for every 250ms driver poll, tight enough to clear a mis-latch within
+    /// `LATCHED_STATE_EXPIRY` + a fraction of a second.
+    // RED: `expire_stale_latch_if_due` has no caller yet — see that fn's own note.
+    #[allow(dead_code)]
+    const LATCH_EXPIRE_CHECK_MS: u64 = 1_000;
 
     /// #1005 Phase A2: minimum hold in the lower-priority state before
     /// a priority-up back into the previous active state is allowed.
@@ -1040,6 +1053,7 @@ impl StateTracker {
             // publishes a high-confidence correction.
             published_observed: Arc::new(AtomicU8::new(OBSERVED_NONE)),
             since: Instant::now(),
+            last_latch_check_ms: 0,
             last_output: Instant::now(),
             last_productive_output: None,
             created_at: Instant::now(),
@@ -2205,6 +2219,26 @@ impl StateTracker {
         if long_expiring && self.since.elapsed() >= Self::INTERACTIVE_EXPIRY {
             self.transition(AgentState::Idle);
         }
+    }
+
+    /// #2524 P3a PR-2: throttled entry point for a caller that polls `get_state()`
+    /// on a fixed cadence but never calls the general `tick()` — the ephemeral
+    /// driver (#1967 avoids `tick()`'s managed-bookkeeping cadence there; see
+    /// `ephemeral_driver.rs`'s module doc). Without SOME periodic caller,
+    /// [`maybe_expire_latched_state`] never runs, so a mis-latched screen state
+    /// (confirm-first finding: codex's ready screen mis-latching `Active` then going
+    /// fully static — no new pty bytes ⇒ no `detect()` re-eval) can never self-heal.
+    /// `now_ms` is the CALLER's own clock — only needs to be monotonic per caller.
+    // RED: no production caller yet — the GREEN commit wires in the ephemeral
+    // driver's Phase 0 call site.
+    #[allow(dead_code)]
+    pub(crate) fn expire_stale_latch_if_due(&mut self, now_ms: u64) {
+        if now_ms.saturating_sub(self.last_latch_check_ms) < Self::LATCH_EXPIRE_CHECK_MS {
+            return;
+        }
+        self.last_latch_check_ms = now_ms;
+        // RED (#2524 P3a PR-2): not yet calling `maybe_expire_latched_state()` here —
+        // the GREEN commit wires it in. A stale latch stays stuck for now.
     }
 
     /// Get current state.

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -264,9 +264,6 @@ pub struct StateTracker {
     /// #2524 P3a PR-2: last caller-supplied `now_ms` [`expire_stale_latch_if_due`]
     /// actually ran on — caller-clock-relative (e.g. the ephemeral driver's own
     /// turn-elapsed-ms), not wall-clock; only needs to be monotonic per caller.
-    // RED: no caller wires this in yet — the GREEN commit adds the ephemeral
-    // driver's Phase 0 call site.
-    #[allow(dead_code)]
     pub(crate) last_latch_check_ms: u64,
     pub last_output: Instant,
     /// F9 (#685 sub-task 4): `Some(t)` only when `infer_productivity()` returned
@@ -986,8 +983,6 @@ impl StateTracker {
     /// #2524 P3a PR-2: throttle window for `expire_stale_latch_if_due` — cheap
     /// enough for every 250ms driver poll, tight enough to clear a mis-latch within
     /// `LATCHED_STATE_EXPIRY` + a fraction of a second.
-    // RED: `expire_stale_latch_if_due` has no caller yet — see that fn's own note.
-    #[allow(dead_code)]
     const LATCH_EXPIRE_CHECK_MS: u64 = 1_000;
 
     /// #1005 Phase A2: minimum hold in the lower-priority state before
@@ -2229,16 +2224,12 @@ impl StateTracker {
     /// (confirm-first finding: codex's ready screen mis-latching `Active` then going
     /// fully static — no new pty bytes ⇒ no `detect()` re-eval) can never self-heal.
     /// `now_ms` is the CALLER's own clock — only needs to be monotonic per caller.
-    // RED: no production caller yet — the GREEN commit wires in the ephemeral
-    // driver's Phase 0 call site.
-    #[allow(dead_code)]
     pub(crate) fn expire_stale_latch_if_due(&mut self, now_ms: u64) {
         if now_ms.saturating_sub(self.last_latch_check_ms) < Self::LATCH_EXPIRE_CHECK_MS {
             return;
         }
         self.last_latch_check_ms = now_ms;
-        // RED (#2524 P3a PR-2): not yet calling `maybe_expire_latched_state()` here —
-        // the GREEN commit wires it in. A stale latch stays stuck for now.
+        self.maybe_expire_latched_state();
     }
 
     /// Get current state.

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -599,6 +599,51 @@ fn feed_fallback_gated_by_hash_dedup() {
     assert_eq!(t.get_state(), AgentState::Active);
 }
 
+// #2524 P3a PR-2: confirm-first finding — a caller (the ephemeral driver) that
+// polls `get_state()` on a fixed cadence but never calls the general `tick()`
+// (#1967) has NO periodic backstop, and `feed_fallback_gated_by_hash_dedup` above
+// already proves the screen-driven path alone can't help either once the screen
+// stops changing (hash-dedup skips re-detection). Without SOME periodic caller, a
+// mis-latched `Active` on a fully static screen (codex's ready screen, confirmed on
+// a real spawn) is permanent. `expire_stale_latch_if_due` is that periodic caller,
+// throttled so the driver can call it every poll cheaply.
+
+/// Throttle not yet due (< `LATCH_EXPIRE_CHECK_MS` since the last check) → no-op,
+/// even though `since` is already well past `LATCHED_STATE_EXPIRY`. Proves the
+/// throttle actually throttles (doesn't just always run the real check).
+#[test]
+fn expire_stale_latch_if_due_noop_before_throttle_window() {
+    let mut t = tracker_at(&Backend::Codex, AgentState::Active, 31);
+    t.expire_stale_latch_if_due(500); // last_latch_check_ms starts at 0; 500 < 1_000
+    assert_eq!(t.get_state(), AgentState::Active);
+}
+
+/// THE decisive test: a mis-latched `Active` with `since` backdated past
+/// `LATCHED_STATE_EXPIRY` (DI clock — no real sleep) and a fully static screen (no
+/// `feed()` call at all — this is the exact "no new pty bytes" shape of the
+/// confirm-first finding) self-heals to `Idle` once the throttle window elapses.
+#[test]
+fn expire_stale_latch_if_due_unsticks_a_stale_active_latch() {
+    let mut t = tracker_at(&Backend::Codex, AgentState::Active, 31);
+    t.expire_stale_latch_if_due(1_000); // >= LATCH_EXPIRE_CHECK_MS since 0 → runs the check
+    assert_eq!(
+        t.get_state(),
+        AgentState::Idle,
+        "a stale Active latch with no screen activity must self-heal once the \
+         throttled check actually runs"
+    );
+}
+
+/// A genuinely-fresh `Active` (well within `LATCHED_STATE_EXPIRY`) must NOT be
+/// touched even once the throttle window is due — the throttle only gates HOW
+/// OFTEN we check, not whether the underlying 30s rule applies.
+#[test]
+fn expire_stale_latch_if_due_leaves_a_fresh_active_alone() {
+    let mut t = tracker_at(&Backend::Codex, AgentState::Active, 2);
+    t.expire_stale_latch_if_due(1_000);
+    assert_eq!(t.get_state(), AgentState::Active);
+}
+
 #[test]
 fn starting_hang_120s() {
     let mut h = HealthTracker::new();


### PR DESCRIPTION
## Summary

PR-2 of the #2524 P3a two-PR split (PR-1 = #2532, merged as `09966b64`
— observation-plane coverage for ephemeral workers). Per decisions
`d-20260702062114010496-7` → `d-20260702062543495557-8` →
`d-20260702063047100813-9`: extends the ephemeral one-shot driver
(Route B, PTY+typed_inject) to codex.

### What's added

- `driver_supported()` adds `Backend::Codex` — codex ephemeral workers
  can now be driven with a prompt (previously rejected as
  `DriverUnsupported`).
- `effective_turn_state(backend, raw, observed)`: the state actually fed
  to `TurnEndDetector`. **No-op for opencode/claude** (zero behavior
  change, per the §5-smoke precedent). **codex-only**: a raw `Idle`
  sample is vetoed to `Active` when `core.observed_status` carries
  fresh `Stream`-authority evidence that the turn is still active —
  `SHADOW-OBSERVER-QUANT-CODEX-2413.md` shows codex's raw screen
  false-idling for several seconds mid-turn (longer than the 3s
  Idle-debounce), while the rollout-tail Stream evidence (#2524 P3a
  PR-1) correctly holds `Responding`.
- `StateTracker::expire_stale_latch_if_due(now_ms)`: a throttled wrapper
  around the existing `maybe_expire_latched_state()`, needed because a
  **confirm-first finding** (real spawn, not hypothetical) showed an
  ephemeral codex worker's ready screen can mis-latch `Active` and then
  go fully static — with no periodic `tick()` (ephemeral never calls
  it, #1967) and no new pty bytes to re-trigger `detect()`, the
  mis-latch is permanent, and the driver's Phase 0 ready-wait always
  times out even on an already-ready worker. Wired into Phase 0 for
  **all backends** (safe — nothing is in-progress yet to cut short) and
  into Phase 2 (turn-end) for **codex only** (see below).
- `is_trailing_chrome` gains a codex pattern: its persistent bottom
  statusline (`<model> · <cwd path>`), matched structurally (path after
  `" · "`) so it survives a model/version change — cosmetic only, the
  turn-end/oracle logic never depends on it.

### The Phase 0 / Phase 2 asymmetry (read this before touching either)

`expire_stale_latch_if_due` transitions on **elapsed time alone**,
without re-checking the actual screen (`StateTracker::record_set`'s
same-state early-return never refreshes `since` on a repeat match, no
matter how often the screen re-renders). Extending it to Phase 2
(turn-end) for **every** backend would silently reopen the exact "false
turn-end on a quiet >30s stretch" risk this module's own top doc
already warns about for the general `tick()`. It's scoped to **codex
only** in Phase 2 because codex alone has the `observed_status` veto as
a safety net: even if `expire_stale_latch_if_due` wrongly forces `Idle`
mid-turn, fresh Stream evidence overrides it back to `Active` before
`TurnEndDetector` ever sees it
(`codex_expiry_forced_idle_is_vetoed_back_to_active` pins this
interaction). opencode/claude have no such veto — extending the check
to their Phase 2 would be new, un-smoked risk for no benefit (their
turn-end already produces a final render burst that `detect()` picks up
naturally). **Do not "simplify" this asymmetry away** — see the
extensive rationale comments at both call sites in `run_turn`.

### Confirm-first: codex's ready-screen mis-latch root cause

Traced to `backend_profile.rs`'s `codex_profile` pattern priority:
`(Active, r"Working|esc to interrupt")` is checked before the `Idle`
patterns, and is unanchored — `docs/F9-PRODUCTIVE-OUTPUT-GATE.md`
already documents codex's in-progress spinner literal as `◦ Working`.
Working hypothesis: this transiently matches during codex's own cold
start (before the ready screen settles), and — because the ready screen
is then 100% static — nothing re-evaluates it. Timeboxed per decision
`d-20260702075424735619-11` item (c): **not fixed here** (this PR adds
the ephemeral-side self-heal instead, which fixes the *symptom* safely
for all backends' ready-wait); full writeup filed as a follow-up
comment on the state-detection-robustness epic:
https://github.com/suzuke/agend-terminal/issues/1523#issuecomment-4863556025

### Not in scope (per task spec)

- app-server / headless transport for codex (Route A) — #1967's own
  PR7-DEFER, not reopened here.
- kiro/agy driver support.
- Fixing the underlying `Working|esc to interrupt` pattern breadth
  itself (filed as a follow-up on #1523 instead — corpus-guarded pattern
  changes are that epic's own domain, not this PR's).

## Commits (RED/GREEN, §3.10) — two pairs per decision `d-20260702075424735619-11`

1. `test(state): RED` — latch-expiry pair 1/2. Pins
   `expire_stale_latch_if_due`'s self-heal behavior (synthetic
   mis-latched `Active`, `since` backdated past 30s — DI clock, no
   sleep) against a stub that doesn't yet call the real check.
2. `feat(state): GREEN` — wires the real check + Phase 0 (all backends).
3. `test(state): RED` — codex enablement pair 2/2. Pins the veto (unit
   tests + the `codex_survives_quant_2413_false_idle_trace` fixture
   replay, fed the REAL raw/observed/authority trace from
   `SHADOW-OBSERVER-QUANT-CODEX-2413.md`) and the decisive
   expiry-vs-veto interaction test, against a no-op veto stub.
4. `feat(state): GREEN` — the real veto + codex chrome pattern.

## Test plan

- [x] `cargo test --bin agend-terminal ephemeral_driver::` → 30/30
- [x] `cargo test --bin agend-terminal ephemeral_tracking::` → 27/27 (+3 ignored, real-backend e2e — require local install/auth)
- [x] `cargo test --bin agend-terminal state::` → 416/416
- [x] `cargo test --bin agend-terminal daemon::` → 1212/1212
- [x] `cargo test --bin agend-terminal daemon::shadow::rollout::` → 13/13 (PR-1, unaffected)
- [x] `cargo test --test src_file_size_invariant` → pass (state/mod.rs 2494/2500 LOC)
- [x] `cargo test --test spawn_rationale_audit` → pass
- [x] all 34 `review_*.rs` static-grep regression tests → pass, no literal collisions
- [x] `cargo clippy --all-targets -- -D warnings` → clean
- [x] `cargo fmt --check` → clean
- [x] **Real isolated codex smoke** (`ephemeral_codex_driver_e2e`, `#[ignore]`d, run manually): spawns a real headless codex worker + the real rollout tailer + a manually-driven `ShadowObserveHandler` tick loop (standing in for the daemon's per-tick supervisor). Full path green: inject → ready (via the latch-expiry fix) → turn-end (via the veto) → oracle success, non-empty transcript, no leaked process afterward.

Refs #2524 P3a-r1 (task `t-20260702062136166045-14977-27`), decisions
`d-20260702062114010496-7` / `d-20260702062543495557-8` /
`d-20260702063047100813-9` / `d-20260702075242022632-10` (confirm-first
finding) / `d-20260702075424735619-11` (fix direction) /
`d-20260702081055743388-12` (Phase 2 scope). Single reviewer:
gapfix-reviewer — focus: the Phase 0/Phase 2 asymmetry rationale, the
veto-vs-expiry interaction test, zero behavior change for
opencode/claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)