### PR TITLE
fix(respawn_watchdog): route auth-expired Resume agents to an operator page instead of blind auto-Fresh

### DIFF
--- a/src/daemon/per_tick/respawn_watchdog.rs
+++ b/src/daemon/per_tick/respawn_watchdog.rs
@@ -165,14 +165,82 @@ fn is_stuck_resume(
         && silent > timeout
 }
 
+/// What the watchdog should do with one agent this tick — computed BEFORE any
+/// auto-Fresh decision so an auth-expired agent is routed away from the
+/// (useless-for-auth) restart ladder.
+#[derive(Debug, PartialEq, Eq)]
+enum Situation {
+    /// Nothing actionable this tick.
+    Ignore,
+    /// Claude authorization expired: exclude from auto-Fresh and page the
+    /// operator (fire-once). A respawn cannot fix auth — a fresh process is just
+    /// as unauthenticated — only the operator can re-authenticate.
+    AuthExpired,
+    /// A stuck `Resume`: eligible for the bounded auto-Fresh ladder.
+    StuckResume,
+}
+
+/// Pure classifier for one agent, so the auth-vs-stuck precedence is
+/// unit-testable without a registry. AUTH TAKES PRECEDENCE: it is recognised via
+/// the EXISTING detection (`backend_profile.rs` regex → `AgentState::AuthError`,
+/// red-anchor FP-guarded — we reuse that signal rather than re-implement loose
+/// string matching at this layer, so the FP boundary is inherited for free). It
+/// is gated to `Resume` to stay inside this watchdog's domain (the module force-
+/// restarts only `Resume` spawns) and disjoint from the supervisor's general
+/// AuthError flow. `AuthError` and `Starting/Restarting` are different
+/// `AgentState`s, so this never reclassifies a genuine stuck Resume.
+fn classify(
+    spawn_mode: SpawnMode,
+    state: AgentState,
+    since_elapsed: Duration,
+    silent: Duration,
+    timeout: Duration,
+) -> Situation {
+    if spawn_mode == SpawnMode::Resume && state == AgentState::AuthError {
+        return Situation::AuthExpired;
+    }
+    if is_stuck_resume(spawn_mode, state, since_elapsed, silent, timeout) {
+        return Situation::StuckResume;
+    }
+    Situation::Ignore
+}
+
+/// Fire-once-until-recovered latch resolver, pure for unit tests. Given the set
+/// of agents currently auth-expired this tick and the latch of already-paged
+/// names (mutated in place): clears the latch for any agent that recovered (no
+/// longer auth-expired) or left, then returns the newly-auth-expired agents to
+/// page now (and latches them). Net effect: each auth-expiry episode pages the
+/// operator exactly once, but a *later* re-expiry after recovery pages again.
+fn auth_notify_targets(auth_now: &HashSet<String>, latch: &mut HashSet<String>) -> Vec<String> {
+    // Forgive recovered/absent agents so a future re-expiry can page again.
+    latch.retain(|n| auth_now.contains(n));
+    // Page each newly-detected auth-expired agent once.
+    let mut to_notify = Vec::new();
+    for n in auth_now {
+        if latch.insert(n.clone()) {
+            to_notify.push(n.clone());
+        }
+    }
+    to_notify
+}
+
 pub(crate) struct RespawnWatchdogHandler {
     retries: Mutex<HashMap<String, RetryRecord>>,
+    /// Fire-once-until-recovered latch for the auth-expiry operator page. Holds
+    /// the names already paged this auth-expiry episode so a still-AuthError
+    /// agent (re-detected every tick) is not re-paged. Lives on the HANDLER
+    /// (daemon-lifetime); `auth_notify_targets` clears an entry when its agent
+    /// recovers (leaves AuthError) or leaves the registry, so a *later*
+    /// re-expiry pages again. Separate from `retries` because an auth-expired
+    /// agent is deliberately NOT on the auto-Fresh ladder.
+    auth_notified: Mutex<HashSet<String>>,
 }
 
 impl RespawnWatchdogHandler {
     pub(crate) fn new() -> Self {
         Self {
             retries: Mutex::new(HashMap::new()),
+            auth_notified: Mutex::new(HashSet::new()),
         }
     }
 }
