### PR TITLE
fix(ci): temporarily ignore RUSTSEC-2026-0194 to unblock all branches

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -29,12 +29,15 @@ ignore = [
     #    dependencies (transitive); no runtime surface. Benign.
     "RUSTSEC-2024-0370", # proc-macro-error — unmaintained, no fix (build-time, benign)
     "RUSTSEC-2026-0173", # proc-macro-error2 — unmaintained, no fix (build-time, benign)
-    # ── quick-xml quadratic-time attribute-duplicate check (DoS on untrusted XML
-    #    with many attributes on one tag) — via `plist`, [dev-dependencies] only,
-    #    no runtime exposure in this codebase. UNLIKE the entries above, a fix
-    #    EXISTS (quick-xml >=0.41.0) — this is a TEMPORARY unblock (advisory
-    #    published 2026-07-02, broke every branch's audit job same-day), not a
-    #    permanent no-fix-available entry. Remove once the version-bump
+    # ── quick-xml DoS pair (quadratic-time attribute-duplicate check +
+    #    unbounded namespace-declaration allocation) — via `plist`,
+    #    [dev-dependencies] only, no runtime exposure in this codebase. UNLIKE
+    #    the entries above, a fix EXISTS for both (quick-xml >=0.41.0) — this is
+    #    a TEMPORARY unblock (both advisories published 2026-06-29, surfaced to
+    #    CI same-day 2026-07-02, broke every branch's audit job), not a
+    #    permanent no-fix-available entry. Same advisory batch — check for
+    #    siblings before adding either alone. Remove once the version-bump
     #    follow-up (t-20260702084620067164-14977-32, verifies plist compat) lands.
-    "RUSTSEC-2026-0194", # quick-xml 0.39.4 — DoS-only, dev-dep via plist, fix pending (follow-up filed)
+    "RUSTSEC-2026-0194", # quick-xml 0.39.4 — quadratic attr-dup check, dev-dep via plist, fix pending
+    "RUSTSEC-2026-0195", # quick-xml 0.39.4 — unbounded ns-decl alloc, dev-dep via plist, fix pending
 ]

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -29,4 +29,12 @@ ignore = [
     #    dependencies (transitive); no runtime surface. Benign.
     "RUSTSEC-2024-0370", # proc-macro-error — unmaintained, no fix (build-time, benign)
     "RUSTSEC-2026-0173", # proc-macro-error2 — unmaintained, no fix (build-time, benign)
+    # ── quick-xml quadratic-time attribute-duplicate check (DoS on untrusted XML
+    #    with many attributes on one tag) — via `plist`, [dev-dependencies] only,
+    #    no runtime exposure in this codebase. UNLIKE the entries above, a fix
+    #    EXISTS (quick-xml >=0.41.0) — this is a TEMPORARY unblock (advisory
+    #    published 2026-07-02, broke every branch's audit job same-day), not a
+    #    permanent no-fix-available entry. Remove once the version-bump
+    #    follow-up (t-20260702084620067164-14977-32, verifies plist compat) lands.
+    "RUSTSEC-2026-0194", # quick-xml 0.39.4 — DoS-only, dev-dep via plist, fix pending (follow-up filed)
 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,14 +266,15 @@ jobs:
           # rationale in `.cargo/audit.toml` (which the action does NOT read —
           # it only honors this input — but which keeps local `cargo audit`
           # consistent). Keep the two lists in sync.
-          # RUSTSEC-2026-0194 (quick-xml 0.39.4, via plist, dev-dependency only —
-          # DoS-only quadratic-time attribute check, no runtime exposure here)
-          # is a DIFFERENT class: a fix (>=0.41.0) exists, this is a TEMPORARY
-          # unblock (advisory published 2026-07-02, broke every branch's audit
-          # job same-day) pending compatibility verification, not a permanent
-          # no-fix-available entry like the rest of this list. Remove once
-          # t-20260702084620067164-14977-32 lands.
-          ignore: RUSTSEC-2024-0411,RUSTSEC-2024-0412,RUSTSEC-2024-0413,RUSTSEC-2024-0414,RUSTSEC-2024-0415,RUSTSEC-2024-0416,RUSTSEC-2024-0418,RUSTSEC-2024-0419,RUSTSEC-2024-0420,RUSTSEC-2024-0429,RUSTSEC-2024-0370,RUSTSEC-2026-0173,RUSTSEC-2026-0194
+          # RUSTSEC-2026-0194 + RUSTSEC-2026-0195 (quick-xml 0.39.4, via plist,
+          # dev-dependency only — both DoS-only, no runtime exposure here) are a
+          # DIFFERENT class from the rest of this list: a fix (>=0.41.0) exists
+          # for both — this is a TEMPORARY unblock (both published 2026-06-29,
+          # surfaced to CI same-day 2026-07-02, broke every branch's audit job)
+          # pending compatibility verification, not a permanent no-fix-available
+          # entry. Same advisory batch — check for siblings before adding either
+          # alone. Remove once t-20260702084620067164-14977-32 lands.
+          ignore: RUSTSEC-2024-0411,RUSTSEC-2024-0412,RUSTSEC-2024-0413,RUSTSEC-2024-0414,RUSTSEC-2024-0415,RUSTSEC-2024-0416,RUSTSEC-2024-0418,RUSTSEC-2024-0419,RUSTSEC-2024-0420,RUSTSEC-2024-0429,RUSTSEC-2024-0370,RUSTSEC-2026-0173,RUSTSEC-2026-0194,RUSTSEC-2026-0195
 
   # #686 (F11): maintainer-side QA infrastructure. Runs cargo-llvm-cov on
   # Ubuntu only (cross-platform consistency comes from `check` job; coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,7 +266,14 @@ jobs:
           # rationale in `.cargo/audit.toml` (which the action does NOT read —
           # it only honors this input — but which keeps local `cargo audit`
           # consistent). Keep the two lists in sync.
-          ignore: RUSTSEC-2024-0411,RUSTSEC-2024-0412,RUSTSEC-2024-0413,RUSTSEC-2024-0414,RUSTSEC-2024-0415,RUSTSEC-2024-0416,RUSTSEC-2024-0418,RUSTSEC-2024-0419,RUSTSEC-2024-0420,RUSTSEC-2024-0429,RUSTSEC-2024-0370,RUSTSEC-2026-0173
+          # RUSTSEC-2026-0194 (quick-xml 0.39.4, via plist, dev-dependency only —
+          # DoS-only quadratic-time attribute check, no runtime exposure here)
+          # is a DIFFERENT class: a fix (>=0.41.0) exists, this is a TEMPORARY
+          # unblock (advisory published 2026-07-02, broke every branch's audit
+          # job same-day) pending compatibility verification, not a permanent
+          # no-fix-available entry like the rest of this list. Remove once
+          # t-20260702084620067164-14977-32 lands.
+          ignore: RUSTSEC-2024-0411,RUSTSEC-2024-0412,RUSTSEC-2024-0413,RUSTSEC-2024-0414,RUSTSEC-2024-0415,RUSTSEC-2024-0416,RUSTSEC-2024-0418,RUSTSEC-2024-0419,RUSTSEC-2024-0420,RUSTSEC-2024-0429,RUSTSEC-2024-0370,RUSTSEC-2026-0173,RUSTSEC-2026-0194
 
   # #686 (F11): maintainer-side QA infrastructure. Runs cargo-llvm-cov on
   # Ubuntu only (cross-platform consistency comes from `check` job; coverage


### PR DESCRIPTION
## Summary

**Urgent, blocks all merges.** `cargo-audit`'s `audit` job started
failing on every branch today (2026-07-02) due to a same-day RustSec
advisory: `RUSTSEC-2026-0194` in `quick-xml` 0.39.4 (pulled in only via
`plist`, `[dev-dependencies]` — no runtime exposure) — a quadratic-time
attribute-duplicate check, DoS-only on untrusted XML with many
attributes on one tag.

Confirmed this is a pure timing-window issue, not caused by any
specific PR: main's own `audit` job passed at 07:25 UTC today
(`09966b64`'s push CI); the advisory's `last-updated` timestamp is
08:19 UTC — every audit run after that point fails, on any branch.

## What's different from the existing ignore-list entries

The other entries in `.github/workflows/ci.yml`'s `audit` job +
`.cargo/audit.toml` (gtk-rs GTK3 bindings, proc-macro-error family) are
genuinely unmaintained with **no fixed version available** — permanent
entries. `RUSTSEC-2026-0194` is different: a fix exists
(`quick-xml >= 0.41.0`). This PR is a **deliberately temporary**
unblock so CI is usable again today; the real fix (bumping the
dependency, with `plist` compatibility verified first) is tracked
separately: follow-up task `t-20260702084620067164-14977-32`.

## Test plan

- [x] `cargo audit` (local): exits 0 with this config — previously
  reported `RUSTSEC-2026-0194` as a blocking vulnerability.
- [x] TOML/YAML syntax validated.
- [ ] This PR's own `audit` job going green on CI is the runtime
  validation (test-first exemption per task spec — CI workflow config +
  comments only, no production code path).

Refs decision `d-20260702084603047195-14`, task
`t-20260702084616078941-14977-31` (this PR) /
`t-20260702084620067164-14977-32` (version-bump follow-up). Single
reviewer, fast-track — this blocks all other merges including PR
#2535 (#2524 P3a PR-2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)