### PR TITLE
fix(daemon): stop ci-ready renudge orphaning + fix inbox=N mislabeling (#26795)

### DIFF
--- a/src/daemon/handoff_timeout_watchdog.rs
+++ b/src/daemon/handoff_timeout_watchdog.rs
@@ -41,6 +41,40 @@ const FALLBACK_RECIPIENT: &str = "lead";
 /// Inbox kind of a CI handoff message.
 const HANDOFF_KIND: &str = "ci-ready-for-action";
 
+/// #26795: if `correlation`'s (`owner/repo@branch`) PR is already known to be
+/// merge-blocked (REJECTED verdict or Draft) per the CACHED `pr_state`
+/// snapshot, resolve its `ci_handoff_track` entry and report `true`. Read-only
+/// from `ci_watch`'s perspective — this never touches the watch registry or
+/// makes a GitHub call, only reads whatever `pr_state::record_verdict` last
+/// wrote when a reviewer's report was processed. Returns `false` (no-op) if
+/// no `pr_state` file exists yet for this correlation, or its verdict isn't
+/// blocking.
+fn resolve_if_merge_blocked(home: &Path, correlation: &str) -> bool {
+    let Some((repo, branch)) = correlation.split_once('@') else {
+        return false;
+    };
+    let blocked = crate::daemon::pr_state::with_pr_state(home, repo, branch, |s| {
+        crate::daemon::pr_state::is_ci_ready_merge_blocked(s)
+    })
+    .ok()
+    .flatten()
+    .unwrap_or(false);
+    if blocked {
+        tracing::info!(
+            tag = "#26795-track-merge-blocked",
+            %correlation,
+            "ci-handoff track resolved — pr_state cache shows REJECTED/Draft; \
+             re-nudging further would be pure noise"
+        );
+        crate::daemon::ci_handoff_track::resolve_by_correlation(
+            home,
+            correlation,
+            "pr_merge_blocked_inline",
+        );
+    }
+    blocked
+}
+
 /// Scan every fleet instance for `ci-ready-for-action` handoffs it received but
 /// never read; (1) #1859: RE-NUDGE the target itself (daemon-side redelivery) and
 /// (2) escalate timed-out ones to the target's team lead. `last_escalated` /
@@ -119,6 +153,22 @@ pub(crate) fn scan_and_emit_with<F>(
             let corr = track.correlation.clone();
             let key = (target.clone(), corr.clone());
             active.insert(key.clone());
+
+            // #26795: a PR already known to be merge-blocked (REJECTED verdict /
+            // Draft) is unactionable by the target no matter how many times we
+            // re-nudge — resolve right here instead of relying on the SEPARATE
+            // `pr_state::scanner` tick to (maybe) reach the same conclusion.
+            // That tick's own resolve path, like `resolve_head_advanced` below,
+            // depends on an active `ci_watch` continuing to refresh state for
+            // this branch; once polling stops (superseded / no active watch —
+            // the exact orphan-track class this fixes), neither ever fires
+            // again except the 24h backstop. This check reads the CACHED
+            // `pr_state` snapshot instead — written the moment a reviewer's
+            // report is processed (`pr_state::record_verdict`), independent of
+            // `ci_watch` state entirely. No GitHub call, no new dependency.
+            if resolve_if_merge_blocked(home, &corr) {
+                continue;
+            }
 
             // (1) #1859 Fix A: daemon-side RE-NUDGE of the target itself. The
             // poller's actionable `[ci-ready-for-action]` wake can be deferred
@@ -738,6 +788,86 @@ mod tests {
         assert_eq!(
             count, 1,
             "2 unread handoffs for one idle target must collapse to a single re-nudge: {nudged:?}"
+        );
+        std::fs::remove_dir_all(home).ok();
+    }
+
+    /// Write a `pr_state` file with `verdict_state = Rejected` for `repo@branch`
+    /// — mirrors what `pr_state::mod::record_verdict` writes the moment a
+    /// reviewer's REJECTED report is processed, independent of whether any
+    /// `ci_watch` is currently active for that branch (the write itself doesn't
+    /// touch the watch registry at all).
+    fn seed_rejected_pr_state(home: &Path, repo: &str, branch: &str, head_sha: &str) {
+        use crate::daemon::pr_state::{
+            CiState, DraftState, MergeState, PrState, ReviewClass, VerdictState,
+        };
+        let now = chrono::Utc::now().to_rfc3339();
+        crate::daemon::pr_state::with_pr_state_or_create(
+            home,
+            repo,
+            branch,
+            || PrState {
+                repo: repo.to_string(),
+                pr_number: 1,
+                branch: branch.to_string(),
+                head_sha: head_sha.to_string(),
+                pr_author: "dev".to_string(),
+                subscribers: vec!["reviewer".to_string()],
+                ci_state: CiState::Pending,
+                verdict_state: VerdictState::None,
+                merge_state: MergeState::NotReady,
+                draft_state: DraftState::Ready,
+                review_class: ReviewClass::Single,
+                ready_emitted_for_sha: None,
+                auto_armed: false,
+                auto_armed_for_sha: None,
+                auto_armed_at: None,
+                last_gh_poll_at: None,
+                gh_poll_failures: 0,
+                last_gh_state: None,
+                closed_unmerged_pending: false,
+                created_at: now.clone(),
+                updated_at: now,
+            },
+            |s| {
+                s.verdict_state = VerdictState::Rejected {
+                    reviewer: "reviewer".to_string(),
+                    reviewed_head: head_sha.to_string(),
+                    reason: None,
+                };
+            },
+        )
+        .unwrap();
+    }
+
+    /// #26795 RED baseline (Phase 1 RCA — REJECTED-head orphan track class):
+    /// a `ci-ready-for-action` track whose PR was REJECTED (verdict already
+    /// recorded in the pr_state cache, independent of any active `ci_watch`)
+    /// must not keep re-nudging — the outcome is already known and unactionable
+    /// by the target. Pre-fix, the watchdog has no idea the PR is
+    /// merge-blocked (it only scans `ci_handoff_track`, never cross-checks
+    /// `pr_state`), so this currently FAILS (renudge fires anyway) — this is
+    /// the RED baseline; the fix makes it pass without touching the
+    /// `RENUDGE_AFTER_MINS`/`RENUDGE_INTERVAL_MINS` gating itself.
+    #[test]
+    fn renudge_skips_when_pr_state_shows_merge_blocked() {
+        let home = tmp_home("merge-blocked");
+        write_fleet(&home);
+        seed_handoff(&home, "reviewer", "o/r@feat", 15, false);
+        seed_snapshot(&home, "reviewer", "idle");
+        seed_rejected_pr_state(&home, "o/r", "feat", "sha-A");
+
+        let nudged = run_watchdog(
+            &home,
+            &chrono::Utc::now(),
+            &mut HashMap::new(),
+            &mut HashMap::new(),
+        );
+        assert!(
+            !nudged.contains(&"reviewer".to_string()),
+            "a REJECTED (merge-blocked) PR's ci-ready handoff must not keep \
+             re-nudging — the pr_state cache already shows the outcome, \
+             independent of ci_watch state: {nudged:?}"
         );
         std::fs::remove_dir_all(home).ok();
     }

--- a/src/inbox/notify.rs
+++ b/src/inbox/notify.rs
@@ -519,13 +519,38 @@ pub(crate) fn renudge_actionable_unread(
     home: &Path,
     target: &str,
     kind: &str,
-    unread_count: usize,
+    pending_count: usize,
 ) {
     let now_field = operator_now_field();
-    let pointer = build_pending_pointer("renudge", kind, "system:ci", unread_count, &now_field);
+    let pointer = build_renudge_pointer("renudge", kind, "system:ci", pending_count, &now_field);
     if let Err(e) = inject_with_submit(home, target, &pointer) {
         tracing::debug!(%target, error = %e, "renudge_actionable_unread: inject failed");
     }
+}
+
+/// #26795: renudge-specific pointer — same shape as [`build_pending_pointer`]
+/// but labels the count honestly as `pending_handoffs`, not `inbox`. The
+/// renudge pointer's count is the target's pending `ci_handoff_track`
+/// entries; nothing is ever enqueued to the inbox for this (see
+/// `renudge_actionable_unread`'s doc comment above), so the shared
+/// formatter's `inbox={N}` + `(use inbox tool)` wording sent the receiving
+/// agent to `inbox drain` looking for a message that was never there.
+fn build_renudge_pointer(
+    id: &str,
+    kind: &str,
+    from_short: &str,
+    pending_count: usize,
+    now_field: &str,
+) -> String {
+    format!(
+        "{} id={} kind={} from={} pending_handoffs={} {} (use `ci action=status` to check)",
+        PENDING_HEADER_PREFIX,
+        sanitize_header_value(id),
+        sanitize_header_value(kind),
+        sanitize_header_value(from_short),
+        pending_count,
+        now_field,
+    )
 }
 
 /// #1335: convenience wrapper for the common daemon notification pattern:
@@ -1011,6 +1036,30 @@ mod actionable_wake_tests {
             1,
             NOW
         )));
