### PR TITLE
test(pty): fd-leak regression guard + ConPTY sideload audit (herdr1)

### DIFF
--- a/docs/PTY-FD-HYGIENE-AUDIT.md
+++ b/docs/PTY-FD-HYGIENE-AUDIT.md
@@ -1,0 +1,162 @@
+# PTY fd hygiene audit (t-20260704054906745324-67777-4)
+
+Scope note on provenance: this task was framed as "herdr-inspired" — herdr is
+AGPL-3.0, so this is a clean-room audit of **our own dependency**
+(`portable-pty` 0.9.0, MIT) and **our own code**, not a reading of herdr's
+implementation. Nothing here cites or is derived from herdr source.
+
+## 1. PTY master fd CLOEXEC (Unix) — premise did not hold
+
+**Finding: already correctly hygienic, at two independent layers. No
+production code change needed.**
+
+`portable-pty` 0.9.0's `src/unix.rs::openpty()` calls `cloexec()` on both the
+master and slave fd immediately after `libc::openpty()`:
+
+```rust
+// portable-pty-0.9.0/src/unix.rs:60-65
+// Ensure that these descriptors will get closed when we execute
+// the child process.  This is done after constructing the Pty
+// instances so that we ensure that the Ptys get drop()'d if
+// the cloexec() functions fail (unlikely!).
+cloexec(master.fd.as_raw_fd())?;
+cloexec(slave.fd.as_raw_fd())?;
+```
+
+Every fd-duplication path also preserves this: `try_clone_reader()` /
+`take_writer()` go through the `filedescriptor` crate's `try_clone()`
+(`filedescriptor-0.8.3/src/unix.rs:144-149`, using `F_DUPFD_CLOEXEC`), and the
+child's own stdio wiring (`as_stdio()`, used by `spawn_command`'s
+`.stdin()/.stdout()/.stderr()`) goes through the same `F_DUPFD_CLOEXEC` dup
+(`filedescriptor-0.8.3/src/unix.rs:261-266`) — the resulting `Stdio` handle is
+itself cloexec'd, and Rust's own `std::process::Command` spawn machinery
+clears `FD_CLOEXEC` on the *new* fd it creates via `dup2` onto 0/1/2 in the
+child (standard POSIX `dup2` semantics — the destination descriptor never
+inherits `FD_CLOEXEC` from the source), so the child's actual stdin/stdout/
+stderr correctly survive `exec` while every other duplicate does not.
+
+**A second, independent layer**: `UnixSlavePty::spawn_command`'s `pre_exec`
+closure (run post-fork, pre-exec, in the child) unconditionally calls
+`close_random_fds()` (`unix.rs:152-172`), which enumerates `/dev/fd` and
+force-closes every fd numbered ≥ 3. Per its own doc comment, this exists
+because "Cocoa leaks various file descriptors to child processes" on macOS
+and "gnome/mutter leak shell extension fds" on Linux — i.e. it's a blanket
+backstop independent of and stronger than per-fd `CLOEXEC`, added to catch
+leaks from *any* source, not just our own PTY fds.
+
+Net effect: there is no fd-hygiene gap to close for item ①. Confirmed by
+direct experiment (see §2) — a deliberately non-cloexec'd fd (`libc::dup()`,
+no `F_DUPFD_CLOEXEC`) still does **not** survive into a child spawned via
+`UnixSlavePty::spawn_command`, because `close_random_fds()` sweeps it anyway.
+
+Our own code was also checked for anywhere it might bypass these safe paths
+(e.g. extracting the raw master fd and duplicating it manually): the only
+`as_raw_fd()` call on a `MasterPty` in this codebase
+(`src/backend_harness.rs`, pre-existing) reads the fd number for a
+`tcgetpgrp()` ioctl — it does not duplicate or leak it.
+
+## 2. fd-leak regression test (added)
+
+`src/backend_harness.rs`:
+- `pty_master_fd_does_not_leak_into_spawned_child` — pins the finding above:
+  opens a real PTY pair, spawns a child via the actual `spawn_command` path
+  this project uses, and asserts the master fd is **not** visible in the
+  child's own fd table (checked via `/dev/fd/N`, which — unlike Linux-only
+  `/proc/self/fd` — works identically on macOS and Linux, so the test runs on
+  both CI Unix runners).
+- `fd_leak_probe_detects_fds_that_are_genuinely_open_control_group` — a
+  control group proving the probe mechanism itself has real detection power
+  (checks fd 1, which is always open in any spawned child) rather than being
+  a probe that vacuously reports "not leaked" for anything. An earlier
+  version of this control tried to manufacture a leak via a raw
+  non-cloexec'd `dup()`; it didn't leak either, which is what led to
+  discovering `close_random_fds()` in §1 — the control was revised once the
+  root cause was understood, rather than force-fitted to the original design.
+
+Both tests are Unix-only (`#[cfg(unix)]`), matching the task's own Unix scope
+for item ①.
+
+## 3. ConPTY dll side-load probe (Windows) — confirmed, proposal below
+
+**Finding: the probing behavior is real, and is a deliberate feature, not an
+accident.** `portable-pty` 0.9.0's `src/win/psuedocon.rs::load_conpty()`:
+
+```rust
+// portable-pty-0.9.0/src/win/psuedocon.rs:44-56
+fn load_conpty() -> ConPtyFuncs {
+    // If the kernel doesn't export these functions then their system is
+    // too old and we cannot run.
+    let kernel = ConPtyFuncs::open(Path::new("kernel32.dll")).expect(
+        "this system does not support conpty.  Windows 10 October 2018 or newer is required",
+    );
+
+    // We prefer to use a sideloaded conpty.dll and openconsole.exe host deployed
+    // alongside the application.  We check for this after checking for kernel
+    // support so that we don't try to proceed and do something crazy.
+    if let Ok(sideloaded) = ConPtyFuncs::open(Path::new("conpty.dll")) {
+        sideloaded
+    } else {
+        kernel
+    }
+}
+```
+
+`ConPtyFuncs::open` (the `shared_library!` macro, from the `shared_library`
+0.1.9 crate, Apache-2.0/MIT) resolves to a **bare, unqualified**
+`LoadLibraryW(filename)` call (`shared_library-0.1.9/src/dynamic_library.rs`
+Windows arm, ~line 340) — no `LoadLibraryExW` flags restricting the search
+path. This is the textbook shape of CWE-427 (Uncontrolled Search Path
+Element / "DLL side-loading"): if a `conpty.dll` exists anywhere earlier in
+the default Windows DLL search order than the legitimate one (the
+application's own directory is searched first by default, before `System32`
+— an attacker who can write into that directory, or into a directory earlier
+in `PATH`, can plant a malicious `conpty.dll` whose exported
+`CreatePseudoConsole`/`ResizePseudoConsole`/`ClosePseudoConsole` get called
+in-process).
+
+This is not a bug in the sense of "unintended behavior" — the comment says
+the crate *deliberately* wants to support a sideloaded, updated
+`conpty.dll` dropped next to the app binary (a real, useful feature: it lets
+an app use a newer ConPTY without requiring a Windows update). The
+vulnerability is that the *search* for that sideload uses the unrestricted
+default order instead of specifically checking the app's own directory.
+
+**Proposal (three options, my recommendation marked):**
+
+1. **Runtime protection (recommended)** — call
+   `SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_APPLICATION_DIR |
+   LOAD_LIBRARY_SEARCH_SYSTEM32)` once, early in `main()` on Windows, before
+   any PTY is opened. This is a **process-wide** setting — per Microsoft's
+   docs, once called, `LoadLibrary`/`LoadLibraryEx` calls that don't specify
+   their own search flags (which is exactly what `shared_library`'s bare
+   `LoadLibraryW` does) use the directories established here instead of the
+   full default order. This closes the `PATH`/current-directory hijack
+   vector while **preserving** the intended sideload-next-to-the-exe feature
+   (`LOAD_LIBRARY_SEARCH_APPLICATION_DIR` covers exactly that case), requires
+   no changes to `portable-pty` or `shared_library`, and is defense-in-depth
+   for every other unqualified `LoadLibrary` call anywhere else in the
+   process (ours or any other dependency's). Effort: one FFI call
+   (`windows-sys` or raw `kernel32` binding) gated `#[cfg(windows)]`, at
+   process startup. Caveat: I could not build/test this on this machine
+   (developing on macOS); it needs verification on a real `windows-latest`
+   CI run or a Windows machine before merging with confidence, and someone
+   with Windows access should confirm the ConPTY sideload feature still
+   works as intended afterward (an app-directory-placed `conpty.dll` should
+   still load; a `PATH`- or cwd-placed one should not).
+2. **Vendor/patch `portable-pty`** — fork and patch `load_conpty()` to build
+   an absolute path via `std::env::current_exe()`'s parent directory instead
+   of a bare `"conpty.dll"`. More surgical and doesn't depend on a
+   process-wide flag some other code path might not expect, but commits us
+   to maintaining a patched fork across upstream version bumps.
+3. **Upstream PR to wezterm/portable-pty** — report this as a CWE-427-class
+   finding and propose the same absolute-path fix upstream. Best long-term
+   outcome for the whole ecosystem, but timeline and acceptance are outside
+   our control, so it doesn't help us in the near term on its own (could be
+   combined with option 1 as an interim mitigation).
+
+I lean toward **option 1** as the immediate fix (low blast radius, doesn't
+touch a dependency, verifiable in CI) with **option 3** filed as a follow-up
+regardless of what's decided here, since it fixes the root cause for every
+downstream consumer of the crate. Deferring the actual implementation
+decision to the lead per this task's own instruction; happy to implement
+whichever option is chosen in a follow-up PR.

