### PR TITLE
feat(#35896-11): notify-noise PR-B (DUAL) — ci-ready fire-and-forget reclaim (④) + report auto-discharge (⑤)

### DIFF
--- a/docs/DESIGN-notify-noise-unified.md
+++ b/docs/DESIGN-notify-noise-unified.md
@@ -39,6 +39,10 @@ ci_handoff_track**. #2622 is the best-shaped unifying primitive; the missing wir
    instead of reverting to unread → kills the 2nd poll-reminder stream (watchdog stays the single ci-ready renudge).
 5. **`kind=report` w/ correlation auto-discharges the reporter's dispatch obligation** (default the ack_inbox
    behavior for report-with-correlation) → poll_reminder stops nudging an already-reported dispatch (35896-11 m-208).
+   *Dependency (reviewer5, #2670):* `ack_by_correlation` keys the settle by `(sender, task_id==correlation_id)`
+   only — it does NOT key on the report's target/original dispatcher. Correctness therefore relies on task /
+   correlation ids being **globally unique** (the fleet's task-id design guarantee); a reused id across unrelated
+   dispatches would let one report settle another's row. Sender-scoping already prevents cross-agent bleed (#2647).
 6. **Persist the renudge/escalation throttle** (anchor `last_renudged`/`last_escalated`/`LAST_NOTIFIED` to a
    disk `last_renudged_at`/count on the track, not an in-mem map reset at boot) → no restart burst. **This is
    24134-4's cross-restart concern, solved minimally via the already-durable track + throttle — NOT a new

--- a/src/inbox/storage.rs
+++ b/src/inbox/storage.rs
@@ -1673,6 +1673,18 @@ fn known_fire_and_forget_kind(msg: &InboxMessage) -> bool {
                 // itself become a nagging un-dischargeable obligation and
                 // regenerate the loop it reports on (the fb2461 lesson).
                 | "channel-reply-discharged"
+                // #35896-11 ④: a `ci-ready-for-action` handoff left in `delivering`
+                // (the reviewer drained but hasn't acted) must NOT be reverted to
+                // unread by reclaim — that reopens a SECOND, uncoordinated poll-
+                // reminder stream for the same event on top of the ci_handoff_track
+                // renudge watchdog (the single intended ci-ready renudge, which is
+                // decoupled from inbox read-state per #1888 and NOT affected by this
+                // settle). Terminally settling the reclaimed row leaves the watchdog
+                // as the one renudge source. NOTE: ci-ready is deliberately kept OUT
+                // of `auto_ack_on_drain_kind` — it must survive the FIRST drain as
+                // `delivering` so the reviewer sees it; only a STALE past-cap
+                // delivering row is settled here.
+                | "ci-ready-for-action"
         )
     )
 }

--- a/src/inbox/tests.rs
+++ b/src/inbox/tests.rs
@@ -1098,6 +1098,46 @@ fn reclaim_still_redelivers_context_alert_conservatively() {
     fs::remove_dir_all(&home).ok();
 }
 