+    }
+
+    /// #26795: the renudge pointer must not claim `inbox=N` — nothing is ever
+    /// enqueued to the inbox for a renudge (see `renudge_actionable_unread`),
+    /// so that field was sending agents to `inbox drain` looking for a
+    /// message that was never there. Still recognized as an actionable wake
+    /// (same `kind=ci-ready-for-action ` match `notification_is_actionable_
+    /// wake` uses) since the underlying handoff is genuinely actionable.
+    #[test]
+    fn renudge_pointer_does_not_claim_inbox_count() {
+        let pointer =
+            super::build_renudge_pointer("renudge", "ci-ready-for-action", "system:ci", 2, NOW);
+        assert!(
+            !pointer.contains("inbox="),
+            "renudge pointer must not claim an inbox count: {pointer}"
+        );
+        assert!(
+            pointer.contains("pending_handoffs=2"),
+            "renudge pointer must honestly label the pending-track count: {pointer}"
+        );
+        assert!(
+            is_actionable(&pointer),
+            "a ci-ready-for-action renudge must still be an actionable wake: {pointer}"
+        );
     }
 }
 


### PR DESCRIPTION
## Summary
Phase 2 of the phantom renudge RCA (`PHANTOM-RENUDGE-RCA.md`, task `t-20260622175035095973-26795-10`). Two independent fixes:

