### PR TITLE
fix(binding): #2533 double-tag render + task_id-attributed self-claim is in-dispatch

### DIFF
--- a/src/binding.rs
+++ b/src/binding.rs
@@ -271,9 +271,11 @@ pub fn bind_full(
     worktree: &std::path::Path,
     source_repo: &std::path::Path,
     // #2158 GR1: true ⟺ an AGENT SELF-CLAIM (`bind_self` / `repo checkout bind:true`),
-    // which surfaces to the operator. Dispatch / internal binds pass false. Keyed on
-    // the caller's EXPLICIT intent, NOT on task_id — a single-target auto-create
-    // `send kind=task` legitimately binds with task_id="" and must NOT false-notify.
+    // which surfaces to the operator UNLESS `task_id` is non-empty (#2533: a
+    // task_id-carrying self-claim is attributable to a task, so it's in-dispatch).
+    // Dispatch / internal binds pass `is_self_claim=false` and are NEVER gated on
+    // task_id here — a single-target auto-create `send kind=task` legitimately
+    // binds with task_id="" and must NOT false-notify.
     is_self_claim: bool,
 ) -> Result<(), String> {
     // #1888 phase-2: the agent claiming a branch is acting on any pending
@@ -426,9 +428,12 @@ pub fn bind_full(
     // guard-b cannot prevent (identity-indistinguishable). NOT gated on `changed`: the
     // dispatch flow double-binds (lease then re-bind), so a self-claim's intent-bind is
     // frequently a no-op (changed=false); the per-(agent,branch) sidecar in the helper
-    // gives fire-once. Keyed on the caller's explicit `is_self_claim`, NOT task_id — a
-    // single-target auto-create dispatch legitimately binds with task_id="".
-    if is_self_claim {
+    // gives fire-once. #2533: ALSO gated on an empty `task_id` — a self-claim that
+    // carries a task_id (e.g. `bind_self(task_id=...)` / `repo checkout bind:true
+    // task_id=...`) is attributable to a task and is treated as in-dispatch, so it
+    // does not warn. A single-target auto-create DISPATCH (is_self_claim=false)
+    // never reaches this branch regardless of task_id (see the param doc above).
+    if is_self_claim && task_id.is_empty() {
         notify_operator_out_of_dispatch_bind(home, agent, branch, &wt_str, prev_branch.as_deref());
     }
     Ok(())
@@ -524,7 +529,7 @@ fn out_of_dispatch_notify_body(agent: &str, branch: &str, prev_branch: Option<&s
         .map(|p| format!(", was `{p}`"))
         .unwrap_or_default();
     format!(
-        "[system:binding_out_of_dispatch] instance `{agent}` bound to branch `{branch}`{was} \
+        "instance `{agent}` bound to branch `{branch}`{was} \
          OUTSIDE a task dispatch (no task_id). If unexpected, a transient sub-agent or a \
          self-claim may have moved this instance's worktree. The daemon CANNOT name the exact \
          caller — a Task sub-agent shares the primary's identity and process. Inspect with \

--- a/src/binding.rs
+++ b/src/binding.rs
@@ -504,22 +504,32 @@ fn notify_operator_out_of_dispatch_bind(
     };
     // Best-effort, file-based inbox to the resolved recipient — mirrors
     // `canonical_auto_stash`.
-    let was = prev_branch
-        .map(|p| format!(", was `{p}`"))
-        .unwrap_or_default();
-    let text = format!(
-        "[system:binding_out_of_dispatch] instance `{agent}` bound to branch `{branch}`{was} \
-         OUTSIDE a task dispatch (no task_id). If unexpected, a transient sub-agent or a \
-         self-claim may have moved this instance's worktree. The daemon CANNOT name the exact \
-         caller — a Task sub-agent shares the primary's identity and process. Inspect with \
-         `binding_state instance={agent}`; undo with `release_worktree`. (#2158 GR1)"
-    );
+    let text = out_of_dispatch_notify_body(agent, branch, prev_branch);
     crate::inbox::notify_agent(
         home,
         &recipient,
         &crate::inbox::NotifySource::System("binding_out_of_dispatch"),
         &text,
     );
+}
+
+/// #2533: the notification BODY text for an out-of-dispatch self-claim bind.
+/// Extracted as a pure fn so the double-tag regression is unit-testable:
+/// `NotifySource::System("binding_out_of_dispatch")` already renders the
+/// `[system:binding_out_of_dispatch]` tag at the delivery-layer wrapper
+/// (`inbox::format_notification_for_inject`) — this body must NOT hardcode
+/// the same tag, or the rendered notification doubles it.
+fn out_of_dispatch_notify_body(agent: &str, branch: &str, prev_branch: Option<&str>) -> String {
+    let was = prev_branch
+        .map(|p| format!(", was `{p}`"))
+        .unwrap_or_default();
+    format!(
+        "[system:binding_out_of_dispatch] instance `{agent}` bound to branch `{branch}`{was} \
+         OUTSIDE a task dispatch (no task_id). If unexpected, a transient sub-agent or a \
+         self-claim may have moved this instance's worktree. The daemon CANNOT name the exact \
+         caller — a Task sub-agent shares the primary's identity and process. Inspect with \
+         `binding_state instance={agent}`; undo with `release_worktree`. (#2158 GR1)"
+    )
 }
 
 /// #2347: resolve WHO receives the out-of-dispatch live notice for `agent`.
@@ -1896,6 +1906,57 @@ mod tests {
             "#2158 GR1: an EMPTY-task_id dispatch (is_self_claim=false) must NOT false-notify: {log}"
         );
         std::fs::remove_dir_all(&home).ok();
+    }
+
+    // ── #2533: task_id-carrying self-claim is in-dispatch (no warning) ───────
+
+    /// A self-claim bind (`bind_self` / `repo checkout bind:true`) that CARRIES a
+    /// task_id — e.g. a dev's `bind_self(task_id=...)` workaround for #2525, or a
+    /// reviewer's `repo checkout bind:true task_id=...` — is legitimately
+    /// attributed to a task and must be treated as IN-DISPATCH: no
+    /// `binding_out_of_dispatch` marker/notify. An EMPTY task_id self-claim
+    /// (`self_claim_bind_surfaces_once_per_branch_2158_gr1` above) still warns —
+    /// unchanged.
+    #[test]
+    fn self_claim_bind_with_task_id_does_not_surface_2533() {
+        let home = tmp_home("2533-task-id-no-warn");
+        let wt = home.join("wt");
+        std::fs::create_dir_all(&wt).unwrap();
+        let src = home.join("src");
+        std::fs::create_dir_all(&src).unwrap();
+
+        bind_full(&home, "ag", "T-123", "feat/x", &wt, &src, true)
+            .expect("self-claim bind with task_id ok");
+
+        let log = read_event_log(&home);
+        assert!(
+            !log.contains("binding_out_of_dispatch"),
+            "#2533: a self-claim bind CARRYING a task_id must be treated as in-dispatch — no \
+             warning: {log}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #2533: `notify_operator_out_of_dispatch_bind`'s body text must NOT
+    /// hardcode the `[system:binding_out_of_dispatch]` tag — `NotifySource::System`
+    /// already renders it once at the delivery-layer wrapper
+    /// (`format_notification_for_inject`). A hardcoded prefix doubles it:
+    /// `[system:binding_out_of_dispatch] [system:binding_out_of_dispatch] ...`.
+    #[test]
+    fn out_of_dispatch_notification_renders_tag_exactly_once_2533() {
+        let text = out_of_dispatch_notify_body("ag", "feat/x", None);
+        let rendered = crate::inbox::format_notification_for_inject(
+            false,
+            &crate::inbox::NotifySource::System("binding_out_of_dispatch"),
+            &text,
+            &[],
+        );
+        assert_eq!(
+            rendered.matches("[system:binding_out_of_dispatch]").count(),
+            1,
+            "#2533: rendered notification must carry the tag exactly once (double-render bug): \
+             {rendered}"
+        );
     }
 
     // ── #2347: route the binding_out_of_dispatch DELIVERY to the team ────────

--- a/src/mcp/handlers/ci/checkout.rs
+++ b/src/mcp/handlers/ci/checkout.rs
@@ -245,10 +245,18 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
                 warnings.push(format!("marker: {e}"));
             }
             if bind {
+                // #2533: optional caller-supplied task_id — attributes this self-claim
+                // to a task (§3.19.1 reviewer checkout is the common case) so `bind_full`
+                // treats it as in-dispatch instead of warning. Absent → "" (unattributed,
+                // pre-#2533 behavior unchanged).
+                let task_id = args["task_id"]
+                    .as_str()
+                    .filter(|s| !s.is_empty())
+                    .unwrap_or("");
                 if let Err(e) = crate::binding::bind_full(
                     home,
                     instance_name,
-                    "",
+                    task_id,
                     branch,
                     &worktree_dir,
                     &source_canonical,

--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -862,6 +862,56 @@ fn checkout_bind_true_writes_binding_marker_and_no_longer_arms_watch_2158_gr1() 
     std::fs::remove_dir_all(&parent).ok();
 }
 
+/// #2533: `repo action=checkout bind:true task_id=...` (the reviewer-workflow
+/// self-claim path, §3.19.1) must thread the caller-supplied `task_id` into
+/// `binding.json` — pre-fix, `handle_checkout_repo_inner` hardcoded `""`
+/// regardless of the `task_id` arg — AND the task_id linkage must suppress the
+/// `binding_out_of_dispatch` warning (the checkout is now attributable to a
+/// task, not a rogue bind).
+#[test]
+#[cfg(unix)]
+fn checkout_bind_true_with_task_id_records_task_id_and_suppresses_warning_2533() {
+    let home = p778_tmp_home("task-id");
+    let parent = p778_tmp_home("task-id-src-parent");
+    let source = p778_setup_source_repo(&parent, "feat/p2533");
+    let agent = "p2533-agent";
+
+    let resp = super::handle_checkout_repo(
+        &home,
+        &serde_json::json!({
+            "repository_path": source.display().to_string(),
+            "branch": "feat/p2533",
+            "bind": true,
+            "task_id": "T-2533",
+        }),
+        agent,
+    );
+    assert!(resp.get("error").is_none(), "checkout must succeed: {resp}");
+
+    let binding = crate::paths::runtime_dir(&home)
+        .join(agent)
+        .join("binding.json");
+    let v: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&binding).unwrap()).unwrap();
+    assert_eq!(
+        v["task_id"].as_str(),
+        Some("T-2533"),
+        "#2533: checkout bind:true must record the caller-supplied task_id, not a hardcoded \
+         empty sentinel: {v}"
+    );
+
+    assert!(
+        !std::fs::read_to_string(home.join("event-log.jsonl"))
+            .unwrap_or_default()
+            .contains("binding_out_of_dispatch"),
+        "#2533: a checkout bind:true CARRYING a task_id must be treated as in-dispatch — no \
+         out-of-dispatch warning"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&parent).ok();
+}
+
 /// §3.9 #1882 (reviewer-2 re-verify): the repo-checkout bind path is the third
 /// production bind site. An end-to-end conflict — agent A checks out + binds a
 /// branch, then agent B repo-checkouts the SAME branch — must end with EXACTLY

--- a/src/mcp/handlers/dispatch_hook/tests.rs
+++ b/src/mcp/handlers/dispatch_hook/tests.rs
@@ -1595,7 +1595,10 @@ fn dispatch_auto_bind_lease_sets_next_after_ci_from_dispatch_hook_931() {
 /// `arm_ci_watch` intent, NOT on task_id presence (r6's catch: a single-target
 /// `send kind=task` is auto-create-exempt and reaches dispatch with task_id=""). The
 /// wrappers encode the intent: `_with_source` (bind_self) → false; `_with_chain`
-/// (delegate/dispatch) → true.
+/// (delegate/dispatch) → true. #2533: the operator NOTIFY decision, unlike arm, DOES
+/// now depend on task_id for a self-claim (task_id-carrying self-claim = in-dispatch
+/// = no notify) — sub-case (a2) below pins that the arm decision stays task_id-blind
+/// while notify does not.
 #[test]
 #[cfg(unix)]
 fn arm_ci_watch_gated_on_dispatch_intent_not_task_id_2158_gr1() {
@@ -1616,22 +1619,26 @@ fn arm_ci_watch_gated_on_dispatch_intent_not_task_id_2158_gr1() {
         ))
     };
     // #2158 GR1: the SAME dispatch-intent signal gates the operator NOTIFY (inverted):
-    // self-claim notifies, dispatch does not — regardless of task_id.
+    // self-claim notifies, dispatch does not. #2533: for a self-claim specifically,
+    // an ATTRIBUTED (task_id-carrying) bind is treated as in-dispatch and does not
+    // notify — see sub-case (a2). A dispatch's notify stays task_id-blind (always
+    // false) regardless — see (b)/(c).
     let notified = |home: &std::path::Path| {
         std::fs::read_to_string(home.join("event-log.jsonl"))
             .unwrap_or_default()
             .contains("binding_out_of_dispatch")
     };
 
-    // (a) bind_self self-claim (`_with_source`) → NO arm, even WITH a task_id
-    //     (self-provision must never silently arm) — and DOES notify the operator.
+    // (a) bind_self self-claim (`_with_source`), UNATTRIBUTED (task_id="") → NO arm
+    //     (self-provision must never silently arm) — and DOES notify the operator
+    //     (no task attribution → still an out-of-dispatch bind).
     let parent_a = mk_parent("bindself");
     let (home_a, _c) =
         p781_canonical_with_team_source_repo(&parent_a, "feat/gr1-bs", true, "val", &["val-dev"]);
     let r = super::dispatch_auto_bind_lease_with_source(
         &home_a,
         "val-dev",
-        "T-has-task",
+        "",
         "feat/gr1-bs",
         None,
         None,
@@ -1643,9 +1650,43 @@ fn arm_ci_watch_gated_on_dispatch_intent_not_task_id_2158_gr1() {
     );
     assert!(
         notified(&home_a),
-        "#2158 GR1: bind_self self-claim MUST notify the operator"
+        "#2158 GR1: an UNATTRIBUTED bind_self self-claim MUST notify the operator"
     );
     std::fs::remove_dir_all(&parent_a).ok();
+
+    // (a2) #2533: bind_self self-claim WITH a task_id → still NO arm (arm decision
+    //      stays task_id-blind for self-claims) but does NOT notify (attributed to a
+    //      task → treated as in-dispatch).
+    let parent_a2 = mk_parent("bindself-tid");
+    let (home_a2, _c) = p781_canonical_with_team_source_repo(
+        &parent_a2,
+        "feat/gr1-bs-tid",
+        true,
+        "val",
+        &["val-dev"],
+    );
+    let r_a2 = super::dispatch_auto_bind_lease_with_source(
+        &home_a2,
+        "val-dev",
+        "T-has-task",
+        "feat/gr1-bs-tid",
+        None,
+        None,
+    );
+    assert!(
+        r_a2.is_ok(),
+        "bind_self bind with task_id must succeed: {:?}",
+        r_a2.err()
+    );
+    assert!(
+        !watch_for(&home_a2, "feat/gr1-bs-tid").exists(),
+        "#2158 GR1: bind_self self-claim must NOT auto-arm ci_watch, even with a task_id"
+    );
+    assert!(
+        !notified(&home_a2),
+        "#2533: a task_id-carrying bind_self self-claim must NOT notify the operator (in-dispatch)"
+    );
+    std::fs::remove_dir_all(&parent_a2).ok();
 
     // (b) dispatch (`_with_chain`) WITH a task_id → arms.
     let parent_b = mk_parent("disp-tid");

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -394,7 +394,8 @@ pub(crate) fn def_repo() -> Value {
             "apply": {"type": "boolean", "description": "#817 cleanup_merged_branches: when false (default), returns dry-run plan; when true, deletes confirm_ids subset."},
             "confirm_ids": {"type": "array", "items": {"type": "string"}, "description": "#817 cleanup_merged_branches apply=true: subset of candidate_ids from prior dry-run to actually delete via `git branch -D`."},
             "audit_reason": {"type": "string", "description": "#817 cleanup_merged_branches apply=true: required audit text recorded in event-log.jsonl per deleted branch with source SHA for restore."},
-            "from_ref": {"type": "string", "description": "checkout bind:true: base ref to auto-create `branch` from when it doesn't exist locally (default `origin/main`)."}
+            "from_ref": {"type": "string", "description": "checkout bind:true: base ref to auto-create `branch` from when it doesn't exist locally (default `origin/main`)."},
+            "task_id": {"type": "string", "description": "#2533: checkout bind:true — optional task board id this self-claim is attributable to. Recorded in binding.json; a task_id-carrying self-claim is treated as in-dispatch (no `binding_out_of_dispatch` operator warning). Absent → unattributed bind, existing warning behavior unchanged."}
         }, "required": ["action"]}})
 }
 
