### PR TITLE
docs(fleet): correct misleading topic_binding_mode=deferred doc (#2550 PR-3)

### DIFF
--- a/src/fleet/mod.rs
+++ b/src/fleet/mod.rs
@@ -502,8 +502,12 @@ pub struct InstanceConfig {
     pub skills_path: Option<String>,
     /// #991: topic binding mode — controls whether a Telegram topic is
     /// created at spawn time. `None` or `Some("auto")` = current behavior.
-    /// `Some("skip")` = no topic ever. `Some("deferred")` = no topic at
-    /// spawn, operator can retrofit later via `bind_topic`.
+    /// `Some("skip")` = no topic ever (this is the fully-supported case).
+    /// `Some("deferred")` = no topic at spawn — but there is currently NO
+    /// retrofit mechanism (`bind_topic` was never implemented; #991 is still
+    /// open on that half). An instance spawned with `deferred` has no
+    /// product-level path to gaining a topic later short of manual
+    /// intervention. Do not rely on this mode expecting a later bind.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub topic_binding_mode: Option<String>,
     /// Per-instance idle timeout in seconds. When set, the idle watchdog


### PR DESCRIPTION
## Summary

Part of #2550 (telegram topic lifecycle), PR-3 per `TELEGRAM-TOPIC-LIFECYCLE-SPIKE.md`. Pure documentation fix, no behavior change.

The `topic_binding_mode` doc comment on `InstanceConfig` claimed `Some("deferred")` lets the "operator retrofit later via `bind_topic`" — a `grep -rn "bind_topic" src/` confirms this function was **never implemented** anywhere in the crate (the doc comment itself is the only occurrence of the name). `#991` is still open on that half of the feature.

`Some("skip")` is unaffected and unchanged in this PR — it's the fully-supported, self-consistent case (no topic, ever, by design).

## Changes
- `src/fleet/mod.rs`: `InstanceConfig::topic_binding_mode`'s doc comment now states plainly that `deferred` has no product-level retrofit path today, instead of the unfulfilled `bind_topic` promise.

**Out of scope** (per lead's explicit call): implementing `bind_topic` for real is a product decision on UX/retrofit semantics, not a doc-fix PR.

## Test plan
- Pure doc-comment change — no logic touched.
- [x] `cargo build --lib --bin agend-terminal` — clean
- [x] `cargo test --bin agend-terminal topic_binding` — 6/6 pass, zero modified
- [x] `cargo clippy --lib --bin agend-terminal -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

Refs #2550