### PR TITLE
fix(ci-handoff): track discharge matches task_id OR repo@branch correlation

### DIFF
--- a/src/api/handlers/messaging.rs
+++ b/src/api/handlers/messaging.rs
@@ -505,7 +505,7 @@ fn process_verdicts(home: &Path, from: &str, msg: &crate::inbox::InboxMessage) {
     }
 }
 
-fn track_dispatch(
+pub(crate) fn track_dispatch(
     home: &Path,
     params: &Value,
     from: &str,

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -15,7 +15,7 @@ use std::path::Path;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
-mod handlers;
+pub(crate) mod handlers;
 mod operator_gate;
 pub mod request_dedup;
 

--- a/src/daemon/ci_handoff_track.rs
+++ b/src/daemon/ci_handoff_track.rs
@@ -277,7 +277,7 @@ pub(crate) fn list(home: &Path) -> Vec<(PathBuf, CiHandoffTrack)> {
 pub(crate) fn resolve_by_correlation(home: &Path, correlation: &str, reason: &str) -> usize {
     let mut resolved = 0;
     for (path, track) in list(home) {
-        if track.correlation == correlation
+        if (track.correlation == correlation || track.task_id.as_deref() == Some(correlation))
             && remove_if_unchanged(
                 home,
                 &path,

--- a/src/daemon/ci_handoff_track.rs
+++ b/src/daemon/ci_handoff_track.rs
@@ -74,6 +74,20 @@ pub(crate) struct CiHandoffTrack {
     /// tier-b) — no `schema_version` bump.
     #[serde(default)]
     pub head_sha: Option<String>,
+    /// #2412-follow-up (ci-handoff correlation convention split): the fleet
+    /// dispatch's own `t-...` task id, when the handoff's `next_after_ci`
+    /// recipient was reached via a dispatch that carries one (the poller's
+    /// `state.task_id`). A standard `kind=report` in this fleet carries
+    /// `correlation_id=t-...` (Sprint 58 W4 PR-1), NOT `repo@branch` — so
+    /// [`resolve_by_correlation`] matching only `correlation` made that the
+    /// common case a permanent no-op (`messaging.rs`'s `track_dispatch`
+    /// forwards every report's correlation here uninspected). Matching EITHER
+    /// key closes it without touching `resolve_claimed`/`resolve_head_advanced`/
+    /// the 24h sweep, whose pinned tests assume `correlation` alone.
+    /// `#[serde(default)]` → a pre-fix track reads back as `None` (matches
+    /// nothing extra, unchanged behavior).
+    #[serde(default)]
+    pub task_id: Option<String>,
 }
 
 fn dir(home: &Path) -> PathBuf {
@@ -198,6 +212,7 @@ pub(crate) fn record(
     correlation: &str,
     sent_at: &str,
     head_sha: Option<&str>,
+    task_id: Option<&str>,
 ) {
     let track = CiHandoffTrack {
         schema_version: SCHEMA_VERSION,
@@ -205,6 +220,7 @@ pub(crate) fn record(
         correlation: correlation.to_string(),
         sent_at: sent_at.to_string(),
         head_sha: head_sha.map(String::from),
+        task_id: task_id.map(String::from),
     };
     let path = file_for(home, target, correlation);
     if let Err(e) = std::fs::create_dir_all(dir(home)) {
@@ -252,8 +268,12 @@ pub(crate) fn list(home: &Path) -> Vec<(PathBuf, CiHandoffTrack)> {
     out
 }
 
-/// Resolve (delete) every track carrying `correlation`, any target. Returns
-/// how many were resolved. `reason` is for the log only.
+/// Resolve (delete) every track carrying `correlation` — matching EITHER the
+/// track's `correlation` (`owner/repo@branch`, what a pr_state/reviewer-verdict
+/// report carries) OR its `task_id` (`t-...`, what a standard fleet
+/// `kind=report` carries per Sprint 58 W4 PR-1 — see the `task_id` field doc
+/// for why both keys are needed). Any target. Returns how many were resolved.
+/// `reason` is for the log only.
 pub(crate) fn resolve_by_correlation(home: &Path, correlation: &str, reason: &str) -> usize {
     let mut resolved = 0;
     for (path, track) in list(home) {
@@ -507,11 +527,32 @@ mod tests {
     #[test]
     fn record_list_roundtrip_and_refresh() {
         let home = tmp_home("roundtrip");
-        record(&home, "reviewer", "o/r@b1", "2026-06-10T00:00:00Z", None);
-        record(&home, "reviewer", "o/r@b2", "2026-06-10T00:00:00Z", None);
+        record(
+            &home,
+            "reviewer",
+            "o/r@b1",
+            "2026-06-10T00:00:00Z",
+            None,
+            None,
+        );
+        record(
+            &home,
+            "reviewer",
+            "o/r@b2",
+            "2026-06-10T00:00:00Z",
+            None,
+            None,
+        );
         assert_eq!(list(&home).len(), 2);
         // Re-record same key = refresh (no duplicate file).
-        record(&home, "reviewer", "o/r@b1", "2026-06-10T01:00:00Z", None);
+        record(
+            &home,
+            "reviewer",
+            "o/r@b1",
+            "2026-06-10T01:00:00Z",
+            None,
+            None,
+        );
         let tracks = list(&home);
         assert_eq!(tracks.len(), 2, "refresh must not duplicate");
         assert!(tracks
@@ -523,13 +564,129 @@ mod tests {
     #[test]
     fn resolve_by_correlation_clears_all_targets() {
         let home = tmp_home("resolve-corr");
-        record(&home, "reviewer", "o/r@b", "2026-06-10T00:00:00Z", None);
-        record(&home, "reviewer-2", "o/r@b", "2026-06-10T00:00:00Z", None);
-        record(&home, "reviewer", "o/r@other", "2026-06-10T00:00:00Z", None);
+        record(
+            &home,
+            "reviewer",
+            "o/r@b",
+            "2026-06-10T00:00:00Z",
+            None,
+            None,
+        );
+        record(
+            &home,
+            "reviewer-2",
+            "o/r@b",
+            "2026-06-10T00:00:00Z",
+            None,
+            None,
+        );
+        record(
+            &home,
+            "reviewer",
+            "o/r@other",
+            "2026-06-10T00:00:00Z",
+            None,
+            None,
+        );
         assert_eq!(resolve_by_correlation(&home, "o/r@b", "test"), 2);
         let left = list(&home);
         assert_eq!(left.len(), 1);
         assert_eq!(left[0].1.correlation, "o/r@other");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #2412-follow-up (ci-handoff correlation convention split): a standard
+    /// fleet `kind=report` carries `correlation_id=t-...` (Sprint 58 W4 PR-1),
+    /// NOT `repo@branch` — so a track must also resolve when the CALLER's
+    /// `correlation` arg is the dispatch's task id, not just when it matches
+    /// the track's `repo@branch` correlation field.
+    #[test]
+    fn resolve_by_correlation_also_matches_task_id() {
+        let home = tmp_home("resolve-taskid");
+        record(
+            &home,
+            "reviewer",
+            "o/r@b",
+            "2026-06-10T00:00:00Z",
+            None,
+            Some("t-20260622133030757281-1"),
+        );
+        assert_eq!(
+            resolve_by_correlation(&home, "t-20260622133030757281-1", "report_arrived"),
+            1,
+            "a standard report's task-id correlation must resolve the track \
+             recorded with that task_id, not just a repo@branch match"
+        );
+        assert!(list(&home).is_empty());
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Sibling of the above: a track with NO recorded `task_id` (the common
+    /// case before this fix, or any dispatch path that never had one) must
+    /// still resolve normally by its `repo@branch` correlation — the new OR
+    /// clause must not require both keys.
+    #[test]
+    fn resolve_by_correlation_still_matches_repo_branch_when_task_id_absent() {
+        let home = tmp_home("resolve-repobranch-only");
+        record(
+            &home,
+            "reviewer",
+            "o/r@b",
+            "2026-06-10T00:00:00Z",
+            None,
+            None,
+        );
+        assert_eq!(
+            resolve_by_correlation(&home, "o/r@b", "report_arrived"),
+            1,
+            "repo@branch matching must be unaffected by the task_id addition"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// §3.9 real-entry regression: drives `messaging::track_dispatch` (the
+    /// actual report-arrival chokepoint `handle_send` wires into), not
+    /// `resolve_by_correlation` in isolation — proves the real wiring, not
+    /// just the matching logic. (Lives here, not in `messaging.rs`'s own
+    /// test module, because that file is LOC-grandfathered and this test
+    /// only needs `track_dispatch` to be `pub(crate)`.)
+    ///
+    /// Live bug (task metadata): a standard fleet `kind=report` carries
+    /// `correlation_id=t-...` (Sprint 58 W4 PR-1), but the ci-handoff track
+    /// recorded `correlation=owner/repo@branch` and `resolve_by_correlation`
+    /// matched only that field — so an ordinary reviewer report (`gapfix-dev`
+    /// reporting on #2633 with `correlation_id=t-...67777-10`) matched no
+    /// track at all (dead code) and the target ate ~95 phantom re-nudges at
+    /// 2-min cadence until a daemon restart cleared the state.
+    #[test]
+    fn standard_report_task_id_correlation_resolves_ci_handoff_track_2412() {
+        let home = tmp_home("2412-taskid-wiring");
+        let task_id = "t-20260622133030757281-1";
+        record(
+            &home,
+            "gapfix-dev",
+            "owner/repo@branch",
+            "2026-06-10T00:00:00Z",
+            None,
+            Some(task_id),
+        );
+        assert_eq!(list(&home).len(), 1);
+
+        let msg = crate::inbox::InboxMessage::new_system("gapfix-dev", "report", "VERIFIED")
+            .with_correlation_id(task_id.to_string());
+        crate::api::handlers::messaging::track_dispatch(
+            &home,
+            &serde_json::json!({}),
+            "gapfix-dev",
+            "lead",
+            &msg,
+        );
+
+        assert!(
+            list(&home).is_empty(),
+            "#2412: a standard kind=report carrying the dispatch's task_id must \
+             resolve the ci-handoff track through the real track_dispatch wiring"
+        );
         std::fs::remove_dir_all(&home).ok();
     }
 
@@ -539,9 +696,23 @@ mod tests {
         // exact repo@branch — a co-subscriber's track (same correlation, different
         // target) and the caller's other-branch track both survive.
         let home = tmp_home("resolve-tc");
-        record(&home, "lead", "o/r@b", "2026-06-10T00:00:00Z", None);
-        record(&home, "reviewer", "o/r@b", "2026-06-10T00:00:00Z", None);
-        record(&home, "lead", "o/r@other", "2026-06-10T00:00:00Z", None);
+        record(&home, "lead", "o/r@b", "2026-06-10T00:00:00Z", None, None);
+        record(
+            &home,
+            "reviewer",
+            "o/r@b",
+            "2026-06-10T00:00:00Z",
+            None,
+            None,
+        );
+        record(
+            &home,
+            "lead",
+            "o/r@other",
+            "2026-06-10T00:00:00Z",
+            None,
+            None,
+        );
         assert_eq!(resolve_for_target_correlation(&home, "lead", "o/r@b"), 1);
         let left = list(&home);
         assert_eq!(left.len(), 2, "only lead's o/r@b cleared");
@@ -557,8 +728,22 @@ mod tests {
     #[test]
     fn resolve_claimed_scopes_to_target_and_branch() {
         let home = tmp_home("resolve-claim");
-        record(&home, "reviewer", "o/r@fix/x", "2026-06-10T00:00:00Z", None);
-        record(&home, "other", "o/r@fix/x", "2026-06-10T00:00:00Z", None);
+        record(
+            &home,
+            "reviewer",
+            "o/r@fix/x",
+            "2026-06-10T00:00:00Z",
+            None,
+            None,
+        );
+        record(
+            &home,
+            "other",
+            "o/r@fix/x",
+            "2026-06-10T00:00:00Z",
+            None,
+            None,
+        );
         assert_eq!(resolve_claimed(&home, "reviewer", "fix/x"), 1);
         let left = list(&home);
         assert_eq!(left.len(), 1, "other target's track untouched");
@@ -572,9 +757,16 @@ mod tests {
         let now = chrono::Utc::now();
         let old = (now - chrono::Duration::hours(25)).to_rfc3339();
         let fresh = now.to_rfc3339();
-        record(&home, "reviewer", "o/r@old", &old, None);
-        record(&home, "reviewer", "o/r@fresh", &fresh, None);
-        record(&home, "reviewer", "o/r@broken", "not-a-timestamp", None);
+        record(&home, "reviewer", "o/r@old", &old, None, None);
+        record(&home, "reviewer", "o/r@fresh", &fresh, None, None);
+        record(
+            &home,
+            "reviewer",
+            "o/r@broken",
+            "not-a-timestamp",
+            None,
+            None,
+        );
         assert_eq!(sweep_expired(&home, &now), 2, "old + broken swept");
         let left = list(&home);
         assert_eq!(left.len(), 1);
@@ -591,7 +783,14 @@ mod tests {
     #[test]
     fn remove_if_unchanged_refuses_stale_delete_1963() {
         let home = tmp_home("cas");
-        record(&home, "reviewer", "o/r@b", "2026-06-10T00:00:00Z", None);
+        record(
+            &home,
+            "reviewer",
+            "o/r@b",
+            "2026-06-10T00:00:00Z",
+            None,
+            None,
+        );
         let path = file_for(&home, "reviewer", "o/r@b");
         // Same episode → delete succeeds.
         assert!(remove_if_unchanged(
@@ -608,8 +807,22 @@ mod tests {
 
         // Re-record a NEW episode (new sent_at = a new CI pass), then a deleter
         // carrying the STALE listed sent_at must NOT delete it (the race).
-        record(&home, "reviewer", "o/r@b", "2026-06-10T00:00:00Z", None); // S1
-        record(&home, "reviewer", "o/r@b", "2026-06-10T09:00:00Z", None); // S2
+        record(
+            &home,
+            "reviewer",
+            "o/r@b",
+            "2026-06-10T00:00:00Z",
+            None,
+            None,
+        ); // S1
+        record(
+            &home,
+            "reviewer",
+            "o/r@b",
+            "2026-06-10T09:00:00Z",
+            None,
+            None,
+        ); // S2
         assert!(
             !remove_if_unchanged(&home, &path, "reviewer", "o/r@b", "2026-06-10T00:00:00Z"),
             "#1963: a delete carrying the STALE listed sent_at must be refused"
@@ -631,7 +844,14 @@ mod tests {
     #[test]
     fn atomic_write_and_sidecars_excluded_from_list_1963() {
         let home = tmp_home("atomic");
-        record(&home, "reviewer", "o/r@b", "2026-06-10T00:00:00Z", None);
+        record(
+            &home,
+            "reviewer",
+            "o/r@b",
+            "2026-06-10T00:00:00Z",
+            None,
+            None,
+        );
         let tracks = list(&home);
         assert_eq!(tracks.len(), 1);
         assert_eq!(tracks[0].1.correlation, "o/r@b");
@@ -659,8 +879,22 @@ mod tests {
     #[test]
     fn sanitize_colliding_keys_get_distinct_files_1969() {
         let home = tmp_home("collide");
-        record(&home, "reviewer", "o/r@a/b", "2026-06-10T00:00:00Z", None);
-        record(&home, "reviewer", "o/r@a_b", "2026-06-10T00:00:00Z", None);
+        record(
+            &home,
+            "reviewer",
+            "o/r@a/b",
+            "2026-06-10T00:00:00Z",
+            None,
+            None,
+        );
+        record(
+            &home,
+            "reviewer",
+            "o/r@a_b",
+            "2026-06-10T00:00:00Z",
+            None,
+            None,
+        );
         let tracks = list(&home);
         assert_eq!(
             tracks.len(),
@@ -694,6 +928,7 @@ mod tests {
             "reviewer",
             "o/r@active",
             "2026-06-10T00:00:00Z",
+            None,
             None,
         );
         let active_lock = lock_for(&home, "reviewer", "o/r@active");
@@ -767,6 +1002,7 @@ mod tests {
             correlation: "o/r@b".into(),
             sent_at: "2026-06-10T00:00:00Z".into(),
             head_sha: None,
+            task_id: None,
         };
         std::fs::write(&old_path, serde_json::to_vec(&track).unwrap()).unwrap();
         assert_eq!(
@@ -797,6 +1033,7 @@ mod tests {
             "o/r@b",
             "2026-06-10T00:00:00Z",
             Some("HEAD_OLD"),
+            None,
         );
         assert_eq!(list(&home).len(), 1);
         let resolved = resolve_head_advanced(&home, "o/r@b", "HEAD_NEW");
@@ -822,6 +1059,7 @@ mod tests {
             "o/r@b",
             "2026-06-10T00:00:00Z",
             Some("HEAD_X"),
+            None,
         );
         let resolved = resolve_head_advanced(&home, "o/r@b", "HEAD_X");
         assert_eq!(resolved, 0, "an unchanged head must keep the track");
@@ -866,6 +1104,7 @@ mod tests {
             "o/r@b1",
             "2026-06-10T00:00:00Z",
             Some("HEAD_OLD"),
+            None,
         );
         record(
             &home,
@@ -873,6 +1112,7 @@ mod tests {
             "o/r@b2",
             "2026-06-10T00:00:00Z",
             Some("HEAD_OLD"),
+            None,
         );
         let resolved = resolve_head_advanced(&home, "o/r@b1", "HEAD_NEW");
         assert_eq!(resolved, 1, "only b1's track is for the moved head");

--- a/src/daemon/ci_watch/poller.rs
+++ b/src/daemon/ci_watch/poller.rs
@@ -2127,6 +2127,11 @@ fn persist_watch_state(
                             // so a later head move can invalidate it (head-aware
                             // resolve).
                             Some(&pr.current_sha),
+                            // #2412-follow-up: a standard `kind=report` carries
+                            // `correlation_id=t-...`, not `repo@branch` — record
+                            // this dispatch's task id too so
+                            // `resolve_by_correlation` can match either key.
+                            task_id,
                         );
                     }
                 }

--- a/src/daemon/ci_watch/poller_tests.rs
+++ b/src/daemon/ci_watch/poller_tests.rs
@@ -1410,6 +1410,7 @@ fn poll_with_advanced_head_resolves_stale_handoff_track() {
         "o/r@feat",
         "2026-06-10T00:00:00Z",
         Some("OLDHEAD"),
+        None,
     );
     assert_eq!(crate::daemon::ci_handoff_track::list(&dir).len(), 1);
     // A real poll observes the branch head has advanced to NEWHEAD.
@@ -1440,6 +1441,7 @@ fn poll_with_unchanged_head_keeps_handoff_track() {
         "o/r@feat",
         "2026-06-10T00:00:00Z",
         Some("abc"),
+        None,
     );
     let provider = MockCiProvider::with_runs(vec![CiRun {
         run_attempt: 1,

--- a/src/daemon/handoff_timeout_watchdog.rs
+++ b/src/daemon/handoff_timeout_watchdog.rs
@@ -349,6 +349,7 @@ mod tests {
             corr,
             &(chrono::Utc::now() - chrono::Duration::minutes(age_min)).to_rfc3339(),
             None, // #2008: head-awareness not exercised by the watchdog tests
+            None,
         );
     }
 
@@ -578,6 +579,7 @@ mod tests {
             "reviewer",
             "o/r@abandoned",
             &(chrono::Utc::now() - chrono::Duration::hours(25)).to_rfc3339(),
+            None,
             None,
         );
         let nudged = run_watchdog(

--- a/src/daemon/pr_state/scanner.rs
+++ b/src/daemon/pr_state/scanner.rs
@@ -763,6 +763,7 @@ mod tests {
             "o/r@b",
             &chrono::Utc::now().to_rfc3339(),
             Some("abcdef0"),
+            None,
         );
 
         let poller = MockGhPoller::new(vec![Ok(vec![open_pr_meta(42, "b")])]);
@@ -800,6 +801,7 @@ mod tests {
             "o/r@b",
             &chrono::Utc::now().to_rfc3339(),
             Some("abcdef1"),
+            None,
         );
 
         let poller = MockGhPoller::new(vec![Ok(vec![open_pr_meta(43, "b")])]);

--- a/src/mcp/handlers/ci/watch.rs
+++ b/src/mcp/handlers/ci/watch.rs
@@ -524,12 +524,14 @@ mod tests {
             "o/r@b",
             "2026-06-10T00:00:00Z",
             None,
+            None,
         );
         crate::daemon::ci_handoff_track::record(
             &home,
             "reviewer",
             "o/r@b",
             "2026-06-10T00:00:00Z",
+            None,
             None,
         );
 


### PR DESCRIPTION
## Summary

RCA (operator-preserved scene: `captures/phantom-renudge-scene-20260705T1050/`). `messaging.rs:593-596`'s own comment says it plainly:

> a report carrying the handoff's `repo@branch` correlation RESOLVES the ci-handoff track... A task-id correlation simply matches no track (no-op).

`ci_handoff_track`'s tracks are keyed by `owner/repo@branch` (the pr_state/reviewer-verdict convention), but a standard fleet `kind=report` carries `correlation_id=t-...` (Sprint 58 W4 PR-1) — the two conventions never overlap, so the #1888 "your own report resolves the track" signal is dead code for the common case.

**Live sample**: gapfix-dev's 07:26 standard report on #2633 (`correlation_id=t-...67777-10` + `reviewed_head`) resolved nothing — the target ate ~95 phantom re-nudges at 2-min cadence (07:26-10:36) until a daemon restart cleared the ledger state. Two earlier report-discharge experiments (01:34/01:52) failed for the same reason; 01:34's apparent "silence" was actually a head-advance resolution (`resolve_head_advanced`), not a report resolution.

## Fix

`CiHandoffTrack` gains a `task_id: Option<String>` field (additive, `#[serde(default)]`, mirrors the existing `head_sha` precedent). `record()` threads it through — the sole production call site (`ci_watch/poller.rs`, the ci-ready-for-action handoff creator) passes the poller's already-available `state.task_id`. `resolve_by_correlation` now matches EITHER key: `track.correlation == correlation || track.task_id.as_deref() == Some(correlation)`. `messaging.rs`'s `track_dispatch` already forwards `msg.correlation_id.as_deref().or(msg.task_id.as_deref())` into this function unchanged — the fix is entirely in the matching predicate.

**Scope discipline** (per dispatch instruction): `resolve_claimed`, `resolve_head_advanced`, and the 24h `sweep_expired` backstop are untouched — all three have their own pinned tests, and none of them accept an externally-supplied correlation string to match against (`resolve_claimed` matches by target+branch-suffix; `resolve_head_advanced`/`sweep_expired` iterate tracks by their own fields), so none carry the same convention-split risk.

**`handoff_timeout_watchdog.rs` checked for the "same-shape" gap** the dispatch asked about — it has none. Its only correlation usage (`resolve_if_merge_blocked`) queries `resolve_by_correlation` with the TRACK's own `correlation` field (self-referential, always matches by construction) — it never receives an externally-supplied task-id-style string to match against, so it was never exposed to this bug and needs no change. It automatically benefits from the widened match since it calls the same shared function.

## LOC-ceiling note

`messaging.rs` is LOC-grandfathered at 3239 (`tests/src_file_size_invariant.rs`) — it must not grow. `track_dispatch` and `src/api/mod.rs`'s `handlers` module become `pub(crate)` (zero LOC growth — visibility-keyword-only edits) so the wiring-level regression test lives in `ci_handoff_track.rs`'s test module instead of growing `messaging.rs` past its ceiling.

## Tests (`src/daemon/ci_handoff_track.rs`, red-green verified — commit `ca4aeb69` fails without `e99006c4`)

- `resolve_by_correlation_also_matches_task_id`
- `resolve_by_correlation_still_matches_repo_branch_when_task_id_absent` (control — proves the OR doesn't regress the existing path; passes both before and after)
- `standard_report_task_id_correlation_resolves_ci_handoff_track_2412` (§3.9 real-entry: drives the actual `track_dispatch` report-arrival chokepoint via its new `pub(crate)` visibility, not `resolve_by_correlation` in isolation)

## Verification

- `cargo test --features tray --bin agend-terminal ci_handoff_track::` — 18/18 pass
- `cargo test --features tray --bin agend-terminal messaging::` — 55/55 pass (1 pre-existing operator-only ignore)
- `cargo test --features tray --bin agend-terminal daemon::ci_watch::` — 233/233 pass
- `cargo test --features tray --bin agend-terminal daemon::handoff_timeout_watchdog::` — 13/13 pass
- `cargo test --features tray --bin agend-terminal daemon::pr_state::` — 91/91 pass
- `cargo test --features tray --bin agend-terminal mcp::handlers::ci::` — 81/81 pass
- `tests/src_file_size_invariant.rs` — pass (messaging.rs held at its 3239-LOC ceiling, not grown)
- `cargo fmt --check`, `cargo clippy --bin agend-terminal --features tray -- -D warnings` — clean

Refs #1888, task t-20260705025405462092-63933-0

🤖 Generated with [Claude Code](https://claude.com/claude-code)