### PR TITLE
fix(restart): defer fresh/resume restart while operator has an unsent draft

### DIFF
--- a/src/inbox/notify.rs
+++ b/src/inbox/notify.rs
@@ -388,14 +388,25 @@ pub(crate) fn should_defer_inject(
         // (draft_state → `None`). `Drafting` is set ONLY by human TUI keystrokes
         // (record_input_activity), so this fires exactly when a person is
         // composing in this pane — agent PTY output never sets it.
-        operator_typing_recent(home, agent_name)
-            || crate::notification_queue::draft_state(home, agent_name)
-                == crate::notification_queue::DraftState::Drafting
+        operator_has_live_draft(home, agent_name)
     } else {
         // Ambient: the #1457 full draft gate is applied downstream by
         // route_notification — don't double-gate here.
         false
     }
+}
+
+/// Does the operator have a LIVE unsent draft in this pane's input line right
+/// now? Union of the brief post-keystroke settle window (`operator_typing_recent`,
+/// 1.5s) and the pause-immune order signal (`draft_state == Drafting`, holds up to
+/// the 5-min escape window). Single "live draft present" source of truth shared by
+/// the notification defer gate (`should_defer_inject`) and the restart defer gate
+/// (`handle_restart_instance`). Set ONLY by human TUI keystrokes — agent PTY output
+/// never sets it, so it fires exactly when a person is composing in this pane.
+pub(crate) fn operator_has_live_draft(home: &Path, agent_name: &str) -> bool {
+    operator_typing_recent(home, agent_name)
+        || crate::notification_queue::draft_state(home, agent_name)
+            == crate::notification_queue::DraftState::Drafting
 }
 
 /// #1513: did the operator type into this pane within the quiet window? Uses the

--- a/src/mcp/handlers/instance_state/mod.rs
+++ b/src/mcp/handlers/instance_state/mod.rs
@@ -419,6 +419,70 @@ fn restart_spawn_params(
     spawn_params
 }
 
