### PR TITLE
refactor(#2550 W3 Wave2): bind_self worktree read-back onto binding::read()

### DIFF
--- a/src/mcp/handlers/worktree.rs
+++ b/src/mcp/handlers/worktree.rs
@@ -118,13 +118,13 @@ pub(crate) fn handle_bind_self(home: &Path, args: &Value, sender: &Option<Sender
     ) {
         Ok(_outcome) => {
             // Successful bind: read back the worktree path from the binding
-            // file we just wrote so the response reflects authoritative
-            // state. #781 `DispatchOutcome` fields are dropped here —
+            // we just wrote so the response reflects authoritative state.
+            // #2550 W3 Wave2: `bind_full` updates `binding::binding_index()`
+            // under the same lock it writes the file in, so the cache is
+            // already current here — `read()` reflects it without a second
+            // disk read. #781 `DispatchOutcome` fields are dropped here —
             // surfacing them is a `bind_self` consumer follow-up.
-            let binding_path = crate::paths::binding_path(home, agent);
-            let worktree_path = std::fs::read_to_string(&binding_path)
-                .ok()
-                .and_then(|s| serde_json::from_str::<Value>(&s).ok())
+            let worktree_path = crate::binding::read(home, agent)
                 .and_then(|v| v["worktree"].as_str().map(String::from))
                 .unwrap_or_default();
             let mut resp = json!({

--- a/src/mcp/handlers/worktree/tests.rs
+++ b/src/mcp/handlers/worktree/tests.rs
@@ -461,6 +461,60 @@ fn bind_self_creates_binding_and_worktree() {
     std::fs::remove_dir_all(&home).ok();
 }
 
+/// #2550 W3 Wave2 pin: the response's `worktree_path` must be an EXACT
+/// match for the `worktree` field the bind just wrote to binding.json (not
+/// just non-empty) — locks the read-back value before converging the raw
+/// `read_to_string`+parse onto `binding::read()`.
+#[test]
+fn bind_self_response_worktree_path_matches_written_binding_2550_w3() {
+    let home = tmp_home("resp-matches-binding");
+    p17_setup_repo(&home, "agent-match");
+
+    let resp = handle_bind_self(
+        &home,
+        &json!({"repository": "owner/name", "branch": "feat/w3-match"}),
+        &sender_for("agent-match"),
+    );
+    assert_eq!(
+        resp["bound"].as_bool(),
+        Some(true),
+        "bind_self must succeed: {resp}"
+    );
+    let resp_worktree = resp["worktree_path"]
+        .as_str()
+        .expect("worktree_path in success response");
+
+    let binding_path = crate::paths::runtime_dir(&home)
+        .join("agent-match")
+        .join("binding.json");
+    let v: Value =
+        serde_json::from_str(&std::fs::read_to_string(&binding_path).expect("read binding"))
+            .expect("parse binding");
+    let disk_worktree = v["worktree"].as_str().expect("worktree field on disk");
+
+    assert_eq!(
+        resp_worktree, disk_worktree,
+        "response worktree_path must exactly match the just-written binding.json worktree field"
+    );
+
+    // Response JSON structure: exactly the documented success shape (no
+    // extra/missing keys for the non-rebase_mode path).
+    let mut keys: Vec<&str> = resp
+        .as_object()
+        .unwrap()
+        .keys()
+        .map(String::as_str)
+        .collect();
+    keys.sort();
+    assert_eq!(
+        keys,
+        vec!["bound", "branch", "worktree_path"],
+        "success response shape must be unchanged: {resp}"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+}
+
 #[test]
 fn bind_self_idempotent_same_agent_same_branch() {
     // Gate 2: a second bind_self call from the same agent on the


### PR DESCRIPTION
## Summary

Part of #2550 W3 (pre-research: `P3-W3-PRERESEARCH.md` §3 Wave 2, last wave in the currently-authorized W3 scope, after Wave 1 #2584 merged). Small, single-site PR.

`handle_bind_self`'s post-bind response assembly hand-rolled a raw `read_to_string` + parse of the `binding.json` it had just written, purely to echo the `worktree` path back in the response. `bind_full` updates `binding::binding_index()` (the in-memory cache) under the same lock it writes the file in — confirmed by lead before dispatch — so the cache is already current by the time this code runs; `binding::read()` reflects it without a second disk read.

## Changes

- `src/mcp/handlers/worktree.rs::handle_bind_self`: swap the raw `read_to_string`+parse for `crate::binding::read(home, agent)`.

## Scope boundary
Only this one site. `mcp/handlers/ci/mod.rs::resolve_repo_or_error` (needs a new binding-accessor variant to preserve its distinct error codes) and `bin/agend-git.rs::read_binding` (separate binary + HMAC verification) remain explicitly out of scope per the pre-research. Wave 0/1's already-converged sites are untouched.

## Test plan
- [x] **Test-first**: added `bind_self_response_worktree_path_matches_written_binding_2550_w3` — asserts the response's `worktree_path` is an EXACT match for the just-written `binding.json`'s `worktree` field (stronger than the pre-existing "non-empty" check), plus asserts the success response's key set (`bound`, `branch`, `worktree_path`) is unchanged. Verified green against the pre-refactor code first, then again after the swap.
- [x] `cargo build --lib --bin agend-terminal` — clean
- [x] `cargo nextest run --lib --bin agend-terminal` — 4775/4775 pass (4774 pre-existing + 1 new pin), zero pre-existing tests modified
- [x] `cargo clippy --lib --bin agend-terminal --tests -- -D warnings` — clean
- [x] `cargo test --test anti_pattern_invariant` — 11/11 pass
- [x] `cargo fmt --check` — clean

Refs #2550