### PR TITLE
feat(discord): P1 — bootstrap wiring

### DIFF
--- a/src/bootstrap/discord_init.rs
+++ b/src/bootstrap/discord_init.rs
@@ -1,0 +1,186 @@
+//! Discord bootstrap — wraps [`crate::channel::discord::init_from_config`],
+//! mirroring `bootstrap::telegram_init`'s fire-and-forget shape (#2562 P1).
+//!
+//! Unlike Telegram's `init_from_config` (which does ~6s of sequential
+//! `create_forum_topic` HTTP calls before returning), Discord's
+//! `init_from_config` returns quickly — it only resolves the token and
+//! starts the gateway connection in its own background thread ([`start_gateway`],
+//! #2562 P0). Still run on a background thread here for the same reason
+//! Telegram is: keep `resolve_fleet_and_reconcile` off any per-channel I/O,
+//! and to match the established two-step pattern (`register_active_channel`
+//! then `attach_pending_registry_when_ready`) exactly.
+//!
+//! [`start_gateway`]: crate::channel::discord::start_gateway
+
+use crate::channel::Channel;
+use crate::fleet::FleetConfig;
+use std::sync::Arc;
+
+/// Initialize the Discord channel when `channel:`/`channels:` configures
+/// `type: discord` and the bot token env var is set. Always returns `None`
+/// in production — actual init runs in a background thread and registers
+/// the channel via [`crate::channel::register_active_channel`] on
+/// completion. Callers should query `active_channel()` rather than relying
+/// on this return (mirrors `bootstrap::telegram_init::init` exactly).
+///
+/// Discord has no `UxEventSink`/`fleet_binding` equivalent yet (Telegram-only
+/// today — no current Discord consumer), so unlike telegram_init this does
+/// NOT register with `ux_sink_registry()`.
+pub(super) fn init(config: &FleetConfig) -> Option<Arc<dyn Channel>> {
+    let config_clone = config.clone();
+    // fire-and-forget: mirrors telegram_init's rationale — init resolves the
+    // token and starts the gateway connection on ITS OWN thread (#2562 P0),
+    // so this thread's own work is fast, but keeping it backgrounded avoids
+    // adding a synchronous env-var/config-parse step to the critical cold-
+    // boot path for a channel most fleets don't use. NO JoinHandle needed —
+    // thread terminates once init completes; process exit cleans it up.
+    let spawn_result = std::thread::Builder::new()
+        .name("discord_init".into())
+        .spawn(move || {
+            let _census = crate::thread_census::register("discord_init");
+            let Some(channel) = crate::channel::discord::init_from_config(&config_clone) else {
+                tracing::info!("discord init: skipped (no token / no config)");
+                return;
+            };
+            let channel_dyn: Arc<dyn Channel> = Arc::new(channel) as Arc<dyn Channel>;
+            crate::channel::register_active_channel(Arc::clone(&channel_dyn));
+            tracing::info!("discord init: channel registered");
+            attach_pending_registry_when_ready(channel_dyn);
+        });
+    if let Err(e) = spawn_result {
+        tracing::error!(error = %e, "discord_init: failed to spawn background thread");
+    }
+    // Always return None — callers must use `active_channel()` to discover
+    // the registered channel post-init.
+    None
+}
+
+/// Poll `crate::agent::get_pending_registry` until the caller has published
+/// the registry, then call `attach_registry`. Bounded poll (30s, 100ms
+/// cadence) — identical contract to
+/// `bootstrap::telegram_init::attach_pending_registry_when_ready`.
+fn attach_pending_registry_when_ready(channel: Arc<dyn Channel>) {
+    attach_pending_registry_when_ready_with_deadline(
+        channel,
+        std::time::Instant::now() + std::time::Duration::from_secs(30),
+    );
+}
+
+/// Test seam: deadline-injectable variant of
+/// [`attach_pending_registry_when_ready`].
+fn attach_pending_registry_when_ready_with_deadline(
+    channel: Arc<dyn Channel>,
+    deadline: std::time::Instant,
+) {
+    loop {
+        if let Some(registry) = crate::agent::get_pending_registry() {
+            channel.attach_registry(registry);
+            tracing::info!("discord init: attach_registry complete");
+            return;
+        }
+        if std::time::Instant::now() >= deadline {
+            tracing::warn!(
+                "discord init: pending registry never published within deadline — inbound \
+                 discord messages will not route to agents until daemon restart. This \
+                 indicates a bug in caller setup ordering."
+            );
+            return;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::agent::AgentRegistry;
+    use parking_lot::Mutex;
+    use std::collections::HashMap;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    /// Mock Channel that records whether `attach_registry` was called.
+    /// Mirrors `bootstrap::telegram_init::tests::MockChannel`.
+    struct MockChannel {
+        attached: AtomicBool,
+        caps: crate::channel::ChannelCapabilities,
+    }
+
+    impl MockChannel {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                attached: AtomicBool::new(false),
+                caps: crate::channel::ChannelCapabilities::default(),
+            })
+        }
+    }
+
+    impl crate::channel::Channel for MockChannel {
+        fn kind(&self) -> &'static str {
+            "mock-2562-test"
+        }
+        fn caps(&self) -> &crate::channel::ChannelCapabilities {
+            &self.caps
+        }
+        fn poll_event(&self) -> Option<crate::channel::ChannelEvent> {
+            None
+        }
+        fn send(
+            &self,
+            _: &crate::channel::BindingRef,
+            _: crate::channel::OutMsg,
+        ) -> anyhow::Result<crate::channel::MsgRef> {
+            anyhow::bail!("mock")
+        }
+        fn edit(
+            &self,
+            _: &crate::channel::MsgRef,
+            _: crate::channel::OutMsg,
+        ) -> anyhow::Result<()> {
+            anyhow::bail!("mock")
+        }
+        fn delete(&self, _: &crate::channel::MsgRef) -> anyhow::Result<()> {
+            anyhow::bail!("mock")
+        }
+        fn create_binding(
+            &self,
+            _: &str,
+            _: crate::channel::BindingOpts,
+        ) -> anyhow::Result<crate::channel::BindingRef> {
+            anyhow::bail!("mock")
+        }
+        fn remove_binding(&self, _: &crate::channel::BindingRef) -> anyhow::Result<()> {
+            anyhow::bail!("mock")
+        }
+        fn has_binding(&self, _: &str) -> bool {
+            false
+        }
+        fn record_binding(&self, _: &str, _: crate::channel::BindingRef, _: String) {}
+        fn take_binding(&self, _: &str) -> Option<crate::channel::BindingRef> {
+            None
+        }
+        fn attach_registry(&self, _registry: AgentRegistry) {
+            self.attached.store(true, Ordering::Relaxed);
+        }
+    }
+
+    /// attach_pending_registry_when_ready calls `attach_registry` once the
+    /// caller publishes a registry — deterministic, no sleep-based timing.
+    /// Mirrors `bootstrap::telegram_init::tests::attach_pending_registry_when_ready_attaches_after_publish_945`.
+    #[test]
+    fn attach_pending_registry_when_ready_attaches_after_publish_2562() {
+        let registry: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
+        crate::agent::set_pending_registry(Arc::clone(&registry));
+
+        let mock = MockChannel::new();
+        let channel_dyn: Arc<dyn crate::channel::Channel> =
+            mock.clone() as Arc<dyn crate::channel::Channel>;
+        attach_pending_registry_when_ready(channel_dyn);
+
+        assert!(
+            mock.attached.load(Ordering::Relaxed),
+            "attach_registry must have been called on the mock channel once the pending \
+             registry was published"
+        );
+    }
+}

