### PR TITLE
refactor(#2549 W3): merge PollReminder + InboxStuck + HandoffTimeout notification-watchdog handlers

### DIFF
--- a/src/daemon/per_tick/handoff_timeout.rs
+++ b/src/daemon/per_tick/handoff_timeout.rs
@@ -30,8 +30,12 @@ impl HandoffTimeoutHandler {
         }
     }
 
+    /// #2549 W3: `pub(crate)` (not just `#[cfg(test)] fn`) so
+    /// `notification_watchdogs`'s merged-handler tests can construct this
+    /// sub-handler past its boot-grace window too. Zero behavior change —
+    /// visibility only.
     #[cfg(test)]
-    fn new_at(every_n_ticks: u64, created_at: std::time::Instant) -> Self {
+    pub(crate) fn new_at(every_n_ticks: u64, created_at: std::time::Instant) -> Self {
         Self {
             gate: crate::daemon::cadence_gate::CadenceGate::new_with_boot_grace_at(
                 every_n_ticks,

--- a/src/daemon/per_tick/inbox_stuck.rs
+++ b/src/daemon/per_tick/inbox_stuck.rs
@@ -48,8 +48,12 @@ impl InboxStuckHandler {
         self.last_alerted.clone()
     }
 
+    /// #2549 W3: `pub(crate)` (not just `#[cfg(test)] fn`) so
+    /// `notification_watchdogs`'s merged-handler tests can construct this
+    /// sub-handler past its boot-grace window too. Zero behavior change —
+    /// visibility only.
     #[cfg(test)]
-    fn new_at(every_n_ticks: u64, created_at: std::time::Instant) -> Self {
+    pub(crate) fn new_at(every_n_ticks: u64, created_at: std::time::Instant) -> Self {
         Self {
             gate: crate::daemon::cadence_gate::CadenceGate::new_with_boot_grace_at(
                 every_n_ticks,

--- a/src/daemon/per_tick/mod.rs
+++ b/src/daemon/per_tick/mod.rs
@@ -57,6 +57,7 @@ pub(crate) mod inbox_stuck;
 pub(crate) mod inject_delivery;
 pub(crate) mod log_rotation;
 pub(crate) mod notification_flush;
+pub(crate) mod notification_watchdogs;
 pub(crate) mod poll_reminder;
 pub(crate) mod pr_state_scan;
 pub(crate) mod reclaim;
@@ -78,15 +79,13 @@ pub(crate) use context_alert::ContextAlertHandler;
 pub(crate) use context_handoff::ContextHandoffHandler;
 pub(crate) use ephemeral_reap::EphemeralReapHandler;
 pub(crate) use external_liveness::ExternalLivenessHandler;
-pub(crate) use handoff_timeout::HandoffTimeoutHandler;
 pub(crate) use hang_detection::HangDetectionHandler;
 pub(crate) use hourly_gc::HourlyGcHandler;
 pub(crate) use inbox_maintenance::InboxMaintenanceHandler;
-pub(crate) use inbox_stuck::InboxStuckHandler;
 pub(crate) use inject_delivery::InjectDeliveryHandler;
 pub(crate) use log_rotation::LogRotationHandler;
 pub(crate) use notification_flush::NotificationFlushHandler;
-pub(crate) use poll_reminder::PollReminderHandler;
+pub(crate) use notification_watchdogs::NotificationWatchdogsHandler;
 pub(crate) use pr_state_scan::PrStateScanHandler;
 pub(crate) use reclaim::ReclaimHandler;
 pub(crate) use recovery_dispatcher::RecoveryDispatcherHandler;
@@ -307,12 +306,13 @@ pub(crate) fn build_default_handlers(
     daemon_binary_stale: crate::daemon::mcp_registry_watcher::DaemonBinaryStale,
 ) -> Vec<Box<dyn PerTickHandler>> {
     let watchdog_dry_run = super::watchdog::watchdog_dry_run_from_env();
-    // #2127 Phase 1: the inbox-stuck handler and the new reclaim handler share one
-    // dedup latch so reclaim can clear an agent's repeat-alert entry. Construct the
-    // inbox-stuck handler first, clone its latch, then move it into the vec at its
-    // original position (order preserved).
-    let inbox_stuck = InboxStuckHandler::new(30);
-    let work_stuck_latch = inbox_stuck.latch();
+    // #2127 Phase 1: the inbox-stuck sub-handler (inside NotificationWatchdogsHandler,
+    // #2549 W3) and the reclaim handler share one dedup latch so reclaim can clear an
+    // agent's repeat-alert entry. Construct the notification-watchdogs handler first,
+    // clone its inbox-stuck latch, then move it into the vec at its original position
+    // (order preserved) — same shape as before the W3 merge.
+    let notification_watchdogs = NotificationWatchdogsHandler::new(30, 30, 12);
+    let work_stuck_latch = notification_watchdogs.inbox_stuck_latch();
     // Vec order MUST match the pre-extraction call order (zero-behavior-change guarantee).
     vec![
         Box::new(HangDetectionHandler::new()),
@@ -357,15 +357,19 @@ pub(crate) fn build_default_handlers(
         Box::new(CiWatchPollHandler::new()),
         Box::new(PrStateScanHandler::new()),
         Box::new(InboxMaintenanceHandler::new(60)),
-        Box::new(PollReminderHandler::new(30)),
-        // #1491(A): inbox-stuck watchdog — every 30 ticks (~5min). Detects an
-        // agent receiving but not draining its inbox; notifies lead (no auto-restart).
-        Box::new(inbox_stuck),
-        // #1491(B): next_after_ci handoff-timeout watchdog. #1859 lowered the
-        // cadence to ~2min (12 ticks) so the daemon-side RE-NUDGE of the target
-        // (Fix A) is timely; the lead ESCALATION stays gated by its own 10min age
-        // + 30min re-alert windows, so the faster scan doesn't escalate sooner.
-        Box::new(HandoffTimeoutHandler::new(12)),
+        // #2549 W3: PollReminder (30 ticks) + InboxStuck watchdog (#1491(A), 30
+        // ticks — every agent receiving but not draining its inbox; notifies lead,
+        // no auto-restart) + HandoffTimeout watchdog (#1491(B), 12 ticks — #1859
+        // lowered the cadence to ~2min so the daemon-side RE-NUDGE of the
+        // next_after_ci target is timely; the lead ESCALATION stays gated by its
+        // own 10min age + 30min re-alert windows, so the faster scan doesn't
+        // escalate sooner) collapsed into one registered handler — same three
+        // cadences, same thread, mutually independent; each sub-check keeps its
+        // own cadence gate / extra state unchanged and is panic-isolated from its
+        // siblings inside `NotificationWatchdogsHandler::run` (per-check
+        // catch_unwind, replacing the per-handler isolation the outer loop used to
+        // provide for these 3 separately).
+        Box::new(notification_watchdogs),
         // Daemon-side deferred-notification flush — every tick (~10s). The
         // #1513 busy-gate defers notifications into the queue whose only other
         // flusher is the TUI loop; headless `run_core` (`start --foreground`)

--- a/src/daemon/per_tick/notification_watchdogs.rs
+++ b/src/daemon/per_tick/notification_watchdogs.rs
@@ -1,0 +1,301 @@
+//! #2549 W3 — collapses the three stale-backlog NOTIFICATION watchdogs
+//! (`PollReminderHandler`, `InboxStuckHandler`, `HandoffTimeoutHandler`) into
+//! ONE registered [`PerTickHandler`] slot (`NotificationWatchdogsHandler`,
+//! 38 → 36 handlers in `build_default_handlers`).
+//!
+//! This is a pure COMPOSITION wrapper, not a rewrite: each inner handler
+//! keeps its own `PerTickHandler` impl, `CadenceGate` (each with its own
+//! `NOTIFICATION_BOOT_GRACE`-suppressed cadence and `every_n_ticks` — 30/30/12,
+//! genuinely different, so they are NOT hoisted onto one shared gate), and
+//! extra state (`InboxStuckHandler`'s shared `AlertLatch`, `HandoffTimeoutHandler`'s
+//! two dedup maps) completely unchanged. `poll_reminder.rs`, `inbox_stuck.rs`,
+//! and `handoff_timeout.rs` are untouched beyond bumping their `#[cfg(test)]`
+//! `new_at` constructors to `pub(crate)` (visibility only, zero behavior
+//! change) so this file's own tests can construct them past boot-grace
+//! (P2-2549-SPIKE.md §3b).
+//!
+//! Panic isolation moves from PER-HANDLER to PER-CHECK (mirrors
+//! `hourly_gc::run_sweep_isolated` / `supervisor_trackers::run_scan_isolated`):
+//! this handler wraps each of its 3 inner `.run()` calls in its own
+//! `catch_unwind`, so the pre-merge invariant — one watchdog panicking never
+//! blocks the other two in the same tick — survives the collapse into a
+//! single registered handler.
+//!
+//! ## InboxStuck ↔ Reclaim latch (hard constraint, §3b)
+//!
+//! `InboxStuckHandler`'s dedup latch (`AlertLatch`) is shared with
+//! `ReclaimHandler` so a successful reclaim clears an agent's repeat stuck-
+//! alert entry (#2127 Phase 1). [`NotificationWatchdogsHandler::inbox_stuck_latch`]
+//! preserves the exact clone-out interface `build_default_handlers` already
+//! used on the standalone `InboxStuckHandler` — construct the merged handler
+//! first, clone the latch, then move the handler into the Vec, same shape as
+//! before. The end-to-end wiring pin lives in `reclaim.rs`'s own test module
+//! (`latch_shared_with_notification_watchdogs_merge_2549_w3`) since it already
+//! owns `ReclaimHandler`'s test conventions.
+
+use super::handoff_timeout::HandoffTimeoutHandler;
+use super::inbox_stuck::{AlertLatch, InboxStuckHandler};
+use super::poll_reminder::PollReminderHandler;
+use super::{PerTickHandler, TickContext};
+
+pub(crate) struct NotificationWatchdogsHandler {
+    poll_reminder: PollReminderHandler,
+    inbox_stuck: InboxStuckHandler,
+    handoff_timeout: HandoffTimeoutHandler,
+}
+
+impl NotificationWatchdogsHandler {
+    pub(crate) fn new(
+        poll_reminder_ticks: u64,
+        inbox_stuck_ticks: u64,
+        handoff_timeout_ticks: u64,
+    ) -> Self {
+        Self {
+            poll_reminder: PollReminderHandler::new(poll_reminder_ticks),
+            inbox_stuck: InboxStuckHandler::new(inbox_stuck_ticks),
+            handoff_timeout: HandoffTimeoutHandler::new(handoff_timeout_ticks),
+        }
+    }
+
+    /// Test-only constructor with an explicit shared `created_at` so all
+    /// three sub-handlers' boot-grace gates can be put past their window in
+    /// one call (mirrors each sub-handler's own `new_at`).
+    #[cfg(test)]
+    pub(crate) fn new_at(
+        poll_reminder_ticks: u64,
+        inbox_stuck_ticks: u64,
+        handoff_timeout_ticks: u64,
+        created_at: std::time::Instant,
+    ) -> Self {
+        Self {
+            poll_reminder: PollReminderHandler::new_at(poll_reminder_ticks, created_at),
+            inbox_stuck: InboxStuckHandler::new_at(inbox_stuck_ticks, created_at),
+            handoff_timeout: HandoffTimeoutHandler::new_at(handoff_timeout_ticks, created_at),
+        }
+    }
+
+    /// A clone of the InboxStuck sub-handler's shared dedup latch — see
+    /// `InboxStuckHandler::latch`. Reclaim clears an agent's entry after
+    /// reclaiming its board work.
+    pub(crate) fn inbox_stuck_latch(&self) -> AlertLatch {
+        self.inbox_stuck.latch()
+    }
+}
+
+impl PerTickHandler for NotificationWatchdogsHandler {
+    fn name(&self) -> &'static str {
+        "notification_watchdogs"
+    }
+
+    fn run(&self, ctx: &TickContext<'_>) {
+        run_check_isolated("poll_reminder", || self.poll_reminder.run(ctx));
+        run_check_isolated("inbox_stuck_watchdog", || self.inbox_stuck.run(ctx));
+        run_check_isolated("handoff_timeout_watchdog", || self.handoff_timeout.run(ctx));
+    }
+}
+
+/// Run one sub-check isolated from its siblings: a panic inside `f` is
+/// caught and logged, never propagated — the per-check equivalent of the
+/// outer per-tick loop's per-HANDLER `catch_unwind`. Preserves "one
+/// notification watchdog panicking doesn't block the other two" now that all
+/// three run inside a single registered handler's `run()` call.
+fn run_check_isolated(name: &'static str, f: impl FnOnce()) {
+    let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        #[cfg(test)]
+        test_hooks::record_and_maybe_force_panic(name);
+        f()
+    }));
+    if let Err(payload) = outcome {
+        tracing::error!(
+            check = name,
+            error = %super::panic_payload_str(&payload),
+            "notification_watchdogs: sub-check panicked — isolated, the other checks in this tick still ran"
+        );
+    }
+}
+
+/// Test-only fault-injection seam: proves the per-check isolation property
+/// against the REAL merged handler (not a mock). Mirrors `hourly_gc`'s
+/// identically-shaped `test_hooks`.
+#[cfg(test)]
+mod test_hooks {
+    use std::cell::{Cell, RefCell};
+
+    thread_local! {
+        static FORCE_PANIC: Cell<Option<&'static str>> = const { Cell::new(None) };
+        static INVOKED: RefCell<Vec<&'static str>> = const { RefCell::new(Vec::new()) };
+    }
+
+    pub(super) fn record_and_maybe_force_panic(name: &'static str) {
+        INVOKED.with(|v| v.borrow_mut().push(name));
+        if FORCE_PANIC.with(|p| p.get()) == Some(name) {
+            panic!("fault-injection: forced panic in check '{name}'");
+        }
+    }
+
+    pub(super) fn force_panic(name: &'static str) {
+        FORCE_PANIC.with(|p| p.set(Some(name)));
+    }
+
+    pub(super) fn clear_force_panic() {
+        FORCE_PANIC.with(|p| p.set(None));
+    }
+
+    pub(super) fn take_invoked() -> Vec<&'static str> {
+        INVOKED.with(|v| std::mem::take(&mut *v.borrow_mut()))
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn tmp_home(tag: &str) -> std::path::PathBuf {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "agend-notification-watchdogs-{}-{}-{}",
+            std::process::id(),
+            tag,
+            id
+        ));
+        std::fs::create_dir_all(&dir).ok();
+        dir
+    }
+
+    fn past_grace() -> std::time::Instant {
+        std::time::Instant::now()
+            - super::super::NOTIFICATION_BOOT_GRACE
+            - std::time::Duration::from_secs(1)
+    }
+
+    fn tick_ctx<'a>(
+        home: &'a std::path::Path,
+        registry: &'a crate::agent::AgentRegistry,
+        externals: &'a crate::agent::ExternalRegistry,
+        configs: &'a std::sync::Arc<
+            parking_lot::Mutex<std::collections::HashMap<String, crate::daemon::AgentConfig>>,
+        >,
+    ) -> TickContext<'a> {
+        TickContext {
+            home,
+            registry,
+            externals,
+            configs,
+        }
+    }
+
+    #[test]
+    fn name_is_notification_watchdogs() {
+        assert_eq!(
+            NotificationWatchdogsHandler::new(30, 30, 12).name(),
+            "notification_watchdogs"
+        );
+    }
+
+    /// #2549 W3 pin (mirrors `hourly_gc`'s panic-isolation tests): the outer
+    /// per-tick loop used to isolate panics PER-HANDLER — 3 separately-
+    /// registered handlers meant a panic in one never touched the other 2's
+    /// invocation this tick. After collapsing all 3 into
+    /// `NotificationWatchdogsHandler`, that guarantee must be reproduced
+    /// INSIDE `run()` at per-check granularity. Force the FIRST check
+    /// (`poll_reminder`) to panic and assert (a) `run()` itself does not
+    /// propagate the panic, and (b) all three checks were still reached, in
+    /// order.
+    #[test]
+    fn one_check_panic_does_not_block_the_other_two() {
+        let home = tmp_home("panic-isolation-first");
+        let registry: crate::agent::AgentRegistry =
+            std::sync::Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new()));
+        let externals: crate::agent::ExternalRegistry =
+            std::sync::Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new()));
+        let configs: std::sync::Arc<
+            parking_lot::Mutex<std::collections::HashMap<String, crate::daemon::AgentConfig>>,
+        > = std::sync::Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new()));
+        let ctx = tick_ctx(&home, &registry, &externals, &configs);
+
+        let handler = NotificationWatchdogsHandler::new_at(1, 1, 1, past_grace());
+        test_hooks::force_panic("poll_reminder");
+
+        handler.run(&ctx);
+
+        test_hooks::clear_force_panic();
+        assert_eq!(
+            test_hooks::take_invoked(),
+            vec![
+                "poll_reminder",
+                "inbox_stuck_watchdog",
+                "handoff_timeout_watchdog"
+            ],
+            "all three checks must be attempted, in order, even though \
+             'poll_reminder' (the first) panicked — per-check isolation (#2549 W3)"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Same property, forcing the MIDDLE check — the ones on either side both
+    /// still ran, closing the "only proved trailing checks survive" gap the
+    /// first test alone would leave.
+    #[test]
+    fn middle_check_panic_does_not_block_its_neighbors() {
+        let home = tmp_home("panic-isolation-middle");
+        let registry: crate::agent::AgentRegistry =
+            std::sync::Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new()));
+        let externals: crate::agent::ExternalRegistry =
+            std::sync::Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new()));
+        let configs: std::sync::Arc<
+            parking_lot::Mutex<std::collections::HashMap<String, crate::daemon::AgentConfig>>,
+        > = std::sync::Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new()));
+        let ctx = tick_ctx(&home, &registry, &externals, &configs);
+
+        let handler = NotificationWatchdogsHandler::new_at(1, 1, 1, past_grace());
+        test_hooks::force_panic("inbox_stuck_watchdog");
+
+        handler.run(&ctx);
+
+        test_hooks::clear_force_panic();
+        assert_eq!(
+            test_hooks::take_invoked(),
+            vec![
+                "poll_reminder",
+                "inbox_stuck_watchdog",
+                "handoff_timeout_watchdog"
+            ],
+            "'inbox_stuck_watchdog' panicking must not stop \
+             'handoff_timeout_watchdog' (after it) from running, nor does it \
+             retroactively un-run 'poll_reminder' (before it)"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Baseline (no forced panic): all three still run in order, on a single
+    /// `run()` call — the composition itself doesn't drop or reorder any of
+    /// the three sub-checks.
+    #[test]
+    fn no_panic_all_three_run_in_order() {
+        let home = tmp_home("baseline");
+        let registry: crate::agent::AgentRegistry =
+            std::sync::Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new()));
+        let externals: crate::agent::ExternalRegistry =
+            std::sync::Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new()));
+        let configs: std::sync::Arc<
+            parking_lot::Mutex<std::collections::HashMap<String, crate::daemon::AgentConfig>>,
+        > = std::sync::Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new()));
+        let ctx = tick_ctx(&home, &registry, &externals, &configs);
+
+        let handler = NotificationWatchdogsHandler::new_at(1, 1, 1, past_grace());
+        handler.run(&ctx);
+
+        assert_eq!(
+            test_hooks::take_invoked(),
+            vec![
+                "poll_reminder",
+                "inbox_stuck_watchdog",
+                "handoff_timeout_watchdog"
+            ]
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+}

