### PR TITLE
fix(team): #2525 forward repository_path on already-exists branch

### DIFF
--- a/src/api/handlers/team.rs
+++ b/src/api/handlers/team.rs
@@ -608,12 +608,8 @@ mod tests_2525 {
         use std::sync::atomic::{AtomicU32, Ordering};
         static C: AtomicU32 = AtomicU32::new(0);
         let id = C.fetch_add(1, Ordering::Relaxed);
-        let dir = std::env::temp_dir().join(format!(
-            "agend-2525-{}-{}-{}",
-            tag,
-            std::process::id(),
-            id
-        ));
+        let dir =
+            std::env::temp_dir().join(format!("agend-2525-{}-{}-{}", tag, std::process::id(), id));
         std::fs::create_dir_all(&dir).ok();
         dir
     }

--- a/src/api/handlers/team.rs
+++ b/src/api/handlers/team.rs
@@ -586,3 +586,82 @@ mod tests_1964 {
         std::fs::remove_dir_all(&home).ok();
     }
 }
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests_2525 {
+    use super::*;
+    use parking_lot::Mutex;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    fn tmp_home(tag: &str) -> std::path::PathBuf {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static C: AtomicU32 = AtomicU32::new(0);
+        let id = C.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "agend-2525-{}-{}-{}",
+            tag,
+            std::process::id(),
+            id
+        ));
+        std::fs::create_dir_all(&dir).ok();
+        dir
+    }
+
+    fn test_ctx(home: &std::path::Path) -> HandlerCtx<'_> {
+        let registry: &'static crate::agent::AgentRegistry =
+            Box::leak(Box::new(Arc::new(Mutex::new(HashMap::new()))));
+        let configs: &'static crate::api::ConfigRegistry =
+            Box::leak(Box::new(Arc::new(Mutex::new(HashMap::new()))));
+        let externals: &'static crate::agent::ExternalRegistry =
+            Box::leak(Box::new(Arc::new(Mutex::new(HashMap::new()))));
+        HandlerCtx {
+            registry,
+            configs,
+            externals,
+            notifier: None,
+            home,
+        }
+    }
+
+    /// #2525: CREATE_TEAM on an EXISTING team (the #1964 already-exists
+    /// branch, routed through `teams::update`) must forward `repository_path`
+    /// the same way the new-team path does (#1833 above) — same
+    /// allowlist-drop class, just never fixed for this branch. Pre-fix,
+    /// `update_params` only carries `name`/`add`/`orchestrator`, so a second
+    /// `create_instance(team=X, repository_path=Y)` call silently drops Y and
+    /// `teams::update`'s set-or-preserve keeps the team's prior (possibly
+    /// absent) source_repo.
+    #[test]
+    fn create_team_on_existing_team_forwards_repository_path_2525() {
+        let home = tmp_home("repo-forward");
+        std::fs::write(
+            crate::fleet::fleet_yaml_path(&home),
+            "instances: {}\nteams:\n  sqd:\n    members: [sqd-lead]\n    orchestrator: sqd-lead\n",
+        )
+        .unwrap();
+        let ctx = test_ctx(&home);
+
+        let resp = handle_create_team(
+            &json!({
+                "name": "sqd",
+                "members": ["sqd-9"],
+                "repository_path": "/srv/canonical-repo",
+            }),
+            &ctx,
+        );
+        assert_eq!(resp["ok"], true, "extend must succeed: {resp}");
+
+        let cfg = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&home)).unwrap();
+        let team = cfg.teams.get("sqd").expect("team still present");
+        assert_eq!(
+            team.source_repo.as_deref(),
+            Some(std::path::Path::new("/srv/canonical-repo")),
+            "#2525: repository_path must reach the team block on the already-exists \
+             (teams::update) branch, got {:?}",
+            team.source_repo
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+}

--- a/src/api/handlers/team.rs
+++ b/src/api/handlers/team.rs
@@ -307,6 +307,15 @@ pub(crate) fn handle_create_team(params: &Value, ctx: &HandlerCtx) -> Value {
         if let Some(orch) = params.get("orchestrator").and_then(|v| v.as_str()) {
             update_params["orchestrator"] = json!(orch);
         }
+        // #2525: same allowlist-drop class as the orchestrator/repository_path/
+        // accept_from forwarding above (#1833/#1837) — this branch re-marshals
+        // into a fresh update_params too, and repository_path was never added
+        // here. teams::update reads args["repository_path"] (set-or-preserve),
+        // so without this a second create_instance(team=X, repository_path=Y)
+        // on an existing team silently drops Y.
+        if let Some(repo) = params.get("repository_path").and_then(|v| v.as_str()) {
+            update_params["repository_path"] = json!(repo);
+        }
         crate::teams::update(ctx.home, &update_params)
     } else {
         crate::teams::create(ctx.home, &team_params)


### PR DESCRIPTION
## Summary
- `handle_create_team`'s already-exists branch (hit when `create_instance(team=X)` targets an existing team, routed through `teams::update`) re-marshals params into a fresh `update_params` from an allowlist that omitted `repository_path` — same class of bug as #1833/#1837 fixed just above it in the new-team path, never applied here.
- Forwards `repository_path` into `update_params` so a second `create_instance(team=X, repository_path=Y)` call actually reaches `teams::update` (which reads `args["repository_path"]`, set-or-preserve) instead of silently dropping `Y`.

## Investigation note (per task spec, timeboxed 10min)
Checked whether `t-20260702132159428591-56872-1` (daemon restart loses `team update add` members + `project_id`) shares this mechanism. It does not: that bug's repro path goes through `handle_update_team`, which forwards `params` to `crate::teams::update` **unmodified** (no re-marshal/allowlist drop). The persistence bug looks like a disk-durability/race issue around the restart, not a param-forwarding omission — keeping it as a separate task.

## Test plan
- [x] RED: added `create_team_on_existing_team_forwards_repository_path_2525` (clean-room e2e via `handle_create_team`) — failed pre-fix (`source_repo: None`, expected `Some(...)`)
- [x] GREEN: fix applied, test passes
- [x] `cargo test --bin agend-terminal api::handlers::team::` — 5/5 pass, no regressions
- [x] `cargo test --bin agend-terminal teams::` — 36/36 pass, no regressions
- [x] `cargo clippy --bin agend-terminal --all-targets` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)