### PR TITLE
test(#2550): fix env-var race in gc_run_archive_fallthrough_stays_off_by_default_2550_w5

### DIFF
--- a/src/daemon/per_tick/gc_tick.rs
+++ b/src/daemon/per_tick/gc_tick.rs
@@ -130,10 +130,15 @@ mod tests {
     /// purged them). Deliberately NOT covered by decision Q3 ("gate coverage
     /// unchanged" applies to the archive-DECISION path only); this is a
     /// separate, intentional fix. Proves an aged `.trash` entry is purged by
-    /// a `gc_tick` pass with `AGEND_WORKTREE_GC` left UNSET.
+    /// a `gc_tick` pass regardless of `AGEND_WORKTREE_GC` — deliberately does
+    /// NOT touch that process-global env var itself (would race
+    /// `retention::worktrees`'s own gate tests under plain multi-threaded
+    /// `cargo test`, across a private per-file mutex nextest doesn't need but
+    /// plain `cargo test` would): this test's `home` has zero GC candidates,
+    /// so `gc_run` never even reaches the gate check either way — only
+    /// `purge_trash`'s own unconditional call is under test here.
     #[test]
     fn purge_trash_runs_regardless_of_worktree_gc_gate_2550_w5() {
-        std::env::remove_var("AGEND_WORKTREE_GC");
         let home = tmp_home("purge-gate-independent");
         let trash_dir = home
             .join(".trash")

--- a/src/daemon/retention/worktrees.rs
+++ b/src/daemon/retention/worktrees.rs
@@ -1482,6 +1482,12 @@ mod tests {
     /// Q3), so the candidate is left on disk, not silently lost.
     #[test]
     fn gc_run_archive_fallthrough_stays_off_by_default_2550_w5() {
+        // reviewer3 (#2599): without this guard, plain multi-threaded `cargo
+        // test` races this test's "AGEND_WORKTREE_GC unset" assumption against
+        // the gate-ON test above setting the same process-global env var —
+        // nextest isolates env vars per test process so it never saw this,
+        // but plain `cargo test` flaked 3/3.
+        let _env_guard = gc_trash_env_guard();
         let dir = tmp_home("w1-q1-gate-off");
         let repo = setup_git_repo(&dir);
         let lease =


### PR DESCRIPTION
## Summary

Fixes t-20260704052055927704-67777-2 (reviewer3, found reviewing #2599, low priority, non-blocking).

The new gate-off pin test from PR #2599 was missing the `gc_trash_env_guard()` its sibling tests use to serialize access to the process-global `AGEND_WORKTREE_GC` env var. Under plain multi-threaded `cargo test` it could race a concurrent test that temporarily sets `AGEND_WORKTREE_GC=1`, reading the wrong value mid-test and failing this gate-off assertion. Reproduced 3/3 under plain `cargo test`; `cargo nextest run` (this repo's actual CI method) isolates env vars per test process and was structurally immune, which is why CI never saw it.

Also drops an unnecessary `remove_var` call from the `gc_tick.rs` `purge_trash` test added in the same PR — that test's `home` has zero GC candidates, so `gc_run` never reaches the gate check either way, and the call would have raced the same env var across files for no benefit.

## Test plan
- [x] 5x plain `cargo test --bin agend-terminal daemon::retention::worktrees::tests::` — all green (was 3/3 failing before this fix).
- [x] `cargo nextest run --profile ci` on the affected suites — clean.
- [x] `cargo clippy --lib --tests -- -D warnings` clean.
- [x] `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)