### PR TITLE
fix(repo): #2539 declare force/force_reason in the repo tool's MCP schema

### DIFF
--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -2352,6 +2352,61 @@ fn merge_force_audit_write_failure_refuses_merge() {
     let _ = std::fs::remove_dir_all(&home);
 }
 
+/// #2539: `handle_tool_with_runtime` reads `AGEND_HOME` via `crate::home_dir()`
+/// (no explicit `home` param, unlike `handle_merge_repo`), so exercising the
+/// full dispatch chain needs the env var set process-wide. Serializes tests
+/// that mutate it — same hazard/pattern as `mcp::handlers::tests::fleet_test_guard`.
+fn ci_env_test_guard() -> std::sync::MutexGuard<'static, ()> {
+    static GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    GUARD.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+/// #2539 confidence pin (§3.9 real-entry-point): the test above calls
+/// `handle_merge_repo` directly, which is a mid-pipeline inject — it cannot
+/// catch a schema-declaration gap because the daemon-internal dispatch never
+/// filters by schema. This variant drives the SAME force-bypass scenario
+/// through the full internal dispatch chain (`handle_tool` → `try_dispatch`
+/// → `ci::handle_merge_repo`), confirming `force`/`force_reason` survive the
+/// whole daemon-side path intact. It is NOT a RED test for #2539 (it passes
+/// even without the `def_repo` schema fix, since that gap lives entirely at
+/// the external MCP-client boundary this test cannot reach) — it documents
+/// that the daemon-internal half of the chain was never the problem.
+#[test]
+fn merge_force_reaches_handler_through_full_dispatch_chain_2539() {
+    let _g = ci_env_test_guard();
+    let home = std::env::temp_dir().join(format!("agend-merge-force-chain-{}", std::process::id()));
+    std::fs::create_dir_all(&home).unwrap();
+    let events_path = home.join("fleet_events.jsonl");
+    std::fs::create_dir_all(&events_path).unwrap();
+    let prev_home = std::env::var("AGEND_HOME").ok();
+    std::env::set_var("AGEND_HOME", &home);
+
+    let result = crate::mcp::handlers::handle_tool(
+        "repo",
+        &json!({
+            "action": "merge",
+            "pr": 9999,
+            "force": true,
+            "force_reason": "test emergency",
+            "repository": "suzuke/agend-terminal",
+        }),
+        "dev",
+    );
+
+    match prev_home {
+        Some(h) => std::env::set_var("AGEND_HOME", h),
+        None => std::env::remove_var("AGEND_HOME"),
+    }
+
+    let err = result["error"].as_str().unwrap_or_default();
+    assert!(
+        err.contains("audit log write failed"),
+        "#2539: force/force_reason must survive the full handle_tool dispatch chain \
+         unmodified (same audit-write reject as the handler-direct test), got: {result}"
+    );
+    let _ = std::fs::remove_dir_all(&home);
+}
+
 /// #1619: a merge with neither an explicit `repository` arg nor an
 /// active binding must FAIL LOUD — never silently fall back to a
 /// hardcoded maintainer repo (the old `.unwrap_or("suzuke/agend-terminal")`

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -398,7 +398,9 @@ pub(crate) fn def_repo() -> Value {
             "confirm_ids": {"type": "array", "items": {"type": "string"}, "description": "#817 cleanup_merged_branches apply=true: subset of candidate_ids from prior dry-run to actually delete via `git branch -D`."},
             "audit_reason": {"type": "string", "description": "#817 cleanup_merged_branches apply=true: required audit text recorded in event-log.jsonl per deleted branch with source SHA for restore."},
             "from_ref": {"type": "string", "description": "checkout bind:true: base ref to auto-create `branch` from when it doesn't exist locally (default `origin/main`)."},
-            "task_id": {"type": "string", "description": "#2533: checkout bind:true — optional task board id this self-claim is attributable to. Recorded in binding.json; a task_id-carrying self-claim is treated as in-dispatch (no `binding_out_of_dispatch` operator warning). Absent → unattributed bind, existing warning behavior unchanged."}
+            "task_id": {"type": "string", "description": "#2533: checkout bind:true — optional task board id this self-claim is attributable to. Recorded in binding.json; a task_id-carrying self-claim is treated as in-dispatch (no `binding_out_of_dispatch` operator warning). Absent → unattributed bind, existing warning behavior unchanged."},
+            "force": {"type": "boolean", "description": "#2539: merge — emergency bypass for the CI fail-closed gate and the base-staleness (BEHIND/DIRTY) refusal. Requires non-empty `force_reason`; the bypass is audit-logged to fleet_events.jsonl. The handler always read this field, but it was never declared here — an MCP client validating against this schema had no way to send it, so force=true silently never reached the daemon (#2539)."},
+            "force_reason": {"type": "string", "description": "#2539: merge — required non-empty justification when `force=true`, recorded in the fleet_events.jsonl audit entry."}
         }, "required": ["action"]}})
 }
 
