### PR TITLE
feat(state): #2524 P6-r2 — discharge ledger consumption: inbox reclaim + poll_reminder chokepoints

### DIFF
--- a/docs/FEATURE-ci-watch.md
+++ b/docs/FEATURE-ci-watch.md
@@ -182,6 +182,59 @@ When polling resumes normally, a `[ci-watch-resumed]` notification is sent.
 
 ---
 
+## Discharge Ledger (Duplicate-Notification Suppression)
+
+A red CI run on a busy branch can produce several `[ci-fail]` notifications
+for the exact same underlying failure (a poll re-emits, a stale row gets
+reclaimed and re-nudged, `poll-reminder` re-pings on an unread-count bump).
+Once an agent has actually triaged a failure — investigated it, told the
+lead it's a known flaky job, or is already fixing it — repeated notifications
+for that SAME failure are noise, not signal.
+
+### Discharging a failure
+
+Report the triage via the SAME `send(kind=update` or `kind=report)` call you'd
+already make, with an added `triaged` field:
+
+```
+send(kind=report, ..., triaged={head: "<commit-sha>", job: "Coverage", reason: "known flaky, reran"})
+```
+
+- `head` and `job` must both be present (or both omitted) — a half-signature
+  is rejected, never silently ignored.
+- `reason` is optional free-text context.
+- This is a field on an existing `send` call, not a separate tool call — the
+  discharge ledger's design deliberately avoids adding a new mandatory
+  action agents have to remember to invoke (a prior mechanism with its own
+  dedicated "mark done" action measured effectively 0% real-world usage).
+
+The daemon persists the discharge to a disk-backed ledger (survives a daemon
+restart — an in-memory-only ledger would replay every already-triaged
+failure as unactioned on every restart, which is worse than no mechanism at
+all).
+
+### What gets suppressed
+
+A discharge is keyed by `(head_sha, job_name)`:
+
+- **Same head, same job** → suppressed (the exact failure you triaged).
+- **Same head, different job** → still notifies (a different check failing
+  is a different problem, even on the same commit).
+- **New head (you pushed a fix, or CI re-ran on a new commit)** → notifies
+  again automatically. There is no separate expiry/cleanup step: the ledger
+  is keyed against the branch's CURRENT head, so once the head moves on, an
+  old discharge simply stops matching.
+
+### Suppression is fail-open
+
+If the daemon can't establish BOTH sides of the signature with confidence —
+the message isn't a recognized ci-fail shape, the branch's current head is
+unknown, the ledger can't be read — it always falls through to notifying.
+Nothing is ever silently dropped on an inability to confirm a discharge;
+worst case is one extra (harmless) notification, never a missed one.
+
+---
+
 ## TTL and Auto-Cleanup
 
 ### Absolute TTL

--- a/docs/FEATURE-ci-watch.zh-TW.md
+++ b/docs/FEATURE-ci-watch.zh-TW.md
@@ -181,6 +181,53 @@ CI Watch 同時監控 PR 的 mergeable 狀態。
 
 ---
 
+## Discharge Ledger（重複通知抑制）
+
+同一個底層失敗，在活躍分支上可能因為輪詢重新發出、stale 訊息被 reclaim 重新
+nudge、poll-reminder 因 unread 數量變化再次提醒等原因，產生多則 `[ci-fail]`
+通知。一旦某個 agent 已經實際處理過這則失敗——查過原因、跟 lead 說這是已知的
+不穩定 job、或正在修——同一件事的重複通知就是雜訊，不是訊號。
+
+### 標記已處理
+
+在你原本就會發出的 `send(kind=update` 或 `kind=report)` 呼叫上，加一個
+`triaged` 欄位即可：
+
+```
+send(kind=report, ..., triaged={head: "<commit-sha>", job: "Coverage", reason: "known flaky, reran"})
+```
+
+- `head` 與 `job` 必須同時提供（或同時省略）——只給一半的簽名會被拒絕，
+  不會被悄悄忽略。
+- `reason` 是選填的自由文字備註。
+- 這是既有 `send` 呼叫上的一個欄位，不是獨立的工具呼叫——discharge ledger
+  的設計刻意避免新增一個 agent 得另外記得呼叫的必要動作（先前一個機制帶了
+  獨立的「標記完成」動作，實測使用率趨近於 0%）。
+
+Daemon 會把這次處理紀錄持久化到磁碟上的 ledger（daemon 重啟後仍然存在——
+純記憶體的 ledger 會讓重啟後所有已處理的失敗瞬間變回「未處理」，比完全沒有
+這個機制還糟）。
+
+### 什麼會被抑制
+
+Discharge 以 `(head_sha, job_name)` 為鍵：
+
+- **同一個 head、同一個 job** → 抑制（你剛處理過的那個確切失敗）。
+- **同一個 head、不同 job** → 照常通知（同一個 commit 上另一個 check 失敗，
+  是不同的問題）。
+- **新的 head（你推了修復，或 CI 在新的 commit 上重跑）** → 自動恢復通知。
+  不需要額外的過期/清理步驟：ledger 是對照分支「目前」的 head 查表，
+  head 一旦前進，舊的 discharge 紀錄自然就不再匹配。
+
+### 抑制邏輯是 fail-open
+
+只要 daemon 無法同時確立簽名的兩端——訊息不是可辨識的 ci-fail 格式、
+分支目前的 head 未知、ledger 讀取失敗——一律照常通知。沒有任何情況會因為
+「無法確認是否已處理」而悄悄漏發；最壞情況只是多一則（無害的）通知，
+絕不會漏掉一則。
+
+---
+
 ## TTL 與自動清理
 
 CI Watch 有兩種過期機制：

