### PR TITLE
refactor(#2550 P0): make instance classifiers (tool,action)-aware (byte-equivalent)

### DIFF
--- a/src/api/handlers/mcp_proxy.rs
+++ b/src/api/handlers/mcp_proxy.rs
@@ -58,8 +58,8 @@ pub(crate) fn tool_timeout(tool: &str) -> Duration {
 /// `task_id` (a repeat is an illegal-transition no-op), and `create_instance`
 /// is keyed on the instance name (a repeat errors, no second spawn). `send` /
 /// `reply` / `decision`-post have NO natural key — they rely on this gate.
-fn is_side_effect_tool(tool: &str) -> bool {
-    crate::mcp::registry::side_effect_on_timeout(tool)
+fn is_side_effect_tool(tool: &str, action: Option<&str>) -> bool {
+    crate::mcp::registry::side_effect_on_timeout_for(tool, action)
 }
 
 /// Stable hash of `(tool, args)` for the timeout instrument. NOT used for any
@@ -77,8 +77,13 @@ fn content_key(tool: &str, args: &Value) -> u64 {
 /// Build the response for a tool that exceeded its timeout budget. Side-effect
 /// tools → `accepted_in_progress` (don't resend); read/idempotent tools → the
 /// retryable `timed out` error. Emits the `#r3-1-timeout-probe` instrument.
-fn timeout_response(tool: &str, timeout: Duration, content_key: u64) -> Value {
-    let side_effect = is_side_effect_tool(tool);
+fn timeout_response(
+    tool: &str,
+    action: Option<&str>,
+    timeout: Duration,
+    content_key: u64,
+) -> Value {
+    let side_effect = is_side_effect_tool(tool, action);
     // #r3-1 instrument ("doubt → add log"): this PR's effect (agent stops
     // retrying) is only observable after a daemon restart (self-dogfood
     // anti-pattern), so log every timeout with a stable content_key. If the
@@ -121,12 +126,16 @@ pub(crate) fn handle_mcp_tool(params: &Value, ctx: &HandlerCtx) -> Value {
         _ => return json!({"ok": false, "error": "missing 'tool' parameter"}),
     };
     let args = params["arguments"].clone();
+    let action = args
+        .get("action")
+        .and_then(|v| v.as_str())
+        .map(String::from);
     let instance = params["instance"].as_str().unwrap_or("").to_string();
     let role_kind = match role_kind_for_instance(ctx.home, &instance, "tool call") {
         Ok(role_kind) => role_kind,
         Err(resp) => return resp,
     };
-    if !crate::mcp::registry::tool_allowed_for_role(role_kind, tool) {
+    if !crate::mcp::registry::tool_allowed_for_role_action(role_kind, tool, action.as_deref()) {
         return json!({
             "ok": false,
             "error": format!(
@@ -144,6 +153,7 @@ pub(crate) fn handle_mcp_tool(params: &Value, ctx: &HandlerCtx) -> Value {
         args,
         instance,
         timeout,
+        action,
         move |tool, args, instance| {
             crate::mcp::execute_tool_with_runtime(tool, args, instance, runtime)
         },
@@ -158,6 +168,7 @@ fn handle_mcp_tool_inner(
     args: Value,
     instance: String,
     timeout: Duration,
+    action: Option<String>,
     exec: impl FnOnce(&str, &Value, &str) -> Value + Send + 'static,
 ) -> Value {
     let key = content_key(tool, &args);
@@ -184,7 +195,9 @@ fn handle_mcp_tool_inner(
     match handle {
         Ok(_) => match rx.recv_timeout(timeout) {
             Ok(result) => json!({"ok": true, "result": result}),
-            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => timeout_response(tool, timeout, key),
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                timeout_response(tool, action.as_deref(), timeout, key)
+            }
             Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
                 json!({"ok": false, "error": format!("tool '{tool}' thread panicked")})
             }
@@ -335,7 +348,10 @@ mod tests {
             "repo",
             "restart_daemon",
         ] {
-            assert!(is_side_effect_tool(t), "{t} must be treated as side-effect");
+            assert!(
+                is_side_effect_tool(t, None),
+                "{t} must be treated as side-effect"
+            );
         }
         // Read / idempotent tools → false (keep retryable error).
         for t in [
@@ -351,12 +367,40 @@ mod tests {
             "release_worktree",
             "ci",
         ] {
-            assert!(!is_side_effect_tool(t), "{t} must stay retry-safe");
+            assert!(!is_side_effect_tool(t, None), "{t} must stay retry-safe");
         }
         // NEW / unknown tools default to side-effect (conservative).
         assert!(
-            is_side_effect_tool("some_future_tool"),
+            is_side_effect_tool("some_future_tool", None),
             "unknown defaults to side-effect"
+        );
+
+        // #2550 P0: the folded `instance` tool is per-action (dormant until P1):
+        // structural actions stay side-effect (no double delete/restart on a
+        // timed-out call), read actions stay retry-safe (the real result is
+        // needed). Byte-equivalent to today's per-name tools.
+        for a in [
+            "delete",
+            "restart",
+            "start",
+            "move_pane",
+            "bind_topic",
+            "interrupt",
+        ] {
+            assert!(
+                is_side_effect_tool("instance", Some(a)),
+                "instance(action={a}) must be side-effect"
+            );
+        }
+        for a in ["list", "pane_snapshot", "set_waiting_on"] {
+            assert!(
+                !is_side_effect_tool("instance", Some(a)),
+                "instance(action={a}) must stay retry-safe"
+            );
+        }
+        assert!(
+            is_side_effect_tool("instance", None),
+            "instance with no action fail-closes to side-effect"
         );
     }
 
@@ -375,6 +419,7 @@ mod tests {
             json!({"instance": "x", "message": "hi"}),
             "caller".to_string(),
             Duration::from_millis(20),
+            None,
             slow,
         );
         assert_eq!(
@@ -401,6 +446,7 @@ mod tests {
             json!({}),
             "caller".to_string(),
             Duration::from_millis(20),
+            None,
             slow,
         );
         assert_eq!(
@@ -423,6 +469,7 @@ mod tests {
             json!({}),
             "caller".to_string(),
             Duration::from_secs(5),
+            None,
             fast,
         );
         assert_eq!(resp["ok"], true);

--- a/src/api/operator_gate.rs
+++ b/src/api/operator_gate.rs
@@ -87,6 +87,21 @@ pub(crate) fn classify(op: &str, action: Option<&str>) -> OpClass {
             Some("display_name") | Some("description") => AlwaysAllow,
             _ => AbsolutelyNever,
         },
+
+        // #2550 P0: the folded `instance` tool (dormant until P1) — authority is
+        // per-action, sourced from the shared registry policy so this gate,
+        // the retry classifier, and the role guard cannot drift. A structural
+        // action (delete/start/restart/move_pane) stays never-delegate exactly
+        // as its pre-fold per-name tool did; a missing/unfolded action
+        // fail-closes to never-delegate.
+        "instance" => match action.and_then(crate::mcp::registry::instance_action_policy) {
+            Some(p) => match p.authority {
+                crate::mcp::registry::InstanceAuthority::AlwaysAllow => AlwaysAllow,
+                crate::mcp::registry::InstanceAuthority::DelegateScoped => DelegateScoped,
+                crate::mcp::registry::InstanceAuthority::AbsolutelyNever => AbsolutelyNever,
+            },
+            None => AbsolutelyNever,
+        },
         "config" => match action {
             Some("set") => AbsolutelyNever,
             _ => AlwaysAllow, // list / get
@@ -339,6 +354,66 @@ mod tests {
             &active
         )
         .is_ok());
+    }
+
+    /// #2550 P0: the same #1575 exploit routed through the FOLDED `instance`
+    /// tool (`{tool: instance, arguments: {action: restart|delete|…}}`) must be
+    /// denied identically. The gate authority is per-action via the shared
+    /// registry policy, so folding `restart` into `instance` does NOT reopen the
+    /// bypass — the structural action stays never-delegate for an agent.
+    #[test]
+    fn agent_instance_structural_action_exploit_is_denied() {
+        for st in [away(), sleep_with("fixup-lead", &[])] {
+            for action in ["restart", "delete", "start", "move_pane"] {
+                let exploit = json!({
+                    "tool": "instance",
+                    "instance": "",
+                    "arguments": {"action": action, "name": "victim-agent"}
+                });
+                assert!(
+                    check_operation_allowed("mcp_tool", &exploit, &st).is_err(),
+                    "instance(action={action}) structural op must be denied for an agent in {:?}",
+                    st.mode
+                );
+            }
+        }
+    }
+
+    /// #2550 P0: `classify` maps folded `instance` actions byte-equivalently to
+    /// their pre-fold per-name tools — structural = never-delegate, read = allow,
+    /// bind_topic = delegate-scoped (the fallback its per-name form hit), and a
+    /// missing/unfolded action fail-closes to never-delegate.
+    #[test]
+    fn classify_instance_actions_match_per_name_authority() {
+        use OpClass::*;
+        assert!(matches!(classify("instance", Some("list")), AlwaysAllow));
+        assert!(matches!(
+            classify("instance", Some("pane_snapshot")),
+            AlwaysAllow
+        ));
+        assert!(matches!(
+            classify("instance", Some("set_waiting_on")),
+            AlwaysAllow
+        ));
+        assert!(matches!(
+            classify("instance", Some("interrupt")),
+            AlwaysAllow
+        ));
+        assert!(matches!(
+            classify("instance", Some("bind_topic")),
+            DelegateScoped
+        ));
+        for a in ["delete", "start", "restart", "move_pane"] {
+            assert!(
+                matches!(classify("instance", Some(a)), AbsolutelyNever),
+                "instance({a}) must be never-delegate"
+            );
+        }
+        assert!(matches!(classify("instance", None), AbsolutelyNever));
+        assert!(matches!(
+            classify("instance", Some("bogus")),
+            AbsolutelyNever
+        ));
     }
 
     // ── An agent must never change operator authority (mode set), in ANY mode. ──

--- a/src/mcp/registry.rs
+++ b/src/mcp/registry.rs
@@ -232,6 +232,118 @@ pub(crate) fn tool_allowed_for_role(role_kind: Option<crate::fleet::RoleKind>, t
             .any(|entry| entry.name == tool)
 }
 
+// ── #2550 P0: instance-family action policy (single source of truth) ──
+//
+// Once the `instance` tool folds the per-name instance lifecycle tools (P1+),
+// the three name-based classifiers below — operator_gate authority
+// (`api::operator_gate::classify`), retry side-effect
+// (`side_effect_on_timeout_for`), and role visibility/deny
+// (`tool_allowed_for_role_action`) — must agree on each action's policy or they
+// drift into a security hole (#2158: role that may `instance(action=list)` must
+// NOT thereby gain `instance(action=delete)`). This table is that shared source
+// of truth. Until the `instance` tool actually ships, it is DORMANT (no caller
+// passes `tool == "instance"`), and every value below is chosen to be
+// byte-equivalent to the CURRENT per-name tool's classifier (pinned by the unit
+// tests in this module). Excludes `create`/`restart_daemon` (operator decision:
+// stay standalone) and `set_metadata` (already action-bearing; folding deferred).
+
+/// operator_gate authority for a folded instance action, expressed in a
+/// registry-local enum so `mcp` need not depend on `api::operator_gate`
+/// (`operator_gate` maps this onto its own `OpClass`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum InstanceAuthority {
+    AlwaysAllow,
+    DelegateScoped,
+    AbsolutelyNever,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct InstanceActionPolicy {
+    pub authority: InstanceAuthority,
+    pub side_effect_on_timeout: bool,
+    pub timeout: ToolTimeoutClass,
+    /// Whether the read/report roles (reviewer/planner/explorer) may use this
+    /// action — mirrors the pre-fold per-name membership in `ROLE_TOOL_SUBSETS`.
+    pub read_role_allowed: bool,
+}
+
+/// Policy for a folded `instance` action; `None` for any action NOT folded into
+/// the `instance` tool (create / restart_daemon / set_metadata / unknown).
+pub(crate) fn instance_action_policy(action: &str) -> Option<InstanceActionPolicy> {
+    use InstanceAuthority::*;
+    use ToolTimeoutClass::*;
+    let p = |authority, side_effect_on_timeout, timeout, read_role_allowed| {
+        Some(InstanceActionPolicy {
+            authority,
+            side_effect_on_timeout,
+            timeout,
+            read_role_allowed,
+        })
+    };
+    // Values MUST mirror the current per-name tool (byte-equivalent); see the
+    // baseline table in the unit tests below.
+    match action {
+        "list" => p(AlwaysAllow, false, Fast, true), // list_instances
+        "pane_snapshot" => p(AlwaysAllow, false, Default, true), // pane_snapshot
+        "set_waiting_on" => p(AlwaysAllow, false, Fast, true), // set_waiting_on
+        "interrupt" => p(AlwaysAllow, true, Default, false), // interrupt
+        "bind_topic" => p(DelegateScoped, true, Default, false), // bind_topic (gate fallback)
+        "move_pane" => p(AbsolutelyNever, true, Default, false), // move_pane
+        "delete" => p(AbsolutelyNever, true, Default, false), // delete_instance
+        "start" => p(AbsolutelyNever, true, Default, false), // start_instance
+        "restart" => p(AbsolutelyNever, true, Default, false), // restart_instance
+        _ => None,
+    }
+}
+
+/// (name, action)-aware [`side_effect_on_timeout`]. For the folded `instance`
+/// tool, per-action; otherwise byte-identical to `side_effect_on_timeout(name)`.
+/// An `instance` call with an unknown/unfolded action stays conservative
+/// (side-effect = true), matching the pre-existing unknown-tool default.
+pub(crate) fn side_effect_on_timeout_for(name: &str, action: Option<&str>) -> bool {
+    if name == "instance" {
+        return action
+            .and_then(instance_action_policy)
+            .map(|p| p.side_effect_on_timeout)
+            .unwrap_or(true);
+    }
+    side_effect_on_timeout(name)
+}
+
+/// Whether `role_kind` narrows to a curated read/report subset (reviewer /
+/// planner / explorer) rather than the full-capability all-open surface.
+fn role_has_read_subset(role_kind: Option<crate::fleet::RoleKind>) -> bool {
+    use crate::fleet::RoleKind;
+    matches!(
+        role_kind,
+        Some(RoleKind::Reviewer) | Some(RoleKind::Planner) | Some(RoleKind::Explorer)
+    )
+}
+
+/// (name, action)-aware [`tool_allowed_for_role`] (the #2158 privilege-escalation
+/// guard). For the folded `instance` tool, a curated read/report role is allowed
+/// ONLY the `read_role_allowed` actions (e.g. `list`/`pane_snapshot`), never a
+/// structural action (`delete`/`restart`/…) — so folding `list` into the same
+/// tool as `delete` cannot silently widen a restricted role. Full-capability
+/// roles keep the full surface. For any non-`instance` tool this is
+/// byte-identical to `tool_allowed_for_role(role_kind, tool)`.
+pub(crate) fn tool_allowed_for_role_action(
+    role_kind: Option<crate::fleet::RoleKind>,
+    tool: &str,
+    action: Option<&str>,
+) -> bool {
+    if tool == "instance" {
+        if !role_has_read_subset(role_kind) {
+            return true; // full-capability role → all instance actions
+        }
+        return action
+            .and_then(instance_action_policy)
+            .map(|p| p.read_role_allowed)
+            .unwrap_or(false);
+    }
+    tool_allowed_for_role(role_kind, tool)
+}
+
 static ALL_TOOLS: [ToolEntry; 28] = [
     // ── Channel ──
     ToolEntry {
@@ -420,6 +532,107 @@ static ALL_TOOLS: [ToolEntry; 28] = [
 mod tests {
     use super::*;
     use crate::fleet::RoleKind;
+
+    /// #2550 P0 byte-equivalence: each folded `instance` action's policy equals
+    /// the CURRENT per-name tool's three classifiers (the instance tool is
+    /// dormant until P1). Baseline read from ALL_TOOLS + operator_gate +
+    /// ROLE_TOOL_SUBSETS — if a per-name tool's class changes, this must too.
+    #[test]
+    fn instance_action_policy_matches_per_name_baseline() {
+        use InstanceAuthority::*;
+        use ToolTimeoutClass::*;
+        // (action, authority, side_effect_on_timeout, timeout, read_role_allowed)
+        let cases: &[(&str, InstanceAuthority, bool, ToolTimeoutClass, bool)] = &[
+            ("list", AlwaysAllow, false, Fast, true),
+            ("pane_snapshot", AlwaysAllow, false, Default, true),
+            ("set_waiting_on", AlwaysAllow, false, Fast, true),
+            ("interrupt", AlwaysAllow, true, Default, false),
+            ("bind_topic", DelegateScoped, true, Default, false),
+            ("move_pane", AbsolutelyNever, true, Default, false),
+            ("delete", AbsolutelyNever, true, Default, false),
+            ("start", AbsolutelyNever, true, Default, false),
+            ("restart", AbsolutelyNever, true, Default, false),
+        ];
+        for (a, auth, se, to, rr) in cases {
+            let p = instance_action_policy(a).unwrap_or_else(|| panic!("no policy for {a}"));
+            assert_eq!(p.authority, *auth, "{a} authority");
+            assert_eq!(p.side_effect_on_timeout, *se, "{a} side_effect");
+            assert_eq!(p.timeout, *to, "{a} timeout");
+            assert_eq!(p.read_role_allowed, *rr, "{a} read_role");
+            assert_eq!(
+                side_effect_on_timeout_for("instance", Some(a)),
+                *se,
+                "{a} variant"
+            );
+        }
+        // create / restart_daemon (operator: standalone) + set_metadata (already
+        // action-bearing) + unknown are NOT folded → no policy.
+        for a in ["create", "restart_daemon", "set_metadata", "bogus"] {
+            assert!(
+                instance_action_policy(a).is_none(),
+                "{a} must not be folded"
+            );
+        }
+    }
+
+    /// The (name,action)-aware variants IGNORE action for every non-`instance`
+    /// tool → byte-identical to the name-only classifiers (zero behavior change
+    /// before the alias ships).
+    #[test]
+    fn non_instance_classifiers_ignore_action() {
+        for name in ["send", "delete_instance", "list_instances", "inbox", "task"] {
+            assert_eq!(
+                side_effect_on_timeout_for(name, Some("x")),
+                side_effect_on_timeout(name),
+                "{name} side_effect"
+            );
+            assert_eq!(
+                side_effect_on_timeout_for(name, None),
+                side_effect_on_timeout(name)
+            );
+        }
+    }
+
+    /// #2158 privilege-escalation guard: a curated read role may
+    /// `instance(list/pane_snapshot/set_waiting_on)` but NEVER a structural
+    /// action — folding `list` and `delete` into one tool must not widen the role.
+    #[test]
+    fn instance_role_guard_blocks_structural_for_read_roles() {
+        let rev = Some(RoleKind::Reviewer);
+        for a in ["list", "pane_snapshot", "set_waiting_on"] {
+            assert!(
+                tool_allowed_for_role_action(rev, "instance", Some(a)),
+                "reviewer must keep instance({a})"
+            );
+        }
+        for a in [
+            "delete",
+            "restart",
+            "start",
+            "move_pane",
+            "bind_topic",
+            "interrupt",
+        ] {
+            assert!(
+                !tool_allowed_for_role_action(rev, "instance", Some(a)),
+                "reviewer must NOT gain instance({a}) via the folded tool"
+            );
+        }
+        assert!(!tool_allowed_for_role_action(rev, "instance", None));
+        // Full-capability role (undeclared) keeps every instance action.
+        for a in ["delete", "list", "restart"] {
+            assert!(tool_allowed_for_role_action(None, "instance", Some(a)));
+        }
+        // Non-instance tools: byte-identical to the name-only guard.
+        assert_eq!(
+            tool_allowed_for_role_action(rev, "delete_instance", Some("x")),
+            tool_allowed_for_role(rev, "delete_instance")
+        );
+        assert_eq!(
+            tool_allowed_for_role_action(rev, "list_instances", None),
+            tool_allowed_for_role(rev, "list_instances")
+        );
+    }
 
     fn names(role: Option<RoleKind>) -> Vec<&'static str> {
         tool_subset_for_role(role).iter().map(|e| e.name).collect()


### PR DESCRIPTION
## #2550 PR-1 (P0) — instance classifiers (tool,action)-aware (byte-equivalent security foundation)

First PR of instance-tool action-ization (operator decision **(A) conservative GO**, d-20260704204302986445-2). Per the vetted spike, P0 is the **security foundation that must land before any `instance` alias ships**: the three name-based decision classifiers become (tool,action)-aware so that folding read-only actions (`list` / `pane_snapshot`) into the same tool as structural ones (`delete` / `restart`) cannot either **bypass the never-delegate gate + role deny (a #2158-class privilege escalation)** or break the read-only actions.

**No `instance` tool exists yet → this is a PURE refactor.** Every current per-name call is byte-equivalent (pinned by tests); the `instance` branch is dormant and unit-tested for when P1 activates it.

### Single source of truth (`registry.rs`)
`instance_action_policy(action)` — per folded action: gate authority (registry-local `InstanceAuthority`), retry `side_effect_on_timeout`, timeout band, read-role visibility. Values mirror the pre-fold per-name tools exactly (ALL_TOOLS `ToolClass` + `operator_gate` + `ROLE_TOOL_SUBSETS`). Excludes `create` / `restart_daemon` (operator: standalone) and `set_metadata` (already action-bearing). Plus `side_effect_on_timeout_for` / `tool_allowed_for_role_action` — (name, action) variants, byte-identical for any non-`instance` tool.

### Consumers
- `operator_gate::classify` — new `"instance"` arm (structural action stays never-delegate; missing / unfolded fail-closes).
- `mcp_proxy` — threads the tool's `action` into the retry classifier + the role guard.

### Tests
- policy byte-equivalence vs the per-name baseline
- non-instance classifiers ignore action (zero behavior change before the alias ships)
- **#2158 role guard** — a curated read role keeps `instance(list)` but never gains `instance(delete)`
- **#1575 impersonation exploit** re-checked through the folded `instance(action=…)` path
- side-effect classifier extended to instance actions

### Verification
- `cargo nextest run` (operator_gate + mcp_proxy + registry) → **80/80 pass**; broader api/mcp regression → 128/128.
- `cargo clippy --all-targets` → clean. `cargo fmt --check` → clean.

Scope note: net +344 / −9 (within the spike's estimate; not a 3× blow-up). Timeout-band awareness (spike surface #4, low severity) deliberately left out — P0 is the three security/correctness classifiers only.

Next: **PR-2 (P1)** — read-only alias validation chain (`instance(action=list / pane_snapshot)` dual-track).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
