### PR TITLE
fix(kind hygiene): agent_ops fallback drops message kind + request_kind enum validation

### DIFF
--- a/src/agent_ops.rs
+++ b/src/agent_ops.rs
@@ -103,13 +103,19 @@ pub fn send_to(
                 return json!({"error": format!("target instance '{target}' not found in fleet.yaml (API unavailable: {e})")});
             }
             let submit_key = get_submit_key(home, target);
+            // t-20260705005551919287-14440-22: preserve the ORIGINAL `kind`
+            // on the fallback path — it was hardcoded to `None` here even
+            // though the API-reachable path above threads it through via
+            // `"kind": kind`. A task/query silently landing as kind=None
+            // loses its obligation classification (poll-reminder doesn't
+            // re-arm for it).
             crate::inbox::deliver(
                 home,
                 target,
                 &crate::inbox::NotifySource::Agent(from_str),
                 text,
                 &submit_key,
-                None,
+                Some(kind.to_string()),
                 broadcast_context.cloned(),
             );
             json!({"target": target, "delivery_mode": "inbox_fallback", "note": format!("API unavailable: {e}")})
@@ -810,6 +816,49 @@ mod tests {
             result.get("delivery_mode").and_then(|d| d.as_str()),
             Some("inbox_fallback"),
             "must NOT report success when the message was lost"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// t-20260705005551919287-14440-22: `send_to`'s API-down fallback hardcoded
+    /// `kind: None` when handing off to `inbox::deliver` — losing the ORIGINAL
+    /// message kind (`"query"`/`"task"`/etc, threaded through fine on the
+    /// API-reachable path via the `"kind": kind` param) the instant the daemon
+    /// API is unreachable. Real production callers pass a real kind here
+    /// (`handle_request_information` → `"query"`; `handle_broadcast` → the
+    /// caller's `request_kind`, which can be `"task"`/`"query"`) — a query/task
+    /// silently landing as kind=None means its obligation classification is
+    /// lost (poll-reminder doesn't re-arm for it), not just cosmetic.
+    ///
+    /// No live daemon exists in this test's fresh `tmp_home`, so `api::call`
+    /// fails deterministically and `send_to` takes the fallback path for real
+    /// — not a mocked substitute for it.
+    #[test]
+    fn send_to_fallback_preserves_original_kind_not_none_2620() {
+        let home = tmp_home("send-to-fallback-kind");
+        std::fs::write(
+            crate::fleet::fleet_yaml_path(&home),
+            "instances:\n  worker:\n    backend: claude\n",
+        )
+        .unwrap();
+        let from = Sender::new("sender").expect("valid sender");
+
+        let result = send_to(&home, &from, "worker", "hello", "query", None);
+        assert_eq!(
+            result.get("delivery_mode").and_then(|d| d.as_str()),
+            Some("inbox_fallback"),
+            "test invariant: no daemon running in this tmp_home, must hit the \
+             fallback path (not skip past it): {result}"
+        );
+
+        let msgs = crate::inbox::drain(&home, "worker");
+        assert_eq!(msgs.len(), 1, "fallback must still enqueue the message");
+        assert_eq!(
+            msgs[0].kind.as_deref(),
+            Some("query"),
+            "the fallback delivery must preserve the ORIGINAL kind passed to \
+             send_to, not silently drop it to None: {:?}",
+            msgs[0]
         );
         std::fs::remove_dir_all(&home).ok();
     }

--- a/src/agent_ops.rs
+++ b/src/agent_ops.rs
@@ -838,12 +838,17 @@ mod tests {
         let home = tmp_home("send-to-fallback-kind");
         std::fs::write(
             crate::fleet::fleet_yaml_path(&home),
-            "instances:\n  worker:\n    backend: claude\n",
+            "instances:\n  sf2620t:\n    backend: claude\n",
         )
         .unwrap();
         let from = Sender::new("sender").expect("valid sender");
 
-        let result = send_to(&home, &from, "worker", "hello", "query", None);
+        // t-20260705005551919287-14440-22 (dev3 heartbeat_pair sweep): NOT the
+        // generic "worker" fixture name — this fallback path writes
+        // `heartbeat_pair["worker"]`, colliding under plain `cargo test`'s
+        // shared process with dispatch_idle's #1516 tests reading that same
+        // process-global (non-`home`-scoped) registry entry.
+        let result = send_to(&home, &from, "sf2620t", "hello", "query", None);
         assert_eq!(
             result.get("delivery_mode").and_then(|d| d.as_str()),
             Some("inbox_fallback"),
@@ -851,7 +856,7 @@ mod tests {
              fallback path (not skip past it): {result}"
         );
 
-        let msgs = crate::inbox::drain(&home, "worker");
+        let msgs = crate::inbox::drain(&home, "sf2620t");
         assert_eq!(msgs.len(), 1, "fallback must still enqueue the message");
         assert_eq!(
             msgs[0].kind.as_deref(),

--- a/src/daemon/dispatch_idle/mod.rs
+++ b/src/daemon/dispatch_idle/mod.rs
@@ -3504,8 +3504,8 @@ mod tests {
     fn working_target_does_not_fire_1516() {
         let home = tmp_home("gate-working");
         let issued = chrono::Utc::now() - chrono::Duration::seconds(700);
-        let id = write_pending_at(&home, "lead", "1516-gate-working", Some("t-w"), "task", 600, issued);
-        crate::snapshot::save(&home, &[mk_agent_snapshot("1516-gate-working", "active")]);
+        let id = write_pending_at(&home, "lead", "gt1516w", Some("t-w"), "task", 600, issued);
+        crate::snapshot::save(&home, &[mk_agent_snapshot("gt1516w", "active")]);
 
         scan_and_emit(&home);
 
@@ -3533,8 +3533,8 @@ mod tests {
     fn idle_target_still_fires_1516() {
         let home = tmp_home("gate-idle");
         let issued = chrono::Utc::now() - chrono::Duration::seconds(700);
-        let id = write_pending_at(&home, "lead", "1516-gate-idle", Some("t-i"), "task", 600, issued);
-        crate::snapshot::save(&home, &[mk_agent_snapshot("1516-gate-idle", "idle")]);
+        let id = write_pending_at(&home, "lead", "gt1516i", Some("t-i"), "task", 600, issued);
+        crate::snapshot::save(&home, &[mk_agent_snapshot("gt1516i", "idle")]);
 
         // #1658: a snapshot present + not-working debounces — fires on the
         // DEBOUNCE_SCANS-th consecutive idle scan, not the first.
@@ -3562,7 +3562,7 @@ mod tests {
     fn no_snapshot_falls_back_to_firing_1516() {
         let home = tmp_home("gate-nosnap");
         let issued = chrono::Utc::now() - chrono::Duration::seconds(700);
-        write_pending_at(&home, "lead", "1516-gate-nosnap", Some("t-n"), "task", 600, issued);
+        write_pending_at(&home, "lead", "gt1516n", Some("t-n"), "task", 600, issued);
         // No snapshot.json written.
         scan_and_emit(&home);
         assert!(

--- a/src/daemon/dispatch_idle/mod.rs
+++ b/src/daemon/dispatch_idle/mod.rs
@@ -1575,6 +1575,20 @@ mod tests {
         dir
     }
 
+    /// #1516 gate tests key off `target_has_active_waiting_on`, which reads
+    /// `heartbeat_pair`'s process-global (`static OnceLock`) registry keyed
+    /// by literal agent name — NOT scoped to `home`. A literal `"worker"`
+    /// target collides with the same generic fixture name used by ~14 other
+    /// test files across the crate; any of them setting `waiting_on` on
+    /// "worker" pollutes these tests regardless of `home` isolation (t-20260705005551919287-14440-22
+    /// Coverage-job flake, confirmed via base-vs-branch A/B). Unique per call
+    /// (same PID+counter shape as `tmp_home`) so no other test can share the key.
+    fn unique_target(tag: &str) -> String {
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        format!("gate-target-{}-{}-{}", std::process::id(), tag, id)
+    }
+
     /// Write a backdated pending sidecar directly (bypasses
     /// `record_dispatch`) so timeout scenarios don't require sleeping.
     fn write_pending_at(
@@ -3503,9 +3517,10 @@ mod tests {
     #[test]
     fn working_target_does_not_fire_1516() {
         let home = tmp_home("gate-working");
+        let target = unique_target("working");
         let issued = chrono::Utc::now() - chrono::Duration::seconds(700);
-        let id = write_pending_at(&home, "lead", "worker", Some("t-w"), "task", 600, issued);
-        crate::snapshot::save(&home, &[mk_agent_snapshot("worker", "active")]);
+        let id = write_pending_at(&home, "lead", &target, Some("t-w"), "task", 600, issued);
+        crate::snapshot::save(&home, &[mk_agent_snapshot(&target, "active")]);
 
         scan_and_emit(&home);
 
@@ -3532,9 +3547,10 @@ mod tests {
     #[test]
     fn idle_target_still_fires_1516() {
         let home = tmp_home("gate-idle");
+        let target = unique_target("idle");
         let issued = chrono::Utc::now() - chrono::Duration::seconds(700);
-        let id = write_pending_at(&home, "lead", "worker", Some("t-i"), "task", 600, issued);
-        crate::snapshot::save(&home, &[mk_agent_snapshot("worker", "idle")]);
+        let id = write_pending_at(&home, "lead", &target, Some("t-i"), "task", 600, issued);
+        crate::snapshot::save(&home, &[mk_agent_snapshot(&target, "idle")]);
 
         // #1658: a snapshot present + not-working debounces — fires on the
         // DEBOUNCE_SCANS-th consecutive idle scan, not the first.
@@ -3561,8 +3577,9 @@ mod tests {
     #[test]
     fn no_snapshot_falls_back_to_firing_1516() {
         let home = tmp_home("gate-nosnap");
+        let target = unique_target("nosnap");
         let issued = chrono::Utc::now() - chrono::Duration::seconds(700);
-        write_pending_at(&home, "lead", "worker", Some("t-n"), "task", 600, issued);
+        write_pending_at(&home, "lead", &target, Some("t-n"), "task", 600, issued);
         // No snapshot.json written.
         scan_and_emit(&home);
         assert!(

--- a/src/daemon/dispatch_idle/mod.rs
+++ b/src/daemon/dispatch_idle/mod.rs
@@ -1575,20 +1575,6 @@ mod tests {
         dir
     }
 
-    /// #1516 gate tests key off `target_has_active_waiting_on`, which reads
-    /// `heartbeat_pair`'s process-global (`static OnceLock`) registry keyed
-    /// by literal agent name — NOT scoped to `home`. A literal `"worker"`
-    /// target collides with the same generic fixture name used by ~14 other
-    /// test files across the crate; any of them setting `waiting_on` on
-    /// "worker" pollutes these tests regardless of `home` isolation (t-20260705005551919287-14440-22
-    /// Coverage-job flake, confirmed via base-vs-branch A/B). Unique per call
-    /// (same PID+counter shape as `tmp_home`) so no other test can share the key.
-    fn unique_target(tag: &str) -> String {
-        static COUNTER: AtomicU32 = AtomicU32::new(0);
-        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
-        format!("gate-target-{}-{}-{}", std::process::id(), tag, id)
-    }
-
     /// Write a backdated pending sidecar directly (bypasses
     /// `record_dispatch`) so timeout scenarios don't require sleeping.
     fn write_pending_at(
@@ -3517,10 +3503,9 @@ mod tests {
     #[test]
     fn working_target_does_not_fire_1516() {
         let home = tmp_home("gate-working");
-        let target = unique_target("working");
         let issued = chrono::Utc::now() - chrono::Duration::seconds(700);
-        let id = write_pending_at(&home, "lead", &target, Some("t-w"), "task", 600, issued);
-        crate::snapshot::save(&home, &[mk_agent_snapshot(&target, "active")]);
+        let id = write_pending_at(&home, "lead", "1516-gate-working", Some("t-w"), "task", 600, issued);
+        crate::snapshot::save(&home, &[mk_agent_snapshot("1516-gate-working", "active")]);
 
         scan_and_emit(&home);
 
@@ -3547,10 +3532,9 @@ mod tests {
     #[test]
     fn idle_target_still_fires_1516() {
         let home = tmp_home("gate-idle");
-        let target = unique_target("idle");
         let issued = chrono::Utc::now() - chrono::Duration::seconds(700);
-        let id = write_pending_at(&home, "lead", &target, Some("t-i"), "task", 600, issued);
-        crate::snapshot::save(&home, &[mk_agent_snapshot(&target, "idle")]);
+        let id = write_pending_at(&home, "lead", "1516-gate-idle", Some("t-i"), "task", 600, issued);
+        crate::snapshot::save(&home, &[mk_agent_snapshot("1516-gate-idle", "idle")]);
 
         // #1658: a snapshot present + not-working debounces — fires on the
         // DEBOUNCE_SCANS-th consecutive idle scan, not the first.
@@ -3577,9 +3561,8 @@ mod tests {
     #[test]
     fn no_snapshot_falls_back_to_firing_1516() {
         let home = tmp_home("gate-nosnap");
-        let target = unique_target("nosnap");
         let issued = chrono::Utc::now() - chrono::Duration::seconds(700);
-        write_pending_at(&home, "lead", &target, Some("t-n"), "task", 600, issued);
+        write_pending_at(&home, "lead", "1516-gate-nosnap", Some("t-n"), "task", 600, issued);
         // No snapshot.json written.
         scan_and_emit(&home);
         assert!(

--- a/src/mcp/handlers/comms.rs
+++ b/src/mcp/handlers/comms.rs
@@ -7,7 +7,9 @@ use std::path::Path;
 
 use super::send_envelope::SendEnvelope;
 use super::{
-    comms_gates::{enforce_send_invariants, record_triaged_if_present, validate_triaged},
+    comms_gates::{
+        enforce_send_invariants, record_triaged_if_present, validate_request_kind, validate_triaged,
+    },
     err_needs_identity, is_ok_result,
 };
 
@@ -17,6 +19,9 @@ use super::{
 pub(super) fn handle_unified_send(home: &Path, args: &Value, sender: &Option<Sender>) -> Value {
     let mut args = args.clone();
     if let Some(err) = enforce_send_invariants(home, &args, sender) {
+        return err;
+    }
+    if let Some(err) = validate_request_kind(&args) {
         return err;
     }
     // Broadcast mode: targets/team/tags present
@@ -601,6 +606,12 @@ pub(super) fn handle_broadcast(home: &Path, args: &Value, sender: &Option<Sender
     let Some(sender) = sender.as_ref() else {
         return err_needs_identity("broadcast");
     };
+    // Also validated in `handle_unified_send` before routing here — repeated
+    // so a direct call to this handler (bypassing the unified dispatch) is
+    // still covered.
+    if let Some(err) = validate_request_kind(args) {
+        return err;
+    }
     let message = match args["message"].as_str() {
         Some(m) => m,
         None => return json!({"error": "missing 'message'"}),

--- a/src/mcp/handlers/comms_gates/mod.rs
+++ b/src/mcp/handlers/comms_gates/mod.rs
@@ -9,6 +9,7 @@
 mod anti_stall;
 mod dispatch;
 mod evidence_gate;
+mod request_kind_gate;
 mod sha_gate;
 mod triaged_gate;
 
@@ -22,6 +23,10 @@ pub(super) use sha_gate::{check_sha_gate, fetch_pr_head_sha};
 
 // Send-invariant gate (handle_unified_send).
 pub(super) use anti_stall::enforce_send_invariants;
+
+// t-20260705005551919287-14440-22: request_kind enum validation
+// (handle_unified_send / handle_broadcast).
+pub(super) use request_kind_gate::validate_request_kind;
 
 // Delegate-task pre-send gates (handle_delegate_task).
 pub(super) use dispatch::run_dispatch_pre_checks;

--- a/src/mcp/handlers/comms_gates/request_kind_gate.rs
+++ b/src/mcp/handlers/comms_gates/request_kind_gate.rs
@@ -6,6 +6,12 @@
 //! rejected. Omitting the field is a valid, deliberate "plain message"
 //! request; a present-but-unknown value is very likely a caller bug and
 //! should be rejected loudly, not silently reinterpreted.
+//!
+//! reviewer4 (#2639 r0): `args["request_kind"].as_str()?` conflated ABSENT
+//! (key missing — a deliberate plain send) with PRESENT-but-not-a-string
+//! (`123`, `null` — a malformed caller bug) — both hit the `?` early-return
+//! and passed validation silently. A malformed value is worse than a typo
+//! and must be rejected, not downgraded.
 
 use serde_json::{json, Value};
 
@@ -13,10 +19,19 @@ use serde_json::{json, Value};
 /// dispatch on. Single source of truth both entry points validate against.
 const VALID_REQUEST_KINDS: &[&str] = &["task", "report", "query", "update"];
 
-/// `None` when `request_kind` is absent (plain send) or one of the
-/// recognized values. `Some(error)` otherwise.
+/// Three-state: `None` when `request_kind` is ABSENT (deliberate plain send)
+/// or a recognized string. `Some(error)` when it's PRESENT but not a string
+/// (wrong type, `null`) or an unrecognized string — never silently
+/// downgraded to a plain send.
 pub(crate) fn validate_request_kind(args: &Value) -> Option<Value> {
-    let rk = args["request_kind"].as_str()?;
+    let rk_value = args.get("request_kind")?;
+    let Some(rk) = rk_value.as_str() else {
+        return Some(json!({
+            "error": format!(
+                "request_kind must be a string (got {rk_value}) — must be one of {VALID_REQUEST_KINDS:?}, or omitted for a plain message"
+            )
+        }));
+    };
     if VALID_REQUEST_KINDS.contains(&rk) {
         return None;
     }

--- a/src/mcp/handlers/comms_gates/request_kind_gate.rs
+++ b/src/mcp/handlers/comms_gates/request_kind_gate.rs
@@ -1,0 +1,28 @@
+//! t-20260705005551919287-14440-22: `request_kind` server-side validation.
+//!
+//! An unrecognized `request_kind` (typo, wrong case, garbage value) used to
+//! fall through `handle_unified_send`'s dispatch `match`'s `_` arm exactly
+//! like an OMITTED one — silently reinterpreted as a plain send instead of
+//! rejected. Omitting the field is a valid, deliberate "plain message"
+//! request; a present-but-unknown value is very likely a caller bug and
+//! should be rejected loudly, not silently reinterpreted.
+
+use serde_json::{json, Value};
+
+/// The only `request_kind` values `handle_unified_send`/`handle_broadcast`
+/// dispatch on. Single source of truth both entry points validate against.
+const VALID_REQUEST_KINDS: &[&str] = &["task", "report", "query", "update"];
+
+/// `None` when `request_kind` is absent (plain send) or one of the
+/// recognized values. `Some(error)` otherwise.
+pub(crate) fn validate_request_kind(args: &Value) -> Option<Value> {
+    let rk = args["request_kind"].as_str()?;
+    if VALID_REQUEST_KINDS.contains(&rk) {
+        return None;
+    }
+    Some(json!({
+        "error": format!(
+            "unknown request_kind '{rk}' — must be one of {VALID_REQUEST_KINDS:?}, or omitted for a plain message"
+        )
+    }))
+}

--- a/src/mcp/handlers/tests.rs
+++ b/src/mcp/handlers/tests.rs
@@ -2292,6 +2292,59 @@ fn send_valid_request_kinds_pass_validation_2620() {
     }
 }
 
+/// reviewer4 (#2639 r0 probe): `args["request_kind"].as_str()?` treated a
+/// PRESENT-but-non-string value the same as an ABSENT field — both hit the
+/// `?` early-return and passed validation, so `request_kind: 123` silently
+/// reached `inbox_fallback` delivery instead of an error. Malformed is worse
+/// than a typo and must reject, not downgrade to a plain send.
+#[test]
+fn send_non_string_request_kind_rejected_2639() {
+    let sender = crate::identity::Sender::new("lead2-test").expect("valid sender name");
+    let args = json!({"instance": "dev", "message": "hi", "request_kind": 123});
+    let result = super::comms::handle_unified_send(&std::env::temp_dir(), &args, &Some(sender));
+    let err = result
+        .get("error")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default();
+    assert!(
+        err.contains("request_kind must be a string"),
+        "a non-string request_kind must be rejected, not silently downgraded \
+         to a plain send: {result}"
+    );
+}
+
+/// Sibling of the above for JSON `null` — `Value::Null.as_str()` also
+/// returns `None`, so it hit the same conflation and must reject too.
+#[test]
+fn send_null_request_kind_rejected_2639() {
+    let sender = crate::identity::Sender::new("lead2-test").expect("valid sender name");
+    let args = json!({"instance": "dev", "message": "hi", "request_kind": null});
+    let result = super::comms::handle_unified_send(&std::env::temp_dir(), &args, &Some(sender));
+    let err = result
+        .get("error")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default();
+    assert!(
+        err.contains("request_kind must be a string"),
+        "a null request_kind must be rejected like any other non-string, not \
+         silently downgraded to a plain send: {result}"
+    );
+}
+
+/// An ABSENT `request_kind` (key not present at all) must still pass —
+/// this is the deliberate "plain message" case the gate must not break.
+#[test]
+fn send_absent_request_kind_still_passes_2639() {
+    let sender = crate::identity::Sender::new("lead2-test").expect("valid sender name");
+    let args = json!({"instance": "dev", "message": "hi"});
+    let result = super::comms::handle_unified_send(&std::env::temp_dir(), &args, &Some(sender));
+    let err = result.get("error").and_then(|v| v.as_str()).unwrap_or("");
+    assert!(
+        !err.contains("request_kind"),
+        "an absent request_kind must still be treated as a valid plain send: {result}"
+    );
+}
+
 // --- Sprint 33 PR-3: pane_snapshot tests ---
 
 #[test]

--- a/src/mcp/handlers/tests.rs
+++ b/src/mcp/handlers/tests.rs
@@ -2236,6 +2236,62 @@ fn send_kind_query_maps_message_field_to_question() {
     );
 }
 
+/// t-20260705005551919287-14440-22: an unrecognized `request_kind` used to
+/// fall through the dispatch `match`'s `_` arm exactly like an OMITTED one
+/// — silently reinterpreted as a plain send instead of rejected. A typo'd
+/// value (e.g. "qeury") is very likely a caller bug and must be rejected
+/// loudly with a clear error, not silently downgraded.
+#[test]
+fn send_unknown_request_kind_rejected_2620() {
+    let sender = crate::identity::Sender::new("lead2-test").expect("valid sender name");
+    let args = json!({"instance": "dev", "message": "hi", "request_kind": "bogus"});
+    let result = super::comms::handle_unified_send(&std::env::temp_dir(), &args, &Some(sender));
+    let err = result
+        .get("error")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default();
+    assert!(
+        err.contains("unknown request_kind") && err.contains("bogus"),
+        "an unrecognized request_kind must be rejected with a clear error, not \
+         silently treated as a plain send: {result}"
+    );
+}
+
+/// Sibling of the above at the `handle_broadcast` entry point — validated
+/// there too so a direct call (bypassing `handle_unified_send`'s dispatch)
+/// is still covered.
+#[test]
+fn broadcast_unknown_request_kind_rejected_2620() {
+    let sender = crate::identity::Sender::new("lead2-test").expect("valid sender name");
+    let home = std::env::temp_dir();
+    let args = json!({"instances": ["a", "b"], "message": "hi", "request_kind": "bogus"});
+    let result = super::comms::handle_broadcast(&home, &args, &Some(sender));
+    let err = result
+        .get("error")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default();
+    assert!(
+        err.contains("unknown request_kind") && err.contains("bogus"),
+        "an unrecognized request_kind on the broadcast path must also be rejected: {result}"
+    );
+}
+
+/// Each of the four valid `request_kind` values must still pass validation
+/// (not be mistaken for unknown) — the exact set `enum` documents.
+#[test]
+fn send_valid_request_kinds_pass_validation_2620() {
+    for kind in ["task", "report", "query", "update"] {
+        let sender = crate::identity::Sender::new("lead2-test").expect("valid sender name");
+        let args = json!({"instance": "dev", "message": "hi", "request_kind": kind, "task_id": "t-test-fixture"});
+        let result = super::comms::handle_unified_send(&std::env::temp_dir(), &args, &Some(sender));
+        let err = result.get("error").and_then(|v| v.as_str()).unwrap_or("");
+        assert!(
+            !err.contains("unknown request_kind"),
+            "a valid request_kind {kind:?} must never be rejected as unknown: {result}"
+        );
+    }
+}
+
 // --- Sprint 33 PR-3: pane_snapshot tests ---
 
 #[test]


### PR DESCRIPTION
## Summary

Two hygiene items found by dev3 while working on #2636 (`t-20260705005551919287-14440-22`):

1. **`agent_ops::send_to`'s API-down fallback hardcoded `kind: None`** when handing off to `inbox::deliver`, losing the ORIGINAL message kind (`"query"`/`"task"`/etc — threaded through fine on the API-reachable path via the `"kind"` param) the instant the daemon API becomes unreachable. Verified this is live, not hypothetical: `handle_request_information` calls `send_to` with `kind="query"`, and `handle_broadcast` forwards the caller's own `request_kind` (can be `"task"`/`"query"`). A task/query silently landing as `kind=None` loses its obligation classification (poll-reminder doesn't re-arm for it) — not just cosmetic. Fix preserves the original kind on the fallback path.

2. **The `send` MCP tool's `request_kind` had no server-side enum validation** — an unrecognized value (typo, wrong case) fell through the dispatch match's `_` arm exactly like an omitted one, silently reinterpreted as a plain send instead of rejected. Added `comms_gates::request_kind_gate` (mirrors the existing `triaged_gate`/`sha_gate` one-concern-per-file pattern) validating against the same 4 recognized values (`task`/`report`/`query`/`update`), wired into both `handle_unified_send` and `handle_broadcast` (the latter covers a direct call bypassing unified dispatch).

The `request_kind_gate` module also resolves a LOC-ceiling bump (`comms.rs` would have hit 770/750 with the validation inlined) — pulling the gate into its own file both fixes that and matches how every other comms gate in this codebase is already organized.

## Test plan
- [x] New test `send_to_fallback_preserves_original_kind_not_none_2620`: confirmed RED against unmodified code (kind silently dropped to `None`), GREEN after the fix (kind preserved as `"query"`). No live daemon exists in the test's fresh `tmp_home`, so `api::call` fails deterministically and `send_to` takes the real fallback path.
- [x] New tests `send_unknown_request_kind_rejected_2620`, `broadcast_unknown_request_kind_rejected_2620`, `send_valid_request_kinds_pass_validation_2620` — unknown kind rejected at both entry points, all 4 valid kinds still pass.
- [x] `cargo test --bin agend-terminal agent_ops::` — 35/35 pass; `mcp::handlers::` — full pass (6 apparent failures on a `cargo test --test-threads=4` run were confirmed to be a shared-process parallel-execution artifact unrelated to this diff — pass individually and pass together under `cargo nextest` process isolation, matching what CI actually uses).
- [x] `cargo fmt --check` clean; `cargo clippy --all-targets` (default + `--features tray`) clean.
- [x] Full `cargo nextest run` (5262 tests): 5260 passed, 2 failed — both confirmed pre-existing (`e2e_dispatch_review_workflow_seam_invariants_1900`, `teardown_leaves_zero_residual_after_full_exercise_1907`), unrelated to this diff (same two flakes tracked across the last several PRs on this lineage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)