--- a/src/backend_harness.rs
+++ b/src/backend_harness.rs
@@ -8,7 +8,7 @@
 use serde::{Deserialize, Serialize};
 #[cfg(all(unix, test))]
 use std::collections::HashMap;
-#[cfg(unix)]
+#[cfg(all(unix, test))]
 use std::os::unix::io::RawFd;
 #[cfg(all(unix, test))]
 use std::path::Path;
@@ -146,32 +146,6 @@ pub fn verify_tcgetpgrp() -> anyhow::Result<i32> {
     } else {
         Err(anyhow::anyhow!("tcgetpgrp returned {pgid}"))
     }
-}
-
-/// herdr-inspired fd-hygiene check (clean-room: this is our own probe, not
-/// herdr's AGPL-3.0 code — see task t-20260704054906745324-67777-4). Spawns a
-/// throwaway PTY + `/bin/sh` child purely as a vehicle to ask "is `fd` (some
-/// fd already open in THIS process) visible in a freshly-exec'd child's own
-/// fd table?" via the POSIX `/dev/fd/N` view (works on both macOS and Linux,
-/// unlike Linux-only `/proc/self/fd`). Returns `true` iff `fd` leaked across
-/// exec — i.e. `false` is the desired/healthy result.
-#[cfg(unix)]
-#[allow(dead_code)]
-fn fd_leaks_into_spawned_child(fd: RawFd) -> anyhow::Result<bool> {
-    use portable_pty::{native_pty_system, CommandBuilder, PtySize};
-    let pty_system = native_pty_system();
-    let pair = pty_system.openpty(PtySize {
-        rows: 24,
-        cols: 80,
-        pixel_width: 0,
-        pixel_height: 0,
-    })?;
-    let mut cmd = CommandBuilder::new("/bin/sh");
-    cmd.args(["-c", &format!("test -e /dev/fd/{fd}")]);
-    let mut child = pair.slave.spawn_command(cmd)?;
-    drop(pair.slave);
-    let status = child.wait()?;
-    Ok(status.success())
 }
 
 /// Probe whether ESC byte stops generation on a real backend CLI.
