### PR TITLE
refactor(#2550 W3 Wave0): converge binding.json path construction onto paths::binding_path

### DIFF
--- a/src/binding.rs
+++ b/src/binding.rs
@@ -681,7 +681,8 @@ pub fn bound_source_repos(home: &Path) -> Vec<std::path::PathBuf> {
     };
     let mut repos: Vec<std::path::PathBuf> = Vec::new();
     for entry in entries.flatten() {
-        let binding_path = entry.path().join("binding.json");
+        let agent_name = entry.file_name().to_string_lossy().into_owned();
+        let binding_path = crate::paths::binding_path(home, &agent_name);
         let Ok(content) = std::fs::read_to_string(&binding_path) else {
             continue;
         };

--- a/src/daemon/task_progress.rs
+++ b/src/daemon/task_progress.rs
@@ -195,7 +195,8 @@ pub(crate) fn touch_progress_for_branch(home: &Path, branch: &str) -> Option<Str
     let runtime_dir = crate::paths::runtime_dir(home);
     let entries = std::fs::read_dir(&runtime_dir).ok()?;
     for entry in entries.flatten() {
-        let binding_path = entry.path().join("binding.json");
+        let agent_name = entry.file_name().to_string_lossy().into_owned();
+        let binding_path = crate::paths::binding_path(home, &agent_name);
         let Ok(content) = std::fs::read_to_string(&binding_path) else {
             continue;
         };

--- a/src/mcp/handlers/binding_state.rs
+++ b/src/mcp/handlers/binding_state.rs
@@ -202,7 +202,7 @@ fn cross_branch_holders_for(home: &Path, branch: &str, exclude_agent: &str) -> V
         if other == exclude_agent {
             continue;
         }
-        let bp = entry.path().join("binding.json");
+        let bp = crate::paths::binding_path(home, &other);
         let Ok(c) = std::fs::read_to_string(&bp) else {
             continue;
         };

--- a/src/mcp/handlers/ci/mod.rs
+++ b/src/mcp/handlers/ci/mod.rs
@@ -71,10 +71,7 @@ fn resolve_repo_or_error(home: &Path, instance_name: &str, args: &Value) -> Resu
             }
         }
         None => {
-            let binding = home
-                .join("runtime")
-                .join(instance_name)
-                .join("binding.json");
+            let binding = crate::paths::binding_path(home, instance_name);
             let Ok(content) = std::fs::read_to_string(&binding) else {
                 return Err(json!({
                     "error": "could not determine repo slug; pass explicit 'repository' arg or call bind_self first (no active binding)",

--- a/src/mcp/handlers/instance_state/lifecycle.rs
+++ b/src/mcp/handlers/instance_state/lifecycle.rs
@@ -364,12 +364,7 @@ pub(crate) fn name_residual_anywhere(
     if crate::daemon::supervisor::usage_limit_notify_has(home, name) {
         sources.push("usage_limit_notify");
     }
-    if home
-        .join("runtime")
-        .join(name)
-        .join("binding.json")
-        .exists()
-    {
+    if crate::paths::binding_path(home, name).exists() {
         sources.push("runtime/binding.json");
     }
     if home

--- a/src/mcp/handlers/worktree.rs
+++ b/src/mcp/handlers/worktree.rs
@@ -121,9 +121,7 @@ pub(crate) fn handle_bind_self(home: &Path, args: &Value, sender: &Option<Sender
             // file we just wrote so the response reflects authoritative
             // state. #781 `DispatchOutcome` fields are dropped here —
             // surfacing them is a `bind_self` consumer follow-up.
-            let binding_path = crate::paths::runtime_dir(home)
-                .join(agent)
-                .join("binding.json");
+            let binding_path = crate::paths::binding_path(home, agent);
             let worktree_path = std::fs::read_to_string(&binding_path)
                 .ok()
                 .and_then(|s| serde_json::from_str::<Value>(&s).ok())

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -13,7 +13,6 @@ pub fn runtime_dir(home: &Path) -> PathBuf {
 }
 
 /// `<home>/runtime/<agent>/binding.json`
-#[allow(dead_code)]
 pub fn binding_path(home: &Path, agent: &str) -> PathBuf {
     runtime_dir(home).join(agent).join(BINDING_FILENAME)
 }

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -578,7 +578,8 @@ pub fn reconcile_orphan_leases(home: &Path) {
     }
     if let Ok(entries) = std::fs::read_dir(&runtime_dir) {
         for entry in entries.flatten() {
-            let binding_path = entry.path().join("binding.json");
+            let agent_name = entry.file_name().to_string_lossy().into_owned();
+            let binding_path = crate::paths::binding_path(home, &agent_name);
             if !binding_path.exists() {
                 continue;
             }

--- a/src/worktree_pool/target_sweep.rs
+++ b/src/worktree_pool/target_sweep.rs
@@ -225,9 +225,7 @@ fn predicate_protects(home: &Path, wt: &Path, roster: &std::collections::HashSet
     if !roster.contains(&owner) {
         return false; // instance gone (deleted) ⇒ no process can build ⇒ sweepable
     }
-    let binding_path = crate::paths::runtime_dir(home)
-        .join(&owner)
-        .join("binding.json");
+    let binding_path = crate::paths::binding_path(home, &owner);
     if !binding_path.exists() {
         return false; // in roster but unbound ⇒ sweepable (can't rebind under our lock)
     }


### PR DESCRIPTION
## Summary

Part of #2550 W3 (pre-research: `P3-W3-PRERESEARCH.md` §3 Wave 0, drafted after lead vet). Mechanical, near-zero-risk PR.

`paths.rs` already had a `binding_path(home, agent) -> PathBuf` helper, marked `#[allow(dead_code)]` — zero callers anywhere (confirmed via grep). Meanwhile 8 production sites hand-rolled the equivalent `.join(agent).join("binding.json")` path construction independently.

## Changes

- `src/paths.rs`: remove `#[allow(dead_code)]` from `binding_path`.
- 8 call sites converted to call `paths::binding_path(home, agent)` instead of hand-rolling the path:
  - `worktree_pool.rs::reconcile_orphan_leases`
  - `mcp/handlers/worktree.rs::handle_bind_self` (bind_self response echo)
  - `mcp/handlers/ci/mod.rs::resolve_repo_or_error`
  - `daemon/task_progress.rs::touch_progress_for_branch`
  - `mcp/handlers/binding_state.rs::cross_branch_holders_for`
  - `mcp/handlers/instance_state/lifecycle.rs::name_residual_anywhere`
  - `worktree_pool/target_sweep.rs::predicate_protects`
  - `binding.rs::bound_source_repos` (the accessor module's own same-shape site)

**Zero behavior change**: read logic, error handling, fail-direction, and `target_sweep.rs`'s explicit "read the FILE directly, not the cache" comment are all untouched — only the path-construction expression changes, to a byte-identical result (`paths::binding_path` = `runtime_dir(home).join(agent).join(BINDING_FILENAME)`, matching every prior hand-rolled construction).

**Explicitly out of scope (per pre-research)**: `bin/agend-git.rs::read_binding` (separate binary, no `paths.rs` link, adds HMAC verification — deferred), and `target_sweep.rs`/`lifecycle.rs`'s `.exists()` semantics are NOT converged to `binding::present_including_future()` (that function's fail-direction on a corrupt file is the opposite of these two sites' current fail-closed/audit-visible behavior — see pre-research §2 "否決的收斂").

## Test plan
- [x] `cargo build --lib --bin agend-terminal` — clean
- [x] `cargo nextest run --lib --bin agend-terminal` — 4764/4764 pass, **zero test files modified**
- [x] `cargo clippy --lib --bin agend-terminal --tests -- -D warnings` — clean
- [x] `cargo test --test anti_pattern_invariant` — 11/11 pass
- [x] `cargo fmt --check` — clean

Refs #2550