@@ -404,7 +405,8 @@ pub(crate) fn def_bind_self() -> Value {
             "repository_path": {"type": "string", "description": "Local filesystem path to source repository. Daemon resolves GitHub owner/repo via `git remote get-url origin`. Sprint 55 P0-B preferred form. Mutually exclusive with `repository` (handler rejects both via `ambiguous_args` code)."},
             "repository": {"type": "string", "description": "GitHub `owner/repo` slug. Legacy form retained for one-Sprint deprecation window — emits warn-log; removal Sprint 57. Mutually exclusive with `repository_path`."},
             "branch": {"type": "string", "description": "Branch to bind (must not be main/master)"},
-            "rebase_mode": {"type": "boolean", "description": "Sprint 60 W1 PR-1: atomic recover-and-bind. When true, releases self's stale on-disk worktree dir + binding state before lease — closes the lease_failed recovery path without an explicit release_worktree call. Cross-agent isolation preserved (rejects branches leased by another agent)."}
+            "rebase_mode": {"type": "boolean", "description": "Sprint 60 W1 PR-1: atomic recover-and-bind. When true, releases self's stale on-disk worktree dir + binding state before lease — closes the lease_failed recovery path without an explicit release_worktree call. Cross-agent isolation preserved (rejects branches leased by another agent)."},
+            "task_id": {"type": "string", "description": "#2533: optional task board id this self-claim is attributable to. Recorded in binding.json; a task_id-carrying self-claim is treated as in-dispatch (no `binding_out_of_dispatch` operator warning). Absent → unattributed bind, existing warning behavior unchanged."}
         }, "required": ["branch"]}})
 }
 
