### PR TITLE
refactor(#2550 W3 Wave1): converge 4 scan-all-agents binding.json reads onto binding_scan_all

### DIFF
--- a/src/binding.rs
+++ b/src/binding.rs
@@ -664,6 +664,30 @@ pub fn scan_existing_branch_binding(
     None
 }
 
+/// #2550 W3 Wave1: fresh (uncached) enumeration of every agent under `home`'s
+/// runtime dir whose `binding.json` is present and parses as JSON. An agent
+/// with a missing/unreadable/corrupt binding.json is silently skipped —
+/// every existing scan-all-agents call site already tolerated this, so the
+/// shared primitive preserves it uniformly. Field-level extraction and any
+/// further validation (branch match, empty-task_id, dedup, ...) is the
+/// caller's job.
+pub(crate) fn binding_scan_all(home: &Path) -> Vec<(String, serde_json::Value)> {
+    let runtime_dir = crate::paths::runtime_dir(home);
+    let Ok(entries) = std::fs::read_dir(&runtime_dir) else {
+        return Vec::new();
+    };
+    entries
+        .flatten()
+        .filter_map(|entry| {
+            let agent_name = entry.file_name().to_string_lossy().into_owned();
+            let binding_path = crate::paths::binding_path(home, &agent_name);
+            let content = std::fs::read_to_string(&binding_path).ok()?;
+            let v: serde_json::Value = serde_json::from_str(&content).ok()?;
+            Some((agent_name, v))
+        })
+        .collect()
+}
+
 /// PR-3 (t-ci-ready-pr3-arm-not-armed): the distinct `source_repo` paths of every
 /// LIVE bound branch (each `runtime/<agent>/binding.json`'s `source_repo`).
 ///
@@ -675,20 +699,8 @@ pub fn scan_existing_branch_binding(
 /// #1782 gap). Returns raw paths (slug resolution is the caller's job) to keep
 /// this module free of the git/scm dependency.
 pub fn bound_source_repos(home: &Path) -> Vec<std::path::PathBuf> {
-    let runtime_dir = crate::paths::runtime_dir(home);
-    let Ok(entries) = std::fs::read_dir(&runtime_dir) else {
-        return Vec::new();
-    };
     let mut repos: Vec<std::path::PathBuf> = Vec::new();
-    for entry in entries.flatten() {
-        let agent_name = entry.file_name().to_string_lossy().into_owned();
-        let binding_path = crate::paths::binding_path(home, &agent_name);
-        let Ok(content) = std::fs::read_to_string(&binding_path) else {
-            continue;
-        };
-        let Ok(v) = serde_json::from_str::<serde_json::Value>(&content) else {
-            continue;
-        };
+    for (_, v) in binding_scan_all(home) {
         if let Some(src) = v["source_repo"].as_str() {
             let path = std::path::PathBuf::from(src);
             if !repos.contains(&path) {
@@ -1086,6 +1098,74 @@ mod tests {
         ));
         std::fs::create_dir_all(&dir).ok();
         dir
+    }
+
+    // ─── #2550 W3 Wave1 pins: bound_source_repos (pre-refactor, zero prior
+    // coverage) — locks current field-extraction/dedup/corruption-tolerance/
+    // missing-field behavior before the binding_scan_all() extraction. ───────
+
+    #[test]
+    fn bound_source_repos_returns_distinct_source_repos_2550_w3() {
+        let home = tmp_home("src-repos-distinct");
+        write_binding_json(&home, "alpha", "feat/a", Some("/repo/a"));
+        write_binding_json(&home, "beta", "feat/b", Some("/repo/b"));
+
+        let mut repos = bound_source_repos(&home);
+        repos.sort();
+        assert_eq!(
+            repos,
+            vec![
+                std::path::PathBuf::from("/repo/a"),
+                std::path::PathBuf::from("/repo/b")
+            ],
+            "distinct source_repo paths across agents must all surface: {repos:?}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn bound_source_repos_dedupes_same_source_repo_2550_w3() {
+        let home = tmp_home("src-repos-dedup");
+        write_binding_json(&home, "alpha", "feat/a", Some("/repo/shared"));
+        write_binding_json(&home, "beta", "feat/b", Some("/repo/shared"));
+
+        let repos = bound_source_repos(&home);
+        assert_eq!(
+            repos,
+            vec![std::path::PathBuf::from("/repo/shared")],
+            "two agents bound to the SAME source_repo must dedupe to one entry: {repos:?}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn bound_source_repos_skips_missing_source_repo_field_2550_w3() {
+        let home = tmp_home("src-repos-missing-field");
+        write_binding_json(&home, "legacy", "feat/legacy", None); // no source_repo
+
+        let repos = bound_source_repos(&home);
+        assert!(
+            repos.is_empty(),
+            "a binding with no source_repo field must not contribute an entry: {repos:?}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn bound_source_repos_tolerates_corrupt_binding_json_2550_w3() {
+        let home = tmp_home("src-repos-corrupt");
+        let corrupt_dir = crate::paths::runtime_dir(&home).join("corrupt-agent");
+        std::fs::create_dir_all(&corrupt_dir).unwrap();
+        std::fs::write(corrupt_dir.join("binding.json"), b"not valid json").unwrap();
+        write_binding_json(&home, "good-agent", "feat/good", Some("/repo/good"));
+
+        let repos = bound_source_repos(&home);
+        assert_eq!(
+            repos,
+            vec![std::path::PathBuf::from("/repo/good")],
+            "a corrupt sibling binding must not block finding the valid one: {repos:?}"
+        );
+        std::fs::remove_dir_all(&home).ok();
     }
 
     /// #2234: install_hooks must write the reference-transaction detach instrument

--- a/src/daemon/task_progress.rs
+++ b/src/daemon/task_progress.rs
@@ -192,17 +192,7 @@ pub(crate) fn touch_progress_for_branch(home: &Path, branch: &str) -> Option<Str
     if branch.is_empty() {
         return None;
     }
-    let runtime_dir = crate::paths::runtime_dir(home);
-    let entries = std::fs::read_dir(&runtime_dir).ok()?;
-    for entry in entries.flatten() {
-        let agent_name = entry.file_name().to_string_lossy().into_owned();
-        let binding_path = crate::paths::binding_path(home, &agent_name);
-        let Ok(content) = std::fs::read_to_string(&binding_path) else {
-            continue;
-        };
-        let Ok(v) = serde_json::from_str::<serde_json::Value>(&content) else {
-            continue;
-        };
+    for (_, v) in crate::binding::binding_scan_all(home) {
         if v["branch"].as_str() != Some(branch) {
             continue;
         }
@@ -470,6 +460,40 @@ mod tests {
         assert!(
             touched.is_none(),
             "self-binding must NOT trigger progress touch"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #2550 W3 Wave1 pin: a corrupt binding.json for one agent must not
+    /// abort the scan — a later agent's matching, valid binding must still
+    /// be found.
+    #[test]
+    fn touch_progress_for_branch_skips_corrupt_binding_continues_scan_2550_w3() {
+        let home = tmp_home("hook-corrupt-continues");
+        let corrupt_dir = crate::paths::runtime_dir(&home).join("corrupt-agent");
+        std::fs::create_dir_all(&corrupt_dir).unwrap();
+        std::fs::write(corrupt_dir.join("binding.json"), b"not valid json").unwrap();
+
+        let good_dir = crate::paths::runtime_dir(&home).join("good-agent");
+        std::fs::create_dir_all(&good_dir).unwrap();
+        let binding = serde_json::json!({
+            "version": 1,
+            "agent": "good-agent",
+            "task_id": "t-scan-continues",
+            "branch": "feature/z",
+            "issued_at": "2026-05-09T00:00:00Z",
+        });
+        std::fs::write(
+            good_dir.join("binding.json"),
+            serde_json::to_string_pretty(&binding).unwrap(),
+        )
+        .unwrap();
+
+        let touched = touch_progress_for_branch(&home, "feature/z");
+        assert_eq!(
+            touched.as_deref(),
+            Some("t-scan-continues"),
+            "a corrupt sibling binding must not block finding the valid match: {touched:?}"
         );
         std::fs::remove_dir_all(&home).ok();
     }

--- a/src/mcp/handlers/binding_state.rs
+++ b/src/mcp/handlers/binding_state.rs
@@ -192,23 +192,11 @@ fn cross_branch_holders_for(home: &Path, branch: &str, exclude_agent: &str) -> V
     if branch.is_empty() {
         return Vec::new();
     }
-    let runtime_dir = crate::paths::runtime_dir(home);
-    let Ok(entries) = std::fs::read_dir(&runtime_dir) else {
-        return Vec::new();
-    };
     let mut out = Vec::new();
-    for entry in entries.flatten() {
-        let other = entry.file_name().to_string_lossy().to_string();
+    for (other, v) in crate::binding::binding_scan_all(home) {
         if other == exclude_agent {
             continue;
         }
-        let bp = crate::paths::binding_path(home, &other);
-        let Ok(c) = std::fs::read_to_string(&bp) else {
-            continue;
-        };
-        let Ok(v) = serde_json::from_str::<Value>(&c) else {
-            continue;
-        };
         if v["branch"].as_str() == Some(branch) {
             out.push(other);
         }
@@ -485,6 +473,24 @@ mod tests {
         assert!(
             !names.contains(&"gamma"),
             "gamma holds a different branch, must NOT appear: {names:?}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #2550 W3 Wave1 pin: a corrupt sibling binding.json must not abort the
+    /// scan — a later agent's valid, matching binding must still surface.
+    #[test]
+    fn cross_branch_holders_for_skips_corrupt_binding_continues_scan_2550_w3() {
+        let home = tmp_home("cross-corrupt");
+        let corrupt_dir = crate::paths::runtime_dir(&home).join("corrupt-agent");
+        std::fs::create_dir_all(&corrupt_dir).unwrap();
+        std::fs::write(corrupt_dir.join("binding.json"), b"not valid json").unwrap();
+        write_binding(&home, "beta", "shared-branch", "/tmp/wt-beta");
+
+        let holders = cross_branch_holders_for(&home, "shared-branch", "alpha");
+        assert!(
+            holders.contains(&"beta".to_string()),
+            "a corrupt sibling binding must not block finding beta: {holders:?}"
         );
         std::fs::remove_dir_all(&home).ok();
     }

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -572,29 +572,14 @@ pub fn is_pinned(worktree_path: &Path) -> bool {
 
 /// Reconcile orphan leases at daemon startup (log only, no delete in Phase 3).
 pub fn reconcile_orphan_leases(home: &Path) {
-    let runtime_dir = crate::paths::runtime_dir(home);
-    if !runtime_dir.exists() {
-        return;
-    }
-    if let Ok(entries) = std::fs::read_dir(&runtime_dir) {
-        for entry in entries.flatten() {
-            let agent_name = entry.file_name().to_string_lossy().into_owned();
-            let binding_path = crate::paths::binding_path(home, &agent_name);
-            if !binding_path.exists() {
-                continue;
-            }
-            if let Ok(content) = std::fs::read_to_string(&binding_path) {
-                if let Ok(v) = serde_json::from_str::<serde_json::Value>(&content) {
-                    if let Some(wt_path) = v["worktree"].as_str() {
-                        if !Path::new(wt_path).exists() {
-                            tracing::warn!(
-                                agent = entry.file_name().to_string_lossy().as_ref(),
-                                worktree = wt_path,
-                                "orphan lease: worktree path missing"
-                            );
-                        }
-                    }
-                }
+    for (agent_name, v) in crate::binding::binding_scan_all(home) {
+        if let Some(wt_path) = v["worktree"].as_str() {
+            if !Path::new(wt_path).exists() {
+                tracing::warn!(
+                    agent = agent_name.as_str(),
+                    worktree = wt_path,
+                    "orphan lease: worktree path missing"
+                );
             }
         }
     }

--- a/src/worktree_pool/tests.rs
+++ b/src/worktree_pool/tests.rs
@@ -3410,3 +3410,85 @@ fn target_sweep_skips_when_bind_lock_contended() {
     );
     std::fs::remove_dir_all(&home).ok();
 }
+
+// ─── #2550 W3 Wave1 pins: reconcile_orphan_leases (pre-refactor, zero prior
+// coverage) — locks current field-extraction/corruption-tolerance/missing-
+// field behavior before the binding_scan_all() extraction. ───────────────
+
+#[tracing_test::traced_test]
+#[test]
+fn reconcile_orphan_leases_warns_when_worktree_path_missing_2550_w3() {
+    let home = tmp_home("orphan-warns");
+    let runtime = crate::paths::runtime_dir(&home).join("dev");
+    std::fs::create_dir_all(&runtime).unwrap();
+    let missing_wt = home.join("nonexistent-worktree");
+    std::fs::write(
+        runtime.join("binding.json"),
+        serde_json::json!({"worktree": missing_wt.to_str().unwrap()}).to_string(),
+    )
+    .unwrap();
+
+    reconcile_orphan_leases(&home);
+
+    assert!(
+        logs_contain("orphan lease"),
+        "a binding pointing at a missing worktree path must warn"
+    );
+    assert!(logs_contain("dev"), "the warn must name the orphaned agent");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[tracing_test::traced_test]
+#[test]
+fn reconcile_orphan_leases_silent_when_worktree_path_exists_2550_w3() {
+    let home = tmp_home("orphan-silent");
+    let runtime = crate::paths::runtime_dir(&home).join("dev");
+    std::fs::create_dir_all(&runtime).unwrap();
+    let real_wt = home.join("real-worktree");
+    std::fs::create_dir_all(&real_wt).unwrap();
+    std::fs::write(
+        runtime.join("binding.json"),
+        serde_json::json!({"worktree": real_wt.to_str().unwrap()}).to_string(),
+    )
+    .unwrap();
+
+    reconcile_orphan_leases(&home);
+
+    assert!(
+        !logs_contain("orphan lease"),
+        "a binding whose worktree path exists must not be flagged as orphaned"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn reconcile_orphan_leases_tolerates_corrupt_binding_json_2550_w3() {
+    let home = tmp_home("orphan-corrupt");
+    let runtime = crate::paths::runtime_dir(&home).join("bad-agent");
+    std::fs::create_dir_all(&runtime).unwrap();
+    std::fs::write(runtime.join("binding.json"), b"not valid json").unwrap();
+
+    reconcile_orphan_leases(&home); // must not panic
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[tracing_test::traced_test]
+#[test]
+fn reconcile_orphan_leases_tolerates_missing_worktree_field_2550_w3() {
+    let home = tmp_home("orphan-no-field");
+    let runtime = crate::paths::runtime_dir(&home).join("dev");
+    std::fs::create_dir_all(&runtime).unwrap();
+    std::fs::write(
+        runtime.join("binding.json"),
+        serde_json::json!({"branch": "feat/x"}).to_string(),
+    )
+    .unwrap();
+
+    reconcile_orphan_leases(&home);
+
+    assert!(
+        !logs_contain("orphan lease"),
+        "a binding.json without a `worktree` field must not be flagged"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}


### PR DESCRIPTION
## Summary

Part of #2550 W3 (pre-research: `P3-W3-PRERESEARCH.md` §3 Wave 1, after Wave 0 #2583 merged). Test-first refactor.

Four production sites each hand-rolled the identical shape — enumerate every agent under `runtime_dir`, read + parse each `binding.json`, silently skip on any read/parse failure:

- `worktree_pool.rs::reconcile_orphan_leases` (warns when a bound worktree path no longer exists on disk)
- `daemon/task_progress.rs::touch_progress_for_branch` (finds the task_id bound to a branch, to touch progress)
- `mcp/handlers/binding_state.rs::cross_branch_holders_for` (P0-1.5 cross-agent branch-uniqueness diagnostic)
- `binding.rs::bound_source_repos` (the accessor module's own same-shape site — seeds the PR-state scanner's poll list)

## Changes

- New `binding::binding_scan_all(home) -> Vec<(String, serde_json::Value)>`: fresh (uncached) enumeration of every agent whose `binding.json` is present and parses as JSON. Silently skips missing/unreadable/corrupt entries — matching what every one of the 4 call sites already did independently. Field-level extraction (branch match, empty-task_id check, dedup, ...) stays entirely in each caller.
- All 4 call sites rewritten to loop over `binding_scan_all(home)` instead of hand-rolling the enumeration + read + parse.
- `bound_source_repos` itself now calls the new primitive too — proof by construction that it's behaviorally equivalent to the original hand-rolled loop.

**Test-first**: 10 new pin tests added *before* the extraction, each verified green against the pre-refactor code first, then again after (unmodified):
- `reconcile_orphan_leases` (zero prior coverage): warns-when-missing / silent-when-present / tolerates-corrupt-json / tolerates-missing-worktree-field (using `#[tracing_test::traced_test]` + `logs_contain`, the codebase's existing pattern for pinning log-based behavior).
- `touch_progress_for_branch`: +1 new test (corrupt sibling binding doesn't block finding a valid match) — the 3 pre-existing tests already pinned match/no-match/self-bind-skip.
- `cross_branch_holders_for`: +1 new **direct** test (same corruption-tolerance case) — the pre-existing coverage only exercised it indirectly via `handle_binding_state`.
- `bound_source_repos` (zero prior coverage): distinct-repos / dedup-same-repo / missing-field-skipped / corruption-tolerance.

All 4764 pre-existing tests are **unmodified** and pass.

## Test plan
- [x] `cargo build --lib --bin agend-terminal` — clean
- [x] New pin tests verified green against pre-refactor code, then again after
- [x] `cargo nextest run --lib --bin agend-terminal` — 4774/4774 pass (4764 pre-existing + 10 new pins), zero pre-existing tests modified
- [x] `cargo clippy --lib --bin agend-terminal --tests -- -D warnings` — clean
- [x] `cargo test --test anti_pattern_invariant` — 11/11 pass
- [x] `cargo fmt --check` — clean

Refs #2550