### PR TITLE
chore(deps): quick-xml 0.39.4 → 0.41.0 via plist 1.10; drop RUSTSEC-2026-0194/0195 ignores

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -29,15 +29,4 @@ ignore = [
     #    dependencies (transitive); no runtime surface. Benign.
     "RUSTSEC-2024-0370", # proc-macro-error — unmaintained, no fix (build-time, benign)
     "RUSTSEC-2026-0173", # proc-macro-error2 — unmaintained, no fix (build-time, benign)
-    # ── quick-xml DoS pair (quadratic-time attribute-duplicate check +
-    #    unbounded namespace-declaration allocation) — via `plist`,
-    #    [dev-dependencies] only, no runtime exposure in this codebase. UNLIKE
-    #    the entries above, a fix EXISTS for both (quick-xml >=0.41.0) — this is
-    #    a TEMPORARY unblock (both advisories published 2026-06-29, surfaced to
-    #    CI same-day 2026-07-02, broke every branch's audit job), not a
-    #    permanent no-fix-available entry. Same advisory batch — check for
-    #    siblings before adding either alone. Remove once the version-bump
-    #    follow-up (t-20260702084620067164-14977-32, verifies plist compat) lands.
-    "RUSTSEC-2026-0194", # quick-xml 0.39.4 — quadratic attr-dup check, dev-dep via plist, fix pending
-    "RUSTSEC-2026-0195", # quick-xml 0.39.4 — unbounded ns-decl alloc, dev-dep via plist, fix pending
 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,15 +283,7 @@ jobs:
           # rationale in `.cargo/audit.toml` (which the action does NOT read —
           # it only honors this input — but which keeps local `cargo audit`
           # consistent). Keep the two lists in sync.
-          # RUSTSEC-2026-0194 + RUSTSEC-2026-0195 (quick-xml 0.39.4, via plist,
-          # dev-dependency only — both DoS-only, no runtime exposure here) are a
-          # DIFFERENT class from the rest of this list: a fix (>=0.41.0) exists
-          # for both — this is a TEMPORARY unblock (both published 2026-06-29,
-          # surfaced to CI same-day 2026-07-02, broke every branch's audit job)
-          # pending compatibility verification, not a permanent no-fix-available
-          # entry. Same advisory batch — check for siblings before adding either
-          # alone. Remove once t-20260702084620067164-14977-32 lands.
-          ignore: RUSTSEC-2024-0411,RUSTSEC-2024-0412,RUSTSEC-2024-0413,RUSTSEC-2024-0414,RUSTSEC-2024-0415,RUSTSEC-2024-0416,RUSTSEC-2024-0418,RUSTSEC-2024-0419,RUSTSEC-2024-0420,RUSTSEC-2024-0429,RUSTSEC-2024-0370,RUSTSEC-2026-0173,RUSTSEC-2026-0194,RUSTSEC-2026-0195
+          ignore: RUSTSEC-2024-0411,RUSTSEC-2024-0412,RUSTSEC-2024-0413,RUSTSEC-2024-0414,RUSTSEC-2024-0415,RUSTSEC-2024-0416,RUSTSEC-2024-0418,RUSTSEC-2024-0419,RUSTSEC-2024-0420,RUSTSEC-2024-0429,RUSTSEC-2024-0370,RUSTSEC-2026-0173
 
   # #686 (F11): maintainer-side QA infrastructure. Runs cargo-llvm-cov on
   # Ubuntu only (cross-platform consistency comes from `check` job; coverage

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3182,9 +3182,9 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plist"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64",
  "indexmap 2.13.1",
@@ -3424,9 +3424,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.39.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -202,7 +202,7 @@ toml = "1.1"
 # extract the AGEND_SUPERVISED sentinel out of its structural env block —
 # the templates are plain text the prod code substitutes into, so these
 # crates are test-only (mirrors the `toml` dev-dep convention above).
-plist = "1.7"
+plist = "1.10"
 rust-ini = "0.21"
 # Sprint 54 P1-A — `tests/cargo_include_invariant.rs` matches resolved
 # `include_str!` paths against `[package].include` glob patterns


### PR DESCRIPTION
## Unblocks the #2536 audit temporary-ignore (task t-20260702084620067164-14977-32)

On 2026-07-02, RUSTSEC-2026-0194 (quick-xml quadratic attribute-duplicate check) and RUSTSEC-2026-0195 (unbounded namespace-declaration allocation) surfaced against `quick-xml 0.39.4` and broke every branch's audit job. The fix (`quick-xml >=0.41.0`) existed, but `plist 1.9.0` capped its requirement at `^0.39.2`, so the two advisories were temporarily ignored pending an upstream `plist` release. This PR lands that upgrade.

**Re-check result (2-week window):** `plist 1.10.0` (released since 1.9.0) bumps its requirement to `quick-xml ^0.41.0`, and `quick-xml 0.41.0` carries the fixes for both advisories.

## Clean single-version replacement

`quick-xml 0.39.4` was pulled **only** by `plist` (a `[dev-dependencies]` used by the launchd-plist real-entry parse test — confirmed via `cargo tree -i quick-xml`). No other consumer, so no residual `0.39.x` pin:

- `Cargo.toml`: `plist` floor `"1.7"` → `"1.10"` — pins the security floor so a future lock regeneration can't reintroduce a `plist` that needs `quick-xml 0.39.x`.
- `cargo update -p plist`: `plist 1.9.0 → 1.10.0`, `quick-xml 0.39.4 → 0.41.0`.
- Remove `RUSTSEC-2026-0194` / `RUSTSEC-2026-0195` (and their temporary comment blocks) from **both** the `ci.yml` `rustsec/audit-check` `ignore:` list **and** `.cargo/audit.toml`, kept in sync per their own note. The remaining ignores are the unchanged no-fix GTK3 / proc-macro-error entries.

## Verification
- `cargo audit` → **exit 0, clean** — both advisories gone (not merely re-suppressed; quick-xml is now 0.41.0).
- Launchd-plist real-entry parse test (`src/daemon/restart.rs` `plist::Value::from_reader_xml`) + all 35 `restart` tests pass with the new `plist`/`quick-xml` — API-compatible, **zero code change**.
- `cargo fmt --check` clean; `cargo clippy --all-targets --features tray -- -D warnings` clean.
- Full suite: 5326/5329 pass. The 3 non-passes are all environmental, none from this dep bump: the 2 known pre-existing local-sandbox-only tests (`e2e_dispatch_review_workflow_seam_invariants_1900`, `teardown_leaves_zero_residual_after_full_exercise_1907`), plus one daemon boot-race flake (`api_port_published_before_agent_spawn_loop_completes`) that **passes on isolated re-run** (flake-gate class, unrelated to a launchd-plist dev-dep). This change touches no runtime source.

Refs #2536. correlation_id: t-20260702084620067164-14977-32