### PR TITLE
refactor(ci-watch): CiOutcome — write-side conclusion typing (Pattern-A follow-up)

### DIFF
--- a/src/daemon/ci_watch/poller.rs
+++ b/src/daemon/ci_watch/poller.rs
@@ -868,6 +868,41 @@ pub(crate) fn parse_review_class(
     }
 }
 
+/// The poller's display-layer distinction over a raw CI `conclusion`
+/// string — exactly the 3-way split the notification/aggregation logic
+/// below makes: `Pending` (no conclusion yet / still running), `Success` /
+/// `Failure` get their own `[ci-pass]` / `[ci-fail]` headline, and
+/// everything else (`cancelled`, `timed_out`, `skipped`, `neutral`,
+/// `action_required`, `stale`, …) falls into `Other` and is displayed
+/// VERBATIM via `[ci-ended] …: {other}` (see `ci_notification_message`).
+///
+/// Distinct from [`crate::daemon::pr_state::CiConclusion`], which is the
+/// REDUCER's 2-state view (`Green` vs `Failed`) — correct at that layer
+/// because `CiState` doesn't distinguish a cancelled run from a failed one.
+/// Merging the two would collapse `Other`'s display semantics here: a
+/// cancelled run would render as `[ci-fail]` instead of `[ci-ended] …:
+/// cancelled`, silently changing user-facing notification text. Do not
+/// merge them. Derived from the Pattern-A follow-up spike, gapfix task
+/// t-20260621072505708315-50793-7 (full ~15-site inventory + rationale).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum CiOutcome {
+    Pending,
+    Success,
+    Failure,
+    Other(String),
+}
+
+impl From<Option<&str>> for CiOutcome {
+    fn from(conclusion: Option<&str>) -> Self {
+        match conclusion {
+            None => Self::Pending,
+            Some("success") => Self::Success,
+            Some("failure") => Self::Failure,
+            Some(other) => Self::Other(other.to_string()),
+        }
+    }
+}
+
 pub(crate) fn aggregate_conclusion_for_sha<'a>(runs: &'a [CiRun], sha: &str) -> Option<&'a str> {
     aggregate_conclusion_for_sha_filtered(runs, sha, None)
 }
@@ -939,7 +974,7 @@ pub(crate) fn aggregate_conclusion_for_sha_filtered<'a>(
     // Fail-fast: any failure → immediately report (don't wait for in-progress)
     if matching
         .iter()
-        .any(|r| r.conclusion.as_deref() == Some("failure"))
+        .any(|r| matches!(CiOutcome::from(r.conclusion.as_deref()), CiOutcome::Failure))
     {
         return Some("failure");
     }
@@ -949,7 +984,7 @@ pub(crate) fn aggregate_conclusion_for_sha_filtered<'a>(
     }
     if let Some(r) = matching
         .iter()
-        .find(|r| r.conclusion.as_deref() != Some("success"))
+        .find(|r| !matches!(CiOutcome::from(r.conclusion.as_deref()), CiOutcome::Success))
     {
         return r.conclusion.as_deref();
     }
@@ -976,7 +1011,7 @@ fn aggregate_conclusion_for_indices<'a>(
     }
     if matching
         .iter()
-        .any(|r| r.conclusion.as_deref() == Some("failure"))
+        .any(|r| matches!(CiOutcome::from(r.conclusion.as_deref()), CiOutcome::Failure))
     {
         return Some("failure");
     }
@@ -985,7 +1020,7 @@ fn aggregate_conclusion_for_indices<'a>(
     }
     if let Some(r) = matching
         .iter()
-        .find(|r| r.conclusion.as_deref() != Some("success"))
+        .find(|r| !matches!(CiOutcome::from(r.conclusion.as_deref()), CiOutcome::Success))
     {
         return r.conclusion.as_deref();
     }
