### PR TITLE
fix(#2624): merge orphaned name-file rows into the id-keyed inbox file

### DIFF
--- a/src/inbox/storage.rs
+++ b/src/inbox/storage.rs
@@ -94,10 +94,22 @@ pub(crate) fn inbox_path_resolved(home: &Path, name: &str) -> PathBuf {
         return inbox_path(home, name);
     };
     let id_path = home.join("inbox").join(format!("{}.jsonl", id.full()));
+    let name_path = inbox_path(home, name);
     if id_path.exists() {
+        // #2624: an id-direct write (bypassing this resolver — e.g. #1902's
+        // teardown path) can leave BOTH files real and independent. Merge the
+        // name file's rows in before short-circuiting to the id file, or they
+        // become permanent orphans: unreachable to drain/ack/clear (which all
+        // route through here), yet still visible to directory-scan readers
+        // (get_thread/find_message/renudge) — an un-settleable re-nudge loop.
+        // Skip when `id_path` is ITSELF a symlink (the classic opposite-
+        // direction migration below) — merging then would create a
+        // name→id→name symlink cycle.
+        if !is_symlink(&id_path) {
+            merge_dual_inbox_files_if_needed(&id_path, &name_path);
+        }
         return id_path;
     }
-    let name_path = inbox_path(home, name);
     if name_path.exists() {
         // Migrate: create symlink from id-based to name-based (or copy on Windows)
         if let Some(parent) = id_path.parent() {
@@ -115,6 +127,136 @@ pub(crate) fn inbox_path_resolved(home: &Path, name: &str) -> PathBuf {
     }
     // New instance — use id-based path directly
     id_path
+}
+
+fn is_symlink(path: &Path) -> bool {
+    std::fs::symlink_metadata(path)
+        .map(|m| m.file_type().is_symlink())
+        .unwrap_or(false)
+}
+
+/// #2624: merges an orphaned name-keyed inbox file's rows into the id-keyed
+/// file, then atomically replaces the name file with a symlink to the id file
+/// (Windows: removes it — this codebase's Windows migration already uses a
+/// one-way `fs::copy` rather than symlinks, so there is no link to keep in
+/// sync). Deduped by message `id`, falling back to exact-line dedup for
+/// id-less legacy rows, so a row present in both files — or a re-run after a
+/// crash mid-merge — is never duplicated.
+///
+/// Idempotent + crash-safe: dedup-by-id means a re-run after a crash between
+/// the id-file write and the name-file swap recomputes to "nothing new to
+/// append" and just retries the swap — never duplicates, never drops a row.
+/// Runs under its own lock file, distinct from [`with_inbox_lock`]'s per-op
+/// flock (which the caller acquires AFTER this function returns — see
+/// `with_inbox_lock`), so the two can't deadlock each other.
+fn merge_dual_inbox_files_if_needed(id_path: &Path, name_path: &Path) {
+    let Ok(meta) = std::fs::symlink_metadata(name_path) else {
+        return; // name file doesn't exist — nothing to merge
+    };
+    if meta.file_type().is_symlink() {
+        return; // already migrated (#2624 direction)
+    }
+
+    let lock_path = id_path.with_extension("jsonl.merge.lock");
+    let Ok(_lock) = crate::store::acquire_file_lock(&lock_path) else {
+        return;
+    };
+
+    // Re-check under the lock: another thread/process may have completed the
+    // swap between our unlocked stat above and acquiring this lock.
+    let Ok(meta) = std::fs::symlink_metadata(name_path) else {
+        return;
+    };
+    if meta.file_type().is_symlink() {
+        return;
+    }
+
+    let Ok(name_content) = std::fs::read_to_string(name_path) else {
+        return;
+    };
+    let id_content = std::fs::read_to_string(id_path).unwrap_or_default();
+
+    let mut seen_ids = std::collections::HashSet::new();
+    let mut seen_lines = std::collections::HashSet::new();
+    for line in id_content.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        seen_lines.insert(line);
+        if let Some(id) = extract_msg_id(line) {
+            seen_ids.insert(id);
+        }
+    }
+
+    let mut extra: Vec<&str> = Vec::new();
+    for line in name_content.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        match extract_msg_id(line) {
+            Some(id) => {
+                if !seen_ids.insert(id) {
+                    continue; // already in the id file — dedup, not a real addition
+                }
+            }
+            None => {
+                if !seen_lines.insert(line) {
+                    continue; // exact-duplicate id-less legacy row
+                }
+            }
+        }
+        extra.push(line);
+    }
+
+    if !extra.is_empty() {
+        let tmp = id_path.with_extension("jsonl.tmp");
+        let result = (|| -> anyhow::Result<()> {
+            let mut f = std::fs::OpenOptions::new()
+                .create(true)
+                .write(true)
+                .truncate(true)
+                .open(&tmp)?;
+            for line in id_content.lines().filter(|l| !l.trim().is_empty()) {
+                writeln!(f, "{line}")?;
+            }
+            for line in &extra {
+                writeln!(f, "{line}")?;
+            }
+            f.sync_all()?;
+            std::fs::rename(&tmp, id_path)?;
+            crate::store::fsync_parent_dir(id_path);
+            Ok(())
+        })();
+        if let Err(e) = result {
+            tracing::warn!(error = %e, "inbox #2624 dual-file merge write-back failed");
+            return; // don't swap the name file if the merge write didn't land
+        }
+    }
+
+    #[cfg(unix)]
+    {
+        let tmp_link = name_path.with_extension("jsonl.symlink_tmp");
+        let _ = std::fs::remove_file(&tmp_link);
+        if std::os::unix::fs::symlink(id_path, &tmp_link).is_ok() {
+            let _ = std::fs::rename(&tmp_link, name_path);
+        }
+    }
+    #[cfg(windows)]
+    {
+        let _ = std::fs::remove_file(name_path);
+    }
+}
+
+/// Cheap `id`-only probe for [`merge_dual_inbox_files_if_needed`]'s dedup.
+/// `id` is genuinely optional (`#[serde(default)]`, matching
+/// [`InboxMessage::id`]) since legacy pre-`ensure_msg_id` rows lack it.
+fn extract_msg_id(line: &str) -> Option<String> {
+    #[derive(serde::Deserialize)]
+    struct IdOnly {
+        #[serde(default)]
+        id: Option<String>,
+    }
+    serde_json::from_str::<IdOnly>(line).ok().and_then(|v| v.id)
 }
 
 /// Acquire a per-agent flock and run `f` with the inbox path.

