### PR TITLE
fix(inbox): #2412 follow-up — full kind-space audit, classify dispatch_idle FYI kinds

### DIFF
--- a/src/inbox/storage.rs
+++ b/src/inbox/storage.rs
@@ -1508,6 +1508,23 @@ fn known_fire_and_forget_kind(msg: &InboxMessage) -> bool {
                 | "ci-watch-resumed"
                 | "poll"
                 | "pr-merged"
+                // #2412 follow-up (kind-taxonomy audit): the rest of the
+                // pr-state FYI class (already fire-and-forget in
+                // `auto_ack_on_drain_kind` since #2506, but missing here —
+                // an inconsistency with no live impact today since
+                // `auto_ack_on_drain_kind` settles them before reclaim ever
+                // sees a stale `delivering` row of these kinds, but a
+                // legacy/older-daemon-written row could still reach this
+                // check) plus the two dispatch_idle notification subtypes
+                // (one-shot-by-design at the source — team_nudge's
+                // `nudge_sent_at` / dispatch_idle's `long_running_escalated`
+                // latch never re-fire the same notice — see
+                // `auto_ack_on_drain_kind` below for the primary fix).
+                | "pr-closed-unmerged"
+                | "pr-ready-for-merge"
+                | "review-verdict"
+                | "dispatch_idle_long_running"
+                | "dispatch_idle_nudge"
         )
     )
 }
@@ -1533,6 +1550,17 @@ fn auto_ack_on_drain_kind(msg: &InboxMessage) -> bool {
                 | "pr-closed-unmerged"
                 | "pr-ready-for-merge"
                 | "review-verdict"
+                // #2412 follow-up: primary fix for the live 58-minute
+                // poll-reminder loop sample — both kinds are one-shot
+                // daemon-generated FYI with no recipient action expected
+                // (dispatch_idle_long_running: "Long run EXPECTED -> no
+                // action"; dispatch_idle_nudge: "No action needed if
+                // you're mid-task"). Settling on first drain, same as the
+                // ci-watch/pr-state pure-daemon-notification precedent
+                // above, means the row never enters `delivering` limbo
+                // long enough to race the reclaim-TTL in the first place.
+                | "dispatch_idle_long_running"
+                | "dispatch_idle_nudge"
         )
     )
 }

--- a/src/inbox/tests.rs
+++ b/src/inbox/tests.rs
@@ -862,6 +862,26 @@ fn drain_auto_acks_daemon_notifications() {
             "system:pr-state",
             "[review-verdict] owner/repo@branch: VERIFIED",
         ),
