### PR TITLE
fix(channel): resolve active_channel() multi-channel blind-spot at 8 call sites

### DIFF
--- a/src/api/handlers/messaging.rs
+++ b/src/api/handlers/messaging.rs
@@ -376,7 +376,11 @@ fn inject_provenance(params: &Value, from: &str, target: &str) {
         .and_then(|v| v.as_str())
         .unwrap_or("")
         .to_string();
-    if let Some(ch) = crate::channel::active_channel() {
+    // Multi-channel-safe (t-20260703164240502572-50899-11): per-`target`
+    // operation, so the right channel is "whichever channel `target` is
+    // bound to", not the `active_channel()` singleton (which returns `None`
+    // once 2+ channels are registered).
+    if let Some(ch) = crate::channel::channel_for_instance(target) {
         if let Err(e) = ch.send_from_agent(
             target,
             crate::channel::AgentOutboundOp::InjectProvenance {

--- a/src/api/handlers/messaging.rs
+++ b/src/api/handlers/messaging.rs
@@ -376,10 +376,6 @@ fn inject_provenance(params: &Value, from: &str, target: &str) {
         .and_then(|v| v.as_str())
         .unwrap_or("")
         .to_string();
-    // Multi-channel-safe (t-20260703164240502572-50899-11): per-`target`
-    // operation, so the right channel is "whichever channel `target` is
-    // bound to", not the `active_channel()` singleton (which returns `None`
-    // once 2+ channels are registered).
     if let Some(ch) = crate::channel::channel_for_instance(target) {
         if let Err(e) = ch.send_from_agent(
             target,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -493,7 +493,11 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
         crate::agent::set_pending_registry(Arc::clone(&registry));
         if let Some(tg) = telegram_state.as_ref() {
             tg.attach_registry(Arc::clone(&registry));
-        } else if let Some(tg) = crate::channel::active_channel() {
+        } else if let Some(tg) = crate::channel::lookup_channel_by_name("telegram") {
+            // Multi-channel-safe (t-20260703164240502572-50899-11): this
+            // fallback is telegram-specific (the `tg`/`telegram_state`
+            // naming already assumed it); `active_channel()` would silently
+            // no-op here once discord is also registered.
             tg.attach_registry(Arc::clone(&registry));
         }
     }
@@ -1504,9 +1508,10 @@ fn app_teardown(
         crate::daemon::terminate_agents_parallel(agents);
         let run_dir = crate::daemon::run_dir(home);
         for name in &names {
-            if let Some(ch) = crate::channel::active_channel() {
-                let _ = ch.take_binding(name);
-            }
+            // Multi-channel-safe (t-20260703164240502572-50899-11): drops on
+            // every registered channel instead of only the `active_channel()`
+            // singleton, which silently no-ops in a telegram+discord fleet.
+            crate::channel::drop_binding_on_all_channels(name);
             crate::ipc::remove_port(&run_dir, name);
             crate::event_log::log(home, "delete", name, "delete: app teardown (parallel)");
         }

--- a/src/channel/discord.rs
+++ b/src/channel/discord.rs
@@ -1092,6 +1092,18 @@ impl crate::channel::Channel for DiscordChannel {
             .downcast::<DiscordBindingPayload>()
             .map(|p| p.channel_id)
             .unwrap_or(0);
+        // t-20260703164240502572-50899-11 (reviewer4 REJECTED finding): unlike
+        // Telegram (whose create_topic persists to topics.json, a durable
+        // self-healing source `resolve_topic` falls back to), Discord's
+        // has_binding/take_binding read ONLY the in-memory `instance_to_channel`
+        // map — populated ONLY by `record_binding`. Without this call the
+        // channel this just created on the Discord API is unroutable (inbound
+        // can't resolve it) and unreachable for cleanup (`take_binding` finds
+        // nothing). Mirrors `app/discord_hooks.rs::maybe_create_discord_binding`'s
+        // create_binding + record_binding pairing; submit_key fallback matches
+        // that hook's own fallback (no registry/pane context at this layer to
+        // look up the real one).
+        self.record_binding(name, binding, "\r".to_string());
         Ok(crate::channel::TopicRef {
             id: cid.to_string(),
             channel_kind: crate::channel::ChannelKind::Discord,
@@ -2220,6 +2232,49 @@ mod tests {
         assert!(
             body["name"].is_string(),
             "request body must have 'name' field"
+        );
+    }
+
+    /// t-20260703164240502572-50899-11 (reviewer4 REJECTED finding on the
+    /// first #2615 pass): `create_topic` used to call `create_binding` but
+    /// never `record_binding`, so `has_binding`/`take_binding` — which
+    /// `channel_for_instance` (routing) and `drop_binding_on_all_channels`
+    /// (cleanup) both depend on — could never find the channel it just
+    /// created. Pins the fix directly on the production `create_topic` path
+    /// (not just the generic mock in `channel::tests`).
+    #[test]
+    fn discord_create_topic_records_a_binding_that_is_routable_and_cleanable() {
+        use crate::channel::Channel;
+
+        let response_body =
+            include_str!("../../tests/fixtures/discord-rest-create-guild-channel-response.json");
+        let (port, handle, _captured) = mock_http_server(200, response_body);
+        let (ch, _tx) = make_test_channel_with_mock(port);
+
+        assert!(
+            !ch.has_binding("test-agent"),
+            "precondition: no binding before create_topic"
+        );
+
+        let result = ch.create_topic("test-agent");
+        handle.join().expect("mock server");
+        assert!(
+            result.is_ok(),
+            "create_topic must succeed: {:?}",
+            result.err()
+        );
+
+        assert!(
+            ch.has_binding("test-agent"),
+            "create_topic must leave the instance bound — otherwise the \
+             channel it just created is unroutable and uncleanable"
+        );
+
+        let taken = ch.take_binding("test-agent");
+        assert!(taken.is_some(), "the recorded binding must be cleanable");
+        assert!(
+            !ch.has_binding("test-agent"),
+            "binding must be gone after take_binding"
         );
     }
 

--- a/src/channel/mod.rs
+++ b/src/channel/mod.rs
@@ -265,9 +265,10 @@ pub enum TopicOutcome {
     Failed(String),
 }
 
-/// #966 hub fn: look up the active channel AT CALL-TIME (not from a
+/// #966 hub fn: look up the registered channels AT CALL-TIME (not from a
 /// cached `Option<Arc<dyn Channel>>` snapshot) and ensure a topic
-/// exists for `name`. Replaces three replicated call sites:
+/// exists for `name` on EVERY registered channel. Replaces three
+/// replicated call sites:
 ///
 /// - `src/api/handlers/instance.rs` (handle_spawn — MCP / deploy_template / api caller)
 /// - `src/api/handlers/team.rs` (team mode)
@@ -278,15 +279,42 @@ pub enum TopicOutcome {
 /// `Option<Arc<dyn Channel>>` are commonly `None`; the channel registers
 /// ~6s later via `register_active_channel`. Cached-snapshot callers
 /// silently no-op forever for that startup window's instances.
-/// `ensure_topic_for` queries `active_channel()` fresh on every call so
-/// the post-init channel is picked up automatically.
+/// `ensure_topic_for` queries the registry fresh on every call so the
+/// post-init channel is picked up automatically.
+///
+/// **Multi-channel fan-out** (t-20260703164240502572-50899-11): this used
+/// to gate on the `active_channel()` singleton, which returns `None` once
+/// 2+ channels are registered — in a telegram+discord fleet, new
+/// instances got NO topic anywhere. The TUI's own pane-create hooks
+/// (`app/telegram_hooks.rs`, `app/discord_hooks.rs`) already call
+/// `lookup_channel_by_name` for each channel explicitly and unconditionally
+/// — i.e. fan-out to every registered channel is the established norm, not
+/// a new policy. This converges `ensure_topic_for` onto that precedent:
+/// `create_topic` is attempted on every registered channel; the 3 callers
+/// only consume a single [`TopicOutcome`], so the result is `Created` with
+/// the first channel's topic id if ANY channel succeeded, `NoChannel` if
+/// the registry was empty, or `Failed` only if the registry was non-empty
+/// and EVERY channel failed.
 pub fn ensure_topic_for(name: &str) -> TopicOutcome {
-    match active_channel() {
-        None => TopicOutcome::NoChannel,
-        Some(ch) => match ch.create_topic(name) {
-            Ok(topic) => TopicOutcome::Created(topic.id),
-            Err(e) => TopicOutcome::Failed(format!("{e}")),
-        },
+    let channels: Vec<Arc<dyn Channel>> = channels_registry().read().values().cloned().collect();
+    if channels.is_empty() {
+        return TopicOutcome::NoChannel;
+    }
+    let mut first_success: Option<String> = None;
+    let mut errors: Vec<String> = Vec::new();
+    for ch in channels {
+        match ch.create_topic(name) {
+            Ok(topic) => {
+                if first_success.is_none() {
+                    first_success = Some(topic.id);
+                }
+            }
+            Err(e) => errors.push(format!("{}: {e}", ch.kind())),
+        }
+    }
+    match first_success {
+        Some(id) => TopicOutcome::Created(id),
+        None => TopicOutcome::Failed(errors.join("; ")),
     }
 }
 
@@ -972,5 +1000,194 @@ mod tests {
             err.to_string().contains("send_from_agent"),
             "error must name the missing method: {err}"
         );
+    }
+
+    // ── t-20260703164240502572-50899-11: multi-channel behavior tests ──
+    // Pins the two remaining bug classes from the active_channel() survey:
+    // (a) delete/drop-binding must reach whichever channel actually holds
+    //     the binding, not just "the" active_channel() singleton; (b)
+    //     ensure_topic_for must fan out topic creation to every registered
+    //     channel, not just one.
+
+    /// Recording channel with real (stateful) `has_binding`/`take_binding`
+    /// and a configurable `create_topic` outcome — `KindedRecording` above
+    /// only mocks `notify`, and `MockChannel`/`RecordingChannel` hardcode
+    /// `has_binding` to `false`, so none of the existing mocks can pin
+    /// either fix.
+    struct BindingTopicChannel {
+        kind: &'static str,
+        caps: ChannelCapabilities,
+        bound: parking_lot::Mutex<std::collections::HashSet<String>>,
+        topic_calls: std::sync::atomic::AtomicUsize,
+        create_topic_ok: bool,
+    }
+
+    impl BindingTopicChannel {
+        fn arc(kind: &'static str, create_topic_ok: bool) -> Arc<Self> {
+            Arc::new(Self {
+                kind,
+                caps: ChannelCapabilities::default(),
+                bound: parking_lot::Mutex::new(std::collections::HashSet::new()),
+                topic_calls: std::sync::atomic::AtomicUsize::new(0),
+                create_topic_ok,
+            })
+        }
+        fn bind(&self, instance: &str) {
+            self.bound.lock().insert(instance.to_string());
+        }
+        fn is_bound(&self, instance: &str) -> bool {
+            self.bound.lock().contains(instance)
+        }
+        fn topic_calls(&self) -> usize {
+            self.topic_calls.load(std::sync::atomic::Ordering::Relaxed)
+        }
+    }
+
+    impl Channel for BindingTopicChannel {
+        fn kind(&self) -> &'static str {
+            self.kind
+        }
+        fn caps(&self) -> &ChannelCapabilities {
+            &self.caps
+        }
+        fn poll_event(&self) -> Option<ChannelEvent> {
+            None
+        }
+        fn send(&self, _: &BindingRef, _: OutMsg) -> Result<MsgRef> {
+            anyhow::bail!("mock")
+        }
+        fn edit(&self, _: &MsgRef, _: OutMsg) -> Result<()> {
+            anyhow::bail!("mock")
+        }
+        fn delete(&self, _: &MsgRef) -> Result<()> {
+            anyhow::bail!("mock")
+        }
+        fn create_binding(&self, _: &str, _: BindingOpts) -> Result<BindingRef> {
+            anyhow::bail!("mock")
+        }
+        fn remove_binding(&self, _: &BindingRef) -> Result<()> {
+            Ok(())
+        }
+        fn has_binding(&self, instance: &str) -> bool {
+            self.bound.lock().contains(instance)
+        }
+        fn record_binding(&self, instance: &str, _: BindingRef, _: String) {
+            self.bound.lock().insert(instance.to_string());
+        }
+        fn take_binding(&self, instance: &str) -> Option<BindingRef> {
+            if self.bound.lock().remove(instance) {
+                Some(BindingRef::new(self.kind, None, ()))
+            } else {
+                None
+            }
+        }
+        fn attach_registry(&self, _: crate::agent::AgentRegistry) {}
+        fn create_topic(&self, name: &str) -> std::result::Result<TopicRef, ChannelError> {
+            self.topic_calls
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            if self.create_topic_ok {
+                Ok(TopicRef {
+                    id: format!("{}-{name}", self.kind),
+                    channel_kind: ChannelKind::Telegram,
+                })
+            } else {
+                Err(ChannelError::Other(anyhow::anyhow!(
+                    "mock create_topic failure"
+                )))
+            }
+        }
+    }
+
+    /// Fix #1/#2 (`drop_active_binding` / app-teardown loop): both now call
+    /// `drop_binding_on_all_channels`, which must clear the binding
+    /// regardless of which registered channel actually holds it — the bug
+    /// was gating cleanup on `active_channel()`, which returns `None` with
+    /// 2+ channels registered and so silently skipped the drop entirely.
+    #[test]
+    fn drop_binding_on_all_channels_clears_binding_on_whichever_channel_holds_it() {
+        let _g = m6_registry_guard();
+        reset_active_channel_for_test();
+
+        let tg = BindingTopicChannel::arc("telegram-drop", true);
+        let dc = BindingTopicChannel::arc("discord-drop", true);
+        register_active_channel(tg.clone());
+        register_active_channel(dc.clone());
+        assert!(
+            active_channel().is_none(),
+            "precondition: 2 channels registered"
+        );
+
+        // Instance is bound on discord only (e.g. it joined via Discord).
+        dc.bind("agent-x");
+        assert!(!tg.is_bound("agent-x"));
+        assert!(dc.is_bound("agent-x"));
+
+        drop_binding_on_all_channels("agent-x");
+
+        assert!(
+            !dc.is_bound("agent-x"),
+            "binding must be cleared on the channel that actually held it"
+        );
+        assert!(
+            !tg.is_bound("agent-x"),
+            "no-op on the channel that never had a binding"
+        );
+
+        reset_active_channel_for_test();
+    }
+
+    /// Fix #3 (`ensure_topic_for`): must create a topic on EVERY registered
+    /// channel in a multi-channel fleet, not just the `active_channel()`
+    /// singleton (which returns `None` with 2+ channels — new instances
+    /// used to get no topic anywhere).
+    #[test]
+    fn ensure_topic_for_fans_out_to_every_registered_channel() {
+        let _g = m6_registry_guard();
+        reset_active_channel_for_test();
+
+        let tg = BindingTopicChannel::arc("telegram-topic", true);
+        let dc = BindingTopicChannel::arc("discord-topic", true);
+        register_active_channel(tg.clone());
+        register_active_channel(dc.clone());
+        assert!(
+            active_channel().is_none(),
+            "precondition: 2 channels registered"
+        );
+
+        let outcome = ensure_topic_for("agent-y");
+
+        assert!(
+            matches!(outcome, TopicOutcome::Created(_)),
+            "expected Created, got {outcome:?}"
+        );
+        assert_eq!(tg.topic_calls(), 1, "telegram must get a create_topic call");
+        assert_eq!(dc.topic_calls(), 1, "discord must get a create_topic call");
+
+        reset_active_channel_for_test();
+    }
+
+    /// Zero channels → `NoChannel` (happy path, unchanged). All-channels-fail
+    /// → `Failed`, only when the registry is non-empty.
+    #[test]
+    fn ensure_topic_for_no_channel_and_all_fail_cases() {
+        let _g = m6_registry_guard();
+        reset_active_channel_for_test();
+
+        assert_eq!(ensure_topic_for("agent-z"), TopicOutcome::NoChannel);
+
+        let tg = BindingTopicChannel::arc("telegram-fail", false);
+        let dc = BindingTopicChannel::arc("discord-fail", false);
+        register_active_channel(tg.clone());
+        register_active_channel(dc.clone());
+
+        let outcome = ensure_topic_for("agent-z");
+        assert!(
+            matches!(outcome, TopicOutcome::Failed(_)),
+            "all channels failing must produce Failed, got {outcome:?}"
+        );
+        assert_eq!(tg.topic_calls(), 1);
+        assert_eq!(dc.topic_calls(), 1);
+
+        reset_active_channel_for_test();
     }
 }

--- a/src/channel/mod.rs
+++ b/src/channel/mod.rs
@@ -1086,6 +1086,11 @@ mod tests {
             self.topic_calls
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             if self.create_topic_ok {
+                // Mirrors the fixed Discord adapter contract
+                // (t-20260703164240502572-50899-11 reviewer4 finding): a
+                // successful create_topic must leave the instance bound, or
+                // the channel it just created is unroutable and uncleanable.
+                self.bound.lock().insert(name.to_string());
                 Ok(TopicRef {
                     id: format!("{}-{name}", self.kind),
                     channel_kind: ChannelKind::Telegram,
@@ -1162,6 +1167,46 @@ mod tests {
         );
         assert_eq!(tg.topic_calls(), 1, "telegram must get a create_topic call");
         assert_eq!(dc.topic_calls(), 1, "discord must get a create_topic call");
+
+        reset_active_channel_for_test();
+    }
+
+    /// reviewer4 REJECTED finding on the first #2615 pass: fan-out alone isn't
+    /// enough — a channel whose `create_topic` creates the platform resource
+    /// but never calls `record_binding` (the real bug found in
+    /// `DiscordChannel::create_topic`) leaves that channel unroutable
+    /// (`channel_for_instance`/inbound can't find it) and uncleanable
+    /// (`drop_binding_on_all_channels`'s `take_binding` finds nothing). Pins
+    /// the now-fixed contract end-to-end: every channel `ensure_topic_for`
+    /// fanned out to must have `has_binding(instance) == true` immediately
+    /// after, and `drop_binding_on_all_channels` must clear all of them.
+    #[test]
+    fn ensure_topic_for_created_topic_is_bound_and_cleanable_on_every_channel() {
+        let _g = m6_registry_guard();
+        reset_active_channel_for_test();
+
+        let tg = BindingTopicChannel::arc("telegram-bind", true);
+        let dc = BindingTopicChannel::arc("discord-bind", true);
+        register_active_channel(tg.clone());
+        register_active_channel(dc.clone());
+
+        ensure_topic_for("agent-w");
+
+        assert!(
+            tg.is_bound("agent-w"),
+            "telegram must be routable/cleanable after create_topic"
+        );
+        assert!(
+            dc.is_bound("agent-w"),
+            "discord must be routable/cleanable after create_topic — this is \
+             exactly the reviewer4 finding: create_topic alone left Discord \
+             unbound"
+        );
+
+        drop_binding_on_all_channels("agent-w");
+
+        assert!(!tg.is_bound("agent-w"), "cleanup must reach telegram");
+        assert!(!dc.is_bound("agent-w"), "cleanup must reach discord");
 
         reset_active_channel_for_test();
     }

--- a/src/channel/mod.rs
+++ b/src/channel/mod.rs
@@ -215,6 +215,35 @@ pub fn reset_active_channel_for_test() {
     channels_registry().write().clear();
 }
 
+/// active_channel() multi-channel blind-spot fix (t-20260703164240502572-50899-11):
+/// find which registered channel (if any) already has a binding recorded for
+/// `instance` — read-only, unlike [`Channel::take_binding`]. Where `active_channel`
+/// would return `None` once a fleet runs 2+ channels, this always finds the one
+/// the instance actually belongs to, because [`Channel::has_binding`] is checked
+/// per-channel rather than requiring exactly one channel to be registered fleet-wide.
+pub fn channel_for_instance(instance: &str) -> Option<Arc<dyn Channel>> {
+    channels_registry()
+        .read()
+        .values()
+        .find(|ch| ch.has_binding(instance))
+        .cloned()
+}
+
+/// active_channel() multi-channel blind-spot fix (t-20260703164240502572-50899-11):
+/// drop `name`'s binding on EVERY registered channel, not just "the active" one.
+/// `active_channel()` returns `None` once a fleet runs 2+ channels, so a caller
+/// gating cleanup on it (as `drop_active_binding` and app-mode teardown used to)
+/// silently skips the drop entirely in a multi-channel fleet — the binding (and
+/// whatever platform resource it references) leaks. [`Channel::take_binding`] is
+/// a safe no-op on a channel where `name` has no recorded binding (it returns
+/// `None` and touches nothing), so iterating every registered channel reaches
+/// whichever one `name` actually happens to be bound to.
+pub fn drop_binding_on_all_channels(name: &str) {
+    for ch in channels_registry().read().values() {
+        let _ = ch.take_binding(name);
+    }
+}
+
 /// #966: Outcome of [`ensure_topic_for`] — explicit enum (no
 /// `Option<String>`) so callers must handle each variant. Mirrors the
 /// #962 surface-failures discipline: silent `let _ = ...` patterns

--- a/src/channel/telegram/inbound.rs
+++ b/src/channel/telegram/inbound.rs
@@ -396,7 +396,11 @@ async fn handle_message(state: &Arc<Mutex<TelegramState>>, msg: &Message) {
         // request's ACK should always reach the operator regardless of mode"
         // semantic is a separate operator-response path, tracked as a follow-up
         // and out of scope here.
-        if let Some(ch) = crate::channel::active_channel() {
+        // Multi-channel-safe (t-20260703164240502572-50899-11): this handler
+        // lives inside telegram/inbound.rs — it's inherently telegram's own
+        // inbound handler, so the ACK belongs on telegram regardless of
+        // which channel `active_channel()` would (or wouldn't) resolve to.
+        if let Some(ch) = crate::channel::lookup_channel_by_name("telegram") {
             let _ = crate::channel::gated_notify(
                 ch.as_ref(),
                 "operator",

--- a/src/daemon/lifecycle.rs
+++ b/src/daemon/lifecycle.rs
@@ -54,13 +54,13 @@ pub fn wait_for_child_exit(child: &ChildArc) -> bool {
     }
 }
 
-/// Drop the active channel's binding for `name`, if any. Channel-agnostic via
-/// the `Channel` trait `take_binding`. No-op when no channel is registered
+/// Drop `name`'s binding on every registered channel. Multi-channel-safe
+/// (t-20260703164240502572-50899-11): `active_channel()` returns `None`
+/// once 2+ channels are registered, which used to make this a silent
+/// no-op in a telegram+discord fleet. No-op when no channel is registered
 /// (e.g. app mode without Telegram init).
 fn drop_active_binding(name: &str) {
-    if let Some(ch) = crate::channel::active_channel() {
-        let _ = ch.take_binding(name);
-    }
+    crate::channel::drop_binding_on_all_channels(name);
 }
 
 /// Tear down all daemon-side state for an agent: kill child + tree, wait for

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1066,7 +1066,11 @@ fn init_daemon_services(
     crate::agent::set_pending_registry(Arc::clone(&registry));
     if let Some(tg) = telegram.as_ref() {
         tg.attach_registry(Arc::clone(&registry));
-    } else if let Some(tg) = crate::channel::active_channel() {
+    } else if let Some(tg) = crate::channel::lookup_channel_by_name("telegram") {
+        // Multi-channel-safe (t-20260703164240502572-50899-11): daemon-boot
+        // twin of the app-mode fallback in `app/mod.rs` — telegram-specific
+        // by naming, so `active_channel()` silently no-opping once discord
+        // is also registered would leave telegram's registry attach dead.
         tg.attach_registry(Arc::clone(&registry));
     }
 

--- a/src/mcp/handlers/channel.rs
+++ b/src/mcp/handlers/channel.rs
@@ -56,8 +56,11 @@ pub(super) fn handle_reply(home: &Path, args: &Value, instance_name: &str) -> Va
 
     // Sprint 55 P0-A — prefer-chain: sender's HeartbeatPair.reply_to_channel
     // (Sprint 52 router-layer attribution) wins when present + registered;
-    // fallback to active_channel() singleton when None. Returns structured
-    // error codes so agents can branch on machine-readable signals.
+    // else fall back to whichever channel the sending instance is bound to
+    // (multi-channel-safe, t-20260703164240502572-50899-11 — `active_channel()`
+    // alone returns `None` once 2+ channels are registered); last resort is
+    // the `active_channel()` singleton. Returns structured error codes so
+    // agents can branch on machine-readable signals.
     let snapshot = crate::daemon::heartbeat_pair::snapshot_for(instance_name);
     let ch: Arc<dyn crate::channel::Channel> = match snapshot.reply_to_channel.as_deref() {
         Some(name) => match crate::channel::lookup_channel_by_name(name) {
@@ -76,7 +79,9 @@ pub(super) fn handle_reply(home: &Path, args: &Value, instance_name: &str) -> Va
                 });
             }
         },
-        None => match crate::channel::active_channel() {
+        None => match crate::channel::channel_for_instance(instance_name)
+            .or_else(crate::channel::active_channel)
+        {
             Some(ch) => ch,
             None => {
                 // #1665 Gap D: no channel to reply on — record the send-failure.


### PR DESCRIPTION
## Summary

`active_channel()` returns `Some` only when **exactly one** channel is registered — `None` for zero OR multiple (per its own doc comment, `src/channel/mod.rs:150`). In a fleet running telegram+discord together, every naive `if let Some(ch) = active_channel()` call site silently no-ops.

Full-repo survey of all 11 non-doc `active_channel()` call sites (task t-20260703164240502572-50899-11, filed from two known sites found during #2593/#991 review + spike) classified each as bug or acceptable:

### Fixed (8 sites)

| # | Site | Fix |
|---|---|---|
| 1 | `daemon/lifecycle.rs` `drop_active_binding` | → `drop_binding_on_all_channels(name)` |
| 2 | `app/mod.rs` app-mode teardown loop | → same helper |
| 3 | `channel/mod.rs` `ensure_topic_for` | → fan out `create_topic` to every registered channel |
| 4 | `app/mod.rs` registry-attach fallback | → `lookup_channel_by_name("telegram")` |
| 5 | `daemon/mod.rs` registry-attach fallback | → same fix |
| 6 | `channel/telegram/inbound.rs` task-create ACK | → `lookup_channel_by_name("telegram")` |
| 7 | `api/handlers/messaging.rs` `inject_provenance` | → `channel_for_instance(target)` (new helper) |
| 8 | `mcp/handlers/channel.rs` reply-channel resolution | → `channel_for_instance(instance_name)` inserted as a new middle tier between the `reply_to_channel` snapshot and the `active_channel()` last resort |

**Fix #3 is the one behavior change worth flagging explicitly**: `ensure_topic_for` used to gate topic creation on the `active_channel()` singleton (no topic anywhere once 2+ channels are registered). It now fans out to every registered channel, converging onto the precedent already set by the TUI's own pane-create hooks (`app/telegram_hooks.rs::maybe_create_telegram_topic`, `app/discord_hooks.rs::maybe_create_discord_binding`), which already call `lookup_channel_by_name` for each channel explicitly and unconditionally. All 3 callers of `ensure_topic_for` only consume a single `TopicOutcome`, so semantics are: `Created(first success)` if ≥1 channel succeeded, `NoChannel` if the registry was empty, `Failed` only if the registry was non-empty and every channel failed.

### Left alone (3 sites) — an already-established design boundary

`src/channel/mod.rs:166-182`'s own doc comment (the #1744-M6 fix) draws an explicit line: error-severity P0 escalations fan out to every channel; routine/non-P0 notices deliberately keep `active_channel()` so multi-channel fan-out "can never leak into routine traffic." Confirmed each site's own severity tier and left them untouched:
- `daemon/supervisor.rs:1126` — "Recovered" notice, `NotifySeverity::Info`
- `daemon/task_sweep.rs:954` — compliance-violation ping, `NotifySeverity::Warn`
- `daemon/ci_watch/poller.rs:1725` — CI-warn notification, `NotifySeverity::Warn`

## Testing

- Added 3 new unit tests in `channel::tests` (using a new `BindingTopicChannel` mock with real stateful `has_binding`/`take_binding`/`create_topic`, registered under `m6_registry_guard()` for registry-touching test isolation):
  - `drop_binding_on_all_channels_clears_binding_on_whichever_channel_holds_it` — pins fix #1/#2
  - `ensure_topic_for_fans_out_to_every_registered_channel` — pins fix #3
  - `ensure_topic_for_no_channel_and_all_fail_cases` — edge cases (empty registry / all-channels-fail)
- `cargo test --features tray --bin agend-terminal channel::tests` — 16/16 pass.
- **A/B verification**: ran `cargo test --workspace --tests --features tray` both with and without this diff (via `git stash -u` against the same base commit). Both runs show the **identical 262 pre-existing failing tests** (all in git-operation-heavy suites — `worktree_pool`/`branch_sweep`/`git_helpers`/`claim_verifier`/`mcp` — environment-specific, unrelated to this change). No new failures introduced, none fixed.
- `cargo fmt --check` clean.
- `cargo clippy --all-targets --features tray -- -D warnings` clean.

Refs t-20260703164240502572-50899-11

🤖 Generated with [Claude Code](https://claude.com/claude-code)