### PR TITLE
docs(heartbeat_pair): warn test authors about the process-global registry hazard

### DIFF
--- a/src/daemon/heartbeat_pair.rs
+++ b/src/daemon/heartbeat_pair.rs
@@ -96,6 +96,42 @@ pub struct HeartbeatPair {
 /// Per-instance lock registry. Keys are agent names (per
 /// `agent::validate_name`); values are the pair locks. Entries are created
 /// lazily on first access via [`pair_for`].
+///
+/// ## Test hazard: process-global, NOT home-scoped, NO reset primitive
+///
+/// This registry is keyed by name ALONE — unlike almost every other piece of
+/// daemon state, it has no `home`/tmp-dir isolation, and there is no
+/// `#[cfg(test)]` reset. Every `#[test]` in the SAME test binary that uses
+/// the same agent-name fixture (e.g. `"worker"`) shares the exact same
+/// `HeartbeatPair` entry, even when each test otherwise uses its own
+/// isolated `tmp_home`. Under `cargo nextest` this is invisible (one process
+/// per test), but under plain `cargo test` (a single shared process — what
+/// CI's `Coverage` job runs) it is a REAL cross-test-file pollution vector:
+/// a test that writes a field this registry tracks (`heartbeat_at_ms`,
+/// `last_input_at_ms`, `waiting_on_since_ms`, `reply_to_channel`, …) via
+/// [`update_with`] or one of its wrappers (`set_waiting_on`, `notify_agent`,
+/// the MCP dispatch chokepoint's implicit-heartbeat bump, `reply_ledger`,
+/// …) leaves that state behind for any LATER test — in any other file, in
+/// any order — that reads the same name via [`snapshot_for`].
+///
+/// Confirmed incident (2026-07-05): `dispatch_idle`'s `#1516` gate tests
+/// (`working_target_does_not_fire_1516` / `idle_target_still_fires_1516` /
+/// `no_snapshot_falls_back_to_firing_1516`, `src/daemon/dispatch_idle/mod.rs`)
+/// all read `"worker"`'s pair via `target_is_working`/
+/// `target_has_active_waiting_on`; a test elsewhere in the binary that
+/// writes to `"worker"`'s pair (e.g. via the `agent_ops::send_to` fallback
+/// path, which calls `inbox::notify_agent` and bumps `last_input_at_ms`)
+/// makes the idle-target test observe a falsely-fresh "working" signal and
+/// wrongly suppress the nudge — deterministic under plain `cargo test`,
+/// invisible under `nextest`. See t-20260705040009178430-63933-1's inventory
+/// for the full audit of which test files/fixture names actually touch this
+/// registry (most fixture-name string collisions across the tree do NOT —
+/// they're unrelated data that happens to share a literal like `"worker"`).
+///
+/// **If you add a test that touches this registry: give the agent-name
+/// fixture a name unique across the WHOLE crate** (e.g. suffix it with the
+/// issue/PR number, as the tests above do), not just unique within your
+/// file — that's the only mitigation in place today.
 fn registry() -> &'static Mutex<HashMap<String, Arc<Mutex<HeartbeatPair>>>> {
     static REGISTRY: OnceLock<Mutex<HashMap<String, Arc<Mutex<HeartbeatPair>>>>> = OnceLock::new();
     REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
@@ -104,6 +140,9 @@ fn registry() -> &'static Mutex<HashMap<String, Arc<Mutex<HeartbeatPair>>>> {
 /// Get (or lazily create) the pair lock for `name`. Subsequent calls with
 /// the same name return the same `Arc` so writers and readers share the
 /// same `Mutex`.
+///
+/// Test authors: see [`registry`]'s doc comment for a real cross-test-file
+/// pollution hazard before picking a fixture agent name.
 pub fn pair_for(name: &str) -> Arc<Mutex<HeartbeatPair>> {
     let mut map = registry().lock();
     map.entry(name.to_string()).or_default().clone()
@@ -111,6 +150,9 @@ pub fn pair_for(name: &str) -> Arc<Mutex<HeartbeatPair>> {
 
 /// Helper: load the pair as a snapshot. Acquires lock briefly, copies the
 /// `Copy` struct, releases. Use when the caller only needs a read view.
+///
+/// Test authors: see [`registry`]'s doc comment for a real cross-test-file
+/// pollution hazard before picking a fixture agent name.
 pub fn snapshot_for(name: &str) -> HeartbeatPair {
     crate::sync_audit::assert_lock_tier(3, "heartbeat_pair");
     let pair = pair_for(name);
@@ -122,6 +164,9 @@ pub fn snapshot_for(name: &str) -> HeartbeatPair {
 /// Callers that also persist to disk MUST call `save_metadata_batch`
 /// AFTER this fn returns (lock-ordering rule: pair lock is leaf-level;
 /// disk I/O happens outside the lock).
+///
+/// Test authors: see [`registry`]'s doc comment for a real cross-test-file
+/// pollution hazard before picking a fixture agent name.
 pub fn update_with<F>(name: &str, f: F)
 where
     F: FnOnce(&mut HeartbeatPair),


### PR DESCRIPTION
## Summary

Follow-up to the heartbeat_pair process-global registry test-hygiene investigation (task `t-20260705040009178430-63933-1`, spawned from #2639's "6 plain-`cargo test` failures, passes under `nextest`" Coverage-job observation).

**The originally-assumed blast radius was wrong.** The dispatch text said "14 files share the `\"worker\"` fixture name → cross-test pollution." A full inventory (Explore fan-out over every direct/indirect touch of the registry, then manually traced) found only **2 files actually collide** — the other 12 reuse the literal `"worker"` for entirely unrelated fixtures (team member lists, task assignee, workspace paths, TUI pane names) that never reach `heartbeat_pair`:

1. `dispatch_idle/mod.rs`'s 3 `#1516` gate tests (`working_target_does_not_fire_1516` / `idle_target_still_fires_1516` / `no_snapshot_falls_back_to_firing_1516`) — read-only, via `target_is_working`/`target_has_active_waiting_on`. Already point-fixed by #2639 (uniquified names).
2. **#2639's own new test** `send_to_fallback_preserves_original_kind_not_none_2620` (`mcp/handlers/tests.rs`) — writes `"worker"`'s `last_input_at_ms` via `agent_ops::send_to`'s fallback path (`-> inbox::deliver -> notify_agent`). **This is the actual root cause** of #2639's reported plain-`cargo test` failures. Routed to #2639 itself (that PR introduces the collision, so the fix belongs there) rather than duplicated in this PR.

## Fix scope (per lead's decision after reviewing the inventory)

Given the real collision surface is 2 files / ~4 tests (not 14), **neither candidate structural fix was warranted**:
- A fixture-name-uniquification sweep across all 14 grep hits would be near-total churn for zero benefit (12 of them don't touch the registry at all).
- A new `cfg(test)` reset/scoped primitive on `heartbeat_pair` — the collision surface is too narrow to justify a new primitive every future test would still have to remember to call (same opt-in-hygiene problem, just relocated).

This PR is the residual: a **permanent warning at the single authoritative source** (`registry()`, plus one-line pointers from the three public accessors `pair_for`/`snapshot_for`/`update_with`) so a future test author picks a crate-unique fixture name before becoming incident #N. This mirrors ad-hoc precedent comments already scattered elsewhere in the codebase (`worktree_pool`/`dispatch_idle` tests already say "process-global registry... a collision would cross-contaminate") — consolidated into the one place a reader would actually look first.

**No functional change — doc comments only.**

## Judgment call: `"alpha"` / `"sender"` (same-file shared names, not touched)

The inventory also found two OTHER fixture names reused across multiple tests within a single file each — genuinely touching `heartbeat_pair` (not string coincidence like the 12 `"worker"` false positives):

- **`"alpha"`** — `src/mcp/handlers/channel_p0a_tests.rs`, 7 tests, via a local `set_reply_to("alpha", ...)` helper + `handle_reply(..., "alpha")`.
- **`"sender"`** — `src/mcp/handlers/tests.rs`, 3 tests (`set_waiting_on_persists_and_clears`, `implicit_heartbeat_recorded_on_tool_call`, `waiting_on_exposed_via_merge_metadata`), via `handle_tool("set_waiting_on"/"inbox", ..., "sender")`.

**Left unchanged, deliberately** — both groups overwrite the exact field they depend on (`reply_to_channel` / `waiting_on_since_ms` / `heartbeat_at_ms`) immediately before reading it back, so leftover state from an earlier test in the same file never changes the outcome (unlike the `dispatch_idle` case, which reads fields it never itself wrote). Both files also already serialize their own tests via a static `Mutex` guard (`registry_guard()` / `fleet_test_guard()`), ruling out a true concurrent-write race too. Renaming them would be gold-plating a failure mode that doesn't reproduce here today.

## CI canary suggestion (not implemented — flagging per dispatch instruction)

`cargo nextest` process-isolates every test, which is why this whole class of bug is invisible in normal CI but bites the `Coverage` job (plain `cargo test --workspace`, per its coverage-tool's requirements) and any local `cargo test` run. Worth considering as a separate follow-up: a lightweight CI canary job running plain `cargo test --workspace` (or a curated subset) specifically to catch this class of hazard before it reaches Coverage — or, cheaper, a comment on the `Coverage` job's workflow YAML pointing back to this doc comment so a future Coverage-only failure gets triaged here first instead of re-diagncosing from scratch.

## Verification

- `cargo nextest run --features tray heartbeat_pair` — 16/16 pass
- `cargo test --features tray --bin agend-terminal heartbeat_pair` (plain, single-process — the exact hazard this PR documents) — 14/14 pass
- `cargo test --features tray --bin agend-terminal dispatch_idle` (plain) — 83/83 pass, including `working_target_does_not_fire_1516`/the other two `#1516` gate tests this PR's comment cites
- `cargo test --workspace --features tray --no-fail-fast` (full workspace, plain): NOT clean in this sandboxed agent worktree, but for an unrelated, pre-existing, environmental reason confirmed by direct log inspection — every one of the ~266 failures traces to `agend-git: FATAL recursion guard tripped (AGEND_GIT_SHIM_DEPTH=3)` (e.g. `worktree::tests::resolve_auto_worktree_flag_on_workspace_reconciles_2234`), i.e. this session's PATH resolves `git` back to the `agend-git` shim instead of real git — every failing test does a real git-worktree/branch operation; zero relate to `heartbeat_pair`/`dispatch_idle`. This is a property of running plain `cargo test` from inside an agent-bound worktree with the shim on `PATH`, not of this diff (which is a doc-comment-only change — `git diff` confirms 45 insertions, 0 deletions, 0 code lines). CI runs in a clean checkout without this shim-on-PATH condition.
- `cargo fmt --check`, `cargo clippy --bin agend-terminal --features tray -- -D warnings` — clean

Refs task `t-20260705040009178430-63933-1`, #2639, #1516.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
