### PR TITLE
fix(branch-sweep): reviewer_checkout candidates silently dropped on apply (#817)

### DIFF
--- a/src/branch_sweep.rs
+++ b/src/branch_sweep.rs
@@ -404,6 +404,7 @@ pub(crate) fn emit_delete_batch(
         .iter()
         .chain(categories.squash_merged.iter())
         .chain(categories.stale_idle.iter())
+        .chain(categories.reviewer_checkout.iter())
         .chain(categories.active_unknown.iter())
     {
         name_to_candidate.insert(cand.name.as_str(), cand);
@@ -415,6 +416,8 @@ pub(crate) fn emit_delete_batch(
             "squash_merged"
         } else if categories.stale_idle.iter().any(|c| c.name == name) {
             "stale_idle"
+        } else if categories.reviewer_checkout.iter().any(|c| c.name == name) {
+            "reviewer_checkout"
         } else {
             "active_unknown"
         }
@@ -893,6 +896,68 @@ mod tests {
             applied, 0,
             "unknown confirm_ids yield 0 deletions, not errors"
         );
+        std::fs::remove_dir_all(repo.parent().unwrap()).ok();
+    }
+
+    /// t-20260704115315460591-14440-0 (#817 behavior gap): a `reviewer_checkout`
+    /// candidate is NOT an unknown confirm_id — it's a recognized category, part
+    /// of `deletable_ids()`'s own documented default-deletable list, and it
+    /// survives the handler's `all_ids()` validation before ever reaching
+    /// `emit_delete_batch`. Unlike `test_branch_sweep_apply_skips_unknown_
+    /// confirm_id`'s intentional "typo confirm_id → silent no-op" contract,
+    /// this must behave like `clean_merged`/`squash_merged`: real delete-or-log,
+    /// never a silent no-op. Production incident (2026-07-04): dry-run listed
+    /// 24 `review/*` branches as candidates, apply=true confirmed them, but
+    /// `applied` didn't count them and no event-log entry appeared — the
+    /// operator had no signal the branches survived.
+    #[test]
+    fn test_branch_sweep_apply_deletes_reviewer_checkout_candidate_2620() {
+        let repo = setup_repo("apply_reviewer_checkout");
+        let home = repo.parent().unwrap().to_path_buf();
+        // Unmerged on purpose — reviewer_checkout is classified by NAME
+        // pattern alone (scan()'s bucket 0, checked before merge-status),
+        // so an unmerged residue branch must still be a REAL candidate.
+        create_branch_with_commit(&repo, "tmp_pr_review", "reviewer checkout residue");
+
+        let now = chrono::Utc::now();
+        let cats = scan(&repo, "main", STALE_IDLE_DEFAULT_DAYS, now).expect("scan");
+        assert_eq!(
+            cats.reviewer_checkout.len(),
+            1,
+            "precondition: review/123 must classify as reviewer_checkout: {cats:?}"
+        );
+        assert!(
+            cats.deletable_ids().contains(&"tmp_pr_review".to_string()),
+            "precondition: reviewer_checkout is in the default deletable list"
+        );
+
+        let mut confirm = std::collections::HashSet::new();
+        confirm.insert("tmp_pr_review".to_string());
+        let applied = emit_delete_batch(&home, &repo, &cats, &confirm, "reviewer-checkout probe")
+            .expect("emit");
+
+        assert_eq!(
+            applied, 1,
+            "a confirmed reviewer_checkout candidate must actually be deleted, \
+             not silently dropped like an unrecognized confirm_id"
+        );
+        let post = enumerate_branches(&repo).expect("enumerate");
+        assert!(
+            !post.iter().any(|b| b.name == "tmp_pr_review"),
+            "review/123 must actually be gone from the repo"
+        );
+        let log = std::fs::read_to_string(home.join("event-log.jsonl")).unwrap_or_default();
+        assert!(
+            log.contains("branch_sweep_apply") && log.contains("tmp_pr_review"),
+            "a real delete must leave the same audit trail as any other category, \
+             not silence: {log}"
+        );
+        assert!(
+            log.contains("category=reviewer_checkout"),
+            "the audit trail must name the correct category, not fall through to \
+             active_unknown: {log}"
+        );
+
         std::fs::remove_dir_all(repo.parent().unwrap()).ok();
     }
 


### PR DESCRIPTION
## Summary
- `emit_delete_batch`'s (`branch_sweep.rs`) `name_to_candidate` map chained `clean_merged`, `squash_merged`, `stale_idle`, and `active_unknown` — but not `reviewer_checkout`, even though `deletable_ids()`'s own doc comment lists it as part of the default-deletable set, and it passes the handler's `all_ids()` confirm-subset validation.
- A confirmed `reviewer_checkout` name reached the apply loop, missed the map lookup, and hit the same silent `continue` used for an unrecognized/typo `confirm_id` — not deleted, not counted in `applied`, no event-log entry. Indistinguishable from an operator typo, with zero operator-visible signal.
- Production incident (2026-07-04): dry-run listed 24 `review/*` branches as candidates; `apply=true` confirmed them; none were actually deleted and nothing was logged. Lead manually cleaned them up (tips were all already-reviewed PR heads — zero data loss, but the tool gave no signal either way).

Fix: chain `reviewer_checkout` into the map, give `category_of()` its own arm (so the event log correctly names `category=reviewer_checkout` instead of falling through to `active_unknown`) — these candidates now take the same real delete-or-log path `squash_merged` already does.

Ref `t-20260704115315460591-14440-0`.

## Test plan
- [x] New regression test `test_branch_sweep_apply_deletes_reviewer_checkout_candidate_2620`: confirmed RED against unmodified code (`applied == 0`, silent drop reproduced), GREEN after the fix (`applied == 1`, branch actually deleted, event log has `branch_sweep_apply` + `category=reviewer_checkout`).
- [x] `cargo test --bin agend-terminal branch_sweep::` — 14/14 pass (no regressions in the existing clean_merged/squash_merged/stale_idle/active_unknown/unknown-confirm-id tests).
- [x] `cargo fmt --check` clean; `cargo clippy --all-targets` (default + `--features tray`) clean.
- [x] Full `cargo nextest run` (5243 tests): 5241 passed, 2 failed — both confirmed pre-existing (`e2e_dispatch_review_workflow_seam_invariants_1900`, `teardown_leaves_zero_residual_after_full_exercise_1907`), unrelated to this diff (same two flakes tracked across the last several PRs on this lineage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)