+/// #35896-11 ④: a `ci-ready-for-action` handoff left STALE in `delivering` (the
+/// reviewer drained it but hasn't acted) must be SETTLED by reclaim, not reverted
+/// to unread. Reverting reopens a SECOND, uncoordinated poll-reminder stream for
+/// the same event on top of the ci_handoff_track renudge watchdog (the single
+/// intended ci-ready renudge, decoupled from inbox read-state and unaffected by
+/// this settle). Pre-④ ci-ready was outside `known_fire_and_forget_kind`, so
+/// `kind_is_unknown` → reclaim reverted it to unread (this test would drain it
+/// back). ci-ready is deliberately kept OUT of `auto_ack_on_drain_kind`, so it
+/// still survives the FIRST drain as `delivering` for the reviewer to see.
+#[test]
+fn reclaim_settles_stale_delivering_ci_ready_for_action_35896_11() {
+    let home = tmp_home("reclaim-ci-ready-35896");
+    enqueue(
+        &home,
+        "reviewer",
+        msg()
+            .sender("system:ci")
+            .text("[ci-ready-for-action] o/r@feat: CI passed, your turn.")
+            .kind("ci-ready-for-action")
+            .id("m-ciready-stale")
+            .delivering_at(&secs_ago(660))
+            .build(),
+    )
+    .unwrap();
+
+    reclaim_stale_delivering(&home);
+
+    assert!(
+        drain(&home, "reviewer").is_empty(),
+        "a stale delivering ci-ready row must be settled by reclaim, not re-delivered (kills the 2nd poll stream)"
+    );
+    let content = fs::read_to_string(inbox_path(&home, "reviewer")).unwrap();
+    let persisted: InboxMessage = serde_json::from_str(content.lines().next().unwrap()).unwrap();
+    assert!(
+        persisted.read_at.is_some(),
+        "reclaim must stamp read_at on the stale ci-ready row (settle), not revert to unread"
+    );
+    fs::remove_dir_all(&home).ok();
+}
+
 /// healthy 不重投 / 在途不雙投: a FRESH in-flight (delivering) row is left
 /// untouched by reclaim and is never returned a second time — no double-deliver
 /// while the agent is mid-turn.
@@ -4645,6 +4685,50 @@ fn ack_by_correlation_preserves_non_matching() {
     let remaining = ack(&home, agent, None);
     assert_eq!(remaining, 1, "t-other should still be delivering");
 
+    fs::remove_dir_all(&home).ok();
+}
+
+/// #35896-11 ⑤ isolation (#2647): the report auto-discharge settles ONLY the
+/// reporting agent's OWN dispatch row. `ack_by_correlation` reads only the named
+/// agent's inbox, so agent A reporting a shared correlation must never settle
+/// agent B's same-task-id obligation — a shared task id must not cross agent
+/// inboxes (the #2647 discharge-key isolation lesson, at the report seam).
+#[test]
+fn ack_by_correlation_isolates_across_agents_35896_11() {
+    let home = tmp_home("ack-corr-cross-agent-35896");
+    // Both agents received a dispatch carrying the SAME task id.
+    for agent in ["agent-a", "agent-b"] {
+        enqueue(
+            &home,
+            agent,
+            msg()
+                .sender("lead")
+                .text("shared-id dispatch")
+                .kind("task")
+                .task_id("t-shared")
+                .id(&format!("m-{agent}-shared"))
+                .build(),
+        )
+        .unwrap();
+        assert_eq!(
+            drain(&home, agent).len(),
+            1,
+            "{agent}: dispatch drained → delivering"
+        );
+    }
+
+    // Agent A reports the shared correlation → only A's row settles.
+    let settled_a = ack_by_correlation(&home, "agent-a", "t-shared");
+    assert_eq!(settled_a, 1, "agent-a's own dispatch row settles");
+
+    // Agent B's SAME-correlation obligation must survive untouched — proven by it
+    // still being settle-able (a second ack finds it still delivering). If A's ack
+    // had leaked across inboxes, this would return 0.
+    let settled_b = ack_by_correlation(&home, "agent-b", "t-shared");
+    assert_eq!(
+        settled_b, 1,
+        "agent-b's same-task-id obligation must NOT be suppressed by agent-a's report (#2647 isolation)"
+    );
     fs::remove_dir_all(&home).ok();
 }
 

