### PR TITLE
feat(#2158-adjacent): preserve dirty WIP on manual worktree release

### DIFF
--- a/src/mcp/handlers/force_release/mod.rs
+++ b/src/mcp/handlers/force_release/mod.rs
@@ -78,7 +78,19 @@ pub(super) fn rebase_clean_self(
         // #2158-adjacent: force_release is destructive-by-design, but a dirty
         // worktree's uncommitted WIP should still be recoverable. Snapshot it to
         // a durable recovery ref before the removal (a clean worktree is a no-op).
-        crate::worktree::preserve_dirty_worktree(home, agent, &target, branch);
+        // reviewer4 #2672 fix — FAIL-CLOSED: if there IS WIP but it could not be
+        // snapshotted (e.g. a contended `index.lock`), refuse to nuke the worktree
+        // so the operator can recover it in place — even force_release must not
+        // silently lose it.
+        if let Some(reason) =
+            crate::worktree::preserve_dirty_worktree(home, agent, &target, branch).blocked_reason()
+        {
+            return Err(format!(
+                "force_release refused: worktree at {} has uncommitted WIP that could not be \
+                 preserved ({reason}); not removing it so the WIP can be recovered in place",
+                target.display()
+            ));
+        }
         match std::fs::remove_dir_all(&target) {
             Ok(()) => {
                 dir_removed = true;
@@ -353,6 +365,69 @@ mod tests {
         assert!(
             String::from_utf8_lossy(&tree.stdout).contains("fr-wip.txt"),
             "untracked WIP captured on the force_release path"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// reviewer4 #2672 (fail-OPEN regression) for the force:true path: a dirty
+    /// worktree whose WIP cannot be snapshotted (contended `index.lock`) must be
+    /// FAIL-CLOSED — `rebase_clean_self` returns Err and leaves the worktree in
+    /// place, NOT a silent destructive `remove_dir_all` that evaporates the WIP.
+    #[test]
+    fn rebase_clean_self_refuses_when_dirty_wip_unpreservable() {
+        let home = tmp_home("force-release-blocked");
+        let repo = home.join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        assert!(git_bypassed(&repo, &["init", "-b", "main"])
+            .status
+            .success());
+        assert!(git_bypassed(
+            &repo,
+            &[
+                "-c",
+                "user.name=t",
+                "-c",
+                "user.email=t@t",
+                "commit",
+                "--allow-empty",
+                "-m",
+                "init",
+            ],
+        )
+        .status
+        .success());
+        let agent = "dev-fr-blk";
+        let branch = "feat/fr-blk";
+        let target = home.join("worktrees").join(agent).join(branch);
+        std::fs::create_dir_all(target.parent().unwrap()).unwrap();
+        assert!(git_bypassed(
+            &repo,
+            &["worktree", "add", "-b", branch, target.to_str().unwrap()],
+        )
+        .status
+        .success());
+        std::fs::write(target.join("fr-wip.txt"), b"must not vanish").unwrap();
+        // Jam the worktree's index so `git add -A` fails during preservation.
+        let gitlink = std::fs::read_to_string(target.join(".git")).unwrap();
+        let gitdir = gitlink.strip_prefix("gitdir:").unwrap().trim();
+        std::fs::write(Path::new(gitdir).join("index.lock"), b"").unwrap();
+
+        let result = rebase_clean_self(&home, agent, branch);
+        assert!(
+            result.is_err(),
+            "force_release must FAIL-CLOSED (Err) when dirty WIP can't be preserved: {result:?}"
+        );
+        assert!(
+            result.unwrap_err().contains("could not be preserved"),
+            "error must name the refusal"
+        );
+        assert!(
+            target.exists(),
+            "worktree must NOT be removed (fail-closed)"
+        );
+        assert!(
+            target.join("fr-wip.txt").exists(),
+            "untracked WIP must survive in place"
         );
         std::fs::remove_dir_all(&home).ok();
     }

--- a/src/mcp/handlers/force_release/mod.rs
+++ b/src/mcp/handlers/force_release/mod.rs
@@ -75,6 +75,10 @@ pub(super) fn rebase_clean_self(
     let dir_existed = target.exists();
     let mut dir_removed = false;
     if dir_existed {
+        // #2158-adjacent: force_release is destructive-by-design, but a dirty
+        // worktree's uncommitted WIP should still be recoverable. Snapshot it to
+        // a durable recovery ref before the removal (a clean worktree is a no-op).
+        crate::worktree::preserve_dirty_worktree(home, agent, &target, branch);
         match std::fs::remove_dir_all(&target) {
             Ok(()) => {
                 dir_removed = true;
@@ -267,6 +271,88 @@ mod tests {
         assert!(
             dir.exists(),
             "without rebase_mode, stale dir must be preserved"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    // ── #2158-adjacent: force_release (force:true) dirty-WIP preservation ──
+
+    fn git_bypassed(dir: &Path, args: &[&str]) -> std::process::Output {
+        std::process::Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .env("AGEND_GIT_BYPASS", "1")
+            .output()
+            .expect("git")
+    }
+
+    #[test]
+    fn rebase_clean_self_preserves_dirty_wip_before_removal() {
+        // A REAL linked worktree at the daemon pool path, dirtied with untracked
+        // WIP, then force_release'd. force_release is destructive-by-design, but
+        // the WIP must still be recoverable via refs/agend/recovery/<branch>/<ts>.
+        let home = tmp_home("force-release-dirty");
+        let repo = home.join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        assert!(git_bypassed(&repo, &["init", "-b", "main"])
+            .status
+            .success());
+        assert!(git_bypassed(
+            &repo,
+            &[
+                "-c",
+                "user.name=t",
+                "-c",
+                "user.email=t@t",
+                "commit",
+                "--allow-empty",
+                "-m",
+                "init",
+            ],
+        )
+        .status
+        .success());
+
+        let agent = "dev-fr-dirty";
+        let branch = "feat/fr-dirty";
+        let target = home.join("worktrees").join(agent).join(branch);
+        std::fs::create_dir_all(target.parent().unwrap()).unwrap();
+        let add = git_bypassed(
+            &repo,
+            &["worktree", "add", "-b", branch, target.to_str().unwrap()],
+        );
+        assert!(
+            add.status.success(),
+            "worktree add failed: {}",
+            String::from_utf8_lossy(&add.stderr)
+        );
+        std::fs::write(target.join("fr-wip.txt"), b"force-release WIP").unwrap();
+
+        let outcome = rebase_clean_self(&home, agent, branch).expect("rebase_clean_self ok");
+        assert!(
+            outcome.dir_existed && outcome.dir_removed,
+            "dirty worktree removed by force_release: {outcome:?}"
+        );
+        assert!(!target.exists(), "worktree dir gone");
+
+        // The WIP survives in a recovery ref.
+        let refs = git_bypassed(
+            &repo,
+            &[
+                "for-each-ref",
+                "--format=%(refname)",
+                &format!("refs/agend/recovery/{branch}/"),
+            ],
+        );
+        let ref_list = String::from_utf8_lossy(&refs.stdout);
+        let ref_name = ref_list
+            .lines()
+            .find(|l| !l.is_empty())
+            .expect("a recovery ref exists after dirty force_release");
+        let tree = git_bypassed(&repo, &["ls-tree", "-r", "--name-only", ref_name]);
+        assert!(
+            String::from_utf8_lossy(&tree.stdout).contains("fr-wip.txt"),
+            "untracked WIP captured on the force_release path"
         );
         std::fs::remove_dir_all(&home).ok();
     }

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -505,10 +505,42 @@ fn worktree_has_preservable_wip(wt_path: &Path) -> bool {
     }
 }
 
-/// Snapshot a dirty worktree's uncommitted WIP into a durable recovery ref
-/// BEFORE a manual release removes the worktree dir. Returns the recovery ref
-/// name if WIP was preserved, or `None` for a clean worktree (no-op) or on any
-/// capture failure (best-effort — preservation must NEVER block the release).
+/// Outcome of a pre-removal WIP-preservation attempt. `#[must_use]` so a release
+/// path cannot silently drop it and destroy the worktree regardless — the
+/// fail-OPEN bug reviewer4 caught in the first cut: a contended `index.lock`
+/// made `git add -A` fail, the ignored `None` let `release_full` proceed, and the
+/// dirty untracked WIP evaporated with zero recovery ref. A caller MUST refuse to
+/// remove the worktree on [`WipPreservation::Blocked`].
+#[must_use]
+pub(crate) enum WipPreservation {
+    /// No preservable WIP (clean, or only the daemon `.agend-managed` marker) —
+    /// safe to remove; zero behaviour change vs a pre-guard release.
+    Clean,
+    /// WIP was snapshotted to a recovery ref (name logged + surfaced to the
+    /// operator inside `preserve_dirty_worktree`) — safe to remove.
+    Preserved,
+    /// Preservable WIP EXISTS but could NOT be snapshotted (git failure or a
+    /// contended index) — the caller MUST NOT remove the worktree, so the operator
+    /// can recover the WIP in place. Carries a human-readable reason.
+    Blocked(String),
+}
+
+impl WipPreservation {
+    /// The block reason when preservation was needed but FAILED — `Some` iff the
+    /// caller must refuse to remove the worktree (fail-closed).
+    pub(crate) fn blocked_reason(&self) -> Option<&str> {
+        match self {
+            WipPreservation::Blocked(reason) => Some(reason),
+            WipPreservation::Clean | WipPreservation::Preserved => None,
+        }
+    }
+}
+
+/// Snapshot a dirty worktree's uncommitted WIP into a durable recovery ref BEFORE
+/// a manual release removes the worktree dir. Returns [`WipPreservation`]:
+/// `Clean` (nothing to preserve → safe to remove), `Preserved(ref)` (WIP captured
+/// → safe to remove), or `Blocked(reason)` (WIP present but the snapshot FAILED →
+/// the caller MUST NOT remove; fail-closed so the operator recovers in place).
 ///
 /// Mechanism (race-free, untracked-complete, bypass-only — no raw subprocess):
 /// stage everything incl. untracked into the worktree's OWN (per-worktree,
@@ -523,17 +555,33 @@ pub(crate) fn preserve_dirty_worktree(
     agent: &str,
     wt_path: &Path,
     branch: &str,
-) -> Option<String> {
-    if branch.is_empty() || !worktree_has_preservable_wip(wt_path) {
-        return None; // clean (or unknown branch) → zero behaviour change
-    }
+) -> WipPreservation {
     use crate::git_helpers::git_cmd;
+    if branch.is_empty() {
+        return WipPreservation::Clean; // unknown branch → nothing to key a recovery ref on
+    }
+    // Not a LIVE git worktree (a pruned/dangling stale dir — its `.git` gitlink
+    // points at a removed gitdir, or there is none) → there is no git WIP to
+    // snapshot, so removal is safe. Gate here so the fail-closed WIP path below
+    // fires ONLY for a real worktree whose preservation genuinely failed (e.g. a
+    // contended `index.lock`), NOT for a stale dir git can't read at all — which
+    // would wrongly block the force_release stale-dir cleanup this backs. Our
+    // call sites pass `home/worktrees/...` (outside any repo), so rev-parse can't
+    // resolve a spurious ancestor `.git`.
+    if git_cmd(wt_path, &["rev-parse", "--git-dir"]).is_err() {
+        return WipPreservation::Clean;
+    }
+    if !worktree_has_preservable_wip(wt_path) {
+        return WipPreservation::Clean; // clean / marker-only → zero behaviour change
+    }
     // Stage tracked modifications + deletions + untracked (respects .gitignore,
-    // matching has_uncommitted_changes) into the worktree's private index.
+    // matching has_uncommitted_changes) into the worktree's private index. On
+    // failure we KNOW there is WIP (checked above) but cannot snapshot it → Blocked
+    // (fail-closed) rather than the old silent `None`.
     if let Err(e) = git_cmd(wt_path, &["add", "-A"]) {
         tracing::warn!(agent, branch, error = %e,
-            "preserve dirty WIP: `add -A` failed — WIP NOT preserved");
-        return None;
+            "preserve dirty WIP: `add -A` failed — refusing to remove (fail-closed)");
+        return WipPreservation::Blocked(format!("`git add -A` failed: {e}"));
     }
     let tree = match git_cmd(wt_path, &["write-tree"]) {
         Ok(t) if !t.is_empty() => t,
@@ -542,9 +590,9 @@ pub(crate) fn preserve_dirty_worktree(
                 agent,
                 branch,
                 ?other,
-                "preserve dirty WIP: `write-tree` failed — WIP NOT preserved"
+                "preserve dirty WIP: `write-tree` failed — refusing to remove (fail-closed)"
             );
-            return None;
+            return WipPreservation::Blocked(format!("`git write-tree` failed: {other:?}"));
         }
     };
     // commit-tree needs a committer identity; supply one via `-c` so the daemon
@@ -571,23 +619,23 @@ pub(crate) fn preserve_dirty_worktree(
                 agent,
                 branch,
                 ?other,
-                "preserve dirty WIP: `commit-tree` failed — WIP NOT preserved"
+                "preserve dirty WIP: `commit-tree` failed — refusing to remove (fail-closed)"
             );
-            return None;
+            return WipPreservation::Blocked(format!("`git commit-tree` failed: {other:?}"));
         }
     };
     let ts = chrono::Utc::now().format("%Y%m%dT%H%M%SZ").to_string();
     let ref_name = format!("{RECOVERY_REF_PREFIX}/{branch}/{ts}");
     if let Err(e) = git_cmd(wt_path, &["update-ref", &ref_name, &commit]) {
         tracing::warn!(agent, branch, error = %e,
-            "preserve dirty WIP: `update-ref` failed — WIP NOT preserved");
-        return None;
+            "preserve dirty WIP: `update-ref` failed — refusing to remove (fail-closed)");
+        return WipPreservation::Blocked(format!("`git update-ref {ref_name}` failed: {e}"));
     }
     tracing::info!(agent, branch, %ref_name,
         "preserve dirty WIP: uncommitted worktree changes snapshotted before manual release");
     prune_recovery_refs(wt_path, branch);
     notify_wip_preserved(home, agent, branch, &ref_name);
-    Some(ref_name)
+    WipPreservation::Preserved
 }
 
 /// Bound the recovery-ref set for `branch`: keep at most
@@ -970,6 +1018,14 @@ mod tests {
         .collect()
     }
 
+    fn pres_kind(p: &WipPreservation) -> &'static str {
+        match p {
+            WipPreservation::Clean => "Clean",
+            WipPreservation::Preserved => "Preserved",
+            WipPreservation::Blocked(_) => "Blocked",
+        }
+    }
+
     #[test]
     fn preserve_dirty_worktree_captures_untracked_wip() {
         let home = tmp_home("preserve-untracked");
@@ -978,13 +1034,16 @@ mod tests {
         // Untracked WIP — the loss-prone case (`clean -fd` would delete it).
         std::fs::write(info.path.join("scratch-wip.txt"), b"unsaved work").unwrap();
 
-        let ref_name = preserve_dirty_worktree(&home, "agent1", &info.path, &info.branch)
-            .expect("dirty worktree must yield a recovery ref");
+        let outcome = preserve_dirty_worktree(&home, "agent1", &info.path, &info.branch);
         assert!(
-            ref_name.starts_with("refs/agend/recovery/"),
-            "ref in recovery namespace: {ref_name}"
+            matches!(outcome, WipPreservation::Preserved),
+            "dirty worktree must be Preserved, got {}",
+            pres_kind(&outcome)
         );
-        let tree = git_out(&repo, &["ls-tree", "-r", "--name-only", &ref_name]);
+        // Verify the ref via git (authoritative — the ref name is not returned).
+        let refs = recovery_ref_names(&repo, &info.branch);
+        assert_eq!(refs.len(), 1, "exactly one recovery ref: {refs:?}");
+        let tree = git_out(&repo, &["ls-tree", "-r", "--name-only", &refs[0]]);
         assert!(
             tree.contains("scratch-wip.txt"),
             "untracked WIP captured in recovery ref tree: {tree}"
@@ -999,15 +1058,60 @@ mod tests {
         let repo = tmp_repo("preserve-clean");
         let info = create(&home, &repo, "agent1", None).expect("worktree created");
         // No real WIP (a freshly-created worktree carries at most the daemon
-        // marker, which is not preservable) → helper must no-op.
+        // marker, which is not preservable) → helper must report Clean.
         assert!(
-            preserve_dirty_worktree(&home, "agent1", &info.path, &info.branch).is_none(),
-            "clean worktree must not create a recovery ref"
+            matches!(
+                preserve_dirty_worktree(&home, "agent1", &info.path, &info.branch),
+                WipPreservation::Clean
+            ),
+            "clean worktree must be Clean (no recovery ref)"
         );
         assert!(
             recovery_ref_names(&repo, &info.branch).is_empty(),
             "no recovery ref for a clean release"
         );
+        std::fs::remove_dir_all(&home).ok();
+        std::fs::remove_dir_all(&repo).ok();
+    }
+
+    /// The linked worktree's private index lives at `<gitdir>/index` (gitdir read
+    /// from the `.git` gitlink file). Planting `<gitdir>/index.lock` makes any
+    /// index write (`git add -A`) fail — reviewer4's #2672 counterexample for a
+    /// contended index.
+    fn plant_index_lock(wt_path: &Path) -> PathBuf {
+        let gitlink = std::fs::read_to_string(wt_path.join(".git")).expect("read .git gitlink");
+        let gitdir = gitlink
+            .strip_prefix("gitdir:")
+            .expect("gitlink form")
+            .trim();
+        let lock = Path::new(gitdir).join("index.lock");
+        std::fs::write(&lock, b"").expect("plant index.lock");
+        lock
+    }
+
+    #[test]
+    fn preserve_dirty_worktree_blocks_when_index_locked() {
+        // reviewer4 #2672 fail-OPEN counterexample: dirty untracked WIP + a
+        // contended index (index.lock) → `git add -A` fails. The old code returned
+        // a silently-ignored `None` and the caller removed the worktree, evaporating
+        // the WIP. It must now be Blocked (fail-closed) with NO recovery ref.
+        let home = tmp_home("preserve-blocked");
+        let repo = tmp_repo("preserve-blocked");
+        let info = create(&home, &repo, "agent1", None).expect("worktree created");
+        std::fs::write(info.path.join("precious-wip.txt"), b"must not vanish").unwrap();
+        let lock = plant_index_lock(&info.path);
+
+        let outcome = preserve_dirty_worktree(&home, "agent1", &info.path, &info.branch);
+        assert!(
+            outcome.blocked_reason().is_some(),
+            "unpreservable WIP must be Blocked (fail-closed), got {}",
+            pres_kind(&outcome)
+        );
+        assert!(
+            recovery_ref_names(&repo, &info.branch).is_empty(),
+            "Blocked must not leave a (partial) recovery ref"
+        );
+        std::fs::remove_file(&lock).ok();
         std::fs::remove_dir_all(&home).ok();
         std::fs::remove_dir_all(&repo).ok();
     }
@@ -1026,22 +1130,25 @@ mod tests {
     fn prune_recovery_refs_enforces_per_branch_cap() {
         let repo = tmp_repo("prune-cap");
         let branch = "feat/prune-cap";
-        // 5 recent refs (all within TTL) → cap keeps the 3 newest.
-        for d in [1, 2, 3, 4, 5] {
-            seed_recovery_ref(&repo, branch, d);
-        }
+        // 5 recent refs (all within TTL); each day is a distinct date so no ts
+        // collision. names[0] = day-1 (newest) … names[4] = day-5 (oldest). Capture
+        // the returned names and assert on THEM (never recompute ts from `now()` —
+        // seed vs assert straddling a second boundary would spuriously mismatch).
+        let names: Vec<String> = [1, 2, 3, 4, 5]
+            .iter()
+            .map(|&d| seed_recovery_ref(&repo, branch, d))
+            .collect();
         assert_eq!(recovery_ref_names(&repo, branch).len(), 5, "seeded 5");
         prune_recovery_refs(&repo, branch);
         let survivors = recovery_ref_names(&repo, branch);
         assert_eq!(survivors.len(), 3, "cap=3 enforced: {survivors:?}");
-        // Survivors are the 3 NEWEST (days_ago 1,2,3).
-        for d in [1, 2, 3] {
-            let ts = (chrono::Utc::now() - chrono::Duration::days(d))
-                .format("%Y%m%dT%H%M%SZ")
-                .to_string();
+        for keep in &names[0..3] {
+            assert!(survivors.contains(keep), "newest ref must survive: {keep}");
+        }
+        for gone in &names[3..5] {
             assert!(
-                survivors.iter().any(|r| r.ends_with(&ts)),
-                "newest ref ({d}d) must survive: {survivors:?}"
+                !survivors.contains(gone),
+                "over-cap ref must be pruned: {gone}"
             );
         }
         std::fs::remove_dir_all(&repo).ok();

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -464,6 +464,209 @@ pub fn has_uncommitted_changes(worktree_dir: &Path) -> bool {
         .unwrap_or(true)
 }
 
+// ── #2158-adjacent: dirty-WIP preservation on MANUAL worktree release ──────
+//
+// The daemon's AUTO-release already refuses to remove a dirty worktree
+// (auto_release.rs SkipDirtyWorktree). The two MANUAL release paths —
+// `worktree_pool::release_full` (release_worktree force:false) and
+// `mcp::handlers::force_release::rebase_clean_self` (force:true) — removed a
+// dirty worktree UNCONDITIONALLY, silently losing uncommitted WIP. Before that
+// destructive removal we snapshot the WIP into a durable git ref that outlives
+// the worktree dir, and notify the operator with a one-line recovery command.
+// A clean worktree is a no-op → zero behaviour change.
+
+/// Namespace for WIP-recovery refs. Each ref is
+/// `refs/agend/recovery/<branch>/<UTC YYYYMMDDTHHMMSSZ>` and points at a commit
+/// whose tree is the full dirty-worktree snapshot (tracked + untracked).
+pub(crate) const RECOVERY_REF_PREFIX: &str = "refs/agend/recovery";
+
+/// Recovery-ref retention (lead-vetted 2026-07-07: 14-day TTL + at most 3 per
+/// branch). Enforced at creation time against the branch's own refs — see
+/// [`prune_recovery_refs`].
+const RECOVERY_TTL_DAYS: i64 = 14;
+const RECOVERY_MAX_PER_BRANCH: usize = 3;
+
+/// Is there WIP in this worktree worth preserving? Any `git status --porcelain`
+/// entry that is NOT the daemon's own `.agend-managed` marker counts (porcelain
+/// without `--ignored` already excludes gitignored build artifacts). This
+/// deliberately differs from [`has_uncommitted_changes`]: a freshly-leased
+/// worktree ALWAYS carries the untracked marker, which must NOT trigger a
+/// recovery snapshot on an otherwise-clean release (mirrors the marker-exempt
+/// rule in `retention::worktrees::maybe_remove_candidate`). Fail-closed
+/// (`Err => true`): a status failure attempts preservation rather than risk
+/// dropping WIP — a broken git then fails the snapshot gracefully (`None`).
+fn worktree_has_preservable_wip(wt_path: &Path) -> bool {
+    match crate::git_helpers::git_cmd(wt_path, &["status", "--porcelain"]) {
+        Ok(s) => s.lines().any(|line| {
+            let path = line.get(3..).map(str::trim).unwrap_or("");
+            !path.is_empty() && path != crate::worktree_pool::MANAGED_MARKER
+        }),
+        Err(_) => true,
+    }
+}
+
+/// Snapshot a dirty worktree's uncommitted WIP into a durable recovery ref
+/// BEFORE a manual release removes the worktree dir. Returns the recovery ref
+/// name if WIP was preserved, or `None` for a clean worktree (no-op) or on any
+/// capture failure (best-effort — preservation must NEVER block the release).
+///
+/// Mechanism (race-free, untracked-complete, bypass-only — no raw subprocess):
+/// stage everything incl. untracked into the worktree's OWN (per-worktree,
+/// isolated) index, snapshot a tree, and anchor a commit to a ref in the SHARED
+/// object/ref store — which survives the worktree-dir removal. Unlike
+/// `git stash create` this captures untracked files; unlike `git stash push` it
+/// never touches the shared `refs/stash` stack, so two concurrent dirty releases
+/// can't cross-contaminate. Dirtying the doomed worktree's private index is
+/// harmless — it is removed next.
+pub(crate) fn preserve_dirty_worktree(
+    home: &Path,
+    agent: &str,
+    wt_path: &Path,
+    branch: &str,
+) -> Option<String> {
+    if branch.is_empty() || !worktree_has_preservable_wip(wt_path) {
+        return None; // clean (or unknown branch) → zero behaviour change
+    }
+    use crate::git_helpers::git_cmd;
+    // Stage tracked modifications + deletions + untracked (respects .gitignore,
+    // matching has_uncommitted_changes) into the worktree's private index.
+    if let Err(e) = git_cmd(wt_path, &["add", "-A"]) {
+        tracing::warn!(agent, branch, error = %e,
+            "preserve dirty WIP: `add -A` failed — WIP NOT preserved");
+        return None;
+    }
+    let tree = match git_cmd(wt_path, &["write-tree"]) {
+        Ok(t) if !t.is_empty() => t,
+        other => {
+            tracing::warn!(
+                agent,
+                branch,
+                ?other,
+                "preserve dirty WIP: `write-tree` failed — WIP NOT preserved"
+            );
+            return None;
+        }
+    };
+    // commit-tree needs a committer identity; supply one via `-c` so the daemon
+    // never depends on ambient user.name/email. Parent = HEAD (the branch tip).
+    let msg = format!("agend recovery: dirty WIP for {branch} preserved on release");
+    let commit = match git_cmd(
+        wt_path,
+        &[
+            "-c",
+            "user.name=agend-recovery",
+            "-c",
+            "user.email=recovery@agend.local",
+            "commit-tree",
+            &tree,
+            "-p",
+            "HEAD",
+            "-m",
+            &msg,
+        ],
+    ) {
+        Ok(c) if !c.is_empty() => c,
+        other => {
+            tracing::warn!(
+                agent,
+                branch,
+                ?other,
+                "preserve dirty WIP: `commit-tree` failed — WIP NOT preserved"
+            );
+            return None;
+        }
+    };
+    let ts = chrono::Utc::now().format("%Y%m%dT%H%M%SZ").to_string();
+    let ref_name = format!("{RECOVERY_REF_PREFIX}/{branch}/{ts}");
+    if let Err(e) = git_cmd(wt_path, &["update-ref", &ref_name, &commit]) {
+        tracing::warn!(agent, branch, error = %e,
+            "preserve dirty WIP: `update-ref` failed — WIP NOT preserved");
+        return None;
+    }
+    tracing::info!(agent, branch, %ref_name,
+        "preserve dirty WIP: uncommitted worktree changes snapshotted before manual release");
+    prune_recovery_refs(wt_path, branch);
+    notify_wip_preserved(home, agent, branch, &ref_name);
+    Some(ref_name)
+}
+
+/// Bound the recovery-ref set for `branch`: keep at most
+/// [`RECOVERY_MAX_PER_BRANCH`] newest and drop any older than
+/// [`RECOVERY_TTL_DAYS`]. Enforced at CREATION time against THIS branch's own
+/// refs, in the repo the worktree shares — deliberately NOT a periodic
+/// retention-tick sweep: recovery refs live in the canonical repo's ref store,
+/// which `retention::worktrees` (a `.trash`-directory mtime GC) does not
+/// enumerate, and per-branch growth is already bounded to the cap.
+///
+/// Known gap (accepted, lead-vetted 2026-07-07): a branch dirty-released exactly
+/// once keeps its single ref indefinitely — the 14d TTL only re-fires on that
+/// branch's NEXT dirty release. The footprint is ≤ cap tiny refs per such branch
+/// (each a single small commit object), so this is negligible. If orphan
+/// recovery refs ever accumulate in practice, escalate to a periodic
+/// repo-registry sweep (enumerate managed repos → prune `refs/agend/recovery/*`
+/// by TTL) rather than widening this per-branch creation-time prune.
+///
+/// Best-effort: a prune failure is logged, never fatal.
+pub(crate) fn prune_recovery_refs(git_dir: &Path, branch: &str) {
+    let pattern = format!("{RECOVERY_REF_PREFIX}/{branch}/");
+    // Timestamp names sort lexically == chronologically → `-refname` == newest-first.
+    let listing = match crate::git_helpers::git_cmd(
+        git_dir,
+        &[
+            "for-each-ref",
+            "--sort=-refname",
+            "--format=%(refname)",
+            &pattern,
+        ],
+    ) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(branch, error = %e, "prune recovery refs: for-each-ref failed");
+            return;
+        }
+    };
+    let refs: Vec<&str> = listing.lines().filter(|l| !l.is_empty()).collect();
+    let cutoff = chrono::Utc::now() - chrono::Duration::days(RECOVERY_TTL_DAYS);
+    for (idx, ref_name) in refs.iter().enumerate() {
+        let over_cap = idx >= RECOVERY_MAX_PER_BRANCH;
+        if over_cap || recovery_ref_expired(ref_name, cutoff) {
+            if let Err(e) = crate::git_helpers::git_cmd(git_dir, &["update-ref", "-d", ref_name]) {
+                tracing::warn!(%ref_name, error = %e, "prune recovery refs: delete failed");
+            }
+        }
+    }
+}
+
+/// Parse the trailing `YYYYMMDDTHHMMSSZ` segment of a recovery ref and report
+/// whether it predates `cutoff`. An unparseable name is treated as NOT expired
+/// (fail-safe — never delete WIP we can't date; the per-branch cap still bounds
+/// growth).
+fn recovery_ref_expired(ref_name: &str, cutoff: chrono::DateTime<chrono::Utc>) -> bool {
+    let Some(ts) = ref_name.rsplit('/').next() else {
+        return false;
+    };
+    match chrono::NaiveDateTime::parse_from_str(ts, "%Y%m%dT%H%M%SZ") {
+        Ok(naive) => naive.and_utc() < cutoff,
+        Err(_) => false,
+    }
+}
+
+/// Notify the operator-mapped agent (`general`, per convention — mirrors
+/// canonical_hygiene's auto-stash notify) that a dirty worktree's WIP was
+/// preserved, with a one-line recovery command. Best-effort.
+fn notify_wip_preserved(home: &Path, agent: &str, branch: &str, ref_name: &str) {
+    let text = format!(
+        "[system:release_dirty_wip_preserved] Agent `{agent}` released a DIRTY worktree \
+         for branch `{branch}`; its uncommitted WIP (tracked + untracked) was snapshotted \
+         to recovery ref:\n  {ref_name}\nRecover it from the canonical repo with:\n  \
+         git worktree add ../wip-recover {ref_name}\n(or inspect: git log -p {ref_name}). \
+         Auto-pruned after {RECOVERY_TTL_DAYS}d / max {RECOVERY_MAX_PER_BRANCH} per branch. \
+         #2158-adjacent."
+    );
+    let source = crate::inbox::NotifySource::System("release_dirty_wip_preserved");
+    crate::inbox::notify_agent(home, "general", &source, &text);
+}
+
 /// #2234 Phase 2: resolve the worktree dir to remove for `(agent, branch)`,
 /// binding-driven so cure-(B) `workspace/<agent>` worktrees are removable.
 ///
@@ -747,6 +950,135 @@ mod tests {
 
         std::fs::remove_dir_all(&home).ok();
         std::fs::remove_dir_all(&repo).ok();
+    }
+
+    // ── #2158-adjacent: dirty-WIP preservation helpers ──────────────────
+    // (reuses the module's existing `git_out`/`git_run` bypass helpers below)
+
+    fn recovery_ref_names(repo: &Path, branch: &str) -> Vec<String> {
+        git_out(
+            repo,
+            &[
+                "for-each-ref",
+                "--format=%(refname)",
+                &format!("refs/agend/recovery/{branch}/"),
+            ],
+        )
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(str::to_string)
+        .collect()
+    }
+
+    #[test]
+    fn preserve_dirty_worktree_captures_untracked_wip() {
+        let home = tmp_home("preserve-untracked");
+        let repo = tmp_repo("preserve-untracked");
+        let info = create(&home, &repo, "agent1", None).expect("worktree created");
+        // Untracked WIP — the loss-prone case (`clean -fd` would delete it).
+        std::fs::write(info.path.join("scratch-wip.txt"), b"unsaved work").unwrap();
+
+        let ref_name = preserve_dirty_worktree(&home, "agent1", &info.path, &info.branch)
+            .expect("dirty worktree must yield a recovery ref");
+        assert!(
+            ref_name.starts_with("refs/agend/recovery/"),
+            "ref in recovery namespace: {ref_name}"
+        );
+        let tree = git_out(&repo, &["ls-tree", "-r", "--name-only", &ref_name]);
+        assert!(
+            tree.contains("scratch-wip.txt"),
+            "untracked WIP captured in recovery ref tree: {tree}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+        std::fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn preserve_dirty_worktree_clean_is_noop() {
+        let home = tmp_home("preserve-clean");
+        let repo = tmp_repo("preserve-clean");
+        let info = create(&home, &repo, "agent1", None).expect("worktree created");
+        // No real WIP (a freshly-created worktree carries at most the daemon
+        // marker, which is not preservable) → helper must no-op.
+        assert!(
+            preserve_dirty_worktree(&home, "agent1", &info.path, &info.branch).is_none(),
+            "clean worktree must not create a recovery ref"
+        );
+        assert!(
+            recovery_ref_names(&repo, &info.branch).is_empty(),
+            "no recovery ref for a clean release"
+        );
+        std::fs::remove_dir_all(&home).ok();
+        std::fs::remove_dir_all(&repo).ok();
+    }
+
+    /// Seed a recovery ref dated `days_ago` (distinct days → distinct names).
+    fn seed_recovery_ref(repo: &Path, branch: &str, days_ago: i64) -> String {
+        let ts = (chrono::Utc::now() - chrono::Duration::days(days_ago))
+            .format("%Y%m%dT%H%M%SZ")
+            .to_string();
+        let name = format!("refs/agend/recovery/{branch}/{ts}");
+        git_run(repo, &["update-ref", &name, "HEAD"]);
+        name
+    }
+
+    #[test]
+    fn prune_recovery_refs_enforces_per_branch_cap() {
+        let repo = tmp_repo("prune-cap");
+        let branch = "feat/prune-cap";
+        // 5 recent refs (all within TTL) → cap keeps the 3 newest.
+        for d in [1, 2, 3, 4, 5] {
+            seed_recovery_ref(&repo, branch, d);
+        }
+        assert_eq!(recovery_ref_names(&repo, branch).len(), 5, "seeded 5");
+        prune_recovery_refs(&repo, branch);
+        let survivors = recovery_ref_names(&repo, branch);
+        assert_eq!(survivors.len(), 3, "cap=3 enforced: {survivors:?}");
+        // Survivors are the 3 NEWEST (days_ago 1,2,3).
+        for d in [1, 2, 3] {
+            let ts = (chrono::Utc::now() - chrono::Duration::days(d))
+                .format("%Y%m%dT%H%M%SZ")
+                .to_string();
+            assert!(
+                survivors.iter().any(|r| r.ends_with(&ts)),
+                "newest ref ({d}d) must survive: {survivors:?}"
+            );
+        }
+        std::fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn prune_recovery_refs_ttl_deletes_expired_within_cap() {
+        let repo = tmp_repo("prune-ttl");
+        let branch = "feat/prune-ttl";
+        let recent = seed_recovery_ref(&repo, branch, 1);
+        let _expired = seed_recovery_ref(&repo, branch, 15); // > 14d TTL
+        prune_recovery_refs(&repo, branch);
+        let survivors = recovery_ref_names(&repo, branch);
+        assert_eq!(
+            survivors,
+            vec![recent],
+            "expired (>14d) ref pruned even under the per-branch cap: {survivors:?}"
+        );
+        std::fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn recovery_ref_expired_parses_timestamp() {
+        let cutoff = chrono::Utc::now() - chrono::Duration::days(RECOVERY_TTL_DAYS);
+        assert!(
+            recovery_ref_expired("refs/agend/recovery/b/20200101T000000Z", cutoff),
+            "a year-2020 ref is well past the 14d cutoff"
+        );
+        let now_ts = chrono::Utc::now().format("%Y%m%dT%H%M%SZ").to_string();
+        assert!(
+            !recovery_ref_expired(&format!("refs/agend/recovery/b/{now_ts}"), cutoff),
+            "a just-created ref is not expired"
+        );
+        assert!(
+            !recovery_ref_expired("refs/agend/recovery/b/not-a-timestamp", cutoff),
+            "unparseable name is fail-safe (NOT expired)"
+        );
     }
 
     #[test]

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -471,6 +471,17 @@ pub fn release_full(home: &Path, agent: &str, dry_run: bool) -> ReleaseOutcome {
                 managed_verified = true;
             }
         } else {
+            // #2158-adjacent: a MANUAL release must not silently drop
+            // uncommitted WIP. Snapshot it to a durable recovery ref BEFORE the
+            // destructive remove (a clean worktree is a no-op → zero behaviour
+            // change). `is_daemon_managed` is false for an absent OR unmanaged
+            // path, so this fires only for the managed-worktree case
+            // `remove_worktree` would actually delete — the workspace-teardown
+            // callers of `remove_worktree` are intentionally left untouched.
+            if is_daemon_managed(wt_path) {
+                let branch = binding["branch"].as_str().unwrap_or("");
+                crate::worktree::preserve_dirty_worktree(home, agent, wt_path, branch);
+            }
             match remove_worktree(agent, wt_path, &source_repo) {
                 WorktreeRemoval::Removed => {
                     managed_verified = true;

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -480,7 +480,22 @@ pub fn release_full(home: &Path, agent: &str, dry_run: bool) -> ReleaseOutcome {
             // callers of `remove_worktree` are intentionally left untouched.
             if is_daemon_managed(wt_path) {
                 let branch = binding["branch"].as_str().unwrap_or("");
-                crate::worktree::preserve_dirty_worktree(home, agent, wt_path, branch);
+                let preservation =
+                    crate::worktree::preserve_dirty_worktree(home, agent, wt_path, branch);
+                if let Some(reason) = preservation.blocked_reason() {
+                    // reviewer4 #2672 fix — FAIL-CLOSED: there IS uncommitted WIP
+                    // but it could not be snapshotted (e.g. a contended
+                    // `index.lock`). Refuse to remove the worktree AND keep the
+                    // binding so the operator can recover the WIP in place. Report
+                    // `released:false` + the reason; the branch cleanup + binding
+                    // clear below are intentionally skipped.
+                    out.error = Some(format!(
+                        "release refused: worktree has uncommitted WIP that could not be \
+                         preserved ({reason}); not removing it so the WIP can be recovered. \
+                         Commit or stash the changes, then release again."
+                    ));
+                    return out;
+                }
             }
             match remove_worktree(agent, wt_path, &source_repo) {
                 WorktreeRemoval::Removed => {

--- a/src/worktree_pool/tests.rs
+++ b/src/worktree_pool/tests.rs
@@ -3630,3 +3630,64 @@ fn release_full_clean_worktree_creates_no_recovery_ref() {
     std::fs::remove_dir_all(&home).ok();
     std::fs::remove_dir_all(&repo).ok();
 }
+
+/// Plant `<gitdir>/index.lock` (gitdir read from the worktree's `.git` gitlink)
+/// so any index write (`git add -A`) fails — reviewer4's #2672 contended-index
+/// counterexample.
+fn plant_index_lock(wt_path: &Path) -> PathBuf {
+    let gitlink = std::fs::read_to_string(wt_path.join(".git")).expect("read .git gitlink");
+    let gitdir = gitlink
+        .strip_prefix("gitdir:")
+        .expect("gitlink form")
+        .trim();
+    let lock = Path::new(gitdir).join("index.lock");
+    std::fs::write(&lock, b"").expect("plant index.lock");
+    lock
+}
+
+/// reviewer4 #2672 (fail-OPEN regression): a dirty worktree whose WIP cannot be
+/// snapshotted (contended `index.lock` → `git add -A` fails) must be FAIL-CLOSED —
+/// `release_full` refuses to remove it (WIP recoverable in place), NOT a silent
+/// `released:true` + evaporated WIP.
+#[test]
+fn release_full_refuses_when_dirty_wip_unpreservable() {
+    let home = tmp_home("release-blocked");
+    let repo = tmp_repo("release-blocked-repo");
+    let l = lease_bound(&home, &repo, "agent-blk", "feat/blk");
+    // Real preservable WIP (untracked), then jam the index so preservation fails.
+    std::fs::write(l.path.join("precious-wip.txt"), b"must not vanish").unwrap();
+    let _lock = plant_index_lock(&l.path);
+
+    let outcome = release_full(&home, "agent-blk", false);
+    assert!(
+        !outcome.released,
+        "must NOT report released on unpreservable WIP"
+    );
+    assert!(
+        outcome
+            .error
+            .as_deref()
+            .unwrap_or("")
+            .contains("could not be preserved"),
+        "error must name the refusal: {:?}",
+        outcome.error
+    );
+    assert!(
+        l.path.exists(),
+        "worktree must NOT be removed (fail-closed)"
+    );
+    assert!(
+        l.path.join("precious-wip.txt").exists(),
+        "untracked WIP must survive in place"
+    );
+    assert!(
+        crate::binding::read(&home, "agent-blk").is_some(),
+        "binding must be kept so the operator can recover in place"
+    );
+    assert!(
+        recovery_refs(&repo, "feat/blk").is_empty(),
+        "no (partial) recovery ref on a Blocked release"
+    );
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&repo).ok();
+}

--- a/src/worktree_pool/tests.rs
+++ b/src/worktree_pool/tests.rs
@@ -3492,3 +3492,141 @@ fn reconcile_orphan_leases_tolerates_missing_worktree_field_2550_w3() {
     );
     std::fs::remove_dir_all(&home).ok();
 }
+
+// ── #2158-adjacent: dirty-release WIP preservation ──────────────────────
+//
+// The daemon's AUTO-release already refuses to remove a dirty worktree
+// (auto_release.rs SkipDirtyWorktree). But MANUAL release (`release_full`,
+// backing `release_worktree`) removed a dirty worktree unconditionally,
+// silently losing uncommitted WIP. RED-first: on pre-guard code
+// `release_full_preserves_dirty_wip_to_recovery_ref` FAILS (no recovery ref).
+// With the guard the WIP is snapshotted to `refs/agend/recovery/<branch>/<ts>`.
+
+/// Recovery refs for `branch` (raw git — cfg(test) fixture; exempt from the
+/// git-subprocess invariants which scan production `src/` portions only).
+fn recovery_refs(repo: &Path, branch: &str) -> Vec<String> {
+    let out = std::process::Command::new("git")
+        .args([
+            "for-each-ref",
+            "--format=%(refname)",
+            &format!("refs/agend/recovery/{branch}/"),
+        ])
+        .current_dir(repo)
+        .env("AGEND_GIT_BYPASS", "1")
+        .output()
+        .expect("git for-each-ref");
+    String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+fn ls_tree_names(repo: &Path, git_ref: &str) -> String {
+    let out = std::process::Command::new("git")
+        .args(["ls-tree", "-r", "--name-only", git_ref])
+        .current_dir(repo)
+        .env("AGEND_GIT_BYPASS", "1")
+        .output()
+        .expect("git ls-tree");
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+fn git_in(wt: &Path, args: &[&str]) {
+    let out = std::process::Command::new("git")
+        .args(args)
+        .current_dir(wt)
+        .env("AGEND_GIT_BYPASS", "1")
+        .output()
+        .expect("git");
+    assert!(
+        out.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn release_full_preserves_dirty_wip_to_recovery_ref() {
+    let home = tmp_home("release-dirty-preserve");
+    let repo = tmp_repo("release-dirty-preserve-repo");
+    let l = lease_bound(&home, &repo, "agent-dirty", "feat/dirty-wip");
+
+    // Seed a tracked file on the branch so we can dirty it with a modification.
+    std::fs::write(l.path.join("tracked.txt"), b"v1\n").unwrap();
+    git_in(&l.path, &["add", "tracked.txt"]);
+    git_in(
+        &l.path,
+        &[
+            "-c",
+            "user.name=t",
+            "-c",
+            "user.email=t@t",
+            "commit",
+            "-m",
+            "seed tracked",
+        ],
+    );
+    // Dirty: a tracked MODIFICATION + an UNTRACKED file (the loss-prone case).
+    std::fs::write(l.path.join("tracked.txt"), b"v1\nMODIFIED-wip\n").unwrap();
+    std::fs::write(l.path.join("untracked-wip.txt"), b"precious untracked").unwrap();
+    assert!(
+        crate::worktree::has_uncommitted_changes(&l.path),
+        "precondition: worktree dirty"
+    );
+
+    let outcome = release_full(&home, "agent-dirty", false);
+    assert!(outcome.released, "release must succeed: {outcome:?}");
+    assert!(!l.path.exists(), "dirty worktree removed on release");
+
+    // WIP must survive in exactly one recovery ref (RED on pre-guard code).
+    let refs = recovery_refs(&repo, "feat/dirty-wip");
+    assert_eq!(
+        refs.len(),
+        1,
+        "exactly one recovery ref after dirty release: {refs:?}"
+    );
+    let files = ls_tree_names(&repo, &refs[0]);
+    assert!(
+        files.contains("untracked-wip.txt"),
+        "untracked WIP captured in recovery ref tree: {files}"
+    );
+    assert!(
+        files.contains("tracked.txt"),
+        "tracked file captured in recovery ref tree: {files}"
+    );
+    let show = std::process::Command::new("git")
+        .args(["show", &format!("{}:tracked.txt", refs[0])])
+        .current_dir(&repo)
+        .env("AGEND_GIT_BYPASS", "1")
+        .output()
+        .expect("git show");
+    assert!(
+        String::from_utf8_lossy(&show.stdout).contains("MODIFIED-wip"),
+        "tracked modification content is recoverable from the ref"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&repo).ok();
+}
+
+#[test]
+fn release_full_clean_worktree_creates_no_recovery_ref() {
+    let home = tmp_home("release-clean-noref");
+    let repo = tmp_repo("release-clean-noref-repo");
+    let l = lease_bound(&home, &repo, "agent-clean", "feat/clean-rel");
+    // A freshly-leased worktree carries only the untracked `.agend-managed`
+    // marker (which `has_uncommitted_changes` reports as dirty but is NOT
+    // preservable WIP) — releasing it must still create no recovery ref.
+    let outcome = release_full(&home, "agent-clean", false);
+    assert!(
+        outcome.released && !l.path.exists(),
+        "clean release succeeds"
+    );
+    assert!(
+        recovery_refs(&repo, "feat/clean-rel").is_empty(),
+        "clean release must create NO recovery ref (zero behaviour change)"
+    );
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&repo).ok();
+}


### PR DESCRIPTION
## What & why

The daemon's **auto**-release already refuses to remove a dirty worktree (`auto_release` `SkipDirtyWorktree`). But the two **manual** release paths removed a dirty worktree **unconditionally**, silently losing uncommitted WIP:

- `worktree_pool::release_full` (backs `release_worktree` force:false) → `remove_worktree`
- `mcp::handlers::force_release::rebase_clean_self` (force:true) → `remove_dir_all`

This PR snapshots the dirty worktree's uncommitted WIP into a durable `refs/agend/recovery/<branch>/<UTC-ts>` ref **before** the destructive removal on both paths, and notifies the operator with a one-line recovery command. Closes the `#2158`-adjacent improper-release orphan-WIP gap (task `t-…62013-7`).

A **clean** release (or a worktree carrying only the untracked `.agend-managed` marker) is a **no-op → zero behaviour change**. Auto-release's dirty-skip path is untouched.

## Mechanism (`preserve_dirty_worktree`)

Stage everything incl. untracked into the worktree's **own** (per-worktree, isolated) index, snapshot a tree, anchor a commit to a ref in the **shared** object/ref store — which survives the worktree-dir removal:

```
git add -A → git write-tree → git commit-tree -p HEAD → git update-ref refs/agend/recovery/<branch>/<ts>
```

All via `git_helpers::git_cmd` (always `AGEND_GIT_BYPASS`, timeout-bounded — no raw `Command::new("git")`, passes the daemon-git-helper invariant). Best-effort throughout: any git failure logs a warn and returns `None` without ever blocking or panicking the release.

### Why not `git stash push --include-untracked` (empirically decided)

The vetted spike floated stash as one option. I verified the premise before choosing: **`refs/stash` is a SHARED per-repo ref across linked worktrees, not per-worktree.** Two coexisting worktrees each `git stash push`:

- `git stash list` from **both** worktrees **and** the canonical repo shows **both** stashes;
- `git rev-parse refs/stash` returns the **same** SHA in both worktrees;
- `.git/refs/stash` and `.git/logs/refs/stash` live in the **common** dir.

So two concurrent dirty releases doing `stash push` → `rev-parse refs/stash` can observe each other's stash and cross-contaminate. The per-worktree index has no such race (each worktree's index is private; each output ref name is unique), and unlike `git stash create` it captures untracked files. The doomed worktree's index is mutated only to build the snapshot — harmless, it's removed next.

## Recovery-ref GC (`prune_recovery_refs`)

**Max 3 per branch + 14-day TTL**, enforced at **creation time** against the branch's own refs (newest-first via `for-each-ref --sort=-refname`; delete over-cap or expired).

Deliberately **not** a periodic retention-tick sweep: recovery refs live in the canonical repo's ref store, which `retention::worktrees` (a `.trash`-directory mtime GC) does not enumerate, and per-branch growth is already bounded to the cap.

**Accepted gap** (lead-vetted): a branch dirty-released exactly once keeps its single ref until its *next* dirty release (the 14d TTL only re-fires then). Footprint ≤3 tiny commit objects per such branch = negligible. **Escalation path** if orphan recovery refs ever accumulate in practice: add a periodic repo-registry sweep (enumerate managed repos → prune `refs/agend/recovery/*` by TTL) rather than widening the per-branch creation-time prune. (Also recorded in the `prune_recovery_refs` doc-comment.)

## Recovery (operator)

The notify message names the ref and gives: `git worktree add ../wip-recover <ref>` (or inspect via `git log -p <ref>`).

## Tests (8 new, RED-first for the behavioural ones)

- `release_full_preserves_dirty_wip_to_recovery_ref` — dirty (tracked mod + untracked) → recovery ref captures both. **RED-verified on base** (0 refs before the fix).
- `release_full_clean_worktree_creates_no_recovery_ref` — marker-only worktree → no ref (zero behaviour change).
- `rebase_clean_self_preserves_dirty_wip_before_removal` — the force:true path.
- `preserve_dirty_worktree_captures_untracked_wip` / `…_clean_is_noop` — direct helper.
- `prune_recovery_refs_enforces_per_branch_cap` / `…_ttl_deletes_expired_within_cap` / `recovery_ref_expired_parses_timestamp` — GC.

## Gate

`cargo fmt --check` ✓ · `cargo clippy --workspace --all-targets -- -D warnings` ✓ · source-scan invariants (daemon-git-helper, git-subprocess, src/mcp file-size, anti-monolith) ✓ · full `cargo nextest run` = 5408 passed. The only 2 failures (`e2e_dispatch_review_workflow_seam_invariants_1900`, `teardown_leaves_zero_residual_after_full_exercise_1907`) are pre-existing local dispatch-infra failures — **verified identical on base with the change stashed** (both fail at a `binding.json`-missing precondition, unrelated to this change; they pass in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
