### PR TITLE
docs: backend capability matrix — honest per-backend signal/resume/MCP audit

### DIFF
--- a/docs/BACKEND-CAPABILITY-MATRIX.md
+++ b/docs/BACKEND-CAPABILITY-MATRIX.md
@@ -1,0 +1,129 @@
+[繁體中文](BACKEND-CAPABILITY-MATRIX.zh-TW.md)
+
+# Backend Capability Matrix
+
+Every backend runs through the same PTY-orchestration machinery, but the UI each one presents — and how much of that UI agend-terminal can trust — is not uniform. This document records, per `Backend` enum variant, what state-detection signal it actually uses today, whether it exposes context usage, how injection/submit behaves, whether resume works, whether MCP is wired, and its known fragile points.
+
+**Discipline**: every cell here is either backed by a `path:line` code citation (this repo, `main` branch) or explicitly marked **unverified**. No cell is a guess. Where a claim couldn't be confirmed against the source, it says so — an honest gap is worth more than a plausible-sounding fabrication.
+
+## Scope boundary vs. #2413
+
+This matrix documents **current, already-shipped** behavior — what state detection actually consumes in production today, for each backend. It is a snapshot, not a plan.
+
+[#2413](https://github.com/suzuke/agend-terminal/issues/2413) ("Out-of-path API-activity probe to fix false-idle blind spot in pattern-based agent_state") is the **improvement roadmap**: an ongoing empirical effort (the Shadow Observer, see `docs/SHADOW-OBSERVER-QUANT-AGY-2413.md` and its claude/codex siblings under `docs/archived/`) to measure whether additional structured signals — beyond raw PTY-pattern matching — can close the false-idle blind spot backend-by-backend. Where this matrix says "PTY heuristic," #2413's work may already be actively quantifying whether that can be upgraded for that backend. This document doesn't speak to that roadmap or its findings — only to what's true today. Read #2413's own docs for where that effort currently stands.
+
+## Signal-authority ladder (for reference)
+
+`src/daemon/shadow/evidence.rs:65-90` ranks signal authority, highest first: **Hook** (`Confirmed` confidence) → **Stream** (session-log tail, e.g. Kiro's jsonl) → **Screen** (PTY pattern match) → **ProcessHeuristic** → **Inferred**. The per-backend sections below say which rung each backend actually sits on for `agent_state` today — not which rung it could theoretically reach.
+
+## Overview
+
+| Backend | Agent-state signal | Context usage | Submit / inject | Resume | MCP | Fragile-points summary |
+|---|---|---|---|---|---|---|
+| **ClaudeCode** | Hook, `Confirmed` authority — the only backend at the top of the ladder | StatusLine (fleet's custom format only) | Bulk, `submit_key="\r"` | `--continue`, gated by on-disk session check | Yes — explicit `--mcp-config` flag | Best-covered backend; still version-pinned to a specific Claude Code release |
+| **Codex** | Pure PTY/Screen heuristic — no hook | Unavailable | Typed/paced (`typed_inject=true`, #1670) | Hardcoded `resume --last` in spawn args, not via the generic `ResumeMode` abstraction | Yes — per-project `.codex/config.toml` | Most PTY-dependent backend; root fragility is #1670's ratatui input widget |
+| **KiroCli** | PTY/Screen heuristic drives `agent_state`; a separate jsonl tail exists but is Stream-authority only and never promotes | StatusLine | Bulk, `submit_key="\r"`, fixed 50ms pre-submit sleep | `--resume` | Yes — own auto-discovery (`.kiro/settings/mcp.json`) | Only backend needing `redraw_after_resize`; several input-line false-latch guards |
+| **OpenCode** | Pure PTY/Screen heuristic — no hook | Unavailable (footer shows a token/cost string that isn't parsed) | Typed/paced (`typed_inject=true`) | `--continue`; carries an **open** dummy-session-id incident | Yes — `opencode.json` `"mcp"` key | Open: dummy-session wedge (rare "process never exits" variant evades detection) |
+| **Agy** | Hybrid — real hooks exist but only for busy/idle transitions; every finer state (rate-limit, API error, git conflict, permission prompt, ...) is PTY/Screen heuristic | Unavailable | Typed/paced, ~2ms/byte | `--continue` — code comment says "operator-verified," no automated behavior test found | Yes — standard `mcpServers` schema at `.agents/mcp_config.json` | Newest first-class backend (#987, Gemini's successor); hooks were dead once and had to be re-fixed |
+| **Shell** / **Raw(String)** | None — no detection patterns at all; `agent_state` is hardcoded to `Idle` on spawn | Not applicable | Bulk; text still gets written + submitted (not a true no-op), just no backend-specific customization | Not supported — `args_for()` returns empty, so Resume and Fresh spawn identically | None — MCP config is skipped entirely for this backend | Utility tier; no incidents found in CHANGELOG (**unverified** whether that means "never broke" or "never tracked") |
+
+---
+
+## ClaudeCode
+
+**Agent-state signal**: Hook-based, `authority=Hook`, `confidence=Confirmed` — the highest rung on the ladder (`src/daemon/shadow/evidence.rs:65-90,92-109`). `has_state_hooks()` names only `ClaudeCode` and `Agy` (`src/backend.rs:55-76`).
+Unverified: whether the initial ready-gate (`ready_pattern: "bypass permissions|❯"`) ever consults hooks, or is pure screen-pattern like every other backend's ready-gate — no hook-based ready path was found, but this is absence-of-evidence, not a confirmed negative.
+
+**Context usage**: `ContextProvider::StatusLine` via `CLAUDE_CONTEXT_PATTERN` (`src/backend_profile.rs:39-46,86-92`) — but the regex only matches the fleet's custom statusline format (`Ctx Used: N%`). A vanilla Claude Code install renders an inverted "remaining %" string this pattern deliberately does not match — an unimplemented gap, not a bug.
+
+**Submit / inject**: Bulk inject, `submit_key: "\r"`, `typed_inject: false` (inherits `DEFAULTS`, `src/backend.rs:382-399`; pinned by test array at `:1474-1486`) — unlike Codex/OpenCode/Agy, which all use paced typed inject. No pre-send confirm-first gate exists; instead there's a post-hoc, hook-gated delivery-verification watchdog (`src/daemon/inject_delivery.rs:1-20`, 30s window) — which in practice only fires for backends with hooks, i.e. effectively Claude-only.
+
+**Resume**: `ResumeMode::ContinueInCwd { flag: "--continue" }` (`src/backend.rs:405`), gated by on-disk session detection reading `~/.claude/projects/<encoded-cwd>/*.jsonl` (`src/backend.rs:878+`) — auto-downgrades to Fresh when no resumable session exists.
+
+**MCP**: Yes, `fleet_mcp_supported: true`, via an explicit `--mcp-config <workdir>/mcp-config.json` CLI flag injected at spawn (`src/backend.rs:784-799`), written by `configure_claude` (`src/mcp_config.rs:177-201`) — project-local file discovery, not passive `.mcp.json` auto-discovery; global `~/.claude` is never touched.
+
+**Known fragile points**: #468 (anchored dismiss regex against false-positive auto-dismiss from operator text), #996 Phase 1 (trust-dialog keystroke changed from up+up+Enter to bare `\r` after a 37× message-duplication-loop incident), #1001 (related earlier fix), #1944/#1947/#1948 (input-box empty-marker `❯`, verified against real captures — explicitly does not generalize to Codex), #2044 (the inject-delivery watchdog, built after a `/model` picker silently swallowed a dispatch). Pattern set last calibrated against Claude Code `2.1.89` (`src/backend.rs:868`) — a version-drift risk shared by every PTY-pattern-dependent backend.
+
+---
+
+## Codex
+
+**Agent-state signal**: Pure PTY/Screen heuristic — no lifecycle hook. `has_state_hooks()` (`src/backend.rs:74-76`) does not list Codex.
+
+**Context usage**: Unavailable — `context_pattern: None` (`src/backend_profile.rs:365-415`, `codex_profile()`).
+
+**Submit / inject**: `submit_key` defaults to `"\r"`; `typed_inject: true` — paced, per-byte writes, because Codex's ratatui-style input widget cannot reliably accept a bulk write (#1670, full rationale at `src/backend.rs:491-565`, esp. `508-522`; pinning test `codex_uses_paced_inject_and_wake_pointer_is_not_a_system_header_1670` at `:1934-1963`). No confirm-first/readback mechanism beyond the pacing itself was found — **unverified**.
+
+**Resume**: `resume_mode` defaults to `NotSupported` at the `ResumeMode` level, but Codex's actual resume is hardcoded directly into `args`/`fresh_args` as `resume --last` — bypassing the generic `ResumeMode` abstraction every other resumable backend uses. Worth flagging to future maintainers as an inconsistency, not just a quirk.
+
+**MCP**: Yes, `fleet_mcp_supported: true` (default), via a per-project `.codex/config.toml` (not the global `~/.codex/config.toml`) written by `configure_codex_with_home` (`src/mcp_config.rs:677-772`).
+
+**Known fragile points**: #1670 (the paced-inject root cause), #1944/#1948 family (ghost placeholder — an empty input box misread as a real prompt marker), an unnumbered finding at `src/state/mod.rs:2196-2202` (the ready screen can falsely latch `Active` and then stop re-detecting). A user-recalled "Codex PTY injection failure" incident is **unverified** — no ticket matching that exact description was found; the closest candidate is `CHANGELOG.md:237` (#603/PR #629, stdin-only delivery), but that mechanism has no trace left in current `src/` and appears superseded by #1670.
+
+---
+
+## KiroCli
+
+**Agent-state signal**: PTY/Screen heuristic drives the real `agent_state` today (`src/backend_profile.rs:220-273`, `kirocli_profile()`). A separate `~/.kiro/sessions/cli/<uuid>.jsonl` read-only tail exists (`src/daemon/shadow/kiro.rs:1-23`, wired live in production per `src/app/mod.rs:2774-2797`), but the whole Shadow Observer system is explicitly "additive only... never drives `agent_state`" (`src/daemon/shadow/mod.rs:15-16`) — it sits at `Authority::Stream`, below `Authority::Hook`. Kiro has no lifecycle hook at all. Caveat: the jsonl only flushes at tool-round/turn-end (not prompt-submit), so a pure-thinking turn with no tool calls isn't caught mid-turn even by the Stream-authority shadow.
+
+**Context usage**: StatusLine, available — `KIRO_CONTEXT_PATTERN = r"◔\s*(\d+(?:\.\d+)?)\s*%"` (`src/backend_profile.rs:97`). The doc comment at `:38-46` explicitly names Claude and Kiro as the only two `StatusLine` providers.
+
+**Submit / inject**: Bulk, `submit_key: "\r"`, `typed_inject: false` (pinned array, `src/backend.rs:1472-1474`). A fixed 50ms sleep precedes submit (`src/agent/mod.rs:2813-2818`); the `readback_confirm_typed` mechanism (#1912, `:2824-2831`) is gated to `typed_inject` backends only, so Kiro never uses it.
+
+**Resume**: Yes — `ResumeMode::ContinueInCwd { flag: "--resume" }` (`src/backend.rs:457`).
+
+**MCP**: Yes, own auto-discovery — Kiro reads `.kiro/settings/mcp.json` (no explicit CLI flag like Claude's), written by `configure_kiro()` via a wrapper script "because Kiro ignores env block" (`src/mcp_config.rs:321-367`).
+
+**Known fragile points**: #7 (no repaint on `SIGWINCH` — the only backend needing `redraw_after_resize`), #996 Phase 2a (trust-modal defaults to the destructive option; Down+Enter required, verified against fixture byte analysis), #468 (startup-hang dismiss regex), #1005 (completion-banner false-positive guard), #1947 (`>` input-line quote false-latch guard), #1948 (no-prompt-marker placeholder heuristic), #2413 (jsonl observer spike — the Shadow Observer work referenced in the scope-boundary note above). Unverified: whether the #2413 jsonl Stream plane also carries token/context-usage evidence for Kiro specifically — only turn/tool-lifecycle evidence mappings were found.
+
+---
+
+## OpenCode
+
+**Agent-state signal**: Pure PTY/Screen heuristic — no structured signal. `has_state_hooks()` excludes OpenCode (`src/backend.rs:74-76`); everything runs through regex-pattern matching (`src/backend_profile.rs:282-355`).
+
+**Context usage**: Unavailable by explicit code declaration, not merely "not implemented yet." `context_pattern: None` (`src/backend_profile.rs:352`); `src/state/mod.rs:1221-1235` groups Codex/OpenCode/Agy together as having "no trustworthy passive context signal" — the rendered footer does show a token/cost string, but it is not parsed into `context_pct`.
+
+**Submit / inject**: `submit_key` defaults to `"\r"` (not overridden), `inject_prefix: "\r"`, `typed_inject: true` — paced per-byte writes, same rationale documented for Codex (#1670). No confirm-first/readback mechanism found beyond the pacing itself — **unverified**.
+
+**Resume**: `ResumeMode::ContinueInCwd { flag: "--continue" }` (`src/backend.rs:571`). Two distinct, separately-tracked incidents:
+- **#2020 (fixed)**: a resumed pane shows no "Ask anything" placeholder, only bare `┃` statusline lines — this used to be misread as `AwaitingOperator`. Fixed by adding a low-priority `ctrl+p commands` Idle pattern, regression-pinned (`src/backend_profile.rs:330-340,564-598`).
+- **Dummy-session wedge (open, needs-repro)**: documented in `docs/KNOWN_ISSUES.md:24-46` — an upstream OpenCode bug where `--continue` can send a placeholder session id. The common case is mitigated (#1519/#1526, fresh-session fallback), but a rarer "process never exits" variant evades all three detection layers. This is the task-board incident referenced by the dispatch note: `t-20260702144219394508-56872-6` (`docs/KNOWN_ISSUES.md:41`), tracked structurally under #2549.
+
+**MCP**: Yes — project-local `opencode.json` `"mcp"` key discovery, `fleet_mcp_supported: true` (pinned test at `src/backend.rs:1432`), implemented by `configure_opencode` (`src/mcp_config.rs:599-638`), plus an auto-approve permission block so OpenCode's own "Permission required" prompt doesn't block MCP tool calls.
+
+**Known fragile points**: #2020 (closed — resumed-pane false-idle) and the dummy-session wedge above (open, `t-20260702144219394508-56872-6`, #2549). These are two separate bugs that likely get conflated in casual conversation — one is fixed, the other isn't.
+
+---
+
+## Agy
+
+**Agent-state signal**: Hybrid. Real lifecycle hooks exist (`has_state_hooks()` returns true, `src/backend.rs:74-76`) but fire only for busy/idle transitions (`PreInvocation`→`UserPromptSubmit`/`Stop`, `src/mcp_config.rs:470`) — empirically confirmed to carry no tool-call-granularity signal (task-board finding `t-...93090-0`). Every finer state (`Active`, `UsageLimit`, `RateLimit`, `ApiError`, `GitConflict`, `PermissionPrompt`) is pure PTY/Screen heuristic — 8 ordered regexes (`src/backend_profile.rs:129-213`).
+
+**Context usage**: Unavailable — `context_pattern: None` (`src/backend_profile.rs:209`), explicitly grouped with Codex/OpenCode as having "no trustworthy passive context signal" (`src/backend_profile.rs:43-45`).
+
+**Submit / inject**: `typed_inject: true`, `inject_prefix: "\r"`, default `submit_key: "\r"` (`src/backend.rs:608-609`); paced ~2ms/byte chunked writes — the shared rationale doc at `src/backend.rs:519` names Agy explicitly alongside Codex. No confirm-first/readback mechanism found.
+
+**Resume**: `ResumeMode::ContinueInCwd { flag: "--continue" }` (`src/backend.rs:613`) — the code comment says "operator-verified in issue body," but no automated CLI-behavior test was found, only a unit-test pin of the args themselves.
+
+**MCP**: Yes — standard `{command, args, env}` `mcpServers` schema at `<workdir>/.agents/mcp_config.json` (`src/mcp_config.rs:391-436`, `mcp_server_entry` at `:86-99`); `fleet_mcp_supported: true` (`src/backend.rs:641`, test `:1436`). A **stale doc comment** was found at `src/backend.rs:1416-1421` claiming Agy's MCP support is `false`/unsupported — this is outdated and directly contradicted by the actual assertion two lines later. Worth a follow-up doc-comment cleanup, independent of this matrix.
+
+**Known fragile points**: #987 (Agy added), #995 (workspace-trust dismiss + a dead `.antigravitycli/` MCP write path), #1547 (fixed the real MCP path to `.agents/`), #1580 (Gemini retired, Agy is its successor), #1523 / #2413 Phase D (hooks were dead at one point and had to be re-fixed — see the scope-boundary note above), #2236 (quota-wall pattern ordering), #2409 (a transient high-traffic `ApiError` pattern), #2524 P1b-r1/r2 (a missing `GitConflict` pattern; the `RateLimit` pattern is flagged low-confidence/synthetic — not yet verified against real Agy output).
+
+---
+
+## Shell and Raw(String)
+
+**Agent-state signal**: None. No detection patterns exist at all — `agent_state` is hardcoded to `Idle` at spawn, skipping the `Starting → Idle` handshake every other backend goes through (`src/backend_profile.rs:506-520` `empty_profile()`; `src/state/mod.rs:1002-1013`; `src/state/patterns.rs:204`).
+
+**Context usage**: Not applicable — `context_pattern: None`, `ContextProvider::Unavailable` (`src/backend_profile.rs:516,44-46`, test `:541-542`).
+
+**Submit / inject**: All fields fall through to `DEFAULTS` (`submit_key: "\r"`, `inject_prefix: ""`, `typed_inject: false`; `src/backend.rs:382-399,648-656`). Important nuance: inject is **not actually a no-op** — text is genuinely written to the PTY and submitted (`src/agent/mod.rs:2776-2818`). What's a no-op is the *preset customization* (no dismiss pattern, no special prefix, no readback confirm).
+
+**Resume**: Not supported — `resume_mode: ResumeMode::NotSupported` (`src/backend.rs:389`), and `args_for()` returns an empty `Vec` for it (`:275-277`) — so a Resume spawn and a Fresh spawn produce byte-identical (empty) args, effectively a no-op distinction.
+
+**MCP**: None — `mcp_config::configure()` returns immediately for `Backend::Shell | Backend::Raw(_) | None` without calling any `configure_*` function (`src/mcp_config.rs:817-830`); `fleet_mcp_supported: false` (`src/backend.rs:648-654`).
+
+**Known fragile points**: None found in `CHANGELOG.md` or tracked incidents. **Unverified** whether that means Shell genuinely never broke (plausible — it has the least backend-specific code to break) or simply was never worth tracking. One structural note, not a fragility: `Backend::from_command` (`src/backend.rs:663-687`) in practice never returns `Some(Shell)` or `Some(Raw(_))` — it only recognizes known preset binary names, so these two `match` arms are a defensive exhaustive-match; the real runtime path for Shell/Raw is the `None` branch.
+
+**Raw(String)**: Shares the exact same preset arm and `empty_profile()` as Shell (`src/backend.rs:648-656`) — identical behavior. The only difference is `command_string()` (`src/backend.rs:228-229`), which uses the stored path string instead of `$SHELL`.

--- a/docs/BACKEND-CAPABILITY-MATRIX.zh-TW.md
+++ b/docs/BACKEND-CAPABILITY-MATRIX.zh-TW.md
@@ -1,0 +1,129 @@
+[English](BACKEND-CAPABILITY-MATRIX.md)
+
+# Backend 能力矩陣
+
+每個 backend 都跑在同一套 PTY orchestration 機制上，但各自呈現的 UI——以及 agend-terminal 對這個 UI 能信任到什麼程度——並不一致。本文檔針對每個 `Backend` enum 變體，記錄它今天實際使用的 state 偵測訊號、是否曝光 context usage、submit/inject 行為、resume 能不能用、MCP 是否接好，以及已知的脆弱點。
+
+**紀律**：本文每一格結論，要嘛有 `path:line` 程式碼依據（本 repo，`main` branch），要嘛明確標示**未查證**。沒有任何一格是用猜的。查不到依據的地方就老實寫出來——誠實的空白比一個聽起來合理但編造出來的結論更有價值。
+
+## 與 #2413 的分界
+
+本文檔記錄的是**現況**——每個 backend 今天在 production 裡實際依賴的 state 偵測訊號。這是一張快照，不是一份計畫。
+
+[#2413](https://github.com/suzuke/agend-terminal/issues/2413)（「Out-of-path API-activity probe to fix false-idle blind spot in pattern-based agent_state」）才是**改善未來的 roadmap**：這是一項持續進行中的實證研究（Shadow Observer，見 `docs/SHADOW-OBSERVER-QUANT-AGY-2413.md` 及其 claude/codex 對照版本，位於 `docs/archived/` 下），目的是逐 backend 量測「除了原始 PTY pattern 比對之外，加上更多 structured 訊號能不能補上 false-idle 的盲點」。當本文說某個 backend 是「PTY heuristic」時，#2413 那邊的工作可能正在量化評估該 backend 能不能升級——本文不涉及那份 roadmap 或其研究結論，只記錄今天的實況。想了解那份改善工作目前進度如何，請直接讀 #2413 本身的文檔。
+
+## 訊號權威性階梯（參考用）
+
+`src/daemon/shadow/evidence.rs:65-90` 把訊號權威性由高到低排列：**Hook**（`Confirmed` confidence）→ **Stream**（session log tail，例如 Kiro 的 jsonl）→ **Screen**（PTY pattern match）→ **ProcessHeuristic** → **Inferred**。下面各 backend 的小節說明的是它今天在 `agent_state` 上實際站在哪一階——不是它理論上能爬到哪一階。
+
+## 總覽
+
+| Backend | Agent-state 訊號 | Context usage | Submit / inject | Resume | MCP | 脆弱點摘要 |
+|---|---|---|---|---|---|---|
+| **ClaudeCode** | Hook，`Confirmed` authority——唯一站上階梯頂端的 backend | StatusLine（僅限 fleet 自訂格式） | Bulk，`submit_key="\r"` | `--continue`，有 on-disk session 檢查把關 | 有——明確的 `--mcp-config` flag | 覆蓋最完整的 backend；但仍綁定特定 Claude Code 版本 |
+| **Codex** | 純 PTY/Screen heuristic——無 hook | Unavailable | Typed/paced（`typed_inject=true`，#1670） | 硬編在 spawn args 裡的 `resume --last`，未走通用的 `ResumeMode` 抽象 | 有——per-project `.codex/config.toml` | 最依賴 PTY 的 backend；根因脆弱點是 #1670 的 ratatui input widget |
+| **KiroCli** | PTY/Screen heuristic 主導 `agent_state`；另有一條 jsonl tail 但只是 Stream authority，從不 promote | StatusLine | Bulk，`submit_key="\r"`，固定 50ms pre-submit sleep | `--resume` | 有——自己的 auto-discovery（`.kiro/settings/mcp.json`） | 唯一需要 `redraw_after_resize` 的 backend；有數個 input-line 誤鎖 guard |
+| **OpenCode** | 純 PTY/Screen heuristic——無 hook | Unavailable（footer 有 token/cost 字串但沒被解析） | Typed/paced（`typed_inject=true`） | `--continue`；帶一個**未關閉**的 dummy-session-id 事故 | 有——`opencode.json` 的 `"mcp"` 欄位 | 未關閉：dummy-session wedge（罕見的「process 永不退出」變種能躲過偵測） |
+| **Agy** | 混合——真的有 hook，但只涵蓋 busy/idle 轉換；其餘更細的狀態（rate-limit、API error、git conflict、permission prompt……）全靠 PTY/Screen heuristic | Unavailable | Typed/paced，約 2ms/byte | `--continue`——程式碼註解說「operator-verified」，但查無自動化行為測試 | 有——標準 `mcpServers` schema，位於 `.agents/mcp_config.json` | 最新加入的 first-class backend（#987，Gemini 的繼任者）；hooks 曾經失效過，後來才修回來 |
+| **Shell** / **Raw(String)** | 無——完全沒有偵測 pattern；`agent_state` spawn 時就硬鎖 `Idle` | 不適用 | Bulk；文字仍會真的寫入並送出（不是真的 no-op），只是沒有 backend 專屬客製化 | 不支援——`args_for()` 回空，Resume 與 Fresh 產生的 spawn args 完全一樣 | 無——這個 backend 完全跳過 MCP config | Utility 層級；CHANGELOG 查無事故記錄（**未查證**這代表「從沒出過包」還是「沒人記錄」） |
+
+---
+
+## ClaudeCode
+
+**Agent-state 訊號**：Hook-based，`authority=Hook`、`confidence=Confirmed`——階梯最高階（`src/daemon/shadow/evidence.rs:65-90,92-109`）。`has_state_hooks()` 只列出 `ClaudeCode` 與 `Agy`（`src/backend.rs:55-76`）。
+未查證：初始 ready-gate（`ready_pattern: "bypass permissions|❯"`）是否曾經會參考 hook，還是跟其他所有 backend 的 ready-gate 一樣純靠 screen pattern——沒找到任何 hook-based ready 路徑，但這只是「沒找到」，不等於「確認為否」。
+
+**Context usage**：`ContextProvider::StatusLine`，靠 `CLAUDE_CONTEXT_PATTERN`（`src/backend_profile.rs:39-46,86-92`）——但這個 regex 只吃 fleet 自訂 statusline 格式（`Ctx Used: N%`）。原生 Claude Code 裝機顯示的是反向的「剩餘 %」字串，這個 pattern 刻意不吃——這是尚未實作的落差，不是 bug。
+
+**Submit / inject**：Bulk inject，`submit_key: "\r"`，`typed_inject: false`（繼承 `DEFAULTS`，`src/backend.rs:382-399`；測試陣列 `:1474-1486` 有 pin 住）——跟 Codex/OpenCode/Agy 用 paced typed inject 不同。沒有 pre-send confirm-first 閘門；取而代之的是事後、靠 hook 才會觸發的 delivery-verification watchdog（`src/daemon/inject_delivery.rs:1-20`，30 秒視窗）——實務上只有有 hook 的 backend 才會真的觸發，等於只對 Claude 生效。
+
+**Resume**：`ResumeMode::ContinueInCwd { flag: "--continue" }`（`src/backend.rs:405`），靠讀取 `~/.claude/projects/<encoded-cwd>/*.jsonl` 的 on-disk session 偵測把關（`src/backend.rs:878+`）——查無可恢復 session 時自動降級成 Fresh。
+
+**MCP**：有，`fleet_mcp_supported: true`，透過 spawn 時注入的明確 `--mcp-config <workdir>/mcp-config.json` CLI flag（`src/backend.rs:784-799`），由 `configure_claude` 寫入（`src/mcp_config.rs:177-201`）——是 project-local 的檔案發現機制，不是被動的 `.mcp.json` auto-discovery；全域的 `~/.claude` 完全不會被碰。
+
+**已知脆弱點**：#468（針對操作者文字誤觸自動 dismiss 的錨定 dismiss regex）、#996 Phase 1（trust-dialog 按鍵從 up+up+Enter 改成純 `\r`，起因是一次 37 次訊息重複迴圈事故）、#1001（相關的較早修復）、#1944/#1947/#1948（input-box 空白標記 `❯`，已對照真實 capture 驗證——明確不適用於 Codex）、#2044（inject-delivery watchdog，起因是一次 `/model` picker 悄悄吞掉一次 dispatch）。Pattern 集合最後一次校準對象是 Claude Code `2.1.89`（`src/backend.rs:868`）——這是所有依賴 PTY pattern 的 backend 共有的版本漂移風險。
+
+---
+
+## Codex
+
+**Agent-state 訊號**：純 PTY/Screen heuristic——沒有 lifecycle hook。`has_state_hooks()`（`src/backend.rs:74-76`）沒有列出 Codex。
+
+**Context usage**：Unavailable——`context_pattern: None`（`src/backend_profile.rs:365-415`，`codex_profile()`）。
+
+**Submit / inject**：`submit_key` 預設 `"\r"`；`typed_inject: true`——逐 byte paced 寫入，因為 Codex 的 ratatui 風格 input widget 沒辦法可靠地接受 bulk 寫入（#1670，完整理由見 `src/backend.rs:491-565`，尤其 `508-522`；pin 住的測試 `codex_uses_paced_inject_and_wake_pointer_is_not_a_system_header_1670` 在 `:1934-1963`）。除了這個 pacing 之外，查無 confirm-first/readback 機制——**未查證**。
+
+**Resume**：`resume_mode` 在 `ResumeMode` 層級預設是 `NotSupported`，但 Codex 實際的 resume 是硬編在 `args`/`fresh_args` 裡的 `resume --last`——繞過了其他所有支援 resume 的 backend 都在用的通用 `ResumeMode` 抽象。這點值得提醒未來的維護者這是個不一致之處，不只是個小怪癖。
+
+**MCP**：有，`fleet_mcp_supported: true`（預設值），透過 per-project 的 `.codex/config.toml`（不是全域的 `~/.codex/config.toml`），由 `configure_codex_with_home` 寫入（`src/mcp_config.rs:677-772`）。
+
+**已知脆弱點**：#1670（paced-inject 的根因）、#1944/#1948 系列（ghost placeholder——空的 input box 被誤讀成真正的 prompt marker）、`src/state/mod.rs:2196-2202` 一則沒有編號的發現（ready screen 可能誤鎖 `Active` 之後就不再重新偵測）。使用者提到的「Codex PTY 注入故障」事故——**未查證**，查無完全符合這個描述的獨立 ticket；最接近的候選是 `CHANGELOG.md:237`（#603/PR #629，stdin-only delivery），但這個機制在目前 `src/` 已無痕跡，看起來已被 #1670 取代。
+
+---
+
+## KiroCli
+
+**Agent-state 訊號**：PTY/Screen heuristic 是今天實際驅動 `agent_state` 的機制（`src/backend_profile.rs:220-273`，`kirocli_profile()`）。另外存在一條 `~/.kiro/sessions/cli/<uuid>.jsonl` 的唯讀 tail（`src/daemon/shadow/kiro.rs:1-23`，在 production 中確實有接上，見 `src/app/mod.rs:2774-2797`），但整個 Shadow Observer 系統明文寫著「additive only……從不驅動 `agent_state`」（`src/daemon/shadow/mod.rs:15-16`）——它站在 `Authority::Stream`，低於 `Authority::Hook`。Kiro 完全沒有 lifecycle hook。附帶說明：這條 jsonl 只在 tool-round/turn 結束時 flush（不是 prompt-submit 時），所以一個沒有呼叫任何 tool 的純思考回合，連 Stream-authority 的 shadow 都抓不到中途狀態。
+
+**Context usage**：StatusLine，可用——`KIRO_CONTEXT_PATTERN = r"◔\s*(\d+(?:\.\d+)?)\s*%"`（`src/backend_profile.rs:97`）。`:38-46` 的文件註解明確點名 Claude 與 Kiro 是僅有的兩個 `StatusLine` provider。
+
+**Submit / inject**：Bulk，`submit_key: "\r"`，`typed_inject: false`（pin 住的陣列，`src/backend.rs:1472-1474`）。送出前有固定 50ms 的 sleep（`src/agent/mod.rs:2813-2818`）；`readback_confirm_typed` 機制（#1912，`:2824-2831`）只對 `typed_inject` 的 backend 生效，所以 Kiro 從來不會用到它。
+
+**Resume**：有——`ResumeMode::ContinueInCwd { flag: "--resume" }`（`src/backend.rs:457`）。
+
+**MCP**：有，自己的 auto-discovery——Kiro 讀取 `.kiro/settings/mcp.json`（沒有像 Claude 那樣明確的 CLI flag），由 `configure_kiro()` 透過一個 wrapper script 寫入，理由是「因為 Kiro 會忽略 env block」（`src/mcp_config.rs:321-367`）。
+
+**已知脆弱點**：#7（`SIGWINCH` 後不重繪——唯一需要 `redraw_after_resize` 的 backend）、#996 Phase 2a（trust-modal 預設是破壞性選項；需要 Down+Enter，已對照 fixture byte 分析驗證）、#468（啟動卡住的 dismiss regex）、#1005（完成橫幅誤判 guard）、#1947（`>` input-line 誤鎖引號 guard）、#1948（無 prompt marker 的 placeholder heuristic）、#2413（jsonl observer 的量測研究——即上方分界說明提到的 Shadow Observer 工作）。未查證：#2413 的 jsonl Stream plane 是否也對 Kiro 帶有 token/context-usage 的證據——只找到 turn/tool-lifecycle 層級的 evidence mapping。
+
+---
+
+## OpenCode
+
+**Agent-state 訊號**：純 PTY/Screen heuristic——沒有 structured 訊號。`has_state_hooks()` 不包含 OpenCode（`src/backend.rs:74-76`）；全部靠 regex pattern 比對（`src/backend_profile.rs:282-355`）。
+
+**Context usage**：程式碼明文宣告 Unavailable，不只是「還沒實作」。`context_pattern: None`（`src/backend_profile.rs:352`）；`src/state/mod.rs:1221-1235` 把 Codex/OpenCode/Agy 歸為同一組，寫著「no trustworthy passive context signal」——畫面 footer 確實有顯示 token/cost 字串，但沒有被解析進 `context_pct`。
+
+**Submit / inject**：`submit_key` 預設 `"\r"`（沒有覆寫），`inject_prefix: "\r"`，`typed_inject: true`——逐 byte paced 寫入，跟 Codex（#1670）記錄的理由相同。除了這個 pacing 之外查無 confirm-first/readback 機制——**未查證**。
+
+**Resume**：`ResumeMode::ContinueInCwd { flag: "--continue" }`（`src/backend.rs:571`）。有兩個各自獨立追蹤的事故：
+- **#2020（已修復）**：resume 出來的 pane 不顯示「Ask anything」placeholder，只有純粹的 `┃` statusline 行——過去會被誤判成 `AwaitingOperator`。修法是新增一個低優先序的 `ctrl+p commands` Idle pattern，並已做回歸測試（`src/backend_profile.rs:330-340,564-598`）。
+- **Dummy-session wedge（未關閉，待重現）**：記錄於 `docs/KNOWN_ISSUES.md:24-46`——OpenCode 上游的一個 bug，`--continue` 可能送出一個 placeholder session id。常見情況已緩解（#1519/#1526，fresh-session fallback），但更罕見的「process 永不退出」變種能躲過全部三層偵測。這就是派工筆記提到的那個 task board 事故：`t-20260702144219394508-56872-6`（`docs/KNOWN_ISSUES.md:41`），結構上追蹤在 #2549 底下。
+
+**MCP**：有——project-local 的 `opencode.json` `"mcp"` 欄位發現機制，`fleet_mcp_supported: true`（pin 住的測試在 `src/backend.rs:1432`），由 `configure_opencode` 實作（`src/mcp_config.rs:599-638`），另外還有一個 auto-approve permission block，避免 OpenCode 自己的「Permission required」提示卡住 MCP tool call。
+
+**已知脆弱點**：#2020（已關閉——resume 後 pane 誤判 idle）與上述 dummy-session wedge（未關閉，`t-20260702144219394508-56872-6`，#2549）。這是兩個各自獨立的 bug，隨口聊天時很容易被混為一談——一個已修，一個還沒。
+
+---
+
+## Agy
+
+**Agent-state 訊號**：混合。真的有 lifecycle hook（`has_state_hooks()` 回傳 true，`src/backend.rs:74-76`），但只在 busy/idle 轉換時觸發（`PreInvocation`→`UserPromptSubmit`/`Stop`，`src/mcp_config.rs:470`）——已有實測證據確認它不帶任何 tool-call 顆粒度的訊號（task board 發現 `t-...93090-0`）。其餘所有更細的狀態（`Active`、`UsageLimit`、`RateLimit`、`ApiError`、`GitConflict`、`PermissionPrompt`）全靠純 PTY/Screen heuristic——8 個依序比對的 regex（`src/backend_profile.rs:129-213`）。
+
+**Context usage**：Unavailable——`context_pattern: None`（`src/backend_profile.rs:209`），明確與 Codex/OpenCode 歸為同一組「no trustworthy passive context signal」（`src/backend_profile.rs:43-45`）。
+
+**Submit / inject**：`typed_inject: true`，`inject_prefix: "\r"`，預設 `submit_key: "\r"`（`src/backend.rs:608-609`）；paced 約 2ms/byte 的分段寫入——`src/backend.rs:519` 那份共用的理由文件明確點名 Agy 跟 Codex 並列。查無 confirm-first/readback 機制。
+
+**Resume**：`ResumeMode::ContinueInCwd { flag: "--continue" }`（`src/backend.rs:613`）——程式碼註解寫著「operator-verified in issue body」，但查無自動化的 CLI 行為測試，只有針對 args 本身的單元測試 pin 住。
+
+**MCP**：有——標準的 `{command, args, env}` `mcpServers` schema，位於 `<workdir>/.agents/mcp_config.json`（`src/mcp_config.rs:391-436`，`mcp_server_entry` 在 `:86-99`）；`fleet_mcp_supported: true`（`src/backend.rs:641`，測試 `:1436`）。在 `src/backend.rs:1416-1421` 發現一則**過時的文件註解**，聲稱 Agy 的 MCP 支援是 `false`/不支援——這已經過時，且被兩行之後的實際斷言直接打臉。值得另外開一個 follow-up 清掉這則註解，跟本文件無關。
+
+**已知脆弱點**：#987（Agy 加入）、#995（workspace-trust dismiss + 一條已死的 `.antigravitycli/` MCP 寫入路徑）、#1547（把真正的 MCP 路徑修正為 `.agents/`）、#1580（Gemini 退役，Agy 是繼任者）、#1523 / #2413 Phase D（hooks 曾經失效，後來才修回來——見上方分界說明）、#2236（quota-wall pattern 順序）、#2409（一個暫時性的高流量 `ApiError` pattern）、#2524 P1b-r1/r2（缺一個 `GitConflict` pattern；`RateLimit` pattern 被標記為低信心/合成，尚未對照真實 Agy 輸出驗證）。
+
+---
+
+## Shell 與 Raw(String)
+
+**Agent-state 訊號**：無。完全沒有偵測 pattern——`agent_state` 在 spawn 時就硬鎖 `Idle`，跳過其他所有 backend 都會走的 `Starting → Idle` 握手（`src/backend_profile.rs:506-520` `empty_profile()`；`src/state/mod.rs:1002-1013`；`src/state/patterns.rs:204`）。
+
+**Context usage**：不適用——`context_pattern: None`，`ContextProvider::Unavailable`（`src/backend_profile.rs:516,44-46`，測試 `:541-542`）。
+
+**Submit / inject**：所有欄位都落回 `DEFAULTS`（`submit_key: "\r"`、`inject_prefix: ""`、`typed_inject: false`；`src/backend.rs:382-399,648-656`）。重要細節：inject 本身**不是真的 no-op**——文字確實會被寫入 PTY 並送出（`src/agent/mod.rs:2776-2818`）。真正 no-op 的是*preset 客製化*（沒有 dismiss pattern、沒有特殊前綴、沒有 readback confirm）。
+
+**Resume**：不支援——`resume_mode: ResumeMode::NotSupported`（`src/backend.rs:389`），`args_for()` 對它回傳空 `Vec`（`:275-277`）——所以 Resume spawn 跟 Fresh spawn 產生的（空）args 完全一樣，等於沒有區別。
+
+**MCP**：無——`mcp_config::configure()` 對 `Backend::Shell | Backend::Raw(_) | None` 直接 return，不呼叫任何 `configure_*` 函式（`src/mcp_config.rs:817-830`）；`fleet_mcp_supported: false`（`src/backend.rs:648-654`）。
+
+**已知脆弱點**：`CHANGELOG.md` 或已追蹤的事故清單裡查無記錄。**未查證**這代表 Shell 真的從沒出過包（有可能——它的 backend 專屬程式碼最少，能壞的地方也最少），還是單純沒人記錄過。附帶一個結構性觀察，不算脆弱點：`Backend::from_command`（`src/backend.rs:663-687`）實務上從不會回傳 `Some(Shell)` 或 `Some(Raw(_))`——它只認得已知的 preset 二進位檔名，所以這兩個 `match` 分支是防禦性的 exhaustive-match；Shell/Raw 實際的執行路徑走的是 `None` 分支。
+
+**Raw(String)**：跟 Shell 共用完全相同的 preset arm 與 `empty_profile()`（`src/backend.rs:648-656`）——行為一致。唯一差異是 `command_string()`（`src/backend.rs:228-229`），它用儲存的路徑字串本身，而不是 `$SHELL`。

--- a/docs/README.md
+++ b/docs/README.md
@@ -61,6 +61,7 @@ process notes are English-only.
 | Git Behavior | [EN](GIT-BEHAVIOR.md) | [中文](GIT-BEHAVIOR.zh-TW.md) | What the daemon changes in a spawned agent's git env |
 | Compatibility Policy | [EN](COMPATIBILITY.md) | [中文](COMPATIBILITY.zh-TW.md) | On-disk format stability guarantees under `$AGEND_HOME` |
 | Known Issues | [EN](KNOWN_ISSUES.md) | [中文](KNOWN_ISSUES.zh-TW.md) | Intentionally-deferred items — check before filing an issue |
+| Backend Capability Matrix | [EN](BACKEND-CAPABILITY-MATRIX.md) | [中文](BACKEND-CAPABILITY-MATRIX.zh-TW.md) | Per-backend state signal, context/resume/MCP support, and known fragile points — honestly cited or marked unverified |
 | Skills Reference | [EN](SKILLS.md) | [中文](SKILLS.zh-TW.md) | The skills catalog and lock format |
 | Launch Flows | [EN](launch-flows.md) | [中文](launch-flows.zh-TW.md) | Every way to start the daemon; cold vs warm start |
 | Recipe: Clean Claude Instance | [EN](RECIPE-clean-claude-instance.md) | [中文](RECIPE-clean-claude-instance.zh-TW.md) | Spawning a Claude Code agent without global instructions |

--- a/docs/README.zh-TW.md
+++ b/docs/README.zh-TW.md
@@ -60,6 +60,7 @@
 | Git 行為 | [EN](GIT-BEHAVIOR.md) | [中文](GIT-BEHAVIOR.zh-TW.md) | daemon 對被啟動 agent 的 git 環境做了哪些修改 |
 | 相容性政策 | [EN](COMPATIBILITY.md) | [中文](COMPATIBILITY.zh-TW.md) | `$AGEND_HOME` 底下磁碟格式的穩定性保證 |
 | 已知問題 | [EN](KNOWN_ISSUES.md) | [中文](KNOWN_ISSUES.zh-TW.md) | 刻意暫緩的項目——開 issue 前請先看 |
+| Backend 能力矩陣 | [EN](BACKEND-CAPABILITY-MATRIX.md) | [中文](BACKEND-CAPABILITY-MATRIX.zh-TW.md) | 逐 backend 的 state 訊號、context/resume/MCP 支援、已知脆弱點——誠實標示依據或標記未查證 |
 | Skills 參考 | [EN](SKILLS.md) | [中文](SKILLS.zh-TW.md) | skill 目錄與 lock 格式 |
 | 啟動流程 | [EN](launch-flows.md) | [中文](launch-flows.zh-TW.md) | 啟動 daemon 的每一種方式；冷啟動 vs 熱啟動 |
 | 秘訣：乾淨的 Claude Instance | [EN](RECIPE-clean-claude-instance.md) | [中文](RECIPE-clean-claude-instance.zh-TW.md) | 啟動不含全域指令的 Claude Code agent |


### PR DESCRIPTION
## What & why

Per fugu's solutions.md §4.2 analysis (batch 1, item 3): adds `docs/BACKEND-CAPABILITY-MATRIX.md` (+ zh-TW) — an honest, per-backend audit of what state-detection signal, context-usage mechanism, submit/inject behavior, resume support, and MCP wiring each `Backend` enum variant (ClaudeCode, Codex, KiroCli, OpenCode, Agy, Shell/Raw) actually has **today**, plus known fragile points with issue/task citations.

**Discipline enforced throughout**: every claim carries a `path:line` code citation (this repo) or is explicitly marked "unverified" — no cell is a guess. Six parallel research passes independently verified against `backend.rs`/`backend_profile.rs`/`state/mod.rs`, and I spot-checked the highest-stakes citations myself against source before writing this up.

Notable findings surfaced along the way (**not fixed here** — this is a pure docs PR, flagging for a separate follow-up):
- Agy has a stale doc comment (`backend.rs:1416-1421`) claiming `fleet_mcp_supported` is `false` — the assertion two lines later says `true` (fixed by #1547, the comment was never updated).
- Codex's resume is hardcoded `resume --last` directly in spawn args, bypassing the generic `ResumeMode` abstraction every other resumable backend uses — an inconsistency worth a maintainer's attention.
- `Backend::from_command` never actually returns `Some(Shell)`/`Some(Raw(_))` in practice (it only recognizes known preset binary names) — those `match` arms are defensive exhaustive-match dead code; the real runtime path is `None`.

The scope boundary vs. [#2413](https://github.com/suzuke/agend-terminal/issues/2413) (the Shadow Observer / API-activity-probe improvement roadmap) is stated explicitly at the top of the doc: this records **current** behavior, #2413 is the effort to improve it.

Closes the fugu-analysis batch-1 item 3 task.

## Prior art check (required)

- [x] Checked `docs/KNOWN_ISSUES.md` — cross-referenced directly in this doc (the OpenCode dummy-session wedge entry), no conflict.
- [x] Compared against current `main` — no existing backend-capability-matrix doc; this is new.
- [x] Searched closed issues/PRs — this documents existing, already-shipped behavior (referencing #468, #987, #995, #1547, #1580, #1670, #1944-1948, #1912, #2020, #2044, #2236, #2409, #2524, #2549 among others); doesn't reopen or contradict any of them.
- [x] Not revisiting an existing decision — pure documentation of current state.

## How it was verified

- Six independent research passes (one per backend) each cited `path:line` evidence from `src/backend.rs`, `src/backend_profile.rs`, `src/state/mod.rs`, `src/mcp_config.rs`, `src/daemon/shadow/*`, and `docs/KNOWN_ISSUES.md`.
- I personally spot-checked the highest-stakes/most-surprising citations directly against source before publishing: `has_state_hooks()` (`backend.rs:74-76`), the `ContextProvider` enum doc (`backend_profile.rs:39-46`), Codex's paced-inject rationale (`backend.rs:505-525`, #1670), the OpenCode dummy-session task-board reference (`docs/KNOWN_ISSUES.md:24-46`, confirms `t-20260702144219394508-56872-6` verbatim), the Agy stale-doc-comment finding (`backend.rs:1410-1440`), and the Shell/Raw MCP-skip logic (`mcp_config.rs:815-832`) — all matched exactly.
- Pure docs change — no `.rs` files touched, so no test suite impact. `git diff --stat`: 4 files changed (2 new docs + 2 one-line `docs/README*.md` index entries), 260 insertions.

## Compatibility (on-disk formats)

- [x] No on-disk format changed — pure documentation.

## Notes for reviewers

- This is intentionally a **snapshot**, not a design doc — it doesn't propose fixes for the fragile points it lists (e.g. the stale Agy doc comment, Codex's inconsistent resume implementation). Those are flagged for separate follow-ups if the lead wants them filed.
- Added a one-line index entry to `docs/README.md` + `docs/README.zh-TW.md` following the existing table convention.