### PR TITLE
fix(daemon): move worktree-registry sweep off main tick loop + cache squash checks (P1-2607)

### DIFF
--- a/src/daemon/per_tick/worktree_registry_sweep.rs
+++ b/src/daemon/per_tick/worktree_registry_sweep.rs
@@ -13,16 +13,42 @@
 use super::{PerTickHandler, TickContext};
 use crate::api::ConfigRegistry;
 use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 
+/// #P1-2607 incident: `worktree_auto_cleanup` (fetch --prune + a squash-merge
+/// check per candidate branch) ran INLINE on the daemon's main tick loop —
+/// its first production run against the canonical repo took 83s wall time
+/// (172 accumulated candidates, five months of #2605's dead repo-discovery
+/// finally fixed) and froze the ENTIRE daemon (TUI, inbox, every other
+/// handler) for that whole window. Because dry-run mode never consumes
+/// candidates, this repeated every ~10 minutes indefinitely.
+///
+/// Fix: the real work now runs in its own background thread; `run()` itself
+/// only checks the cadence gate, checks/sets the re-entrancy guard, and
+/// spawns — it never blocks the tick loop. `in_flight` prevents a second
+/// round from stacking on top of one still running (which would compound the
+/// cost, not fix it) — if the previous round hasn't finished by the next
+/// scheduled fire, that fire is skipped and logged; the round after tries
+/// again. See `worktree_cleanup::is_squash_gc_eligible`'s tip-SHA cache for
+/// the complementary fix (bounds each round's cost to just the NEW/moved
+/// candidates instead of re-deriving the whole accumulated set every time).
 pub(crate) struct WorktreeRegistrySweepHandler {
     gate: crate::daemon::cadence_gate::CadenceGate,
+    in_flight: Arc<AtomicBool>,
 }
 
 impl WorktreeRegistrySweepHandler {
     pub(crate) fn new(every_n_ticks: u64) -> Self {
         Self {
             gate: crate::daemon::cadence_gate::CadenceGate::new(every_n_ticks),
+            in_flight: Arc::new(AtomicBool::new(false)),
         }
+    }
+
+    #[cfg(test)]
+    fn is_in_flight(&self) -> bool {
+        self.in_flight.load(Ordering::Acquire)
     }
 }
 
@@ -35,7 +61,57 @@ impl PerTickHandler for WorktreeRegistrySweepHandler {
         if !self.gate.fire() {
             return;
         }
-        worktree_auto_cleanup(ctx.home, ctx.configs);
+        // #P1-2607: a previous round is still running in its background
+        // thread — skip this tick's fire instead of stacking a second sweep
+        // on top of it.
+        if self.in_flight.swap(true, Ordering::AcqRel) {
+            tracing::warn!(
+                "worktree_registry_sweep: previous round still in flight, \
+                 skipping this tick's fire (will retry next cadence)"
+            );
+            return;
+        }
+        let home = ctx.home.to_path_buf();
+        let configs = Arc::clone(ctx.configs);
+        let in_flight = Arc::clone(&self.in_flight);
+        // fire-and-forget: #P1-2607 — moves the potentially-slow sweep
+        // (git subprocess per candidate branch) off the daemon's main tick
+        // loop. No JoinHandle is kept; completion is signaled via
+        // `in_flight` (cleared once the sweep returns) and results remain
+        // fully observable via tracing + event_log per candidate, same as
+        // before this offload.
+        std::thread::spawn(move || {
+            #[cfg(test)]
+            test_hooks::maybe_delay();
+            worktree_auto_cleanup(&home, &configs);
+            in_flight.store(false, Ordering::Release);
+        });
+    }
+}
+
+/// #P1-2607 regression-test seam: lets a test simulate a slow sweep (the
+/// pathological case that froze the daemon) without needing a real repo with
+/// hundreds of candidate branches. No-op in production — `maybe_delay` is
+/// only ever called from a `#[cfg(test)]` call site.
+#[cfg(test)]
+mod test_hooks {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static DELAY_MS: AtomicU64 = AtomicU64::new(0);
+
+    pub(crate) fn set_delay_ms(ms: u64) {
+        DELAY_MS.store(ms, Ordering::Release);
+    }
+
+    pub(crate) fn clear_delay() {
+        DELAY_MS.store(0, Ordering::Release);
+    }
+
+    pub(crate) fn maybe_delay() {
+        let ms = DELAY_MS.load(Ordering::Acquire);
+        if ms > 0 {
+            std::thread::sleep(std::time::Duration::from_millis(ms));
+        }
     }
 }
 