--- a/src/inbox/tests.rs
+++ b/src/inbox/tests.rs
@@ -1,6 +1,6 @@
 use super::disk::DISK_READONLY;
 use super::notify::route_notification;
-use super::storage::inbox_path;
+use super::storage::{inbox_path, inbox_path_for_id};
 use super::*;
 use parking_lot::Mutex;
 use std::fs;
@@ -1277,6 +1277,174 @@ fn reclaim_busy_gate_engages_on_uuid_keyed_production_topology() {
         drain(&home, name).is_empty(),
         "a busy agent's in-flight row on a UUID-keyed inbox must not be re-delivered"
     );
+    fs::remove_dir_all(&home).ok();
+}
+
+/// #2624 live topology: a name-keyed file and a UUID-keyed file both exist as
+/// REAL, independent files (an id-direct write — e.g. #1902's teardown path —
+/// bypassed `inbox_path_resolved` and created the UUID file directly, while
+/// the name file already had its own row). Before the fix, `drain`/`ack`
+/// always resolved straight to the UUID file and the name file's row was a
+/// permanent, unreachable orphan (`general`'s live `m-…-125`: drain returned
+/// `[]`, `ack` returned `acked:0`, forever).
+#[test]
+fn drain_reaches_orphaned_name_file_row_when_uuid_file_coexists() {
+    let home = tmp_home("2624-dual-file");
+    let name = "general";
+    let uuid = "bbbbbbbb-cccc-4ddd-8eee-ffffffffffff";
+    write_fleet_with_id(&home, name, uuid);
+
+    let id = crate::types::InstanceId::parse(uuid).unwrap();
+    let id_path = inbox_path_for_id(&home, &id);
+    let name_path = inbox_path(&home, name);
+    fs::create_dir_all(id_path.parent().unwrap()).unwrap();
+
+    // UUID file: real, independent file (mirrors #1902's id-direct write
+    // path) already carrying its own row.
+    let uuid_row = msg()
+        .sender("user:op")
+        .text("uuid-file message")
+        .id("m-uuid-side")
+        .build();
+    fs::write(
+        &id_path,
+        format!("{}\n", serde_json::to_string(&uuid_row).unwrap()),
+    )
+    .unwrap();
+
+    // Name file: real, independent file with its own UNREAD orphan row (the
+    // #2624 live case: general's m-…-125).
+    let orphan = msg()
+        .sender("user:op")
+        .text("orphaned name-file message")
+        .id("m-name-orphan")
+        .build();
+    fs::write(
+        &name_path,
+        format!("{}\n", serde_json::to_string(&orphan).unwrap()),
+    )
+    .unwrap();
+
+    assert!(
+        !fs::symlink_metadata(&name_path)
+            .unwrap()
+            .file_type()
+            .is_symlink(),
+        "test setup must produce two REAL files, not an already-migrated symlink"
+    );
+
+    // RED (pre-fix behavior): drain resolved straight to the UUID file and
+    // never returned the orphan at all.
+    let drained = drain(&home, name);
+    assert!(
+        drained
+            .iter()
+            .any(|m| m.id.as_deref() == Some("m-name-orphan")),
+        "drain must reach the orphaned name-file row once the dual-file merge \
+         runs, not just the UUID file's own rows"
+    );
+
+    // The pre-existing uuid-file row must survive the merge, unduplicated.
+    let resolved = inbox_path_resolved(&home, name);
+    let merged_content = fs::read_to_string(&resolved).unwrap();
+    assert_eq!(
+        merged_content.matches("m-uuid-side").count(),
+        1,
+        "merge must not duplicate the pre-existing uuid-file row"
+    );
+
+    #[cfg(unix)]
+    {
+        let meta = fs::symlink_metadata(&name_path)
+            .expect("name file must still exist (as a symlink) post-merge");
+        assert!(
+            meta.file_type().is_symlink(),
+            "name file must become a symlink to the id file after merge (unix)"
+        );
+    }
+    #[cfg(windows)]
+    {
+        assert!(
+            !name_path.exists(),
+            "name file must be removed after merge (windows has no symlink here)"
+        );
+    }
+
+    // Settle: ack the freshly-delivered orphan row, then confirm it never
+    // reappears (the #2624 live bug: ack always failed with acked:0 because
+    // the row was never reachable to begin with).
+    let acked = ack(&home, name, Some("m-name-orphan"));
+    assert_eq!(
+        acked, 1,
+        "ack must be able to settle the now-merged orphan row"
+    );
+
+    assert!(
+        drain(&home, name).is_empty(),
+        "a settled row must not be redelivered"
+    );
+
+    // Idempotency: re-resolving (e.g. a second merge trigger from a
+    // concurrent op) must not re-duplicate anything or crash on a symlink
+    // cycle.
+    let resolved_again = inbox_path_resolved(&home, name);
+    assert_eq!(resolved, resolved_again);
+    let content_again = fs::read_to_string(&resolved_again).unwrap();
+    assert_eq!(
+        content_again.matches("m-name-orphan").count(),
+        1,
+        "re-resolving after the merge must not duplicate the merged row"
+    );
+
+    fs::remove_dir_all(&home).ok();
+}
+
+/// Crash-safety: simulate a crash between the id-file merge write landing and
+/// the name-file→symlink swap completing (both files still real, both already
+/// carrying the merged row). Re-resolving must complete the swap without
+/// duplicating the row — dedup-by-id makes the merge idempotent regardless of
+/// how many times a partial run is retried.
+#[test]
+fn dual_file_merge_recovers_from_crash_between_id_write_and_name_swap() {
+    let home = tmp_home("2624-dual-file-crash-resume");
+    let name = "general2";
+    let uuid = "cccccccc-dddd-4eee-8fff-000000000000";
+    write_fleet_with_id(&home, name, uuid);
+
+    let id = crate::types::InstanceId::parse(uuid).unwrap();
+    let id_path = inbox_path_for_id(&home, &id);
+    let name_path = inbox_path(&home, name);
+    fs::create_dir_all(id_path.parent().unwrap()).unwrap();
+
+    let row = msg()
+        .sender("user:op")
+        .text("hi")
+        .id("m-crash-resume")
+        .build();
+    let line = format!("{}\n", serde_json::to_string(&row).unwrap());
+
+    // Both files already carry the SAME row — as if a prior run's merge write
+    // landed in the id file but crashed before swapping the name file.
+    fs::write(&id_path, &line).unwrap();
+    fs::write(&name_path, &line).unwrap();
+
+    let resolved = inbox_path_resolved(&home, name);
+    let content = fs::read_to_string(&resolved).unwrap();
+    assert_eq!(
+        content.matches("m-crash-resume").count(),
+        1,
+        "resuming a partially-completed merge must not duplicate the row"
+    );
+
+    #[cfg(unix)]
+    {
+        let meta = fs::symlink_metadata(&name_path).unwrap();
+        assert!(
+            meta.file_type().is_symlink(),
+            "the interrupted swap must complete on the next resolve"
+        );
+    }
+
     fs::remove_dir_all(&home).ok();
 }
 


