### PR TITLE
feat(discord): bounded gateway restart supervisor (#2562 PR-3b)

### DIFF
--- a/src/channel/discord.rs
+++ b/src/channel/discord.rs
@@ -514,6 +514,91 @@ pub(crate) fn start_gateway(
     }
 }
 
+/// #2562 PR-3b: maximum number of restart attempts after `start_gateway`
+/// dies, before giving up permanently. Bounded (unlike Telegram's
+/// `poll_supervisor`, which retries most errors indefinitely) because
+/// every condition that kills `start_gateway` is a config/auth problem
+/// (see `should_stop_gateway_loop`'s doc comment) that won't self-resolve
+/// by waiting — see `DISCORD-P2-RECONNECT-PRERESEARCH.md` §1. The cap
+/// exists so a still-bad token/intents config doesn't hot-loop forever,
+/// while still giving an operator who fixes the config WHILE the daemon
+/// keeps running a chance at automatic recovery without a full restart.
+const GATEWAY_RESTART_MAX_ATTEMPTS: u32 = 3;
+
+/// Backoff before restart attempt number `attempt` (1-indexed: the delay
+/// before the FIRST restart, i.e. the second overall try). Mirrors
+/// Telegram's `poll_supervisor::backoff_delay` shape (exponential, base
+/// 5s, cap 60s) — same constants for consistency, not because the two
+/// domains share an error taxonomy (they don't; see PRERESEARCH §2).
+fn discord_gateway_backoff_delay(attempt: u32) -> std::time::Duration {
+    let exp = attempt.saturating_sub(1).min(20);
+    let mult = 1u32 << exp;
+    std::time::Duration::from_secs(5)
+        .saturating_mul(mult)
+        .min(std::time::Duration::from_secs(60))
+}
+
+/// Whether another restart attempt should be made, given how many restart
+/// attempts have already happened (not counting the original attempt).
+/// `false` once [`GATEWAY_RESTART_MAX_ATTEMPTS`] is reached.
+fn should_restart_gateway(attempts_so_far: u32) -> bool {
+    attempts_so_far < GATEWAY_RESTART_MAX_ATTEMPTS
+}
+
+/// Supervises `start_gateway`: restarts it (up to
+/// [`GATEWAY_RESTART_MAX_ATTEMPTS`] times, with backoff) if it dies. Polls
+/// [`gateway_is_dead`] rather than holding a `JoinHandle` on
+/// `start_gateway`'s inner thread, since `start_gateway` itself is
+/// fire-and-forget by design (§10.5) and `GATEWAY_DEAD` already carries
+/// exactly the "has it exited" signal this loop needs — no reason to widen
+/// `start_gateway`'s contract just to duplicate that signal via a handle.
+///
+/// fire-and-forget (§10.5): mirrors every other Discord/Telegram
+/// background thread — no `JoinHandle`, lives for the daemon's process
+/// lifetime, process exit cleans it up.
+pub(crate) fn spawn_gateway_supervisor(
+    token: String,
+    intents: twilight_model::gateway::Intents,
+    allowlist: Option<Vec<i64>>,
+    tx: mpsc::Sender<ChannelEvent>,
+) {
+    if let Err(e) = std::thread::Builder::new()
+        .name("discord-gateway-supervisor".into())
+        .spawn(move || {
+            let mut attempt: u32 = 0;
+            loop {
+                start_gateway(token.clone(), intents, allowlist.clone(), tx.clone());
+                // start_gateway resets GATEWAY_DEAD to false synchronously
+                // before it returns here (its own thread runs
+                // independently) — poll until that thread's exit path
+                // flips it back to true.
+                while !gateway_is_dead() {
+                    std::thread::sleep(std::time::Duration::from_millis(200));
+                }
+                if !should_restart_gateway(attempt) {
+                    tracing::error!(
+                        attempt,
+                        "discord gateway: giving up after max restart attempts \
+                         (operator must fix config and restart the daemon)"
+                    );
+                    break;
+                }
+                attempt += 1;
+                let delay = discord_gateway_backoff_delay(attempt);
+                tracing::warn!(
+                    attempt,
+                    delay_secs = delay.as_secs(),
+                    "discord gateway: died, restarting after backoff"
+                );
+                std::thread::sleep(delay);
+            }
+        })
+    {
+        tracing::error!(error = %e, "failed to spawn discord gateway supervisor thread");
+        GATEWAY_DEAD.store(true, std::sync::atomic::Ordering::Relaxed);
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Bootstrap (#2562 P1)
 // ---------------------------------------------------------------------------
@@ -584,7 +669,7 @@ pub fn init_from_config(config: &crate::fleet::FleetConfig) -> Option<DiscordCha
     // stays correct even if an operator pastes an already-prefixed token)
     // — pass the raw token to both, per their documented contract.
     let (tx, rx) = mpsc::channel();
-    start_gateway(token.clone(), discord_intents(), user_allowlist.clone(), tx);
+    spawn_gateway_supervisor(token.clone(), discord_intents(), user_allowlist.clone(), tx);
     let http_client = std::sync::Arc::new(build_http_client(token));
     Some(DiscordChannel::new(
         rx,
@@ -1268,6 +1353,42 @@ mod tests {
             !super::gateway_is_dead(),
             "reset must clear it back to alive"
         );
+    }
+
+    /// #2562 PR-3b: exponential backoff, base 5s, cap 60s — same shape and
+    /// same expected sequence as Telegram's `poll_supervisor::backoff_delay`
+    /// test, confirming the constants chosen for consistency actually land
+    /// on the same numbers.
+    #[test]
+    fn discord_gateway_backoff_delay_follows_expected_sequence() {
+        let expected = [5u64, 10, 20, 40, 60, 60, 60];
+        for (i, &secs) in expected.iter().enumerate() {
+            let attempt = (i + 1) as u32;
+            assert_eq!(
+                super::discord_gateway_backoff_delay(attempt),
+                std::time::Duration::from_secs(secs),
+                "attempt {attempt} backoff mismatch"
+            );
+        }
+    }
+
+    /// #2562 PR-3b: restart attempts are allowed strictly below the cap,
+    /// and refused at and beyond it — the supervisor must give up for good
+    /// rather than hot-loop a still-bad config forever.
+    #[test]
+    fn should_restart_gateway_caps_at_max_attempts() {
+        for n in 0..super::GATEWAY_RESTART_MAX_ATTEMPTS {
+            assert!(
+                super::should_restart_gateway(n),
+                "attempt {n} should still be allowed to retry"
+            );
+        }
+        assert!(!super::should_restart_gateway(
+            super::GATEWAY_RESTART_MAX_ATTEMPTS
+        ));
+        assert!(!super::should_restart_gateway(
+            super::GATEWAY_RESTART_MAX_ATTEMPTS + 5
+        ));
     }
 
     /// Contract test: DiscordChannel satisfies the registry-side

--- a/src/channel/discord.rs
+++ b/src/channel/discord.rs
@@ -430,14 +430,16 @@ pub(crate) fn should_stop_gateway_loop(state: twilight_gateway::ShardState) -> b
 /// `block_on_value` calls in `send`/`edit`/`delete`/etc.) — this loop runs
 /// forever, and sharing a single-threaded runtime with it would starve
 /// every outbound call behind the permanently-running reader.
-/// #2562 PR-3a: set when the gateway connection thread has permanently
-/// stopped (fatal close, or its event receiver disappeared) and nothing
-/// will restart it without an operator fix / daemon restart. `false`
-/// initially and while the gateway is live — including while it's
-/// transiently reconnecting, since `twilight_gateway::Shard` handles that
-/// internally (see `should_stop_gateway_loop`'s doc comment) and the loop
-/// never reaches a break point for a merely-transient disconnect. Exposed
-/// so status/MCP surfaces can show "Discord: dead" instead of requiring a
+/// #2562 PR-3a: set each time the gateway connection thread stops (fatal
+/// close, or its event receiver disappeared). `false` initially and while
+/// the gateway is live — including while it's transiently reconnecting,
+/// since `twilight_gateway::Shard` handles that internally (see
+/// `should_stop_gateway_loop`'s doc comment) and the loop never reaches a
+/// break point for a merely-transient disconnect. `spawn_gateway_supervisor`
+/// (#2562 PR-3b) does a bounded number of automatic restarts (with
+/// backoff) when this flips true; only once it gives up for good does an
+/// operator need to fix the config / restart the daemon. Exposed so
+/// status/MCP surfaces can show "Discord: dead" instead of requiring a
 /// log grep.
 static GATEWAY_DEAD: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 
@@ -1370,6 +1372,13 @@ mod tests {
                 "attempt {attempt} backoff mismatch"
             );
         }
+        // Never panics / overflows for a pathologically large attempt
+        // count — same saturating-exponent-cap shape as Telegram's
+        // `poll_supervisor::backoff_delay`, same assertion.
+        assert_eq!(
+            super::discord_gateway_backoff_delay(u32::MAX),
+            std::time::Duration::from_secs(60)
+        );
     }
 
     /// #2562 PR-3b: restart attempts are allowed strictly below the cap,


### PR DESCRIPTION
## Summary
- `start_gateway` itself has no outer supervisor — `twilight_gateway::Shard` already handles transport-level reconnect and resume-vs-reidentify internally (confirmed against the vendored 0.17.1 source, see `DISCORD-P2-RECONNECT-PRERESEARCH.md` §1), so the only gap is what happens after `start_gateway`'s thread has ALREADY died for good: nothing restarts it.
- `spawn_gateway_supervisor` wraps `start_gateway` with a bounded retry: up to `GATEWAY_RESTART_MAX_ATTEMPTS` (3) restarts with exponential backoff (same constants as `telegram/poll_supervisor`'s shape: base 5s, cap 60s), then gives up permanently. Bounded rather than Telegram's mostly-indefinite retry because every fatal-close condition here is a config/auth problem (bad token, invalid intents, etc.) that won't self-resolve by waiting — the cap exists so a still-bad config doesn't hot-loop forever, while still giving an operator who fixes the config WHILE the daemon is running a shot at automatic recovery without a full daemon restart.
- Reuses PR-3a's `GATEWAY_DEAD` flag as the "has `start_gateway`'s thread exited" signal (polled, not a `JoinHandle`) rather than widening `start_gateway`'s fire-and-forget contract just to duplicate that same signal.

## Test plan
- [x] `discord_gateway_backoff_delay_follows_expected_sequence` — same sequence as Telegram's `backoff_delay` test (5, 10, 20, 40, 60, 60, 60)
- [x] `should_restart_gateway_caps_at_max_attempts` — allowed below the cap, refused at and beyond it
- [x] The outer loop's actual thread-restart mechanics aren't independently tested — matching this codebase's existing precedent for background-thread loops (neither `telegram::start_polling` nor `start_gateway`/`spawn_inbound_dispatcher` have thread-loop-level tests)
- [x] `cargo test --features discord --bin agend-terminal channel::discord::` — 44 passed, 1 ignored (network-manual), zero existing tests modified
- [x] `cargo clippy --all-targets --features discord -- -D warnings` — clean
- [x] `cargo check --features tray` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)