### PR TITLE
test(worktree_registry_sweep): deterministic offload seams (#2661 follow-up)

### DIFF
--- a/src/daemon/per_tick/worktree_registry_sweep.rs
+++ b/src/daemon/per_tick/worktree_registry_sweep.rs
@@ -82,36 +82,91 @@ impl PerTickHandler for WorktreeRegistrySweepHandler {
         // remain fully observable via tracing + event_log per candidate, same
         // as before this offload.
         std::thread::spawn(move || {
-            let _guard = super::ClearOnDrop::new(in_flight);
+            // The guard is SCOPED so `in_flight` is cleared (its `Drop`) BEFORE
+            // the test-only completion signal below — a test waking on that
+            // signal then observes `!is_in_flight()` deterministically, with no
+            // wall-clock poll. In non-test builds both `#[cfg(test)]` lines
+            // vanish and the extra scope is a no-op (the guard still drops at
+            // closure end), so production behaviour is byte-identical.
+            {
+                let _guard = super::ClearOnDrop::new(in_flight);
+                #[cfg(test)]
+                test_hooks::round_gate();
+                worktree_auto_cleanup(&home, &configs);
+            }
             #[cfg(test)]
-            test_hooks::maybe_delay();
-            worktree_auto_cleanup(&home, &configs);
+            test_hooks::signal_round_complete();
         });
     }
 }
 
