### PR TITLE
fix(agend-git): resolve push guards' default branch instead of hardcoding origin/main (#2379 ③)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -81,12 +81,12 @@ slow-timeout = { period = "120s", terminate-after = 3 }
 retries = 2
 
 [[profile.ci.overrides]]
-filter = 'test(/(^(worktree|worktree_pool|worktree_cleanup|admin|mcp::handlers::(ci|dispatch_hook|force_release|worktree|p0b_tests)|daemon::(retention::worktrees|pr_state|auto_release|conflict_notify|per_tick::tmp_review_gc)|bootstrap::(agent_resolve|canonical_hygiene))::|checkout_repo_|dispatch_branch_skips_metadata_stub|send_with_branch_checkout_failure|task_done_cleans_post_lease|closes_markers_extract_cleanly_from_actual_main|resolve_sweep_boards_pairs_each_project_with_its_own_repo_2117_p2|shim_denies_agent_bypass_canonical_provisioning_2234|denylist_[a-z_]+_2379|tracked_tree_[a-z_]+_2379)/)'
+filter = 'test(/(^(worktree|worktree_pool|worktree_cleanup|admin|mcp::handlers::(ci|dispatch_hook|force_release|worktree|p0b_tests)|daemon::(retention::worktrees|pr_state|auto_release|conflict_notify|per_tick::tmp_review_gc)|bootstrap::(agent_resolve|canonical_hygiene))::|checkout_repo_|dispatch_branch_skips_metadata_stub|send_with_branch_checkout_failure|task_done_cleans_post_lease|closes_markers_extract_cleanly_from_actual_main|resolve_sweep_boards_pairs_each_project_with_its_own_repo_2117_p2|shim_denies_agent_bypass_canonical_provisioning_2234|denylist_[a-z_]+_(2379|2390)|tracked_tree_[a-z_]+_2379|resolve_default_branch_base_[a-z_]+_2390)/)'
 test-group = 'git-subprocess'
 retries = 2
 
 # Local `default` profile has no terminate-after, so no false-kill risk — just
 # serialize the same cluster for parity with CI.
 [[profile.default.overrides]]
-filter = 'test(/(^(worktree|worktree_pool|worktree_cleanup|admin|mcp::handlers::(ci|dispatch_hook|force_release|worktree|p0b_tests)|daemon::(retention::worktrees|pr_state|auto_release|conflict_notify|per_tick::tmp_review_gc)|bootstrap::(agent_resolve|canonical_hygiene))::|checkout_repo_|dispatch_branch_skips_metadata_stub|send_with_branch_checkout_failure|task_done_cleans_post_lease|closes_markers_extract_cleanly_from_actual_main|resolve_sweep_boards_pairs_each_project_with_its_own_repo_2117_p2|shim_denies_agent_bypass_canonical_provisioning_2234|denylist_[a-z_]+_2379|tracked_tree_[a-z_]+_2379)/)'
+filter = 'test(/(^(worktree|worktree_pool|worktree_cleanup|admin|mcp::handlers::(ci|dispatch_hook|force_release|worktree|p0b_tests)|daemon::(retention::worktrees|pr_state|auto_release|conflict_notify|per_tick::tmp_review_gc)|bootstrap::(agent_resolve|canonical_hygiene))::|checkout_repo_|dispatch_branch_skips_metadata_stub|send_with_branch_checkout_failure|task_done_cleans_post_lease|closes_markers_extract_cleanly_from_actual_main|resolve_sweep_boards_pairs_each_project_with_its_own_repo_2117_p2|shim_denies_agent_bypass_canonical_provisioning_2234|denylist_[a-z_]+_(2379|2390)|tracked_tree_[a-z_]+_2379|resolve_default_branch_base_[a-z_]+_2390)/)'
 test-group = 'git-subprocess'

--- a/src/bin/agend-git.rs
+++ b/src/bin/agend-git.rs
@@ -30,6 +30,11 @@ mod integrity_core;
 #[path = "../protected_refs.rs"]
 mod protected_refs;
 
+// #2390 ③: default-branch resolution for the push-range guards (denylist +
+// init-pile cleanup), replacing a hardcoded `origin/main` — shim-local.
+#[path = "agend-git/git_refs.rs"]
+mod git_refs;
+
 /// #1504 L3: max times the shim may re-enter before hard-failing. Healthy
 /// operation never exceeds 1 (real git ≠ shim → no re-entry), so a small cap
 /// has zero false-trip risk while containing a self-resolution spawn storm.
