### PR TITLE
refactor(#2549 W2): merge dispatch_idle + decision_timeout tracker wrapper slots

### DIFF
--- a/src/daemon/per_tick/mod.rs
+++ b/src/daemon/per_tick/mod.rs
@@ -92,9 +92,8 @@ pub(crate) use shadow_observe::ShadowObserveHandler;
 pub(crate) use snapshot::SnapshotRotationHandler;
 pub(crate) use supervisor_trackers::{
     AntiStallHandler, AutoReleaseHandler, CanonicalDriftHandler, ConflictNotifyHandler,
-    DecisionBoardTimeoutHandler, DecisionTimeoutHandler, DispatchIdleHandler,
-    DispatchIdleNudgeHandler, HelperStalenessHandler, IdleWatchdogHandler, McpRegistryHandler,
-    RetentionHandler, WaitingOnStaleHandler,
+    DecisionTimeoutHandler, DispatchIdleHandler, HelperStalenessHandler, IdleWatchdogHandler,
+    McpRegistryHandler, RetentionHandler, WaitingOnStaleHandler,
 };
 pub(crate) use thread_dump::ThreadDumpHandler;
 pub(crate) use watchdog::WatchdogHandler;
@@ -429,10 +428,18 @@ pub(crate) fn build_default_handlers(
         // ticks at the identical 10s interval and holds no lock across them, so
         // this is behavior-preserving on unix (both run_core and app mode).
         // Cadence-hoist to the handler (`should_fire`) is W2.4, not W1.1.
+        //
+        // #2549 W2 (P2-2549-SPIKE.md §3d, decision `d-20260702044452277394-4`):
+        // `DecisionTimeoutHandler` now also runs the former
+        // `DecisionBoardTimeoutHandler`'s scan, and `DispatchIdleHandler` now
+        // also runs the former `DispatchIdleNudgeHandler`'s scan — WRAPPER-layer
+        // registration-slot merges only (40 → 38 handlers); the four underlying
+        // tracker modules (dispatch_idle/mod.rs, dispatch_idle/team_nudge.rs,
+        // decision_timeout.rs, decision_board_timeout.rs) are untouched. See
+        // `supervisor_trackers.rs` for the per-scan panic-isolation wrapper.
         Box::new(AntiStallHandler::new()),
         Box::new(IdleWatchdogHandler::new()),
         Box::new(DecisionTimeoutHandler::new()),
-        Box::new(DecisionBoardTimeoutHandler::new()),
         Box::new(HelperStalenessHandler::new()),
         Box::new(McpRegistryHandler::new(daemon_binary_stale)),
         Box::new(WaitingOnStaleHandler::new()),
@@ -440,7 +447,6 @@ pub(crate) fn build_default_handlers(
         Box::new(CanonicalDriftHandler::new()),
         Box::new(AutoReleaseHandler::new()),
         Box::new(DispatchIdleHandler::new()),
-        Box::new(DispatchIdleNudgeHandler::new()),
         Box::new(RetentionHandler::new()),
         // #2127 Phase 1: reclaim board tasks from agents stuck in a non-recoverable
         // usage_limit window (operator decision d-…085112: Phase 1, grace=10min).

--- a/src/daemon/per_tick/supervisor_trackers.rs
+++ b/src/daemon/per_tick/supervisor_trackers.rs
@@ -88,18 +88,45 @@ tracker_handler!(
     IdleWatchdogHandler => IdleWatchdogTracker, "idle_watchdog"
 );
 
-tracker_handler!(
-    /// Sprint 59 Wave 1 PR-4-recover (B): operator-decision auto-default on
-    /// timeout, 5min throttle.
-    DecisionTimeoutHandler => DecisionTimeoutTracker, "decision_timeout"
-);
-
-tracker_handler!(
-    /// #2524 P2c / #2313: decision-board per-decision timeout+default,
-    /// 5min throttle. NOT the same tracker as `DecisionTimeoutHandler`
-    /// above (see `daemon::decision_board_timeout` module doc for why).
-    DecisionBoardTimeoutHandler => DecisionBoardTimeoutTracker, "decision_board_timeout"
-);
+/// #2549 W2 (P2-2549-SPIKE.md §3d): merges ONLY the per-tick WRAPPER slot for
+/// the former `DecisionTimeoutHandler` + `DecisionBoardTimeoutHandler` into
+/// one registered [`PerTickHandler`] (40 → 39 handlers in
+/// `build_default_handlers`, paired with the `dispatch_idle` merge below for
+/// 40 → 38 total). The underlying trackers stay separate, UNTOUCHED modules:
+/// `daemon::decision_board_timeout`'s module doc records operator decision
+/// `d-20260702044452277394-4` — their store/data-model/routing genuinely
+/// differ (single-sender-cancels-prior sidecar vs. multi-author board; fixed
+/// fleet-wide recipient vs. per-decision author) — so this is NOT a logic
+/// merge, only a registration-slot collapse (same shape as W1's
+/// `HourlyGcHandler`). Each sub-scan keeps its own `CadenceGate` and
+/// self-throttles exactly as before; `run_scan_isolated` reproduces the
+/// pre-merge per-handler panic isolation at per-scan granularity (§3a
+/// precedent — see `hourly_gc::run_sweep_isolated`).
+pub(crate) struct DecisionTimeoutHandler {
+    decision_timeout: Mutex<DecisionTimeoutTracker>,
+    decision_board_timeout: Mutex<DecisionBoardTimeoutTracker>,
+}
+impl DecisionTimeoutHandler {
+    pub(crate) fn new() -> Self {
+        Self {
+            decision_timeout: Mutex::new(DecisionTimeoutTracker::default()),
+            decision_board_timeout: Mutex::new(DecisionBoardTimeoutTracker::default()),
+        }
+    }
+}
+impl PerTickHandler for DecisionTimeoutHandler {
+    fn name(&self) -> &'static str {
+        "decision_timeout"
+    }
+    fn run(&self, ctx: &TickContext<'_>) {
+        run_scan_isolated("decision_timeout", || {
+            self.decision_timeout.lock().maybe_scan(ctx.home);
+        });
+        run_scan_isolated("decision_board_timeout", || {
+            self.decision_board_timeout.lock().maybe_scan(ctx.home);
+        });
+    }
+}
 
 tracker_handler!(
     /// Sprint 59 Wave 2 PR-3 (#13): deployment-cadence helper-staleness ping.
@@ -199,15 +226,42 @@ tracker_handler!(
     AutoReleaseHandler => AutoReleaseTracker, "auto_release"
 );
 
-tracker_handler!(
-    /// PR1 watchdog L1: cross-team-safe dispatch-idle scan (~60s, internal).
-    DispatchIdleHandler => DispatchIdleTracker, "dispatch_idle"
-);
-
-tracker_handler!(
-    /// PR1 watchdog L2: generic per-team auto-nudge on exceeded dispatches.
-    DispatchIdleNudgeHandler => DispatchIdleNudgeTracker, "dispatch_idle_nudge"
-);
+/// #2549 W2 (P2-2549-SPIKE.md §3d): merges ONLY the per-tick WRAPPER slot for
+/// the former `DispatchIdleHandler` (PR1 watchdog L1) + `DispatchIdleNudgeHandler`
+/// (PR1 watchdog L2) into one registered [`PerTickHandler`]. Unlike the
+/// Decision pair above, L1/L2 already share the same `PendingDispatch` sidecar
+/// schema and live in the same module tree (`team_nudge` is a submodule of
+/// `dispatch_idle`) — no separate-decision boundary applies here, but this PR
+/// still touches ONLY the wrapper: `dispatch_idle/mod.rs` and
+/// `dispatch_idle/team_nudge.rs` are untouched. Each sub-scan keeps its own
+/// `CadenceGate` and self-throttles exactly as before; `run_scan_isolated`
+/// reproduces the pre-merge per-handler panic isolation at per-scan
+/// granularity.
+pub(crate) struct DispatchIdleHandler {
+    dispatch_idle: Mutex<DispatchIdleTracker>,
+    dispatch_idle_nudge: Mutex<DispatchIdleNudgeTracker>,
+}
+impl DispatchIdleHandler {
+    pub(crate) fn new() -> Self {
+        Self {
+            dispatch_idle: Mutex::new(DispatchIdleTracker::default()),
+            dispatch_idle_nudge: Mutex::new(DispatchIdleNudgeTracker::default()),
+        }
+    }
+}
+impl PerTickHandler for DispatchIdleHandler {
+    fn name(&self) -> &'static str {
+        "dispatch_idle"
+    }
+    fn run(&self, ctx: &TickContext<'_>) {
+        run_scan_isolated("dispatch_idle", || {
+            self.dispatch_idle.lock().maybe_scan(ctx.home);
+        });
+        run_scan_isolated("dispatch_idle_nudge", || {
+            self.dispatch_idle_nudge.lock().maybe_scan(ctx.home);
+        });
+    }
+}
 
 /// Retention sweep (review-task / tmp GC supervisor).
 pub(crate) struct RetentionHandler {
@@ -229,8 +283,67 @@ impl PerTickHandler for RetentionHandler {
     }
 }
 
-/// The 12 supervisor trackers migrated by W1.1, in the relative order they ran
-/// in the supervisor `run_loop` (supervisor.rs:384-395, pre-W1.1). The
+/// Run one sub-scan isolated from its merged sibling — the per-scan
+/// equivalent of the outer per-tick loop's per-HANDLER `catch_unwind`, so a
+/// panic in one tracker's scan can never block the other tracker sharing its
+/// registration slot this tick (#2549 W2, mirrors `hourly_gc::run_sweep_isolated`).
+fn run_scan_isolated(name: &'static str, f: impl FnOnce()) {
+    let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        #[cfg(test)]
+        test_hooks::record_and_maybe_force_panic(name);
+        f()
+    }));
+    if let Err(payload) = outcome {
+        tracing::error!(
+            scan = name,
+            error = %super::panic_payload_str(&payload),
+            "supervisor_trackers: merged-handler sub-scan panicked — isolated, its sibling still ran"
+        );
+    }
+}
+
+/// Test-only fault-injection seam for [`run_scan_isolated`] — proves the
+/// per-scan isolation property against the REAL merged handlers (not a mock),
+/// without needing to trigger a genuine panic from inside either tracker's
+/// real logic. Mirrors `hourly_gc`'s identically-shaped `test_hooks`.
+#[cfg(test)]
+mod test_hooks {
+    use std::cell::{Cell, RefCell};
+
+    thread_local! {
+        static FORCE_PANIC: Cell<Option<&'static str>> = const { Cell::new(None) };
+        static INVOKED: RefCell<Vec<&'static str>> = const { RefCell::new(Vec::new()) };
+    }
+
+    /// Records that `name`'s scan was reached, then panics if
+    /// `force_panic(name)` armed this name.
+    pub(super) fn record_and_maybe_force_panic(name: &'static str) {
+        INVOKED.with(|v| v.borrow_mut().push(name));
+        if FORCE_PANIC.with(|p| p.get()) == Some(name) {
+            panic!("fault-injection: forced panic in scan '{name}'");
+        }
+    }
+
+    pub(super) fn force_panic(name: &'static str) {
+        FORCE_PANIC.with(|p| p.set(Some(name)));
+    }
+
+    pub(super) fn clear_force_panic() {
+        FORCE_PANIC.with(|p| p.set(None));
+    }
+
+    pub(super) fn take_invoked() -> Vec<&'static str> {
+        INVOKED.with(|v| std::mem::take(&mut *v.borrow_mut()))
+    }
+}
+
+/// The supervisor trackers migrated by W1.1 (originally 12; #2549 W2 folded
+/// `dispatch_idle_nudge`'s registration into `dispatch_idle`'s slot, so this
+/// pinned list is now 11 — the merged `DispatchIdleHandler::run` still invokes
+/// BOTH sub-scans every tick, proven by
+/// `dispatch_idle_merge_runs_both_scans_with_no_panic` below, not just by this
+/// name-presence check), in the relative order they
+/// ran in the supervisor `run_loop` (supervisor.rs:384-395, pre-W1.1). The
 /// completeness invariant below pins this exact list against the registered
 /// handler set.
 #[cfg(test)]
