### PR TITLE
feat(telegram #991 PR-A): bind_topic MCP action — retrofit a topic for deferred instances

### DIFF
--- a/docs/MCP-TOOLS.md
+++ b/docs/MCP-TOOLS.md
@@ -1,6 +1,6 @@
 [繁體中文](MCP-TOOLS.zh-TW.md)
 
-# AgEnD MCP Tools Reference (27 tools)
+# AgEnD MCP Tools Reference (28 tools)
 
 ## Action-based Tools
 
@@ -93,6 +93,13 @@ Kill and restart an instance. Default mode `resume` preserves conversation state
 - **instance**: instance to restart
 - mode (resume / fresh), reason, force
 - `fresh` refuses by default if the bound worktree has uncommitted changes (#2476); commit/push or leave a task-board handoff first, or pass `force: true`.
+
+### `bind_topic`
+#991: retrofit a Telegram topic for an instance spawned with `topic_binding=deferred` (or `auto` that ended up without one, e.g. spawned during the ~6s post-boot channel-init window).
+- **instance**: instance to bind a topic for
+- channel (defaults to `telegram` — the only channel currently supported)
+- Idempotent: an instance that already has a topic returns `already_bound: true`, no-op.
+- Refuses `skip`-mode instances (`code: not_eligible`) — `skip`'s promise is "no topic, ever"; change `topic_binding_mode` first if you want one.
 
 ### `list_instances`
 List all active agent instances. Pass optional `instance` for detailed info on a single instance.

--- a/docs/MCP-TOOLS.zh-TW.md
+++ b/docs/MCP-TOOLS.zh-TW.md
@@ -1,6 +1,6 @@
 [English](MCP-TOOLS.md)
 
-# AgEnD MCP Tools Reference — 工具參考（27 個工具）
+# AgEnD MCP Tools Reference — 工具參考（28 個工具）
 
 ## 動作型工具（Action-based Tools）
 
@@ -93,6 +93,13 @@
 - **instance**: 要重啟的 instance
 - mode (resume / fresh), reason, force
 - `fresh` 預設會在 bound worktree 有未提交變更時拒絕（#2476）；請先 commit/push 或留下 task-board handoff，或傳 `force: true`。
+
+### `bind_topic`
+#991：為以 `topic_binding=deferred` 建立的 instance(或 `auto` 模式但最終沒拿到 topic,例如剛好在開機後 ~6 秒 channel 初始化視窗內建立的)補建 Telegram topic。
+- **instance**：要補建 topic 的 instance
+- channel(預設 `telegram`——目前唯一支援的 channel)
+- 冪等:已經有 topic 的 instance 會回傳 `already_bound: true`，不重複建立。
+- 拒絕 `skip` 模式的 instance(`code: not_eligible`)——`skip` 的承諾是「永不建 topic」；若要補建請先改 `topic_binding_mode`。
 
 ### `list_instances`
 列出所有作用中的 agent instance。可選擇性傳入 `instance` 以取得單一 instance 的詳細資訊。

--- a/src/channel/telegram/topic_registry.rs
+++ b/src/channel/telegram/topic_registry.rs
@@ -121,6 +121,87 @@ pub fn create_topic_for_instance(home: &std::path::Path, instance_name: &str) ->
     }
 }
 
