### PR TITLE
refactor: #2548 W4a — provider_detect.rs single-provider axis collapse

### DIFF
--- a/src/provider_detect.rs
+++ b/src/provider_detect.rs
@@ -161,10 +161,8 @@ pub struct ProviderBlock {
     pub wire_api: Option<String>,
 }
 
-fn provider_block_matches_descriptor(
-    block: &ProviderBlock,
-    descriptor: ModelProviderDescriptor,
-) -> bool {
+fn provider_block_matches_fugu(block: &ProviderBlock) -> bool {
+    let descriptor = FUGU_PROVIDER_DESCRIPTOR;
     block.id.contains(descriptor.provider_id_hint)
         || block
             .base_url
@@ -179,16 +177,13 @@ fn host_from_url(url: &str) -> &str {
 }
 
 /// Parse a codex `config.toml` body and return the first provider block that
-/// matches `descriptor` — either the section id contains the descriptor's
+/// matches the Fugu/Sakana descriptor — either the section id contains
 /// `provider_id_hint` or its `base_url` host matches the descriptor host.
 ///
 /// Lightweight line scanner (no `toml` production dependency): tracks the
 /// current `[section]` header and collects simple `key = "value"` pairs until
 /// the next header. Good enough for detection; values are unquoted leniently.
-pub fn find_provider(
-    config_toml: &str,
-    descriptor: ModelProviderDescriptor,
-) -> Option<ProviderBlock> {
+pub fn find_sakana_provider(config_toml: &str) -> Option<ProviderBlock> {
     let mut blocks: Vec<ProviderBlock> = Vec::new();
     let mut cur: Option<ProviderBlock> = None;
 
@@ -241,23 +236,15 @@ pub fn find_provider(
     }
     flush(&mut cur, &mut blocks);
 
-    blocks
-        .into_iter()
-        .find(|b| provider_block_matches_descriptor(b, descriptor))
+    blocks.into_iter().find(provider_block_matches_fugu)
 }
 
-/// Back-compat helper for the first shipped provider.
-pub fn find_sakana_provider(config_toml: &str) -> Option<ProviderBlock> {
-    find_provider(config_toml, FUGU_PROVIDER_DESCRIPTOR)
-}
-
-/// Does a codex profile body (`<name>.config.toml`) select `descriptor` by
-/// provider id and/or model prefix? Returns the referenced `model_catalog_json`
-/// path when present so the caller can resolve the model list.
-pub fn profile_targets_provider(
-    profile_toml: &str,
-    descriptor: ModelProviderDescriptor,
-) -> Option<Option<String>> {
+/// Does a codex profile body (`<name>.config.toml`) select the Fugu/Sakana
+/// descriptor by provider id and/or model prefix? Returns the referenced
+/// `model_catalog_json` path when present so the caller can resolve the model
+/// list.
+pub fn profile_targets_fugu(profile_toml: &str) -> Option<Option<String>> {
+    let descriptor = FUGU_PROVIDER_DESCRIPTOR;
     let mut provider_matches = false;
     let mut model_matches = false;
     let mut catalog: Option<String> = None;
@@ -286,11 +273,6 @@ pub fn profile_targets_provider(
     } else {
         None
     }
-}
-
-/// Back-compat helper for the first shipped provider.
-pub fn profile_targets_fugu(profile_toml: &str) -> Option<Option<String>> {
-    profile_targets_provider(profile_toml, FUGU_PROVIDER_DESCRIPTOR)
 }
 
 /// Resolve whether a credential is usable from a provider's `env_key`, given an
@@ -795,13 +777,6 @@ mod tests {
         assert!(FIXED_PROVIDER_BACKENDS
             .iter()
             .all(|b| b.reason.contains("not bearer base_url")));
-    }
-
-    #[test]
-    fn generic_descriptor_finds_provider_by_host() {
-        let cfg = "[model_providers.anything]\nbase_url = 'https://api.sakana.ai/v1'\n";
-        let b = find_provider(cfg, FUGU_PROVIDER_DESCRIPTOR).expect("block");
-        assert_eq!(b.id, "anything");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Part of #2548 P1 Wave 4a (spike: `P1-2548-SPIKE.md` §5, decision `d-20260702214904234072-5`).

`provider_detect.rs` (1,116 → 1,091 LOC) had a generic multi-provider
parameterization — `find_provider(config, descriptor)` /
`profile_targets_provider(profile, descriptor)` plus single-provider
"back-compat" wrappers (`find_sakana_provider`, `profile_targets_fugu`)
that just called the generic version with `FUGU_PROVIDER_DESCRIPTOR`.

Verified via `rg`: **every** call site (both real callers — `cli.rs`,
`app/menu.rs` — and the module's own tests) always passes
`FUGU_PROVIDER_DESCRIPTOR`. `PROVIDER_DESCRIPTORS` has exactly one entry.
The two other CLI-adjacent backends (`kiro-cli`, `agy`) are explicitly
`FixedProviderBackend` — structurally non-swappable (fixed AWS-signed /
Google OAuth auth shapes), so a second descriptor is not a "not yet"
case, it's a "never" case. This is unused generality, collapsed to the
concrete single-provider functions.

**Scope note** (premise check per team practice before cutting further):
the issue also flagged "tri-state judgment + credential + cache" as
heavy. Traced both to real, live behavior:
- The tri-state `FuguStatus` (Available/ConfiguredNoCredential/NotConfigured)
  gates the Fugu menu item in `app/menu.rs` and drives `doctor providers`
  output in `cli.rs`.
- The probe/cache machinery (`ProviderProbeCache`, `probe_provider_models_fail_open`,
  TTL'd disk cache) backs the documented `doctor providers --probe` flag
  (`main.rs`'s `DoctorAction::Providers { probe: bool }`) — a real,
  fail-open network health check, not dead scaffolding.

Removing either would change `doctor providers`/menu observable output,
which is out of scope for this PR (behavior anchor per the task). Only
the generic-descriptor axis — genuinely unused — was cut.

## Changes
- Merge `find_provider`/`find_sakana_provider` → single `find_sakana_provider(config_toml)`, descriptor hardcoded internally.
- Merge `profile_targets_provider`/`profile_targets_fugu` → single `profile_targets_fugu(profile_toml)`.
- `provider_block_matches_descriptor(block, descriptor)` → `provider_block_matches_fugu(block)`.
- Removed one now-duplicate test (`generic_descriptor_finds_provider_by_host`, redundant with `finds_provider_by_base_url_host_even_with_other_id` once the generic function is gone).

No change to `cli.rs` / `app/menu.rs` — public API shape they consume (`detect_default`, `FuguStatus`, `FuguDetection`, `ensure_fugu_profile`, `default_codex_home`, `PROVIDER_DESCRIPTORS`, `FIXED_PROVIDER_BACKENDS`, `provider_probe_cache_path`, `probe_provider_models_fail_open`) is unchanged.

## Test plan
- [x] `cargo build` — clean
- [x] `cargo test --lib provider_detect` — 23/23 pass (was 24, one redundant test removed)
- [x] `cargo clippy --lib --bin agend-terminal -- -D warnings` — clean
- [x] `rg` sweep confirms no stale references to removed `find_provider`/`profile_targets_provider` names anywhere in the repo