### PR TITLE
refactor(#2549 P2): converge RecoveryDispatcher to Stage-1-only, remove Stage 2/3

### DIFF
--- a/docs/FEATURE-health.md
+++ b/docs/FEATURE-health.md
@@ -140,34 +140,25 @@ avoid false Hung classification during MCP roundtrip completion.
 
 ---
 
-## Auto-Recovery Ladder
+## Auto-Recovery (Stage 1)
 
-When an agent is classified as `Hung`, the daemon initiates a three-stage
-recovery:
+When an agent is classified as `Hung`, the daemon fires an ESC key to the
+agent's PTY (interrupts the current operation) and waits 10 seconds for
+recovery. Cooldown: 60 seconds (prevents rapid ESC spam). If the PTY write
+fails, or the agent doesn't recover in time, or it's classified dead-likely
+(silence exceeds threshold — ESC wouldn't help), the daemon logs the outcome
+and stops there; no further automated action is taken (#2549: the Stage 2
+auto-restart and Stage 3 pause-and-escalate stages that used to follow were
+removed — see `docs/RECOVERY-STAGES.md` for the historical design and why
+this is a behavior-preserving cut, not a capability regression).
 
-### Stage 1: ESC Key
+Toggled via the `hang_auto_recovery_enabled` runtime config gate (or the
+`AGEND_AUTO_RECOVERY_STAGE1` env var).
 
-- Sends an ESC key to the agent's PTY (interrupts the current operation).
-- Waits 10 seconds for recovery.
-- Cooldown: 60 seconds (prevents rapid ESC spam).
-
-### Stage 2: Auto-Restart
-
-- If Stage 1 fails, restarts the agent process.
-- Waits 30 seconds for recovery.
-- Maximum 3 restarts (cumulative across Hung cycles).
-- Backoff delay: 1 second.
-
-### Stage 3: Pause
-
-- If all 3 Stage 2 restarts fail:
-  - Sets HealthState to `Paused` (terminal state).
-  - Notifies the operator that manual intervention is needed.
-  - `check_hang` short-circuits (returns false) for this agent.
-  - Crash decay does not affect the `Paused` state.
-
-The entire ladder can be toggled via the `hang_auto_recovery_enabled` runtime
-config gate.
+`HealthState::Paused` still exists as a terminal state — `RespawnWatchdogHandler`
+(a separate mechanism, for a stuck `resume` spawn rather than a Hung agent)
+still escalates into it after its own retry cap. `check_hang` short-circuits
+and crash decay does not affect `Paused` regardless of which handler set it.
 
 ---
 

--- a/docs/FEATURE-health.zh-TW.md
+++ b/docs/FEATURE-health.zh-TW.md
@@ -137,32 +137,22 @@ input 送達和 heartbeat 刷新之間有 5 秒的寬限窗口，避免在 MCP r
 
 ---
 
-## 自動恢復階梯
+## 自動恢復(Stage 1)
 
-當 agent 被分類為 `Hung` 時，daemon 啟動三階段恢復：
+當 agent 被分類為 `Hung` 時，daemon 會向其 PTY 發送 ESC 鍵(中斷當前操作),
+並等待 10 秒看是否恢復。冷卻時間 60 秒(避免頻繁發送 ESC)。若 PTY 寫入失敗、
+逾時未恢復,或被判定為 dead-likely(靜默超過閾值 — ESC 也無濟於事),daemon
+會記錄結果後停止,不再有進一步的自動動作(#2549:原本後續的 Stage 2 自動重啟
+與 Stage 3 暫停升級已移除 — 歷史設計與「這是行為保真、非能力倒退」的理由詳見
+`docs/RECOVERY-STAGES.md`)。
 
-### Stage 1：ESC 鍵
+可透過 runtime config 的 `hang_auto_recovery_enabled` 開關(或
+`AGEND_AUTO_RECOVERY_STAGE1` 環境變數)控制。
 
-- 向 agent 的 PTY 發送 ESC 鍵（中斷當前操作）
-- 等待 10 秒看是否恢復
-- 冷卻時間 60 秒（避免頻繁發送 ESC）
-
-### Stage 2：自動重啟
-
-- Stage 1 失敗後，自動重啟 agent 程序
-- 等待 30 秒看是否恢復
-- 最多重啟 3 次（跨 Hung 週期累計）
-- 退避延遲 1 秒
-
-### Stage 3：暫停
-
-- Stage 2 的 3 次重啟都失敗後
-- 將 HealthState 設為 `Paused`（終態）
-- 通知 operator 需要手動介入
-- `check_hang` 不再觸發（短路返回 false）
-- crash 衰減不會改變 `Paused` 狀態
-
-整個階梯可以透過 runtime config 的 `hang_auto_recovery_enabled` 開關控制。
+`HealthState::Paused` 這個終態仍然存在 —— `RespawnWatchdogHandler`(另一套獨立
+機制,處理卡住的 `resume` spawn,而非 Hung agent)在自己的重試上限後仍會升級進
+入該狀態。無論是哪個 handler 設定的,`check_hang` 都會短路、crash 衰減也不會
+影響 `Paused` 狀態。
 
 ---
 

--- a/docs/HUNG-STATE-TRANSITIONS.md
+++ b/docs/HUNG-STATE-TRANSITIONS.md
@@ -462,6 +462,9 @@ reset mechanic.
   + env-var-gated shadow-mode default. Stages 2 and 3 follow-up
   sub-tasks reuse the same dispatcher tick + state machine. See
   `docs/RECOVERY-STAGES.md` for full lifecycle + promotion criteria.
+  **Update (#2549)**: Stage 2/3 (and the dispatcher-driven Stage 3 arm)
+  were later removed — converged to Stage-1-only. See
+  `docs/RECOVERY-STAGES.md`'s header banner for the rationale.
 
 ## Consumer audit
 

--- a/docs/RECOVERY-STAGES.md
+++ b/docs/RECOVERY-STAGES.md
@@ -1,20 +1,34 @@
 # Recovery Stages
 
-Source-of-truth for the `#685` Phase 2 staged auto-recovery dispatcher.
+Source-of-truth for the `#685` staged auto-recovery dispatcher.
+
+**#2549 P2 update (operator decision `d-20260703021554626467-13`):**
+Stage 2 (auto-restart) and the dispatcher-driven Stage 3 escalation path
+were **removed** — converged to **Stage-1-only**. `§RS.9` (Stage 2) and
+`§RS.10` (Stage 3, dispatcher-side) below are kept as a **historical
+decision record** of what sub-tasks 7b/7c shipped and why, but no longer
+describe live code — see the banners on each section. `HealthState::Paused`
+/ `HealthTracker::enter_paused` / `RecoveryStageState::Stage3Pending`
+themselves are **still live** (`§RS.7`, `§10.2`-`§10.7` mechanics) — they
+are shared terminal-escalation machinery now also used independently by
+`RespawnWatchdogHandler` (an unrelated failure mode), not exclusive to
+this dispatcher's ladder. See `src/daemon/per_tick/recovery_dispatcher.rs`'s
+module doc for the full rationale (why the pre-#2549 default-gate-off
+behavior made this a behavior-preserving, not a scope-expanding, cut).
+
 This PR (`#685` sub-task 7a) ships **Stage 1 ESC interrupt** with full
 infrastructure (state machine, env-var gate, anti-thrash cooldown,
-telemetry pattern) reusable by future Stages 2 (auto-restart) and 3
-(pause + escalate).
+telemetry pattern).
 
 Decision: `d-20260514030404021793-1` (three-party consensus: lead-claude
 + dev-claude + reviewer-opencode).
 
 Sibling chain: sub-task 1 (PR #750) + 2 (#752) + 3 (#763) + 4 (#766) +
-5 (#769) + 6 (#770). Stages 2 (7b) and 3 (7c) are follow-up sub-tasks
-of `#685` that add their dispatch arms but reuse this module's
-infrastructure.
+5 (#769) + 6 (#770). Stages 2 (7b) and 3 (7c) were follow-up sub-tasks
+of `#685` that added dispatch arms reusing this module's infrastructure
+— since removed per #2549 (see above).
 
-Maintenance: section IDs (`§RS.1`-`§RS.8`) are stable contract anchors
+Maintenance: section IDs (`§RS.1`-`§RS.10`) are stable contract anchors
 per the M1/M2/M3 discipline established in sub-task 1.
 
 ## §RS.1 — Why staged auto-recovery
@@ -25,28 +39,32 @@ nothing. Operators must manually press ESC in the agent's TUI pane to
 recover. Issue `#685` Phase 2 mandates staged automation:
 
 - **Stage 1**: daemon writes ESC byte to PTY (simulate operator ESC)
-- **Stage 2**: Stage 1 fails to recover → auto-restart agent + telegram
-  warn operator
-- **Stage 3**: Stage 2 fails N times → pause + telegram escalate +
-  flag for manual investigation
+- ~~**Stage 2**: Stage 1 fails to recover → auto-restart agent + telegram
+  warn operator~~ — **removed #2549**, see the banner above.
+- ~~**Stage 3**: Stage 2 fails N times → pause + telegram escalate +
+  flag for manual investigation~~ — **removed #2549** as a
+  dispatcher-driven arm; `Paused`/`enter_paused` themselves stay live
+  as shared machinery (`§RS.7`).
 
 Each stage gated behind an env var with operator default `warn-only`.
 
 ## §RS.2 — Lifecycle (state machine)
 
+**Current (post-#2549):**
+
 ```rust
 pub enum RecoveryStageState {
     None,
     Stage1Pending { entered_at: Instant },
-    Stage2Eligible,
-    Stage2Pending { entered_at: Instant },
-    Stage3Eligible,
-    Stage3Pending,
+    Stage3Pending { entered_at: Instant },
 }
 ```
 
 Carried inside `HealthTracker` so the dispatcher reads both
 `HealthState` and stage progression under one per-agent lock.
+`Stage3Pending` is reached only via `HealthTracker::enter_paused` —
+by `RespawnWatchdogHandler` independently of this dispatcher, not by
+a `Stage3Eligible` waiting-room state (removed, see below).
 
 ```
                       ┌──────┐
@@ -56,51 +74,33 @@ Carried inside `HealthTracker` so the dispatcher reads both
         HealthState::Hung + alive-stuck branch
                          ▼
               ┌─────────────────┐
-              │ Stage1Pending   │── Stage 1 timeout / dead-likely / cooldown
-              └────────┬────────┘
-                       ▼
+              │ Stage1Pending   │── Stage 1 timeout / dead-likely / cooldown:
+              └─────────────────┘   log-only, terminal (#2549 — see below)
+
               ┌─────────────────┐
-              │ Stage2Eligible  │── (7b) Stage 2 fires
-              └────────┬────────┘
-                       ▼
-              ┌─────────────────┐
-              │ Stage2Pending   │── (7b) timeout
-              └────────┬────────┘
-                       ▼
-              ┌─────────────────┐
-              │ Stage3Eligible  │── (7c) Stage 3 fires:
-              └────────┬────────┘    enter_paused(now) writes
-                       ▼               HealthState::Paused atomically
-              ┌─────────────────┐    Terminal. `Paused` short-circuits
-              │ Stage3Pending   │    check_hang + maybe_decay; only an
-              │   { entered_at }│    operator unpause (future sub-task)
-              └─────────────────┘    leaves this state.
+              │ Stage3Pending   │── reached via a DIFFERENT handler
+              │   { entered_at }│   (RespawnWatchdogHandler's own
+              └─────────────────┘   enter_paused call), not from
+                                     Stage1Pending in this dispatcher.
 ```
 
-Sub-task 7a (Stage 1) implemented:
-- `None → Stage1Pending` (alive-stuck branch)
-- `None → Stage2Eligible` (dead-likely branch OR cooldown skip)
-- `Stage1Pending → Stage2Eligible` (Stage 1 timeout expired)
+Sub-task 7a (Stage 1) implemented, **current shape post-#2549**:
+- `None → Stage1Pending` (alive-stuck branch, incl. PTY-write-failure —
+  parks as a one-shot "attempted, stop" marker instead of retrying)
+- `None → None` (dead-likely branch OR cooldown skip — log-only, no
+  transition; was `None → Stage2Eligible` pre-#2549)
+- `Stage1Pending → Stage1Pending` (Stage 1 timeout expired — log-only,
+  re-logs every tick; was `→ Stage2Eligible` pre-#2549)
 - `* → None` (spontaneous recovery on `Healthy`)
 
-**Sub-task 7b (Stage 2) implemented** (this PR):
-- `None → Stage3Eligible` (cumulative restart cap reached — direct
-  escalation, bypass Stages 1/2)
-- `Stage2Eligible → Stage2Pending` (Stage 2 fire — emits
-  `AgentExitEvent::Stage2Restart` via `try_send`; counter increment
-  lives in respawn worker `selective-restore` arm)
-- `Stage2Pending → Stage3Eligible` (Stage 2 timeout expired without
-  recovery)
-- `Stage2Eligible → Stage2Eligible` (channel-full retry — `try_send`
-  failed, state stays for next-tick retry without counter increment)
+**Sub-task 7b (Stage 2) — REMOVED #2549.** Historical record of what it
+implemented is kept in `§RS.9` below (banner marks it non-current).
 
-**Sub-task 7c (Stage 3) implemented** (this PR):
-- `Stage3Eligible → Stage3Pending { entered_at }` (Stage 3 fire — only
-  via `HealthTracker::enter_paused` per §F39.5; atomically writes
-  `state = Paused`, `recovery_stage_state = Stage3Pending`,
-  `last_stage3_fired_at = Some(now)`)
-- `Stage3Pending` is terminal — explicit no-op arm in dispatcher; only
-  a future operator-unpause sub-task transitions out.
+**Sub-task 7c (Stage 3), dispatcher-driven arm — REMOVED #2549.**
+Historical record kept in `§RS.10` below. The underlying
+`HealthTracker::enter_paused` / `Stage3Pending` / `HealthState::Paused`
+mechanics themselves are unchanged and still live — see `§RS.7` and
+`§10.2`-`§10.7`.
 
 ## §RS.3 — Tick order & dispatcher placement
 
@@ -129,7 +129,7 @@ Stage 1 ships valuable independent of F9 promotion timeline:
 | Branch | Condition | Action |
 |---|---|---|
 | **alive-stuck** | `productive_silence > threshold` && `silence < threshold` | Fire Stage 1 ESC (agent process reading PTY, just not productive). State → `Stage1Pending`. |
-| **dead-likely** | `silence > threshold` | Skip Stage 1, ESC won't help a process not reading. State → `Stage2Eligible`. |
+| **dead-likely** | `silence > threshold` | Skip Stage 1, ESC won't help a process not reading. Log-only, state stays `None` (#2549: was `→ Stage2Eligible`, removed). |
 | **anomaly** | Neither condition holds | Log warning, leave state unchanged. Agent shouldn't be `Hung`. |
 
 Thresholds match `silence_exceeds_threshold` in `check_hang`:
@@ -139,8 +139,7 @@ Thresholds match `silence_exceeds_threshold` in `check_hang`:
 - Other states: 120s
 
 Productive-silence threshold extracted via `health::productive_silence_exceeds`
-helper (decision §1.4 Delta 2 Option a — DRY, single source of truth
-shared with future Stages 2/3 and any other dispatcher consumers).
+helper (decision §1.4 Delta 2 Option a — DRY, single source of truth).
 
 ## §RS.5 — Shadow-mode default + env var gate
 
@@ -183,7 +182,8 @@ is worse than no infra" discipline.
 
 Decision §1.4 Refinement B — if agent re-enters `Hung` within
 `STAGE1_COOLDOWN_DEFAULT_MS` of a recent Stage 1 fire, dispatcher skips
-Stage 1 and transitions directly to `Stage2Eligible`. Prevents
+re-firing Stage 1; log-only, no further stage to escalate to (#2549:
+was a transition to the now-removed `Stage2Eligible`). Prevents
 rapid-fire ESC sending that would mask underlying issues like infinite
 loops or persistent backend bugs.
 
@@ -193,28 +193,28 @@ the linear-escalation discipline.
 
 ## §RS.7 — `HealthState::Paused` guards
 
-Stage 3 (sub-task 7c) will transition `HealthState::Hung →
-HealthState::Paused` when Stage 2 exhausts its retry budget. `Paused`
-is an operator-action-required terminal state distinct from `Failed`
-(crash counter exhausted):
+**Still live post-#2549** — `Paused` is an operator-action-required
+terminal state distinct from `Failed` (crash counter exhausted).
+Originally reached only via this dispatcher's (now-removed) Stage 3 arm;
+`enter_paused` — its sole writer — is now called independently by
+`RespawnWatchdogHandler` too (an unrelated failure mode: a stuck
+`resume` spawn), making `Paused` shared terminal-escalation machinery
+rather than exclusive to the Hung ladder:
 
 | State | Trigger | Recovery |
 |---|---|---|
 | `Failed` | `record_crash` counter ≥ `max_retries` (5 process crashes within window) | Operator action OR `maybe_decay` slowly clears the counter |
-| `Paused` | Stage 3 dispatcher | Operator unpause command (separate sub-task) |
+| `Paused` | `HealthTracker::enter_paused` (`RespawnWatchdogHandler`'s retry-cap escalation; previously also this dispatcher's Stage 3 arm, removed #2549) | Operator unpause command (separate sub-task) |
 
-Phase 1 implements the guards already (decision §5):
+Phase 1 implements the guards already (decision §5), still in effect:
 
 - `check_hang` short-circuits on `Paused` (returns `false` — no
-  auto-recovery dispatcher work; operator already alerted via Stage 3
-  telegram notify, further warns are noise).
+  auto-recovery dispatcher work; operator already alerted, further
+  warns are noise).
 - `maybe_decay` does NOT touch `Paused` (crash decay must not exit
   Paused; only operator unpause can).
 - `display_name() -> "paused"` for telegram visibility + JSON API
   consumer (`api/handlers/query.rs`).
-
-The variant itself ships in this PR but is constructed only by
-sub-task 7c's Stage 3 dispatcher arm.
 
 ## §RS.8 — Cross-references & out-of-scope
 
@@ -230,26 +230,29 @@ sub-task 7c's Stage 3 dispatcher arm.
   capture PTY traces around Stage 1 shadow fires for fixture
   collection).
 - `src/daemon/per_tick/recovery_dispatcher.rs` — module implementation.
-- `src/health.rs::RecoveryStageState` — state machine variants.
-- `src/health.rs::HealthState::Paused` — terminal state for Stage 3.
-- `src/agent.rs::AgentExitEvent::Stage2Restart` — variant definition
-  for sub-task 7b emission.
+- `src/health.rs::RecoveryStageState` — state machine variants
+  (`None` / `Stage1Pending` / `Stage3Pending` post-#2549).
+- `src/health.rs::HealthState::Paused` — terminal state, now reached via
+  either `RespawnWatchdogHandler` or (historically) this dispatcher.
 
 ### Out of scope (sub-task 7a baseline)
 
-- Stage 3 pause + escalate dispatcher arm — sub-task 7c.
-- Operator unpause command (CLI or MCP tool) — separate sub-task,
-  required before Stage 3 ships in production.
+- Operator unpause command (CLI or MCP tool) — separate sub-task.
 - Per-backend stage timing tuning — needs corpus measurement, follow-up
   similar to sub-task 6's per-backend marker calibration.
 - Telegram notify for Stage 1 — decision §6 Refinement A: Stage 1
-  silent on success (info-level log only). Stages 2/3 will fire
-  telegram via existing `gated_notify` infrastructure.
+  silent on success (info-level log only).
 - F39 mitigation selection / F9 promotion — fixture-corpus-N-gated.
-- Multi-stage timeout per-backend overrides beyond uniform defaults +
-  env-var overrides.
 
 ## §RS.9 — Stage 2 specifics (sub-task 7b)
+
+> ⚠ **HISTORICAL — REMOVED IN #2549.** Everything below this line in
+> `§RS.9` describes what sub-task 7b built and why, kept as a decision
+> record. It no longer describes live code: `AgentExitEvent::Stage2Restart`,
+> `RecoveryStageState::{Stage2Eligible,Stage2Pending}`,
+> `recovery_restart_count`, `daemon/mod.rs::handle_stage2_restart`, and the
+> `AGEND_AUTO_RECOVERY_STAGE2*` env vars are all deleted. See the file
+> header banner for the rationale.
 
 Sub-task 7b (decision `d-20260514034230950032-2`) implements Stage 2 on
 top of the 7a infrastructure. Stage 2 is **controlled auto-restart**:
@@ -403,6 +406,18 @@ removal candidate.
   integration deferred unless shadow telemetry surfaces edge cases.
 
 ## §RS.10 — Stage 3 specifics (sub-task 7c)
+
+> ⚠ **HISTORICAL — the dispatcher-driven arm described in this section
+> was REMOVED IN #2549.** `RecoveryStageState::Stage3Eligible`,
+> `recovery_dispatcher.rs::handle_stage3_escalate` /
+> `notify_stage3_escalate` / `format_stage3_body`, and this dispatcher's
+> own call into `enter_paused` are all deleted. **`HealthTracker::enter_paused`
+> / `HealthState::Paused` / `RecoveryStageState::Stage3Pending` themselves
+> are still live** — `§10.2`-`§10.5`'s atomic-invariant / no-op-arm
+> mechanics still apply verbatim, just triggered by `RespawnWatchdogHandler`
+> instead of this dispatcher. `§10.4`'s `recovery_restart_count` no longer
+> exists (deleted with Stage 2, not reset-on-unpause since there's nothing
+> to reset). See the file header banner for the rationale.
 
 Stage 3 is the terminal stage of the auto-recovery state machine.
 After Stage 1 ESC failed and Stage 2 auto-restart was attempted up to

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -63,16 +63,14 @@ The variables below are the **default names** for that indirection.
 
 ## 4. Auto-recovery
 
-The Stage gates are **value-based** (must equal `"1"`); when off they run in
+The Stage 1 gate is **value-based** (must equal `"1"`); when off it runs in
 "shadow mode" (telemetry/logging only, no live action). A separate runtime-config
-master gate (`hang_auto_recovery_enabled`) can also enable Stages 1–3.
+master gate (`hang_auto_recovery_enabled`) can also enable it. (#2549: Stage 2/3
+gates removed — converged to Stage-1-only, see `docs/RECOVERY-STAGES.md`.)
 
 | Name | Purpose | Default (unset) | Valid values / format | Source | Notes |
 |------|---------|-----------------|-----------------------|--------|-------|
 | `AGEND_AUTO_RECOVERY_STAGE1` | Stage 1 gate: write ESC byte to a hung agent's PTY. | Inactive (shadow mode) unless master gate on. | `"1"` enables; else off. | `src/daemon/per_tick/recovery_dispatcher.rs:193` | Operator flag; mutates a live PTY. |
-| `AGEND_AUTO_RECOVERY_STAGE2` | Stage 2 gate: emit `Stage2Restart` event (restarts the agent). | Inactive (shadow mode) unless master gate on. | `"1"` enables; else off. | `src/daemon/per_tick/recovery_dispatcher.rs:155` | Operator flag; triggers agent restart. |
-| `AGEND_AUTO_RECOVERY_STAGE2_MAX_RESTARTS` | Max Stage 2 restart attempts. | `3` (`STAGE2_MAX_RESTARTS_DEFAULT`). | `u32`. | `src/daemon/per_tick/recovery_dispatcher.rs:161` | Safety bound on restart loops. |
-| `AGEND_AUTO_RECOVERY_STAGE3` | Stage 3 gate: escalate by writing `HealthState::Paused`. | Inactive (shadow mode: telegram + tracing only) unless master gate on. | `"1"` enables; else off. | `src/daemon/per_tick/recovery_dispatcher.rs:114` | Operator escalation gate. |
 | `AGEND_PRODUCTIVE_GATE` | Activates the F9 "productive-silence" hang-detection path (can flag an agent Hung). Off → shadow telemetry only. | `false` (inactive). | `"1"` activates; else off. | `src/health.rs:753` | Rollout feature gate. |
 
 ---

--- a/docs/env-vars.zh-TW.md
+++ b/docs/env-vars.zh-TW.md
@@ -61,16 +61,14 @@
 
 ## 4. Auto-recovery
 
-各 Stage 閘門都是**以值判定**（必須等於 `"1"`）；關閉時它們會以
+Stage 1 閘門是**以值判定**（必須等於 `"1"`）；關閉時它會以
 「shadow mode」運行（只做 telemetry／logging，不做實際動作）。另有一個 runtime-config
-的總開關（`hang_auto_recovery_enabled`）也能啟用 Stage 1–3。
+的總開關（`hang_auto_recovery_enabled`）也能啟用它。（#2549：Stage 2/3 閘門已移除 —
+收斂為 Stage-1-only，詳見 `docs/RECOVERY-STAGES.md`。）
 
 | Name | Purpose | Default (unset) | Valid values / format | Source | Notes |
 |------|---------|-----------------|-----------------------|--------|-------|
 | `AGEND_AUTO_RECOVERY_STAGE1` | Stage 1 閘門：對 hung 的 agent 的 PTY 寫入 ESC byte。 | 除非總開關開啟，否則不啟用（shadow mode）。 | `"1"` 啟用；否則關閉。 | `src/daemon/per_tick/recovery_dispatcher.rs:193` | Operator 旗標；會更動一個運行中的 PTY。 |
-| `AGEND_AUTO_RECOVERY_STAGE2` | Stage 2 閘門：發出 `Stage2Restart` 事件（重啟該 agent）。 | 除非總開關開啟，否則不啟用（shadow mode）。 | `"1"` 啟用；否則關閉。 | `src/daemon/per_tick/recovery_dispatcher.rs:155` | Operator 旗標；會觸發 agent 重啟。 |
-| `AGEND_AUTO_RECOVERY_STAGE2_MAX_RESTARTS` | Stage 2 的最大重啟嘗試次數。 | `3`（`STAGE2_MAX_RESTARTS_DEFAULT`）。 | `u32`。 | `src/daemon/per_tick/recovery_dispatcher.rs:161` | 對重啟迴圈的安全上限。 |
-| `AGEND_AUTO_RECOVERY_STAGE3` | Stage 3 閘門：藉由寫入 `HealthState::Paused` 來升級處理。 | 除非總開關開啟，否則不啟用（shadow mode：只有 telegram + tracing）。 | `"1"` 啟用；否則關閉。 | `src/daemon/per_tick/recovery_dispatcher.rs:114` | Operator 升級閘門。 |
 | `AGEND_PRODUCTIVE_GATE` | 啟用 F9 的「productive-silence」hang 偵測路徑（可把 agent 標記為 Hung）。關閉 → 只做 shadow telemetry。 | `false`（不啟用）。 | `"1"` 啟用；否則關閉。 | `src/health.rs:753` | Rollout 功能閘門。 |
 
 ---

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -592,16 +592,6 @@ pub enum AgentExitEvent {
     Crash(String),
     /// Agent exited cleanly (exit code 0, e.g. `/exit` or `/quit`) — no respawn.
     CleanExit(String),
-    /// `#685` sub-task 7a: emitted by the recovery dispatcher when Stage 2
-    /// auto-restart fires after Stage 1 ESC fails to clear `Hung` within
-    /// the timeout window. Semantically distinct from `Crash` so the
-    /// respawn worker can skip the crash-counter increment (Stage 2
-    /// is recovery-initiated, not a process crash). Phase 1 (sub-task
-    /// 7a / Stage 1) ships the variant definition only — emission and
-    /// handler logic land in sub-task 7b (Stage 2 PR). Until then this
-    /// variant is constructed only by tests pinning the channel shape.
-    #[allow(dead_code)]
-    Stage2Restart(String),
 }
 
 /// Channel for exit events from reaper to daemon.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -163,10 +163,9 @@ pub fn run(fleet_path_override: Option<&str>) -> Result<()> {
 /// daemon runs in app mode (`app::run_app`, never `run_core`), so allowlisting it
 /// out meant the #685 recovery ladder was silently dead in the live daemon (the
 /// #1720 class). It now runs in app mode: Stage1 (ESC-nudge to the PTY) needs no
-/// `crash_rx`; Stage2 (restart) has no app-mode consumer, so it escalates to
-/// Stage3 instead of silent-dropping (see `build_default_handlers`'
-/// `stage2_dispatch_available = false` below). All stages stay shadow-gated-off by
-/// default — zero behavior change unless an operator opts in.
+/// `crash_rx` at all (#2549: Stage2/3 were converged away — see
+/// `daemon/per_tick/recovery_dispatcher.rs`'s module doc). Stage1 stays
+/// shadow-gated-off by default — zero behavior change unless an operator opts in.
 ///
 /// #2413 Phase B (live-fix): `shadow_observe` was REMOVED from this allowlist (same
 /// #1720/#685 class as `recovery_dispatcher` above). The original #2433 allowlisted it
@@ -202,16 +201,10 @@ fn app_snapshot_rotation_enabled() -> bool {
 /// `build_default_handlers` minus `APP_TICK_ALLOWLIST` (and minus `snapshot_rotation` only when
 /// the `AGEND_APP_SNAPSHOT=0` kill-switch is set). Extracted so the completeness invariant can
 /// compare it against the full daemon set.
-///
-/// #1694(a): `crash_tx` here is a throwaway sender (its receiver is dropped), so
-/// `stage2_dispatch_available = false` — `RecoveryDispatcherHandler` now RUNS
-/// (no longer allowlisted out) and its Stage2 path escalates to Stage3 rather
-/// than emit onto the consumerless channel.
 fn app_tick_handlers(
     daemon_binary_stale: crate::daemon::mcp_registry_watcher::DaemonBinaryStale,
 ) -> Vec<Box<dyn crate::daemon::per_tick::PerTickHandler>> {
-    let (crash_tx, _crash_rx) = crossbeam_channel::bounded(1);
-    let mut handlers = crate::daemon::build_default_handlers(crash_tx, false, daemon_binary_stale);
+    let mut handlers = crate::daemon::build_default_handlers(daemon_binary_stale);
     let skip_snapshot = !app_snapshot_rotation_enabled();
     handlers.retain(|h| {
         let name = h.name();
@@ -2063,10 +2056,9 @@ mod tests {
     #[test]
     fn app_tick_handlers_cover_every_non_allowlisted_daemon_handler() {
         use std::collections::HashSet;
-        let (crash_tx, _rx) = crossbeam_channel::bounded(1);
         let stale: crate::daemon::mcp_registry_watcher::DaemonBinaryStale =
             Arc::new(std::sync::atomic::AtomicBool::new(false));
-        let all: HashSet<&str> = crate::daemon::build_default_handlers(crash_tx, true, stale)
+        let all: HashSet<&str> = crate::daemon::build_default_handlers(stale)
             .iter()
             .map(|h| h.name())
             .collect();

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1258,14 +1258,12 @@ fn build_tick_infrastructure(
     // by instances deleted before the cascade-on-delete fix existed.
     crate::daemon::orphan_sweep::run(home);
 
-    // #1694(a): run_core wires `crash_rx` → `handle_crash_respawn`, so Stage2
-    // restarts have a live consumer here (true). `run_core` is headless (no
-    // TUI), so the `DaemonBinaryStale` flag the `mcp_registry` handler flips is
-    // a throwaway here — nothing surfaces it, exactly as the pre-W1.1
-    // supervisor-side flag was in run_core.
+    // `run_core` is headless (no TUI), so the `DaemonBinaryStale` flag the
+    // `mcp_registry` handler flips is a throwaway here — nothing surfaces it,
+    // exactly as the pre-W1.1 supervisor-side flag was in run_core.
     let daemon_binary_stale: crate::daemon::mcp_registry_watcher::DaemonBinaryStale =
         Arc::new(AtomicBool::new(false));
-    let handlers = build_default_handlers(ctx.crash_tx.clone(), true, daemon_binary_stale);
+    let handlers = build_default_handlers(daemon_binary_stale);
 
     let tick_rx = {
         let (tx, rx) = crossbeam_channel::bounded(1);
@@ -1284,27 +1282,6 @@ fn build_tick_infrastructure(
     };
 
     (TickKeepalive { _task_sweep }, handlers, tick_rx)
-}
-
-fn spawn_stage2_thread(home: &Path, name: &str, ctx: &DaemonContext) {
-    let home_owned = home.to_path_buf();
-    let name_owned = name.to_owned();
-    let reg = Arc::clone(&ctx.registry);
-    let cfgs = Arc::clone(&ctx.configs);
-    let tx = ctx.crash_tx.clone();
-    let sd = Arc::clone(&ctx.shutdown);
-    // fire-and-forget: stage2 restart worker is short-lived (backoff sleep
-    // then spawn_agent + restore health counters). Observes shutdown flag
-    // after backoff to abort cleanly. JoinHandle dropped because errors are
-    // logged inside handle_stage2_restart + event_log records outcome.
-    if let Err(e) = std::thread::Builder::new()
-        .name(format!("{name}_stage2"))
-        .spawn(move || {
-            handle_stage2_restart(&home_owned, &name_owned, &reg, &cfgs, &tx, &sd);
-        })
-    {
-        tracing::warn!(agent = %name, error = %e, "failed to spawn stage2 restart thread");
-    }
 }
 
 fn log_residual_worktrees(home: &Path) {
@@ -1854,202 +1831,6 @@ fn spawn_and_register_agent(
         return Err(e.into());
     }
     Ok(())
-}
-
-/// `#685` sub-task 7b: Stage 2 auto-restart handler. Distinct from
-/// the Crash path (which calls `record_crash` + uses exponential
-/// backoff): Stage 2 is a *controlled* restart initiated by the
-/// recovery dispatcher when the agent failed to recover from Stage 1
-/// ESC. Selectively preserves crash counters + recovery counter
-/// across the spawn boundary so the cap (`STAGE2_MAX_RESTARTS_DEFAULT`)
-/// survives the restart it drove.
-///
-/// Decision §1 selective restore (5 fields): `crash_times`,
-/// `total_crashes`, `last_crash_notification`, `last_hung_notification`,
-/// `recovery_restart_count` (+1).
-/// All other `HealthTracker` fields reset to fresh defaults — including
-/// `state: Healthy` (Stage 2 success seed) and `recovery_stage_state:
-/// None` (linear escalation rule restarts).
-///
-/// `spawn_agent` failure: agent removed from registry, dispatcher
-/// next-tick won't find it. Operator already received Stage 2 telegram
-/// pre-emit so visibility is preserved. Phase 1 limitation acknowledged
-/// in `docs/RECOVERY-STAGES.md §RS.9` — full operator unpause +
-/// re-spawn flow ships in sub-task 7c.
-fn handle_stage2_restart(
-    home: &Path,
-    name: &str,
-    registry: &AgentRegistry,
-    configs: &Arc<Mutex<HashMap<String, crate::daemon::AgentConfig>>>,
-    crash_tx: &crossbeam_channel::Sender<crate::agent::AgentExitEvent>,
-    shutdown: &Arc<std::sync::atomic::AtomicBool>,
-) {
-    use std::time::{Duration, Instant};
-    tracing::warn!(
-        target: "recovery_shadow",
-        agent = %name,
-        "stage2 restart initiated"
-    );
-    crate::event_log::log(home, "stage2_restart", name, "stage 2 auto-restart");
-
-    // #1441: registry is UUID-keyed; resolve once and key both the snapshot
-    // read and the post-spawn restore by it.
-    let instance_id = crate::fleet::resolve_uuid(home, name);
-
-    // Snapshot the 4 fields we'll preserve across spawn. Reads then
-    // drops the lock before backoff sleep + spawn.
-    let saved = {
-        let reg = agent::lock_registry(registry);
-        instance_id.and_then(|id| reg.get(&id)).map(|h| {
-            let core = h.core.lock();
-            (
-                core.health.crash_times.clone(),
-                core.health.total_crashes,
-                // #1744-H3: the former shared `last_notification` is now two
-                // per-class cooldowns — preserve both across the Stage-2 respawn.
-                core.health.last_crash_notification,
-                core.health.last_hung_notification,
-                core.health.recovery_restart_count,
-            )
-        })
-    };
-    let saved = match saved {
-        Some(s) => s,
-        None => {
-            tracing::warn!(
-                target: "recovery_shadow",
-                agent = %name,
-                "stage2 restart: agent not in registry, skipping"
-            );
-            return;
-        }
-    };
-
-    let config = match configs.lock().get(name).cloned() {
-        Some(c) => c,
-        None => {
-            tracing::warn!(
-                target: "recovery_shadow",
-                agent = %name,
-                "stage2 restart: no config for respawn (likely deleted)"
-            );
-            return;
-        }
-    };
-
-    let backoff = Duration::from_millis(crate::health::STAGE2_BACKOFF_DEFAULT_MS);
-
-    std::thread::sleep(backoff);
-    if shutdown.load(std::sync::atomic::Ordering::Relaxed) {
-        tracing::info!(
-            target: "recovery_shadow",
-            agent = %name,
-            "shutdown during stage2 backoff, aborting"
-        );
-        return;
-    }
-
-    // #1080: re-install skills on stage2 restart (idempotent).
-    if let Some(ref wd) = config.working_dir {
-        let skills_filter: Option<Vec<String>> =
-            crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))
-                .ok()
-                .and_then(|c| c.instances.get(name).and_then(|i| i.skills.clone()));
-        let custom_skills_source: Option<std::path::PathBuf> =
-            crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))
-                .ok()
-                .and_then(|c| c.instances.get(name).and_then(|i| i.skills_path.clone()))
-                .map(|p| crate::fleet::resolve::expand_tilde_path(&p));
-        let backend_skill = crate::backend::Backend::from_command(&config.backend_command)
-            .and_then(|b| b.skill_dir_name());
-        if let Err(e) = crate::skills::install_for_agent_backend_with_source(
-            home,
-            wd,
-            skills_filter.as_deref(),
-            backend_skill,
-            custom_skills_source.as_deref(),
-        ) {
-            tracing::warn!(
-                target: "recovery_shadow",
-                agent = %name, error = %e, "stage2 skills install failed"
-            );
-        }
-    }
-
-    // #1547 M2(b): re-run MCP config on the recovery/respawn path (idempotent).
-    // Critical for agy: its HOME-level discovery cache means a respawn that does
-    // NOT re-configure comes back WITHOUT fleet tools (recovery is exactly when
-    // they're needed). `configure_agy` rewrites `.agents/mcp_config.json` and
-    // busts the discovery cache; for other backends this is a harmless
-    // idempotent rewrite of the project-local config. Mirrors the skills
-    // re-install above (the spawn path's config-generation is otherwise only
-    // run on the INITIAL spawn, not here).
-    if let Some(ref wd) = config.working_dir {
-        crate::mcp_config::configure(wd, &config.backend_command, Some(name));
-    }
-
-    let (cols, rows) = crossterm::terminal::size().unwrap_or((120, 40));
-    let spawn_result = agent::spawn_agent(
-        &agent::SpawnConfig {
-            name,
-            backend_command: &config.backend_command,
-            args: &config.args,
-            spawn_mode: crate::backend::SpawnMode::Fresh,
-            cols,
-            rows,
-            env: config.env.as_ref(),
-            working_dir: config.working_dir.as_deref(),
-            submit_key: &config.submit_key,
-            home: Some(home),
-            crash_tx: Some(crash_tx.clone()),
-            shutdown: Some(Arc::clone(shutdown)),
-        },
-        registry,
-    );
-
-    match spawn_result {
-        Ok(_) => {
-            tracing::info!(
-                target: "recovery_shadow",
-                agent = %name,
-                "stage2 spawn ok"
-            );
-            crate::event_log::log(home, "stage2_spawn_ok", name, "stage 2 spawn succeeded");
-
-            // Selective restore — fresh tracker starts with default
-            // values; we overwrite only the 4 preserved fields and
-            // increment recovery_restart_count by 1 (this Stage 2 fire
-            // contributes to the cap). All other fields stay at
-            // default — state stays Healthy (recovery success seed),
-            // recovery_stage_state stays None (linear escalation reset
-            // already encoded by spontaneous-recovery reset in
-            // dispatcher).
-            let reg = agent::lock_registry(registry);
-            if let Some(handle) = instance_id.and_then(|id| reg.get(&id)) {
-                let mut core = handle.core.lock();
-                let (crash_times, total_crashes, last_crash_notif, last_hung_notif, prev_count) =
-                    saved;
-                core.health.crash_times = crash_times;
-                core.health.total_crashes = total_crashes;
-                core.health.last_crash_notification = last_crash_notif;
-                core.health.last_hung_notification = last_hung_notif;
-                core.health.recovery_restart_count = prev_count.saturating_add(1);
-                core.health.last_stage2_fired_at = Some(Instant::now());
-            }
-        }
-        Err(e) => {
-            tracing::warn!(
-                target: "recovery_shadow",
-                agent = %name,
-                error = %e,
-                "stage2 spawn failed — agent removed, operator notified via telegram"
-            );
-            crate::event_log::log(home, "stage2_spawn_failed", name, &format!("error: {e}"));
-            // Agent left removed; operator handles via manual re-spawn
-            // OR future operator-unpause / re-spawn sub-task. Phase 1
-            // limitation documented in §RS.9.
-        }
-    }
 }
 
 #[cfg(test)]
@@ -3019,44 +2800,6 @@ mod tests {
         for name in &agent_names {
             kill_registered_child(&registry, name);
         }
-        std::fs::remove_dir_all(&home).ok();
-    }
-
-    /// #1126 characterization: handle_stage2_restart runs on a spawned
-    /// thread without blocking the caller. Pre-fix, the function ran
-    /// inline on the main loop with `thread::sleep(backoff)`.
-    #[test]
-    fn stage2_restart_does_not_block_caller() {
-        let home = tmp_home("stage2_nonblock");
-        let registry: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
-        let configs: Arc<Mutex<HashMap<String, AgentConfig>>> =
-            Arc::new(Mutex::new(HashMap::new()));
-        let (crash_tx, _crash_rx) = crossbeam_channel::unbounded();
-        let shutdown = Arc::new(std::sync::atomic::AtomicBool::new(false));
-
-        // Backoff is the fixed STAGE2_BACKOFF_DEFAULT_MS const; the spawned
-        // worker sleeps it on its own thread, so the caller must still return
-        // immediately (that non-blocking contract is what this test pins).
-        let start = std::time::Instant::now();
-        let home_owned = home.to_path_buf();
-        let reg = Arc::clone(&registry);
-        let cfgs = Arc::clone(&configs);
-        let tx = crash_tx.clone();
-        let sd = Arc::clone(&shutdown);
-        let handle = std::thread::Builder::new()
-            .name("test_stage2".into())
-            .spawn(move || {
-                handle_stage2_restart(&home_owned, "ghost", &reg, &cfgs, &tx, &sd);
-            })
-            .unwrap();
-
-        assert!(
-            start.elapsed() < std::time::Duration::from_millis(100),
-            "spawn must return immediately — main loop is not blocked"
-        );
-
-        handle.join().unwrap();
-
         std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/daemon/per_tick/mod.rs
+++ b/src/daemon/per_tick/mod.rs
@@ -250,11 +250,11 @@ pub(crate) fn run_handlers_with_panic_guard(
 }
 
 /// AUDIT2-007: run the crash-event dispatch arm under the same panic guard the
-/// per-tick handlers get (#1002). `handle_clean_exit` / `spawn_stage2_thread` /
-/// `handle_crash_respawn` do telegram `block_on`, `escalation_persist` and fleet
-/// resolve — a panic there would unwind out of `run_core` and take down the whole
-/// daemon, escalating one agent's crash into a fleet-wide supervisor outage. Lives
-/// here (not in `daemon/mod.rs`) to keep that grandfathered file under its ceiling.
+/// per-tick handlers get (#1002). `handle_clean_exit` / `handle_crash_respawn` do
+/// telegram `block_on`, `escalation_persist` and fleet resolve — a panic there
+/// would unwind out of `run_core` and take down the whole daemon, escalating one
+/// agent's crash into a fleet-wide supervisor outage. Lives here (not in
+/// `daemon/mod.rs`) to keep that grandfathered file under its ceiling.
 pub(crate) fn dispatch_exit_event_guarded(
     exit_event: crate::agent::AgentExitEvent,
     home: &std::path::Path,
@@ -264,9 +264,6 @@ pub(crate) fn dispatch_exit_event_guarded(
     let guarded = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| match exit_event {
         AgentExitEvent::CleanExit(ref name) => {
             super::handle_clean_exit(home, name.as_str(), &ctx.registry, &ctx.configs);
-        }
-        AgentExitEvent::Stage2Restart(name) => {
-            super::spawn_stage2_thread(home, &name, ctx);
         }
         AgentExitEvent::Crash(name) => {
             super::crash_respawn::handle_crash_respawn(home, &name, ctx);
@@ -288,21 +285,12 @@ pub(crate) fn dispatch_exit_event_guarded(
 /// invariant fails CI if a new handler lands here but neither runs in app nor is
 /// allowlisted.
 ///
-/// `crash_tx` is consumed by `RecoveryDispatcherHandler`. `stage2_dispatch_available`
-/// tells the handler whether a `Stage2Restart` on that channel has a live consumer
-/// in this runtime: `run_core` wires `crash_rx` (true); app-standalone passes a
-/// throwaway sender (false) — #1694(a) now RUNS the handler in app mode (Stage1
-/// ESC-nudge), but its Stage2 path escalates to Stage3 rather than silent-drop
-/// onto the consumerless channel.
-///
 /// #2538: relocated verbatim from `daemon::mod` (that grandfathered file was at
 /// its LOC ceiling with zero slack) — every `per_tick::X` reference below became
 /// bare `X` (already in scope via this module's own re-exports) and the one
 /// daemon-level reference (`watchdog::watchdog_dry_run_from_env`) became
 /// `super::watchdog::...`; no other change.
 pub(crate) fn build_default_handlers(
-    crash_tx: crossbeam_channel::Sender<crate::agent::AgentExitEvent>,
-    stage2_dispatch_available: bool,
     daemon_binary_stale: crate::daemon::mcp_registry_watcher::DaemonBinaryStale,
 ) -> Vec<Box<dyn PerTickHandler>> {
     let watchdog_dry_run = super::watchdog::watchdog_dry_run_from_env();
@@ -321,10 +309,7 @@ pub(crate) fn build_default_handlers(
         // set health state" concerns). Ordering-independent of RecoveryDispatcher
         // below (that reacts only to `Hung`, never `Unhealthy`).
         Box::new(BackendExitDetectionHandler::new()),
-        Box::new(RecoveryDispatcherHandler::new(
-            std::sync::Arc::new(crash_tx),
-            stage2_dispatch_available,
-        )),
+        Box::new(RecoveryDispatcherHandler::new()),
         // #t-777-3: respawn-stuck watchdog — auto-Fresh-restart an agent whose
         // Resume spawn hung (corrupt-session `resume --last`), bounded by a
         // retry cap that escalates a P0 + pause. Recovers via the proven API

--- a/src/daemon/per_tick/notification_flush.rs
+++ b/src/daemon/per_tick/notification_flush.rs
@@ -221,10 +221,9 @@ mod tests {
     /// `run_core` is exactly where the TUI flush doesn't exist.
     #[test]
     fn registered_in_default_daemon_pipeline() {
-        let (crash_tx, _crash_rx) = crossbeam_channel::bounded(1);
         let stale: crate::daemon::mcp_registry_watcher::DaemonBinaryStale =
             std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
-        let handlers = crate::daemon::build_default_handlers(crash_tx, false, stale);
+        let handlers = crate::daemon::build_default_handlers(stale);
         assert!(
             handlers.iter().any(|h| h.name() == "notification_flush"),
             "NotificationFlushHandler must run in headless run_core — \

--- a/src/daemon/per_tick/recovery_dispatcher.rs
+++ b/src/daemon/per_tick/recovery_dispatcher.rs
@@ -1,21 +1,43 @@
-//! `#685` sub-task 7a Stage 1 — auto-recovery dispatcher.
+//! `#685` sub-task 7a — Stage-1-only auto-recovery dispatcher.
 //!
 //! Decision: `d-20260514030404021793-1`. Three-party consensus
 //! (lead-claude + dev-claude + reviewer-opencode).
 //!
-//! Phase 2 of `#685`: when `check_hang` (sub-task 1) detects `Hung`,
-//! the daemon currently emits a single `tracing::warn!` and does
-//! nothing else. This handler is the first step toward staged
-//! auto-recovery — Stage 1 sends an ESC byte to the agent's PTY
-//! ("simulate operator pressing ESC") and monitors whether the agent
-//! self-recovers within a timeout window.
+//! When `check_hang` (sub-task 1) detects `Hung`, this handler sends an
+//! ESC byte to the agent's PTY ("simulate operator pressing ESC") and
+//! monitors whether the agent self-recovers within a timeout window.
 //!
-//! Stages 2 (auto-restart) and 3 (pause + escalate) are follow-up
-//! sub-tasks (`7b`, `7c`). This module ships the **infrastructure** for
-//! all three stages: the `RecoveryStageState` state machine, per-agent
-//! tracking field on `HealthTracker`, env-var gate, anti-thrash
-//! cooldown. Stages 2/3 will add their dispatch arms but reuse this
-//! tick loop, this state machine, and this telemetry pattern.
+//! #2549 P2 (operator decision `d-20260703021554626467-13`): Stage 2
+//! (auto-restart) and the dispatcher-driven Stage 3 escalation path were
+//! removed — converged to Stage-1-only. Prior to this PR, Stage 2/3 were
+//! shipped but gated OFF by default (`hang_auto_recovery_enabled: false`
+//! and no per-stage env var set); under that default, `Stage2Eligible`
+//! parked indefinitely re-logging a shadow message every tick and NEVER
+//! reached Stage 3 — `stage2_decision`'s `Shadow` arm returned without
+//! mutating `recovery_stage_state`, and the only two paths that ever
+//! advanced past `Stage2Eligible` (`Stage2Pending` timeout,
+//! `EscalateNoConsumer`) both required the Stage 2 gate active. So the
+//! three branches that used to transition into `Stage2Eligible` (Stage 1
+//! timeout, PTY write failure, dead-likely classification) are now
+//! **log-only** — this preserves the default-gate-off behavior exactly
+//! (no new pause/restart side effects for agents that previously just sat
+//! in shadow-logged limbo). See the per-branch comments below.
+//!
+//! One consequence: since nothing in this file transitions into it
+//! anymore, `RecoveryStageState::Stage3Eligible` became permanently
+//! unreachable and was removed along with `Stage2Eligible`/`Stage2Pending`.
+//! `Stage3Pending` / `HealthState::Paused` /
+//! [`crate::health::HealthTracker::enter_paused`] are **untouched** — they
+//! are shared terminal-escalation machinery also used independently by
+//! `RespawnWatchdogHandler` (an unrelated failure mode: a stuck `resume`
+//! spawn, not the Hung ladder), so this dispatcher's `Stage3Pending` arm
+//! stays reachable via that path even though this file no longer
+//! constructs the state itself.
+//!
+//! `recovery_restart_count` (the Stage 2 cumulative-restart cap) is
+//! deleted, not kept for hypothetical future reuse — with Stage 2 gone
+//! nothing increments it, so the cap check was a permanently-dead branch;
+//! git history is the reuse mechanism if Stage 2 is ever revisited.
 //!
 //! ## Tick order
 //!
@@ -35,7 +57,6 @@
 //! (env var unset) emits the same telemetry log but does NOT send the
 //! ESC byte or transition the state machine — observability without
 //! production impact, mirroring the F9 shadow-mode SOP (sub-task 4).
-//! Stages 2/3 follow the same pattern with their own env vars.
 //!
 //! ## Combined-gate three branches
 //!
@@ -46,8 +67,9 @@
 //! - **alive-stuck**: `productive_silence > threshold` && `silent < threshold`
 //!   → fire Stage 1 ESC (agent process reading PTY, just not productive)
 //! - **dead-likely**: `silent > threshold`
-//!   → skip Stage 1, transition directly to `Stage2Eligible`
-//!   (ESC won't help a process that's not reading)
+//!   → skip Stage 1 (ESC won't help a process that's not reading); log
+//!   only, state stays `None` (#2549: was a transition to the now-removed
+//!   `Stage2Eligible`)
 //! - **anomaly**: neither condition holds (agent shouldn't be `Hung`)
 //!   → log warning, leave state unchanged
 //!
@@ -55,8 +77,9 @@
 //!
 //! Decision §1.4 Refinement B — if agent re-enters `Hung` within
 //! `STAGE1_COOLDOWN_DEFAULT_MS` of a recent Stage 1 fire, dispatcher
-//! skips Stage 1 and goes directly to `Stage2Eligible`. Prevents
-//! rapid-fire ESC sending that would mask the underlying issue.
+//! skips re-firing Stage 1; log only, state stays `None` (#2549: was a
+//! transition to the now-removed `Stage2Eligible`). Prevents rapid-fire
+//! ESC sending that would mask the underlying issue.
 
 use super::{PerTickHandler, TickContext};
 use crate::agent;
@@ -69,9 +92,9 @@ use std::time::{Duration, Instant};
 
 /// #1617 (#1593 F1): per-agent snapshot captured under the registry lock
 /// so the recovery state machine — including the Stage-1 blocking PTY
-/// write and the Stage-2/3 notify I/O — runs AFTER the lock is dropped.
-/// `core` + `pty_writer` are both `Arc`, so cloning them out is cheap and
-/// lets the registry guard be released before any blocking work.
+/// write — runs AFTER the lock is dropped. `core` + `pty_writer` are both
+/// `Arc`, so cloning them out is cheap and lets the registry guard be
+/// released before any blocking work.
 struct RecoveryTarget {
     name: String,
     core: Arc<crate::sync_audit::CoreMutex<agent::AgentCore>>,
@@ -89,80 +112,12 @@ const STAGE1_ENV_VAR: &str = "AGEND_AUTO_RECOVERY_STAGE1";
 /// audit observability surface.
 const TARGET: &str = "recovery_shadow";
 
-/// `#685` sub-task 7b: env var controlling Stage 2 activation. When
-/// set to `"1"`, the dispatcher emits `AgentExitEvent::Stage2Restart`
-/// to `crash_tx` (active mode). Default unset = shadow mode: same
-/// telemetry, no event emission.
-const STAGE2_ENV_VAR: &str = "AGEND_AUTO_RECOVERY_STAGE2";
-const STAGE2_MAX_RESTARTS_ENV_VAR: &str = "AGEND_AUTO_RECOVERY_STAGE2_MAX_RESTARTS";
-
-/// `#685` sub-task 7c: env var controlling Stage 3 escalation activation.
-/// When set to `"1"`, the dispatcher writes `HealthState::Paused` via
-/// `HealthTracker::enter_paused` (active mode). Default unset = shadow
-/// mode: telegram + tracing only, no state write — operator can observe
-/// the decision pattern before flipping. Mirrors STAGE1 / STAGE2 env
-/// gate pattern.
-const STAGE3_ENV_VAR: &str = "AGEND_AUTO_RECOVERY_STAGE3";
-
-pub(crate) struct RecoveryDispatcherHandler {
-    /// `#685` sub-task 7b: handle to the daemon's `crash_tx` channel.
-    /// Stage 1 path (already shipped in 7a) holds but never sends —
-    /// kept for uniform constructor across stages. Stage 2 path uses
-    /// `try_send` to emit `AgentExitEvent::Stage2Restart` events that
-    /// the respawn worker arm (in `daemon/mod.rs:642`) splits on.
-    ///
-    /// `Arc` so the dispatcher can clone-as-needed; channel `Sender` is
-    /// itself cheap-to-clone but `Arc` keeps the surface uniform across
-    /// future stages and avoids leaking `crossbeam_channel::Sender`
-    /// across the trait boundary.
-    crash_tx: std::sync::Arc<crossbeam_channel::Sender<crate::agent::AgentExitEvent>>,
-    /// #1694(a): whether a `Stage2Restart` emitted on `crash_tx` actually has a
-    /// live consumer in THIS runtime. `run_core` wires `crash_rx` →
-    /// `handle_crash_respawn` (true); app-standalone passes a throwaway channel
-    /// whose `rx` is dropped (false), so a Stage2 `try_send` there would silently
-    /// vanish. When false, `handle_stage2_fire` escalates straight to Stage3
-    /// (graceful pause + operator escalation) instead of a no-op restart — the
-    /// M-class silent-drop this whole sprint has been closing. (The real fix —
-    /// Stage2 driving app mode's pane-based respawn — is a follow-up; Stage2 stays
-    /// gated-off by default, so this only fires if an operator enables Stage2 in
-    /// app mode.)
-    stage2_dispatch_available: bool,
-}
+pub(crate) struct RecoveryDispatcherHandler;
 
 impl RecoveryDispatcherHandler {
-    pub(crate) fn new(
-        crash_tx: std::sync::Arc<crossbeam_channel::Sender<crate::agent::AgentExitEvent>>,
-        stage2_dispatch_available: bool,
-    ) -> Self {
-        Self {
-            crash_tx,
-            stage2_dispatch_available,
-        }
+    pub(crate) fn new() -> Self {
+        Self
     }
-}
-
-fn stage2_gate_active() -> bool {
-    crate::runtime_config::get().hang_auto_recovery_enabled
-        || std::env::var(STAGE2_ENV_VAR)
-            .map(|v| v == "1")
-            .unwrap_or(false)
-}
-
-fn stage2_max_restarts() -> u32 {
-    match std::env::var(STAGE2_MAX_RESTARTS_ENV_VAR) {
-        Ok(v) => match v.parse::<u32>() {
-            Ok(n) => n,
-            Err(_) => crate::health::STAGE2_MAX_RESTARTS_DEFAULT,
-        },
-        Err(_) => crate::health::STAGE2_MAX_RESTARTS_DEFAULT,
-    }
-}
-
-fn stage3_gate_active() -> bool {
-    crate::runtime_config::get().hang_auto_recovery_enabled
-        || std::env::var(STAGE3_ENV_VAR)
-            .map(|v| v == "1")
-            .unwrap_or(false)
 }
 
 fn stage1_gate_active() -> bool {
@@ -181,7 +136,7 @@ enum Stage1Branch {
     /// `silence < threshold`. ESC is the right action.
     AliveStuck,
     /// Agent is dead-likely — `silence > threshold`. Stage 1 would be
-    /// wasted; transition directly to `Stage2Eligible`.
+    /// wasted (ESC won't help a process not reading its PTY).
     DeadLikely,
     /// Neither condition holds; agent shouldn't be `Hung`. Log warning
     /// but leave dispatcher state untouched.
@@ -209,31 +164,6 @@ fn classify_branch(
     }
 }
 
-/// #1694(a): three-way decision for `handle_stage2_fire`, extracted (like
-/// [`Stage1Branch`]) so the branch logic is unit-testable independent of the
-/// PTY/channel side effects — no AgentHandle harness needed.
-#[derive(Debug, PartialEq, Eq)]
-enum Stage2Decision {
-    /// Gate off — shadow mode: log the would-fire, no send, no transition.
-    Shadow,
-    /// Gate on but no live crash consumer in this runtime (app-standalone) —
-    /// escalate to Stage3 (graceful pause + escalation) rather than silent-drop
-    /// the `Stage2Restart` onto a receiver-less channel.
-    EscalateNoConsumer,
-    /// Gate on + a live consumer — emit the `Stage2Restart` (active mode).
-    Fire,
-}
-
-fn stage2_decision(gate_active: bool, stage2_dispatch_available: bool) -> Stage2Decision {
-    if !gate_active {
-        Stage2Decision::Shadow
-    } else if !stage2_dispatch_available {
-        Stage2Decision::EscalateNoConsumer
-    } else {
-        Stage2Decision::Fire
-    }
-}
-
 impl PerTickHandler for RecoveryDispatcherHandler {
     fn name(&self) -> &'static str {
         "recovery_dispatcher"
@@ -243,18 +173,14 @@ impl PerTickHandler for RecoveryDispatcherHandler {
         let stage1_active = stage1_gate_active();
         let stage1_timeout = Duration::from_millis(STAGE1_TIMEOUT_DEFAULT_MS);
         let stage1_cooldown = Duration::from_millis(STAGE1_COOLDOWN_DEFAULT_MS);
-        let stage2_active = stage2_gate_active();
-        let stage2_timeout = Duration::from_millis(crate::health::STAGE2_TIMEOUT_DEFAULT_MS);
-        let stage2_max = stage2_max_restarts();
-        let stage3_active = stage3_gate_active();
 
         // #1617 (#1593 F1): snapshot each agent's `core` + `pty_writer`
         // (both `Arc`) UNDER the registry lock, then DROP the lock before
         // any per-agent recovery work. The Stage-1 path does a blocking PTY
-        // write and Stages 2/3 do notify I/O — holding the global registry
-        // lock across those is the deadlock class #1593 closed elsewhere:
-        // a hung agent's PTY never drains, the write blocks, and the
-        // supervisor tick stalls holding the registry → whole daemon hangs.
+        // write — holding the global registry lock across that is the
+        // deadlock class #1593 closed elsewhere: a hung agent's PTY never
+        // drains, the write blocks, and the supervisor tick stalls holding
+        // the registry → whole daemon hangs.
         // #941 holder-tracking still wraps the (now brief) snapshot hold.
         let targets: Vec<RecoveryTarget> = {
             let reg = agent::lock_registry_tracked(ctx.registry, "recovery_dispatcher");
@@ -282,7 +208,6 @@ impl PerTickHandler for RecoveryDispatcherHandler {
                     health_state: core.health.state,
                     recovery_stage_state: core.health.recovery_stage_state,
                     last_stage1_fired_at: core.health.last_stage1_fired_at,
-                    recovery_restart_count: core.health.recovery_restart_count,
                     // KEEP-RAW (#2465): the recovery dispatcher is a health-state machine — feeding it
                     // the promoted/observed state could let a stale/false 'Active' hook MASK a genuinely
                     // stuck agent and skip its recovery escalation. Do NOT migrate to operated_state.
@@ -332,40 +257,24 @@ impl PerTickHandler for RecoveryDispatcherHandler {
                     &snapshot,
                     stage1_active,
                     stage1_cooldown,
-                    stage2_max,
                 ),
                 RecoveryStageState::Stage1Pending { entered_at } => {
+                    // #2549: Stage 1 timeout used to escalate to the now-removed
+                    // `Stage2Eligible`. Under the pre-#2549 default (Stage 2 gate
+                    // off), `Stage2Eligible` re-logged a shadow "would-have-fired"
+                    // message every tick and never advanced further — so log-only
+                    // here (state stays `Stage1Pending`, re-logging every tick the
+                    // same way) preserves that default behavior exactly, with zero
+                    // new pause/restart side effects.
                     if entered_at.elapsed() >= stage1_timeout {
                         tracing::info!(
                             target: TARGET,
                             agent = %name,
                             timeout_ms = stage1_timeout.as_millis() as u64,
                             gate_active = stage1_active,
-                            "stage1 timeout expired without recovery — escalating to Stage2Eligible"
+                            "stage1 timeout expired without recovery — no further auto-recovery stage available (Stage 2/3 removed #2549); agent remains Hung pending manual intervention or spontaneous recovery"
                         );
-                        let mut core = target.core.lock();
-                        core.health.recovery_stage_state = RecoveryStageState::Stage2Eligible;
                     }
-                }
-                RecoveryStageState::Stage2Eligible => {
-                    self.handle_stage2_fire(name, target, &snapshot, stage2_active);
-                }
-                RecoveryStageState::Stage2Pending { entered_at } => {
-                    if entered_at.elapsed() >= stage2_timeout {
-                        tracing::info!(
-                            target: TARGET,
-                            agent = %name,
-                            timeout_ms = stage2_timeout.as_millis() as u64,
-                            gate_active = stage2_active,
-                            recovery_restart_count = snapshot.recovery_restart_count,
-                            "stage2 timeout expired without recovery — escalating to Stage3Eligible"
-                        );
-                        let mut core = target.core.lock();
-                        core.health.recovery_stage_state = RecoveryStageState::Stage3Eligible;
-                    }
-                }
-                RecoveryStageState::Stage3Eligible => {
-                    self.handle_stage3_escalate(name, target, &snapshot, stage3_active);
                 }
                 RecoveryStageState::Stage3Pending { entered_at } => {
                     // Stage 3 is terminal — no further auto-recovery,
@@ -399,27 +308,7 @@ impl RecoveryDispatcherHandler {
         snapshot: &DispatchSnapshot,
         gate_active: bool,
         cooldown_window: Duration,
-        stage2_max: u32,
     ) {
-        // `#685` sub-task 7b: cumulative restart cap check. If the agent
-        // has already been Stage-2-restarted `stage2_max` times across
-        // prior Hung cycles (decayed by `maybe_decay` per
-        // `STABILITY_WINDOW`), skip Stages 1/2 entirely and escalate
-        // directly to `Stage3Eligible`. Operator intervention required
-        // rather than further automated thrashing.
-        if snapshot.recovery_restart_count >= stage2_max {
-            tracing::info!(
-                target: TARGET,
-                agent = %name,
-                recovery_restart_count = snapshot.recovery_restart_count,
-                stage2_max,
-                "recovery restart cap reached — escalating directly to Stage3Eligible"
-            );
-            let mut core = target.core.lock();
-            core.health.recovery_stage_state = RecoveryStageState::Stage3Eligible;
-            return;
-        }
-
         let branch = classify_branch(
             snapshot.agent_state,
             snapshot.silent,
@@ -442,26 +331,29 @@ impl RecoveryDispatcherHandler {
                 );
             }
             (Stage1Branch::AliveStuck, true) => {
+                // #2549: used to escalate to the now-removed `Stage2Eligible`.
+                // Under the pre-#2549 default (Stage 2 gate off) that state
+                // just re-logged a shadow message every tick with no further
+                // action, so log-only + leave state at `None` (re-classified
+                // fresh next tick) preserves that behavior exactly.
                 tracing::info!(
                     target: TARGET,
                     agent = %name,
                     cooldown_ms = cooldown_window.as_millis() as u64,
                     gate_active,
-                    "stage1 skipped (cooldown active) — escalating to Stage2Eligible"
+                    "stage1 skipped (cooldown active) — no further auto-recovery stage available (Stage 2/3 removed #2549)"
                 );
-                let mut core = target.core.lock();
-                core.health.recovery_stage_state = RecoveryStageState::Stage2Eligible;
             }
             (Stage1Branch::DeadLikely, _) => {
+                // #2549: see the cooldown-skip arm above — same log-only
+                // preservation of the pre-#2549 default-gate-off behavior.
                 tracing::info!(
                     target: TARGET,
                     agent = %name,
                     silent_ms = snapshot.silent.as_millis() as u64,
                     gate_active,
-                    "stage1 skipped (dead-likely: silence > threshold) — escalating to Stage2Eligible"
+                    "stage1 skipped (dead-likely: silence > threshold) — no further auto-recovery stage available (Stage 2/3 removed #2549)"
                 );
-                let mut core = target.core.lock();
-                core.health.recovery_stage_state = RecoveryStageState::Stage2Eligible;
             }
             (Stage1Branch::Anomaly, _) => {
                 tracing::warn!(
@@ -475,190 +367,6 @@ impl RecoveryDispatcherHandler {
             }
         }
     }
-
-    /// Stage 2 fire arm. Emits `AgentExitEvent::Stage2Restart` to the
-    /// respawn worker via `try_send` (channel-full safety: failed send
-    /// does NOT increment counter; state stays `Stage2Eligible` for
-    /// next-tick retry). Telegram notify pre-emit per dev refinement A
-    /// (Stages 2/3 fire telegram; Stage 1 silent on success).
-    ///
-    /// #1339 DAEMON-AUTONOMIC, GATE-EXEMPT BY DESIGN: the restart this triggers is
-    /// reached ONLY from the per-tick recovery state machine on an internal
-    /// trigger — a Hung-state detection (gated by `hang_auto_recovery_enabled`) —
-    /// never from the API socket. Daemon self-heal (a third trusted principal),
-    /// so the operator-mode gate does NOT apply: a hung agent is still recovered
-    /// in away/sleep. Not agent-invocable (an agent can at most hang ITSELF).
-    fn handle_stage2_fire(
-        &self,
-        name: &str,
-        target: &RecoveryTarget,
-        snapshot: &DispatchSnapshot,
-        gate_active: bool,
-    ) {
-        match stage2_decision(gate_active, self.stage2_dispatch_available) {
-            Stage2Decision::Shadow => {
-                // Emit telemetry but no event send and no state transition.
-                // Operator can observe the decision pattern before flipping
-                // `AGEND_AUTO_RECOVERY_STAGE2=1`.
-                tracing::info!(
-                    target: TARGET,
-                    agent = %name,
-                    recovery_restart_count = snapshot.recovery_restart_count,
-                    silent_ms = snapshot.silent.as_millis() as u64,
-                    silent_productive_ms = snapshot.silent_productive.as_millis() as u64,
-                    gate_active = false,
-                    "stage2 would-have-fired (shadow mode): Stage2Restart event NOT emitted"
-                );
-                return;
-            }
-            Stage2Decision::EscalateNoConsumer => {
-                // #1694(a): Stage 2 auto-restart has no consumer in THIS runtime —
-                // app-standalone passes a throwaway `crash_tx` whose `rx` is
-                // dropped, so `try_send(Stage2Restart)` would silently vanish (the
-                // M-class silent-drop). Escalate straight to Stage3 (graceful pause
-                // + operator escalation, which needs no crash consumer) so the
-                // stuck agent is SURFACED, not dropped. Stage2 stays gated-off by
-                // default, so this only fires if an operator enabled Stage2 in app
-                // mode; the proper fix (Stage2 driving app mode's pane-based
-                // respawn) is a follow-up.
-                tracing::warn!(
-                    target: TARGET,
-                    agent = %name,
-                    recovery_restart_count = snapshot.recovery_restart_count,
-                    "stage2 restart unavailable in this runtime (no crash consumer) — escalating to Stage3 instead of silent-drop"
-                );
-                let mut core = target.core.lock();
-                core.health.recovery_stage_state = RecoveryStageState::Stage3Eligible;
-                return;
-            }
-            Stage2Decision::Fire => {}
-        }
-
-        // Active mode — emit telegram notify pre-emit so operators have
-        // visibility into the restart even if the channel send fails.
-        // AUDIT2-008: but a persistently-full crash_tx keeps the agent in
-        // Stage2Eligible, so this fire path re-runs every tick. Notify on the
-        // FIRST attempt (and at most once per backoff thereafter), not on every
-        // retry — otherwise it's an operator telegram every ~10s per stuck agent
-        // (and the changing silent_ms in the body even defeats channel dedup).
-        const STAGE2_NOTIFY_BACKOFF: std::time::Duration = std::time::Duration::from_secs(300);
-        let should_notify = {
-            let mut core = target.core.lock();
-            let now = Instant::now();
-            let due = core
-                .health
-                .last_stage2_notify_at
-                .map(|t| now.duration_since(t) >= STAGE2_NOTIFY_BACKOFF)
-                .unwrap_or(true);
-            if due {
-                core.health.last_stage2_notify_at = Some(now);
-            }
-            due
-        };
-        if should_notify {
-            notify_stage2_fire(name, snapshot);
-        }
-
-        // try_send returns `Err(TrySendError::Full)` if the bounded(64)
-        // channel is saturated. Counter NOT incremented on rejection;
-        // state stays `Stage2Eligible` so the next tick retries.
-        match self
-            .crash_tx
-            .try_send(crate::agent::AgentExitEvent::Stage2Restart(
-                name.to_string(),
-            )) {
-            Ok(_) => {
-                tracing::info!(
-                    target: TARGET,
-                    agent = %name,
-                    recovery_restart_count = snapshot.recovery_restart_count,
-                    gate_active = true,
-                    "stage2 fired: Stage2Restart event emitted to respawn worker"
-                );
-                let mut core = target.core.lock();
-                core.health.recovery_stage_state = RecoveryStageState::Stage2Pending {
-                    entered_at: Instant::now(),
-                };
-                core.health.last_stage2_fired_at = Some(Instant::now());
-                // AUDIT2-008: the restart fired and we left Stage2Eligible — reset
-                // the notify backoff so a fresh future Stage-2 episode notifies
-                // immediately rather than being suppressed by this episode's stamp.
-                core.health.last_stage2_notify_at = None;
-                // Counter increment lives on the respawn worker side
-                // (selective-restore arm in `daemon/mod.rs` Stage 2 path)
-                // — it preserves the counter across the spawn boundary
-                // AND increments by 1. This avoids double-counting if
-                // the dispatcher tick fires here and the respawn worker
-                // also increments.
-            }
-            Err(e) => {
-                tracing::warn!(
-                    target: TARGET,
-                    agent = %name,
-                    error = ?e,
-                    "stage2 try_send failed (channel full?) — state stays Stage2Eligible for retry"
-                );
-            }
-        }
-    }
-
-    /// Stage 3 escalate arm. Stage 3 is the terminal stage of the
-    /// recovery state machine — after Stage 1 ESC failed and Stage 2
-    /// auto-restart was attempted up to the cumulative cap, the agent
-    /// is escalated to `HealthState::Paused` and the operator is
-    /// notified that manual intervention is required.
-    ///
-    /// Order of operations (atomicity-relevant):
-    /// 1. Pre-emit telegram via `notify_stage3_escalate` — fires in
-    ///    BOTH shadow and active modes so operators have visibility
-    ///    into the decision pattern before flipping the gate to `=1`.
-    /// 2. If `gate_active`: acquire the per-agent lock once and call
-    ///    `core.health.enter_paused(now)` — atomically writes
-    ///    `state = Paused`, `recovery_stage_state = Stage3Pending`,
-    ///    `last_stage3_fired_at = Some(now)`. Next-tick dispatcher
-    ///    lands on the `Stage3Pending` no-op arm and on the top-level
-    ///    `Paused` `continue` guard, so the telegram never re-fires.
-    /// 3. Else (shadow): emit `tracing::info!` with would-have-paused
-    ///    details; no state mutation.
-    ///
-    /// `recovery_restart_count` is NOT reset on entry — per decision
-    /// `enter_paused` documentation, the count is preserved so a
-    /// future operator-unpause that doesn't address the root cause
-    /// immediately re-escalates rather than burning further auto-
-    /// restart budget.
-    fn handle_stage3_escalate(
-        &self,
-        name: &str,
-        target: &RecoveryTarget,
-        snapshot: &DispatchSnapshot,
-        gate_active: bool,
-    ) {
-        // Pre-emit telegram in BOTH modes — operator visibility on
-        // shadow promotions matters as much as on active escalations.
-        notify_stage3_escalate(name, snapshot);
-
-        if gate_active {
-            let now = Instant::now();
-            let mut core = target.core.lock();
-            core.health.enter_paused(now);
-            tracing::info!(
-                target: TARGET,
-                agent = %name,
-                recovery_restart_count = snapshot.recovery_restart_count,
-                gate_active = true,
-                "stage3 fired: HealthState transitioned to Paused via enter_paused"
-            );
-        } else {
-            tracing::info!(
-                target: TARGET,
-                agent = %name,
-                recovery_restart_count = snapshot.recovery_restart_count,
-                silent_ms = snapshot.silent.as_millis() as u64,
-                gate_active = false,
-                "stage3 would-have-fired (shadow mode): Paused write NOT applied"
-            );
-        }
-    }
 }
 
 /// Read-only snapshot of per-agent state captured under a single lock
@@ -668,82 +376,21 @@ struct DispatchSnapshot {
     health_state: HealthState,
     recovery_stage_state: RecoveryStageState,
     last_stage1_fired_at: Option<Instant>,
-    recovery_restart_count: u32,
     agent_state: crate::state::AgentState,
     silent: Duration,
     silent_productive: Duration,
 }
 
-/// Stage 2 telegram notify (pre-emit). Decision §A "Stages 2/3 fire
-/// telegram; Stage 1 silent on success". Operator-actionable content:
-/// agent name + backend + Hung duration + Stage 1 fire correlation +
-/// next-step expectation. Uses existing `gated_notify` so the
-/// info-leak gate prevents leakage when channel is unauthorised.
-fn notify_stage2_fire(name: &str, snapshot: &DispatchSnapshot) {
-    let body = format!(
-        "[recovery] {name}: Stage 2 auto-restart triggered.\n\
-         Hung silence: {silent_ms}ms (productive silence: {prod_ms}ms)\n\
-         Recovery restart count: {count}\n\
-         Next: monitoring 30s for recovery; Stage 3 (pause + operator action) on continued failure.",
-        silent_ms = snapshot.silent.as_millis(),
-        prod_ms = snapshot.silent_productive.as_millis(),
-        count = snapshot.recovery_restart_count,
-    );
-    if let Some(channel) = crate::channel::active_channel() {
-        let _ = crate::channel::gated_notify(
-            channel.as_ref(),
-            name,
-            crate::channel::NotifySeverity::Warn,
-            &body,
-            false,
-        );
-    } else {
-        tracing::debug!(
-            target: TARGET,
-            agent = %name,
-            "stage2 telegram skipped: no active channel"
-        );
-    }
-}
-
-/// Build the Stage 3 escalation telegram body. Extracted so unit
-/// tests can pin the operator-facing wording (decision §3 "dev's
-/// revised 4-line content") independent of the `gated_notify` plumbing.
-fn format_stage3_body(name: &str, recovery_restart_count: u32) -> String {
-    format!(
-        "[recovery ESCALATION] {name}: PAUSED — manual intervention required.\n  \
-         Stage 2 auto-restart fired {count} time(s), all exhausted.\n  \
-         Final state: Paused (no further auto-recovery).\n  \
-         Action: investigate root cause + manual unpause (CLI command pending sub-task).",
-        count = recovery_restart_count,
-    )
-}
-
-/// Stage 3 escalation telegram. Operator-action-required severity =
-/// `NotifySeverity::Error` (per decision §3 dev-grep evidence: enum has
-/// only Info/Warn/Error; Stage 2 = Warn, crash = Error; Stage 3 ≥ crash
-/// since auto-recovery is exhausted and only operator action can
-/// resume). `silent=false` so the operator's channel surfaces it
-/// alongside crash notifications. Uses `gated_notify` so the
-/// info-leak gate prevents leakage when channel is unauthorised.
-fn notify_stage3_escalate(name: &str, snapshot: &DispatchSnapshot) {
-    let body = format_stage3_body(name, snapshot.recovery_restart_count);
-    // #1744-M6: Stage 3 is an Error-severity operator P0 (auto-recovery exhausted,
-    // only operator action resumes) — deliver to EVERY registered channel.
-    // `active_channel()` would silently drop it in a multi-channel fleet. (Stage 2
-    // above stays `Warn` + `active_channel()` — not a P0.) `gated_notify` inside
-    // the helper still enforces the info-leak / authorization gate per channel.
-    crate::channel::notify_all_escalation_channels(
-        name,
-        crate::channel::NotifySeverity::Error,
-        &body,
-        false,
-    );
-}
-
 /// Stage 1 alive-stuck branch — emit ESC byte (or shadow-log it),
 /// transition state machine to `Stage1Pending`, stamp the cooldown
 /// clock.
+///
+/// #1339 DAEMON-AUTONOMIC, GATE-EXEMPT BY DESIGN: this ESC write is reached
+/// ONLY from the per-tick recovery state machine on an internal trigger — a
+/// Hung-state detection (gated by `hang_auto_recovery_enabled`) — never from
+/// the API socket. Daemon self-heal (a third trusted principal), so the
+/// operator-mode gate does NOT apply: a hung agent is still recovered in
+/// away/sleep. Not agent-invocable (an agent can at most hang ITSELF).
 fn fire_stage1_alive_stuck(
     name: &str,
     target: &RecoveryTarget,
@@ -776,15 +423,25 @@ fn fire_stage1_alive_stuck(
                 );
             }
             Err(e) => {
+                // #2549: used to escalate to the now-removed `Stage2Eligible`.
+                // Falling through to the common `Stage1Pending` tail below
+                // (instead of an early return) is the deliberate fix here —
+                // NOT a leftover no-op. Leaving state at `None` would have
+                // `handle_stage1_entry` re-classify and retry the write
+                // EVERY tick (a retry storm on a persistently-failing PTY,
+                // new behavior the pre-#2549 default never had); landing in
+                // `Stage1Pending` instead makes this a one-shot "attempted,
+                // stop" marker — closest to the pre-#2549 default's
+                // "fails once, then parks" shape. `entered_at`/
+                // `last_stage1_fired_at` below are stamped purely as a
+                // re-fire guard (drives the timeout log + cooldown skip),
+                // NOT a claim that the ESC byte was actually delivered.
                 tracing::warn!(
                     target: TARGET,
                     agent = %name,
                     error = %e,
-                    "stage1 PTY write failed — escalating to Stage2Eligible"
+                    "stage1 PTY write failed — no further auto-recovery stage available (Stage 2/3 removed #2549); parking in Stage1Pending to stop retrying"
                 );
-                let mut core = target.core.lock();
-                core.health.recovery_stage_state = RecoveryStageState::Stage2Eligible;
-                return;
             }
         }
     } else {
@@ -800,6 +457,9 @@ fn fire_stage1_alive_stuck(
         );
     }
 
+    // #2549: entered_at/last_stage1_fired_at are a re-fire guard (timeout log
+    // + cooldown skip), not a success claim — reached on the PTY-write-Err
+    // path too (see the comment there).
     let mut core = target.core.lock();
     core.health.recovery_stage_state = RecoveryStageState::Stage1Pending { entered_at: now };
     core.health.last_stage1_fired_at = Some(now);
@@ -938,19 +598,6 @@ mod tests {
         std::sync::Arc<parking_lot::Mutex<HashMap<String, crate::daemon::AgentConfig>>>,
     );
 
-    /// Sentinel `crash_tx` for tests — bounded(8) sender that nobody
-    /// reads. Tests that only exercise empty-registry / classification
-    /// paths never send through it; tests verifying try_send behaviour
-    /// can drain the matching `Receiver` via `crossbeam_channel::bounded`.
-    fn sentinel_crash_tx() -> std::sync::Arc<crossbeam_channel::Sender<crate::agent::AgentExitEvent>>
-    {
-        let (tx, _rx) = crossbeam_channel::bounded(8);
-        // Leak the receiver so the channel stays open. For tests that
-        // need to drain, use `crossbeam_channel::bounded` directly.
-        std::mem::forget(_rx);
-        std::sync::Arc::new(tx)
-    }
-
     /// Build an empty TickContext for smoke tests. `home` is a unique
     /// tempdir per test to avoid registry/snapshot cross-talk.
     fn empty_ctx() -> EmptyCtxBundle {
@@ -981,7 +628,7 @@ mod tests {
             externals: &externals,
             configs: &configs,
         };
-        RecoveryDispatcherHandler::new(sentinel_crash_tx(), true).run(&ctx);
+        RecoveryDispatcherHandler::new().run(&ctx);
         assert!(registry.lock().is_empty());
         std::fs::remove_dir_all(&home).ok();
     }
@@ -1051,7 +698,7 @@ mod tests {
     #[test]
     fn name_matches_module() {
         assert_eq!(
-            RecoveryDispatcherHandler::new(sentinel_crash_tx(), true).name(),
+            RecoveryDispatcherHandler::new().name(),
             "recovery_dispatcher"
         );
     }
@@ -1086,7 +733,7 @@ mod tests {
                 externals: &externals,
                 configs: &configs,
             };
-            RecoveryDispatcherHandler::new(sentinel_crash_tx(), true).run(&ctx);
+            RecoveryDispatcherHandler::new().run(&ctx);
             std::fs::remove_dir_all(&home).ok();
         });
     }
@@ -1106,211 +753,115 @@ mod tests {
     }
 
     // -------------------------------------------------------------------
-    // `#685` sub-task 7b Stage 2 tests. Cover the new dispatcher arm
-    // surface: counter cap → Stage3Eligible, channel try_send + no-
-    // increment-on-rejection, decay reduces counter, shadow vs active.
-    // Branch classification + cooldown + spontaneous reset already
-    // pinned by Stage 1 tests above.
+    // #2549 pin tests: the three branches that used to escalate into the
+    // now-removed `Stage2Eligible` are log-only. One test per branch,
+    // each asserting the terminal state + absence of a second (mutating)
+    // action — via a structural source-scan (no AgentHandle/PTY harness
+    // exists for these arms, same constraint as
+    // `recovery_loop_never_holds_registry_across_blocking_io` above).
     // -------------------------------------------------------------------
 
-    fn with_stage2_gate<R>(active: bool, f: impl FnOnce() -> R) -> R {
-        // #1812: shared crate-wide env lock (see `with_stage1_gate`).
-        let _guard = crate::daemon::test_env_lock()
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
-        let prior = std::env::var(STAGE2_ENV_VAR).ok();
-        unsafe {
-            if active {
-                std::env::set_var(STAGE2_ENV_VAR, "1");
-            } else {
-                std::env::remove_var(STAGE2_ENV_VAR);
-            }
-        }
-        let result = f();
-        unsafe {
-            match prior {
-                Some(v) => std::env::set_var(STAGE2_ENV_VAR, v),
-                None => std::env::remove_var(STAGE2_ENV_VAR),
-            }
-        }
-        result
-    }
-
+    /// Branch 1 — Stage 1 timeout (`Stage1Pending` arm in `run()`): must log
+    /// but NOT mutate `recovery_stage_state` (terminal: stays `Stage1Pending`,
+    /// re-logs every tick — same every-tick cadence the pre-#2549 default's
+    /// `Stage2Eligible` shadow-log had, zero new side effects).
     #[test]
-    fn stage2_gate_env_var_round_trip() {
-        // Same shape as Stage 1 env var test — operator can flip
-        // `AGEND_AUTO_RECOVERY_STAGE2=1` without restarting daemon.
-        with_stage2_gate(true, || {
-            assert!(stage2_gate_active());
-        });
-        with_stage2_gate(false, || {
-            assert!(!stage2_gate_active());
-        });
-    }
+    fn stage1_timeout_is_log_only_no_second_action_2549() {
+        let src = include_str!("recovery_dispatcher.rs");
+        let cfg_test = ["#[cfg(", "test)]"].concat();
+        let prod = &src[..src.find(&cfg_test).expect("test mod present")];
 
-    /// #1694(a): the three-way Stage2 decision — the seam that makes
-    /// `handle_stage2_fire`'s no-consumer escalation testable without a full
-    /// AgentHandle/PTY harness (same pattern as `classify_branch`/`Stage1Branch`).
-    #[test]
-    fn stage2_decision_escalates_on_no_consumer_else_fires_1694a() {
-        // Gate OFF → shadow, regardless of consumer (no send, no transition).
-        assert_eq!(stage2_decision(false, true), Stage2Decision::Shadow);
-        assert_eq!(stage2_decision(false, false), Stage2Decision::Shadow);
-        // Gate ON + live consumer (run_core's crash_rx) → Fire (emit Stage2Restart).
-        assert_eq!(stage2_decision(true, true), Stage2Decision::Fire);
-        // Gate ON + NO consumer (app-standalone's throwaway crash_tx) → escalate
-        // to Stage3 instead of silently dropping the restart onto a dead channel.
-        assert_eq!(
-            stage2_decision(true, false),
-            Stage2Decision::EscalateNoConsumer
+        let arm_marker = ["RecoveryStageState::Stage1Pending", " { entered_at } => {"].concat();
+        let astart = prod.find(&arm_marker).expect("Stage1Pending arm present");
+        let arest = &prod[astart..];
+        // Arm ends at the next arm (`Stage3Pending` — the only other variant).
+        let aend = arest
+            .find("RecoveryStageState::Stage3Pending")
+            .expect("Stage3Pending arm follows");
+        let arm_body = &arest[..aend];
+
+        assert!(
+            arm_body.contains("no further auto-recovery stage available"),
+            "must log the terminal-no-escalation message: {arm_body}"
+        );
+        let mutation = ["recovery_stage_state", " ="].concat();
+        assert!(
+            !arm_body.contains(&mutation),
+            "must NOT mutate recovery_stage_state (log-only, terminal): {arm_body}"
         );
     }
 
+    /// Branches 2 — dead-likely classification and cooldown-active skip
+    /// (both arms in `handle_stage1_entry`): must log but NOT touch
+    /// `target.core` (terminal: state stays `None`, re-classified fresh
+    /// next tick — no second action).
     #[test]
-    fn stage2_max_restarts_default_is_three() {
-        // Default cap N=3 per decision §Q1/Q2. Env var override unset
-        // returns the default. #1812: hold the shared crate-wide env lock
-        // — `stage2_max_restarts()` READS env, which races a concurrent
-        // `set_var` from another module's test (e.g. daemon::restart)
-        // just as a write would.
-        let _guard = crate::daemon::test_env_lock()
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
-        let prior = std::env::var(STAGE2_MAX_RESTARTS_ENV_VAR).ok();
-        unsafe {
-            std::env::remove_var(STAGE2_MAX_RESTARTS_ENV_VAR);
-        }
+    fn stage1_entry_dead_likely_and_cooldown_skip_are_log_only_2549() {
+        let src = include_str!("recovery_dispatcher.rs");
+        let cfg_test = ["#[cfg(", "test)]"].concat();
+        let prod = &src[..src.find(&cfg_test).expect("test mod present")];
+
+        let start_marker = ["(Stage1Branch::AliveStuck", ", true) => {"].concat();
+        let sstart = prod.find(&start_marker).expect("cooldown-skip arm present");
+        let srest = &prod[sstart..];
+        let end_marker = ["(Stage1Branch::Anomaly", ", _) => {"].concat();
+        let send = srest.find(&end_marker).expect("Anomaly arm follows");
+        // Covers BOTH the cooldown-skip (AliveStuck, true) arm and the
+        // DeadLikely arm — Anomaly is the next (and last) arm in the match.
+        let both_arms = &srest[..send];
+
+        let no_escalation_msg = "no further auto-recovery stage available";
         assert_eq!(
-            stage2_max_restarts(),
-            crate::health::STAGE2_MAX_RESTARTS_DEFAULT
+            both_arms.matches(no_escalation_msg).count(),
+            2,
+            "both the cooldown-skip and dead-likely arms must log the terminal message: {both_arms}"
         );
-        unsafe {
-            match prior {
-                Some(v) => std::env::set_var(STAGE2_MAX_RESTARTS_ENV_VAR, v),
-                None => std::env::remove_var(STAGE2_MAX_RESTARTS_ENV_VAR),
-            }
-        }
+        let lock_call = ["target.core", ".lock()"].concat();
+        assert!(
+            !both_arms.contains(&lock_call),
+            "neither arm may touch target.core (log-only, no mutation): {both_arms}"
+        );
     }
 
+    /// Branch 3 — PTY write failure (`fire_stage1_alive_stuck`'s `Err` arm):
+    /// must NOT `return` early (the pre-#2549 escalation path) — falling
+    /// through to the function's common tail is the fix, landing in
+    /// `Stage1Pending` as a one-shot "attempted, stop" marker instead of
+    /// retrying the write every tick.
     #[test]
-    fn stage2_max_restarts_env_override() {
-        // #1812: shared crate-wide env lock + save/restore (see above).
-        let _guard = crate::daemon::test_env_lock()
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
-        let prior = std::env::var(STAGE2_MAX_RESTARTS_ENV_VAR).ok();
-        unsafe {
-            std::env::set_var(STAGE2_MAX_RESTARTS_ENV_VAR, "5");
-        }
-        assert_eq!(stage2_max_restarts(), 5);
-        unsafe {
-            match prior {
-                Some(v) => std::env::set_var(STAGE2_MAX_RESTARTS_ENV_VAR, v),
-                None => std::env::remove_var(STAGE2_MAX_RESTARTS_ENV_VAR),
-            }
-        }
-    }
+    fn fire_stage1_pty_write_failure_falls_through_to_stage1_pending_2549() {
+        let src = include_str!("recovery_dispatcher.rs");
+        let cfg_test = ["#[cfg(", "test)]"].concat();
+        let prod = &src[..src.find(&cfg_test).expect("test mod present")];
 
-    #[test]
-    fn maybe_decay_reduces_recovery_restart_count_after_stability_window() {
-        // Decay discipline (decision §Delta 3): `maybe_decay_at`
-        // decrements `recovery_restart_count` by 1 when
-        // `last_stage2_fired_at` is older than `STABILITY_WINDOW`.
-        // Mirror crash counter decay shape.
-        //
-        // Cross-platform `Instant` discipline (PR #775 v2): use
-        // `base + offset` + `maybe_decay_at(future_now)` instead of
-        // `Instant::now() - offset`. Windows anchors `Instant::now()` to
-        // system uptime and subtracting from a low-uptime CI VM panics;
-        // `Instant::add` saturates and is safe on all platforms.
-        let mut tracker = crate::health::HealthTracker::new();
-        tracker.recovery_restart_count = 2;
-        let base = Instant::now();
-        tracker.last_stage2_fired_at = Some(base);
-        tracker.maybe_decay_at(base + Duration::from_secs(31 * 60), true);
-        assert_eq!(tracker.recovery_restart_count, 1);
-    }
+        let fire_marker = ["fn fire_stage1", "_alive_stuck"].concat();
+        let fstart = prod.find(&fire_marker).expect("fire fn present");
+        let fire_body = &prod[fstart..];
 
-    #[test]
-    fn maybe_decay_does_not_reduce_recovery_count_within_stability_window() {
-        // Counter stays put if Stage 2 fired recently — agent hasn't
-        // demonstrated stability long enough to forgive prior restart.
-        let mut tracker = crate::health::HealthTracker::new();
-        tracker.recovery_restart_count = 2;
-        let base = Instant::now();
-        tracker.last_stage2_fired_at = Some(base);
-        tracker.maybe_decay_at(base, true);
-        assert_eq!(tracker.recovery_restart_count, 2);
-    }
+        let err_marker = "Err(e) => {";
+        let estart = fire_body.find(err_marker).expect("Err arm present");
+        let erest = &fire_body[estart..];
+        let eend = erest
+            .find("} else {")
+            .expect("shadow-mode else branch follows");
+        let err_arm = &erest[..eend];
 
-    #[test]
-    fn maybe_decay_skips_recovery_count_on_paused_state() {
-        // `HealthState::Paused` guard (sub-task 7a invariant): decay
-        // must NOT exit Paused. Counter also untouched.
-        //
-        // Cross-platform `Instant` discipline (PR #775 v2): use
-        // `base + offset` + `maybe_decay_at(future_now)` — see sibling
-        // test for rationale.
-        let mut tracker = crate::health::HealthTracker::new();
-        tracker.state = HealthState::Paused;
-        tracker.recovery_restart_count = 2;
-        let base = Instant::now();
-        tracker.last_stage2_fired_at = Some(base);
-        tracker.maybe_decay_at(base + Duration::from_secs(31 * 60), true);
-        assert_eq!(tracker.state, HealthState::Paused);
-        assert_eq!(tracker.recovery_restart_count, 2);
-    }
+        // `return;` (not the bare word "return", which also appears in this
+        // test's own explanatory prose above) — an early-return statement.
+        assert!(
+            !err_arm.contains("return;"),
+            "the Err arm must NOT early-return (must fall through to the common Stage1Pending tail): {err_arm}"
+        );
 
-    // Removed `stage2_pending_timeout_drives_stage3_eligible_in_unit_form`: its
-    // two assertions reduced to pure arithmetic facts on locally-constructed
-    // values (`31s >= 30s`, `5s < 30s`) and called no production code, so it
-    // could never catch a regression in the real `entered_at.elapsed() >=
-    // stage2_timeout` dispatcher path. The comment itself deferred the actual
-    // integration coverage; this stub added none.
-
-    // -------------------------------------------------------------------
-    // `#685` sub-task 7c Stage 3 tests. Cover the new dispatcher arm
-    // surface: env gate round-trip, enter_paused atomic invariants,
-    // recovery_restart_count NOT reset on Paused entry (operator-must-
-    // fix-root-cause signal), Stage3Pending idempotent no-op semantics,
-    // and operator-facing telegram content. Decision §7.
-    // -------------------------------------------------------------------
-
-    fn with_stage3_gate<R>(active: bool, f: impl FnOnce() -> R) -> R {
-        // #1812: shared crate-wide env lock (see `with_stage1_gate`).
-        let _guard = crate::daemon::test_env_lock()
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
-        let prior = std::env::var(STAGE3_ENV_VAR).ok();
-        unsafe {
-            if active {
-                std::env::set_var(STAGE3_ENV_VAR, "1");
-            } else {
-                std::env::remove_var(STAGE3_ENV_VAR);
-            }
-        }
-        let result = f();
-        unsafe {
-            match prior {
-                Some(v) => std::env::set_var(STAGE3_ENV_VAR, v),
-                None => std::env::remove_var(STAGE3_ENV_VAR),
-            }
-        }
-        result
-    }
-
-    #[test]
-    fn stage3_gate_env_var_round_trip() {
-        // Operator can flip `AGEND_AUTO_RECOVERY_STAGE3=1` without
-        // restarting the daemon — same shape as Stage 1 / Stage 2 gate
-        // env tests. Decision §4 shadow-mode default + env var promotion
-        // workflow.
-        with_stage3_gate(true, || {
-            assert!(stage3_gate_active());
-        });
-        with_stage3_gate(false, || {
-            assert!(!stage3_gate_active());
-        });
+        let common_tail = [
+            "core.health.recovery_stage_state = RecoveryStageState::Stage1Pending",
+            " { entered_at: now };",
+        ]
+        .concat();
+        assert!(
+            fire_body.contains(&common_tail),
+            "the function's common tail must unconditionally set Stage1Pending (reached by both Ok and Err paths)"
+        );
     }
 
     #[test]
@@ -1335,66 +886,27 @@ mod tests {
         assert_eq!(tracker.last_stage3_fired_at, Some(now));
     }
 
-    #[test]
-    fn enter_paused_does_not_reset_recovery_restart_count() {
-        // Decision §1 critical invariant: `recovery_restart_count` is
-        // preserved across `enter_paused` to keep the operator-must-fix
-        // signal. If a future operator unpauses the agent without
-        // addressing the root cause and it Hungs again, the dispatcher
-        // cap check immediately escalates to Stage3Eligible rather than
-        // burning further auto-restart budget.
-        let mut tracker = crate::health::HealthTracker::new();
-        tracker.recovery_restart_count = 3;
-        let now = Instant::now();
-        tracker.enter_paused(now);
-        assert_eq!(tracker.recovery_restart_count, 3);
-        assert_eq!(tracker.state, HealthState::Paused);
-    }
-
+    /// #2549: `Stage3Pending`/`enter_paused` are shared terminal-escalation
+    /// machinery — `RespawnWatchdogHandler` calls `enter_paused` independently
+    /// of this dispatcher (an unrelated failure mode, a stuck `resume` spawn).
+    /// This pins that this dispatcher's convergence to Stage-1-only did NOT
+    /// touch that shared path: `Stage3Pending` is still terminal under the
+    /// crate-wide `maybe_decay_at` sweep (dispatcher's own `Stage3Pending` arm
+    /// is an explicit no-op, verified by reading the source — no AgentHandle
+    /// harness exists for the `run()` arm).
     #[test]
     fn stage3_pending_state_no_op_under_maybe_decay() {
-        // Stage 3 is terminal: dispatcher's `Stage3Pending` arm is
-        // explicit no-op, and `maybe_decay_at` honours the
-        // `HealthState::Paused` short-circuit. Together these ensure
-        // that ticking the dispatcher / decay loop while an agent is
-        // Paused does NOT silently mutate state away from Paused or
-        // re-fire Stage 3. Pinned at the decay boundary because that's
-        // the only health-side mutation that runs on every tick;
-        // dispatcher-tick Stage3Pending no-op is verified by reading
-        // the source (no AgentHandle harness exists for the run() arm).
         let mut tracker = crate::health::HealthTracker::new();
         let entered = Instant::now();
         tracker.enter_paused(entered);
-        // Simulate a very long stable window — decay must still not
-        // exit Paused or touch the preserved counter.
-        tracker.recovery_restart_count = 2;
-        tracker.last_stage2_fired_at = Some(entered);
+        // Simulate a very long stable window — decay must still not exit Paused.
         tracker.maybe_decay_at(entered + Duration::from_secs(31 * 60), true);
         assert_eq!(tracker.state, HealthState::Paused);
-        assert_eq!(tracker.recovery_restart_count, 2);
         match tracker.recovery_stage_state {
             RecoveryStageState::Stage3Pending { entered_at } => {
                 assert_eq!(entered_at, entered);
             }
             other => panic!("expected Stage3Pending preserved, got {other:?}"),
         }
-    }
-
-    #[test]
-    fn format_stage3_body_includes_recovery_restart_count_and_action() {
-        // Decision §3 telegram content (dev-revised after grep evidence
-        // cut Backend + N1): operator-facing wording must surface the
-        // exhausted Stage 2 count + manual-unpause action hint. Cuts
-        // Backend (DispatchSnapshot lacks the field) and Stage 1 N1
-        // (HealthTracker doesn't track the count).
-        let body = format_stage3_body("orchestrator", 3);
-        assert!(body.contains("ESCALATION"));
-        assert!(body.contains("orchestrator"));
-        assert!(body.contains("PAUSED"));
-        assert!(body.contains("Stage 2 auto-restart fired 3 time(s)"));
-        assert!(body.contains("manual unpause"));
-        // Negative: must NOT include the cut fields per decision §3.
-        assert!(!body.contains("Backend:"));
-        assert!(!body.contains("Stage 1 ESC"));
     }
 }

--- a/src/daemon/per_tick/supervisor_trackers.rs
+++ b/src/daemon/per_tick/supervisor_trackers.rs
@@ -398,10 +398,9 @@ mod tests {
     /// order — handler order in the `build_default_handlers` Vec is load-bearing.
     #[test]
     fn all_migrated_supervisor_trackers_registered_in_order() {
-        let (crash_tx, _rx) = crossbeam_channel::bounded(1);
         let stale: crate::daemon::mcp_registry_watcher::DaemonBinaryStale =
             std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
-        let names: Vec<&str> = crate::daemon::build_default_handlers(crash_tx, true, stale)
+        let names: Vec<&str> = crate::daemon::build_default_handlers(stale)
             .iter()
             .map(|h| h.name())
             .collect();

--- a/src/health.rs
+++ b/src/health.rs
@@ -100,85 +100,57 @@ impl HealthState {
 }
 
 /// `#685` sub-task 7a: per-agent recovery dispatcher state machine for
-/// the auto-recovery ladder. Carried inside `HealthTracker` so the
-/// dispatcher can read both `HealthState` and stage progression in one
-/// per-tick lock acquisition. Compile-time exhaustive match in the
+/// the Stage-1-only auto-recovery ladder. Carried inside `HealthTracker`
+/// so the dispatcher can read both `HealthState` and stage progression in
+/// one per-tick lock acquisition. Compile-time exhaustive match in the
 /// dispatcher catches missing-state bugs.
+///
+/// **#2549 P2**: Stage 2 (auto-restart) and the dispatcher-driven Stage 3
+/// escalation path (`Stage2Eligible` / `Stage2Pending` / `Stage3Eligible`)
+/// were removed — see `daemon/per_tick/recovery_dispatcher.rs`'s module
+/// doc for the convergence rationale. `Stage3Pending` and
+/// [`HealthTracker::enter_paused`] stay: they are shared terminal-escalation
+/// machinery also used independently by `RespawnWatchdogHandler`, unrelated
+/// to this ladder.
 ///
 /// **Spontaneous recovery reset** (decision §5 Refinement): when
 /// `health.state` transitions back to `Healthy` (either Stage success
 /// or external recovery), the dispatcher resets `recovery_stage_state`
-/// to `None`. Subsequent `Hung` re-entry begins a fresh sequence —
-/// linear escalation rule restarts from Stage 1.
-///
-/// **Future variant**: a 7th `Disabling { until_operator_unpauses }`
-/// variant is intentionally NOT added in Phase 1 — Stage 3 + Paused
-/// HealthState already covers the operator-action-required terminal
-/// case. Recorded here as a comment-only note for future sub-tasks
-/// that add operator-unpause command surfaces.
+/// to `None`. Subsequent `Hung` re-entry begins a fresh sequence.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[allow(dead_code)] // Stage2Pending / Stage3Eligible / Stage3Pending: emitted by sub-tasks 7b / 7c
 pub enum RecoveryStageState {
     /// No recovery in progress. Default.
     None,
-    /// Stage 1 ESC dispatched (or shadow-logged); monitoring for recovery.
-    /// `entered_at` drives the Stage 1 timeout window.
+    /// Stage 1 ESC dispatched (or shadow-logged), or Stage 1 was
+    /// adjudicated but had no further automated action available
+    /// (PTY write failed) — monitoring stops here in Stage-1-only mode.
+    /// `entered_at` drives the Stage 1 timeout window / re-fire guard.
     Stage1Pending { entered_at: Instant },
-    /// Stage 1 timed out (or skipped via dead-likely branch). Dispatcher
-    /// will fire Stage 2 on the next tick once 7b ships. Phase 1 logs
-    /// the eligibility transition and stops here.
-    Stage2Eligible,
-    /// Stage 2 restart in progress; monitoring for recovery. (Phase 1
-    /// stub — emitted by 7b when Stage 2 ships.)
-    Stage2Pending { entered_at: Instant },
-    /// Stage 2 timed out. Dispatcher will fire Stage 3 on next tick.
-    Stage3Eligible,
-    /// Stage 3 dispatched (HealthState transitioned to Paused).
-    /// Awaiting operator unpause action. `entered_at` is the
-    /// `Instant` passed to [`HealthTracker::enter_paused`] and is the
-    /// same value stamped into [`HealthTracker::last_stage3_fired_at`]
-    /// — kept on the variant so dispatcher tick-time debug logs can
-    /// report Paused-since duration without reaching back into
-    /// `HealthTracker` (parallel `Stage1Pending` / `Stage2Pending`).
+    /// Terminal (HealthState transitioned to Paused). Awaiting operator
+    /// unpause action. `entered_at` is the `Instant` passed to
+    /// [`HealthTracker::enter_paused`] and is the same value stamped into
+    /// [`HealthTracker::last_stage3_fired_at`] — kept on the variant so
+    /// tick-time debug logs can report Paused-since duration without
+    /// reaching back into `HealthTracker`. Reached only via
+    /// `enter_paused` (shared with `RespawnWatchdogHandler`), never via
+    /// this dispatcher directly in Stage-1-only mode.
     Stage3Pending { entered_at: Instant },
 }
 
 /// Stage 1 default timeout — ESC dispatched, dispatcher waits this long
-/// before declaring failure and transitioning to `Stage2Eligible`.
+/// before declaring failure (Stage-1-only: logged, not escalated further).
 /// Decision §1.4 Delta 1: 10s default (reviewer recommendation: ESC
 /// delivery latency = PTY write + agent process scheduling + Ink TUI
-/// state reset; under load, 5s false-positives Stage 2 escalation).
+/// state reset; under load, 5s false-positived the old Stage 2 escalation).
 /// Fixed const (#env-cleanup: was env-overridable; demoted to YAGNI).
 pub const STAGE1_TIMEOUT_DEFAULT_MS: u64 = 10_000;
 
 /// Stage 1 default cooldown — if agent re-enters Hung within this window
-/// after a recent Stage 1 fire, dispatcher skips Stage 1 (goes directly
-/// to `Stage2Eligible`). Prevents rapid-fire ESC sending that masks
-/// underlying issues. Decision §1.4 Refinement B.
+/// after a recent Stage 1 fire, dispatcher skips re-firing Stage 1.
+/// Prevents rapid-fire ESC sending that masks underlying issues.
+/// Decision §1.4 Refinement B.
 /// Fixed const (#env-cleanup: was env-overridable; demoted to YAGNI).
 pub const STAGE1_COOLDOWN_DEFAULT_MS: u64 = 60_000;
-
-/// Stage 2 default backoff — sleep before `spawn_agent` re-runs in the
-/// respawn worker's Stage 2 arm. Decision §1.4 Delta 2: 1s default
-/// (defensive padding against tight-loop on transient spawn errors —
-/// transient filesystem / network / PTY allocation failures).
-/// Fixed const (#env-cleanup: was env-overridable; demoted to YAGNI).
-pub const STAGE2_BACKOFF_DEFAULT_MS: u64 = 1_000;
-
-/// Stage 2 default monitoring window — how long the dispatcher waits in
-/// `Stage2Pending` for the agent to settle on `Healthy` before
-/// classifying Stage 2 as failed and escalating to `Stage3Eligible`.
-/// Mirrors the 30s window already documented in `docs/RECOVERY-STAGES.md`.
-/// Fixed const (#env-cleanup: was env-overridable; demoted to YAGNI).
-pub const STAGE2_TIMEOUT_DEFAULT_MS: u64 = 30_000;
-
-/// Stage 2 cumulative retry cap — when `recovery_restart_count` reaches
-/// this number across Hung cycles, the dispatcher skips Stages 1/2 on
-/// the next Hung and escalates directly to `Stage3Eligible`. Decision
-/// §Q1/Q2: N=3 default mirrors the issue body's "fails N times → Stage 3"
-/// language with a conservative restart budget before operator intervention.
-/// Operator override via env var `AGEND_AUTO_RECOVERY_STAGE2_MAX_RESTARTS`.
-pub const STAGE2_MAX_RESTARTS_DEFAULT: u32 = 3;
 
 /// Returns `true` when `silent_productive` (silence since last productive
 /// output) exceeds the per-`AgentState` threshold. Mirrors the
@@ -399,42 +371,10 @@ pub struct HealthTracker {
     /// `#685` sub-task 7a: timestamp of last Stage 1 ESC fire (or
     /// shadow-log emission). Used by the cooldown guard — if agent
     /// re-enters `Hung` within `STAGE1_COOLDOWN_DEFAULT_MS` of this
-    /// timestamp, dispatcher skips Stage 1 and escalates directly to
-    /// `Stage2Eligible`. `None` means Stage 1 has never fired for this
-    /// agent in the current daemon run.
-    pub last_stage1_fired_at: Option<Instant>,
-    /// `#685` sub-task 7b: cumulative Stage 2 auto-restart count across
-    /// Hung cycles. Increments on each Stage 2 fire that the respawn
-    /// worker successfully consumes (channel `try_send` `Ok`). When
-    /// count reaches `STAGE2_MAX_RESTARTS_DEFAULT`, the dispatcher
-    /// skips Stages 1/2 on the next Hung cycle and escalates directly
-    /// to `Stage3Eligible` — operator must intervene rather than the
-    /// daemon repeatedly thrashing the agent.
-    ///
-    /// Decays via `maybe_decay`: 1 unit per `STABILITY_WINDOW` (30 min)
-    /// of last-crash stability. Mirrors `total_crashes` decay
-    /// discipline so an agent that recovers and stays stable does not
-    /// carry recovery-restart attribution forever.
-    ///
-    /// Preserved selectively across the Stage 2 respawn boundary in
-    /// `daemon/mod.rs` Stage 2 variant arm — fresh `HealthTracker` on
-    /// spawn re-applies this counter (plus crash_times + total_crashes,
-    /// plus the per-class notify cooldowns) so the cap survives the restart
-    /// that the counter itself drove.
-    pub recovery_restart_count: u32,
-    /// `#685` sub-task 7b: timestamp of last Stage 2 auto-restart fire.
-    /// Used to drive `recovery_restart_count` decay alongside
-    /// `crash_times` — `maybe_decay` checks the most recent of the two
-    /// when deciding whether the agent has been stable long enough to
-    /// decrement the recovery counter. `None` means Stage 2 has never
+    /// timestamp, dispatcher skips re-firing Stage 1 (#2549: logs only,
+    /// no further stage to escalate to). `None` means Stage 1 has never
     /// fired for this agent in the current daemon run.
-    pub last_stage2_fired_at: Option<Instant>,
-    /// AUDIT2-008: timestamp of the last Stage-2 operator notification. The
-    /// stage-2 fire path notifies BEFORE `try_send`, and a persistently-full
-    /// `crash_tx` leaves the agent in `Stage2Eligible` so the fire path re-runs
-    /// every tick — without this backoff the operator gets a telegram every ~10s
-    /// per stuck agent. Notify at most once per `STAGE2_NOTIFY_BACKOFF`.
-    pub last_stage2_notify_at: Option<Instant>,
+    pub last_stage1_fired_at: Option<Instant>,
     /// `#685` sub-task 7c: timestamp of last Stage 3 escalation (the
     /// transition into `HealthState::Paused`). Reserved for the future
     /// operator-unpause sub-task — it will read this to display "Paused
@@ -531,9 +471,6 @@ impl HealthTracker {
             rate_limit_self_cleared: false,
             recovery_stage_state: RecoveryStageState::None,
             last_stage1_fired_at: None,
-            recovery_restart_count: 0,
-            last_stage2_fired_at: None,
-            last_stage2_notify_at: None,
             last_stage3_fired_at: None,
         }
     }
@@ -555,14 +492,6 @@ impl HealthTracker {
     ///    arm rather than re-firing Stage 3.
     /// 3. `last_stage3_fired_at` → `Some(now)` for the future operator-
     ///    unpause sub-task's UX (Paused-since-{duration}).
-    ///
-    /// **`recovery_restart_count` is NOT reset** — preserves the
-    /// operator-must-fix-root-cause signal across a future manual
-    /// unpause. If the post-unpause agent Hungs again without the root
-    /// cause being addressed, the cap check in
-    /// [`crate::daemon::per_tick::recovery_dispatcher`] immediately
-    /// re-escalates to Stage3Eligible rather than burning further
-    /// auto-restart budget.
     ///
     /// DI-friendly signature (parallels [`Self::maybe_decay_at`]) so
     /// tests can supply a deterministic `now`. Production callers
@@ -1056,25 +985,6 @@ impl HealthTracker {
         if self.state == HealthState::Paused {
             return;
         }
-        // `#685` sub-task 7b: decay recovery_restart_count via the same
-        // STABILITY_WINDOW discipline as crash decay. Independent of
-        // crash counter — if agent went through Stage 2 restart without
-        // crashing, last_stage2_fired_at drives the decay clock alone.
-        // Mirrors decision §Delta 3: long-stability decay (NOT
-        // reset-on-Healthy, which oscillates too aggressively).
-        if self.recovery_restart_count > 0 {
-            let last_stage2_idle = self
-                .last_stage2_fired_at
-                .map(|t| now.saturating_duration_since(t) >= STABILITY_WINDOW)
-                .unwrap_or(false);
-            if last_stage2_idle {
-                self.recovery_restart_count = self.recovery_restart_count.saturating_sub(1);
-                // [M1] advance the decay anchor so the NEXT unit needs another full
-                // STABILITY_WINDOW — without this, once one window elapsed every
-                // subsequent tick (~10s) decremented, draining the count in seconds.
-                self.last_stage2_fired_at = Some(now);
-            }
-        }
         if self.total_crashes == 0 {
             return;
         }
@@ -1184,34 +1094,6 @@ mod tests {
         }
         assert_eq!(
             h.total_crashes, 2,
-            "[M1] the next window decays exactly 1 more"
-        );
-    }
-
-    /// [M1] §3.9: the same 1-unit-per-window discipline for `recovery_restart_count`
-    /// (decay anchored on `last_stage2_fired_at`, advanced on each decrement).
-    #[test]
-    fn recovery_restart_count_decay_one_unit_per_window_m1() {
-        let mut h = HealthTracker::new();
-        let base = Instant::now();
-        h.recovery_restart_count = 3;
-        h.last_stage2_fired_at = Some(base);
-
-        let t1 = base + Duration::from_secs(31 * 60);
-        for _ in 0..10 {
-            h.maybe_decay_at(t1, true);
-        }
-        assert_eq!(
-            h.recovery_restart_count, 2,
-            "[M1] recovery count decays at most 1 within one window"
-        );
-
-        let t2 = base + Duration::from_secs(62 * 60);
-        for _ in 0..10 {
-            h.maybe_decay_at(t2, true);
-        }
-        assert_eq!(
-            h.recovery_restart_count, 1,
             "[M1] the next window decays exactly 1 more"
         );
     }


### PR DESCRIPTION
## Summary

Implements the RecoveryDispatcher Stage-1-only convergence approved in decision `d-20260703021554626467-13`, following a design-alignment exchange with lead once the real scope diverged materially from the original estimate. Split from #2571 (the already-clean 3-item deletion PR) per lead's risk-tiering ruling.

**Scope-mismatch discovery.** The decision estimated "~200 LOC Stage2/3 skeleton" inside the 1,400 LOC `recovery_dispatcher.rs`. The real footprint spans 5 files: `health.rs` (`RecoveryStageState` enum + 3 `HealthTracker` fields + a `maybe_decay_at` branch), `daemon/per_tick/mod.rs` (an `AgentExitEvent` match arm), `agent/mod.rs` (the `AgentExitEvent::Stage2Restart` variant), and `daemon/mod.rs` (a ~140 LOC dedicated respawn-worker function + its thread wrapper + test). Flagged before touching anything.

**Shared-dependency finding.** `HealthTracker::enter_paused` / `HealthState::Paused` / `RecoveryStageState::Stage3Pending` are **not** exclusive to this dispatcher — `RespawnWatchdogHandler` (a stuck `resume` spawn, unrelated to the Hung ladder) calls `enter_paused` independently for its own retry-cap escalation. Left completely untouched; only Stage 2 and this dispatcher's own Stage 3-arm wiring are removed.

**Behavior-preserving three-branch design.** Verified that under today's production default (Stage 2 gate off), `stage2_decision`'s `Shadow` arm returned without ever mutating `recovery_stage_state` — an agent reaching `Stage2Eligible` parked there indefinitely, re-logging every tick, never reaching Stage 3. The three branches that used to transition into `Stage2Eligible` (Stage 1 timeout, PTY write failure, dead-likely classification) are now log-only, preserving that exact default behavior instead of introducing new escalation:
- Stage 1 timeout: log-only, stays `Stage1Pending` (same every-tick cadence).
- Dead-likely / cooldown-skip: log-only, stays `None`.
- PTY write failure: falls through to the common tail (was an early return) — lands in `Stage1Pending` as a one-shot "attempted, stop" marker, avoiding a retry-storm that leaving state at `None` would cause.

Each branch has a dedicated pin test (structural source-scan, matching this file's existing no-PTY-harness idiom).

**Consequence: `Stage3Eligible` also removed.** Nothing transitions into it anymore (its only feeders were `Stage2Eligible`/`Stage2Pending`), so it's permanently unreachable — removed along with this dispatcher's own `handle_stage3_escalate`/`notify_stage3_escalate`/`format_stage3_body`. `Stage3Pending` stays, reached only via the shared `enter_paused` path.

`recovery_restart_count` deleted per lead's explicit instruction (nothing increments it once Stage 2 is gone; kept-for-future-reuse rejected as speculative).

**Regression caught by the full suite.** `api::operator_gate::tests::autonomic_paths_are_gate_exempt_by_construction` asserts this file carries the `#1339 DAEMON-AUTONOMIC, GATE-EXEMPT BY DESIGN` marker. It lived on the deleted `handle_stage2_fire`; restored on `fire_stage1_alive_stuck` (the function now performing the actual gate-exempt action) since the underlying invariant is unchanged.

**Docs.** `docs/RECOVERY-STAGES.md` §RS.9/§RS.10 marked historical with explicit banners (not deleted — the `enter_paused`/`Paused`/`Stage3Pending` mechanics they describe are still live). `docs/FEATURE-health.md` (+zh-TW), `docs/env-vars.md` (+zh-TW), `docs/HUNG-STATE-TRANSITIONS.md` updated to the current Stage-1-only reality.

## Test plan
- [x] `cargo check` / `cargo clippy --all-targets --features tray -- -D warnings` / `cargo check --features discord` — all clean
- [x] `cargo fmt` applied
- [x] Full `cargo nextest run --features tray --profile ci` (5162 tests), twice: first run caught the `operator_gate` regression above; second run after the fix has exactly the 2 pre-existing sandboxed-CI flakes (`e2e_dispatch_review_workflow_seam_invariants_1900`, `teardown_leaves_zero_residual_after_full_exercise_1907`) and nothing else

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>