### PR TITLE
fix(telegram): TUI pane create/kill hooks never fire (frozen post-#945 channel ref)

### DIFF
--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -10,7 +10,6 @@ use crate::layout::{Layout, SplitDir, Tab};
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 
 /// Bundle of mutable references the command handler needs to affect the
 /// running TUI state. Constructed by the caller for each invocation.
@@ -20,7 +19,6 @@ pub(super) struct CommandCtx<'a> {
     pub home: &'a Path,
     pub wakeup_tx: &'a crossbeam_channel::Sender<usize>,
     pub name_counter: &'a mut HashMap<String, usize>,
-    pub telegram_state: &'a Option<Arc<dyn crate::channel::Channel>>,
 }
 
 /// The dynamic source feeding a command-argument position, declared per token in
@@ -408,7 +406,6 @@ pub(super) fn execute(cmd: &str, ctx: &mut CommandCtx<'_>) -> bool {
             match pane_result {
                 Ok(pane) => {
                     super::telegram_hooks::maybe_create_telegram_topic(
-                        ctx.telegram_state,
                         ctx.registry,
                         ctx.home,
                         &pane,
@@ -439,11 +436,7 @@ pub(super) fn execute(cmd: &str, ctx: &mut CommandCtx<'_>) -> bool {
         "kill" => {
             if let Some(name) = parts.get(1) {
                 if let Some(fleet_name) = lookup_fleet_name(ctx.layout, name) {
-                    super::telegram_hooks::maybe_delete_telegram_topic(
-                        ctx.telegram_state,
-                        ctx.home,
-                        &fleet_name,
-                    );
+                    super::telegram_hooks::maybe_delete_telegram_topic(ctx.home, &fleet_name);
                     let _ = crate::fleet::remove_instance_from_yaml(ctx.home, &fleet_name);
                 }
                 super::kill_agent(ctx.home, ctx.registry, name);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1019,7 +1019,6 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
                                 fleet_path: &fleet_path,
                                 wakeup_tx: &wakeup_tx,
                                 name_counter: &mut name_counter,
-                                telegram_state: &telegram_state,
                             };
                             let outcome = overlay::handle_key(&mut overlay, key, &mut octx);
                             if outcome.needs_resize {

--- a/src/app/overlay.rs
+++ b/src/app/overlay.rs
@@ -5,7 +5,6 @@
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use std::collections::HashMap;
 use std::path::Path;
-use std::sync::Arc;
 
 use crate::agent::AgentRegistry;
 use crate::backend::Backend;
@@ -181,7 +180,6 @@ pub(super) struct OverlayCtx<'a> {
     pub fleet_path: &'a Path,
     pub wakeup_tx: &'a crossbeam_channel::Sender<usize>,
     pub name_counter: &'a mut HashMap<String, usize>,
-    pub telegram_state: &'a Option<Arc<dyn crate::channel::Channel>>,
 }
 
 #[derive(Default)]
@@ -232,7 +230,6 @@ pub(super) fn handle_key(
                         ) {
                             Ok(pane) => {
                                 super::telegram_hooks::maybe_create_telegram_topic(
-                                    ctx.telegram_state,
                                     ctx.registry,
                                     ctx.home,
                                     &pane,
@@ -298,7 +295,6 @@ pub(super) fn handle_key(
                             ) {
                                 Ok(p) => {
                                     super::telegram_hooks::maybe_create_telegram_topic(
-                                        ctx.telegram_state,
                                         ctx.registry,
                                         ctx.home,
                                         &p,
@@ -587,7 +583,6 @@ pub(super) fn handle_key(
                     home: ctx.home,
                     wakeup_tx: ctx.wakeup_tx,
                     name_counter: &mut *ctx.name_counter,
-                    telegram_state: ctx.telegram_state,
                 };
                 if super::commands::execute(&cmd, &mut cctx) {
                     outcome.needs_resize = true;
@@ -1104,7 +1099,6 @@ mod tests {
         let registry: crate::agent::AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
         let (tx, _rx) = crossbeam_channel::unbounded();
         let mut name_counter = HashMap::new();
-        let tg: Option<Arc<dyn crate::channel::Channel>> = None;
         let mut layout = crate::layout::Layout::new();
         let mut ctx = OverlayCtx {
             layout: &mut layout,
@@ -1113,7 +1107,6 @@ mod tests {
             fleet_path: home,
             wakeup_tx: &tx,
             name_counter: &mut name_counter,
-            telegram_state: &tg,
         };
         for k in keys {
             handle_key(overlay, press(*k), &mut ctx);
@@ -1127,7 +1120,6 @@ mod tests {
         let registry: crate::agent::AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
         let (tx, _rx) = crossbeam_channel::unbounded();
         let mut name_counter = HashMap::new();
-        let tg: Option<Arc<dyn crate::channel::Channel>> = None;
         let mut layout = crate::layout::Layout::new();
         let mut ctx = OverlayCtx {
             layout: &mut layout,
@@ -1136,7 +1128,6 @@ mod tests {
             fleet_path: &home,
             wakeup_tx: &tx,
             name_counter: &mut name_counter,
-            telegram_state: &tg,
         };
         let mut overlay = task_overlay();
         handle_key(&mut overlay, press(KeyCode::Char('?')), &mut ctx);
@@ -1151,7 +1142,6 @@ mod tests {
         let registry: crate::agent::AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
         let (tx, _rx) = crossbeam_channel::unbounded();
         let mut name_counter = HashMap::new();
-        let tg: Option<Arc<dyn crate::channel::Channel>> = None;
         let mut layout = crate::layout::Layout::new();
         let mut ctx = OverlayCtx {
             layout: &mut layout,
@@ -1160,7 +1150,6 @@ mod tests {
             fleet_path: &home,
             wakeup_tx: &tx,
             name_counter: &mut name_counter,
-            telegram_state: &tg,
         };
         let mut overlay = Overlay::Tasks {
             items: Vec::new(),
@@ -1181,7 +1170,6 @@ mod tests {
         let registry: crate::agent::AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
         let (tx, _rx) = crossbeam_channel::unbounded();
         let mut name_counter = HashMap::new();
-        let tg: Option<Arc<dyn crate::channel::Channel>> = None;
         let mut layout = crate::layout::Layout::new();
         let mut ctx = OverlayCtx {
             layout: &mut layout,
@@ -1190,7 +1178,6 @@ mod tests {
             fleet_path: &home,
             wakeup_tx: &tx,
             name_counter: &mut name_counter,
-            telegram_state: &tg,
         };
         let mut overlay = Overlay::Tasks {
             items: Vec::new(),
@@ -1229,7 +1216,6 @@ mod tests {
         registry: &'a crate::agent::AgentRegistry,
         tx: &'a crossbeam_channel::Sender<usize>,
         name_counter: &'a mut HashMap<String, usize>,
-        tg: &'a Option<Arc<dyn crate::channel::Channel>>,
     ) -> OverlayCtx<'a> {
         OverlayCtx {
             layout,
@@ -1238,7 +1224,6 @@ mod tests {
             fleet_path: home,
             wakeup_tx: tx,
             name_counter,
-            telegram_state: tg,
         }
     }
 
@@ -1250,7 +1235,6 @@ mod tests {
         let registry: crate::agent::AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
         let (tx, _rx) = crossbeam_channel::unbounded();
         let mut name_counter = HashMap::new();
-        let tg: Option<Arc<dyn crate::channel::Channel>> = None;
         let mut layout = crate::layout::Layout::new();
 
         // Create a task (status=open) — #2306: open lives in the Todo column (0).
@@ -1271,7 +1255,7 @@ mod tests {
         };
 
         // Kitty protocol: Shift+L → KeyCode::Char('l') + SHIFT
-        let mut ctx = make_ctx(&home, &mut layout, &registry, &tx, &mut name_counter, &tg);
+        let mut ctx = make_ctx(&home, &mut layout, &registry, &tx, &mut name_counter);
         handle_key(&mut overlay, shift(KeyCode::Char('l')), &mut ctx);
 
         // Reload from disk — must be persisted. #2306: Todo →L→ Working (in_progress).
@@ -1298,7 +1282,6 @@ mod tests {
             let registry: crate::agent::AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
             let (tx, _rx) = crossbeam_channel::unbounded();
             let mut name_counter = HashMap::new();
-            let tg: Option<Arc<dyn crate::channel::Channel>> = None;
             let mut layout = crate::layout::Layout::new();
 
             crate::tasks::handle(
@@ -1319,7 +1302,7 @@ mod tests {
                 view: BoardView::Tasks,
             };
 
-            let mut ctx = make_ctx(&home, &mut layout, &registry, &tx, &mut name_counter, &tg);
+            let mut ctx = make_ctx(&home, &mut layout, &registry, &tx, &mut name_counter);
             handle_key(&mut overlay, key_event, &mut ctx);
 
             let reloaded = crate::tasks::list_all(&home);
@@ -1343,7 +1326,6 @@ mod tests {
         let registry: crate::agent::AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
         let (tx, _rx) = crossbeam_channel::unbounded();
         let mut name_counter = HashMap::new();
-        let tg: Option<Arc<dyn crate::channel::Channel>> = None;
         let mut layout = crate::layout::Layout::new();
 
         // Create two tasks in Open column with different priorities
@@ -1379,7 +1361,7 @@ mod tests {
             view: BoardView::Tasks,
         };
 
-        let mut ctx = make_ctx(&home, &mut layout, &registry, &tx, &mut name_counter, &tg);
+        let mut ctx = make_ctx(&home, &mut layout, &registry, &tx, &mut name_counter);
         handle_key(&mut overlay, shift(KeyCode::Char('l')), &mut ctx);
 
         // high-pri must have moved, low-pri must stay
@@ -1412,7 +1394,6 @@ mod tests {
         let registry: crate::agent::AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
         let (tx, _rx) = crossbeam_channel::unbounded();
         let mut name_counter = HashMap::new();
-        let tg: Option<Arc<dyn crate::channel::Channel>> = None;
         let mut layout = crate::layout::Layout::new();
         let mut ctx = OverlayCtx {
             layout: &mut layout,
@@ -1421,7 +1402,6 @@ mod tests {
             fleet_path: &home,
             wakeup_tx: &tx,
             name_counter: &mut name_counter,
-            telegram_state: &tg,
         };
         let mut overlay = Overlay::Tasks {
             items: Vec::new(),
@@ -1458,7 +1438,6 @@ mod tests {
         let registry: crate::agent::AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
         let (tx, _rx) = crossbeam_channel::unbounded();
         let mut name_counter = HashMap::new();
-        let tg: Option<Arc<dyn crate::channel::Channel>> = None;
         let mut layout = crate::layout::Layout::new();
         let mut ctx = OverlayCtx {
             layout: &mut layout,
@@ -1467,7 +1446,6 @@ mod tests {
             fleet_path: &home,
             wakeup_tx: &tx,
             name_counter: &mut name_counter,
-            telegram_state: &tg,
         };
         let mut overlay = Overlay::Tasks {
             items: Vec::new(),

--- a/src/app/telegram_hooks.rs
+++ b/src/app/telegram_hooks.rs
@@ -4,11 +4,10 @@
 //! Telegram API calls run on background threads to avoid blocking the TUI event loop.
 
 use crate::agent::{self, AgentRegistry};
-use crate::channel::{BindingOpts, Channel, TelegramStatus};
+use crate::channel::{BindingOpts, TelegramStatus};
 use crate::layout::Pane;
 
 use std::path::Path;
-use std::sync::Arc;
 
 /// Derive Telegram status from an already-loaded FleetConfig (no disk I/O).
 pub(super) fn telegram_status_from_config(config: &crate::fleet::FleetConfig) -> TelegramStatus {
@@ -29,13 +28,18 @@ pub(super) fn telegram_status_from_config(config: &crate::fleet::FleetConfig) ->
 
 /// Create a Telegram topic for a newly spawned fleet instance (non-blocking).
 /// Spawns a background thread for the Telegram API call to avoid freezing the TUI.
-pub(super) fn maybe_create_telegram_topic(
-    tg: &Option<Arc<dyn Channel>>,
-    registry: &AgentRegistry,
-    _home: &Path,
-    pane: &Pane,
-) {
-    let Some(tg) = tg else { return };
+///
+/// Looks up the "telegram" channel live at call time rather than taking a
+/// pre-resolved reference: `telegram_init` has been backgrounded since #945
+/// (its synchronous return is always `None`), so a reference captured once at
+/// `setup_app_bootstrap` time stays `None` for the process lifetime and this
+/// hook silently never fires. Mirrors `maybe_create_discord_binding`'s
+/// `lookup_channel_by_name` pattern (#2588), which never had this bug because
+/// Discord's init was async from the start.
+pub(super) fn maybe_create_telegram_topic(registry: &AgentRegistry, _home: &Path, pane: &Pane) {
+    let Some(tg) = crate::channel::lookup_channel_by_name("telegram") else {
+        return;
+    };
     let Some(fleet_name) = &pane.fleet_instance_name else {
         return;
     };
@@ -48,7 +52,6 @@ pub(super) fn maybe_create_telegram_topic(
             .map(|h| h.submit_key.clone())
             .unwrap_or_else(|| "\r".to_string())
     };
-    let tg = Arc::clone(tg);
     let fleet_name = fleet_name.clone();
     // fire-and-forget: create_binding posts to Telegram + records into
     // TelegramState (Arc-shared). Short-lived; tied to UI pane creation.
@@ -63,16 +66,17 @@ pub(super) fn maybe_create_telegram_topic(
 
 /// Delete Telegram topic for a fleet instance (non-blocking).
 /// State is updated immediately; the Telegram API call runs on a background thread.
-pub(super) fn maybe_delete_telegram_topic(
-    tg: &Option<Arc<dyn Channel>>,
-    _home: &Path,
-    fleet_name: &str,
-) {
-    let Some(tg) = tg else { return };
+///
+/// Same live-lookup fix as [`maybe_create_telegram_topic`] — a frozen
+/// pre-#945 reference here meant killing a pane via the TUI never cleaned up
+/// its Telegram topic.
+pub(super) fn maybe_delete_telegram_topic(_home: &Path, fleet_name: &str) {
+    let Some(tg) = crate::channel::lookup_channel_by_name("telegram") else {
+        return;
+    };
     let Some(binding) = tg.take_binding(fleet_name) else {
         return;
     };
-    let tg = Arc::clone(tg);
     // fire-and-forget: remove_binding posts to Telegram delete-topic API.
     // Short-lived; tied to UI pane delete. State already updated synchronously
     // (take_binding returned the binding). No JoinHandle needed — Telegram
@@ -82,4 +86,261 @@ pub(super) fn maybe_delete_telegram_topic(
             tracing::warn!(error = %e, "remove_binding failed");
         }
     });
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::channel::{
+        active_channel, register_active_channel, reset_active_channel_for_test, BindingRef,
+        Channel, ChannelCapabilities, ChannelEvent, MsgRef, OutMsg,
+    };
+    use crate::layout::{Pane, PaneSource};
+    use crate::vterm::VTerm;
+    use serial_test::serial;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    fn test_pane(fleet_name: Option<&str>) -> Pane {
+        Pane {
+            agent_name: "agent".into(),
+            instance_id: crate::types::InstanceId::default(),
+            vterm: VTerm::new(10, 10),
+            rx: crossbeam_channel::bounded(1).1,
+            id: 1,
+            backend: None,
+            working_dir: None,
+            display_name: None,
+            scroll_offset: 0,
+            has_notification: false,
+            fleet_instance_name: fleet_name.map(String::from),
+            last_input_at: None,
+            pending_notification_count: 0,
+            pending_decision_count: 0,
+            selection: None,
+            source: PaneSource::Local,
+            offthread: None,
+            _fwd_cancel: None,
+        }
+    }
+
+    /// Records `has_binding` / `take_binding` calls synchronously (these run
+    /// on the CALLER's thread, before either hook spawns its background
+    /// thread) so tests can assert the live-lookup path was reached without
+    /// synchronizing with the fire-and-forget thread.
+    struct MockChannel {
+        caps: ChannelCapabilities,
+        has_binding_calls: AtomicUsize,
+        has_binding_return: bool,
+        take_binding_calls: AtomicUsize,
+        take_binding_return: bool,
+    }
+
+    impl MockChannel {
+        fn new(has_binding_return: bool, take_binding_return: bool) -> Self {
+            Self {
+                caps: ChannelCapabilities::default(),
+                has_binding_calls: AtomicUsize::new(0),
+                has_binding_return,
+                take_binding_calls: AtomicUsize::new(0),
+                take_binding_return,
+            }
+        }
+    }
+
+    impl Channel for MockChannel {
+        fn kind(&self) -> &'static str {
+            "telegram"
+        }
+        fn caps(&self) -> &ChannelCapabilities {
+            &self.caps
+        }
+        fn poll_event(&self) -> Option<ChannelEvent> {
+            None
+        }
+        fn send(&self, _: &BindingRef, _: OutMsg) -> anyhow::Result<MsgRef> {
+            anyhow::bail!("mock")
+        }
+        fn edit(&self, _: &MsgRef, _: OutMsg) -> anyhow::Result<()> {
+            anyhow::bail!("mock")
+        }
+        fn delete(&self, _: &MsgRef) -> anyhow::Result<()> {
+            anyhow::bail!("mock")
+        }
+        fn create_binding(&self, _: &str, _: BindingOpts) -> anyhow::Result<BindingRef> {
+            anyhow::bail!("mock")
+        }
+        fn remove_binding(&self, _: &BindingRef) -> anyhow::Result<()> {
+            anyhow::bail!("mock")
+        }
+        fn has_binding(&self, _: &str) -> bool {
+            self.has_binding_calls.fetch_add(1, Ordering::SeqCst);
+            self.has_binding_return
+        }
+        fn record_binding(&self, _: &str, _: BindingRef, _: String) {}
+        fn take_binding(&self, _: &str) -> Option<BindingRef> {
+            self.take_binding_calls.fetch_add(1, Ordering::SeqCst);
+            self.take_binding_return
+                .then(|| BindingRef::new("telegram", Some("mock".to_string()), 0i32))
+        }
+        fn attach_registry(&self, _: crate::agent::AgentRegistry) {}
+    }
+
+    fn empty_registry() -> crate::agent::AgentRegistry {
+        Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new()))
+    }
+
+    /// #2550-adjacent (telegram topic lifecycle): pre-fix, `maybe_create_telegram_topic`
+    /// took a pre-resolved `&Option<Arc<dyn Channel>>` that stayed frozen at `None` for
+    /// the process lifetime post-#945 backgrounding — this hook never reached
+    /// `has_binding` at all, TUI-created panes silently got no topic tracking.
+    /// Post-fix: a channel registered under kind "telegram" is found via a live
+    /// `lookup_channel_by_name` at call time.
+    #[test]
+    #[serial]
+    fn maybe_create_telegram_topic_finds_channel_via_live_lookup() {
+        reset_active_channel_for_test();
+        let mock = Arc::new(MockChannel::new(/* has_binding */ true, false));
+        register_active_channel(mock.clone() as Arc<dyn Channel>);
+
+        let registry = empty_registry();
+        let pane = test_pane(Some("agent-a"));
+        maybe_create_telegram_topic(&registry, Path::new("/tmp"), &pane);
+
+        assert_eq!(
+            mock.has_binding_calls.load(Ordering::SeqCst),
+            1,
+            "has_binding must be reached via a live lookup of the registered \
+             \"telegram\" channel — pre-fix this was unreachable (frozen None)"
+        );
+        reset_active_channel_for_test();
+    }
+
+    #[test]
+    #[serial]
+    fn maybe_create_telegram_topic_is_noop_without_registered_channel() {
+        reset_active_channel_for_test();
+        let registry = empty_registry();
+        let pane = test_pane(Some("agent-b"));
+        // Must not panic when no "telegram" channel is registered.
+        maybe_create_telegram_topic(&registry, Path::new("/tmp"), &pane);
+        assert!(active_channel().is_none());
+    }
+
+    #[test]
+    #[serial]
+    fn maybe_create_telegram_topic_is_noop_without_fleet_instance_name() {
+        reset_active_channel_for_test();
+        let mock = Arc::new(MockChannel::new(true, false));
+        register_active_channel(mock.clone() as Arc<dyn Channel>);
+
+        let registry = empty_registry();
+        let pane = test_pane(None); // no fleet_instance_name
+        maybe_create_telegram_topic(&registry, Path::new("/tmp"), &pane);
+
+        assert_eq!(
+            mock.has_binding_calls.load(Ordering::SeqCst),
+            0,
+            "no fleet_instance_name must short-circuit before checking has_binding"
+        );
+        reset_active_channel_for_test();
+    }
+
+    /// Same regression class as the create-side test above, for the "kill"
+    /// command's teardown hook.
+    #[test]
+    #[serial]
+    fn maybe_delete_telegram_topic_finds_channel_via_live_lookup() {
+        reset_active_channel_for_test();
+        let mock = Arc::new(MockChannel::new(false, /* take_binding */ false));
+        register_active_channel(mock.clone() as Arc<dyn Channel>);
+
+        maybe_delete_telegram_topic(Path::new("/tmp"), "agent-c");
+
+        assert_eq!(
+            mock.take_binding_calls.load(Ordering::SeqCst),
+            1,
+            "take_binding must be reached via a live lookup of the registered \
+             \"telegram\" channel — pre-fix this was unreachable (frozen None)"
+        );
+        reset_active_channel_for_test();
+    }
+
+    #[test]
+    #[serial]
+    fn maybe_delete_telegram_topic_is_noop_without_registered_channel() {
+        reset_active_channel_for_test();
+        // Must not panic when no "telegram" channel is registered.
+        maybe_delete_telegram_topic(Path::new("/tmp"), "agent-d");
+        assert!(active_channel().is_none());
+    }
+
+    /// End-to-end happy path: a genuine binding exists, so the hook spawns its
+    /// background thread and `remove_binding` actually fires. Bounded poll
+    /// (not an indefinite sleep) waits for the fire-and-forget thread.
+    #[test]
+    #[serial]
+    fn maybe_delete_telegram_topic_removes_binding_on_background_thread() {
+        struct RemovingMock {
+            caps: ChannelCapabilities,
+            removed: Arc<AtomicBool>,
+        }
+        impl Channel for RemovingMock {
+            fn kind(&self) -> &'static str {
+                "telegram"
+            }
+            fn caps(&self) -> &ChannelCapabilities {
+                &self.caps
+            }
+            fn poll_event(&self) -> Option<ChannelEvent> {
+                None
+            }
+            fn send(&self, _: &BindingRef, _: OutMsg) -> anyhow::Result<MsgRef> {
+                anyhow::bail!("mock")
+            }
+            fn edit(&self, _: &MsgRef, _: OutMsg) -> anyhow::Result<()> {
+                anyhow::bail!("mock")
+            }
+            fn delete(&self, _: &MsgRef) -> anyhow::Result<()> {
+                anyhow::bail!("mock")
+            }
+            fn create_binding(&self, _: &str, _: BindingOpts) -> anyhow::Result<BindingRef> {
+                anyhow::bail!("mock")
+            }
+            fn remove_binding(&self, _: &BindingRef) -> anyhow::Result<()> {
+                self.removed.store(true, Ordering::SeqCst);
+                Ok(())
+            }
+            fn has_binding(&self, _: &str) -> bool {
+                false
+            }
+            fn record_binding(&self, _: &str, _: BindingRef, _: String) {}
+            fn take_binding(&self, _: &str) -> Option<BindingRef> {
+                Some(BindingRef::new("telegram", Some("mock".to_string()), 0i32))
+            }
+            fn attach_registry(&self, _: crate::agent::AgentRegistry) {}
+        }
+
+        reset_active_channel_for_test();
+        let removed = Arc::new(AtomicBool::new(false));
+        let mock = Arc::new(RemovingMock {
+            caps: ChannelCapabilities::default(),
+            removed: removed.clone(),
+        });
+        register_active_channel(mock as Arc<dyn Channel>);
+
+        maybe_delete_telegram_topic(Path::new("/tmp"), "agent-e");
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        while !removed.load(Ordering::SeqCst) && std::time::Instant::now() < deadline {
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+        assert!(
+            removed.load(Ordering::SeqCst),
+            "remove_binding must fire on the background thread once a live \
+             \"telegram\" channel is found and take_binding returns a binding"
+        );
+        reset_active_channel_for_test();
+    }
 }


### PR DESCRIPTION
## Summary

Follow-up to reviewer3's static-read finding (t-20260703155211396370-50899-7) folded into the telegram-topic-lifecycle task (t-20260703154305965646-50899-6) per lead's priority call. Confirmed root cause via direct code tracing (not just static reading) before implementing.

`maybe_create_telegram_topic` and `maybe_delete_telegram_topic` took a pre-resolved `&Option<Arc<dyn Channel>>` threaded through `CommandCtx`/`OverlayCtx` from a local variable (`telegram_state`) captured once at `setup_app_bootstrap` time in `app/mod.rs`. `telegram_init` has been backgrounded since #945 (its synchronous return is always `None`, per that commit's own comment at `mod.rs:487-489`), so the captured reference stays `None` for the entire process lifetime. Both hooks silently no-op via their `let Some(tg) = tg else { return }` guard — for **every** TUI-driven pane create (`:spawn`/`:vsplit`/`:hsplit`, NewTabMenu, SplitMenu) and pane kill (`:kill`), not just a boot-time race window.

**Impact differs by direction** (verified by tracing each call site's full chain, not assumed):
- **Creation**: already has a working fallback — #966's `tui_spawn::add_instance_with_topic` runs *first* at all 3 create call sites (`commands.rs`'s `:spawn`/`:vsplit`/`:hsplit`, and `menu.rs::pane_from_menu_item` used by both overlay menus) and correctly persists `topic_id` to `topics.json` via a live `active_channel()` lookup. The frozen create-hook call afterward was mostly redundant (though it did mean `TelegramState`'s in-memory `instance_to_topic`/`topic_to_instance` maps never got directly populated via `record_binding` for TUI-created panes — self-healed by `topics.json` fallback on first inbound-routing cache miss).
- **Deletion**: no such fallback exists. Killing a pane via the TUI's `:kill` command routes through `daemon::lifecycle::delete_transaction` (process/registry/configs cleanup only) + inline `fleet.yaml` removal — `maybe_delete_telegram_topic` was the *only* Telegram-topic cleanup mechanism for this path, and it was genuinely, permanently broken. This directly contributes to the residual-topic problem this branch is about.

## Fix

Both hooks now do a live `crate::channel::lookup_channel_by_name("telegram")` lookup at call time instead of taking a frozen parameter — mirroring `maybe_create_discord_binding`'s pattern (#2588), which never had this bug because Discord's init was async from the start (its own PR body contrasts this exact difference). `telegram_state` is no longer threaded through `CommandCtx`/`OverlayCtx` — removed from both structs and all construction sites (`app/mod.rs`, `overlay.rs`'s command-palette bridge, and 7 test fixtures).

## Test plan
- **Test-first**: new `MockChannel` (kind=`"telegram"`) suite in `telegram_hooks.rs` proves both hooks reach their live-looked-up channel — `has_binding`/`take_binding` are recorded synchronously (these run on the caller's thread, before either hook's background thread spawns), so no thread-timing flakiness. Also covers: no-op when no `"telegram"` channel is registered, no-op when `pane.fleet_instance_name` is absent. One end-to-end test uses a bounded poll (not a sleep loop, not an indefinite wait) to confirm `remove_binding` actually fires on the background thread once `take_binding` returns a binding.
- [x] `cargo build --lib --bin agend-terminal --tests` — clean
- [x] `cargo test --bin agend-terminal telegram_hooks` — 6/6 new tests pass
- [x] `cargo test --bin agend-terminal app::` — 154/154 pass, zero pre-existing tests modified
- [x] `cargo nextest run --lib --bin agend-terminal` — 4781/4781 pass
- [x] `cargo clippy --lib --bin agend-terminal --tests -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

Refs #2550, mirrors #2588