**(A) REJECTED/no-active-watch orphan track class** (sample: #2415 — "REJECTED head, `ci action=status` shows `watches:[]`, renudge every ~2min"). Every existing auto-resolver for a `ci_handoff_track` (`resolve_head_advanced`, `pr_state::scanner`'s `pr_merge_blocked` resolve) depends on an active `ci_watch` continuing to poll/re-scan that branch. Once polling stops for a branch (superseded, torn down, or never re-armed after REJECTED), none of them ever run again except the 24h backstop — exactly the "no dismiss path" the task title names.

`resolve_if_merge_blocked` reads the branch's **cached** `pr_state` snapshot directly inside the watchdog's own per-tick scan, before deciding to re-nudge. That snapshot is written by `pr_state::record_verdict` the moment a reviewer's report is processed — independent of `ci_watch` state entirely, no GitHub call. A REJECTED/Draft verdict now self-heals within one watchdog tick (~2 min) instead of waiting on a poll cycle that may never happen again.

Scope: read-only `pr_state` lookup; does not touch `resolve_head_advanced` (still needs live polling for genuine head-advance detection) or the unrelated `poll_reminder`/obligation family (confirmed different root cause in the RCA).

**(B) `inbox=N` mislabeling.** `renudge_actionable_unread` never enqueues anything to the inbox (direct PTY inject via `build_pending_pointer`, shared with the real inbox-pending pointer) — yet its header claimed `inbox={pending_track_count}` and told the agent to "(use inbox tool)", sending them to look for a message that was never there. New `build_renudge_pointer` keeps the same wire shape (still `kind=ci-ready-for-action`, still recognized as an actionable wake) but labels the count honestly as `pending_handoffs` and points at `ci action=status` instead.

## Test plan
- [x] RED-first for (A): `renudge_skips_when_pr_state_shows_merge_blocked` reproduces the orphan-track bug before the fix, passes after
- [x] (B): `renudge_pointer_does_not_claim_inbox_count` pins the new wording and confirms actionable-wake detection is unaffected
- [x] `cargo test --bin agend-terminal daemon::handoff_timeout_watchdog::` — 13 passed
- [x] `cargo test --bin agend-terminal daemon::ci_handoff_track::` — 15 passed
- [x] `cargo test --bin agend-terminal daemon::pr_state::` — 91 passed
- [x] `cargo test --bin agend-terminal inbox::notify::` — 20 passed
- [x] Zero existing tests modified
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo clippy --all-targets --features tray -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)