### PR TITLE
feat(#2642 PR-1): FleetConfig::configured_channels() canonical multi-channel view

### DIFF
--- a/src/fleet/mod.rs
+++ b/src/fleet/mod.rs
@@ -310,6 +310,22 @@ pub enum ChannelConfig {
     },
 }
 
+impl ChannelConfig {
+    /// Stable channel-type discriminant (`"telegram"` / `"discord"`), matching
+    /// the serde `type:` tag. Used as the synthetic map key when a singular
+    /// `channel:` is surfaced through the plural [`FleetConfig::configured_channels`]
+    /// view (#2642), and for per-channel log context.
+    // #2642 PR-1 lands the API; bootstrap/init consume it in PR-2. Until then it
+    // is exercised only by tests, so silence the bin-target dead_code lint.
+    #[allow(dead_code)]
+    pub fn type_name(&self) -> &'static str {
+        match self {
+            ChannelConfig::Telegram { .. } => "telegram",
+            ChannelConfig::Discord { .. } => "discord",
+        }
+    }
+}
+
 /// Where fleet activity gets mirrored on a channel. Accepts two YAML
 /// forms for operator ergonomics:
 ///
@@ -714,6 +730,39 @@ impl FleetConfig {
                 }
             }
         }
+    }
+
+    /// #2642: canonical unified view of every configured channel, so
+    /// multi-channel consumers (bootstrap, per-channel `init_from_config`)
+    /// iterate one list instead of branching on singular-vs-plural.
+    ///
+    /// - `channels:` (plural) present and non-empty → all entries, sorted by
+    ///   key for deterministic order (this is what unlocks telegram+discord
+    ///   coexistence in PR-2).
+    /// - else singular `channel:` → a single `(type_name, cfg)` entry (the
+    ///   "singular is a 1-entry map" contract).
+    /// - else (no channel configured) → empty.
+    ///
+    /// Non-mutating: reads only the fields `normalize()` already populated, so
+    /// a single-channel fleet is byte-identical — every existing call site
+    /// still reads `self.channel` directly, and this view returns exactly that
+    /// one channel.
+    // #2642 PR-1 lands the API; bootstrap/init consume it in PR-2. Until then it
+    // is exercised only by tests, so silence the bin-target dead_code lint.
+    #[allow(dead_code)]
+    pub fn configured_channels(&self) -> Vec<(String, &ChannelConfig)> {
+        if let Some(map) = self.channels.as_ref() {
+            if !map.is_empty() {
+                let mut entries: Vec<(String, &ChannelConfig)> =
+                    map.iter().map(|(k, v)| (k.clone(), v)).collect();
+                entries.sort_by(|a, b| a.0.cmp(&b.0));
+                return entries;
+            }
+        }
+        if let Some(cfg) = self.channel.as_ref() {
+            return vec![(cfg.type_name().to_string(), cfg)];
+        }
+        Vec::new()
     }
 
     /// Resolve an instance config by merging with defaults + backend preset.

--- a/src/fleet/tests.rs
+++ b/src/fleet/tests.rs
@@ -557,6 +557,127 @@ instances:
     fs::remove_dir_all(&dir).ok();
 }
 
