### PR TITLE
refactor(#2550 W2): git_worktree.rs primitives module — conservative consolidation

### DIFF
--- a/src/admin/mod.rs
+++ b/src/admin/mod.rs
@@ -25,19 +25,13 @@ pub enum BranchAction {
 
 /// List local branches that are NOT checked out in any worktree.
 fn worktree_branches(repo: &Path) -> std::collections::HashSet<String> {
-    // #1899: bounded via git_bypass (LOCAL 60s) — a stuck local git returns Err
-    // instead of hanging; the empty-set fallback is unchanged.
-    let output = crate::git_helpers::git_bypass(repo, &["worktree", "list", "--porcelain"]);
-    let mut branches = std::collections::HashSet::new();
-    if let Ok(out) = output {
-        let text = String::from_utf8_lossy(&out.stdout);
-        for line in text.lines() {
-            if let Some(b) = line.strip_prefix("branch refs/heads/") {
-                branches.insert(b.to_string());
-            }
-        }
-    }
-    branches
+    // #1899/#2550: bounded via git_worktree::list_porcelain (git_bypass, LOCAL
+    // 60s) — a stuck local git returns Err/empty instead of hanging.
+    crate::git_worktree::list_porcelain(repo)
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|(_, branch)| branch)
+        .collect()
 }
 
 /// List all local branch names.

--- a/src/git_worktree.rs
+++ b/src/git_worktree.rs
@@ -1,0 +1,306 @@
+//! #2550 P3 W2 — git worktree lifecycle primitives.
+//!
+//! Built ON TOP of `git_helpers.rs`'s low-level wrappers (`git_bypass`/
+//! `git_cmd`/`git_ok`), not a replacement for them: `git_helpers.rs` is the
+//! single source of truth for HOW a git subprocess is invoked (bypass env,
+//! timeout bound, process-group kill on timeout); this module is the single
+//! source of truth for WHAT worktree-lifecycle argv/parsing looks like.
+//!
+//! ## Conservative scope (P3-W2-PRERESEARCH.md + lead's 3 decisions,
+//! `m-20260703064336281447-62`)
+//!
+//! This is a MECHANICAL consolidation, not a behavior-unifying one:
+//! - `git worktree list --porcelain` parsing: [`parse_porcelain`] is moved
+//!   verbatim from `worktree_pool/gc.rs` (the most complete existing
+//!   version — handles blank-line-absent trailing records via an explicit
+//!   final flush, unlike the other 3 call sites' blank-line-triggered
+//!   flush). [`list_porcelain`] adds the `git_bypass` call on top. Each of
+//!   the 4 callers keeps its OWN caller-specific filtering (main/master
+//!   exclusion, branch-name-only extraction, etc.) as a thin layer over
+//!   this shared core — the core does NOT bake in any one caller's filter.
+//! - `git worktree remove --force`: [`remove_force`] extracts the
+//!   INTENTIONALLY-duplicated empty-`source_repo` dual-cwd branch shared
+//!   verbatim by `worktree_pool.rs::remove_worktree` and
+//!   `worktree_pool/workspace.rs::teardown_workspace_worktree` (both
+//!   already had matching comments citing the same "lead ruling": git
+//!   needs a resolvable cwd, and an empty `source_repo` means the ONLY
+//!   correct move is a bypass-enabled raw `Command` with NO `current_dir`,
+//!   never `git_bypass`/`git_cmd` — those both require a cwd).
+//! - Wrapper/error-handling-granularity CHOICE (`git_bypass` vs `git_ok` vs
+//!   `git_cmd`) stays with each existing caller — this module does not
+//!   force a uniform return type onto call sites that currently rely on
+//!   distinguishing `GitError::NonZero` from `GitError::Spawn`, or that only
+//!   need a plain `bool`. Unifying that is an explicit non-goal of W2 (would
+//!   be a behavior change requiring its own review, not a mechanical PR).
+//!
+//! ## Explicitly NOT touched (documented exceptions, not oversights)
+//!
+//! - `mcp/handlers/ci/release.rs`'s `worktree remove --force` call
+//!   deliberately does NOT bypass and does NOT set a cwd (see that file's
+//!   own comment at the call site) — a known, still-undecided behavioral
+//!   inconsistency versus every other remove-force call site. Lead's
+//!   decision (`m-20260703064336281447-62`): leave it as-is, do not fold it
+//!   into [`remove_force`] — that would be silently deciding an open design
+//!   question inside a mechanical-consolidation PR. Tracked as an open item
+//!   for operator/a future lead, not part of this wave.
+//! - `worktree_cleanup.rs`'s Windows-specific retry loop around `git_ok`
+//!   (3 attempts with exponential backoff, `cfg!(windows)`-gated) is an
+//!   application-layer flake mitigation for the SAME infra-flake class
+//!   `.config/nextest.toml`'s scoped `retries` addresses at the test-runner
+//!   layer (#2578). Not extracted — no second call site needs it yet, so
+//!   there's no real abstraction to name (lead's decision, same message).
+
+use std::path::{Path, PathBuf};
+
+/// `git worktree list --porcelain` argv.
+pub(crate) const LIST_PORCELAIN_ARGS: [&str; 3] = ["worktree", "list", "--porcelain"];
+
+/// Parse `git worktree list --porcelain` stdout into `(path, branch)` pairs.
+/// Porcelain records are blank-line-separated; `worktree <path>` opens a
+/// record, `branch refs/heads/<b>` names the checked-out branch (absent =
+/// detached). Flushes on the NEXT `worktree` line (not on the blank
+/// separator) plus an explicit final flush after the loop, so it does not
+/// depend on trailing-blank-line presence — safe against trimmed input,
+/// unlike the ad-hoc blank-line-triggered parsers this replaces.
+///
+/// Moved verbatim from `worktree_pool/gc.rs` (was `parse_worktree_porcelain`,
+/// the most complete of the 4 existing copies — see module doc).
+pub(crate) fn parse_porcelain(out: &str) -> Vec<(PathBuf, Option<String>)> {
+    let mut records = Vec::new();
+    let mut cur_path: Option<PathBuf> = None;
+    let mut cur_branch: Option<String> = None;
+    let flush = |p: &mut Option<PathBuf>, b: &mut Option<String>, out: &mut Vec<_>| {
+        if let Some(path) = p.take() {
+            out.push((path, b.take()));
+        }
+        *b = None;
+    };
+    for line in out.lines() {
+        if let Some(p) = line.strip_prefix("worktree ") {
+            flush(&mut cur_path, &mut cur_branch, &mut records);
+            cur_path = Some(PathBuf::from(p.trim()));
+        } else if let Some(b) = line.strip_prefix("branch ") {
+            cur_branch = Some(
+                b.trim()
+                    .strip_prefix("refs/heads/")
+                    .unwrap_or(b.trim())
+                    .to_string(),
+            );
+        }
+    }
+    flush(&mut cur_path, &mut cur_branch, &mut records);
+    records
+}
+
+/// `git worktree list --porcelain` (via `git_helpers::git_bypass`, #1899
+/// LOCAL 60s bound) parsed into `(path, branch)` pairs. `Ok(vec![])` on a
+/// non-zero exit (matches every existing caller's "no entries" fallback);
+/// `Err` only on a spawn/timeout failure.
+pub(crate) fn list_porcelain(repo: &Path) -> std::io::Result<Vec<(PathBuf, Option<String>)>> {
+    let out = crate::git_helpers::git_bypass(repo, &LIST_PORCELAIN_ARGS)?;
+    if !out.status.success() {
+        return Ok(Vec::new());
+    }
+    Ok(parse_porcelain(&String::from_utf8_lossy(&out.stdout)))
+}
+
+/// `git worktree remove --force <wt_path>`.
+///
+/// `source_repo` empty → runs with NO `current_dir` (git resolves the repo
+/// from the absolute `wt_path` itself; `AGEND_GIT_BYPASS=1` still set via
+/// `env`) — the documented exception both original call sites shared
+/// verbatim (see module doc: `git_bypass`/`git_cmd` both REQUIRE a cwd, and
+/// the worktrees-pool parent dir is NOT the owning repo).
+/// `source_repo` non-empty → `git_helpers::git_bypass(source_repo, ...)`.
+pub(crate) fn remove_force(
+    source_repo: &Path,
+    wt_path: &str,
+) -> std::io::Result<std::process::Output> {
+    if source_repo.as_os_str().is_empty() {
+        std::process::Command::new("git")
+            .args(["worktree", "remove", "--force", wt_path])
+            .env("AGEND_GIT_BYPASS", "1")
+            .output()
+    } else {
+        crate::git_helpers::git_bypass(source_repo, &["worktree", "remove", "--force", wt_path])
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn tmp_home(tag: &str) -> PathBuf {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "agend-git-worktree-{}-{}-{}",
+            std::process::id(),
+            tag,
+            id
+        ));
+        std::fs::create_dir_all(&dir).ok();
+        dir
+    }
+
+    fn git(cwd: &Path, args: &[&str]) {
+        let status = std::process::Command::new("git")
+            .env("AGEND_GIT_BYPASS", "1")
+            .env("GIT_AUTHOR_NAME", "t")
+            .env("GIT_AUTHOR_EMAIL", "t@t")
+            .env("GIT_COMMITTER_NAME", "t")
+            .env("GIT_COMMITTER_EMAIL", "t@t")
+            .current_dir(cwd)
+            .args(args)
+            .status()
+            .expect("spawn git");
+        assert!(status.success(), "git {args:?} failed in {}", cwd.display());
+    }
+
+    fn make_repo(path: &Path) -> PathBuf {
+        std::fs::create_dir_all(path).unwrap();
+        git(path, &["init", "-b", "main"]);
+        git(path, &["commit", "--allow-empty", "-m", "init"]);
+        path.to_path_buf()
+    }
+
+    #[test]
+    fn parse_porcelain_pairs_path_with_branch() {
+        let out = "worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\n\
+                    worktree /repo/wt-feature\nHEAD def456\nbranch refs/heads/feat/x\n";
+        let parsed = parse_porcelain(out);
+        assert_eq!(
+            parsed,
+            vec![
+                (PathBuf::from("/repo"), Some("main".to_string())),
+                (
+                    PathBuf::from("/repo/wt-feature"),
+                    Some("feat/x".to_string())
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_porcelain_detached_head_has_no_branch() {
+        let out = "worktree /repo/wt-detached\nHEAD abc123\ndetached\n";
+        assert_eq!(
+            parse_porcelain(out),
+            vec![(PathBuf::from("/repo/wt-detached"), None)]
+        );
+    }
+
+    #[test]
+    fn parse_porcelain_last_record_survives_without_trailing_blank_line() {
+        // #2550 W2: the point of using this parser as canonical — it does NOT
+        // depend on a trailing blank-line record terminator (unlike the
+        // ad-hoc parsers it replaces), so trimmed/blank-line-stripped input
+        // still yields the final record.
+        let out =
+            "worktree /repo\nbranch refs/heads/main\n\nworktree /repo/wt\nbranch refs/heads/x";
+        assert_eq!(
+            parse_porcelain(out),
+            vec![
+                (PathBuf::from("/repo"), Some("main".to_string())),
+                (PathBuf::from("/repo/wt"), Some("x".to_string())),
+            ]
+        );
+    }
+
+    #[test]
+    fn list_porcelain_real_repo_round_trip() {
+        let home = tmp_home("list-porcelain");
+        let repo = make_repo(&home.join("repo"));
+        let wt = home.join("wt-feature");
+        git(&repo, &["branch", "feat-x"]);
+        git(
+            &repo,
+            &["worktree", "add", &wt.display().to_string(), "feat-x"],
+        );
+
+        let entries = list_porcelain(&repo).unwrap();
+        assert!(
+            entries
+                .iter()
+                .any(|(p, b)| p.ends_with("repo") && b.as_deref() == Some("main")),
+            "main worktree entry present: {entries:?}"
+        );
+        assert!(
+            entries
+                .iter()
+                .any(|(p, b)| p.ends_with("wt-feature") && b.as_deref() == Some("feat-x")),
+            "feature worktree entry present: {entries:?}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn remove_force_with_source_repo_removes_registration() {
+        let home = tmp_home("remove-force-with-repo");
+        let repo = make_repo(&home.join("repo"));
+        let wt = home.join("wt-feature");
+        git(&repo, &["branch", "feat-x"]);
+        git(
+            &repo,
+            &["worktree", "add", &wt.display().to_string(), "feat-x"],
+        );
+        assert!(wt.exists());
+
+        let out = remove_force(&repo, &wt.display().to_string()).unwrap();
+        assert!(
+            out.status.success(),
+            "{}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        assert!(!wt.exists(), "worktree dir removed");
+        let entries = list_porcelain(&repo).unwrap();
+        assert!(
+            !entries.iter().any(|(p, _)| p.ends_with("wt-feature")),
+            "registration cleared from the owning repo: {entries:?}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn remove_force_with_empty_source_repo_does_not_set_current_dir() {
+        // #2550 W2 pin: the documented "empty source_repo" exception — git
+        // runs with NO `current_dir`, so the outcome depends on the CALLING
+        // PROCESS's ambient cwd (matching the two original call sites'
+        // shared, commented behavior — their own TODO already flags this
+        // path's real-world reachability as unaudited; W2 preserves the
+        // exact mechanism, not a stronger guarantee than the original had).
+        // Run from a cwd (the test binary's own, unrelated to `wt`) that
+        // canNOT resolve `wt` as a worktree — proves the call does NOT
+        // silently fall back to using `wt`'s parent (or any other inferred
+        // path) as current_dir: a real cwd substitution would still fail the
+        // same way (unrelated repo), so a *different* failure shape (e.g. a
+        // spawn error) would indicate the no-current_dir branch broke.
+        let home = tmp_home("remove-force-empty-repo");
+        let repo = make_repo(&home.join("repo"));
+        let wt = home.join("wt-feature");
+        git(&repo, &["branch", "feat-x"]);
+        git(
+            &repo,
+            &["worktree", "add", &wt.display().to_string(), "feat-x"],
+        );
+        assert!(wt.exists());
+
+        let out = remove_force(Path::new(""), &wt.display().to_string())
+            .expect("command spawns (git binary found, args accepted) regardless of cwd");
+        // Not asserting success: whether this resolves depends on the test
+        // process's own ambient cwd, which this test does not control (and
+        // safely cannot, in a parallel test binary — see module doc's note
+        // on the original TODO). The worktree dir must still exist either
+        // way: a broken empty-source_repo branch would either panic or spawn
+        // successfully-but-touch-the-wrong-repo, not silently succeed here.
+        assert!(
+            wt.exists() || out.status.success(),
+            "either the removal genuinely succeeded, or the (expected) \
+             ambient-cwd-mismatch failure left the worktree untouched — \
+             never a partial/corrupt state"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,7 @@ mod event_log;
 mod fleet;
 mod framing;
 mod git_helpers;
+mod git_worktree;
 mod github_token;
 mod health;
 mod identity;

--- a/src/mcp/handlers/ci/release.rs
+++ b/src/mcp/handlers/ci/release.rs
@@ -91,6 +91,16 @@ pub(crate) fn handle_release_repo(args: &Value) -> Value {
     // git-raw-allowed: deliberate non-bypass + no current_dir; already bounded via
     // spawn_group_bounded; the Ok(non-zero) arm surfaces stderr in the JSON `note`
     // (git_ok would discard it), so git_cmd/git_ok would not be byte-identical.
+    //
+    // #2550 W2 (git_worktree.rs primitives module): this is the ONE
+    // `worktree remove --force` call site NOT converged onto
+    // `git_worktree::remove_force` — that helper always either bypasses
+    // (non-empty repo) or sets AGEND_GIT_BYPASS without a cwd (empty repo),
+    // neither of which matches this site's deliberate no-bypass/no-cwd
+    // shape. Lead's decision (`m-20260703064336281447-62`): a mechanical
+    // consolidation PR must not silently resolve this still-open "should it
+    // bypass like ci/mod:270" question above — left as-is, tracked as an
+    // open item for operator/a future lead, not part of W2.
     let mut cmd = std::process::Command::new("git");
     cmd.args(["worktree", "remove", "--force", &path_str]);
     let result = match crate::git_helpers::spawn_group_bounded(

--- a/src/mcp/handlers/force_release/gc.rs
+++ b/src/mcp/handlers/force_release/gc.rs
@@ -130,41 +130,27 @@ pub(crate) fn prune_git_metadata_for_agent(
     outcome
 }
 
-/// #826 L2 fork of `crate::worktree_cleanup::list_worktrees`. The
-/// shared helper omits `AGEND_GIT_BYPASS=1`, which means the daemon
-/// `agend-git` shim may intercept the call when an instance binding
-/// is active in the calling context — list_worktrees would then
-/// return Vec::new() instead of the real entries. Daemon-internal
-/// L2 GC always wants the raw `git worktree list --porcelain` output
-/// from the source repo, so we run it with the shim bypass set
-/// (mirrors the `release_full` precedent at src/worktree_pool.rs:311).
+/// #826 L2 fork of `crate::worktree_cleanup::list_worktrees` — #2550 W2
+/// converged both onto the shared `git_worktree::list_porcelain` core
+/// (always bypass-enabled via `git_helpers::git_bypass`; mirrors the
+/// `release_full` precedent at src/worktree_pool.rs:311), keeping this
+/// site's own main/master exclusion + `WorktreeEntry` conversion as a thin
+/// caller-specific layer on top (unchanged from the pre-#2550 fork).
 fn list_worktrees_bypass_shim(repo_root: &Path) -> Vec<crate::worktree_cleanup::WorktreeEntry> {
-    // #1899: bounded via git_bypass (LOCAL 60s).
-    let output = crate::git_helpers::git_bypass(repo_root, &["worktree", "list", "--porcelain"]);
-    let output = match output {
-        Ok(o) if o.status.success() => o,
-        _ => return Vec::new(),
-    };
-    let text = String::from_utf8_lossy(&output.stdout);
-    let mut entries = Vec::new();
-    let mut current_path = None;
-    let mut current_branch = None;
-    for line in text.lines() {
-        if let Some(p) = line.strip_prefix("worktree ") {
-            current_path = Some(p.to_string());
-        } else if let Some(b) = line.strip_prefix("branch refs/heads/") {
-            current_branch = Some(b.to_string());
-        } else if line.is_empty() {
-            if let (Some(path), Some(branch)) = (current_path.take(), current_branch.take()) {
-                if branch != "main" && branch != "master" {
-                    entries.push(crate::worktree_cleanup::WorktreeEntry { path, branch });
-                }
+    crate::git_worktree::list_porcelain(repo_root)
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|(path, branch)| {
+            let branch = branch?;
+            if branch == "main" || branch == "master" {
+                return None;
             }
-            current_path = None;
-            current_branch = None;
-        }
-    }
-    entries
+            Some(crate::worktree_cleanup::WorktreeEntry {
+                path: path.display().to_string(),
+                branch,
+            })
+        })
+        .collect()
 }
 
 /// #826 L2: best-effort source-repo enumeration when the operator

--- a/src/worktree_cleanup.rs
+++ b/src/worktree_cleanup.rs
@@ -29,42 +29,32 @@ pub struct WorktreeEntry {
 }
 
 /// List all git worktrees (excluding the main worktree).
+///
+/// #2550 W2: converged onto `git_worktree::list_porcelain` (via
+/// `git_helpers::git_bypass`) — that parser flushes on the NEXT `worktree`
+/// line plus an explicit final flush after the loop, so unlike the ad-hoc
+/// blank-line-triggered loop this replaced, it does NOT depend on a
+/// trailing blank-line record terminator (the exact fragility the old
+/// TRIM-SENSITIVE comment here warned about — `git_bypass` doesn't trim
+/// either way, so this was already safe, but the new parser isn't even
+/// exposed to that failure mode). Adds the #1897 60s LOCAL_GIT_TIMEOUT
+/// bound `git_bypass` provides — the raw `Command` this replaced had NO
+/// timeout, unlike the other 3 porcelain call sites already converged here.
 fn list_worktrees(repo_root: &Path) -> Vec<WorktreeEntry> {
-    // git-raw-allowed: TRIM-SENSITIVE parser. `--porcelain` terminates each
-    // worktree record with a blank line; the loop below flushes a pending entry
-    // on that blank line. `git_cmd` trims trailing whitespace → the final record's
-    // terminator is dropped → the last (often only) worktree is never pushed →
-    // the sweep silently finds nothing. Must read raw, untrimmed stdout.
-    // (Already AGEND_GIT_BYPASS.)
-    let output = match Command::new("git")
-        .args(["worktree", "list", "--porcelain"])
-        .current_dir(repo_root)
-        .env("AGEND_GIT_BYPASS", "1")
-        .output()
-    {
-        Ok(o) if o.status.success() => o,
-        _ => return Vec::new(),
-    };
-    let text = String::from_utf8_lossy(&output.stdout);
-    let mut entries = Vec::new();
-    let mut current_path = None;
-    let mut current_branch = None;
-    for line in text.lines() {
-        if let Some(p) = line.strip_prefix("worktree ") {
-            current_path = Some(p.to_string());
-        } else if let Some(b) = line.strip_prefix("branch refs/heads/") {
-            current_branch = Some(b.to_string());
-        } else if line.is_empty() {
-            if let (Some(path), Some(branch)) = (current_path.take(), current_branch.take()) {
-                if branch != "main" && branch != "master" {
-                    entries.push(WorktreeEntry { path, branch });
-                }
+    crate::git_worktree::list_porcelain(repo_root)
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|(path, branch)| {
+            let branch = branch?;
+            if branch == "main" || branch == "master" {
+                return None;
             }
-            current_path = None;
-            current_branch = None;
-        }
-    }
-    entries
+            Some(WorktreeEntry {
+                path: path.display().to_string(),
+                branch,
+            })
+        })
+        .collect()
 }
 
 /// Check if a branch is merged into the default branch (local check, no API needed).

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -354,22 +354,16 @@ fn remove_worktree(agent: &str, wt_path: &Path, source_repo: &Path) -> WorktreeR
         ));
     }
 
+    // #2550 W2: empty source_repo → `git_worktree::remove_force` runs with NO
+    // `current_dir` (git resolves the repo from `--force <abs wt>` itself;
+    // `git_cmd`/`git_bypass` both REQUIRE a cwd, and `wt_path.parent()` is
+    // wrong — it's the worktrees-pool dir, outside the repo tree, per lead
+    // ruling). Converged with `worktree_pool/workspace.rs::teardown_workspace_worktree`'s
+    // byte-identical dual-cwd arm (see git_worktree.rs module doc).
+    // TODO(W1.2): audit whether the empty-source_repo branch is still
+    // reachable in practice; if dead, delete this arm rather than migrate it.
     let wt_str = wt_path.display().to_string();
-    let result = if source_repo.as_os_str().is_empty() {
-        // git-raw-allowed: empty source_repo → this arm intentionally runs with
-        // NO `current_dir`, so `git` resolves the repo from `--force <abs wt>`
-        // itself. `git_cmd`/`git_bypass` both REQUIRE a cwd; passing `wt_path
-        // .parent()` is wrong (it's the worktrees-pool dir `~/.agend-terminal/
-        // worktrees/<agent>/`, outside the repo tree, per lead ruling). Keep raw.
-        // TODO(W1.2): audit whether the empty-source_repo branch is still
-        // reachable in practice; if dead, delete this arm rather than migrate it.
-        std::process::Command::new("git")
-            .args(["worktree", "remove", "--force", &wt_str])
-            .env("AGEND_GIT_BYPASS", "1")
-            .output()
-    } else {
-        crate::git_helpers::git_bypass(source_repo, &["worktree", "remove", "--force", &wt_str])
-    };
+    let result = crate::git_worktree::remove_force(source_repo, &wt_str);
     match result {
         Ok(o) if o.status.success() => WorktreeRemoval::Removed,
         Ok(o) => {

--- a/src/worktree_pool/gc.rs
+++ b/src/worktree_pool/gc.rs
@@ -171,36 +171,6 @@ pub struct ManagedWorktree {
     pub registered: bool,
 }
 
-/// Parse `git worktree list --porcelain` into `(path, branch)` pairs. Porcelain
-/// records are blank-line-separated; `worktree <path>` opens a record, `branch
-/// refs/heads/<b>` names the checked-out branch (absent = detached).
-fn parse_worktree_porcelain(out: &str) -> Vec<(PathBuf, Option<String>)> {
-    let mut records = Vec::new();
-    let mut cur_path: Option<PathBuf> = None;
-    let mut cur_branch: Option<String> = None;
-    let flush = |p: &mut Option<PathBuf>, b: &mut Option<String>, out: &mut Vec<_>| {
-        if let Some(path) = p.take() {
-            out.push((path, b.take()));
-        }
-        *b = None;
-    };
-    for line in out.lines() {
-        if let Some(p) = line.strip_prefix("worktree ") {
-            flush(&mut cur_path, &mut cur_branch, &mut records);
-            cur_path = Some(PathBuf::from(p.trim()));
-        } else if let Some(b) = line.strip_prefix("branch ") {
-            cur_branch = Some(
-                b.trim()
-                    .strip_prefix("refs/heads/")
-                    .unwrap_or(b.trim())
-                    .to_string(),
-            );
-        }
-    }
-    flush(&mut cur_path, &mut cur_branch, &mut records);
-    records
-}
-
 /// #2234 Phase 2: cure-(B) workspace worktrees — `workspace/<agent>` dirs whose
 /// `.git` is a gitlink FILE (a real worktree, Phase 0's discriminator). Empty
 /// when (B) is OFF (no workspace dir is a worktree), so every consumer stays
@@ -283,24 +253,20 @@ pub fn enumerate_managed_worktrees(home: &Path, source_repo: &Path) -> Vec<Manag
 
     // Registry pass — authoritative, any path. Filter to the managed roots
     // (excludes the canonical main worktree + foreign worktrees).
-    if let Ok(out) =
-        crate::git_helpers::git_bypass(source_repo, &["worktree", "list", "--porcelain"])
-    {
-        if out.status.success() {
-            for (path, branch) in parse_worktree_porcelain(&String::from_utf8_lossy(&out.stdout)) {
-                let cp = canon(&path);
-                if under_managed(&cp) {
-                    let agent = agent_of(&cp);
-                    by_path.insert(
-                        cp.clone(),
-                        ManagedWorktree {
-                            path: cp,
-                            agent,
-                            branch,
-                            registered: true,
-                        },
-                    );
-                }
+    if let Ok(entries) = crate::git_worktree::list_porcelain(source_repo) {
+        for (path, branch) in entries {
+            let cp = canon(&path);
+            if under_managed(&cp) {
+                let agent = agent_of(&cp);
+                by_path.insert(
+                    cp.clone(),
+                    ManagedWorktree {
+                        path: cp,
+                        agent,
+                        branch,
+                        registered: true,
+                    },
+                );
             }
         }
     }

--- a/src/worktree_pool/workspace.rs
+++ b/src/worktree_pool/workspace.rs
@@ -56,20 +56,12 @@ pub fn teardown_workspace_worktree(home: &Path, agent: &str, working_dir: &Path)
 
     // Mirror `remove_worktree`'s git call, WITHOUT the marker veto: run from the
     // owning repo so the registration is cleared (not just the dir).
+    // #2550 W2: `git_worktree::remove_force` — defensive empty-source_repo
+    // fallback (effectively unreachable — a real gitlink always yields a
+    // common-dir) mirrors `remove_worktree`'s byte-identical arm; see
+    // git_worktree.rs module doc for the shared "lead ruling" rationale.
     let wt_str = working_dir.display().to_string();
-    let result = if source_repo.as_os_str().is_empty() {
-        // git-raw-allowed: defensive fallback when the owning repo can't be
-        // resolved (effectively unreachable — a real gitlink always yields a
-        // common-dir). Mirrors `remove_worktree`'s empty-source_repo arm: git
-        // must resolve the repo from the absolute `<wt>` itself, so this runs
-        // with NO `current_dir` — `git_bypass`/`git_cmd` both REQUIRE a cwd.
-        std::process::Command::new("git")
-            .args(["worktree", "remove", "--force", &wt_str])
-            .env("AGEND_GIT_BYPASS", "1")
-            .output()
-    } else {
-        crate::git_helpers::git_bypass(&source_repo, &["worktree", "remove", "--force", &wt_str])
-    };
+    let result = crate::git_worktree::remove_force(&source_repo, &wt_str);
     let removed = matches!(&result, Ok(o) if o.status.success());
     if !removed {
         if let Ok(o) = &result {


### PR DESCRIPTION
## Summary
Adds `src/git_worktree.rs` (built on top of `git_helpers.rs`, not a replacement) with three primitives, per `P3-W2-PRERESEARCH.md` + lead's 3 scope decisions (`m-20260703064336281447-62`):

- **`parse_porcelain`/`list_porcelain`**: `git worktree list --porcelain` parsing, moved verbatim from `worktree_pool/gc.rs` (the most complete of 4 near-duplicate copies — its explicit final flush means it doesn't depend on a trailing blank-line record terminator, unlike the other 3). Each of the 4 callers (`worktree_cleanup.rs`, `admin/mod.rs`, `mcp/handlers/force_release/gc.rs`, `worktree_pool/gc.rs`) keeps its OWN caller-specific filtering (main/master exclusion, branch-only extraction) as a thin layer on top — the shared core doesn't bake in any one caller's filter.
- **`remove_force`**: `git worktree remove --force`, extracting the intentionally-duplicated empty-`source_repo` dual-cwd branch shared verbatim by `worktree_pool.rs::remove_worktree` and `worktree_pool/workspace.rs::teardown_workspace_worktree` (both already had matching "lead ruling" comments — git needs a resolvable cwd, and an empty `source_repo` means a bypass-enabled raw `Command` with NO `current_dir` is the only correct move).

Wrapper/error-handling-granularity choice (`git_bypass` vs `git_ok` vs `git_cmd`) stays with each existing caller — not unified, since that would be a behavior change outside this wave's mechanical-consolidation scope.

## Notable behavior notes (disclosed, not hidden)
- `worktree_cleanup.rs::list_worktrees` switches from a raw, unbounded `Command` to `git_bypass` — closes a real timeout gap (the other 3 sites already had the #1897 60s `LOCAL_GIT_TIMEOUT` bound) while preserving the exact untrimmed-stdout property its own (now-removed) comment warned about — `git_bypass` doesn't trim either; only `git_cmd` does.
- `mcp/handlers/ci/release.rs`'s remove-force call is the ONE site NOT converged — its own comment already documented a still-undecided bypass/cwd inconsistency versus every other site. Lead's decision: leave it as-is with a pointer comment, don't silently resolve an open design question inside a mechanical PR.
- `worktree_cleanup.rs`'s Windows-specific `git_ok` retry loop (same infra-flake class as #2578's nextest retries) is not extracted — no second call site needs it yet, so there's no real abstraction to name.

## Test plan
- [x] New `git_worktree.rs` unit tests (6): porcelain parsing incl. no-trailing-blank-line edge case, `list_porcelain` real-repo round trip, `remove_force` with/without `source_repo`
- [x] All 4 original callers' existing test suites run unmodified and green (39 tests: `worktree_cleanup`, `admin`, `force_release`, `worktree_pool`)
- [x] `cargo nextest run --profile ci` on the full affected surface (237 tests) — all pass
- [x] `cargo nextest run --profile ci --no-fail-fast` full suite — same 2 pre-existing local-environment-flaky failures seen consistently across #2568/#2577/#2578 (`e2e_dispatch_review_workflow_seam_invariants_1900`, `teardown_leaves_zero_residual_after_full_exercise_1907`, unrelated dispatch/binding/teardown files)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Full repo sweep for dangling references — clean; net -67 LOC in the 8 modified files (+395/-156 total incl. new module + tests)