@@ -432,6 +406,35 @@ mod tests {
     fn test_tcgetpgrp_returns_valid_pgid() {
         let pgid = verify_tcgetpgrp().expect("tcgetpgrp must return valid pgid");
         assert!(pgid > 0);
+    }
+
+    /// herdr-inspired fd-hygiene check (clean-room: this is our own probe, not
+    /// herdr's AGPL-3.0 code — see task t-20260704054906745324-67777-4). Test-
+    /// only (review finding on #2613: an earlier version of this lived at
+    /// module scope under plain `#[cfg(unix)]`, which meant it compiled into
+    /// production Unix builds despite being used only by the two tests
+    /// below — moved inside `mod tests` so it's genuinely test-gated).
+    /// Spawns a throwaway PTY + `/bin/sh` child purely as a vehicle to ask
+    /// "is `fd` (some fd already open in THIS process) visible in a
+    /// freshly-exec'd child's own fd table?" via the POSIX `/dev/fd/N` view
+    /// (works on both macOS and Linux, unlike Linux-only `/proc/self/fd`).
+    /// Returns `true` iff `fd` leaked across exec — i.e. `false` is the
+    /// desired/healthy result.
+    fn fd_leaks_into_spawned_child(fd: RawFd) -> anyhow::Result<bool> {
+        use portable_pty::{native_pty_system, CommandBuilder, PtySize};
+        let pty_system = native_pty_system();
+        let pair = pty_system.openpty(PtySize {
+            rows: 24,
+            cols: 80,
+            pixel_width: 0,
+            pixel_height: 0,
+        })?;
+        let mut cmd = CommandBuilder::new("/bin/sh");
+        cmd.args(["-c", &format!("test -e /dev/fd/{fd}")]);
+        let mut child = pair.slave.spawn_command(cmd)?;
+        drop(pair.slave);
+        let status = child.wait()?;
+        Ok(status.success())
     }
 
     /// herdr-inspired fd-hygiene regression (t-20260704054906745324-67777-4):

--- a/src/backend_harness.rs
+++ b/src/backend_harness.rs
@@ -8,6 +8,8 @@
 use serde::{Deserialize, Serialize};
 #[cfg(all(unix, test))]
 use std::collections::HashMap;
+#[cfg(unix)]
+use std::os::unix::io::RawFd;
 #[cfg(all(unix, test))]
 use std::path::Path;
 
@@ -144,6 +146,32 @@ pub fn verify_tcgetpgrp() -> anyhow::Result<i32> {
     } else {
         Err(anyhow::anyhow!("tcgetpgrp returned {pgid}"))
     }
+}
+
+/// herdr-inspired fd-hygiene check (clean-room: this is our own probe, not
+/// herdr's AGPL-3.0 code — see task t-20260704054906745324-67777-4). Spawns a
+/// throwaway PTY + `/bin/sh` child purely as a vehicle to ask "is `fd` (some
+/// fd already open in THIS process) visible in a freshly-exec'd child's own
+/// fd table?" via the POSIX `/dev/fd/N` view (works on both macOS and Linux,
+/// unlike Linux-only `/proc/self/fd`). Returns `true` iff `fd` leaked across
+/// exec — i.e. `false` is the desired/healthy result.
+#[cfg(unix)]
+#[allow(dead_code)]
+fn fd_leaks_into_spawned_child(fd: RawFd) -> anyhow::Result<bool> {
+    use portable_pty::{native_pty_system, CommandBuilder, PtySize};
+    let pty_system = native_pty_system();
+    let pair = pty_system.openpty(PtySize {
+        rows: 24,
+        cols: 80,
+        pixel_width: 0,
+        pixel_height: 0,
+    })?;
+    let mut cmd = CommandBuilder::new("/bin/sh");
+    cmd.args(["-c", &format!("test -e /dev/fd/{fd}")]);
+    let mut child = pair.slave.spawn_command(cmd)?;
+    drop(pair.slave);
+    let status = child.wait()?;
+    Ok(status.success())
 }
 
 /// Probe whether ESC byte stops generation on a real backend CLI.
