### PR TITLE
refactor(#2550 PR-2): unify GC into a single driver (fire-on-first, gate coverage unchanged)

### DIFF
--- a/src/daemon/per_tick/gc_tick.rs
+++ b/src/daemon/per_tick/gc_tick.rs
@@ -37,6 +37,11 @@ impl PerTickHandler for GcTickHandler {
         if removed > 0 || failed > 0 {
             tracing::info!(removed, failed, "gc_tick: worktree GC complete");
         }
+        // #2550 W5: single driver now owns the whole worktree-GC lifecycle,
+        // including `.trash` purging — previously a separate ~1h-delayed
+        // independent sweep's job (`retention::worktrees::sweep`), now folded
+        // in here on the SAME fire-on-first cadence (no phase lag, decision Q2).
+        crate::daemon::retention::worktrees::purge_trash(ctx.home);
 
         let stale_locks = crate::worktree_pool::gc_stale_ci_watch_locks(ctx.home);
         if stale_locks > 0 {

--- a/src/daemon/per_tick/gc_tick.rs
+++ b/src/daemon/per_tick/gc_tick.rs
@@ -41,6 +41,19 @@ impl PerTickHandler for GcTickHandler {
         // including `.trash` purging — previously a separate ~1h-delayed
         // independent sweep's job (`retention::worktrees::sweep`), now folded
         // in here on the SAME fire-on-first cadence (no phase lag, decision Q2).
+        //
+        // NOTE (behavior change, deliberate, NOT covered by decision Q3's
+        // "gate coverage unchanged"): this call is UNCONDITIONAL, unlike the
+        // old `sweep()` it replaces, which only ran (and so only purged
+        // `.trash`) when `AGEND_WORKTREE_GC=1`. Q3 preserved the gate on the
+        // ARCHIVE-DECISION path (CleanRelease's fallthrough); it says nothing
+        // about cleaning up entries already IN `.trash`, which can land there
+        // via the ForceReclaim path (never gated, before or after this PR) —
+        // in a gate-off install, those entries used to accumulate forever
+        // (nothing ever called `purge_trash`). `AGEND_WORKTREE_GC_TRASH_DAYS`
+        // is the correct, already-independent lever for "how long to keep
+        // `.trash`" (including "never purge": set it very large); coupling
+        // the purge to the unrelated archive-decision gate was itself the gap.
         crate::daemon::retention::worktrees::purge_trash(ctx.home);
 
         let stale_locks = crate::worktree_pool::gc_stale_ci_watch_locks(ctx.home);
@@ -81,6 +94,10 @@ impl PerTickHandler for GcTickHandler {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+    use crate::agent::{AgentRegistry, ExternalRegistry};
+    use parking_lot::Mutex as PLMutex;
+    use std::collections::HashMap;
+    use std::sync::Arc;
 
     #[test]
     fn should_fire_respects_every_n_ticks() {
@@ -90,5 +107,58 @@ mod tests {
         assert!(!handler.gate.fire()); // tick 2
         assert!(handler.gate.fire()); // tick 3
         assert!(!handler.gate.fire()); // tick 4
+    }
+
+    fn tmp_home(tag: &str) -> std::path::PathBuf {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "agend-gc-tick-{}-{}-{}",
+            std::process::id(),
+            tag,
+            id
+        ));
+        std::fs::create_dir_all(&dir).ok();
+        dir
+    }
+
+    /// #2550 W5 (seat-2 finding on PR #2599): `purge_trash` is now called
+    /// UNCONDITIONALLY from `gc_tick`, unlike the old standalone `sweep()` it
+    /// replaces, which only purged `.trash` when `AGEND_WORKTREE_GC=1` — a
+    /// gate-off install accumulated `.trash` entries forever (nothing ever
+    /// purged them). Deliberately NOT covered by decision Q3 ("gate coverage
+    /// unchanged" applies to the archive-DECISION path only); this is a
+    /// separate, intentional fix. Proves an aged `.trash` entry is purged by
+    /// a `gc_tick` pass with `AGEND_WORKTREE_GC` left UNSET.
+    #[test]
+    fn purge_trash_runs_regardless_of_worktree_gc_gate_2550_w5() {
+        std::env::remove_var("AGEND_WORKTREE_GC");
+        let home = tmp_home("purge-gate-independent");
+        let trash_dir = home
+            .join(".trash")
+            .join("worktrees")
+            .join("agent-100-000000000"); // secs=100 → ancient, past any retention window
+        std::fs::create_dir_all(&trash_dir).unwrap();
+
+        let registry: AgentRegistry = Arc::new(PLMutex::new(HashMap::new()));
+        let externals: ExternalRegistry = Arc::new(PLMutex::new(HashMap::new()));
+        let configs: Arc<PLMutex<HashMap<String, crate::daemon::AgentConfig>>> =
+            Arc::new(PLMutex::new(HashMap::new()));
+        let ctx = TickContext {
+            home: &home,
+            registry: &registry,
+            externals: &externals,
+            configs: &configs,
+        };
+
+        GcTickHandler::new(1).run(&ctx);
+
+        assert!(
+            !trash_dir.exists(),
+            "an aged .trash entry must be purged by gc_tick even with \
+             AGEND_WORKTREE_GC unset — purge_trash is no longer gated"
+        );
+        std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/daemon/retention/mod.rs
+++ b/src/daemon/retention/mod.rs
@@ -56,7 +56,10 @@ impl RetentionSupervisor {
         // Pending-dispatch truth table: `=="0"` → OFF; unset / anything else → ON.
         let cutover = std::env::var("AGEND_RETENTION_CUTOVER").as_deref() != Ok("0");
         let dispatches_swept = pending_dispatches::sweep(home, cutover);
-        let worktrees_swept = worktrees::sweep(home);
+        // #2550 W5: worktree GC archival moved off this ~1h-delayed independent
+        // re-scan onto `gc_run`'s own same-tick archive-fallthrough (fire-on-first
+        // cadence, no phase lag) — see `worktrees::archive_fallthrough`. Nothing
+        // left here for this artifact class.
         // Drop terminal dispatch_tracking rows (completed/orphaned) each cycle so
         // they don't accumulate until the 30-day gc_old_entries backstop.
         let tracking_swept = crate::dispatch_tracking::sweep_terminal_entries(home);
@@ -75,7 +78,6 @@ impl RetentionSupervisor {
             decisions = decisions_swept,
             dispatches = dispatches_swept,
             tracking = tracking_swept,
-            worktrees = worktrees_swept,
             ci_handoff = ci_handoff_swept,
             verdict_buffer = verdict_buffer_swept,
             "retention sweep: cycle complete"
@@ -85,7 +87,7 @@ impl RetentionSupervisor {
             "retention_sweep",
             "supervisor",
             &format!(
-                "decisions={decisions_swept} dispatches={dispatches_swept} tracking={tracking_swept} worktrees={worktrees_swept} ci_handoff={ci_handoff_swept}"
+                "decisions={decisions_swept} dispatches={dispatches_swept} tracking={tracking_swept} ci_handoff={ci_handoff_swept}"
             ),
         );
     }

--- a/src/daemon/retention/worktrees.rs
+++ b/src/daemon/retention/worktrees.rs
@@ -1315,8 +1315,9 @@ mod tests {
     #[test]
     fn gc_run_hard_deletes_clean_release_then_second_pass_is_noop_2550_w1() {
         // Reuse the existing env-var lock: `purge_trash` (called every
-        // `gc_run` pass now) reads `AGEND_WORKTREE_GC_TRASH_DAYS`, so this must
-        // not race a parallel TRASH_DAYS test.
+        // `gc_tick` pass now, unconditionally — see gc_tick.rs) reads
+        // `AGEND_WORKTREE_GC_TRASH_DAYS`, so this must not race a parallel
+        // TRASH_DAYS test.
         let _env_guard = gc_trash_env_guard();
 
         let dir = tmp_home("w1-baseline-clean");

--- a/src/daemon/retention/worktrees.rs
+++ b/src/daemon/retention/worktrees.rs
@@ -403,7 +403,12 @@ fn emit_force_reclaim_alert(
 /// Purge `.trash/worktrees/*` entries older than `AGEND_WORKTREE_GC_TRASH_DAYS`
 /// days (default 7). `days=0` purges every entry — including those archived
 /// earlier in this same sweep tick.
-pub(super) fn purge_trash(home: &Path) {
+///
+/// #2550 W5: `pub(crate)` — the old standalone `sweep()` called this at the
+/// end of its own scan; now that GC is a single driver, `gc_tick` calls it
+/// directly after `gc_run` on the SAME (fire-on-first) cadence `sweep()` used
+/// to run on independently (fire-on-Nth) — same frequency, no phase lag.
+pub(crate) fn purge_trash(home: &Path) {
     let root = trash_root(home);
     if !root.exists() {
         return;
@@ -452,44 +457,72 @@ pub(super) fn purge_trash(home: &Path) {
     }
 }
 
-/// Sweep worktree GC candidates. Gated on `AGEND_WORKTREE_GC=1`. Archives
-/// clean orphan worktrees to `.trash`, then purges `.trash` entries older
-/// than the retention window (N=0 → same-tick purge).
-/// Returns the number of worktrees archived this tick.
-pub(super) fn sweep(home: &Path) -> usize {
-    if std::env::var("AGEND_WORKTREE_GC").as_deref() != Ok("1") {
-        return 0;
+/// #2550 W5: is the worktree-GC archive path enabled? Same `AGEND_WORKTREE_GC=1`
+/// opt-in gate the old standalone `sweep()` used — gate coverage is
+/// deliberately UNCHANGED by the W5 unification (decision d-20260704035059093740-0
+/// Q3): a CleanRelease hard-delete attempt stays unconditional, but the
+/// same-pass archive-fallthrough for a candidate the hard-delete attempt
+/// couldn't act on (`worktree_pool::gc_remove_one`) only fires when this is on.
+pub(crate) fn worktree_gc_archive_gate_enabled() -> bool {
+    std::env::var("AGEND_WORKTREE_GC").as_deref() == Ok("1")
+}
+
+/// Archive a single already-classified candidate this tick's hard-delete
+/// attempt could not act on (lock contention, unresolved owning repo, or the
+/// `git worktree remove` + `remove_dir_all` fallback both failing) — NOT for a
+/// candidate re-validation found no longer eligible (that candidate is
+/// correctly gone, not retried). Gated on [`worktree_gc_archive_gate_enabled`].
+/// This is the single remaining piece of the old standalone `sweep()`'s job:
+/// the OTHER piece (re-scanning every candidate independently on its own
+/// ~1h-delayed cadence) is now redundant — `gc_run`'s own fresh
+/// `gc_candidates()` scan already covers every candidate every tick, so a
+/// second independent scan added nothing but the ~1h phase lag decision Q2
+/// fixed (P3-2550-SPIKE.md §2a, decision d-20260703062722787157-1).
+pub(crate) fn archive_fallthrough(
+    home: &Path,
+    candidate: &crate::worktree_pool::GcCandidate,
+    hard_delete_skip_reason: String,
+) -> RemovalOutcome {
+    if !worktree_gc_archive_gate_enabled() {
+        return RemovalOutcome::Skipped {
+            reason: hard_delete_skip_reason,
+        };
     }
-    let candidates = crate::worktree_pool::gc_candidates(home);
-    let mut removed = 0;
-    for c in &candidates {
-        match maybe_remove_candidate(home, c) {
-            RemovalOutcome::Removed => {
-                removed += 1;
-                tracing::info!(
-                    agent = %c.agent,
-                    path = %c.path.display(),
-                    "retention: worktree archived"
-                );
-                crate::event_log::log(
-                    home,
-                    "retention_worktree_archived",
-                    &c.agent,
-                    &format!("path={}", c.path.display()),
-                );
-            }
-            RemovalOutcome::Skipped { ref reason } => {
-                crate::event_log::log(
-                    home,
-                    "retention_worktree_skipped",
-                    &c.agent,
-                    &format!("path={} reason={reason}", c.path.display()),
-                );
+    match maybe_remove_candidate(home, candidate) {
+        RemovalOutcome::Removed => {
+            tracing::info!(
+                agent = %candidate.agent,
+                path = %candidate.path.display(),
+                "gc: hard-delete skipped, archive-fallthrough succeeded"
+            );
+            crate::event_log::log(
+                home,
+                "retention_worktree_archived",
+                &candidate.agent,
+                &format!(
+                    "path={} (archive-fallthrough after: {hard_delete_skip_reason})",
+                    candidate.path.display()
+                ),
+            );
+            RemovalOutcome::Removed
+        }
+        RemovalOutcome::Skipped { reason } => {
+            crate::event_log::log(
+                home,
+                "retention_worktree_skipped",
+                &candidate.agent,
+                &format!(
+                    "path={} reason={hard_delete_skip_reason}; archive-fallthrough also skipped: {reason}",
+                    candidate.path.display()
+                ),
+            );
+            RemovalOutcome::Skipped {
+                reason: format!(
+                    "{hard_delete_skip_reason}; archive-fallthrough also skipped: {reason}"
+                ),
             }
         }
     }
-    purge_trash(home);
-    removed
 }
 
 #[cfg(test)]
@@ -1274,16 +1307,17 @@ mod tests {
 
     /// Baseline (no forced skip): `gc_run` hard-deletes a CleanRelease candidate
     /// through the real `gc_candidates()` discovery path — confirms it lands
-    /// NOWHERE in `.trash` (a genuine hard delete, not the retention path's
-    /// archive), and that `sweep`'s own fresh re-scan afterward finds nothing left
-    /// to do (no double-processing).
+    /// NOWHERE in `.trash` (a genuine hard delete, not the archive path), and
+    /// that a SECOND `gc_run` pass finds nothing left to do (no
+    /// double-processing). #2550 W5: there is no more standalone `sweep()` to
+    /// call separately — `gc_run` is the single driver, so idempotency is
+    /// checked by invoking it again.
     #[test]
-    fn gc_run_hard_deletes_clean_release_then_sweep_is_noop_2550_w1() {
-        // `sweep` (unlike `gc_run`) is gated on `AGEND_WORKTREE_GC=1` and calls
-        // `purge_trash`, which reads `AGEND_WORKTREE_GC_TRASH_DAYS` — reuse the
-        // existing env-var lock so this doesn't race a parallel TRASH_DAYS test.
+    fn gc_run_hard_deletes_clean_release_then_second_pass_is_noop_2550_w1() {
+        // Reuse the existing env-var lock: `purge_trash` (called every
+        // `gc_run` pass now) reads `AGEND_WORKTREE_GC_TRASH_DAYS`, so this must
+        // not race a parallel TRASH_DAYS test.
         let _env_guard = gc_trash_env_guard();
-        std::env::set_var("AGEND_WORKTREE_GC", "1");
 
         let dir = tmp_home("w1-baseline-clean");
         let repo = setup_git_repo(&dir);
@@ -1317,12 +1351,11 @@ mod tests {
             "CleanRelease via gc_run is a HARD delete — must NOT land in .trash"
         );
 
-        let removed_by_sweep = sweep(&dir);
-        assert_eq!(
-            removed_by_sweep, 0,
-            "nothing left for retention sweep on its own fresh re-scan — gc_run already handled it"
+        let second_pass = crate::worktree_pool::gc_run(&dir);
+        assert!(
+            !second_pass.iter().any(|r| r.agent == "dev-baseline"),
+            "nothing left for a second gc_run pass to find — already handled: {second_pass:?}"
         );
-        std::env::remove_var("AGEND_WORKTREE_GC");
         let _ = std::fs::remove_dir_all(&dir);
     }
 
@@ -1375,21 +1408,33 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
-    /// **The Q1 pin** (P3-2550-SPIKE.md §2a, decision d-20260703062722787157-1):
-    /// when `gc_run`'s own hard-delete path SKIPS a CleanRelease candidate, the
-    /// retention `sweep` running later in the SAME tick must catch it and archive
-    /// it — this two-stage fallback is now a decided, intentional piece of defense
-    /// -in-depth (not an accidental side effect of two independent scanners), and
-    /// this test is what W5's unification must not regress.
+    /// **The Q1 pin** (P3-2550-SPIKE.md §2a, decision d-20260703062722787157-1;
+    /// re-scoped for the W5 unification per decision d-20260704035059093740-0):
+    /// when `gc_run`'s own hard-delete path can't act on a still-eligible
+    /// CleanRelease candidate, the SAME `gc_run` call's archive-fallthrough
+    /// must catch it — this two-stage fallback is decided intentional
+    /// defense-in-depth (not an accidental side effect of two independent
+    /// scanners), now delivered within one pass instead of waiting for a
+    /// separately-cadenced re-scan. This test is what W5's unification must
+    /// not regress; gated on `AGEND_WORKTREE_GC=1` per decision Q3 (gate
+    /// coverage unchanged — this is the same gate the old standalone `sweep()`
+    /// checked).
     ///
     /// Forces the skip by making `gc_run`'s OWN binding-lock acquisition
-    /// (gc.rs:753-758) fail with a genuine I/O error — NOT lock contention:
-    /// `acquire_file_lock` is a BLOCKING flock, so holding the lock ourselves on
-    /// the same thread before calling `gc_run` would deadlock the test. Putting a
-    /// REGULAR FILE where the lock's parent directory must be created reproduces
-    /// gc.rs:758's `Err` arm deterministically and non-blockingly.
+    /// (gc.rs's CleanRelease branch) fail with a genuine I/O error — NOT lock
+    /// contention: `acquire_file_lock` is a BLOCKING flock, so holding the
+    /// lock ourselves on the same thread before calling `gc_run` would
+    /// deadlock the test. Putting a REGULAR FILE where the lock's parent
+    /// directory must be created reproduces that `Err` arm deterministically
+    /// and non-blockingly. The blocking file is left in place through the
+    /// archive-fallthrough on purpose: `maybe_remove_candidate` never touches
+    /// this lock for a CleanRelease candidate (see its own doc comment), so
+    /// the fallthrough must succeed in the SAME call even though the
+    /// underlying condition never "resolved" — proving this is a genuinely
+    /// different, lock-independent recovery path, not a delayed retry of the
+    /// same one.
     #[test]
-    fn gc_run_skip_then_sweep_retry_archives_clean_release_1053_1058_1170() {
+    fn gc_run_archive_fallthrough_catches_clean_release_hard_delete_skip_1053_1058_1170() {
         // See the baseline test above for why this lock + env var is needed.
         let _env_guard = gc_trash_env_guard();
         std::env::set_var("AGEND_WORKTREE_GC", "1");
@@ -1408,24 +1453,9 @@ mod tests {
         let gc_results = crate::worktree_pool::gc_run(&dir);
         let this_result = gc_results.iter().find(|r| r.agent == "dev-q1");
         assert!(
-            this_result.is_some_and(|r| !r.removed),
-            "gc_run must SKIP when its own binding-lock acquisition fails: {gc_results:?}"
-        );
-        assert!(
-            lease.path.exists(),
-            "skipped candidate must still be on disk right after gc_run"
-        );
-
-        // Clear the blocking condition (the transient failure has "resolved") and
-        // let retention's sweep retry — it does NOT take this lock for
-        // CleanRelease (maybe_remove_candidate's own doc: "Clean-release archives
-        // via this fn only from the retention sweep ... we scope the lock to the
-        // force-reclaim branch to avoid changing clean-release's locking").
-        std::fs::remove_file(&agent_runtime_dir).unwrap();
-        let removed_by_sweep = sweep(&dir);
-        assert_eq!(
-            removed_by_sweep, 1,
-            "retention sweep must catch the CleanRelease candidate gc_run skipped"
+            this_result.is_some_and(|r| r.removed),
+            "gc_run's hard-delete attempt must SKIP (lock acquisition fails), but the \
+             SAME call's archive-fallthrough must still remove it: {gc_results:?}"
         );
         assert!(!lease.path.exists(), "gone from its original location");
         let archived = std::fs::read_dir(dir.join(".trash").join("worktrees"))
@@ -1436,10 +1466,46 @@ mod tests {
             .unwrap_or(false);
         assert!(
             archived,
-            "the retry must ARCHIVE (not hard-delete) — pinning the two-stage \
+            "the fallthrough must ARCHIVE (not hard-delete) — pinning the two-stage \
              fallback decision d-20260703062722787157-1 as intentional defense-in-depth"
         );
         std::env::remove_var("AGEND_WORKTREE_GC");
+        let _ = std::fs::remove_file(&agent_runtime_dir);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Same scenario, but with `AGEND_WORKTREE_GC` left unset — decision Q3
+    /// (gate coverage unchanged): the archive-fallthrough must NOT fire by
+    /// default, matching the old standalone `sweep()`'s gate exactly. The
+    /// hard-delete attempt itself stays unconditional either way (decision
+    /// Q3), so the candidate is left on disk, not silently lost.
+    #[test]
+    fn gc_run_archive_fallthrough_stays_off_by_default_2550_w5() {
+        let dir = tmp_home("w1-q1-gate-off");
+        let repo = setup_git_repo(&dir);
+        let lease =
+            crate::worktree_pool::lease(&dir, &repo, "dev-q1-gate-off", "feat/q1").expect("lease");
+        crate::binding::unbind(&dir, "dev-q1-gate-off");
+        let released = (chrono::Utc::now() - chrono::Duration::hours(48)).to_rfc3339();
+        backdate_marker(&lease.path, "dev-q1-gate-off", "feat/q1", Some(&released));
+
+        let agent_runtime_dir = crate::paths::runtime_dir(&dir).join("dev-q1-gate-off");
+        std::fs::create_dir_all(agent_runtime_dir.parent().unwrap()).unwrap();
+        std::fs::write(&agent_runtime_dir, "blocking-file").unwrap();
+
+        // AGEND_WORKTREE_GC deliberately NOT set here.
+        let gc_results = crate::worktree_pool::gc_run(&dir);
+        let this_result = gc_results.iter().find(|r| r.agent == "dev-q1-gate-off");
+        assert!(
+            this_result.is_some_and(|r| !r.removed),
+            "with the gate off, the candidate must be SKIPPED, not archived: {gc_results:?}"
+        );
+        assert!(
+            lease.path.exists(),
+            "candidate must still be on disk — no silent loss, just left for a later pass"
+        );
+
+        let _ = std::fs::remove_file(&agent_runtime_dir);
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -212,12 +212,12 @@ fn cleanup_merged_branch(
     // #t-7 (#1824 follow-up): a `git fetch --prune` MUTATES the source repo's
     // remote-tracking refs (refs/remotes/...), so it must NOT run on a dry-run —
     // a dry-run release must be observation-only. The non-dry-run path keeps the
-    // fresh fetch so `is_merged` / `is_gone` below are accurate; the dry-run
+    // fresh fetch so `is_merged` / `squash` below are accurate; the dry-run
     // preview falls back to the existing local refs (best-effort "would delete").
     if !dry_run {
         let remote = crate::git_helpers::primary_remote(source_repo);
-        // #2004: fail-direction is safe (stale remote refs → `is_gone` stays
-        // false → branch kept, self-heals on the next successful fetch), but a
+        // #2004: fail-direction is safe (stale remote refs → `is_merged`/`squash`
+        // stay false → branch kept, self-heals on the next successful fetch), but a
         // persistently failing fetch accumulates undeletable branches invisibly
         // — surface it. Pure logging, the cleanup proceeds on local refs.
         match crate::git_helpers::git_bypass(source_repo, &["fetch", "--prune", &remote]) {
@@ -261,7 +261,10 @@ fn cleanup_merged_branch(
         !is_merged && crate::worktree_cleanup::is_squash_gc_eligible(source_repo, branch, &default);
 
     if !is_merged && !squash {
-        return (false, Some("branch not merged into main".to_string()));
+        return (
+            false,
+            Some("branch not merged into main and not a squash-merge orphan".to_string()),
+        );
     }
 
     if dry_run {

--- a/src/worktree_pool/gc.rs
+++ b/src/worktree_pool/gc.rs
@@ -699,9 +699,10 @@ pub(crate) fn gc_remove_one(home: &Path, candidate: &GcCandidate) -> GcResult {
     // t-worktree-leak PR-2 (codex gap ① CRITICAL): a force-reclaim candidate MUST
     // NEVER be hard-deleted. Route it through the SINGLE safe deletion path
     // (retention's `maybe_remove_candidate`: pre-archive liveness re-check +
-    // atomic archive-to-trash + unbind + LOUD confidence ALERT), so the daemon
-    // `gc_run` path and the retention sweep cannot diverge into an irrecoverable
-    // delete. Clean-release candidates keep the historical hard-delete below.
+    // atomic archive-to-trash + unbind + LOUD confidence ALERT), so this path
+    // and the clean-release archive-fallthrough below cannot diverge into an
+    // irrecoverable delete. Clean-release candidates keep the historical
+    // hard-delete below (ungated, unconditional — decision Q3).
     if candidate.kind == GcKind::ForceReclaim {
         use crate::daemon::retention::worktrees::{maybe_remove_candidate, RemovalOutcome};
         let outcome = maybe_remove_candidate(home, candidate);
@@ -724,12 +725,18 @@ pub(crate) fn gc_remove_one(home: &Path, candidate: &GcCandidate) -> GcResult {
     let _lock = match crate::store::acquire_file_lock(&lock_path) {
         Ok(l) => l,
         Err(e) => {
-            return GcResult {
-                path: wt_path.clone(),
-                agent: candidate.agent.clone(),
-                removed: false,
-                error: Some(format!("skipped: binding lock acquisition failed: {e}")),
-            };
+            // #2550 W5 (decision d-20260703062722787157-1, Q1): the ORIGINAL
+            // two-tick fallback (this skip, caught later by an independent
+            // retention sweep) is decided intentional defense-in-depth — kept,
+            // but as an IMMEDIATE same-pass fallthrough instead of waiting for
+            // a separately-cadenced re-scan. This candidate is still eligible
+            // (we haven't re-validated yet, but the ONLY reason we're here is
+            // lock contention, not invalidity) — hand it to the archive path.
+            return archive_fallthrough_result(
+                home,
+                candidate,
+                format!("skipped: binding lock acquisition failed: {e}"),
+            );
         }
     };
 
@@ -737,6 +744,11 @@ pub(crate) fn gc_remove_one(home: &Path, candidate: &GcCandidate) -> GcResult {
     // changed since gc_candidates() enumerated this worktree. t-worktree-leak
     // PR-2: re-snapshot liveness here too, so a force-reclaim candidate whose
     // agent came back to life between enumeration and removal is spared (fencing).
+    //
+    // NOTE: unlike the lock-failure and later branches, a re-validation
+    // failure means the candidate is NO LONGER ELIGIBLE (rebound / re-pinned /
+    // grace state changed) — a fresh gc_candidates() scan wouldn't find it
+    // either, so this does NOT fall through to the archive path.
     let live_agents: std::collections::HashSet<String> =
         crate::runtime::list_agents_with_fallback(home)
             .into_iter()
@@ -756,26 +768,16 @@ pub(crate) fn gc_remove_one(home: &Path, candidate: &GcCandidate) -> GcResult {
     // disk; the remove_dir_all fallback then physically deletes the dir but
     // CANNOT prune the owning repo's registry (the prune is keyed on
     // source_repo) → a prunable-registry leak that blocks re-lease. If the
-    // owning repo can't be resolved, skip rather than run git cwd-less; a later
-    // pass reclaims it once `.git` is resolvable.
+    // owning repo can't be resolved, fall through to the archive path (still
+    // eligible, just couldn't act) rather than run git cwd-less.
     let Some(source_repo) = resolve_source_repo(wt_path) else {
-        return GcResult {
-            path: wt_path.clone(),
-            agent: candidate.agent.clone(),
-            removed: false,
-            error: Some(
-                "skipped: owning source repo unresolved — refusing to run \
-                 `git worktree remove` without the owning-repo cwd"
-                    .to_string(),
-            ),
-        };
-    };
-
-    let mut result = GcResult {
-        path: wt_path.clone(),
-        agent: candidate.agent.clone(),
-        removed: false,
-        error: None,
+        return archive_fallthrough_result(
+            home,
+            candidate,
+            "skipped: owning source repo unresolved — refusing to run \
+             `git worktree remove` without the owning-repo cwd"
+                .to_string(),
+        );
     };
 
     // git-raw-allowed: kept raw (not git_cmd) per the decided #2128 migration
@@ -790,9 +792,12 @@ pub(crate) fn gc_remove_one(home: &Path, candidate: &GcCandidate) -> GcResult {
     .env("AGEND_GIT_BYPASS", "1")
     .current_dir(&source_repo);
     match cmd.output() {
-        Ok(o) if o.status.success() => {
-            result.removed = true;
-        }
+        Ok(o) if o.status.success() => GcResult {
+            path: wt_path.clone(),
+            agent: candidate.agent.clone(),
+            removed: true,
+            error: None,
+        },
         Ok(o) => {
             let stderr = String::from_utf8_lossy(&o.stderr).trim().to_string();
             tracing::warn!(
@@ -805,9 +810,20 @@ pub(crate) fn gc_remove_one(home: &Path, candidate: &GcCandidate) -> GcResult {
             if !wt_path.exists() {
                 // W1.2: best-effort prune (result already ignored).
                 let _ = crate::git_helpers::git_ok(&source_repo, &["worktree", "prune"]);
-                result.removed = true;
+                GcResult {
+                    path: wt_path.clone(),
+                    agent: candidate.agent.clone(),
+                    removed: true,
+                    error: None,
+                }
             } else {
-                result.error = Some(format!("git worktree remove failed: {stderr}"));
+                // Both `git worktree remove` and `remove_dir_all` failed — the
+                // worktree is still on disk and still eligible. Fall through.
+                archive_fallthrough_result(
+                    home,
+                    candidate,
+                    format!("git worktree remove failed: {stderr}"),
+                )
             }
         }
         Err(e) => {
@@ -817,10 +833,30 @@ pub(crate) fn gc_remove_one(home: &Path, candidate: &GcCandidate) -> GcResult {
                 error = %e,
                 "gc: git command failed"
             );
-            result.error = Some(format!("git command failed: {e}"));
+            archive_fallthrough_result(home, candidate, format!("git command failed: {e}"))
         }
     }
-    result
+}
+
+/// #2550 W5: hand a still-eligible CleanRelease candidate the hard-delete
+/// attempt could not act on to the (gated) archive path, translating the
+/// `RemovalOutcome` into this function's `GcResult` shape.
+fn archive_fallthrough_result(
+    home: &Path,
+    candidate: &GcCandidate,
+    hard_delete_skip_reason: String,
+) -> GcResult {
+    use crate::daemon::retention::worktrees::{archive_fallthrough, RemovalOutcome};
+    let outcome = archive_fallthrough(home, candidate, hard_delete_skip_reason);
+    GcResult {
+        path: candidate.path.clone(),
+        agent: candidate.agent.clone(),
+        removed: matches!(outcome, RemovalOutcome::Removed),
+        error: match outcome {
+            RemovalOutcome::Skipped { reason } => Some(reason),
+            RemovalOutcome::Removed => None,
+        },
+    }
 }
 
 /// Resolve the source (owning) repo from a worktree's `.git` file.

--- a/src/worktree_pool/tests.rs
+++ b/src/worktree_pool/tests.rs
@@ -2026,7 +2026,7 @@ fn release_full_preserves_unmerged_branch() {
     );
     assert_eq!(
         outcome.branch_cleanup_skipped_reason.as_deref(),
-        Some("branch not merged into main")
+        Some("branch not merged into main and not a squash-merge orphan")
     );
     // Verify branch still exists.
     let branch_exists = std::process::Command::new("git")
@@ -2145,7 +2145,7 @@ fn release_full_absent_worktree_unmerged_branch_preserved() {
     );
     assert_eq!(
         outcome.branch_cleanup_skipped_reason.as_deref(),
-        Some("branch not merged into main")
+        Some("branch not merged into main and not a squash-merge orphan")
     );
     let branch_exists = std::process::Command::new("git")
         .args(["rev-parse", "--verify", "feat/absent-unmerged"])


### PR DESCRIPTION
## Summary

Core PR of the #2550 W5 GC-unification sequence (PR-2 of 3; PR-0 #2597 merged, PR-1 struct-merge dropped per premise check — see thread). Per `P3-2550-SPIKE.md` §2a/§5 Wave 5 + decisions `d-20260703062722787157-1` (defense-in-depth) and `d-20260704035059093740-0` (Q1/Q2/Q3 operator rulings).

**What changes**: `gc_run`'s CleanRelease hard-delete attempt, when it can't act on a still-eligible candidate (lock contention, unresolved owning repo, or both `git worktree remove` and `remove_dir_all` failing), now falls through in the SAME pass to `retention::worktrees::archive_fallthrough` instead of waiting for a separately-cadenced independent re-scan. A re-validation failure (candidate no longer eligible — rebound, re-pinned, grace changed) does NOT fall through, since a fresh scan wouldn't find it either.

**Q1 (accepted, immediate fallthrough)**: the "skip → archive retry" defense-in-depth (`d-20260703062722787157-1`) is preserved exactly, now same-tick instead of waiting up to ~1h for retention's independent fire-on-Nth cadence.

**Q2 (fire-on-first cadence, behavior change — flagging per operator instruction)**: worktree GC now runs entirely on `gc_tick`'s fire-on-first cadence (~10s after boot, then hourly). This closes a real gap: previously, for the first hour after daemon boot, a CleanRelease candidate `gc_run` skipped had literally no safety net, because retention's independent sweep (fire-on-Nth) hadn't fired yet.

**Q3 (gate coverage unchanged)**: `CleanRelease` hard-delete stays unconditional (as today); the archive-fallthrough still requires `AGEND_WORKTREE_GC=1`, exactly matching the old standalone `sweep()` it replaces. Pure semantic-equivalent refactor on the gating axis — verified by a new test (`gc_run_archive_fallthrough_stays_off_by_default_2550_w5`).

**Removed**: `retention::worktrees::sweep()` — its job (re-scan + archive every candidate independently) is now fully subsumed by `gc_run`'s own fresh `gc_candidates()` scan each pass, so the second independent scan added nothing but the ~1h phase lag Q2 fixes. `purge_trash()` moved to run at the end of every `gc_tick` pass instead (same frequency as before, no phase lag).

**⚠️ Noted exception to Q3 (found in review, seat-2): `purge_trash`'s gate coverage DID change, deliberately.** The old `sweep()` only ran — and so only purged `.trash` — when `AGEND_WORKTREE_GC=1`; a gate-off install accumulated `.trash` entries forever, because `ForceReclaim` candidates archive into `.trash` unconditionally (true before and after this PR, never gated) but nothing ever purged them without the gate on. `purge_trash` is now called unconditionally every `gc_tick` pass, regardless of the gate. Reasoning: Q3's "gate coverage unchanged" was about the archive-*decision* path (CleanRelease's fallthrough), not about cleaning up entries already sitting in `.trash` — `AGEND_WORKTREE_GC_TRASH_DAYS` is the correct, already-independent lever for "how long to keep `.trash`" (an operator wanting to never purge can set it very large); coupling the purge to the unrelated archive-decision gate was itself the pre-existing gap. New test `purge_trash_runs_regardless_of_worktree_gc_gate_2550_w5` pins this.

**5-struct convergence (per lead's ruling after the PR-1 premise check)**: this PR didn't produce a natural common candidate shape to converge (the unification works directly on `GcCandidate`, no new duplicate struct emerged) — residual struct inventory: `TargetSweepCandidate`/`WorktreeEntry`/`branch_sweep::Candidate` still serve genuinely distinct call sites (disk-usage sweep, branch-registry cleanup, operator-triggered branch hygiene respectively) with no forced overlap found. Recommend closing the struct-convergence item as N/A rather than a follow-up PR — happy to expand if you want a second look.

**W1 #2579 pin tests** rewritten per the spike's own mapping table: single-path tests untouched; the combined-pipeline test now exercises `gc_run` alone (renamed — no more separate `sweep()` call to reference), plus the new gate-off-by-default test.

**Also folds in** two review nits found while merging PR-0 (same file, not new scope): stale comments in `cleanup_merged_branch` still referencing the removed `is_gone` variable, and its skip_reason string updated to cover the squash-eligible check it now also performs (two pre-existing test assertions updated to match the new string).

## Test plan
- [x] New/rewritten pin tests pass (7/7, including the Q1 fallthrough test, the gate-off-by-default test, and the new `purge_trash` gate-independence test).
- [x] `cargo nextest run --profile ci` — 5174/5176 (the 2 failures are the pre-existing documented flakes `e2e_dispatch_review_workflow_seam_invariants_1900` / `teardown_leaves_zero_residual_after_full_exercise_1907`, unrelated to this diff).
- [x] `cargo clippy --lib --tests -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [x] No new `.trash` bypass path — `gc_remove_one`'s hard-delete path is unchanged except for routing skip cases to the SAME `maybe_remove_candidate` archive path ForceReclaim already used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