-/// #P1-2607 regression-test seam: lets a test simulate a slow sweep (the
-/// pathological case that froze the daemon) without needing a real repo with
-/// hundreds of candidate branches. No-op in production — `maybe_delay` is
-/// only ever called from a `#[cfg(test)]` call site.
+/// #P1-2607 offload-determinism seams (t-20260706052959557862-96214-2, #2661
+/// follow-up): a `GATE` the spawned round blocks on (so a test can hold a round
+/// provably in-flight) and a monotone `COMPLETIONS` counter bumped AFTER the
+/// round's `ClearOnDrop` clears `in_flight`. These replace the old wall-clock
+/// `DELAY_MS` sleep, whose `elapsed() < 100ms` / 2s-poll assertions are the
+/// same flake pattern #2661 fixed for `hourly_gc`. Process-global (the round
+/// observes them from its background thread); the two tests that use them are
+/// `serial(worktree_registry_sweep_gate)`, so they never race each other. No-op
+/// in production — every call site is `#[cfg(test)]`.
 #[cfg(test)]
 mod test_hooks {
-    use std::sync::atomic::{AtomicU64, Ordering};
+    use parking_lot::{Condvar, Mutex};
 
-    static DELAY_MS: AtomicU64 = AtomicU64::new(0);
+    /// `true` while the gate is armed — a spawned round blocks in `round_gate`.
+    static GATE_ARMED: Mutex<bool> = Mutex::new(false);
+    static GATE_CV: Condvar = Condvar::new();
+    /// Monotone count of rounds that have finished (and cleared `in_flight`).
+    static COMPLETIONS: Mutex<u64> = Mutex::new(0);
+    static COMPLETIONS_CV: Condvar = Condvar::new();
 
-    pub(crate) fn set_delay_ms(ms: u64) {
-        DELAY_MS.store(ms, Ordering::Release);
+    /// Reset both seams to idle. Called at the start of each test that uses
+    /// them so a prior test — or an early return/panic before `release_gate` —
+    /// can't leave the gate armed or the counter dirty.
+    pub(super) fn reset() {
+        *GATE_ARMED.lock() = false;
+        GATE_CV.notify_all();
+        *COMPLETIONS.lock() = 0;
     }
 
-    pub(crate) fn clear_delay() {
-        DELAY_MS.store(0, Ordering::Release);
+    /// Arm the gate so the NEXT spawned round blocks in `round_gate` until
+    /// `release_gate`, letting a test hold a round provably in-flight.
+    pub(super) fn arm_gate() {
+        *GATE_ARMED.lock() = true;
     }
 
-    pub(crate) fn maybe_delay() {
-        let ms = DELAY_MS.load(Ordering::Acquire);
-        if ms > 0 {
-            std::thread::sleep(std::time::Duration::from_millis(ms));
+    /// Release a gated round (and any future ones) so it runs to completion.
+    pub(super) fn release_gate() {
+        *GATE_ARMED.lock() = false;
+        GATE_CV.notify_all();
+    }
+
+    /// Called by a spawned round (replaces the old `maybe_delay`): blocks while
+    /// the gate is armed, else falls straight through.
+    pub(super) fn round_gate() {
+        let mut armed = GATE_ARMED.lock();
+        while *armed {
+            GATE_CV.wait(&mut armed);
+        }
+    }
+
+    /// Bumped by a spawned round AFTER its `ClearOnDrop` cleared `in_flight`.
+    pub(super) fn signal_round_complete() {
+        *COMPLETIONS.lock() += 1;
+        COMPLETIONS_CV.notify_all();
+    }
+
+    /// Snapshot of the completed-round count (baseline before an action).
+    pub(super) fn completions() -> u64 {
+        *COMPLETIONS.lock()
+    }
+
+    /// Block until the completed-round count exceeds `prev`. Deterministic — no
+    /// wall-clock ceiling; a genuine hang is caught by nextest's slow-timeout.
+    pub(super) fn wait_for_completion(prev: u64) {
+        let mut n = COMPLETIONS.lock();
+        while *n <= prev {
+            COMPLETIONS_CV.wait(&mut n);
         }
     }
 }
@@ -189,15 +244,23 @@ mod tests {
         );
     }
 
-    /// Smoke test: `run()` against an empty registry + temp home must
-    /// complete without panic (empty configs, no fleet.yaml).
+    /// Smoke, made deterministic (t-20260706052959557862-96214-2): `run()`
+    /// against an empty registry + temp home spawns a round that finishes and
+    /// clears `in_flight`, with no panic. Waits on the completion signal
+    /// (bumped after the guard clears the flag) instead of the old 50ms sleep,
+    /// which was a latent teardown race (the sweep reads `home` while
+    /// `remove_dir_all` tears it down). A single `run()` keeps the completed
+    /// count unambiguous — re-entrancy is pinned deterministically by the
+    /// freeze test below.
     #[test]
+    #[serial_test::serial(worktree_registry_sweep_gate)]
     fn run_is_no_op_on_empty_fixtures() {
         use crate::agent::{AgentRegistry, ExternalRegistry};
         use parking_lot::Mutex;
         use std::collections::HashMap;
         use std::sync::Arc;
 
+        test_hooks::reset();
         let tag = std::process::id();
         let home = std::env::temp_dir().join(format!("agend-worktree-reg-sweep-handler-{tag}"));
         std::fs::create_dir_all(&home).unwrap();
@@ -214,30 +277,38 @@ mod tests {
 
         // N=1 forces every call to fire.
         let h = WorktreeRegistrySweepHandler::new(1);
+        let before = test_hooks::completions();
         h.run(&ctx);
-        h.run(&ctx);
-
-        // #P1-2607: the real work now runs in a background thread; give it a
-        // moment to finish before tearing down `home` out from under it.
-        std::thread::sleep(std::time::Duration::from_millis(50));
+        test_hooks::wait_for_completion(before);
+        assert!(
+            !h.is_in_flight(),
+            "background round should finish on empty fixtures"
+        );
         std::fs::remove_dir_all(&home).ok();
     }
 
-    /// #P1-2607 freeze-regression pin: `run()` must return near-instantly
-    /// even while the sweep itself is slow (the pathological case that froze
-    /// the daemon — 83s of git subprocess work on the main tick loop,
-    /// simulated here via the `test_hooks` delay seam instead of a real repo
-    /// with hundreds of candidates). Also pins the re-entrancy guard: a
-    /// second fire while the first round is still "running" must skip, not
-    /// spawn an overlapping second round.
+    /// #P1-2607 freeze-regression pin, made DETERMINISTIC
+    /// (t-20260706052959557862-96214-2, #2661 follow-up): `run()` must offload
+    /// the sweep to a background thread and return without waiting for it. The
+    /// old version proved this with wall-clock `elapsed() < 100ms` assertions —
+    /// the same pattern that flaked for `hourly_gc` under full-parallel-nextest
+    /// CPU contention (#2661). Here a test GATE holds the spawned round provably
+    /// in-flight, so the property is proven STRUCTURALLY at any machine speed:
+    /// had `run()` done the sweep inline it would block on the armed gate and
+    /// never return (a hang nextest's slow-timeout attributes), so reaching the
+    /// post-`run()` assertions — with the round still `in_flight` — is itself
+    /// the proof of offload. Re-entrancy is pinned deterministically: exactly
+    /// ONE round completes even though `run()` fired twice while the first was
+    /// in flight. Serial: the gate/counter seams are process-global.
     #[test]
+    #[serial_test::serial(worktree_registry_sweep_gate)]
     fn run_does_not_block_tick_loop_during_slow_sweep_p1_2607() {
         use crate::agent::{AgentRegistry, ExternalRegistry};
         use parking_lot::Mutex;
         use std::collections::HashMap;
         use std::sync::Arc;
-        use std::time::{Duration, Instant};
 
+        test_hooks::reset();
         let tag = std::process::id();
         let home = std::env::temp_dir().join(format!("agend-worktree-reg-sweep-slow-{tag}"));
         std::fs::create_dir_all(&home).unwrap();
@@ -252,44 +323,43 @@ mod tests {
             configs: &configs,
         };
 
-        test_hooks::set_delay_ms(300);
+        // Arm the gate so the spawned round blocks mid-flight until we release.
+        test_hooks::arm_gate();
         let h = WorktreeRegistrySweepHandler::new(1); // fires on every call
 
-        let start = Instant::now();
+        // If `run()` ran the sweep inline it would block on the armed gate and
+        // never return — reaching the next line proves it offloaded.
         h.run(&ctx);
-        assert!(
-            start.elapsed() < Duration::from_millis(100),
-            "run() must not block the tick loop on the (delayed) sweep, took {:?}",
-            start.elapsed()
-        );
         assert!(
             h.is_in_flight(),
-            "the background round should still be running (300ms delay, checked immediately)"
+            "the offloaded round must still be in flight (blocked on the gate)"
         );
 
-        // Simulates the very next tick arriving while the previous round is
-        // still in flight: the gate fires again, but the re-entrancy guard
-        // must skip spawning a second overlapping round.
-        let start2 = Instant::now();
+        // A second tick while the first round is still in flight: the
+        // re-entrancy guard must skip spawning a second overlapping round — and
+        // this call must also return (not block on the gate).
         h.run(&ctx);
         assert!(
-            start2.elapsed() < Duration::from_millis(100),
-            "the re-entrant skip path must also return near-instantly"
+            h.is_in_flight(),
+            "re-entrant tick must neither block nor clear the in-flight round"
         );
 
-        // Poll for the background round to finish (bounded — the delay is
-        // 300ms, so 2s is a generous ceiling for CI jitter) and confirm the
-        // guard clears once it does.
-        let deadline = Instant::now() + Duration::from_secs(2);
-        while h.is_in_flight() && Instant::now() < deadline {
-            std::thread::sleep(Duration::from_millis(10));
-        }
+        // Release the round and wait — deterministically — for it to finish.
+        let before = test_hooks::completions();
+        test_hooks::release_gate();
+        test_hooks::wait_for_completion(before);
+
+        assert_eq!(
+            test_hooks::completions(),
+            before + 1,
+            "exactly ONE round may complete — the re-entrant second run() must \
+             have skipped, not spawned an overlapping round"
+        );
         assert!(
             !h.is_in_flight(),
             "in_flight must clear once the background sweep completes"
         );
 
-        test_hooks::clear_delay();
         std::fs::remove_dir_all(&home).ok();
     }
 }


### PR DESCRIPTION
## Follow-up to #2661 — `t-20260706052959557862-96214-2`

While fixing #2661 (hourly_gc offload-test flake) I flagged that the sibling `worktree_registry_sweep` offload test carries the **identical wall-clock pattern**. This is the preventive root-fix (the flake hasn't been observed in the wild for this module yet, but the failure mode is the same and this module is likewise **not** in the serialized `git-subprocess` nextest group, so full-parallel CPU contention can trip it).

### Before
- `run_does_not_block_tick_loop_during_slow_sweep_p1_2607` asserted `start.elapsed() < 100ms` against a 300ms sleep seam + a 2s poll deadline for `in_flight` to clear — wall-clock thresholds that flake under CPU oversubscription.
- `run_is_no_op_on_empty_fixtures` slept a fixed `50ms` hoping the background round finished before `remove_dir_all` — a latent teardown race (the sweep reads `home` while it's torn down). It also shared the process-global `DELAY_MS` with the other test **without** `serial`, so a concurrent `set_delay_ms(300)` could bleed in.

### After — same approach #2661 landed on `main`
Replace the `DELAY_MS` sleep seam with two deterministic `#[cfg(test)]` seams:
1. a **release-GATE** the spawned round blocks on — "`run()` offloaded" is proven **structurally** (inline work would block on the gate and never return → a hang nextest's slow-timeout attributes), no wall-clock at any machine speed;
2. a monotone **COMPLETIONS counter** bumped *after* `ClearOnDrop` clears `in_flight` (guard scoped so its `Drop`/`Release` precedes the signal) — the test blocks on `wait_for_completion` instead of polling, and re-entrancy is proven by asserting **exactly one** completion after two `run()` fires.

Both tests are now `serial(worktree_registry_sweep_gate)` (the seams are process-global). Production `run()` is **byte-identical** — both `#[cfg(test)]` lines vanish in release and the extra guard block-scope is a no-op.

## Verification
- `cargo fmt --check` clean; `cargo clippy --all-targets` clean.
- Isolation: 3/3 pass (the two deterministic tests now run in ~0.02s vs the old ~300ms+poll).
- **Full-parallel `cargo nextest run --no-fail-fast` ×3 — `worktree_registry_sweep` 3/3 pass every run** (~325s each, 5372 tests). Only failures are the two documented always-fail-locally infra tests (`e2e_dispatch_review_workflow_seam_invariants_1900`, `teardown_leaves_zero_residual_after_full_exercise_1907`); neither is `worktree_registry_sweep`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)