### PR TITLE
fix(#2550 PR-0): cleanup_merged_branch is_gone delete gate → is_squash_gc_eligible

### DIFF
--- a/src/worktree_cleanup.rs
+++ b/src/worktree_cleanup.rs
@@ -339,7 +339,11 @@ fn branch_tip_age(repo_root: &Path, branch: &str) -> Option<Duration> {
 /// it is squash-merged into the default branch AND its tip is older than
 /// [`SQUASH_GC_MIN_TIP_AGE`]. Reuses `branch_sweep`'s detection (git cherry +
 /// #1280 tree-diff fallback) so the auto path matches the operator sweep.
-fn is_squash_gc_eligible(repo_root: &Path, branch: &str, default: &str) -> bool {
+///
+/// t-...50899-10: `pub(crate)` so `worktree_pool::cleanup_merged_branch` reuses
+/// the SAME squash-safe delete gate this file's `prune_orphaned_branches`
+/// uses, instead of treating a remote-gone branch as independently deletable.
+pub(crate) fn is_squash_gc_eligible(repo_root: &Path, branch: &str, default: &str) -> bool {
     crate::branch_sweep::is_squash_merged(repo_root, default, branch)
         && branch_tip_age(repo_root, branch).is_some_and(|age| age >= SQUASH_GC_MIN_TIP_AGE)
 }

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -182,13 +182,19 @@ pub struct ReleaseOutcome {
 
 /// Delete the local branch ref after worktree release, IFF:
 /// - `managed_verified` is true (caller confirmed .agend-managed marker)
-/// - Branch is merged into main OR remote tracking ref is gone
+/// - Branch is merged into main (ancestor) OR a squash-merge orphan whose tip
+///   clears the age floor (`is_squash_gc_eligible`)
 ///
 /// SAFETY: This function ONLY receives the branch from the daemon's own
 /// binding record. User-checkout branches never reach here because
-/// release_full early-returns on unmanaged worktrees. The merge-base
-/// check below prevents deletion of unmerged branches regardless of
-/// the managed_verified flag (#1249).
+/// release_full early-returns on unmanaged worktrees. The merge-base check
+/// below prevents deletion of unmerged branches regardless of the
+/// managed_verified flag (#1249). t-...50899-10 (CR-2026-06-14 parity): a
+/// remote-tracking ref being gone is NOT by itself proof the branch's work is
+/// preserved — a branch pushed once, then its remote deleted by a squash
+/// merge, that keeps accruing unpushed local commits afterward is
+/// remote-gone yet carries committed-but-unpushed work `git branch -D` would
+/// destroy irrecoverably. Mirrors `worktree_cleanup.rs::prune_orphaned_branches`.
 ///
 /// Returns `(deleted, skip_reason)`:
 /// - `(true, None)` — branch was deleted
@@ -245,30 +251,16 @@ fn cleanup_merged_branch(
         &["merge-base", "--is-ancestor", branch, &default],
     );
 
-    let is_gone = {
-        let remote_name = crate::git_helpers::git_bypass(
-            source_repo,
-            &["config", &format!("branch.{branch}.remote")],
-        )
-        .ok()
-        .filter(|o| o.status.success())
-        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
-        .unwrap_or_default();
-        if !remote_name.is_empty() {
-            let remote_ref = format!("refs/remotes/{remote_name}/{branch}");
-            let exists = crate::git_helpers::git_bypass(
-                source_repo,
-                &["rev-parse", "--verify", &remote_ref],
-            )
-            .map(|o| o.status.success())
-            .unwrap_or(true);
-            !exists
-        } else {
-            false
-        }
-    };
+    // t-...50899-10 / CR-2026-06-14 parity: `is_gone` (remote-tracking ref
+    // deleted) is no longer an independent delete trigger — a remote-gone
+    // branch carrying commits NOT reachable from `default` (unpushed local
+    // work) must be KEPT. Delete only when the branch's work is provably in
+    // `default`: merged (ancestor) or squash-merged (age-gated heuristic),
+    // same gate `worktree_cleanup.rs::prune_orphaned_branches` uses.
+    let squash =
+        !is_merged && crate::worktree_cleanup::is_squash_gc_eligible(source_repo, branch, &default);
 
-    if !is_merged && !is_gone {
+    if !is_merged && !squash {
         return (false, Some("branch not merged into main".to_string()));
     }
 

--- a/src/worktree_pool/review_repro_worktree_git.rs
+++ b/src/worktree_pool/review_repro_worktree_git.rs
@@ -126,3 +126,141 @@ fn evaluate_candidate_derives_real_agent_for_slash_branch_worktree_git() {
 
     std::fs::remove_dir_all(&home).ok();
 }
+
+// ──────────────────────────────────────────────────────────────────────────
+// t-...50899-10 (CR-2026-06-14 parity, data-loss): cleanup_merged_branch's
+// delete gate was `!is_merged && !is_gone` — a remote-tracking ref being gone
+// was an INDEPENDENT delete trigger, with no squash verification (unlike
+// worktree_cleanup.rs's prune_orphaned_branches, already fixed by
+// CR-2026-06-14 to require `merged || is_squash_gc_eligible`). A branch
+// pushed once, then its remote deleted (e.g. squash-merge on GitHub), that
+// keeps accruing LOCAL commits never re-pushed was reaped by `git branch -D`
+// — those unmerged local commits are unrecoverable. CORRECT: a remote-gone
+// branch carrying commits NOT reachable from default must be KEPT.
+// ──────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn cleanup_merged_branch_keeps_remote_gone_branch_with_unpushed_commits_worktree_git() {
+    // A bare "remote" + a clone, so `branch.<name>.remote` is real.
+    let remote = scratch("cmb-remote-gone-bare");
+    git(&remote, &["init", "--bare", "-b", "main"]);
+
+    let repo = scratch("cmb-remote-gone-clone");
+    std::process::Command::new("git")
+        .args([
+            "clone",
+            &remote.display().to_string(),
+            &repo.display().to_string(),
+        ])
+        .env("AGEND_GIT_BYPASS", "1")
+        .env("GIT_AUTHOR_NAME", "test")
+        .env("GIT_AUTHOR_EMAIL", "t@t")
+        .env("GIT_COMMITTER_NAME", "test")
+        .env("GIT_COMMITTER_EMAIL", "t@t")
+        .output()
+        .expect("git clone");
+
+    git(&repo, &["commit", "--allow-empty", "-m", "init"]);
+    git(&repo, &["push", "-u", "origin", "main"]);
+
+    // Feature branch: push it (configures upstream), then add MORE local
+    // commits that are never re-pushed.
+    git(&repo, &["checkout", "-b", "feat/unpushed"]);
+    git(&repo, &["commit", "--allow-empty", "-m", "first (pushed)"]);
+    git(&repo, &["push", "-u", "origin", "feat/unpushed"]);
+    git(
+        &repo,
+        &["commit", "--allow-empty", "-m", "unpushed local work"],
+    );
+    git(&repo, &["checkout", "main"]);
+
+    // Remote head deleted (e.g. PR closed / branch removed) — cleanup_merged_branch
+    // itself runs `fetch --prune` on the non-dry-run path, so is_gone will be true.
+    git(&remote, &["branch", "-D", "feat/unpushed"]);
+
+    let (deleted, reason) = cleanup_merged_branch(&repo, "feat/unpushed", false);
+    assert!(
+        !deleted,
+        "must NOT delete a remote-gone branch carrying unpushed local commits \
+         (data-loss risk t-...50899-10): {reason:?}"
+    );
+    let ref_exists = std::process::Command::new("git")
+        .args(["rev-parse", "--verify", "refs/heads/feat/unpushed"])
+        .current_dir(&repo)
+        .env("AGEND_GIT_BYPASS", "1")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    assert!(ref_exists, "branch ref must still exist locally after skip");
+
+    std::fs::remove_dir_all(&repo).ok();
+    std::fs::remove_dir_all(&remote).ok();
+}
+
+/// Closes the loop on the fix above: a branch that IS genuinely squash-merged
+/// (every commit's patch already applied to default) AND old enough to clear
+/// `SQUASH_GC_MIN_TIP_AGE`, with its remote gone, must still be deletable —
+/// proving the new gate reuses `is_squash_gc_eligible` rather than silently
+/// disabling remote-gone cleanup altogether.
+#[test]
+fn cleanup_merged_branch_still_deletes_aged_squash_merged_remote_gone_branch_worktree_git() {
+    let remote = scratch("cmb-squash-gone-bare");
+    git(&remote, &["init", "--bare", "-b", "main"]);
+
+    let repo = scratch("cmb-squash-gone-clone");
+    std::process::Command::new("git")
+        .args([
+            "clone",
+            &remote.display().to_string(),
+            &repo.display().to_string(),
+        ])
+        .env("AGEND_GIT_BYPASS", "1")
+        .env("GIT_AUTHOR_NAME", "test")
+        .env("GIT_AUTHOR_EMAIL", "t@t")
+        .env("GIT_COMMITTER_NAME", "test")
+        .env("GIT_COMMITTER_EMAIL", "t@t")
+        .output()
+        .expect("git clone");
+
+    git(&repo, &["commit", "--allow-empty", "-m", "init"]);
+    git(&repo, &["push", "-u", "origin", "main"]);
+
+    // Branch tip is backdated past SQUASH_GC_MIN_TIP_AGE (24h) so the
+    // heuristic squash detection clears its age floor.
+    let old_date = (chrono::Utc::now() - chrono::Duration::hours(48)).to_rfc3339();
+    git(&repo, &["checkout", "-b", "feat/squashed"]);
+    std::fs::write(repo.join("feat.txt"), "feat content\n").expect("write");
+    git(&repo, &["add", "feat.txt"]);
+    std::process::Command::new("git")
+        .args(["commit", "-m", "feat: squashed body"])
+        .current_dir(&repo)
+        .env("AGEND_GIT_BYPASS", "1")
+        .env("GIT_AUTHOR_NAME", "test")
+        .env("GIT_AUTHOR_EMAIL", "t@t")
+        .env("GIT_COMMITTER_NAME", "test")
+        .env("GIT_COMMITTER_EMAIL", "t@t")
+        .env("GIT_AUTHOR_DATE", &old_date)
+        .env("GIT_COMMITTER_DATE", &old_date)
+        .output()
+        .expect("git commit dated");
+    git(&repo, &["push", "-u", "origin", "feat/squashed"]);
+
+    // Squash-apply feat/squashed's diff onto main as a separate commit (mirrors
+    // GitHub's "Squash and merge"), then simulate the remote branch deletion
+    // that follows a squash-merge.
+    git(&repo, &["checkout", "main"]);
+    git(&repo, &["cherry-pick", "--no-commit", "feat/squashed"]);
+    git(&repo, &["commit", "-m", "squash: feat/squashed body"]);
+    git(&repo, &["push", "origin", "main"]);
+    git(&remote, &["branch", "-D", "feat/squashed"]);
+
+    let (deleted, reason) = cleanup_merged_branch(&repo, "feat/squashed", false);
+    assert!(
+        deleted,
+        "a genuinely squash-merged, aged, remote-gone branch must still be \
+         reaped via is_squash_gc_eligible: {reason:?}"
+    );
+
+    std::fs::remove_dir_all(&repo).ok();
+    std::fs::remove_dir_all(&remote).ok();
+}


### PR DESCRIPTION
## Summary

Fixes t-20260703160308595650-50899-10 (data-loss risk found by reviewer3 during #2589's review). PR-0 of the #2550 W5 GC-unification sequence — independent of the rest of W5, landing first per the operator-approved execution order.

`worktree_pool.rs::cleanup_merged_branch` gated branch deletion on `!is_merged && !is_gone` — meaning a remote-tracking ref being gone was, by itself, sufficient to trigger `git branch -D`, with no squash verification. `worktree_cleanup.rs::prune_orphaned_branches` already fixed the identical pattern under CR-2026-06-14 (`merged || is_squash_gc_eligible`), but `worktree_pool.rs`'s copy was never updated to match.

**Concrete risk**: a branch pushed once, then its remote ref deleted (e.g. GitHub squash-merge), that keeps accruing local commits never re-pushed, is remote-gone yet carries committed-but-unpushed work — `git branch -D` destroys it irrecoverably. Given this fleet's worktrees are reused at high frequency, this is a realistic scenario, not a theoretical edge case.

## Changes
- `worktree_cleanup.rs::is_squash_gc_eligible` → `pub(crate)`, so both call sites share one implementation instead of drifting again.
- `worktree_pool.rs::cleanup_merged_branch`'s gate: `!is_merged && !is_gone` → `!is_merged && !is_squash_gc_eligible(...)`, mirroring `prune_orphaned_branches` exactly. Docstring corrected (it claimed "prevents deletion of unmerged branches," which was only true when `is_gone` was also false).
- Two new pin tests in `worktree_pool/review_repro_worktree_git.rs`:
  - `cleanup_merged_branch_keeps_remote_gone_branch_with_unpushed_commits_worktree_git` — the negative case this PR fixes.
  - `cleanup_merged_branch_still_deletes_aged_squash_merged_remote_gone_branch_worktree_git` — proves the new gate still reaps genuinely squash-merged branches, not just silently disabling remote-gone cleanup.

## Test plan
- [x] Both new pin tests pass.
- [x] `cargo nextest run --profile ci` — 5172/5174 (the 2 failures are the pre-existing documented flakes `e2e_dispatch_review_workflow_seam_invariants_1900` / `teardown_leaves_zero_residual_after_full_exercise_1907`, unrelated to this diff).
- [x] `cargo clippy --lib --tests -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [x] Existing tests unmodified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)