### PR TITLE
test(mcp): lock in mcp-usage-stats.jsonl's concurrent-write safety (#2353)

### DIFF
--- a/src/mcp/usage_stats.rs
+++ b/src/mcp/usage_stats.rs
@@ -407,6 +407,76 @@ mod tests {
         std::fs::remove_dir_all(&home).ok();
     }
 
+    /// t-20260702101119069418-7916-3: a 20-day production sample showed 2.5%
+    /// of lines in this file failing to parse — corruption shaped like
+    /// concurrent-writer interleaving (a torn line with another writer's
+    /// bytes injected mid-line). `append_line_with_policy` already serializes
+    /// via `crate::store::acquire_file_lock` (added by #2353, 8 days after
+    /// this file's original unprotected launch — the corrupted sample almost
+    /// certainly comes from that now-closed window). This test locks the
+    /// CURRENT lock-protected behavior in place: many threads racing
+    /// `record()` concurrently must never produce a torn/interleaved line —
+    /// every appended line parses as valid JSON, and none are lost.
+    #[test]
+    fn record_concurrent_writers_produce_zero_torn_lines_2620() {
+        let home = tmp_home("concurrent-record");
+        let threads = 50;
+
+        let home_arc = std::sync::Arc::new(home.clone());
+        let mut handles = Vec::with_capacity(threads);
+        for i in 0..threads {
+            let h = std::sync::Arc::clone(&home_arc);
+            handles.push(std::thread::spawn(move || {
+                // `action` is recorded VERBATIM (build_line lifts args.action
+                // as-is, unlike opt_params which only records PARAM NAMES,
+                // not values) — a unique per-thread marker that survives into
+                // the written line, so a torn/interleaved line is directly
+                // detectable by parse failure or a missing/duplicate marker.
+                record(&h, "task", &json!({"action": format!("thread-{i}")}));
+            }));
+        }
+        for h in handles {
+            h.join().expect("record thread must not panic");
+        }
+
+        let body = std::fs::read_to_string(stats_path(&home)).expect("stats file written");
+        let lines: Vec<&str> = body.lines().filter(|l| !l.is_empty()).collect();
+        assert_eq!(
+            lines.len(),
+            threads,
+            "every concurrent record() call must produce exactly one surviving line, \
+             not lost or merged with another: got {} lines, expected {threads}",
+            lines.len()
+        );
+
+        let mut seen_markers = std::collections::HashSet::new();
+        for (i, line) in lines.iter().enumerate() {
+            let parsed: Value = serde_json::from_str(line).unwrap_or_else(|e| {
+                panic!(
+                    "line {i} must parse as valid JSON (a parse failure here IS the torn-line \
+                     corruption this test guards against): {e}\nline={line:?}"
+                )
+            });
+            let marker = parsed["action"]
+                .as_str()
+                .expect("action recorded as this thread's unique marker")
+                .to_string();
+            assert!(
+                seen_markers.insert(marker.clone()),
+                "each thread's marker must appear exactly once — a duplicate means a line was \
+                 doubly-counted or a torn line coincidentally still parsed: {marker}"
+            );
+        }
+        assert_eq!(
+            seen_markers.len(),
+            threads,
+            "every thread's distinct marker must be present — a missing one means its line \
+             was silently lost or corrupted beyond parseability"
+        );
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
     fn tmp_home(name: &str) -> PathBuf {
         let dir = std::env::temp_dir().join(format!(
             "agend-usage-{name}-{}-{:?}",


### PR DESCRIPTION
## Summary

**This PR does not fix a bug — there wasn't one left to fix.** The originally-reported issue (task `t-20260702101119069418-7916-3`: a 20-day production sample of `mcp-usage-stats.jsonl` with 2.5% torn/interleaved JSONL lines, corruption shaped like concurrent-writer interleaving) was already fixed 8 days after the feature shipped:

- `85a19e36` (2026-06-12, #2055 step 1) — feature ships, writer has no locking.
- `b59c5d27` (2026-06-20, #2353 "fix: rotate MCP usage stats") — adds `crate::store::acquire_file_lock` (the same cross-process `fs4` flock inbox enqueue already uses), wrapping rotation + append in one lock scope.

The corrupted 20-day sample's window almost certainly overlaps the 6/12–6/20 unprotected gap. Verified by reading current `append_line_with_policy` directly (flock acquired before rotation, held through the `writeln!`, released at scope end) — not just inferring from the commit message.

**What this PR actually adds**: the concurrency stress test that never existed for this module — 50 threads racing `record()` concurrently, asserting zero torn lines and zero lost/duplicated per-thread markers. It passes against current `main` unmodified, which is exactly the point: it pins the already-correct lock-protected behavior instead of resting on inference from a commit message and a timeline.

**Scope decision (no `sync_all()` parity)**: considered adding an `fsync` after `writeln!` for parity with inbox's durability guarantee, but decided against it — usage-stats is loss-tolerant telemetry (the read side already skips unparseable lines), and `record()` fires on every non-read-only MCP call. Paying a real fsync cost on every call to protect data that can tolerate loss isn't a good trade, unlike inbox rows (an obligation, not telemetry). Cost-vs-value mismatch, not a "match inbox for consistency" call.

## Test plan
- [x] New test `record_concurrent_writers_produce_zero_torn_lines_2620`: 50 concurrent threads, asserts exact line count, zero JSON-parse failures, zero lost/duplicated markers. Passes against unmodified `main`.
- [x] `cargo test --bin agend-terminal mcp::usage_stats::` — 7/7 pass.
- [x] `cargo fmt --check` clean; `cargo clippy --all-targets` (default + `--features tray`) clean.
- [x] Full `cargo nextest run` (5244 tests): 5242 passed, 2 failed — both confirmed pre-existing (`e2e_dispatch_review_workflow_seam_invariants_1900`, `teardown_leaves_zero_residual_after_full_exercise_1907`), unrelated to this diff (same two flakes tracked across the last several PRs on this lineage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)