### PR TITLE
fix(#26795-3 ②): drop ineffective self-clear instruction from ratelimit-retry payload (plain continue)

### DIFF
--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -116,17 +116,21 @@ const RETRY_AFTER_INJECT_FAIL: Duration = Duration::from_secs(5);
 /// #1316: replaces the old `last_input_text` replay that caused
 /// infinite modal-keystroke loops.
 const CONTINUE_RETRY_PAYLOAD: &[u8] = b"continue\n";
-/// #2232: ServerRateLimit retry payload — `continue` plus a one-line instruction
-/// telling a now-awake agent to self-clear its rate-limit block (MCP
-/// `clear_blocked_reason` reason=rate_limit) so the daemon stops auto-retrying.
-/// That agent-initiated clear is the ground-truth recovery signal the supervisor
-/// latches on; LLM compliance isn't guaranteed, so a missed call gracefully
-/// degrades to the `recovered_within` / state-exit / 12-cap heuristics. ASCII,
-/// SINGLE line + one trailing "\n" (no embedded newline that would submit early).
-/// Kept SEPARATE from the shared `CONTINUE_RETRY_PAYLOAD` so the apierror-nudge
-/// wording is unchanged and the #1680 source-guard literal stays intact — same
-/// split rationale as `inject_channel_reply_missing_gated`.
-const RATELIMIT_RETRY_PAYLOAD: &[u8] = b"continue (if you can act on this you have recovered from a rate limit -- call the agend-terminal health MCP action clear_blocked_reason with reason=rate_limit to stop these auto-retries)\n";
+/// #2232 / #26795-3: ServerRateLimit retry payload. It originally carried
+/// `continue` PLUS a one-line instruction telling a now-awake agent to self-clear
+/// its rate-limit block (MCP `clear_blocked_reason` reason=rate_limit). The
+/// #26795-3 SRL spike found that instruction is INEFFECTIVE noise: agents
+/// essentially never call it (recovery_shadow: 2746/2746 `self_cleared=false`),
+/// and the recovery it was meant to signal is now covered by the hook-authoritative
+/// path (#t-26795 `hook_recovered`, claude) + the `recovered_within` heuristic. So
+/// the payload is now a PLAIN `continue` nudge — the `[AGEND-AUTO
+/// kind=ratelimit-retry]` marker (driven by `auto_kind`, NOT this body) still tags
+/// it, matching the protocol doc's `[AGEND-AUTO kind=ratelimit-retry] continue`
+/// example. ASCII, SINGLE line + one trailing "\n". Kept as a SEPARATE const from
+/// the shared `CONTINUE_RETRY_PAYLOAD` so the #1680 source-guard's distinct
+/// `RATELIMIT_RETRY_PAYLOAD, false, Some(auto_kind)` scan stays intact. (Removing
+/// the now-dead `self_cleared` recovery SIGNAL is the separate #26795-3 ① PR.)
+const RATELIMIT_RETRY_PAYLOAD: &[u8] = b"continue\n";
 
 /// Per-agent notify tracking: last notify time + consecutive error count.
 pub(crate) struct NotifyTrack {
@@ -1308,12 +1312,13 @@ fn inject_continue_gated(
 }
 
 /// #2232 sibling of [`inject_continue_gated`] for the ServerRateLimit retry path:
-/// injects [`RATELIMIT_RETRY_PAYLOAD`] (`continue` + a self-clear instruction)
-/// instead of the bare shared `CONTINUE_RETRY_PAYLOAD`. Kept separate so the
-/// apierror-nudge keeps the plain payload and the #1680 source-guard literal on
-/// the shared one stays intact (same split rationale as
-/// [`inject_channel_reply_missing_gated`]). Same draft-gating (`force=false`) +
-/// `[AGEND-AUTO kind=...]` tagging; returns the 3-state [`InjectOutcome`].
+/// injects [`RATELIMIT_RETRY_PAYLOAD`] (a plain `continue` since #26795-3 dropped
+/// the ineffective self-clear instruction) via its own const instead of the shared
+/// `CONTINUE_RETRY_PAYLOAD`, so the #1680 source-guard's distinct
+/// `RATELIMIT_RETRY_PAYLOAD, false, Some(auto_kind)` scan stays intact (same split
+/// rationale as [`inject_channel_reply_missing_gated`]). Same draft-gating
+/// (`force=false`) + `[AGEND-AUTO kind=...]` tagging; returns the 3-state
+/// [`InjectOutcome`].
 fn inject_ratelimit_retry_gated(
     home: &std::path::Path,
     registry: &AgentRegistry,

--- a/src/daemon/supervisor/tests.rs
+++ b/src/daemon/supervisor/tests.rs
@@ -3854,8 +3854,9 @@ fn continue_inject_is_draft_gated_force_false_1680() {
         !norm.contains(&force_true),
         "#1680: no force=true continue-inject may remain"
     );
-    // #2232: the ratelimit-retry self-clear-guidance inject (sibling payload)
-    // must ALSO be draft-gated (force=false) — same #1680 safety on the new path.
+    // #2232: the ratelimit-retry inject (sibling payload; #26795-3 dropped its
+    // self-clear guidance) must ALSO be draft-gated (force=false) — same #1680
+    // safety on the new path.
     assert!(
         norm.contains("RATELIMIT_RETRY_PAYLOAD, false, Some(auto_kind),"),
         "#2232: the ratelimit-retry inject must pass force=false (draft-gated)"
@@ -3865,6 +3866,34 @@ fn continue_inject_is_draft_gated_force_false_1680() {
         !norm.contains(&rl_force_true),
         "#2232: no force=true ratelimit-retry inject may remain"
     );
+}
+
+/// #26795-3 ② (payload copy): the ServerRateLimit auto-retry payload is now a
+/// PLAIN `continue` nudge — the ineffective self-clear instruction (agents never
+/// called it: recovery_shadow 2746/2746 `self_cleared=false`; recovery is now
+/// carried by hook_recovered + the recovered_within heuristic) is gone. The
+/// `[AGEND-AUTO kind=ratelimit-retry]` marker is driven by `auto_kind`, NOT this
+/// body, so the marker contract is unchanged.
+#[test]
+fn ratelimit_retry_payload_is_plain_continue_no_self_clear_26795_3() {
+    let payload = std::str::from_utf8(super::RATELIMIT_RETRY_PAYLOAD).expect("ASCII payload");
+    assert!(
+        !payload.contains("clear_blocked_reason"),
+        "the ineffective self-clear instruction must be gone (agents never called it): {payload:?}"
+    );
+    assert_eq!(
+        super::RATELIMIT_RETRY_PAYLOAD,
+        b"continue\n",
+        "ratelimit-retry payload is now the plain continue nudge"
+    );
+    // Single-line submit contract: exactly one trailing newline, no embedded one
+    // that would submit the nudge early.
+    assert_eq!(
+        payload.matches('\n').count(),
+        1,
+        "exactly one trailing newline"
+    );
+    assert!(payload.ends_with('\n'));
 }
 
 /// #1595 Step 1 (source guard): the ServerRateLimit retry-exhausted Telegram


### PR DESCRIPTION
## SRL self-clear convergence — PR ② (solo, light review): ratelimit-retry payload copy

Task `t-…-26795-3` (spike-vetted by lead). PR **②** of two.

The AGEND-AUTO ratelimit-retry auto-nudge instructed a rate-limited agent to call
`health clear_blocked_reason reason=rate_limit` to stop the retries — the #26795-3 SRL
spike quantified this as **ineffective noise**: agents essentially never call it
(`recovery_shadow.jsonl`: 2746/2746 `self_cleared=false`). The recovery it was meant to
signal is now carried by the hook-authoritative path (#t-26795 `hook_recovered`, claude)
+ the `recovered_within` heuristic.

### Change (payload copy only)
`RATELIMIT_RETRY_PAYLOAD` (supervisor.rs) → plain `continue\n`. The `[AGEND-AUTO
kind=ratelimit-retry]` marker is driven by `auto_kind`, **not** this body — so the marker
contract is unchanged, and the payload now *matches* the protocol doc's `[AGEND-AUTO
kind=ratelimit-retry] continue` example. Kept as a **separate const** from the shared
`CONTINUE_RETRY_PAYLOAD` so the #1680 source-guard's distinct `RATELIMIT_RETRY_PAYLOAD,
false, Some(auto_kind)` scan stays intact (the #1680 / #2232 draft-gating tests scan the
call site, not the payload text, so they pass unchanged).

**Out of scope (separate ① PR):** removing the now-dead `self_cleared` recovery SIGNAL
(the latch + its use in the SRL recovery composition). The `clear_blocked_reason` VERB
stays (operator + daemon use it).

### Tests
- `ratelimit_retry_payload_is_plain_continue_no_self_clear_26795_3`: payload no longer
  instructs self-clear, is the plain `continue\n`, single trailing newline.
- `continue_inject_is_draft_gated_force_false_1680` (#1680/#2232 force-gating) stays green.
- `cargo fmt --check` + both file-size invariants + `clippy --workspace --all-targets -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