@@ -1657,31 +1662,32 @@ fn log_init_heartbeat_forensics(home: &str, agent: &str, args: &[String]) {
 
 // ── #883 pre-push cleanup ───────────────────────────────────────────────
 
-/// #883: drop empty `init` heartbeat commits between `origin/main..HEAD`
-/// before the real `git push` fires. Targets the operator-visible case
-/// (PR #882 saw 16 inits before the real commit on mobile UI). The
-/// cleanup is a local soft-reset to `origin/main` ONLY when EVERY commit
-/// in the range is an empty init heartbeat — that's the common case the
-/// operator hit. The mixed-history case (real commits interleaved with
-/// inits) is left for the existing `repo action=cleanup_init_commits`
-/// MCP tool to handle via interactive rebase; we deliberately do not
-/// replicate that more-complex path in the shim to keep this function
-/// small + self-contained (the shim builds standalone without the
-/// library surface — see comment at line ~188).
+/// #883: drop empty `init` heartbeat commits between `<default-branch>..HEAD`
+/// (base via `git_refs::resolve_default_branch_base`, #2390) before the real
+/// `git push` fires (PR #882 saw 16 inits before the real commit on mobile UI).
+/// Soft-resets to that base ONLY when EVERY commit in the range is an empty init
+/// heartbeat (the common operator case); the mixed-history case is left to the
+/// `repo action=cleanup_init_commits` MCP tool (interactive rebase) — we keep
+/// this shim function small + self-contained (builds standalone, no lib surface).
 ///
-/// **NEVER blocks `git push`.** Any subprocess failure is logged to
-/// stderr and the function returns; `main` then proceeds to
-/// `exec_real_git` as usual. Cleanup is a best-effort hygiene
-/// improvement, not a correctness gate.
-///
-/// (THIS function's never-blocks contract is unchanged. Note the push PATH can
-/// now block: `#2379` `push_trust_root_denylist_violation` runs BEFORE this in
-/// the `CleanupAndChdirPushPass` arm and may `exit(1)` — a separate guardrail,
-/// not part of this hygiene pass.)
+/// **NEVER blocks `git push`.** Any subprocess failure (incl. an undeterminable
+/// base) is logged and the function returns; hygiene, not a correctness gate.
+/// (Unchanged by #2379: `push_trust_root_denylist_violation` runs BEFORE this in
+/// the `CleanupAndChdirPushPass` arm and MAY `exit(1)` — a separate guardrail.)
 fn cleanup_init_pile_pre_push(worktree: &str) {
-    // List commits between origin/main..HEAD with hash + subject.
+    // #2390 ③: resolve the default-branch base (not hardcoded origin/main); soft —
+    // an undeterminable base just no-ops this hygiene pass (never blocks push).
+    let base = match git_refs::resolve_default_branch_base(worktree) {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("agend-git: #883 pre-push cleanup skipped (default branch: {e})");
+            return;
+        }
+    };
+    let range = format!("{base}..HEAD");
+    // List commits between <base>..HEAD with hash + subject.
     let log_out = match Command::new("git")
-        .args(["log", "origin/main..HEAD", "--format=%H %s"])
+        .args(["log", &range, "--format=%H %s"])
         .current_dir(worktree)
         .env("AGEND_GIT_BYPASS", "1")
         .output()
@@ -1726,11 +1732,11 @@ fn cleanup_init_pile_pre_push(worktree: &str) {
         return;
     }
     // All-init case: soft-reset is enough — drops every commit on the
-    // branch above origin/main, leaving working tree clean (since the
+    // branch above the base, leaving working tree clean (since the
     // dropped commits had no file changes).
     if empty_init_hashes.len() == total {
         let reset = Command::new("git")
-            .args(["reset", "--soft", "origin/main"])
+            .args(["reset", "--soft", &base])
             .current_dir(worktree)
             .env("AGEND_GIT_BYPASS", "1")
             .status();
@@ -1769,7 +1775,7 @@ fn cleanup_init_pile_pre_push(worktree: &str) {
         .collect();
     let sed_script = sed_parts.join(";");
     let rebase = Command::new("git")
-        .args(["-c", "core.abbrev=7", "rebase", "-i", "origin/main"])
+        .args(["-c", "core.abbrev=7", "rebase", "-i", &base])
         .current_dir(worktree)
         .env("AGEND_GIT_BYPASS", "1")
         .env("GIT_SEQUENCE_EDITOR", format!("sed -i.bak '{sed_script}'"))
@@ -1889,27 +1895,22 @@ fn trust_root_basename_denied(repo_relative_path: &str) -> bool {
 }
 
 /// The repo-relative paths touched by any commit in the push range
-/// (`origin/main..HEAD`) — the union of `--name-only` across the range, so a
+/// (`<default-branch>..HEAD`) — the `--name-only` union across the range, so a
 /// trust-root blob added in an intermediate commit is caught even if a later
-/// commit deletes it (the blob is still in the pushed history). Runs real git in
-/// the worktree with `AGEND_GIT_BYPASS=1` (mirrors `cleanup_init_pile_pre_push`'s
-/// established range base). Returns `Err(msg)` when the range can't be computed
-/// (e.g. `origin/main` not fetched) so the caller can fail CLOSED.
+/// commit deletes it. Base is `git_refs::resolve_default_branch_base` (not a
+/// hardcoded `origin/main`, #2390). Returns `Err(msg)` when the base or range
+/// can't be computed so the caller can fail CLOSED.
 fn push_range_files(worktree: &str) -> Result<Vec<String>, String> {
+    let range = format!("{}..HEAD", git_refs::resolve_default_branch_base(worktree)?);
     let out = Command::new("git")
-        .args([
-            "log",
-            "--name-only",
-            "--pretty=format:",
-            "origin/main..HEAD",
-        ])
+        .args(["log", "--name-only", "--pretty=format:", &range])
         .current_dir(worktree)
         .env("AGEND_GIT_BYPASS", "1")
         .output()
         .map_err(|e| format!("git log spawn failed: {e}"))?;
     if !out.status.success() {
         return Err(format!(
-            "git log origin/main..HEAD failed: {}",
+            "git log {range} failed: {}",
             String::from_utf8_lossy(&out.stderr).trim()
         ));
     }
@@ -1944,8 +1945,8 @@ fn push_trust_root_denylist_violation(worktree: &str) -> Option<String> {
             }),
         Err(e) => Some(format!(
             "could not verify the push against the trust-root denylist ({e}); refusing to \
-             push (fail-closed). Fetch origin so `origin/main..HEAD` resolves \
-             (`git fetch origin`), then retry."
+             push (fail-closed). Set the remote's default branch so the range resolves — \
+             `git remote set-head origin -a` (works for any default branch name), then retry."
         )),
     }
 }

--- a/src/bin/agend-git/git_refs.rs
+++ b/src/bin/agend-git/git_refs.rs
@@ -16,11 +16,14 @@ use std::process::Command;
 ///    literal `"origin/HEAD"` (looks like success) instead of failing when the
 ///    ref is unset, which is the common case in managed worktrees that never ran
 ///    `git remote set-head`.
-/// 2. Existence-probe the conventional trunks `origin/main` then `origin/master`.
-///    This is why a normal clone (origin/HEAD unset but origin/main present)
-///    keeps working.
+/// 2. Existence-probe the conventional trunks — but only when EXACTLY ONE of
+///    `origin/main` / `origin/master` exists (a normal clone with origin/HEAD
+///    unset but one trunk present keeps working). BOTH present is ambiguous — we
+///    can't tell the default and must NOT guess `main` (that could scan the wrong
+///    base and miss a trust-root file), so it fails to path 3 (#2662).
 /// 3. Otherwise `Err` — the caller fails CLOSED (denylist) / no-ops (cleanup), so
-///    a truly-undeterminable base stays safe. Remedy: `git remote set-head origin -a`.
+///    an undeterminable OR ambiguous base stays safe. Remedy (resolves both):
+///    `git remote set-head origin -a`.
 ///
 /// Deliberately does NOT consult the branch's `@{upstream}`: post-push it points
 /// at the branch's OWN remote ref, so diffing against it would shrink the denylist
@@ -41,24 +44,26 @@ pub fn resolve_default_branch_base(worktree: &str) -> Result<String, String> {
             }
         }
     }