### PR DESCRIPTION
## Summary

`inbox_path_resolved` (`src/inbox/storage.rs:88`) short-circuited to the UUID-keyed path the instant it existed, never checking whether a name-keyed file *also* existed as an independent real file (created by an id-direct write bypassing this resolver — #1902's teardown path is one confirmed source: `src/mcp/handlers/instance_state/lifecycle/tests.rs:165-170`). Every keyed inbox op (drain/ack/clear, all via `with_inbox_lock` → `inbox_path_resolved`) then permanently missed the name file's rows, while directory-scan readers (`get_thread`/`find_message`, and whatever renudges) could still see them — an un-settleable re-nudge loop. Live evidence (RCA appendix C of #2622): `general`'s `m-20260622164145291567-125` — `drain` returned `[]`, `ack` returned `acked:0`, forever.

This is a sibling of #2622 (main line: reclaim-TTL had no busy gate → PR #2623), discovered during that issue's live-smoke verification as a second, independent root cause.

## Fix

When both files are real (`id_path` isn't itself a symlink from the pre-existing opposite-direction migration below it), merge the name file's rows into the id file — deduped by message `id`, falling back to exact-line dedup for id-less legacy rows — then atomically swap the name file for a symlink to the id file (Windows: remove it, matching the existing one-way `fs::copy` migration's lack of a live link).

Dedup-by-id makes the merge idempotent: a crash between the id-file write and the name-file swap just re-runs to "nothing new to append" and retries the swap — never duplicating or dropping a row. Runs under its own lock file, separate from `with_inbox_lock`'s per-op flock, so the two can't deadlock each other.

**Scan-side/keyed-side consistency post-merge**: once the name file becomes a symlink to the id file, `inbox_files()` enumerates both as before — the same topology as the pre-existing symlink migration direction. `get_thread` already dedupes cross-file by id (CR-2026-06-14), `find_message` just returns its first match, and `sweep_expired`/`reclaim_stale_delivering` already redirect through `inbox_path_resolved` regardless of which stem they saw. No new divergence class introduced.

**Scope**: evaluated issue #2624's secondary suggestion (converge id-direct writes into a single chokepoint) but skipped it — the merge-on-access design here already self-heals regardless of how a dual-file state arises, so narrowing the write path is reinforcement, not required for the fix. `poll_reminder::remove_agent` keying and `notify.rs` are untouched, per dispatch scope.

## Tests (`src/inbox/tests.rs`)

Real dual-file topology (two non-symlink files + fleet.yaml id), red-green verified (commit `f5bd16d7` fails without the fix in `bff9b542`):

- `drain_reaches_orphaned_name_file_row_when_uuid_file_coexists`
- `dual_file_merge_recovers_from_crash_between_id_write_and_name_swap`

## Verification

- `cargo test --features tray --bin agend-terminal inbox::` — 206/206 pass
- `cargo test --workspace --tests --features tray` — 262 pre-existing unrelated failures (`worktree_pool::*`, environment-dependent), 0 new, 0 inbox-related
- `tests/snapshot_failopen_invariant.rs`, `tests/src_file_size_invariant.rs` — pass (`storage.rs` at 2061 LOC, under the 2500 ceiling)
- `cargo fmt --check`, `cargo clippy --all-targets --features tray -- -D warnings` — clean

Refs #2624, task t-20260704170613774930-14440-19

🤖 Generated with [Claude Code](https://claude.com/claude-code)