### PR TITLE
refactor(#2549 W5): merge ContextAlert + ContextHandoff into ContextThresholdsHandler

### DIFF
--- a/src/daemon/per_tick/context_alert.rs
+++ b/src/daemon/per_tick/context_alert.rs
@@ -89,6 +89,17 @@ impl ContextAlertHandler {
             states: Mutex::new(HashMap::new()),
         }
     }
+
+    /// Test-only: whether `name`'s alert latch is currently armed (`None` if
+    /// the agent has no latch entry yet). Used by the #2549 W5 merge's
+    /// cross-independence pin — proves `ContextHandoffHandler` firing never
+    /// touches this handler's OWN latch, and vice versa (P2-2549-SPIKE.md
+    /// §3c: the two handlers' latch/hysteresis state must stay independent
+    /// after the merge).
+    #[cfg(test)]
+    pub(crate) fn is_armed(&self, name: &str) -> Option<bool> {
+        self.states.lock().get(name).map(|s| s.armed)
+    }
 }
 
 impl PerTickHandler for ContextAlertHandler {

--- a/src/daemon/per_tick/context_handoff.rs
+++ b/src/daemon/per_tick/context_handoff.rs
@@ -64,7 +64,7 @@ fn escalate_threshold() -> f32 {
 /// Episode phase per agent. One episode = one continuous stay above the
 /// handoff threshold.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
-enum Phase {
+pub(crate) enum Phase {
     /// Below threshold (or never seen): the next crossing acts.
     #[default]
     Armed,
@@ -211,6 +211,16 @@ impl ContextHandoffHandler {
             gate: crate::daemon::cadence_gate::CadenceGate::new(every_n_ticks),
             states: Mutex::new(HashMap::new()),
         }
+    }
+
+    /// Test-only: `name`'s current episode phase (`None` if the agent has no
+    /// episode latch entry yet). Used by the #2549 W5 merge's
+    /// cross-independence pin — proves `ContextAlertHandler` firing never
+    /// touches this handler's OWN episode state, and vice versa
+    /// (P2-2549-SPIKE.md §3c).
+    #[cfg(test)]
+    pub(crate) fn phase_of(&self, name: &str) -> Option<Phase> {
+        self.states.lock().get(name).map(|s| s.phase)
     }
 }
 

--- a/src/daemon/per_tick/context_thresholds.rs
+++ b/src/daemon/per_tick/context_thresholds.rs
@@ -1,0 +1,330 @@
+//! #2549 W5 — collapses the two context-percent threshold watchdogs
+//! (`ContextAlertHandler`, `ContextHandoffHandler`) into ONE registered
+//! [`PerTickHandler`] slot (`ContextThresholdsHandler`).
+//!
+//! ## Premise check (P2-2549-SPIKE.md discipline — verify before merging)
+//!
+//! The #2549 issue describes both handlers as reading "同一份
+//! transcript-estimate 檔" (the same transcript-estimate FILE) every 6
+//! ticks. That is stale: per the #1945-disable decision (2026-06-10), the
+//! transcript-estimate fallback is DISABLED in both — `context_alert.rs`'s
+//! and `context_handoff.rs`'s own module docs, and `StateTracker::resolved_context`'s
+//! doc comment, all say so explicitly. What both ACTUALLY read is
+//! `handle.core.lock().state.resolved_context()` — the agent's own
+//! in-memory statusline-pattern reading, not a file at all (the stale
+//! "transcript-estimate file IO" framing also appears in this crate's own
+//! `build_default_handlers` registration comment, now corrected below). The
+//! underlying redundancy the issue is really pointing at is real (both
+//! handlers separately lock the registry, iterate every live agent, and
+//! call the SAME cheap in-memory accessor once each, every 6th tick) — just
+//! smaller than "shared file I/O" implies: an in-memory Mutex lock + a
+//! statusline-cache read, not a filesystem call.
+//!
+//! Given that, and given this is the SPIKE's own highest-risk merge group
+//! (`ContextAlertHandler`'s re-alertable latch and `ContextHandoffHandler`'s
+//! one-shot-per-episode latch are genuinely different state machines, see
+//! §3c), this follows the W1–W4 pure-COMPOSITION precedent rather than
+//! fusing the two registry scans into one shared snapshot: `context_alert.rs`
+//! and `context_handoff.rs` are UNTOUCHED beyond two tiny `#[cfg(test)]`-only
+//! accessor methods (`ContextAlertHandler::is_armed`, `ContextHandoffHandler::phase_of`)
+//! used by this file's cross-independence pin below — zero production
+//! behavior change. Each inner handler keeps its own `PerTickHandler` impl,
+//! `CadenceGate` (both currently 6 ticks, exposed as separate constructor
+//! params rather than hoisted onto one shared gate — same shape as W3's
+//! genuinely-different-but-currently-equal cadences), and completely
+//! separate per-agent latch state (`AlertState` vs `EpisodeState`/`Phase`).
+//!
+//! Panic isolation moves from PER-HANDLER to PER-CHECK (mirrors
+//! `hourly_gc::run_sweep_isolated` / `notification_watchdogs::run_check_isolated`):
+//! this handler wraps each of its 2 inner `.run()` calls in its own
+//! `catch_unwind`, so the pre-merge invariant — one threshold watchdog
+//! panicking never blocks the other in the same tick — survives the
+//! collapse into a single registered handler.
+
+use super::context_alert::ContextAlertHandler;
+use super::context_handoff::ContextHandoffHandler;
+use super::{PerTickHandler, TickContext};
+
+pub(crate) struct ContextThresholdsHandler {
+    context_alert: ContextAlertHandler,
+    context_handoff: ContextHandoffHandler,
+}
+
+impl ContextThresholdsHandler {
+    pub(crate) fn new(alert_ticks: u64, handoff_ticks: u64) -> Self {
+        Self {
+            context_alert: ContextAlertHandler::new(alert_ticks),
+            context_handoff: ContextHandoffHandler::new(handoff_ticks),
+        }
+    }
+}
+
+impl PerTickHandler for ContextThresholdsHandler {
+    fn name(&self) -> &'static str {
+        "context_thresholds"
+    }
+
+    fn run(&self, ctx: &TickContext<'_>) {
+        run_check_isolated("context_alert", || self.context_alert.run(ctx));
+        run_check_isolated("context_handoff", || self.context_handoff.run(ctx));
+    }
+}
+
+/// Run one sub-check isolated from its sibling: a panic inside `f` is
+/// caught and logged, never propagated — the per-check equivalent of the
+/// outer per-tick loop's per-HANDLER `catch_unwind`. Preserves "one context
+/// threshold watchdog panicking doesn't block the other" now that both run
+/// inside a single registered handler's `run()` call.
+fn run_check_isolated(name: &'static str, f: impl FnOnce()) {
+    let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        #[cfg(test)]
+        test_hooks::record_and_maybe_force_panic(name);
+        f()
+    }));
+    if let Err(payload) = outcome {
+        tracing::error!(
+            check = name,
+            error = %super::panic_payload_str(&payload),
+            "context_thresholds: sub-check panicked — isolated, the other check in this tick still ran"
+        );
+    }
+}
+
+/// Test-only fault-injection seam: proves the per-check isolation property
+/// against the REAL merged handler (not a mock). Mirrors `hourly_gc`'s and
+/// `notification_watchdogs`'s identically-shaped `test_hooks`.
+#[cfg(test)]
+mod test_hooks {
+    use std::cell::{Cell, RefCell};
+
+    thread_local! {
+        static FORCE_PANIC: Cell<Option<&'static str>> = const { Cell::new(None) };
+        static INVOKED: RefCell<Vec<&'static str>> = const { RefCell::new(Vec::new()) };
+    }
+
+    pub(super) fn record_and_maybe_force_panic(name: &'static str) {
+        INVOKED.with(|v| v.borrow_mut().push(name));
+        if FORCE_PANIC.with(|p| p.get()) == Some(name) {
+            panic!("fault-injection: forced panic in check '{name}'");
+        }
+    }
+
+    pub(super) fn force_panic(name: &'static str) {
+        FORCE_PANIC.with(|p| p.set(Some(name)));
+    }
+
+    pub(super) fn clear_force_panic() {
+        FORCE_PANIC.with(|p| p.set(None));
+    }
+
+    pub(super) fn take_invoked() -> Vec<&'static str> {
+        INVOKED.with(|v| std::mem::take(&mut *v.borrow_mut()))
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use parking_lot::Mutex as PLMutex;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    fn tmp_home(tag: &str) -> std::path::PathBuf {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "agend-context-thresholds-{}-{}-{}",
+            std::process::id(),
+            tag,
+            id
+        ));
+        std::fs::create_dir_all(&dir).ok();
+        dir
+    }
+
+    fn empty_ctx_parts() -> (
+        crate::agent::AgentRegistry,
+        crate::agent::ExternalRegistry,
+        Arc<PLMutex<HashMap<String, crate::daemon::AgentConfig>>>,
+    ) {
+        (
+            Arc::new(PLMutex::new(HashMap::new())),
+            Arc::new(PLMutex::new(HashMap::new())),
+            Arc::new(PLMutex::new(HashMap::new())),
+        )
+    }
+
+    #[test]
+    fn name_is_context_thresholds() {
+        assert_eq!(
+            ContextThresholdsHandler::new(6, 6).name(),
+            "context_thresholds"
+        );
+    }
+
+    /// #2549 W5 pin (mirrors `hourly_gc`/`notification_watchdogs`): the outer
+    /// per-tick loop used to isolate panics PER-HANDLER — 2 separately-
+    /// registered handlers meant a panic in one never touched the other's
+    /// invocation this tick. After collapsing both into
+    /// `ContextThresholdsHandler`, that guarantee must be reproduced INSIDE
+    /// `run()` at per-check granularity.
+    #[test]
+    fn alert_panic_does_not_block_handoff() {
+        let home = tmp_home("panic-alert");
+        let (registry, externals, configs) = empty_ctx_parts();
+        let ctx = TickContext {
+            home: &home,
+            registry: &registry,
+            externals: &externals,
+            configs: &configs,
+        };
+
+        let handler = ContextThresholdsHandler::new(1, 1);
+        test_hooks::force_panic("context_alert");
+        handler.run(&ctx); // must not propagate
+
+        test_hooks::clear_force_panic();
+        assert_eq!(
+            test_hooks::take_invoked(),
+            vec!["context_alert", "context_handoff"],
+            "'context_alert' panicking must not stop 'context_handoff' from running"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn handoff_panic_does_not_block_alert() {
+        let home = tmp_home("panic-handoff");
+        let (registry, externals, configs) = empty_ctx_parts();
+        let ctx = TickContext {
+            home: &home,
+            registry: &registry,
+            externals: &externals,
+            configs: &configs,
+        };
+
+        let handler = ContextThresholdsHandler::new(1, 1);
+        test_hooks::force_panic("context_handoff");
+        handler.run(&ctx);
+
+        test_hooks::clear_force_panic();
+        assert_eq!(
+            test_hooks::take_invoked(),
+            vec!["context_alert", "context_handoff"],
+            "'context_handoff' panicking must not retroactively un-run 'context_alert' (before it)"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn no_panic_both_run_in_order() {
+        let home = tmp_home("baseline");
+        let (registry, externals, configs) = empty_ctx_parts();
+        let ctx = TickContext {
+            home: &home,
+            registry: &registry,
+            externals: &externals,
+            configs: &configs,
+        };
+
+        let handler = ContextThresholdsHandler::new(1, 1);
+        handler.run(&ctx);
+
+        assert_eq!(
+            test_hooks::take_invoked(),
+            vec!["context_alert", "context_handoff"]
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #2549 W5 cross-independence pin (P2-2549-SPIKE.md §3c, the exact
+    /// property the task calls out): drive the REAL merged handler against a
+    /// live agent at 82% — ABOVE ContextAlert's 80% threshold, BELOW
+    /// ContextHandoff's 85% threshold (and its own 80% hysteresis floor, so
+    /// handoff's `decide()` takes the "hold current phase, no action"
+    /// branch). Assert:
+    /// (a) ContextAlert's latch fired (armed → disarmed) for this agent —
+    ///     proves the merged handler's alert leg still actually ran the real
+    ///     decision, not just "was invoked".
+    /// (b) ContextHandoff's episode phase for this SAME agent stayed at the
+    ///     default `Armed` — proves alert firing never touches handoff's
+    ///     independent latch.
+    #[test]
+    fn alert_firing_does_not_perturb_handoff_state() {
+        let home = tmp_home("cross-independence-alert-only");
+        let (registry, externals, configs) = empty_ctx_parts();
+        let (handle, _reader) =
+            crate::daemon::per_tick::mock_live_agent_with_context("watched", 82.0);
+        registry.lock().insert(handle.id, handle);
+        let ctx = TickContext {
+            home: &home,
+            registry: &registry,
+            externals: &externals,
+            configs: &configs,
+        };
+
+        let handler = ContextThresholdsHandler::new(1, 1);
+        handler.run(&ctx);
+
+        assert_eq!(
+            handler.context_alert.is_armed("watched"),
+            Some(false),
+            "82% crosses the 80% alert threshold — alert must have fired \
+             (armed → disarmed) for a real decision to have run"
+        );
+        assert_eq!(
+            handler.context_handoff.phase_of("watched"),
+            Some(super::super::context_handoff::Phase::Armed),
+            "82% is below the 85% handoff threshold (and above its 80% \
+             hysteresis floor) — handoff's episode phase must stay Armed, \
+             completely unaffected by the alert leg firing on the SAME agent \
+             in the SAME run() call"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Mirror direction: a live agent at 90% crosses BOTH thresholds (alert
+    /// 80%, handoff 85%). `mock_live_agent_with_context` only feeds a
+    /// statusline frame (no activity pattern), which the REAL state
+    /// classifier honestly resolves as `Idle` — matching an actual idle
+    /// Claude pane sitting at its prompt — so handoff's own `decide()` takes
+    /// the idle branch (`IdleMarked`, not `Inject`; #2008's "idle
+    /// context-full is not urgent" rule). What this test proves is
+    /// independence, not which specific handoff phase results: alert firing
+    /// (`armed → disarmed`) must not perturb handoff's own phase transition
+    /// (`Armed → IdleMarked`), even though both ran off the SAME registry
+    /// scan on the SAME agent in the SAME `run()` call.
+    #[test]
+    fn both_firing_on_same_agent_keep_independent_latches() {
+        let home = tmp_home("cross-independence-both");
+        let (registry, externals, configs) = empty_ctx_parts();
+        let (handle, _reader) =
+            crate::daemon::per_tick::mock_live_agent_with_context("watched", 90.0);
+        registry.lock().insert(handle.id, handle);
+        let ctx = TickContext {
+            home: &home,
+            registry: &registry,
+            externals: &externals,
+            configs: &configs,
+        };
+
+        let handler = ContextThresholdsHandler::new(1, 1);
+        handler.run(&ctx);
+
+        assert_eq!(
+            handler.context_alert.is_armed("watched"),
+            Some(false),
+            "90% crosses the alert threshold — alert fired"
+        );
+        assert_eq!(
+            handler.context_handoff.phase_of("watched"),
+            Some(super::super::context_handoff::Phase::IdleMarked),
+            "90% crosses the handoff threshold on an Idle mock agent — handoff \
+             must have independently transitioned Armed → IdleMarked, got {:?}",
+            handler.context_handoff.phase_of("watched")
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+}

--- a/src/daemon/per_tick/mod.rs
+++ b/src/daemon/per_tick/mod.rs
@@ -46,6 +46,7 @@ pub(crate) mod check_schedules;
 pub(crate) mod ci_watch_poll;
 pub(crate) mod context_alert;
 pub(crate) mod context_handoff;
+pub(crate) mod context_thresholds;
 pub(crate) mod ephemeral_reap;
 pub(crate) mod external_liveness;
 pub(crate) mod gc_tick;
@@ -75,8 +76,7 @@ pub(crate) mod workspace_boundary_sweep;
 pub(crate) use backend_exit_detection::BackendExitDetectionHandler;
 pub(crate) use check_schedules::CheckSchedulesHandler;
 pub(crate) use ci_watch_poll::CiWatchPollHandler;
-pub(crate) use context_alert::ContextAlertHandler;
-pub(crate) use context_handoff::ContextHandoffHandler;
+pub(crate) use context_thresholds::ContextThresholdsHandler;
 pub(crate) use ephemeral_reap::EphemeralReapHandler;
 pub(crate) use external_liveness::ExternalLivenessHandler;
 pub(crate) use hang_detection::HangDetectionHandler;
@@ -385,16 +385,19 @@ pub(crate) fn build_default_handlers(
         // already-dead workers. Runs in app mode too (not allowlisted out); the
         // live daemon is app-mode. Idle cost: one read of a usually-tiny JSON sidecar.
         Box::new(EphemeralReapHandler::new(6)),
-        // Context% alert (operator-directed): every 6 ticks (~1min) refresh +
-        // ≥80% orchestrator alert. The transcript-estimate file IO lives in
-        // this handler's tick (lock-free during the read), NOT in the PTY
-        // feed path. Runs in app mode (the live daemon is app-mode).
-        Box::new(ContextAlertHandler::new(6)),
-        // #2007 context-full safety net: every 6 ticks (~1min) — 85% one-shot
-        // [AGEND-AUTO kind=context-handoff] injection to the agent itself,
-        // 92% one-shot operator escalation. Noise-budgeted (per-episode
-        // latch + hysteresis re-arm). Runs in app mode (live daemon).
-        Box::new(ContextHandoffHandler::new(6)),
+        // #2549 W5: ContextAlertHandler (operator-directed: every 6 ticks
+        // ~1min, ≥80% orchestrator alert) and ContextHandoffHandler (#2007
+        // context-full safety net: every 6 ticks, 85% one-shot
+        // [AGEND-HANDOFF] injection to the agent itself, 92% one-shot
+        // operator escalation) collapsed into one registered handler. Both
+        // read `handle.core.lock().state.resolved_context()` — the agent's
+        // in-memory statusline-pattern reading (NOT a transcript-estimate
+        // file; #1945-disable retired that fallback) — lock-free during the
+        // read. Each keeps its own noise-budgeted latch/hysteresis state
+        // (re-alertable vs one-shot-per-episode — genuinely different state
+        // machines, not shared) and is panic-isolated from the other inside
+        // `ContextThresholdsHandler::run`. Runs in app mode (live daemon).
+        Box::new(ContextThresholdsHandler::new(6, 6)),
         // #2044 inject-delivery watchdog: every tick (~10s) verify that an
         // armed actionable wake produced a UserPromptSubmit; re-deliver once
         // + WARN if a dialog swallowed it. Cheap (iterates a usually-empty
@@ -491,6 +494,77 @@ pub(crate) fn mock_live_agent_no_context(
         vterm: crate::vterm::VTerm::with_pty_writer(80, 10, Arc::clone(&pty_writer)),
         subscribers: Vec::new(),
         state: crate::state::StateTracker::new(None),
+        health: crate::health::HealthTracker::new(),
+        api_activity: crate::agent::ApiActivity::default(),
+        observed_status: None,
+    }));
+    let handle = crate::agent::AgentHandle {
+        id: crate::types::InstanceId::default(),
+        name: name.to_string().into(),
+        backend_command: "claude".to_string(),
+        pty_writer,
+        pty_master: Arc::new(parking_lot::Mutex::new(pair.master)),
+        published_state: crate::agent::published_state_of(&core),
+        published_observed: crate::agent::published_observed_of(&core),
+        core,
+        child: Arc::new(parking_lot::Mutex::new(child)),
+        submit_key: "\r".to_string(),
+        inject_prefix: String::new(),
+        typed_inject: false,
+        spawned_at: std::time::Instant::now(),
+        spawned_at_epoch_ms: 0,
+        spawn_mode: crate::backend::SpawnMode::Fresh,
+        deleted: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    };
+    (handle, reader)
+}
+
+/// Test-only: build a LIVE `AgentHandle` (real openpty, child `cat`) whose
+/// `StateTracker` has a REAL, fresh Claude context-percent reading (fed via
+/// a synthetic statusline frame, same shape as `state::tests::CLAUDE_STATUSLINE_FRAME`)
+/// — so `core.state.resolved_context()` resolves to `Some((pct, "pattern"))`.
+/// Sibling of [`mock_live_agent_no_context`] (kept separate rather than
+/// parameterizing it, to avoid touching that function's signature and its 6
+/// existing call sites across `per_tick`'s test suites — #2549 W5). Used by
+/// the `ContextAlertHandler`/`ContextHandoffHandler` merge's cross-
+/// independence pin, which needs a live agent whose threshold-crossing
+/// decision actually fires.
+#[cfg(test)]
+pub(crate) fn mock_live_agent_with_context(
+    name: &str,
+    pct: f32,
+) -> (crate::agent::AgentHandle, Box<dyn std::io::Read + Send>) {
+    use std::sync::Arc;
+    let pty_system = portable_pty::native_pty_system();
+    let pair = pty_system
+        .openpty(portable_pty::PtySize {
+            rows: 10,
+            cols: 80,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .expect("open pty");
+    #[cfg(not(target_os = "windows"))]
+    let cmd = portable_pty::CommandBuilder::new("cat");
+    #[cfg(target_os = "windows")]
+    let cmd = {
+        let mut c = portable_pty::CommandBuilder::new("cmd");
+        c.args(["/c", "findstr", ".*"]);
+        c
+    };
+    let child = pair.slave.spawn_command(cmd).expect("spawn cat");
+    drop(pair.slave);
+    let reader = pair.master.try_clone_reader().expect("clone reader");
+    let writer = pair.master.take_writer().expect("take writer");
+    let pty_writer: crate::agent::PtyWriter = Arc::new(parking_lot::Mutex::new(writer));
+    let mut state = crate::state::StateTracker::new(Some(&crate::backend::Backend::ClaudeCode));
+    state.feed(&format!(
+        "  Model: Fable 5 | Ctx Used: {pct:.1}% | ⎇ b | (+0,-0)\n  ⏵⏵ bypass permissions on (shift+tab to cycle)"
+    ));
+    let core = Arc::new(crate::sync_audit::CoreMutex::new(crate::agent::AgentCore {
+        vterm: crate::vterm::VTerm::with_pty_writer(80, 10, Arc::clone(&pty_writer)),
+        subscribers: Vec::new(),
+        state,
         health: crate::health::HealthTracker::new(),
         api_activity: crate::agent::ApiActivity::default(),
         observed_status: None,


### PR DESCRIPTION
## Summary
- Collapses `ContextAlertHandler` and `ContextHandoffHandler` (both 6-tick cadence) into one registered `PerTickHandler`, `ContextThresholdsHandler` — the spike's own highest-risk merge group (`P2-2549-SPIKE.md` §3c).
- Pure composition, following the W1–W4 precedent: `context_alert.rs` and `context_handoff.rs` are untouched beyond two tiny `#[cfg(test)]`-only accessor methods (`is_armed`, `phase_of`) used by the new cross-independence pin. Both existing test suites (18 tests) run unmodified and green.

## Premise check (spike discipline)
The #2549 issue describes both handlers as reading "同一份 transcript-estimate 檔" (the same transcript-estimate **file**) every 6 ticks. That's stale: per the #1945-disable decision (2026-06-10), the transcript fallback is retired in both — they actually call `handle.core.lock().state.resolved_context()`, an in-memory statusline-cache accessor, not a file read. (The `mod.rs` registration comment carried the same stale "transcript-estimate file IO" framing — corrected in this PR too.)

Given that, the real redundancy this merge targets is smaller than the issue implies (an in-memory `Mutex` lock + cheap field read, done twice per matching tick — not duplicated file I/O), which is part of why this stays pure-composition rather than fusing the two registry scans into one shared snapshot: the actual latch/hysteresis state machines (`AlertState`'s re-alertable latch vs `EpisodeState`'s one-shot-per-episode `Phase`) are genuinely different, and for the highest-risk group in this wave series, minimizing the change footprint is the more defensible call.

## Cross-independence pin (the exact property §3c calls out)
Added `mock_live_agent_with_context` (sibling of the existing `mock_live_agent_no_context`, added rather than reparameterizing it to avoid touching its 6 existing call sites) — builds a live agent with a real fed statusline reading. Two tests drive the REAL merged handler:
- Agent at 82% (crosses alert's 80% threshold, below handoff's 85%): asserts alert fired (`armed → disarmed`) while handoff's phase stayed `Armed`, untouched.
- Agent at 90% (crosses both): asserts alert fired AND handoff independently transitioned (`Armed → IdleMarked` — the mock resolves as Idle, matching how `mock_live_agent_with_context` only feeds a statusline frame with no activity pattern, same as a real idle Claude pane), proving neither handler's latch leaked into the other's even on the same agent in the same `run()` call.

## Panic isolation
`run_check_isolated` (mirrors `hourly_gc`/`notification_watchdogs`) wraps each of the 2 inner `.run()` calls in its own `catch_unwind`, pinned by 3 tests (baseline + panic-in-alert + panic-in-handoff).

## Test plan
- [x] `cargo test --bin agend-terminal -- per_tick:: app::` — 303 passed, including the two original handlers' 18 unmodified tests and the app-tick completeness invariant
- [x] `cargo nextest run --profile ci --no-fail-fast` — same 2 pre-existing local-environment-flaky failures as W1/W3 (`e2e_dispatch_review_workflow_seam_invariants_1900`, `teardown_leaves_zero_residual_after_full_exercise_1907`, unrelated dispatch/binding/teardown files, main's CI green)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Full repo sweep for dangling `ContextAlertHandler`/`ContextHandoffHandler` references — only descriptive comments remain