### PR TITLE
feat(#2642 PR-2): register telegram+discord together — consume configured_channels()

### DIFF
--- a/src/app/telegram_hooks.rs
+++ b/src/app/telegram_hooks.rs
@@ -11,18 +11,18 @@ use std::path::Path;
 
 /// Derive Telegram status from an already-loaded FleetConfig (no disk I/O).
 pub(super) fn telegram_status_from_config(config: &crate::fleet::FleetConfig) -> TelegramStatus {
-    match config.channel {
-        Some(crate::fleet::ChannelConfig::Telegram {
-            ref bot_token_env, ..
-        }) => {
+    // #2642: resolve Telegram from the unified multi-channel view so the TUI
+    // status is correct in a telegram+discord fleet (not only when Telegram is
+    // the first-sorted / singular channel). Single-channel telegram unchanged.
+    match config.telegram_channel() {
+        Some(crate::fleet::ChannelConfig::Telegram { bot_token_env, .. }) => {
             if std::env::var(bot_token_env).is_ok() {
                 TelegramStatus::Connected
             } else {
                 TelegramStatus::NoToken
             }
         }
-        None => TelegramStatus::NotConfigured,
-        Some(crate::fleet::ChannelConfig::Discord { .. }) => TelegramStatus::NotConfigured,
+        _ => TelegramStatus::NotConfigured,
     }
 }
 

--- a/src/channel/discord/bootstrap.rs
+++ b/src/channel/discord/bootstrap.rs
@@ -75,14 +75,19 @@ pub(crate) fn init_from_config_with_source(
         mpsc::Sender<ChannelEvent>,
     ),
 ) -> Option<DiscordChannel> {
-    let (bot_token_env, guild_id, user_allowlist) = match config.channel.as_ref()? {
-        crate::fleet::ChannelConfig::Telegram { .. } => return None,
-        crate::fleet::ChannelConfig::Discord {
-            bot_token_env,
-            guild_id,
-            user_allowlist,
-        } => (bot_token_env, *guild_id, user_allowlist.clone()),
+    // #2642: resolve the Discord channel from the unified multi-channel view
+    // (not the singular `config.channel`), so a telegram+discord fleet inits
+    // Discord even when Telegram is also present or sorts first.
+    let Some(crate::fleet::ChannelConfig::Discord {
+        bot_token_env,
+        guild_id,
+        user_allowlist,
+    }) = config.discord_channel()
+    else {
+        return None;
     };
+    let guild_id = *guild_id;
+    let user_allowlist = user_allowlist.clone();
     let token = match std::env::var(bot_token_env) {
         Ok(t) => t,
         Err(_) => {

--- a/src/channel/discord/tests.rs
+++ b/src/channel/discord/tests.rs
@@ -1701,3 +1701,58 @@ fn init_from_config_with_source_wires_config_to_inbox() {
     );
     let _ = std::fs::remove_dir_all(&home);
 }
+
+/// #2642 coexistence: a telegram+discord fleet must still assemble the Discord
+/// channel via the same #2625 bootstrap seam. Discord init now resolves its OWN
+/// entry (`discord_channel()`) from the unified multi-channel view instead of
+/// the singular `config.channel`, so the presence of telegram — even sorted
+/// FIRST (`a-telegram` < `z-discord`, the exact state that collapses the singular
+/// primary to telegram) — no longer returns None and skips discord.
+#[test]
+#[serial]
+fn discord_init_assembles_alongside_telegram_2642() {
+    let channel_id = 290926798999357250_u64;
+    let author_id = 82198898841029460_i64;
+    let token_env = "AGEND_TEST_DISCORD_TOKEN_2642";
+    let text = "coexistence bootstrap e2e ".repeat(10); // ≥ 200 chars
+
+    std::env::set_var(token_env, "Bot dummy-2642-token");
+    let mut channels = std::collections::HashMap::new();
+    channels.insert(
+        "a-telegram".to_string(),
+        crate::fleet::ChannelConfig::Telegram {
+            bot_token_env: "AGEND_TEST_TG_2642".into(),
+            group_id: -1,
+            mode: "topic".into(),
+            user_allowlist: Some(vec![]),
+            fleet_binding: None,
+        },
+    );
+    channels.insert(
+        "z-discord".to_string(),
+        crate::fleet::ChannelConfig::Discord {
+            bot_token_env: token_env.to_string(),
+            guild_id: 42,
+            user_allowlist: Some(vec![author_id]),
+        },
+    );
+    let config = crate::fleet::FleetConfig {
+        channels: Some(channels),
+        ..Default::default()
+    };
+
+    let inner = text.clone();
+    let ch =
+        super::init_from_config_with_source(&config, move |_token, _intents, allowlist, tx| {
+            let event = message_create_event(channel_id, author_id as u64, &inner);
+            if let Some(msg) = super::gateway_event_to_channel_event(event, &allowlist) {
+                let _ = tx.send(msg);
+            }
+        });
+    std::env::remove_var(token_env);
+
+    assert!(
+        ch.is_some(),
+        "discord must assemble from a telegram+discord fleet (coexistence) even though telegram sorts first"
+    );
+}

--- a/src/channel/telegram/bootstrap.rs
+++ b/src/channel/telegram/bootstrap.rs
@@ -24,15 +24,19 @@ pub fn init_from_config(
     home: &Path,
     submit_keys: HashMap<String, String>,
 ) -> Option<Arc<Mutex<TelegramState>>> {
-    let (bot_token_env, group_id, user_allowlist, fleet_binding) = match config.channel.as_ref()? {
-        ChannelConfig::Telegram {
-            bot_token_env,
-            group_id,
-            user_allowlist,
-            fleet_binding,
-            ..
-        } => (bot_token_env, group_id, user_allowlist, fleet_binding),
-        ChannelConfig::Discord { .. } => return None,
+    // #2642: resolve the Telegram channel from the unified multi-channel view
+    // (not the singular `config.channel`), so a telegram+discord fleet still
+    // finds Telegram regardless of which entry normalize collapsed into
+    // `channel`. Single-channel telegram → exactly `config.channel` (unchanged).
+    let Some(ChannelConfig::Telegram {
+        bot_token_env,
+        group_id,
+        user_allowlist,
+        fleet_binding,
+        ..
+    }) = config.telegram_channel()
+    else {
+        return None;
     };
     let token = match std::env::var(bot_token_env) {
         Ok(t) => t,

--- a/src/channel/telegram/creds.rs
+++ b/src/channel/telegram/creds.rs
@@ -17,59 +17,58 @@ pub(crate) fn resolve_channel_from(
     home: &std::path::Path,
 ) -> anyhow::Result<(TelegramCreds, crate::fleet::FleetConfig)> {
     let config = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))?;
-    match &config.channel {
-        Some(crate::fleet::ChannelConfig::Telegram {
-            bot_token_env,
-            group_id,
-            ..
-        }) => {
-            // #2005: SYMMETRIC fallback. Pre-#2005 the only fallback was
-            // legacy-ward (`AGEND_BOT_TOKEN`) — dead code whenever
-            // `bot_token_env` already WAS the legacy name (exactly the pair
-            // the old quickstart template generated: fleet pinned the legacy
-            // name while `.env` was written under the canonical key, so a
-            // fresh install failed to resolve at startup). Order: the
-            // configured name first, then whichever of canonical/legacy it
-            // isn't — covering both drift directions (old fleet template +
-            // migrated `.env`, new template + legacy `.env`).
-            const CANONICAL: &str = "AGEND_TELEGRAM_BOT_TOKEN";
-            const LEGACY: &str = "AGEND_BOT_TOKEN";
-            let token = std::env::var(bot_token_env)
-                .or_else(|_| {
-                    let fallback_name = if bot_token_env == CANONICAL {
-                        LEGACY
-                    } else {
-                        CANONICAL
-                    };
-                    let fallback = std::env::var(fallback_name);
-                    if fallback.is_ok() {
-                        if fallback_name == LEGACY {
-                            tracing::warn!(
-                                "AGEND_BOT_TOKEN is deprecated — migrate to {bot_token_env}"
-                            );
-                        } else {
-                            tracing::warn!(
-                                "fleet.yaml bot_token_env '{bot_token_env}' is not set; using \
-                                 {CANONICAL} — update bot_token_env to the canonical name"
-                            );
-                        }
-                    }
-                    fallback
-                })
-                .map_err(|_| anyhow::anyhow!("bot token env '{bot_token_env}' not set"))?;
-            Ok((
-                TelegramCreds {
-                    token,
-                    group_id: *group_id,
-                },
-                config,
-            ))
+    // #2642: resolve Telegram from the unified multi-channel view (not the
+    // singular `config.channel`) so a telegram+discord fleet still finds
+    // Telegram regardless of sort order. Extract to owned values so the borrow
+    // of `config` is released before it is returned. Single-channel telegram
+    // resolves the same channel as before — byte-identical.
+    let Some(crate::fleet::ChannelConfig::Telegram {
+        bot_token_env,
+        group_id,
+        ..
+    }) = config.telegram_channel()
+    else {
+        if config.discord_channel().is_some() {
+            anyhow::bail!("Discord channel configured but telegram resolver called");
         }
-        Some(crate::fleet::ChannelConfig::Discord { .. }) => {
-            anyhow::bail!("Discord channel configured but telegram resolver called")
-        }
-        None => anyhow::bail!("No Telegram channel configured"),
-    }
+        anyhow::bail!("No Telegram channel configured");
+    };
+    let bot_token_env = bot_token_env.clone();
+    let group_id = *group_id;
+
+    // #2005: SYMMETRIC fallback. Pre-#2005 the only fallback was
+    // legacy-ward (`AGEND_BOT_TOKEN`) — dead code whenever
+    // `bot_token_env` already WAS the legacy name (exactly the pair
+    // the old quickstart template generated: fleet pinned the legacy
+    // name while `.env` was written under the canonical key, so a
+    // fresh install failed to resolve at startup). Order: the
+    // configured name first, then whichever of canonical/legacy it
+    // isn't — covering both drift directions (old fleet template +
+    // migrated `.env`, new template + legacy `.env`).
+    const CANONICAL: &str = "AGEND_TELEGRAM_BOT_TOKEN";
+    const LEGACY: &str = "AGEND_BOT_TOKEN";
+    let token = std::env::var(&bot_token_env)
+        .or_else(|_| {
+            let fallback_name = if bot_token_env == CANONICAL {
+                LEGACY
+            } else {
+                CANONICAL
+            };
+            let fallback = std::env::var(fallback_name);
+            if fallback.is_ok() {
+                if fallback_name == LEGACY {
+                    tracing::warn!("AGEND_BOT_TOKEN is deprecated — migrate to {bot_token_env}");
+                } else {
+                    tracing::warn!(
+                        "fleet.yaml bot_token_env '{bot_token_env}' is not set; using \
+                         {CANONICAL} — update bot_token_env to the canonical name"
+                    );
+                }
+            }
+            fallback
+        })
+        .map_err(|_| anyhow::anyhow!("bot token env '{bot_token_env}' not set"))?;
+    Ok((TelegramCreds { token, group_id }, config))
 }
 
 pub(super) fn resolve_channel_only() -> anyhow::Result<TelegramCreds> {

--- a/src/channel/telegram/notify.rs
+++ b/src/channel/telegram/notify.rs
@@ -52,7 +52,10 @@ fn notify_telegram_inner(
     disable_notification: bool,
 ) -> Option<()> {
     let config = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home)).ok()?;
-    let (token, group_id, topic_id) = match &config.channel {
+    // #2642: resolve Telegram from the unified multi-channel view (not the
+    // singular `config.channel`) so a telegram+discord fleet still notifies via
+    // Telegram regardless of sort order. Single-channel telegram is byte-identical.
+    let (token, group_id, topic_id) = match config.telegram_channel() {
         Some(crate::fleet::ChannelConfig::Telegram {
             bot_token_env,
             group_id,
@@ -65,8 +68,7 @@ fn notify_telegram_inner(
             ),
             Err(_) => return None,
         },
-        Some(crate::fleet::ChannelConfig::Discord { .. }) => return None,
-        None => return None,
+        _ => return None,
     };
 
     // #969: channel-wide dedup. If this (telegram, instance, topic,

--- a/src/fleet/mod.rs
+++ b/src/fleet/mod.rs
@@ -159,9 +159,12 @@ pub struct FleetConfig {
     pub channel: Option<ChannelConfig>,
     /// Named channel configurations. Each key is a user-chosen name
     /// (e.g. `tg-main`, `discord-ops`) and the value follows the same
-    /// tagged `type: telegram` shape as the singular form. Multi-channel
-    /// routing is wired in a later PR; for now, this is a parser-level
-    /// extension that normalizes back into [`FleetConfig::channel`].
+    /// tagged `type: telegram` shape as the singular form. #2642: this is the
+    /// canonical multi-channel set — every declared channel is registered
+    /// (telegram+discord coexist) via [`FleetConfig::configured_channels`],
+    /// which each channel's `init_from_config` consumes. `normalize()` still
+    /// collapses the first entry (by name) into [`FleetConfig::channel`] as a
+    /// back-compat primary for the readers that use the singular field.
     #[serde(default)]
     pub channels: Option<HashMap<String, ChannelConfig>>,
     /// Template definitions for batch deployment.
@@ -315,9 +318,6 @@ impl ChannelConfig {
     /// the serde `type:` tag. Used as the synthetic map key when a singular
     /// `channel:` is surfaced through the plural [`FleetConfig::configured_channels`]
     /// view (#2642), and for per-channel log context.
-    // #2642 PR-1 lands the API; bootstrap/init consume it in PR-2. Until then it
-    // is exercised only by tests, so silence the bin-target dead_code lint.
-    #[allow(dead_code)]
     pub fn type_name(&self) -> &'static str {
         match self {
             ChannelConfig::Telegram { .. } => "telegram",
@@ -702,28 +702,21 @@ impl FleetConfig {
             }
         }
 
-        // Channel dual-accept: if the user wrote only `channels:` (plural
-        // map), collapse the first entry — sorted by name for determinism
-        // — into the legacy `channel:` field so existing call sites keep
-        // working unchanged. Multi-channel routing is wired in a later PR;
-        // until then, we pick one and log a warning when more than one is
-        // declared. When `channel:` is already set, plural is a no-op and
-        // runtime behavior is byte-identical to today.
+        // Back-compat primary channel. `channels:` (plural) is the canonical
+        // multi-channel set — surfaced via `configured_channels()` and consumed
+        // by each channel's `init_from_config` (#2642), so every declared channel
+        // now registers (telegram+discord coexist). For the readers that still
+        // use the singular `self.channel` (presence checks, doctor, persisted-id
+        // reload), collapse the first entry — sorted by name for determinism —
+        // into `channel` as the primary. Type-specific resolvers use
+        // `telegram_channel()` / `discord_channel()`, so they are unaffected by
+        // which entry lands here. When `channel:` is already set, plural is a
+        // no-op and single-channel behavior is byte-identical to today.
         if self.channel.is_none() {
             if let Some(map) = self.channels.as_ref() {
                 let mut names: Vec<&String> = map.keys().collect();
                 names.sort();
                 if let Some(first) = names.first().copied() {
-                    if names.len() > 1 {
-                        tracing::warn!(
-                            count = names.len(),
-                            picked = %first,
-                            "fleet.yaml declares {} channels but multi-channel routing \
-                             is not yet wired; using first entry by name. Follow-up PR \
-                             in T1 will merge inbound streams across all channels.",
-                            names.len(),
-                        );
-                    }
                     if let Some(cfg) = map.get(first) {
                         self.channel = Some(cfg.clone());
                     }
@@ -747,9 +740,6 @@ impl FleetConfig {
     /// a single-channel fleet is byte-identical — every existing call site
     /// still reads `self.channel` directly, and this view returns exactly that
     /// one channel.
-    // #2642 PR-1 lands the API; bootstrap/init consume it in PR-2. Until then it
-    // is exercised only by tests, so silence the bin-target dead_code lint.
-    #[allow(dead_code)]
     pub fn configured_channels(&self) -> Vec<(String, &ChannelConfig)> {
         if let Some(map) = self.channels.as_ref() {
             if !map.is_empty() {
@@ -763,6 +753,30 @@ impl FleetConfig {
             return vec![(cfg.type_name().to_string(), cfg)];
         }
         Vec::new()
+    }
+
+    /// #2642: the first configured Telegram channel, resolved from the unified
+    /// [`configured_channels`](Self::configured_channels) view rather than the
+    /// singular `self.channel` — so a telegram+discord fleet resolves Telegram
+    /// independently of which entry `normalize()` collapsed into `channel`
+    /// (sort order no longer decides which single channel "wins"). For a
+    /// single-channel telegram fleet this is exactly `self.channel`, byte-
+    /// identical to the pre-#2642 singular reads it replaces (init / creds /
+    /// notify / TUI status).
+    pub fn telegram_channel(&self) -> Option<&ChannelConfig> {
+        self.configured_channels()
+            .into_iter()
+            .map(|(_, c)| c)
+            .find(|c| matches!(c, ChannelConfig::Telegram { .. }))
+    }
+
+    /// #2642: the first configured Discord channel — Discord counterpart of
+    /// [`telegram_channel`](Self::telegram_channel).
+    pub fn discord_channel(&self) -> Option<&ChannelConfig> {
+        self.configured_channels()
+            .into_iter()
+            .map(|(_, c)| c)
+            .find(|c| matches!(c, ChannelConfig::Discord { .. }))
     }
 
     /// Resolve an instance config by merging with defaults + backend preset.

--- a/src/fleet/tests.rs
+++ b/src/fleet/tests.rs
@@ -678,6 +678,126 @@ instances: {}
     fs::remove_dir_all(&dir).ok();
 }
 
+// ── #2642 PR-2: telegram_channel()/discord_channel() typed resolvers ──
+// These replace the singular `config.channel` reads at init / creds / notify /
+// TUI-status. The hard-constraint pins: a single-channel telegram fleet
+// resolves EXACTLY as before; the coexistence pins prove telegram+discord
+// resolve independently regardless of sort order.
+
+#[test]
+fn telegram_channel_single_is_byte_identical_and_no_discord() {
+    // Production shape: single telegram. telegram_channel() resolves it; a
+    // discord consumer sees None (discord_init skips) — identical to today.
+    let dir = std::env::temp_dir().join(format!("agend-fleet-tc-single-{}", std::process::id()));
+    let path = write_fleet(
+        &dir,
+        r#"
+channel:
+  type: telegram
+  bot_token_env: PROD_TOKEN
+  group_id: -100
+instances: {}
+"#,
+    );
+    let config = FleetConfig::load(&path).expect("load");
+    match config.telegram_channel() {
+        Some(ChannelConfig::Telegram {
+            bot_token_env,
+            group_id,
+            ..
+        }) => {
+            assert_eq!(bot_token_env, "PROD_TOKEN");
+            assert_eq!(*group_id, -100);
+        }
+        other => panic!("telegram_channel() must resolve the single telegram, got {other:?}"),
+    }
+    assert!(
+        config.discord_channel().is_none(),
+        "no discord → discord_init skips"
+    );
+    fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn both_channels_resolve_independently_in_coexistence() {
+    // The coexistence unlock: a telegram+discord fleet resolves EACH channel to
+    // its own entry (this is what lets both init_from_config register).
+    let dir = std::env::temp_dir().join(format!("agend-fleet-tc-coexist-{}", std::process::id()));
+    let path = write_fleet(
+        &dir,
+        r#"
+channels:
+  tg:
+    type: telegram
+    bot_token_env: TG_TOKEN
+    group_id: -100
+  dc:
+    type: discord
+    bot_token_env: DC_TOKEN
+    guild_id: 999
+instances: {}
+"#,
+    );
+    let config = FleetConfig::load(&path).expect("load");
+    match config.telegram_channel() {
+        Some(ChannelConfig::Telegram { bot_token_env, .. }) => {
+            assert_eq!(bot_token_env, "TG_TOKEN")
+        }
+        other => panic!("expected telegram, got {other:?}"),
+    }
+    match config.discord_channel() {
+        Some(ChannelConfig::Discord {
+            bot_token_env,
+            guild_id,
+            ..
+        }) => {
+            assert_eq!(bot_token_env, "DC_TOKEN");
+            assert_eq!(*guild_id, 999);
+        }
+        other => panic!("expected discord, got {other:?}"),
+    }
+    fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn telegram_resolves_even_when_discord_sorts_first() {
+    // The exact bug PR-2 fixes: normalize collapses `channel` to the FIRST entry
+    // by name ("a-discord" < "z-telegram"), so the singular `config.channel`
+    // would be Discord — the pre-#2642 telegram readers would then see "no
+    // telegram" and go silent. telegram_channel() resolves telegram regardless.
+    let dir = std::env::temp_dir().join(format!("agend-fleet-tc-order-{}", std::process::id()));
+    let path = write_fleet(
+        &dir,
+        r#"
+channels:
+  a-discord:
+    type: discord
+    bot_token_env: DC_TOKEN
+    guild_id: 42
+  z-telegram:
+    type: telegram
+    bot_token_env: TG_TOKEN
+    group_id: -7
+instances: {}
+"#,
+    );
+    let config = FleetConfig::load(&path).expect("load");
+    // Sanity: the collapsed singular primary IS the discord (first by name) —
+    // exactly the state that used to hide telegram from the singular readers.
+    assert!(
+        matches!(config.channel, Some(ChannelConfig::Discord { .. })),
+        "collapsed primary is the first-sorted (discord)"
+    );
+    // But the typed resolver still finds telegram.
+    match config.telegram_channel() {
+        Some(ChannelConfig::Telegram { bot_token_env, .. }) => {
+            assert_eq!(bot_token_env, "TG_TOKEN")
+        }
+        other => panic!("telegram must resolve despite discord sorting first, got {other:?}"),
+    }
+    fs::remove_dir_all(&dir).ok();
+}
+
 #[test]
 fn test_channel_config_default_mode() {
     let dir = std::env::temp_dir().join(format!("agend-fleet-defmode-{}", std::process::id()));


### PR DESCRIPTION
## What

PR-2 of #2642 (config-layer multi-channel coexistence). **The behavior-change segment**: every channel declared under `channels:` now registers, so telegram and discord run **side-by-side**. PR-1 (#2643) landed the read-side `configured_channels()` view; this wires the consumers to it.

## Changes (proposal points ②③④⑤)

- Two typed resolvers `FleetConfig::telegram_channel()` / `discord_channel()` over the PR-1 view (first entry of each type).
- **Migrate the 5 singular `config.channel` readers** to their typed resolver:
  1. telegram init (`channel/telegram/bootstrap.rs`)
  2. discord init (`channel/discord/bootstrap.rs`)
  3. telegram creds (`channel/telegram/creds.rs`)
  4. telegram notify (`channel/telegram/notify.rs`)
  5. TUI telegram status (`app/telegram_hooks.rs`) — a **5th site a full-repo grep survey surfaced** beyond the 4 in the proposal (would have shown telegram "NotConfigured" when discord sorts first).
- Remove `normalize()`'s stale *"multi-channel routing is not yet wired"* warn. The first-by-name collapse into `channel` **stays** as the back-compat primary for the remaining singular readers (presence checks, doctor, persisted-id reload).

**Consumers unchanged**: `telegram_init` and `discord_init` already both run at bootstrap; each `init_from_config` now self-selects its own type, so both register (each returns `None` when its type isn't configured — the same skip path as today).

## Hard constraint — single-channel telegram byte-identical (positively pinned)

`telegram_channel()` for a `channel:`-only telegram fleet resolves **exactly** the same channel as the old `config.channel` read; `discord_channel()` is `None`, so `discord_init` skips — identical to today. Pinned by `telegram_channel_single_is_byte_identical_and_no_discord` + the untouched `normalize()` collapse tests from PR-1.

## Coexistence pins

- `both_channels_resolve_independently_in_coexistence` — each type → its own entry.
- `telegram_resolves_even_when_discord_sorts_first` — the exact bug: `normalize()` collapses `channel` to `a-discord`, but `telegram_channel()` still finds telegram (the singular readers would have gone silent).
- `discord_init_assembles_alongside_telegram_2642` — the **#2625 mock-gateway seam**: discord assembles from a telegram+discord fleet even though telegram sorts first.

## Out of scope (noted)

- `doctor.rs` shows only the primary channel in a multi-channel fleet (diagnostic display, not routing) — a candidate follow-up.
- Multiple channels of the **same** type resolve to the first by name (telegram+discord is the target).

## Verification

fleet 79 pass, discord 59 pass (`--features discord`), telegram 119, quickstart (#2005 regressions) 51, bootstrap 72, hooks 6. `cargo clippy --all-targets --features tray,discord -- -D warnings` clean; `cargo fmt --check` clean. Gates LINE adapter #2342.

🤖 Generated with [Claude Code](https://claude.com/claude-code)