### PR TITLE
feat(#2622 PR-1): channel-reply discharge ledger (data layer)

### DIFF
--- a/src/daemon/channel_reply_discharge.rs
+++ b/src/daemon/channel_reply_discharge.rs
@@ -107,9 +107,31 @@ pub(crate) fn record_discharge(
     discharged_by: &str,
     reason: Option<&str>,
 ) -> anyhow::Result<()> {
-    // PR-1 RED stub — real disk-durable RMW lands in the GREEN commit.
-    let _ = (home, group_key, message_id, discharged_by, reason);
-    Ok(())
+    let key = discharge_key(group_key, message_id);
+    let path = ledger_path(home, &key);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let lock_path = path.with_extension("lock");
+    let _lock = crate::store::acquire_file_lock(&lock_path)?;
+    let mut record: DischargeRecord = std::fs::read_to_string(&path)
+        .ok()
+        .and_then(|c| serde_json::from_str(&c).ok())
+        .unwrap_or_else(|| DischargeRecord {
+            discharged_by: String::new(),
+            discharged_at: String::new(),
+            reason: None,
+            group_key: group_key.filter(|s| !s.is_empty()).map(String::from),
+            message_ids: Vec::new(),
+        });
+    record.discharged_by = discharged_by.to_string();
+    record.discharged_at = chrono::Utc::now().to_rfc3339();
+    record.reason = reason.filter(|s| !s.is_empty()).map(String::from);
+    record.group_key = group_key.filter(|s| !s.is_empty()).map(String::from);
+    if !record.message_ids.iter().any(|m| m == message_id) {
+        record.message_ids.push(message_id.to_string());
+    }
+    crate::store::save_atomic(&path, &record)
 }
 
 /// Look up whether the obligation identified by `(group_key, message_id)` has
@@ -121,9 +143,11 @@ pub(crate) fn is_discharged(
     group_key: Option<&str>,
     message_id: &str,
 ) -> Option<DischargeRecord> {
-    // PR-1 RED stub — real lookup lands in the GREEN commit.
-    let _ = (home, group_key, message_id);
-    None
+    let key = discharge_key(group_key, message_id);
+    let path = ledger_path(home, &key);
+    std::fs::read_to_string(&path)
+        .ok()
+        .and_then(|c| serde_json::from_str(&c).ok())
 }
 
 #[cfg(test)]

--- a/src/daemon/channel_reply_discharge.rs
+++ b/src/daemon/channel_reply_discharge.rs
@@ -1,0 +1,271 @@
+//! #2622 residual-axis PR-1: channel-reply discharge ledger — a disk-durable
+//! record of channel-reply obligations that have been explicitly discharged
+//! ("no longer owed a reply"), so a future consumer (PR-2) can suppress
+//! re-arming an obligation someone already closed.
+//!
+//! ## Why durable (the #2622 root cause this closes)
+//!
+//! `reply_ledger`'s only "this obligation is settled" memory today is
+//! `HeartbeatPair.settled_reply_groups` — **in-memory + a 600 s TTL**
+//! (`SETTLED_GROUP_TTL_MS`). A channel message that keeps redelivering past
+//! that window (the live `m-…-125`: an operator message now 13 days stale)
+//! **re-arms a fresh obligation on every drain**, resetting the nudge ladder
+//! to stage 0 forever. A disk-durable, long-lived discharge record — consulted
+//! by `reply_ledger::arm` before it opens an obligation (PR-2) — is the
+//! structural exit that in-memory + short-TTL state cannot provide. This
+//! mirrors #2537's `discharge_ledger` premise (a memory-only cache replays
+//! every triaged obligation on restart), made empirical by
+//! [`tests::daemon_refresh_survival`] rather than asserted in prose.
+//!
+//! ## Key: `group_key`, with a `message_id` fallback (vetted Fork B)
+//!
+//! `reply_ledger::arm` already keys its in-memory settled-suppression by the
+//! obligation's `group_key` (`sender|content-hash`, `reply_ledger::group_key`).
+//! Keying THIS durable record the same way makes the PR-2 arm guard the exact
+//! durable parallel of that existing check — the "seamless" integration the
+//! design vet required (a discharged group never re-arms, incl. after
+//! restart, AND an operator's resend of the same text — same `group_key`,
+//! new `message_id` — stays discharged). When the inbound had no usable text
+//! (`group_key` is `None`), the record is keyed by `message_id` instead. Both
+//! PR-2 consumers (`arm`, the reply-by-id settle) hold the inbox row and so
+//! compute the same key, keeping lookups O(1). The named `message_id`s are
+//! stored inside the record for audit + the text-less path.
+//!
+//! ## PR-1 scope (zero behavior change, per the dispatching task)
+//!
+//! This module is write/read only. Nothing on the obligation-decision path
+//! (`reply_ledger::arm`, `handle_reply`) calls [`is_discharged`] yet — that
+//! consumer wiring, plus the discharge MCP primitive and the
+//! `channel-reply-discharged` operator-notification kind, are PR-2's job. GC
+//! for stale records is likewise deferred (align to the inbox retention
+//! window when built) — a natural PR-3 follow-up, not built now, mirroring
+//! #2537 PR-1's GC deferral.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// Canonical directory — sibling of `discharge-ledger` (#2537), same on-disk
+/// convention (one JSON file per discharge key).
+pub(crate) fn channel_reply_discharge_dir(home: &Path) -> PathBuf {
+    home.join("channel-reply-discharge")
+}
+
+/// The durable discharge key: the obligation's `group_key` when the inbound
+/// carried usable text, else its `message_id`. Both are untrusted / arbitrary
+/// strings, so the on-disk filename is `sha256(key)` — path-traversal-safe,
+/// mirroring `discharge_ledger::ledger_path` (#2537) and
+/// `ci_watch::registry::watch_filename` (#943).
+fn discharge_key(group_key: Option<&str>, message_id: &str) -> String {
+    group_key
+        .filter(|s| !s.is_empty())
+        .unwrap_or(message_id)
+        .to_string()
+}
+
+fn ledger_path(home: &Path, key: &str) -> PathBuf {
+    channel_reply_discharge_dir(home).join(format!(
+        "{}.json",
+        crate::daemon::utils::sha256_hex(key.as_bytes())
+    ))
+}
+
+/// One discharged channel-reply obligation.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub(crate) struct DischargeRecord {
+    /// The agent name that self-discharged, or `"operator"` for an
+    /// operator-authorized discharge (PR-2 sets this via `operator_gate`).
+    pub discharged_by: String,
+    /// RFC3339 discharge time.
+    pub discharged_at: String,
+    /// Mandatory for agent self-discharge (PR-2 enforces); optional for an
+    /// operator discharge. Empty normalizes to `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    /// The `group_key` this record is keyed by, when the inbound had usable
+    /// text (else `None`, keyed by `message_id`). Stored for audit /
+    /// introspection.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub group_key: Option<String>,
+    /// Every message id known to belong to this discharged obligation (the
+    /// primary the discharge named, plus any that PR-2 records as group
+    /// members). Audit + the text-less fallback path.
+    #[serde(default)]
+    pub message_ids: Vec<String>,
+}
+
+/// Record that the channel-reply obligation identified by
+/// `(group_key, message_id)` was discharged by `discharged_by`. flock +
+/// atomic RMW, mirroring `discharge_ledger::record_discharge` (#2537). The
+/// record is keyed by [`discharge_key`]; a re-discharge of the same key
+/// merges the `message_id` (latest `discharged_by`/`reason`/`at` win — the
+/// obligation is closed either way).
+pub(crate) fn record_discharge(
+    home: &Path,
+    group_key: Option<&str>,
+    message_id: &str,
+    discharged_by: &str,
+    reason: Option<&str>,
+) -> anyhow::Result<()> {
+    // PR-1 RED stub — real disk-durable RMW lands in the GREEN commit.
+    let _ = (home, group_key, message_id, discharged_by, reason);
+    Ok(())
+}
+
+/// Look up whether the obligation identified by `(group_key, message_id)` has
+/// been discharged. `None` = not discharged (no record for this key — the
+/// common case; the obligation is live). Consumed by `reply_ledger::arm`
+/// (PR-2) before it opens an obligation.
+pub(crate) fn is_discharged(
+    home: &Path,
+    group_key: Option<&str>,
+    message_id: &str,
+) -> Option<DischargeRecord> {
+    // PR-1 RED stub — real lookup lands in the GREEN commit.
+    let _ = (home, group_key, message_id);
+    None
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn tmp_home(label: &str) -> PathBuf {
+        let home = std::env::temp_dir().join(format!(
+            "agend-channel-reply-discharge-{}-{label}",
+            std::process::id()
+        ));
+        std::fs::remove_dir_all(&home).ok();
+        std::fs::create_dir_all(&home).unwrap();
+        home
+    }
+
+    #[test]
+    fn write_then_read_round_trip_by_group_key() {
+        let home = tmp_home("roundtrip-gk");
+        record_discharge(
+            &home,
+            Some("user:op|deadbeef"),
+            "m-1",
+            "operator",
+            Some("stale, no longer needed"),
+        )
+        .unwrap();
+
+        let rec = is_discharged(&home, Some("user:op|deadbeef"), "m-1")
+            .expect("a discharged group must read back");
+        assert_eq!(rec.discharged_by, "operator");
+        assert_eq!(rec.reason.as_deref(), Some("stale, no longer needed"));
+        assert_eq!(rec.group_key.as_deref(), Some("user:op|deadbeef"));
+        assert!(rec.message_ids.contains(&"m-1".to_string()));
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn undischarged_obligation_reads_none() {
+        let home = tmp_home("undischarged");
+        assert!(
+            is_discharged(&home, Some("user:op|deadbeef"), "m-1").is_none(),
+            "a live (never-discharged) obligation must read back None"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn operator_resend_same_text_new_id_stays_discharged() {
+        // The seamless-integration guarantee the design vet required: an
+        // operator resending the SAME text lands a new message_id but the
+        // SAME group_key, so a group discharged under m-1 stays discharged
+        // when m-2 (same content) arrives.
+        let home = tmp_home("resend-same-group");
+        record_discharge(&home, Some("user:op|cafe"), "m-1", "operator", None).unwrap();
+
+        let rec = is_discharged(&home, Some("user:op|cafe"), "m-2")
+            .expect("same group_key, different message_id must still read discharged");
+        assert_eq!(rec.group_key.as_deref(), Some("user:op|cafe"));
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn text_less_obligation_keyed_by_message_id() {
+        // No usable text → group_key is None → the record keys by message_id.
+        let home = tmp_home("textless");
+        record_discharge(
+            &home,
+            None,
+            "m-textless",
+            "general",
+            Some("acted, no reply owed"),
+        )
+        .unwrap();
+
+        assert!(
+            is_discharged(&home, None, "m-textless").is_some(),
+            "a text-less obligation must be reachable by its message_id"
+        );
+        assert!(
+            is_discharged(&home, None, "m-other").is_none(),
+            "a different message_id must not collide with it"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn distinct_groups_do_not_collide() {
+        let home = tmp_home("distinct");
+        record_discharge(&home, Some("user:op|aaaa"), "m-1", "operator", None).unwrap();
+
+        assert!(
+            is_discharged(&home, Some("user:op|bbbb"), "m-2").is_none(),
+            "an unrelated group must read back None, not the sibling group's record"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// The empirical proof behind the "must persist to disk, not memory"
+    /// premise: write via one call, read via a completely independent call
+    /// chain sharing only `home` (i.e. the disk) — this module holds no
+    /// in-memory state. A memory-only cache would fail this (the whole reason
+    /// #2622's in-memory `settled_reply_groups` cannot fix the loop).
+    #[test]
+    fn daemon_refresh_survival() {
+        let home = tmp_home("refresh-survival");
+        record_discharge(&home, Some("user:op|beef"), "m-1", "operator", None).unwrap();
+
+        let reopened_home = PathBuf::from(home.to_string_lossy().to_string());
+        assert!(
+            is_discharged(&reopened_home, Some("user:op|beef"), "m-1").is_some(),
+            "the discharge must be readable from disk alone, independent of the writer's in-memory state"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn re_discharge_same_group_merges_ids_latest_wins() {
+        let home = tmp_home("merge");
+        record_discharge(&home, Some("user:op|dd"), "m-1", "operator", Some("first")).unwrap();
+        record_discharge(&home, Some("user:op|dd"), "m-2", "general", Some("second")).unwrap();
+
+        let rec = is_discharged(&home, Some("user:op|dd"), "m-1").unwrap();
+        assert_eq!(rec.discharged_by, "general", "latest discharge wins");
+        assert_eq!(rec.reason.as_deref(), Some("second"));
+        assert!(
+            rec.message_ids.contains(&"m-1".to_string())
+                && rec.message_ids.contains(&"m-2".to_string()),
+            "both message_ids belonging to the group are retained for audit: {:?}",
+            rec.message_ids
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn empty_reason_normalizes_to_none() {
+        let home = tmp_home("empty-reason");
+        record_discharge(&home, Some("user:op|ee"), "m-1", "operator", Some("")).unwrap();
+
+        let rec = is_discharged(&home, Some("user:op|ee"), "m-1").unwrap();
+        assert_eq!(rec.reason, None, "empty-string reason normalizes to None");
+        std::fs::remove_dir_all(&home).ok();
+    }
+}

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -6,6 +6,11 @@ pub(crate) mod auto_release;
 pub(crate) mod boot_sweep;
 pub(crate) mod cadence_gate;
 pub(crate) mod canonical_drift;
+// #2622 PR-1: data layer only — production consumers (`reply_ledger::arm`
+// pre-arm guard, the discharge MCP primitive) are wired in PR-2. Its
+// `pub(crate)` fns are test-exercised only until then.
+#[allow(dead_code)]
+pub(crate) mod channel_reply_discharge;
 pub(crate) mod ci_handoff_track;
 pub(crate) mod ci_watch;
 pub(crate) mod conflict_notify;


### PR DESCRIPTION
## Summary

#2622 residual-axis, **PR-1 of 2** (mirrors #2537's data-layer → consumer split). Design vetted by lead 2026-07-05 (`workspace/gapfix-dev3/CHANNEL-REPLY-DISCHARGE-DESIGN.md`).

**Root cause this closes** (RCA §②): `reply_ledger`'s only "this obligation is settled" memory is `HeartbeatPair.settled_reply_groups` — **in-memory + a 600 s TTL** (`SETTLED_GROUP_TTL_MS`). A channel message that keeps redelivering past that window (the live `m-…-125`: an operator message now 13 days stale) **re-arms a fresh obligation on every drain**, resetting the nudge ladder to stage 0 forever. This module is the disk-durable, long-lived discharge record that an in-memory + short-TTL cache structurally cannot be. PR-2 wires `reply_ledger::arm` to consult it before opening an obligation — the exact durable parallel of `arm`'s existing `group_key`-keyed settled-suppression.

## Scope (this PR — zero behavior change)

`src/daemon/channel_reply_discharge.rs`, write/read only, **no production consumer** (`#[allow(dead_code)]` on the mod until PR-2), exactly like #2537 PR-1:

- `record_discharge(home, group_key, message_id, discharged_by, reason)` — flock + atomic read-modify-write, mirroring `discharge_ledger::record_discharge`'s idiom.
- `is_discharged(home, group_key, message_id) -> Option<DischargeRecord>` — reads the `sha256(key)`-named JSON back; `None` = live (not discharged).
- `DischargeRecord { discharged_by, discharged_at, reason, group_key, message_ids }`.

## Key design (vetted Fork B: "cross-restart-stable + externally-visible")

Keyed by **`group_key`** (`sender|content-hash`, the same identity `reply_ledger::arm` already keys its in-memory settled-suppression by), falling back to **`message_id`** when the inbound had no usable text. The named `message_id`s are stored inside the record for audit + the text-less path. Rationale (the "seamless" integration the vet required): keying this durable record by `group_key` makes PR-2's `arm` guard the exact durable twin of arm's existing group-key check, so **a discharged group never re-arms — including after a daemon restart, and including an operator's resend of the same text (same `group_key`, new `message_id`)**. That last property is proven by `operator_resend_same_text_new_id_stays_discharged`. The discharge *call* (PR-2) will take a `message_id` (the id the operator sees in the nudge — externally visible) and resolve its row's `group_key`, satisfying both halves of Fork B.

Filename is `sha256(key)` — `group_key`/`message_id` are arbitrary/untrusted strings, so this is path-traversal-safe, mirroring `discharge_ledger::ledger_path` (#2537) and `ci_watch::registry::watch_filename` (#943).

## Tests (`src/daemon/channel_reply_discharge.rs`) — reviewer-visible RED→GREEN

Commit `6501aed5` lands the module + 8 tests with **stubbed** bodies (`record` = `Ok` no-op, `is_discharged` = `None`): 6 positive-assertion tests fail, the 2 degenerate-negative tests (undischarged→None, distinct-groups→None) pass against the stub. Commit `6d0e4e86` fills the real disk-durable bodies → 8/8 pass.

- `write_then_read_round_trip_by_group_key`
- `undischarged_obligation_reads_none`
- `operator_resend_same_text_new_id_stays_discharged` (the seamless-suppression guarantee)
- `text_less_obligation_keyed_by_message_id`
- `distinct_groups_do_not_collide`
- `daemon_refresh_survival` (the empirical "must persist to disk, not memory" proof — the exact premise #2622's in-memory `settled_reply_groups` violates)
- `re_discharge_same_group_merges_ids_latest_wins`
- `empty_reason_normalizes_to_none`

## Deferred to PR-2 / PR-3 (stated, not silently dropped)

- **PR-2 (behavior change, DUAL):** wire `reply_ledger::arm`'s pre-arm guard to `is_discharged`; the discharge MCP primitive (operator-unrestricted via `operator_gate`; agent-self reason-mandatory + a one-shot operator notification whose kind lands in **both** #2636 fire-and-forget lists from birth — the fb2461 lesson); ① `reply` optional `message_id` (channel-kind-from-row + dual-ledger settle).
- **PR-3 (deferred):** GC for stale records (align to the inbox retention window), mirroring #2537 PR-1's GC deferral.

## Verification

- `cargo test --features tray --bin agend-terminal channel_reply_discharge` — 8/8 pass
- `tests/src_file_size_invariant.rs` — pass (module 295 LOC)
- `cargo fmt --check`, `cargo clippy --bin agend-terminal --features tray -- -D warnings` — clean

Refs #2622 (residual axis, PR-1 of 2), task t-20260705110020993237-26515-0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)