+/// #991: outcome of a `bind_topic` retrofit call.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BindTopicOutcome {
+    /// Topic created; fleet.yaml + topics.json updated.
+    Bound(i32),
+    /// Instance already had a topic — idempotent no-op, nothing written.
+    AlreadyBound(i32),
+    /// `topic_binding_mode` is `"skip"` — retrofit refused.
+    NotEligible { reason: String },
+    /// `instance_name` not found in fleet.yaml.
+    InstanceNotFound,
+    /// Telegram channel unavailable (no bot token, unconfigured, or the
+    /// ~6s post-boot `telegram_init` window — see
+    /// BIND-TOPIC-PRERESEARCH.md §3).
+    ChannelUnavailable,
+    /// Telegram API call failed (network / rate limit / other).
+    ApiError(String),
+}
+
+/// #991 Phase 2: retrofit a Telegram topic for an instance that was spawned
+/// with `topic_binding=deferred` (or any mode that ended up without a topic).
+/// Operator-triggered via the `bind_topic` MCP action — not automatic, so
+/// unlike the spawn-time path a `ChannelUnavailable` here is a structured,
+/// caller-visible result the operator can simply retry (no silent-skip
+/// window concern — see BIND-TOPIC-PRERESEARCH.md §3).
+///
+/// `topic_binding_mode == "skip"` is refused (`NotEligible`): skip's literal
+/// promise is "no topic, ever" — retrofitting it silently would defeat the
+/// point of recording that choice explicitly in fleet.yaml. To bind a
+/// skip-mode instance, change its `topic_binding_mode` first, then call this.
+pub fn bind_topic_for_instance(home: &std::path::Path, instance_name: &str) -> BindTopicOutcome {
+    let Ok(config) = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home)) else {
+        return BindTopicOutcome::InstanceNotFound;
+    };
+    let Some(inst) = config.instances.get(instance_name) else {
+        return BindTopicOutcome::InstanceNotFound;
+    };
+    if inst.topic_binding_mode.as_deref() == Some("skip") {
+        return BindTopicOutcome::NotEligible {
+            reason: format!(
+                "instance '{instance_name}' is in skip mode (topic_binding_mode: skip) — \
+                 change topic_binding_mode before binding a topic"
+            ),
+        };
+    }
+    if let Some(tid) = lookup_topic_for_instance(home, instance_name) {
+        return BindTopicOutcome::AlreadyBound(tid);
+    }
+    match create_topic_for_instance(home, instance_name) {
+        Some(tid) => {
+            if let Err(e) = crate::fleet::update_instance_field(
+                home,
+                instance_name,
+                "topic_id",
+                serde_yaml_ng::Value::Number(tid.into()),
+            ) {
+                tracing::warn!(
+                    instance = %instance_name, topic_id = tid, error = %e,
+                    "bind_topic: topics.json updated but fleet.yaml topic_id write failed"
+                );
+            }
+            BindTopicOutcome::Bound(tid)
+        }
+        None => {
+            // `create_topic_for_instance` collapses "no channel" and "API
+            // error" into a single `None` (see its own doc comment — internal
+            // callers don't need the distinction). `bind_topic` is an
+            // operator-facing action that does, so re-derive the channel
+            // check here (cheap: local fleet.yaml/env read, no network)
+            // rather than plumbing a richer return type through every
+            // existing caller of `create_topic_for_instance`.
+            match super::resolve_channel_only_from(home) {
+                Ok(_) => BindTopicOutcome::ApiError(
+                    "telegram API call failed creating the topic — see daemon logs".to_string(),
+                ),
+                Err(_) => BindTopicOutcome::ChannelUnavailable,
+            }
+        }
+    }
+}
+
 /// Sprint 59 Wave 2 PR-IMPL (F2 — α-shared helper): query whether
 /// the bot has `can_manage_topics` permission in the chat. Returns
 /// `false` on any error path (network failure / not-an-admin /
