### PR TITLE
fix(telegram): close topic-reuse identity-confusion hole (#2550 PR-2)

### DIFF
--- a/src/channel/telegram/topic_registry.rs
+++ b/src/channel/telegram/topic_registry.rs
@@ -82,6 +82,18 @@ pub fn lookup_topic_for_instance(home: &std::path::Path, instance_name: &str) ->
 /// Create a forum topic for a new instance.
 pub fn create_topic_for_instance(home: &std::path::Path, instance_name: &str) -> Option<i32> {
     // Idempotent: reuse existing topic from topics.json if present.
+    //
+    // #2550: this reuse is trusted without verifying the topic still exists /
+    // still means what the mapping claims — the Bot API has no read-only
+    // "does this forum topic still exist" call (only state-changing
+    // edit/close/reopen/delete/unpin methods), so a clean, side-effect-free
+    // verification isn't available. `full_delete_instance` unregisters this
+    // mapping unconditionally on delete (regardless of whether the Telegram-
+    // side delete itself succeeded), which closes the main way a stale
+    // mapping used to survive to be reused here. The remaining exposure is
+    // narrow: the Telegram-side topic vanishing unilaterally (not through our
+    // own delete path) or the daemon crashing mid-teardown before reaching
+    // the unregister step above — accepted residual risk, not guarded here.
     if let Some(tid) = lookup_topic_for_instance(home, instance_name) {
         tracing::info!(instance = %instance_name, topic_id = tid, "reusing existing topic");
         return Some(tid);

--- a/src/mcp/handlers/instance_state/lifecycle.rs
+++ b/src/mcp/handlers/instance_state/lifecycle.rs
@@ -105,7 +105,30 @@ pub(crate) fn full_delete_instance(home: &Path, name: &str) -> Result<(), String
         tracing::error!(name, error = %e, "full_delete_instance: fleet.yaml removal failed");
     }
     if let Some(tid) = topic_id {
-        telegram::delete_topic(home, tid);
+        // #2550 identity-confusion root cause: `delete_topic` only unregisters
+        // `topics.json` on its own `Deleted` outcome. A `PermissionDenied` /
+        // `ApiError` / `ChannelUnavailable` result left the mapping in place —
+        // our own bookkeeping said this instance still owned `tid` even though
+        // we'd already decided to tear it down. A LATER instance created under
+        // the same name then silently inherited that stale mapping via
+        // `create_topic_for_instance`'s reuse-if-found check, with no
+        // verification the topic still meant what the mapping claimed.
+        // Unregister unconditionally: our registry reflects our own intent
+        // (this instance is gone) regardless of whether the Telegram-side API
+        // call could complete. A Telegram-side topic left dangling after a
+        // failed delete becomes a genuine orphan (no daemon-side mapping to
+        // anything) for the existing orphan-sweep paths (`doctor_topics`,
+        // `bootstrap::init_from_config`) to reap later — not a landmine for
+        // the next same-name instance.
+        match telegram::delete_topic(home, tid) {
+            telegram::DeleteTopicOutcome::Deleted => {}
+            other => {
+                telegram::unregister_topic(home, tid);
+                let detail = format!("telegram topic {tid} cleanup: {other:?}");
+                tracing::warn!(%name, topic_id = tid, %detail, "full_delete_instance: topic cleanup incomplete — registry unregistered anyway");
+                step_errors.push(detail);
+            }
+        }
     } else {
         tracing::warn!(%name, "no topic_id found for full_delete_instance — possible orphan");
     }

--- a/src/mcp/handlers/instance_state/lifecycle/tests.rs
+++ b/src/mcp/handlers/instance_state/lifecycle/tests.rs
@@ -274,6 +274,45 @@ fn full_delete_instance_removes_usage_limit_notify_1906() {
     std::fs::remove_dir_all(home).ok();
 }
 
+/// #2550 telegram-topic-lifecycle (identity-confusion root cause): when
+/// `telegram::delete_topic` can't reach Telegram (no channel configured here
+/// → `ChannelUnavailable`, the same "topic-side cleanup failed" shape as a
+/// live `PermissionDenied`/`ApiError`), `full_delete_instance` must STILL
+/// unregister the topic_id from `topics.json` — leaving it mapped is exactly
+/// what let a LATER same-name instance silently inherit a stale/foreign
+/// topic_id via `create_topic_for_instance`'s reuse-if-found check, which
+/// could then have its own first genuine topic-closed event tear down the
+/// wrong (new) instance.
+#[test]
+fn full_delete_instance_unregisters_topic_even_when_telegram_delete_fails_2550() {
+    let home = tmp_home("topic_unregister_on_fail");
+    std::fs::write(
+        crate::fleet::fleet_yaml_path(&home),
+        "instances:\n  doomed:\n    backend: claude\n    topic_id: 501\n",
+    )
+    .unwrap();
+    // No `channel:` section in fleet.yaml → `resolve_channel_only_from` errors
+    // → `delete_topic` returns `ChannelUnavailable` without ever reaching
+    // `unregister_topic` pre-fix (deterministic, no network/bot-token needed).
+    crate::channel::telegram::register_topic(&home, 501, "doomed").expect("seed topics.json");
+    assert_eq!(
+        crate::channel::telegram::lookup_topic_for_instance(&home, "doomed"),
+        Some(501),
+        "pre: topic mapping must exist"
+    );
+
+    let _ = super::full_delete_instance(&home, "doomed");
+
+    assert_eq!(
+        crate::channel::telegram::lookup_topic_for_instance(&home, "doomed"),
+        None,
+        "topics.json must be unregistered even when the Telegram-side delete \
+         couldn't run — a stale mapping left behind is what a later same-name \
+         instance would silently (and wrongly) inherit"
+    );
+    std::fs::remove_dir_all(home).ok();
+}
+
 #[test]
 fn full_delete_instance_releases_worktree_1906() {
     // #1906 Leak 1 §3.9: a single delete must release the PHYSICAL worktree


### PR DESCRIPTION
## Summary

Part of #2550 (telegram topic lifecycle). Correctness-priority PR-2 from `TELEGRAM-TOPIC-LIFECYCLE-SPIKE.md`, per lead's approved (a)+(b) fix decision (d-20260703152322447451-2, confirmed in follow-up).

**Root cause corrected mid-investigation** — my own spike's stated trigger ("同名重建撞殘留 tid → 首訊 thread-not-found → cleanup_deleted_topic 刪 instance", i.e. an outbound send hitting `thread-not-found` via `send_reply`) turned out to be **unreachable in production**: `send_reply`/`handle_send_failure`/`cleanup_deleted_topic` via that specific path has exactly one caller crate-wide — a contract test. The MCP `reply` tool's real path (`send_from_agent` → `try_telegram_reply_from`) already self-heals via `invalidate_and_recreate_topic` on a topic-deleted error, without touching the instance.

The **actually reachable** danger: `full_delete_instance`'s topic cleanup only unregistered `topics.json` on `delete_topic`'s `Deleted` outcome. A `PermissionDenied`/`ApiError`/`ChannelUnavailable` result left the mapping in place even though we'd already decided to tear the instance down. A **later instance created under the same name** then silently inherited that stale `tid` via `create_topic_for_instance`'s reuse-if-found check, with no verification the topic still meant what the mapping claimed — a subsequent genuine close/delete of that topic (permission fixed and a retry finally succeeding, or a human closing what looks like an orphan via the Telegram UI) would tear down the **wrong (new) instance** via `inbound.rs`'s `forum_topic_closed` handler.

## Changes

- **Fix (b), unconditionally approved**: `full_delete_instance` now unregisters the topic_id from `topics.json` regardless of `delete_topic`'s outcome — our registry reflects our own intent (this instance is gone), not whether the Telegram-side API call could complete. A topic left dangling after a failed delete becomes a genuine *orphan* (no mapping to anything) for the existing sweep paths (`doctor_topics`, `bootstrap::init_from_config`) to reap later — never a landmine for the next same-name instance. Folds in PR-1's ask (surface `DeleteTopicOutcome` via `step_errors`) at the same call site rather than as a separate PR touching the identical lines (flagged to lead; happy to split if preferred).
- **Fix (a), conditional — verified no clean path exists**: checked teloxide's forum-topic payload set (`create`/`edit`/`close`/`reopen`/`delete`/`unpin_all`) — no read-only "does this topic still exist" method, so a side-effect-free reuse-time verification isn't available. Per lead's fallback: documented the narrow remaining exposure (Telegram-side topic vanishing unilaterally, or a daemon crash mid-teardown before the unregister step) at `create_topic_for_instance`'s reuse point instead of probing.

## Test plan
- **Test-first**: pinned the repro at the registry-invariant level (`topics.json` must be clean after delete regardless of Telegram-side outcome) rather than constructing a full `teloxide::types::Message` `forum_topic_closed` fixture — `inbound.rs` has zero existing Message-fixture test infra, and this level directly proves the vulnerability's root cause (the stale mapping) is closed, which is what prevents the identity-confusion scenario from being reachable at all. Verified **RED** on pre-fix code (`Some(501)` instead of `None`), **GREEN** after.
- [x] `cargo build --lib --bin agend-terminal` — clean
- [x] `cargo nextest run --lib --bin agend-terminal` — 4780/4780 pass (4779 pre-existing + 1 new), zero pre-existing tests modified
- [x] `cargo clippy --lib --bin agend-terminal --tests -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

Refs #2550