### PR TITLE
docs(#2549 W6): hook_shadow.rs module header refresh — accurate current status

### DIFF
--- a/src/daemon/hook_shadow.rs
+++ b/src/daemon/hook_shadow.rs
@@ -1,18 +1,51 @@
-//! Hook-driven state SHADOW store (PoC, #hook-state-spike phase 2).
+//! Hook-driven state SHADOW store — originated as a PoC (#hook-state-spike
+//! phase 2), now LIVE production infrastructure with real consumers (see
+//! "Current status" below). **Do not delete this module on a "PoC cleanup"
+//! pass** — it backs the inject-delivery watchdog and the ServerRateLimit
+//! hook-override.
 //!
 //! Claude Code lifecycle hooks (injected per-workspace by `mcp_config.rs`
 //! under the `AGEND_HOOK_STATE_POC=1` flag) report back via the
 //! `agend-terminal hook-event` subcommand → the `HOOK_EVENT` API method →
-//! here. SHADOW-MODE ONLY: events are recorded and compared against the
-//! screen-heuristic state (`#hook-shadow` log) — they do NOT drive
-//! transitions. Empirically verified before wiring (2026-06-11, live fleet
+//! [`record_event`], which populates this store unconditionally for any hook
+//! event received (independent of whether promotion — see below — is
+//! enabled). Empirically verified before wiring (2026-06-11, live fleet
 //! spawn): SessionStart / UserPromptSubmit / PreToolUse / PostToolUse / Stop
 //! / Notification(idle_prompt) all fire as documented with the expected
 //! payload fields; the TUI shows no artifacts (async hooks).
 //!
-//! Promotion to authoritative (hook state wins over heuristic within a
-//! freshness window, the #1945 resolution pattern) is the PRODUCTION step,
-//! gated on shadow agreement data from this PoC.
+//! ## Current status (post-#2413)
+//!
+//! The original PoC goal — this module's own `authoritative_state` snapshot
+//! promotion (hook state overriding the screen heuristic within a freshness
+//! window, gated on shadow-agreement data collected here) — was REMOVED,
+//! superseded by the multi-backend Shadow Observer's `observed_status`
+//! promotion at a different chokepoint (`per_tick/snapshot.rs`, gated by
+//! `shadow::operated_dispatch_enabled` + `shadow::gate`; see the comment
+//! above [`is_promoted`] for detail). That removal does NOT make this
+//! module dead: its store is independently read by name from three
+//! production call sites, none of which go through any promotion mechanism —
+//! - [`fresh_active_hook_seq`] / [`latest_hook_seq`] — `daemon::supervisor`'s
+//!   ServerRateLimit-retry hook-override (a fresh active hook proves the
+//!   agent is genuinely working, so a sticky screen-scraped SRL must not
+//!   fire).
+//! - [`last_user_prompt_submit_for`] — `daemon::inject_delivery`'s watchdog
+//!   (a `UserPromptSubmit` is the only proof a daemon-injected prompt
+//!   physically reached the agent; a dialog-swallowed inject never submits
+//!   one).
+//! - [`is_promoted`] and [`record_event`] — `api::handlers::hook_event`, the
+//!   API handler that writes every hook event into this store and reports
+//!   whether THIS backend is hook-promoted (for the `#hook-shadow` log's
+//!   honest disposition).
+//! - [`forget`] — `mcp::handlers::instance_state::lifecycle`'s delete path
+//!   (evicts a deleted agent's entry so a same-name redeploy doesn't inherit
+//!   stale state).
+//!
+//! [`resolved_state_for`] is the one piece that IS production-dead (#2547:
+//! its sole caller, `recovery_shadow.rs`, was deleted as dead code) — kept
+//! `#[cfg(test)]`-only as a convenience wrapper for the freshness-window
+//! regression tests below, which exercise the same `resolve_snapshot` logic
+//! production code still calls directly (see its own doc comment).
 
 use parking_lot::Mutex;
 use std::collections::HashMap;
@@ -21,11 +54,13 @@ use std::sync::OnceLock;
 
 /// One agent's latest hook-derived observation.
 ///
-/// PoC scaffolding (deferred consumers, not ghost — the #649-trio annotation
-/// pattern): in shadow-mode the only readers are the `#hook-shadow` log (which
-/// reads the values at record time) and tests; the PRODUCTION promotion step
-/// (hook state wins over heuristic within a freshness window) is the consumer
-/// of `snapshot_for` + these fields.
+/// LIVE fields, not scaffolding — see the module doc's "Current status" for
+/// the three production call sites that read `snapshot_for` + these fields
+/// directly (`fresh_active_hook_seq`/`latest_hook_seq`,
+/// `last_user_prompt_submit_for`, `is_promoted`/`record_event`), none of them
+/// through the now-removed `authoritative_state` promotion step. Every field
+/// is read by at least one of those paths (`resolve_snapshot`,
+/// `last_user_prompt_submit_for`) or the freshness-window tests.
 #[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct HookShadow {


### PR DESCRIPTION
## Summary

Part of #2549 P2 Wave 6 (spike: `P2-2549-SPIKE.md` §1/§6), pure documentation — zero code changes.

The module header still described `hook_shadow.rs` as "PoC ... SHADOW-MODE ONLY ... do NOT drive transitions" and framed hook-state promotion as a still-pending production step gated on this file's own shadow-agreement data. Both claims are stale post-#2413:

- The module's own `authoritative_state` snapshot-promotion path (the thing the old doc called "the PRODUCTION step") was **removed** — superseded by the multi-backend Shadow Observer's `observed_status` promotion at a different chokepoint (`per_tick/snapshot.rs`).
- That removal did **not** make the store dead. Verified three production call sites still read specific fields/functions directly, by name, never through any promotion mechanism:
  - `fresh_active_hook_seq` / `latest_hook_seq` — `daemon::supervisor`'s ServerRateLimit-retry hook-override
  - `last_user_prompt_submit_for` — `daemon::inject_delivery`'s watchdog
  - `is_promoted` / `record_event` — `api::handlers::hook_event`
  - `forget` — `mcp::handlers::instance_state::lifecycle`'s delete path

Only `resolved_state_for` is genuinely production-dead (`#2547`, already `#[cfg(test)]`-only).

**Why this matters**: the old header's "SHADOW-MODE ONLY, do NOT drive transitions" framing reads exactly like a green light for a future "PoC cleanup" pass to delete the whole module — which would silently break the inject-delivery watchdog and the SRL hook-override. Rewrote the module doc (and the `HookShadow` struct's doc, which made the identical stale "deferred consumer" claim) to state the current status plainly and name the production consumers.

Also fixed one inaccuracy I caught while writing this: the old `HookShadow` doc implied some fields were unread scaffolding. Checked — every field (`derived_state`, `last_event`, `at_ms`, `last_user_prompt_submit_ms`, `seq`) is actually read by a production path or the freshness-window tests.

## Scope note

Per the vet decision cited in the task, this PR's scope is deliberately narrow — the risky part (`resolved_state_for`'s production-caller removal) was already handled in #2547/#2554; this is a documentation-drift fix, not an architecture change.

## Test plan
- [x] `cargo build --lib` — clean
- [x] `cargo test hook_shadow` — 9/9 pass (zero test changes)
- [x] `cargo clippy --lib -- -D warnings` — clean
- [x] `cargo doc --no-deps --lib` — no new broken intra-doc-link warnings (5 pre-existing warnings, all unrelated to this file)

Refs #2549