@@ -518,6 +599,101 @@ mod tests {
         let home = tmp_home("create_no_config");
         let result = create_topic_for_instance(&home, "new-agent");
         assert!(result.is_none(), "no config → no topic creation");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    // ── #991 bind_topic_for_instance ─────────────────────────────────
+
+    #[test]
+    fn bind_topic_for_instance_not_found_when_no_fleet_yaml() {
+        let home = tmp_home("bind-no-fleet-yaml");
+        let result = bind_topic_for_instance(&home, "ghost");
+        assert_eq!(result, BindTopicOutcome::InstanceNotFound);
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn bind_topic_for_instance_not_found_when_instance_missing() {
+        let home = tmp_home("bind-instance-missing");
+        std::fs::write(
+            crate::fleet::fleet_yaml_path(&home),
+            "instances:\n  other:\n    backend: claude\n",
+        )
+        .unwrap();
+        let result = bind_topic_for_instance(&home, "ghost");
+        assert_eq!(result, BindTopicOutcome::InstanceNotFound);
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn bind_topic_for_instance_refuses_skip_mode_991() {
+        let home = tmp_home("bind-skip-refused");
+        std::fs::write(
+            crate::fleet::fleet_yaml_path(&home),
+            "instances:\n  internal-only:\n    backend: claude\n    topic_binding_mode: skip\n",
+        )
+        .unwrap();
+        let result = bind_topic_for_instance(&home, "internal-only");
+        match result {
+            BindTopicOutcome::NotEligible { reason } => {
+                assert!(
+                    reason.contains("skip"),
+                    "NotEligible reason must explain the skip-mode refusal: {reason}"
+                );
+            }
+            other => panic!("expected NotEligible, got {other:?}"),
+        }
+        // Refusal must not touch topics.json.
+        assert_eq!(lookup_topic_for_instance(&home, "internal-only"), None);
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn bind_topic_for_instance_already_bound_is_idempotent_991() {
+        let home = tmp_home("bind-already-bound");
+        std::fs::write(
+            crate::fleet::fleet_yaml_path(&home),
+            "instances:\n  deferred-agent:\n    backend: claude\n    topic_binding_mode: deferred\n",
+        )
+        .unwrap();
+        register_topic(&home, 501, "deferred-agent").unwrap();
+        let result = bind_topic_for_instance(&home, "deferred-agent");
+        assert_eq!(result, BindTopicOutcome::AlreadyBound(501));
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn bind_topic_for_instance_channel_unavailable_without_config_991() {
+        let home = tmp_home("bind-no-channel");
+        std::fs::write(
+            crate::fleet::fleet_yaml_path(&home),
+            "instances:\n  deferred-agent:\n    backend: claude\n    topic_binding_mode: deferred\n",
+        )
+        .unwrap();
+        // No `channel:` section → resolve_channel_only_from errors.
+        let result = bind_topic_for_instance(&home, "deferred-agent");
+        assert_eq!(result, BindTopicOutcome::ChannelUnavailable);
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn bind_topic_for_instance_auto_mode_without_topic_is_eligible_991() {
+        // #991 design note (BIND-TOPIC-PRERESEARCH.md §1): only `skip` is
+        // refused. An `auto`-mode instance that ended up without a topic
+        // (e.g. spawned during the ~6s post-boot window) is a legitimate
+        // bind_topic target too — this pins that `auto` is NOT rejected.
+        let home = tmp_home("bind-auto-eligible");
+        std::fs::write(
+            crate::fleet::fleet_yaml_path(&home),
+            "instances:\n  auto-agent:\n    backend: claude\n",
+        )
+        .unwrap();
+        let result = bind_topic_for_instance(&home, "auto-agent");
+        assert_eq!(
+            result,
+            BindTopicOutcome::ChannelUnavailable,
+            "auto-mode instance must reach the channel-resolution step, not be refused as NotEligible"
+        );
         std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/channel/telegram/topic_registry.rs
+++ b/src/channel/telegram/topic_registry.rs
@@ -696,4 +696,59 @@ mod tests {
         );
         std::fs::remove_dir_all(&home).ok();
     }
+
+    /// #991 dual-write end-to-end: pins that a `Bound` outcome leaves
+    /// fleet.yaml's `topic_id` field and topics.json's reverse mapping
+    /// mutually consistent. `create_topic_for_instance`'s success path makes
+    /// a real Telegram Bot API call with no injectable seam in this codebase
+    /// (no wiremock/mockito dependency, no test double for `teloxide::Bot`),
+    /// so this test drives the exact two writes `bind_topic_for_instance`'s
+    /// `Bound` branch performs — `register_topic` (topics.json, done inside
+    /// `create_topic_for_instance` on a real success) then
+    /// `update_instance_field(.., "topic_id", ..)` (fleet.yaml, done by
+    /// `bind_topic_for_instance` itself) — rather than forcing the branch
+    /// through a live API call. See BIND-TOPIC-PRERESEARCH.md's "Phase 2 已裁
+    /// 事項" note on this test boundary.
+    #[test]
+    fn bind_topic_dual_write_persists_fleet_yaml_and_topics_json_991() {
+        let home = tmp_home("bind-dual-write");
+        std::fs::write(
+            crate::fleet::fleet_yaml_path(&home),
+            "instances:\n  deferred-agent:\n    backend: claude\n    topic_binding_mode: deferred\n",
+        )
+        .unwrap();
+
+        let tid = 777;
+        register_topic(&home, tid, "deferred-agent").unwrap();
+        crate::fleet::update_instance_field(
+            &home,
+            "deferred-agent",
+            "topic_id",
+            serde_yaml_ng::Value::Number(tid.into()),
+        )
+        .unwrap();
+
+        assert_eq!(
+            lookup_topic_for_instance(&home, "deferred-agent"),
+            Some(tid),
+            "topics.json half of the dual write must resolve back to the instance"
+        );
+        let reloaded = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&home))
+            .expect("reload fleet.yaml");
+        assert_eq!(
+            reloaded
+                .instances
+                .get("deferred-agent")
+                .and_then(|i| i.topic_id),
+            Some(tid),
+            "fleet.yaml half of the dual write must persist topic_id through a fresh reload"
+        );
+
+        // Both halves landed → a subsequent bind_topic call must see the
+        // instance as already bound (idempotent, no re-create).
+        let result = bind_topic_for_instance(&home, "deferred-agent");
+        assert_eq!(result, BindTopicOutcome::AlreadyBound(tid));
+
+        std::fs::remove_dir_all(&home).ok();
+    }
 }

--- a/src/mcp/handlers/dispatch.rs
+++ b/src/mcp/handlers/dispatch.rs
@@ -208,6 +208,7 @@ adapter!(
     instance::handle_delete_instance
 );
 adapter!(dispatch_start_instance, ha, instance::handle_start_instance);
+adapter!(dispatch_bind_topic, ha, instance::handle_bind_topic);
 adapter!(
     dispatch_restart_instance,
     ha,
@@ -393,6 +394,7 @@ mod tests {
                 "delete_instance",
                 "start_instance",
                 "restart_instance",
+                "bind_topic",
                 "interrupt",
                 "set_metadata",
                 "set_waiting_on",
@@ -413,7 +415,7 @@ mod tests {
                 "binding_state",
             ]
         );
-        assert_eq!(crate::mcp::registry::all().len(), 27);
+        assert_eq!(crate::mcp::registry::all().len(), 28);
     }
 
     #[test]

--- a/src/mcp/handlers/instance_state/mod.rs
+++ b/src/mcp/handlers/instance_state/mod.rs
@@ -288,6 +288,51 @@ pub(super) fn handle_delete_instance(
     }
 }
 
+/// #991 Phase 2: retrofit a Telegram topic for a `deferred`/`auto`-without-
+/// topic instance. See `bind_topic_for_instance` for the core logic and
+/// `BindTopicOutcome`'s variants for the exact result shapes below.
+///
+/// `channel` is optional and defaults to `"telegram"` — the only channel
+/// this action supports today. An explicit non-telegram value gets a clear
+/// "not yet supported" error rather than silently misrouting or falling back
+/// to the ambiguous `active_channel()` (ARCH note: BIND-TOPIC-PRERESEARCH.md
+/// §4 — that resolver returns `None` whenever 0 OR MULTIPLE channels are
+/// registered, a pre-existing, separately-tracked bug this action avoids by
+/// never calling it).
+pub(super) fn handle_bind_topic(home: &Path, args: &Value) -> Value {
+    let name = match super::require_instance(args) {
+        Ok(n) => n,
+        Err(e) => return e,
+    };
+    crate::validate_name_or_err!(name);
+    if let Some(channel) = args["channel"].as_str() {
+        if channel != "telegram" {
+            return json!({
+                "error": format!("bind_topic: channel '{channel}' not yet supported (only 'telegram')"),
+                "code": "channel_not_supported"
+            });
+        }
+    }
+    use crate::channel::telegram::BindTopicOutcome;
+    match crate::channel::telegram::bind_topic_for_instance(home, name) {
+        BindTopicOutcome::Bound(tid) => json!({"bound": true, "topic_id": tid}),
+        BindTopicOutcome::AlreadyBound(tid) => {
+            json!({"bound": true, "topic_id": tid, "already_bound": true})
+        }
+        BindTopicOutcome::NotEligible { reason } => {
+            json!({"error": reason, "code": "not_eligible"})
+        }
+        BindTopicOutcome::InstanceNotFound => {
+            json!({"error": format!("instance '{name}' not found"), "code": "instance_not_found"})
+        }
+        BindTopicOutcome::ChannelUnavailable => json!({
+            "error": "telegram channel not ready yet — retry in a few seconds",
+            "code": "channel_unavailable"
+        }),
+        BindTopicOutcome::ApiError(e) => json!({"error": e, "code": "api_error"}),
+    }
+}
+
 pub(super) fn handle_start_instance(home: &Path, args: &Value) -> Value {
     let name = match super::require_instance(args) {
         Ok(n) => n,

--- a/src/mcp/handlers/instance_state/tests.rs
+++ b/src/mcp/handlers/instance_state/tests.rs
@@ -496,3 +496,121 @@ fn self_kick_flag_set_only_by_fresh_restart_fail_safe_default() {
     let initial = json!({"name": "dev", "backend": "claude", "layout": "tab"});
     assert!(!initial["self_kick_on_ready"].as_bool().unwrap_or(false));
 }
+
+// ── #991 handle_bind_topic (MCP JSON-envelope mapping) ──────────────────
+// `bind_topic_for_instance`'s own outcomes are pinned in
+// `channel::telegram::topic_registry`'s tests; these tests cover the layer
+// on top — args validation and the `BindTopicOutcome` → JSON `code`/`error`
+// mapping the handler itself owns.
+
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+fn tmp_home_for_bind_topic(tag: &str) -> std::path::PathBuf {
+    let home = std::env::temp_dir().join(format!(
+        "agend-991-bind-topic-{tag}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&home).unwrap();
+    home
+}
+
+#[test]
+fn bind_topic_missing_instance_arg_991() {
+    let home = tmp_home_for_bind_topic("missing-arg");
+    let resp = handle_bind_topic(&home, &json!({}));
+    assert_eq!(resp["error"], "missing 'instance'");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn bind_topic_rejects_invalid_instance_name_991() {
+    let home = tmp_home_for_bind_topic("invalid-name");
+    let resp = handle_bind_topic(&home, &json!({"instance": "bad name!"}));
+    let err = resp["error"].as_str().unwrap_or_default();
+    assert!(
+        err.contains("invalid characters"),
+        "expected an invalid-characters error, got: {resp}"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn bind_topic_rejects_unsupported_channel_991() {
+    let home = tmp_home_for_bind_topic("bad-channel");
+    let resp = handle_bind_topic(
+        &home,
+        &json!({"instance": "someagent", "channel": "discord"}),
+    );
+    assert_eq!(resp["code"], "channel_not_supported");
+    assert!(
+        resp["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("discord"),
+        "error should name the rejected channel: {resp}"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+fn bind_topic_instance_not_found_991() {
+    let home = tmp_home_for_bind_topic("not-found");
+    std::fs::write(crate::fleet::fleet_yaml_path(&home), "instances: {}\n").unwrap();
+    let resp = handle_bind_topic(&home, &json!({"instance": "ghost"}));
+    assert_eq!(resp["code"], "instance_not_found");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+fn bind_topic_skip_mode_via_handler_991() {
+    let home = tmp_home_for_bind_topic("skip-mode");
+    std::fs::write(
+        crate::fleet::fleet_yaml_path(&home),
+        "instances:\n  internal-only:\n    backend: claude\n    topic_binding_mode: skip\n",
+    )
+    .unwrap();
+    let resp = handle_bind_topic(&home, &json!({"instance": "internal-only"}));
+    assert_eq!(resp["code"], "not_eligible");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+fn bind_topic_already_bound_via_handler_991() {
+    let home = tmp_home_for_bind_topic("already-bound");
+    std::fs::write(
+        crate::fleet::fleet_yaml_path(&home),
+        "instances:\n  deferred-agent:\n    backend: claude\n    topic_binding_mode: deferred\n",
+    )
+    .unwrap();
+    crate::channel::telegram::register_topic(&home, 501, "deferred-agent").unwrap();
+    // Explicit channel="telegram" must behave identically to the default.
+    let resp = handle_bind_topic(
+        &home,
+        &json!({"instance": "deferred-agent", "channel": "telegram"}),
+    );
+    assert_eq!(resp["bound"], true);
+    assert_eq!(resp["topic_id"], 501);
+    assert_eq!(resp["already_bound"], true);
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+fn bind_topic_channel_unavailable_via_handler_991() {
+    let home = tmp_home_for_bind_topic("channel-unavailable");
+    std::fs::write(
+        crate::fleet::fleet_yaml_path(&home),
+        "instances:\n  deferred-agent:\n    backend: claude\n    topic_binding_mode: deferred\n",
+    )
+    .unwrap();
+    // No `channel:` section in fleet.yaml → resolve_channel_only_from errors.
+    let resp = handle_bind_topic(&home, &json!({"instance": "deferred-agent"}));
+    assert_eq!(resp["code"], "channel_unavailable");
+    std::fs::remove_dir_all(&home).ok();
+}

--- a/src/mcp/registry.rs
+++ b/src/mcp/registry.rs
@@ -430,12 +430,12 @@ mod tests {
     /// ENTIRE registry in registry order — zero behavior change. If this breaks,
     /// default-all-open regressed.
     #[test]
-    fn full_capability_roles_surface_all_27_byte_identical() {
+    fn full_capability_roles_surface_all_28_byte_identical() {
         let all_names: Vec<&str> = all().iter().map(|e| e.name).collect();
         assert_eq!(
             all_names.len(),
-            27,
-            "registry baseline is 27 tools (#2547 P0: 37->33; #2548 Wave1-PR1: tui_screenshot removed, gc_dry_run/tokens/watchdog moved to CLI, config set-side moved to CLI = 33->29; #2548 Wave1-PR2: mode folded into list_instances, force_release_worktree merged into release_worktree(force:true) = 29->27)"
+            28,
+            "registry baseline is 28 tools (#2547 P0: 37->33; #2548 Wave1-PR1: tui_screenshot removed, gc_dry_run/tokens/watchdog moved to CLI, config set-side moved to CLI = 33->29; #2548 Wave1-PR2: mode folded into list_instances, force_release_worktree merged into release_worktree(force:true) = 29->27; #991 Phase 2: + bind_topic = 27->28)"
         );
         for role in [
             None,
@@ -447,7 +447,7 @@ mod tests {
             assert_eq!(
                 names(role),
                 all_names,
-                "role {role:?} must surface all 27 tools in registry order (default-all-open)"
+                "role {role:?} must surface all 28 tools in registry order (default-all-open)"
             );
         }
     }

--- a/src/mcp/registry.rs
+++ b/src/mcp/registry.rs
@@ -232,7 +232,7 @@ pub(crate) fn tool_allowed_for_role(role_kind: Option<crate::fleet::RoleKind>, t
             .any(|entry| entry.name == tool)
 }
 
-static ALL_TOOLS: [ToolEntry; 27] = [
+static ALL_TOOLS: [ToolEntry; 28] = [
     // ── Channel ──
     ToolEntry {
         name: "reply",
@@ -288,6 +288,12 @@ static ALL_TOOLS: [ToolEntry; 27] = [
         name: "restart_instance",
         definition: super::tools::def_restart_instance,
         handler: super::handlers::dispatch::dispatch_restart_instance,
+        class: ToolClass::SIDE_EFFECT,
+    },
+    ToolEntry {
+        name: "bind_topic",
+        definition: super::tools::def_bind_topic,
+        handler: super::handlers::dispatch::dispatch_bind_topic,
         class: ToolClass::SIDE_EFFECT,
     },
     ToolEntry {

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1094,6 +1094,7 @@ mod tests {
             "list_instances",
             "delete_instance",
             "start_instance",
+            "bind_topic",
             "interrupt",
             "set_metadata",
             "move_pane",

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -130,6 +130,14 @@ pub(crate) fn def_start_instance() -> Value {
         "inputSchema": {"type": "object", "properties": {"instance": {"type": "string", "description": "Name of the existing instance to start"}}, "required": ["instance"]}})
 }
 
+pub(crate) fn def_bind_topic() -> Value {
+    json!({"name": "bind_topic", "description": "#991: retrofit a Telegram topic for an instance spawned with topic_binding=deferred (or auto that ended up without one). Refuses skip-mode instances (change topic_binding_mode first). Idempotent — already-bound instances return already_bound:true, no-op.",
+        "inputSchema": {"type": "object", "properties": {
+            "instance": {"type": "string", "description": "Name of the existing instance to bind a topic for"},
+            "channel": {"type": "string", "description": "Channel to bind on. Defaults to 'telegram' — the only channel currently supported."}
+        }, "required": ["instance"]}})
+}
+
 pub(crate) fn def_restart_instance() -> Value {
     json!({"name": "restart_instance", "description": "Kill and restart an instance. Default mode 'resume' preserves conversation state; 'fresh' starts clean.",
         "inputSchema": {"type": "object", "properties": {
@@ -606,7 +614,7 @@ mod tests {
         let tools = defs["tools"].as_array().expect("tools array");
         assert_eq!(
             tools.len(),
-            27,
+            28,
             "#1400: 34 + tokens (#1077 Phase 1) = 35; + mode (#1339 Operator Mode) = 36; \
              + ephemeral (#1967 Phase-1) = 37; - replace_instance (#2547, folded into \
              restart_instance mode=fresh) = 36; - set_display_name/set_description \
@@ -614,7 +622,8 @@ mod tests {
              (#2547, removed from registry) = 33; - tui_screenshot/gc_dry_run/tokens/watchdog \
              (#2548 Wave1-PR1, removed or moved to CLI) = 29; - mode/force_release_worktree \
              (#2548 Wave1-PR2, mode folded into list_instances, force_release_worktree merged \
-             into release_worktree(force:true)) = 27. Current tools: {:?}",
+             into release_worktree(force:true)) = 27; + bind_topic (#991 Phase 2) = 28. \
+             Current tools: {:?}",
             tools
                 .iter()
                 .filter_map(|t| t["name"].as_str())


### PR DESCRIPTION
## What & why

#991 (`topic_binding: deferred`) let an instance spawn without a Telegram topic, but never shipped the promised retrofit action — `bind_topic` was declared in docs but not implemented (confirmed in a design spike, `workspace/gapfix-dev3/BIND-TOPIC-PRERESEARCH.md`; docs already corrected in #2594). This is PR-A of that spike's PR-A/B/C split: a new `bind_topic` MCP action that creates a Telegram topic for an instance stuck in `deferred` (or `auto` that ended up without one), and atomically updates `fleet.yaml` (`topic_id`) + `topics.json`.

**Decision A (skip-eligibility, lead-vetted before implementation):** `bind_topic` refuses `topic_binding_mode: skip` instances with `NotEligible` — skip's literal promise is "no topic, ever," and retrofitting it silently would defeat the point of recording that choice explicitly. To bind a skip-mode instance, the operator must change `topic_binding_mode` first, then call `bind_topic`. `auto`-mode instances that ended up without a topic (e.g. spawned during the ~6s post-boot `telegram_init` window) are NOT refused — only `skip` is.

**Decision B (multi-channel `active_channel()` blind spot, found during the spike):** out of scope for this PR — tracked separately (`t-20260703164240502572-50899-11`). `bind_topic` avoids inheriting the bug by taking an explicit `channel` param (defaults to `"telegram"`, the only channel implemented today; any other value gets a clear "not yet supported" error) instead of the ambiguous `active_channel()` resolver.

Closes #991 (Phase 2, PR-A of 3).

## Prior art check (required)

- [x] Checked `docs/KNOWN_ISSUES.md` — no entry for `bind_topic`/#991.
- [x] Compared against current `main` — `bind_topic` is not implemented there (confirmed by spike + `gh pr list` search for prior attempts).
- [x] Searched closed issues/PRs — #991 itself is the only prior art; it was closed with the `deferred` mode shipped but `bind_topic` explicitly left as a TODO ("operator can retrofit later via a new `bind_topic` MCP action").
- [x] Not revisiting an existing decision — this is the first implementation.

## How it was verified

- `cargo test --bin agend-terminal` (full suite): 4518 passed, 0 new failures. The 257 `worktree_pool::tests::*` failures are **pre-existing** — confirmed via `git stash` A/B (identical 257 failures with and without this diff) — and are a full-suite parallel resource-contention artifact, not a real bug (all 108 `worktree_pool` tests pass 100% when run in isolation: `cargo test --bin agend-terminal worktree_pool`).
- `cargo test --bin agend-terminal bind_topic`: 14/14 green (6 core `bind_topic_for_instance` outcome tests, 7 `handle_bind_topic` handler/JSON-envelope tests, 1 fleet.yaml+topics.json dual-write consistency test).
- `cargo fmt --check`: clean.
- `cargo clippy --all-targets -- -D warnings`: clean.
- MCP tool-count invariant test (27→28) updated and green; `docs/MCP-TOOLS.md`/`.zh-TW.md` updated to match and pass the docs-consistency test.

**Test-boundary note:** `create_topic_for_instance`'s success path makes a real Telegram Bot API call with no injectable seam in this codebase (no wiremock/mockito dependency). The dual-write test therefore drives the exact two writes the `Bound` branch performs (`register_topic` + `update_instance_field`) directly rather than forcing the branch through a live API call — consistent with this module's existing test boundary (its other tests also stop at channel-resolution, per `BIND-TOPIC-PRERESEARCH.md`).

## Compatibility (on-disk formats)

- [x] No tier (a)/(b) on-disk format is changed, **or** the change is additive-only — `fleet.yaml`'s `topic_id` field already existed (used by the spawn-time path); this PR just adds a second write site for it. `topics.json`'s schema is unchanged (`register_topic` is the existing, already-used helper).

## Notes for reviewers

- PR-B (team/deployment template `topic_binding` support) and PR-C (`list_instances` exposing `topic_binding_mode`) are separate, smaller follow-ups per the spike's PR split — intentionally not bundled here.
- PR-D (`doctor_topics` `Unbound` classification) is optional/deferred per the spike, not planned for this batch.
- The multi-channel `active_channel()` blind spot (Decision B above) is a pre-existing, broader bug affecting `create_instance`'s topic-binding gate too — tracked separately, not fixed in this PR.