--- a/src/bootstrap/doctor.rs
+++ b/src/bootstrap/doctor.rs
@@ -508,6 +508,7 @@ mod tests {
             channel: Some(ChannelConfig::Discord {
                 bot_token_env: "AGEND_DISCORD_BOT_TOKEN".into(),
                 guild_id: 123,
+                user_allowlist: None,
             }),
             ..Default::default()
         };

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -16,11 +16,29 @@ mod agent_resolve;
 mod attach_detect;
 pub(crate) mod canonical_hygiene;
 pub mod daemon_spawn;
+#[cfg(feature = "discord")]
+mod discord_init;
 pub(crate) mod doctor;
 pub(crate) mod doctor_topics;
 mod fleet_normalize;
 pub mod signals;
 mod telegram_init;
+
+/// #2562 P1: `channel::discord` (and this module's own `discord_init`) only
+/// exist behind the `discord` feature — this wrapper keeps
+/// `resolve_fleet_and_reconcile` callable unconditionally regardless of
+/// whether the feature is compiled in.
+#[cfg(feature = "discord")]
+fn maybe_init_discord(config: &crate::fleet::FleetConfig, enabled: bool) {
+    if enabled {
+        time_step("discord_init::init", || {
+            discord_init::init(config);
+        });
+    }
+}
+
+#[cfg(not(feature = "discord"))]
+fn maybe_init_discord(_config: &crate::fleet::FleetConfig, _enabled: bool) {}
 
 pub use agent_resolve::AgentDef;
 
