### PR TITLE
test: snapshot fail-open invariants (fugu §3.4, batch-1 ②)

### DIFF
--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -245,4 +245,93 @@ mod tests {
         );
         fs::remove_dir_all(&home).ok();
     }
+
+    /// [fugu §3.4] The snapshot read primitives that every dispatch decider
+    /// reads through must return the CONSERVATIVE sentinel when the snapshot is
+    /// missing, corrupt, or written in an older format — so the decider fails
+    /// OPEN (proceeds / fires / injects) instead of suppressing on stale data.
+    ///
+    /// Sentinel -> decider effect it drives (see docs/SOURCE-OF-TRUTH.md):
+    ///   `load() == None`           -> dispatch_idle fires; startup-log / status
+    ///                                 query / bugreport degrade to empty.
+    ///   `agent_state_of() == None` -> inbox inject does NOT defer (injects).
+    ///   `agent_is_busy() == false` -> handoff re-nudges; reply-ledger nudges;
+    ///                                 inbox injects.
+    ///
+    /// Irreversibility boundary: every one of those effects is REVERSIBLE (a
+    /// nudge, or an already-authoritative inbox delivery). A stale snapshot must
+    /// never drive an irreversible action (delete / overwrite / fabricated
+    /// outbound send). The source-scan companion
+    /// `snapshot_stale_never_causes_irreversible_action`
+    /// (tests/snapshot_failopen_invariant.rs) enforces that no un-reviewed
+    /// reader is added.
+    #[test]
+    fn snapshot_missing_fails_open_for_dispatch_deciders() {
+        let home = tmp_home("failopen");
+        // Start from a guaranteed-absent snapshot.
+        fs::remove_dir_all(&home).ok();
+        fs::create_dir_all(&home).ok();
+
+        // (a) Missing snapshot -> conservative sentinels, no panic.
+        assert!(load(&home).is_none(), "missing snapshot -> load None");
+        assert!(
+            agent_state_of(&home, "a").is_none(),
+            "missing snapshot -> agent_state_of None"
+        );
+        assert!(
+            !agent_is_busy(&home, "a"),
+            "missing snapshot MUST read as NOT busy (fail-open: deciders proceed)"
+        );
+
+        // (b) Corrupt snapshot.json -> still None / not-busy, still no panic.
+        fs::write(home.join("snapshot.json"), b"{ this is not valid json")
+            .expect("write corrupt snapshot");
+        assert!(load(&home).is_none(), "corrupt snapshot -> load None");
+        assert!(
+            !agent_is_busy(&home, "a"),
+            "corrupt snapshot MUST fail-open to NOT busy"
+        );
+
+        // (c) Valid snapshot, agent absent -> not busy (unknown != busy).
+        save(&home, &[make_agent("present", "active")]);
+        assert!(
+            !agent_is_busy(&home, "absent"),
+            "unknown agent -> NOT busy (fail-open)"
+        );
+        // Sanity: the sentinel is not a blanket false — a known active agent
+        // still reads busy, so fail-open never masks real state.
+        assert!(
+            agent_is_busy(&home, "present"),
+            "known active agent reads busy"
+        );
+
+        // (d) Old-format snapshot missing silent_secs / output_silent_secs ->
+        // serde default i64::MAX ("very silent" -> the idle watchdog fires
+        // rather than suppressing). This is the field-level fail-open base.
+        let old_format = concat!(
+            r#"{"timestamp":"2020-01-01T00:00:00Z","agents":[{"#,
+            r#""name":"legacy","backend_command":"claude","args":[],"#,
+            r#""working_dir":null,"submit_key":"\r","health_state":"healthy","#,
+            r#""agent_state":"idle"}]}"#
+        );
+        fs::write(home.join("snapshot.json"), old_format).expect("write old-format snapshot");
+        let snap = load(&home).expect("old-format snapshot must still deserialize");
+        let a = snap
+            .agents
+            .iter()
+            .find(|a| a.name == "legacy")
+            .expect("legacy agent present");
+        assert_eq!(
+            a.silent_secs,
+            i64::MAX,
+            "missing silent_secs MUST default to i64::MAX (fail-open)"
+        );
+        assert_eq!(
+            a.output_silent_secs,
+            i64::MAX,
+            "missing output_silent_secs MUST default to i64::MAX (fail-open)"
+        );
+
+        fs::remove_dir_all(&home).ok();
+    }
 }

--- a/tests/snapshot_failopen_invariant.rs
+++ b/tests/snapshot_failopen_invariant.rs
@@ -9,128 +9,119 @@
 //!
 //! ## Irreversible-vs-reversible boundary (what this invariant guards)
 //!
-//! IRREVERSIBLE (forbidden on a snapshot read):
-//!   - deleting or overwriting a source-of-truth store (worktree, branch,
-//!     task / inbox / decision file), or
-//!   - fabricating an OUTBOUND send (a Telegram / Discord / PTY message that
-//!     would not exist under a correct snapshot).
+//! IRREVERSIBLE (forbidden on a snapshot read): deleting/overwriting a
+//! source-of-truth store (worktree, branch, task/inbox/decision file), or
+//! fabricating an OUTBOUND send (a Telegram/Discord/PTY message that would not
+//! exist under a correct snapshot).
 //!
-//! REVERSIBLE / acceptable (fail-open):
-//!   - a nudge, a warn, a log line, a re-nudge, or
-//!   - delivering an ALREADY-AUTHORITATIVE inbox message whose TIMING (not
-//!     existence) the snapshot gates — the payload is owned by the inbox
-//!     source-of-truth and is bounded by the `MAX_DEFER` cap, so a stale
-//!     snapshot at worst shifts delivery timing, never invents or drops a
-//!     message.
+//! REVERSIBLE / acceptable (fail-open): a nudge, a warn, a log line, a
+//! re-nudge, or delivering an ALREADY-AUTHORITATIVE inbox message whose TIMING
+//! (not existence) the snapshot gates — the payload is owned by the inbox
+//! source-of-truth and is bounded by `MAX_DEFER`, so a stale snapshot at worst
+//! shifts delivery timing, never invents or drops a message.
 //!
-//! ## Detection — a two-layer fence (PR #2612 rework)
+//! ## Detection — a `syn` AST walk (PR #2612 rework #2)
 //!
-//! The first cut of this test matched only the literal call form
-//! `snapshot::load(` on a single line. The reviewer (cross-vantage, PR #2612)
-//! correctly rejected it: four ordinary Rust forms read the same primitives yet
-//! slip past a literal-call scan —
-//!   1. `use crate::snapshot::load; ... load(home)`            (direct import)
-//!   2. `use crate::snapshot::{agent_is_busy as busy}; ...`    (aliased import)
-//!   3. `use crate::snapshot as snap; ... snap::agent_is_busy` (module alias)
-//!   4. `let f = crate::snapshot::load; f(home)`               (fn pointer)
+//! The first two cuts scanned source text for literal call/import substrings.
+//! Both were defeated: the reviewer (cross-vantage) injected real production
+//! readers that string scanning missed — first alias/bare-call/fn-pointer
+//! forms, then crate-level grouped imports `use crate::{snapshot as snap};`
+//! and `use crate::{snapshot::{load}};`. Rust's `use` grammar (grouped,
+//! nested, aliased, glob, arbitrary spacing, multi-line) cannot be enumerated
+//! with literal substrings — that is a METHOD failure, not a patch gap.
 //!
-//! A new reader in any of those forms would silently escape `ALLOWED_READERS`,
-//! turning the anti-growth guard into a false guarantee.
+//! This cut parses each production file with `syn` and walks the AST, which
+//! NORMALIZES every syntactic variant into the same tree. A file is a
+//! "snapshot projection user" iff it contains, OUTSIDE `#[cfg(test)]`:
+//!   - a `use` tree that imports from `crate::snapshot` (any form — path,
+//!     name, rename, grouped, nested, glob), OR
+//!   - an expression/type path with consecutive segments `crate :: snapshot`.
 //!
-//! The fix makes the scan COMPLETE by combining two layers over production code
-//! (`#[cfg(test)]` regions and comments excluded):
+//! Every such file must appear in [`AUDITED_FILES`] with a role.
 //!
-//!   Layer 1 — import ban. Production code may reference the snapshot module
-//!   only in FULLY-QUALIFIED form. The import shapes that could bring a read
-//!   primitive into local scope under a name the read-scan can't see are
-//!   banned outright: `use crate::snapshot::{…}` (grouped/aliased), `use
-//!   crate::snapshot as …` (module alias), `use crate::snapshot;` (bare
-//!   module). This kills forms 2 and 3 at the source.
+//! ## Completeness argument (name-resolution-free)
 //!
-//!   Layer 2 — read-reference scan. Any production line naming a read primitive
-//!   in fully-qualified form (`snapshot::load` / `snapshot::agent_state_of` /
-//!   `snapshot::agent_is_busy`, WITHOUT requiring a trailing `(` so fn-pointers
-//!   and single-item imports are caught too) marks its file a reader — which
-//!   must appear in `ALLOWED_READERS`. This catches forms 1 and 4 and every
-//!   current fully-qualified call.
+//! To read the projection a file must, in ITS OWN text, either (a) import a
+//! primitive/the module — caught by the use-tree walk regardless of grouping —
+//! or (b) name it fully-qualified `crate::snapshot::…` — caught by the path
+//! walk. No cross-file name resolution is needed: the reference is always
+//! LOCAL to the reading file. The only two ways to reference the projection
+//! WITHOUT the local token are closed by bans below, both currently at zero
+//! violations:
+//!   1. a `pub`/`pub(crate)` RE-EXPORT of `crate::snapshot` (would let a
+//!      token-free downstream file read via the alias) — banned; the
+//!      re-exporting file itself is caught, so the ban is enforceable there.
+//!   2. aliasing the crate root, `use crate as c; c::snapshot::…` — banned.
 //!