-    // 2. Conventional-trunk existence probe. `.output()` (not `.status()`) so the
-    //    rev-parse SHA never leaks onto the shim's stdout.
-    for cand in ["origin/main", "origin/master"] {
-        let exists = Command::new("git")
-            .args([
-                "rev-parse",
-                "--verify",
-                "--quiet",
-                &format!("{cand}^{{commit}}"),
-            ])
-            .current_dir(worktree)
-            .env("AGEND_GIT_BYPASS", "1")
-            .output()
-            .map(|o| o.status.success())
-            .unwrap_or(false);
-        if exists {
-            return Ok(cand.to_string());
+    // 2. Conventional-trunk existence probe — use it ONLY when EXACTLY ONE of
+    //    origin/main / origin/master exists. If BOTH exist we cannot tell which is
+    //    the default (origin/HEAD would have said, but it's unset), so we FAIL
+    //    rather than guess: blindly picking the non-default trunk could scan
+    //    `<wrong-trunk>..HEAD` and OMIT a trust-root commit reachable only from the
+    //    true default — a fail-open false-negative in the denylist (#2662).
+    match (
+        trunk_exists(worktree, "origin/main"),
+        trunk_exists(worktree, "origin/master"),
+    ) {
+        (true, false) => return Ok("origin/main".to_string()),
+        (false, true) => return Ok("origin/master".to_string()),
+        (true, true) => {
+            return Err(
+                "ambiguous default branch: both origin/main and origin/master \
+                        exist and origin/HEAD is unset — cannot safely pick the trunk"
+                    .to_string(),
+            )
         }
+        (false, false) => {}
     }
     // 3. Undeterminable.
     Err(
@@ -66,4 +71,21 @@ pub fn resolve_default_branch_base(worktree: &str) -> Result<String, String> {
          origin/main nor origin/master exists"
             .to_string(),
     )
+}
+
+/// Does `<rev>` resolve to a commit in `worktree`? `.output()` (not `.status()`)
+/// so the `rev-parse` SHA never leaks onto the shim's stdout.
+fn trunk_exists(worktree: &str, rev: &str) -> bool {
+    Command::new("git")
+        .args([
+            "rev-parse",
+            "--verify",
+            "--quiet",
+            &format!("{rev}^{{commit}}"),
+        ])
+        .current_dir(worktree)
+        .env("AGEND_GIT_BYPASS", "1")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
 }

--- a/src/bin/agend-git/git_refs.rs
+++ b/src/bin/agend-git/git_refs.rs
@@ -1,0 +1,69 @@
+//! #2390 ③: resolve the push guards' range base (the remote's default branch)
+//! instead of hardcoding `origin/main`. A non-main-default repo (master / trunk /
+//! develop) otherwise makes `origin/main..HEAD` un-resolvable → the denylist
+//! fails CLOSED → every push is blocked. Shared by both `push_range_files`
+//! (denylist, hard) and `cleanup_init_pile_pre_push` (hygiene, soft).
+
+use std::process::Command;
+
+/// Resolve the range base for the push guards as a rev (`origin/<default>`), so
+/// callers diff `origin/<default>..HEAD`.
+///
+/// Fallback order (conservative — always a TRUNK, never the branch's own upstream):
+/// 1. `git symbolic-ref --short refs/remotes/origin/HEAD` — the authoritative
+///    default branch WHEN SET. We use `symbolic-ref`, NOT
+///    `git rev-parse --abbrev-ref origin/HEAD`: the latter LIES — it echoes the
+///    literal `"origin/HEAD"` (looks like success) instead of failing when the
+///    ref is unset, which is the common case in managed worktrees that never ran
+///    `git remote set-head`.
+/// 2. Existence-probe the conventional trunks `origin/main` then `origin/master`.
+///    This is why a normal clone (origin/HEAD unset but origin/main present)
+///    keeps working.
+/// 3. Otherwise `Err` — the caller fails CLOSED (denylist) / no-ops (cleanup), so
+///    a truly-undeterminable base stays safe. Remedy: `git remote set-head origin -a`.
+///
+/// Deliberately does NOT consult the branch's `@{upstream}`: post-push it points
+/// at the branch's OWN remote ref, so diffing against it would shrink the denylist
+/// scan to "commits since the last push" and weaken the guardrail. The denylist
+/// must scan the whole branch vs. trunk — conservative over precise.
+pub fn resolve_default_branch_base(worktree: &str) -> Result<String, String> {
+    // 1. origin/HEAD, only when explicitly set (symbolic-ref errors cleanly if not).
+    if let Ok(o) = Command::new("git")
+        .args(["symbolic-ref", "--short", "refs/remotes/origin/HEAD"])
+        .current_dir(worktree)
+        .env("AGEND_GIT_BYPASS", "1")
+        .output()
+    {
+        if o.status.success() {
+            let head = String::from_utf8_lossy(&o.stdout).trim().to_string();
+            if !head.is_empty() {
+                return Ok(head);
+            }
+        }
+    }
+    // 2. Conventional-trunk existence probe. `.output()` (not `.status()`) so the
+    //    rev-parse SHA never leaks onto the shim's stdout.
+    for cand in ["origin/main", "origin/master"] {
+        let exists = Command::new("git")
+            .args([
+                "rev-parse",
+                "--verify",
+                "--quiet",
+                &format!("{cand}^{{commit}}"),
+            ])
+            .current_dir(worktree)
+            .env("AGEND_GIT_BYPASS", "1")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+        if exists {
+            return Ok(cand.to_string());
+        }
+    }
+    // 3. Undeterminable.
+    Err(
+        "cannot resolve the remote default branch: origin/HEAD is unset and neither \
+         origin/main nor origin/master exists"
+            .to_string(),
+    )
+}

--- a/src/bin/agend-git/tests.rs
+++ b/src/bin/agend-git/tests.rs
@@ -3017,3 +3017,167 @@ fn tracked_tree_has_zero_trust_root_hits_persistent_guard_2379() {
              through silently."
     );
 }
+
+// ── #2390 ③: default-branch resolution (push guards no longer hardcode
+// origin/main → a non-main-default repo isn't fail-closed-blocked on every push) ──
+
+/// Build a MASTER-default repo (origin default = master, no `origin/main`) with a
+/// feature branch checked out — the footgun fixture #2390 fixes. Mirrors
+/// `build_repo_with_origin_main_2379` but `-b master`.
+fn build_repo_with_origin_master_2390(tag: &str) -> std::path::PathBuf {
+    let id = format!(
+        "{}-{tag}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    );
+    let base = std::env::temp_dir().join(format!("agend-2390-{id}"));
+    let _ = std::fs::remove_dir_all(&base);
+    std::fs::create_dir_all(&base).unwrap();
+    let origin_bare = base.join("origin.git");
+    let worktree = base.join("worktree");
+    assert!(git_run_2379(
+        &[
+            "init",
+            "--bare",
+            "-b",
+            "master",
+            origin_bare.to_str().unwrap()
+        ],
+        &base
+    )
+    .status
+    .success());
+    assert!(git_run_2379(
+        &[
+            "clone",
+            origin_bare.to_str().unwrap(),
+            worktree.to_str().unwrap()
+        ],
+        &base
+    )
+    .status
+    .success());
+    git_run_2379(&["config", "user.name", "test"], &worktree);
+    git_run_2379(&["config", "user.email", "test@test.local"], &worktree);
+    git_run_2379(&["config", "commit.gpgsign", "false"], &worktree);
+    std::fs::write(worktree.join("README.md"), "initial\n").unwrap();
+    assert!(git_run_2379(&["add", "README.md"], &worktree)
+        .status
+        .success());
+    assert!(git_run_2379(&["commit", "-m", "initial"], &worktree)
+        .status
+        .success());
+    assert!(git_run_2379(&["push", "origin", "master"], &worktree)
+        .status
+        .success());
+    assert!(git_run_2379(&["checkout", "-b", "feat/test"], &worktree)
+        .status
+        .success());
+    worktree
+}
+
+/// The resolver returns the real default branch — via origin/HEAD when set, and
+/// via the main→master existence-probe when it is NOT (the managed-worktree case,
+/// where `git remote set-head` never ran). Joins `git-subprocess`.
+#[test]
+fn resolve_default_branch_base_main_and_master_2390() {
+    // main-default (clone sets origin/HEAD → path 1).
+    let main_wt = build_repo_with_origin_main_2379("resolve-main");
+    assert_eq!(
+        git_refs::resolve_default_branch_base(main_wt.to_str().unwrap()).as_deref(),
+        Ok("origin/main")
+    );
+    // Unset origin/HEAD to mimic a managed worktree → path 2 existence-probe.
+    git_run_2379(&["remote", "set-head", "origin", "-d"], &main_wt);
+    assert_eq!(
+        git_refs::resolve_default_branch_base(main_wt.to_str().unwrap()).as_deref(),
+        Ok("origin/main"),
+        "origin/HEAD unset must still resolve via the origin/main probe"
+    );
+    let _ = std::fs::remove_dir_all(main_wt.parent().unwrap());
+
+    // master-default — must resolve to origin/master, NOT error.
+    let master_wt = build_repo_with_origin_master_2390("resolve-master");
+    assert_eq!(
+        git_refs::resolve_default_branch_base(master_wt.to_str().unwrap()).as_deref(),
+        Ok("origin/master")
+    );
+    git_run_2379(&["remote", "set-head", "origin", "-d"], &master_wt);
+    assert_eq!(
+        git_refs::resolve_default_branch_base(master_wt.to_str().unwrap()).as_deref(),
+        Ok("origin/master"),
+        "master default with origin/HEAD unset must probe to origin/master"
+    );
+    let _ = std::fs::remove_dir_all(master_wt.parent().unwrap());
+}
+
+/// Truly undeterminable base (no remote at all: origin/HEAD unset, no origin/main
+/// or origin/master) → `Err`, so the denylist caller stays fail-closed. Joins
+/// `git-subprocess`.
+#[test]
+fn resolve_default_branch_base_errs_when_undeterminable_2390() {
+    let base = std::env::temp_dir().join(format!(
+        "agend-2390-noremote-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    ));
+    let _ = std::fs::remove_dir_all(&base);
+    std::fs::create_dir_all(&base).unwrap();
+    assert!(
+        git_run_2379(&["init", "-b", "trunk", base.to_str().unwrap()], &base)
+            .status
+            .success()
+    );
+    git_run_2379(&["config", "user.name", "test"], &base);
+    git_run_2379(&["config", "user.email", "test@test.local"], &base);
+    git_run_2379(&["config", "commit.gpgsign", "false"], &base);
+    std::fs::write(base.join("a.txt"), "x\n").unwrap();
+    assert!(git_run_2379(&["add", "a.txt"], &base).status.success());
+    assert!(git_run_2379(&["commit", "-m", "c"], &base).status.success());
+    assert!(
+        git_refs::resolve_default_branch_base(base.to_str().unwrap()).is_err(),
+        "no remote default + no origin/main|master must be Err (→ caller fail-closed)"
+    );
+    let _ = std::fs::remove_dir_all(&base);
+}
+
+/// #2390 footgun fix: on a MASTER-default repo the denylist must NOT falsely block
+/// a clean push (pre-fix `origin/main..HEAD` errored → fail-closed → every push
+/// blocked), yet must still catch a force-added trust-root file. Joins
+/// `git-subprocess`.
+#[test]
+fn denylist_not_falsely_blocked_on_master_default_repo_2390() {
+    let wt = build_repo_with_origin_master_2390("denylist");
+    // Clean commit on the feature branch — must be allowed (was wrongly blocked).
+    std::fs::write(wt.join("feature.txt"), "real work\n").unwrap();
+    assert!(git_run_2379(&["add", "feature.txt"], &wt).status.success());
+    assert!(git_run_2379(&["commit", "-m", "feat: real"], &wt)
+        .status
+        .success());
+    assert_eq!(
+        push_trust_root_denylist_violation(wt.to_str().unwrap()),
+        None,
+        "a clean push on a master-default repo must NOT be fail-closed-blocked"
+    );
+    // And the guardrail still fires for a real trust-root violation.
+    std::fs::write(wt.join("fleet.yaml"), "stolen\n").unwrap();
+    assert!(git_run_2379(&["add", "-f", "fleet.yaml"], &wt)
+        .status
+        .success());
+    assert!(git_run_2379(&["commit", "-m", "sneak"], &wt)
+        .status
+        .success());
+    assert!(
+        push_trust_root_denylist_violation(wt.to_str().unwrap())
+            .as_deref()
+            .is_some_and(|r| r.contains("fleet.yaml")),
+        "trust-root violation must still be denied on a master-default repo"
+    );
+    let _ = std::fs::remove_dir_all(wt.parent().unwrap());
+}

--- a/src/bin/agend-git/tests.rs
+++ b/src/bin/agend-git/tests.rs
@@ -3181,3 +3181,115 @@ fn denylist_not_falsely_blocked_on_master_default_repo_2390() {
     );
     let _ = std::fs::remove_dir_all(wt.parent().unwrap());
 }
+
+/// #2662 reviewer4 repro fixture: BOTH `origin/main` and `origin/master` exist,
+/// actual default = master, `origin/HEAD` unset, and `origin/main` carries a
+/// trust-root file (`fleet.yaml`) absent from master. `feat/test` is based on
+/// origin/main. Returns the worktree.
+fn build_repo_ambiguous_dual_trunk_2390(tag: &str) -> std::path::PathBuf {
+    let id = format!(
+        "{}-{tag}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    );
+    let base = std::env::temp_dir().join(format!("agend-2390-ambig-{id}"));
+    let _ = std::fs::remove_dir_all(&base);
+    std::fs::create_dir_all(&base).unwrap();
+    let origin_bare = base.join("origin.git");
+    let worktree = base.join("worktree");
+    assert!(git_run_2379(
+        &[
+            "init",
+            "--bare",
+            "-b",
+            "master",
+            origin_bare.to_str().unwrap()
+        ],
+        &base
+    )
+    .status
+    .success());
+    assert!(git_run_2379(
+        &[
+            "clone",
+            origin_bare.to_str().unwrap(),
+            worktree.to_str().unwrap()
+        ],
+        &base
+    )
+    .status
+    .success());
+    git_run_2379(&["config", "user.name", "test"], &worktree);
+    git_run_2379(&["config", "user.email", "test@test.local"], &worktree);
+    git_run_2379(&["config", "commit.gpgsign", "false"], &worktree);
+    std::fs::write(worktree.join("README.md"), "initial\n").unwrap();
+    assert!(git_run_2379(&["add", "README.md"], &worktree)
+        .status
+        .success());
+    assert!(git_run_2379(&["commit", "-m", "initial"], &worktree)
+        .status
+        .success());
+    assert!(git_run_2379(&["push", "origin", "master"], &worktree)
+        .status
+        .success());
+    // A NON-default `main` that carries a trust-root file absent from master.
+    assert!(git_run_2379(&["checkout", "-b", "main"], &worktree)
+        .status
+        .success());
+    std::fs::write(worktree.join("fleet.yaml"), "stolen\n").unwrap();
+    assert!(git_run_2379(&["add", "-f", "fleet.yaml"], &worktree)
+        .status
+        .success());
+    assert!(git_run_2379(
+        &["commit", "-m", "trust-root on non-default main"],
+        &worktree
+    )
+    .status
+    .success());
+    assert!(git_run_2379(&["push", "origin", "main"], &worktree)
+        .status
+        .success());
+    // Ambiguity: both origin/main + origin/master exist, origin/HEAD unset.
+    git_run_2379(&["remote", "set-head", "origin", "-d"], &worktree);
+    assert!(
+        git_run_2379(&["checkout", "-b", "feat/test", "origin/main"], &worktree)
+            .status
+            .success()
+    );
+    worktree
+}
+
+/// #2662: dual-trunk ambiguity (both origin/main + origin/master, origin/HEAD
+/// unset) is UNRESOLVABLE → `Err`, so the denylist stays fail-closed rather than
+/// blindly picking `main`. Joins `git-subprocess`.
+#[test]
+fn resolve_default_branch_base_ambiguous_dual_trunk_errs_2390() {
+    let wt = build_repo_ambiguous_dual_trunk_2390("resolve");
+    let got = git_refs::resolve_default_branch_base(wt.to_str().unwrap());
+    assert!(
+        got.as_ref().err().is_some_and(|e| e.contains("ambiguous")),
+        "both trunks + unset origin/HEAD must be Err(ambiguous), got: {got:?}"
+    );
+    let _ = std::fs::remove_dir_all(wt.parent().unwrap());
+}
+
+/// #2662 reviewer4 fail-open repro (RED before the exactly-one fix, GREEN after):
+/// with a trust-root file present only on non-default `origin/main`, blindly
+/// picking `main` scanned `origin/main..HEAD` and MISSED it (returned None =
+/// allow). The ambiguous state must instead fail CLOSED. Joins `git-subprocess`.
+#[test]
+fn denylist_fails_closed_on_ambiguous_dual_trunk_2390() {
+    let wt = build_repo_ambiguous_dual_trunk_2390("denylist");
+    let violation = push_trust_root_denylist_violation(wt.to_str().unwrap());
+    assert!(
+        violation
+            .as_deref()
+            .is_some_and(|r| r.contains("fail-closed")),
+        "ambiguous dual-trunk must FAIL CLOSED (not silently pick main and miss a \
+             trust-root file only visible from the true default base), got: {violation:?}"
+    );
+    let _ = std::fs::remove_dir_all(wt.parent().unwrap());
+}


### PR DESCRIPTION
## Problem (#2379 ③ / #2390 r4 C2 follow-up — latent footgun)

`push_range_files` (trust-root denylist) and `cleanup_init_pile_pre_push` both
compute their range against a hardcoded `origin/main..HEAD`. On a **non-main-default
repo** (default=master, or origin/main not fetched) that range errors — and the
denylist **fails CLOSED**, so *every* push is hard-blocked, with an invalid
`git fetch origin` remedy. `cleanup` shares the assumption but no-ops (soft). AgEnD
is generic to any repo, so this is a latent footgun; main-default + canonical-sourced
managed worktrees don't trip it today.

## Fix

Shared resolver `git_refs::resolve_default_branch_base`, used by **both** sites (DRY).
Fallback order (a **spike** informed this — see below):

1. `git symbolic-ref --short refs/remotes/origin/HEAD` — authoritative default branch
   when set. **Not** `git rev-parse --abbrev-ref origin/HEAD`, which *lies*: it echoes
   the literal `"origin/HEAD"` instead of failing when unset.
2. Existence-probe `origin/main` then `origin/master` (why a normal clone with
   origin/HEAD unset but origin/main present keeps working).
3. Otherwise `Err` → denylist fails CLOSED / cleanup no-ops — only when the base is
   **truly** undeterminable.

Deliberately **excludes** the branch's `@{upstream}`: post-push it points at the
branch's own remote ref, so diffing against it would shrink the denylist scan to
"commits since last push" and weaken the guardrail. The denylist must scan the whole
branch vs. trunk — conservative over precise.

Also fixes the fail-closed remedy to the actually-effective **`git remote set-head
origin -a`** (sets origin/HEAD once → any default-branch name resolves), replacing the
master-repo-useless "git fetch origin".

### Spike finding
`origin/HEAD` is **not set** in managed worktrees (never ran `git remote set-head`),
and `rev-parse --abbrev-ref origin/HEAD` deceptively returns the literal string rather
than failing — so the resolver uses `symbolic-ref` (clean error) + the existence probe.

### Placement / LOC
Resolver lives in a shim-local `src/bin/agend-git/git_refs.rs` — the shim is a separate
bin that can't link the lib, and `agend-git.rs` sits at the anti-monolith ceiling
(kept at 2497 ≤ 2500 by condensing the now-updated cleanup doc).

## Tests (agend-git/tests.rs, joined to the `git-subprocess` nextest group)
- `denylist_not_falsely_blocked_on_master_default_repo_2390` — master-default repo: clean
  push NOT blocked (the footgun), trust-root file still caught.
- `resolve_default_branch_base_main_and_master_2390` — resolves origin/main|master via
  both origin/HEAD-set and origin/HEAD-unset (managed-worktree) paths.
- `resolve_default_branch_base_errs_when_undeterminable_2390` — no remote → Err.
- Existing `denylist_fails_closed_when_origin_main_missing_2379` still passes (fail-closed
  preserved when truly undeterminable).

## Verification
- 88/88 agend-git bin tests pass (incl. the existing fail-closed test — no regression).
- `cargo fmt --check` clean; `cargo clippy --all-targets --features tray -- -D warnings` clean.
- `src_file_size_invariant` passes (agend-git.rs 2497 ≤ 2500).