@@ -128,6 +146,10 @@ pub struct PrepareOptions {
     /// If true, initialize Telegram polling when `channel:` is configured.
     /// Set false for tests that don't need real bot traffic.
     pub init_telegram: bool,
+    /// If true, initialize the Discord gateway connection when
+    /// `channel:`/`channels:` configures `type: discord` (#2562 P1). Set
+    /// false for tests that don't need a real bot connection.
+    pub init_discord: bool,
     /// If true, resolve every fleet instance into an [`AgentDef`] (creates
     /// worktrees, generates instructions, appends resume/model/Claude flags).
     /// Set false for app mode, where pane_factory spawns on demand from tabs
@@ -140,6 +162,7 @@ impl Default for PrepareOptions {
         Self {
             mutate_fleet_yaml: true,
             init_telegram: true,
+            init_discord: true,
             resolve_agents: true,
         }
     }
@@ -322,6 +345,16 @@ pub(crate) fn resolve_fleet_and_reconcile(
     } else {
         None
     };
+
+    // #2562 P1: mirrors telegram_init's fire-and-forget shape exactly, but
+    // its result isn't threaded through `ResolvedFleet`/`OwnedFleet` the way
+    // `telegram` is above — `telegram_init::init` ALSO always returns `None`
+    // in production (real registration happens async via
+    // `register_active_channel`), so that field is already inert on every
+    // real code path; adding a second always-`None` slot for symmetry alone
+    // would be speculative surface with no consumer. Callers on both
+    // channels discover the real registered channel via `active_channel()`.
+    maybe_init_discord(&config, opts.init_discord);
 
     // agend-git-shim init (shared by daemon + app mode).
     time_step("protocol::extract_default", || {
@@ -576,6 +609,7 @@ mod tests {
         let opts = PrepareOptions {
             mutate_fleet_yaml: false,
             init_telegram: false,
+            init_discord: false,
             resolve_agents: false,
         };
         let outcome = prepare(&home, &fleet, opts).expect("prepare");
@@ -605,6 +639,7 @@ mod tests {
         let opts = PrepareOptions {
             mutate_fleet_yaml: false,
             init_telegram: false,
+            init_discord: false,
             resolve_agents: false,
         };
         let outcome = prepare(&home, &fleet, opts).expect("prepare");
@@ -641,6 +676,7 @@ mod tests {
         let opts = PrepareOptions {
             mutate_fleet_yaml: false,
             init_telegram: false,
+            init_discord: false,
             resolve_agents: false,
         };
         let err = match prepare(&home, &fleet, opts) {
@@ -669,6 +705,7 @@ mod tests {
         let opts = PrepareOptions {
             mutate_fleet_yaml: false,
             init_telegram: false,
+            init_discord: false,
             resolve_agents: false,
         };
         let outcome = prepare(&home, &fleet, opts).expect("prepare");
@@ -709,6 +746,7 @@ mod tests {
         let opts = PrepareOptions {
             mutate_fleet_yaml: false,
             init_telegram: false,
+            init_discord: false,
             resolve_agents: false,
         };
         let outcome = prepare(&home, &fleet, opts).expect("prepare");
@@ -737,6 +775,7 @@ mod tests {
         let opts = PrepareOptions {
             mutate_fleet_yaml: false,
             init_telegram: false,
+            init_discord: false,
             resolve_agents: true,
         };
         let outcome = prepare(&home, &fleet, opts).expect("prepare");
@@ -877,6 +916,7 @@ mod tests {
         let opts = PrepareOptions {
             mutate_fleet_yaml: false,
             init_telegram: false,
+            init_discord: false,
             resolve_agents: false,
         };
         let _ = prepare(&home, &fleet, opts).expect("prepare must succeed");

--- a/src/channel/discord.rs
+++ b/src/channel/discord.rs
@@ -458,6 +458,65 @@ pub(crate) fn start_gateway(
 }
 
 // ---------------------------------------------------------------------------
+// Bootstrap (#2562 P1)
+// ---------------------------------------------------------------------------
+
+/// Intents this adapter requests — matches the shape already pinned by
+/// `discord_gateway_identify_shape_matches_spec` (PR1, 2026-04-29): guild
+/// membership + message content, the minimum needed to receive
+/// `MESSAGE_CREATE` for a bound channel.
+fn discord_intents() -> twilight_model::gateway::Intents {
+    twilight_model::gateway::Intents::GUILDS
+        | twilight_model::gateway::Intents::GUILD_MESSAGES
+        | twilight_model::gateway::Intents::MESSAGE_CONTENT
+}
+
+/// Initialize Discord from fleet config: on `Some`, the gateway connection
+/// is ALREADY running (via [`start_gateway`]) and the returned
+/// [`DiscordChannel`] is ready to register. Returns `None` when Discord
+/// isn't configured or the bot token env var isn't set — mirrors
+/// `channel::telegram::init_from_config`'s not-configured contract so
+/// callers can treat both channels symmetrically.
+pub fn init_from_config(config: &crate::fleet::FleetConfig) -> Option<DiscordChannel> {
+    let (bot_token_env, guild_id, user_allowlist) = match config.channel.as_ref()? {
+        crate::fleet::ChannelConfig::Telegram { .. } => return None,
+        crate::fleet::ChannelConfig::Discord {
+            bot_token_env,
+            guild_id,
+            user_allowlist,
+        } => (bot_token_env, *guild_id, user_allowlist.clone()),
+    };
+    let token = match std::env::var(bot_token_env) {
+        Ok(t) => t,
+        Err(_) => {
+            tracing::info!(env = %bot_token_env, "discord bot token env not set, skipping");
+            return None;
+        }
+    };
+    if user_allowlist.is_none() {
+        tracing::warn!(
+            "discord channel.user_allowlist is not set — fail-closed default: ALL inbound \
+             messages are dropped. Set `user_allowlist: [123456789012345678]` in fleet.yaml \
+             to enable the channel."
+        );
+    }
+
+    // twilight_gateway::Config::new and twilight_http::Client::new each
+    // add the `Bot ` prefix themselves if it's missing (checked, so this
+    // stays correct even if an operator pastes an already-prefixed token)
+    // — pass the raw token to both, per their documented contract.
+    let (tx, rx) = mpsc::channel();
+    start_gateway(token.clone(), discord_intents(), user_allowlist.clone(), tx);
+    let http_client = std::sync::Arc::new(twilight_http::Client::new(token));
+    Some(DiscordChannel::new(
+        rx,
+        user_allowlist,
+        http_client,
+        guild_id,
+    ))
+}
+
+// ---------------------------------------------------------------------------
 // Outbound request body construction
 // ---------------------------------------------------------------------------
 

--- a/src/fleet/mod.rs
+++ b/src/fleet/mod.rs
@@ -265,8 +265,8 @@ pub enum ChannelConfig {
         #[serde(default)]
         fleet_binding: Option<FleetBindingConfig>,
     },
-    /// Discord adapter (Phase 2+). Bootstrap selection lands in Phase 1;
-    /// actual adapter implementation is behind the `discord` feature gate.
+    /// Discord adapter. Bootstrap wiring landed #2562 P1; the adapter
+    /// implementation is behind the `discord` feature gate.
     #[serde(rename = "discord")]
     Discord {
         /// Env var name containing the Discord bot token.
@@ -274,6 +274,22 @@ pub enum ChannelConfig {
         bot_token_env: String,
         /// Discord guild (server) ID.
         guild_id: u64,
+        /// Optional allowlist of Discord user IDs (snowflakes) permitted to
+        /// command the fleet via messages.
+        ///
+        /// - `None` (field omitted): fail-closed — every inbound message is
+        ///   dropped (see `channel::auth::is_authorized_recipient`,
+        ///   `channel::discord::map_message_create_to_message_in`).
+        /// - `Some([])`: reject all — same effect as `None` today, but
+        ///   explicit in fleet.yaml.
+        /// - `Some([...])`: only those user IDs are accepted.
+        ///
+        /// Unlike Telegram's `user_allowlist` (`Vec<AllowlistEntry>`),
+        /// entries are bare snowflakes — Discord messages always carry a
+        /// real username (`msg.author.name`), so there's no "no public
+        /// handle" case needing an operator-supplied display name.
+        #[serde(default)]
+        user_allowlist: Option<Vec<i64>>,
     },
 }
 


### PR DESCRIPTION
## Summary
refs #2562 P1. Wires P0's gateway connection into real daemon/app startup — `ChannelConfig::Discord` in fleet.yaml now actually constructs a live `DiscordChannel` instead of every consumer treating it as a no-op.

- `channel::discord::init_from_config(config)` — resolves the bot token, starts the gateway connection (P0's `start_gateway`), builds the HTTP client, returns a ready `DiscordChannel`. Mirrors Telegram's not-configured contract.
- `bootstrap/discord_init.rs` — fire-and-forget background-thread wrapper, structurally identical to `bootstrap/telegram_init.rs`.
- Wired into `resolve_fleet_and_reconcile` via `PrepareOptions.init_discord` (default true). Entirely `#[cfg(feature = "discord")]`-gated with a no-op fallback so the default build is unaffected.

**Necessary schema fix found here**: `ChannelConfig::Discord` had no `user_allowlist` field at all — every inbound message would have been fail-closed-dropped forever with no way to configure it. Added `user_allowlist: Option<Vec<i64>>` (`#[serde(default)]`, backward compatible, fail-closed default unchanged). Without this, P3's E2E smoke test would be impossible regardless of how correct P0/P1 are.

## Test plan
- [x] `cargo test --features discord` — 35/35 discord+bootstrap tests green
- [x] Full suite (both with and without `--features discord`) diffed against the established baseline — byte-identical 246 pre-existing sandboxed-CI failures, zero new regressions
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --features discord -- -D warnings` clean
- [x] `cargo clippy --all-targets --features tray -- -D warnings` (default CI combo) clean

Agend-Agent: gapfix-dev
Agend-Task: t-20260703004200930774-56872-29