### PR TITLE
chore: hygiene batch — Agy MCP stale comment + GC sub-handler trait residue

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1414,11 +1414,14 @@ mod tests {
     }
 
     /// #995 Bug 3: `fleet_mcp_supported` flag pins which backends ship with
-    /// the `agend-mcp-bridge` working in fleet mode. Currently every
-    /// backend except Agy supports it; Agy is `false` because its MCP
-    /// discovery ignores `<workdir>/.antigravitycli/mcp_config.json`
-    /// mcpServers field (only HOME-level loads, which the scope rule
-    /// at `src/mcp_config.rs:5-11` forbids).
+    /// the `agend-mcp-bridge` working in fleet mode. Agy was `false` under
+    /// #995 Bug 3 because its MCP discovery ignored
+    /// `<workdir>/.antigravitycli/mcp_config.json`'s `mcpServers` field
+    /// (only HOME-level loads, which the scope rule at
+    /// `src/mcp_config.rs:5-11` forbids). #1547 fixed this: Agy now loads
+    /// the bridge via `<workspace>/.agents/mcp_config.json` (the official
+    /// Customization Roots dir), so `fleet_mcp_supported` is `true` for
+    /// every backend except the no-MCP-discovery sentinels (Shell, Raw).
     ///
     /// Daemon spawn path (`src/agent.rs spawn_agent`) emits a
     /// `[fleet-mcp-unsupported]` tracing::warn when this is `false` so

--- a/src/daemon/per_tick/gc_tick.rs
+++ b/src/daemon/per_tick/gc_tick.rs
@@ -92,6 +92,12 @@ impl GcTickHandler {
     }
 }
 
+/// #2616-residual: kept for `due()`/`work()`'s convenience-wrapper `run()`
+/// (exercised by this file's own tests) — do NOT register this directly in
+/// `build_default_handlers`. `HourlyGcHandler` already drives this sweep via
+/// direct `due()`/`work()` calls (#2549 W1); a direct registration here would
+/// double-execute it every due tick. Guarded by the source-scan invariant in
+/// `tests/hourly_gc_sub_handlers_not_directly_registered.rs`.
 impl PerTickHandler for GcTickHandler {
     fn name(&self) -> &'static str {
         "gc_tick"

--- a/src/daemon/per_tick/reconcile_backups_gc.rs
+++ b/src/daemon/per_tick/reconcile_backups_gc.rs
@@ -66,6 +66,12 @@ impl ReconcileBackupsGcHandler {
     }
 }
 
+/// #2616-residual: kept for the `due()`/`work()` convenience-wrapper `run()`
+/// — do NOT register this directly in `build_default_handlers`.
+/// `HourlyGcHandler` already drives this sweep via direct `due()`/`work()`
+/// calls (#2549 W1); a direct registration here would double-execute it
+/// every due tick. Guarded by the source-scan invariant in
+/// `tests/hourly_gc_sub_handlers_not_directly_registered.rs`.
 impl PerTickHandler for ReconcileBackupsGcHandler {
     fn name(&self) -> &'static str {
         "reconcile_backups_gc"

--- a/src/daemon/per_tick/tmp_review_gc.rs
+++ b/src/daemon/per_tick/tmp_review_gc.rs
@@ -73,6 +73,12 @@ impl TmpReviewGcHandler {
     }
 }
 
+/// #2616-residual: kept for the `due()`/`work()` convenience-wrapper `run()`
+/// — do NOT register this directly in `build_default_handlers`.
+/// `HourlyGcHandler` already drives this sweep via direct `due()`/`work()`
+/// calls (#2549 W1); a direct registration here would double-execute it
+/// every due tick. Guarded by the source-scan invariant in
+/// `tests/hourly_gc_sub_handlers_not_directly_registered.rs`.
 impl PerTickHandler for TmpReviewGcHandler {
     fn name(&self) -> &'static str {
         "tmp_review_gc"

--- a/src/daemon/per_tick/workspace_boundary_sweep.rs
+++ b/src/daemon/per_tick/workspace_boundary_sweep.rs
@@ -104,6 +104,12 @@ impl WorkspaceBoundarySweepHandler {
     }
 }
 
