### PR TITLE
feat(#2550 P1): register folded read-only `instance` tool (list/pane_snapshot alias)

### DIFF
--- a/docs/MCP-TOOLS.md
+++ b/docs/MCP-TOOLS.md
@@ -1,6 +1,6 @@
 [繁體中文](MCP-TOOLS.zh-TW.md)
 
-# AgEnD MCP Tools Reference (28 tools)
+# AgEnD MCP Tools Reference (29 tools)
 
 ## Action-based Tools
 
@@ -133,6 +133,12 @@ Read visible text from a target instance's PTY scrollback (ANSI stripped).
 - **instance**: instance name
 - lines (default 100, max 10000)
 - `to_file: true` (#2478) writes the full snapshot under `$AGEND_HOME/captures/` and returns only a compact summary + path, keeping diagnostic dumps out of context.
+
+### `instance`
+#2550: folded **read-only** alias for the per-name instance tools. Read-only only — the standalone `list_instances` / `pane_snapshot` tools remain available unchanged, and structural lifecycle (create/delete/start/restart/move_pane) stays on its own tools.
+- **action**: list / pane_snapshot
+- action=list ≡ `list_instances` (optional `instance` for one instance's detail; `verbose` / `include_evidence` for the full evidence trail)
+- action=pane_snapshot ≡ `pane_snapshot` (`instance` required; `lines`, `to_file`, `head`)
 
 ## Worktree & Binding
 

--- a/docs/MCP-TOOLS.zh-TW.md
+++ b/docs/MCP-TOOLS.zh-TW.md
@@ -1,6 +1,6 @@
 [English](MCP-TOOLS.md)
 
-# AgEnD MCP Tools Reference — 工具參考（28 個工具）
+# AgEnD MCP Tools Reference — 工具參考（29 個工具）
 
 ## 動作型工具（Action-based Tools）
 
@@ -133,6 +133,12 @@
 - **instance**: instance 名稱
 - lines（預設 100，最大 10000）
 - `to_file: true`（#2478）會把完整 snapshot 寫到 `$AGEND_HOME/captures/`，tool 只回精簡摘要與路徑，避免診斷 dump 灌進 context。
+
+### `instance`
+#2550：per-name instance 工具的 folded **唯讀** alias。只開唯讀 action——原本的 `list_instances` / `pane_snapshot` 工具原樣保留，結構性生命週期（create/delete/start/restart/move_pane）仍留在各自的獨立工具。
+- **action**: list / pane_snapshot
+- action=list ≡ `list_instances`（可選 `instance` 取單一 instance 詳情；`verbose` / `include_evidence` 取完整 evidence trail）
+- action=pane_snapshot ≡ `pane_snapshot`（`instance` 必填；`lines`、`to_file`、`head`）
 
 ## Worktree 與 Binding（Worktree & Binding）
 

--- a/src/mcp/handlers/dispatch.rs
+++ b/src/mcp/handlers/dispatch.rs
@@ -196,6 +196,25 @@ macro_rules! action_adapter {
 pub(crate) fn dispatch_list_instances(ctx: &HandlerCtx<'_>) -> Value {
     instance::handle_list_instances_with_runtime(ctx.home, ctx.args, ctx.instance_name, ctx.runtime)
 }
+
+/// #2550 P1: folded READ-ONLY `instance` tool. Custom (not `action_adapter!`)
+/// because `list` needs the runtime context (`handle_list_instances_with_runtime`),
+/// a handler shape the shared `adapter!` macro doesn't cover. Only the read
+/// actions are wired here and the schema's `action` enum keeps structural actions
+/// off this tool; the three (name,action)-aware classifiers (operator_gate,
+/// side-effect-on-timeout, role guard) independently enforce the read-only policy.
+pub(crate) fn dispatch_instance(ctx: &HandlerCtx<'_>) -> Value {
+    match ctx.args["action"].as_str().unwrap_or("") {
+        "list" => instance::handle_list_instances_with_runtime(
+            ctx.home,
+            ctx.args,
+            ctx.instance_name,
+            ctx.runtime,
+        ),
+        "pane_snapshot" => instance::handle_pane_snapshot(ctx.home, ctx.args),
+        other => json!({"error": format!("unknown instance action: {other}")}),
+    }
+}
 adapter!(
     dispatch_create_instance,
     hai,
@@ -400,6 +419,7 @@ mod tests {
                 "set_waiting_on",
                 "move_pane",
                 "pane_snapshot",
+                "instance",
                 "decision",
                 "task",
                 "restart_daemon",
@@ -415,7 +435,7 @@ mod tests {
                 "binding_state",
             ]
         );
-        assert_eq!(crate::mcp::registry::all().len(), 28);
+        assert_eq!(crate::mcp::registry::all().len(), 29);
     }
 
     #[test]
@@ -504,6 +524,93 @@ mod tests {
             err.contains("unknown") || err.contains("action"),
             "expected unknown-action error from base; got: {v:?}"
         );
+    }
+
+    /// #2550 P1: the folded `instance` tool routes its read actions AND produces
+    /// byte-identical results to the standalone per-name tools (the alias
+    /// contract). `runtime:None` + a temp home makes both paths deterministic:
+    /// `list` short-circuits to the compact `list_agents()` view, `pane_snapshot`
+    /// converges on the same handler once an `instance` is supplied — same
+    /// handler, same args modulo the ignored `action` key.
+    ///
+    /// NOTE the ONE deliberate divergence (asserted separately below): a MISSING
+    /// `instance` for pane_snapshot is caught by the SCHEMA layer for the per-name
+    /// tool (`required:["instance"]`) but by the HANDLER's `require_instance` for
+    /// the folded tool (`required:["action"]`, union-schema limitation). Both
+    /// reject; only the error string differs. That's why we pin equivalence with
+    /// `instance` PRESENT (both pass schema validation → identical handler call).
+    #[test]
+    fn folded_instance_read_actions_alias_per_name_tools() {
+        let home = std::env::temp_dir();
+
+        // action=list ≡ list_instances (neither declares a required `instance`, so
+        // both pass schema validation and return the full compact list).
+        let list_args = json!({"action": "list"});
+        let ctx = ctx_for(&home, &list_args, "");
+        let via_instance = try_dispatch("instance", &ctx).expect("instance(list) must route");
+        let plain_args = json!({});
+        let ctx = ctx_for(&home, &plain_args, "");
+        let via_name = try_dispatch("list_instances", &ctx).expect("list_instances must route");
+        assert_eq!(
+            via_instance, via_name,
+            "instance(action=list) must be byte-identical to list_instances"
+        );
+
+        // action=pane_snapshot ≡ pane_snapshot, with `instance` supplied so both
+        // clear schema validation and converge on the identical handler call.
+        let snap_args = json!({"action": "pane_snapshot", "instance": "alias-probe"});
+        let ctx = ctx_for(&home, &snap_args, "");
+        let via_instance =
+            try_dispatch("instance", &ctx).expect("instance(pane_snapshot) must route");
+        let plain_args = json!({"instance": "alias-probe"});
+        let ctx = ctx_for(&home, &plain_args, "");
+        let via_name = try_dispatch("pane_snapshot", &ctx).expect("pane_snapshot must route");
+        assert_eq!(
+            via_instance, via_name,
+            "instance(action=pane_snapshot, instance=…) must be byte-identical to pane_snapshot(instance=…)"
+        );
+    }
+
+    /// #2550 P1: the ONE intentional divergence — a MISSING `instance` for
+    /// pane_snapshot is rejected at a DIFFERENT layer (schema vs handler) between
+    /// the per-name and folded tools, because the folded schema can only require
+    /// `action` (union limitation). Both still reject; this pins that neither
+    /// silently accepts, documenting the layer difference.
+    #[test]
+    fn folded_instance_pane_snapshot_missing_instance_rejected_both_paths() {
+        let home = std::env::temp_dir();
+        let via_instance = try_dispatch(
+            "instance",
+            &ctx_for(&home, &json!({"action": "pane_snapshot"}), ""),
+        )
+        .expect("instance must route");
+        let via_name =
+            try_dispatch("pane_snapshot", &ctx_for(&home, &json!({}), "")).expect("must route");
+        for (label, v) in [("folded", &via_instance), ("per-name", &via_name)] {
+            let err = v.get("error").and_then(|e| e.as_str()).unwrap_or("");
+            assert!(
+                err.contains("instance"),
+                "{label} pane_snapshot without instance must error about 'instance'; got: {v:?}"
+            );
+        }
+    }
+
+    /// A structural / unknown action on the folded tool never reaches a handler —
+    /// it falls through to the tool-specific unknown-action error (the schema's
+    /// `action` enum already blocks it upstream; this is the dispatch backstop).
+    #[test]
+    fn folded_instance_unknown_action_errors() {
+        let home = std::env::temp_dir();
+        for action in ["delete", "restart", "bogus"] {
+            let args = json!({ "action": action });
+            let ctx = ctx_for(&home, &args, "");
+            let v = try_dispatch("instance", &ctx).expect("instance must still return Some");
+            let err = v.get("error").and_then(|e| e.as_str()).unwrap_or("");
+            assert!(
+                err.contains("unknown instance action"),
+                "instance({action}) must be an unknown-action error; got: {v:?}"
+            );
+        }
     }
 
     #[test]

--- a/src/mcp/registry.rs
+++ b/src/mcp/registry.rs
@@ -130,6 +130,7 @@ const ROLE_TOOL_SUBSETS: &[(&str, &[&str])] = &[
             "list_instances",
             "binding_state",
             "pane_snapshot",
+            "instance",
             "task",
             "decision",
             "ci",
@@ -151,6 +152,7 @@ const ROLE_TOOL_SUBSETS: &[(&str, &[&str])] = &[
             "list_instances",
             "binding_state",
             "pane_snapshot",
+            "instance",
             "task",
             "decision",
             "ci",
@@ -173,6 +175,7 @@ const ROLE_TOOL_SUBSETS: &[(&str, &[&str])] = &[
             "list_instances",
             "binding_state",
             "pane_snapshot",
+            "instance",
             "task",
             "decision",
             "config",
@@ -344,7 +347,7 @@ pub(crate) fn tool_allowed_for_role_action(
     tool_allowed_for_role(role_kind, tool)
 }
 
-static ALL_TOOLS: [ToolEntry; 28] = [
+static ALL_TOOLS: [ToolEntry; 29] = [
     // ── Channel ──
     ToolEntry {
         name: "reply",
@@ -437,6 +440,19 @@ static ALL_TOOLS: [ToolEntry; 28] = [
         definition: super::tools::def_pane_snapshot,
         handler: super::handlers::dispatch::dispatch_pane_snapshot,
         class: ToolClass::READ_ONLY,
+    },
+    // #2550 P1: folded read-only alias for list_instances + pane_snapshot. The
+    // ToolClass is deliberately RETRY_SAFE (not READ_ONLY): the folded tool is a
+    // forward-looking mixed read/write surface (P2+ will add mutating actions), so
+    // a name-level disk-skip would wrongly apply to future mutations. The read
+    // disk-skip optimization is traded away; the security-relevant classification
+    // is (name,action)-aware (side_effect_on_timeout_for / operator_gate / role
+    // guard), independent of this ToolClass.
+    ToolEntry {
+        name: "instance",
+        definition: super::tools::def_instance,
+        handler: super::handlers::dispatch::dispatch_instance,
+        class: ToolClass::RETRY_SAFE,
     },
     // ── Decision ──
     ToolEntry {
@@ -643,12 +659,12 @@ mod tests {
     /// ENTIRE registry in registry order — zero behavior change. If this breaks,
     /// default-all-open regressed.
     #[test]
-    fn full_capability_roles_surface_all_28_byte_identical() {
+    fn full_capability_roles_surface_all_29_byte_identical() {
         let all_names: Vec<&str> = all().iter().map(|e| e.name).collect();
         assert_eq!(
             all_names.len(),
-            28,
-            "registry baseline is 28 tools (#2547 P0: 37->33; #2548 Wave1-PR1: tui_screenshot removed, gc_dry_run/tokens/watchdog moved to CLI, config set-side moved to CLI = 33->29; #2548 Wave1-PR2: mode folded into list_instances, force_release_worktree merged into release_worktree(force:true) = 29->27; #991 Phase 2: + bind_topic = 27->28)"
+            29,
+            "registry baseline is 29 tools (#2547 P0: 37->33; #2548 Wave1-PR1: tui_screenshot removed, gc_dry_run/tokens/watchdog moved to CLI, config set-side moved to CLI = 33->29; #2548 Wave1-PR2: mode folded into list_instances, force_release_worktree merged into release_worktree(force:true) = 29->27; #991 Phase 2: + bind_topic = 27->28; #2550 P1: + instance (folded read-only alias) = 28->29)"
         );
         for role in [
             None,
@@ -660,7 +676,7 @@ mod tests {
             assert_eq!(
                 names(role),
                 all_names,
-                "role {role:?} must surface all 28 tools in registry order (default-all-open)"
+                "role {role:?} must surface all 29 tools in registry order (default-all-open)"
             );
         }
     }
@@ -775,6 +791,40 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// #2550 P1: the folded `instance` read actions must track the LIVE per-name
+    /// registry entries, not just hardcoded literals. If a future change flips
+    /// `list_instances` / `pane_snapshot` to side-effect-on-timeout, this fails —
+    /// forcing the fold's policy to stay in lockstep with the tool it aliases.
+    #[test]
+    fn folded_instance_read_actions_track_live_per_name_side_effect() {
+        assert_eq!(
+            side_effect_on_timeout_for("instance", Some("list")),
+            side_effect_on_timeout("list_instances"),
+            "instance(list) side-effect must track live list_instances"
+        );
+        assert_eq!(
+            side_effect_on_timeout_for("instance", Some("pane_snapshot")),
+            side_effect_on_timeout("pane_snapshot"),
+            "instance(pane_snapshot) side-effect must track live pane_snapshot"
+        );
+    }
+
+    /// #2550 P1: now that the tool is registered, the curated read roles SEE the
+    /// folded `instance` tool (its read actions are their legitimate surface). The
+    /// #2158 guard (`instance_role_guard_blocks_structural_for_read_roles`) still
+    /// blocks the structural actions per-action — visibility here is read-only.
+    #[test]
+    fn read_roles_gain_folded_instance_visibility() {
+        for role in [RoleKind::Reviewer, RoleKind::Planner, RoleKind::Explorer] {
+            assert!(
+                names(Some(role)).contains(&"instance"),
+                "read role {role:?} must see the folded instance tool"
+            );
+        }
+        // Registered → default-all-open full-capability roles see it too.
+        assert!(names(None).contains(&"instance"));
     }
 
     /// Parse the `### `name`` tool-section headers from a MCP-TOOLS doc body.

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -190,6 +190,19 @@ pub(crate) fn def_pane_snapshot() -> Value {
         }, "required": ["instance"]}})
 }
 
+pub(crate) fn def_instance() -> Value {
+    json!({"name": "instance", "description": "#2550: folded READ-ONLY alias for the per-name instance tools. action=list is `list_instances` (all active instances; pass `instance` for one instance's detail, `verbose`/`include_evidence` for the full evidence trail); action=pane_snapshot reads a target instance's PTY scrollback (ANSI stripped). Read-only only — structural lifecycle (create/delete/start/restart/move_pane) stays on the standalone tools, and the per-name `list_instances` / `pane_snapshot` tools remain available unchanged.",
+        "inputSchema": {"type": "object", "properties": {
+            "action": {"type": "string", "enum": ["list", "pane_snapshot"]},
+            "instance": {"type": "string", "description": "action=list: optional — return detail for this one instance. action=pane_snapshot: required — the instance to snapshot."},
+            "verbose": {"type": "boolean", "description": "action=list: include the per-instance `observed_status.evidence` trail (omitted by default)."},
+            "include_evidence": {"type": "boolean", "description": "action=list: alias of `verbose`."},
+            "lines": {"type": "integer", "description": "action=pane_snapshot: number of lines to return/capture (default 100, max 10000)."},
+            "to_file": {"type": "boolean", "description": "action=pane_snapshot: write the full snapshot to $AGEND_HOME/captures/ and return only a summary + path."},
+            "head": {"type": "integer", "description": "action=pane_snapshot to_file summary: leading lines in the returned preview (default 40)."}
+        }, "required": ["action"]}})
+}
+
 pub(crate) fn def_decision() -> Value {
     json!({"name": "decision", "description": "Manage decisions. Actions: post, list, update, answer. #2305: `post` with `needs_answer:true` (+ `options`, `allow_free_text`) creates an async pending QUESTION the operator answers later; `answer` (id + answer) records the operator's choice and notifies the decision author.",
         "inputSchema": {"type": "object", "properties": {
@@ -614,7 +627,7 @@ mod tests {
         let tools = defs["tools"].as_array().expect("tools array");
         assert_eq!(
             tools.len(),
-            28,
+            29,
             "#1400: 34 + tokens (#1077 Phase 1) = 35; + mode (#1339 Operator Mode) = 36; \
              + ephemeral (#1967 Phase-1) = 37; - replace_instance (#2547, folded into \
              restart_instance mode=fresh) = 36; - set_display_name/set_description \
@@ -622,7 +635,8 @@ mod tests {
              (#2547, removed from registry) = 33; - tui_screenshot/gc_dry_run/tokens/watchdog \
              (#2548 Wave1-PR1, removed or moved to CLI) = 29; - mode/force_release_worktree \
              (#2548 Wave1-PR2, mode folded into list_instances, force_release_worktree merged \
-             into release_worktree(force:true)) = 27; + bind_topic (#991 Phase 2) = 28. \
+             into release_worktree(force:true)) = 27; + bind_topic (#991 Phase 2) = 28; \
+             + instance (#2550 P1, folded read-only alias for list_instances/pane_snapshot) = 29. \
              Current tools: {:?}",
             tools
                 .iter()
@@ -1099,6 +1113,7 @@ mod tests {
             "set_metadata",
             "move_pane",
             "pane_snapshot",
+            "instance",
             "restart_daemon",
             "binding_state",
         ];


### PR DESCRIPTION
## What

PR-2 of #2550. Activates the dormant P0 `(name,action)`-aware instance classifiers (#2635, merged) by **registering** a folded `instance` MCP tool that exposes ONLY the read actions:

- `instance(action=list)` ≡ `list_instances`
- `instance(action=pane_snapshot)` ≡ `pane_snapshot`

The per-name tools are **untouched** (dual-track). Structural lifecycle (`create`/`delete`/`start`/`restart`/`move_pane`) and `create_instance`/`restart_daemon` stay standalone per the operator ruling.

## Why

P0 made the three security classifiers `(name,action)`-aware and wired them at their call sites, but left them **dormant** (no caller passes `tool == "instance"`). This PR is the minimal activation: it registers the tool so the `instance` branch finally has a caller. **No P0 logic changes.**

## Change-set (5 files)

- **`src/mcp/tools.rs`** — `def_instance()` (action enum `[list, pane_snapshot]`, flat-union params, `required=["action"]`); classified `NON_COORDINATION` (read-only, not directive-bearing).
- **`src/mcp/handlers/dispatch.rs`** — custom `dispatch_instance` (the `list` action needs the runtime context, a shape the shared `action_adapter!` macro doesn't cover); unknown action → tool-specific error.
- **`src/mcp/registry.rs`** — `ALL_TOOLS` +`instance` (class **`RETRY_SAFE`** — see note); +`instance` to the reviewer/planner/explorer read subsets (the #2158 role guard still blocks structural actions *per-action*).
- **`docs/MCP-TOOLS.md` + `.zh-TW`** — `### instance` section, tool count 28 → 29.

### Note on `ToolClass::RETRY_SAFE` (not `READ_ONLY`)
The folded tool is a forward-looking mixed read/write surface (P2+ adds mutating actions), so a name-level `READ_ONLY` disk-skip would wrongly apply to future mutations. The read disk-skip optimization is deliberately traded away; the **security-relevant** classification is `(name,action)`-aware (`side_effect_on_timeout_for` / `operator_gate::classify` / `tool_allowed_for_role_action`) and independent of `ToolClass`.

### One intentional divergence
A **missing** `instance` for `pane_snapshot` is rejected at the **schema layer** for the per-name tool (`required:["instance"]`) but at the **handler layer** (`require_instance`) for the folded tool (`required:["action"]`, union-schema limitation). Both reject; only the error string differs. Pinned by a dedicated test.

## Verification

- New tests: `folded_instance_read_actions_alias_per_name_tools` (byte-identical to per-name), `folded_instance_pane_snapshot_missing_instance_rejected_both_paths`, `folded_instance_unknown_action_errors`, `folded_instance_read_actions_track_live_per_name_side_effect`, `read_roles_gain_folded_instance_visibility`. Existing count / name-pin / docs-drift invariants updated 28→29.
- `mcp::registry/dispatch/tools/operator_gate` test modules: **all pass**.
- Full `mcp::` suite: **536 pass** under nextest. (Under single-process `cargo test`, 10 git-worktree/CI tests hit the agend-git shim recursion guard — all confirmed passing under nextest/per-process, i.e. environmental, unrelated to this change.)
- `cargo fmt --check` ✓, `cargo clippy` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)