### PR TITLE
feat(#2413): reconcile_log — offline-join ObservedStatus accuracy telemetry (default-off)

### DIFF
--- a/src/daemon/per_tick/shadow_observe.rs
+++ b/src/daemon/per_tick/shadow_observe.rs
@@ -52,12 +52,17 @@ impl PerTickHandler for ShadowObserveHandler {
         // it before touching any per-agent core lock (never hold the registry lock
         // across another lock — mirrors `api_activity_probe::probe_once`). child_alive
         // is read here (its own `child.lock()`) so the reduce loop needs only core.lock.
-        let mut agents: Vec<(String, Arc<CoreMutex<AgentCore>>, bool)> = {
+        let mut agents: Vec<(String, Arc<CoreMutex<AgentCore>>, bool, String)> = {
             let reg = crate::agent::lock_registry(ctx.registry);
             reg.values()
                 .map(|h| {
                     let child_alive = h.child.lock().process_id().is_some();
-                    (h.name.to_string(), Arc::clone(&h.core), child_alive)
+                    (
+                        h.name.to_string(),
+                        Arc::clone(&h.core),
+                        child_alive,
+                        h.backend_command.clone(),
+                    )
                 })
                 .collect()
         };
@@ -72,13 +77,16 @@ impl PerTickHandler for ShadowObserveHandler {
         agents.extend(
             crate::ephemeral_tracking::live_children_snapshot()
                 .into_iter()
-                .map(|w| (w.worker_id, w.core, w.child_alive)),
+                .map(|w| (w.worker_id, w.core, w.child_alive, String::new())),
         );
         if agents.is_empty() {
             return;
         }
+        // #2413 (a): campaign-gated (default-off) reconcile telemetry. Checked once
+        // per tick so a disabled campaign costs one env read, not one per agent.
+        let reconcile = crate::daemon::shadow::reconcile_log::enabled();
         let now_ms = chrono::Utc::now().timestamp_millis().max(0) as u64;
-        for (name, core, child_alive) in &agents {
+        for (name, core, child_alive, backend_command) in &agents {
             // Read the screen + liveness inputs under one core.lock(), drop it, run the
             // reduce (which takes the shadow buffer/runtime locks — DISJOINT from
             // core.lock, and no thread ever acquires core.lock while holding those, so
@@ -95,6 +103,17 @@ impl PerTickHandler for ShadowObserveHandler {
             };
             let status = shadow::observe(name, screen, &live, now_ms);
             log_correction(name, raw_state, screen, &status, &live);
+            if reconcile {
+                crate::daemon::shadow::reconcile_log::record(
+                    ctx.home,
+                    name,
+                    backend_command,
+                    raw_state,
+                    screen,
+                    &status,
+                    &live,
+                );
+            }
             // #2413 (A): publish the GATED badge override into the lock-free mirror the
             // render snapshot reads (Some ⇒ a high-confidence correction the badge shows;
             // None ⇒ render keeps the raw state). Computed BEFORE `status` moves into

--- a/src/daemon/per_tick/shadow_observe.rs
+++ b/src/daemon/per_tick/shadow_observe.rs
@@ -26,6 +26,11 @@ use crate::state::AgentState;
 use crate::sync_audit::CoreMutex;
 use std::sync::Arc;
 
+/// One agent's per-tick snapshot: `(name, core, child_alive, backend_command)`.
+/// `backend_command` is `Some` ONLY when the reconcile campaign is on (#2664 F1) —
+/// off-campaign it stays `None`, so no per-agent `String` clone happens.
+type TickAgentSnapshot = (String, Arc<CoreMutex<AgentCore>>, bool, Option<String>);
+
 /// Per-tick reduce driver. Stateless: the per-agent accumulators live in the shadow
 /// module's runtime registry (keyed by name, pruned on despawn), so nothing here needs
 /// interior mutability.
@@ -52,7 +57,13 @@ impl PerTickHandler for ShadowObserveHandler {
         // it before touching any per-agent core lock (never hold the registry lock
         // across another lock — mirrors `api_activity_probe::probe_once`). child_alive
         // is read here (its own `child.lock()`) so the reduce loop needs only core.lock.
-        let mut agents: Vec<(String, Arc<CoreMutex<AgentCore>>, bool, String)> = {
+        // #2413 (a): campaign-gated (default-off) reconcile telemetry. Read the flag
+        // ONCE, up front — so when it's off the snapshot below allocates NOTHING extra:
+        // the per-agent `backend_command` clone lives STRUCTURALLY inside
+        // `reconcile.then(...)`, so it can never run off-campaign (reviewer4 #2664 F1 —
+        // a type/branch guarantee, not an ordering convention).
+        let reconcile = crate::daemon::shadow::reconcile_log::enabled();
+        let mut agents: Vec<TickAgentSnapshot> = {
             let reg = crate::agent::lock_registry(ctx.registry);
             reg.values()
                 .map(|h| {
@@ -61,7 +72,7 @@ impl PerTickHandler for ShadowObserveHandler {
                         h.name.to_string(),
                         Arc::clone(&h.core),
                         child_alive,
-                        h.backend_command.clone(),
+                        reconcile.then(|| h.backend_command.clone()),
                     )
                 })
                 .collect()
@@ -77,14 +88,11 @@ impl PerTickHandler for ShadowObserveHandler {
         agents.extend(
             crate::ephemeral_tracking::live_children_snapshot()
                 .into_iter()
-                .map(|w| (w.worker_id, w.core, w.child_alive, String::new())),
+                .map(|w| (w.worker_id, w.core, w.child_alive, None)),
         );
         if agents.is_empty() {
             return;
         }
-        // #2413 (a): campaign-gated (default-off) reconcile telemetry. Checked once
-        // per tick so a disabled campaign costs one env read, not one per agent.
-        let reconcile = crate::daemon::shadow::reconcile_log::enabled();
         let now_ms = chrono::Utc::now().timestamp_millis().max(0) as u64;
         for (name, core, child_alive, backend_command) in &agents {
             // Read the screen + liveness inputs under one core.lock(), drop it, run the
@@ -107,7 +115,7 @@ impl PerTickHandler for ShadowObserveHandler {
                 crate::daemon::shadow::reconcile_log::record(
                     ctx.home,
                     name,
-                    backend_command,
+                    backend_command.as_deref().unwrap_or(""),
                     raw_state,
                     screen,
                     &status,
@@ -292,6 +300,47 @@ mod tests {
             "flag-OFF ⇒ no reduce ⇒ observed_status stays None"
         );
         shadow::forget_agent(&name);
+    }
+
+    /// #2664 F1: exercise the FULL `ShadowObserveHandler::run` with the shadow
+    /// observer ON but the reconcile campaign flag OFF (default). The prior
+    /// `disabled_writes_nothing` test only drove `record()` directly, so it couldn't
+    /// cover the per-tick hot path; this asserts the whole run writes NO reconcile
+    /// file when off — paired with the structural `Option` guarantee (the per-agent
+    /// `backend_command` clone lives inside `reconcile.then(...)`, so it cannot run
+    /// off-campaign). Reconcile-off short-circuits before any file/budget work, so
+    /// this is independent of the day/budget statics.
+    #[test]
+    #[serial(shadow_observer)]
+    fn run_path_reconcile_off_writes_no_reconcile_file() {
+        let home =
+            std::env::temp_dir().join(format!("agend-recon-runpath-off-{}", std::process::id()));
+        std::fs::create_dir_all(&home).unwrap();
+        let externals: ExternalRegistry = Arc::new(PLMutex::new(HashMap::new()));
+        let configs = Arc::new(PLMutex::new(HashMap::new()));
+        let (registry, _core, name, _reader) = one_agent_registry("shadow-recon-off");
+        let token = shadow::new_session_token().unwrap();
+        shadow::register(&token, &name);
+        shadow::push(&name, Evidence::hook(EvidenceKind::TurnStarted, 1_000));
+
+        std::env::remove_var("AGEND_SHADOW_RECONCILE_LOG"); // default OFF
+        with_flag(true, || {
+            // shadow observer ON ⇒ run() executes the full snapshot + per-agent loop
+            let ctx = ctx_for(&home, &registry, &externals, &configs);
+            ShadowObserveHandler::new().run(&ctx);
+        });
+
+        let wrote_reconcile = std::fs::read_dir(&home).unwrap().flatten().any(|e| {
+            e.file_name()
+                .to_string_lossy()
+                .starts_with("shadow-reconcile.")
+        });
+        assert!(
+            !wrote_reconcile,
+            "reconcile OFF ⇒ the full run() path must write no shadow-reconcile file"
+        );
+        shadow::forget_agent(&name);
+        std::fs::remove_dir_all(&home).ok();
     }
 
     /// Representative confirm-first: flag-ON, a buffered `TurnStarted` (episode open) +

--- a/src/daemon/shadow/mod.rs
+++ b/src/daemon/shadow/mod.rs
@@ -21,6 +21,7 @@ pub mod evidence;
 pub(crate) mod gate;
 pub mod kiro;
 pub mod opencode;
+pub(crate) mod reconcile_log;
 pub mod reducer;
 pub mod rollout;
 

--- a/src/daemon/shadow/reconcile_log.rs
+++ b/src/daemon/shadow/reconcile_log.rs
@@ -18,7 +18,9 @@
 //! 1/K (`AGEND_SHADOW_RECONCILE_SAMPLE`, default 60) and stamped `weight=K`, so
 //! the offline denominator (total decisive ticks) = Σ`weight` — an unbiased
 //! Horvitz–Thompson estimate. Output rotates into daily files
-//! `shadow-reconcile.<YYYY-MM-DD>.jsonl`; a total-size budget reaps oldest days.
+//! `shadow-reconcile.<YYYY-MM-DD>.jsonl`; each day file is a HARD byte cap
+//! (stop-write past the budget, drops counted so the offline join sees the gap —
+//! 寧 drop 別漲), and oldest days are reaped to bound the cross-day total.
 
 use super::evidence::{Authority, Confidence};
 use super::gate;
@@ -30,9 +32,11 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::sync::LazyLock;
 
-/// Total on-disk budget across all `shadow-reconcile.*.jsonl` day files; oldest
-/// days are reaped past it. ~1 MB/day at 13 agents (PR body) ⇒ ~50 days headroom.
-const BUDGET_BYTES: u64 = 50 * 1024 * 1024;
+/// Default byte budget, applied BOTH as the per-active-day file cap (stop-write
+/// past it — reviewer4 #2664 F2) AND as the cross-day total reaped by oldest-first
+/// GC. Env-overridable via `AGEND_SHADOW_RECONCILE_BUDGET_BYTES`. ~1 MB/day at 13
+/// agents (PR body).
+const DEFAULT_BUDGET_BYTES: u64 = 50 * 1024 * 1024;
 
 /// Default agreement sample rate: 1 in K steady agreeing ticks is logged.
 const DEFAULT_SAMPLE_RATE: u64 = 60;
@@ -150,23 +154,75 @@ pub(crate) fn record(
     }
 }
 
+fn budget_bytes() -> u64 {
+    std::env::var("AGEND_SHADOW_RECONCILE_BUDGET_BYTES")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(DEFAULT_BUDGET_BYTES)
+}
+
+/// Per-active-day write accounting for the budget cap (reviewer4 #2664 F2). An
+/// in-memory byte counter gates every append cheaply; once the active day file
+/// would exceed the budget we STOP writing and count the drop (寧 drop 別漲),
+/// rather than delete the newest file or let it grow unbounded.
+#[derive(Default)]
+struct DayWrite {
+    date: String,
+    bytes: u64,
+    dropped: u64,
+    warned: bool,
+}
+
+static DAY: LazyLock<Mutex<DayWrite>> = LazyLock::new(|| Mutex::new(DayWrite::default()));
+
 fn append(home: &Path, ts: &str, line: &str) {
     // `ts` is rfc3339 (`YYYY-MM-DDT…`); its first 10 chars are the UTC date.
     let date = ts.get(..10).unwrap_or("0000-00-00");
     let path = home.join(format!("shadow-reconcile.{date}.jsonl"));
-    let new_day = !path.exists();
+    let need = line.len() as u64 + 1; // +1 for the trailing newline
+    let budget = budget_bytes();
+
+    let mut d = DAY.lock();
+    if d.date != date {
+        // Day rolled over: recalibrate the counter from any pre-existing file,
+        // reset the drop/warn flags, and reap oldest day files to bound the
+        // cross-day total (never the newest — that's what the per-append cap below
+        // guards instead).
+        d.date = date.to_string();
+        d.bytes = std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
+        d.dropped = 0;
+        d.warned = false;
+        enforce_budget(home, budget);
+    }
+    if d.bytes.saturating_add(need) > budget {
+        // The in-memory counter says we'd cross the cap — stat once to calibrate
+        // against the real file (跨越門檻才 stat 校準) before committing to a drop.
+        d.bytes = std::fs::metadata(&path).map(|m| m.len()).unwrap_or(d.bytes);
+        if d.bytes.saturating_add(need) > budget {
+            d.dropped += 1;
+            if !d.warned {
+                d.warned = true;
+                tracing::warn!(
+                    tag = "#shadow-observer",
+                    date = %date,
+                    budget_bytes = budget,
+                    "shadow-reconcile day file hit its byte budget — DROPPING further \
+                     records today (寧 drop 別漲); offline join: a gap follows the last \
+                     record for this day"
+                );
+            }
+            return;
+        }
+    }
     if let Ok(mut f) = std::fs::OpenOptions::new()
         .create(true)
         .append(true)
         .open(&path)
     {
         use std::io::Write;
-        let _ = writeln!(f, "{line}");
-    }
-    // Enforce the disk budget only when a new day file first appears — O(1) per
-    // day, not per write.
-    if new_day {
-        enforce_budget(home, BUDGET_BYTES);
+        if writeln!(f, "{line}").is_ok() {
+            d.bytes = d.bytes.saturating_add(need);
+        }
     }
 }
 
@@ -367,6 +423,42 @@ mod tests {
             home.join("shadow-reconcile.2026-01-03.jsonl").exists(),
             "newest kept"
         );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #2664 F2: the ACTIVE day file is a hard byte cap — once an append would push
+    /// it past the budget, further records are DROPPED (not written, not grown) and
+    /// counted so the offline join sees the gap. Drives `append` directly with a tiny
+    /// budget for determinism (each "aaaa" line = 5 bytes incl. newline; budget 10 ⇒
+    /// 2 fit, the rest drop).
+    #[test]
+    #[serial]
+    fn active_day_append_stops_at_budget_and_counts_drops() {
+        std::env::set_var("AGEND_SHADOW_RECONCILE_BUDGET_BYTES", "10");
+        *DAY.lock() = DayWrite::default(); // isolate from any prior test's day state
+        let home = tmp_home("budget-cap");
+        let ts = "2026-09-09T12:00:00+00:00";
+        for _ in 0..5 {
+            append(&home, ts, "aaaa");
+        }
+        let path = home.join("shadow-reconcile.2026-09-09.jsonl");
+        let content = std::fs::read_to_string(&path).unwrap_or_default();
+        assert_eq!(
+            content.lines().count(),
+            2,
+            "only 2 lines fit under the 10-byte budget: {content:?}"
+        );
+        assert!(
+            std::fs::metadata(&path).unwrap().len() <= 10,
+            "active day file must never exceed the budget"
+        );
+        assert_eq!(
+            DAY.lock().dropped,
+            3,
+            "3 of 5 records dropped after the cap"
+        );
+        std::env::remove_var("AGEND_SHADOW_RECONCILE_BUDGET_BYTES");
+        *DAY.lock() = DayWrite::default();
         std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/daemon/shadow/reconcile_log.rs
+++ b/src/daemon/shadow/reconcile_log.rs
@@ -1,0 +1,372 @@
+//! #2413 §(a) — ObservedStatus reconcile telemetry (offline-join accuracy campaign).
+//!
+//! Persists, per decisive-screen tick, a structured record pairing the fused
+//! [`ObservedStatus`] with the raw screen baseline it was derived against, so an
+//! OFFLINE forward-join (each record → that agent's next definitive convergence
+//! event: a later hook terminal event, `usage_limit_detected`, or process
+//! liveness) can label ground truth and compute ObservedStatus accuracy + a
+//! per-backend breakdown over an N-day window. NO forward-looking logic runs in
+//! the daemon — truth is defined offline, iterable without a redeploy (and
+//! deliberately NOT the API plane itself, to keep the measurement non-circular).
+//!
+//! DEFAULT-OFF (`AGEND_SHADOW_RECONCILE_LOG=1` to enable) — opt-in for a bounded
+//! campaign, distinct from the always-on shadow observer kill-switch.
+//!
+//! Volume control (the daemon must not grow a new unbounded log like
+//! `state-transitions.jsonl` did): every disagreement AND every fused-state
+//! transition is logged in full (`weight=1`); steady agreeing ticks are SAMPLED
+//! 1/K (`AGEND_SHADOW_RECONCILE_SAMPLE`, default 60) and stamped `weight=K`, so
+//! the offline denominator (total decisive ticks) = Σ`weight` — an unbiased
+//! Horvitz–Thompson estimate. Output rotates into daily files
+//! `shadow-reconcile.<YYYY-MM-DD>.jsonl`; a total-size budget reaps oldest days.
+
+use super::evidence::{Authority, Confidence};
+use super::gate;
+use super::reducer::{Liveness, ObservedState, ObservedStatus, ScreenSignal};
+use crate::state::AgentState;
+use parking_lot::Mutex;
+use serde::Serialize;
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::LazyLock;
+
+/// Total on-disk budget across all `shadow-reconcile.*.jsonl` day files; oldest
+/// days are reaped past it. ~1 MB/day at 13 agents (PR body) ⇒ ~50 days headroom.
+const BUDGET_BYTES: u64 = 50 * 1024 * 1024;
+
+/// Default agreement sample rate: 1 in K steady agreeing ticks is logged.
+const DEFAULT_SAMPLE_RATE: u64 = 60;
+
+/// Campaign opt-in. Distinct from `shadow::enabled()` (the always-on observer
+/// kill-switch): this logging is DEFAULT-OFF, on only for an explicit campaign.
+pub(crate) fn enabled() -> bool {
+    std::env::var("AGEND_SHADOW_RECONCILE_LOG").as_deref() == Ok("1")
+}
+
+fn sample_rate() -> u64 {
+    std::env::var("AGEND_SHADOW_RECONCILE_SAMPLE")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .filter(|&k| k >= 1)
+        .unwrap_or(DEFAULT_SAMPLE_RATE)
+}
+
+#[derive(Default)]
+struct AgentReconcileState {
+    last_coarse: Option<ObservedState>,
+    /// Continuous count of steady agreeing ticks (NOT reset on transition), so
+    /// 1/K sampling stays unbiased across short agree runs.
+    agree_run: u64,
+}
+
+/// Per-agent transition + sampling state. Touched only while the campaign flag is
+/// on; one small entry per live agent (the daemon process is the campaign's life).
+static STATE: LazyLock<Mutex<HashMap<String, AgentReconcileState>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+#[derive(Serialize)]
+struct ReconcileRecord<'a> {
+    ts: &'a str,
+    agent: &'a str,
+    backend: &'a str,
+    observed: ObservedState,
+    raw_screen: &'static str,
+    agreed: bool,
+    authority: Authority,
+    confidence: Confidence,
+    api_in_flight: bool,
+    productive_silent_ms: u64,
+    since_ms: u64,
+    /// # of actual decisive ticks this record stands for (1, or K for a sampled
+    /// steady-agree). Offline denominator = Σ weight.
+    weight: u64,
+}
+
+/// Append one decisive-screen tick's reconcile record (see module docs for the
+/// sampling contract). No-op unless the campaign flag is on and the screen is
+/// decisive; steady agreeing ticks between samples return without writing.
+pub(crate) fn record(
+    home: &Path,
+    agent: &str,
+    backend_command: &str,
+    raw_state: AgentState,
+    screen: ScreenSignal,
+    status: &ObservedStatus,
+    live: &Liveness,
+) {
+    if !enabled() {
+        return;
+    }
+    // Decisive screen only — a non-decisive ("Other") screen has no baseline to
+    // agree/disagree against (mirrors `shadow_observe::log_correction`'s gate).
+    let Some(screen_state) = gate::screen_as_observed(screen) else {
+        return;
+    };
+    let coarse = status.state.coarse();
+    let agreed = screen_state == coarse;
+
+    let k = sample_rate();
+    let weight = {
+        let mut guard = STATE.lock();
+        let st = guard.entry(agent.to_string()).or_default();
+        let changed = st.last_coarse != Some(coarse);
+        st.last_coarse = Some(coarse);
+        if !agreed || changed {
+            // Disagreement or a fused-state transition: always logged in full.
+            1
+        } else {
+            // Steady agreement: continuous 1/K sample; weight K stands for the
+            // K-1 unlogged steady ticks. Counter is NOT reset on transitions, so
+            // short agree runs still contribute unbiasedly to the denominator.
+            st.agree_run += 1;
+            if st.agree_run.is_multiple_of(k) {
+                k
+            } else {
+                return;
+            }
+        }
+    };
+
+    let backend = crate::backend::Backend::from_command(backend_command)
+        .map(|b| b.as_str().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+    let ts = chrono::Utc::now().to_rfc3339();
+    let rec = ReconcileRecord {
+        ts: &ts,
+        agent,
+        backend: &backend,
+        observed: status.state,
+        raw_screen: raw_state.display_name(),
+        agreed,
+        authority: status.authority,
+        confidence: status.confidence,
+        api_in_flight: live.api_in_flight,
+        productive_silent_ms: live.productive_silent_ms,
+        since_ms: status.since_ms,
+        weight,
+    };
+    if let Ok(line) = serde_json::to_string(&rec) {
+        append(home, &ts, &line);
+    }
+}
+
+fn append(home: &Path, ts: &str, line: &str) {
+    // `ts` is rfc3339 (`YYYY-MM-DDT…`); its first 10 chars are the UTC date.
+    let date = ts.get(..10).unwrap_or("0000-00-00");
+    let path = home.join(format!("shadow-reconcile.{date}.jsonl"));
+    let new_day = !path.exists();
+    if let Ok(mut f) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+    {
+        use std::io::Write;
+        let _ = writeln!(f, "{line}");
+    }
+    // Enforce the disk budget only when a new day file first appears — O(1) per
+    // day, not per write.
+    if new_day {
+        enforce_budget(home, BUDGET_BYTES);
+    }
+}
+
+fn enforce_budget(home: &Path, budget: u64) {
+    let Ok(rd) = std::fs::read_dir(home) else {
+        return;
+    };
+    let mut files: Vec<(String, std::path::PathBuf, u64)> = rd
+        .flatten()
+        .filter_map(|e| {
+            let name = e.file_name().to_string_lossy().into_owned();
+            (name.starts_with("shadow-reconcile.") && name.ends_with(".jsonl")).then(|| {
+                let len = e.metadata().map(|m| m.len()).unwrap_or(0);
+                (name, e.path(), len)
+            })
+        })
+        .collect();
+    let total: u64 = files.iter().map(|(_, _, l)| *l).sum();
+    if total <= budget {
+        return;
+    }
+    // Date-stamped names sort lexicographically = chronologically; reap oldest
+    // first and NEVER the newest (today's active) file.
+    files.sort_by(|a, b| a.0.cmp(&b.0));
+    let last = files.len().saturating_sub(1);
+    let mut over = total - budget;
+    for (i, (_, path, len)) in files.into_iter().enumerate() {
+        if over == 0 || i == last {
+            break;
+        }
+        let _ = std::fs::remove_file(&path);
+        over = over.saturating_sub(len);
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    fn tmp_home(tag: &str) -> PathBuf {
+        static C: AtomicU32 = AtomicU32::new(0);
+        let dir = std::env::temp_dir().join(format!(
+            "agend-reconcile-{}-{}-{}",
+            tag,
+            std::process::id(),
+            C.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn status(state: ObservedState) -> ObservedStatus {
+        ObservedStatus {
+            state,
+            confidence: Confidence::Strong,
+            authority: Authority::Hook,
+            evidence: vec![],
+            since_ms: 42,
+        }
+    }
+
+    fn live() -> Liveness {
+        Liveness {
+            api_in_flight: true,
+            productive_silent_ms: 100,
+            child_alive: true,
+        }
+    }
+
+    fn read_records(home: &Path) -> Vec<serde_json::Value> {
+        let mut out = Vec::new();
+        for e in std::fs::read_dir(home).unwrap().flatten() {
+            let n = e.file_name().to_string_lossy().into_owned();
+            if n.starts_with("shadow-reconcile.") && n.ends_with(".jsonl") {
+                let content = std::fs::read_to_string(e.path()).unwrap_or_default();
+                for line in content.lines().filter(|l| !l.is_empty()) {
+                    out.push(serde_json::from_str(line).unwrap());
+                }
+            }
+        }
+        out
+    }
+
+    /// The campaign flag is default-OFF: `record` writes nothing without it, even
+    /// on a genuine disagreement.
+    #[test]
+    #[serial]
+    fn disabled_writes_nothing() {
+        std::env::remove_var("AGEND_SHADOW_RECONCILE_LOG");
+        let home = tmp_home("off");
+        record(
+            &home,
+            "off-agent",
+            "claude",
+            AgentState::Idle,
+            ScreenSignal::Idle,
+            &status(ObservedState::Active),
+            &live(),
+        );
+        assert!(read_records(&home).is_empty());
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// A disagreement (screen Idle, fused Active) is always logged in full,
+    /// weight 1, agreed=false, carrying the backend field.
+    #[test]
+    #[serial]
+    fn disagreement_logged_weight_1_with_backend() {
+        std::env::set_var("AGEND_SHADOW_RECONCILE_LOG", "1");
+        let home = tmp_home("disagree");
+        record(
+            &home,
+            "disagree-agent",
+            "/opt/homebrew/bin/codex",
+            AgentState::Idle,
+            ScreenSignal::Idle,
+            &status(ObservedState::Active),
+            &live(),
+        );
+        record(
+            &home,
+            "disagree-agent-2",
+            "mystery-binary",
+            AgentState::Idle,
+            ScreenSignal::Idle,
+            &status(ObservedState::Active),
+            &live(),
+        );
+        let recs = read_records(&home);
+        assert_eq!(recs.len(), 2, "disagreements must be logged: {recs:?}");
+        assert_eq!(recs[0]["agreed"], serde_json::json!(false));
+        assert_eq!(recs[0]["weight"], serde_json::json!(1));
+        // basename of the command path resolves the backend; unknown → "unknown".
+        assert_eq!(recs[0]["backend"], serde_json::json!("codex"));
+        assert_eq!(recs[1]["backend"], serde_json::json!("unknown"));
+        assert_eq!(recs[0]["observed"], serde_json::json!("active"));
+        std::env::remove_var("AGEND_SHADOW_RECONCILE_LOG");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Steady agreement is sampled 1/K with weight K; the first tick (a
+    /// transition from None) always logs. Over 4 identical agreeing ticks at K=3:
+    /// records at tick1 (transition, w1) and tick4 (3rd steady, w3); Σweight = 4
+    /// = the true tick count (unbiased denominator).
+    #[test]
+    #[serial]
+    fn steady_agreement_sampled_denominator_preserved() {
+        std::env::set_var("AGEND_SHADOW_RECONCILE_LOG", "1");
+        std::env::set_var("AGEND_SHADOW_RECONCILE_SAMPLE", "3");
+        let home = tmp_home("sample");
+        for _ in 0..4 {
+            record(
+                &home,
+                "sample-agent",
+                "claude",
+                AgentState::Idle,
+                ScreenSignal::Idle,
+                &status(ObservedState::Idle),
+                &live(),
+            );
+        }
+        let recs = read_records(&home);
+        assert_eq!(recs.len(), 2, "transition + 1 sampled steady: {recs:?}");
+        let weights: Vec<u64> = recs.iter().map(|r| r["weight"].as_u64().unwrap()).collect();
+        assert_eq!(
+            weights.iter().sum::<u64>(),
+            4,
+            "Σweight must equal tick count"
+        );
+        assert!(recs.iter().all(|r| r["agreed"] == serde_json::json!(true)));
+        std::env::remove_var("AGEND_SHADOW_RECONCILE_LOG");
+        std::env::remove_var("AGEND_SHADOW_RECONCILE_SAMPLE");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// The size budget reaps oldest day files first and never the newest.
+    #[test]
+    fn enforce_budget_reaps_oldest_keeps_newest() {
+        let home = tmp_home("budget");
+        for (day, bytes) in [
+            ("2026-01-01", 4000usize),
+            ("2026-01-02", 4000),
+            ("2026-01-03", 10),
+        ] {
+            std::fs::write(
+                home.join(format!("shadow-reconcile.{day}.jsonl")),
+                "x".repeat(bytes),
+            )
+            .unwrap();
+        }
+        enforce_budget(&home, 5000); // total 8010 > 5000 → reap oldest
+        assert!(!home.join("shadow-reconcile.2026-01-01.jsonl").exists());
+        assert!(
+            home.join("shadow-reconcile.2026-01-03.jsonl").exists(),
+            "newest kept"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+}


### PR DESCRIPTION
## What & why

Instrument **(a)** for the #2413 ObservedStatus accuracy quantification (task `t-…44436-0`, operator-directed, gating the API-proxy-plane decision). The **(b)** analysis established the existing logs **cannot** measure fused ObservedStatus accuracy: the only ground-truth-shaped log (`recovery_shadow.jsonl`) was deleted in #2554 and was recovery-scoped; the rate-limit join is circular (the screen classifier feeds both the reducer's rate-limit state and the event-log rate-limit events); and the agreement ticks that would form a denominator are logged only at DEBUG. So there is no on-disk surface to measure against — this PR adds it.

Lead-approved design: an **env-gated (default-off) structured reconcile log**, truth derived by an **offline forward-join** (each record → that agent's next definitive convergence event: a later hook terminal event, `usage_limit_detected`, process liveness). No forward-looking logic runs in the daemon — truth is defined offline, iterable without redeploy, and **deliberately not the API plane itself** (keeps the measurement non-circular).

## Change

`shadow_observe` already runs `log_correction` per decisive-screen tick per agent; alongside it (only when the campaign flag is on), it now persists a structured record via the new `src/daemon/shadow/reconcile_log.rs`:

```
{ts, agent, backend, observed, raw_screen, agreed, authority,
 confidence, api_in_flight, productive_silent_ms, since_ms, weight}
```

- `backend` (per the lead) → enables the per-backend accuracy breakdown (task `t-…44436-7` waits on it).
- **Volume control** (no new unbounded log like `state-transitions.jsonl`):
  - every **disagreement** and every **fused-state transition** → logged in full (`weight=1`);
  - **steady agreements** → sampled continuously 1/K (`AGEND_SHADOW_RECONCILE_SAMPLE`, default 60), stamped `weight=K`. Offline denominator = **Σ weight** (unbiased Horvitz–Thompson; counter is not reset on transitions so short agree runs still contribute). This also closes the **denominator gap (b) found**.
  - daily files `shadow-reconcile.<date>.jsonl`; a 50 MB total budget reaps oldest days (checked once per new-day file, never the newest).
- **DEFAULT-OFF**: `AGEND_SHADOW_RECONCILE_LOG=1` opt-in, distinct from the always-on shadow-observer kill-switch. Flag-off = one env read/tick, zero writes, **zero behaviour change**.

## Daily volume estimate

13 agents, 10 s tick = 8640 ticks/agent/day → ≈112k decisive-tick-opportunities/day. Records/day ≈ ~800 disagreements + ~1–2k transitions + ~1.8k sampled steady-agrees (112k/60) ≈ **~4k records/day ≈ ~1 MB/day**. A 5–7 day campaign ≈ 5–7 MB. (Without sampling: ~27 MB/day — the growth we're avoiding.) 50 MB budget ⇒ ~50 days headroom.

## Scope / limitation

v1 logs **decisive-screen ticks only** (mirrors `log_correction`'s gate). Fused errors during a non-decisive ("Other") screen aren't captured — a documented follow-up, out of scope here.

## Tests (RED-checked)

- `disabled_writes_nothing` — flag-off ⇒ no file even on a genuine disagreement.
- `disagreement_logged_weight_1_with_backend` — weight=1, agreed=false, `backend` from command basename (+ `unknown` fallback).
- `steady_agreement_sampled_denominator_preserved` — K=3, 4 identical agree ticks ⇒ 2 records (transition w1 + sampled steady w3), **Σweight==4** (denominator pin).
- `enforce_budget_reaps_oldest_keeps_newest`.

## Gate

`cargo fmt --check` clean · `cargo clippy --all-targets --features tray,discord -- -D warnings` exit 0 · `reconcile_log` 4/4 · `shadow`/`shadow_observe` 104/104 (no regression) · anti-monolith invariant pass (reconcile_log.rs 372 LOC).

## Rollout

After merge, on the next natural daemon restart the operator sets `AGEND_SHADOW_RECONCILE_LOG=1` (lead coordinates timing). After N=5–7 days I run the offline join → accuracy + per-backend + denominator report for the operator's API-proxy decision.

Single review (pure additive logging, flag-off = zero behaviour change).
