### PR TITLE
refactor(#2550 PR-3): sweep_from_registry -> own GC-owned 60-tick handler

### DIFF
--- a/src/daemon/per_tick/inbox_maintenance.rs
+++ b/src/daemon/per_tick/inbox_maintenance.rs
@@ -1,12 +1,16 @@
-//! Inbox-maintenance composite: every-60-tick batch of 6 sub-ops gated
+//! Inbox-maintenance composite: every-60-tick batch of sub-ops gated
 //! on a single cadence counter. Extracted verbatim from
 //! `src/daemon/mod.rs:667-728` (pre-T-B3) — sub-ops preserved in the
 //! same order, same call signatures, same gating. The pre-extraction
 //! `static AtomicU64` counter moves onto the struct.
+//!
+//! #2550 W5 PR-3: the `worktree_auto_cleanup` sub-op moved out to its own
+//! [`super::worktree_registry_sweep::WorktreeRegistrySweepHandler`] — it has
+//! nothing to do with inbox maintenance and is semantically GC, but keeps
+//! the SAME 60-tick cadence value (decision Q4: not merged into the 360-tick
+//! GC handler).
 
 use super::{PerTickHandler, TickContext};
-use crate::api::ConfigRegistry;
-use std::path::Path;
 
 pub(crate) struct InboxMaintenanceHandler {
     gate: crate::daemon::cadence_gate::CadenceGate,
@@ -42,48 +46,6 @@ impl PerTickHandler for InboxMaintenanceHandler {
         crate::inbox::reclaim_stale_delivering(ctx.home);
         crate::inbox::check_disk_space(ctx.home);
         crate::daemon::run_task_maintenance(ctx.home);
-        worktree_auto_cleanup(ctx.home, ctx.configs);
-    }
-}
-
-/// Worktree auto-cleanup (runtime registry based): drop branches whose
-/// PRs have merged into main. Logged via `event_log` + tracing on every
-/// removal so operators can audit. Verbatim from the pre-extraction
-/// block at mod.rs:678-717.
-fn worktree_auto_cleanup(home: &Path, configs: &ConfigRegistry) {
-    let cfgs = configs.lock();
-    let config_data: std::collections::HashMap<
-        String,
-        (Option<std::path::PathBuf>, Option<std::path::PathBuf>),
-    > = cfgs
-        .iter()
-        .map(|(name, cfg)| {
-            (
-                name.clone(),
-                (cfg.working_dir.clone(), cfg.worktree_source.clone()),
-            )
-        })
-        .collect();
-    drop(cfgs);
-    let fleet_dirs: Vec<std::path::PathBuf> =
-        crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))
-            .ok()
-            .map(|c| {
-                c.instance_names()
-                    .iter()
-                    .filter_map(|n| c.resolve_instance(n).and_then(|r| r.working_directory))
-                    .collect()
-            })
-            .unwrap_or_default();
-    let cleaned = crate::worktree_cleanup::sweep_from_registry(&config_data, &fleet_dirs);
-    for (branch, path) in &cleaned {
-        crate::event_log::log(
-            home,
-            "worktree_auto_removed",
-            branch,
-            &format!("path={path}, branch merged into main"),
-        );
-        tracing::info!(branch, path, "worktree auto-removed (branch merged)");
     }
 }
 

--- a/src/daemon/per_tick/mod.rs
+++ b/src/daemon/per_tick/mod.rs
@@ -72,6 +72,7 @@ pub(crate) mod thread_dump;
 pub(crate) mod tmp_review_gc;
 pub(crate) mod watchdog;
 pub(crate) mod workspace_boundary_sweep;
+pub(crate) mod worktree_registry_sweep;
 
 pub(crate) use backend_exit_detection::BackendExitDetectionHandler;
 pub(crate) use check_schedules::CheckSchedulesHandler;
@@ -99,6 +100,7 @@ pub(crate) use supervisor_trackers::{
 };
 pub(crate) use thread_dump::ThreadDumpHandler;
 pub(crate) use watchdog::WatchdogHandler;