@@ -140,6 +216,79 @@ mod tests {
         h.run(&ctx);
         h.run(&ctx);
 
+        // #P1-2607: the real work now runs in a background thread; give it a
+        // moment to finish before tearing down `home` out from under it.
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #P1-2607 freeze-regression pin: `run()` must return near-instantly
+    /// even while the sweep itself is slow (the pathological case that froze
+    /// the daemon — 83s of git subprocess work on the main tick loop,
+    /// simulated here via the `test_hooks` delay seam instead of a real repo
+    /// with hundreds of candidates). Also pins the re-entrancy guard: a
+    /// second fire while the first round is still "running" must skip, not
+    /// spawn an overlapping second round.
+    #[test]
+    fn run_does_not_block_tick_loop_during_slow_sweep_p1_2607() {
+        use crate::agent::{AgentRegistry, ExternalRegistry};
+        use parking_lot::Mutex;
+        use std::collections::HashMap;
+        use std::sync::Arc;
+        use std::time::{Duration, Instant};
+
+        let tag = std::process::id();
+        let home = std::env::temp_dir().join(format!("agend-worktree-reg-sweep-slow-{tag}"));
+        std::fs::create_dir_all(&home).unwrap();
+
+        let registry: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let externals: ExternalRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let configs = Arc::new(Mutex::new(HashMap::new()));
+        let ctx = TickContext {
+            home: &home,
+            registry: &registry,
+            externals: &externals,
+            configs: &configs,
+        };
+
+        test_hooks::set_delay_ms(300);
+        let h = WorktreeRegistrySweepHandler::new(1); // fires on every call
+
+        let start = Instant::now();
+        h.run(&ctx);
+        assert!(
+            start.elapsed() < Duration::from_millis(100),
+            "run() must not block the tick loop on the (delayed) sweep, took {:?}",
+            start.elapsed()
+        );
+        assert!(
+            h.is_in_flight(),
+            "the background round should still be running (300ms delay, checked immediately)"
+        );
+
+        // Simulates the very next tick arriving while the previous round is
+        // still in flight: the gate fires again, but the re-entrancy guard
+        // must skip spawning a second overlapping round.
+        let start2 = Instant::now();
+        h.run(&ctx);
+        assert!(
+            start2.elapsed() < Duration::from_millis(100),
+            "the re-entrant skip path must also return near-instantly"
+        );
+
+        // Poll for the background round to finish (bounded — the delay is
+        // 300ms, so 2s is a generous ceiling for CI jitter) and confirm the
+        // guard clears once it does.
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while h.is_in_flight() && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(
+            !h.is_in_flight(),
+            "in_flight must clear once the background sweep completes"
+        );
+
+        test_hooks::clear_delay();
         std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/worktree_cleanup.rs
+++ b/src/worktree_cleanup.rs
@@ -396,19 +396,37 @@ pub fn sweep_from_registry(
 /// clears this floor on the next sweep.
 const SQUASH_GC_MIN_TIP_AGE: Duration = Duration::from_secs(24 * 60 * 60);
 
-/// #1750-B3: age of `branch`'s tip commit (committer date), or `None` if it
-/// can't be resolved. `%ct` is a unix timestamp (seconds), so no date parsing.
-fn branch_tip_age(repo_root: &Path, branch: &str) -> Option<Duration> {
+/// #1750-B3/#P1-2607: `branch`'s tip SHA + committer-date unix timestamp, in
+/// ONE `git log` call (`%H%x09%ct`) — was two separate concerns (a `rev-parse`
+/// for the SHA, a `log --format=%ct` for the age) collapsed into one spawn,
+/// since #P1-2607's cache needs the tip SHA as its key anyway.
+fn branch_tip_info(repo_root: &Path, branch: &str) -> Option<(String, u64)> {
     // W1.2: git_cmd → trimmed stdout; spawn-error + non-zero both collapse to `None`.
-    let ts_str =
-        crate::git_helpers::git_cmd(repo_root, &["log", "-1", "--format=%ct", branch]).ok()?;
+    let out = crate::git_helpers::git_cmd(repo_root, &["log", "-1", "--format=%H%x09%ct", branch])
+        .ok()?;
+    let (sha, ts_str) = out.split_once('\t')?;
     let ts: u64 = ts_str.parse().ok()?;
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .ok()?
-        .as_secs();
-    Some(Duration::from_secs(now.saturating_sub(ts)))
+    Some((sha.to_string(), ts))
 }
+
+/// #P1-2607: process-wide cache of the STRUCTURAL squash-merged check (git
+/// cherry + #1280 tree-diff fallback), keyed by `(repo, branch, tip_sha)`.
+/// A fixed tip's relationship to `default` never changes, so once computed
+/// for a given tip it is reused for free on every later sweep round — the
+/// branch naturally falls out of cache (new key) the moment its tip moves,
+/// no explicit invalidation needed. Entries for long-deleted branches are
+/// never looked up again and just sit unused; at realistic branch-churn
+/// rates that's a few KB over the daemon's lifetime, not worth evicting.
+///
+/// This is the fix for the #2607 freeze incident: `sweep_from_registry`'s
+/// dry-run mode never consumes candidates, so — before this cache — EVERY
+/// ~10-minute sweep round re-ran the expensive cherry/tree-diff check for
+/// ALL 172 accumulated candidates from scratch (83s, synchronously blocking
+/// the daemon's main tick loop). With this cache, only a candidate whose tip
+/// actually moved since the last round pays that cost again.
+type SquashCacheKey = (PathBuf, String, String);
+static SQUASH_MERGED_CACHE: std::sync::OnceLock<parking_lot::Mutex<HashMap<SquashCacheKey, bool>>> =
+    std::sync::OnceLock::new();
 
 /// #1750-B3: is `branch` a squash-merge orphan eligible for auto-GC? True when
 /// it is squash-merged into the default branch AND its tip is older than
@@ -418,9 +436,34 @@ fn branch_tip_age(repo_root: &Path, branch: &str) -> Option<Duration> {
 /// t-...50899-10: `pub(crate)` so `worktree_pool::cleanup_merged_branch` reuses
 /// the SAME squash-safe delete gate this file's `prune_orphaned_branches`
 /// uses, instead of treating a remote-gone branch as independently deletable.
+///
+/// #P1-2607: age is checked FIRST off the one mandatory `branch_tip_info`
+/// call (short-circuits the expensive squash check for branches too young
+/// to qualify regardless — a bonus, not just a cache hit) and the
+/// structural squash-merged result is cache-checked by tip SHA before
+/// falling back to the real `is_squash_merged` computation. Same final
+/// boolean as the pre-#P1-2607 `is_squash_merged(..) && age(..)` — only the
+/// evaluation order and repeat-call cost changed.
 pub(crate) fn is_squash_gc_eligible(repo_root: &Path, branch: &str, default: &str) -> bool {
-    crate::branch_sweep::is_squash_merged(repo_root, default, branch)
-        && branch_tip_age(repo_root, branch).is_some_and(|age| age >= SQUASH_GC_MIN_TIP_AGE)
+    let Some((tip_sha, tip_ts)) = branch_tip_info(repo_root, branch) else {
+        return false;
+    };
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    if Duration::from_secs(now.saturating_sub(tip_ts)) < SQUASH_GC_MIN_TIP_AGE {
+        return false;
+    }
+
+    let key = (repo_root.to_path_buf(), branch.to_string(), tip_sha);
+    let cache = SQUASH_MERGED_CACHE.get_or_init(|| parking_lot::Mutex::new(HashMap::new()));
+    if let Some(&cached) = cache.lock().get(&key) {
+        return cached;
+    }
+    let result = crate::branch_sweep::is_squash_merged(repo_root, default, branch);
+    cache.lock().insert(key, result);
+    result
 }
 
 /// Run `git worktree prune` then delete local branches whose remote tracking
@@ -1034,6 +1077,76 @@ mod tests {
             crate::git_helpers::git_ok(&repo, &["rev-parse", "--verify", "feat/merged"]),
             "#2605: dry-run must NOT actually delete the branch"
         );
+        std::fs::remove_dir_all(&repo).ok();
+    }
+
+    // ── #P1-2607: squash-eligibility tip-SHA cache ──
+
+    /// The #2607-freeze incident's second fix: `is_squash_gc_eligible`'s
+    /// expensive structural check must be reused across calls for the SAME
+    /// tip, not re-run every sweep round. Proven by inserting a cache entry
+    /// for a fixed tip, then observing that a second call for that EXACT
+    /// tip does not add another entry (the branch-keyed set is unique per
+    /// test repo path, so this is immune to interference from other tests
+    /// sharing the same process-wide cache).
+    #[test]
+    fn is_squash_gc_eligible_reuses_cache_for_same_tip_p1_2607() {
+        let repo = setup_test_repo("p1-2607-cache");
+        make_squash_orphan(&repo, "feat/cache-me", "2024-01-01T00:00:00 +0000");
+        let (tip_sha, _) = branch_tip_info(&repo, "feat/cache-me")
+            .expect("tip info must resolve for an existing branch");
+        let key = (repo.clone(), "feat/cache-me".to_string(), tip_sha);
+
+        let cache = SQUASH_MERGED_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+        assert!(
+            !cache.lock().contains_key(&key),
+            "precondition: this fresh tip must not already be cached"
+        );
+
+        assert!(is_squash_gc_eligible(&repo, "feat/cache-me", "main"));
+        assert!(
+            cache.lock().contains_key(&key),
+            "first call must populate the cache for this (repo, branch, tip_sha)"
+        );
+
+        // Second call for the identical tip: must still be true (cache hit),
+        // and must not have replaced the entry with a different key (the
+        // tip hasn't moved, so the key is unchanged).
+        assert!(is_squash_gc_eligible(&repo, "feat/cache-me", "main"));
+        assert!(cache.lock().contains_key(&key));
+
+        std::fs::remove_dir_all(&repo).ok();
+    }
+
+    /// A branch's tip moving (new commit) must fall out of the OLD cache
+    /// entry and be re-evaluated fresh under its NEW tip-SHA key — the
+    /// cache must never pin a branch to a stale verdict once its tip
+    /// changes.
+    #[test]
+    fn is_squash_gc_eligible_recomputes_after_tip_moves_p1_2607() {
+        let repo = setup_test_repo("p1-2607-cache-move");
+        make_squash_orphan(&repo, "feat/moves", "2024-01-01T00:00:00 +0000");
+        let (old_tip, _) = branch_tip_info(&repo, "feat/moves").expect("tip info must resolve");
+        assert!(is_squash_gc_eligible(&repo, "feat/moves", "main"));
+
+        // Move the tip: a fresh, unmerged, TOO-YOUNG commit — must now be
+        // ineligible (age floor), proving the stale cache entry (keyed on
+        // the OLD tip) is not consulted for the new tip.
+        git_in(&repo, &["checkout", "feat/moves"]);
+        std::fs::write(repo.join("more.txt"), "more").ok();
+        git_in(&repo, &["add", "."]);
+        git_in(&repo, &["commit", "-m", "new unmerged work"]); // now-dated tip
+        git_in(&repo, &["checkout", "main"]);
+        let (new_tip, _) = branch_tip_info(&repo, "feat/moves").expect("tip info must resolve");
+        assert_ne!(old_tip, new_tip, "precondition: the tip must have moved");
+
+        assert!(
+            !is_squash_gc_eligible(&repo, "feat/moves", "main"),
+            "after the tip moves to a fresh young commit, eligibility must be \
+             re-derived under the NEW tip key, not answered from the OLD tip's \
+             cached (stale) verdict"
+        );
+
         std::fs::remove_dir_all(&repo).ok();
     }
 }


### PR DESCRIPTION
## Summary
**P1 production regression from #2607.** Operator reported daemon freezes shortly after restart. Root cause (task `t-20260704093123912790-827-0`, lead-verified):

1. #2607 fixed `sweep_from_registry`'s repo discovery — it saw the canonical repo for the first time since May.
2. First run hit 172 accumulated dry-run candidates; each pays a `git fetch --prune` plus a squash-merge check (`git cherry` + tree-diff) — **83 seconds** wall time (event log 09:26:21→09:27:44).
3. `run_handlers_with_panic_guard` (`daemon/mod.rs:887`) runs every per-tick handler **synchronously** on the daemon's own thread — that 83s froze the entire daemon (TUI, inbox, every other handler) for its whole duration.
4. Dry-run mode never consumes candidates, so this repeated in full every ~60 ticks (~10 min), indefinitely.

Immediate mitigation already given to the operator: `AGEND_WORKTREE_AUTO_CLEANUP=0`. This PR is the real fix.

## Fix (two independent pieces, both required)

**(A) Offload + re-entrancy guard.** `WorktreeRegistrySweepHandler::run()` no longer does the sweep inline — it checks the cadence gate + an `AtomicBool` re-entrancy guard, then spawns the real work on a background thread (fire-and-forget; no `JoinHandle` — completion signaled via the guard, results stay observable via the existing tracing + event_log). If a previous round is still running when the next cadence fire arrives, that fire is skipped and logged instead of stacking a second round on top (which would compound the cost, not fix it) — the next scheduled fire retries.

**(B) Tip-SHA cache for squash detection.** `is_squash_gc_eligible`'s expensive structural check is now cached process-wide, keyed by `(repo, branch, tip_sha)`. A fixed tip's squash-merged-ness never changes, so once computed it's free on every later round; a branch falls out of cache (new key) the instant its tip moves — no explicit invalidation. The age-floor check and the cache key now come from ONE combined `git log` call (tip SHA + committer timestamp together, was two separate spawns) and short-circuits before the expensive check for branches too young regardless. This bounds each round's cost to just the new/moved candidates instead of re-deriving the whole accumulated set every ~10 minutes forever.

**Not in this PR:** `HourlyGcHandler` has the same synchronous-handler shape (four sub-sweeps over daemon-managed worktrees), but its candidate volume is bounded by live agent count (small today), so it hasn't caused an incident. Kept out of this emergency fix to minimize change size / review burden; filed as a normal-priority follow-up (`t-20260704094218256877-827-1`) since the same pattern applies directly.

## Test plan
- [x] Freeze regression (`run_does_not_block_tick_loop_during_slow_sweep_p1_2607`): injects an artificial 300ms delay via a test-only seam, asserts `run()` returns in <100ms on both the first fire and an immediate re-fire while still in flight (proves the guard skips rather than stacking), then polls the guard back to false once the delayed round completes
- [x] Cache correctness (`is_squash_gc_eligible_reuses_cache_for_same_tip_p1_2607`, `is_squash_gc_eligible_recomputes_after_tip_moves_p1_2607`): same tip reuses the cache; a moved tip is re-derived fresh under its new key, never answered from a stale entry
- [x] All existing `worktree_cleanup` + `worktree_registry_sweep` tests pass unchanged — dry-run event reason/path semantics from #2607's rework are untouched
- [x] `cargo test --bin agend-terminal worktree_cleanup::` — 23 passed
- [x] `cargo test --bin agend-terminal daemon::per_tick::worktree_registry_sweep::` — 3 passed
- [x] `cargo test --bin agend-terminal worktree_pool::` — 108 passed (`is_squash_gc_eligible`'s other caller, `cleanup_merged_branch`, unaffected)
- [x] `cargo nextest run --bin agend-terminal` (full suite) — 4797 passed, 0 failed
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo clippy --all-targets --features tray -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

## Review lesson (for record)
#2607's dual review + lead seat-2 review did not evaluate the synchronous handler's wall-clock budget before merge. This should become a standing checklist item for per-tick-handler PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)