### PR TITLE
feat(#2622 PR-3): reply optional message_id — targeted-channel routing + row settle

### DIFF
--- a/src/mcp/handlers/channel.rs
+++ b/src/mcp/handlers/channel.rs
@@ -54,41 +54,85 @@ pub(super) fn handle_reply(home: &Path, args: &Value, instance_name: &str) -> Va
         return json!({"error": "No fleet.yaml — cannot send reply"});
     }
 
-    // Sprint 55 P0-A — prefer-chain: sender's HeartbeatPair.reply_to_channel
-    // (Sprint 52 router-layer attribution) wins when present + registered;
-    // else fall back to whichever channel the sending instance is bound to
-    // (multi-channel-safe, t-20260703164240502572-50899-11 — `active_channel()`
-    // alone returns `None` once 2+ channels are registered); last resort is
-    // the `active_channel()` singleton. Returns structured error codes so
-    // agents can branch on machine-readable signals.
-    let snapshot = crate::daemon::heartbeat_pair::snapshot_for(instance_name);
-    let ch: Arc<dyn crate::channel::Channel> = match snapshot.reply_to_channel.as_deref() {
-        Some(name) => match crate::channel::lookup_channel_by_name(name) {
+    // #2622 PR-3: an explicit `message_id` routes by THAT message's own
+    // channel (from its inbox row) instead of the process-global prefer-chain
+    // below — the targeted-reply path (Fork C: a late reply to an
+    // old/reclaimed message must land on ITS channel even when the sender's
+    // CURRENT `reply_to_channel` tag has moved on or gone stale). No
+    // `message_id` → byte-identical to the pre-#2622 prefer-chain.
+    let message_id = args["message_id"].as_str().filter(|s| !s.is_empty());
+    let ch: Arc<dyn crate::channel::Channel> = if let Some(msg_id) = message_id {
+        let Some(row) = crate::inbox::storage::find_message(home, msg_id) else {
+            crate::reply_ledger::record_reply_outcome(instance_name, false);
+            return json!({
+                "error": format!("message '{msg_id}' not found in any inbox"),
+                "code": "message_not_found"
+            });
+        };
+        let Some(kind) = row.channel else {
+            crate::reply_ledger::record_reply_outcome(instance_name, false);
+            return json!({
+                "error": format!(
+                    "message '{msg_id}' has no channel — cannot route a targeted reply"
+                ),
+                "code": "message_has_no_channel"
+            });
+        };
+        let channel_name = match kind {
+            crate::channel::ChannelKind::Telegram => "telegram",
+            crate::channel::ChannelKind::Discord => "discord",
+        };
+        match crate::channel::lookup_channel_by_name(channel_name) {
             Some(ch) => ch,
             None => {
                 tracing::warn!(
-                    from = %instance_name, channel = %name,
-                    "reply_to_channel tagged but not registered — divergence"
+                    from = %instance_name, channel = %channel_name,
+                    "targeted reply's channel not registered — divergence"
                 );
-                // #1665 Gap D: the agent tried to reply but the channel is
-                // unreachable — record the send-failure (never blocks the reply).
                 crate::reply_ledger::record_reply_outcome(instance_name, false);
                 return json!({
-                    "error": format!("reply_to_channel '{name}' not registered or offline"),
+                    "error": format!("channel '{channel_name}' not registered or offline"),
                     "code": "reply_channel_unavailable"
                 });
             }
-        },
-        None => match crate::channel::channel_for_instance(instance_name)
-            .or_else(crate::channel::active_channel)
-        {
-            Some(ch) => ch,
-            None => {
-                // #1665 Gap D: no channel to reply on — record the send-failure.
-                crate::reply_ledger::record_reply_outcome(instance_name, false);
-                return json!({"error": "no active channel", "code": "no_active_channel"});
-            }
-        },
+        }
+    } else {
+        // Sprint 55 P0-A — prefer-chain: sender's HeartbeatPair.reply_to_channel
+        // (Sprint 52 router-layer attribution) wins when present + registered;
+        // else fall back to whichever channel the sending instance is bound to
+        // (multi-channel-safe, t-20260703164240502572-50899-11 — `active_channel()`
+        // alone returns `None` once 2+ channels are registered); last resort is
+        // the `active_channel()` singleton. Returns structured error codes so
+        // agents can branch on machine-readable signals.
+        let snapshot = crate::daemon::heartbeat_pair::snapshot_for(instance_name);
+        match snapshot.reply_to_channel.as_deref() {
+            Some(name) => match crate::channel::lookup_channel_by_name(name) {
+                Some(ch) => ch,
+                None => {
+                    tracing::warn!(
+                        from = %instance_name, channel = %name,
+                        "reply_to_channel tagged but not registered — divergence"
+                    );
+                    // #1665 Gap D: the agent tried to reply but the channel is
+                    // unreachable — record the send-failure (never blocks the reply).
+                    crate::reply_ledger::record_reply_outcome(instance_name, false);
+                    return json!({
+                        "error": format!("reply_to_channel '{name}' not registered or offline"),
+                        "code": "reply_channel_unavailable"
+                    });
+                }
+            },
+            None => match crate::channel::channel_for_instance(instance_name)
+                .or_else(crate::channel::active_channel)
+            {
+                Some(ch) => ch,
+                None => {
+                    // #1665 Gap D: no channel to reply on — record the send-failure.
+                    crate::reply_ledger::record_reply_outcome(instance_name, false);
+                    return json!({"error": "no active channel", "code": "no_active_channel"});
+                }
+            },
+        }
     };
     // #969 RC2 fix: set mirror_skip BEFORE the send. Pre-fix this set
     // ran in the Ok arm AFTER ch.send_from_agent returned; on the
@@ -116,6 +160,13 @@ pub(super) fn handle_reply(home: &Path, args: &Value, instance_name: &str) -> Va
         Ok(msg) => {
             // #1665: reply delivered — closes the user-turn (no warn at sweep).
             crate::reply_ledger::record_reply_outcome(instance_name, true);
+            // #2622 PR-3 Fork C: a targeted reply also settles the persistent
+            // row (unconditionally — a `read` row is a no-op, an `unread`/
+            // `delivering` row is marked read) so an old/reclaimed message
+            // stops redelivering once it's actually been answered.
+            if let Some(msg_id) = message_id {
+                crate::inbox::storage::settle_read_by_id(home, instance_name, msg_id);
+            }
             // Sprint 59 Wave 1 PR-4: surface the pending-decision /
             // resolved-decision IDs so caller observability is
             // complete (operator can reference IDs, agent can verify

--- a/src/mcp/handlers/channel_p0a_tests.rs
+++ b/src/mcp/handlers/channel_p0a_tests.rs
@@ -561,3 +561,186 @@ fn discharge_for_one_agent_must_not_suppress_same_text_for_another_agent() {
     );
     std::fs::remove_dir_all(&home).ok();
 }
+
+// ── #2622 PR-3: `reply` optional `message_id` — targeted-channel routing ──
+
+/// Like [`enqueue_channel_msg`] but lets the test pick the row's channel kind
+/// (the shared helper hardcodes Telegram — these tests need a row whose
+/// channel DIFFERS from whatever the prefer-chain would otherwise pick, to
+/// prove the `message_id` path overrides it).
+fn enqueue_channel_msg_with_kind(
+    home: &std::path::Path,
+    agent: &str,
+    id: &str,
+    from: &str,
+    text: &str,
+    kind: crate::channel::ChannelKind,
+) {
+    let msg = crate::inbox::InboxMessage {
+        schema_version: 1,
+        id: Some(id.into()),
+        from: from.into(),
+        text: text.into(),
+        kind: None,
+        timestamp: "2026-06-22T16:41:45Z".into(),
+        channel: Some(kind),
+        ..Default::default()
+    };
+    crate::inbox::enqueue(home, agent, msg).expect("test setup: enqueue must succeed");
+}
+
+/// The core PR-3 fix: a `message_id` routes by THAT message's own channel
+/// (from its inbox row), not the sender's process-global `reply_to_channel`
+/// tag — so a late reply to an old/reclaimed message lands correctly even
+/// when the agent's CURRENT tag points somewhere else (or somewhere broken).
+#[test]
+fn reply_with_message_id_routes_by_row_channel_not_prefer_chain_2622() {
+    let _g = registry_guard();
+    crate::channel::reset_active_channel_for_test();
+    let agent = "reply-mid-routes-2622";
+    let home = tmp_home("reply-mid-routes");
+    // The sender's CURRENT tag points at telegram, which is registered but
+    // deliberately incapable — proves the targeted path does NOT consult it.
+    crate::channel::register_active_channel(MockChannel::arc(
+        "telegram",
+        ReplyOutcome::NotSupported,
+    ));
+    crate::channel::register_active_channel(MockChannel::arc("discord", ReplyOutcome::Ok));
+    set_reply_to(agent, Some("telegram"));
+
+    enqueue_channel_msg_with_kind(
+        &home,
+        agent,
+        "m-old-1",
+        "user:op",
+        "old question",
+        crate::channel::ChannelKind::Discord,
+    );
+
+    let result = super::handle_reply(
+        &home,
+        &serde_json::json!({"message": "answer", "message_id": "m-old-1"}),
+        agent,
+    );
+    assert_eq!(
+        result["message_id"], "mock-msg-1",
+        "must route via the row's OWN channel (discord), not the stale telegram tag: {result}"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// No `message_id` → byte-identical to the pre-#2622 prefer-chain: the same
+/// stale telegram tag now DOES get consulted and its incapability surfaces.
+#[test]
+fn reply_without_message_id_still_uses_prefer_chain_2622() {
+    let _g = registry_guard();
+    crate::channel::reset_active_channel_for_test();
+    let agent = "reply-mid-backcompat-2622";
+    let home = tmp_home("reply-mid-backcompat");
+    crate::channel::register_active_channel(MockChannel::arc(
+        "telegram",
+        ReplyOutcome::NotSupported,
+    ));
+    crate::channel::register_active_channel(MockChannel::arc("discord", ReplyOutcome::Ok));
+    set_reply_to(agent, Some("telegram"));
+
+    let result = super::handle_reply(&home, &serde_json::json!({"message": "answer"}), agent);
+    assert_eq!(
+        result["code"], "channel_capability_unsupported",
+        "omitting message_id must still hit the tagged (incapable) channel: {result}"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// Fork C: on send success, a targeted reply also settles the persistent row
+/// (unconditionally — an `unread` row from an old/reclaimed message is the
+/// core use case) so it stops redelivering.
+#[test]
+fn reply_with_message_id_settles_the_row_on_success_2622() {
+    let _g = registry_guard();
+    crate::channel::reset_active_channel_for_test();
+    let agent = "reply-mid-settles-2622";
+    let home = tmp_home("reply-mid-settles");
+    crate::channel::register_active_channel(MockChannel::arc("telegram", ReplyOutcome::Ok));
+
+    enqueue_channel_msg(&home, agent, "m-settle-1", "user:op", "old question");
+    assert!(
+        crate::inbox::storage::find_message(&home, "m-settle-1")
+            .and_then(|m| m.read_at)
+            .is_none(),
+        "precondition: the row starts unread"
+    );
+
+    let result = super::handle_reply(
+        &home,
+        &serde_json::json!({"message": "answer", "message_id": "m-settle-1"}),
+        agent,
+    );
+    assert_eq!(
+        result["message_id"], "mock-msg-1",
+        "reply must succeed: {result}"
+    );
+    assert!(
+        crate::inbox::storage::find_message(&home, "m-settle-1")
+            .and_then(|m| m.read_at)
+            .is_some(),
+        "a successful targeted reply must settle the row so it stops redelivering"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// An unknown `message_id` must error, never silently fall back to the
+/// prefer-chain (that would silently answer on the WRONG channel).
+#[test]
+fn reply_with_unknown_message_id_errors_2622() {
+    let _g = registry_guard();
+    crate::channel::reset_active_channel_for_test();
+    let agent = "reply-mid-unknown-2622";
+    let home = tmp_home("reply-mid-unknown");
+    crate::channel::register_active_channel(MockChannel::arc("telegram", ReplyOutcome::Ok));
+
+    let result = super::handle_reply(
+        &home,
+        &serde_json::json!({"message": "answer", "message_id": "m-nope"}),
+        agent,
+    );
+    assert_eq!(
+        result["code"], "message_not_found",
+        "an unknown message_id must error, not silently fall back: {result}"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// A row with no recorded channel (e.g. a non-channel inbox message) can't be
+/// targeted-routed — must error, never silently fall back to the prefer-chain.
+#[test]
+fn reply_with_message_id_missing_channel_on_row_errors_2622() {
+    let _g = registry_guard();
+    crate::channel::reset_active_channel_for_test();
+    let agent = "reply-mid-nochannel-2622";
+    let home = tmp_home("reply-mid-nochannel");
+    crate::channel::register_active_channel(MockChannel::arc("telegram", ReplyOutcome::Ok));
+
+    let msg = crate::inbox::InboxMessage {
+        schema_version: 1,
+        id: Some("m-nochannel-1".into()),
+        from: "peer".into(),
+        text: "not a channel message".into(),
+        kind: Some("update".into()),
+        timestamp: "2026-06-22T16:41:45Z".into(),
+        channel: None,
+        ..Default::default()
+    };
+    crate::inbox::enqueue(&home, agent, msg).expect("test setup: enqueue must succeed");
+
+    let result = super::handle_reply(
+        &home,
+        &serde_json::json!({"message": "answer", "message_id": "m-nochannel-1"}),
+        agent,
+    );
+    assert_eq!(
+        result["code"], "message_has_no_channel",
+        "a channel-less row must error, not silently fall back: {result}"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -27,6 +27,7 @@ pub(crate) fn def_reply() -> Value {
     json!({"name": "reply", "description": "Reply to the user via the active channel. Requires daemon API. Sprint 59 Wave 1 PR-4 ((B) decision default with timeout): when both `default_action` and `timeout_secs` are set, the daemon records a pending operator decision sidecar and auto-fires the default after the timeout window. Subsequent reply calls without `default_action` resolve the pending decision (operator override / explicit answer arrived).",
         "inputSchema": {"type": "object", "properties": {
             "message": {"type": "string", "description": "The reply text to send to the user."},
+            "message_id": {"type": "string", "description": "#2622 PR-3: target an original inbox message by id. When set, routes by THAT message's own channel (instead of the process-global reply_to_channel prefer-chain) and, on send success, settles that row so it stops redelivering. Omit for the default prefer-chain behavior."},
             "default_action": {"type": "string", "description": "Action to auto-execute on timeout when the operator doesn't reply within `timeout_secs`. e.g. 'proceed-with-lean' / 'abort'. Pair with `timeout_secs` (Sprint 59 Wave 1 PR-4)."},
             "timeout_secs": {"type": "integer", "description": "Seconds to wait for an operator response before firing `default_action`. Required when `default_action` is set; ignored otherwise (Sprint 59 Wave 1 PR-4)."}
         }, "required": ["message"]}})
@@ -501,6 +502,34 @@ mod tests {
         assert!(
             !required_strs.contains(&"target_pane"),
             "target_pane must stay optional"
+        );
+    }
+
+    #[test]
+    fn reply_has_message_id_param_2622() {
+        // #2622 PR-3 reviewer5 r0: handle_reply reads args["message_id"] and
+        // implements the targeted-channel-routing path, but the schema never
+        // declared it — an MCP client validating against the advertised
+        // inputSchema has no way to pass `message_id`, so the capability is
+        // unreachable exactly like #2539's repo force/force_reason gap above.
+        let defs = tool_definitions();
+        let tools = defs["tools"].as_array().expect("tools array");
+        let reply = tools
+            .iter()
+            .find(|t| t["name"] == "reply")
+            .expect("reply tool not found");
+        let props = &reply["inputSchema"]["properties"];
+        assert!(
+            props["message_id"].is_object(),
+            "reply tool must declare 'message_id' so MCP clients can target an original message"
+        );
+        let required_strs: Vec<&str> = reply["inputSchema"]["required"]
+            .as_array()
+            .map(|r| r.iter().filter_map(|v| v.as_str()).collect())
+            .unwrap_or_default();
+        assert!(
+            !required_strs.contains(&"message_id"),
+            "message_id must stay optional (backward-compat: omitting it is byte-identical)"
         );
     }
 


### PR DESCRIPTION
## Summary

Closes the last #2622 axis (RCA: `TELEGRAM-REPLY-OBLIGATION-RCA.md`; design: `CHANNEL-REPLY-DISCHARGE-DESIGN.md`, Fork C). PR-1 (#2644, merged) added the durable discharge ledger; PR-2 (#2647, merged) wired the arm guard + discharge primitive. This PR closes the remaining gap: **replying to an old/reclaimed message must route by that message's own channel, not the sender's current process-global tag.**

- `handle_reply` (`src/mcp/handlers/channel.rs`) now accepts an optional `message_id`.
- When present: the channel is picked from that message's own inbox row (`.channel`, via `inbox::storage::find_message`) instead of the `reply_to_channel` prefer-chain — so a late reply to a 13-day-old message (the `-125` case) lands correctly even if the sender's current tag has moved on or gone stale.
- On send success, the row is also settled via `settle_read_by_id` (added in PR-2) — Fork C: a `read` row is a no-op, an `unread`/`delivering` row is marked read, so it stops redelivering once actually answered.
- **Backward compatible**: no `message_id` → byte-identical to the pre-#2622 prefer-chain (verified via the existing EC1/EC2/EC8/EC12 tests, unchanged and passing).
- New structured error codes: `message_not_found`, `message_has_no_channel` (mirrors `handle_discharge`'s pattern from PR-2).

Test-first: 5 new tests written before implementation (confirmed red), now green:
- `reply_with_message_id_routes_by_row_channel_not_prefer_chain_2622`
- `reply_without_message_id_still_uses_prefer_chain_2622`
- `reply_with_message_id_settles_the_row_on_success_2622`
- `reply_with_unknown_message_id_errors_2622`
- `reply_with_message_id_missing_channel_on_row_errors_2622`

## Test plan
- [x] fmt/clippy clean (`cargo clippy --all-targets --features tray -- -D warnings`)
- [x] All 5 new tests pass; confirmed red before implementation
- [x] Existing EC1/EC2/EC8/EC12 prefer-chain tests unchanged and passing (backward-compat proof)
- [x] Full suite: 5326/5328 pass — the 2 failures are pre-existing local-sandbox-only e2e/dispatch-binding tests (`e2e_dispatch_review_workflow_seam_invariants_1900`, `teardown_leaves_zero_residual_after_full_exercise_1907`), confirmed identical on a clean main checkout, unrelated to this change (same finding as PR-2's verification)
- [ ] CI green on this PR

Refs #2622. correlation_id: t-20260705110020993237-26515-0