### PR TITLE
feat(telegram #991 PR-C): list_instances exposes topic_binding_mode

### DIFF
--- a/docs/MCP-TOOLS.md
+++ b/docs/MCP-TOOLS.md
@@ -105,6 +105,7 @@ Kill and restart an instance. Default mode `resume` preserves conversation state
 List all active agent instances. Pass optional `instance` for detailed info on a single instance.
 - **compact by default** (#2475): each row drops the noisy `observed_status.evidence` trail. Pass `verbose: true` (or `include_evidence: true`) to include it.
 - **operator_mode** (#2548): the response also carries a top-level `operator_mode: {mode, delegate_to, delegate_scope}` field — the retired `mode` tool's read side folded in here, so agents can observe operator availability alongside fleet state. Setting the mode stays CLI-only (`agend-terminal mode <active|away|sleep>`).
+- **topic_binding_mode** (#991): each row carries `topic_binding_mode` when the instance was spawned with `topic_binding: skip`/`deferred` — omitted for `auto` (the default), so an operator can grep the fleet for intentionally topic-less agents.
 
 ### `set_metadata`
 Set per-instance display metadata. #2547: merged from the former standalone `set_display_name` / `set_description` tools.

--- a/docs/MCP-TOOLS.zh-TW.md
+++ b/docs/MCP-TOOLS.zh-TW.md
@@ -105,6 +105,7 @@
 列出所有作用中的 agent instance。可選擇性傳入 `instance` 以取得單一 instance 的詳細資訊。
 - 預設為 **compact**（#2475）：每列會移除雜訊較大的 `observed_status.evidence` trail。傳 `verbose: true`（或 `include_evidence: true`）可包含它。
 - **operator_mode**（#2548）：回應也會帶一個頂層的 `operator_mode: {mode, delegate_to, delegate_scope}` 欄位——已退役的 `mode` 工具的讀取端折入這裡，讓 agent 能連同 fleet 狀態一起觀察 operator 的可用性。設定模式仍僅限 CLI（`agend-terminal mode <active|away|sleep>`）。
+- **topic_binding_mode**（#991）：instance 若以 `topic_binding: skip`/`deferred` 建立，每列會帶 `topic_binding_mode` 欄位——`auto`（預設）則省略此欄位，讓 operator 能一次 grep 出刻意不建 topic 的 instance。
 
 ### `set_metadata`
 設定 per-instance 顯示中繼資料。#2547：從原本獨立的 `set_display_name` / `set_description` 工具合併而來。

--- a/src/mcp/handlers/instance_queries.rs
+++ b/src/mcp/handlers/instance_queries.rs
@@ -25,6 +25,12 @@ pub(super) fn handle_list_instances_with_runtime(
     };
     let resp = crate::api::list_response(home, &runtime.registry, &runtime.externals);
     if let Some(agents) = resp["result"]["agents"].as_array() {
+        // #991 PR-C: load fleet.yaml ONCE for the whole batch (not per-agent)
+        // so operators can grep "which agents intentionally have no topic"
+        // via `list_instances` — previously only `describe_instance`
+        // (single-instance) exposed this field.
+        let fleet_config =
+            crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home)).ok();
         let instances: Vec<Value> = agents
             .iter()
             .filter(|a| {
@@ -37,6 +43,15 @@ pub(super) fn handle_list_instances_with_runtime(
                 merge_metadata(home, name, &mut info);
                 if name == instance_name {
                     info["is_self"] = json!(true);
+                }
+                // Omit when unset (auto default) — matches describe_instance's
+                // existing omission convention, not an explicit "auto" value.
+                if let Some(mode) = fleet_config
+                    .as_ref()
+                    .and_then(|c| c.instances.get(name))
+                    .and_then(|i| i.topic_binding_mode.as_ref())
+                {
+                    info["topic_binding_mode"] = json!(mode);
                 }
                 if !include_evidence {
                     strip_observed_evidence(&mut info);
@@ -194,5 +209,95 @@ mod tests {
                 .any(|agent| agent["name"].as_str() == Some("external-one")),
             "runtime registry result should be returned without depending on the API socket: {result}"
         );
+    }
+
+    fn runtime_with_external_one() -> RuntimeContext {
+        RuntimeContext {
+            registry: Arc::new(parking_lot::Mutex::new(HashMap::new())),
+            externals: Arc::new(parking_lot::Mutex::new(HashMap::from([(
+                "external-one".to_string(),
+                crate::agent::ExternalAgentHandle {
+                    backend_command: "codex".to_string(),
+                    pid: 4242,
+                },
+            )]))),
+        }
+    }
+
+    /// #991 PR-C: `list_instances` must expose `topic_binding_mode` (the
+    /// original acceptance criterion literally names `list_instances`, not
+    /// just `describe_instance` — see BIND-TOPIC-PRERESEARCH.md §1) so an
+    /// operator can grep the whole fleet in one call for intentionally
+    /// topic-less agents.
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn list_instances_exposes_topic_binding_mode_991() {
+        let home = std::env::temp_dir().join(format!(
+            "agend-list-topic-binding-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&home).unwrap();
+        std::fs::write(
+            crate::fleet::fleet_yaml_path(&home),
+            "instances:\n  external-one:\n    backend: codex\n    topic_binding_mode: skip\n",
+        )
+        .unwrap();
+        let runtime = runtime_with_external_one();
+
+        let result =
+            handle_list_instances_with_runtime(&home, &json!({}), "caller", Some(&runtime));
+        let instances = result["instances"].as_array().expect("instances array");
+        let agent = instances
+            .iter()
+            .find(|a| a["name"].as_str() == Some("external-one"))
+            .expect("external-one present");
+        assert_eq!(
+            agent["topic_binding_mode"], "skip",
+            "list_instances must surface topic_binding_mode: {agent}"
+        );
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #991 PR-C companion: omitting `topic_binding` in fleet.yaml (the auto
+    /// default) must NOT surface a `topic_binding_mode` key at all — matches
+    /// `describe_instance`'s existing omission convention (not an explicit
+    /// `"auto"` string value).
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn list_instances_omits_topic_binding_mode_when_unset_991() {
+        let home = std::env::temp_dir().join(format!(
+            "agend-list-topic-binding-omit-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&home).unwrap();
+        std::fs::write(
+            crate::fleet::fleet_yaml_path(&home),
+            "instances:\n  external-one:\n    backend: codex\n",
+        )
+        .unwrap();
+        let runtime = runtime_with_external_one();
+
+        let result =
+            handle_list_instances_with_runtime(&home, &json!({}), "caller", Some(&runtime));
+        let instances = result["instances"].as_array().expect("instances array");
+        let agent = instances
+            .iter()
+            .find(|a| a["name"].as_str() == Some("external-one"))
+            .expect("external-one present");
+        assert!(
+            agent.get("topic_binding_mode").is_none(),
+            "unset topic_binding must NOT surface a topic_binding_mode key: {agent}"
+        );
+
+        std::fs::remove_dir_all(&home).ok();
     }
 }


### PR DESCRIPTION
## What & why

#991's original acceptance criteria explicitly names `list_instances`: "`list_instances` exposes the binding mode so operators can grep 'which agents intentionally have no topic'." But only `describe_instance` (single-instance query) ever surfaced `topic_binding_mode` — the real `list_instances` body (`handle_list_instances_with_runtime`) had no knowledge of fleet.yaml's `topic_binding_mode` field at all. This is a literal, word-for-word gap from the original acceptance criteria, flagged during the Phase 1 design spike (`BIND-TOPIC-PRERESEARCH.md` §1) and left for this PR.

This is PR-C of the #991 completion series (PR-A `bind_topic` action merged `a0bf79e6`; PR-B deployment/team template propagation merged `3adace43`).

## Prior art check (required)

- [x] Checked `docs/KNOWN_ISSUES.md` — no entry for this gap.
- [x] Compared against current `main` (`3adace43`) — `list_instances` doesn't expose `topic_binding_mode` there; only `describe_instance` does.
- [x] Searched closed issues/PRs — #991 itself (closed) lists this exact acceptance criterion; this PR completes it.
- [x] Not revisiting an existing decision — first implementation of this sub-scope.

## How it was verified

- New tests, both green:
  - `list_instances_exposes_topic_binding_mode_991` — an instance with `topic_binding_mode: skip` in fleet.yaml surfaces it in the `list_instances` row.
  - `list_instances_omits_topic_binding_mode_when_unset_991` — an instance with no `topic_binding` setting does NOT get a `topic_binding_mode` key at all (matches `describe_instance`'s existing omission convention — not an explicit `"auto"` string).
- `docs_match_registry_tool_set` (the doc-drift guard) still green — this is an output-shape addition, not a new tool/input-schema field, so the guard (which checks tool-section headers + title count) is unaffected.
- `cargo test --workspace --tests --features tray` (exact CI invocation): verified via `git stash` A/B against a **fresh** baseline taken on the same `main` commit — identical 258-failure set with and without this diff (pre-existing, unrelated resource-contention flakes, not caused by this change).
- `cargo fmt --check`: clean.
- `cargo clippy --all-targets --features tray -- -D warnings`: clean.

## Compatibility (on-disk formats)

- [x] No on-disk format changed at all — this reads the existing `topic_binding_mode` fleet.yaml field (already read elsewhere since PR-A) and adds it to an MCP *response* shape, not a stored format.

## Notes for reviewers

- Loads `fleet.yaml` **once** for the whole `list_instances` batch (not per-agent like `describe_instance`'s single-lookup shape) — `list_instances` iterates a potentially large agent list, so a per-row `FleetConfig::load` would be wasteful.
- PR-D (`doctor_topics` `Unbound` classification) is optional per the original preresearch — the lead will decide whether to do it after this lands, per the preresearch's PR split.