### PR TITLE
docs(#2524 P5a): solo profile — which fleet ceremony applies with just operator + one agent

### DIFF
--- a/docs/SOLO-PROFILE.md
+++ b/docs/SOLO-PROFILE.md
@@ -1,0 +1,108 @@
+[繁體中文](SOLO-PROFILE.zh-TW.md)
+
+# Solo Profile — Running AgEnD as Operator + One Agent
+
+**Status:** informative, non-normative. Where this document and
+`FLEET-DEV-PROTOCOL.md` disagree, the protocol wins for anything touching
+merge safety (CI gates, worktree discipline); this document only narrows
+which *ceremony* actually applies when there's no one else to coordinate
+with.
+
+## Why this exists
+
+The quickstart path — one `general` instance talking to the operator, no
+team, no fleet peers — is AgEnD's official entry point. But
+`FLEET-DEV-PROTOCOL.md` is written for the *fleet* case: dispatch
+contracts, dual review, decision boards other agents read, timeout
+staircases for a peer who's gone quiet. A solo agent following every rule
+literally ends up doing ceremony whose entire purpose is "keep another
+agent from being surprised" — when there is no other agent.
+
+#2524's workflow-gap audit (three perspectives: multi-agent / solo /
+non-Claude-backend) named this directly: *"單人：quickstart 單 instance 是官方入
+門路徑，但 protocol ceremony 全是 fleet 導向，輕量化只靠 §3.21 lead judgment"* — solo
+right-sizing had no written guidance, only case-by-case judgment. This
+document is that guidance, not a new gate.
+
+## You're solo if
+
+No team (`team` is absent from your identity block) and no other fleet
+peers are listed. If either is present, you're in a fleet context —
+follow `FLEET-DEV-PROTOCOL.md` as written.
+
+## What still applies solo
+
+These protect *you*, the operator's repo, or the merge pipeline — not a
+peer agent. Nothing about being alone changes their purpose:
+
+- **Worktree discipline (§10).** Still use a worktree + branch, never
+  commit to main. This isolates your changes from the operator's canonical
+  working tree, which exists whether or not you have teammates.
+- **Test-first (§3.10).** Still write the failing test before the fix.
+  This catches *your own* regressions — the value isn't "so a reviewer can
+  verify," it's "so you don't ship a fix that doesn't fix anything."
+- **CI fail-closed merge.** CI doesn't know or care how many agents are
+  on the repo. Green is green.
+- **Evidence-gated claims (§3.3's "comments are claims, not evidence").**
+  Still true when you're the only one who'll ever read your own claim back.
+
+## What's exempt or optional solo
+
+- **Task board (§1).** Optional, not load-bearing. The board's value is
+  a *shared* source of truth for others to read; solo, your own working
+  memory (or a local scratch note) is a legitimate substitute. Using the
+  board anyway is harmless and keeps a paper trail — do so if it's not
+  extra friction, but it isn't a requirement.
+- **Review dispatch / dual-VERIFIED (§3.2–3.5).** There's no second party
+  to dispatch to. Either the operator reviews directly, or you self-assess
+  under §3.21's axis C (review tier) — solo is not "dual review, minus
+  one," it's a different mode entirely. Don't manufacture a fake second
+  reviewer to satisfy the letter of a fleet rule written for a different
+  situation.
+- **Decision-board threading / badges (#2313).** These exist so *other
+  agents* notice an open decision. Solo, the operator either sees it
+  directly (same terminal) or answers via the timeout+default path below.
+- **`send`/`inbox`/team communication tools.** Largely no-ops with no
+  peers to reach. Operator communication still goes through the
+  channel-appropriate `reply` path — that's unrelated to fleet size.
+- **Timeout staircase for a "stale peer" (§9).** Nothing to escalate
+  against when there's no peer.
+
+## The one hard blocker this closed
+
+Before #2531, a `decision(needs_answer: true)` with the operator offline
+had no resolution path — it waited indefinitely. That's a real solo/
+overnight failure mode: no peer to answer in the operator's place, and no
+default to fall back to.
+
+**Fixed**: `decision(action: post, needs_answer: true, timeout_secs: N,
+timeout_default: "...")` — after `timeout_secs` unanswered, the daemon
+auto-resolves to `timeout_default` and notifies the decision's `author`.
+Solo and overnight decisions now have a real exit path instead of an
+indefinite wait. This was #2524's *only* hard blocker across the
+multi-agent / solo / non-Claude-backend audit — everything else in this
+document is right-sizing, not a missing mechanism.
+
+## When to escalate from solo to fleet
+
+Use §3.21 axis A verbatim — it's already general-purpose, not
+fleet-specific:
+
+> FLEET iff *"wrong = expensive"* AND *"only an adversary-who-tries-to-
+> break-it catches the flaw — a test you could write would not"*. Else
+> SINGLE.
+
+Lead's 5-second question, restated for a solo agent deciding for itself:
+*"If I'm subtly wrong here, how bad is it, and would my own test catch
+it, or only someone actively trying to break it?"* If the honest answer
+is "only an adversary," don't stay solo out of momentum — pull in a
+second perspective (a reviewer instance, or the operator) before shipping.
+
+## See also
+
+- `FLEET-DEV-PROTOCOL.md` §3.6 (LOW docs-only exception) is an existing
+  example of the protocol already carving out a lighter path when the
+  blast radius is small — the same instinct this document generalizes.
+- `FLEET-DEV-PROTOCOL.md` §3.21 (Proportional Ceremony) — the three
+  independent axes (fleet-vs-single, spike-vs-skip, review tier) this
+  document's escalation criterion is drawn from.

--- a/docs/SOLO-PROFILE.zh-TW.md
+++ b/docs/SOLO-PROFILE.zh-TW.md
@@ -1,0 +1,89 @@
+[English](SOLO-PROFILE.md)
+
+# Solo Profile — 單人（operator + 一個 agent）情境指引
+
+**性質：** 說明性，非規範性。本文件與 `FLEET-DEV-PROTOCOL.md` 衝突時，凡涉及 merge
+安全（CI gate、worktree 紀律）者以 protocol 為準；本文件只收斂「單人時哪些
+ceremony 真的適用」，不推翻既有硬規則。
+
+## 為什麼需要這份文件
+
+quickstart 的預設路徑——一個 `general` instance 對 operator 講話、無 team、無其
+他 fleet peer——是 AgEnD 的官方入門路徑。但 `FLEET-DEV-PROTOCOL.md` 是為**多
+agent**情境寫的：dispatch contract、雙 reviewer、其他 agent 會讀的 decision
+board、對「久未回應的 peer」的 timeout staircase。單人若逐字照辦，會把整套
+「避免另一個 agent 被搞混」的 ceremony 全跑一遍——但根本沒有另一個 agent。
+
+#2524 的 workflow gap 盤點（三視角：多 agent／單人／非 Claude backend）直接點名
+這個缺口：*「單人：quickstart 單 instance 是官方入門路徑，但 protocol ceremony
+全是 fleet 導向，輕量化只靠 §3.21 lead judgment」*——單人的輕量化過去只能個案判
+斷，沒有寫下來的指引。本文件就是那份指引，不是新開一個閘門。
+
+## 什麼情況算「單人」
+
+沒有 team（身分區塊裡沒有 `team`）且沒有列出其他 fleet peer。只要兩者之一存
+在，就是 fleet 情境——照 `FLEET-DEV-PROTOCOL.md` 字面執行。
+
+## 單人時仍然適用的規則
+
+以下這些保護的是**你自己**、operator 的 repo，或 merge 管線本身——不是某個
+peer agent。人數多寡不改變它們存在的理由：
+
+- **Worktree 紀律（§10）。** 仍然要用 worktree + branch，絕不直接 commit main。
+  這是為了把你的改動跟 operator 的 canonical working tree 隔開，這件事跟有沒
+  有隊友無關。
+- **Test-first（§3.10）。** 仍然要先寫會失敗的測試再修。這是為了抓**你自己**
+  的迴歸——價值不是「讓 reviewer 能驗證」，是「讓你自己不會交出一個其實沒修好
+  的修法」。
+- **CI fail-closed merge。** CI 不知道也不在乎 repo 上有幾個 agent。綠燈就是
+  綠燈。
+- **證據閘（§3.3「comments are claims, not evidence」）。** 就算只有你自己會
+  回頭看自己的宣稱，這條依然成立。
+
+## 單人時可以豁免或選用的部分
+
+- **Task board（§1）。** 選用，非硬性。board 的價值在於給**別人**看的共享真
+  相來源；單人時，你自己的工作記憶（或本地便箋）是合理的替代品。順手用 board
+  也無害、留個記錄——只要不增加額外摩擦，用也可以，但不是硬性要求。
+- **Review dispatch／雙 VERIFIED（§3.2–3.5）。** 沒有第二方可以派。要嘛 operator
+  直接審，要嘛你依 §3.21 的軸 C（review tier）自我判定——單人不是「雙審少一
+  個」，是完全不同的模式。不要為了滿足一條為別的情境寫的規則字面，硬生生捏造
+  一個假的第二審查者。
+- **Decision board 討論串／badge（#2313）。** 這些機制存在是為了讓**其他 agent**
+  注意到有未決的 decision。單人時，operator 要嘛直接看到（同一個終端），要嘛
+  走下面的 timeout+default 路徑。
+- **`send`／`inbox`／team 通訊工具。** 沒有 peer 可以聯絡，基本上是 no-op。跟
+  operator 的溝通還是走對應 channel 的 `reply` 路徑——這跟 fleet 大小無關。
+- **對「久未回應 peer」的 timeout staircase（§9）。** 沒有 peer 可以升級處理。
+
+## 已經解掉的那個硬卡點
+
+在 #2531 之前，`decision(needs_answer: true)` 若 operator 離線，完全沒有解法
+——只能無限期等。這是真實的單人／overnight 失效模式：沒有 peer 能代答，也沒
+有預設值可退。
+
+**已修復**：`decision(action: post, needs_answer: true, timeout_secs: N,
+timeout_default: "...")`——超過 `timeout_secs` 未答，daemon 自動採
+`timeout_default` 並通知該 decision 的 `author`。單人與 overnight 的 decision
+現在有真正的出口，不再是無限期等待。這是 #2524 在多 agent／單人／非 Claude
+backend 三視角盤點裡**唯一**的硬卡點——本文件其他部分都是「輕量化」，不是補
+缺失機制。
+
+## 什麼時候該從單人升級成 fleet
+
+直接套用 §3.21 軸 A——它本來就不是 fleet 專屬：
+
+> FLEET iff *「錯了代價很高」* 且 *「只有想惡意破壞它的人才抓得到這個缺陷——你自
+> 己會寫的測試抓不到」*。否則 SINGLE。
+
+lead 的 5 秒問題，改寫成單人 agent 自問自答的版本：*「如果我這裡悄悄錯了，有
+多嚴重，我自己寫的測試抓得到，還是只有主動想搞破壞的人才抓得到？」*如果誠實
+的答案是「只有惡意的人才抓得到」，別因為慣性留在單人模式——在出手前拉進第二
+個視角（一個 reviewer instance，或 operator 本人）。
+
+## 另見
+
+- `FLEET-DEV-PROTOCOL.md` §3.6（LOW docs-only 例外）是 protocol 本身已經開出的
+  一條輕量路徑範例——本文件是把同一種直覺推廣開來。
+- `FLEET-DEV-PROTOCOL.md` §3.21（Proportional Ceremony）——本文件的升級判準取
+  自這裡的三個獨立軸（fleet-vs-single、spike-vs-skip、review tier）。

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -216,6 +216,17 @@ pub(crate) fn build_instructions_body(
                 content.push_str(&format!("- `{safe_peer}` — {safe_peer_role}\n"));
             }
             content.push('\n');
+        } else if ctx.team.is_none() {
+            // #2524 P5a: no team and no other fleet peers observed — most of
+            // the ceremony below (task board coordination, decision
+            // threading, dual-review) assumes there's someone else to
+            // coordinate with. Point at the solo profile rather than let a
+            // single-instance user read fleet-only ceremony as mandatory.
+            content.push_str(
+                "You appear to be the only agent right now — see \
+                 docs/SOLO-PROFILE.md for which of the fleet ceremony below \
+                 actually applies solo.\n\n",
+            );
         }
     }
 