@@ -1037,6 +1039,8 @@ mod tests {
             ("repo", "audit_reason", "ci/mod.rs cleanup_merged audit"),
             ("repo", "from_ref", "ci/mod.rs checkout auto-create base"),
             ("repo", "task_id", "ci/checkout.rs checkout bind:true → binding::bind_full task_id linkage (#2533)"),
+            ("repo", "force", "ci/merge.rs handle_merge_repo — CI/base-staleness fail-closed gate bypass (#2539)"),
+            ("repo", "force_reason", "ci/merge.rs handle_merge_repo — required non-empty when force=true, audit-logged (#2539)"),
             // ── bind_self ──
             ("bind_self", "repository_path", "mcp/handlers/worktree.rs preferred source"),
             ("bind_self", "repository", "mcp/handlers/worktree.rs legacy slug"),

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -497,6 +497,39 @@ mod tests {
     }
 
     #[test]
+    fn repo_merge_has_force_and_force_reason_params() {
+        // #2539: `handle_merge_repo` (ci/merge.rs) has ALWAYS read
+        // `args["force"]` / `args["force_reason"]` directly and correctly
+        // gated the CI-checks / base-drift / #2140 freshness refusals behind
+        // `if !force` — but the `repo` tool's inputSchema never DECLARED
+        // these two params. An MCP client that validates a tool call against
+        // the advertised inputSchema (the normal contract) has no way to
+        // include `force`/`force_reason` in a `repo action=merge` call, so
+        // `force=true` never reaches the daemon — the merge is refused
+        // exactly as if force had never been passed (#2539's live repro).
+        // The daemon-internal dispatch chain (execute_tool → handle_tool →
+        // ci::handle_merge_repo) never filters args by schema — confirmed by
+        // reading `mcp/handlers/mod.rs::handle_tool_with_runtime`, which
+        // passes `args` through unmodified — so this schema declaration IS
+        // the complete fix; no merge.rs logic change is needed.
+        let defs = tool_definitions();
+        let tools = defs["tools"].as_array().expect("tools array");
+        let repo = tools
+            .iter()
+            .find(|t| t["name"] == "repo")
+            .expect("repo tool not found");
+        let props = &repo["inputSchema"]["properties"];
+        assert!(
+            props["force"].is_object(),
+            "#2539: repo tool must declare 'force' so MCP clients can pass it on merge"
+        );
+        assert!(
+            props["force_reason"].is_object(),
+            "#2539: repo tool must declare 'force_reason' so MCP clients can pass it on merge"
+        );
+    }
+
+    #[test]
     fn create_instance_has_target_pane_param() {
         // target_pane is optional but must be declared so MCP clients surface
         // it to the agent — without it, agents can't place new panes next to


### PR DESCRIPTION
Closes #2539

## Root cause (rewrites the issue's original conclusion)

The issue hypothesized that `handle_merge_repo`'s base-staleness (BEHIND)
gate wasn't wired to `force`. **That's not the case — it always was.**
`src/mcp/handlers/ci/merge.rs`'s `if !force { ... }` block already wraps
the CI-checks gate, the base-drift (`BEHIND`/`DIRTY`) refusal, and the
`#2140` freshness gate. Confirmed this control flow existed unchanged at
`b8090229` (the daemon build the live `#2539` repro ran against, introduced
2026-06-16 via #2268's byte-identical `ci/mod.rs` split) — not a recent
regression.

**The actual bug**: the `repo` tool's MCP `inputSchema` never declared
`force` / `force_reason` as properties, even though `handle_merge_repo` has
always read `args["force"]` / `args["force_reason"]` directly. An MCP
client that validates a tool call against the advertised schema (the normal
contract) has no way to include fields the schema doesn't list — so
`force=true` never reached the daemon in the live repro (`pr=2536`); the
merge was refused exactly as if force had never been passed at all,
matching the reported symptom byte-for-byte.

Traced the full daemon-internal dispatch chain
(`execute_tool_with_runtime` → `handle_tool_with_runtime` →
`dispatch::try_dispatch` → `ci::handle_merge_repo`) to confirm the daemon
**never** filters args by schema internally — args flow through
unmodified. So the gap is entirely at the external MCP-client/schema
contract boundary, not in any daemon-side logic.

## Fix

`src/mcp/tools.rs`'s `def_repo()` now declares `force` (boolean) and
`force_reason` (string), with descriptions citing #2539. Added the
ghost-guard `CONSUMED` entries so
`coordination_tool_schema_fields_are_consumed_or_deferred` recognizes the
pre-existing handler wiring. **No `merge.rs` change** — the gate logic and
its audit-logging were already correct.

Per the original task scope: hint text is unchanged (it already promised
`force=true` bypass; that promise is now actually true once callers can
send it).

## Test-first (§3.10)

- RED commit: `mcp::tools::tests::repo_merge_has_force_and_force_reason_params`
  — asserts the schema declares both fields. Confirmed FAILING before the
  fix.
- Also added (not RED, a confidence pin — see commit message for why a
  true end-to-end RED test isn't possible from inside this repo):
  `mcp::handlers::ci::tests::merge_force_reaches_handler_through_full_dispatch_chain_2539`
  — drives `force=true` through the full internal `handle_tool` dispatch
  chain, confirming the daemon-internal half was never broken. This test
  passes even without the schema fix (expected — it documents scope, not a
  regression pin).
- GREEN commit: schema fix, same tests pass.

## Verification

- `cargo test --bin agend-terminal repo_merge_has_force_and_force_reason_params` — pass
- `cargo test --bin agend-terminal merge_force_reaches_handler_through_full_dispatch_chain_2539` — pass
- `cargo test --bin agend-terminal mcp::tools::` — 13/13 pass (incl. ghost-guard)
- `cargo test --bin agend-terminal mcp::handlers::ci::` — 80/80 pass (2 tests
  flaky under plain `cargo test`'s thread-parallelism, confirmed pass
  individually and under `cargo nextest`'s process isolation)
- `cargo fmt --check` — clean
- `cargo clippy --bin agend-terminal --all-targets -- -D warnings` — clean
- `cargo nextest run --features tray --profile ci` — 5093/5095 pass. The 2
  remaining failures are the same pre-existing, unrelated #2525-linked
  failures seen on the sibling #2533 PR
  (`e2e_dispatch_review_workflow_seam_invariants_1900`,
  `teardown_leaves_zero_residual_after_full_exercise_1907`) — both hit
  `send(kind=task, branch, repository)`'s known-broken repo-derivation, a
  code path this PR doesn't touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)