@@ -245,17 +358,35 @@ pub(crate) const MIGRATED_TRACKER_NAMES: &[&str] = &[
     "canonical_drift",
     "auto_release",
     "dispatch_idle",
-    "dispatch_idle_nudge",
     "retention",
 ];
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
-    use super::MIGRATED_TRACKER_NAMES;
+    use super::*;
+    use crate::agent::{AgentRegistry, ExternalRegistry};
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    fn tmp_home(tag: &str) -> std::path::PathBuf {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "agend-supervisor-trackers-{}-{}-{}",
+            std::process::id(),
+            tag,
+            id
+        ));
+        std::fs::create_dir_all(&dir).ok();
+        dir
+    }
 
     /// W1.1 completeness invariant (#2050; the #1002 / #1719 app-mode-wiring-
-    /// drift class applied to the supervisor → handler migration).
+    /// drift class applied to the supervisor → handler migration). Updated by
+    /// #2549 W2 for the `dispatch_idle`/`dispatch_idle_nudge` slot merge (see
+    /// [`MIGRATED_TRACKER_NAMES`] doc).
     ///
     /// Every tracker moved off the supervisor `run_loop` MUST be registered in
     /// `build_default_handlers`. The existing `app_tick_handlers_cover_*`
@@ -263,10 +394,10 @@ mod tests {
     /// from BOTH the daemon and app sets, so their set-difference stays empty and
     /// that test stays green. This one pins the full expected set against the
     /// registered handler names directly, so dropping (or never adding) a tracker
-    /// fails CI. It also asserts the 12 keep their original RELATIVE order —
-    /// handler order in the `build_default_handlers` Vec is load-bearing.
+    /// fails CI. It also asserts the pinned names keep their original RELATIVE
+    /// order — handler order in the `build_default_handlers` Vec is load-bearing.
     #[test]
-    fn all_twelve_supervisor_trackers_registered_in_order() {
+    fn all_migrated_supervisor_trackers_registered_in_order() {
         let (crash_tx, _rx) = crossbeam_channel::bounded(1);
         let stale: crate::daemon::mcp_registry_watcher::DaemonBinaryStale =
             std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
@@ -297,7 +428,7 @@ mod tests {
         sorted.sort_unstable();
         assert_eq!(
             positions, sorted,
-            "the 12 migrated trackers must keep their original relative order (load-bearing); positions={positions:?}"
+            "the migrated trackers must keep their original relative order (load-bearing); positions={positions:?}"
         );
 
         // No duplicate handler names (HANDLER_TIMING + the completeness invariant
@@ -311,5 +442,130 @@ mod tests {
             uniq.len(),
             "handler names must be unique — got {names:?}"
         );
+    }
+
+    /// #2549 W2 pin (mirrors `hourly_gc`'s panic-isolation tests, §3a
+    /// precedent applied to §3d): the outer per-tick loop used to isolate
+    /// panics PER-HANDLER — `decision_timeout` and the former
+    /// `decision_board_timeout` were separately registered, so a panic in one
+    /// never touched the other's invocation this tick. After merging them
+    /// into one registered `DecisionTimeoutHandler`, that guarantee must be
+    /// reproduced INSIDE `run()` at per-scan granularity. Force the FIRST
+    /// scan to panic and assert (a) `run()` itself does not propagate the
+    /// panic, and (b) both scans were still reached, in order.
+    #[test]
+    fn decision_timeout_merge_isolates_panics_between_scans() {
+        let home = tmp_home("decision-timeout-panic-isolation");
+        let registry: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let externals: ExternalRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let configs: Arc<Mutex<HashMap<String, crate::daemon::AgentConfig>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+        let ctx = TickContext {
+            home: &home,
+            registry: &registry,
+            externals: &externals,
+            configs: &configs,
+        };
+
+        let handler = DecisionTimeoutHandler::new();
+        test_hooks::force_panic("decision_timeout");
+
+        handler.run(&ctx);
+
+        test_hooks::clear_force_panic();
+        assert_eq!(
+            test_hooks::take_invoked(),
+            vec!["decision_timeout", "decision_board_timeout"],
+            "both scans must be attempted, in order, even though 'decision_timeout' \
+             (the first) panicked — per-scan isolation (#2549 W2)"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Baseline (no forced panic): both scans still run, in order, on a
+    /// single `run()` call — the merge itself doesn't drop or reorder either
+    /// sub-scan. Referenced by the [`MIGRATED_TRACKER_NAMES`] doc as the proof
+    /// that `decision_board_timeout` still runs every tick despite no longer
+    /// being a separately-registered handler name.
+    #[test]
+    fn decision_timeout_merge_runs_both_scans_with_no_panic() {
+        let home = tmp_home("decision-timeout-baseline");
+        let registry: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let externals: ExternalRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let configs: Arc<Mutex<HashMap<String, crate::daemon::AgentConfig>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+        let ctx = TickContext {
+            home: &home,
+            registry: &registry,
+            externals: &externals,
+            configs: &configs,
+        };
+
+        let handler = DecisionTimeoutHandler::new();
+        handler.run(&ctx);
+
+        assert_eq!(
+            test_hooks::take_invoked(),
+            vec!["decision_timeout", "decision_board_timeout"]
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Same property as `decision_timeout_merge_isolates_panics_between_scans`,
+    /// applied to the `dispatch_idle`/`dispatch_idle_nudge` merge.
+    #[test]
+    fn dispatch_idle_merge_isolates_panics_between_scans() {
+        let home = tmp_home("dispatch-idle-panic-isolation");
+        let registry: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let externals: ExternalRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let configs: Arc<Mutex<HashMap<String, crate::daemon::AgentConfig>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+        let ctx = TickContext {
+            home: &home,
+            registry: &registry,
+            externals: &externals,
+            configs: &configs,
+        };
+
+        let handler = DispatchIdleHandler::new();
+        test_hooks::force_panic("dispatch_idle");
+
+        handler.run(&ctx);
+
+        test_hooks::clear_force_panic();
+        assert_eq!(
+            test_hooks::take_invoked(),
+            vec!["dispatch_idle", "dispatch_idle_nudge"],
+            "both scans must be attempted, in order, even though 'dispatch_idle' \
+             (the first) panicked — per-scan isolation (#2549 W2)"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Baseline (no forced panic) for the `dispatch_idle` merge — see
+    /// `decision_timeout_merge_runs_both_scans_with_no_panic`; this is the test
+    /// the [`MIGRATED_TRACKER_NAMES`] doc references for `dispatch_idle_nudge`.
+    #[test]
+    fn dispatch_idle_merge_runs_both_scans_with_no_panic() {
+        let home = tmp_home("dispatch-idle-baseline");
+        let registry: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let externals: ExternalRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let configs: Arc<Mutex<HashMap<String, crate::daemon::AgentConfig>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+        let ctx = TickContext {
+            home: &home,
+            registry: &registry,
+            externals: &externals,
+            configs: &configs,
+        };
+
+        let handler = DispatchIdleHandler::new();
+        handler.run(&ctx);
+
+        assert_eq!(
+            test_hooks::take_invoked(),
+            vec!["dispatch_idle", "dispatch_idle_nudge"]
+        );
+        std::fs::remove_dir_all(&home).ok();
     }
 }


### PR DESCRIPTION
## Summary

Part of #2549 P2 Wave 2 (spike: `P2-2549-SPIKE.md` §3d, decision `d-20260702044452277394-4`), following W1's `HourlyGcHandler` precedent (#2568).

Collapses the per-tick **WRAPPER layer only** for two pairs of macro-generated supervisor-tracker handlers into two registered `PerTickHandler` slots (40 → 38 in `build_default_handlers`):

- `DecisionTimeoutHandler` now also runs the former `DecisionBoardTimeoutHandler`'s scan.
- `DispatchIdleHandler` now also runs the former `DispatchIdleNudgeHandler`'s scan.

## Hard scope boundary (dual-reviewer please check this)

The four underlying tracker modules — `dispatch_idle/mod.rs`, `dispatch_idle/team_nudge.rs`, `decision_timeout.rs`, `decision_board_timeout.rs` — are **untouched**. This matters most for the Decision pair: `decision_board_timeout.rs`'s own module doc records a standing decision (`d-20260702044452277394-4`) that its store/data-model/routing are *deliberately* kept unshared from `decision_timeout` (single-sender-cancels-prior sidecar vs. multi-author board; fixed fleet-wide recipient vs. per-decision author). This PR does not touch that boundary — only the registration-slot count. `dispatch_idle`/`dispatch_idle_nudge` had no such decision (they already share one sidecar schema and module tree), but the same "wrapper-only" discipline was applied for consistency and blast-radius control.

## Behavior preservation

- Each sub-scan keeps its own `CadenceGate` and self-throttles exactly as before — merging the wrapper doesn't change scan cadence.
- Per-scan `catch_unwind` (`run_scan_isolated`, mirroring W1's `hourly_gc::run_sweep_isolated`) reproduces the pre-merge per-handler panic isolation: a panic in one tracker's scan can't block its merged sibling. Pinned by 4 new tests (2 per merged handler: forced-panic-in-first-scan + no-panic-baseline), using the same test-only fault-injection-seam pattern as `hourly_gc.rs`.
- `MIGRATED_TRACKER_NAMES` (the W1.1 completeness-invariant pin) drops `dispatch_idle_nudge` since it's no longer a separately-registered handler name. `decision_board_timeout` was never in that list to begin with (it was added after the original W1.1 supervisor-thread migration), so no removal needed there.
- App-mode wiring (`app_tick_handlers_cover_every_non_allowlisted_daemon_handler`) is untouched and stays green — neither handler is in `APP_TICK_ALLOWLIST`.

## Test plan
- [x] `cargo build --lib` — clean
- [x] `cargo test per_tick::` — 163/163 pass (includes the 4 new panic-isolation/wiring tests + the updated completeness invariant)
- [x] `cargo test decision_timeout` — 25/25 pass, **zero modifications** to that file's own test suite
- [x] `cargo test dispatch_idle` — all `dispatch_idle`/`team_nudge` tests pass, **zero modifications**
- [x] `cargo test app_tick_handlers` — 2/2 pass (app-mode completeness invariant unaffected)
- [x] `cargo clippy --lib --bin agend-terminal --tests -- -D warnings` — clean

Refs #2549