+pub(crate) use worktree_registry_sweep::WorktreeRegistrySweepHandler;
 
 /// Shared per-tick context. Field types match what the daemon main loop
 /// holds verbatim — the trait is pure relocation, not abstraction. New
@@ -380,6 +382,15 @@ pub(crate) fn build_default_handlers(
         // used to provide for these 4 separately). All four run in app mode
         // too (not allowlisted out) since the live daemon is app-mode.
         Box::new(HourlyGcHandler::new(360)),
+        // #2550 W5 PR-3: worktree-registry auto-cleanup (branches whose PRs
+        // merged into main, via the runtime config registry — a different
+        // mechanism from the marker-based GC candidates above). Extracted
+        // out of InboxMaintenanceHandler (unrelated to inbox concerns,
+        // semantically GC) but kept on its OWN 60-tick cadence — SAME value
+        // as when it lived inside InboxMaintenanceHandler — per decision Q4:
+        // folding it into HourlyGcHandler's 360-tick cadence would regress
+        // its cleanup latency from ~10min to ~1h.
+        Box::new(WorktreeRegistrySweepHandler::new(60)),
         // #1967 Phase-1 (PR1): reap ephemeral workers every ~1min (6 ticks) —
         // removes/terminates terminal, max-wall-TTL-expired (cost guard), or
         // already-dead workers. Runs in app mode too (not allowlisted out); the

--- a/src/daemon/per_tick/worktree_registry_sweep.rs
+++ b/src/daemon/per_tick/worktree_registry_sweep.rs
@@ -1,0 +1,130 @@
+//! #2550 W5 PR-3: worktree-registry auto-cleanup — drops local branches
+//! whose PRs have merged into main, via the runtime config registry (not the
+//! GC-candidate marker walk `worktree_pool::gc.rs` uses). Extracted verbatim
+//! from `inbox_maintenance.rs` (was one of its sub-ops, gated on the SAME
+//! every-60-tick cadence) — this logic has nothing to do with inbox
+//! maintenance and is semantically GC, but per decision Q4
+//! (d-20260704035059093740-0) it keeps its OWN independent 60-tick
+//! `PerTickHandler` registration rather than folding into `HourlyGcHandler`'s
+//! 360-tick cadence: doing so would regress this cleanup's latency from
+//! ~10min to ~1h, a real-world-visible regression the operator did not
+//! approve.
+
+use super::{PerTickHandler, TickContext};
+use crate::api::ConfigRegistry;
+use std::path::Path;
+
+pub(crate) struct WorktreeRegistrySweepHandler {
+    gate: crate::daemon::cadence_gate::CadenceGate,
+}
+
+impl WorktreeRegistrySweepHandler {
+    pub(crate) fn new(every_n_ticks: u64) -> Self {
+        Self {
+            gate: crate::daemon::cadence_gate::CadenceGate::new(every_n_ticks),
+        }
+    }
+}
+
+impl PerTickHandler for WorktreeRegistrySweepHandler {
+    fn name(&self) -> &'static str {
+        "worktree_registry_sweep"
+    }
+
+    fn run(&self, ctx: &TickContext<'_>) {
+        if !self.gate.fire() {
+            return;
+        }
+        worktree_auto_cleanup(ctx.home, ctx.configs);
+    }
+}
+
+/// Worktree auto-cleanup (runtime registry based): drop branches whose
+/// PRs have merged into main. Logged via `event_log` + tracing on every
+/// removal so operators can audit. Verbatim from `inbox_maintenance.rs`
+/// (was verbatim from the pre-extraction block at mod.rs:678-717).
+fn worktree_auto_cleanup(home: &Path, configs: &ConfigRegistry) {
+    let cfgs = configs.lock();
+    let config_data: std::collections::HashMap<
+        String,
+        (Option<std::path::PathBuf>, Option<std::path::PathBuf>),
+    > = cfgs
+        .iter()
+        .map(|(name, cfg)| {
+            (
+                name.clone(),
+                (cfg.working_dir.clone(), cfg.worktree_source.clone()),
+            )
+        })
+        .collect();
+    drop(cfgs);
+    let fleet_dirs: Vec<std::path::PathBuf> =
+        crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))
+            .ok()
+            .map(|c| {
+                c.instance_names()
+                    .iter()
+                    .filter_map(|n| c.resolve_instance(n).and_then(|r| r.working_directory))
+                    .collect()
+            })
+            .unwrap_or_default();
+    let cleaned = crate::worktree_cleanup::sweep_from_registry(&config_data, &fleet_dirs);
+    for (branch, path) in &cleaned {
+        crate::event_log::log(
+            home,
+            "worktree_auto_removed",
+            branch,
+            &format!("path={path}, branch merged into main"),
+        );
+        tracing::info!(branch, path, "worktree auto-removed (branch merged)");
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    /// Cadence predicate test (same pattern as InboxMaintenanceHandler's,
+    /// which this handler's cadence was extracted out of unchanged).
+    #[test]
+    fn fires_on_first_tick_then_every_n() {
+        let h = WorktreeRegistrySweepHandler::new(4);
+        let fires: Vec<bool> = (0..9).map(|_| h.gate.fire()).collect();
+        assert_eq!(
+            fires,
+            vec![true, false, false, false, true, false, false, false, true]
+        );
+    }
+
+    /// Smoke test: `run()` against an empty registry + temp home must
+    /// complete without panic (empty configs, no fleet.yaml).
+    #[test]
+    fn run_is_no_op_on_empty_fixtures() {
+        use crate::agent::{AgentRegistry, ExternalRegistry};
+        use parking_lot::Mutex;
+        use std::collections::HashMap;
+        use std::sync::Arc;
+
+        let tag = std::process::id();
+        let home = std::env::temp_dir().join(format!("agend-worktree-reg-sweep-handler-{tag}"));
+        std::fs::create_dir_all(&home).unwrap();
+
+        let registry: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let externals: ExternalRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let configs = Arc::new(Mutex::new(HashMap::new()));
+        let ctx = TickContext {
+            home: &home,
+            registry: &registry,
+            externals: &externals,
+            configs: &configs,
+        };
+
+        // N=1 forces every call to fire.
+        let h = WorktreeRegistrySweepHandler::new(1);
+        h.run(&ctx);
+        h.run(&ctx);
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+}


### PR DESCRIPTION
## Summary

Last PR of the #2550 W5 GC-unification sequence (PR-0 #2597, PR-2 #2599, test-hygiene #2602, this PR-3). Per `P3-2550-SPIKE.md` §5 Wave 5 + decision Q4 (`d-20260704035059093740-0`).

Moves the worktree-registry auto-cleanup sub-op (drops local branches whose PRs merged into main, via the runtime config registry + `worktree_cleanup::sweep_from_registry` — a different mechanism from the marker-based GC candidates PR-2 touches) out of `InboxMaintenanceHandler` into its own `WorktreeRegistrySweepHandler`. It has nothing to do with inbox maintenance and is semantically GC.

**Per Q4's explicit ruling, this does NOT fold into `HourlyGcHandler`'s 360-tick cadence.** The new handler keeps the exact same 60-tick cadence value it had inside `InboxMaintenanceHandler` — merging it into the hourly cadence would regress this cleanup's latency from ~10min to ~1h, a real operator-visible regression that was evaluated and not approved (see `W5-GC-UNIFY-PRERESEARCH.md` §3).

Extraction is verbatim: function body, doc comments, and logic are unchanged. `inbox_maintenance.rs`'s remaining 4 sub-ops (inbox `sweep_expired`, `reclaim_stale_delivering`, `check_disk_space`, task maintenance) and their cadence are untouched.

## Test plan
- [x] New handler's cadence + smoke tests pass (2/2).
- [x] `cargo nextest run --profile ci` — 5190/5192 (the 2 failures are the pre-existing documented flakes `e2e_dispatch_review_workflow_seam_invariants_1900` / `teardown_leaves_zero_residual_after_full_exercise_1907`, unrelated to this diff).
- [x] `cargo clippy --lib --tests -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [x] Existing `inbox_maintenance` tests and `worktree_cleanup::sweep_from_registry`'s own tests unmodified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)