### PR TITLE
test(#2550): dedupe review_repro scratch()/git() test helpers

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -69,6 +69,8 @@ mod provider_detect;
 mod quickstart;
 mod render;
 mod reply_ledger;
+#[cfg(test)]
+mod review_repro_test_util;
 mod runtime;
 pub mod runtime_config;
 mod schedules;

--- a/src/review_repro_test_util.rs
+++ b/src/review_repro_test_util.rs
@@ -22,7 +22,15 @@ pub(crate) fn scratch(prefix: &str, tag: &str) -> PathBuf {
 }
 
 /// Run `git` with the daemon bypass env (mirrors the in-module test harness).
-pub(crate) fn git(dir: &Path, args: &[&str]) {
+///
+/// Named `review_repro_git`, not the bare `git` the two call sites' own
+/// local wrappers used — `tests/anti_pattern_invariant.rs`'s Rule 1
+/// (dead-code-helper-pattern) scans `src/` for `pub`/`pub(crate)` fn names
+/// that collide with a `tests/`-integration-test's own local helper of the
+/// same name (several already define their own `fn git(...)`); a bare `git`
+/// here would trip that lint by newly colliding with those pre-existing,
+/// unrelated helpers.
+pub(crate) fn review_repro_git(dir: &Path, args: &[&str]) {
     std::process::Command::new("git")
         .args(args)
         .current_dir(dir)

--- a/src/review_repro_test_util.rs
+++ b/src/review_repro_test_util.rs
@@ -1,0 +1,36 @@
+//! Shared test-only helpers for the `review_repro_worktree_git` regression
+//! guards attached to `worktree_pool.rs` and `worktree_cleanup.rs` (#2550 P3
+//! §6) — previously two near-identical copies (`scratch()` + `git()`)
+//! differing only in the scratch-dir prefix string baked into each. Behavior
+//! is unchanged: each caller still passes its own prefix, so the resulting
+//! temp-dir names are byte-identical to before.
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU32, Ordering};
+
+/// Unique scratch dir under the system temp, namespaced by `prefix` (so two
+/// callers' temp dirs never collide) and `tag` (per-test identification).
+pub(crate) fn scratch(prefix: &str, tag: &str) -> PathBuf {
+    static C: AtomicU32 = AtomicU32::new(0);
+    let dir = std::env::temp_dir().join(format!(
+        "{prefix}-{tag}-{}-{}",
+        std::process::id(),
+        C.fetch_add(1, Ordering::Relaxed)
+    ));
+    std::fs::create_dir_all(&dir).expect("mkdir scratch");
+    dir
+}
+
+/// Run `git` with the daemon bypass env (mirrors the in-module test harness).
+pub(crate) fn git(dir: &Path, args: &[&str]) {
+    std::process::Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .env("AGEND_GIT_BYPASS", "1")
+        .env("GIT_AUTHOR_NAME", "test")
+        .env("GIT_AUTHOR_EMAIL", "t@t")
+        .env("GIT_COMMITTER_NAME", "test")
+        .env("GIT_COMMITTER_EMAIL", "t@t")
+        .output()
+        .expect("git invocation");
+}

--- a/src/worktree_cleanup/review_repro_worktree_git.rs
+++ b/src/worktree_cleanup/review_repro_worktree_git.rs
@@ -23,7 +23,7 @@ fn scratch(tag: &str) -> PathBuf {
 
 /// Run `git` with the daemon bypass env (mirrors the in-module test harness).
 fn git(dir: &Path, args: &[&str]) {
-    crate::review_repro_test_util::git(dir, args)
+    crate::review_repro_test_util::review_repro_git(dir, args)
 }
 
 /// True iff `branch` still exists as a local ref in `repo`.

--- a/src/worktree_cleanup/review_repro_worktree_git.rs
+++ b/src/worktree_cleanup/review_repro_worktree_git.rs
@@ -15,33 +15,15 @@ use super::{prune_orphaned_branches, sweep_from_registry};
 use super::is_in_use;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU32, Ordering};
 
 /// Unique scratch dir under the system temp.
 fn scratch(tag: &str) -> PathBuf {
-    static C: AtomicU32 = AtomicU32::new(0);
-    let dir = std::env::temp_dir().join(format!(
-        "agend-wtclean-reprowg-{}-{}-{}",
-        tag,
-        std::process::id(),
-        C.fetch_add(1, Ordering::Relaxed)
-    ));
-    std::fs::create_dir_all(&dir).expect("mkdir scratch");
-    dir
+    crate::review_repro_test_util::scratch("agend-wtclean-reprowg", tag)
 }
 
 /// Run `git` with the daemon bypass env (mirrors the in-module test harness).
 fn git(dir: &Path, args: &[&str]) {
-    std::process::Command::new("git")
-        .args(args)
-        .current_dir(dir)
-        .env("AGEND_GIT_BYPASS", "1")
-        .env("GIT_AUTHOR_NAME", "test")
-        .env("GIT_AUTHOR_EMAIL", "t@t")
-        .env("GIT_COMMITTER_NAME", "test")
-        .env("GIT_COMMITTER_EMAIL", "t@t")
-        .output()
-        .expect("git invocation");
+    crate::review_repro_test_util::git(dir, args)
 }
 
 /// True iff `branch` still exists as a local ref in `repo`.

--- a/src/worktree_pool/review_repro_worktree_git.rs
+++ b/src/worktree_pool/review_repro_worktree_git.rs
@@ -20,7 +20,7 @@ fn scratch(tag: &str) -> PathBuf {
 
 /// Run `git` with the daemon bypass env (mirrors the in-module test harness).
 fn git(dir: &Path, args: &[&str]) {
-    crate::review_repro_test_util::git(dir, args)
+    crate::review_repro_test_util::review_repro_git(dir, args)
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/worktree_pool/review_repro_worktree_git.rs
+++ b/src/worktree_pool/review_repro_worktree_git.rs
@@ -12,33 +12,15 @@
 use super::{cleanup_merged_branch, evaluate_candidate, GcKind, MANAGED_MARKER};
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU32, Ordering};
 
 /// Unique scratch dir under the system temp.
 fn scratch(tag: &str) -> PathBuf {
-    static C: AtomicU32 = AtomicU32::new(0);
-    let dir = std::env::temp_dir().join(format!(
-        "agend-wtpool-reprowg-{}-{}-{}",
-        tag,
-        std::process::id(),
-        C.fetch_add(1, Ordering::Relaxed)
-    ));
-    std::fs::create_dir_all(&dir).expect("mkdir scratch");
-    dir
+    crate::review_repro_test_util::scratch("agend-wtpool-reprowg", tag)
 }
 
 /// Run `git` with the daemon bypass env (mirrors the in-module test harness).
 fn git(dir: &Path, args: &[&str]) {
-    std::process::Command::new("git")
-        .args(args)
-        .current_dir(dir)
-        .env("AGEND_GIT_BYPASS", "1")
-        .env("GIT_AUTHOR_NAME", "test")
-        .env("GIT_AUTHOR_EMAIL", "t@t")
-        .env("GIT_COMMITTER_NAME", "test")
-        .env("GIT_COMMITTER_EMAIL", "t@t")
-        .output()
-        .expect("git invocation");
+    crate::review_repro_test_util::git(dir, args)
 }
 
 // ──────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Part of #2550 P3 (spike: `P3-2550-SPIKE.md` §6, scope I identified in the spike itself). Test-only, minimal-diff PR.

`worktree_pool/review_repro_worktree_git.rs` and `worktree_cleanup/review_repro_worktree_git.rs` each carried a byte-identical `scratch()` + `git()` helper pair, differing only in the scratch-dir prefix string (`agend-wtpool-reprowg` vs `agend-wtclean-reprowg`).

## Changes

- New `src/review_repro_test_util.rs`: shared `scratch(prefix, tag)` + `review_repro_git(dir, args)`, gated `#[cfg(test)]` in `main.rs` like the files that use it. (The shared fn is named `review_repro_git`, not the bare `git` the two files' own local wrappers use — a bare `pub(crate) fn git` under `src/` collided with `tests/anti_pattern_invariant.rs`'s Rule 1 dead-code-helper-pattern gate, which flagged several *unrelated* pre-existing integration tests — `e2e_workflow.rs`, `teardown_completeness_regression.rs`, `common/git_isolated.rs` — that already define their own local `fn git(...)` helpers of the same name. First push tripped this; fixed in a follow-up commit, confirmed via `cargo test --test anti_pattern_invariant`.)
- Each of the two `review_repro_worktree_git.rs` files' own `scratch()`/`git()` shrink to one-line delegations passing their original prefix string — so the resulting temp-dir names are byte-identical to before.
- **Scope discipline**: only these two functions, per the spike. `branch_exists()` (worktree_cleanup-only, no duplicate exists) is untouched.
- Zero test call-site changes — none of the 5 `review_repro_worktree_git` tests across both files needed to change; only the two helper function *bodies* moved. (Correction: 5, not 6 — `cleanup_merged_branch_uses_true_default_not_main_worktree_git` + `evaluate_candidate_derives_real_agent_for_slash_branch_worktree_git` in worktree_pool, plus 3 in worktree_cleanup. My earlier count of 6 came from a loose `cargo test worktree_git` substring filter that also matched an unrelated test, `force_release_worktree_git_metadata_pruned_count_in_response`.)

## Test plan
- [x] `cargo build --tests --bin agend-terminal` — clean
- [x] `cargo test --bin agend-terminal review_repro_worktree_git::` (precise filter) — 5/5 pass (all unmodified)
- [x] `cargo test --test anti_pattern_invariant` — clean (confirms no dead-code-helper-pattern collision)
- [x] `cargo clippy --lib --bin agend-terminal --tests -- -D warnings` — clean (no unused-import warnings from the removed `AtomicU32`/`Ordering` imports)
- [x] `cargo fmt --check` — clean
- [x] Confirmed test names/paths are unchanged, so the existing `.config/nextest.toml` `git-subprocess` retry filter (#2578) still covers them — no config change needed

Refs #2550