### PR TITLE
fix: close 3 worktree-reclaim false-positive classes (PRUNE_LIVE P0)

### DIFF
--- a/src/binding.rs
+++ b/src/binding.rs
@@ -711,30 +711,11 @@ pub fn bound_source_repos(home: &Path) -> Vec<std::path::PathBuf> {
     repos
 }
 
-/// #t-…81457-1: the distinct `worktree` paths of every LIVE bound branch (each
-/// `runtime/<agent>/binding.json`'s `worktree`), read fresh from disk every
-/// call — mirrors `bound_source_repos`'s self-healing shape.
-///
-/// worktree-reclaim's occupancy check (`worktree_cleanup::is_in_use`) only
-/// consulted the daemon's in-memory `AgentConfig.working_dir` registry, a
-/// SEPARATE, independently-updated signal from `binding.json` — a worktree the
-/// daemon itself auto-bound moments ago (binding.json written) can be invisible
-/// to that check until the in-memory registry catches up, so the sweep reaps a
-/// worktree the daemon knows is live. Feeding these paths into the same
-/// occupancy check closes that gap: binding.json is authoritative and always
-/// current, no registry-sync race possible.
-pub fn bound_worktree_paths(home: &Path) -> Vec<std::path::PathBuf> {
-    let mut paths: Vec<std::path::PathBuf> = Vec::new();
-    for (_, v) in binding_scan_all(home) {
-        if let Some(wt) = v["worktree"].as_str() {
-            let path = std::path::PathBuf::from(wt);
-            if !paths.contains(&path) {
-                paths.push(path);
-            }
-        }
-    }
-    paths
-}
+// #t-…81457-1: the worktree-occupancy equivalent of `bound_source_repos`
+// lives in `worktree_cleanup` (its only consumer) as
+// `bound_worktree_paths_or_ambiguous` — it needs to distinguish "no
+// binding.json" from "unreadable/corrupt binding.json" for the delete-path
+// fail-closed requirement, unlike this module's existing scan helpers.
 
 /// Read the current binding for an agent.
 /// Hot path: returns from in-memory index (read lock). Cold path

--- a/src/binding.rs
+++ b/src/binding.rs
@@ -711,6 +711,31 @@ pub fn bound_source_repos(home: &Path) -> Vec<std::path::PathBuf> {
     repos
 }
 
+/// #t-…81457-1: the distinct `worktree` paths of every LIVE bound branch (each
+/// `runtime/<agent>/binding.json`'s `worktree`), read fresh from disk every
+/// call — mirrors `bound_source_repos`'s self-healing shape.
+///
+/// worktree-reclaim's occupancy check (`worktree_cleanup::is_in_use`) only
+/// consulted the daemon's in-memory `AgentConfig.working_dir` registry, a
+/// SEPARATE, independently-updated signal from `binding.json` — a worktree the
+/// daemon itself auto-bound moments ago (binding.json written) can be invisible
+/// to that check until the in-memory registry catches up, so the sweep reaps a
+/// worktree the daemon knows is live. Feeding these paths into the same
+/// occupancy check closes that gap: binding.json is authoritative and always
+/// current, no registry-sync race possible.
+pub fn bound_worktree_paths(home: &Path) -> Vec<std::path::PathBuf> {
+    let mut paths: Vec<std::path::PathBuf> = Vec::new();
+    for (_, v) in binding_scan_all(home) {
+        if let Some(wt) = v["worktree"].as_str() {
+            let path = std::path::PathBuf::from(wt);
+            if !paths.contains(&path) {
+                paths.push(path);
+            }
+        }
+    }
+    paths
+}
+
 /// Read the current binding for an agent.
 /// Hot path: returns from in-memory index (read lock). Cold path
 /// (first access per agent): acquires write lock, double-checks,