--- a/src/mcp/handlers/comms.rs
+++ b/src/mcp/handlers/comms.rs
@@ -539,15 +539,14 @@ pub(super) fn handle_report_result(home: &Path, args: &Value, sender: &Option<Se
         // Mark dispatch as completed so timeout sweep doesn't false-warn.
         let cid = args["correlation_id"].as_str();
         crate::dispatch_tracking::mark_completed(home, cid, sender.as_str());
-        // ack_inbox: auto-settle the sender's DELIVERING inbox messages whose
-        // task_id matches correlation_id. Eliminates the "remember to ack"
-        // gap — the daemon settles atomically with the report send.
-        if args["ack_inbox"].as_bool() == Some(true) {
-            if let Some(cid) = cid.filter(|s| !s.is_empty()) {
-                let settled = crate::inbox::ack_by_correlation(home, sender.as_str(), cid);
-                if let Some(obj) = result.as_object_mut() {
-                    obj.insert("inbox_settled".to_string(), json!(settled));
-                }
+        // #35896-11 ⑤ (Q2 vet): any kind=report+correlation auto-settles the
+        // SENDER's own delivering dispatch row (was gated on ack_inbox=true);
+        // sender-scoped via ack_by_correlation (#2647 isolation), ack_inbox now a
+        // no-op. Q2 over-settle tradeoff: docs/DESIGN-notify-noise-unified.md.
+        if let Some(cid) = cid.filter(|s| !s.is_empty()) {
+            let settled = crate::inbox::ack_by_correlation(home, sender.as_str(), cid);
+            if let Some(obj) = result.as_object_mut() {
+                obj.insert("inbox_settled".to_string(), json!(settled));
             }
         }
         // #2537/#2524 P6 PR-1: best-effort — a ledger write failure doesn't

--- a/src/mcp/handlers/comms_p0c_tests.rs
+++ b/src/mcp/handlers/comms_p0c_tests.rs
@@ -4,6 +4,7 @@
 //! keep src/mcp/handlers/comms.rs under the file_size_invariant 700 LOC
 //! ceiling. Same module layout pattern as the
 //! `instance_state::lifecycle` split.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use super::dispatch_should_skip_auto_bind;
 use serde_json::json;
@@ -34,3 +35,77 @@ fn proceed_auto_bind_when_bind_absent() {
 // — replacing this brittle source-text grep, which broke on the smells#2
 // SendEnvelope refactor though the behavior was preserved (source-grep tests
 // are themselves a flagged de2eb8 smell / Pattern A).
+
+/// #35896-11 ⑤ (Q2 vet): a kind=report carrying a correlation_id auto-settles the
+/// SENDER's own delivering dispatch row EVEN WITHOUT `ack_inbox` — the gate was
+/// removed so poll-reminder stops nagging a dispatch the reporter already
+/// answered. End-to-end through the real `handle_report_result`: `api::call(SEND)`
+/// fails in-test (no daemon) → `fallback_deliver` returns a no-error result →
+/// `is_ok_result` true → the settle block runs. Sender-scoped, so only the
+/// reporter's row is touched (isolation unit-tested in
+/// `inbox::tests::ack_by_correlation_isolates_across_agents_35896_11`).
+#[test]
+fn report_with_correlation_auto_settles_dispatch_row_without_ack_inbox_35896_11() {
+    let home = std::env::temp_dir().join(format!(
+        "agend-35896-report-autosettle-{}-{}",
+        std::process::id(),
+        line!()
+    ));
+    let _ = std::fs::remove_dir_all(&home);
+    std::fs::create_dir_all(&home).unwrap();
+    // Minimal fleet so the report's in-test fallback delivery to `lead` resolves
+    // (api::call has no daemon → fallback_deliver, which validates the target
+    // against fleet.yaml; without this the send returns an error result and the
+    // settle block is correctly skipped).
+    let reporter = "reporter-35896";
+    std::fs::write(
+        home.join("fleet.yaml"),
+        format!("instances:\n  lead:\n    backend: claude\n  {reporter}:\n    backend: claude\n"),
+    )
+    .unwrap();
+
+    // Reporter received a task dispatch (task_id=t-x) and drained it → delivering.
+    crate::inbox::enqueue(
+        &home,
+        reporter,
+        crate::inbox::InboxMessage {
+            schema_version: 1,
+            id: Some("m-dispatch".into()),
+            from: "lead".into(),
+            text: "[task] do the thing".into(),
+            kind: Some("task".into()),
+            task_id: Some("t-x".into()),
+            timestamp: "2026-07-07T00:00:00Z".into(),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        crate::inbox::drain(&home, reporter).len(),
+        1,
+        "dispatch drained → delivering"
+    );
+
+    // Report back WITHOUT ack_inbox — ⑤ must still settle the reporter's row.
+    let sender = crate::identity::Sender::new(reporter);
+    let result = super::handle_report_result(
+        &home,
+        &json!({
+            "instance": "lead",
+            "summary": "done",
+            "correlation_id": "t-x"
+        }),
+        &sender,
+    );
+    assert_eq!(
+        result["inbox_settled"], 1,
+        "report+correlation must auto-settle the sender's dispatch row without ack_inbox: {result}"
+    );
+
+    // The settled dispatch row is read → poll-reminder no longer sees it unread.
+    assert!(
+        crate::inbox::drain(&home, reporter).is_empty(),
+        "the settled dispatch row must not re-surface as unread"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}


### PR DESCRIPTION
## notify-noise bundle — PR-B (DUAL): state-transition repair (④⑤)

Task `t-…-83936-7` (dispatch) / design `t-…-35896-11`. Vet: decision `d-20260706154250095696-2`.
Design: `docs/DESIGN-notify-noise-unified.md`. On top of the merged **PR-A** (①②③, `e40a7afa`).
**DUAL review** (obligation semantics).

### ④ `ci-ready-for-action` → `known_fire_and_forget_kind` (`storage.rs`)
A ci-ready handoff left STALE in `delivering` (reviewer drained it but hasn't acted) was
reverted to unread by `reclaim_stale_delivering`, reopening a **second, uncoordinated
poll-reminder stream** for the same event on top of the `ci_handoff_track` renudge
watchdog (the single intended ci-ready renudge — decoupled from inbox read-state per
#1888 and **unaffected** by this settle). Reclaim now terminally settles the stale row
instead. ci-ready is deliberately kept OUT of `auto_ack_on_drain_kind`, so it still
survives the FIRST drain as `delivering` for the reviewer to see — only a stale past-cap
delivering row is settled.

### ⑤ any `kind=report`+correlation auto-settles the sender's dispatch row (`comms.rs`)
Per vet **Q2**: once the reporter has engaged (sent a report for this correlation),
poll-reminder's job on that dispatch row is done — task completion is tracked by the board
+ dispatch_idle, not the inbox read-state. Dropped the `ack_inbox==true` gate in
`handle_report_result` so the settle is automatic for reports (`ack_inbox` is now a
back-compat no-op). Closes the phantom-renudge class where a fully-reported dispatch keeps
nudging because its row never left `delivering` (35896-11 m-…-208). **Sender-scoped** via
`ack_by_correlation` (keyed by sender + `task_id==correlation`), so a DIFFERENT agent's
same-correlation obligation is never suppressed (**#2647 isolation**); the escalation
watchdog is untouched.

### Tests (④ and the ⑤-wiring test verified RED→GREEN; the isolation guard is fix-independent by design)
- `reclaim_settles_stale_delivering_ci_ready_for_action_35896_11` (`inbox::tests`): stale
  delivering ci-ready → settled (`read_at`), not re-delivered.
- `report_with_correlation_auto_settles_dispatch_row_without_ack_inbox_35896_11`
  (`comms::p0c_tests`): real `handle_report_result`, **no `ack_inbox`** → sender's dispatch
  row settled (`inbox_settled=1`, row no longer unread). Verified RED-for-the-right-reason
  (fleet present, missing fix → `Null != 1`).
- `ack_by_correlation_isolates_across_agents_35896_11` (`inbox::tests`): agent A's report
  does not settle agent B's same-`task_id` obligation (**#2647** dimension).

### Verification
`cargo fmt --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean;
affected `nextest` green (349/350 — the one failure is `e2e_dispatch_review_workflow_seam_invariants_1900`,
a real-daemon e2e that fails **identically on the untouched base** locally, `mock-dev/binding.json`
missing — a local-env limitation, not this change).

### Follow-up (same vet)
**PR-C** (solo review, over-suppression risk): ⑥ persist the renudge/escalation throttle
(kills the cross-restart renudge burst) — also the minimal close for task `…-24134-4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