@@ -195,9 +263,10 @@ impl PerTickHandler for RespawnWatchdogHandler {
         // the full live name-set. No I/O / api::call under the lock — the
         // recovery work runs in phase 2 after the guard drops (lock-ordering /
         // #1593 deadlock-class discipline, mirroring recovery_dispatcher).
-        let (stuck, live): (Vec<String>, HashSet<String>) = {
+        let (stuck, auth, live): (Vec<String>, HashSet<String>, HashSet<String>) = {
             let reg = agent::lock_registry_tracked(ctx.registry, "respawn_watchdog");
             let mut stuck = Vec::new();
+            let mut auth = HashSet::new();
             let mut live = HashSet::new();
             for handle in reg.values() {
                 let name = handle.name.to_string();
@@ -221,21 +290,48 @@ impl PerTickHandler for RespawnWatchdogHandler {
                 let since_elapsed = core.state.since.elapsed();
                 let silent = core.state.last_output.elapsed();
                 drop(core);
-                if is_stuck_resume(
+                // Consult auth-expiry BEFORE the stuck/auto-Fresh decision: an
+                // AuthError agent must never be auto-Fresh'd (respawn can't
+                // re-authenticate) — route it to an actionable operator page
+                // instead, mirroring the `:214` Paused exclusion.
+                match classify(
                     spawn_mode,
                     state,
                     since_elapsed,
                     silent,
                     RESPAWN_STUCK_TIMEOUT,
                 ) {
-                    stuck.push(name);
+                    Situation::AuthExpired => {
+                        auth.insert(name);
+                    }
+                    Situation::StuckResume => {
+                        stuck.push(name);
+                    }
+                    Situation::Ignore => {}
                 }
             }
-            (stuck, live)
+            (stuck, auth, live)
         };
 
         // Forgive/evict stale retry records (agent recovered or left).
         self.gc_records(&stuck, &live);
+
+        // Auth-expiry pass (lock dropped): page the operator once per episode,
+        // never auto-Fresh. The latch is on the handler so a still-AuthError
+        // agent is not re-paged each tick.
+        let auth_targets = {
+            let mut latch = self.auth_notified.lock();
+            auth_notify_targets(&auth, &mut latch)
+        };
+        for name in &auth_targets {
+            crate::event_log::log(
+                ctx.home,
+                "respawn_watchdog_auth_expiry",
+                name,
+                "Claude auth expired on a resume — paged operator, skipped auto-Fresh",
+            );
+            notify_auth_expiry(name);
+        }
 
         // Phase 2 (lock dropped): decide + act per stuck agent.
         for name in &stuck {
@@ -382,6 +478,32 @@ fn notify_escalation(name: &str, attempts: u32) {
     );
 }
 
+/// Page the operator that an agent's Claude authorization has expired (detected
+/// via the existing `AgentState::AuthError`). Unlike a stuck Resume this is NOT
+/// auto-recoverable — a fresh respawn would be just as unauthenticated — so the
+/// watchdog deliberately SKIPS auto-Fresh and asks the operator to re-login.
+/// Mirrors `notify_escalation`'s Error-severity, Sleep-penetrating
+/// `notify_all_escalation_channels` path; fire-once via the `auth_notified`
+/// latch in `run`. Message names the only effective action (re-authenticate).
+fn notify_auth_expiry(name: &str) {
+    tracing::error!(
+        target: TARGET,
+        agent = %name,
+        "respawn-stuck watchdog: agent in AuthError on a Resume — Claude auth expired, paging operator (auto-Fresh skipped)"
+    );
+    let msg = format!(
+        "🔑 {name}: Claude 授權過期（偵測到 AuthError）。自動重啟無法修復授權，已略過 auto-Fresh —— \
+         只有操作者能重新登入。請在該 agent 的 pane 重新授權（執行 `claude` / `/login` 完成登入），\
+         授權後再 `restart_instance` resume 即可。"
+    );
+    crate::channel::notify_all_escalation_channels(
+        name,
+        crate::channel::NotifySeverity::Error,
+        &msg,
+        false,
+    );
+}
+
 /// Page the operator that a single auto-Fresh restart's SPAWN failed (agent
 /// likely gone), so a failed recovery is surfaced, not silently dropped.
 fn notify_restart_failed(name: &str) {
@@ -478,6 +600,144 @@ mod tests {
             Duration::from_secs(30),
             RESPAWN_STUCK_TIMEOUT,
         ));
+    }
+
+    // ── auth-expiry classification (route away from auto-Fresh) ─────────
+
+    #[test]
+    fn classify_auth_error_on_resume_is_auth_expired() {
+        // An AuthError agent spawned via Resume must be routed to the operator
+        // page, NOT the auto-Fresh ladder (respawn can't re-authenticate).
+        assert_eq!(
+            classify(
+                SpawnMode::Resume,
+                AgentState::AuthError,
+                Duration::from_secs(120),
+                Duration::from_secs(120),
+                RESPAWN_STUCK_TIMEOUT,
+            ),
+            Situation::AuthExpired
+        );
+    }
+
+    #[test]
+    fn classify_auth_error_takes_precedence_over_timing() {
+        // Even well within the stuck timeout, AuthError is auth-expiry — the
+        // timing gates are irrelevant once the auth signal is present.
+        assert_eq!(
+            classify(
+                SpawnMode::Resume,
+                AgentState::AuthError,
+                Duration::from_secs(1),
+                Duration::from_secs(1),
+                RESPAWN_STUCK_TIMEOUT,
+            ),
+            Situation::AuthExpired
+        );
+    }
+
+    #[test]
+    fn classify_auth_error_non_resume_is_ignored_by_watchdog() {
+        // Gated to the watchdog's Resume domain (the supervisor's general
+        // AuthError flow owns non-Resume auth pages); a Fresh AuthError agent is
+        // not this handler's concern.
+        assert_eq!(
+            classify(
+                SpawnMode::Fresh,
+                AgentState::AuthError,
+                Duration::from_secs(120),
+                Duration::from_secs(120),
+                RESPAWN_STUCK_TIMEOUT,
+            ),
+            Situation::Ignore
+        );
+    }
+
+    #[test]
+    fn classify_stuck_resume_still_fires_no_regression() {
+        // The existing stuck-Resume behaviour is preserved: a non-auth stuck
+        // Resume still routes to the auto-Fresh ladder.
+        assert_eq!(
+            classify(
+                SpawnMode::Resume,
+                AgentState::Starting,
+                Duration::from_secs(61),
+                Duration::from_secs(61),
+                RESPAWN_STUCK_TIMEOUT,
+            ),
+            Situation::StuckResume
+        );
+    }
+
+    #[test]
+    fn classify_healthy_and_slow_fresh_are_ignored() {
+        // An idle (healthy) agent and a slow-but-healthy Fresh boot are both
+        // left alone — no false auth page, no false auto-Fresh.
+        assert_eq!(
+            classify(
+                SpawnMode::Resume,
+                AgentState::Idle,
+                Duration::from_secs(600),
+                Duration::from_secs(600),
+                RESPAWN_STUCK_TIMEOUT,
+            ),
+            Situation::Ignore
+        );
+        assert_eq!(
+            classify(
+                SpawnMode::Fresh,
+                AgentState::Starting,
+                Duration::from_secs(600),
+                Duration::from_secs(600),
+                RESPAWN_STUCK_TIMEOUT,
+            ),
+            Situation::Ignore
+        );
+    }
+
+    // ── auth-expiry fire-once-until-recovered latch ─────────────────────
+
+    fn names(items: &[&str]) -> HashSet<String> {
+        items.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn auth_latch_pages_each_agent_once_then_stays_silent() {
+        let mut latch = HashSet::new();
+        let auth = names(&["a", "b"]);
+        // First detection pages both (order-independent).
+        let mut first = auth_notify_targets(&auth, &mut latch);
+        first.sort();
+        assert_eq!(first, vec!["a".to_string(), "b".to_string()]);
+        assert_eq!(latch, names(&["a", "b"]));
+        // Still auth-expired next tick → no re-page.
+        let second = auth_notify_targets(&auth, &mut latch);
+        assert!(
+            second.is_empty(),
+            "fire-once: no re-page while still expired"
+        );
+        assert_eq!(latch, names(&["a", "b"]));
+    }
+
+    #[test]
+    fn auth_latch_clears_on_recovery_then_repages_on_reexpiry() {
+        let mut latch = names(&["a"]);
+        // "a" recovered (no longer auth-expired) → latch cleared, nothing paged.
+        let recovered = auth_notify_targets(&HashSet::new(), &mut latch);
+        assert!(recovered.is_empty());
+        assert!(latch.is_empty(), "recovered agent forgiven");
+        // Later re-expiry pages again (new episode).
+        let reexpiry = auth_notify_targets(&names(&["a"]), &mut latch);
+        assert_eq!(reexpiry, vec!["a".to_string()]);
+    }
+
+    #[test]
+    fn auth_latch_only_pages_newly_expired_agents() {
+        let mut latch = names(&["a"]); // "a" already paged
+        let now = names(&["a", "b"]); // "b" newly expired
+        let targets = auth_notify_targets(&now, &mut latch);
+        assert_eq!(targets, vec!["b".to_string()], "only the new one pages");
+        assert_eq!(latch, names(&["a", "b"]));
     }
 
     // ── bounded-retry / cooldown / fire-once-escalate state machine ──────

--- a/src/daemon/per_tick/respawn_watchdog.rs
+++ b/src/daemon/per_tick/respawn_watchdog.rs
@@ -182,9 +182,12 @@ enum Situation {
 
 /// Pure classifier for one agent, so the auth-vs-stuck precedence is
 /// unit-testable without a registry. AUTH TAKES PRECEDENCE: it is recognised via
-/// the EXISTING detection (`backend_profile.rs` regex → `AgentState::AuthError`,
-/// red-anchor FP-guarded — we reuse that signal rather than re-implement loose
-/// string matching at this layer, so the FP boundary is inherited for free). It
+/// the EXISTING detection (`backend_profile.rs` regex → `AgentState::AuthError`).
+/// t-...30532-0: that regex is red-anchor-guarded but the STATE it drives is
+/// still content-FP-prone at the instant level (a transient blip flips it, ~31s
+/// self-heal observed), so AuthExpired is additionally gated on the supervisor's
+/// `AUTH_ERROR_NOTIFY_STABILITY` continuous-held window — the same FP defence the
+/// #1523 re-auth alert uses — rather than trusting the bare instant signal. It
 /// is gated to `Resume` to stay inside this watchdog's domain (the module force-
 /// restarts only `Resume` spawns) and disjoint from the supervisor's general
 /// AuthError flow. `AuthError` and `Starting/Restarting` are different
@@ -196,7 +199,22 @@ fn classify(
     silent: Duration,
     timeout: Duration,
 ) -> Situation {
-    if spawn_mode == SpawnMode::Resume && state == AgentState::AuthError {
+    if spawn_mode == SpawnMode::Resume
+        && state == AgentState::AuthError
+        && since_elapsed >= crate::daemon::supervisor::AUTH_ERROR_NOTIFY_STABILITY
+    {
+        // t-...30532-0 (reviewer5 REJECTED): the `AuthError` STATE is content-FP-
+        // prone at the instant level — transient PTY content flips it cosmetically
+        // (an instance self-healed back to Thinking in ~31s), so firing on the
+        // bare signal blip-pages the operator AND blindly skips the auto-Fresh
+        // that would have recovered it. Gate on the SAME stability window the
+        // supervisor's #1523 re-auth alert uses: only page once AuthError has been
+        // held CONTINUOUSLY past it. `since_elapsed` is `state.since.elapsed()`,
+        // reset on every transition (state/mod.rs `record_set`), so it is exactly
+        // the continuous-`AuthError` held-duration — a flicker out-and-back never
+        // accumulates. UNDER the window: fall through — `is_stuck_resume` needs
+        // `Starting`/`Restarting` (never `AuthError`), so this lands on `Ignore`
+        // and the blip is left to self-heal, no page, no auto-Fresh interference.
         return Situation::AuthExpired;
     }
     if is_stuck_resume(spawn_mode, state, since_elapsed, silent, timeout) {
@@ -605,14 +623,15 @@ mod tests {
     // ── auth-expiry classification (route away from auto-Fresh) ─────────
 
     #[test]
-    fn classify_auth_error_on_resume_is_auth_expired() {
-        // An AuthError agent spawned via Resume must be routed to the operator
-        // page, NOT the auto-Fresh ladder (respawn can't re-authenticate).
+    fn classify_auth_error_on_resume_held_past_window_is_auth_expired() {
+        // An AuthError agent spawned via Resume, held CONTINUOUSLY past the
+        // stability window, is a real auth expiry → operator page, NOT the
+        // auto-Fresh ladder (respawn can't re-authenticate).
         assert_eq!(
             classify(
                 SpawnMode::Resume,
                 AgentState::AuthError,
-                Duration::from_secs(120),
+                Duration::from_secs(120), // > 90s window
                 Duration::from_secs(120),
                 RESPAWN_STUCK_TIMEOUT,
             ),
@@ -620,19 +639,53 @@ mod tests {
         );
     }
 
+    /// t-...30532-0 (reviewer5 REJECTED, flipped): a SHORT-lived AuthError blip
+    /// (under the stability window) must NOT immediately page the operator or
+    /// skip auto-Fresh — `AuthError` is content-FP-prone (~31s self-heal seen), so
+    /// it must fall through and be left to self-heal. Pre-fix this returned
+    /// `AuthExpired` off a 1s signal (the merged defect). `AuthError` isn't
+    /// `Starting`/`Restarting`, so `is_stuck_resume` can't catch it either → `Ignore`.
     #[test]
-    fn classify_auth_error_takes_precedence_over_timing() {
-        // Even well within the stuck timeout, AuthError is auth-expiry — the
-        // timing gates are irrelevant once the auth signal is present.
+    fn classify_auth_error_under_stability_window_is_ignored_not_paged() {
         assert_eq!(
             classify(
                 SpawnMode::Resume,
                 AgentState::AuthError,
-                Duration::from_secs(1),
+                Duration::from_secs(1), // << 90s window — a transient blip
                 Duration::from_secs(1),
                 RESPAWN_STUCK_TIMEOUT,
             ),
-            Situation::AuthExpired
+            Situation::Ignore,
+            "a sub-window AuthError blip must self-heal, not page + skip auto-Fresh"
+        );
+    }
+
+    /// Boundary pin on the reused supervisor window (single source of truth): at
+    /// exactly `AUTH_ERROR_NOTIFY_STABILITY` it pages; one tick under, it doesn't.
+    #[test]
+    fn classify_auth_error_window_boundary() {
+        let window = crate::daemon::supervisor::AUTH_ERROR_NOTIFY_STABILITY;
+        assert_eq!(
+            classify(
+                SpawnMode::Resume,
+                AgentState::AuthError,
+                window,
+                window,
+                RESPAWN_STUCK_TIMEOUT,
+            ),
+            Situation::AuthExpired,
+            "held == window → page"
+        );
+        assert_eq!(
+            classify(
+                SpawnMode::Resume,
+                AgentState::AuthError,
+                window - Duration::from_millis(1),
+                window - Duration::from_millis(1),
+                RESPAWN_STUCK_TIMEOUT,
+            ),
+            Situation::Ignore,
+            "held one tick under window → do not page yet"
         );
     }
 

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -59,7 +59,12 @@ const AWAITING_ENGAGEMENT_WINDOW_MS: i64 = 15_000;
 /// indefinitely and still notifies; a transient blip clears before the window
 /// and never does. 90s = ~3× the observed 31s self-heal, with margin. Sibling to
 /// `AWAITING_STABILITY` (#1552); classification/retry/timers are untouched.
-const AUTH_ERROR_NOTIFY_STABILITY: Duration = Duration::from_secs(90);
+///
+/// t-...30532-0: `pub(crate)` so `per_tick::respawn_watchdog`'s auth-expiry
+/// classifier reuses this SAME window (single source of truth) rather than
+/// copying the 90s — both gates defend the identical content-FP boundary on the
+/// identical `StateTracker::since` continuous-`AuthError` signal.
+pub(crate) const AUTH_ERROR_NOTIFY_STABILITY: Duration = Duration::from_secs(90);
 /// #1696: tiered retry budget. Phase A burst (5/15/30s) handles instant jitter;
 /// Phase B backoff (1m/2m/5m) handles minute-scale proxy faults; Phase C
 /// sustained (10m × 6 = 1hr) keeps a "pilot light" through a long outage. The


### PR DESCRIPTION
## Problem

The respawn watchdog force-restarts stuck `Resume` spawns via a bounded auto-Fresh ladder. But when an agent's underlying Claude authorization has **expired**, auto-Fresh is worse than useless: a fresh process is *just as unauthenticated*, so the ladder burns restarts (and can silently drop the agent's session) while never fixing the real problem. Only the operator can re-authenticate. The watchdog had no way to distinguish "stuck, restart me" from "auth-expired, page a human".

## Fix

`fix(respawn_watchdog): route auth-expired Resume agents to an actionable operator page instead of blind auto-Fresh` (orig `8c403505`), entirely within `src/daemon/per_tick/respawn_watchdog.rs`.

- **Pre-decision classification**: a new pure `classify(...)` computes a `Situation` for each agent *before* any auto-Fresh decision. `Situation::AuthExpired` takes precedence over `StuckResume`.
- **Reuses existing auth detection**: auth-expiry is recognised via the existing signal (`backend_profile.rs` regex → `AgentState::AuthError`, already red-anchor false-positive-guarded), rather than re-implementing loose string matching at this layer — so the FP boundary is inherited for free. It is gated to `spawn_mode == Resume` to stay within this watchdog's domain and disjoint from the supervisor's general `AuthError` flow. Because `AuthError` and `Starting/Restarting` are distinct `AgentState`s, this never reclassifies a genuine stuck Resume.
- **Excluded from the ladder**: an `AuthExpired` agent is removed from the auto-Fresh path (mirroring the existing `Paused` exclusion) and instead the operator is paged with an actionable "re-authenticate" prompt.
- **Fire-once-until-recovered latch**: a new `auth_notified` latch on the handler (daemon-lifetime), resolved by a pure `auth_notify_targets(...)`, pages the operator **exactly once** per auth-expiry episode (an `AuthError` agent is re-detected every tick, so this prevents re-paging). The latch is cleared when the agent recovers (leaves `AuthError`) or leaves the registry, so a *later* re-expiry pages again. It is kept separate from `retries` precisely because an auth-expired agent is deliberately not on the restart ladder.

## Testing

- `cargo check` passes clean on the branch rebased onto current upstream `main` (`113a509a`); no conflicts during cherry-pick.
- The classifier (`classify`) and latch resolver (`auth_notify_targets`) are written as pure functions specifically so the auth-vs-stuck precedence and the fire-once semantics are unit-testable without a live registry; unit tests included.
- Running in our fleet production daemon.

_Cherry-picked with `-x` from our fork `yujunchao/agend-terminal` (orig `8c403505`)._