--- a/src/daemon/per_tick/poll_reminder.rs
+++ b/src/daemon/per_tick/poll_reminder.rs
@@ -22,8 +22,12 @@ impl PollReminderHandler {
         }
     }
 
+    /// #2549 W3: `pub(crate)` (not just `#[cfg(test)] fn`) so
+    /// `notification_watchdogs`'s merged-handler tests can construct this
+    /// sub-handler past its boot-grace window too. Zero behavior change —
+    /// visibility only.
     #[cfg(test)]
-    fn new_at(every_n_ticks: u64, created_at: std::time::Instant) -> Self {
+    pub(crate) fn new_at(every_n_ticks: u64, created_at: std::time::Instant) -> Self {
         Self {
             gate: crate::daemon::cadence_gate::CadenceGate::new_with_boot_grace_at(
                 every_n_ticks,

--- a/src/daemon/per_tick/reclaim.rs
+++ b/src/daemon/per_tick/reclaim.rs
@@ -961,4 +961,64 @@ mod tests {
         );
         std::fs::remove_dir_all(&home).ok();
     }
+
+    /// #2549 W3 (P2-2549-SPIKE.md §3b, the merge's hard constraint): end-to-end
+    /// pin proving Reclaim's shared-latch consumption survives the
+    /// `NotificationWatchdogsHandler` merge. Constructs the merged handler
+    /// EXACTLY the way `build_default_handlers` wires it — merged handler
+    /// first, clone its InboxStuck sub-handler's latch via
+    /// `NotificationWatchdogsHandler::inbox_stuck_latch`, hand that SAME Arc to
+    /// Reclaim — not a synthetic fresh latch like this file's other tests use.
+    /// A wiring regression (cloning the wrong sub-handler, or handing Reclaim a
+    /// fresh Arc instead of a shared clone) would fail THIS test even though
+    /// the tests above (which construct their own local latch) stay green.
+    #[test]
+    fn latch_shared_with_notification_watchdogs_merge_2549_w3() {
+        use crate::daemon::per_tick::notification_watchdogs::NotificationWatchdogsHandler;
+        use parking_lot::Mutex as PLMutex;
+        use std::sync::Arc;
+
+        let now = chrono::Utc::now();
+        let home = tmp_home("w3-latch-wiring");
+        seed_claimed_task(&home, "t-w3", "dev-w3");
+        seed_usage_notify(&home, "dev-w3", now, 30); // 30min > 10min grace
+
+        let past = std::time::Instant::now()
+            - super::super::NOTIFICATION_BOOT_GRACE
+            - Duration::from_secs(1);
+        let notify = NotificationWatchdogsHandler::new_at(1, 1, 1, past);
+        let latch = notify.inbox_stuck_latch();
+        // As if InboxStuck already alerted on "dev-w3" last tick.
+        latch.lock().insert("dev-w3".to_string(), now);
+
+        let registry: crate::agent::AgentRegistry = Arc::new(PLMutex::new(HashMap::new()));
+        let (handle, _reader) = crate::daemon::per_tick::mock_live_agent_no_context("dev-w3");
+        handle.core.lock().state.current = AgentState::UsageLimit;
+        registry.lock().insert(handle.id, handle);
+        let externals: crate::agent::ExternalRegistry = Arc::new(PLMutex::new(HashMap::new()));
+        let configs: Arc<PLMutex<HashMap<String, crate::daemon::AgentConfig>>> =
+            Arc::new(PLMutex::new(HashMap::new()));
+        let ctx = TickContext {
+            home: &home,
+            registry: &registry,
+            externals: &externals,
+            configs: &configs,
+        };
+
+        let reclaim = ReclaimHandler::new_at(1, latch, past);
+        reclaim.run(&ctx);
+
+        assert_eq!(
+            task_status(&home, "t-w3"),
+            crate::task_events::TaskStatus::Open,
+            "sanity: reclaim must actually have fired"
+        );
+        assert!(
+            !notify.inbox_stuck_latch().lock().contains_key("dev-w3"),
+            "reclaim must clear the SAME Arc InboxStuckHandler owns inside the \
+             merged NotificationWatchdogsHandler — proves the #2127 latch-sharing \
+             wiring survived the W3 merge"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
 }


### PR DESCRIPTION
## Summary

Part of #2549 P2 Wave 3 (spike: `P2-2549-SPIKE.md` §3b/§6 W3), following the W1 (`HourlyGcHandler`, #2568) / W2 (`supervisor_trackers`, #2569) pure-composition precedent.

Collapses the three stale-backlog NOTIFICATION watchdogs — `PollReminderHandler`, `InboxStuckHandler`, `HandoffTimeoutHandler` — into one registered `PerTickHandler` slot (`NotificationWatchdogsHandler`, 38 → 36 in `build_default_handlers`).

## What changed vs. what didn't

- **New file** `notification_watchdogs.rs`: the merged wrapper. Each sub-handler keeps its own `CadenceGate` (30/30/12 ticks — genuinely different cadences, so NOT hoisted onto one shared gate), its own extra state, and its own `PerTickHandler` impl, unchanged.
- **`poll_reminder.rs` / `inbox_stuck.rs` / `handoff_timeout.rs`**: untouched except bumping their `#[cfg(test)] new_at` constructors from private to `pub(crate)` — visibility only, zero behavior change — so the new wrapper's tests can construct them past the 180s boot-grace window (needed because, unlike W1's GC handlers, all three of these use time-based `new_with_boot_grace`, not a plain tick counter).
- **`reclaim.rs`**: one new test added (see below); nothing else touched.
- **`mod.rs`**: registration + a few now-dead `use` re-exports removed.

## InboxStuck ↔ Reclaim shared latch (the hard constraint)

`InboxStuckHandler`'s dedup latch (`AlertLatch`) is shared with `ReclaimHandler` (#2127 Phase 1) so a successful reclaim clears an agent's repeat stuck-alert entry. `NotificationWatchdogsHandler::inbox_stuck_latch()` preserves the exact clone-out interface `build_default_handlers` already used on the standalone `InboxStuckHandler` (construct handler first, clone latch, move handler into the Vec — same shape as before).

Added an **end-to-end wiring pin** in `reclaim.rs`'s own test module (`latch_shared_with_notification_watchdogs_merge_2549_w3`) that constructs the merged handler + `ReclaimHandler` *exactly* the way `build_default_handlers` wires them — not a synthetic fresh latch like the file's other tests use — so a wiring regression (cloning the wrong sub-handler, or handing Reclaim a fresh Arc instead of a shared clone) fails this specific test even though the existing tests (which construct their own local latch) would stay green.

## Panic isolation

`run_check_isolated` (mirrors `hourly_gc::run_sweep_isolated` / `supervisor_trackers::run_scan_isolated`) reproduces the pre-merge per-handler panic isolation at per-check granularity. Pinned by 3 new tests: baseline (all three run, in order), panic in the first check, panic in the middle check — each proving the other checks still ran.

## Premise check (before touching anything)

The task flagged that `notification_handlers_wire_boot_grace` (a source-scan test asserting each of the three files contains the literal `"new_with_boot_grace("` substring) would need rewriting since its "all three files wire it" premise breaks under the merge. Traced this before implementing: the test scans the three files' **raw content**, not the registered-handler set — since pure composition leaves those three files' `new()` bodies untouched, the substring is still present in all three, so the test's premise does NOT actually break. Verified it passes unmodified (no changes made to it).

## Test plan
- [x] `cargo build --tests --bin agend-terminal` — clean
- [x] `cargo test notification_watchdogs` — 4 new tests pass (name + 3 panic-isolation/ordering)
- [x] `cargo test notification_handlers_wire_boot_grace` — passes **unmodified**
- [x] `cargo test reclaim` — 51/51 pass (50 existing + 1 new wiring pin)
- [x] `cargo test poll_reminder` / `inbox_stuck` / `handoff_timeout` — 18/18, 8/8, 15/15 pass, zero modifications to any of their own tests
- [x] `cargo test app_tick_handlers` — 2/2 pass (app-mode completeness invariant unaffected)
- [x] `cargo test per_tick::` — 168/168 pass
- [x] `cargo clippy --lib --bin agend-terminal --tests -- -D warnings` — clean

## Merge-order note
PR #2571 (`approved-deletions`) is open concurrently and also touches `per_tick/mod.rs` (deletes `ProgressBackstopHandler`/`ProgressMirrorHandler`/`CrossBoardDepDetectiveHandler` registrations, unrelated lines to this PR's). Per the task's instruction, whichever of us merges second rebases — the overlap is registration-list adjacency, not logic conflict.

Refs #2549