@@ -1098,7 +1133,7 @@ pub(crate) fn build_inbox_body(
     run_id: Option<u64>,
     log_tail: Option<&str>,
 ) -> String {
-    if conclusion == "failure" {
+    if matches!(CiOutcome::from(Some(conclusion)), CiOutcome::Failure) {
         let detail = failure_detail.unwrap_or("unknown step");
         let run_id_str = run_id
             .map(|id| id.to_string())
@@ -1139,14 +1174,14 @@ fn ci_notification_message(
     _failure_detail: Option<&str>,
     head_sha: Option<&str>,
 ) -> Option<String> {
-    let conclusion = conclusion?;
     let sha_short = head_sha
         .map(|s| format!(" ({})", &s[..s.len().min(7)]))
         .unwrap_or_default();
-    let msg = match conclusion {
-        "failure" => format!("[ci-fail] {repo}@{branch}{sha_short}: failure"),
-        "success" => format!("[ci-pass] {repo}@{branch}{sha_short}: passed ✓"),
-        other => format!("[ci-ended] {repo}@{branch}{sha_short}: {other}"),
+    let msg = match CiOutcome::from(conclusion) {
+        CiOutcome::Pending => return None,
+        CiOutcome::Failure => format!("[ci-fail] {repo}@{branch}{sha_short}: failure"),
+        CiOutcome::Success => format!("[ci-pass] {repo}@{branch}{sha_short}: passed ✓"),
+        CiOutcome::Other(other) => format!("[ci-ended] {repo}@{branch}{sha_short}: {other}"),
     };
     Some(msg)
 }
@@ -1237,7 +1272,7 @@ async fn check_early_job_failures(
         let jobs = provider.fetch_run_jobs(ctx.repo, run.id).await;
         let failed: Vec<&CiJob> = jobs
             .iter()
-            .filter(|j| j.conclusion.as_deref() == Some("failure"))
+            .filter(|j| matches!(CiOutcome::from(j.conclusion.as_deref()), CiOutcome::Failure))
             .collect();
         if failed.is_empty() {
             continue;
@@ -1802,6 +1837,11 @@ async fn fan_out_notifications(
         if conclusion.is_none() {
             continue;
         }
+        // CiOutcome (Pattern-A follow-up, t-20260621072505708315-50793-7):
+        // `conclusion` is guaranteed `Some` past the check above, so `outcome`
+        // never observes `Pending` here — see `ci_notification_message` for
+        // the site that legitimately maps `None` to `Pending`.
+        let outcome = CiOutcome::from(conclusion);
         if *run_id > max_notified_id {
             max_notified_id = *run_id;
         }
@@ -1838,7 +1878,7 @@ async fn fan_out_notifications(
         // re-evaluates — a LATER required failure on this same sha is never hidden
         // (the lead's hard rule). fail-OPEN: only a definitive Some(false) suppresses;
         // None (no open PR / API error / no rollup) falls through to the normal emit.
-        if conclusion == Some("failure")
+        if matches!(outcome, CiOutcome::Failure)
             && provider.required_check_failed(ctx.repo, ctx.branch).await == Some(false)
         {
             tracing::debug!(
@@ -1861,7 +1901,7 @@ async fn fan_out_notifications(
             let rep = conclusion
                 .and_then(|c| representative_run(&pr.runs, sha, c))
                 .unwrap_or(run);
-            let failure_detail = if conclusion == Some("failure") {
+            let failure_detail = if matches!(outcome, CiOutcome::Failure) {
                 Some(provider.fetch_failure_summary(ctx.repo, rep.id).await)
             } else {
                 None
@@ -1870,7 +1910,7 @@ async fn fan_out_notifications(
             // agent doesn't need an extra `gh run view` round-trip. Async on the
             // ci runtime (the provider impl uses `gh … --log-failed` via
             // tokio::process — never block_on the shared runtime, #1476).
-            let log_tail = if conclusion == Some("failure") {
+            let log_tail = if matches!(outcome, CiOutcome::Failure) {
                 provider.fetch_failure_log_tail(ctx.repo, rep.id, 120).await
             } else {
                 None
@@ -1886,7 +1926,7 @@ async fn fan_out_notifications(
 
             let repo_branch_key = format!("{}@{}", ctx.repo, ctx.branch);
             let supersede_token = format!("ci-{}-{}", run_id, sha);
-            let action_targets_on_success = if conclusion == Some("success") {
+            let action_targets_on_success = if matches!(outcome, CiOutcome::Success) {
                 state.next_after_ci_targets()
             } else {
                 Vec::new()
@@ -1921,8 +1961,8 @@ async fn fan_out_notifications(
                 // #event-bus Step 2 (legacy-zero): the success/failure pair emits
                 // (the subscriber delivers via deliver_ci_watch). A non-pair
                 // "[ci-ended]" conclusion has no event kind → direct deliver.
-                let emitted = match conclusion {
-                    Some("failure") => {
+                let emitted = match outcome {
+                    CiOutcome::Failure => {
                         crate::daemon::event_bus::global().emit(
                             ctx.home,
                             crate::daemon::event_bus::EventKind::CiFail {
@@ -1934,7 +1974,7 @@ async fn fan_out_notifications(
                         );
                         true
                     }
-                    Some("success") => {
+                    CiOutcome::Success => {
                         crate::daemon::event_bus::global().emit(
                             ctx.home,
                             crate::daemon::event_bus::EventKind::CiReady {
@@ -2050,12 +2090,14 @@ fn persist_watch_state(
         // `record_ci_result` below is keyed on repo/branch independent of routing.)
         // The ONE genuinely-silent case — no `next_after_ci` AND no subscribers
         // (a malformed watch) — is loud-logged rather than dropped silently.
-        if aggregate_conclusion_for_sha_filtered(
-            &pr.runs,
-            &pr.current_sha,
-            state.required_checks.as_deref(),
-        ) == Some("success")
-        {
+        if matches!(
+            CiOutcome::from(aggregate_conclusion_for_sha_filtered(
+                &pr.runs,
+                &pr.current_sha,
+                state.required_checks.as_deref(),
+            )),
+            CiOutcome::Success
+        ) {
             let targets = state.next_after_ci_targets();
             if !targets.is_empty() {
                 // The suppression decision is loop-INVARIANT (keyed on repo/branch/

--- a/src/daemon/ci_watch/poller_tests.rs
+++ b/src/daemon/ci_watch/poller_tests.rs
@@ -10,6 +10,25 @@ fn ci_watches_dir_returns_expected_path() {
     );
 }
 
+/// Pattern-A follow-up (t-20260621072505708315-50793-7): pin `CiOutcome`'s
+/// mapping before it replaces the raw `== Some("...")` sites — `Other` must
+/// preserve the raw conclusion string (the poller's `[ci-ended] …: {other}`
+/// display depends on it).
+#[test]
+fn ci_outcome_from_maps_pending_success_failure_other() {
+    assert_eq!(CiOutcome::from(None), CiOutcome::Pending);
+    assert_eq!(CiOutcome::from(Some("success")), CiOutcome::Success);
+    assert_eq!(CiOutcome::from(Some("failure")), CiOutcome::Failure);
+    assert_eq!(
+        CiOutcome::from(Some("cancelled")),
+        CiOutcome::Other("cancelled".to_string())
+    );
+    assert_eq!(
+        CiOutcome::from(Some("timed_out")),
+        CiOutcome::Other("timed_out".to_string())
+    );
+}
+
 fn tmp_dir(tag: &str) -> std::path::PathBuf {
     use std::sync::atomic::{AtomicU32, Ordering};
     static COUNTER: AtomicU32 = AtomicU32::new(0);
@@ -965,6 +984,32 @@ fn test_inbox_body_success_has_url_no_detail() {
     assert!(
         !body.contains("checklist"),
         "success body must not have checklist: {body}"
+    );
+}
+
+/// Pattern-A follow-up (t-20260621072505708315-50793-7): pin that a
+/// non-failure, non-success conclusion (e.g. "cancelled") takes the SAME
+/// generic body path as "success" — no Detail:/checklist. The CiOutcome
+/// conversion at this site splits on `Failure` vs not-`Failure`, so this
+/// must keep holding for every `Other` value, not just "success".
+#[test]
+fn test_inbox_body_other_conclusion_takes_success_shaped_path() {
+    let body = build_inbox_body(
+        "[ci-ended] o/r@main: cancelled",
+        "cancelled",
+        None,
+        "https://github.com/o/r/actions/runs/999",
+        Some(999),
+        None,
+    );
+    assert!(body.contains("URL: https://"), "body must have URL: {body}");
+    assert!(
+        !body.contains("Detail:"),
+        "non-failure body must not have Detail: {body}"
+    );
+    assert!(
+        !body.contains("checklist"),
+        "non-failure body must not have checklist: {body}"
     );
 }
 
@@ -4154,6 +4199,42 @@ fn github_check_pr_terminal_uses_owner_prefix_in_head_query() {
         !path.contains("head=feat/foo&"),
         "URL must NOT use bare `head={{branch}}` (the silent-drop bug); got: {path}"
     );
+}
+
+/// Pattern-A follow-up (t-20260621072505708315-50793-7): pin
+/// `GitHubCiProvider::fetch_failure_summary` finding the failed step before
+/// its `step["conclusion"].as_str() == Some("failure")` site converts to
+/// `CiOutcome`. No prior direct test covered the GitHub provider's summary
+/// path (only GitLab/Bitbucket had one — see
+/// `gitlab_fetch_failure_summary_finds_failed_job` below).
+#[test]
+fn github_fetch_failure_summary_finds_failed_step() {
+    let body = r#"{
+        "jobs": [{
+            "name": "build",
+            "steps": [
+                {"name": "Checkout", "conclusion": "success"},
+                {"name": "Run tests", "conclusion": "failure"}
+            ]
+        }]
+    }"#;
+    let (port, handle, captured) = github_mock_server(body);
+    let provider = super::GitHubCiProvider::with_base_url(format!("http://127.0.0.1:{port}"))
+        .expect("provider");
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("rt");
+    let summary = rt.block_on(provider.fetch_failure_summary("foo/bar", 48));
+
+    handle.join().expect("mock");
+    let (path, _req) = captured.lock().expect("lock").take().expect("captured");
+    assert!(
+        path.contains("/repos/foo/bar/actions/runs/48/jobs"),
+        "path: {path}"
+    );
+    assert_eq!(summary, "build / Run tests", "summary: {summary}");
 }
 
 #[test]

--- a/src/daemon/ci_watch/provider.rs
+++ b/src/daemon/ci_watch/provider.rs
@@ -781,7 +781,11 @@ impl CiProvider for GitHubCiProvider {
                 jobs.iter().find_map(|job| {
                     job["steps"].as_array().and_then(|steps| {
                         steps.iter().find_map(|step| {
-                            (step["conclusion"].as_str() == Some("failure")).then(|| {
+                            matches!(
+                                super::poller::CiOutcome::from(step["conclusion"].as_str()),
+                                super::poller::CiOutcome::Failure
+                            )
+                            .then(|| {
                                 format!(
                                     "{} / {}",
                                     job["name"].as_str().unwrap_or("?"),

--- a/src/daemon/pr_state/mod.rs
+++ b/src/daemon/pr_state/mod.rs
@@ -238,6 +238,18 @@ pub enum Event<'a> {
     ClosedUnmergedObserved { closed_at: String },
 }
 
+/// The reducer's 2-state view of a CI outcome — `Green` vs `Failed` — used
+/// to drive `CiState` transitions, where a cancelled run and a failed run
+/// are not actionably different (neither is "your turn").
+///
+/// Distinct from [`crate::daemon::ci_watch::poller::CiOutcome`], the
+/// poller's 3-state view — it keeps a separate `Other` case because the
+/// poller's notification/aggregation layer displays cancelled/timed_out/etc.
+/// VERBATIM (`[ci-ended] …: {other}`) rather than reporting them as a
+/// failure. Do NOT merge `CiOutcome` into this enum: collapsing `Other`
+/// into `Failed` is correct for the reducer but would change the poller's
+/// notification text. Derived from the Pattern-A follow-up spike, gapfix
+/// task t-20260621072505708315-50793-7.
 #[derive(Debug, Clone, Copy)]
 pub enum CiConclusion<'a> {
     Pending,


### PR DESCRIPTION
## Summary
- Pattern-A follow-up (2nd deferred sub-pattern): the poller/provider notification+aggregation logic compared CI `conclusion` against raw string literals (`== Some("success"/"failure")`) at ~15 sites in `poller.rs`/`provider.rs`, instead of using a typed value.
- Existing `pr_state::CiConclusion` is already typed but is the *wrong* fit here: it's a 2-state reducer view (`Green`/`Failed`) that collapses `cancelled`/`timed_out`/etc into `Failed`, while the poller's notification layer displays these distinctly (`[ci-ended] …: cancelled` vs `[ci-fail]`). Reusing it would silently change notification text for non-success/non-failure conclusions.
- Adds a new `CiOutcome{Pending, Success, Failure, Other(String)}` (poller's own 3-state view) + `From<Option<&str>>`, and converts all ~15 raw comparisons to match on it. `CiConclusion` (reducer), `CiRun.conclusion: Option<String>` (provider wire type), and the provider normalizers are untouched — small blast radius, behavior-preserving.
- Both enums' doc comments now cross-reference each other and explain why they must not be merged (anti-cleanup guard).

## Test plan
- [x] New pin tests added *before* converting the two previously-uncovered sites: `test_inbox_body_other_conclusion_takes_success_shaped_path` (build_inbox_body's non-failure path) and `github_fetch_failure_summary_finds_failed_step` (no prior direct test existed for `GitHubCiProvider::fetch_failure_summary`), plus `ci_outcome_from_maps_pending_success_failure_other` for the new type itself.
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --bin agend-terminal --all-targets` — 0 warnings
- [x] `cargo nextest run --bin agend-terminal` — full suite 4938/4938 passed (0 failed) on second run; a first run hit 2 unrelated `per_tick::hourly_gc` failures that passed in isolation (parallel-load flake, confirmed via `[[local-sandbox-test-failures]]`-style isolated re-run, not caused by this change)
- [x] All 236 pre-existing `ci_watch::` tests + 91 `pr_state::` tests still pass unchanged — confirms byte-equivalent behavior at every converted site

Spike + design vetted by lead (`claude-aef7c0`) on task `t-20260621072505708315-50793-7`; full site inventory and rationale in the task's spike doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)