@@ -404,6 +432,67 @@ mod tests {
     fn test_tcgetpgrp_returns_valid_pgid() {
         let pgid = verify_tcgetpgrp().expect("tcgetpgrp must return valid pgid");
         assert!(pgid > 0);
+    }
+
+    /// herdr-inspired fd-hygiene regression (t-20260704054906745324-67777-4):
+    /// pins that a PTY master fd does NOT survive into a freshly-spawned
+    /// child's fd table. Verified (BIND-TOPIC-PRERESEARCH.md-style code
+    /// citation, not a guess): `portable-pty` 0.9.0's `unix.rs::openpty()`
+    /// already calls `cloexec()` on both master and slave immediately after
+    /// `libc::openpty()`, and every clone path (`try_clone_reader`,
+    /// `take_writer`, and the `filedescriptor` crate's `as_stdio` used to wire
+    /// up the child's own stdio) goes through `F_DUPFD_CLOEXEC` — this test
+    /// exists to CATCH A REGRESSION (e.g. a portable-pty downgrade, or a
+    /// future direct fd duplication in our own code that bypasses the safe
+    /// path), not because the fd currently leaks.
+    #[test]
+    fn pty_master_fd_does_not_leak_into_spawned_child() {
+        use portable_pty::{native_pty_system, PtySize};
+        let pty_system = native_pty_system();
+        let pair = pty_system
+            .openpty(PtySize {
+                rows: 24,
+                cols: 80,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .expect("openpty");
+        let master_fd = pair.master.as_raw_fd().expect("master must have a raw fd");
+        let leaked =
+            fd_leaks_into_spawned_child(master_fd).expect("fd-leak probe spawn must succeed");
+        assert!(
+            !leaked,
+            "PTY master fd {master_fd} is visible in a freshly-spawned child's fd \
+             table — CLOEXEC regression (portable-pty should have closed it across exec)"
+        );
+    }
+
+    /// Control group for the test above: proves `fd_leaks_into_spawned_child`
+    /// can actually detect an fd that IS open in the child (not a probe that
+    /// always trivially reports "closed" regardless of input). fd 1 (stdout)
+    /// is guaranteed to be open in any spawned child — it's what the child
+    /// shell's own stdout is dup'd onto.
+    ///
+    /// Note: an earlier version of this test tried to manufacture a leak via
+    /// a raw `libc::dup()` WITHOUT cloexec, expecting it to survive into the
+    /// child. It didn't — `fd_leaks_into_spawned_child` correctly reported
+    /// `false`. Root cause (verified by reading `portable-pty` 0.9.0's
+    /// `unix.rs::spawn_command`, MIT-licensed, not herdr's code):
+    /// `spawn_command`'s `pre_exec` calls `close_random_fds()` unconditionally
+    /// — a blanket enumerate-`/dev/fd`-and-`close(2)`-everything-≥3
+    /// sweep (added for a Big-Sur Cocoa fd-leak class, per its doc comment),
+    /// independent of and stronger than per-fd `CLOEXEC`. There is no way to
+    /// leak an arbitrary fd across this spawn path short of fd 0/1/2
+    /// themselves — hence this control group checks one of those instead.
+    #[test]
+    fn fd_leak_probe_detects_fds_that_are_genuinely_open_control_group() {
+        let visible = fd_leaks_into_spawned_child(1).expect("fd-leak probe spawn must succeed");
+        assert!(
+            visible,
+            "fd 1 (stdout) must be visible in ANY spawned child — if this is false, \
+             the leak-detection probe itself is broken, not the thing it's supposed \
+             to be testing"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What & why

herdr-inspired PTY fd-hygiene task. **Clean-room note**: herdr is AGPL-3.0 — this PR audits our own dependency (`portable-pty` 0.9.0, MIT-licensed) and our own code; nothing here reads, cites, or is derived from herdr's implementation. Full findings + citations in the new `docs/PTY-FD-HYGIENE-AUDIT.md`.

### Item 1 (Unix master fd CLOEXEC) — premise did not hold

Verified by reading `portable-pty` 0.9.0's actual source (vendored, MIT): `unix.rs::openpty()` already calls `cloexec()` on both the master and slave fd immediately at creation, every duplication path (`try_clone_reader`/`take_writer`/the `as_stdio` used to wire up a child's stdio) goes through `filedescriptor`'s `F_DUPFD_CLOEXEC`, and — a second, independent layer — `spawn_command`'s `pre_exec` unconditionally calls `close_random_fds()`, a blanket "close everything ≥3" sweep added for a documented Big-Sur Cocoa fd-leak class. No production code change needed; **no** MCP-surface or behavior change either.

### Item 2 (fd-leak regression test) — added regardless of item 1's finding, per the task's own instruction

- `pty_master_fd_does_not_leak_into_spawned_child`: spawns a real child via this project's actual `spawn_command` path and asserts the master fd is invisible in the child's fd table (via `/dev/fd/N` — portable across the macOS + Linux CI runners, unlike Linux-only `/proc/self/fd`).
- `fd_leak_probe_detects_fds_that_are_genuinely_open_control_group`: proves the detection mechanism has real power (checks fd 1, always open in any child) rather than being a probe that's vacuously always "not leaked". Worth noting honestly: an earlier version of this control tried to manufacture a leak via a raw non-cloexec `dup()`, expecting it to survive — it didn't, and chasing down *why* is what led to finding `close_random_fds()` above. The control was revised once the root cause was understood.

Both new tests are `#[cfg(unix)]`, matching item 1's own Unix scope.

### Item 3 (ConPTY dll sideload probe, Windows) — confirmed real, documentation-only per this task's success criteria

Source citation: `win/psuedocon.rs::load_conpty()` deliberately probes for a sideloaded `conpty.dll` via a bare, unqualified `LoadLibraryW` (through the `shared_library` crate) — the textbook shape of CWE-427 (Uncontrolled Search Path Element). This is a deliberate feature (letting an app ship an updated ConPTY without a Windows update), not an accident — the vulnerability is the *unrestricted* search path, not the feature itself.

`docs/PTY-FD-HYGIENE-AUDIT.md` §3 has the full writeup + a 3-option remediation proposal for the lead to choose from:
1. **Runtime protection (my recommendation)** — `SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_APPLICATION_DIR | LOAD_LIBRARY_SEARCH_SYSTEM32)` early in Windows `main()`. Process-wide, preserves the sideload-next-to-exe feature, touches no dependency — but I could not build/test this on macOS, so it needs Windows CI/hardware verification before merging with confidence.
2. Vendor/patch `portable-pty` to use an absolute path.
3. Upstream PR to wezterm/portable-pty (best long-term fix, outside our control on timeline).

**Not implementing any of these in this PR** — deferring the choice to the lead as instructed ("處置提案...回報給我裁").

## Prior art check (required)

- [x] Checked `docs/KNOWN_ISSUES.md` — no entry for PTY fd hygiene or ConPTY sideloading.
- [x] Compared against current `main` — no existing fd-leak regression test for the PTY spawn path.
- [x] Searched closed issues/PRs — first pass at this specific audit; no prior PR touched this.
- [x] Not revisiting an existing decision — first implementation/investigation.

## How it was verified

- New tests, both green: `pty_master_fd_does_not_leak_into_spawned_child`, `fd_leak_probe_detects_fds_that_are_genuinely_open_control_group` (`cargo test --bin agend-terminal backend_harness`).
- Every claim in the audit doc is backed by a direct source citation against the vendored dependency (`~/.cargo/registry/src/.../portable-pty-0.9.0`, `.../filedescriptor-0.8.3`, `.../shared_library-0.1.9` — all confirmed MIT/Apache-2.0, not AGPL) — spot-verified myself, not just from a subagent's summary.
- `cargo test --workspace --tests --features tray` (exact CI invocation): verified via `git stash -u` A/B on the same commit — **identical** 258-failure set with and without this diff (pre-existing, unrelated resource-contention flakes).
- `cargo fmt --check` and `cargo clippy --all-targets --features tray -- -D warnings`: clean.

## Compatibility (on-disk formats)

- [x] No on-disk format changed — test-only + documentation.

## Notes for reviewers

- This PR does **not** implement the ConPTY sideload fix — item 3's own success criteria explicitly allows "a documentation-only conclusion," and the remediation choice needs the lead's decision (and, realistically, someone with Windows access to verify the sideload feature still works after hardening).
- MCP surface: zero changes.