### PR TITLE
fix(P0): refuse to `repo release` a primary/main working tree — canonical-deletion root cause

### DIFF
--- a/src/mcp/handlers/ci/release.rs
+++ b/src/mcp/handlers/ci/release.rs
@@ -15,26 +15,24 @@ use serde_json::{json, Value};
 /// here). Without this, a `repo release` on a canonical / bare / separate-git-dir
 /// repo deletes the ENTIRE repo (the 2026-07-06 canonical-deletion incident).
 fn is_linked_worktree(p: &std::path::Path) -> bool {
-    let Some(dir) = p.to_str() else {
-        return false;
-    };
-    let out = match std::process::Command::new("git")
-        .args([
-            "-C",
-            dir,
+    // Route through the sanctioned `git_helpers::git_cmd` (always-bypass, bounded)
+    // — a raw git subprocess here would trip the daemon-git invariant
+    // (tests/daemon_git_helper_invariant.rs). `git_cmd` runs from `p` as its cwd,
+    // so no `-C` is needed; `--path-format=absolute` makes git-dir/common-dir
+    // directly comparable.
+    let Ok(out) = crate::git_helpers::git_cmd(
+        p,
+        &[
             "rev-parse",
             "--path-format=absolute",
             "--git-dir",
             "--git-common-dir",
             "--is-bare-repository",
-        ])
-        .output()
-    {
-        Ok(o) if o.status.success() => o,
-        _ => return false, // not a repo / git failed → unclassifiable → refuse
+        ],
+    ) else {
+        return false; // not a repo / git failed → unclassifiable → refuse (fail-safe)
     };
-    let stdout = String::from_utf8_lossy(&out.stdout);
-    let lines: Vec<&str> = stdout.lines().map(str::trim).collect();
+    let lines: Vec<&str> = out.lines().map(str::trim).collect();
     match lines.as_slice() {
         [git_dir, common_dir, is_bare] => git_dir != common_dir && *is_bare == "false",
         _ => false, // unexpected output shape → refuse

--- a/src/mcp/handlers/ci/release.rs
+++ b/src/mcp/handlers/ci/release.rs
@@ -1,5 +1,18 @@
 use serde_json::{json, Value};
 
+/// #t-…83936-6 P0 (data-loss incident): is `p` a git PRIMARY/main working tree
+/// (i.e. a real source repo), as opposed to a linked worktree?
+///
+/// A main working tree's `.git` is a DIRECTORY (the actual object store); a
+/// linked worktree's `.git` is a gitlink FILE (`gitdir: <repo>/.git/worktrees/…`).
+/// `handle_release_repo`'s `remove_dir_all` fallback runs whenever
+/// `git worktree remove` fails — and git ALWAYS refuses to remove a main working
+/// tree — so without this guard a `repo release` pointed at a canonical repo
+/// deletes the ENTIRE repo (the 2026-07-06 canonical-deletion incident).
+pub(crate) fn is_primary_working_tree(p: &std::path::Path) -> bool {
+    p.join(".git").is_dir()
+}
+
 /// Reject paths that would be dangerous to `remove_dir_all`.
 /// Validate and canonicalize a release path. Returns canonical absolute
 /// path on success, or error message on rejection.
@@ -52,6 +65,15 @@ pub(crate) fn validate_release_path(path_str: &str) -> Result<std::path::PathBuf
     }
     if canonical.components().count() < 3 {
         return Err(format!("rejected: too shallow: {}", canonical.display()));
+    }
+    // #t-…83936-6 P0: NEVER release a primary/main working tree — the fallback
+    // below would `remove_dir_all` the whole source repo (canonical-deletion
+    // incident). A releasable worktree is a LINKED one (`.git` is a gitlink file).
+    if is_primary_working_tree(&canonical) {
+        return Err(format!(
+            "rejected: primary working tree (source repo), not a releasable worktree: {}",
+            canonical.display()
+        ));
     }
     Ok(canonical)
 }
@@ -110,11 +132,18 @@ pub(crate) fn handle_release_repo(args: &Value) -> Value {
     ) {
         Ok(o) if o.status.success() => return json!({"path": path}),
         Ok(o) => {
-            let _ = std::fs::remove_dir_all(&canonical);
+            // #t-…83936-6 depth guard: NEVER `remove_dir_all` a primary working
+            // tree even if `git worktree remove` failed and validate was somehow
+            // bypassed — this fallback is what deleted the canonical.
+            if !is_primary_working_tree(&canonical) {
+                let _ = std::fs::remove_dir_all(&canonical);
+            }
             json!({"path": path, "note": String::from_utf8_lossy(&o.stderr).to_string()})
         }
         Err(_) => {
-            let _ = std::fs::remove_dir_all(&canonical);
+            if !is_primary_working_tree(&canonical) {
+                let _ = std::fs::remove_dir_all(&canonical);
+            }
             json!({"path": path})
         }
     };

--- a/src/mcp/handlers/ci/release.rs
+++ b/src/mcp/handlers/ci/release.rs
@@ -1,16 +1,44 @@
 use serde_json::{json, Value};
 
-/// #t-…83936-6 P0 (data-loss incident): is `p` a git PRIMARY/main working tree
-/// (i.e. a real source repo), as opposed to a linked worktree?
+/// #t-…83936-6 P0 (data-loss incident): is `p` a TRUE linked git worktree — the
+/// ONLY shape `handle_release_repo`'s `remove_dir_all` fallback may delete?
 ///
-/// A main working tree's `.git` is a DIRECTORY (the actual object store); a
-/// linked worktree's `.git` is a gitlink FILE (`gitdir: <repo>/.git/worktrees/…`).
-/// `handle_release_repo`'s `remove_dir_all` fallback runs whenever
-/// `git worktree remove` fails — and git ALWAYS refuses to remove a main working
-/// tree — so without this guard a `repo release` pointed at a canonical repo
-/// deletes the ENTIRE repo (the 2026-07-06 canonical-deletion incident).
-pub(crate) fn is_primary_working_tree(p: &std::path::Path) -> bool {
-    p.join(".git").is_dir()
+/// GIT is the source of truth, NOT a filesystem heuristic. A `.git`-is-a-file
+/// test can't tell a linked worktree from a `--separate-git-dir` MAIN tree —
+/// both have a gitlink file (reviewer4); a `.git`-is-a-dir blacklist missed BARE
+/// repos (reviewer5). A linked worktree is the UNIQUE shape whose per-worktree
+/// git-dir (`.../worktrees/<name>`) differs from the shared common-dir (the main
+/// `.git`) AND that is non-bare. For main / bare / separate-git-dir-main, git-dir
+/// == common-dir. Any git failure or unexpected output ⇒ `false` (FAIL-SAFE:
+/// prefer a false reject over deleting a repo; a stale/orphan worktree whose
+/// admin entry was pruned is left for other cleanup, never `remove_dir_all`'d
+/// here). Without this, a `repo release` on a canonical / bare / separate-git-dir
+/// repo deletes the ENTIRE repo (the 2026-07-06 canonical-deletion incident).
+fn is_linked_worktree(p: &std::path::Path) -> bool {
+    let Some(dir) = p.to_str() else {
+        return false;
+    };
+    let out = match std::process::Command::new("git")
+        .args([
+            "-C",
+            dir,
+            "rev-parse",
+            "--path-format=absolute",
+            "--git-dir",
+            "--git-common-dir",
+            "--is-bare-repository",
+        ])
+        .output()
+    {
+        Ok(o) if o.status.success() => o,
+        _ => return false, // not a repo / git failed → unclassifiable → refuse
+    };
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let lines: Vec<&str> = stdout.lines().map(str::trim).collect();
+    match lines.as_slice() {
+        [git_dir, common_dir, is_bare] => git_dir != common_dir && *is_bare == "false",
+        _ => false, // unexpected output shape → refuse
+    }
 }
 
 /// Reject paths that would be dangerous to `remove_dir_all`.
@@ -66,12 +94,14 @@ pub(crate) fn validate_release_path(path_str: &str) -> Result<std::path::PathBuf
     if canonical.components().count() < 3 {
         return Err(format!("rejected: too shallow: {}", canonical.display()));
     }
-    // #t-…83936-6 P0: NEVER release a primary/main working tree — the fallback
-    // below would `remove_dir_all` the whole source repo (canonical-deletion
-    // incident). A releasable worktree is a LINKED one (`.git` is a gitlink file).
-    if is_primary_working_tree(&canonical) {
+    // #t-…83936-6 P0: WHITELIST — the only safely-releasable shape is a LINKED
+    // worktree (`.git` is a gitlink file). Refuse main (`.git` is a dir), bare (no
+    // `.git` child — it IS a git dir), and non-repo dirs, else the `remove_dir_all`
+    // fallback nukes the whole source repo (canonical-deletion incident; reviewer5
+    // bare-repo bypass of the earlier blacklist).
+    if !is_linked_worktree(&canonical) {
         return Err(format!(
-            "rejected: primary working tree (source repo), not a releasable worktree: {}",
+            "rejected: not a releasable linked worktree (main/bare/non-repo): {}",
             canonical.display()
         ));
     }
@@ -132,16 +162,16 @@ pub(crate) fn handle_release_repo(args: &Value) -> Value {
     ) {
         Ok(o) if o.status.success() => return json!({"path": path}),
         Ok(o) => {
-            // #t-…83936-6 depth guard: NEVER `remove_dir_all` a primary working
-            // tree even if `git worktree remove` failed and validate was somehow
-            // bypassed — this fallback is what deleted the canonical.
-            if !is_primary_working_tree(&canonical) {
+            // #t-…83936-6 depth guard (WHITELIST): only `remove_dir_all` a LINKED
+            // worktree, even if `git worktree remove` failed and validate was
+            // somehow bypassed — this fallback is what deleted the canonical/bare.
+            if is_linked_worktree(&canonical) {
                 let _ = std::fs::remove_dir_all(&canonical);
             }
             json!({"path": path, "note": String::from_utf8_lossy(&o.stderr).to_string()})
         }
         Err(_) => {
-            if !is_primary_working_tree(&canonical) {
+            if is_linked_worktree(&canonical) {
                 let _ = std::fs::remove_dir_all(&canonical);
             }
             json!({"path": path})

--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -59,6 +59,131 @@ fn validate_release_path_accepts_deep_existing() {
     std::fs::remove_dir_all(&dir).ok();
 }
 
+// ── #t-…83936-6 P0: NEVER release a primary/main working tree ───────────────
+// The 2026-07-06 canonical-deletion incident: `repo release path=<canonical>`
+// → validate passed → `git worktree remove` refused the main tree → the
+// `remove_dir_all` fallback deleted the ENTIRE repo. Fixtures live under $HOME
+// (a plain path like the real incident) NOT temp_dir — `/var`→`/private` is
+// already system-prefix-rejected and would MASK the guard under test.
+
+#[cfg(unix)]
+fn release_guard_tmp(tag: &str) -> std::path::PathBuf {
+    let home = std::env::var("HOME").expect("HOME must be set");
+    let d = std::path::PathBuf::from(home).join(format!(
+        ".agend-release-guard-{tag}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    ));
+    std::fs::create_dir_all(&d).ok();
+    d
+}
+
+#[cfg(unix)]
+fn release_guard_git_init(dir: &Path) {
+    std::fs::create_dir_all(dir).ok();
+    for args in [
+        &["init", "-b", "main"][..],
+        &[
+            "-c",
+            "user.name=test",
+            "-c",
+            "user.email=t@t",
+            "commit",
+            "--allow-empty",
+            "-m",
+            "init",
+        ][..],
+    ] {
+        let _ = std::process::Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .env("AGEND_GIT_BYPASS", "1")
+            .output();
+    }
+}
+
+#[test]
+#[cfg(unix)]
+fn validate_release_path_refuses_primary_working_tree_83936() {
+    let base = release_guard_tmp("validate-main");
+    let repo = base.join("source-repo");
+    release_guard_git_init(&repo);
+    assert!(
+        repo.join(".git").is_dir(),
+        "a main repo's .git must be a dir"
+    );
+    let result = super::validate_release_path(repo.to_str().unwrap());
+    assert!(
+        result
+            .as_ref()
+            .is_err_and(|e| e.contains("primary working tree")),
+        "a primary/main working tree must be refused, got {result:?}"
+    );
+    std::fs::remove_dir_all(&base).ok();
+}
+
+/// Incident repro (RED against pre-fix code, which `remove_dir_all`s the repo):
+/// a `repo release` pointed at a main repo must leave the repo fully intact.
+#[test]
+#[cfg(unix)]
+fn handle_release_repo_never_deletes_main_repo_83936() {
+    let base = release_guard_tmp("no-delete-main");
+    let repo = base.join("source-repo");
+    release_guard_git_init(&repo);
+    let keep = repo.join("KEEP.txt");
+    std::fs::write(&keep, "canonical content").unwrap();
+
+    let _ = handle_release_repo(&serde_json::json!({"path": repo.to_str().unwrap()}));
+
+    assert!(
+        repo.exists(),
+        "the main repo dir MUST survive a release call (canonical incident)"
+    );
+    assert!(repo.join(".git").is_dir(), ".git MUST survive");
+    assert!(keep.exists(), "repo contents MUST survive");
+    std::fs::remove_dir_all(&base).ok();
+}
+
+/// Counter-example: a genuine LINKED worktree (`.git` is a gitlink file) is
+/// still releasable — the guard must not over-block legitimate releases.
+#[test]
+#[cfg(unix)]
+fn handle_release_repo_still_removes_linked_worktree_83936() {
+    let base = release_guard_tmp("linked-ok");
+    let repo = base.join("source-repo");
+    release_guard_git_init(&repo);
+    let _ = std::process::Command::new("git")
+        .args(["branch", "feat", "main"])
+        .current_dir(&repo)
+        .env("AGEND_GIT_BYPASS", "1")
+        .output();
+    let wt = base.join("linked-wt");
+    let add = std::process::Command::new("git")
+        .args(["worktree", "add", wt.to_str().unwrap(), "feat"])
+        .current_dir(&repo)
+        .env("AGEND_GIT_BYPASS", "1")
+        .output()
+        .unwrap();
+    assert!(
+        wt.join(".git").is_file(),
+        "a linked worktree's .git must be a gitlink FILE; add stderr: {}",
+        String::from_utf8_lossy(&add.stderr)
+    );
+    assert!(
+        super::validate_release_path(wt.to_str().unwrap()).is_ok(),
+        "a linked worktree must validate OK"
+    );
+    let _ = handle_release_repo(&serde_json::json!({"path": wt.to_str().unwrap()}));
+    assert!(
+        !wt.exists(),
+        "a linked worktree must still be releasable/removed"
+    );
+    std::fs::remove_dir_all(&base).ok();
+}
+
 #[test]
 fn dispatch_with_branch_and_repo_auto_invokes_watch_ci() {
     let home = std::env::temp_dir().join(format!("agend-auto-watch-{}", std::process::id()));

--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -42,19 +42,22 @@ fn validate_release_path_rejects_shallow() {
 
 #[test]
 #[cfg(unix)]
-fn validate_release_path_accepts_deep_existing() {
-    // Create a temp dir deep enough to pass.
+fn validate_release_path_refuses_non_worktree_deep_dir_83936() {
+    // #t-…83936-6: SEMANTIC TIGHTENING (was `..._accepts_deep_existing`, which
+    // asserted a plain deep dir is ACCEPTED — that permissive accept is exactly
+    // what let a canonical repo through to the `remove_dir_all` fallback). Under
+    // the whitelist, validate now accepts ONLY a real linked worktree; a deep
+    // non-worktree dir is refused. The positive control (a legit linked worktree
+    // IS accepted) is `handle_release_repo_still_removes_linked_worktree_83936`.
     let home = std::env::var("HOME").expect("HOME must be set");
     let dir =
         std::path::PathBuf::from(home).join(format!(".agend-release-test-{}", std::process::id()));
     let deep = dir.join("sub");
     std::fs::create_dir_all(&deep).ok();
     let result = super::validate_release_path(deep.to_str().expect("valid UTF-8"));
-    // Should pass (deep enough, not system dir).
     assert!(
-        result.is_ok(),
-        "deep existing path should pass: {:?}",
-        result.err()
+        result.is_err(),
+        "a non-worktree deep dir must now be REFUSED (whitelist), got {result:?}"
     );
     std::fs::remove_dir_all(&dir).ok();
 }
@@ -119,8 +122,89 @@ fn validate_release_path_refuses_primary_working_tree_83936() {
     assert!(
         result
             .as_ref()
-            .is_err_and(|e| e.contains("primary working tree")),
+            .is_err_and(|e| e.contains("linked worktree")),
         "a primary/main working tree must be refused, got {result:?}"
+    );
+    std::fs::remove_dir_all(&base).ok();
+}
+
+/// reviewer5's bypass (#2668 r0): a BARE repo has NO `.git` child (it IS a git
+/// dir), so the earlier `.git.is_dir()` blacklist let it through and the fallback
+/// `remove_dir_all`'d it. The whitelist (`.git` must be a gitlink FILE) refuses
+/// it. RED against the blacklist code, GREEN after.
+#[test]
+#[cfg(unix)]
+fn handle_release_repo_never_deletes_bare_repo_83936() {
+    let base = release_guard_tmp("no-delete-bare");
+    let bare = base.join("bare-repo.git");
+    std::fs::create_dir_all(&bare).ok();
+    let _ = std::process::Command::new("git")
+        .args(["init", "--bare"])
+        .current_dir(&bare)
+        .env("AGEND_GIT_BYPASS", "1")
+        .output();
+    assert!(bare.join("HEAD").exists(), "a bare repo must have HEAD");
+    assert!(!bare.join(".git").exists(), "a bare repo has NO .git child");
+
+    let _ = handle_release_repo(&serde_json::json!({"path": bare.to_str().unwrap()}));
+
+    assert!(
+        bare.exists() && bare.join("HEAD").exists(),
+        "a bare source repo MUST survive a release call (reviewer5 bare-repo bypass)"
+    );
+    std::fs::remove_dir_all(&base).ok();
+}
+
+/// reviewer4's bypass (#2668 r0'): a `git init --separate-git-dir` MAIN tree has
+/// a gitlink `.git` FILE, so a filesystem `.git`-is-file whitelist would wrongly
+/// DELETE it. The git-based check (a main tree's git-dir == common-dir) refuses
+/// it. RED against the filesystem whitelist, GREEN with the git check.
+#[test]
+#[cfg(unix)]
+fn handle_release_repo_never_deletes_separate_git_dir_main_83936() {
+    let base = release_guard_tmp("no-delete-sepgit");
+    let worktree = base.join("main-worktree");
+    let gitdir = base.join("main-gitdir");
+    let _ = std::process::Command::new("git")
+        .args([
+            "init",
+            "--separate-git-dir",
+            gitdir.to_str().unwrap(),
+            worktree.to_str().unwrap(),
+        ])
+        .env("AGEND_GIT_BYPASS", "1")
+        .output();
+    assert!(
+        worktree.join(".git").is_file(),
+        "a --separate-git-dir main's .git must be a gitlink FILE"
+    );
+    let keep = worktree.join("KEEP.txt");
+    std::fs::write(&keep, "main content").unwrap();
+
+    let _ = handle_release_repo(&serde_json::json!({"path": worktree.to_str().unwrap()}));
+
+    assert!(
+        worktree.exists() && keep.exists(),
+        "a --separate-git-dir MAIN tree MUST survive (reviewer4 gitlink-file bypass)"
+    );
+    std::fs::remove_dir_all(&base).ok();
+}
+
+/// Fail-safe (⑤): a non-repo dir git cannot classify must be REFUSED, not
+/// deleted (prefer a false reject over data loss).
+#[test]
+#[cfg(unix)]
+fn handle_release_repo_refuses_non_repo_dir_83936() {
+    let base = release_guard_tmp("non-repo");
+    let dir = base.join("just-a-dir");
+    std::fs::create_dir_all(&dir).ok();
+    std::fs::write(dir.join("file.txt"), "data").unwrap();
+
+    let _ = handle_release_repo(&serde_json::json!({"path": dir.to_str().unwrap()}));
+
+    assert!(
+        dir.exists(),
+        "a non-repo dir must be refused (git can't classify → fail-safe)"
     );
     std::fs::remove_dir_all(&base).ok();
 }


### PR DESCRIPTION
## 🛑 P0 — root cause of the 2026-07-06 canonical-repo deletion

The operator's canonical repo was deleted by a **daemon production bug**, not an external actor. `handle_release_repo` (the MCP `repo release` verb), given a canonical/source-repo path:
1. `validate_release_path` passed it (not a system path, ≥3 components) — it had **no notion of "primary working tree"**;
2. `git worktree remove --force <canonical>` — git **always refuses** to remove a main working tree → non-zero;
3. the fallback **`remove_dir_all(&canonical)`** (release.rs:113 **and** :117) deleted the **entire repo**.

The running daemon (63d4422d) still has this code, so the canonical can be deleted again at any time — this is stop-the-bleeding.

## Fix (root, minimal)

`validate_release_path` now **refuses a primary/main working tree** before any filesystem op. The distinguishing signal is exact:

| | `.git` | releasable? |
|---|---|---|
| main / primary working tree (a source repo) | **directory** (object store) | ❌ refuse |
| linked worktree | gitlink **file** (`gitdir: …`) | ✅ allowed |

New `is_primary_working_tree(p) = p.join(".git").is_dir()` helper gates it. **Defense-in-depth**: both `remove_dir_all` fallback arms also refuse a primary working tree, so even a future bypass of `validate` can't nuke the repo.

## Tests (unix; RED-verified by stashing the fix)

- `validate_release_path_refuses_primary_working_tree` — `.git`-is-dir repo → rejected with "primary working tree".
- `handle_release_repo_never_deletes_main_repo` — **the incident repro**: a release pointed at a main repo leaves the repo + `.git` + contents intact. **RED against pre-fix code** (`the main repo dir MUST survive` panics — it's deleted), GREEN after.
- `handle_release_repo_still_removes_linked_worktree` — counter-example: a genuine linked worktree is still releasable (no over-block).

Fixtures live under `$HOME` (a plain path like the real incident), NOT `temp_dir` — `/var`→`/private` is already system-prefix-rejected and would **mask** the guard.

## Gate
`fmt --check` clean · `clippy --all-targets --features tray,discord -- -D warnings` exit 0 · `mcp::handlers::ci::` **85/85** (3 new + all regression).

## ⚠ Requires a daemon restart to take effect
The running daemon still has the bug — merge alone does not protect the canonical; the daemon must be restarted after merge. DUAL (data-loss / delete path).
