### PR TITLE
fix(#t-83936-5): bind_self re-provision must not orphan an existing origin/<branch> (data-loss)

### DIFF
--- a/BIND-SELF-STARTPOINT-SPIKE.md
+++ b/BIND-SELF-STARTPOINT-SPIKE.md
@@ -1,0 +1,112 @@
+# Spike: bind_self re-provision start-point data-loss (t-…83936-5)
+
+Spike-first (lead vet BEFORE impl — data-loss surface, DUAL). All file:line in
+`src/mcp/handlers/dispatch_hook/mod.rs` unless noted.
+
+## Root cause (confirmed at file:line)
+`ensure_branch_exists` (`mod.rs:693`) gates on the **LOCAL** ref only:
+`mod.rs:749` `git rev-parse --verify refs/heads/<branch>`.
+- **branch_exists = true** (`mod.rs:753-846`): fetches `origin/<branch>` and
+  `update-ref`s the local ref to it (`:778-793`) → correct tip. `from_ref` is
+  only used (ff-align) when `origin/<branch>` is ABSENT (`:794-844`).
+- **branch_exists = false** (`mod.rs:847-882`): "Step 2: create from `from_ref`"
+  → `git branch <branch> <from_ref>` (`:882`), `from_ref` hard-coded to
+  `"origin/main"` by the bind caller (`:487`). **This arm NEVER fetches or
+  consults `origin/<branch>`** (`:859-870` fetch only `from_ref`).
+
+So: **local `refs/heads/<branch>` absent + `origin/<branch>` exists → new local
+branch is based on origin/main; the branch's remote commits are orphaned the
+moment the agent commits.** The two arms are INCONSISTENT: EXISTS gives
+`origin/<branch>` precedence over `from_ref`; CREATE ignores `origin/<branch>`.
+
+## Why it's conditional (explains why my own binds were fine)
+The trigger is a MISSING local ref: fresh canonical clone / pruned-after-release
+re-bind (= canonical-incident recovery, dev2's case). When the local ref
+survives across dispatch cycles, the EXISTS path runs and picks the right tip.
+
+## Blast radius (ALL reach `mod.rs:487`→`ensure_branch_exists`)
+- `bind_self`: `worktree.rs:33`→`:111`→lease→`:487`.
+- dispatch auto-bind (`send kind=task`): `comms.rs:269`→lease→`:487`.
+- `repo checkout bind:true`: `ci/checkout.rs` → `ensure_branch_exists(from_ref)`.
+- `bind_self rebase_mode` recovery + release/re-claim: safe-repair then same lease.
+- NOT affected: reuse-live-worktree short-circuit (`mod.rs:483-488`, `reused` skips
+  ensure_branch_exists). → A single fix in ensure_branch_exists covers all.
+
+## Fix (mirror the EXISTS-path precedence in the CREATE path)
+Insert between the branch_exists block (`:846`) and "Step 2" (`:847`): when the
+LOCAL ref is absent, fetch `+refs/heads/<branch>:refs/remotes/origin/<branch>`
+(bounded, best-effort), and if `origin/<branch>` exists →
+`git branch <branch> refs/remotes/origin/<branch>` and return; else fall through
+to the existing from_ref create. Safe: there is NO local ref here, so nothing to
+clobber (no ff-check needed — unlike the EXISTS path). Centralized = fixes every
+entry point at once. `origin` is the working-branch push remote (#2047), correct
+regardless of a fork `from_ref`.
+
+## Return value (n_branch / auto_created)
+Purely observability (surfaced as `n_branch` in the response JSON via
+`ci/checkout.rs`; no destructive gate). For create-from-`origin/<branch>` return
+**(false, fetched)** = "pre-existing on the remote, materialized locally" —
+consistent with the EXISTS path's `(false, …)` and accurate (branch has history,
+is not brand-new).
+
+## Test plan (RED-first)
+Bare-remote fixture mirroring `tests.rs:108-131` (`git init --bare`, push):
+1. **RED regression**: origin/main @A; push `origin/<branch>` @B (B≠A, B not an
+   ancestor of A); ensure LOCAL `refs/heads/<branch>` ABSENT →
+   `ensure_branch_exists(branch, "origin/main")` → assert `refs/heads/<branch>` ==
+   **B** (origin/<branch>), NOT A. Fails RED on current code (lands on A).
+2. remote has NO `origin/<branch>` → still creates from from_ref (no regression).
+3. Full `dispatch_hook` suite green — esp. `..._refreshes_stale_origin_before_
+   create_1755` (`tests.rs:85`, its branch is not on origin → unaffected) and the
+   EXISTS-path `..._syncs_stale_local_to_origin` (`tests.rs:2655`).
+
+## Vet questions
+Q1. Return `n_branch=false` for create-from-origin (my rec, consistent+accurate) OK?
+Q2. Centralize in `ensure_branch_exists` (fixes all entry points) — confirm scope
+    vs bind_self-only. I rec centralized (all entries want the same safety).
+Q3. Extra bounded fetch of `origin/<branch>` only on the local-ref-absent
+    (provision/recovery) path — acceptable? (steady-state dispatch of an existing
+    local ref is untouched).
+
+## POST-VET IMPL FINDING (2026-07-07) — fail-closed blast radius + design fork
+Lead vetted GO with a fail-closed refinement (fetch-fail → Err). Implementing it
+(strict) surfaced two facts sent to lead as an A/B query (correlation t-…83936-5):
+
+1. **Blast radius (strict)**: ~25 of 66 dispatch_hook tests fail — all because
+   `setup_test_repo` (used 33×) configures a DELIBERATELY UNREACHABLE origin
+   (`file:///dev/null`) + staged `refs/remotes/origin/main`; strict `git fetch
+   origin` always fails there → every "create new branch" test hits the
+   fail-closed Err. Making the fixture reachable also flips ~5 `!fetch_attempted`
+   assertions. = core test-infra migration.
+2. **Premise partly invalid (verified in /tmp)**: `git clone` populates
+   `refs/remotes/origin/*` for ALL remote branches with NO extra fetch
+   (`rev-parse refs/remotes/origin/spike/xyz` → exit 0 on a fresh clone). Recovery
+   (fresh clone; prune-after-release removes only local `refs/heads`, never
+   `refs/remotes/origin/<branch>`) ⇒ the remote-tracking ref is ALREADY present.
+   So a **no-fetch check of `refs/remotes/origin/<branch>` catches dev2's case with
+   0 test breakage**; strict fetch+Err only adds cover for "stale clone + branch
+   pushed after last fetch + offline now", a non-incident edge, and blocks ALL
+   new-branch dispatch during any origin outage.
+
+**A/B to lead**:
+- A (strict, as vetted): fetch-fail→Err + migrate setup_test_repo reachable + fix
+  ~5 assertions + 3 bespoke. Most conservative, large diff, outage blocks all provision.
+- B (hybrid, RECOMMENDED): (1) refs/remotes/origin/<branch> present → create from it
+  (no fetch, 0 breakage); (2) absent → bounded best-effort fetch + recheck; (3) still
+  absent → create from from_ref if any refs/remotes/origin/* view exists, else Err.
+  Catches incident + online-stale, fixture-compatible, fail-closes only when totally
+  blind. Narrow uncovered edge: offline + stale-clone + branch pushed since last fetch.
+
+Current code = A (strict, uncommitted). Awaiting lead A/B before finalizing + tests.
+
+## RESOLUTION (2026-07-07) — lead chose B (hybrid); IMPLEMENTED
+Lead ruled B (evidence corrected the fetch premise). Implemented in
+ensure_branch_exists, extracted to `branch_start_point::create_new_branch` (the whole
+create path — Step 1.5 guard + #1755 from_ref create) to keep mod.rs under its 1575-LOC
+grandfathered ceiling (was 1574; pure move). 4 lead-required items done:
+(1) state-3 fail-open tradeoff + non-ff backstop commented at the code; (2) 4 state tests
+pin all states (state 1 RED-verified); (3) layer-1 lag-vs-EXISTS-arm asymmetry noted in
+the code comment (pre-fetch advances the view to tip when online); (4) "view non-empty"
+includes origin/HEAD, commented. B breaks 0 existing tests except 2 fixtures with no
+origin view (#2010 fork, p780 broken-origin) → each given a staged refs/remotes/origin/main
+(a real clone always has one). Full gate green.

--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -1728,6 +1728,26 @@ fn p780_setup_source_broken_origin(parent: &Path) -> std::path::PathBuf {
         .current_dir(&repo)
         .env(bypass.0, bypass.1)
         .output();
+    // #t-83936-5: a real checkout source is a clone, so it always has a
+    // refs/remotes/origin/* view. Stage one so the create-path data-loss guard —
+    // which fail-closes ONLY when there is no origin view at all — proceeds to the
+    // from_ref resolution this test pins, instead of refusing up front.
+    let head = std::process::Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(&repo)
+        .env(bypass.0, bypass.1)
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_default();
+    if !head.is_empty() {
+        let _ = std::process::Command::new("git")
+            .args(["update-ref", "refs/remotes/origin/main", &head])
+            .current_dir(&repo)
+            .env(bypass.0, bypass.1)
+            .output();
+    }
     repo
 }
 

--- a/src/mcp/handlers/dispatch_hook/branch_start_point.rs
+++ b/src/mcp/handlers/dispatch_hook/branch_start_point.rs
@@ -1,0 +1,318 @@
+//! #t-83936-5 — `ensure_branch_exists` create path (local `refs/heads/<branch>`
+//! absent → create it), extracted from `dispatch_hook/mod.rs` to keep that handler
+//! under its LOC ceiling (Sprint-26 file_size_invariant split pattern). The
+//! data-loss guard (prefer an existing `origin/<branch>` over `from_ref`) and its
+//! fail-closed state table live inline below, next to the code they govern.
+
+use super::{DispatchError, ErrorCode, Stage, DISPATCH_FETCH_TIMEOUT};
+use std::path::Path;
+
+/// Create the local `refs/heads/<branch>` when it does not yet exist. Prefers an
+/// existing `origin/<branch>` (the #t-83936-5 data-loss guard), fails CLOSED only
+/// when totally blind (no remote-tracking view AND origin unreachable), and
+/// otherwise creates from `from_ref` (the #1755 refresh-then-create path). Returns
+/// `(n_branch, fetch_attempted)`. `remote` / `from_ref_branch` are the base ref's
+/// resolved remote (`resolve_from_ref_remote`), computed once by the caller.
+pub(super) fn create_new_branch(
+    home: &Path,
+    source: &Path,
+    branch: &str,
+    from_ref: &str,
+    actor: &str,
+    remote: &str,
+    from_ref_branch: Option<&str>,
+) -> Result<(bool, bool), DispatchError> {
+    // Step 1.5 (#t-83936-5 data-loss, incident-followup — lead-vetted hybrid):
+    // the LOCAL ref is absent, but the branch may ALREADY EXIST on the remote — the
+    // fresh-canonical-clone / pruned-after-release re-bind scenario (exactly
+    // canonical-incident recovery, where dev2 lost commits before catching it with a
+    // diff-stat). The "Step 2: create from `from_ref`" arm below bases the new local
+    // branch on origin/main and would SILENTLY ORPHAN every commit already on
+    // origin/<branch> the moment the agent commits. Mirror the branch-EXISTS path's
+    // precedence (origin/<branch> wins over from_ref): if origin/<branch> exists,
+    // create the local branch FROM that remote tip so history is preserved. There is
+    // NO local ref here, so nothing to clobber — no ff-check (unlike the EXISTS
+    // path). `origin` is the working-branch push remote (#2047), correct regardless
+    // of a fork `from_ref`.
+    //
+    // The PRIMARY signal is the remote-tracking VIEW `refs/remotes/origin/<branch>`,
+    // not a live fetch: `git clone` populates refs/remotes/origin/* for ALL remote
+    // branches, and pruning a local `refs/heads/<branch>` never touches the
+    // remote-tracking ref — so in EVERY recovery scenario the view already knows the
+    // branch with NO network I/O. We still `git fetch origin` first (best-effort) to
+    // (a) advance the view to the current tip when online and (b) discover a branch
+    // pushed since our last fetch.
+    //
+    // FAIL-CLOSED, state-enumerated (#2662 lesson — lead-confirmed 4-state table):
+    //   1. view HAS origin/<branch>              → create from it (definitely exists).
+    //   2. view none, fetch OK, still none       → origin reachable & confirmed to
+    //                                               lack it ⇒ genuinely new ⇒ from_ref.
+    //   3. view none, fetch FAILED, view NON-EMPTY (we HAVE synced with origin before
+    //      — refs/remotes/origin/* incl. origin/HEAD is populated) → create from
+    //      from_ref. This is the ONE fail-OPEN state, DELIBERATELY accepted:
+    //        · its residual data-loss window needs THREE conditions stacked — offline
+    //          NOW + a stale (non-fresh) clone + the branch pushed to origin only
+    //          AFTER this repo's last fetch. The incident is a FRESH clone (view
+    //          complete → caught by state 1), so this edge is NOT the incident.
+    //        · it is NOT silent: a later push of the wrong-based branch to the
+    //          existing origin/<branch> is a non-fast-forward and is REJECTED — a
+    //          natural second line of defense + a loud signal.
+    //   4. view none, fetch FAILED, view EMPTY (never synced with origin at all)
+    //                                            → truly blind ⇒ REFUSE (Err).
+    // Asymmetry vs the EXISTS arm (state 1): that arm update-refs the local ref to the
+    // tip; here we base on the view SHA, which when OFFLINE may LAG origin's tip. Lag
+    // ≠ loss — the base is a real ancestor on the correct branch and the non-ff
+    // backstop covers the rest; when online the pre-fetch above advances the view to
+    // the tip anyway.
+    let work_tracking_ref = format!("refs/remotes/origin/{branch}");
+    let work_fetch_ok = crate::git_helpers::git_bypass_timeout(
+        source,
+        &["fetch", "origin", "--quiet"],
+        DISPATCH_FETCH_TIMEOUT,
+    )
+    .map(|o| o.status.success())
+    .unwrap_or(false);
+    let work_remote_exists =
+        crate::git_helpers::git_bypass(source, &["rev-parse", "--verify", &work_tracking_ref])
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+    if work_remote_exists {
+        match crate::git_helpers::git_bypass(source, &["branch", branch, &work_tracking_ref]) {
+            Ok(o) if o.status.success() => {
+                crate::event_log::log(
+                    home,
+                    "ensure_branch_from_origin",
+                    actor,
+                    &format!("branch={branch} based on refs/remotes/origin/{branch} fetched={work_fetch_ok} (#t-83936-5 data-loss guard)"),
+                );
+                // n_branch=false: the branch pre-existed on the remote; we only
+                // materialized the local ref (consistent with the EXISTS path).
+                return Ok((false, work_fetch_ok));
+            }
+            Ok(o) if String::from_utf8_lossy(&o.stderr).contains("already exists") => {
+                // Race: a concurrent caller authored the local ref between our
+                // rev-parse gate and here. Idempotent — observed, not created.
+                return Ok((false, work_fetch_ok));
+            }
+            Ok(o) => {
+                let stderr = String::from_utf8_lossy(&o.stderr).to_string();
+                return Err(DispatchError {
+                    message: format!(
+                        "failed to create '{branch}' from existing origin/{branch}: {}",
+                        stderr.trim()
+                    ),
+                    code: ErrorCode::BranchCreateFailed,
+                    stage: Stage::CreateBranch,
+                    fetch_attempted: work_fetch_ok,
+                    raw: Some(stderr),
+                });
+            }
+            Err(e) => {
+                return Err(DispatchError {
+                    message: format!("git branch from origin/{branch} spawn failed: {e}"),
+                    code: ErrorCode::BranchCreateFailed,
+                    stage: Stage::CreateBranch,
+                    fetch_attempted: work_fetch_ok,
+                    raw: Some(e.to_string()),
+                });
+            }
+        }
+    }
+    if !work_fetch_ok {
+        // origin/<branch> is absent from our view AND we could not refresh it.
+        // Discriminate state 3 (fail-open) from state 4 (fail-closed) by whether we
+        // have ANY remote-tracking view of origin at all. `refs/remotes/origin/HEAD`
+        // counts — `git clone` always populates it, so "have we ever synced with
+        // origin?" == "is refs/remotes/origin/* non-empty?".
+        let have_origin_view = crate::git_helpers::git_bypass(
+            source,
+            &["for-each-ref", "--count=1", "refs/remotes/origin/"],
+        )
+        .map(|o| o.status.success() && !o.stdout.is_empty())
+        .unwrap_or(false);
+        if !have_origin_view {
+            // State 4 — FAIL-CLOSED: we have never synced with origin (no
+            // remote-tracking view) and cannot reach it now, so we cannot rule out an
+            // existing origin/<branch> at all. Creating from `from_ref` could silently
+            // orphan its remote commits — the recovery-scenario data-loss this guard
+            // prevents. Refuse loudly.
+            crate::event_log::log(
+                home,
+                "ensure_branch_fail_closed",
+                actor,
+                &format!("branch={branch} from_ref={from_ref} refused: no origin remote-tracking view + fetch failed, cannot rule out existing origin/{branch} (#t-83936-5 data-loss guard)"),
+            );
+            return Err(DispatchError {
+                message: format!(
+                    "refusing to provision '{branch}': cannot reach origin and have no \
+                     remote-tracking view to confirm whether origin/{branch} already exists. \
+                     Creating from '{from_ref}' now could silently orphan existing remote \
+                     commits on that branch. Restore connectivity and retry."
+                ),
+                code: ErrorCode::FetchFailed,
+                stage: Stage::Fetch,
+                fetch_attempted: false,
+                raw: None,
+            });
+        }
+        // State 3 — FAIL-OPEN (the one accepted gap; see the state table above):
+        // origin is unreachable NOW but we DO have a remote-tracking view in which
+        // origin/<branch> is absent. Create from `from_ref`. The residual data-loss
+        // needs offline + stale-clone + a branch pushed since our last fetch to stack
+        // (non-incident — the incident is a fresh, complete clone), and a wrong-based
+        // push to an existing origin/<branch> is a rejected non-ff (loud 2nd defense).
+        crate::event_log::log(
+            home,
+            "ensure_branch_fail_open",
+            actor,
+            &format!("branch={branch} from_ref={from_ref}: origin unreachable but remote-tracking view present and lacks origin/{branch}; creating from from_ref (residual-edge, non-ff backstop) (#t-83936-5)"),
+        );
+    }
+    // States 2 & 3: origin reachable & confirmed to lack the branch, or offline with a
+    // view that lacks it → genuinely new (for our purposes).
+    // Step 2: create from `from_ref`. #1755: a remote-tracking `from_ref` like
+    // `origin/main` ALWAYS resolves as a local ref, so a bare `git branch` here
+    // silently bases the new branch on a STALE local ref (whatever was last
+    // fetched) — the reverse-revert hazard where a fresh checkout starts behind
+    // main and would clobber merges that landed since. Refresh the remote ref
+    // FIRST (mirrors the #869 branch-EXISTS path above) so the create lands on
+    // current `origin/<x>`. Best-effort: a fetch failure (offline / no-remote
+    // fixture) leaves the local ref as-is and the create still succeeds against
+    // whatever's present (degraded but functional, same contract as #869).
+    // `fetch_attempted` reports SUCCESS (matches #869's `fetched_ok`), so the
+    // no-remote test fixtures keep reporting `false`.
+    let mut create_fetched = false;
+    if let Some(remote_branch) = from_ref_branch {
+        let fetch_start = std::time::Instant::now();
+        let fetch_out = crate::git_helpers::git_bypass_timeout(
+            source,
+            &[
+                "fetch",
+                remote,
+                &format!("+{remote_branch}:refs/remotes/{remote}/{remote_branch}"),
+                "--quiet",
+            ],
+            DISPATCH_FETCH_TIMEOUT,
+        );
+        create_fetched = matches!(&fetch_out, Ok(o) if o.status.success());
+        crate::event_log::log(
+            home,
+            "ensure_branch_fetch",
+            actor,
+            &format!(
+                "branch={branch} from_ref={from_ref} duration_ms={} ok={create_fetched} (#1755 pre-create refresh)",
+                fetch_start.elapsed().as_millis()
+            ),
+        );
+    }
+    match crate::git_helpers::git_bypass(source, &["branch", branch, from_ref]) {
+        Ok(o) if o.status.success() => Ok((true, create_fetched)),
+        Ok(o) => {
+            let stderr = String::from_utf8_lossy(&o.stderr).to_string();
+            if stderr.contains("already exists") {
+                // Race: concurrent caller authored the branch between
+                // rev-parse and branch. Idempotent fall-through —
+                // auto_created stays false so callers can distinguish
+                // "I created it" vs "I observed it pre-existing".
+                Ok((false, false))
+            } else if stderr.contains("not a valid object name")
+                || stderr.contains("not a valid ref")
+            {
+                tracing::warn!(
+                    target: "dispatch_hook",
+                    %branch,
+                    %from_ref,
+                    "ensure_branch_exists fallback: from_ref unresolved locally — fetching origin"
+                );
+                let fetch_start = std::time::Instant::now();
+                let fetch_out = crate::git_helpers::git_bypass_timeout(
+                    source,
+                    &["fetch", remote, "--quiet"],
+                    DISPATCH_FETCH_TIMEOUT,
+                );
+                let fetch_ms = fetch_start.elapsed().as_millis();
+                crate::event_log::log(
+                    home,
+                    "ensure_branch_fetch",
+                    actor,
+                    &format!("branch={branch} from_ref={from_ref} duration_ms={fetch_ms}"),
+                );
+                match fetch_out {
+                    Ok(fo) if fo.status.success() => {
+                        match crate::git_helpers::git_bypass(source, &["branch", branch, from_ref])
+                        {
+                            Ok(ro) if ro.status.success() => Ok((true, true)),
+                            Ok(ro) => {
+                                let rstderr = String::from_utf8_lossy(&ro.stderr).to_string();
+                                if rstderr.contains("already exists") {
+                                    Ok((false, true))
+                                } else {
+                                    tracing::warn!(
+                                        target: "dispatch_hook",
+                                        %branch, %from_ref, stderr = %rstderr,
+                                        "ensure_branch_exists retry failed after fetch"
+                                    );
+                                    Err(DispatchError {
+                                        message: format!(
+                                            "from_ref '{from_ref}' invalid (branch creation failed after fetch)"
+                                        ),
+                                        code: ErrorCode::InvalidFromRef,
+                                        stage: Stage::RetryCreate,
+                                        fetch_attempted: true,
+                                        raw: Some(rstderr),
+                                    })
+                                }
+                            }
+                            Err(e) => Err(DispatchError {
+                                message: format!("git branch retry spawn failed: {e}"),
+                                code: ErrorCode::BranchCreateFailed,
+                                stage: Stage::RetryCreate,
+                                fetch_attempted: true,
+                                raw: Some(e.to_string()),
+                            }),
+                        }
+                    }
+                    Ok(fo) => {
+                        let fstderr = String::from_utf8_lossy(&fo.stderr).to_string();
+                        tracing::warn!(
+                            target: "dispatch_hook",
+                            %branch, %from_ref, stderr = %fstderr,
+                            "ensure_branch_exists fetch failed"
+                        );
+                        Err(DispatchError {
+                            message: format!(
+                                "git fetch origin failed (from_ref '{from_ref}' cannot be resolved)"
+                            ),
+                            code: ErrorCode::FetchFailed,
+                            stage: Stage::Fetch,
+                            fetch_attempted: true,
+                            raw: Some(fstderr),
+                        })
+                    }
+                    Err(e) => Err(DispatchError {
+                        message: format!("git fetch spawn failed: {e}"),
+                        code: ErrorCode::FetchFailed,
+                        stage: Stage::Fetch,
+                        fetch_attempted: true,
+                        raw: Some(e.to_string()),
+                    }),
+                }
+            } else {
+                Err(DispatchError {
+                    message: format!("git branch failed: {}", stderr.trim()),
+                    code: ErrorCode::BranchCreateFailed,
+                    stage: Stage::CreateBranch,
+                    fetch_attempted: false,
+                    raw: Some(stderr),
+                })
+            }
+        }
+        Err(e) => Err(DispatchError {
+            message: format!("git branch spawn failed: {e}"),
+            code: ErrorCode::BranchCreateFailed,
+            stage: Stage::CreateBranch,
+            fetch_attempted: false,
+            raw: Some(e.to_string()),
+        }),
+    }
+}

--- a/src/mcp/handlers/dispatch_hook/mod.rs
+++ b/src/mcp/handlers/dispatch_hook/mod.rs
@@ -6,6 +6,7 @@ use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 mod auto_watch;
+mod branch_start_point;
 mod from_ref;
 mod live_binding;
 pub(crate) use from_ref::resolve_from_ref_remote; // CR-2026-06-14 extraction
@@ -844,151 +845,18 @@ pub(crate) fn ensure_branch_exists(
         }
         return Ok((false, fetched_ok));
     }
-    // Step 2: create from `from_ref`. #1755: a remote-tracking `from_ref` like
-    // `origin/main` ALWAYS resolves as a local ref, so a bare `git branch` here
-    // silently bases the new branch on a STALE local ref (whatever was last
-    // fetched) — the reverse-revert hazard where a fresh checkout starts behind
-    // main and would clobber merges that landed since. Refresh the remote ref
-    // FIRST (mirrors the #869 branch-EXISTS path above) so the create lands on
-    // current `origin/<x>`. Best-effort: a fetch failure (offline / no-remote
-    // fixture) leaves the local ref as-is and the create still succeeds against
-    // whatever's present (degraded but functional, same contract as #869).
-    // `fetch_attempted` reports SUCCESS (matches #869's `fetched_ok`), so the
-    // no-remote test fixtures keep reporting `false`.
-    let mut create_fetched = false;
-    if let Some(remote_branch) = from_ref_branch.as_deref() {
-        let fetch_start = std::time::Instant::now();
-        let fetch_out = crate::git_helpers::git_bypass_timeout(
-            source,
-            &[
-                "fetch",
-                &remote,
-                &format!("+{remote_branch}:refs/remotes/{remote}/{remote_branch}"),
-                "--quiet",
-            ],
-            DISPATCH_FETCH_TIMEOUT,
-        );
-        create_fetched = matches!(&fetch_out, Ok(o) if o.status.success());
-        crate::event_log::log(
-            home,
-            "ensure_branch_fetch",
-            actor,
-            &format!(
-                "branch={branch} from_ref={from_ref} duration_ms={} ok={create_fetched} (#1755 pre-create refresh)",
-                fetch_start.elapsed().as_millis()
-            ),
-        );
-    }
-    match crate::git_helpers::git_bypass(source, &["branch", branch, from_ref]) {
-        Ok(o) if o.status.success() => Ok((true, create_fetched)),
-        Ok(o) => {
-            let stderr = String::from_utf8_lossy(&o.stderr).to_string();
-            if stderr.contains("already exists") {
-                // Race: concurrent caller authored the branch between
-                // rev-parse and branch. Idempotent fall-through —
-                // auto_created stays false so callers can distinguish
-                // "I created it" vs "I observed it pre-existing".
-                Ok((false, false))
-            } else if stderr.contains("not a valid object name")
-                || stderr.contains("not a valid ref")
-            {
-                tracing::warn!(
-                    target: "dispatch_hook",
-                    %branch,
-                    %from_ref,
-                    "ensure_branch_exists fallback: from_ref unresolved locally — fetching origin"
-                );
-                let fetch_start = std::time::Instant::now();
-                let fetch_out = crate::git_helpers::git_bypass_timeout(
-                    source,
-                    &["fetch", &remote, "--quiet"],
-                    DISPATCH_FETCH_TIMEOUT,
-                );
-                let fetch_ms = fetch_start.elapsed().as_millis();
-                crate::event_log::log(
-                    home,
-                    "ensure_branch_fetch",
-                    actor,
-                    &format!("branch={branch} from_ref={from_ref} duration_ms={fetch_ms}"),
-                );
-                match fetch_out {
-                    Ok(fo) if fo.status.success() => {
-                        match crate::git_helpers::git_bypass(source, &["branch", branch, from_ref])
-                        {
-                            Ok(ro) if ro.status.success() => Ok((true, true)),
-                            Ok(ro) => {
-                                let rstderr = String::from_utf8_lossy(&ro.stderr).to_string();
-                                if rstderr.contains("already exists") {
-                                    Ok((false, true))
-                                } else {
-                                    tracing::warn!(
-                                        target: "dispatch_hook",
-                                        %branch, %from_ref, stderr = %rstderr,
-                                        "ensure_branch_exists retry failed after fetch"
-                                    );
-                                    Err(DispatchError {
-                                        message: format!(
-                                            "from_ref '{from_ref}' invalid (branch creation failed after fetch)"
-                                        ),
-                                        code: ErrorCode::InvalidFromRef,
-                                        stage: Stage::RetryCreate,
-                                        fetch_attempted: true,
-                                        raw: Some(rstderr),
-                                    })
-                                }
-                            }
-                            Err(e) => Err(DispatchError {
-                                message: format!("git branch retry spawn failed: {e}"),
-                                code: ErrorCode::BranchCreateFailed,
-                                stage: Stage::RetryCreate,
-                                fetch_attempted: true,
-                                raw: Some(e.to_string()),
-                            }),
-                        }
-                    }
-                    Ok(fo) => {
-                        let fstderr = String::from_utf8_lossy(&fo.stderr).to_string();
-                        tracing::warn!(
-                            target: "dispatch_hook",
-                            %branch, %from_ref, stderr = %fstderr,
-                            "ensure_branch_exists fetch failed"
-                        );
-                        Err(DispatchError {
-                            message: format!(
-                                "git fetch origin failed (from_ref '{from_ref}' cannot be resolved)"
-                            ),
-                            code: ErrorCode::FetchFailed,
-                            stage: Stage::Fetch,
-                            fetch_attempted: true,
-                            raw: Some(fstderr),
-                        })
-                    }
-                    Err(e) => Err(DispatchError {
-                        message: format!("git fetch spawn failed: {e}"),
-                        code: ErrorCode::FetchFailed,
-                        stage: Stage::Fetch,
-                        fetch_attempted: true,
-                        raw: Some(e.to_string()),
-                    }),
-                }
-            } else {
-                Err(DispatchError {
-                    message: format!("git branch failed: {}", stderr.trim()),
-                    code: ErrorCode::BranchCreateFailed,
-                    stage: Stage::CreateBranch,
-                    fetch_attempted: false,
-                    raw: Some(stderr),
-                })
-            }
-        }
-        Err(e) => Err(DispatchError {
-            message: format!("git branch spawn failed: {e}"),
-            code: ErrorCode::BranchCreateFailed,
-            stage: Stage::CreateBranch,
-            fetch_attempted: false,
-            raw: Some(e.to_string()),
-        }),
-    }
+    // Local ref absent -> create it. Prefers an existing origin/<branch>
+    // over from_ref (#t-83936-5 data-loss guard); the full rationale and the
+    // fail-closed state table live in branch_start_point::create_new_branch.
+    branch_start_point::create_new_branch(
+        home,
+        source,
+        branch,
+        from_ref,
+        actor,
+        &remote,
+        from_ref_branch.as_deref(),
+    )
 }
 
 /// Resolve source_repo from the agent's team configuration.

--- a/src/mcp/handlers/dispatch_hook/tests.rs
+++ b/src/mcp/handlers/dispatch_hook/tests.rs
@@ -3249,6 +3249,15 @@ fn ensure_branch_exists_creates_from_non_origin_remote_2010() {
     }
     let upstream_head = git(&["rev-parse", "HEAD"], &repo);
     git(&["push", "-q", "upstream", "main"], &repo);
+    // #t-83936-5: a real fork clone always has refs/remotes/origin/* — give the
+    // (dummy, unreachable) origin a remote-tracking view so the new data-loss guard
+    // sees origin HAS been synced and, finding it lacks the work branch, proceeds to
+    // the upstream from_ref create (state 3 fail-open) instead of fail-closing on a
+    // viewless origin (state 4).
+    git(
+        &["update-ref", "refs/remotes/origin/main", &upstream_head],
+        &repo,
+    );
     // Drop the local main + any tracking refs so the create MUST fetch upstream.
     git(&["update-ref", "-d", "refs/remotes/upstream/main"], &repo);
 
@@ -3266,6 +3275,246 @@ fn ensure_branch_exists_creates_from_non_origin_remote_2010() {
     assert_eq!(
         new_sha, upstream_head,
         "branch must land on upstream/main HEAD"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+// ── #t-83936-5: bind_self re-provision start-point data-loss — 4-state pins ──
+// The create path (local refs/heads/<branch> ABSENT) must base a new local branch
+// on origin/<branch> when it exists, and fail-CLOSED only when totally blind. The
+// 4 states are the lead-confirmed table; each is pinned below.
+
+fn s5_git(args: &[&str], dir: &std::path::Path) -> String {
+    let out = std::process::Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .env("AGEND_GIT_BYPASS", "1")
+        .output()
+        .expect("git spawn");
+    assert!(
+        out.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+fn s5_commit(dir: &std::path::Path, msg: &str) -> String {
+    s5_git(
+        &[
+            "-c",
+            "user.name=t",
+            "-c",
+            "user.email=t@t",
+            "commit",
+            "--allow-empty",
+            "-m",
+            msg,
+        ],
+        dir,
+    );
+    s5_git(&["rev-parse", "HEAD"], dir)
+}
+
+fn s5_local_branch_absent(repo: &std::path::Path, branch: &str) -> bool {
+    std::process::Command::new("git")
+        .args(["rev-parse", "--verify", &format!("refs/heads/{branch}")])
+        .current_dir(repo)
+        .env("AGEND_GIT_BYPASS", "1")
+        .output()
+        .map(|o| !o.status.success())
+        .unwrap_or(true)
+}
+
+/// STATE 1 (RED — the incident): local `refs/heads/<branch>` ABSENT but the
+/// remote-tracking view HAS `origin/<branch>` (a fresh clone / prune-after-release
+/// re-bind: `git clone` populates refs/remotes/origin/* and pruning refs/heads
+/// never touches them). `ensure_branch_exists(<branch>, "origin/main")` must base
+/// the new local branch on `origin/<branch>`'s tip, NOT origin/main. Pre-fix the
+/// create arm bases on origin/main and the branch's divergent commits are silently
+/// orphaned — this assertion fails RED against that old behaviour.
+#[test]
+fn ensure_branch_from_origin_when_view_has_branch_state1_83936_5() {
+    let home = std::env::temp_dir().join(format!("agend-83936-5-s1-{}", std::process::id()));
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::create_dir_all(&home).ok();
+    let workspace = crate::paths::workspace_dir(&home);
+    std::fs::create_dir_all(&workspace).ok();
+    let origin = workspace.join("o.git");
+    let seed = workspace.join("seed");
+    let repo = workspace.join("agent");
+
+    // Real bare origin: main@A, feat/x@B where B is NOT an ancestor of A (divergent,
+    // so create-from-origin/main would truly orphan B). No checkout needed — push
+    // the divergent commit straight to a new remote ref.
+    std::fs::create_dir_all(&origin).ok();
+    s5_git(&["init", "--bare", "-b", "main"], &origin);
+    std::fs::create_dir_all(&seed).ok();
+    s5_git(&["init", "-b", "main"], &seed);
+    s5_git(
+        &["remote", "add", "origin", origin.to_str().unwrap()],
+        &seed,
+    );
+    let sha_a = s5_commit(&seed, "A");
+    s5_git(&["push", "-q", "origin", "main"], &seed);
+    let sha_b = s5_commit(&seed, "B");
+    s5_git(&["push", "-q", "origin", "HEAD:refs/heads/feat/x"], &seed);
+    assert_ne!(sha_a, sha_b);
+
+    // Agent source repo = a fresh CLONE of origin → refs/remotes/origin/feat/x is
+    // present, only main is checked out (no local refs/heads/feat/x).
+    s5_git(
+        &[
+            "clone",
+            "-q",
+            origin.to_str().unwrap(),
+            repo.to_str().unwrap(),
+        ],
+        &workspace,
+    );
+    assert!(
+        s5_local_branch_absent(&repo, "feat/x"),
+        "precondition: local refs/heads/feat/x must be ABSENT after clone"
+    );
+
+    let (created, _) = super::ensure_branch_exists(&home, &repo, "feat/x", "origin/main", "agent")
+        .expect("must provision");
+    let head = s5_git(&["rev-parse", "refs/heads/feat/x"], &repo);
+    assert_eq!(
+        head, sha_b,
+        "must base new local branch on origin/feat/x tip (B), NOT origin/main (A={sha_a})"
+    );
+    assert!(
+        !created,
+        "n_branch=false: branch pre-existed on origin, only materialized locally"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// STATE 2: local ref absent AND the remote-tracking view does NOT yet know the
+/// branch, but it exists on a REACHABLE origin (pushed since our last fetch). The
+/// best-effort `git fetch origin` must discover it and create from its tip.
+#[test]
+fn ensure_branch_from_origin_after_fetch_discovers_branch_state2_83936_5() {
+    let home = std::env::temp_dir().join(format!("agend-83936-5-s2-{}", std::process::id()));
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::create_dir_all(&home).ok();
+    let workspace = crate::paths::workspace_dir(&home);
+    std::fs::create_dir_all(&workspace).ok();
+    let origin = workspace.join("o.git");
+    let seed = workspace.join("seed");
+    let repo = workspace.join("agent");
+
+    std::fs::create_dir_all(&origin).ok();
+    s5_git(&["init", "--bare", "-b", "main"], &origin);
+    std::fs::create_dir_all(&seed).ok();
+    s5_git(&["init", "-b", "main"], &seed);
+    s5_git(
+        &["remote", "add", "origin", origin.to_str().unwrap()],
+        &seed,
+    );
+    s5_commit(&seed, "A");
+    s5_git(&["push", "-q", "origin", "main"], &seed);
+
+    // Clone the repo while origin has ONLY main (view lacks feat/y).
+    s5_git(
+        &[
+            "clone",
+            "-q",
+            origin.to_str().unwrap(),
+            repo.to_str().unwrap(),
+        ],
+        &workspace,
+    );
+    // Now push feat/y@B to origin from the seed (repo's view is stale — it has no
+    // refs/remotes/origin/feat/y yet).
+    let sha_b = s5_commit(&seed, "B");
+    s5_git(&["push", "-q", "origin", "HEAD:refs/heads/feat/y"], &seed);
+    assert!(
+        s5_local_branch_absent(&repo, "feat/y"),
+        "precondition: local refs/heads/feat/y absent"
+    );
+
+    let (created, fetched) =
+        super::ensure_branch_exists(&home, &repo, "feat/y", "origin/main", "agent")
+            .expect("must provision");
+    let head = s5_git(&["rev-parse", "refs/heads/feat/y"], &repo);
+    assert_eq!(head, sha_b, "must fetch + base on origin/feat/y tip (B)");
+    assert!(!created, "pre-existing on remote → n_branch=false");
+    assert!(fetched, "the discovering fetch must have succeeded");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// STATE 3 (fail-OPEN, the one accepted gap): origin is UNREACHABLE now but we DO
+/// have a remote-tracking view (refs/remotes/origin/main staged) that lacks the
+/// work branch → create from `from_ref`. Pins the fail-open semantic so a future
+/// change can't silently turn this into a refusal (which would block all provision
+/// on any origin blip).
+#[test]
+fn ensure_branch_fail_open_when_unreachable_but_has_view_state3_83936_5() {
+    let home = std::env::temp_dir().join(format!("agend-83936-5-s3-{}", std::process::id()));
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::create_dir_all(&home).ok();
+    let workspace = crate::paths::workspace_dir(&home);
+    std::fs::create_dir_all(&workspace).ok();
+    let repo = workspace.join("agent");
+
+    std::fs::create_dir_all(&repo).ok();
+    s5_git(&["init", "-b", "main"], &repo);
+    s5_git(
+        &["remote", "add", "origin", "file:///dev/null/unreachable-s3"],
+        &repo,
+    );
+    let sha_a = s5_commit(&repo, "A");
+    // A remote-tracking VIEW exists (we've synced with origin before) though origin
+    // is unreachable now.
+    s5_git(&["update-ref", "refs/remotes/origin/main", &sha_a], &repo);
+
+    let (created, _) = super::ensure_branch_exists(&home, &repo, "feat/z", "origin/main", "agent")
+        .expect("fail-OPEN: must create from from_ref, not refuse");
+    let head = s5_git(&["rev-parse", "refs/heads/feat/z"], &repo);
+    assert_eq!(head, sha_a, "must base on origin/main view (A)");
+    assert!(created, "genuinely new branch → n_branch=true");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// STATE 4 (fail-CLOSED): origin is UNREACHABLE and there is NO remote-tracking
+/// view at all (never synced) → cannot rule out an existing origin/<branch> →
+/// REFUSE (Err) rather than silently orphan it. This is the guard the lead
+/// explicitly required (#2662 fail-closed on the truly-blind state).
+#[test]
+fn ensure_branch_fail_closed_when_unreachable_and_no_view_state4_83936_5() {
+    let home = std::env::temp_dir().join(format!("agend-83936-5-s4-{}", std::process::id()));
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::create_dir_all(&home).ok();
+    let workspace = crate::paths::workspace_dir(&home);
+    std::fs::create_dir_all(&workspace).ok();
+    let repo = workspace.join("agent");
+
+    std::fs::create_dir_all(&repo).ok();
+    s5_git(&["init", "-b", "main"], &repo);
+    s5_git(
+        &["remote", "add", "origin", "file:///dev/null/unreachable-s4"],
+        &repo,
+    );
+    s5_commit(&repo, "A");
+    // NO refs/remotes/origin/* staged — the view is completely empty.
+
+    let err = super::ensure_branch_exists(&home, &repo, "feat/w", "origin/main", "agent")
+        .expect_err("fail-CLOSED: must refuse when blind");
+    assert_eq!(
+        err.code,
+        super::ErrorCode::FetchFailed,
+        "must be the fail-closed FetchFailed code: {err:?}"
+    );
+    assert!(
+        err.message.contains("refusing to provision"),
+        "message must name the refusal: {}",
+        err.message
+    );
+    assert!(
+        s5_local_branch_absent(&repo, "feat/w"),
+        "must NOT have created the branch on refusal"
     );
     std::fs::remove_dir_all(&home).ok();
 }


### PR DESCRIPTION
## Summary
Incident follow-up (`t-…83936-5`, data-loss). `ensure_branch_exists`' **create path**
(local `refs/heads/<branch>` absent) always based the new local branch on `from_ref`
(`origin/main`) and never consulted `origin/<branch>`. On a fresh canonical clone /
pruned-after-release re-bind — **exactly the incident-recovery scenario** — the branch
already exists on origin, so committing after such a provision **silently orphaned its
remote commits** (dev2 hit this; caught only by a pre-commit diff-stat). The branch-EXISTS
path already gives `origin/<branch>` precedence over `from_ref`; this makes the CREATE path
consistent. Centralized in `ensure_branch_exists`, so **all** provision entry points
(`bind_self`, dispatch auto-bind, `repo checkout bind:true`, rebase recovery) are fixed at
once.

## The 4-state decision (lead-vetted hybrid; fail-CLOSED only when truly blind)
The PRIMARY signal is the remote-tracking VIEW `refs/remotes/origin/<branch>`, **not** a
live fetch — `git clone` populates `refs/remotes/origin/*` for all branches and pruning a
local `refs/heads` never touches the remote-tracking ref, so in every recovery scenario the
view already knows the branch with **no network I/O** (verified empirically). A best-effort
`git fetch origin` runs first to advance the view to tip when online / discover a
since-last-fetch push.

| # | view has `origin/<branch>`? | `git fetch origin` | any `refs/remotes/origin/*`? | action |
|---|---|---|---|---|
| 1 | yes | (either) | — | **create from `origin/<branch>` tip** (history preserved) |
| 2 | no | OK | — | reachable & confirmed absent → genuinely new → `from_ref` |
| 3 | no | FAIL | non-empty | `from_ref` — **fail-OPEN** (see below) |
| 4 | no | FAIL | empty | **REFUSE (Err)** — fail-closed |

## ⚠ State 3 is the one fail-OPEN state — reviewers, read this
When origin is unreachable *now* but we DO have a remote-tracking view (we've synced with
origin before — `refs/remotes/origin/*`, incl. `origin/HEAD`, is populated) and the branch
is absent from it, we create from `from_ref` rather than refuse. Rationale (also pinned in a
code comment above the branch):
- The residual data-loss window needs **three** conditions stacked: offline **now** + a
  **stale** (non-fresh) clone + the branch pushed to origin **only after this repo's last
  fetch**. The incident is a *fresh* clone (view complete → caught by state 1), so this edge
  is **not** the incident.
- It is **not silent**: a later push of the wrong-based branch to the existing
  `origin/<branch>` is a **non-fast-forward** and is **rejected** — a natural second line of
  defense and a loud signal.
- The alternative (fail-closed on *any* fetch failure) would block **all** new-branch
  provisioning during any origin blip and forced a 33-test fixture migration for zero
  incident-relevant safety. Lead chose this hybrid after the fetch-premise was corrected.

**Asymmetry vs the EXISTS arm (state 1):** that arm `update-ref`s the local ref to the tip;
here we base on the view SHA, which when OFFLINE may LAG origin's tip. Lag ≠ loss — the base
is a real ancestor on the correct branch and the non-ff backstop covers the rest; when
online the pre-fetch advances the view to the tip anyway.

## Structure
The whole create path (the new guard + the existing #1755 `from_ref` create) is extracted
**verbatim** into `branch_start_point::create_new_branch` so `dispatch_hook/mod.rs` stays
under its **1575-LOC grandfathered ceiling** (it sat at 1574). Pure move — `git diff -M`
shows it; no behaviour change.

## Tests
- 4 state pins (`*_state{1,2,3,4}_83936_5`). **State 1 verified RED** against the pre-fix
  create-from-`from_ref` arm (neutralizing the guard lands the branch on `origin/main` — the
  data-loss — and the assertion fails).
- Two fixtures (`#2010` fork, `p780` broken-origin) gain a staged `refs/remotes/origin/main`
  view — a real clone always has one — so they exercise their intended paths, not the new
  fail-closed refusal.

## Gate
- `cargo fmt --check` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo nextest run --workspace`: **5401 passed** (incl. `file_size_invariant` + all git
  invariants). The only excluded tests are 4 real-daemon/timing e2e (#1900 `e2e_workflow`,
  #1907 `teardown_completeness_regression`, 2 `attached_path` — a 5ms timing overshoot +
  daemon-unreachable) that fail environmentally in this sandbox and are orthogonal to
  `ensure_branch_exists` (they never reference it).

Task: `t-20260706165139511902-83936-5` · Spike + full rationale: `BIND-SELF-STARTPOINT-SPIKE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