+        // #2412 follow-up (kind-taxonomy audit): the live bug sample — a
+        // dispatcher drains a "still active, just long" confirm, never
+        // explicitly acks it (there is nothing to act on), and the reclaim-TTL
+        // then reverted it to unread, re-nagging poll-reminder every cycle
+        // until a manual `inbox action=ack`. Both dispatch_idle subtypes are
+        // one-shot-by-design at the source (team_nudge's `nudge_sent_at` /
+        // dispatch_idle's `long_running_escalated` latch never re-fire the
+        // same notice), so seeing it once via drain is sufficient closure.
+        (
+            "dispatch_idle_long_running",
+            "system:dispatch_idle",
+            "[dispatch_idle_long_running] dispatch d-1 from 'lead' -> 'dev' - \
+             Long run EXPECTED -> no action; it resolves when the report arrives.",
+        ),
+        (
+            "dispatch_idle_nudge",
+            "system:dispatch-watchdog",
+            "[team-watchdog] FYI: 'lead' dispatch has been quiet 900s. No \
+             action needed if you're mid-task.",
+        ),
     ] {
         let home = tmp_home(&format!("drain-{kind}-auto-ack"));
         let id = format!("m-{kind}");
@@ -978,6 +998,92 @@ fn reclaim_settles_legacy_stale_pr_merged_delivering_row() {
         persisted.delivering_at.is_some(),
         "settle stamps read_at; delivering_at may remain as historical audit"
     );
+    fs::remove_dir_all(&home).ok();
+}
+
+/// #2412 follow-up (kind-taxonomy audit): reclaim-level consistency for the
+/// kinds this task adds to `known_fire_and_forget_kind`. In normal operation
+/// these never actually reach a stale-`delivering` row — `auto_ack_on_drain_kind`
+/// already settles them on first drain (see `drain_auto_acks_daemon_notifications`),
+/// and `pr-ready-for-merge`/`pr-closed-unmerged`/`review-verdict` were already
+/// covered by `auto_ack_on_drain_kind` alone (#2506) even before this task —
+/// but a row written by an OLDER daemon build (pre-fix, still `delivering`) or
+/// any other path that leaves one of these kinds in `delivering` must still be
+/// settled by reclaim rather than looping forever. Belt-and-suspenders: proves
+/// `known_fire_and_forget_kind` (not just `auto_ack_on_drain_kind`) now also
+/// recognises the full pr-state FYI class plus the two new dispatch_idle kinds.
+#[test]
+fn reclaim_settles_stale_delivering_for_newly_audited_fire_and_forget_kinds() {
+    for kind in [
+        "dispatch_idle_long_running",
+        "dispatch_idle_nudge",
+        "pr-ready-for-merge",
+        "pr-closed-unmerged",
+        "review-verdict",
+    ] {
+        let home = tmp_home(&format!("reclaim-faf-{kind}"));
+        enqueue(
+            &home,
+            "a",
+            msg()
+                .sender("system:test")
+                .text_owned(format!("[{kind}] legacy stale delivering row"))
+                .kind(kind)
+                .id(&format!("m-{kind}-stale"))
+                .delivering_at(&secs_ago(660))
+                .build(),
+        )
+        .unwrap();
+
+        reclaim_stale_delivering(&home);
+
+        assert!(
+            drain(&home, "a").is_empty(),
+            "{kind}: stale delivering row must be settled, not re-delivered"
+        );
+        let content = fs::read_to_string(inbox_path(&home, "a")).unwrap();
+        let persisted: InboxMessage =
+            serde_json::from_str(content.lines().next().unwrap()).unwrap();
+        assert!(
+            persisted.read_at.is_some(),
+            "{kind}: reclaim must settle (stamp read_at), not revert to unread"
+        );
+        fs::remove_dir_all(&home).ok();
+    }
+}
+
+/// #2412 follow-up (kind-taxonomy audit) — control/regression guard: a kind
+/// this audit deliberately did NOT reclassify (genuinely actionable, per its
+/// own message text — "Handling is NOT automated... consider a handoff") must
+/// keep the pre-audit conservative behavior: a stale delivering row reverts to
+/// unread and is re-delivered, exactly like an unrecognised kind. Guards
+/// against over-broadening `known_fire_and_forget_kind` while auditing it.
+#[test]
+fn reclaim_still_redelivers_context_alert_conservatively() {
+    let home = tmp_home("reclaim-context-alert-conservative");
+    enqueue(
+        &home,
+        "a",
+        msg()
+            .sender("system:context_alert")
+            .text("[context_alert] agent at 92% context — consider a handoff + restart")
+            .kind("context_alert")
+            .id("m-context-alert-stale")
+            .delivering_at(&secs_ago(660))
+            .build(),
+    )
+    .unwrap();
+
+    reclaim_stale_delivering(&home);
+
+    let redelivered = drain(&home, "a");
+    assert_eq!(
+        redelivered.len(),
+        1,
+        "context_alert is a genuine action item and must still be re-delivered \
+         after reclaim, not silently settled"
+    );
+    assert_eq!(redelivered[0].id.as_deref(), Some("m-context-alert-stale"));
     fs::remove_dir_all(&home).ok();
 }
 


### PR DESCRIPTION
## Summary

#2412 follow-up (task t-20260622133030757281-61487-10). #2412's poll-reminder rework used a narrow known-set (`obligation_reason` for `query`/non-terminal `task`; `known_fire_and_forget_kind` for `report`/`update`/`ci-watch`*/`poll`/`pr-merged`). Everything else fell to `kind_is_unknown` → conservative re-arm (residual noise, non-loss, safe). This PR does the promised full audit of the `InboxMessage.kind` space and reclassifies only what's confirmed safe.

**Live bug sample** (task metadata): `claude-fb2461` stuck 58 minutes re-nudged by poll-reminder for a `system:dispatch_idle` **`dispatch_idle_long_running`** notice — pure FYI ("Long run EXPECTED → no action; it resolves when the report arrives") — drained but never explicitly acked, so reclaim's flat TTL reverted it to unread every cycle until a manual `inbox action=ack`.

## Discipline: misclassify = silent-loss

Every kind below is classified with its actual body-text evidence, not vibes. When in doubt, **left unchanged** (still conservatively re-armed) — that's the current safe default per the task's own priority note. Only two kinds + a 3-kind consistency gap are reclassified in this PR.

## Full kind enumeration (exhaustive producer search across `src/`)

