### PR TITLE
feat(#t-83936-4): canonical heartbeat + binding_state liveness — make canonical deletion loud

### DIFF
--- a/CANONICAL-HEARTBEAT-SPIKE.md
+++ b/CANONICAL-HEARTBEAT-SPIKE.md
@@ -1,0 +1,73 @@
+# Spike: canonical heartbeat + binding path-resolve (t-…83936-4)
+
+Spike-first design for lead vet BEFORE impl (touches daemon lifecycle core). DUAL.
+
+## Root cause (confirmed at file:line)
+`binding_state.rs:116-117`:
+```rust
+let worktree_valid = worktree_exists_on_disk
+    && (wt_path.join(".git").exists() || wt_path.join(".agend-managed").exists());
+```
+A linked worktree's `.git` is a **pointer file** (`gitdir: <canonical>/.git/worktrees/<name>`).
+`wt_path.join(".git").exists()` is true for the *pointer file itself* even after the
+canonical it points to is deleted → `worktree_valid=true` while the worktree is
+unusable. That is exactly tonight's 40-min-silent incident AND the dev3
+dangling-`.git` hazard (t-…83936-2) — same class, fold both in.
+
+## Protection ① — binding_state path-resolve liveness (binding_state.rs)
+Add, in the bound branch, real resolution (all paths are ABSOLUTE from
+binding.json → cwd-independent):
+```rust
+let source_repo = b["source_repo"].as_str().unwrap_or("");
+let canonical_present = !source_repo.is_empty() && std::fs::metadata(source_repo).is_ok();
+let gitdir_resolves = git_ok(wt_path, &["rev-parse","--git-dir"]); // resolves the .git POINTER
+let worktree_valid = worktree_exists_on_disk
+    && (wt_path.join(".git").exists() || wt_path.join(".agend-managed").exists())
+    && gitdir_resolves;                       // NEW: pointer must RESOLVE, not just exist
+let invalid_reason =                          // NEW explicit field
+    if !worktree_exists_on_disk { Some("worktree_missing") }
+    else if !canonical_present   { Some("canonical_missing") }
+    else if !gitdir_resolves     { Some("gitdir_dangling") }
+    else { None };
+```
+- `git_ok(dir, args)` = `git -C <dir> …` exit 0 (fail-closed on any error), a
+  read-only subprocess — fine for an on-demand diagnostic tool.
+- **Consumer impact (vet point):** `worktree_valid` becomes correctly *false* when
+  the gitdir dangles (today it's falsely true). Consumers use it for the rebuild
+  decision, so tightening is the desired behavior (agent rebuilds instead of
+  committing into a dead worktree). New `invalid_reason` is additive.
+
+## Protection ② — canonical heartbeat (NEW per-tick handler)
+New `src/daemon/per_tick/canonical_heartbeat.rs`, registered in
+`per_tick/mod.rs:322` `vec![ … Box::new(CanonicalHeartbeatHandler::new(60)) ]`.
+Mirrors `OfflineUnreadAlertHandler` (offline_unread_alert.rs) 1:1:
+- cadence 60 ticks (~10 min at the 10 s tick) — vs 40 min silent tonight; tunable
+  via env. Cheap: 1-few repos, a stat + optional `git rev-parse` each.
+- each fire: `binding::bound_source_repos(home)` → distinct ABSOLUTE source_repo
+  paths. For each: **fresh `std::fs::metadata(abs)` + `abs/.git` present** (cheap
+  deletion detect); optionally `git -C abs rev-parse --git-dir` (corruption).
+- missing → `crate::channel::notify_all_escalation_channels(...)` (loud operator
+  page) + event-log `kind=canonical_repo_missing`.
+- per-repo dedup latch (count/state-keyed, like offline_unread_alert): page ONCE,
+  re-page on a new repo missing, reset when it returns → no per-tick spam.
+
+### The cwd-orphaned-inode trap (explicit)
+Tonight the daemon's own cwd WAS the deleted canonical (held inode → looked
+alive). The heartbeat must therefore resolve by ABSOLUTE PATH, never cwd-relative:
+`bound_source_repos` yields absolute paths; `std::fs::metadata(abs)` and
+`git -C abs` both do fresh path lookups independent of the process cwd. Invariant:
+**never `.`/relative in this handler.** Pin with a test that runs the check with
+the process cwd set to a since-deleted dir and asserts it still flags the missing
+absolute repo.
+
+## Tests (RED-first)
+- ①: worktree with a `.git` pointer to a deleted canonical → `worktree_valid=false`,
+  `invalid_reason="gitdir_dangling"` (RED against current code = true). Plus
+  `canonical_missing` (source_repo path gone) and the happy path.
+- ②: pure `decide()` dedup latch (page-once / re-page / reset), and a
+  cwd-independence test (cwd = deleted dir, abs repo missing → still fires).
+
+## Ask
+Vet: (1) tightening `worktree_valid` (consumer impact) OK, or add a NEW field
+`worktree_resolves` and leave `worktree_valid` as-is? (2) cadence 60t OK? (3)
+git-subprocess vs stat-only for the heartbeat's per-repo check? Then I impl → DUAL.

--- a/src/daemon/per_tick/canonical_heartbeat.rs
+++ b/src/daemon/per_tick/canonical_heartbeat.rs
@@ -1,0 +1,211 @@
+//! #t-…83936-4 incident follow-up: canonical `source_repo` existence heartbeat.
+//!
+//! On 2026-07-06 the operator's canonical repo was deleted and went undetected
+//! for ~40 minutes: the daemon held the deleted dir as its cwd (an orphaned
+//! inode still answers cwd-relative lookups), so `binding_state` reported a stale
+//! `valid=true` and nothing surfaced the disappearance until an agent's commit
+//! hit the dangling gitdir. The root problem was "deleted with nobody noticing".
+//!
+//! This watchdog closes that gap. Every N ticks it enumerates the registered
+//! source_repos (`binding::bound_source_repos` — distinct ABSOLUTE paths from
+//! each `binding.json`) and checks, BY ABSOLUTE PATH, that each still (a) exists
+//! and (b) is a git repo (`git -C <abs> rev-parse --git-dir`). A vanished or
+//! corrupt canonical pages ALL operator escalation channels + writes an
+//! event-log `canonical_repo_missing` row.
+//!
+//! ⚠ The cwd trap (the soul of this fix): the daemon's own cwd may itself BE the
+//! deleted canonical, and an orphaned inode still resolves cwd-relative lookups —
+//! exactly the incident. Every check here MUST resolve by ABSOLUTE PATH, never
+//! `.`/cwd-relative. `bound_source_repos` yields absolute paths, and
+//! `std::fs::metadata(abs)` / `git -C abs` do fresh path lookups. This invariant
+//! is pinned by a test that runs the check with the process cwd set to a
+//! since-deleted directory (see `flags_missing_repo_even_when_cwd_is_deleted`).
+//!
+//! Complements protection ① (`binding_state`'s `worktree_resolves`): any agent
+//! calling `binding_state` (bind / release / introspect) detects a dead canonical
+//! INSTANTLY, so during normal activity detection is second-level; this periodic
+//! heartbeat is the backstop for a fully-idle fleet.
+//!
+//! Dedup: a per-repo latch pages ONCE on the present→missing transition; recovery
+//! (missing→present) clears the latch so a later re-deletion pages again.
+
+use super::{PerTickHandler, TickContext};
+use parking_lot::Mutex;
+use std::collections::HashSet;
+use std::path::Path;
+
+/// Per-tick canonical-existence watchdog. Default cadence 60 ticks (~10 min at
+/// the 10 s tick) — a 4× improvement over the incident's 40-min silence; the
+/// real-time path is protection ①.
+pub(crate) struct CanonicalHeartbeatHandler {
+    gate: crate::daemon::cadence_gate::CadenceGate,
+    /// Repos currently in the alerted-missing state (dedup: one page per outage).
+    alerted: Mutex<HashSet<String>>,
+}
+
+impl CanonicalHeartbeatHandler {
+    pub(crate) fn new(every_n_ticks: u64) -> Self {
+        Self {
+            gate: crate::daemon::cadence_gate::CadenceGate::new(every_n_ticks),
+            alerted: Mutex::new(HashSet::new()),
+        }
+    }
+}
+
+impl PerTickHandler for CanonicalHeartbeatHandler {
+    fn name(&self) -> &'static str {
+        "canonical_heartbeat"
+    }
+
+    fn run(&self, ctx: &TickContext<'_>) {
+        if !self.gate.fire() {
+            return;
+        }
+        let repos = crate::binding::bound_source_repos(ctx.home);
+        let registered: HashSet<String> =
+            repos.iter().map(|r| r.to_string_lossy().into_owned()).collect();
+        let mut alerted = self.alerted.lock();
+        for repo in &repos {
+            let key = repo.to_string_lossy().into_owned();
+            let Some(reason) = canonical_missing_reason(repo) else {
+                alerted.remove(&key); // healthy → reset latch so a future loss re-pages
+                continue;
+            };
+            if !alerted.insert(key.clone()) {
+                continue; // already paged this outage — don't re-page every cadence
+            }
+            let msg = format!(
+                "[canonical-missing] registered source_repo '{}' is GONE ({reason}). \
+                 Every worktree bound to it is now unusable (dangling gitdir) and \
+                 agents may silently commit into dead worktrees until it is \
+                 restored — re-clone/restore the canonical, then repair worktrees.",
+                repo.display(),
+            );
+            let dispatched = crate::channel::notify_all_escalation_channels(
+                &key,
+                crate::channel::NotifySeverity::Error,
+                &msg,
+                false,
+            );
+            crate::event_log::log(ctx.home, "canonical_repo_missing", &key, &msg);
+            tracing::error!(
+                repo = %repo.display(),
+                reason,
+                channels = dispatched,
+                "canonical_repo_missing: registered source_repo vanished"
+            );
+        }
+        // De-registered repos (no live binding references them) drop out of the
+        // latch so it can't grow unbounded.
+        alerted.retain(|k| registered.contains(k));
+    }
+}
+
+/// `None` = the canonical is healthy; `Some(reason)` = it's gone or corrupt.
+/// Resolves STRICTLY by absolute path (the caller passes absolute source_repo
+/// paths) so the daemon's own — possibly orphaned — cwd can never mask a
+/// deletion. `git_ok` runs only after the path exists, so it never touches a
+/// missing dir.
+fn canonical_missing_reason(repo: &Path) -> Option<&'static str> {
+    if std::fs::metadata(repo).is_err() {
+        return Some("path missing");
+    }
+    if !crate::git_helpers::git_ok(repo, &["rev-parse", "--git-dir"]) {
+        return Some("not a git repo (corrupt/removed .git)");
+    }
+    None
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use std::process::Command;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    fn tmp(tag: &str) -> std::path::PathBuf {
+        static C: AtomicU32 = AtomicU32::new(0);
+        let d = std::env::temp_dir().join(format!(
+            "agend-canon-hb-{tag}-{}-{}",
+            std::process::id(),
+            C.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::create_dir_all(&d).unwrap();
+        d
+    }
+
+    fn git_init(dir: &Path) {
+        Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(dir)
+            .env("AGEND_GIT_BYPASS", "1")
+            .output()
+            .expect("git init");
+    }
+
+    #[test]
+    fn healthy_repo_is_not_missing() {
+        let d = tmp("healthy");
+        git_init(&d);
+        assert_eq!(canonical_missing_reason(&d), None);
+        std::fs::remove_dir_all(&d).ok();
+    }
+
+    #[test]
+    fn deleted_dir_is_path_missing() {
+        let d = tmp("deleted");
+        git_init(&d);
+        std::fs::remove_dir_all(&d).unwrap();
+        assert_eq!(canonical_missing_reason(&d), Some("path missing"));
+    }
+
+    #[test]
+    fn existing_non_git_dir_is_corrupt() {
+        let d = tmp("nongit"); // exists but never `git init`ed
+        assert_eq!(
+            canonical_missing_reason(&d),
+            Some("not a git repo (corrupt/removed .git)")
+        );
+        std::fs::remove_dir_all(&d).ok();
+    }
+
+    /// THE SOUL of this fix (#t-…83936-4): the check must resolve by ABSOLUTE PATH
+    /// and stay correct even when the process cwd is itself a deleted directory —
+    /// exactly the incident, where the daemon's cwd was the orphaned canonical.
+    /// A future refactor to a `.`/cwd-relative check would silently reintroduce
+    /// the 40-min blind spot; this pins against that.
+    #[test]
+    #[serial_test::serial]
+    fn flags_missing_repo_even_when_cwd_is_deleted() {
+        let healthy = tmp("cwd-healthy");
+        git_init(&healthy);
+        let gone = tmp("cwd-gone");
+        git_init(&gone);
+        std::fs::remove_dir_all(&gone).unwrap(); // an absolute repo that is now gone
+
+        // Put the process into an orphaned-inode cwd (delete our own cwd).
+        let prev_cwd = std::env::current_dir().ok();
+        let orphan_cwd = tmp("cwd-orphan");
+        std::env::set_current_dir(&orphan_cwd).unwrap();
+        std::fs::remove_dir_all(&orphan_cwd).unwrap(); // cwd now points at a deleted inode
+
+        // Despite the deleted cwd, absolute-path resolution must be correct:
+        let gone_verdict = canonical_missing_reason(&gone);
+        let healthy_verdict = canonical_missing_reason(&healthy);
+
+        // Restore cwd BEFORE asserting so a failure can't strand the test process.
+        if let Some(p) = prev_cwd {
+            std::env::set_current_dir(p).ok();
+        }
+        assert_eq!(
+            gone_verdict,
+            Some("path missing"),
+            "a deleted absolute repo must be flagged even from a deleted cwd"
+        );
+        assert_eq!(
+            healthy_verdict, None,
+            "a healthy absolute repo must resolve even from a deleted cwd"
+        );
+        std::fs::remove_dir_all(&healthy).ok();
+    }
+}

--- a/src/daemon/per_tick/canonical_heartbeat.rs
+++ b/src/daemon/per_tick/canonical_heartbeat.rs
@@ -176,6 +176,13 @@ mod tests {
     /// exactly the incident, where the daemon's cwd was the orphaned canonical.
     /// A future refactor to a `.`/cwd-relative check would silently reintroduce
     /// the 40-min blind spot; this pins against that.
+    ///
+    /// `#[cfg(unix)]`: the hazard being pinned is a POSIX semantic — an orphaned
+    /// inode keeps answering cwd-relative lookups after its dir is unlinked.
+    /// Windows LOCKS the process cwd, so it cannot even be deleted (the fixture's
+    /// `remove_dir_all(cwd)` errors) and the blind spot cannot occur there. The
+    /// production check is cross-platform; only this simulation is Unix-only.
+    #[cfg(unix)]
     #[test]
     #[serial_test::serial]
     fn flags_missing_repo_even_when_cwd_is_deleted() {

--- a/src/daemon/per_tick/canonical_heartbeat.rs
+++ b/src/daemon/per_tick/canonical_heartbeat.rs
@@ -62,8 +62,10 @@ impl PerTickHandler for CanonicalHeartbeatHandler {
             return;
         }
         let repos = crate::binding::bound_source_repos(ctx.home);
-        let registered: HashSet<String> =
-            repos.iter().map(|r| r.to_string_lossy().into_owned()).collect();
+        let registered: HashSet<String> = repos
+            .iter()
+            .map(|r| r.to_string_lossy().into_owned())
+            .collect();
         let mut alerted = self.alerted.lock();
         for repo in &repos {
             let key = repo.to_string_lossy().into_owned();

--- a/src/daemon/per_tick/mod.rs
+++ b/src/daemon/per_tick/mod.rs
@@ -42,6 +42,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 pub(crate) mod backend_exit_detection;
+pub(crate) mod canonical_heartbeat;
 pub(crate) mod check_schedules;
 pub(crate) mod ci_watch_poll;
 pub(crate) mod context_alert;
@@ -346,6 +347,12 @@ pub(crate) fn build_default_handlers(
         Box::new(RespawnWatchdogHandler::new()),
         Box::new(WatchdogHandler::new(watchdog_dry_run)),
         Box::new(ExternalLivenessHandler::new()),
+        // #t-…83936-4: canonical source_repo existence heartbeat — pages the
+        // operator if a registered canonical repo vanishes (the 40-min-silent
+        // deletion incident). 60-tick backstop; the real-time path is
+        // binding_state's `worktree_resolves` (protection ①). Order-independent:
+        // reads bound_source_repos + emits alerts, shares no state with others.
+        Box::new(canonical_heartbeat::CanonicalHeartbeatHandler::new(60)),
         // #2413 (B): ShadowObserve MUST run immediately BEFORE SnapshotRotation so the
         // snapshot's operated `agent_state` promotion reads THIS tick's `observed_status`
         // (it was previously LAST in the list → the snapshot would read last tick's). The

--- a/src/mcp/handlers/binding_state.rs
+++ b/src/mcp/handlers/binding_state.rs
@@ -116,6 +116,36 @@ pub(crate) fn handle_binding_state(home: &Path, args: &Value, _sender: &Option<S
         let worktree_valid = worktree_exists_on_disk
             && (wt_path.join(".git").exists() || wt_path.join(".agend-managed").exists());
 
+        // #t-…83936-4: `worktree_valid` above checks that the worktree's `.git`
+        // EXISTS, but a linked worktree's `.git` is a POINTER file
+        // (`gitdir: <canonical>/.git/worktrees/<name>`) — it survives even after
+        // the canonical it points to is deleted, so `.git`-exists is falsely
+        // "valid". `worktree_resolves` does the REAL liveness check (canonical
+        // present + is a git repo, AND the worktree's gitdir actually resolves).
+        // ADDITIVE (lead Q1): `worktree_valid` semantics are untouched so existing
+        // rebuild-decision consumers don't shift; callers that need strictness read
+        // `worktree_resolves` / `invalid_reason`. All paths are ABSOLUTE (from
+        // binding.json), so `metadata`/`git -C` resolve by path, never cwd — this
+        // is what lets it catch the case where the daemon's own cwd is the deleted
+        // canonical (the 40-min-silent incident). Same class as the dev3
+        // dangling-.git hazard (t-…83936-2), folded in here.
+        let source_repo = b["source_repo"].as_str().unwrap_or("");
+        let canonical_present = !source_repo.is_empty()
+            && std::fs::metadata(source_repo).is_ok()
+            && crate::git_helpers::git_ok(Path::new(source_repo), &["rev-parse", "--git-dir"]);
+        let gitdir_resolves =
+            worktree_exists_on_disk && crate::git_helpers::git_ok(wt_path, &["rev-parse", "--git-dir"]);
+        let worktree_resolves = canonical_present && gitdir_resolves;
+        let invalid_reason: Option<&str> = if !worktree_exists_on_disk {
+            Some("worktree_missing")
+        } else if !canonical_present {
+            Some("canonical_missing")
+        } else if !gitdir_resolves {
+            Some("gitdir_dangling")
+        } else {
+            None
+        };
+
         // Cross-branch holders: any other agent currently bound to
         // the same branch (should be 0 — `dispatch_auto_bind_lease`'s
         // P0-1.5 cross-agent uniqueness check enforces this — but
@@ -133,6 +163,8 @@ pub(crate) fn handle_binding_state(home: &Path, args: &Value, _sender: &Option<S
             "issued_at": b["issued_at"].as_str().unwrap_or(""),
             "worktree_exists_on_disk": worktree_exists_on_disk,
             "worktree_valid": worktree_valid,
+            "worktree_resolves": worktree_resolves,
+            "invalid_reason": invalid_reason,
             "marker_present": marker_present,
             "ci_watches": ci_watches,
             "bind_in_flight": bind_in_flight,

--- a/src/mcp/handlers/binding_state.rs
+++ b/src/mcp/handlers/binding_state.rs
@@ -133,8 +133,8 @@ pub(crate) fn handle_binding_state(home: &Path, args: &Value, _sender: &Option<S
         let canonical_present = !source_repo.is_empty()
             && std::fs::metadata(source_repo).is_ok()
             && crate::git_helpers::git_ok(Path::new(source_repo), &["rev-parse", "--git-dir"]);
-        let gitdir_resolves =
-            worktree_exists_on_disk && crate::git_helpers::git_ok(wt_path, &["rev-parse", "--git-dir"]);
+        let gitdir_resolves = worktree_exists_on_disk
+            && crate::git_helpers::git_ok(wt_path, &["rev-parse", "--git-dir"]);
         let worktree_resolves = canonical_present && gitdir_resolves;
         let invalid_reason: Option<&str> = if !worktree_exists_on_disk {
             Some("worktree_missing")
@@ -236,6 +236,14 @@ fn cross_branch_holders_for(home: &Path, branch: &str, exclude_agent: &str) -> V
     out.sort();
     out
 }
+
+// #t-…83936-4 protection ① liveness tests (worktree_resolves / invalid_reason)
+// live in a sibling file loaded via `#[path]` so binding_state.rs stays under
+// the MCP-handler LOC ceiling (file_size_invariant skips "*test*"-named files) —
+// the Sprint 54/55 file_size_invariant pattern also used by channel.rs.
+#[cfg(test)]
+#[path = "binding_state_liveness_tests.rs"]
+mod liveness_tests;
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]

--- a/src/mcp/handlers/binding_state_liveness_tests.rs
+++ b/src/mcp/handlers/binding_state_liveness_tests.rs
@@ -1,0 +1,181 @@
+//! #t-…83936-4 protection ① — `binding_state` canonical/gitdir liveness tests.
+//!
+//! Located in this sibling file (loaded via `#[path]` from binding_state.rs) per
+//! the Sprint 54/55 `file_size_invariant` pattern (channel.rs / comms.rs use the
+//! same idiom) so the handler's production file stays under the 750-LOC ceiling.
+//!
+//! Pins the additive `worktree_resolves` + `invalid_reason` fields that make the
+//! 40-min-silent canonical-deletion incident detectable: a linked worktree's
+//! `.git` is a POINTER file that OUTLIVES its canonical, so `worktree_valid`
+//! (which only checks `.git` *exists*) stays falsely true. Per lead Q1 the new
+//! fields are ADDITIVE — `worktree_valid` semantics are untouched.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use super::handle_binding_state;
+use serde_json::json;
+use std::path::Path;
+
+fn tmp_home(suffix: &str) -> std::path::PathBuf {
+    let h = std::env::temp_dir().join(format!(
+        "agend-binding-live-{}-{}",
+        std::process::id(),
+        suffix
+    ));
+    std::fs::create_dir_all(&h).ok();
+    h
+}
+
+/// Write a `binding.json` with a caller-chosen `source_repo` — the liveness
+/// checks need to point `source_repo` at a real / a deleted canonical to
+/// exercise `canonical_present`.
+fn write_binding_src(home: &Path, agent: &str, branch: &str, worktree: &str, source_repo: &str) {
+    let dir = crate::paths::runtime_dir(home).join(agent);
+    std::fs::create_dir_all(&dir).unwrap();
+    let payload = json!({
+        "version": 1,
+        "agent": agent,
+        "task_id": "test-task",
+        "branch": branch,
+        "worktree": worktree,
+        "source_repo": source_repo,
+        "issued_at": "2026-05-09T00:00:00Z",
+    });
+    std::fs::write(
+        dir.join("binding.json"),
+        serde_json::to_string_pretty(&payload).unwrap(),
+    )
+    .unwrap();
+}
+
+/// Initialise a real git repo (test fixture). `AGEND_GIT_BYPASS=1` satisfies the
+/// git-test-bypass invariant; this is a `#[cfg(test)]`-only file so the
+/// daemon-git-helper scanner (production-portion only) never sees the raw git.
+fn git_init(dir: &Path) {
+    std::process::Command::new("git")
+        .args(["init", "-q"])
+        .current_dir(dir)
+        .env("AGEND_GIT_BYPASS", "1")
+        .output()
+        .expect("git init");
+}
+
+/// RED (protection ①): the incident's soul at the binding_state layer. A linked
+/// worktree's `.git` is a POINTER file that OUTLIVES the canonical it points to,
+/// so `worktree_valid` — which only checks that `.git` *exists* — stays falsely
+/// `true` after the canonical is gone (the 40-min-silent incident). The additive
+/// `worktree_resolves` field (lead Q1: `worktree_valid` semantics UNTOUCHED)
+/// resolves the pointer for a real liveness verdict, and `invalid_reason` names
+/// the failure. Both fields are new, so every assertion here fails RED against
+/// the pre-fix handler (the keys are absent → `as_bool()`/`as_str()` → `None`).
+#[test]
+fn binding_state_worktree_resolves_and_invalid_reason() {
+    let home = tmp_home("resolves");
+    // A real canonical git repo → `canonical_present` is true in the happy and
+    // gitdir-dangling cases (isolates them from `canonical_missing`).
+    let canonical = home.join("canonical");
+    std::fs::create_dir_all(&canonical).unwrap();
+    git_init(&canonical);
+    let canonical_str = canonical.to_str().unwrap();
+
+    // ── Happy: a worktree whose gitdir resolves + a live canonical.
+    let wt_ok = home.join("wt-ok");
+    std::fs::create_dir_all(&wt_ok).unwrap();
+    git_init(&wt_ok);
+    write_binding_src(
+        &home,
+        "hap",
+        "feature/x",
+        wt_ok.to_str().unwrap(),
+        canonical_str,
+    );
+    let r = handle_binding_state(&home, &json!({"instance": "hap"}), &None);
+    assert_eq!(r["worktree_valid"].as_bool(), Some(true), "{r}");
+    assert_eq!(
+        r["worktree_resolves"].as_bool(),
+        Some(true),
+        "resolving worktree + live canonical → alive: {r}"
+    );
+    assert!(r["invalid_reason"].is_null(), "healthy → no reason: {r}");
+
+    // ── gitdir_dangling (SOUL): the `.git` pointer file exists but points at a
+    // since-deleted admin dir; the canonical itself is still present.
+    // `worktree_valid` stays TRUE (pointer file present — untouched semantics)
+    // while `worktree_resolves` is FALSE. Exactly the dangling gitdir that went
+    // silent for 40 minutes.
+    let wt_dangle = home.join("wt-dangle");
+    std::fs::create_dir_all(&wt_dangle).unwrap();
+    std::fs::write(
+        wt_dangle.join(".git"),
+        format!("gitdir: {}/never-existed-admin\n", home.display()),
+    )
+    .unwrap();
+    write_binding_src(
+        &home,
+        "dng",
+        "feature/x",
+        wt_dangle.to_str().unwrap(),
+        canonical_str,
+    );
+    let r = handle_binding_state(&home, &json!({"instance": "dng"}), &None);
+    assert_eq!(
+        r["worktree_valid"].as_bool(),
+        Some(true),
+        "the `.git` pointer file exists → valid stays true (semantics untouched): {r}"
+    );
+    assert_eq!(
+        r["worktree_resolves"].as_bool(),
+        Some(false),
+        "pointer resolves to a deleted admin dir → NOT alive: {r}"
+    );
+    assert_eq!(
+        r["invalid_reason"].as_str(),
+        Some("gitdir_dangling"),
+        "canonical present but gitdir dangles: {r}"
+    );
+
+    // ── canonical_missing: the worktree resolves, but `source_repo` is gone.
+    let wt_live = home.join("wt-live");
+    std::fs::create_dir_all(&wt_live).unwrap();
+    git_init(&wt_live);
+    write_binding_src(
+        &home,
+        "cm",
+        "feature/x",
+        wt_live.to_str().unwrap(),
+        home.join("no-such-canonical").to_str().unwrap(),
+    );
+    let r = handle_binding_state(&home, &json!({"instance": "cm"}), &None);
+    assert_eq!(
+        r["worktree_resolves"].as_bool(),
+        Some(false),
+        "canonical gone → not alive even though the worktree itself resolves: {r}"
+    );
+    assert_eq!(
+        r["invalid_reason"].as_str(),
+        Some("canonical_missing"),
+        "{r}"
+    );
+
+    // ── worktree_missing: the worktree dir itself was never created.
+    write_binding_src(
+        &home,
+        "wm",
+        "feature/x",
+        home.join("never").to_str().unwrap(),
+        canonical_str,
+    );
+    let r = handle_binding_state(&home, &json!({"instance": "wm"}), &None);
+    assert_eq!(
+        r["worktree_resolves"].as_bool(),
+        Some(false),
+        "no worktree → not alive: {r}"
+    );
+    assert_eq!(
+        r["invalid_reason"].as_str(),
+        Some("worktree_missing"),
+        "{r}"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+}


### PR DESCRIPTION
## Summary
Incident follow-up (`t-…83936-4`): make "canonical repo deleted" impossible to
miss for 40 minutes again. Two additive, lead-vetted protections.

**① `binding_state` liveness** — new additive `worktree_resolves` +
`invalid_reason` fields. A linked worktree's `.git` is a POINTER file that
outlives its canonical, so the existing `worktree_valid` (checks `.git`
*exists*) stays falsely `true` after the canonical is deleted — the
40-min-silent incident. `worktree_resolves` does the real liveness check
(canonical present + is a git repo, AND the worktree's gitdir resolves) and
`invalid_reason` names the failure (`worktree_missing` / `canonical_missing` /
`gitdir_dangling`). Per lead Q1, `worktree_valid` semantics are **UNTOUCHED**
(additive) so existing rebuild-decision consumers don't shift. Any agent
calling `binding_state` (bind / release / introspect) now detects a dead
canonical instantly — this is the real-time path.

**② `CanonicalHeartbeatHandler` (60-tick backstop)** — a new per-tick handler
that enumerates registered `bound_source_repos` (distinct ABSOLUTE paths) and
checks each still exists + is a git repo, BY ABSOLUTE PATH. A vanished/corrupt
canonical pages all operator escalation channels + writes an event-log
`canonical_repo_missing` row, with a per-repo dedup latch (page once per
outage, re-page on recovery→re-loss). 40-min silence → ~10-min backstop for a
fully-idle fleet.

### The cwd-orphaned-inode trap (the soul)
The incident's daemon held the DELETED canonical as its own cwd — an orphaned
inode still answers cwd-relative lookups, masking the deletion. Every check
here resolves by ABSOLUTE PATH, never `.`/cwd-relative. Pinned by
`flags_missing_repo_even_when_cwd_is_deleted` (runs the check with the process
cwd set to a since-deleted dir).

## Tests
- `binding_state_worktree_resolves_and_invalid_reason` (sibling
  `binding_state_liveness_tests.rs`, loaded via `#[path]` per the
  file_size_invariant "*test*"-skip pattern used by `channel.rs`, keeping
  `binding_state.rs` under the 750-LOC handler ceiling) — gitdir-dangling SOUL
  case (`worktree_valid` true / `worktree_resolves` false) + `canonical_missing`
  + `worktree_missing` + happy. RED-first verified (removing the two new output
  fields makes it fail).
- 4 heartbeat tests incl. the cwd-deleted soul test.

## Gate
- `cargo fmt --check` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo nextest run --workspace`: **5386 passed**. The only 2 failures are the
  real-daemon e2e tests #1900 (`e2e_workflow`) and #1907
  (`teardown_completeness_regression`) — both fail **identically with this
  handler disabled** and both panic at the same upstream "victim should be
  bound after dispatch" precondition. They need the sandbox-unavailable
  real-daemon auto-bind flow; unrelated to this change (CI has the full env).

Task: `t-20260706164720986443-83936-4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