-//! Given Layer 1, Layer 2's fully-qualified patterns are complete: there is no
-//! way to read a primitive without either a fully-qualified reference (Layer 2)
-//! or a banned import (Layer 1). `scanner_catches_all_bypass_forms` below is the
-//! fence's fence — it proves all four forms are caught.
+//! Root-anchoring on `crate::snapshot` excludes the unrelated, identically
+//! named `crate::daemon::per_tick::snapshot` rotation module.
 //!
-//! (Detection relies on rustfmt-normalized spacing, e.g. `crate::snapshot::`
-//! not `crate :: snapshot ::`; the repo's `cargo fmt --check` CI gate enforces
-//! that normalization, so hand-spaced evasions cannot land.)
+//! Residual limits (accepted, mirroring `enqueue_drop_invariant`'s honest
+//! limits): a read manufactured entirely inside a macro body defined in
+//! another file, or via `build.rs`/`include!`, is out of scope for an
+//! AST-of-source scan. None exist and such a form would be extraordinary.
+//!
+//! `scanner_catches_all_bypass_forms` below is the fence's fence: it proves
+//! all six reviewer forms plus glob/multi-line are caught and the bans fire.
 //!
 //! ## The allowlist
 //!
-//! Adding a file to `ALLOWED_READERS` REQUIRES a fail-open review of the new
-//! reader — the list records that the review happened; it does not waive it.
-//! The behavioral companion `snapshot_missing_fails_open_for_dispatch_deciders`
-//! (unit test in `src/snapshot.rs`) proves the primitives themselves return the
-//! conservative sentinel on a missing / corrupt / old-format snapshot. It lives
-//! there because the `snapshot` module is not on the curated `lib.rs` public
-//! surface; exposing it would be a production change out of scope here.
-//!
-//! Inventory as of origin/main: 7 reader files (see `ALLOWED_READERS`). Writers
-//! (`snapshot::save`) and type-only refs (`snapshot::FleetSnapshot`) are not
-//! reads and are intentionally out of scope.
+//! Adding a file to `AUDITED_FILES` REQUIRES review of the new user — for a
+//! `reader`, a fail-open review; the list records that review, it does not
+//! waive it. The behavioral companion
+//! `snapshot_missing_fails_open_for_dispatch_deciders` (unit test in
+//! `src/snapshot.rs`) proves the primitives return the conservative sentinel
+//! on a missing/corrupt/old-format snapshot; it lives there because the
+//! `snapshot` module is not on the curated `lib.rs` surface.
 
-use std::collections::HashSet;
 use std::path::{Path, PathBuf};
+use syn::visit::{self, Visit};
 
-/// Fully-qualified read-primitive references. No trailing `(` — so a fn-pointer
-/// (`let f = crate::snapshot::load;`) and a single-item import
-/// (`use crate::snapshot::load;`) are caught, not just direct calls. The writer
-/// `snapshot::save` and type refs `snapshot::FleetSnapshot` are deliberately
-/// absent (not reads).
-const READ_FN_REFS: &[&str] = &[
-    "snapshot::load",
-    "snapshot::agent_state_of",
-    "snapshot::agent_is_busy",
-];
-
-/// Import shapes banned in production (Layer 1): each could bring a read
-/// primitive into scope under a name Layer 2's fully-qualified scan cannot see.
-/// Banning them forces every snapshot reference to stay fully-qualified.
-const BANNED_IMPORTS: &[&str] = &[
-    "use crate::snapshot::{",
-    "use crate::snapshot as ",
-    "use crate::snapshot;",
-];
-
-/// Every production file allowed to READ the snapshot projection, each with the
-/// reviewed reason its snapshot-driven action is REVERSIBLE / fail-open.
-/// Suffix-matched against the `src/`-relative path.
-const ALLOWED_READERS: &[(&str, &str)] = &[
+/// Every production file that references the `crate::snapshot` projection, with
+/// its role. `reader` entries carry the reviewed reason a stale/missing
+/// snapshot drives only a REVERSIBLE action; `writer`/`type-user` produce or
+/// type the projection and do not read it for a decision. Suffix-matched
+/// against the `src/`-relative path.
+const AUDITED_FILES: &[(&str, &str, &str)] = &[
     (
         "src/daemon/dispatch_idle/mod.rs",
+        "reader",
         "idle silence gate; missing -> target_is_working=false -> still FIRES the nudge (fail-open by design, #1516). Reversible: a nudge.",
     ),
     (
         "src/inbox/notify.rs",
-        "inject defer/drain TIMING gate; missing -> not-busy -> inject now (bounded by MAX_DEFER). Payload is authoritative from the inbox source-of-truth; the snapshot gates timing, not existence.",
+        "reader",
+        "inject defer/drain TIMING gate; missing -> not-busy -> inject now (bounded by MAX_DEFER). Payload authoritative from the inbox source-of-truth; the snapshot gates timing, not existence.",
     ),
     (
         "src/daemon/handoff_timeout_watchdog.rs",
+        "reader",
         "re-nudge gate + telemetry; missing -> not-busy -> re-nudge. Reversible: a nudge.",
     ),
     (
         "src/reply_ledger.rs",
+        "reader",
         "sweep gate; missing -> not-busy -> emit_warn + NudgeAgent. Reversible: a warn/nudge, never a delete.",
     ),
     (
         "src/daemon/mod.rs",
-        "startup diagnostic only: logs 'previous snapshot found' via tracing::info; missing -> skip the log. No action at all.",
+        "reader",
+        "startup diagnostic only: logs 'previous snapshot found' via tracing::info; missing -> skip the log. No action.",
     ),
     (
         "src/api/handlers/query.rs",
+        "reader",
         "read-only: builds the status query response; missing -> empty {agents:[], timestamp:null}. No mutation.",
     ),
     (
         "src/bugreport.rs",
-        "read-only: renders the snapshot section of a bug report; missing -> section shows nothing. No mutation.",
+        "reader",
+        "read-only: renders the snapshot section of a bug report; missing -> section empty. No mutation.",
+    ),
+    (
+        "src/daemon/per_tick/snapshot.rs",
+        "writer",
+        "the per-tick rotation handler: PRODUCES the projection via crate::snapshot::save. Not a reader; no decision reads snapshot here.",
     ),
 ];
 
@@ -148,57 +139,119 @@ fn collect_rs_files(dir: &Path, out: &mut Vec<PathBuf>) {
     }
 }
 
-/// 1-based line numbers inside `#[cfg(test)] mod` regions (brace-depth tracked),
-/// so in-file test modules are sliced out. Mirrors the proven helper in
-/// `tests/enqueue_drop_invariant.rs::test_region_lines`.
-fn test_region_lines(content: &str) -> HashSet<usize> {
-    let mut out = HashSet::new();
-    let mut depth: i32 = 0;
-    let mut pending_cfg_test = false;
-    let mut region_depth: Option<i32> = None;
-    for (i, line) in content.lines().enumerate() {
-        let t = line.trim();
-        if region_depth.is_none() {
-            if t.starts_with("#[cfg(test)]") {
-                pending_cfg_test = true;
-            } else if pending_cfg_test && t.contains("mod ") && line.contains('{') {
-                region_depth = Some(depth);
-                pending_cfg_test = false;
-            }
-        }
-        if region_depth.is_some_and(|d| depth >= d) {
-            out.insert(i + 1);
-        }
-        let next = depth + line.matches('{').count() as i32 - line.matches('}').count() as i32;
-        if let Some(d) = region_depth {
-            if next <= d {
-                region_depth = None;
-            }
-        }
-        depth = next;
-    }
-    out
-}
-
-fn is_comment(line: &str) -> bool {
-    line.trim_start().starts_with("//")
-}
-
-/// Layer 1: a banned import form (grouped/aliased/bare-module snapshot import).
-fn is_banned_import(line: &str) -> bool {
-    BANNED_IMPORTS.iter().any(|b| line.contains(b))
-}
-
-/// Layer 2: a fully-qualified reference to a snapshot READ primitive.
-fn is_read_ref(line: &str) -> bool {
-    READ_FN_REFS.iter().any(|r| line.contains(r))
-}
-
 fn rel_str(path: &Path, root: &Path) -> String {
     path.strip_prefix(root)
         .unwrap_or(path)
         .to_string_lossy()
         .replace('\\', "/")
+}
+
+/// True if any attribute is `#[cfg(test)]` (or a `cfg(...)` mentioning `test`).
+fn has_cfg_test(attrs: &[syn::Attribute]) -> bool {
+    attrs.iter().any(|a| {
+        a.path().is_ident("cfg")
+            && matches!(&a.meta, syn::Meta::List(l) if l.tokens.to_string().contains("test"))
+    })
+}
+
+/// Given a use-subtree positioned immediately after the `crate` root, does it
+/// bring the `snapshot` projection module (or something under it) into scope?
+fn after_crate_is_snapshot(t: &syn::UseTree) -> bool {
+    match t {
+        syn::UseTree::Path(p) => p.ident == "snapshot",
+        syn::UseTree::Name(n) => n.ident == "snapshot",
+        syn::UseTree::Rename(r) => r.ident == "snapshot",
+        syn::UseTree::Group(g) => g.items.iter().any(after_crate_is_snapshot),
+        // `use crate::*;` glob-imports the crate root, which includes
+        // `snapshot`; treat conservatively as a hit.
+        syn::UseTree::Glob(_) => true,
+    }
+}
+
+/// True if this use tree imports from `crate::snapshot` in any form.
+fn use_tree_hits_projection(t: &syn::UseTree) -> bool {
+    match t {
+        syn::UseTree::Path(p) if p.ident == "crate" => after_crate_is_snapshot(&p.tree),
+        // A leading group, e.g. `use {crate::snapshot, ...};`.
+        syn::UseTree::Group(g) => g.items.iter().any(use_tree_hits_projection),
+        _ => false,
+    }
+}
+
+/// True if this use tree aliases the crate root, e.g. `use crate as c;` — a
+/// token-free escape hatch (`c::snapshot::…`) that the ban forbids.
+fn use_tree_aliases_crate_root(t: &syn::UseTree) -> bool {
+    match t {
+        syn::UseTree::Rename(r) => r.ident == "crate",
+        syn::UseTree::Group(g) => g.items.iter().any(use_tree_aliases_crate_root),
+        _ => false,
+    }
+}
+
+/// True if a path names consecutive segments `crate :: snapshot` (the
+/// projection), excluding the identically named `…::per_tick::snapshot`.
+fn path_is_crate_snapshot(p: &syn::Path) -> bool {
+    let idents: Vec<String> = p.segments.iter().map(|s| s.ident.to_string()).collect();
+    idents
+        .windows(2)
+        .any(|w| w[0] == "crate" && w[1] == "snapshot")
+}
+
+#[derive(Default)]
+struct Scan {
+    refs_projection: bool,
+    reexports_projection: bool,
+    aliases_crate_root: bool,
+}
+
+impl<'ast> Visit<'ast> for Scan {
+    fn visit_item_mod(&mut self, i: &'ast syn::ItemMod) {
+        if has_cfg_test(&i.attrs) {
+            return;
+        }
+        visit::visit_item_mod(self, i);
+    }
+    fn visit_item_fn(&mut self, i: &'ast syn::ItemFn) {
+        if has_cfg_test(&i.attrs) {
+            return;
+        }
+        visit::visit_item_fn(self, i);
+    }
+    fn visit_item_impl(&mut self, i: &'ast syn::ItemImpl) {
+        if has_cfg_test(&i.attrs) {
+            return;
+        }
+        visit::visit_item_impl(self, i);
+    }
+    fn visit_item_use(&mut self, i: &'ast syn::ItemUse) {
+        if has_cfg_test(&i.attrs) {
+            return;
+        }
+        if use_tree_aliases_crate_root(&i.tree) {
+            self.aliases_crate_root = true;
+        }
+        if use_tree_hits_projection(&i.tree) {
+            self.refs_projection = true;
+            // pub / pub(crate) / pub(super) etc. re-export reaches other files.
+            if !matches!(i.vis, syn::Visibility::Inherited) {
+                self.reexports_projection = true;
+            }
+        }
+        visit::visit_item_use(self, i);
+    }
+    fn visit_path(&mut self, p: &'ast syn::Path) {
+        if path_is_crate_snapshot(p) {
+            self.refs_projection = true;
+        }
+        visit::visit_path(self, p);
+    }
+}
+
+fn scan_file(content: &str) -> Result<Scan, syn::Error> {
+    let ast = syn::parse_file(content)?;
+    let mut scan = Scan::default();
+    scan.visit_file(&ast);
+    Ok(scan)
 }
 
 #[test]
