### PR TITLE
feat(#2604): escalate offline-target unread obligations before the silent 30d sweep

### DIFF
--- a/src/daemon/per_tick/mod.rs
+++ b/src/daemon/per_tick/mod.rs
@@ -59,6 +59,7 @@ pub(crate) mod inject_delivery;
 pub(crate) mod log_rotation;
 pub(crate) mod notification_flush;
 pub(crate) mod notification_watchdogs;
+pub(crate) mod offline_unread_alert;
 pub(crate) mod poll_reminder;
 pub(crate) mod pr_state_scan;
 pub(crate) mod reclaim;
@@ -368,6 +369,13 @@ pub(crate) fn build_default_handlers(
         Box::new(CiWatchPollHandler::new()),
         Box::new(PrStateScanHandler::new()),
         Box::new(InboxMaintenanceHandler::new(60)),
+        // #2604: offline-target unread-obligation escalation. Same 60-tick
+        // cadence as the inbox sweep it races — an offline/nonexistent target's
+        // pending obligations get an operator P0 before `sweep_expired`'s 30-day
+        // TTL silently drops them. Independent handler (self-owned dedup latch),
+        // NOT folded into InboxMaintenanceHandler (that composite takes only
+        // ctx.home; this needs ctx.registry to tell offline from online).
+        Box::new(offline_unread_alert::OfflineUnreadAlertHandler::new(60)),
         // #2549 W3: PollReminder (30 ticks) + InboxStuck watchdog (#1491(A), 30
         // ticks — every agent receiving but not draining its inbox; notifies lead,
         // no auto-restart) + HandoffTimeout watchdog (#1491(B), 12 ticks — #1859

--- a/src/daemon/per_tick/offline_unread_alert.rs
+++ b/src/daemon/per_tick/offline_unread_alert.rs
@@ -1,0 +1,408 @@
+//! #2604: offline-target unread-obligation escalation. When a message with a
+//! real obligation (query / open task) is sent to an instance that is OFFLINE
+//! (not in the live registry) — or never existed — it sits actionable-unread
+//! until `sweep_expired`'s 30-day `UNREAD_TTL_DAYS` backstop SILENTLY drops it
+//! (storage.rs). poll-reminder only nudges the target's OWN pane (useless when
+//! the target is gone); nothing surfaces the pending loss to an operator.
+//!
+//! This watchdog closes that gap: per tick (60-cadence, co-located with the
+//! inbox-maintenance sweep it races against) it scans every inbox file, and for
+//! each agent that is (a) offline and (b) has an obligation older than the
+//! threshold, pages ALL operator escalation channels
+//! ([`crate::channel::notify_all_escalation_channels`]) + writes an event-log
+//! row. Fire-and-forget rows (report / update / ci-watch / poll, post-#2636)
+//! are NOT obligations — they carry no waiting work, so they never trip the P0
+//! (their count rides along in the alert body only, as context).
+//!
+//! Dedup: per-agent, count-keyed (mirrors poll-reminder's
+//! `should_notify_and_record`) — a fixed obligation backlog pages ONCE; a NEW
+//! obligation piling on (count change) re-pages; draining to zero (agent
+//! returned) or the backlog dropping below threshold resets the latch so a
+//! later re-accumulation can page again. Latch entries for inboxes that
+//! vanished (swept / deleted) are pruned each run so the map can't grow
+//! unbounded.
+
+use super::{PerTickHandler, TickContext};
+use parking_lot::Mutex;
+use std::collections::{HashMap, HashSet};
+
+/// Default obligation-age threshold before an offline target is escalated.
+/// Must stay well below `UNREAD_TTL_DAYS` (30) so the operator is paged with
+/// runway to act before the silent sweep. Override:
+/// `AGEND_OFFLINE_UNREAD_ALERT_DAYS`.
+const DEFAULT_ALERT_DAYS: i64 = 7;
+/// The inbox unread sweep TTL this watchdog races (storage.rs `UNREAD_TTL_DAYS`),
+/// surfaced in the alert body so the operator knows the drop-dead window.
+const UNREAD_TTL_DAYS: i64 = 30;
+
+fn alert_threshold_days() -> i64 {
+    std::env::var("AGEND_OFFLINE_UNREAD_ALERT_DAYS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .filter(|d| *d > 0)
+        .unwrap_or(DEFAULT_ALERT_DAYS)
+}
+
+/// Pure dedup decision, isolated for unit testing. `last_escalated` = the count
+/// last paged at (`None` = never / reset). Fire when the count is non-zero AND
+/// differs from the last escalated count (first crossing, or a genuinely
+/// larger/smaller backlog). A zero count resets the latch to `None` so a future
+/// re-accumulation pages again. Mutates `last_escalated` to the new state.
+fn decide(last_escalated: &mut Option<usize>, obligation_count: usize) -> bool {
+    if obligation_count == 0 {
+        *last_escalated = None;
+        return false;
+    }
+    if *last_escalated == Some(obligation_count) {
+        return false;
+    }
+    *last_escalated = Some(obligation_count);
+    true
+}
+
+/// Classify an offline target for the alert wording. An agent absent from the
+/// registry is OFFLINE if still declared in fleet.yaml, NONEXISTENT if declared
+/// nowhere (a message addressed to a name that never was).
+fn describe_target(name: &str, fleet_instances: &HashSet<String>) -> &'static str {
+    if fleet_instances.contains(name) {
+        "offline"
+    } else {
+        "nonexistent"
+    }
+}
+
+pub(crate) struct OfflineUnreadAlertHandler {
+    gate: crate::daemon::cadence_gate::CadenceGate,
+    /// Per-agent last-escalated obligation count (dedup latch). Presence = last
+    /// escalated count; absence = never escalated / reset.
+    latch: Mutex<HashMap<String, usize>>,
+}
+
+impl OfflineUnreadAlertHandler {
+    pub(crate) fn new(every_n_ticks: u64) -> Self {
+        Self {
+            gate: crate::daemon::cadence_gate::CadenceGate::new(every_n_ticks),
+            latch: Mutex::new(HashMap::new()),
+        }
+    }
+}
+
+impl PerTickHandler for OfflineUnreadAlertHandler {
+    fn name(&self) -> &'static str {
+        "offline_unread_alert"
+    }
+
+    fn run(&self, ctx: &TickContext<'_>) {
+        if !self.gate.fire() {
+            return;
+        }
+
+        // Phase 1 (locked, cheap): snapshot the ONLINE agent names — an agent in
+        // the live registry is not offline, so it's excluded here and its own
+        // poll-reminder handles its unread. Drop the lock before any inbox /
+        // task-board IO (#1617 fleet-stall class).
+        let online: HashSet<String> = {
+            let reg = crate::agent::lock_registry(ctx.registry);
+            reg.values().map(|h| h.name.as_str().to_string()).collect()
+        };
+
+        // fleet.yaml membership distinguishes "offline (declared, not running)"
+        // from "nonexistent (addressed name that never was)" — both escalate,
+        // only the wording differs.
+        let fleet_instances: HashSet<String> =
+            crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(ctx.home))
+                .map(|f| f.instances.keys().cloned().collect())
+                .unwrap_or_default();
+
+        let threshold_days = alert_threshold_days();
+        let threshold = chrono::Duration::days(threshold_days);
+        let now = chrono::Utc::now();
+
+        // Phase 2 (unlocked): scan every inbox file. `seen` collects the live
+        // inbox agent-name set for the latch prune below.
+        let mut seen: HashSet<String> = HashSet::new();
+        let mut latch = self.latch.lock();
+        for name in crate::inbox::inbox_agent_names(ctx.home) {
+            seen.insert(name.clone());
+            // Online agents are not our concern (poll-reminder owns them); keep
+            // no latch entry so a later going-offline starts clean.
+            if online.contains(&name) {
+                latch.remove(&name);
+                continue;
+            }
+            let summary: crate::inbox::UnreadObligationSummary =
+                crate::inbox::unread_obligation_summary(ctx.home, &name);
+            // Only obligations older than the threshold are escalation-worthy.
+            let over_threshold = summary
+                .oldest_obligation
+                .is_some_and(|ts| now.signed_duration_since(ts) >= threshold);
+            let escalate_count = if over_threshold {
+                summary.obligation_count
+            } else {
+                0
+            };
+            // Latch presence = last escalated count; absence = never / reset.
+            let mut last = latch.get(&name).copied();
+            let fire = decide(&mut last, escalate_count);
+            match last {
+                Some(c) => {
+                    latch.insert(name.clone(), c);
+                }
+                None => {
+                    latch.remove(&name);
+                }
+            }
+            if !fire {
+                continue;
+            }
+            let oldest_age_days = summary
+                .oldest_obligation
+                .map(|ts| now.signed_duration_since(ts).num_days())
+                .unwrap_or(0);
+            let target_kind = describe_target(&name, &fleet_instances);
+            let msg = format!(
+                "[offline-unread] {target_kind} target '{name}' has {escalate_count} \
+                 unhandled obligation(s) (oldest {oldest_age_days}d, threshold \
+                 {threshold_days}d) sitting unread — the target is not running, so \
+                 poll-reminder cannot reach it. These will be SILENTLY dropped by \
+                 the {UNREAD_TTL_DAYS}-day inbox sweep unless the target is \
+                 restarted (or the sender reassigns). ({} total unread incl. \
+                 fire-and-forget, context only.)",
+                summary.raw_unread_total,
+            );
+            let dispatched = crate::channel::notify_all_escalation_channels(
+                &name,
+                crate::channel::NotifySeverity::Error,
+                &msg,
+                false,
+            );
+            crate::event_log::log(ctx.home, "offline_unread_alert", &name, &msg);
+            tracing::info!(
+                agent = %name,
+                target_kind,
+                obligations = escalate_count,
+                oldest_age_days,
+                channels = dispatched,
+                "offline_unread_alert: escalated offline target's unread obligation backlog"
+            );
+        }
+        // Prune latch entries whose inbox no longer exists (swept / deleted), so
+        // the map tracks only currently-present inboxes (cleanup-on-delete).
+        latch.retain(|name, _| seen.contains(name));
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decide_fires_once_then_dedups_same_count() {
+        let mut latch = None;
+        assert!(decide(&mut latch, 3), "first non-zero count fires");
+        assert!(!decide(&mut latch, 3), "same count dedups");
+        assert!(!decide(&mut latch, 3), "still dedups");
+    }
+
+    #[test]
+    fn decide_refires_on_count_change() {
+        let mut latch = None;
+        assert!(decide(&mut latch, 2));
+        assert!(decide(&mut latch, 4), "a larger backlog re-pages");
+        assert!(
+            decide(&mut latch, 1),
+            "a smaller (but non-zero) backlog re-pages"
+        );
+    }
+
+    #[test]
+    fn decide_zero_count_resets_latch_and_never_fires() {
+        let mut latch = Some(5);
+        assert!(!decide(&mut latch, 0), "zero count never fires");
+        assert_eq!(latch, None, "zero resets the latch");
+        // After reset, a re-accumulation to the SAME prior count pages again.
+        assert!(
+            decide(&mut latch, 5),
+            "re-accumulation after reset re-pages"
+        );
+    }
+
+    #[test]
+    fn decide_below_threshold_zero_behaves_like_drained() {
+        // The handler passes escalate_count=0 when under the age threshold; that
+        // must behave exactly like a drained backlog (reset, no page).
+        let mut latch = Some(3);
+        assert!(!decide(&mut latch, 0));
+        assert_eq!(latch, None);
+    }
+
+    #[test]
+    fn describe_target_distinguishes_offline_from_nonexistent() {
+        let mut fleet = HashSet::new();
+        fleet.insert("declared".to_string());
+        assert_eq!(describe_target("declared", &fleet), "offline");
+        assert_eq!(describe_target("ghost", &fleet), "nonexistent");
+    }
+
+    #[test]
+    fn threshold_env_override_positive_only() {
+        std::env::remove_var("AGEND_OFFLINE_UNREAD_ALERT_DAYS");
+        assert_eq!(alert_threshold_days(), DEFAULT_ALERT_DAYS);
+        // A zero / negative override is rejected (falls back to default) so the
+        // watchdog can't be silently turned into paging on every fresh unread.
+        std::env::set_var("AGEND_OFFLINE_UNREAD_ALERT_DAYS", "0");
+        assert_eq!(alert_threshold_days(), DEFAULT_ALERT_DAYS);
+        std::env::set_var("AGEND_OFFLINE_UNREAD_ALERT_DAYS", "14");
+        assert_eq!(alert_threshold_days(), 14);
+        std::env::remove_var("AGEND_OFFLINE_UNREAD_ALERT_DAYS");
+    }
+
+    // ── run() integration (REAL entry point) ──
+
+    use parking_lot::Mutex as PLMutex;
+    use std::path::Path;
+    use std::sync::Arc;
+
+    fn tmp_home(tag: &str) -> std::path::PathBuf {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "agend-offline-alert-{}-{}-{}",
+            std::process::id(),
+            tag,
+            id
+        ));
+        std::fs::create_dir_all(&dir).ok();
+        dir
+    }
+
+    fn seed_obligation(home: &Path, agent: &str, id: &str, days_ago: i64) {
+        let ts = (chrono::Utc::now() - chrono::Duration::days(days_ago)).to_rfc3339();
+        crate::inbox::enqueue(
+            home,
+            agent,
+            crate::inbox::InboxMessage {
+                schema_version: 1,
+                id: Some(id.to_string()),
+                from: "lead".to_string(),
+                kind: Some("query".to_string()),
+                timestamp: ts,
+                text: "please reply".to_string(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    }
+
+    fn empty_ctx_parts() -> (
+        crate::agent::AgentRegistry,
+        crate::agent::ExternalRegistry,
+        Arc<PLMutex<HashMap<String, crate::daemon::AgentConfig>>>,
+    ) {
+        (
+            Arc::new(PLMutex::new(HashMap::new())),
+            Arc::new(PLMutex::new(HashMap::new())),
+            Arc::new(PLMutex::new(HashMap::new())),
+        )
+    }
+
+    fn event_log(home: &Path) -> String {
+        std::fs::read_to_string(home.join("event-log.jsonl")).unwrap_or_default()
+    }
+
+    /// An OFFLINE agent (empty registry) with an obligation older than the
+    /// threshold escalates: an `offline_unread_alert` event-log row naming the
+    /// agent is written (the operator-visible artifact; the channel fan-out is a
+    /// no-op with no channel registered, which is fine — the row still lands).
+    #[test]
+    fn offline_over_threshold_escalates_2604() {
+        let home = tmp_home("over");
+        seed_obligation(&home, "gone", "q-old", 10); // 10d > 7d default
+        let (registry, externals, configs) = empty_ctx_parts();
+        let ctx = TickContext {
+            home: &home,
+            registry: &registry,
+            externals: &externals,
+            configs: &configs,
+        };
+        OfflineUnreadAlertHandler::new(1).run(&ctx);
+        let log = event_log(&home);
+        assert!(
+            log.contains("offline_unread_alert") && log.contains("gone"),
+            "offline over-threshold obligation must write an escalation event-log row: {log}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// An obligation YOUNGER than the threshold does not escalate (the operator
+    /// still has runway before the 30-day sweep).
+    #[test]
+    fn offline_under_threshold_does_not_escalate_2604() {
+        let home = tmp_home("under");
+        seed_obligation(&home, "gone", "q-fresh", 1); // 1d < 7d default
+        let (registry, externals, configs) = empty_ctx_parts();
+        let ctx = TickContext {
+            home: &home,
+            registry: &registry,
+            externals: &externals,
+            configs: &configs,
+        };
+        OfflineUnreadAlertHandler::new(1).run(&ctx);
+        assert!(
+            !event_log(&home).contains("offline_unread_alert"),
+            "a fresh obligation (under threshold) must NOT escalate"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// An ONLINE agent (present in the registry) is skipped even with an old
+    /// obligation — its own poll-reminder owns it; the offline watchdog must not
+    /// double-page. Reverse-regression for the registry-membership skip.
+    #[test]
+    fn online_agent_with_old_obligation_skipped_2604() {
+        let home = tmp_home("online");
+        seed_obligation(&home, "alive", "q-old", 10);
+        let (registry, externals, configs) = empty_ctx_parts();
+        let (handle, _reader) = crate::daemon::per_tick::mock_live_agent_no_context("alive");
+        registry.lock().insert(handle.id, handle);
+        let ctx = TickContext {
+            home: &home,
+            registry: &registry,
+            externals: &externals,
+            configs: &configs,
+        };
+        OfflineUnreadAlertHandler::new(1).run(&ctx);
+        assert!(
+            !event_log(&home).contains("offline_unread_alert"),
+            "an ONLINE agent must be skipped (poll-reminder owns it), no offline escalation"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Dedup across ticks: the same backlog pages ONCE, not every tick.
+    #[test]
+    fn repeated_run_dedups_same_backlog_2604() {
+        let home = tmp_home("dedup");
+        seed_obligation(&home, "gone", "q-old", 10);
+        let (registry, externals, configs) = empty_ctx_parts();
+        let ctx = TickContext {
+            home: &home,
+            registry: &registry,
+            externals: &externals,
+            configs: &configs,
+        };
+        let h = OfflineUnreadAlertHandler::new(1);
+        h.run(&ctx);
+        let rows_after_first = event_log(&home).matches("offline_unread_alert").count();
+        h.run(&ctx);
+        let rows_after_second = event_log(&home).matches("offline_unread_alert").count();
+        assert_eq!(rows_after_first, 1, "first run escalates once");
+        assert_eq!(
+            rows_after_second, 1,
+            "second run with the SAME backlog must be deduped (no new row)"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+}

--- a/src/inbox/mod.rs
+++ b/src/inbox/mod.rs
@@ -29,9 +29,10 @@ pub use disk::{check_disk_space, recover_half_writes};
 // Storage CRUD (pub)
 pub use storage::{
     ack, ack_by_correlation, clear_compact, describe_message, drain, enqueue, find_message,
-    get_thread, has_drained_blocker_for_correlation, mark_ci_watch_superseded, obligation_reason,
-    reclaim_stale_delivering, settle_delivering_for_session_reset, sweep_expired, unread_count,
-    unread_count_after_discharge,
+    get_thread, has_drained_blocker_for_correlation, inbox_agent_names, mark_ci_watch_superseded,
+    obligation_reason, reclaim_stale_delivering, settle_delivering_for_session_reset,
+    sweep_expired, unread_count, unread_count_after_discharge, unread_obligation_summary,
+    UnreadObligationSummary,
 };
 // Storage CRUD (pub(crate))
 pub(crate) use storage::inbox_path_resolved;

--- a/src/inbox/storage.rs
+++ b/src/inbox/storage.rs
@@ -305,6 +305,17 @@ fn inbox_files(home: &Path) -> impl Iterator<Item = PathBuf> {
         .filter(|path| path.extension().and_then(|e| e.to_str()) == Some("jsonl"))
 }
 
+/// #2604: the agent names with an inbox file (the `*.jsonl` file stems under
+/// `home/inbox`). The offline-unread watchdog iterates these to reach agents
+/// that are NOT in the live registry (offline / never-existed) — the exact set
+/// `poll_reminder` (registry-driven) can never see. A `read_dir` error yields an
+/// empty iteration, same as [`inbox_files`].
+pub fn inbox_agent_names(home: &Path) -> Vec<String> {
+    inbox_files(home)
+        .filter_map(|p| p.file_stem().and_then(|s| s.to_str()).map(String::from))
+        .collect()
+}
+
 /// Enqueue a message — in-place flock'd append + fsync (O(1) JSONL append).
 ///
 /// NOT crash-atomic: enqueue appends in place — no tmp+rename (only the
@@ -1442,6 +1453,63 @@ pub fn obligation_reason(home: &Path, msg: &InboxMessage) -> Option<String> {
         }
         _ => None,
     }
+}
+
+/// #2604: per-agent split of ACTIONABLE-UNREAD messages into real OBLIGATIONS
+/// (query / open task, via [`obligation_reason`]) vs the raw unread total, plus
+/// the timestamp of the OLDEST obligation (the escalation watermark).
+///
+/// The offline-target escalation watchdog
+/// ([`crate::daemon::per_tick::offline_unread_alert`]) keys the operator P0 on
+/// the OBLIGATION watermark, not raw unread: a fire-and-forget report/update
+/// piling up for an offline agent is not lost work (post-#2636 those kinds are
+/// classified non-obligation), so it must never trip an Error-severity page.
+/// `raw_unread_total` is carried only as context for the alert body.
+///
+/// LOCK-DISCIPLINE (mirrors [`unread_count`] + the [`obligation_reason`] warning):
+/// reads the inbox file WITHOUT [`with_inbox_lock`] and calls [`obligation_reason`]
+/// (task-board IO for `kind=task`). Safe ONLY because the per-tick caller runs it
+/// unlocked — calling it inside an inbox flock is the #1617 fleet-stall class.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct UnreadObligationSummary {
+    /// Actionable-unread rows that are real obligations (query / open task).
+    pub obligation_count: usize,
+    /// Timestamp of the oldest obligation row — `None` when `obligation_count == 0`.
+    pub oldest_obligation: Option<chrono::DateTime<chrono::Utc>>,
+    /// All actionable-unread rows (obligations + fire-and-forget), context only.
+    pub raw_unread_total: usize,
+}
+
+pub fn unread_obligation_summary(home: &Path, name: &str) -> UnreadObligationSummary {
+    let path = inbox_path_resolved(home, name);
+    let content = match std::fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(_) => return UnreadObligationSummary::default(),
+    };
+    let mut summary = UnreadObligationSummary::default();
+    for line in content.lines() {
+        let msg: InboxMessage = match serde_json::from_str(line) {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        // Actionable-unread filter — the SAME predicate as `UnreadProbe::is_unread`
+        // (storage.rs, post-#2299): a delivering (in-flight) / superseded (silently
+        // retired by drain) / read row is not actionable unread.
+        if msg.read_at.is_some() || msg.delivering_at.is_some() || msg.superseded_by.is_some() {
+            continue;
+        }
+        summary.raw_unread_total += 1;
+        if obligation_reason(home, &msg).is_some() {
+            summary.obligation_count += 1;
+            if let Ok(ts) = chrono::DateTime::parse_from_rfc3339(&msg.timestamp) {
+                let ts_utc = ts.with_timezone(&chrono::Utc);
+                if summary.oldest_obligation.is_none_or(|t| t > ts_utc) {
+                    summary.oldest_obligation = Some(ts_utc);
+                }
+            }
+        }
+    }
+    summary
 }
 
 /// #t-…61487: is a reverted (stale-`delivering` → unread) row worth RE-ARMING the

--- a/src/inbox/tests.rs
+++ b/src/inbox/tests.rs
@@ -4665,3 +4665,116 @@ fn ack_by_correlation_idempotent() {
 
     fs::remove_dir_all(&home).ok();
 }
+
+// ── #2604: unread_obligation_summary (offline-target escalation input) ──
+
+/// Core split: only real obligations (query / open task) count toward the
+/// escalation watermark; fire-and-forget (report / update) rides in
+/// raw_unread_total only. `oldest_obligation` is the EARLIEST obligation ts.
+#[test]
+fn unread_obligation_summary_splits_obligations_from_fire_and_forget_2604() {
+    let home = tmp_home("oblig-split");
+    // Two obligations (query) at distinct timestamps + two fire-and-forget.
+    enqueue(
+        &home,
+        "off",
+        msg()
+            .sender("lead")
+            .kind("query")
+            .timestamp("2025-06-01T00:00:00Z")
+            .text("newer q")
+            .build(),
+    )
+    .unwrap();
+    enqueue(
+        &home,
+        "off",
+        msg()
+            .sender("lead")
+            .kind("query")
+            .timestamp("2025-01-01T00:00:00Z")
+            .text("older q")
+            .build(),
+    )
+    .unwrap();
+    enqueue(
+        &home,
+        "off",
+        msg().sender("x").kind("report").text("r").build(),
+    )
+    .unwrap();
+    enqueue(
+        &home,
+        "off",
+        msg().sender("x").kind("update").text("u").build(),
+    )
+    .unwrap();
+
+    let s = unread_obligation_summary(&home, "off");
+    assert_eq!(s.obligation_count, 2, "only the 2 queries are obligations");
+    assert_eq!(
+        s.raw_unread_total, 4,
+        "raw total counts all 4 actionable-unread rows"
+    );
+    let oldest = s.oldest_obligation.expect("has an obligation");
+    assert_eq!(
+        oldest,
+        chrono::DateTime::parse_from_rfc3339("2025-01-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc),
+        "oldest_obligation is the EARLIEST obligation ts, not the fire-and-forget"
+    );
+    fs::remove_dir_all(&home).ok();
+}
+
+/// A read (drained) obligation is not actionable unread — excluded from both
+/// the obligation count and the raw total (same predicate as unread_count).
+#[test]
+fn unread_obligation_summary_excludes_read_row_2604() {
+    let home = tmp_home("oblig-read");
+    enqueue(
+        &home,
+        "off",
+        msg()
+            .sender("lead")
+            .kind("query")
+            .id("q-read")
+            .text("will read")
+            .build(),
+    )
+    .unwrap();
+    // Drain stamps read_at on the first query.
+    let drained = drain(&home, "off");
+    assert_eq!(drained.len(), 1);
+    // A second, still-unread obligation.
+    enqueue(
+        &home,
+        "off",
+        msg()
+            .sender("lead")
+            .kind("query")
+            .id("q-live")
+            .text("still unread")
+            .build(),
+    )
+    .unwrap();
+
+    let s = unread_obligation_summary(&home, "off");
+    assert_eq!(
+        s.obligation_count, 1,
+        "the drained (read) obligation must not count, only the live unread one"
+    );
+    assert_eq!(s.raw_unread_total, 1);
+    fs::remove_dir_all(&home).ok();
+}
+
+/// No inbox file → zeroed summary (never panics), matching unread_count.
+#[test]
+fn unread_obligation_summary_empty_inbox_is_default_2604() {
+    let home = tmp_home("oblig-empty");
+    let s = unread_obligation_summary(&home, "nobody");
+    assert_eq!(s.obligation_count, 0);
+    assert_eq!(s.raw_unread_total, 0);
+    assert!(s.oldest_obligation.is_none());
+    fs::remove_dir_all(&home).ok();
+}


### PR DESCRIPTION
Closes #2604.

## Problem

A message carrying a real obligation (query / open task) sent to an **offline** target (not in the live registry) — or a name that never existed — sits actionable-unread until `sweep_expired`'s 30-day `UNREAD_TTL_DAYS` backstop **silently** drops it. `poll-reminder` only nudges the target's own pane (useless when the target is gone); nothing surfaces the pending loss to an operator.

## Change

New per-tick watchdog `OfflineUnreadAlertHandler` (60-tick cadence, co-located with the inbox sweep it races). Per tick it scans every inbox file, and for each agent that is **(a) offline** (absent from the live registry) and **(b) has an obligation older than the threshold**, pages **all** operator escalation channels (`notify_all_escalation_channels`, `Error` severity) + writes an event-log row.

- **Threshold** `AGEND_OFFLINE_UNREAD_ALERT_DAYS` (default **7d**, well under the 30d sweep so the operator has runway). A non-positive override is rejected (can't silently degrade into paging on every fresh unread).
- **Obligation-scoped (lead-vetted, ref #2636):** keys on obligation-unread via `obligation_reason()` — the single source of truth already shared by inbox-clear's KEEP-set and the reclaim re-nudge gate, so this alert stays consistent with those consumers. Post-#2636 fire-and-forget kinds (report/update/ci-watch/poll) are not lost work; they ride in the alert body as raw-unread **context** only, never trip the P0.
- **offline vs nonexistent:** fleet.yaml membership distinguishes a declared-but-not-running target from a name that never was; both escalate, only the wording differs.
- **Dedup:** per-agent count-keyed latch (mirrors poll-reminder) — a fixed backlog pages once; a new obligation (count change) re-pages; draining to zero or dropping below threshold resets it; latch entries for vanished (swept/deleted) inboxes are pruned each run.
- **Lock discipline:** the new `unread_obligation_summary()` reads the inbox unlocked and calls `obligation_reason()` (task-board IO) only in the unlocked per-tick pass — same #1617 fleet-stall rule the existing `unread_count` / reclaim paths follow.

## Premise verification (done before coding, per lead's ask)

Confirmed the #2604 gap is real and un-fixed on latest main: `sweep_expired` drops unread at `UNREAD_TTL_DAYS=30` with zero notification; `is_unread` unchanged by today's #2636/#2638/#2639. The one premise that #2636 *did* touch — which kinds are fire-and-forget vs obligations — is exactly why this keys on `obligation_reason` (lead chose obligation-scoping over raw-unread).

## Tests

- Pure units (RED-checkable, no IO): `decide` dedup/reset, `describe_target` offline/nonexistent, threshold env override.
- `run()` integration: offline-over-threshold **escalates** (event-log row), under-threshold **skipped**, **online** agent skipped (poll-reminder owns it), cross-tick **dedup**.
- Inbox `unread_obligation_summary` units: obligation vs fire-and-forget split + oldest-obligation watermark, read-row exclusion, empty-inbox default.
- App-mode completeness invariant + LOC ceilings + clippy + fmt all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)