### PR TITLE
test(#2562 P4): outbound REST matrix completion + reconnect backoff edge

### DIFF
--- a/src/channel/discord/tests.rs
+++ b/src/channel/discord/tests.rs
@@ -1213,6 +1213,124 @@ fn discord_keepalive_patch_method_matches_spec() {
     assert_eq!(body["archived"], false, "must set archived=false");
 }
 
+// ── #2562 P4 (PR-2): outbound matrix completion + reconnect pure-fn gap ──
+//
+// Fills the holes a coverage sweep found in the P0-P4 outbound/reconnect
+// tests: send lacked a (method, path) assertion; the empty-text guards and the
+// create_binding category placement branch were unexercised; and the backoff
+// sequence test started at attempt=1, leaving the attempt=0 edge unpinned.
+// (Error-path 4xx->Err coverage is a separate, larger gap — deferred pending a
+// scope decision, since delete/remove_binding don't call `.model()` and
+// twilight's 4xx handling needs its own investigation.)
+
+/// §3.5.10 wire-format completion: POST /channels/{cid}/messages — pins send's
+/// HTTP method + URL path. The existing `discord_send_outbound_body_matches_
+/// spec` uses an inline mock that captures only the body; this closes the
+/// (method, path) columns of send's outbound matrix row via the shared
+/// `mock_http_server` harness.
+#[test]
+fn discord_send_outbound_method_and_path_match_spec() {
+    use crate::channel::Channel;
+    let response_body =
+        include_str!("../../../tests/fixtures/discord-rest-create-message-response.json");
+    let (port, handle, captured) = mock_http_server(200, response_body);
+    let (ch, _tx) = make_test_channel_with_mock(port);
+    let binding = test_binding(290926798999357250);
+    ch.record_binding("test-agent", binding.clone(), "\r".into());
+
+    let result = ch.send(&binding, crate::channel::OutMsg::text("hi"));
+
+    handle.join().expect("mock server");
+    assert!(result.is_ok(), "send must succeed: {:?}", result.err());
+    let req = captured.lock().expect("lock").take().expect("captured");
+    assert_eq!(req.method, "POST", "send must use POST");
+    assert!(
+        req.path.contains("/channels/290926798999357250/messages"),
+        "send path must be /channels/{{cid}}/messages, got: {}",
+        req.path
+    );
+}
+
+/// send() rejects an empty `OutMsg` BEFORE any HTTP call — pins the
+/// attachment-only-deferred guard; no network / http client needed.
+#[test]
+fn discord_send_rejects_empty_text() {
+    use crate::channel::Channel;
+    let (ch, _tx) = super::DiscordChannel::new_for_test();
+    let binding = test_binding(290926798999357250);
+    ch.record_binding("test-agent", binding.clone(), "\r".into());
+
+    let err = ch
+        .send(&binding, crate::channel::OutMsg::text(""))
+        .expect_err("empty send must error");
+    assert!(
+        format!("{err}").contains("no text"),
+        "error must mention empty text, got: {err}"
+    );
+}
+
+/// edit() rejects empty text BEFORE any HTTP call — Discord editMessage
+/// requires non-empty content (adapter guard); no network needed.
+#[test]
+fn discord_edit_rejects_empty_text() {
+    use crate::channel::Channel;
+    let (ch, _tx) = super::DiscordChannel::new_for_test();
+    let msg_ref = test_msg_ref(290926798999357250, "444385199974967099");
+
+    let err = ch
+        .edit(&msg_ref, crate::channel::OutMsg::text(""))
+        .expect_err("empty edit must error");
+    assert!(
+        format!("{err}").contains("empty"),
+        "error must mention empty text, got: {err}"
+    );
+}
+
+/// create_binding honors a `category_id` hint by setting the created channel's
+/// `parent_id` in the request (adapter branch) — pins the previously-untested
+/// category-placement path via the outgoing request body.
+#[test]
+fn discord_create_binding_with_category_id_sets_parent_id() {
+    use crate::channel::Channel;
+    let response_body =
+        include_str!("../../../tests/fixtures/discord-rest-create-guild-channel-response.json");
+    let (port, handle, captured) = mock_http_server(200, response_body);
+    let (ch, _tx) = make_test_channel_with_mock(port);
+
+    let mut opts = crate::channel::BindingOpts::default();
+    opts.extra
+        .insert("category_id".to_string(), "123456789012345678".to_string());
+    let result = ch.create_binding("test-agent", opts);
+
+    handle.join().expect("mock server");
+    assert!(
+        result.is_ok(),
+        "create_binding must succeed: {:?}",
+        result.err()
+    );
+    let req = captured.lock().expect("lock").take().expect("captured");
+    let body: serde_json::Value = serde_json::from_str(&req.body).expect("body must be JSON");
+    assert!(
+        !body["parent_id"].is_null(),
+        "category_id hint must set parent_id in the create-channel request body, got: {}",
+        req.body
+    );
+}
+
+/// #2562 PR-3b boundary: `discord_gateway_backoff_delay(0)`. The supervisor
+/// increments `attempt` before computing the delay, so 0 is the pre-first-
+/// restart value; `saturating_sub(1)` must keep it at the 5s base (no
+/// underflow). The existing sequence test starts at attempt=1; this pins the
+/// attempt=0 edge.
+#[test]
+fn discord_gateway_backoff_delay_attempt_zero_is_base() {
+    assert_eq!(
+        super::discord_gateway_backoff_delay(0),
+        std::time::Duration::from_secs(5),
+        "attempt 0 must yield the 5s base, not underflow"
+    );
+}
+
 /// TLS smoke (network, manual): proves twilight-http 0.17's
 /// rustls-native-roots/ring stack actually completes a real TLS handshake —
 /// the one merge-gate CI can't cover (the spec tests use a plaintext mock


### PR DESCRIPTION
## #2562 P4 PR-2 — outbound REST matrix completion + reconnect backoff edge

Second staged P4 PR. A coverage sweep of the existing P0–P4 outbound/reconnect tests found a few holes; this fills the in-scope ones (design doc §3.B outbound matrix + §3.C reconnect pure functions). **Test-only — no production code touched.** Independent of PR-1 (#2625); rebased onto latest main.

### Tests added
| Test | Closes |
|---|---|
| `discord_send_outbound_method_and_path_match_spec` | send's **(method, path)** columns — the existing body test uses an inline mock capturing only the body |
| `discord_send_rejects_empty_text` / `discord_edit_rejects_empty_text` | the empty-`OutMsg` **guards** (both bail before any HTTP call), previously unexercised |
| `discord_create_binding_with_category_id_sets_parent_id` | the previously-untested **`category_id` → `parent_id`** channel-placement branch, via the outgoing request body |
| `discord_gateway_backoff_delay_attempt_zero_is_base` | §3.C: the **attempt=0** backoff edge (`saturating_sub` keeps it at the 5s base) — the sequence test started at attempt=1 |

### Deferred / flagged (NOT in this PR — for your call)
- **Error-path (4xx → Err) coverage** is a larger, separate gap (currently zero across all outbound methods). Deferred because it's beyond §3.B's method/path/body itemization **and** has a real question: `delete`/`remove_binding` only do `.await?` (no `.model()`), so whether twilight surfaces a 4xx as an `Err` on the request future — vs deferring the error to body deserialization — needs its own investigation before we can assert it (a test failing there could indicate real error-swallowing, not a test bug). Recommend a follow-up PR-3 if you want this covered.
- **`send.rs build_create_message_body` appears to be dead code** (no callers found repo-wide) — a production cleanup, out of this test-infra PR's scope; flagging for your triage.

### Verification
- `cargo nextest run --features discord` → **50/50 discord tests pass** (5 new + PR-1's 3 + no regression). The one `leaky` is the shared `discord_runtime()` global (process-lifetime tokio runtime), non-deterministically attributed — same as on main, not CI-failing.
- `cargo clippy --features discord --all-targets` → clean.
- `cargo fmt --check` → clean.

Completes #2562 P4's planned scope (design + inbound harness + outbound matrix) modulo the deferred error-path decision above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
