### PR TITLE
fix(render): pending-decision pane marker inherits the title background

### DIFF
--- a/src/render/core_render.rs
+++ b/src/render/core_render.rs
@@ -1101,6 +1101,57 @@ mod tests {
     }
 
     #[test]
+    fn pane_title_decision_marker_inherits_label_background_pane_label_bg_lost() {
+        let pane = Pane {
+            agent_name: "agent".into(),
+            instance_id: crate::types::InstanceId::default(),
+            vterm: VTerm::new(10, 10),
+            rx: crossbeam_channel::bounded(1).1,
+            id: 1,
+            backend: None,
+            working_dir: None,
+            display_name: None,
+            scroll_offset: 0,
+            has_notification: false,
+            fleet_instance_name: None,
+            last_input_at: None,
+            pending_notification_count: 0,
+            pending_decision_count: 1,
+            selection: None,
+            source: PaneSource::Local,
+            offthread: None,
+            _fwd_cancel: None,
+        };
+        // Mirrors `render_pane`'s real focused-pane `title_style` construction
+        // (a solid background band, black text, bold) — the two prior tests
+        // above pass `Style::default()` (no background), which can't catch a
+        // background-inheritance regression because `Style::default()` has no
+        // background to inherit in the first place.
+        let title_style = Style::default()
+            .bg(Color::Cyan)
+            .fg(Color::Black)
+            .add_modifier(Modifier::BOLD);
+        let segments = pane_title_segments(&pane, title_style, AgentState::Idle, false);
+        let (_, icon_style) = segments
+            .iter()
+            .find(|(text, _)| text.contains('🔴'))
+            .expect("pending decision marker segment must be present");
+        assert_eq!(
+            icon_style.bg,
+            Some(Color::Cyan),
+            "the 🔴 marker must inherit the surrounding title's background, \
+             not fall back to the terminal default (breaks the visually \
+             continuous label band)"
+        );
+        assert_eq!(
+            icon_style.fg,
+            Some(Color::Red),
+            "the marker itself must stay red (only the background should \
+             inherit from the title)"
+        );
+    }
+
+    #[test]
     fn pane_title_no_decision_marker_when_zero_2313() {
         let pane = Pane {
             agent_name: "agent".into(),

--- a/src/render/core_render.rs
+++ b/src/render/core_render.rs
@@ -901,7 +901,13 @@ pub(super) fn pane_title_segments(
     if pane.pending_decision_count > 0 {
         segments.push((
             " 🔴".to_string(),
-            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+            // pane-label-bg-lost: inherit the surrounding title's background
+            // (and any other modifier, e.g. the repeat-mode/drag-state
+            // overrides above) instead of Style::default() — the marker is
+            // one segment in a visually continuous label band, not a
+            // standalone badge like the `[N]` notification count above,
+            // which deliberately uses its own contrasting bg.
+            title_style.fg(Color::Red).add_modifier(Modifier::BOLD),
         ));
     }
     // #1713/#1523 diagnostic (runtime_config.show_pane_state, default off): append


### PR DESCRIPTION
## Summary

Operator-reported screenshot (`~/.agend-terminal/captures/pane-label-pending-icon-bg-lost-20260705T0740.png`): the active pane's title bar shows `claude-aef7c0` (teal background) then a bare 🔴 dot (default terminal background) then `[Idle]` (teal background again) — three visually disconnected segments where the label should read as one continuous band.

## Root cause

`pane_title_segments` (`src/render/core_render.rs:901`) builds the `#2313` P2b "pending decision" marker segment from `Style::default().fg(Color::Red)` — no background at all — instead of the `title_style` the surrounding segments (the agent-name label and the `[<State>]` diagnostic suffix) already use. `title_style` carries the pane's actual title-bar background (teal for a focused/idle pane, yellow in repeat-mode, etc., computed in `render_pane`), so every other segment continues that band while this one drops to the terminal's default.

**Not a deliberate design choice**: checked PR #2530 (which introduced this marker) — the review (VERIFIED) covered the decision-counting/scan-chokepoint correctness (single `list_pending` scan, no render-side filesystem I/O, etc.) and never discussed the marker's visual styling. The two existing tests for this marker (`pane_title_shows_pending_decision_marker_2313`, `pane_title_no_decision_marker_when_zero_2313`) pass `Style::default()` as `title_style` — which has no background to begin with — so neither test could have caught a background-inheritance bug even in principle.

## Fix

Build the marker from `title_style.fg(Color::Red).add_modifier(Modifier::BOLD)` instead of `Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)`. This inherits whatever background (and other style overrides — repeat-mode yellow, drag-state reversed, etc.) the rest of the title is using, exactly like the base label segment and the `[<State>]` diagnostic suffix already do. `add_modifier(BOLD)` stays explicit so an unfocused pane's marker (whose `title_style` has no BOLD) still renders bold, unchanged from before.

Left the `[N]` notification badge alone — it deliberately uses its own contrasting yellow background as a standalone badge, not a title-band segment, so it's a different design intent than the 🔴 marker.

## Tests (`src/render/core_render.rs`)

Red-green verified (commit `0f6d054d` fails without the fix in `23ca33d7`):

- `pane_title_decision_marker_inherits_label_background_pane_label_bg_lost` — passes a realistic `title_style` (an actual background color, mirroring `render_pane`'s real focused-pane style construction, unlike the two pre-existing tests) and asserts the marker segment's `Style.bg` matches it while `Style.fg` stays red.

## Verification

- `cargo test --features tray --bin agend-terminal core_render::tests::` — 31/31 pass (1 pre-existing env-gated ignore)
- `cargo test --features tray --bin agend-terminal render::` — 81/81 pass
- `cargo test --features tray --bin agend-terminal layout::` — 61/61 pass
- `cargo test --features tray --bin agend-terminal app::` — 157/157 pass
- `tests/src_file_size_invariant.rs` — pass
- `cargo fmt --check`, `cargo clippy --bin agend-terminal --features tray -- -D warnings` — clean

Refs task t-20260705000411308217-14440-21

🤖 Generated with [Claude Code](https://claude.com/claude-code)