@@ -1074,6 +1085,44 @@ mod tests {
             "no team context should not produce a Team section: {body}"
         );
         assert!(!body.contains("## Other Fleet Members"));
+    }
+
+    /// #2524 P5a: no team and no other fleet peers → the solo-profile pointer
+    /// appears (there's no one else to apply fleet ceremony toward).
+    #[test]
+    fn body_points_to_solo_profile_when_truly_alone() {
+        let peers: Vec<(String, Option<String>)> = vec![];
+        let ctx = AgentContext {
+            name: "lonely",
+            role: None,
+            fleet_peers: &peers,
+            team: None,
+            extra_instructions: None,
+        };
+        let body = build_instructions_body(Some(&ctx), None, None);
+        assert!(
+            body.contains("docs/SOLO-PROFILE.md"),
+            "no team + no peers must point at the solo profile: {body}"
+        );
+    }
+
+    /// The solo-profile pointer must NOT appear once there's an actual peer
+    /// or team to coordinate with — it's additive guidance, not a blanket note.
+    #[test]
+    fn body_omits_solo_profile_pointer_when_peers_present() {
+        let peers = vec![("helper".to_string(), Some("assistant".to_string()))];
+        let ctx = AgentContext {
+            name: "not-alone",
+            role: None,
+            fleet_peers: &peers,
+            team: None,
+            extra_instructions: None,
+        };
+        let body = build_instructions_body(Some(&ctx), None, None);
+        assert!(
+            !body.contains("docs/SOLO-PROFILE.md"),
+            "a real fleet peer present must suppress the solo pointer: {body}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

#2524 P5a (近零代碼). quickstart's single-instance path is official, but
`FLEET-DEV-PROTOCOL.md` is written fleet-shaped throughout — dispatch
contracts, dual review, decision boards other agents read, timeout
staircases for a peer gone quiet. Solo right-sizing previously had no
written guidance, only §3.21 lead judgment case-by-case. This is that
guidance.

## What's added

- `docs/SOLO-PROFILE.md` + `docs/SOLO-PROFILE.zh-TW.md` (standalone
  files, not a `FLEET-DEV-PROTOCOL.md` appendix — the protocol's two
  existing appendices, A = rationale/incident log and B = section-number
  archaeology, don't fit new normative guidance):
  - What still applies solo: worktree discipline, test-first, CI gate,
    evidence-gated claims — these protect you/the repo/the pipeline, not
    a peer, so being alone doesn't change their purpose.
  - What's exempt/optional solo: task board, dual-review dispatch,
    decision-board threading, `send`/`inbox` tooling, stale-peer timeout
    staircase — ceremony whose entire point is "don't surprise another
    agent."
  - The one real blocker #2524's three-perspective audit (multi-agent /
    solo / non-Claude-backend) found: `decision(needs_answer: true)` had
    no offline/overnight resolution path. Anchored on its actual fix,
    #2531's `timeout_secs`/`timeout_default` — already shipped, cited
    here as evidence, not re-implemented.
  - Escalation criterion: `FLEET-DEV-PROTOCOL.md` §3.21 axis A verbatim
    (fleet iff wrong-is-expensive AND only-an-adversary-catches-it),
    restated as a solo self-check question.
- `src/instructions.rs`: one new conditional in the identity/peers
  render — when there's no team AND no other fleet peers (the literal
  solo signal the existing peer-rendering logic already computes),
  append a one-line pointer to `docs/SOLO-PROFILE.md`, so a
  single-instance user doesn't read the fleet-only communication-tools
  section below as mandatory. Template-string-only (§3.6 condition 3
  exemption). Two new tests: the pointer appears exactly when solo, and
  is absent once any real peer is present.

## §3.6 LOW docs-only exception self-check (task item 4)

Honest accounting, not claiming the fast-track by default:
- Condition 2 (no `src/` behavior change) — holds via the explicit
  `instructions.rs` template-string exemption.
- Condition 1 (only `docs/FLEET-DEV-PROTOCOL-*.md` or
  `REVIEWER-CONTRACT-*.md` edits) — literal near-miss: this PR adds a
  NEW standalone file, matching neither glob, and total diff (~246 LOC
  across 3 files) exceeds the "≤50 LOC" framing once new doc content is
  counted.

Flagging this so the LOW-exception claim isn't overstated — practical
effect is the same either way (single-reviewer review per the task's
own dispatch), this is just an honest self-check per item 4, not an
attempt to skip review depth.

## Test plan

- [x] `cargo build` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test --bin agend-terminal instructions::` → 48/48 (incl. the
  2 new solo-pointer tests)

Refs #2524 P5a (task `t-20260702095007171803-7916-0`). Single reviewer:
gapfix-reviewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)