### PR TITLE
fix(#2648-followup): declare ci watch task_id; remove unwatch instance cross-agent override

### DIFF
--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -361,12 +361,12 @@ fn ci_unwatch_unknown_caller_is_noop_keeps_watch() {
 
 #[test]
 fn ci_unwatch_explicit_empty_instance_keeps_other_subscribers() {
-    // H4 hardening (CR-2026-06-14): an agent-supplied EXPLICIT empty
-    // `instance:""` arg must not reach the empty-caller `subscribers.clear()`
-    // branch (same blast radius as the original H4 bug). The
-    // `.filter(|s| !s.is_empty())` drops the empty arg so resolution falls
-    // through to the validated caller (instance_name) — removing only the
-    // caller. Without the filter, caller="" wipes every other subscriber.
+    // H4 hardening (CR-2026-06-14), now reinforced by
+    // t-20260705161926295621-30532-2 ②: an agent-supplied `instance` arg must
+    // not reach the empty-caller `subscribers.clear()` branch. Since the
+    // `instance` override was removed (caller is ALWAYS the validated sender),
+    // the arg is ignored entirely — caller resolves to instance_name ("lead"),
+    // removing only "lead". Guards the clear-all edge stays closed.
     let home = std::env::temp_dir().join(format!("agend-unwatch-empty-arg-{}", std::process::id()));
     std::fs::create_dir_all(&home).ok();
     let args = serde_json::json!({"repository": "owner/repo", "branch": "feat-test"});
@@ -390,6 +390,40 @@ fn ci_unwatch_explicit_empty_instance_keeps_other_subscribers() {
     assert!(
         !subs.iter().any(|s| s == "lead"),
         "lead (the validated caller) should be removed. got {subs:?}"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn ci_unwatch_instance_arg_cannot_drop_another_agents_subscription_30532() {
+    // #2622-followup t-20260705161926295621-30532-2 ② (decision
+    // d-20260705165815268234-1): the former `args["instance"]` override let
+    // agent A pass `instance="agent-B"` to silently drop B's CI-watch
+    // subscription (and resolve B's ci-handoff obligation track) — an
+    // unauthenticated cross-agent state change, the #2622 obligation-loss
+    // class. The override is REMOVED: caller is ALWAYS the validated sender, so
+    // a forged `instance` arg naming another agent is ignored and B stays
+    // subscribed. Pins the new self-only semantics against regression.
+    let home = std::env::temp_dir().join(format!("agend-unwatch-xagent-{}", std::process::id()));
+    std::fs::create_dir_all(&home).ok();
+    let args = serde_json::json!({"repository": "owner/repo", "branch": "feat-xagent"});
+    // B subscribes to the watch.
+    handle_watch_ci(&home, &args, "agent-b");
+
+    // A (validated sender) tries to unwatch B by naming it in the instance arg.
+    let unwatch_args = serde_json::json!({
+        "repository": "owner/repo",
+        "branch": "feat-xagent",
+        "instance": "agent-b",
+    });
+    handle_unwatch_ci(&home, &unwatch_args, "agent-a");
+
+    let path = watch_path_for(&home, "owner/repo", "feat-xagent");
+    let subs = crate::daemon::ci_watch::parse_subscribers(&read_watch(&path));
+    assert!(
+        subs.iter().any(|s| s == "agent-b"),
+        "A must NOT be able to drop B's subscription via a forged `instance` arg \
+         (caller is the validated sender); got {subs:?}"
     );
     std::fs::remove_dir_all(&home).ok();
 }

--- a/src/mcp/handlers/ci/watch.rs
+++ b/src/mcp/handlers/ci/watch.rs
@@ -254,15 +254,20 @@ pub(crate) fn handle_unwatch_ci(home: &Path, args: &Value, instance_name: &str) 
         None => return json!({"error": "missing 'repository'"}),
     };
     let branch = args["branch"].as_str().unwrap_or("main");
-    // Caller identity for selective removal (H4, CR-2026-06-14): the VALIDATED
-    // sender when `instance` arg is absent/empty (`.filter`, mirroring the
-    // sibling cleanup handlers) — NOT a daemon `std::env::var` read (was EMPTY in
-    // the daemon → the empty-caller `subscribers.clear()` path below).
-    let caller = args["instance"]
-        .as_str()
-        .map(String::from)
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| instance_name.to_string());
+    // Caller identity for selective removal is ALWAYS the MCP-validated sender.
+    // (#2622-followup t-20260705161926295621-30532-2 ②, decision
+    // d-20260705165815268234-1): the former `args["instance"]` override was an
+    // unauthenticated cross-agent footgun — agent A could pass
+    // `instance="agent-B"` to silently drop B's CI-watch subscription AND
+    // resolve B's ci-handoff obligation track (the #2622 obligation-loss class,
+    // B never notified). It had no production caller, no test, and was
+    // undeclared in the schema, so it is REMOVED rather than gated (name-based
+    // cross-agent authority is the #1575 class). A legitimate "clean a dead
+    // agent's subscription" need would be a separate authenticated + audited
+    // surface, not a silent arg on a general agent tool. The empty-caller
+    // `subscribers.clear()` path below stays as a defensive fallback (an MCP
+    // call always supplies a non-empty validated sender).
+    let caller = instance_name.to_string();
     // #t-92758 P2: unwatch is also the lead's dismiss path for a stuck ci-ready —
     // clear the caller's own ci-handoff track for this repo@branch so the re-nudge
     // watchdog stops (previously unwatch removed the watch subscription but NOT the

--- a/src/mcp/per_tool_arg_invariant.rs
+++ b/src/mcp/per_tool_arg_invariant.rs
@@ -476,31 +476,16 @@ fn find_violations(
 /// tool's declaration can never satisfy them (the #2648 blind spot this whole
 /// module closes). Each entry is a latent read the union check hid; convert to a
 /// schema declaration instead if the param becomes a primary agent surface.
-const PER_TOOL_ALLOWLIST: &[(&str, &str, &str)] = &[
-    // `ci action=watch` persists task_id as a back-link on the watch sidecar
-    // (watch.rs:163). It is PRIMARILY dispatch-injected by the auto-watch hook
-    // (dispatch_hook/auto_watch.rs:39, from dispatch_auto_bind_lease); the manual
-    // pass-through the comment mentions is a secondary affordance, not the
-    // primary agent surface. Declaring it in def_ci (discoverability) would pull
-    // in the #1933 consumption table — deferred to follow-up task
-    // t-20260705161926295621-30532-2 ①; allow-listed here.
-    (
-        "ci",
-        "task_id",
-        "dispatch-injected watch back-link (auto_watch.rs:39); secondary manual pass-through; schema-declaration deferred to t-20260705161926295621-30532-2 ①",
-    ),
-    // `ci action=unwatch` reads `instance` as an OPTIONAL caller-identity override
-    // for selective subscription removal (watch.rs:261), falling back to the
-    // validated sender (`instance_name`). Caller-identity, not a primary tool
-    // param — and whether agent A may drop agent B's subscription is an authority
-    // question deferred to follow-up task t-20260705161926295621-30532-2 ②;
-    // allow-listed here rather than advertised.
-    (
-        "ci",
-        "instance",
-        "optional caller-identity override for selective unwatch (watch.rs:261); falls back to validated sender; isolation/authority review deferred to t-20260705161926295621-30532-2 ②",
-    ),
-];
+// Currently EMPTY: the two original `ci` entries (watch `task_id`, unwatch
+// `instance`) were resolved by follow-up task t-20260705161926295621-30532-2 —
+// ① `task_id` is now declared in `def_ci`'s schema (discoverability), and ②
+// the unwatch `instance` cross-agent override was removed (decision
+// d-20260705165815268234-1), so `handle_unwatch_ci` no longer reads it. The
+// #2648 invariant now self-verifies both. New entries go here `(tool, key,
+// reason)` only for a genuinely-internal entry-handler read that is NOT an
+// agent-facing schema param for THAT tool; prefer a schema declaration when the
+// param is a real agent surface.
+const PER_TOOL_ALLOWLIST: &[(&str, &str, &str)] = &[];
 
 fn per_tool_allow_set() -> BTreeSet<(String, String)> {
     PER_TOOL_ALLOWLIST

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -315,7 +315,8 @@ pub(crate) fn def_ci() -> Value {
             "next_after_ci": {"oneOf": [{"type": "string"}, {"type": "array", "items": {"type": "string"}}], "description": "Instance or instances to auto-notify when CI passes. Daemon sends [ci-ready-for-action] to each target."},
             "review_class": {"type": "string", "enum": ["single", "dual"], "description": "#972: review threshold for the daemon's PR-state aggregator. `single` (default) — §3.6 one VERIFIED unlocks the merge gate. `dual` — §3.5 two distinct VERIFIED required before `[pr-ready-for-merge]` fires."},
             "ci_provider": {"type": "string", "description": "watch: CI provider override — `github` (default) or `bitbucket_cloud`. `bitbucket_server` is rejected (not yet supported). Persisted on the watch sidecar."},
-            "ci_provider_url": {"type": "string", "description": "watch: base URL for a self-hosted CI provider, persisted on the watch sidecar alongside `ci_provider`."}
+            "ci_provider_url": {"type": "string", "description": "watch: base URL for a self-hosted CI provider, persisted on the watch sidecar alongside `ci_provider`."},
+            "task_id": {"type": "string", "description": "watch: optional task id to bind this watch to. Persisted on the watch sidecar as a back-link so the `[ci-ready-for-action]` the daemon emits on CI pass carries a structured reference to the originating task. Normally injected by the dispatch auto-watch (dispatch_auto_bind_lease); a manual `ci action=watch` caller may also pass it to bind the watch to a specific task (#1031)."}
         }, "required": ["action"]}})
 }
 
@@ -1018,6 +1019,7 @@ mod tests {
             ("ci", "review_class", "ci/mod.rs dual-review gate (#972)"),
             ("ci", "ci_provider", "ci/mod.rs provider override"),
             ("ci", "ci_provider_url", "ci/mod.rs self-hosted base URL"),
+            ("ci", "task_id", "ci/watch.rs:163 handle_watch_ci watch back-link (#1031)"),
             // ── repo ──
             ("repo", "action", "ci/mod.rs routing"),
             ("repo", "pr", "ci/mod.rs handle_merge_repo"),


### PR DESCRIPTION
Resolves the two latent `ci` reads #2650's per-(tool,arg) invariant surfaced and per-tool-allowlisted (task t-20260705161926295621-30532-2). Both are now legitimately closed, **emptying `PER_TOOL_ALLOWLIST`** so the #2648 invariant self-verifies both.

## ① `ci watch` `task_id` — declared (discoverability)

`handle_watch_ci` reads `args["task_id"]` (watch.rs:163) to persist a task back-link on the watch sidecar, but `def_ci` never declared it — undiscoverable to agents (the #2648-class gap #2650 flagged).

- Declared `task_id` (optional string) in `def_ci`'s `inputSchema` with a dual-use description: dispatch auto-watch back-link (injected by `dispatch_auto_bind_lease` / `auto_watch.rs`) **and** a manual `ci action=watch` caller may pass it to bind the watch to a task (#1031).
- Added the matching `#1933` consumption-table entry (`coordination_tool_schema_fields_are_consumed_or_deferred`) citing `watch.rs:163`.
- Removed the `("ci","task_id",…)` `PER_TOOL_ALLOWLIST` entry.

## ② `ci unwatch` `instance` override — removed (authority)

Per lead ruling **decision d-20260705165815268234-1** (recommendation (b) from the spike). `handle_unwatch_ci` resolved `caller` from `args["instance"]` (falling back to the validated sender), so **agent A could pass `instance="agent-B"` to silently drop B's CI-watch subscription AND resolve B's ci-handoff obligation track** — an unauthenticated cross-agent state change (the #2622 obligation-loss class, B never notified).

Spike findings (workspace `PROPOSAL-ci-unwatch-instance-override.md`): the override had **no production caller, no test coverage, and was undeclared** in the schema; the tested/legit "unwatch yourself" path works via the `instance_name` fallback, not the arg.

- `caller` is now **ALWAYS** the MCP-validated sender (`instance_name`); the `args["instance"]` read is removed — not gated (name-based cross-agent authority is the #1575 class). A real "clean a dead agent's subscription" need would be a separate authenticated + audited surface.
- The empty-caller `subscribers.clear()` path stays as a defensive fallback (an MCP call always supplies a non-empty sender).
- Removed the `("ci","instance",…)` allowlist entry (`PER_TOOL_ALLOWLIST` is now empty).
- **Regression test** `ci_unwatch_instance_arg_cannot_drop_another_agents_subscription_30532`: A calls unwatch with `instance="agent-B"` → B stays subscribed (pins the new self-only semantics).

## Test plan
- [x] `cargo fmt --check` clean; `cargo clippy --all-targets --features tray -- -D warnings` clean
- [x] `per_tool_entry_handler_arg_reads_declared_in_own_schema_2648` green with the now-empty allowlist (both ci reads legitimately resolved)
- [x] ci watch/unwatch suite green incl. the new counterexample, the `unwatch_uses_validated_caller_not_clear_all` review-repro, and `dispatch_persists_task_id_into_ci_watch_sidecar_1031`
- [x] all 15 tools-mod invariants green (`mcp_handler_arg_reads_are_declared_or_allowlisted` union, `coordination_tool_schema_fields_are_consumed_or_deferred` #1933, tool-count)
- [ ] CI green

Refs #2648. Decision d-20260705165815268234-1. correlation_id: t-20260705161926295621-30532-2