@@ -209,9 +262,10 @@ fn snapshot_stale_never_causes_irreversible_action() {
     collect_rs_files(&src, &mut files);
     files.sort();
 
+    let mut parse_failures: Vec<String> = Vec::new();
     let mut banned: Vec<String> = Vec::new();
-    let mut unlisted: Vec<String> = Vec::new();
-    let mut matched: HashSet<&str> = HashSet::new();
+    let mut unaudited: Vec<String> = Vec::new();
+    let mut matched: std::collections::HashSet<&str> = std::collections::HashSet::new();
 
     for f in &files {
         let rel = rel_str(f, root);
@@ -222,127 +276,153 @@ fn snapshot_stale_never_causes_irreversible_action() {
         let Ok(content) = std::fs::read_to_string(f) else {
             continue;
         };
-        let test_lines = test_region_lines(&content);
-        for (idx, line) in content.lines().enumerate() {
-            let lineno = idx + 1;
-            if test_lines.contains(&lineno) || is_comment(line) {
+        let scan = match scan_file(&content) {
+            Ok(s) => s,
+            // A file we cannot parse could hide a reader — surface it, never
+            // silently skip.
+            Err(e) => {
+                parse_failures.push(format!("  {rel}: {e}"));
                 continue;
             }
-            // Layer 1 (applies to ALL files, allowlisted or not): the bypass-
-            // enabling import forms are forbidden outright.
-            if is_banned_import(line) {
-                banned.push(format!("  {rel}:{lineno}: {}", line.trim()));
-                continue;
-            }
-            // Layer 2: a fully-qualified read reference marks a reader file.
-            if !is_read_ref(line) {
-                continue;
-            }
-            match ALLOWED_READERS
+        };
+        if scan.reexports_projection {
+            banned.push(format!(
+                "  {rel}: pub/pub(crate) re-export of crate::snapshot"
+            ));
+        }
+        if scan.aliases_crate_root {
+            banned.push(format!("  {rel}: crate-root alias `use crate as …`"));
+        }
+        if scan.refs_projection {
+            match AUDITED_FILES
                 .iter()
-                .find(|(suffix, _)| rel.ends_with(suffix))
+                .find(|(suffix, _, _)| rel.ends_with(suffix))
             {
-                Some((suffix, _)) => {
+                Some((suffix, _, _)) => {
                     matched.insert(*suffix);
                 }
-                None => unlisted.push(format!("  {rel}:{lineno}: {}", line.trim())),
+                None => unaudited.push(format!("  {rel}")),
             }
         }
     }
 
     assert!(
+        parse_failures.is_empty(),
+        "Could not parse these source files with syn (a reader could hide in \
+         one). Fix the parse or narrow the walk:\n{}",
+        parse_failures.join("\n")
+    );
+
+    assert!(
         banned.is_empty(),
-        "Banned snapshot import form(s) in production (Layer 1).\n\n\
-         Reference the snapshot module only in FULLY-QUALIFIED form \
-         (`crate::snapshot::<fn>(...)`). Grouped/aliased/bare-module imports \
-         (`use crate::snapshot::{{…}}`, `use crate::snapshot as …`, \
-         `use crate::snapshot;`) can bring a read primitive into scope under a \
-         name the reader-scan cannot see, defeating the fail-open allowlist.\n\n\
-         Offending line(s):\n{}",
+        "Forbidden snapshot reference form(s) in production.\n\n\
+         A `pub`/`pub(crate)` re-export of crate::snapshot, or a crate-root \
+         alias, lets a downstream file read the projection WITHOUT any local \
+         `snapshot` reference — defeating the audited-files completeness \
+         argument. Reference the projection only in fully-qualified, \
+         non-re-exported form.\n\n{}",
         banned.join("\n")
     );
 
     assert!(
-        unlisted.is_empty(),
-        "New snapshot reader(s) outside the fail-open ALLOWLIST (Layer 2).\n\n\
-         Every reader of the snapshot projection must fail-open: a stale/missing \
-         snapshot may cause only a REVERSIBLE action (nudge/warn/log/timing), never \
-         an irreversible one (delete/overwrite/fabricated outbound send). Add the \
-         site to ALLOWED_READERS in this file WITH a one-line reversibility \
-         rationale — and only after confirming the read actually fails open.\n\n\
-         Unlisted read site(s):\n{}",
-        unlisted.join("\n")
+        unaudited.is_empty(),
+        "Production file(s) reference crate::snapshot but are not in \
+         AUDITED_FILES.\n\n\
+         Any reader of the snapshot projection must fail-open: a stale/missing \
+         snapshot may cause only a REVERSIBLE action (nudge/warn/log/timing), \
+         never an irreversible one. Add each file to AUDITED_FILES in this test \
+         with a role (reader/writer/type-user) and — for a reader — a one-line \
+         reversibility rationale, only after confirming it fails open.\n\n{}",
+        unaudited.join("\n")
     );
 
-    let stale: Vec<&str> = ALLOWED_READERS
+    let stale: Vec<&str> = AUDITED_FILES
         .iter()
-        .map(|(s, _)| *s)
+        .map(|(s, _, _)| *s)
         .filter(|s| !matched.contains(s))
         .collect();
     assert!(
         stale.is_empty(),
-        "Stale ALLOWED_READERS entr(y/ies) — no snapshot read found in: {stale:?}.\n\
-         Remove the entry (the reader was deleted/moved) to keep the inventory honest.",
+        "Stale AUDITED_FILES entr(y/ies) — no crate::snapshot reference found \
+         in: {stale:?}. Remove the entry to keep the inventory honest.",
     );
 }
 
-/// The fence's fence: prove the two-layer scan catches every read form the
-/// reviewer (PR #2612) showed the literal-call scan missed, and does NOT flag
-/// benign lines. Each `case` is classified by the same predicates the main test
-/// uses; "caught" = Layer 1 (banned import) OR Layer 2 (read ref) on a
-/// non-comment line.
+/// The fence's fence: prove the AST walk catches every read form the reviewer
+/// showed the string scans missed (and the crate-level grouped/nested/glob/
+/// multi-line variants), that the bans fire, and that benign non-projection
+/// references are not flagged.
 #[test]
 fn scanner_catches_all_bypass_forms() {
-    fn caught(line: &str) -> bool {
-        !is_comment(line) && (is_banned_import(line) || is_read_ref(line))
+    let caught = |src: &str| -> bool {
+        let s = scan_file(src).expect("parse snippet");
+        s.refs_projection || s.reexports_projection || s.aliases_crate_root
+    };
+
+    // Every read form must be caught. Forms 1-4 are the first review's; forms
+    // 5-6 are the crate-level grouped imports the second review injected;
+    // 7-8 harden glob and multi-line grouping.
+    let read_forms: &[(&str, &str)] = &[
+        ("baseline call", "fn f(h: &std::path::Path) { let _ = crate::snapshot::load(h); }"),
+        ("form1 direct import", "use crate::snapshot::load;\nfn f(h: &std::path::Path){ let _ = load(h); }"),
+        ("form2 grouped alias", "use crate::snapshot::{agent_is_busy as busy};\nfn f(h:&std::path::Path){ let _=busy(h,\"a\"); }"),
+        ("form3 module alias", "use crate::snapshot as snap;\nfn f(h:&std::path::Path){ let _=snap::agent_is_busy(h,\"a\"); }"),
+        ("form4 fn pointer", "fn f(h:&std::path::Path){ let g = crate::snapshot::load; let _=g(h); }"),
+        ("form5 crate-grouped alias", "use crate::{snapshot as snap};\nfn f(h:&std::path::Path){ let _=snap::load(h); }"),
+        ("form6 crate-grouped nested", "use crate::{snapshot::{load}};\nfn f(h:&std::path::Path){ let _=load(h); }"),
+        ("form7 crate glob", "use crate::*;\nfn f(h:&std::path::Path){ let _=snapshot::load(h); }"),
+        ("form8 multiline group", "use crate::{\n    snapshot::agent_is_busy,\n    fmt_util,\n};\nfn f(h:&std::path::Path){ let _=agent_is_busy(h,\"a\"); }"),
+    ];
+    for (name, src) in read_forms {
+        assert!(caught(src), "read form NOT caught by the AST fence: {name}");
     }
 
-    // Every bypass form the reviewer flagged, plus the baseline call. Each must
-    // be caught on at least one of its lines.
-    let must_catch: &[(&str, &[&str])] = &[
-        ("baseline call", &["let _ = crate::snapshot::load(home);"]),
+    // Token-free escape hatches must be caught as bans.
+    let ban_forms: &[(&str, &str)] = &[
+        ("pub re-export fn", "pub use crate::snapshot::load;"),
         (
-            "form 1: direct import + bare call",
-            &["use crate::snapshot::load;", "    let _ = load(home);"],
+            "pub(crate) re-export module",
+            "pub(crate) use crate::snapshot as snap;",
         ),
         (
-            "form 2: grouped/aliased import",
-            &[
-                "use crate::snapshot::{agent_is_busy as busy};",
-                "    let _ = busy(home, name);",
-            ],
-        ),
-        (
-            "form 3: module alias",
-            &[
-                "use crate::snapshot as snap;",
-                "    let _ = snap::agent_is_busy(home, name);",
-            ],
-        ),
-        (
-            "form 4: fn pointer",
-            &["let f = crate::snapshot::load;", "    let _ = f(home);"],
-        ),
-        (
-            "bare module import + call",
-            &["use crate::snapshot;", "    let _ = snapshot::load(home);"],
+            "crate-root alias",
+            "use crate as c;\nfn f(h:&std::path::Path){ let _=c::snapshot::load(h); }",
         ),
     ];
-    for (name, lines) in must_catch {
+    for (name, src) in ban_forms {
+        let s = scan_file(src).expect("parse snippet");
         assert!(
-            lines.iter().any(|l| caught(l)),
-            "bypass form NOT caught by the fence: {name}"
+            s.reexports_projection || s.aliases_crate_root,
+            "escape-hatch form not banned: {name}"
         );
     }
 
-    // Negative controls: benign lines must NOT be flagged.
-    let must_not_catch: &[&str] = &[
-        "    let snapshotter = build_snapshotter();", // unrelated identifier
-        "// see crate::snapshot::load for the fail-open contract", // comment
-        "    let s: Option<&crate::snapshot::FleetSnapshot> = None;", // type ref, not a read
-        "        crate::snapshot::save(home, &snaps);", // writer, not a read
+    // Benign references must NOT be flagged: the identically named per_tick
+    // rotation module, an unrelated identifier, a foreign Snapshot type, and a
+    // comment (syn drops comments entirely).
+    let benign: &[(&str, &str)] = &[
+        (
+            "per_tick::snapshot module",
+            "use crate::daemon::per_tick::snapshot::SnapshotRotationHandler;",
+        ),
+        (
+            "per_tick bare re-export",
+            "pub(crate) use snapshot::SnapshotRotationHandler;",
+        ),
+        (
+            "unrelated identifier",
+            "fn f(){ let snapshot_count = 3; let _ = snapshot_count; }",
+        ),
+        (
+            "foreign Snapshot type",
+            "fn f(x: other_crate::Snapshot){ let _ = x; }",
+        ),
+        (
+            "comment mention only",
+            "// reads crate::snapshot::load elsewhere\nfn f(){}",
+        ),
     ];
-    for line in must_not_catch {
-        assert!(!caught(line), "benign line wrongly flagged: {line:?}");
+    for (name, src) in benign {
+        assert!(!caught(src), "benign reference wrongly flagged: {name}");
     }
 }

--- a/tests/snapshot_failopen_invariant.rs
+++ b/tests/snapshot_failopen_invariant.rs
@@ -20,49 +20,53 @@
 //! source-of-truth and is bounded by `MAX_DEFER`, so a stale snapshot at worst
 //! shifts delivery timing, never invents or drops a message.
 //!
-//! ## Detection — a `syn` AST walk (PR #2612 rework #2)
+//! ## Detection — a `syn` AST walk (PR #2612 rework #3)
 //!
-//! The first two cuts scanned source text for literal call/import substrings.
-//! Both were defeated: the reviewer (cross-vantage) injected real production
-//! readers that string scanning missed — first alias/bare-call/fn-pointer
-//! forms, then crate-level grouped imports `use crate::{snapshot as snap};`
-//! and `use crate::{snapshot::{load}};`. Rust's `use` grammar (grouped,
-//! nested, aliased, glob, arbitrary spacing, multi-line) cannot be enumerated
-//! with literal substrings — that is a METHOD failure, not a patch gap.
+//! Earlier cuts scanned source text for literal substrings and were defeated by
+//! ordinary Rust the reviewer injected: alias/bare-call/fn-pointer, then
+//! crate-level grouped imports. Rust's `use` grammar cannot be enumerated with
+//! literal substrings — that is a METHOD failure. This cut parses each file
+//! with `syn`, which NORMALIZES every syntactic variant into the same tree.
 //!
-//! This cut parses each production file with `syn` and walks the AST, which
-//! NORMALIZES every syntactic variant into the same tree. A file is a
-//! "snapshot projection user" iff it contains, OUTSIDE `#[cfg(test)]`:
-//!   - a `use` tree that imports from `crate::snapshot` (any form — path,
-//!     name, rename, grouped, nested, glob), OR
-//!   - an expression/type path with consecutive segments `crate :: snapshot`.
+//! A file is a "snapshot projection user" iff, OUTSIDE `#[cfg(test)]`, it has a
+//! use-tree or an expression/type path that names the `crate::snapshot`
+//! projection module under any of the FOUR Rust module-path roots:
+//!   - `crate` — PRECISE: `snapshot` must sit directly under `crate`, which
+//!     excludes the identically named `crate::…::per_tick::snapshot` rotation
+//!     module.
+//!   - `super` / `self` — CONSERVATIVE: any `snapshot` path segment counts;
+//!     module depth is NOT resolved (wide is stable), so a false hit becomes a
+//!     benign audited entry. (A glob such as `use super::*;` is NOT matched —
+//!     any real read it enables is a bare `snapshot::X` path caught below.)
+//!   - bare `snapshot` root — CONSERVATIVE: reachable-as-projection only from
+//!     the crate root (`main.rs`/`lib.rs` declare `mod snapshot;`); elsewhere a
+//!     same-named child module (per_tick), which audits benignly.
 //!
 //! Every such file must appear in [`AUDITED_FILES`] with a role.
 //!
 //! ## Completeness argument (name-resolution-free)
 //!
-//! To read the projection a file must, in ITS OWN text, either (a) import a
-//! primitive/the module — caught by the use-tree walk regardless of grouping —
-//! or (b) name it fully-qualified `crate::snapshot::…` — caught by the path
-//! walk. No cross-file name resolution is needed: the reference is always
-//! LOCAL to the reading file. The only two ways to reference the projection
-//! WITHOUT the local token are closed by bans below, both currently at zero
-//! violations:
-//!   1. a `pub`/`pub(crate)` RE-EXPORT of `crate::snapshot` (would let a
-//!      token-free downstream file read via the alias) — banned; the
-//!      re-exporting file itself is caught, so the ban is enforceable there.
-//!   2. aliasing the crate root, `use crate as c; c::snapshot::…` — banned.
-//!
-//! Root-anchoring on `crate::snapshot` excludes the unrelated, identically
-//! named `crate::daemon::per_tick::snapshot` rotation module.
+//! To read the projection a file must, in ITS OWN text, name the module — and
+//! the module's name is `snapshot`, reachable only via one of the four roots
+//! above (Rust 2018+ forbids a bare non-rooted `use` of a local module, and
+//! `::snapshot` would be a nonexistent extern crate). All four are matched, so
+//! the reference is always caught LOCALLY; no cross-file resolution is needed.
+//! The only token-free escapes are closed:
+//!   - a `pub`/`pub(crate)` RE-EXPORT of `crate::snapshot` (precise-crate form)
+//!     is auto-banned; the re-exporting file is itself caught, so the ban is
+//!     enforceable there.
+//!   - aliasing the crate root, `use crate as c; c::snapshot::…`, is banned.
 //!
 //! Residual limits (accepted, mirroring `enqueue_drop_invariant`'s honest
-//! limits): a read manufactured entirely inside a macro body defined in
-//! another file, or via `build.rs`/`include!`, is out of scope for an
-//! AST-of-source scan. None exist and such a form would be extraordinary.
+//! limits): a `pub` re-export via a `super`/`self`/bare root is flagged as an
+//! audited file (so it is REVIEWED) but not auto-banned — distinguishing it
+//! from the benign per_tick re-export needs module resolution; a reviewer
+//! catches a leaky re-export at audit time. A read manufactured entirely inside
+//! a macro body defined in another file, or via `build.rs`/`include!`, is out
+//! of scope for an AST-of-source scan. None of these exist today.
 //!
 //! `scanner_catches_all_bypass_forms` below is the fence's fence: it proves
-//! all six reviewer forms plus glob/multi-line are caught and the bans fire.
+//! every reviewer form across all four roots is caught and the bans fire.
 //!
 //! ## The allowlist
 //!
@@ -70,18 +74,18 @@
 //! `reader`, a fail-open review; the list records that review, it does not
 //! waive it. The behavioral companion
 //! `snapshot_missing_fails_open_for_dispatch_deciders` (unit test in
-//! `src/snapshot.rs`) proves the primitives return the conservative sentinel
-//! on a missing/corrupt/old-format snapshot; it lives there because the
-//! `snapshot` module is not on the curated `lib.rs` surface.
+//! `src/snapshot.rs`) proves the primitives return the conservative sentinel on
+//! a missing/corrupt/old-format snapshot; it lives there because the `snapshot`
+//! module is not on the curated `lib.rs` surface.
 
 use std::path::{Path, PathBuf};
 use syn::visit::{self, Visit};
 
 /// Every production file that references the `crate::snapshot` projection, with
 /// its role. `reader` entries carry the reviewed reason a stale/missing
-/// snapshot drives only a REVERSIBLE action; `writer`/`type-user` produce or
-/// type the projection and do not read it for a decision. Suffix-matched
-/// against the `src/`-relative path.
+/// snapshot drives only a REVERSIBLE action; `writer`/`type-user`/`per-tick`
+/// produce, type, or merely name-clash with the projection and do not read it
+/// for a decision. Suffix-matched against the `src/`-relative path.
 const AUDITED_FILES: &[(&str, &str, &str)] = &[
     (
         "src/daemon/dispatch_idle/mod.rs",
@@ -123,6 +127,11 @@ const AUDITED_FILES: &[(&str, &str, &str)] = &[
         "writer",
         "the per-tick rotation handler: PRODUCES the projection via crate::snapshot::save. Not a reader; no decision reads snapshot here.",
     ),
+    (
+        "src/daemon/per_tick/mod.rs",
+        "per-tick",
+        "benign name-clash: `pub(crate) use snapshot::SnapshotRotationHandler` re-exports the SAME-NAMED per_tick child module (crate::daemon::per_tick::snapshot, the rotation handler), NOT the crate::snapshot projection. The conservative bare-root rule cannot resolve the two apart, so this is audited as benign. Reads no snapshot.",
+    ),
 ];
 
 fn collect_rs_files(dir: &Path, out: &mut Vec<PathBuf>) {
@@ -154,32 +163,90 @@ fn has_cfg_test(attrs: &[syn::Attribute]) -> bool {
     })
 }
 
-/// Given a use-subtree positioned immediately after the `crate` root, does it
-/// bring the `snapshot` projection module (or something under it) into scope?
+/// Does a use-tree name a `snapshot` segment anywhere in it?
+fn use_tree_names_snapshot(t: &syn::UseTree) -> bool {
+    match t {
+        syn::UseTree::Path(p) => p.ident == "snapshot" || use_tree_names_snapshot(&p.tree),
+        syn::UseTree::Name(n) => n.ident == "snapshot",
+        syn::UseTree::Rename(r) => r.ident == "snapshot",
+        syn::UseTree::Group(g) => g.items.iter().any(use_tree_names_snapshot),
+        syn::UseTree::Glob(_) => false,
+    }
+}
+
+/// Immediately after `crate`, does the subtree name the `snapshot` projection
+/// module directly? (Precise: excludes `crate::…::per_tick::snapshot`.)
 fn after_crate_is_snapshot(t: &syn::UseTree) -> bool {
     match t {
         syn::UseTree::Path(p) => p.ident == "snapshot",
         syn::UseTree::Name(n) => n.ident == "snapshot",
         syn::UseTree::Rename(r) => r.ident == "snapshot",
         syn::UseTree::Group(g) => g.items.iter().any(after_crate_is_snapshot),
-        // `use crate::*;` glob-imports the crate root, which includes
-        // `snapshot`; treat conservatively as a hit.
-        syn::UseTree::Glob(_) => true,
+        // A glob (`use crate::*;`) is NOT matched here: it does not name
+        // `snapshot`, and any actual read it enables is a bare `snapshot::X`
+        // path caught by `path_hit`. Flagging every glob would be noise.
+        syn::UseTree::Glob(_) => false,
     }
 }
 
-/// True if this use tree imports from `crate::snapshot` in any form.
-fn use_tree_hits_projection(t: &syn::UseTree) -> bool {
+/// A match against the projection: `any` = referenced at all; `precise_crate` =
+/// via the unambiguous `crate::snapshot` form (the only form that is auto-banned
+/// when re-exported).
+#[derive(Default, Clone, Copy)]
+struct Hit {
+    any: bool,
+    precise_crate: bool,
+}
+
+impl Hit {
+    fn merge(self, o: Hit) -> Hit {
+        Hit {
+            any: self.any || o.any,
+            precise_crate: self.precise_crate || o.precise_crate,
+        }
+    }
+}
+
+fn use_tree_hit(t: &syn::UseTree) -> Hit {
     match t {
-        syn::UseTree::Path(p) if p.ident == "crate" => after_crate_is_snapshot(&p.tree),
-        // A leading group, e.g. `use {crate::snapshot, ...};`.
-        syn::UseTree::Group(g) => g.items.iter().any(use_tree_hits_projection),
-        _ => false,
+        syn::UseTree::Path(p) if p.ident == "crate" => {
+            let precise = after_crate_is_snapshot(&p.tree);
+            Hit {
+                any: precise,
+                precise_crate: precise,
+            }
+        }
+        // super::/self:: rooted — conservative (module depth unresolved): the
+        // subtree must NAME `snapshot` (e.g. `use super::snapshot`). A super/self
+        // glob is not matched — a real read through it is a bare `snapshot::X`
+        // path caught by `path_hit`.
+        syn::UseTree::Path(p) if p.ident == "super" || p.ident == "self" => Hit {
+            any: use_tree_names_snapshot(&p.tree),
+            precise_crate: false,
+        },
+        // Bare `snapshot` root (crate-root child, or same-named per_tick child).
+        syn::UseTree::Path(p) if p.ident == "snapshot" => Hit {
+            any: true,
+            precise_crate: false,
+        },
+        syn::UseTree::Name(n) if n.ident == "snapshot" => Hit {
+            any: true,
+            precise_crate: false,
+        },
+        syn::UseTree::Rename(r) if r.ident == "snapshot" => Hit {
+            any: true,
+            precise_crate: false,
+        },
+        syn::UseTree::Group(g) => g
+            .items
+            .iter()
+            .map(use_tree_hit)
+            .fold(Hit::default(), Hit::merge),
+        _ => Hit::default(),
     }
 }
 
-/// True if this use tree aliases the crate root, e.g. `use crate as c;` — a
-/// token-free escape hatch (`c::snapshot::…`) that the ban forbids.
+/// True if this use tree aliases the crate root, e.g. `use crate as c;`.
 fn use_tree_aliases_crate_root(t: &syn::UseTree) -> bool {
     match t {
         syn::UseTree::Rename(r) => r.ident == "crate",
@@ -188,13 +255,32 @@ fn use_tree_aliases_crate_root(t: &syn::UseTree) -> bool {
     }
 }
 
-/// True if a path names consecutive segments `crate :: snapshot` (the
-/// projection), excluding the identically named `…::per_tick::snapshot`.
-fn path_is_crate_snapshot(p: &syn::Path) -> bool {
-    let idents: Vec<String> = p.segments.iter().map(|s| s.ident.to_string()).collect();
-    idents
+fn path_hit(p: &syn::Path) -> Hit {
+    let segs: Vec<String> = p.segments.iter().map(|s| s.ident.to_string()).collect();
+    if segs
         .windows(2)
         .any(|w| w[0] == "crate" && w[1] == "snapshot")
+    {
+        return Hit {
+            any: true,
+            precise_crate: true,
+        };
+    }
+    // Conservative: `snapshot` used as a MODULE segment — i.e. `snapshot::X`
+    // (module access), NOT a terminal `snapshot` (a variable/fn/field named
+    // snapshot). Rooted at super/self, or bare `snapshot` as the first segment.
+    let n = segs.len();
+    if n >= 2 {
+        let first = segs[0].as_str();
+        let snapshot_as_module = segs[..n - 1].iter().any(|s| s == "snapshot");
+        if snapshot_as_module && matches!(first, "super" | "self" | "snapshot") {
+            return Hit {
+                any: true,
+                precise_crate: false,
+            };
+        }
+    }
+    Hit::default()
 }
 
 #[derive(Default)]
@@ -230,17 +316,21 @@ impl<'ast> Visit<'ast> for Scan {
         if use_tree_aliases_crate_root(&i.tree) {
             self.aliases_crate_root = true;
         }
-        if use_tree_hits_projection(&i.tree) {
+        let hit = use_tree_hit(&i.tree);
+        if hit.any {
             self.refs_projection = true;
-            // pub / pub(crate) / pub(super) etc. re-export reaches other files.
-            if !matches!(i.vis, syn::Visibility::Inherited) {
+            // Auto-ban a re-export only for the unambiguous crate::snapshot
+            // form (a super/self/bare pub re-export cannot be told apart from
+            // the benign per_tick one without resolution — it is audited, not
+            // auto-banned; see the module doc's residual limits).
+            if hit.precise_crate && !matches!(i.vis, syn::Visibility::Inherited) {
                 self.reexports_projection = true;
             }
         }
         visit::visit_item_use(self, i);
     }
     fn visit_path(&mut self, p: &'ast syn::Path) {
-        if path_is_crate_snapshot(p) {
+        if path_hit(p).any {
             self.refs_projection = true;
         }
         visit::visit_path(self, p);
@@ -278,8 +368,6 @@ fn snapshot_stale_never_causes_irreversible_action() {
         };
         let scan = match scan_file(&content) {
             Ok(s) => s,
-            // A file we cannot parse could hide a reader — surface it, never
-            // silently skip.
             Err(e) => {
                 parse_failures.push(format!("  {rel}: {e}"));
                 continue;
@@ -309,7 +397,7 @@ fn snapshot_stale_never_causes_irreversible_action() {
     assert!(
         parse_failures.is_empty(),
         "Could not parse these source files with syn (a reader could hide in \
-         one). Fix the parse or narrow the walk:\n{}",
+         one):\n{}",
         parse_failures.join("\n")
     );
 
@@ -318,8 +406,7 @@ fn snapshot_stale_never_causes_irreversible_action() {
         "Forbidden snapshot reference form(s) in production.\n\n\
          A `pub`/`pub(crate)` re-export of crate::snapshot, or a crate-root \
          alias, lets a downstream file read the projection WITHOUT any local \
-         `snapshot` reference — defeating the audited-files completeness \
-         argument. Reference the projection only in fully-qualified, \
+         `snapshot` reference. Reference the projection only in fully-qualified, \
          non-re-exported form.\n\n{}",
         banned.join("\n")
     );
@@ -330,9 +417,9 @@ fn snapshot_stale_never_causes_irreversible_action() {
          AUDITED_FILES.\n\n\
          Any reader of the snapshot projection must fail-open: a stale/missing \
          snapshot may cause only a REVERSIBLE action (nudge/warn/log/timing), \
-         never an irreversible one. Add each file to AUDITED_FILES in this test \
-         with a role (reader/writer/type-user) and — for a reader — a one-line \
-         reversibility rationale, only after confirming it fails open.\n\n{}",
+         never an irreversible one. Add each file to AUDITED_FILES with a role \
+         (reader/writer/type-user) and — for a reader — a one-line reversibility \
+         rationale, only after confirming it fails open.\n\n{}",
         unaudited.join("\n")
     );
 
@@ -348,10 +435,9 @@ fn snapshot_stale_never_causes_irreversible_action() {
     );
 }
 
-/// The fence's fence: prove the AST walk catches every read form the reviewer
-/// showed the string scans missed (and the crate-level grouped/nested/glob/
-/// multi-line variants), that the bans fire, and that benign non-projection
-/// references are not flagged.
+/// The fence's fence: prove the AST walk catches every read form across all
+/// four module-path roots (crate / super / self / bare), that the bans fire,
+/// and that benign non-projection references are not flagged.
 #[test]
 fn scanner_catches_all_bypass_forms() {
     let caught = |src: &str| -> bool {
@@ -359,9 +445,9 @@ fn scanner_catches_all_bypass_forms() {
         s.refs_projection || s.reexports_projection || s.aliases_crate_root
     };
 
-    // Every read form must be caught. Forms 1-4 are the first review's; forms
-    // 5-6 are the crate-level grouped imports the second review injected;
-    // 7-8 harden glob and multi-line grouping.
+    // Every read form must be caught. Forms 1-4: first review. 5-6: crate-level
+    // grouped imports (second review). 7-8: glob / multi-line. 9-12: the
+    // super/self/bare roots (third review — 9 is reviewer4's exact injection).
     let read_forms: &[(&str, &str)] = &[
         ("baseline call", "fn f(h: &std::path::Path) { let _ = crate::snapshot::load(h); }"),
         ("form1 direct import", "use crate::snapshot::load;\nfn f(h: &std::path::Path){ let _ = load(h); }"),
@@ -372,6 +458,12 @@ fn scanner_catches_all_bypass_forms() {
         ("form6 crate-grouped nested", "use crate::{snapshot::{load}};\nfn f(h:&std::path::Path){ let _=load(h); }"),
         ("form7 crate glob", "use crate::*;\nfn f(h:&std::path::Path){ let _=snapshot::load(h); }"),
         ("form8 multiline group", "use crate::{\n    snapshot::agent_is_busy,\n    fmt_util,\n};\nfn f(h:&std::path::Path){ let _=agent_is_busy(h,\"a\"); }"),
+        ("form9 super import (reviewer4)", "use super::snapshot;\nfn f(h:&std::path::Path){ let _=snapshot::agent_is_busy(h,\"a\"); }"),
+        ("form10 self import", "use self::snapshot;\nfn f(h:&std::path::Path){ let _=snapshot::load(h); }"),
+        ("form11 super multi-level path", "fn f(h:&std::path::Path){ let _=super::super::snapshot::load(h); }"),
+        ("form12 bare path", "fn f(h:&std::path::Path){ let _=snapshot::load(h); }"),
+        ("form13 super path call", "fn f(h:&std::path::Path){ let _=super::snapshot::agent_is_busy(h,\"a\"); }"),
+        ("form14 super glob", "use super::*;\nfn f(h:&std::path::Path){ let _=snapshot::load(h); }"),
     ];
     for (name, src) in read_forms {
         assert!(caught(src), "read form NOT caught by the AST fence: {name}");
@@ -398,16 +490,21 @@ fn scanner_catches_all_bypass_forms() {
     }
 
     // Benign references must NOT be flagged: the identically named per_tick
-    // rotation module, an unrelated identifier, a foreign Snapshot type, and a
-    // comment (syn drops comments entirely).
+    // rotation module addressed via a crate/bare path, a `snapshot`-PREFIXED
+    // identifier (not the module), an unrelated identifier, a foreign Snapshot
+    // type, and a comment (syn drops comments).
     let benign: &[(&str, &str)] = &[
         (
-            "per_tick::snapshot module",
+            "per_tick via crate path",
             "use crate::daemon::per_tick::snapshot::SnapshotRotationHandler;",
         ),
         (
-            "per_tick bare re-export",
-            "pub(crate) use snapshot::SnapshotRotationHandler;",
+            "per_tick via bare path",
+            "fn f(){ let _ = daemon::per_tick::snapshot::timings(); }",
+        ),
+        (
+            "snapshot-prefixed fn ident",
+            "fn f(){ let _ = super::snapshot_handler_timings(); }",
         ),
         (
             "unrelated identifier",

--- a/tests/snapshot_failopen_invariant.rs
+++ b/tests/snapshot_failopen_invariant.rs
@@ -1,0 +1,220 @@
+//! [fugu §3.4] Snapshot fail-open invariant — every reader of the snapshot
+//! projection must be a reviewed fail-open consumer.
+//!
+//! `workspace/fugu-0acdd8/agend-terminal-solutions.md` §3.4: `snapshot.json` is
+//! a FAIL-OPEN projection of the in-memory `StateTracker`. It MAY be read by
+//! deciders, but — per the corrected rule — a decision that reads it MUST
+//! fail-open, be idempotent, and NEVER cause an IRREVERSIBLE action from a
+//! stale or missing snapshot.
+//!
+//! ## Irreversible-vs-reversible boundary (what this invariant guards)
+//!
+//! IRREVERSIBLE (forbidden on a snapshot read):
+//!   - deleting or overwriting a source-of-truth store (worktree, branch,
+//!     task / inbox / decision file), or
+//!   - fabricating an OUTBOUND send (a Telegram / Discord / PTY message that
+//!     would not exist under a correct snapshot).
+//!
+//! REVERSIBLE / acceptable (fail-open):
+//!   - a nudge, a warn, a log line, a re-nudge, or
+//!   - delivering an ALREADY-AUTHORITATIVE inbox message whose TIMING (not
+//!     existence) the snapshot gates — the payload is owned by the inbox
+//!     source-of-truth and is bounded by the `MAX_DEFER` cap, so a stale
+//!     snapshot at worst shifts delivery timing, never invents or drops a
+//!     message.
+//!
+//! ## What this test does
+//!
+//! It enumerates every PRODUCTION call site of a snapshot READ primitive
+//! (`snapshot::load`, `snapshot::agent_state_of`, `snapshot::agent_is_busy`;
+//! the writer `snapshot::save` is intentionally out of scope) and asserts each
+//! lives in a file on [`ALLOWED_READERS`], whose entry records the reviewed
+//! reason the read's action is reversible. A NEW reader in an unlisted file
+//! fails this test until its author adds an entry — forcing a fail-open review
+//! at the moment a new snapshot dependency is introduced. This is the same
+//! anti-growth contract as `task_events_invariant` / `spawn_rationale_audit`.
+//!
+//! The "never causes an irreversible action" property is therefore enforced by
+//! three layers: (1) this allowlist forces review when a reader is added,
+//! (2) each entry records the reviewed reversibility rationale, and (3) the
+//! behavioral companion below proves the read primitives fail open.
+//!
+//! Behavioral companion: `snapshot_missing_fails_open_for_dispatch_deciders`
+//! (unit test in `src/snapshot.rs`) proves the read primitives return the
+//! conservative sentinel on a missing / corrupt / old-format snapshot. It lives
+//! there rather than here because the `snapshot` module is not on the curated
+//! `lib.rs` public surface — exposing it would be a production change out of
+//! scope for this test-only PR.
+//!
+//! Inventory as of origin/main: 7 files, 10 read sites (see `ALLOWED_READERS`).
+//! `#[cfg(test)]` reads (notify / per_tick::snapshot / app) are sliced out.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+/// Snapshot READ primitives. Qualified `snapshot::` form only — the writer
+/// `snapshot::save` and the module's own bare internal calls are excluded.
+const READ_PATTERNS: &[&str] = &[
+    "snapshot::load(",
+    "snapshot::agent_state_of(",
+    "snapshot::agent_is_busy(",
+];
+
+/// Every production file allowed to read the snapshot projection, each with the
+/// reviewed reason its snapshot-driven action is REVERSIBLE / fail-open.
+/// Suffix-matched against the `src/`-relative path.
+///
+/// Adding an entry REQUIRES a fail-open review of the new reader — this list
+/// records that the review happened; it does not waive it. The bar for every
+/// entry: "a stale / missing snapshot here causes only a reversible action."
+const ALLOWED_READERS: &[(&str, &str)] = &[
+    (
+        "src/daemon/dispatch_idle/mod.rs",
+        "idle silence gate; missing -> target_is_working=false -> still FIRES the nudge (fail-open by design, #1516). Reversible: a nudge.",
+    ),
+    (
+        "src/inbox/notify.rs",
+        "inject defer/drain TIMING gate; missing -> not-busy -> inject now (bounded by MAX_DEFER). Payload is authoritative from the inbox source-of-truth; the snapshot gates timing, not existence.",
+    ),
+    (
+        "src/daemon/handoff_timeout_watchdog.rs",
+        "re-nudge gate + telemetry; missing -> not-busy -> re-nudge. Reversible: a nudge.",
+    ),
+    (
+        "src/reply_ledger.rs",
+        "sweep gate; missing -> not-busy -> emit_warn + NudgeAgent. Reversible: a warn/nudge, never a delete.",
+    ),
+    (
+        "src/daemon/mod.rs",
+        "startup diagnostic only: logs 'previous snapshot found' via tracing::info; missing -> skip the log. No action at all.",
+    ),
+    (
+        "src/api/handlers/query.rs",
+        "read-only: builds the status query response; missing -> empty {agents:[], timestamp:null}. No mutation.",
+    ),
+    (
+        "src/bugreport.rs",
+        "read-only: renders the snapshot section of a bug report; missing -> section shows nothing. No mutation.",
+    ),
+];
+
+fn collect_rs_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let p = entry.path();
+        if p.is_dir() {
+            collect_rs_files(&p, out);
+        } else if p.extension().and_then(|e| e.to_str()) == Some("rs") {
+            out.push(p);
+        }
+    }
+}
+
+/// 1-based line numbers inside `#[cfg(test)] mod` regions (brace-depth tracked),
+/// so in-file test modules are sliced out. Mirrors the proven helper in
+/// `tests/enqueue_drop_invariant.rs::test_region_lines`.
+fn test_region_lines(content: &str) -> HashSet<usize> {
+    let mut out = HashSet::new();
+    let mut depth: i32 = 0;
+    let mut pending_cfg_test = false;
+    let mut region_depth: Option<i32> = None;
+    for (i, line) in content.lines().enumerate() {
+        let t = line.trim();
+        if region_depth.is_none() {
+            if t.starts_with("#[cfg(test)]") {
+                pending_cfg_test = true;
+            } else if pending_cfg_test && t.contains("mod ") && line.contains('{') {
+                region_depth = Some(depth);
+                pending_cfg_test = false;
+            }
+        }
+        if region_depth.is_some_and(|d| depth >= d) {
+            out.insert(i + 1);
+        }
+        let next = depth + line.matches('{').count() as i32 - line.matches('}').count() as i32;
+        if let Some(d) = region_depth {
+            if next <= d {
+                region_depth = None;
+            }
+        }
+        depth = next;
+    }
+    out
+}
+
+fn rel_str(path: &Path, root: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+#[test]
+fn snapshot_stale_never_causes_irreversible_action() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let src = root.join("src");
+    let mut files = Vec::new();
+    collect_rs_files(&src, &mut files);
+    files.sort();
+
+    let mut unlisted: Vec<String> = Vec::new();
+    let mut matched: HashSet<&str> = HashSet::new();
+
+    for f in &files {
+        let rel = rel_str(f, root);
+        // The definition module itself is not a consumer.
+        if rel == "src/snapshot.rs" {
+            continue;
+        }
+        let Ok(content) = std::fs::read_to_string(f) else {
+            continue;
+        };
+        let test_lines = test_region_lines(&content);
+        for (idx, line) in content.lines().enumerate() {
+            let lineno = idx + 1;
+            if test_lines.contains(&lineno) {
+                continue;
+            }
+            if line.trim_start().starts_with("//") {
+                continue;
+            }
+            if !READ_PATTERNS.iter().any(|p| line.contains(p)) {
+                continue;
+            }
+            match ALLOWED_READERS
+                .iter()
+                .find(|(suffix, _)| rel.ends_with(suffix))
+            {
+                Some((suffix, _)) => {
+                    matched.insert(*suffix);
+                }
+                None => unlisted.push(format!("  {rel}:{lineno}: {}", line.trim())),
+            }
+        }
+    }
+
+    assert!(
+        unlisted.is_empty(),
+        "New snapshot reader(s) outside the fail-open ALLOWLIST.\n\n\
+         Every reader of the snapshot projection must fail-open: a stale/missing \
+         snapshot may cause only a REVERSIBLE action (nudge/warn/log/timing), never \
+         an irreversible one (delete/overwrite/fabricated outbound send). Add the \
+         site to ALLOWED_READERS in this file WITH a one-line reversibility \
+         rationale — and only after confirming the read actually fails open.\n\n\
+         Unlisted read site(s):\n{}",
+        unlisted.join("\n")
+    );
+
+    let stale: Vec<&str> = ALLOWED_READERS
+        .iter()
+        .map(|(s, _)| *s)
+        .filter(|s| !matched.contains(s))
+        .collect();
+    assert!(
+        stale.is_empty(),
+        "Stale ALLOWED_READERS entr(y/ies) — no snapshot read found in: {stale:?}.\n\
+         Remove the entry (the reader was deleted/moved) to keep the inventory honest.",
+    );
+}

--- a/tests/snapshot_failopen_invariant.rs
+++ b/tests/snapshot_failopen_invariant.rs
@@ -23,50 +23,86 @@
 //!     snapshot at worst shifts delivery timing, never invents or drops a
 //!     message.
 //!
-//! ## What this test does
+//! ## Detection — a two-layer fence (PR #2612 rework)
 //!
-//! It enumerates every PRODUCTION call site of a snapshot READ primitive
-//! (`snapshot::load`, `snapshot::agent_state_of`, `snapshot::agent_is_busy`;
-//! the writer `snapshot::save` is intentionally out of scope) and asserts each
-//! lives in a file on [`ALLOWED_READERS`], whose entry records the reviewed
-//! reason the read's action is reversible. A NEW reader in an unlisted file
-//! fails this test until its author adds an entry — forcing a fail-open review
-//! at the moment a new snapshot dependency is introduced. This is the same
-//! anti-growth contract as `task_events_invariant` / `spawn_rationale_audit`.
+//! The first cut of this test matched only the literal call form
+//! `snapshot::load(` on a single line. The reviewer (cross-vantage, PR #2612)
+//! correctly rejected it: four ordinary Rust forms read the same primitives yet
+//! slip past a literal-call scan —
+//!   1. `use crate::snapshot::load; ... load(home)`            (direct import)
+//!   2. `use crate::snapshot::{agent_is_busy as busy}; ...`    (aliased import)
+//!   3. `use crate::snapshot as snap; ... snap::agent_is_busy` (module alias)
+//!   4. `let f = crate::snapshot::load; f(home)`               (fn pointer)
 //!
-//! The "never causes an irreversible action" property is therefore enforced by
-//! three layers: (1) this allowlist forces review when a reader is added,
-//! (2) each entry records the reviewed reversibility rationale, and (3) the
-//! behavioral companion below proves the read primitives fail open.
+//! A new reader in any of those forms would silently escape `ALLOWED_READERS`,
+//! turning the anti-growth guard into a false guarantee.
 //!
-//! Behavioral companion: `snapshot_missing_fails_open_for_dispatch_deciders`
-//! (unit test in `src/snapshot.rs`) proves the read primitives return the
+//! The fix makes the scan COMPLETE by combining two layers over production code
+//! (`#[cfg(test)]` regions and comments excluded):
+//!
+//!   Layer 1 — import ban. Production code may reference the snapshot module
+//!   only in FULLY-QUALIFIED form. The import shapes that could bring a read
+//!   primitive into local scope under a name the read-scan can't see are
+//!   banned outright: `use crate::snapshot::{…}` (grouped/aliased), `use
+//!   crate::snapshot as …` (module alias), `use crate::snapshot;` (bare
+//!   module). This kills forms 2 and 3 at the source.
+//!
+//!   Layer 2 — read-reference scan. Any production line naming a read primitive
+//!   in fully-qualified form (`snapshot::load` / `snapshot::agent_state_of` /
+//!   `snapshot::agent_is_busy`, WITHOUT requiring a trailing `(` so fn-pointers
+//!   and single-item imports are caught too) marks its file a reader — which
+//!   must appear in `ALLOWED_READERS`. This catches forms 1 and 4 and every
+//!   current fully-qualified call.
+//!
+//! Given Layer 1, Layer 2's fully-qualified patterns are complete: there is no
+//! way to read a primitive without either a fully-qualified reference (Layer 2)
+//! or a banned import (Layer 1). `scanner_catches_all_bypass_forms` below is the
+//! fence's fence — it proves all four forms are caught.
+//!
+//! (Detection relies on rustfmt-normalized spacing, e.g. `crate::snapshot::`
+//! not `crate :: snapshot ::`; the repo's `cargo fmt --check` CI gate enforces
+//! that normalization, so hand-spaced evasions cannot land.)
+//!
+//! ## The allowlist
+//!
+//! Adding a file to `ALLOWED_READERS` REQUIRES a fail-open review of the new
+//! reader — the list records that the review happened; it does not waive it.
+//! The behavioral companion `snapshot_missing_fails_open_for_dispatch_deciders`
+//! (unit test in `src/snapshot.rs`) proves the primitives themselves return the
 //! conservative sentinel on a missing / corrupt / old-format snapshot. It lives
-//! there rather than here because the `snapshot` module is not on the curated
-//! `lib.rs` public surface — exposing it would be a production change out of
-//! scope for this test-only PR.
+//! there because the `snapshot` module is not on the curated `lib.rs` public
+//! surface; exposing it would be a production change out of scope here.
 //!
-//! Inventory as of origin/main: 7 files, 10 read sites (see `ALLOWED_READERS`).
-//! `#[cfg(test)]` reads (notify / per_tick::snapshot / app) are sliced out.
+//! Inventory as of origin/main: 7 reader files (see `ALLOWED_READERS`). Writers
+//! (`snapshot::save`) and type-only refs (`snapshot::FleetSnapshot`) are not
+//! reads and are intentionally out of scope.
 
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
-/// Snapshot READ primitives. Qualified `snapshot::` form only — the writer
-/// `snapshot::save` and the module's own bare internal calls are excluded.
-const READ_PATTERNS: &[&str] = &[
-    "snapshot::load(",
-    "snapshot::agent_state_of(",
-    "snapshot::agent_is_busy(",
+/// Fully-qualified read-primitive references. No trailing `(` — so a fn-pointer
+/// (`let f = crate::snapshot::load;`) and a single-item import
+/// (`use crate::snapshot::load;`) are caught, not just direct calls. The writer
+/// `snapshot::save` and type refs `snapshot::FleetSnapshot` are deliberately
+/// absent (not reads).
+const READ_FN_REFS: &[&str] = &[
+    "snapshot::load",
+    "snapshot::agent_state_of",
+    "snapshot::agent_is_busy",
 ];
 
-/// Every production file allowed to read the snapshot projection, each with the
+/// Import shapes banned in production (Layer 1): each could bring a read
+/// primitive into scope under a name Layer 2's fully-qualified scan cannot see.
+/// Banning them forces every snapshot reference to stay fully-qualified.
+const BANNED_IMPORTS: &[&str] = &[
+    "use crate::snapshot::{",
+    "use crate::snapshot as ",
+    "use crate::snapshot;",
+];
+
+/// Every production file allowed to READ the snapshot projection, each with the
 /// reviewed reason its snapshot-driven action is REVERSIBLE / fail-open.
 /// Suffix-matched against the `src/`-relative path.
-///
-/// Adding an entry REQUIRES a fail-open review of the new reader — this list
-/// records that the review happened; it does not waive it. The bar for every
-/// entry: "a stale / missing snapshot here causes only a reversible action."
 const ALLOWED_READERS: &[(&str, &str)] = &[
     (
         "src/daemon/dispatch_idle/mod.rs",
@@ -144,6 +180,20 @@ fn test_region_lines(content: &str) -> HashSet<usize> {
     out
 }
 
+fn is_comment(line: &str) -> bool {
+    line.trim_start().starts_with("//")
+}
+
+/// Layer 1: a banned import form (grouped/aliased/bare-module snapshot import).
+fn is_banned_import(line: &str) -> bool {
+    BANNED_IMPORTS.iter().any(|b| line.contains(b))
+}
+
+/// Layer 2: a fully-qualified reference to a snapshot READ primitive.
+fn is_read_ref(line: &str) -> bool {
+    READ_FN_REFS.iter().any(|r| line.contains(r))
+}
+
 fn rel_str(path: &Path, root: &Path) -> String {
     path.strip_prefix(root)
         .unwrap_or(path)
@@ -159,6 +209,7 @@ fn snapshot_stale_never_causes_irreversible_action() {
     collect_rs_files(&src, &mut files);
     files.sort();
 
+    let mut banned: Vec<String> = Vec::new();
     let mut unlisted: Vec<String> = Vec::new();
     let mut matched: HashSet<&str> = HashSet::new();
 
@@ -174,13 +225,17 @@ fn snapshot_stale_never_causes_irreversible_action() {
         let test_lines = test_region_lines(&content);
         for (idx, line) in content.lines().enumerate() {
             let lineno = idx + 1;
-            if test_lines.contains(&lineno) {
+            if test_lines.contains(&lineno) || is_comment(line) {
                 continue;
             }
-            if line.trim_start().starts_with("//") {
+            // Layer 1 (applies to ALL files, allowlisted or not): the bypass-
+            // enabling import forms are forbidden outright.
+            if is_banned_import(line) {
+                banned.push(format!("  {rel}:{lineno}: {}", line.trim()));
                 continue;
             }
-            if !READ_PATTERNS.iter().any(|p| line.contains(p)) {
+            // Layer 2: a fully-qualified read reference marks a reader file.
+            if !is_read_ref(line) {
                 continue;
             }
             match ALLOWED_READERS
@@ -196,8 +251,20 @@ fn snapshot_stale_never_causes_irreversible_action() {
     }
 
     assert!(
+        banned.is_empty(),
+        "Banned snapshot import form(s) in production (Layer 1).\n\n\
+         Reference the snapshot module only in FULLY-QUALIFIED form \
+         (`crate::snapshot::<fn>(...)`). Grouped/aliased/bare-module imports \
+         (`use crate::snapshot::{{…}}`, `use crate::snapshot as …`, \
+         `use crate::snapshot;`) can bring a read primitive into scope under a \
+         name the reader-scan cannot see, defeating the fail-open allowlist.\n\n\
+         Offending line(s):\n{}",
+        banned.join("\n")
+    );
+
+    assert!(
         unlisted.is_empty(),
-        "New snapshot reader(s) outside the fail-open ALLOWLIST.\n\n\
+        "New snapshot reader(s) outside the fail-open ALLOWLIST (Layer 2).\n\n\
          Every reader of the snapshot projection must fail-open: a stale/missing \
          snapshot may cause only a REVERSIBLE action (nudge/warn/log/timing), never \
          an irreversible one (delete/overwrite/fabricated outbound send). Add the \
@@ -217,4 +284,65 @@ fn snapshot_stale_never_causes_irreversible_action() {
         "Stale ALLOWED_READERS entr(y/ies) — no snapshot read found in: {stale:?}.\n\
          Remove the entry (the reader was deleted/moved) to keep the inventory honest.",
     );
+}
+
+/// The fence's fence: prove the two-layer scan catches every read form the
+/// reviewer (PR #2612) showed the literal-call scan missed, and does NOT flag
+/// benign lines. Each `case` is classified by the same predicates the main test
+/// uses; "caught" = Layer 1 (banned import) OR Layer 2 (read ref) on a
+/// non-comment line.
+#[test]
+fn scanner_catches_all_bypass_forms() {
+    fn caught(line: &str) -> bool {
+        !is_comment(line) && (is_banned_import(line) || is_read_ref(line))
+    }
+
+    // Every bypass form the reviewer flagged, plus the baseline call. Each must
+    // be caught on at least one of its lines.
+    let must_catch: &[(&str, &[&str])] = &[
+        ("baseline call", &["let _ = crate::snapshot::load(home);"]),
+        (
+            "form 1: direct import + bare call",
+            &["use crate::snapshot::load;", "    let _ = load(home);"],
+        ),
+        (
+            "form 2: grouped/aliased import",
+            &[
+                "use crate::snapshot::{agent_is_busy as busy};",
+                "    let _ = busy(home, name);",
+            ],
+        ),
+        (
+            "form 3: module alias",
+            &[
+                "use crate::snapshot as snap;",
+                "    let _ = snap::agent_is_busy(home, name);",
+            ],
+        ),
+        (
+            "form 4: fn pointer",
+            &["let f = crate::snapshot::load;", "    let _ = f(home);"],
+        ),
+        (
+            "bare module import + call",
+            &["use crate::snapshot;", "    let _ = snapshot::load(home);"],
+        ),
+    ];
+    for (name, lines) in must_catch {
+        assert!(
+            lines.iter().any(|l| caught(l)),
+            "bypass form NOT caught by the fence: {name}"
+        );
+    }
+
+    // Negative controls: benign lines must NOT be flagged.
+    let must_not_catch: &[&str] = &[
+        "    let snapshotter = build_snapshotter();", // unrelated identifier
+        "// see crate::snapshot::load for the fail-open contract", // comment
+        "    let s: Option<&crate::snapshot::FleetSnapshot> = None;", // type ref, not a read
+        "        crate::snapshot::save(home, &snaps);", // writer, not a read
+    ];
+    for line in must_not_catch {
+        assert!(!caught(line), "benign line wrongly flagged: {line:?}");
+    }
 }


### PR DESCRIPTION
## What
Two test-only invariants enforcing fugu solutions.md §3.4: `snapshot.json` is a **fail-open projection** — a stale/missing snapshot may drive only a *reversible* action (nudge/warn/log/timing), never an irreversible one (delete/overwrite/fabricated outbound send). Pure test PR, **zero production code change** (`src/snapshot.rs` diff is entirely within its existing `#[cfg(test)] mod tests`).

## The two tests
1. **`snapshot_stale_never_causes_irreversible_action`** — `tests/snapshot_failopen_invariant.rs`. Source-scan allowlist: every production call site of `snapshot::{load,agent_state_of,agent_is_busy}` must be in `ALLOWED_READERS`, each carrying a reviewed reversibility rationale. A new reader in an unlisted file fails the test until reviewed + listed (anti-growth contract, mirrors `task_events_invariant`/`spawn_rationale_audit`). Plus an anti-rot check that every listed file still reads snapshot. `#[cfg(test)]` reads are brace-depth sliced out (reusing `enqueue_drop_invariant`'s proven `test_region_lines`).
2. **`snapshot_missing_fails_open_for_dispatch_deciders`** — `src/snapshot.rs` `#[cfg(test)]`. Behavioral: missing / corrupt / old-format snapshot → read primitives return the conservative sentinel (`None` / not-busy / `silent_secs=i64::MAX`), no panic; with a sanity assert that a known-active agent still reads busy (fail-open doesn't blanket-mask state).

**Placement note**: test 2 is a unit test rather than an integration test because the `snapshot` module is **not** on the curated `lib.rs` public surface, and exposing it would be a production change the task forbids. The behavioral fail-open must call the primitives directly, so it lives beside them.

## Consumer inventory (verified vs origin/main)
7 production reader files, 10 sites — **all fail-open deciders or read-only. No current violator found** (no bug ticket needed).

| File | Site(s) | Class | Fallback on missing/stale |
|---|---|---|---|
| `daemon/dispatch_idle/mod.rs` | 1041 | fail-open decider | `target_is_working=false` → still fires nudge (#1516) |
| `inbox/notify.rs` | 326, 423, 807 | fail-open decider | not-busy → inject now, bounded by `MAX_DEFER`; payload authoritative from inbox (snapshot gates *timing*, not existence) |
| `daemon/handoff_timeout_watchdog.rs` | 192, 213 | fail-open decider | not-busy → re-nudge |
| `reply_ledger.rs` | 374 | fail-open decider | not-busy → `emit_warn` + `NudgeAgent` |
| `daemon/mod.rs` | 554 | read-only | startup `tracing::info` only; missing → skip log |
| `api/handlers/query.rs` | 135 | read-only | status query → empty `{agents:[], timestamp:null}` |
| `bugreport.rs` | 82 | read-only | report section → empty |

Excluded as test code (`#[cfg(test)]`): `inbox/notify.rs` (1285+), `daemon/per_tick/snapshot.rs` (211), `app/mod.rs` (2288/2293).

## Verification
`cargo test --test snapshot_failopen_invariant` ✓ · `cargo test --bin agend-terminal snapshot_missing_fails_open_for_dispatch_deciders` ✓ · `cargo fmt --check` ✓ · `cargo clippy --tests --bin agend-terminal` clean.

Companion to docs/SOURCE-OF-TRUTH.md (#2608) snapshot section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)