+/// Grace ceiling for [`await_unsent_draft_or_grace`]: even while the operator
+/// keeps typing, force the restart after this long so a context-full / stuck
+/// agent can't be deferred indefinitely. The primary release is the operator
+/// submitting (draft clears well before this); the ceiling only bounds the
+/// pathological continuous-typing case. Tunable.
+const RESTART_DRAFT_GRACE: std::time::Duration = std::time::Duration::from_secs(60);
+/// Re-check cadence while deferring — silent (no per-poll event / nudge).
+const RESTART_DRAFT_POLL: std::time::Duration = std::time::Duration::from_millis(500);
+
+#[derive(Debug, PartialEq, Eq)]
+enum DraftGate {
+    Proceed,
+    Defer,
+}
+
+/// Pure restart-gate decision (unit-tested exhaustively): proceed with the kill
+/// iff `force`, there is no live operator draft, or the grace ceiling has
+/// elapsed; otherwise keep deferring. Kept pure (no clock / no IO) so the whole
+/// decision matrix is deterministic without real sleeps.
+fn restart_draft_gate(
+    force: bool,
+    has_live_draft: bool,
+    elapsed: std::time::Duration,
+    grace: std::time::Duration,
+) -> DraftGate {
+    if force || !has_live_draft || elapsed >= grace {
+        DraftGate::Proceed
+    } else {
+        DraftGate::Defer
+    }
+}
+
+/// Block the restart while the operator has unsent keystrokes in `name`'s input
+/// line, releasing the instant the draft is submitted/cleared or after
+/// [`RESTART_DRAFT_GRACE`]. Emits exactly two log lines (defer-start, proceed) —
+/// no per-poll noise. Thread-safety rationale is at the call site.
+fn await_unsent_draft_or_grace(home: &Path, name: &str, force: bool) {
+    if restart_draft_gate(
+        force,
+        crate::inbox::notify::operator_has_live_draft(home, name),
+        std::time::Duration::ZERO,
+        RESTART_DRAFT_GRACE,
+    ) == DraftGate::Proceed
+    {
+        return; // fast path: force, or no live draft — no wait, no log.
+    }
+    tracing::info!(%name, "restart deferred: operator has an unsent draft in the input line");
+    let start = std::time::Instant::now();
+    while restart_draft_gate(
+        force,
+        crate::inbox::notify::operator_has_live_draft(home, name),
+        start.elapsed(),
+        RESTART_DRAFT_GRACE,
+    ) == DraftGate::Defer
+    {
+        std::thread::sleep(RESTART_DRAFT_POLL);
+    }
+    tracing::info!(
+        %name,
+        elapsed_ms = start.elapsed().as_millis() as u64,
+        "restart proceeding: draft submitted/cleared or grace ceiling reached"
+    );
+}
+
 pub(super) fn handle_restart_instance(home: &Path, args: &Value) -> Value {
     let name = match super::require_instance(args) {
         Ok(n) => n,
@@ -464,6 +528,16 @@ pub(super) fn handle_restart_instance(home: &Path, args: &Value) -> Value {
         Some(r) => r,
         None => return json!({"error": format!("Instance '{name}' not in fleet.yaml")}),
     };
+
+    // t-95913-5: the operator's unsent keystrokes live ONLY in the input line of
+    // the process we're about to kill — a fresh OR resume restart destroys them
+    // (`--continue` restores the conversation, not the input line). If the pane
+    // has a live draft, defer the kill until the operator submits (draft clears)
+    // or a grace ceiling elapses (so continuous typing can't defer forever).
+    // Mode-agnostic; `force:true` bypasses. Safe to block here: each api tool call
+    // runs on its own `api_handler` thread (`api::serve` per-session spawn), and
+    // the operator's submit arrives via the TUI write path, not this thread.
+    await_unsent_draft_or_grace(home, name, args["force"].as_bool().unwrap_or(false));
 
     // Session-reset inbox settle: for a FRESH restart (context-lost), settle
     // all DELIVERING rows to PROCESSED before killing the old instance.

--- a/src/mcp/handlers/instance_state/tests.rs
+++ b/src/mcp/handlers/instance_state/tests.rs
@@ -614,3 +614,96 @@ fn bind_topic_channel_unavailable_via_handler_991() {
     assert_eq!(resp["code"], "channel_unavailable");
     std::fs::remove_dir_all(&home).ok();
 }
+
+// ── t-95913-5: defer fresh/resume restart while the operator has an unsent
+// draft in the target pane's input line. The pure `restart_draft_gate` covers
+// the whole decision matrix deterministically (no clock, no sleep). ──
+
+#[test]
+fn restart_draft_gate_proceeds_when_no_live_draft() {
+    // No unsent draft → kill immediately (gate is a no-op), any elapsed.
+    assert_eq!(
+        restart_draft_gate(false, false, std::time::Duration::ZERO, RESTART_DRAFT_GRACE),
+        DraftGate::Proceed
+    );
+}
+
+#[test]
+fn restart_draft_gate_defers_live_draft_within_grace() {
+    // Live draft, still inside the grace window → defer the kill.
+    assert_eq!(
+        restart_draft_gate(
+            false,
+            true,
+            std::time::Duration::from_secs(10),
+            RESTART_DRAFT_GRACE
+        ),
+        DraftGate::Defer
+    );
+}
+
+#[test]
+fn restart_draft_gate_proceeds_when_grace_ceiling_reached() {
+    // Live draft but grace elapsed → force the kill so continuous typing can't
+    // defer forever. Boundary: elapsed == grace proceeds.
+    assert_eq!(
+        restart_draft_gate(false, true, RESTART_DRAFT_GRACE, RESTART_DRAFT_GRACE),
+        DraftGate::Proceed
+    );
+    assert_eq!(
+        restart_draft_gate(
+            false,
+            true,
+            std::time::Duration::from_secs(61),
+            RESTART_DRAFT_GRACE
+        ),
+        DraftGate::Proceed
+    );
+}
+
+#[test]
+fn restart_draft_gate_force_bypasses_live_draft() {
+    // force:true → kill immediately even with a live draft inside the window.
+    assert_eq!(
+        restart_draft_gate(true, true, std::time::Duration::ZERO, RESTART_DRAFT_GRACE),
+        DraftGate::Proceed
+    );
+}
+
+#[test]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+fn operator_has_live_draft_reflects_unsent_keystrokes() {
+    let home = std::env::temp_dir().join(format!(
+        "agend-live-draft-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&home).unwrap();
+    // No metadata → no draft.
+    assert!(!crate::inbox::notify::operator_has_live_draft(&home, "a"));
+    // A keystroke with no following submit → a live unsent draft.
+    crate::notification_queue::record_input_activity(&home, "a");
+    assert!(crate::inbox::notify::operator_has_live_draft(&home, "a"));
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+fn await_unsent_draft_or_grace_returns_fast_without_a_draft() {
+    // No draft → the fast path returns immediately (no block). A regression that
+    // dropped the no-draft check would hang this test to the nextest timeout.
+    let home = std::env::temp_dir().join(format!(
+        "agend-await-nodraft-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&home).unwrap();
+    await_unsent_draft_or_grace(&home, "a", false);
+    std::fs::remove_dir_all(&home).ok();
+}


### PR DESCRIPTION
## Problem (operator-reported data loss)

When an agent hits context-full and fresh-restarts (it self-calls
`restart_instance(self, fresh)`), any keystrokes the operator had **typed but not
yet submitted** into that pane are destroyed by the kill. The draft lives only in
the killed process's own TUI input line — `--continue` restores the conversation,
not the input line — so a `resume` restart loses it too.

Task `t-20260623072910789109-95913-5`. Spike-first; design vetted by lead before impl.

## Design (evidence-backed spike — confirmed by direct reads + runtime observation)

**Gate at the daemon convergence point.** `handle_restart_instance`
(`instance_state/mod.rs`) is where BOTH the self-initiated path and the autonomic
respawn-stuck path (`restart_instance_autonomic`, mode=fresh) converge, right
before `DELETE`+`SPAWN`. There is **no** daemon context-full auto-restart
(`context_alert.rs` is notify-only), so the restart is always the agent
self-calling — it can't see the operator typing, which is exactly why the gate
must live in the daemon, not agent logic.

**Behavior.** Before the kill, if the pane has a live unsent draft, block until the
operator submits (draft clears) or a **60s grace ceiling** elapses (so continuous
typing can't defer forever). `force:true` bypasses.

**Mode-agnostic** (both fresh and resume destroy the draft). Audited the resume
callers: the only resume-restart routing through this function is the manual
`restart_instance` tool — daemon recovery paths don't route here
(`restart_instance_autonomic` is fresh-only; rate/usage-limit recovery injects a
retry payload with no kill; the `:358` resume-spawn is a `SPAWN` with no `DELETE`),
so none has a hard-immediacy need that a ≤60s defer (with `force` bypass) would break.

**Signal — reuse the proven one.** `should_defer_inject` already defers wakes while
the operator has a live draft, using the union of `operator_typing_recent` (1.5s
settle window) and `draft_state == Drafting` (order-based: `typed > submit`,
pause-immune up to the 5-min escape window). `last_input_epoch_ms` is written
per-keystroke and only by human TUI input — agent PTY output never sets it.
Extracted that union as `notification_queue`-adjacent `operator_has_live_draft`
so the notification gate and the restart gate share one source of truth.

**No noise.** Silent poll (500ms), two `tracing::info` lines only (defer-start,
proceed) — no per-poll event or nudge.

**Blocking is safe.** Each api tool call runs on its own `api_handler` thread
(`api::serve` per-session `thread::spawn`), so a ≤60s block occupies one connection
slot and never freezes the accept loop, other sessions, or the internal API. The
operator's submit arrives via the TUI write path, not this thread, so it clears the
draft mid-block.

## Tests (deterministic — no real sleeps)

The decision is a pure fn `restart_draft_gate(force, has_live_draft, elapsed, grace)`
unit-tested across the full matrix:
- no live draft → **Proceed** (gate no-op)
- live draft within grace → **Defer**
- live draft, grace ceiling reached (incl. the `elapsed == grace` boundary) → **Proceed**
- `force` with a live draft → **Proceed**

Plus `operator_has_live_draft` (seeded keystroke → true; empty → false) and the
`await_unsent_draft_or_grace` no-draft fast-path (returns without blocking).

## Verification
- New tests + the refactored `should_defer_inject` tests: all pass.
- `cargo fmt --check` clean; `cargo clippy --all-targets --features tray -- -D warnings` clean.
- Full bin-target `nextest --features tray,discord --no-fail-fast`: 5009/5011 pass.
  The 2 failures (`daemon::per_tick::hourly_gc::tests::run_*`) are **pre-existing
  timing flakes** under full-suite parallel load — they pass **3/3 in isolation** and
  have no causal link to this change (the added sleep-loop only runs during an actual
  restart-with-draft, never during those tests).
