### PR TITLE
refactor(#2550 W6): merge-detection convergence — ancestor-check dedup + squash cross-test (no unification)

### DIFF
--- a/src/branch_sweep.rs
+++ b/src/branch_sweep.rs
@@ -692,6 +692,45 @@ mod tests {
         std::fs::remove_dir_all(repo.parent().unwrap()).ok();
     }
 
+    // #2550 W6: cross-test pinning the behavior GAP between the
+    // ancestor-check (`git merge-base --is-ancestor`, used by
+    // worktree_cleanup.rs's is_branch_merged / worktree_pool.rs's
+    // cleanup_merged_branch via git_helpers::git_ok) and this file's own
+    // squash-merge detection (is_squash_merged, cherry + tree-diff based) —
+    // for a GitHub-style squash-merged branch. This is the decision input
+    // for whether the three merge-detection sites should unify onto
+    // branch_sweep.rs's heavier squash-aware method.
+    #[test]
+    fn ancestor_check_misses_squash_merge_that_branch_sweep_catches() {
+        let repo = setup_repo("w6_ancestor_vs_squash");
+        create_branch_with_commit(&repo, "feat-c", "feat: c body");
+        // Make main diverge first so cherry-pick doesn't fast-forward
+        // (mirrors test_branch_sweep_scan_categorizes_squash_merged above).
+        std::fs::write(repo.join("unrelated2.txt"), "main moves\n").expect("write");
+        git_run(&repo, &["add", "unrelated2.txt"]);
+        git_run(&repo, &["commit", "-m", "main: unrelated work 2"]);
+        git_run(&repo, &["cherry-pick", "--no-commit", "feat-c"]);
+        git_run(&repo, &["commit", "-m", "squash: feat-c body"]);
+
+        assert!(
+            !crate::git_helpers::git_ok(&repo, &["merge-base", "--is-ancestor", "feat-c", "main"],),
+            "ancestor-check must return false for a squash-merged branch — \
+             squash produces a new commit on main with no direct ancestry \
+             back to feat-c's tip, so this is a real (not incidental) gap, \
+             not a bug to unify away lightly"
+        );
+        assert!(
+            is_squash_merged(&repo, "main", "feat-c"),
+            "is_squash_merged (this file's cherry/patch-id detection) must \
+             still catch it — this is the gap ancestor-check callers close \
+             via a DIFFERENT, cheaper signal instead (remote-tracking-ref-gone,\
+             see worktree_cleanup.rs's is_remote_gone / worktree_pool.rs's \
+             is_gone), not by adopting this file's cherry+diff(+gh API) method"
+        );
+
+        std::fs::remove_dir_all(repo.parent().unwrap()).ok();
+    }
+
     #[test]
     fn test_branch_sweep_scan_categorizes_stale_idle() {
         // #817 RED 3: branch "old-wip" with committer-date 100 days

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -236,12 +236,14 @@ fn cleanup_merged_branch(
     }
 
     let default = crate::git_helpers::default_branch(source_repo);
-    let is_merged = crate::git_helpers::git_bypass(
+    // W6: converged onto git_helpers::git_ok — byte-identical to the prior
+    // git_bypass(...).map(|o| o.status.success()).unwrap_or(false) idiom this
+    // absorbs (worktree_cleanup.rs's is_branch_merged already used it; this
+    // was the one remaining manual call site).
+    let is_merged = crate::git_helpers::git_ok(
         source_repo,
         &["merge-base", "--is-ancestor", branch, &default],
-    )
-    .map(|o| o.status.success())
-    .unwrap_or(false);
+    );
 
     let is_gone = {
         let remote_name = crate::git_helpers::git_bypass(


### PR DESCRIPTION
## Summary

Two independent halves per the #2550 P3 spike (§1b/§5 Wave 6), operator-approved 2026-07-03:

**W6a (mechanical, low-risk)** — converged the remaining manual `merge-base --is-ancestor` call site in `worktree_pool.rs`'s `cleanup_merged_branch` onto `git_helpers::git_ok`. `worktree_cleanup.rs`'s `is_branch_merged` already used `git_ok` for the same check — this was the one holdout. Byte-identical behavior (`git_bypass(...).map(|o| o.status.success()).unwrap_or(false)` is exactly `git_ok`'s body).

**W6b (test-first verification)** — wrote a cross-test (`ancestor_check_misses_squash_merge_that_branch_sweep_catches` in `branch_sweep.rs`) pinning the behavior gap between the ancestor-check (used by `worktree_cleanup.rs` / `worktree_pool.rs`) and `branch_sweep.rs`'s own squash-merge detection (`is_squash_merged`, cherry + tree-diff based) for a GitHub-style squash-merged branch.

**Decision (accepted non-unification, per spike's explicit allowance):** keep all three merge-detection sites as-is (2+1, not unified). `worktree_cleanup.rs` / `worktree_pool.rs` already close the squash-merge gap via a different, cheaper signal — the remote-tracking-ref being gone (`is_remote_gone` / `is_gone`) — which needs no `git cherry` walk and no GitHub API call. Adopting `branch_sweep.rs`'s heavier method on the per-tick GC path would add cost with no behavioral gain. This turns the squash misjudgment from an unverified assumption into a documented, test-guarded known semantic (spike open question #4, now answered).

## Test plan
- [x] `cargo nextest run --profile ci` — 5160/5162 passed (the 2 failures are the pre-existing documented flakes `e2e_dispatch_review_workflow_seam_invariants_1900` / `teardown_leaves_zero_residual_after_full_exercise_1907`, unrelated to dispatch/binding/teardown, not touched by this PR)
- [x] `cargo clippy --lib --tests -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Existing tests unmodified; only one new test added

🤖 Generated with [Claude Code](https://claude.com/claude-code)