+/// #2616-residual: kept for the `due()`/`work()` convenience-wrapper `run()`
+/// — do NOT register this directly in `build_default_handlers`.
+/// `HourlyGcHandler` already drives this sweep via direct `due()`/`work()`
+/// calls (#2549 W1); a direct registration here would double-execute it
+/// every due tick. Guarded by the source-scan invariant in
+/// `tests/hourly_gc_sub_handlers_not_directly_registered.rs`.
 impl PerTickHandler for WorkspaceBoundarySweepHandler {
     fn name(&self) -> &'static str {
         "workspace_boundary_sweep"

--- a/tests/hourly_gc_sub_handlers_not_directly_registered.rs
+++ b/tests/hourly_gc_sub_handlers_not_directly_registered.rs
@@ -1,0 +1,70 @@
+//! #2616-residual invariant (backlog low, 2026-07-04): `GcTickHandler`,
+//! `WorkspaceBoundarySweepHandler`, `TmpReviewGcHandler`, and
+//! `ReconcileBackupsGcHandler` still `impl PerTickHandler` each (kept —
+//! `gc_tick.rs`'s own test suite drives one of them via `PerTickHandler::run`
+//! as a convenience one-liner), but MUST NOT be directly registered in
+//! `build_default_handlers`: `HourlyGcHandler` already composes all four via
+//! its own `due()`/`work()` calls (#2549 W1 / #2616). A direct
+//! `Box::new(GcTickHandler::new(..))` registration there would double-execute
+//! every due sweep once via `HourlyGcHandler`'s composition and again via its
+//! own standalone slot.
+//!
+//! METHOD: source-text scan of `build_default_handlers`'s function body,
+//! matching `tests/src_file_size_invariant.rs`'s style. Checks for the
+//! `Box::new(<Handler>` REGISTRATION pattern, not bare name occurrence — a
+//! bare-name scan would false-positive on the function's own explanatory
+//! comment, which legitimately names all four while describing the #2549 W1
+//! collapse. Registration is the only reachable bypass form here (an
+//! accidental registration necessarily writes `Box::new(HandlerName::new(...))`
+//! literally at this one call site — trait objects can't enter the vec any
+//! other way), so the literal scan is sufficient (contrast the #2612 lesson:
+//! there the scanned surface had import/alias/re-export bypass forms; here
+//! there is exactly one construction site to check).
+
+use std::path::PathBuf;
+
+const SUB_HANDLERS: &[&str] = &[
+    "GcTickHandler",
+    "WorkspaceBoundarySweepHandler",
+    "TmpReviewGcHandler",
+    "ReconcileBackupsGcHandler",
+];
+
+#[test]
+fn hourly_gc_sub_handlers_are_not_directly_registered() {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/daemon/per_tick/mod.rs");
+    let content = std::fs::read_to_string(&path).expect("src/daemon/per_tick/mod.rs must exist");
+    let lines: Vec<&str> = content.lines().collect();
+
+    let start = lines
+        .iter()
+        .position(|l| l.contains("fn build_default_handlers"))
+        .expect("build_default_handlers must exist in per_tick/mod.rs");
+    let end = (start..lines.len())
+        .find(|&i| i > start && lines[i] == "}")
+        .expect("build_default_handlers must have a closing brace");
+
+    let body = lines[start..=end].join("\n");
+
+    for handler in SUB_HANDLERS {
+        let pattern = format!("Box::new({handler}");
+        assert!(
+            !body.contains(&pattern),
+            "#2616-residual: `{handler}` must not be directly registered in \
+             build_default_handlers (found `{pattern}`) — HourlyGcHandler \
+             already composes it via due()/work(); a direct registration \
+             would double-execute its sweep every due tick. Drive it through \
+             HourlyGcHandler instead."
+        );
+    }
+
+    // Guards against the invariant trivially passing if the composition
+    // wrapper's own registration were ever deleted (the four sweeps would
+    // then never run at all).
+    assert!(
+        body.contains("Box::new(HourlyGcHandler"),
+        "#2616-residual: HourlyGcHandler must be registered in \
+         build_default_handlers — it's the sole entry point that drives the \
+         four GC sub-sweeps"
+    );
+}


### PR DESCRIPTION
## Summary

Two operator-confirmed low-priority backlog items, bundled into one PR.

### 1. `src/backend.rs` — stale Agy MCP doc comment

The doc comment above `fleet_mcp_supported_pins_per_backend` claimed Agy's `fleet_mcp_supported` is `false` (the pre-#1547 `.antigravitycli/`-era description), contradicting both the preset (`backend.rs:641`, `true`) and the test body itself (`backend.rs:1436`, asserts `true`) a few lines below — a maintainer reading only the doc comment would be misled. Rewrote it to match #1547 (Agy now loads the bridge via `<workspace>/.agents/mcp_config.json`). Found by gapfix-dev3 during the #2609 BACKEND-CAPABILITY-MATRIX sweep; operator confirmed 2026-07-04.

### 2. #2616 residual — GC sub-handler trait shape

After the #2549 W1 / #2616 collapse, `GcTickHandler`, `WorkspaceBoundarySweepHandler`, `TmpReviewGcHandler`, and `ReconcileBackupsGcHandler` are driven exclusively through `HourlyGcHandler`'s own `due()`/`work()` calls — but each still `impl PerTickHandler`, a shape that invites a future maintainer to register one directly in `build_default_handlers` (double-executing its sweep alongside `HourlyGcHandler`'s composition).

Investigated both options from the task:
- **Removing the trait impls** (tighter shape) would touch `gc_tick.rs`'s own test (`purge_trash_runs_regardless_of_worktree_gc_gate_2550_w5`), which drives `PerTickHandler::run()` as a `due()`+`work()` convenience one-liner — expanding the diff beyond this hygiene pass's scope.
- **Kept the trait impls** (chosen): added a doc comment on each of the four `impl PerTickHandler for X` blocks stating the non-registration invariant, backed by an executable guard.

New test: `tests/hourly_gc_sub_handlers_not_directly_registered.rs` — a source-text scan of `build_default_handlers`'s function body for the `Box::new(<Handler>` registration pattern (not bare name occurrence, which would false-positive on the function's own explanatory comment naming all four handlers). Red/green-verified locally (a temporarily-injected fake registration made the test fail with the expected message; reverted before commit).

## Verification

- `cargo test --features tray --test hourly_gc_sub_handlers_not_directly_registered`: ok.
- `cargo test --workspace --tests --features tray`, run twice: identical 262 pre-existing unrelated failures vs. the established baseline both times (0 new). The first run additionally showed `daemon::shadow::opencode::tests::alloc_port_returns_a_usable_port` as failed; it passed 3/3 in isolation and vanished on the second full run — a parallel-execution port-contention flake, unrelated to this diff.
- `cargo fmt --check`, `cargo clippy --all-targets --features tray -- -D warnings`: clean.

Refs #2609, #2616, task t-20260704152417346565-14440-13, task t-20260704152423591009-14440-14

🤖 Generated with [Claude Code](https://claude.com/claude-code)