--- a/src/daemon/discharge_ledger.rs
+++ b/src/daemon/discharge_ledger.rs
@@ -90,9 +90,7 @@ pub(crate) fn record_discharge(
 /// Look up whether `job` at `head_sha` has been discharged. `None` covers
 /// both "no ledger file for this head" (head advanced past it — free
 /// invalidation, per the spike) and "file exists but this job isn't in it
-/// yet". Not called from any notification-decision code in PR-1 — exists for
-/// this module's own round-trip tests; PR-2 wires a real caller.
-#[cfg_attr(not(test), allow(dead_code))]
+/// yet". Consumed by `inbox::storage::is_discharged_ci_fail` (#2524 P6-r2).
 pub(crate) fn lookup_discharge(home: &Path, head_sha: &str, job: &str) -> Option<DischargeEntry> {
     let path = ledger_path(home, head_sha);
     let ledger: LedgerFile = std::fs::read_to_string(&path)

--- a/src/daemon/poll_reminder.rs
+++ b/src/daemon/poll_reminder.rs
@@ -63,9 +63,19 @@ pub fn collect_poll_reminders(home: &Path, registry: &AgentRegistry) -> Vec<(Str
         // count, so re-nudging a duplicate the agent already handled stops here.
         let (count, oldest) = crate::inbox::unread_count_after_discharge(home, name);
         if count == 0 {
-            // RED stub (§3.10) — dedup-baseline reset intentionally omitted
-            // (this is the exact gap the r0 REJECTED finding caught); restored
-            // in the immediately-following GREEN commit.
+            // #2537 fix (reviewer-caught REJECTED finding on the first pass):
+            // discharging the ONLY unread ci-fail drops the count to 0 here,
+            // but pre-fix `LAST_NOTIFIED` was left stale at whatever it was
+            // before the discharge — so a LATER, genuinely different-signature
+            // failure whose count happened to coincide with that stale value
+            // was silently suppressed by `should_notify_and_record`'s
+            // `prev == count` check below. Clear the dedup baseline whenever
+            // the count is confirmed zero, mirroring the SAME invalidation
+            // `reclaim_stale_delivering` already performs when a restore
+            // changes the count out from under the ledger (see its
+            // `remove_agent` call in `inbox::storage`) — a real signature
+            // change must never be masked by a stale prior count.
+            remove_agent(name);
             continue;
         }
         if !should_notify_and_record(name, count) {
@@ -880,7 +890,11 @@ mod tests {
         let registry = mock_registry(agent, AgentState::Idle);
         reset_dedup(agent);
         let first = collect_poll_reminders(&home, &registry);
-        assert_eq!(first.len(), 1, "job A's undischarged ci-fail must nudge once");
+        assert_eq!(
+            first.len(),
+            1,
+            "job A's undischarged ci-fail must nudge once"
+        );
 
         // Triage job A. It was the ONLY unread row, so the discharge-aware
         // count drops to 0 this pass.

--- a/src/daemon/poll_reminder.rs
+++ b/src/daemon/poll_reminder.rs
@@ -63,6 +63,9 @@ pub fn collect_poll_reminders(home: &Path, registry: &AgentRegistry) -> Vec<(Str
         // count, so re-nudging a duplicate the agent already handled stops here.
         let (count, oldest) = crate::inbox::unread_count_after_discharge(home, name);
         if count == 0 {
+            // RED stub (§3.10) — dedup-baseline reset intentionally omitted
+            // (this is the exact gap the r0 REJECTED finding caught); restored
+            // in the immediately-following GREEN commit.
             continue;
         }
         if !should_notify_and_record(name, count) {
@@ -820,6 +823,87 @@ mod tests {
             "a fully-discharged (head, job) — including its duplicate — must not \
              re-nudge: {second:?}"
         );
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #2524 P6-r2 regression (gapfix-reviewer REJECTED finding, DUAL review r0):
+    /// discharging job A's ONLY unread ci-fail drops the count to 0, but
+    /// `collect_poll_reminders` used to `continue` on `count == 0` WITHOUT
+    /// updating `LAST_NOTIFIED` — leaving it stale at job A's pre-discharge
+    /// count. When a DIFFERENT job B then fails at the same head,
+    /// `unread_count_after_discharge` correctly reports count=1 (job B is not
+    /// discharged), but `should_notify_and_record` saw `prev(1) == count(1)`
+    /// (the stale value from job A) and silently suppressed the reminder — a
+    /// real silent-loss, not merely a missed optimization. Fixed by clearing the
+    /// agent's dedup entry whenever the discharge-aware count is confirmed
+    /// zero (the SAME invalidation `reclaim_stale_delivering` already performs
+    /// via `remove_agent` when a restore changes the count out from under the
+    /// ledger). REAL entry point (§3.9): drives `collect_poll_reminders`
+    /// itself, not the dedup helper in isolation.
+    #[test]
+    fn collect_poll_reminders_renotifies_for_different_job_after_discharge_zeroes_count() {
+        let home = tmp_home("collect-discharge-then-diff-job");
+        let agent = "collect-discharge-diff-job-agent";
+        let (repo, branch, head, short) = (
+            "o/r",
+            "feat/y",
+            "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+            "deadbee",
+        );
+
+        let watch_dir = crate::daemon::ci_watch::ci_watches_dir(&home);
+        std::fs::create_dir_all(&watch_dir).unwrap();
+        let ws = crate::daemon::ci_watch::WatchState {
+            repo: repo.to_string(),
+            branch: branch.to_string(),
+            head_sha: Some(head.to_string()),
+            ..Default::default()
+        };
+        std::fs::write(
+            watch_dir.join(crate::daemon::ci_watch::watch_filename(repo, branch)),
+            serde_json::to_string_pretty(&ws).unwrap(),
+        )
+        .unwrap();
+
+        let ci_fail_msg = |job: &str| {
+            crate::inbox::InboxMessage::new_system(
+                "system:ci",
+                "ci-watch",
+                format!("[ci-fail] {repo}@{branch} ({short}): failure\nDetail: {job}\nURL: https://example/run/1"),
+            )
+            .with_correlation_id(format!("{repo}@{branch}"))
+        };
+
+        // Job A fails — undischarged, must nudge.
+        crate::inbox::enqueue(&home, agent, ci_fail_msg("audit")).unwrap();
+        let registry = mock_registry(agent, AgentState::Idle);
+        reset_dedup(agent);
+        let first = collect_poll_reminders(&home, &registry);
+        assert_eq!(first.len(), 1, "job A's undischarged ci-fail must nudge once");
+
+        // Triage job A. It was the ONLY unread row, so the discharge-aware
+        // count drops to 0 this pass.
+        crate::daemon::discharge_ledger::record_discharge(&home, head, "audit", agent, None)
+            .unwrap();
+        let after_discharge = collect_poll_reminders(&home, &registry);
+        assert!(
+            after_discharge.is_empty(),
+            "job A is discharged and was the only unread row — count is 0, no nudge"
+        );
+
+        // Job B — a DIFFERENT job at the SAME head — fails.
+        crate::inbox::enqueue(&home, agent, ci_fail_msg("Coverage")).unwrap();
+        let third = collect_poll_reminders(&home, &registry);
+        assert_eq!(
+            third.len(),
+            1,
+            "job B is a genuinely different signature — it must notify even \
+             though its count (1) coincides with job A's stale pre-discharge \
+             count; a silent suppression here is exactly the #2537 \
+             different-signature-must-not-drop guarantee being violated"
+        );
+        assert!(third[0].1.contains("unread=1"));
 
         std::fs::remove_dir_all(&home).ok();
     }

--- a/src/daemon/poll_reminder.rs
+++ b/src/daemon/poll_reminder.rs
@@ -35,9 +35,10 @@ pub fn remove_agent(name: &str) {
 pub fn collect_poll_reminders(home: &Path, registry: &AgentRegistry) -> Vec<(String, String)> {
     // #1617-class (mirror conflict_notify's phase-1-collect / phase-2-IO): snapshot
     // the idle-agent names UNDER the registry lock, then DROP the guard before any
-    // inbox file IO. `inbox::unread_count` does `fs::read_to_string` + full-file
-    // parse; holding the GLOBAL registry lock across that (per agent, in a loop)
-    // stalls every other registry user when the inbox is large or the FS is slow.
+    // inbox file IO. `inbox::unread_count_after_discharge` does `fs::read_to_string`
+    // + full-file parse; holding the GLOBAL registry lock across that (per agent,
+    // in a loop) stalls every other registry user when the inbox is large or the
+    // FS is slow.
     let idle_names: Vec<String> = {
         let reg = agent::lock_registry(registry);
         reg.values()
@@ -57,7 +58,10 @@ pub fn collect_poll_reminders(home: &Path, registry: &AgentRegistry) -> Vec<(Str
     // Phase 2: the inbox reads + dedup + formatting run lock-free.
     let mut result = Vec::new();
     for name in &idle_names {
-        let (count, oldest) = crate::inbox::unread_count(home, name);
+        // #2524 P6-r2 (#2537): discharge-aware count — a ci-fail row whose
+        // (head_sha, job) is already triaged (`send.triaged`) doesn't bump this
+        // count, so re-nudging a duplicate the agent already handled stops here.
+        let (count, oldest) = crate::inbox::unread_count_after_discharge(home, name);
         if count == 0 {
             continue;
         }
@@ -182,19 +186,21 @@ mod tests {
         }
         assert!(block_end > block_start, "binding block must close");
 
-        // #t-…61487: match the CALL form (`unread_count(home`), not a bare
-        // `unread_count` token — a doc/comment mention must NOT satisfy the guard
-        // (that is exactly how v1 left this guard "blind": the obligation-count
-        // refactor moved the real call away but a comment kept the loose needle green).
-        let io_needle = ["unread_count", "(home"].concat();
+        // #t-…61487: match the CALL form (`unread_count_after_discharge(home`), not
+        // a bare `unread_count` token — a doc/comment mention must NOT satisfy the
+        // guard (that is exactly how v1 left this guard "blind": the
+        // obligation-count refactor moved the real call away but a comment kept
+        // the loose needle green). #2524 P6-r2: the call site is now
+        // `unread_count_after_discharge` (discharge-aware count), same IO shape.
+        let io_needle = ["unread_count_after_discharge", "(home"].concat();
         let locked_region = &prod[block_start..=block_end];
         assert!(
             !locked_region.contains(&io_needle),
-            "collect_poll_reminders must NOT call inbox::unread_count under the registry lock (#1617 class)"
+            "collect_poll_reminders must NOT call inbox::unread_count_after_discharge under the registry lock (#1617 class)"
         );
         assert!(
             prod[block_end..].contains(&io_needle),
-            "inbox::unread_count must run AFTER the registry lock is dropped"
+            "inbox::unread_count_after_discharge must run AFTER the registry lock is dropped"
         );
     }
 
@@ -748,6 +754,71 @@ mod tests {
         assert!(
             crate::notification_queue::pending_count(&home, agent) > 0,
             "#event-bus Option A: gate-off must deliver via legacy (no regression)"
+        );
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #2524 P6-r2 (#2537), REAL entry point (§3.9): `collect_poll_reminders`
+    /// itself — not just the `unread_count_after_discharge` helper it now calls
+    /// — must not re-nudge a duplicate `[ci-fail]` for a `(head, job)` already
+    /// discharged via `send.triaged`.
+    #[test]
+    fn collect_poll_reminders_no_nudge_for_fully_discharged_ci_fail() {
+        let home = tmp_home("collect-discharged");
+        let agent = "collect-discharged-agent";
+        let (repo, branch, head, short, job) = (
+            "o/r",
+            "feat/x",
+            "cafef00dcafef00dcafef00dcafef00dcafef00d",
+            "cafef00",
+            "Coverage",
+        );
+
+        // A real ci-watch WatchState at the CURRENT head — `is_discharged_ci_fail`
+        // resolves the signature's head from here, not the message body.
+        let watch_dir = crate::daemon::ci_watch::ci_watches_dir(&home);
+        std::fs::create_dir_all(&watch_dir).unwrap();
+        let ws = crate::daemon::ci_watch::WatchState {
+            repo: repo.to_string(),
+            branch: branch.to_string(),
+            head_sha: Some(head.to_string()),
+            ..Default::default()
+        };
+        std::fs::write(
+            watch_dir.join(crate::daemon::ci_watch::watch_filename(repo, branch)),
+            serde_json::to_string_pretty(&ws).unwrap(),
+        )
+        .unwrap();
+
+        let ci_fail_msg = || {
+            crate::inbox::InboxMessage::new_system(
+                "system:ci",
+                "ci-watch",
+                format!("[ci-fail] {repo}@{branch} ({short}): failure\nDetail: {job}\nURL: https://example/run/1"),
+            )
+            .with_correlation_id(format!("{repo}@{branch}"))
+        };
+
+        crate::inbox::enqueue(&home, agent, ci_fail_msg()).unwrap();
+        let registry = mock_registry(agent, AgentState::Idle);
+        reset_dedup(agent);
+
+        // First pass: undischarged — must nudge.
+        let first = collect_poll_reminders(&home, &registry);
+        assert_eq!(first.len(), 1, "the undischarged ci-fail must nudge once");
+
+        // Triage it (the real send.triaged→record_discharge path).
+        crate::daemon::discharge_ledger::record_discharge(&home, head, job, agent, None).unwrap();
+
+        // A duplicate [ci-fail] for the exact same (head, job) arrives.
+        crate::inbox::enqueue(&home, agent, ci_fail_msg()).unwrap();
+
+        let second = collect_poll_reminders(&home, &registry);
+        assert!(
+            second.is_empty(),
+            "a fully-discharged (head, job) — including its duplicate — must not \
+             re-nudge: {second:?}"
         );
 
         std::fs::remove_dir_all(&home).ok();

--- a/src/inbox/mod.rs
+++ b/src/inbox/mod.rs
@@ -31,6 +31,7 @@ pub use storage::{
     ack, ack_by_correlation, clear_compact, describe_message, drain, enqueue, find_message,
     get_thread, has_drained_blocker_for_correlation, mark_ci_watch_superseded, obligation_reason,
     reclaim_stale_delivering, settle_delivering_for_session_reset, sweep_expired, unread_count,
+    unread_count_after_discharge,
 };
 // Storage CRUD (pub(crate))
 pub(crate) use storage::inbox_path_resolved;

--- a/src/inbox/storage.rs
+++ b/src/inbox/storage.rs
@@ -1107,10 +1107,45 @@ pub fn clear_compact(
 ///
 /// Only an EXPLICIT ledger hit for the watch's CURRENT head returns `true`.
 fn is_discharged_ci_fail(home: &Path, msg: &InboxMessage) -> bool {
-    // RED stub (§3.10) — intentionally always false (byte-identical to pre-#2537,
-    // the safest possible stub); restored in the immediately-following GREEN commit.
-    let _ = (home, msg);
-    false
+    if msg.kind.as_deref() != Some("ci-watch") {
+        return false;
+    }
+    let Some(job) = extract_ci_fail_job(&msg.text) else {
+        return false;
+    };
+    let Some((repo, branch)) = msg
+        .correlation_id
+        .as_deref()
+        .and_then(|c| c.split_once('@'))
+    else {
+        return false;
+    };
+    let watch_path = crate::daemon::ci_watch::ci_watches_dir(home)
+        .join(crate::daemon::ci_watch::watch_filename(repo, branch));
+    let Some(head_sha) = std::fs::read_to_string(&watch_path)
+        .ok()
+        .and_then(|c| serde_json::from_str::<crate::daemon::ci_watch::WatchState>(&c).ok())
+        .and_then(|w| w.head_sha)
+    else {
+        return false;
+    };
+    let Some(entry) = crate::daemon::discharge_ledger::lookup_discharge(home, &head_sha, &job)
+    else {
+        return false;
+    };
+    // Audit trail (dispatching task's explicit ask): every absorption is logged,
+    // even if the SAME row is re-evaluated on a later tick/sweep — the audit log
+    // is append-only history, not a dedup ledger (the discharge ledger already is).
+    crate::event_log::log(
+        home,
+        "discharge_absorbed",
+        &msg.from,
+        &format!(
+            "head={head_sha} job={job} discharged_by={} discharged_at={}",
+            entry.discharged_by, entry.discharged_at
+        ),
+    );
+    true
 }
 
 /// Pull the job name out of a ci-fail body's `Detail: <job>` line — the daemon's

--- a/src/inbox/storage.rs
+++ b/src/inbox/storage.rs
@@ -1088,6 +1088,43 @@ pub fn clear_compact(
     }
 }
 
+/// #2524 P6-r2 (#2537): does `msg` represent a ci-fail whose `(head_sha, job_name)`
+/// signature is already discharged (`send.triaged`, PR-1)?
+///
+/// Silent-loss defense (§3.21 — this predicate can ONLY suppress, it is consumed
+/// by callers that only ever narrow "worthy of nudge" to "not worthy", never widen
+/// it): every extraction step fails OPEN — `false` = "not confirmed discharged,
+/// treat as a normal live obligation":
+/// - wrong `kind` (only `"ci-watch"` rows are ci-fail-shaped at all),
+/// - no `Detail: <job>` line in the body ([`extract_ci_fail_job`] — a ci-pass/
+///   ci-ended body has none, or the format has drifted),
+/// - `correlation_id` isn't a parseable `repo@branch` pair,
+/// - no on-disk ci-watch file for that `repo@branch`, or it has no `head_sha` yet,
+/// - the ledger has no entry for `(head_sha, job)` — including a genuinely
+///   different job, or the SAME job at an OLDER head (the watch's `head_sha` is
+///   always the CURRENT head, so a discharge recorded against a since-superseded
+///   head naturally stops matching — free head-invalidation, per PR-1's spike).
+///
+/// Only an EXPLICIT ledger hit for the watch's CURRENT head returns `true`.
+fn is_discharged_ci_fail(home: &Path, msg: &InboxMessage) -> bool {
+    // RED stub (§3.10) — intentionally always false (byte-identical to pre-#2537,
+    // the safest possible stub); restored in the immediately-following GREEN commit.
+    let _ = (home, msg);
+    false
+}
+
+/// Pull the job name out of a ci-fail body's `Detail: <job>` line — the daemon's
+/// own `build_inbox_body` format (`daemon/ci_watch/poller.rs`), the SAME material
+/// `send.triaged.job` reports when an agent discharges it. `None` when the line
+/// is absent (a ci-pass/ci-ended body has none) or empty.
+fn extract_ci_fail_job(text: &str) -> Option<String> {
+    text.lines()
+        .find_map(|l| l.strip_prefix("Detail: "))
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
 /// Count unread messages (read_at == None) for an agent.
 pub fn unread_count(home: &Path, name: &str) -> (usize, Option<chrono::DateTime<chrono::Utc>>) {
     let path = inbox_path_resolved(home, name);
@@ -1125,6 +1162,56 @@ pub fn unread_count(home: &Path, name: &str) -> (usize, Option<chrono::DateTime<
                         oldest = Some(ts_utc);
                     }
                 }
+            }
+        }
+    }
+    (count, oldest)
+}
+
+/// #2524 P6-r2 (#2537): [`unread_count`], but a ci-fail row already discharged
+/// (`(head_sha, job)` — [`is_discharged_ci_fail`]) doesn't count. Byte-identical
+/// to `unread_count` for every row that isn't a discharged ci-fail — same TTL/
+/// delivering/superseded filter, same `oldest` computation.
+///
+/// This is the fix for `collect_poll_reminders`'s literal observed duplicate-nudge:
+/// `should_notify_and_record` only compares whether the unread COUNT changed. A
+/// second `[ci-fail]` for the SAME `(head, job)` an agent already triaged is a
+/// genuinely NEW file row (0→1, a real count change) even though the daemon and
+/// the agent both already know it's the same failure — `unread_count` alone has no
+/// way to see that. This function is the discharge-aware count `collect_poll_reminders`
+/// needs instead.
+pub fn unread_count_after_discharge(
+    home: &Path,
+    name: &str,
+) -> (usize, Option<chrono::DateTime<chrono::Utc>>) {
+    let path = inbox_path_resolved(home, name);
+    let content = match std::fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(_) => return (0, None),
+    };
+    let mut count = 0usize;
+    let mut oldest: Option<chrono::DateTime<chrono::Utc>> = None;
+    for line in content.lines() {
+        let Ok(probe) = serde_json::from_str::<UnreadProbe>(line) else {
+            continue;
+        };
+        if !probe.is_unread() {
+            continue;
+        }
+        // Only a ci-watch row needs the full parse (signature extraction) — every
+        // other kind is counted exactly as `unread_count` does, cheap-probe-only.
+        if probe.kind.as_deref() == Some("ci-watch") {
+            if let Ok(full) = serde_json::from_str::<InboxMessage>(line) {
+                if is_discharged_ci_fail(home, &full) {
+                    continue; // absorbed — does not count, does not set `oldest`
+                }
+            }
+        }
+        count += 1;
+        if let Ok(ts) = chrono::DateTime::parse_from_rfc3339(&probe.timestamp) {
+            let ts_utc = ts.with_timezone(&chrono::Utc);
+            if oldest.is_none_or(|t| t > ts_utc) {
+                oldest = Some(ts_utc);
             }
         }
     }
@@ -1181,7 +1268,21 @@ pub fn obligation_reason(home: &Path, msg: &InboxMessage) -> Option<String> {
 /// [`reclaim_stale_delivering`], after the `with_inbox_lock` closure closes — never
 /// inside it (holding the per-agent inbox flock across a blocking board read is the
 /// #1617 fleet-stall class).
+///
+/// #2524 P6-r2 (#2537): [`is_discharged_ci_fail`] is checked FIRST and can only
+/// force `false` (never override an existing `false` back to `true`) — a
+/// discharged ci-fail is never worth re-arming regardless of what
+/// `obligation_reason`/`kind_is_unknown` would otherwise say. In practice this is
+/// a defense-in-depth wire, not a behavior change TODAY: `ci-watch` is already in
+/// `known_fire_and_forget_kind`, so `obligation_reason` already returns `None` and
+/// `kind_is_unknown` already returns `false` for it — this function already
+/// returns `false` for every ci-watch row before this change. Wired anyway per the
+/// dispatching task, so a future kind-taxonomy change can't silently reopen the
+/// gap this closes.
 fn reclaim_renudge_worthy(home: &Path, msg: &InboxMessage) -> bool {
+    if is_discharged_ci_fail(home, msg) {
+        return false;
+    }
     obligation_reason(home, msg).is_some() || kind_is_unknown(msg)
 }
 
@@ -1721,3 +1822,9 @@ mod perf_r3_equiv;
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod perf_r3_bench;
+
+// #2524 P6-r2 (#2537): discharge-ledger consumption tests for the two
+// chokepoints (reclaim_renudge_worthy + unread_count_after_discharge).
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod p6_discharge_consume;

--- a/src/inbox/storage/p6_discharge_consume.rs
+++ b/src/inbox/storage/p6_discharge_consume.rs
@@ -1,0 +1,411 @@
+//! #2524 P6-r2 (#2537) — discharge ledger consumption tests for the two
+//! chokepoints: `reclaim_renudge_worthy` (via `is_discharged_ci_fail`) and
+//! `unread_count_after_discharge`. §3.9: exercised through the REAL entry
+//! points (`enqueue`, `record_discharge`, real ci-watch JSON files on disk),
+//! not synthetic mid-pipeline injection.
+//!
+//! Attached to `src/inbox/storage.rs`; private items are reached via `super::`.
+
+use super::{enqueue, is_discharged_ci_fail, reclaim_renudge_worthy, unread_count_after_discharge};
+use crate::daemon::ci_watch::{ci_watches_dir, watch_filename, WatchState};
+use crate::daemon::discharge_ledger::record_discharge;
+use crate::inbox::InboxMessage;
+use std::fs;
+use std::path::PathBuf;
+
+fn tmp_home(suffix: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "agend-p6-discharge-consume-{}-{}",
+        suffix,
+        std::process::id()
+    ));
+    fs::remove_dir_all(&dir).ok();
+    fs::create_dir_all(&dir).ok();
+    dir
+}
+
+/// A ci-fail body byte-identical in shape to `daemon/ci_watch/poller.rs`'s
+/// `build_inbox_body` (`"{headline}\nDetail: {detail}\nURL: {run_url}"`).
+fn ci_fail_body(repo: &str, branch: &str, short_sha: &str, job: &str) -> String {
+    format!("[ci-fail] {repo}@{branch} ({short_sha}): failure\nDetail: {job}\nURL: https://example/run/1")
+}
+
+fn ci_fail_msg(repo: &str, branch: &str, short_sha: &str, job: &str) -> InboxMessage {
+    InboxMessage::new_system(
+        "system:ci",
+        "ci-watch",
+        ci_fail_body(repo, branch, short_sha, job),
+    )
+    .with_correlation_id(format!("{repo}@{branch}"))
+}
+
+/// Write a minimal ci-watch WatchState with the given CURRENT head_sha — the
+/// on-disk file `is_discharged_ci_fail` reads to resolve "the watch's current
+/// head" (not the message body's truncated short-sha).
+fn write_watch(home: &std::path::Path, repo: &str, branch: &str, head_sha: &str) {
+    let dir = ci_watches_dir(home);
+    fs::create_dir_all(&dir).unwrap();
+    let ws = WatchState {
+        repo: repo.to_string(),
+        branch: branch.to_string(),
+        head_sha: Some(head_sha.to_string()),
+        ..Default::default()
+    };
+    fs::write(
+        dir.join(watch_filename(repo, branch)),
+        serde_json::to_string_pretty(&ws).unwrap(),
+    )
+    .unwrap();
+}
+
+fn event_log_contents(home: &std::path::Path) -> String {
+    fs::read_to_string(home.join("event-log.jsonl")).unwrap_or_default()
+}
+
+const REPO: &str = "o/r";
+const BRANCH: &str = "feat/x";
+const HEAD: &str = "abcdef1234567890abcdef1234567890abcdef12";
+const SHORT: &str = "abcdef1";
+const JOB: &str = "Coverage";
+
+// ───────────────────── extract_ci_fail_job (pure parser) ─────────────────────
+
+#[test]
+fn extract_job_reads_detail_line() {
+    let body = ci_fail_body(REPO, BRANCH, SHORT, JOB);
+    assert_eq!(
+        super::extract_ci_fail_job(&body).as_deref(),
+        Some(JOB),
+        "must extract the exact Detail: line content"
+    );
+}
+
+#[test]
+fn extract_job_none_when_no_detail_line() {
+    // A ci-pass/ci-ended body has no `Detail:` line at all.
+    let body = "[ci-pass] o/r@feat/x (abcdef1): passed ✓\nURL: https://example/run/1";
+    assert_eq!(super::extract_ci_fail_job(body), None);
+}
+
+#[test]
+fn extract_job_none_when_detail_empty() {
+    let body = "[ci-fail] o/r@feat/x: failure\nDetail: \nURL: x";
+    assert_eq!(super::extract_ci_fail_job(body), None);
+}
+
+// ───────────────────── is_discharged_ci_fail (pure predicate) ─────────────────────
+
+#[test]
+fn is_discharged_true_on_exact_signature_match() {
+    let home = tmp_home("discharged-true");
+    write_watch(&home, REPO, BRANCH, HEAD);
+    record_discharge(&home, HEAD, JOB, "dev-1", Some("flaky, reran")).unwrap();
+
+    let msg = ci_fail_msg(REPO, BRANCH, SHORT, JOB);
+    assert!(
+        is_discharged_ci_fail(&home, &msg),
+        "exact (head, job) match against the watch's CURRENT head must be discharged"
+    );
+
+    fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn is_discharged_false_wrong_kind() {
+    let home = tmp_home("wrong-kind");
+    write_watch(&home, REPO, BRANCH, HEAD);
+    record_discharge(&home, HEAD, JOB, "dev-1", None).unwrap();
+
+    let mut msg = ci_fail_msg(REPO, BRANCH, SHORT, JOB);
+    msg.kind = Some("report".to_string());
+    assert!(
+        !is_discharged_ci_fail(&home, &msg),
+        "only kind=ci-watch is ever eligible for discharge absorption"
+    );
+
+    fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn is_discharged_false_different_job_2_of_5() {
+    let home = tmp_home("diff-job");
+    write_watch(&home, REPO, BRANCH, HEAD);
+    record_discharge(&home, HEAD, "audit", "dev-1", None).unwrap();
+
+    // Same head, DIFFERENT job — must not be absorbed (fail-open to notify).
+    let msg = ci_fail_msg(REPO, BRANCH, SHORT, "Coverage");
+    assert!(
+        !is_discharged_ci_fail(&home, &msg),
+        "a different job at the same head must not be silently absorbed"
+    );
+
+    fs::remove_dir_all(&home).ok();
+}
+
+/// Requirement 3: head advanced past the discharged one — resumes notifying.
+#[test]
+fn is_discharged_false_after_head_advances_3_of_5() {
+    let home = tmp_home("head-advanced");
+    // Discharge was recorded against the OLD head...
+    record_discharge(&home, "old-head-sha", JOB, "dev-1", None).unwrap();
+    // ...but the watch's CURRENT head has since moved on.
+    write_watch(&home, REPO, BRANCH, "new-head-sha");
+
+    let msg = ci_fail_msg(REPO, BRANCH, "new-head", JOB);
+    assert!(
+        !is_discharged_ci_fail(&home, &msg),
+        "a discharge recorded against a superseded head must not suppress the NEW head's failure"
+    );
+
+    fs::remove_dir_all(&home).ok();
+}
+
+/// Requirement 4: no ledger entry at all → regression/invariance (fail-open).
+#[test]
+fn is_discharged_false_no_ledger_entry_4_of_5() {
+    let home = tmp_home("no-ledger");
+    write_watch(&home, REPO, BRANCH, HEAD);
+    // No `record_discharge` call at all — the discharge-ledger dir doesn't exist.
+    assert!(!crate::daemon::discharge_ledger::discharge_ledger_dir(&home).exists());
+
+    let msg = ci_fail_msg(REPO, BRANCH, SHORT, JOB);
+    assert!(
+        !is_discharged_ci_fail(&home, &msg),
+        "no discharge ever recorded → never absorbed, byte-identical to pre-#2537"
+    );
+
+    fs::remove_dir_all(&home).ok();
+}
+
+/// Requirement 5: a corrupt ledger file fails OPEN (never panics, never
+/// silently absorbs on a read error).
+#[test]
+fn is_discharged_false_on_corrupt_ledger_file_5_of_5() {
+    let home = tmp_home("corrupt-ledger");
+    write_watch(&home, REPO, BRANCH, HEAD);
+    let dir = crate::daemon::discharge_ledger::discharge_ledger_dir(&home);
+    fs::create_dir_all(&dir).unwrap();
+    let sha_hex = crate::daemon::utils::sha256_hex(HEAD.as_bytes());
+    fs::write(dir.join(format!("{sha_hex}.json")), b"{ not valid json").unwrap();
+
+    let msg = ci_fail_msg(REPO, BRANCH, SHORT, JOB);
+    assert!(
+        !is_discharged_ci_fail(&home, &msg),
+        "a corrupt ledger file must fail OPEN (deliver), never panic, never silently absorb"
+    );
+
+    fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn is_discharged_false_no_correlation_id() {
+    let home = tmp_home("no-correlation");
+    write_watch(&home, REPO, BRANCH, HEAD);
+    record_discharge(&home, HEAD, JOB, "dev-1", None).unwrap();
+
+    let mut msg = ci_fail_msg(REPO, BRANCH, SHORT, JOB);
+    msg.correlation_id = None;
+    assert!(
+        !is_discharged_ci_fail(&home, &msg),
+        "no correlation_id → can't resolve a watch → fail open"
+    );
+
+    fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn is_discharged_false_no_watch_file() {
+    let home = tmp_home("no-watch-file");
+    // No `write_watch` call — no ci-watch JSON exists for this repo@branch.
+    record_discharge(&home, HEAD, JOB, "dev-1", None).unwrap();
+
+    let msg = ci_fail_msg(REPO, BRANCH, SHORT, JOB);
+    assert!(
+        !is_discharged_ci_fail(&home, &msg),
+        "no on-disk watch to resolve the current head from → fail open"
+    );
+
+    fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn is_discharged_absorption_writes_audit_log_entry() {
+    let home = tmp_home("audit-log");
+    write_watch(&home, REPO, BRANCH, HEAD);
+    record_discharge(&home, HEAD, JOB, "dev-1", Some("flaky")).unwrap();
+
+    let msg = ci_fail_msg(REPO, BRANCH, SHORT, JOB);
+    assert!(is_discharged_ci_fail(&home, &msg));
+
+    let log = event_log_contents(&home);
+    assert!(
+        log.contains("discharge_absorbed"),
+        "absorption must leave an audit trail: {log}"
+    );
+    assert!(log.contains(HEAD) && log.contains(JOB));
+
+    fs::remove_dir_all(&home).ok();
+}
+
+// ───────────────────── reclaim_renudge_worthy (chokepoint a) ─────────────────────
+
+#[test]
+fn reclaim_renudge_worthy_false_for_discharged_ci_fail() {
+    let home = tmp_home("reclaim-discharged");
+    write_watch(&home, REPO, BRANCH, HEAD);
+    record_discharge(&home, HEAD, JOB, "dev-1", None).unwrap();
+
+    let msg = ci_fail_msg(REPO, BRANCH, SHORT, JOB);
+    assert!(
+        !reclaim_renudge_worthy(&home, &msg),
+        "a discharged ci-fail is never worthy of reclaim re-nudge"
+    );
+
+    fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn reclaim_renudge_worthy_false_for_undischarged_ci_fail_regression() {
+    // #2537's own honest finding: ci-watch was ALREADY non-worthy before this
+    // change (obligation_reason=None, kind_is_unknown=false) — this pins that
+    // pre-existing behavior is unchanged for the non-discharged case too.
+    let home = tmp_home("reclaim-undischarged");
+    let msg = ci_fail_msg(REPO, BRANCH, SHORT, JOB);
+    assert!(!reclaim_renudge_worthy(&home, &msg));
+    fs::remove_dir_all(&home).ok();
+}
+
+// ───────────────────── unread_count_after_discharge (chokepoint b) ─────────────────────
+
+/// Requirement 1: after discharge, a same-signature duplicate no longer counts
+/// (this is `collect_poll_reminders`'s literal observed bug — re-nudge on a
+/// count bump the daemon can't otherwise tell is the same obligation).
+#[test]
+fn unread_count_after_discharge_absorbs_same_signature_duplicate_1_of_5() {
+    let home = tmp_home("count-absorbs");
+    write_watch(&home, REPO, BRANCH, HEAD);
+
+    // First failure — not yet discharged, counts normally.
+    enqueue(&home, "dev", ci_fail_msg(REPO, BRANCH, SHORT, JOB)).unwrap();
+    let (before, _) = unread_count_after_discharge(&home, "dev");
+    assert_eq!(before, 1);
+
+    // Agent triages it — discharge applies to the SIGNATURE, not to any one
+    // message row, so it retroactively quiets the still-unread first row too
+    // (there is nothing left to act on: the agent already explained it).
+    record_discharge(&home, HEAD, JOB, "dev", None).unwrap();
+
+    // A SECOND notification for the exact same (head, job) — a real new file
+    // row (a naive count would go 1→2), but semantically the same
+    // already-handled failure.
+    enqueue(&home, "dev", ci_fail_msg(REPO, BRANCH, SHORT, JOB)).unwrap();
+    let (after, _) = unread_count_after_discharge(&home, "dev");
+    assert_eq!(
+        after, 0,
+        "once (head, job) is discharged, BOTH the pre-discharge row and the \
+         duplicate are absorbed — discharge is a signature-level fact, not a \
+         per-message-row one"
+    );
+
+    fs::remove_dir_all(&home).ok();
+}
+
+/// Requirement 2: a different job's failure still counts (never silently
+/// absorbed just because SOME job on this head was discharged).
+#[test]
+fn unread_count_after_discharge_still_counts_different_signature_2_of_5() {
+    let home = tmp_home("count-diff-sig");
+    write_watch(&home, REPO, BRANCH, HEAD);
+    record_discharge(&home, HEAD, "audit", "dev", None).unwrap();
+
+    enqueue(&home, "dev", ci_fail_msg(REPO, BRANCH, SHORT, "Coverage")).unwrap();
+    let (count, _) = unread_count_after_discharge(&home, "dev");
+    assert_eq!(
+        count, 1,
+        "a different job at the same head must still be counted/notified"
+    );
+
+    fs::remove_dir_all(&home).ok();
+}
+
+/// Requirement 3: once the head advances, notifications resume even though an
+/// old head's job was discharged.
+#[test]
+fn unread_count_after_discharge_resumes_after_head_advance_3_of_5() {
+    let home = tmp_home("count-head-advance");
+    record_discharge(&home, "old-head", JOB, "dev", None).unwrap();
+    write_watch(&home, REPO, BRANCH, "new-head");
+
+    enqueue(&home, "dev", ci_fail_msg(REPO, BRANCH, "new-head", JOB)).unwrap();
+    let (count, _) = unread_count_after_discharge(&home, "dev");
+    assert_eq!(
+        count, 1,
+        "a NEW head's failure must count even if the SAME job was discharged \
+         at an older head"
+    );
+
+    fs::remove_dir_all(&home).ok();
+}
+
+/// Requirement 4: regression/invariance — with no discharge ledger at all,
+/// `unread_count_after_discharge` must be byte-identical to `unread_count`.
+#[test]
+fn unread_count_after_discharge_matches_unread_count_with_no_ledger_4_of_5() {
+    let home = tmp_home("count-invariance");
+    write_watch(&home, REPO, BRANCH, HEAD);
+    enqueue(&home, "dev", ci_fail_msg(REPO, BRANCH, SHORT, JOB)).unwrap();
+    enqueue(
+        &home,
+        "dev",
+        InboxMessage::new_system("peer", "report", "hi".to_string()),
+    )
+    .unwrap();
+
+    let plain = super::unread_count(&home, "dev");
+    let discharge_aware = unread_count_after_discharge(&home, "dev");
+    assert_eq!(
+        plain, discharge_aware,
+        "with nothing ever discharged, the two counters must agree exactly"
+    );
+    assert_eq!(plain.0, 2);
+
+    fs::remove_dir_all(&home).ok();
+}
+
+/// Requirement 5: a corrupt ledger file fails open — the row still counts
+/// (never silently dropped on a read error).
+#[test]
+fn unread_count_after_discharge_counts_through_corrupt_ledger_5_of_5() {
+    let home = tmp_home("count-corrupt-ledger");
+    write_watch(&home, REPO, BRANCH, HEAD);
+    let dir = crate::daemon::discharge_ledger::discharge_ledger_dir(&home);
+    fs::create_dir_all(&dir).unwrap();
+    let sha_hex = crate::daemon::utils::sha256_hex(HEAD.as_bytes());
+    fs::write(dir.join(format!("{sha_hex}.json")), b"{ not valid json").unwrap();
+
+    enqueue(&home, "dev", ci_fail_msg(REPO, BRANCH, SHORT, JOB)).unwrap();
+    let (count, _) = unread_count_after_discharge(&home, "dev");
+    assert_eq!(count, 1, "a corrupt ledger must never cause a silent drop");
+
+    fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn unread_count_after_discharge_non_ci_watch_rows_unaffected() {
+    let home = tmp_home("count-non-ci-watch");
+    enqueue(
+        &home,
+        "dev",
+        InboxMessage::new_system("peer", "report", "hi".to_string()),
+    )
+    .unwrap();
+    enqueue(
+        &home,
+        "dev",
+        InboxMessage::new_system("peer", "update", "status".to_string()),
+    )
+    .unwrap();
+    let (count, _) = unread_count_after_discharge(&home, "dev");
+    assert_eq!(count, 2, "non-ci-watch rows are counted exactly as before");
+    fs::remove_dir_all(&home).ok();
+}

--- a/src/inbox/storage/p6_discharge_consume.rs
+++ b/src/inbox/storage/p6_discharge_consume.rs
@@ -228,6 +228,57 @@ fn is_discharged_false_no_watch_file() {
     fs::remove_dir_all(&home).ok();
 }
 
+/// #2524 P6-r2 r1 (gapfix-reviewer secondary coverage-gap finding): a
+/// `correlation_id` PRESENT but not a parseable `repo@branch` pair (no `@`)
+/// must fail open — distinct from the already-covered "correlation_id
+/// entirely absent" case above.
+#[test]
+fn is_discharged_false_malformed_correlation_id() {
+    let home = tmp_home("malformed-correlation");
+    write_watch(&home, REPO, BRANCH, HEAD);
+    record_discharge(&home, HEAD, JOB, "dev-1", None).unwrap();
+
+    let mut msg = ci_fail_msg(REPO, BRANCH, SHORT, JOB);
+    msg.correlation_id = Some("not-a-repo-at-branch-pair".to_string());
+    assert!(
+        !is_discharged_ci_fail(&home, &msg),
+        "a correlation_id with no '@' separator can't split into (repo, branch) → fail open"
+    );
+
+    fs::remove_dir_all(&home).ok();
+}
+
+/// #2524 P6-r2 r1 (gapfix-reviewer secondary coverage-gap finding): a
+/// ci-watch file that EXISTS but has no `head_sha` yet (a fresh watch before
+/// its first poll populates it) must fail open — distinct from the
+/// already-covered "no watch file at all" case above.
+#[test]
+fn is_discharged_false_watch_file_with_no_head_sha_yet() {
+    let home = tmp_home("watch-no-head-sha");
+    let dir = ci_watches_dir(&home);
+    fs::create_dir_all(&dir).unwrap();
+    let ws = WatchState {
+        repo: REPO.to_string(),
+        branch: BRANCH.to_string(),
+        head_sha: None, // fresh watch, first poll hasn't run yet
+        ..Default::default()
+    };
+    fs::write(
+        dir.join(watch_filename(REPO, BRANCH)),
+        serde_json::to_string_pretty(&ws).unwrap(),
+    )
+    .unwrap();
+    record_discharge(&home, HEAD, JOB, "dev-1", None).unwrap();
+
+    let msg = ci_fail_msg(REPO, BRANCH, SHORT, JOB);
+    assert!(
+        !is_discharged_ci_fail(&home, &msg),
+        "a watch file with head_sha=None can't resolve a current head → fail open"
+    );
+
+    fs::remove_dir_all(&home).ok();
+}
+
 #[test]
 fn is_discharged_absorption_writes_audit_log_entry() {
     let home = tmp_home("audit-log");


### PR DESCRIPTION
## Summary

PR-2 of #2537 (notification obligation lifecycle) — wires the discharge ledger (PR-1, #2541) into the two notification-decision chokepoints identified in the P6 spike (`d-20260702101809035049-1`), so a `[ci-fail]` an agent has already explicitly triaged (`send(..., triaged={head, job, reason})`) stops re-nudging. This is the last behavior-changing piece of #2537.

Closes #2537

## The two chokepoints

1. **`daemon::poll_reminder::collect_poll_reminders`** — the literal observed bug. `should_notify_and_record` only compares whether the unread **count** changed; a duplicate `[ci-fail]` for an already-triaged `(head, job)` is a genuinely new file row (a real count bump) even though the agent already explained it. Now calls a new `inbox::unread_count_after_discharge` instead of `unread_count` — same TTL/delivering/superseded filter, same `oldest` computation, except a discharged ci-fail row doesn't count.
2. **`inbox::storage::reclaim_renudge_worthy`** — defensive wire per the dispatching task. `is_discharged_ci_fail` is checked first and can only force the result to `false`, never override an existing `false` back to `true`. In practice this is a no-op **today**: `ci-watch` is already in `known_fire_and_forget_kind`, so `obligation_reason` already returns `None` and `kind_is_unknown` already returns `false` for it — this function already returned `false` for every ci-watch row before this PR. Wired anyway so a future kind-taxonomy change can't silently reopen the gap this closes.

Both share one new predicate, `inbox::storage::is_discharged_ci_fail(home, msg)`.

## Silent-loss defense — the reasoning (§3.21, this is why it's DUAL review)

The predicate can **only ever narrow** "worthy of nudge" → "not worthy," never the reverse — every extraction step in the signature derivation **fails open** (returns `false` = "not confirmed discharged, treat as a live obligation"):

| Step | Failure mode | Result |
|---|---|---|
| `msg.kind` | not `"ci-watch"` | fail open — only ci-fail-shaped messages are ever eligible |
| `extract_ci_fail_job` | no `Detail: <job>` line (format drift, or a ci-pass/ci-ended body) | fail open |
| `msg.correlation_id` | missing, or not a parseable `repo@branch` pair | fail open |
| on-disk ci-watch file | doesn't exist, or has no `head_sha` yet | fail open |
| discharge ledger | no entry, corrupt JSON, wrong job, or the SAME job at an **older** head | fail open |

Only an **explicit ledger hit for the watch's CURRENT head** returns `true`. Each row of that table has a dedicated test (`src/inbox/storage/p6_discharge_consume.rs`), including a deliberately-corrupted ledger file proving a read error fails open rather than panicking or silently absorbing.

**Why "current head from the on-disk WatchState," not the message body's truncated sha**: the message text only carries a 7-char short sha (cosmetic); the ledger is keyed on whatever full string an agent passed as `triaged.head`. Re-deriving the signature from the watch's own `head_sha` field (already the authoritative full-length current head, already how the spike defined "head not advanced") avoids a string-length mismatch between write-side and read-side entirely, and gives head-invalidation for free: once the branch's head moves past a discharged commit, the ledger lookup naturally misses (no separate expiry/cleanup needed — this was PR-1's design already, verified end-to-end here).

**Known non-goal**: discharge is a signature-level fact, not a per-message-row one — once `(head, job)` is discharged, *every* unread row carrying that signature is absorbed, including ones that arrived *before* the discharge call. This is intentional (see `unread_count_after_discharge_absorbs_same_signature_duplicate_1_of_5`'s test comment) — there is nothing left to act on once the agent has explained it, regardless of which specific row happens to still be sitting unread.

## Test plan (§3.10 RED-first, §3.9 real entry points)

- [x] RED→GREEN commit split: `is_discharged_ci_fail` stubbed to always `false` first (17/21 new tests pass — every "must NOT be absorbed" case, exactly as expected since `false` is the safe default; 4 fail — the actual absorption claims), committed, then restored (all 21 pass).
- [x] `src/inbox/storage/p6_discharge_consume.rs` (20 tests): `extract_ci_fail_job` parsing, `is_discharged_ci_fail`'s full fail-open matrix (wrong kind / no job / no correlation_id / no watch file / head advanced / no ledger entry / corrupt ledger file), `reclaim_renudge_worthy` regression + discharge, `unread_count_after_discharge`'s 5 requirements (absorb duplicate / different-job still counts / head-advance resumes / byte-identical-to-`unread_count` when nothing's discharged / fail-open on corrupt ledger), plus a non-ci-watch-rows-unaffected pin.
- [x] `daemon::poll_reminder`'s own test module (1 new test, real entry point): `collect_poll_reminders` itself — not just the helper it calls — nudges once for an undischarged `[ci-fail]`, then produces **zero** reminders after discharge + a duplicate arrives.
- [x] Updated an existing structural guard (`poll_reminder_unread_read_not_held_across_registry_lock`) whose source-scan needle hard-coded the old `unread_count(home` call text — now matches the renamed `unread_count_after_discharge(home` call, preserving the #1617 lock-discipline invariant it protects.
- [x] Full regression: `inbox::` (461 incl. this PR's) + `daemon::discharge_ledger` + `daemon::poll_reminder` + `daemon::ci_watch::` + `mcp::tools::` — all green, zero pre-existing test touched/broken.
- [x] `spawn_rationale_audit`, `file_size_invariant` — green (no new spawn sites, no handler file size regressions).
- [x] `cargo fmt --check`, `cargo clippy --all-targets` — clean.

## Docs

`docs/FEATURE-ci-watch.md` (+ zh-TW) gains a "Discharge Ledger (Duplicate-Notification Suppression)" section — how to discharge via `send(..., triaged=...)`, the `(head_sha, job_name)` signature scope, head-advance auto-resume, and the fail-open guarantee — now that the mechanism is complete end-to-end (PR-1 alone had nothing user-visible to document yet).

## Not done (explicitly out of scope per the dispatching task)

Binding-warning noise class (#2533, separate task), tombstone-pattern merge (decision: not merging — different layer, see PR-1's spike §4/§5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)