--- a/src/worktree_cleanup.rs
+++ b/src/worktree_cleanup.rs
@@ -92,10 +92,30 @@ fn is_branch_merged(repo_root: &Path, branch: &str) -> bool {
     let default = crate::git_helpers::default_branch(repo_root);
     // W1.2: git_ok = always-bypass + bounded, true iff exit-0 (the
     // `output().map(success).unwrap_or(false)` idiom, byte-for-byte).
-    crate::git_helpers::git_ok(
+    if !crate::git_helpers::git_ok(
         repo_root,
         &["merge-base", "--is-ancestor", branch, &default],
-    )
+    ) {
+        return false;
+    }
+    // #t-…81457-1: is-ancestor is trivially TRUE when `branch`'s tip IS
+    // `default`'s tip — indistinguishable, from git state alone, between a
+    // brand-new zero-commit branch (nothing ever merged — dev3's PRUNE_LIVE
+    // incident) and a genuinely fast-forward-merged branch (whose tip
+    // legitimately became identical to default's). There is no git-content
+    // signal that tells these apart. Reuse the SAME `SQUASH_GC_MIN_TIP_AGE`
+    // floor the squash path already relies on for the identical reason: only
+    // trust "merged" once the shared tip has sat for a while, giving a
+    // just-created branch's binding-registry entry (fix #1, the primary
+    // defense) time to be observed even if that check somehow lagged.
+    let Some((_, tip_ts)) = branch_tip_info(repo_root, branch) else {
+        return false;
+    };
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    Duration::from_secs(now.saturating_sub(tip_ts)) >= SQUASH_GC_MIN_TIP_AGE
 }
 
 /// Check if a branch's remote tracking ref has been deleted (i.e. the PR was
@@ -114,6 +134,25 @@ fn is_remote_gone(repo_root: &Path, branch: &str) -> bool {
         // No remote configured — not a remote-tracking branch, don't treat as "gone"
         return false;
     };
+    // #t-…81457-1: `refs/remotes/{remote}/{branch}`'s absence only means "the
+    // remote branch was deleted" when the branch was ever tracking THAT same
+    // remote branch to begin with. `bind_self`'s branch creation (`git branch
+    // <name> origin/main`) auto-sets `branch.<name>.merge = refs/heads/main`
+    // (tracks origin/main, not a same-named remote branch) — a branch that's
+    // simply never been pushed under its own name would otherwise be
+    // conflated with "was pushed, remote then deleted" and misclassified as
+    // gone. Self-reproduced live: this agent's own fresh worktree and
+    // gapfix-dev2's were both reaped this way within ~70s of bind, before
+    // either had pushed. Require the upstream `merge` ref to actually be
+    // `refs/heads/<branch>` first; on any ambiguity (missing/mismatched)
+    // prefer NOT concluding gone — a false negative just waits for the next
+    // sweep once the branch is genuinely pushed-then-orphaned, a false
+    // positive is an irrecoverable delete.
+    let merge_ref =
+        crate::git_helpers::git_cmd(repo_root, &["config", &format!("branch.{branch}.merge")]).ok();
+    if merge_ref.as_deref() != Some(format!("refs/heads/{branch}").as_str()) {
+        return false;
+    }
     // Check if the remote ref still exists
     let remote_ref = format!("refs/remotes/{remote}/{branch}");
     // git-raw-allowed: error→EXISTS (`unwrap_or(true)`) is a deliberate safe