+// ── #2642 P6 PR-1: `configured_channels()` canonical unified view ──
+// The accessor is purely additive (normalize's field mutations are untouched
+// and pinned by the tests above), so a single-channel production fleet stays
+// byte-identical. PR-2 wires bootstrap/init to consume this view.
+
+#[test]
+fn configured_channels_singular_is_one_entry_byte_identical() {
+    // Production shape: only `channel:` set. The view must return exactly that
+    // one channel (keyed by type), and must NOT have mutated the fields.
+    let dir = std::env::temp_dir().join(format!("agend-fleet-cc-singular-{}", std::process::id()));
+    let path = write_fleet(
+        &dir,
+        r#"
+channel:
+  type: telegram
+  bot_token_env: PROD_TOKEN
+  group_id: -100
+instances: {}
+"#,
+    );
+    let config = FleetConfig::load(&path).expect("load");
+    // Field values untouched (byte-identical to the singular-only input).
+    assert!(config.channel.is_some(), "singular channel preserved");
+    assert!(
+        config.channels.is_none(),
+        "no plural map synthesized into the field"
+    );
+    // Unified view: exactly the one singular channel, keyed by its type.
+    let view = config.configured_channels();
+    assert_eq!(view.len(), 1, "singular is a 1-entry view");
+    assert_eq!(view[0].0, "telegram", "synthetic key is the channel type");
+    match view[0].1 {
+        ChannelConfig::Telegram { bot_token_env, .. } => assert_eq!(bot_token_env, "PROD_TOKEN"),
+        other => panic!("expected the singular telegram channel, got {other:?}"),
+    }
+    fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn configured_channels_plural_returns_all_sorted_incl_mixed_types() {
+    // The coexistence unlock: `channels:` with telegram + discord must surface
+    // BOTH (not just the first-by-name that `normalize()` collapses into
+    // `channel`), sorted by key for determinism.
+    let dir = std::env::temp_dir().join(format!("agend-fleet-cc-plural-{}", std::process::id()));
+    let path = write_fleet(
+        &dir,
+        r#"
+channels:
+  z-telegram:
+    type: telegram
+    bot_token_env: TG_TOKEN
+    group_id: -100
+  a-discord:
+    type: discord
+    bot_token_env: DC_TOKEN
+    guild_id: 999
+instances: {}
+"#,
+    );
+    let config = FleetConfig::load(&path).expect("load");
+    let view = config.configured_channels();
+    let keys: Vec<&str> = view.iter().map(|(k, _)| k.as_str()).collect();
+    assert_eq!(
+        keys,
+        vec!["a-discord", "z-telegram"],
+        "all entries, sorted by key"
+    );
+    assert!(
+        matches!(view[0].1, ChannelConfig::Discord { .. }),
+        "a-discord is discord"
+    );
+    assert!(
+        matches!(view[1].1, ChannelConfig::Telegram { .. }),
+        "z-telegram is telegram"
+    );
+    fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn configured_channels_empty_when_no_channel() {
+    let dir = std::env::temp_dir().join(format!("agend-fleet-cc-none-{}", std::process::id()));
+    let path = write_fleet(&dir, "instances: {}\n");
+    let config = FleetConfig::load(&path).expect("load");
+    assert!(config.configured_channels().is_empty());
+    fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn configured_channels_prefers_plural_when_both_set() {
+    // Mixing `channel:` + `channels:` is not a supported multi-channel config
+    // (the field docs say "prefer channels going forward"). The unified view
+    // treats the explicit plural map as authoritative; the legacy `channel:`
+    // field is left untouched for un-migrated singular readers (pinned by
+    // `test_channel_singular_wins_when_both_set`).
+    let dir = std::env::temp_dir().join(format!("agend-fleet-cc-both-{}", std::process::id()));
+    let path = write_fleet(
+        &dir,
+        r#"
+channel:
+  type: telegram
+  bot_token_env: SINGULAR_TOKEN
+  group_id: -111
+channels:
+  plural-entry:
+    type: telegram
+    bot_token_env: PLURAL_TOKEN
+    group_id: -222
+instances: {}
+"#,
+    );
+    let config = FleetConfig::load(&path).expect("load");
+    let view = config.configured_channels();
+    assert_eq!(view.len(), 1);
+    assert_eq!(view[0].0, "plural-entry");
+    match view[0].1 {
+        ChannelConfig::Telegram { bot_token_env, .. } => assert_eq!(bot_token_env, "PLURAL_TOKEN"),
+        other => panic!("expected plural telegram entry, got {other:?}"),
+    }
+    fs::remove_dir_all(&dir).ok();
+}
+
 #[test]
 fn test_channel_config_default_mode() {
     let dir = std::env::temp_dir().join(format!("agend-fleet-defmode-{}", std::process::id()));


### PR DESCRIPTION
## What

PR-1 of #2642 (config-layer multi-channel coexistence — the deferred residual from #2562 Discord completion). Lands the **read-side foundation**; **PR-2** wires bootstrap / `init_from_config` to consume it.

- `ChannelConfig::type_name()` — stable `"telegram"`/`"discord"` discriminant (the serde `type:` tag), used as the synthetic map key for the singular-as-1-entry view.
- `FleetConfig::configured_channels()` — canonical unified view:
  - plural `channels:` present & non-empty → **all** entries, sorted by key (deterministic) — this is what lets PR-2 iterate one list and register telegram+discord together instead of today's pick-one collapse;
  - else singular `channel:` → a single `(type_name, cfg)` entry (the "singular is a 1-entry map" contract);
  - else → empty.

## Hard constraint: single-channel fleet byte-identical

Production `fleet.yaml` is single-channel telegram; breaking this = all fleet comms down. This PR is **purely additive and non-mutating**:

- `normalize()`'s field writes are **untouched** — its collapse+preserve behavior stays pinned by the existing `test_channels_plural_single_entry_collapses_to_singular`, `test_channels_plural_multi_entry_picks_first_by_name`, `test_channel_singular_wins_when_both_set`.
- `configured_channels()` reads only the fields normalize already populated; a `channel:`-only fleet sees zero behavior change and the view returns exactly that one channel.
- Verified `FleetConfig` is **never re-serialized to disk** after normalize (quickstart/teams/agy write freshly-generated YAML, not round-tripped configs), so both field values and serialized output are unchanged.

## Tests (`fleet::tests`)

- `configured_channels_singular_is_one_entry_byte_identical` — field values untouched (`channel` Some, `channels` None) + 1-entry view keyed by type.
- `configured_channels_plural_returns_all_sorted_incl_mixed_types` — telegram **and** discord both surfaced, sorted (the coexistence unlock).
- `configured_channels_empty_when_no_channel`, `configured_channels_prefers_plural_when_both_set` (documents precedence; legacy `channel:` field left for un-migrated singular readers).

76 fleet tests pass; `cargo clippy --all-targets --features tray -- -D warnings` clean; `cargo fmt --check` clean. (`type_name`/`configured_channels` carry `#[allow(dead_code)]` with a PR-2 pointer — consumed there.)

## Follow-up

PR-2: `init_from_config` reads its own entry + bootstrap consumers iterate `configured_channels()` + telegram singular readers (creds/notify) sweep + coexistence regression (mock-gateway #2625 + telegram fixture). Gates LINE adapter #2342.

🤖 Generated with [Claude Code](https://claude.com/claude-code)