@@ -995,11 +997,13 @@ mod tests {
             ("repo", "confirm_ids", "ci/mod.rs cleanup_merged subset"),
             ("repo", "audit_reason", "ci/mod.rs cleanup_merged audit"),
             ("repo", "from_ref", "ci/mod.rs checkout auto-create base"),
+            ("repo", "task_id", "ci/checkout.rs checkout bind:true → binding::bind_full task_id linkage (#2533)"),
             // ── bind_self ──
             ("bind_self", "repository_path", "mcp/handlers/worktree.rs preferred source"),
             ("bind_self", "repository", "mcp/handlers/worktree.rs legacy slug"),
             ("bind_self", "branch", "mcp/handlers/worktree.rs validated bind branch"),
             ("bind_self", "rebase_mode", "mcp/handlers/worktree.rs recover-and-bind gate"),
+            ("bind_self", "task_id", "mcp/handlers/worktree.rs → binding::bind_full task_id linkage (#2533)"),
             // ── release_worktree / force_release_worktree ──
             ("release_worktree", "instance", "mcp/handlers/worktree.rs release target"),
             ("release_worktree", "dry_run", "mcp/handlers/worktree.rs preview gate (#1933 declared)"),


### PR DESCRIPTION
Closes #2533

## Summary

Two independent fixes for the `binding_out_of_dispatch` operator warning:

1. **Double-tag render bug** — `src/binding.rs:511`'s notify body hardcoded
   `[system:binding_out_of_dispatch]`, while the delivery-layer wrapper
   (`NotifySource::System` → `format_notification_for_inject`) already
   renders the same tag, doubling it:
   `[system:binding_out_of_dispatch] [system:binding_out_of_dispatch] instance ...`.
   Removed the hardcoded prefix; the delivery layer remains the single source
   of the tag.

2. **task_id attribution** — `bind_self` and `repo action=checkout bind:true`
   now accept an optional `task_id`, written into `binding.json`. A
   self-claim CARRYING a task_id is attributable to a task and is now
   treated as in-dispatch — no `binding_out_of_dispatch` operator warning.
   An unattributed self-claim (empty/absent task_id) still warns, unchanged.
   Per-source-channel suppression was explicitly rejected in the issue body
   (a rogue `bind_self` must still be caught regardless of channel);
   attribution via task_id is the adopted design.

   `repo action=checkout` previously **hardcoded `task_id=""`** regardless of
   any caller-supplied value — now threads a caller-supplied `task_id`
   through. `bind_self`'s handler already read `task_id` from `args` but the
   MCP tool schema never declared it (invisible to callers / the ghost-guard
   test); both `bind_self` and `repo`'s schemas now declare it, with
   `CONSUMED` cites added so `coordination_tool_schema_fields_are_consumed_or_deferred`
   stays green.

## Test-first (§3.10)

- RED commit (`test(binding): RED — pin #2533 ...`): 3 new tests added,
  confirmed failing pre-fix via `cargo test --bin agend-terminal 2533`.
- GREEN commit (`fix(binding): #2533 ...`): same 3 tests pass; existing
  `arm_ci_watch_gated_on_dispatch_intent_not_task_id_2158_gr1` updated (it
  encoded the old "self-claim always notifies, even with task_id" semantics
  this PR intentionally changes) — split into (a) unattributed self-claim
  (still notifies, unchanged) and (a2) task_id-carrying self-claim (arm
  decision stays task_id-blind, notify now suppressed).

New tests:
- `binding::tests::self_claim_bind_with_task_id_does_not_surface_2533`
- `binding::tests::out_of_dispatch_notification_renders_tag_exactly_once_2533`
- `mcp::handlers::ci::tests::checkout_bind_true_with_task_id_records_task_id_and_suppresses_warning_2533`

## Verification

- `cargo test --bin agend-terminal 2533` — 3/3 pass
- `cargo test --bin agend-terminal binding::` — 61/61 pass
- `cargo test --bin agend-terminal mcp::handlers::ci::` — 80/80 pass
- `cargo test --bin agend-terminal mcp::tools::` — 12/12 pass (incl. the
  ghost-guard schema-field test)
- `cargo fmt --check` — clean
- `cargo clippy --bin agend-terminal --all-targets -- -D warnings` — clean
- `cargo nextest run --features tray --profile ci` — 5092/5094 pass. The 2
  remaining failures
  (`e2e_dispatch_review_workflow_seam_invariants_1900`,
  `teardown_leaves_zero_residual_after_full_exercise_1907`) are
  **pre-existing and unrelated** — both hit `send(kind=task, branch=X,
  repository=Y)`'s known-broken repo-derivation (**#2525**, already flagged
  in this task's dispatch brief: "daemon dispatch 帶 branch 有 bug #2525，別
  用"). Confirmed unrelated: dispatch always calls `bind_full` with
  `is_self_claim=false`, so this PR's `is_self_claim && task_id.is_empty()`
  gate change is a no-op on that path (both old and new code evaluate the
  guard to `false` there) — none of the 3 files this PR touches
  (`binding.rs`'s notify gate, `checkout.rs`'s `repo checkout` handler,
  `tools.rs`'s `bind_self`/`repo` schemas) are on the `send`/dispatch code
  path at all.

## Scope note

Per the issue body, explicitly **not** implementing per-source-channel
suppression of the warning (withdrawn in the issue's own revision) — task_id
attribution is the adopted fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)