@@ -280,6 +319,13 @@ pub fn sweep_from_registry(
     let mut active_dirs: Vec<PathBuf> = configs.values().flatten().cloned().collect();
     // Add fleet.yaml dirs as fallback for stopped agents
     active_dirs.extend(fleet_dirs.iter().cloned());
+    // #t-…81457-1: `configs` (in-memory AgentConfig.working_dir) is a SEPARATE
+    // registry from binding.json, updated on its own schedule — a worktree the
+    // daemon itself just auto-bound (binding.json written) can be invisible to
+    // `configs` until it catches up. binding.json is read fresh every call and
+    // is authoritative for "is anyone bound here right now", so feed it into
+    // the same occupancy check directly instead of relying solely on `configs`.
+    active_dirs.extend(crate::binding::bound_worktree_paths(home));
 
     let mut removed = Vec::new();
 
@@ -602,6 +648,19 @@ mod tests {
             .expect("git");
     }
 
+    /// #t-…81457-1: build a branch with a single OLD dated commit (checked out
+    /// then back to main), so `is_branch_merged`'s age gate treats it as
+    /// genuinely merged rather than a suspiciously-fresh zero-commit branch.
+    /// Mirrors `make_squash_orphan`'s dating approach but for a plain
+    /// fast-forward-mergeable branch (no divergence from main).
+    fn make_old_dated_branch(repo: &Path, branch: &str, tip_date: &str) {
+        git_in(repo, &["checkout", "-b", branch]);
+        std::fs::write(repo.join("feat.txt"), "feature").ok();
+        git_in(repo, &["add", "."]);
+        git_commit_dated(repo, "feature work", tip_date);
+        git_in(repo, &["checkout", "main"]);
+    }
+
     /// #2605: fake daemon `home` for `bound_source_repos` — repo discovery now
     /// reads live `binding.json` state instead of the old configs-tuple field.
     fn tmp_home(tag: &str) -> PathBuf {
@@ -702,7 +761,11 @@ mod tests {
     fn test_sweep_dry_run_by_default_identifies_but_does_not_delete() {
         let _lock = ENV_LOCK.lock();
         let repo = setup_test_repo("v2-dry-run");
-        git_in(&repo, &["branch", "feat/done"]);
+        // #t-…81457-1: `is_branch_merged` now age-gates on the shared tip's
+        // commit date (indistinguishable, from git state alone, between a
+        // zero-commit branch and a genuinely ff-merged one) — give feat/done
+        // an OLD dated commit so it clears the gate like a real merged branch.
+        make_old_dated_branch(&repo, "feat/done", "2024-01-01T00:00:00 +0000");
         let wt = repo.join("wt-done");
         git_in(
             &repo,
@@ -734,7 +797,9 @@ mod tests {
     fn test_v2_merged_worktree_removed() {
         let _lock = ENV_LOCK.lock();
         let repo = setup_test_repo("v2-merged");
-        git_in(&repo, &["branch", "feat/done"]);
+        // #t-…81457-1: see the "v2-dry-run" test above for why this needs an
+        // old dated commit now.
+        make_old_dated_branch(&repo, "feat/done", "2024-01-01T00:00:00 +0000");
         let wt = repo.join("wt-done");
         git_in(
             &repo,
@@ -861,7 +926,13 @@ mod tests {
     /// both). `write_source_repo_binding` (above) only sets `source_repo`,
     /// which is enough for repo-discovery tests but not for exercising
     /// worktree-occupancy via the binding registry.
-    fn write_full_binding(home: &Path, agent: &str, branch: &str, source_repo: &Path, worktree: &Path) {
+    fn write_full_binding(
+        home: &Path,
+        agent: &str,
+        branch: &str,
+        source_repo: &Path,
+        worktree: &Path,
+    ) {
         let dir = crate::paths::runtime_dir(home).join(agent);
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(
@@ -910,7 +981,10 @@ mod tests {
              when `configs` hasn't caught up yet (the exact dev3 PRUNE_LIVE \
              incident): {removed:?}"
         );
-        assert!(wt.exists(), "the live-bound worktree directory must survive");
+        assert!(
+            wt.exists(),
+            "the live-bound worktree directory must survive"
+        );
 
         std::env::remove_var("AGEND_WORKTREE_AUTO_CLEANUP");
         std::env::remove_var("AGEND_WORKTREE_PRUNE_LIVE");
@@ -951,7 +1025,12 @@ mod tests {
         let wt = repo.join("wt-fresh-no-commits");
         git_in(
             &repo,
-            &["worktree", "add", wt.to_str().unwrap(), "feat/fresh-no-commits"],
+            &[
+                "worktree",
+                "add",
+                wt.to_str().unwrap(),
+                "feat/fresh-no-commits",
+            ],
         );
 
         std::env::set_var("AGEND_WORKTREE_AUTO_CLEANUP", "1");
@@ -1263,7 +1342,8 @@ mod tests {
         let _lock = ENV_LOCK.lock();
         let repo = setup_test_repo("b3-dry-run");
         // A genuinely merged (fast-forward) branch — unambiguously eligible.
-        git_in(&repo, &["branch", "feat/merged"]);
+        // #t-…81457-1: old dated commit so it clears is_branch_merged's age gate.
+        make_old_dated_branch(&repo, "feat/merged", "2024-01-01T00:00:00 +0000");
         git_in(&repo, &["merge", "feat/merged"]);
 
         let pruned = prune_orphaned_branches(&repo, true);

--- a/src/worktree_cleanup.rs
+++ b/src/worktree_cleanup.rs
@@ -266,6 +266,36 @@ fn canonicalize_lenient(p: &Path) -> Option<PathBuf> {
     None
 }
 
+/// #t-…81457-1: distinct `worktree` paths of every LIVE `binding.json`, for
+/// the delete-path occupancy check (mirrors `binding::bound_source_repos`'s
+/// self-healing shape, but this one MUST distinguish "no binding.json"
+/// (normal — agent never bound) from "binding.json exists but failed to
+/// read/parse" (ambiguous — may be hiding a live binding). `Err` signals the
+/// latter; the caller fails the whole sweep round closed rather than treat
+/// an ambiguous row as absent.
+fn bound_worktree_paths_or_ambiguous(home: &Path) -> Result<Vec<PathBuf>, ()> {
+    let Ok(entries) = std::fs::read_dir(crate::paths::runtime_dir(home)) else {
+        return Ok(Vec::new());
+    };
+    let mut paths = Vec::new();
+    for entry in entries.flatten() {
+        let agent = entry.file_name().to_string_lossy().into_owned();
+        let content = match std::fs::read_to_string(crate::paths::binding_path(home, &agent)) {
+            Ok(c) => c,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(_) => return Err(()),
+        };
+        let v: serde_json::Value = serde_json::from_str(&content).map_err(|_| ())?;
+        if let Some(wt) = v["worktree"].as_str() {
+            let path = PathBuf::from(wt);
+            if !paths.contains(&path) {
+                paths.push(path);
+            }
+        }
+    }
+    Ok(paths)
+}
+
 /// Check if a worktree path is in use by any active agent.
 fn is_in_use(wt_path: &Path, active_dirs: &[PathBuf]) -> bool {
     let wt_norm = normalize_path(
@@ -325,7 +355,23 @@ pub fn sweep_from_registry(
     // `configs` until it catches up. binding.json is read fresh every call and
     // is authoritative for "is anyone bound here right now", so feed it into
     // the same occupancy check directly instead of relying solely on `configs`.
-    active_dirs.extend(crate::binding::bound_worktree_paths(home));
+    //
+    // reviewer4 REJECTED r0 of this fix: an unreadable/corrupt binding.json is
+    // an AMBIGUITY, not an absence — it could be hiding a live worktree. Fail
+    // the whole round closed (no removals) rather than treat it as "not
+    // bound"; deletion is auto-run, "寧可漏收不可誤收". A merely-missing file
+    // (agent never bound) is the normal steady state and does not trigger this.
+    match bound_worktree_paths_or_ambiguous(home) {
+        Ok(paths) => active_dirs.extend(paths),
+        Err(()) => {
+            tracing::warn!(
+                "worktree-reclaim: an unreadable/corrupt binding.json was found — \
+                 skipping ALL removals this sweep tick (fail-closed); will retry \
+                 next tick"
+            );
+            return Vec::new();
+        }
+    }
 
     let mut removed = Vec::new();
 
@@ -958,7 +1004,10 @@ mod tests {
     fn sweep_skips_worktree_known_only_via_binding_json_not_yet_in_configs_registry() {
         let _lock = ENV_LOCK.lock();
         let repo = setup_test_repo("binding-only-occupancy");
-        git_in(&repo, &["branch", "feat/fresh-bind"]);
+        // Old dated commit so `is_branch_merged`'s age gate (fix #2) does NOT
+        // protect this worktree — isolates fix #1 (binding-registry occupancy)
+        // as the ONLY thing standing between this live-bound worktree and removal.
+        make_old_dated_branch(&repo, "feat/fresh-bind", "2024-01-01T00:00:00 +0000");
         let wt = repo.join("wt-fresh-bind");
         git_in(
             &repo,
@@ -984,6 +1033,93 @@ mod tests {
         assert!(
             wt.exists(),
             "the live-bound worktree directory must survive"
+        );
+
+        std::env::remove_var("AGEND_WORKTREE_AUTO_CLEANUP");
+        std::env::remove_var("AGEND_WORKTREE_PRUNE_LIVE");
+        std::fs::remove_dir_all(&repo).ok();
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #t-…81457-1 REJECTED rework (reviewer4 r0): an unreadable/corrupt
+    /// `binding.json` for ANY agent is an AMBIGUITY, not an absence — it could
+    /// be hiding the very live binding that would have protected the worktree
+    /// under test. Pre-rework, `bound_worktree_paths` silently skipped it
+    /// (same as a missing file), so an old (age-gate-cleared), clean, merged
+    /// worktree with no binding of its OWN was still removed even though a
+    /// SIBLING agent's binding.json existed but failed to parse. Reproduces
+    /// reviewer4's exact repro shape: this must now skip the ENTIRE sweep
+    /// round (fail closed), not just the ambiguous row.
+    #[test]
+    fn sweep_fails_closed_when_any_binding_json_is_corrupt() {
+        let _lock = ENV_LOCK.lock();
+        let repo = setup_test_repo("corrupt-binding-ambiguity");
+        make_old_dated_branch(&repo, "feat/live-bound", "2024-01-01T00:00:00 +0000");
+        let wt = repo.join("wt-live-bound");
+        git_in(
+            &repo,
+            &["worktree", "add", wt.to_str().unwrap(), "feat/live-bound"],
+        );
+        git_in(&repo, &["merge", "feat/live-bound"]);
+
+        std::env::set_var("AGEND_WORKTREE_AUTO_CLEANUP", "1");
+        std::env::set_var("AGEND_WORKTREE_PRUNE_LIVE", "1");
+        let home = tmp_home("corrupt-binding-ambiguity");
+        let configs: HashMap<String, Option<PathBuf>> = HashMap::new();
+        // One valid binding for repo discovery ...
+        write_source_repo_binding(&home, "other-agent", &repo);
+        // ... and one CORRUPT binding.json for a DIFFERENT agent — unrelated to
+        // `feat/live-bound` on its face, but the daemon cannot know that from a
+        // file it failed to parse.
+        let corrupt_dir = crate::paths::runtime_dir(&home).join("dev3");
+        std::fs::create_dir_all(&corrupt_dir).unwrap();
+        std::fs::write(corrupt_dir.join("binding.json"), b"not valid json").unwrap();
+
+        let removed = sweep_from_registry(&home, &configs, &[]);
+        assert!(
+            removed.is_empty(),
+            "an unreadable/corrupt binding.json anywhere must fail the WHOLE \
+             sweep round closed, even for an unrelated, otherwise-eligible \
+             worktree: {removed:?}"
+        );
+        assert!(wt.exists(), "the worktree must survive the ambiguous round");
+
+        std::env::remove_var("AGEND_WORKTREE_AUTO_CLEANUP");
+        std::env::remove_var("AGEND_WORKTREE_PRUNE_LIVE");
+        std::fs::remove_dir_all(&repo).ok();
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #t-…81457-1 REJECTED rework, negative control: a MISSING binding.json
+    /// (the normal steady state — most agents are never bound) must NOT
+    /// trigger the fail-closed ambiguity path, or every legitimate cleanup
+    /// case regresses (the 26 real candidates PRUNE_LIVE's first tick
+    /// correctly reaped would silently stop being collected).
+    #[test]
+    fn sweep_still_removes_when_no_binding_json_exists_at_all() {
+        let _lock = ENV_LOCK.lock();
+        let repo = setup_test_repo("no-binding-normal");
+        make_old_dated_branch(&repo, "feat/done", "2024-01-01T00:00:00 +0000");
+        let wt = repo.join("wt-done");
+        git_in(
+            &repo,
+            &["worktree", "add", wt.to_str().unwrap(), "feat/done"],
+        );
+        git_in(&repo, &["merge", "feat/done"]);
+
+        std::env::set_var("AGEND_WORKTREE_AUTO_CLEANUP", "1");
+        std::env::set_var("AGEND_WORKTREE_PRUNE_LIVE", "1");
+        let home = tmp_home("no-binding-normal");
+        let configs: HashMap<String, Option<PathBuf>> = HashMap::new();
+        // Repo discovery needs ONE valid binding; no agent has a binding
+        // pointing at `wt` itself, and no binding.json anywhere is corrupt.
+        write_source_repo_binding(&home, "other-agent", &repo);
+
+        let removed = sweep_from_registry(&home, &configs, &[]);
+        assert!(
+            removed.iter().any(|(b, _, _)| b == "feat/done"),
+            "a genuinely unbound, old, clean, merged worktree must still be \
+             removed — a merely-absent binding.json is not an ambiguity: {removed:?}"
         );
 
         std::env::remove_var("AGEND_WORKTREE_AUTO_CLEANUP");

--- a/src/worktree_cleanup.rs
+++ b/src/worktree_cleanup.rs
@@ -851,6 +851,189 @@ mod tests {
         std::fs::remove_dir_all(&home).ok();
     }
 
+    // ── #t-…81457-1 (PRUNE_LIVE first-day false positives): three independent
+    // occupancy/eligibility gaps found live on 2026-07-06 within the first
+    // sweep tick after PRUNE_LIVE went on. Each RED test below reproduces one
+    // class against the pre-fix code. ──
+
+    /// Seed `home/runtime/<agent>/binding.json` with BOTH `source_repo` and
+    /// `worktree` — the real production shape (`binding::bind`'s writer sets
+    /// both). `write_source_repo_binding` (above) only sets `source_repo`,
+    /// which is enough for repo-discovery tests but not for exercising
+    /// worktree-occupancy via the binding registry.
+    fn write_full_binding(home: &Path, agent: &str, branch: &str, source_repo: &Path, worktree: &Path) {
+        let dir = crate::paths::runtime_dir(home).join(agent);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("binding.json"),
+            serde_json::to_string(&serde_json::json!({
+                "branch": branch,
+                "source_repo": source_repo.display().to_string(),
+                "worktree": worktree.display().to_string(),
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+    }
+
+    /// #t-…81457-1 primary fix: a worktree with a LIVE `binding.json` entry
+    /// must never be swept, even when the daemon's in-memory `configs`
+    /// (AgentConfig.working_dir) registry hasn't caught up yet — the exact
+    /// dev3 PRUNE_LIVE incident (auto-bind at 11:04, sweep at 11:08, `configs`
+    /// still empty for that agent). Pre-fix, `is_in_use` only ever consulted
+    /// `configs`/`fleet_dirs`, never `binding.json`, so this worktree — merged
+    /// AND clean, exactly like dev3's — was eligible and got removed.
+    #[test]
+    fn sweep_skips_worktree_known_only_via_binding_json_not_yet_in_configs_registry() {
+        let _lock = ENV_LOCK.lock();
+        let repo = setup_test_repo("binding-only-occupancy");
+        git_in(&repo, &["branch", "feat/fresh-bind"]);
+        let wt = repo.join("wt-fresh-bind");
+        git_in(
+            &repo,
+            &["worktree", "add", wt.to_str().unwrap(), "feat/fresh-bind"],
+        );
+        git_in(&repo, &["merge", "feat/fresh-bind"]);
+
+        std::env::set_var("AGEND_WORKTREE_AUTO_CLEANUP", "1");
+        std::env::set_var("AGEND_WORKTREE_PRUNE_LIVE", "1");
+        let home = tmp_home("binding-only-occupancy");
+        // `configs` deliberately EMPTY — the in-memory registry hasn't caught
+        // up to the fresh bind yet. binding.json is the only live signal.
+        let configs: HashMap<String, Option<PathBuf>> = HashMap::new();
+        write_full_binding(&home, "dev3", "feat/fresh-bind", &repo, &wt);
+
+        let removed = sweep_from_registry(&home, &configs, &[]);
+        assert!(
+            removed.is_empty(),
+            "a worktree with a LIVE binding.json entry must never be swept, even \
+             when `configs` hasn't caught up yet (the exact dev3 PRUNE_LIVE \
+             incident): {removed:?}"
+        );
+        assert!(wt.exists(), "the live-bound worktree directory must survive");
+
+        std::env::remove_var("AGEND_WORKTREE_AUTO_CLEANUP");
+        std::env::remove_var("AGEND_WORKTREE_PRUNE_LIVE");
+        std::fs::remove_dir_all(&repo).ok();
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #t-…81457-1 depth fix #1: `is_branch_merged`'s is-ancestor check is
+    /// trivially true for a branch whose tip is IDENTICAL to the default
+    /// branch (zero commits ever made) — nothing has actually been merged,
+    /// there's nothing to merge. This is a unit-level pin on the exact
+    /// function so the fix can't regress even if the occupancy fix (above)
+    /// changes shape later — "單靠 ① 未來 binding 生命週期一變又漏" (lead).
+    #[test]
+    fn is_branch_merged_rejects_zero_commit_branch_tip_equals_default() {
+        let _lock = ENV_LOCK.lock();
+        let repo = setup_test_repo("zero-commit-merged-unit");
+        git_in(&repo, &["branch", "feat/never-touched"]);
+
+        assert!(
+            !is_branch_merged(&repo, "feat/never-touched"),
+            "a branch whose tip is IDENTICAL to main (zero commits, nothing ever \
+             diverged) must not be classified as merged — there is nothing to merge"
+        );
+
+        std::fs::remove_dir_all(&repo).ok();
+    }
+
+    /// #t-…81457-1 depth fix #1, integration level: the same zero-commit
+    /// scenario through the full sweep, with NO occupancy signal at all (no
+    /// binding, no configs) — isolates this fix from the binding-registry fix
+    /// above. This is dev3's actual incident mechanics minus the binding gap.
+    #[test]
+    fn sweep_does_not_treat_zero_commit_worktree_as_merged() {
+        let _lock = ENV_LOCK.lock();
+        let repo = setup_test_repo("zero-commit-sweep");
+        git_in(&repo, &["branch", "feat/fresh-no-commits"]);
+        let wt = repo.join("wt-fresh-no-commits");
+        git_in(
+            &repo,
+            &["worktree", "add", wt.to_str().unwrap(), "feat/fresh-no-commits"],
+        );
+
+        std::env::set_var("AGEND_WORKTREE_AUTO_CLEANUP", "1");
+        std::env::set_var("AGEND_WORKTREE_PRUNE_LIVE", "1");
+        let home = tmp_home("zero-commit-sweep");
+        let configs: HashMap<String, Option<PathBuf>> = HashMap::new();
+        write_source_repo_binding(&home, "other-agent", &repo); // repo discovery only
+
+        let removed = sweep_from_registry(&home, &configs, &[]);
+        assert!(
+            removed.is_empty(),
+            "a zero-commit branch (tip==main, nothing diverged) must not be \
+             classified merged just because is-ancestor is trivially true: {removed:?}"
+        );
+        assert!(wt.exists());
+
+        std::env::remove_var("AGEND_WORKTREE_AUTO_CLEANUP");
+        std::env::remove_var("AGEND_WORKTREE_PRUNE_LIVE");
+        std::fs::remove_dir_all(&repo).ok();
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #t-…81457-1 depth fix #2, LIVE self-reproduced incident: production
+    /// branch creation (`bind_self`'s `ensure_branch_fetch` → `git branch
+    /// <name> origin/main`) auto-sets upstream tracking to `origin/main`
+    /// (`branch.<name>.merge = refs/heads/main`), NOT to a same-named remote
+    /// branch — because the branch has never been pushed under its own name.
+    /// `is_remote_gone`'s `refs/remotes/{remote}/{branch}` existence check
+    /// assumes the upstream mirrors the LOCAL branch's own name; it never does
+    /// for a from-origin/main tracked branch, so a legitimately-never-pushed
+    /// branch is misclassified as "remote gone". Self-reproduced live: this
+    /// agent's own fresh worktree AND gapfix-dev2's were both
+    /// `worktree_auto_removed reason=remote-gone` within ~70s of bind, before
+    /// either had pushed (event-log confirmed, same tick).
+    #[test]
+    fn is_remote_gone_does_not_misfire_for_never_pushed_branch_tracking_main() {
+        let _lock = ENV_LOCK.lock();
+        let remote_dir = std::env::temp_dir().join(format!(
+            "agend-wt-v2-neverpushed-remote-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&remote_dir).ok();
+        git_in(&remote_dir, &["init", "--bare", "-b", "main"]);
+
+        let repo = std::env::temp_dir().join(format!(
+            "agend-wt-v2-neverpushed-clone-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&repo);
+        Command::new("git")
+            .args([
+                "clone",
+                remote_dir.to_str().unwrap(),
+                repo.to_str().unwrap(),
+            ])
+            .env("AGEND_GIT_BYPASS", "1")
+            .env("GIT_AUTHOR_NAME", "test")
+            .env("GIT_AUTHOR_EMAIL", "t@t")
+            .env("GIT_COMMITTER_NAME", "test")
+            .env("GIT_COMMITTER_EMAIL", "t@t")
+            .output()
+            .expect("clone");
+        std::fs::write(repo.join("README.md"), "init").ok();
+        git_in(&repo, &["add", "."]);
+        git_in(&repo, &["commit", "-m", "init"]);
+        git_in(&repo, &["push", "-u", "origin", "main"]);
+
+        // Production shape: `git branch <name> origin/main`, NEVER pushed
+        // under its own name.
+        git_in(&repo, &["branch", "fix/never-pushed", "origin/main"]);
+
+        assert!(
+            !is_remote_gone(&repo, "fix/never-pushed"),
+            "a branch that tracks origin/main (never pushed under its own name) \
+             must NOT be classified remote-gone — refs/remotes/origin/<name> was \
+             never supposed to exist for it in the first place"
+        );
+
+        std::fs::remove_dir_all(&repo).ok();
+        std::fs::remove_dir_all(&remote_dir).ok();
+    }
+
     #[test]
     fn test_v2_remote_gone_worktree_removed() {
         // Simulate squash-merge: branch is NOT merged (different hash) but


### PR DESCRIPTION
## Summary

PRUNE_LIVE's first sweep tick reaped a live-bound, zero-commit worktree (dev3's) and, independently, two more freshly-bound worktrees within ~70s of bind (this agent's own + gapfix-dev2's) via a third, distinct vector. All three classes reproduced with RED tests first, then fixed:

1. **Binding-registry occupancy gap** — `sweep_from_registry`'s `is_in_use` only ever consulted the in-memory `configs` (AgentConfig.working_dir) registry, never `binding.json` — a separate, independently-updated signal. A worktree the daemon itself just auto-bound is invisible to it until `configs` catches up. Added `binding::bound_worktree_paths` and fed it into `active_dirs`.
2. **Zero-commit misclassified as merged** — `is_branch_merged`'s is-ancestor check is trivially true when a branch's tip IS the default branch's tip — indistinguishable, from git state alone, between a brand-new zero-commit branch and a genuinely fast-forward-merged one. Reused the same `SQUASH_GC_MIN_TIP_AGE` (24h) floor the squash path already relies on for the identical reason.
3. **`is_remote_gone` false positive on never-pushed branches** — `bind_self`'s branch creation (`git branch <name> origin/main`) auto-tracks `origin/main`, not a same-named remote branch. `is_remote_gone` checked `refs/remotes/origin/<name>` existence, which never existed for a branch simply never pushed under its own name — misclassified as "remote gone". Self-reproduced live: this agent's own fresh worktree and gapfix-dev2's were both `worktree_auto_removed reason=remote-gone` within ~70s of bind (event-log confirmed, same tick). Now requires `branch.<name>.merge == refs/heads/<name>` before trusting the absence; ambiguous cases fail toward NOT concluding gone.

**Data-loss note for the operator**: `is_worktree_dirty` (uncommitted changes) already gates removal before any of the above is even evaluated — no dirty worktree was ever at risk. What was at risk: a clean-but-just-bound worktree's *directory* getting yanked out from under an agent mid-dispatch (branch ref survives unless also merged/squash-eligible, per the existing CR-2026-06-14 decoupling).

## Test plan
- [x] 4 RED counter-example tests written first, confirmed failing against pre-fix `main`
- [x] All 4 GREEN after the fix
- [x] 3 pre-existing "genuinely merged" tests updated (old dated commit, mirrors the squash path's own test convention) to clear the new age gate — still pass
- [x] Full `cargo nextest run`: 4942 passed, 0 failed
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --tests` (default + `--features tray`) clean

DUAL review requested (deletion path, silent-loss sensitive per lead).

t-20260706031351455614-81457-1