### PR TITLE
test(teams): pin update-add-member + project_id restart survival (#2548)

### DIFF
--- a/src/teams.rs
+++ b/src/teams.rs
@@ -816,6 +816,84 @@ mod tests {
         std::fs::remove_dir_all(&home).ok();
     }
 
+    // ── team-update-persistence: `update add` + `project_id` must survive a
+    //    daemon restart (t-20260702132159428591-56872-1) ──
+
+    /// Reported 2026-07-02: `team create` survives a daemon rebuild+restart,
+    /// but a member added via a LATER `team update add=[...]` call does not
+    /// — the added instance comes back with `team=None` post-restart, and
+    /// its orchestrator's authority over it silently breaks.
+    ///
+    /// This drives the exact real code path (`create` then `update`, both
+    /// through the public API, no direct fleet.yaml poking) and re-reads
+    /// fleet.yaml with a FRESH `FleetConfig::load` call — not `list()`,
+    /// not any handle carried over from `create`/`update` — to simulate a
+    /// cold daemon boot re-parsing the file from scratch, the same way
+    /// #2552's `created_by` persistence was pinned.
+    #[test]
+    fn update_add_member_survives_fresh_fleet_reload_2548() {
+        let home = tmp_home("update-add-restart");
+        let created = create(
+            &home,
+            &serde_json::json!({"name": "gapfix", "members": ["lead"], "orchestrator": "lead"}),
+        );
+        assert_eq!(created["status"], "created", "{created}");
+
+        let updated = update(
+            &home,
+            &serde_json::json!({"name": "gapfix", "add": ["dev2"]}),
+        );
+        assert_eq!(updated["status"], "updated", "{updated}");
+
+        // Simulate a daemon restart: a brand-new, from-scratch parse of
+        // fleet.yaml, independent of anything `create`/`update` touched.
+        let reloaded = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&home))
+            .expect("fleet.yaml must parse on cold reload");
+        let team = reloaded
+            .teams
+            .get("gapfix")
+            .expect("team 'gapfix' must survive a cold reload");
+        assert!(
+            team.members.iter().any(|m| m == "dev2"),
+            "member added via `update add` must survive a cold fleet.yaml reload, got members={:?}",
+            team.members
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Same restart-survival contract as above, for `project_id` set via
+    /// `update` (not `create`) — the other half of the reported bug
+    /// (#2509's project_id, board-isolation-critical for `orchestrator`
+    /// task authority).
+    #[test]
+    fn update_project_id_survives_fresh_fleet_reload_2548() {
+        let home = tmp_home("update-project-id-restart");
+        let created = create(
+            &home,
+            &serde_json::json!({"name": "gapfix", "members": ["lead"]}),
+        );
+        assert_eq!(created["status"], "created", "{created}");
+
+        let updated = update(
+            &home,
+            &serde_json::json!({"name": "gapfix", "project_id": "Hack_agend-terminal"}),
+        );
+        assert_eq!(updated["status"], "updated", "{updated}");
+
+        let reloaded = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&home))
+            .expect("fleet.yaml must parse on cold reload");
+        let team = reloaded
+            .teams
+            .get("gapfix")
+            .expect("team 'gapfix' must survive a cold reload");
+        assert_eq!(
+            team.project_id.as_deref(),
+            Some("Hack_agend-terminal"),
+            "project_id set via `update` must survive a cold fleet.yaml reload"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
     // ── #1744-M7: deterministic + fail-closed self-orch verdict ──
     // (#1701's boolean `is_self_orchestrator` was replaced by the 3-state
     // `self_orch_status`; the Yes/No verdict is covered by


### PR DESCRIPTION
## Summary
- Adds two real-write + cold-`FleetConfig::load` reload tests for the reported bug (t-20260702132159428591-56872-1): `team update add=[...]` member roster and `project_id` set via `update` allegedly don't survive a daemon restart.
- Both tests are **GREEN** on current `main` — test-only, no production code change.

## Investigation trail (why test-only)
Traced the full persistence chain and found no code-level bug:
- `teams::update` → `update_team_in_yaml` → `mutate_fleet_yaml` re-reads fleet.yaml fresh under a file lock and writes synchronously (`atomic_write_yaml`, blocking, calls `invalidate_cache()`).
- MCP `team(action=update)`'s self-IPC forwarding (`api/handlers/team.rs` UPDATE_TEAM handler) does not re-marshal params — unlike the sibling CREATE_TEAM handler's historical "allowlist-drop" bug class (#1833/#1837/#2525), it passes params straight through to `teams::update`.
- `FleetConfig::load`'s mtime+size cache (`FLEET_CACHE`, #perf-R4) is a plain process-static `Mutex<Option<...>>` — empty on every fresh process, so it cannot explain data loss surviving into a new process.
- Both real boot paths converge on the same `bootstrap::resolve_fleet_and_reconcile`, which never touches `teams:` (only auto-creates `general` + prunes worktrees). Confirmed via `src/app/mod.rs:462` that the live fleet actually runs `app::run_app` (not `daemon::run_core`), and traced its `setup_app_bootstrap` to the same `bootstrap::prepare` → `resolve_fleet_and_reconcile` path.
- Cross-checked real `mcp-usage-stats.jsonl` telemetry: the `team(action=update, add=..., name=...)` calls at 2026-07-02T12:20:49Z/13:21:39Z line up with the reported "21:20 實測" — confirming the tests' call shape matches the real invocation.
- Checked every team read-path (`self_orch_status`, `find_team_for`, `is_orchestrator_of`, `resolve_team_orchestrator`, `get_members`) — all read fresh via `FleetConfig::load`, no independent cache.
- Checked the actual `list_instances` MCP tool response shape (`api/handlers/query.rs::list_response`) — it has **no `team` field at all** in its per-agent JSON in the current codebase, so the originally-reported "list_instances showed team=None" observation couldn't have come from this tool's current output structure.

Full trail: decision `d-20260703010124992646-10`.

Keeping the two tests as regression pins and to save the next investigator this round's legwork, per lead (claude-aef7c0) direction — task closes as a documented negative result / needs-second-sample (dev2 and dev3's own team membership is a live, zero-cost canary for the next real daemon restart).

## Test plan
- [x] `cargo test --bin agend-terminal -- teams::` — 38 passed, 0 failed
- [x] `cargo fmt --check` clean