### PR TITLE
fix(daemon): move HourlyGc sweeps off main tick loop (#P1-2607 follow-up)

### DIFF
--- a/src/daemon/per_tick/gc_tick.rs
+++ b/src/daemon/per_tick/gc_tick.rs
@@ -3,6 +3,7 @@
 //! Also cleans up stale ci-watch lock files.
 
 use super::{PerTickHandler, TickContext};
+use std::path::Path;
 
 pub(crate) struct GcTickHandler {
     gate: crate::daemon::cadence_gate::CadenceGate,
@@ -20,18 +21,19 @@ impl GcTickHandler {
             target_sweep_armed: std::sync::atomic::AtomicBool::new(false),
         }
     }
-}
 
-impl PerTickHandler for GcTickHandler {
-    fn name(&self) -> &'static str {
-        "gc_tick"
+    /// #P1-2607 offload seam: the cadence check, kept ON the daemon tick loop
+    /// (cheap, so gate advancement never drifts). `HourlyGcHandler` calls this
+    /// to decide whether to include this sweep in the offloaded round.
+    pub(crate) fn due(&self) -> bool {
+        self.gate.fire()
     }
 
-    fn run(&self, ctx: &TickContext<'_>) {
-        if !self.gate.fire() {
-            return;
-        }
-        let results = crate::worktree_pool::gc_run(ctx.home);
+    /// #P1-2607 offload seam: the (potentially-slow) sweep body, split out so
+    /// `HourlyGcHandler` runs it in a background thread. Behaviour is unchanged
+    /// from the pre-offload `run()` — only its call site moves off the tick loop.
+    pub(crate) fn work(&self, home: &Path) {
+        let results = crate::worktree_pool::gc_run(home);
         let removed = results.iter().filter(|r| r.removed).count();
         let failed = results.iter().filter(|r| !r.removed).count();
         if removed > 0 || failed > 0 {
@@ -54,9 +56,9 @@ impl PerTickHandler for GcTickHandler {
         // is the correct, already-independent lever for "how long to keep
         // `.trash`" (including "never purge": set it very large); coupling
         // the purge to the unrelated archive-decision gate was itself the gap.
-        crate::daemon::retention::worktrees::purge_trash(ctx.home);
+        crate::daemon::retention::worktrees::purge_trash(home);
 
-        let stale_locks = crate::worktree_pool::gc_stale_ci_watch_locks(ctx.home);
+        let stale_locks = crate::worktree_pool::gc_stale_ci_watch_locks(home);
         if stale_locks > 0 {
             tracing::info!(stale_locks, "gc_tick: stale ci-watch locks cleaned");
         }
@@ -71,7 +73,7 @@ impl PerTickHandler for GcTickHandler {
             .swap(true, std::sync::atomic::Ordering::Relaxed);
         if armed {
             if let Some((max_age, min_size)) = crate::worktree_pool::target_gc_config() {
-                let swept = crate::worktree_pool::target_sweep_run(ctx.home, max_age, min_size);
+                let swept = crate::worktree_pool::target_sweep_run(home, max_age, min_size);
                 let reclaimed = swept.iter().filter(|r| r.removed).count();
                 if reclaimed > 0 {
                     let freed: u64 = swept
@@ -86,6 +88,18 @@ impl PerTickHandler for GcTickHandler {
                     );
                 }
             }
+        }
+    }
+}
+
+impl PerTickHandler for GcTickHandler {
+    fn name(&self) -> &'static str {
+        "gc_tick"
+    }
+
+    fn run(&self, ctx: &TickContext<'_>) {
+        if self.due() {
+            self.work(ctx.home);
         }
     }
 }

--- a/src/daemon/per_tick/hourly_gc.rs
+++ b/src/daemon/per_tick/hourly_gc.rs
@@ -5,43 +5,63 @@
 //! `build_default_handlers`).
 //!
 //! This is a pure COMPOSITION wrapper, not a rewrite: each inner handler
-//! keeps its own `PerTickHandler` impl, cadence gate, and extra state
-//! completely unchanged. They are NOT identical — only
-//! `WorkspaceBoundarySweepHandler` builds its gate via
+//! keeps its own cadence gate and extra state completely unchanged. They are
+//! NOT identical — only `WorkspaceBoundarySweepHandler` builds its gate via
 //! `CadenceGate::new_with_boot_grace` (the other three use plain
 //! `CadenceGate::new`), and `GcTickHandler` carries its own
-//! `target_sweep_armed` first-firing suppression for the `target/` sweep
-//! sub-part — none of that is touched here (P2-2549-SPIKE.md §3a).
+//! `target_sweep_armed` first-firing suppression — none of that is touched
+//! here (P2-2549-SPIKE.md §3a).
 //!
-//! Panic isolation moves from PER-HANDLER (the outer per-tick loop wrapped
-//! each of the 4 previously-separately-registered handlers in its own
-//! `catch_unwind`, see `run_handlers_with_panic_guard`) to PER-SWEEP (this
-//! handler wraps each of its 4 inner `.run()` calls in its own
-//! `catch_unwind`), so the pre-merge invariant — one GC sub-task panicking
-//! never blocks the other three in the same tick — survives the collapse
-//! into a single registered handler.
+//! Panic isolation is PER-SWEEP (this handler wraps each of its 4 inner sweep
+//! calls in its own `catch_unwind`), so the pre-merge invariant — one GC
+//! sub-task panicking never blocks the other three in the same tick — survives
+//! the collapse into a single registered handler.
+//!
+//! ## #P1-2607 offload
+//!
+//! The four sweeps do potentially-slow work (git subprocess per worktree /
+//! candidate, fs walks) that used to run INLINE on the daemon's main tick loop
+//! — the same freeze class as `worktree_registry_sweep` (#2614). Here the
+//! cheap CADENCE checks (`sub.due()`) stay on the tick loop so gate advancement
+//! never drifts, but when any sweep is due the actual WORK (`sub.work()`) runs
+//! in a background thread — `run()` never blocks the loop. `in_flight` skips a
+//! new round's work while a previous one is still running (its gates already
+//! advanced, so cadence is unaffected). Mirrors #2614's single offload shape.
 
 use super::gc_tick::GcTickHandler;
 use super::reconcile_backups_gc::ReconcileBackupsGcHandler;
 use super::tmp_review_gc::TmpReviewGcHandler;
 use super::workspace_boundary_sweep::WorkspaceBoundarySweepHandler;
 use super::{PerTickHandler, TickContext};
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 
 pub(crate) struct HourlyGcHandler {
-    gc_tick: GcTickHandler,
-    workspace_boundary: WorkspaceBoundarySweepHandler,
-    tmp_review: TmpReviewGcHandler,
-    reconcile_backups: ReconcileBackupsGcHandler,
+    gc_tick: Arc<GcTickHandler>,
+    workspace_boundary: Arc<WorkspaceBoundarySweepHandler>,
+    tmp_review: Arc<TmpReviewGcHandler>,
+    reconcile_backups: Arc<ReconcileBackupsGcHandler>,
+    /// #P1-2607 re-entrancy guard: true while a round's work is running in its
+    /// background thread. A later tick whose gate fires skips spawning a second
+    /// overlapping round (cleared by `ClearOnDrop`, even on a panicking round).
+    in_flight: Arc<AtomicBool>,
 }
 
 impl HourlyGcHandler {
     pub(crate) fn new(every_n_ticks: u64) -> Self {
         Self {
-            gc_tick: GcTickHandler::new(every_n_ticks),
-            workspace_boundary: WorkspaceBoundarySweepHandler::new(every_n_ticks),
-            tmp_review: TmpReviewGcHandler::new(every_n_ticks),
-            reconcile_backups: ReconcileBackupsGcHandler::new(every_n_ticks),
+            gc_tick: Arc::new(GcTickHandler::new(every_n_ticks)),
+            workspace_boundary: Arc::new(WorkspaceBoundarySweepHandler::new(every_n_ticks)),
+            tmp_review: Arc::new(TmpReviewGcHandler::new(every_n_ticks)),
+            reconcile_backups: Arc::new(ReconcileBackupsGcHandler::new(every_n_ticks)),
+            in_flight: Arc::new(AtomicBool::new(false)),
         }
+    }
+
+    #[cfg(test)]
+    fn is_in_flight(&self) -> bool {
+        self.in_flight.load(Ordering::Acquire)
     }
 }
 
@@ -51,21 +71,84 @@ impl PerTickHandler for HourlyGcHandler {
     }
 
     fn run(&self, ctx: &TickContext<'_>) {
-        run_sweep_isolated("gc_tick", || self.gc_tick.run(ctx));
-        run_sweep_isolated("workspace_boundary_sweep", || {
-            self.workspace_boundary.run(ctx)
+        // Advance every sub-gate ON THE TICK LOOP, in the pinned order (cheap;
+        // this is what keeps cadence from ever drifting), recording which are
+        // due this tick.
+        let due_gc = self.gc_tick.due();
+        let due_wb = self.workspace_boundary.due();
+        let due_tmp = self.tmp_review.due();
+        let due_rec = self.reconcile_backups.due();
+        if !(due_gc || due_wb || due_tmp || due_rec) {
+            return;
+        }
+        // #P1-2607: a previous round's work is still running in its background
+        // thread — skip THIS round's work (the gates already advanced above, so
+        // the cadence is unaffected), retry next cadence.
+        if self.in_flight.swap(true, Ordering::AcqRel) {
+            tracing::warn!(
+                "hourly_gc: previous round still in flight, skipping this round's \
+                 work (gates advanced; retries next cadence)"
+            );
+            return;
+        }
+        let home = ctx.home.to_path_buf();
+        let gc_tick = Arc::clone(&self.gc_tick);
+        let workspace_boundary = Arc::clone(&self.workspace_boundary);
+        let tmp_review = Arc::clone(&self.tmp_review);
+        let reconcile_backups = Arc::clone(&self.reconcile_backups);
+        let in_flight = Arc::clone(&self.in_flight);
+        // fire-and-forget: #P1-2607 — the four sub-sweeps' potentially-slow work
+        // (git subprocess per worktree/candidate) runs off the daemon's main
+        // tick loop. `ClearOnDrop` releases `in_flight` even if a sweep panics
+        // past its per-sweep isolation. Per-sweep results stay observable via
+        // tracing/event_log, exactly as before this offload.
+        std::thread::spawn(move || {
+            let _guard = super::ClearOnDrop::new(in_flight);
+            #[cfg(test)]
+            test_hooks::maybe_delay();
+            run_due_sweeps_isolated(
+                &home,
+                (due_gc, &gc_tick),
+                (due_wb, &workspace_boundary),
+                (due_tmp, &tmp_review),
+                (due_rec, &reconcile_backups),
+            );
         });
-        run_sweep_isolated("tmp_review_gc", || self.tmp_review.run(ctx));
-        run_sweep_isolated("reconcile_backups_gc", || self.reconcile_backups.run(ctx));
     }
 }
 
-/// Run one sub-sweep isolated from its siblings: a panic inside `f` is
-/// caught and logged, never propagated — the per-sweep equivalent of the
-/// outer per-tick loop's per-HANDLER `catch_unwind`. Preserves "one GC
-/// sub-task panicking doesn't block the other three" now that all four run
-/// inside a single registered handler's `run()` call (P2-2549-SPIKE.md
-/// §3a).
+/// Run the DUE sub-sweeps in their pinned order (gc_tick → workspace_boundary →
+/// tmp_review → reconcile_backups), each isolated from the others by its own
+/// `catch_unwind` — a panic in one is logged, never blocks the rest (the
+/// per-sweep guarantee from #2549 W1, preserved through the #P1-2607 offload).
+/// Split out of the spawned closure so tests exercise the isolation
+/// synchronously against the REAL sub-handlers, without a thread. The order
+/// (gc_tick cleans worktrees before workspace_boundary sweeps for them) is
+/// pinned by the tests below.
+fn run_due_sweeps_isolated(
+    home: &Path,
+    gc: (bool, &GcTickHandler),
+    wb: (bool, &WorkspaceBoundarySweepHandler),
+    tmp: (bool, &TmpReviewGcHandler),
+    rec: (bool, &ReconcileBackupsGcHandler),
+) {
+    if gc.0 {
+        run_sweep_isolated("gc_tick", || gc.1.work(home));
+    }
+    if wb.0 {
+        run_sweep_isolated("workspace_boundary_sweep", || wb.1.work(home));
+    }
+    if tmp.0 {
+        run_sweep_isolated("tmp_review_gc", || tmp.1.work(home));
+    }
+    if rec.0 {
+        run_sweep_isolated("reconcile_backups_gc", || rec.1.work(home));
+    }
+}
+
+/// Run one sub-sweep isolated from its siblings: a panic inside `f` is caught
+/// and logged, never propagated — the per-sweep equivalent of the outer
+/// per-tick loop's per-HANDLER `catch_unwind` (P2-2549-SPIKE.md §3a).
 fn run_sweep_isolated(name: &'static str, f: impl FnOnce()) {
     let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         #[cfg(test)]
@@ -76,27 +159,30 @@ fn run_sweep_isolated(name: &'static str, f: impl FnOnce()) {
         tracing::error!(
             sweep = name,
             error = %super::panic_payload_str(&payload),
-            "hourly_gc: sweep panicked — isolated, the other sweeps in this tick still ran"
+            "hourly_gc: sweep panicked — isolated, the other sweeps in this round still ran"
         );
     }
 }
 
-/// Test-only fault-injection seam: proves the per-sweep isolation property
-/// against the REAL merged handler (not a mock), without needing to trigger
-/// a genuine panic from inside any of the four sweeps' real filesystem
-/// logic. Mirrors the `AGEND_FORCE_SUCCESSOR_FAIL`-style injection seams
-/// already established elsewhere in the daemon for hard-to-trigger paths.
+/// Test-only seams: fault injection for the per-sweep isolation property, and a
+/// delay seam for the #P1-2607 freeze regression. `FORCE_PANIC`/`INVOKED` are
+/// thread-local because the isolation tests drive `run_due_sweeps_isolated`
+/// SYNCHRONOUSLY on the test thread; `DELAY_MS` is a global because the freeze
+/// test observes it from the spawned background thread (mirrors #2614's seam).
 #[cfg(test)]
 mod test_hooks {
     use std::cell::{Cell, RefCell};
+    use std::sync::atomic::{AtomicU64, Ordering};
 
     thread_local! {
         static FORCE_PANIC: Cell<Option<&'static str>> = const { Cell::new(None) };
         static INVOKED: RefCell<Vec<&'static str>> = const { RefCell::new(Vec::new()) };
     }
 
-    /// Records that `name`'s sweep was reached (so a test can assert ALL
-    /// FOUR were attempted, in order, even when one panics), then panics if
+    static DELAY_MS: AtomicU64 = AtomicU64::new(0);
+
+    /// Records that `name`'s sweep was reached (so a test can assert every DUE
+    /// sweep was attempted, in order, even when one panics), then panics if
     /// `force_panic(name)` armed this name.
     pub(super) fn record_and_maybe_force_panic(name: &'static str) {
         INVOKED.with(|v| v.borrow_mut().push(name));
@@ -116,6 +202,21 @@ mod test_hooks {
     pub(super) fn take_invoked() -> Vec<&'static str> {
         INVOKED.with(|v| std::mem::take(&mut *v.borrow_mut()))
     }
+
+    pub(super) fn set_delay_ms(ms: u64) {
+        DELAY_MS.store(ms, Ordering::Release);
+    }
+
+    pub(super) fn clear_delay() {
+        DELAY_MS.store(0, Ordering::Release);
+    }
+
+    pub(super) fn maybe_delay() {
+        let ms = DELAY_MS.load(Ordering::Acquire);
+        if ms > 0 {
+            std::thread::sleep(std::time::Duration::from_millis(ms));
+        }
+    }
 }
 
 #[cfg(test)]
@@ -126,6 +227,7 @@ mod tests {
     use parking_lot::Mutex as PLMutex;
     use std::collections::HashMap;
     use std::sync::Arc;
+    use std::time::{Duration, Instant};
 
     fn tmp_home(tag: &str) -> std::path::PathBuf {
         use std::sync::atomic::{AtomicU32, Ordering};
@@ -141,102 +243,86 @@ mod tests {
         dir
     }
 
+    /// Runs all four sweeps as DUE, synchronously (no thread), so the per-sweep
+    /// isolation is asserted via the thread-local INVOKED recorder. Explicit
+    /// due-flags sidestep `workspace_boundary`'s boot-grace (which would
+    /// otherwise leave it not-due in a fresh handler).
+    fn run_all_due(home: &Path) {
+        let gc = GcTickHandler::new(1);
+        let wb = WorkspaceBoundarySweepHandler::new(1);
+        let tmp = TmpReviewGcHandler::new(1);
+        let rec = ReconcileBackupsGcHandler::new(1);
+        run_due_sweeps_isolated(home, (true, &gc), (true, &wb), (true, &tmp), (true, &rec));
+    }
+
+    const ORDER: [&str; 4] = [
+        "gc_tick",
+        "workspace_boundary_sweep",
+        "tmp_review_gc",
+        "reconcile_backups_gc",
+    ];
+
     #[test]
     fn name_is_hourly_gc() {
         assert_eq!(HourlyGcHandler::new(360).name(), "hourly_gc");
     }
 
-    /// #2549 W1 pin (P2-2549-SPIKE.md §3a): the outer per-tick loop used to
-    /// isolate panics PER-HANDLER — 4 separately-registered handlers meant a
-    /// panic in one never touched the other 3's invocation this tick. After
-    /// collapsing all 4 into `HourlyGcHandler`, that guarantee must be
-    /// reproduced INSIDE `run()` at per-sweep granularity. Force the FIRST
-    /// sweep (`gc_tick`) to panic and assert:
-    /// (a) `run()` itself does not propagate the panic, and
-    /// (b) all four sweeps were still reached, in their original order —
-    ///     the three AFTER the panicking one are proof the isolation is
-    ///     real, not just "nothing after the panic point crashed by luck".
+    /// #2549 W1 pin (P2-2549-SPIKE.md §3a), preserved through the #P1-2607
+    /// offload: force the FIRST sweep (`gc_tick`) to panic and assert
+    /// (a) the round does not propagate the panic, and
+    /// (b) all four sweeps still ran, in their original order — the three AFTER
+    ///     the panicking one prove the isolation is real.
     #[test]
     fn one_sweep_panic_does_not_block_the_other_three() {
         let home = tmp_home("panic-isolation");
-        let registry: AgentRegistry = Arc::new(PLMutex::new(HashMap::new()));
-        let externals: ExternalRegistry = Arc::new(PLMutex::new(HashMap::new()));
-        let configs: Arc<PLMutex<HashMap<String, crate::daemon::AgentConfig>>> =
-            Arc::new(PLMutex::new(HashMap::new()));
-        let ctx = TickContext {
-            home: &home,
-            registry: &registry,
-            externals: &externals,
-            configs: &configs,
-        };
-
-        let handler = HourlyGcHandler::new(1);
         test_hooks::force_panic("gc_tick");
-
-        // Must NOT propagate — HourlyGcHandler::run itself stays panic-free
-        // from the caller's perspective, exactly like the outer per-tick
-        // loop's existing per-handler guarantee.
-        handler.run(&ctx);
-
+        run_all_due(&home);
         test_hooks::clear_force_panic();
         assert_eq!(
             test_hooks::take_invoked(),
-            vec![
-                "gc_tick",
-                "workspace_boundary_sweep",
-                "tmp_review_gc",
-                "reconcile_backups_gc"
-            ],
+            ORDER,
             "all four sweeps must be attempted, in original order, even though \
              'gc_tick' (the first) panicked — per-sweep isolation (§3a)"
         );
         std::fs::remove_dir_all(&home).ok();
     }
 
-    /// Same property, forcing a MIDDLE sweep — the two on either side both
-    /// still ran, closing the "only proved trailing sweeps survive" gap the
-    /// first test alone would leave.
+    /// Same property forcing a MIDDLE sweep — the neighbours on both sides ran.
     #[test]
     fn middle_sweep_panic_does_not_block_its_neighbors() {
         let home = tmp_home("panic-isolation-middle");
-        let registry: AgentRegistry = Arc::new(PLMutex::new(HashMap::new()));
-        let externals: ExternalRegistry = Arc::new(PLMutex::new(HashMap::new()));
-        let configs: Arc<PLMutex<HashMap<String, crate::daemon::AgentConfig>>> =
-            Arc::new(PLMutex::new(HashMap::new()));
-        let ctx = TickContext {
-            home: &home,
-            registry: &registry,
-            externals: &externals,
-            configs: &configs,
-        };
-
-        let handler = HourlyGcHandler::new(1);
         test_hooks::force_panic("tmp_review_gc");
-
-        handler.run(&ctx);
-
+        run_all_due(&home);
         test_hooks::clear_force_panic();
         assert_eq!(
             test_hooks::take_invoked(),
-            vec![
-                "gc_tick",
-                "workspace_boundary_sweep",
-                "tmp_review_gc",
-                "reconcile_backups_gc"
-            ],
-            "'tmp_review_gc' panicking must not stop 'reconcile_backups_gc' \
-             (after it) from running, nor does it retroactively un-run the \
-             two before it"
+            ORDER,
+            "'tmp_review_gc' panicking must not stop 'reconcile_backups_gc' (after \
+             it) nor un-run the two before it"
         );
         std::fs::remove_dir_all(&home).ok();
     }
 
-    /// Baseline (no forced panic): all four still run in order, on a single
-    /// `run()` call — the composition itself doesn't drop or reorder any of
-    /// the four sub-sweeps.
+    /// Baseline (no forced panic): all four run in order — the composition
+    /// doesn't drop or reorder any sub-sweep.
     #[test]
     fn no_panic_all_four_run_in_order() {
         let home = tmp_home("baseline");
+        run_all_due(&home);
+        assert_eq!(test_hooks::take_invoked(), ORDER);
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #P1-2607 freeze-regression pin: `run()` must return near-instantly even
+    /// while the round's work is slow (the pathological case that froze the
+    /// daemon — heavy git subprocess work on the main tick loop, simulated via
+    /// the `test_hooks` delay seam). Also pins the re-entrancy guard: a second
+    /// fire while the first round is still running must skip, not spawn an
+    /// overlapping round. Serial: the delay seam is a process-global.
+    #[test]
+    #[serial_test::serial(hourly_gc_delay)]
+    fn run_does_not_block_tick_loop_during_slow_round_p1_2607() {
+        let home = tmp_home("slow-round");
         let registry: AgentRegistry = Arc::new(PLMutex::new(HashMap::new()));
         let externals: ExternalRegistry = Arc::new(PLMutex::new(HashMap::new()));
         let configs: Arc<PLMutex<HashMap<String, crate::daemon::AgentConfig>>> =
@@ -248,17 +334,73 @@ mod tests {
             configs: &configs,
         };
 
-        let handler = HourlyGcHandler::new(1);
-        handler.run(&ctx);
+        test_hooks::set_delay_ms(300);
+        let h = HourlyGcHandler::new(1); // fires every call
 
-        assert_eq!(
-            test_hooks::take_invoked(),
-            vec![
-                "gc_tick",
-                "workspace_boundary_sweep",
-                "tmp_review_gc",
-                "reconcile_backups_gc"
-            ]
+        let start = Instant::now();
+        h.run(&ctx);
+        assert!(
+            start.elapsed() < Duration::from_millis(100),
+            "run() must not block the tick loop on the (delayed) round, took {:?}",
+            start.elapsed()
+        );
+        assert!(
+            h.is_in_flight(),
+            "the background round should still be running (300ms delay, checked immediately)"
+        );
+
+        // The very next tick arriving while the previous round is still in
+        // flight: gates fire again, but the re-entrancy guard must skip spawning
+        // a second overlapping round — and still return near-instantly.
+        let start2 = Instant::now();
+        h.run(&ctx);
+        assert!(
+            start2.elapsed() < Duration::from_millis(100),
+            "the re-entrant skip path must also return near-instantly"
+        );
+
+        // Poll for the background round to finish (300ms delay; 2s is a generous
+        // CI-jitter ceiling) and confirm the guard clears.
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while h.is_in_flight() && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(
+            !h.is_in_flight(),
+            "in_flight must clear once the background round completes"
+        );
+
+        test_hooks::clear_delay();
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Smoke: `run()` against empty fixtures completes (the background round
+    /// finishes and clears `in_flight`) without panic.
+    #[test]
+    #[serial_test::serial(hourly_gc_delay)]
+    fn run_is_no_op_on_empty_fixtures() {
+        let home = tmp_home("empty");
+        let registry: AgentRegistry = Arc::new(PLMutex::new(HashMap::new()));
+        let externals: ExternalRegistry = Arc::new(PLMutex::new(HashMap::new()));
+        let configs: Arc<PLMutex<HashMap<String, crate::daemon::AgentConfig>>> =
+            Arc::new(PLMutex::new(HashMap::new()));
+        let ctx = TickContext {
+            home: &home,
+            registry: &registry,
+            externals: &externals,
+            configs: &configs,
+        };
+
+        let h = HourlyGcHandler::new(1);
+        h.run(&ctx);
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while h.is_in_flight() && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(
+            !h.is_in_flight(),
+            "background round should finish on empty fixtures"
         );
         std::fs::remove_dir_all(&home).ok();
     }

--- a/src/daemon/per_tick/mod.rs
+++ b/src/daemon/per_tick/mod.rs
@@ -146,6 +146,30 @@ pub(crate) fn in_boot_grace(created_at: std::time::Instant) -> bool {
     created_at.elapsed() < NOTIFICATION_BOOT_GRACE
 }
 
+/// Releases an in-flight re-entrancy flag on drop — so a panic inside an
+/// offloaded sweep's background thread still clears the guard. Without it, the
+/// manual `in_flight.store(false)` at the end of the spawned closure is skipped
+/// when the closure unwinds, leaving `in_flight` stuck `true` forever and the
+/// sweep permanently skipped. Shared by the per-tick offload handlers
+/// (`worktree_registry_sweep`, `hourly_gc`). #P1-2607 / #2614 follow-up
+/// (reviewer non-blocking suggestion).
+pub(crate) struct ClearOnDrop(std::sync::Arc<std::sync::atomic::AtomicBool>);
+
+impl ClearOnDrop {
+    /// Takes the shared flag; call AFTER the loop-side re-entrancy `swap(true)`.
+    /// The flag is released (`store(false)`) when this guard drops — on normal
+    /// completion OR an unwinding panic.
+    pub(crate) fn new(in_flight: std::sync::Arc<std::sync::atomic::AtomicBool>) -> Self {
+        Self(in_flight)
+    }
+}
+
+impl Drop for ClearOnDrop {
+    fn drop(&mut self) {
+        self.0.store(false, std::sync::atomic::Ordering::Release);
+    }
+}
+
 // ── #941: per-handler timing observability ─────────────────────────────
 //
 // `HANDLER_TIMING` accumulates per-handler wall-clock stats so the
@@ -727,6 +751,36 @@ mod tests {
         assert_eq!(
             panic_payload_str(&other_payload),
             "<non-string panic payload>"
+        );
+    }
+
+    /// #P1-2607 / #2614 follow-up: `ClearOnDrop` releases the in-flight guard on
+    /// BOTH normal completion and an unwinding panic — the panic path is the
+    /// whole point (the old manual `store(false)` was skipped on unwind, wedging
+    /// the guard `true` forever). Proves both.
+    #[test]
+    fn clear_on_drop_releases_flag_on_normal_and_panic() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Arc;
+
+        // Normal scope exit.
+        let flag = Arc::new(AtomicBool::new(true));
+        {
+            let _g = ClearOnDrop::new(Arc::clone(&flag));
+        }
+        assert!(!flag.load(Ordering::Acquire), "guard clears on normal drop");
+
+        // Unwinding panic — the guard must STILL clear.
+        let flag = Arc::new(AtomicBool::new(true));
+        let flag2 = Arc::clone(&flag);
+        let res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _g = ClearOnDrop::new(flag2);
+            panic!("boom");
+        }));
+        assert!(res.is_err(), "the closure panicked");
+        assert!(
+            !flag.load(Ordering::Acquire),
+            "guard MUST clear on an unwinding panic — the whole reason it exists"
         );
     }
 }

--- a/src/daemon/per_tick/reconcile_backups_gc.rs
+++ b/src/daemon/per_tick/reconcile_backups_gc.rs
@@ -44,6 +44,26 @@ impl ReconcileBackupsGcHandler {
             gate: crate::daemon::cadence_gate::CadenceGate::new(every_n_ticks),
         }
     }
+
+    /// #P1-2607 offload seam: cadence check kept ON the tick loop (cheap, no
+    /// drift). `HourlyGcHandler` calls it to decide inclusion in the round.
+    pub(crate) fn due(&self) -> bool {
+        self.gate.fire()
+    }
+
+    /// #P1-2607 offload seam: the GC body, run off the tick loop by
+    /// `HourlyGcHandler`. Behaviour unchanged from the pre-offload `run()`.
+    pub(crate) fn work(&self, home: &Path) {
+        // The fleet roster disambiguates the `<agent>[-<branch>]-<epoch>` dir name
+        // (hyphenated agent names make a plain split ambiguous). Falls back to a
+        // glob of the runtime dir when the daemon registry is unreachable.
+        let agents = crate::runtime::list_agents_with_fallback(home);
+        let removed = gc_reconcile_backups(home, &agents, MIN_AGE, SystemTime::now());
+        if removed > 0 {
+            tracing::info!(target: "reconcile_backups_gc", removed,
+                "#2234: GC'd aged reconcile-backups (per-agent newest-1 kept)");
+        }
+    }
 }
 
 impl PerTickHandler for ReconcileBackupsGcHandler {
@@ -52,17 +72,8 @@ impl PerTickHandler for ReconcileBackupsGcHandler {
     }
 
     fn run(&self, ctx: &TickContext<'_>) {
-        if !self.gate.fire() {
-            return;
-        }
-        // The fleet roster disambiguates the `<agent>[-<branch>]-<epoch>` dir name
-        // (hyphenated agent names make a plain split ambiguous). Falls back to a
-        // glob of the runtime dir when the daemon registry is unreachable.
-        let agents = crate::runtime::list_agents_with_fallback(ctx.home);
-        let removed = gc_reconcile_backups(ctx.home, &agents, MIN_AGE, SystemTime::now());
-        if removed > 0 {
-            tracing::info!(target: "reconcile_backups_gc", removed,
-                "#2234: GC'd aged reconcile-backups (per-agent newest-1 kept)");
+        if self.due() {
+            self.work(ctx.home);
         }
     }
 }

--- a/src/daemon/per_tick/tmp_review_gc.rs
+++ b/src/daemon/per_tick/tmp_review_gc.rs
@@ -53,6 +53,24 @@ impl TmpReviewGcHandler {
             gate: crate::daemon::cadence_gate::CadenceGate::new(every_n_ticks),
         }
     }
+
+    /// #P1-2607 offload seam: cadence check kept ON the tick loop (cheap, no
+    /// drift). `HourlyGcHandler` calls it to decide inclusion in the round.
+    pub(crate) fn due(&self) -> bool {
+        self.gate.fire()
+    }
+
+    /// #P1-2607 offload seam: the sweep body (git worktree removes under `/tmp`),
+    /// run off the tick loop by `HourlyGcHandler`. Behaviour unchanged from the
+    /// pre-offload `run()`.
+    pub(crate) fn work(&self, home: &Path) {
+        let removed =
+            gc_stale_tmp_review_worktrees(home, &std::env::temp_dir(), MIN_AGE, SystemTime::now());
+        if removed > 0 {
+            tracing::info!(target: "tmp_review_gc", removed,
+                "Class2: GC'd stale /tmp worktrees/clones of managed repos");
+        }
+    }
 }
 
 impl PerTickHandler for TmpReviewGcHandler {
@@ -61,18 +79,8 @@ impl PerTickHandler for TmpReviewGcHandler {
     }
 
     fn run(&self, ctx: &TickContext<'_>) {
-        if !self.gate.fire() {
-            return;
-        }
-        let removed = gc_stale_tmp_review_worktrees(
-            ctx.home,
-            &std::env::temp_dir(),
-            MIN_AGE,
-            SystemTime::now(),
-        );
-        if removed > 0 {
-            tracing::info!(target: "tmp_review_gc", removed,
-                "Class2: GC'd stale /tmp worktrees/clones of managed repos");
+        if self.due() {
+            self.work(ctx.home);
         }
     }
 }

--- a/src/daemon/per_tick/workspace_boundary_sweep.rs
+++ b/src/daemon/per_tick/workspace_boundary_sweep.rs
@@ -89,6 +89,19 @@ impl WorkspaceBoundarySweepHandler {
         *seen = current.into_keys().collect();
         (appeared, resolved)
     }
+
+    /// #P1-2607 offload seam: cadence check kept ON the tick loop (cheap, no
+    /// drift). `HourlyGcHandler` calls it to decide inclusion in the offloaded
+    /// round. Preserves this handler's boot-grace (the gate itself carries it).
+    pub(crate) fn due(&self) -> bool {
+        self.gate.fire()
+    }
+
+    /// #P1-2607 offload seam: the sweep body, run off the tick loop by
+    /// `HourlyGcHandler`. Behaviour unchanged from the pre-offload `run()`.
+    pub(crate) fn work(&self, home: &Path) {
+        self.sweep_once(home);
+    }
 }
 
 impl PerTickHandler for WorkspaceBoundarySweepHandler {
@@ -97,10 +110,9 @@ impl PerTickHandler for WorkspaceBoundarySweepHandler {
     }
 
     fn run(&self, ctx: &TickContext<'_>) {
-        if !self.gate.fire() {
-            return;
+        if self.due() {
+            self.work(ctx.home);
         }
-        self.sweep_once(ctx.home);
     }
 }
 

--- a/src/daemon/per_tick/worktree_registry_sweep.rs
+++ b/src/daemon/per_tick/worktree_registry_sweep.rs
@@ -76,15 +76,16 @@ impl PerTickHandler for WorktreeRegistrySweepHandler {
         let in_flight = Arc::clone(&self.in_flight);
         // fire-and-forget: #P1-2607 — moves the potentially-slow sweep
         // (git subprocess per candidate branch) off the daemon's main tick
-        // loop. No JoinHandle is kept; completion is signaled via
-        // `in_flight` (cleared once the sweep returns) and results remain
-        // fully observable via tracing + event_log per candidate, same as
-        // before this offload.
+        // loop. No JoinHandle is kept; completion is signaled via `in_flight`,
+        // released by `ClearOnDrop` on the sweep's return OR an unwinding panic
+        // (so a panicking round can't wedge the guard true forever). Results
+        // remain fully observable via tracing + event_log per candidate, same
+        // as before this offload.
         std::thread::spawn(move || {
+            let _guard = super::ClearOnDrop::new(in_flight);
             #[cfg(test)]
             test_hooks::maybe_delay();
             worktree_auto_cleanup(&home, &configs);
-            in_flight.store(false, Ordering::Release);
         });
     }
 }


### PR DESCRIPTION
## What
`HourlyGcHandler` ran its four sub-sweeps (`gc_tick` / `workspace_boundary_sweep` / `tmp_review_gc` / `reconcile_backups_gc`) **inline on the daemon's main tick loop** — the same freeze class as `worktree_registry_sweep` (#2614). Candidate volume is small today (~10-15 worktrees) so it hasn't frozen, but git-subprocess-per-worktree work grows with the fleet. This is the preventive port of #2614's offload (follow-up ticket from gapfix-dev).

## Design (lead-approved **B** — #2614 parity)
The two viable shapes were: **(A)** keep sub-handlers untouched + spawn a thread every tick, or **(B)** split each sub-handler `run()` into `due()` (gate) + `work()` and keep gates on the loop. Lead picked **B** (A's every-tick no-op thread is a structural smell; B is a behaviour-preserving mechanical refactor and establishes a single standard offload shape).

- Each sub-handler `run()` → `if self.due() { self.work(ctx.home) }`. `due()` = the cadence gate, kept **on the tick loop** so gate advancement never drifts. `work(&self, home: &Path)` = the body, behaviour-identical. Each handler's own tests + any direct call stay synchronous and unchanged.
- `HourlyGcHandler` advances all four gates on the loop (in the pinned order), and when any is due spawns **one** background thread that runs the due sweeps' work **in the pinned order** → `run()` never blocks the loop. `in_flight` skips a new round's work while a previous one runs (gates already advanced → cadence unaffected). Mirrors #2614's `due`-on-loop / `work`-in-thread shape exactly.

### Judgment calls (from the dispatch)
1. **whole-group vs per-sweep** → **whole-group** (one thread, sequential): the sweep order (`gc_tick` before `workspace_boundary`) is test-pinned, and the four gates are out-of-phase (workspace_boundary uses `new_with_boot_grace`) so no single outer gate can replace them — concurrent per-sweep threads would break the order.
2. **purge_trash (#2599) + gc_stale_ci_watch_locks** → stay inside `gc_tick.work` exactly as before. `target_sweep` first-fire suppression and `workspace_boundary` boot-grace untouched. **Zero semantic change** to the four sub-sweeps.
3. **Drop guard** (reviewer4's #2614 non-blocking point) → shared `ClearOnDrop` releases `in_flight` even if a round panics past its per-sweep isolation (the old manual `store(false)` was skipped on unwind, wedging the guard `true` forever). `worktree_registry_sweep` **retrofitted** to it too.

## Verification
- **Freeze-regression pin**: `run()` returns <100 ms while the round's work is slow (delay seam) + re-entrancy skip returns fast + guard clears.
- **ClearOnDrop panic-clears**: guard releases on normal drop AND unwinding panic.
- Existing per-sweep panic-isolation (#2549 W1 §3a) preserved via `run_due_sweeps_isolated` (split out so isolation is tested synchronously).
- **162 per_tick tests green**; `cargo fmt --check` ✓; `cargo clippy --all-targets --features tray -D warnings` clean.

7 files: `hourly_gc.rs` (offload) + 4 sub-handlers (`due`/`work` split) + `mod.rs` (`ClearOnDrop`) + `worktree_registry_sweep.rs` (retrofit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)