### PR TITLE
test(notification_queue): deterministic drain-lock seam — kill the llvm-cov flake class

### DIFF
--- a/src/notification_queue.rs
+++ b/src/notification_queue.rs
@@ -368,8 +368,7 @@ pub fn enqueue_coalesced_auto(home: &Path, agent_name: &str, text: &str) -> anyh
         return append_queued(home, agent_name, &new_msg);
     };
     // Serialize vs the drainer; lock held → plain append (no coalesce, no loss).
-    let Ok(Some(_lock)) = crate::store::try_acquire_file_lock(&drain_lock_path(home, agent_name))
-    else {
+    let Ok(Some(_lock)) = acquire_drain_lock(&drain_lock_path(home, agent_name)) else {
         return append_queued(home, agent_name, &new_msg);
     };
     let path = queue_path(home, agent_name);
@@ -473,6 +472,98 @@ fn drain_lock_path(home: &Path, agent_name: &str) -> PathBuf {
     queue_path(home, agent_name).with_extension("drain.lock")
 }
 
+/// Acquire the per-agent drain lock. Production is a direct pass-through to
+/// [`crate::store::try_acquire_file_lock`] — byte-identical.
+///
+/// In `#[cfg(test)]` builds it (a) honors a path-keyed `force_contention` seam
+/// so a test can simulate a peer holding the lock with NO real thread or timing
+/// window, and (b) RETRIES PAST a transient `Err` (an `EMFILE` hiccup from the
+/// Coverage job's llvm-cov fd pressure — the lock is FREE, the `open()` just
+/// failed) so an UNCONTENDED acquire is deterministic. `Ok(None)` (a real peer
+/// holds the OS lock) is returned immediately, never retried, so contention
+/// semantics are unchanged. The retry is BOUNDED: after `ACQUIRE_RETRIES` the
+/// original `Err` is PROPAGATED (a genuine, non-transient open failure surfaces
+/// loudly as the caller's contended/`Unavailable` path — never an infinite
+/// hang). This is the root fix for the #2028/#2072/#2074/#2333/#2383 flake
+/// family, where `Err`-under-fd-pressure was misread as contention and broke
+/// strict-outcome assertions.
+fn acquire_drain_lock(lock_path: &Path) -> anyhow::Result<Option<crate::store::FileFlockGuard>> {
+    #[cfg(not(test))]
+    {
+        crate::store::try_acquire_file_lock(lock_path)
+    }
+    #[cfg(test)]
+    {
+        test_hooks::note_acquire_attempt(lock_path);
+        if test_hooks::force_contention(lock_path) {
+            return Ok(None);
+        }
+        let mut result = crate::store::try_acquire_file_lock(lock_path);
+        let mut retries = 0;
+        while result.is_err() && retries < test_hooks::ACQUIRE_RETRIES {
+            std::thread::sleep(std::time::Duration::from_millis(2));
+            result = crate::store::try_acquire_file_lock(lock_path);
+            retries += 1;
+        }
+        result
+    }
+}
+
+/// Path-keyed test seams for the drain-lock acquire. Keyed by the lock PATH
+/// (every test uses a unique `home` → unique path) so arming/counting for one
+/// test never touches another running in parallel — no `serial` needed.
+#[cfg(test)]
+mod test_hooks {
+    use parking_lot::Mutex;
+    use std::collections::{HashMap, HashSet};
+    use std::path::{Path, PathBuf};
+
+    /// Upper bound on retries past a transient `Err`; ~128ms at 2ms/step. Past
+    /// this the original `Err` propagates (loud real-failure, never a hang).
+    pub(super) const ACQUIRE_RETRIES: u32 = 64;
+
+    /// Lock paths whose acquire must deterministically read as held (`Ok(None)`).
+    static FORCED: Mutex<Option<HashSet<PathBuf>>> = Mutex::new(None);
+    /// Per-path count of acquire ATTEMPTS (one per `acquire_drain_lock` call,
+    /// NOT per internal Err-retry) so a test asserts structural properties like
+    /// "true-empty drained in exactly one attempt" without a wall-clock bound.
+    static ATTEMPTS: Mutex<Option<HashMap<PathBuf, u64>>> = Mutex::new(None);
+
+    pub(super) fn note_acquire_attempt(p: &Path) {
+        *ATTEMPTS
+            .lock()
+            .get_or_insert_with(HashMap::new)
+            .entry(p.to_path_buf())
+            .or_insert(0) += 1;
+    }
+    pub(super) fn acquire_attempts(p: &Path) -> u64 {
+        ATTEMPTS
+            .lock()
+            .as_ref()
+            .and_then(|m| m.get(p).copied())
+            .unwrap_or(0)
+    }
+    pub(super) fn reset_acquire_attempts(p: &Path) {
+        if let Some(m) = ATTEMPTS.lock().as_mut() {
+            m.remove(p);
+        }
+    }
+    pub(super) fn force_contention(p: &Path) -> bool {
+        FORCED.lock().as_ref().is_some_and(|s| s.contains(p))
+    }
+    pub(super) fn arm_contention(p: &Path) {
+        FORCED
+            .lock()
+            .get_or_insert_with(HashSet::new)
+            .insert(p.to_path_buf());
+    }
+    pub(super) fn clear_contention(p: &Path) {
+        if let Some(s) = FORCED.lock().as_mut() {
+            s.remove(p);
+        }
+    }
+}
+
 /// Claim-exclusive drain. The TUI flush loop and the daemon's per-tick
 /// `notification_flush` handler run in DIFFERENT processes and may drain the
 /// same agent concurrently, so the whole critical section is serialized by a
@@ -540,9 +631,7 @@ pub(crate) fn try_drain_with_stale_threshold(
     agent_name: &str,
     stale_ms: u128,
 ) -> DrainAttempt {
-    let Ok(Some(_drain_lock)) =
-        crate::store::try_acquire_file_lock(&drain_lock_path(home, agent_name))
-    else {
+    let Ok(Some(_drain_lock)) = acquire_drain_lock(&drain_lock_path(home, agent_name)) else {
         return DrainAttempt::Unavailable;
     };
     let mut out = Vec::new();
@@ -826,41 +915,28 @@ mod tests {
     #[test]
     fn drain_settled_retries_through_transient_lock_contention_2072() {
         // Deterministic reproduction of the #2072 coverage-flake MECHANISM:
-        // while a peer holds the drain lock, a one-shot `drain()` returns empty
+        // while the drain lock reads as held, a one-shot `drain()` returns empty
         // (#2028 `Unavailable→empty`), so a test that trusts it indexes an empty
         // vec → index panic (the live failure at `again[0]`). `drain_settled`
         // must RETRY across the contention window and recover the item once the
-        // lock frees — exactly what the production flusher does next tick.
-        use std::sync::mpsc;
+        // lock frees — exactly what the production flusher does next tick. The
+        // contention is injected via the path-keyed `force_contention` seam (no
+        // peer thread, no timing window), so it's immune to llvm-cov timing.
         let home = tmp_home("transient_lock_2072");
         std::fs::remove_dir_all(&home).ok();
         std::fs::create_dir_all(&home).ok();
         enqueue(&home, "a", "delayed").expect("enqueue");
+        let lp = drain_lock_path(&home, "a");
 
-        let (held_tx, held_rx) = mpsc::channel::<()>();
-        let (go_tx, go_rx) = mpsc::channel::<()>();
-        let lock_path = drain_lock_path(&home, "a");
-        let peer = std::thread::spawn(move || {
-            let guard = crate::store::try_acquire_file_lock(&lock_path)
-                .expect("lock op")
-                .expect("peer acquires drain lock");
-            held_tx.send(()).expect("signal held");
-            // Hold until the test has observed the contention, then release
-            // inside `drain_settled`'s retry window.
-            go_rx.recv().expect("await go");
-            std::thread::sleep(std::time::Duration::from_millis(20));
-            drop(guard);
-        });
-
-        held_rx.recv().expect("peer holds the lock");
-        // A one-shot drain while the lock is held is empty — the exact trap.
+        test_hooks::arm_contention(&lp);
+        // A one-shot drain while the lock reads held is empty — the exact trap.
         assert!(
             drain(&home, "a").is_empty(),
             "one-shot drain under contention returns empty (#2028 Unavailable→empty)"
         );
-        go_tx.send(()).expect("let the peer schedule its release");
+        test_hooks::clear_contention(&lp);
+
         let got = drain_settled(&home, "a", 1);
-        peer.join().ok();
         assert_eq!(
             got.len(),
             1,
@@ -1376,21 +1452,29 @@ mod tests {
         std::fs::remove_dir_all(home).ok();
     }
 
-    /// drain_one outlasts a SHORT contention window (the healthy-peer shape:
-    /// a live flusher holds the lock for the duration of a rename+read). The
-    /// hold here (15ms) is well inside drain_one's retry budget (5×10ms), so
-    /// margins are wide, not timing-fragile.
+    /// drain_one outlasts a contention window (the healthy-peer shape: a live
+    /// flusher holds the lock for the duration of a rename+read). Deterministic:
+    /// the contention is injected via the path-keyed `force_contention` seam and
+    /// released only AFTER `drain_one` has provably hit the held lock at least
+    /// once (a structural wait on the acquire-attempt counter, not a wall-clock
+    /// sleep), so it genuinely RETRIES through the contention before succeeding —
+    /// with no timing bet for llvm-cov to stretch.
     #[test]
     fn drain_one_retries_through_short_contention_2028() {
         let home = tmp_home("drain-one-retry");
         enqueue(&home, "a", "the-item").expect("enqueue");
-        let guard = crate::store::try_acquire_file_lock(&drain_lock_path(&home, "a"))
-            .expect("lock open")
-            .expect("lock acquired");
+        let lp = drain_lock_path(&home, "a");
+        test_hooks::reset_acquire_attempts(&lp);
+        test_hooks::arm_contention(&lp);
         let h = home.clone();
         let worker = std::thread::spawn(move || drain_one(&h, "a"));
-        std::thread::sleep(std::time::Duration::from_millis(15));
-        drop(guard);
+        // Wait until drain_one has attempted (and hit the held lock) at least
+        // once, then release — proves the retry path without a fixed sleep.
+        let lp_wait = lp.clone();
+        while test_hooks::acquire_attempts(&lp_wait) < 1 {
+            std::thread::yield_now();
+        }
+        test_hooks::clear_contention(&lp);
         let popped = worker.join().expect("join");
         assert_eq!(
             popped
@@ -1406,11 +1490,16 @@ mod tests {
     #[test]
     fn drain_one_true_empty_is_immediate_none_2028() {
         let home = tmp_home("drain-one-empty");
-        let start = std::time::Instant::now();
+        let lp = drain_lock_path(&home, "a");
+        test_hooks::reset_acquire_attempts(&lp);
         assert!(drain_one(&home, "a").is_none());
-        assert!(
-            start.elapsed() < std::time::Duration::from_millis(40),
-            "true empty must not burn the retry budget"
+        // Structural (not wall-clock) proof the retry budget wasn't burned: a
+        // truly-empty queue acquires the lock exactly ONCE and returns — the
+        // retry loop only engages on Unavailable, never on a real empty drain.
+        assert_eq!(
+            test_hooks::acquire_attempts(&lp),
+            1,
+            "true-empty must drain in exactly one attempt, not burn the retry budget"
         );
         std::fs::remove_dir_all(home).ok();
     }

--- a/src/notification_queue.rs
+++ b/src/notification_queue.rs
@@ -482,11 +482,12 @@ fn drain_lock_path(home: &Path, agent_name: &str) -> PathBuf {
 /// failed) so an UNCONTENDED acquire is deterministic. `Ok(None)` (a real peer
 /// holds the OS lock) is returned immediately, never retried, so contention
 /// semantics are unchanged. The retry is BOUNDED: after `ACQUIRE_RETRIES` the
-/// original `Err` is PROPAGATED (a genuine, non-transient open failure surfaces
-/// loudly as the caller's contended/`Unavailable` path — never an infinite
-/// hang). This is the root fix for the #2028/#2072/#2074/#2333/#2383 flake
-/// family, where `Err`-under-fd-pressure was misread as contention and broke
-/// strict-outcome assertions.
+/// ORIGINAL (first) `Err` is PROPAGATED — not the last retry's — so a genuine,
+/// non-transient open failure surfaces loudly and identically as the caller's
+/// contended/`Unavailable` path (never an infinite hang). This is the root fix
+/// for the #2028/#2072/#2074/#2333/#2383 flake family, where
+/// `Err`-under-fd-pressure was misread as contention and broke strict-outcome
+/// assertions.
 fn acquire_drain_lock(lock_path: &Path) -> anyhow::Result<Option<crate::store::FileFlockGuard>> {
     #[cfg(not(test))]
     {
@@ -498,14 +499,23 @@ fn acquire_drain_lock(lock_path: &Path) -> anyhow::Result<Option<crate::store::F
         if test_hooks::force_contention(lock_path) {
             return Ok(None);
         }
-        let mut result = crate::store::try_acquire_file_lock(lock_path);
-        let mut retries = 0;
-        while result.is_err() && retries < test_hooks::ACQUIRE_RETRIES {
-            std::thread::sleep(std::time::Duration::from_millis(2));
-            result = crate::store::try_acquire_file_lock(lock_path);
-            retries += 1;
+        // Preserve the FIRST error: an `Ok(..)` (acquired or real contention)
+        // returns immediately; otherwise retry transient `Err`s but keep the
+        // original so IT is what propagates once the bound is exhausted — not
+        // the last retry's error. `raw_acquire` also honors a forced-error seam
+        // so a test can prove that identity across exhaustion.
+        let first = test_hooks::raw_acquire(lock_path);
+        if first.is_ok() {
+            return first;
         }
-        result
+        for _ in 0..test_hooks::ACQUIRE_RETRIES {
+            std::thread::sleep(std::time::Duration::from_millis(2));
+            let retry = test_hooks::raw_acquire(lock_path);
+            if retry.is_ok() {
+                return retry;
+            }
+        }
+        first
     }
 }
 
@@ -561,6 +571,40 @@ mod test_hooks {
         if let Some(s) = FORCED.lock().as_mut() {
             s.remove(p);
         }
+    }
+
+    /// Per-path forced-error mode. While armed, `raw_acquire` returns a DISTINCT
+    /// `Err` on every call (message carries an incrementing ordinal) instead of
+    /// touching the real lock, so a test can exhaust the retry bound and assert
+    /// that the FIRST/original `Err` is the one propagated. Value = count so far.
+    static FORCED_ERRORS: Mutex<Option<HashMap<PathBuf, u64>>> = Mutex::new(None);
+
+    pub(super) fn arm_forced_errors(p: &Path) {
+        FORCED_ERRORS
+            .lock()
+            .get_or_insert_with(HashMap::new)
+            .insert(p.to_path_buf(), 0);
+    }
+    pub(super) fn clear_forced_errors(p: &Path) {
+        if let Some(m) = FORCED_ERRORS.lock().as_mut() {
+            m.remove(p);
+        }
+    }
+
+    /// The single lock-acquire step used by `acquire_drain_lock`: the real OS
+    /// lock, UNLESS forced-error mode is armed for `p` — then a distinct
+    /// `Err("forced-acquire-err-{n}")` (n = 1, 2, 3…) so the retry-exhaustion
+    /// path is exercised with identifiable errors. The `FORCED_ERRORS` guard is
+    /// dropped before the real lock op.
+    pub(super) fn raw_acquire(p: &Path) -> anyhow::Result<Option<crate::store::FileFlockGuard>> {
+        {
+            let mut g = FORCED_ERRORS.lock();
+            if let Some(n) = g.as_mut().and_then(|m| m.get_mut(p)) {
+                *n += 1;
+                return Err(anyhow::anyhow!("forced-acquire-err-{n}"));
+            }
+        }
+        crate::store::try_acquire_file_lock(p)
     }
 }
 
@@ -1500,6 +1544,31 @@ mod tests {
             test_hooks::acquire_attempts(&lp),
             1,
             "true-empty must drain in exactly one attempt, not burn the retry budget"
+        );
+        std::fs::remove_dir_all(home).ok();
+    }
+
+    /// reviewer5 (PR #2666): past the retry bound, `acquire_drain_lock` must
+    /// propagate the ORIGINAL (first) `Err`, not the last retry's — the contract
+    /// the doc + dispatch spec require. Forced-error mode makes every acquire
+    /// return a DISTINCT `Err`, so exhausting the bound proves the first one
+    /// survives.
+    #[test]
+    fn acquire_drain_lock_propagates_original_err_after_retry_exhaustion() {
+        let home = tmp_home("acquire-err-identity");
+        let lp = drain_lock_path(&home, "a");
+        test_hooks::arm_forced_errors(&lp);
+        let result = acquire_drain_lock(&lp);
+        test_hooks::clear_forced_errors(&lp);
+        // (`FileFlockGuard` isn't `Debug`, so match rather than `expect_err`.)
+        let err = match result {
+            Ok(_) => panic!("all acquires forced to Err → the wrapper must return an Err"),
+            Err(e) => e,
+        };
+        assert_eq!(
+            err.to_string(),
+            "forced-acquire-err-1",
+            "the ORIGINAL (first) error must survive retry exhaustion, not the last retry's"
         );
         std::fs::remove_dir_all(home).ok();
     }


### PR DESCRIPTION
## Root-fix the `notification_queue` lock-timing × llvm-cov flake class

The Coverage job (`cargo test` under llvm-cov) has re-flaked `notification_queue`'s lock-contention tests for days — **#2665** (`coalesce_falls_back..._no_loss`), **#2651** (`try_drain..._2028`) — and three prior *widening* fixes (**#2072/#2333/#2383**) never root-caused it.

### Real root cause (deeper than "peer-hold timing")
`store::try_acquire_file_lock` returns `Ok(Some)`=acquired / `Ok(None)`=real contention / **`Err`=open failure**. Under the Coverage job's llvm-cov fd pressure the `open()` transiently **EMFILE**s → `Err`, and `notification_queue`'s two call sites (`let Ok(Some) = … else { contended }`) route that `Err` into the **contended** branch. So an *uncontended* lock is misread as held, breaking strict-outcome assertions (`coalesce == 1`, post-release drain, exactly-once completeness). A peer-hold gate cannot fix this — it is not a timing problem, it is a spurious-`Err` problem. (In production this misread is the *conservative* direction — it just falls back to a no-loss append / next-tick retry — so nothing changes there.)

### Fix — deterministic `#[cfg(test)]` lock-acquire seam
`acquire_drain_lock()` wraps the two call sites. **Production is a byte-identical passthrough.** In test builds it:
1. **Retries past a transient `Err`** so an uncontended acquire is deterministic. `Ok(None)` (real contention) returns immediately, never retried → contention semantics unchanged.
2. **Bounds** the retry (64 × 2 ms) and **propagates the original `Err`** past the bound — a genuine non-transient open failure surfaces loudly as the caller's contended/`Unavailable` path, never an infinite hang.

This transparently fixes `coalesce_falls_back..._no_loss`, `try_drain_reports_unavailable..._2028`, `flusher_drain_still_collapses..._2028`, and `concurrent_drains_deliver_exactly_once` **with no change to their bodies**.

The three remaining wall-clock bets become structural, via **path-keyed** test seams (keyed on each test's unique lock path → parallel-safe, no `serial`):
- `drain_settled_retries..._2072` and `drain_one_retries_through_short_contention_2028`: inject contention with a `force_contention` seam and release only after a structural wait on the acquire-attempt counter (no thread-timing `sleep`).
- `drain_one_true_empty_is_immediate_none_2028`: assert **"exactly one acquire attempt"** instead of `elapsed() < 40ms`.

### Verification
- `cargo fmt --check` + `cargo clippy --all-targets` clean.
- Isolation: all 39 `notification_queue` tests pass.
- Full-parallel `cargo nextest run --no-fail-fast` ×3: `notification_queue` green every run (only reds = the 2 known always-fail-locally e2e/teardown infra tests).
- **Under llvm-cov** (`cargo llvm-cov nextest`, the flake's exact trigger): `notification_queue` green.
- The authoritative gate is this PR's own **Coverage CI job** (`cargo test` under llvm-cov — the exact context that produced the #2665/#2651 flakes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
