### PR TITLE
docs(known-issues): note opencode dummy-session wedge variant

### DIFF
--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -29,6 +29,18 @@ Status legend: **Upstream-blocker** (fix lives in another project) ·
   session is not resumed. This is an OpenCode-side bug, not an agend root fix.
 - **Revisit when:** OpenCode fixes the dummy-session id upstream.
 - **Refs:** #1526 (agend mitigation: #1519)
+- **Wedge variant (2026-07-02, needs-repro):** the same dummy-session bug can
+  also manifest as the OpenCode *process not exiting* — the TUI chrome keeps
+  rendering while the uncaught exception stack bleeds into the pane, and
+  agend's three existing detection layers (state-pattern classifier,
+  respawn-stuck watchdog, backend-exit detection) all miss it because the
+  process never crashes and no known error signature matches the stack. One
+  incident is captured (confirmed a real capture exists this time, contra an
+  earlier session's belief it was unrecoverable); a second sample is needed
+  before a detection pattern is added, to avoid false-positiving on
+  legitimate output (see t-20260702144219394508-56872-6). Structural
+  hardening for the watchdog side is tracked under the round-3 #2549 scope
+  rather than as a standalone fix.
 
 ## Deferred — awaiting operator capture or decision
 

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -40,7 +40,10 @@ Status legend: **Upstream-blocker** (fix lives in another project) ·
   before a detection pattern is added, to avoid false-positiving on
   legitimate output (see t-20260702144219394508-56872-6). Structural
   hardening for the watchdog side is tracked under the round-3 #2549 scope
-  rather than as a standalone fix.
+  rather than as a standalone fix. **If you hit this again: capture it BEFORE
+  restarting or otherwise intervening** — `pane_snapshot(to_file=true)` on the
+  wedged instance writes the full pane to `$AGEND_HOME/captures/`; a
+  restart/replace destroys the only evidence.
 
 ## Deferred — awaiting operator capture or decision
 

--- a/docs/KNOWN_ISSUES.zh-TW.md
+++ b/docs/KNOWN_ISSUES.zh-TW.md
@@ -33,7 +33,10 @@
   都接不住，因為行程從未真的崩潰，也沒有已知錯誤簽名能匹配這段堆疊。目前已存到一份
   真實 capture（推翻了先前一次 session 認為證據不可回收的判斷）；要再有第二個樣本才
   會補偵測 pattern，避免誤判合法輸出（見 t-20260702144219394508-56872-6）。
-  respawn_watchdog 側的結構性加固併入 round-3 #2549 的範圍，不另立單。
+  respawn_watchdog 側的結構性加固併入 round-3 #2549 的範圍，不另立單。**若再次遇到：
+  務必在 restart 或任何介入之前先存證**——對卡住的 instance 呼叫
+  `pane_snapshot(to_file=true)` 會把完整畫面寫進 `$AGEND_HOME/captures/`；一旦
+  restart/replace，唯一的證據就沒了。
 
 ## Deferred — 等待 operator 擷取資料或決策
 

--- a/docs/KNOWN_ISSUES.zh-TW.md
+++ b/docs/KNOWN_ISSUES.zh-TW.md
@@ -27,6 +27,13 @@
   bug，不是 agend 的根本修正。
 - **Revisit when：** OpenCode 在 upstream 修正 dummy-session id 的問題。
 - **Refs：** #1526（agend 緩解：#1519）
+- **半死 wedge 變體（2026-07-02，待重現）：** 同一個 dummy-session bug 也可能表現成
+  OpenCode 行程「不退出」——TUI 框架持續渲染，未捕捉例外的堆疊卻疊加在畫面上，agend
+  現有三層偵測（state-pattern 分類器、respawn-stuck watchdog、backend-exit 偵測）全
+  都接不住，因為行程從未真的崩潰，也沒有已知錯誤簽名能匹配這段堆疊。目前已存到一份
+  真實 capture（推翻了先前一次 session 認為證據不可回收的判斷）；要再有第二個樣本才
+  會補偵測 pattern，避免誤判合法輸出（見 t-20260702144219394508-56872-6）。
+  respawn_watchdog 側的結構性加固併入 round-3 #2549 的範圍，不另立單。
 
 ## Deferred — 等待 operator 擷取資料或決策
 


### PR DESCRIPTION
## Summary
- Adds a note to the existing "`opencode --continue` occasionally fails to resume" entry (both EN and zh-TW) documenting a variant where the process wedges instead of exiting, which none of agend's three existing detection layers catch.
- Follow-up to the round-2 opencode-resume spike, decision `d-20260702144005524658-3`.

## Test plan
- Docs-only change, no behavior touched — §3.10 test-first exemption applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)