| kind | producer | what/who | classification (this PR) | why |
|---|---|---|---|---|
| `task` | `mcp/handlers/comms.rs:343` | Work dispatch, target must claim/execute/report | unchanged (obligation, handled by `obligation_reason`) | task-board status gates it |
| `query` | `mcp/handlers/comms.rs:597` | Question expecting a reply | unchanged (obligation) | `obligation_reason` always `Some` |
| `report` | `mcp/handlers/comms.rs:498` | Work-done / verdict report | unchanged (already fire-and-forget) | drives auto-close, not a fresh obligation |
| `update` | `mcp/handlers/comms.rs` broadcast/send fallback | Generic FYI status | unchanged (already fire-and-forget) | deliberately chosen over `query` by callers wanting no reply-loop |
| `ci-watch` | `daemon/ci_watch/poller.rs` | CI pass/fail/ended/conflict | unchanged (already both lists) | — |
| `ci-watch-stalled` / `ci-watch-resumed` | `daemon/ci_watch/sweep.rs` | CI polling paused/resumed | unchanged (already both lists) | — |
| `ci-ready-for-action` | `daemon/ci_watch/poller.rs:1187` | CI green, review turn handed off | unchanged (unknown→re-arm) | has its **own independent** renudge/escalation system (`notify.rs` `ACTIONABLE_KINDS`, `handoff_timeout_watchdog.rs`'s `HANDOFF_KIND`) — deliberately left out of scope, per dispatch instruction not to touch that mechanism |
| `pr-merged` | `daemon/pr_state/scanner.rs:229` | PR merged, author FYI+checklist | unchanged (already both lists) | — |
| **`pr-ready-for-merge`** | `daemon/pr_state/scanner.rs:176` | Merge-ready, notifies merge authority | **added to `known_fire_and_forget_kind`** | already in `auto_ack_on_drain_kind` since #2506 — closing a list inconsistency, no live behavior change (auto-ack already settles it before reclaim can see it `delivering`) |
| **`pr-closed-unmerged`** | `daemon/pr_state/scanner.rs:258` | PR closed unmerged, author checklist | **added to `known_fire_and_forget_kind`** | same as above |
| **`review-verdict`** | `daemon/pr_state/mod.rs:1013` | Reviewer verdict recorded, not yet merge-ready | **added to `known_fire_and_forget_kind`** | same as above |
| `schedule` | `daemon/cron_tick.rs:300` | Cron/one-shot fires, target offline → inbox fallback | unchanged (unknown→re-arm) | body is arbitrary operator-authored text — could be a real reminder; task text explicitly flagged this as needing special care |
| `schedule_replay` | `daemon/mod.rs:1626` | Missed one-shot replayed at boot | unchanged (unknown→re-arm) | same reasoning as `schedule` |
| `parent_cancelled` | `tasks/handler.rs:1660` | Parent task cancelled, child owner FYI | unchanged (unknown→re-arm) | body reads "**may need attention**" — despite being one of the original task's suggested candidates, on inspection this is actionable, not pure FYI |
| `member_state_change` | `daemon/supervisor/reactions.rs:166` | Team member health-state change (Hang/UsageLimit/Crashed/PermissionPrompt) | unchanged (unknown→re-arm) | orchestrator must decide intervention |
| `member_retry_exhausted` | `daemon/supervisor.rs:1226` | Auto-retry exhausted | unchanged (unknown→re-arm) | body: "Manual intervention required" |
| **`dispatch_idle_nudge`** | `daemon/dispatch_idle/team_nudge.rs:161` | Dispatchee check-in | **added to both lists** | body: "No action needed if you're mid-task"; source has its own fire-once `nudge_sent_at` guard |
| `dispatch_idle_threshold_exceeded` | `daemon/dispatch_idle/mod.rs:1387` | Dispatcher stuck-target alarm | unchanged (unknown→re-arm) | body has a real action checklist (check pane / force-release+redispatch / restart) |
| **`dispatch_idle_long_running`** | `daemon/dispatch_idle/mod.rs:1387` | Dispatcher "still active, just long" confirm | **added to both lists** — primary fix | body: "Long run EXPECTED → no action"; source has its own fire-once `long_running_escalated` latch — this is the exact kind in the live bug sample |
| `context_alert` | `daemon/per_tick/context_alert.rs:163` | Member context% threshold crossed | unchanged (unknown→re-arm) | body: "Handling is NOT automated... consider a handoff + restart" — see regression-guard test |
| `inbox_stuck_watchdog` | `daemon/inbox_stuck_watchdog.rs:74` | Member accumulating unread | unchanged (unknown→re-arm) | body: "check and nudge/restart if needed" |
| `handoff_timeout_watchdog` | `daemon/handoff_timeout_watchdog.rs:271` | Unclaimed CI-ready handoff escalated to lead | unchanged (unknown→re-arm) | escalation demands lead action |
| `task_stalled` | `daemon/anti_stall.rs:226` | Task ETA-based stall notice | unchanged (unknown→re-arm) | body: "Consider: lead re-dispatch / dev unblock-ping" |
| `dev_idle_watchdog` | `daemon/idle_watchdog.rs:471` | Dev silent >60min | unchanged (unknown→re-arm) | re-dispatch/unblock ask |
| `fleet_idle_watchdog` | `daemon/idle_watchdog.rs:798` | Whole fleet silent >30min | unchanged (unknown→re-arm) | cross-vantage alarm |
| `helper_staleness_watchdog` | `daemon/helper_staleness_watchdog.rs:163` | Tracked helper build stale | unchanged (unknown→re-arm) | asks for a rebuild action |
| `waiting_on_stale` | `daemon/waiting_on_stale.rs:152` | Agent's own `waiting_on` unresolved >15min | unchanged (unknown→re-arm) | body: "re-evaluate/clear/escalate" |
| `decision_timeout` | `daemon/decision_timeout.rs:363` | Pending decision auto-defaulted | unchanged (unknown→re-arm) | "Operator can reverse via reply" implies a real optional follow-up |
| `decision_board_timeout` | `daemon/decision_board_timeout.rs:81` | Decision-board question auto-answered | unchanged (unknown→re-arm) | same reversibility reasoning |
| `status-summary` | `channel/telegram/inbound.rs:325` | Fleet status summary for relay to operator | unchanged (unknown→re-arm) | receiving agent (`general`) is expected to actively relay it — a real action, not pure FYI |

**Explicit non-findings** (checked, not real `InboxMessage.kind` values, no action needed):
- `"verdict"` (`daemon/auto_release.rs`) — an unrelated `AutoReleaseIntent.event_kind` field, not `InboxMessage.kind`.
- `"decision-answered"` — only a `[decision-answered]` tag inside message **text**; the real `kind` for that notify is `"update"` (already fire-and-forget).
- `"channel-reply-missing"` — a direct-PTY inject tag, no inbox row created at all.
- `"telegram"` as a kind — dead, pre-refactor legacy shape only in test fixtures; production uses `kind: None` + `channel: Some(...)`.
- `"poll"` in both existing classification lists — no producer anywhere in `src/`; a dead/aspirational entry, left untouched (out of scope for this audit).
- Plain `kind=None` (ordinary channel/user messages) — intentionally outside every fire-and-forget list; #2299's anti-silent-loss guarantee.

## Found but NOT fixed here (flagged for a separate follow-up, not this PR's scope)

- `src/agent_ops.rs`'s `send_to` API-down fallback always writes `kind: None` regardless of the caller's real kind — a `task`/`query` could silently lose its obligation classification if that fallback path is hit. Worth its own investigation.
- The MCP `send` tool's `request_kind` has no server-side enum validation — an arbitrary/typo'd string falls through to `kind_is_unknown()==true` (conservative re-arm, safe by default, just noting the gap exists).

## Tests (`src/inbox/tests.rs`, red-green verified — commit `2d678ef1` fails without `ede562e5`)

- `drain_auto_acks_daemon_notifications`: extended with `dispatch_idle_long_running` + `dispatch_idle_nudge`.
- `reclaim_settles_stale_delivering_for_newly_audited_fire_and_forget_kinds`: reclaim-level consistency for all 5 newly-classified kinds (belt-and-suspenders for legacy/older-daemon-written rows).
- `reclaim_still_redelivers_context_alert_conservatively`: regression guard — proves a genuinely-actionable kind this audit deliberately did NOT reclassify keeps its pre-audit conservative behavior (still passes before AND after this change — a baseline, not a RED case).

## Verification

- `cargo test --features tray --bin agend-terminal inbox::tests::` — 156/156 pass
- `cargo test --features tray --bin agend-terminal daemon::dispatch_idle::` — 80/80 pass
- `cargo test --features tray --bin agend-terminal daemon::poll_reminder::` — 14/14 pass
- `cargo test --features tray --bin agend-terminal daemon::pr_state::` — 91/91 pass
- `tests/src_file_size_invariant.rs` — pass
- `cargo fmt --check`, `cargo clippy --bin agend-terminal --features tray -- -D warnings` — clean

Refs #2412 follow-up, task t-20260622133030757281-61487-10. DUAL review requested (reviewer4 + lead) per the task's silent-loss-sensitive flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
