### PR TITLE
fix(#26795-3 ①): remove the dead rate_limit_self_cleared recovery signal (keep the verb)

### DIFF
--- a/src/api/handlers/hook_event.rs
+++ b/src/api/handlers/hook_event.rs
@@ -26,37 +26,14 @@ pub(crate) fn handle_hook_event(params: &Value, ctx: &HandlerCtx) -> Value {
     let derived =
         crate::daemon::hook_shadow::record_event(name, hook_event_name, notification_type);
 
-    // #t-3558: a fresh failure hook (StopFailure → ApiError) signals a NEW error
-    // episode. If the agent earlier self-cleared a rate-limit block, drop the
-    // #2232 `rate_limit_self_cleared` liveness latch so the supervisor's
-    // ServerRateLimit retry path re-arms. Without this the latch stays set until
-    // the SCREEN exits ServerRateLimit (supervisor.rs:1955), but the stale
-    // "Server is temporarily limiting" line keeps the screen pinned to SRL
-    // forever (#1769 positional defeat) → the retry track is cleared every tick
-    // and never re-injected: a permanent silent wedge (RCA t-…2345-2,
-    // live-reproduced on fixup-dev-2). Re-arm is still gated on
-    // screen==ServerRateLimit in the supervisor (:1994), so a non-SRL ApiError
-    // (e.g. an auth error) only drops the latch and cannot trigger a spurious
-    // inject. Only ApiError-derived hooks reset — a clean Stop / PreToolUse /
-    // UserPromptSubmit during normal post-self-clear work never does.
-    let is_apierror_hook = derived == Some(crate::state::AgentState::ApiError);
-
     // Shadow comparison: the screen-heuristic state at event receipt. This is
     // the PoC's primary output — production promotion is gated on this agreement
-    // data. Doubles as the #t-3558 latch-reset site (same single core lock).
+    // data.
     let (screen_state, backend) = {
         let reg = agent::lock_registry(ctx.registry);
         match crate::fleet::resolve_uuid(ctx.home, name).and_then(|id| {
             reg.get(&id).map(|h| {
-                let mut core = h.core.lock();
-                if is_apierror_hook && core.health.rate_limit_self_cleared {
-                    core.health.rate_limit_self_cleared = false;
-                    tracing::info!(
-                        agent = %name,
-                        "#t-3558 rate-limit self-clear latch reset — fresh ApiError hook (new \
-                         error episode); supervisor ServerRateLimit retry re-arms"
-                    );
-                }
+                let core = h.core.lock();
                 (core.state.get_state(), h.backend_command.clone())
             })
         }) {
@@ -141,112 +118,6 @@ mod tests {
         // Missing event name → honest error, nothing recorded for that call.
         let bad = handle_hook_event(&json!({"name": "hooked"}), &ctx);
         assert_eq!(bad["ok"], false);
-        std::fs::remove_dir_all(&home).ok();
-    }
-
-    // #t-3558: seed a registered agent (fleet.yaml id ↔ registry handle) whose
-    // `rate_limit_self_cleared` latch is set, then drive hook events through the
-    // handler. Mirrors the external.rs handler-test seeding pattern.
-    // `unix`-gated: `mk_test_handle` (the `true`-backed PTY handle) is
-    // `#[cfg(all(test, unix))]`, so the helpers + tests that use it — and the
-    // const only they reference — must be unix-only to keep the Windows build
-    // warning-clean.
-    #[cfg(unix)]
-    const T3558_ID: &str = "0d0d0d0d-0000-4000-8000-0000035580a1";
-
-    #[cfg(unix)]
-    fn seed_latched_agent(ctx: &HandlerCtx<'_>, name: &str) {
-        let id = crate::types::InstanceId::parse(T3558_ID).unwrap();
-        std::fs::write(
-            crate::fleet::fleet_yaml_path(ctx.home),
-            format!("instances:\n  {name}:\n    id: {T3558_ID}\n"),
-        )
-        .unwrap();
-        let handle = agent::mk_test_handle(name, id);
-        handle.core.lock().health.rate_limit_self_cleared = true;
-        agent::lock_registry(ctx.registry).insert(id, handle);
-    }
-
-    #[cfg(unix)]
-    fn latch_of(ctx: &HandlerCtx<'_>) -> bool {
-        let id = crate::types::InstanceId::parse(T3558_ID).unwrap();
-        agent::lock_registry(ctx.registry)
-            .get(&id)
-            .map(|h| h.core.lock().health.rate_limit_self_cleared)
-            .expect("agent present")
-    }
-
-    #[cfg(unix)]
-    fn set_latch(ctx: &HandlerCtx<'_>, val: bool) {
-        let id = crate::types::InstanceId::parse(T3558_ID).unwrap();
-        agent::lock_registry(ctx.registry)
-            .get(&id)
-            .expect("agent present")
-            .core
-            .lock()
-            .health
-            .rate_limit_self_cleared = val;
-    }
-
-    #[cfg(unix)]
-    fn t3558_home(tag: &str) -> std::path::PathBuf {
-        let home = std::env::temp_dir().join(format!(
-            "agend-t3558-{}-{}-{}",
-            tag,
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_nanos())
-                .unwrap_or(0)
-        ));
-        std::fs::create_dir_all(&home).ok();
-        home
-    }
-
-    /// #t-3558 POSITIVE: a fresh `StopFailure` hook (→ ApiError) resets the
-    /// `rate_limit_self_cleared` latch so the supervisor SRL retry re-arms.
-    /// RED before the fix (the latch was only reset on a screen-state exit).
-    #[cfg(unix)]
-    #[test]
-    fn apierror_hook_resets_rate_limit_self_clear_latch() {
-        let home = t3558_home("reset");
-        let ctx = test_ctx(&home);
-        let name = "wedged";
-        seed_latched_agent(&ctx, name);
-        assert!(latch_of(&ctx), "precondition: latch set");
-
-        let resp = handle_hook_event(
-            &json!({"name": name, "hook_event_name": "StopFailure"}),
-            &ctx,
-        );
-        assert_eq!(resp["ok"], true, "{resp}");
-        assert!(
-            !latch_of(&ctx),
-            "StopFailure (→ApiError) must reset rate_limit_self_cleared so SRL retry re-arms"
-        );
-        std::fs::remove_dir_all(&home).ok();
-    }
-
-    /// #t-3558 NEGATIVE (mandatory — pins "normal completion never re-arms"):
-    /// clean lifecycle hooks during normal post-self-clear work must NOT reset
-    /// the latch — only a genuine failure hook does.
-    #[cfg(unix)]
-    #[test]
-    fn normal_hooks_do_not_reset_rate_limit_self_clear_latch() {
-        let home = t3558_home("noreset");
-        let ctx = test_ctx(&home);
-        let name = "working";
-        seed_latched_agent(&ctx, name);
-
-        for ev in ["Stop", "PreToolUse", "PostToolUse", "UserPromptSubmit"] {
-            set_latch(&ctx, true);
-            let resp = handle_hook_event(&json!({"name": name, "hook_event_name": ev}), &ctx);
-            assert_eq!(resp["ok"], true, "{resp}");
-            assert!(
-                latch_of(&ctx),
-                "normal hook {ev:?} must NOT reset the latch (no spurious re-arm on healthy work)"
-            );
-        }
         std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/api/handlers/instance.rs
+++ b/src/api/handlers/instance.rs
@@ -478,18 +478,6 @@ pub(crate) fn handle_clear_blocked_reason(params: &Value, ctx: &HandlerCtx) -> V
                 .current_reason
                 .as_ref()
                 .map(|r| serde_json::to_value(r).unwrap_or_default());
-            // #2232: was the agent clearing a rate-limit / quota block? Captured
-            // BEFORE the clear below. An AGENT-initiated clear of such a block is
-            // ground-truth that it is awake and acted on the retry inject (the
-            // watchdog's heuristic auto-clear goes through `clear_blocked_reason`
-            // directly, NOT this MCP path, so it never trips the latch).
-            let was_rate_limit_block = matches!(
-                core.health.current_reason,
-                Some(
-                    crate::health::BlockedReason::RateLimit { .. }
-                        | crate::health::BlockedReason::QuotaExceeded
-                )
-            );
             // If a reason filter is specified, only clear if it matches
             if let Some(filter) = filter_reason {
                 let matches = core
@@ -502,13 +490,6 @@ pub(crate) fn handle_clear_blocked_reason(params: &Value, ctx: &HandlerCtx) -> V
                 }
             }
             core.health.clear_blocked_reason();
-            // #2232: latch the ground-truth recovery so the supervisor's next
-            // process_error_recovery tick drops the ServerRateLimit retry track —
-            // closing the gap where a pure-text fast reply never stamped
-            // `last_productive_output` so the `recovered_within` heuristic missed.
-            if was_rate_limit_block {
-                core.health.rate_limit_self_cleared = true;
-            }
             json!({"ok": true, "status": "cleared", "instance": name, "was": was})
         }
         None => json!({"ok": false, "error": format!("instance '{name}' not found")}),
@@ -833,58 +814,6 @@ mod tests {
         drop(reg);
 
         cleanup_agent(&ctx, "health-clear");
-    }
-
-    /// #2232: clearing a rate-limit/quota block via this MCP path sets the
-    /// `rate_limit_self_cleared` ground-truth latch the supervisor reads to drop
-    /// the ServerRateLimit retry track. Scoped (D3): only a RateLimit/QuotaExceeded
-    /// clear latches; an unrelated reason or a no-op clear does NOT.
-    #[test]
-    fn clear_rate_limit_block_sets_self_clear_latch_2232() {
-        let (ctx, _home) = test_ctx_with_agent("health-rl-latch");
-        std::thread::sleep(std::time::Duration::from_millis(500));
-        let latch = |ctx: &HandlerCtx| {
-            let reg = agent::lock_registry(ctx.registry);
-            let h = reg
-                .values()
-                .find(|h| h.name.as_str() == "health-rl-latch")
-                .expect("agent exists");
-            let l = h.core.lock().health.rate_limit_self_cleared;
-            l
-        };
-
-        // (1) clearing with nothing blocked → ok no-op, NO latch (idempotent).
-        let r = handle_clear_blocked_reason(&json!({"name": "health-rl-latch"}), &ctx);
-        assert_eq!(r["ok"], true);
-        assert!(!latch(&ctx), "#2232: a no-op clear must not latch");
-
-        // (2) clearing a non-rate-limit reason → NO latch (scoped, D3).
-        handle_set_blocked_reason(
-            &json!({"name": "health-rl-latch", "reason": "awaiting_operator"}),
-            &ctx,
-        );
-        handle_clear_blocked_reason(&json!({"name": "health-rl-latch"}), &ctx);
-        assert!(
-            !latch(&ctx),
-            "#2232: clearing a non-rate-limit block must not latch"
-        );
-
-        // (3) clearing a RateLimit block → latch set (ground-truth recovery).
-        handle_set_blocked_reason(
-            &json!({"name": "health-rl-latch", "reason": "rate_limit", "retry_after_secs": 30}),
-            &ctx,
-        );
-        let r = handle_clear_blocked_reason(
-            &json!({"name": "health-rl-latch", "reason": "rate_limit"}),
-            &ctx,
-        );
-        assert_eq!(r["ok"], true);
-        assert!(
-            latch(&ctx),
-            "#2232: an agent self-clearing its RateLimit block must set the recovery latch"
-        );
-
-        cleanup_agent(&ctx, "health-rl-latch");
     }
 
     /// #1933 §3.9: the operator-readable `note` round-trips report → operator-

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -1180,7 +1180,7 @@ fn clears_server_rate_limit_retry(state: crate::state::AgentState) -> bool {
 /// - `blocked_rl` (primary, lead-vetted) — classify matched a real RATE-LIMIT error pattern,
 ///   not a generic ApiError; `QuotaExceeded` is a distinct variant, so user quota is excluded.
 /// - `has_throttle_hint` — corroborating throttle token still on screen.
-/// - `!recovered && !self_cleared` — the agent is not awake/progressing. `recovered` =
+/// - `!recovered` — the agent is not awake/progressing. `recovered` =
 ///   `recovered_within(RECOVERY_SILENCE)`, so `!recovered` already encodes the productive-silence
 ///   requirement AND preserves the never-produced fresh-agent edge (a just-spawned agent that
 ///   immediately 529s still arms — an explicit silence threshold would wrongly block it).
@@ -1193,13 +1193,8 @@ fn clears_server_rate_limit_retry(state: crate::state::AgentState) -> bool {
 ///
 /// StopFailure-hook corroboration is deliberately NOT required (hooks are best-effort/droppable,
 /// and would re-introduce a false-negative); it only adds confidence when present (claude).
-fn work_turn_throttle_arm(
-    blocked_rl: bool,
-    has_throttle_hint: bool,
-    recovered: bool,
-    self_cleared: bool,
-) -> bool {
-    blocked_rl && has_throttle_hint && !recovered && !self_cleared
+fn work_turn_throttle_arm(blocked_rl: bool, has_throttle_hint: bool, recovered: bool) -> bool {
+    blocked_rl && has_throttle_hint && !recovered
 }
 
 /// #1470 (re-scoped slice, credit @cheerc): notify an agent's team
@@ -1522,7 +1517,7 @@ pub(crate) fn process_error_recovery(
             // produced (`last_productive_output == None`) is NOT recovery, so it
             // latches + injects normally (the fresh-agent edge the creation stamp
             // used to mis-suppress). `productive_silence` is for the log only.
-            let (state, recovered, self_cleared, has_throttle_hint, blocked_rl, productive_silence) = {
+            let (state, recovered, has_throttle_hint, blocked_rl, productive_silence) = {
                 let mut core = handle.core.lock();
                 // KEEP-RAW (#2465): the SRL retry arm reads raw core.state.current. claude hooks
                 // never emit RateLimited (a StopFailure → ApiError, the API plane owns rate-limit),
@@ -1542,24 +1537,16 @@ pub(crate) fn process_error_recovery(
                     Some(crate::health::BlockedReason::RateLimit { .. })
                 );
                 let recovered = core.state.recovered_within(RECOVERY_SILENCE);
-                // #2232: ground-truth recovery latch the agent set by self-clearing
-                // its rate-limit block via the MCP `clear_blocked_reason` action.
-                let self_cleared = core.health.rate_limit_self_cleared;
                 let has_hint =
                     crate::state::screen_has_throttle_hint(&core.vterm.tail_lines(TAIL_LINES));
                 let productive_silence = core.state.productive_silence();
                 if state == AgentState::ServerRateLimit {
-                    // #2232 D1(b): we are about to track/inject a rate-limit retry,
-                    // so we ALREADY KNOW the agent is rate-limited — mark it blocked
-                    // (only when not already RateLimit-latched, to avoid clobbering a
-                    // watchdog-set `retry_after_secs`). This guarantees the agent's
-                    // later self-clear (`clear_blocked_reason reason=rate_limit`)
-                    // reliably matches and latches, making it a dependable
-                    // ground-truth recovery signal rather than a tick-window
-                    // best-effort. Skip once self-cleared so we never re-block an
-                    // agent that already proved it recovered.
+                    // We are about to track/inject a rate-limit retry, so we ALREADY
+                    // KNOW the agent is rate-limited — mark it blocked (only when not
+                    // already RateLimit-latched, to avoid clobbering a watchdog-set
+                    // `retry_after_secs`). Feeds the loose-arm `blocked_rl` read on
+                    // the next tick and the operator-visible health status.
                     if !recovered
-                        && !self_cleared
                         && !matches!(
                             core.health.current_reason,
                             Some(crate::health::BlockedReason::RateLimit { .. })
@@ -1570,20 +1557,8 @@ pub(crate) fn process_error_recovery(
                                 retry_after_secs: None,
                             });
                     }
-                } else {
-                    // #2232: a genuine ServerRateLimit EXIT resets the latch so a
-                    // FUTURE rate-limit episode re-arms the retry path
-                    // (cross-episode), mirroring `clears_server_rate_limit_retry`.
-                    core.health.rate_limit_self_cleared = false;
                 }
-                (
-                    state,
-                    recovered,
-                    self_cleared,
-                    has_hint,
-                    blocked_rl,
-                    productive_silence,
-                )
+                (state, recovered, has_hint, blocked_rl, productive_silence)
             };
 
             // ── #t-26795 SRL hook-override (operator-reported sticky-screen flap) ──
@@ -1593,7 +1568,7 @@ pub(crate) fn process_error_recovery(
             // overwrites → survives the detect→clear→re-detect flap; removed only on a
             // genuine screen exit); a fresh ACTIVE hook whose seq is STRICTLY newer
             // than the floor is a third recovery signal. ADD-ONLY — composes with
-            // recovered/self_cleared; claude-only; a non-claude / missing / stale /
+            // recovered; claude-only; a non-claude / missing / stale /
             // pre-onset hook falls through to the unchanged screen-driven path.
             // r6 finding-2: key the floor by the STABLE InstanceId, not name, so a
             // same-name replacement gets a fresh floor (the hook STORE is still
@@ -1638,8 +1613,7 @@ pub(crate) fn process_error_recovery(
             // fight). Single-ownership vs the future 529-recovery is left to a PRODUCTION signal
             // (the #2547-removed measure-only recovery_shadow shadow never counted); see
             // `work_turn_throttle_arm`.
-            let loose_arm =
-                work_turn_throttle_arm(blocked_rl, has_throttle_hint, recovered, self_cleared);
+            let loose_arm = work_turn_throttle_arm(blocked_rl, has_throttle_hint, recovered);
 
             // ── #1713 root-fix: ServerRateLimit retry — DECIDE with fresh state ──
             // The "should we inject this tick" decision lives HERE, under the lock,
@@ -1649,8 +1623,7 @@ pub(crate) fn process_error_recovery(
             // only EXECUTES the lock-free PTY inject for the names decided here. So a
             // track can never blind-fire `continue` into a non-error state (e.g. a
             // PermissionPrompt the agent reached after the throttle cleared).
-            if state == AgentState::ServerRateLimit && (recovered || self_cleared || hook_recovered)
-            {
+            if state == AgentState::ServerRateLimit && (recovered || hook_recovered) {
                 // #ratelimit-recovery: still latched ServerRateLimit (the stale
                 // "Server is temporarily limiting" line re-matches in the tail and
                 // working_state_below can't see a marker BELOW the most-recent error
@@ -1659,22 +1632,21 @@ pub(crate) fn process_error_recovery(
                 //   • `recovered` — productive output within RECOVERY_SILENCE
                 //     (heuristic; `last_productive_output` is position-independent,
                 //     breaking the Thinking↔ServerRateLimit flicker). MISSES a pure
-                //     fast TEXT reply that never stamped a behaviour marker (#2232).
-                //   • `self_cleared` (#2232) — the agent itself called
-                //     `clear_blocked_reason` on its rate-limit block: ground-truth
-                //     proof it is awake and read the inject, backend-agnostic, zero
-                //     false-positive for liveness. Closes the over-inject gap the
-                //     heuristic alone left. The latch stays set (so no re-arm) until
-                //     a genuine ServerRateLimit exit resets it (capture block above).
+                //     fast TEXT reply that never stamped a behaviour marker — that
+                //     gap is now covered by `hook_recovered` below (#26795-3
+                //     removed the earlier `self_cleared` agent-driven signal, which
+                //     2746/2746 telemetry proved agents never set).
+                //   • `hook_recovered` (#t-26795) — a fresh post-onset claude hook
+                //     proves the agent is mid-tool-call (see the SRL hook-override
+                //     block above): ground-truth liveness that closes the pure-text
+                //     gap the heuristic alone left. claude-only, ADD-ONLY.
                 // Either way: clear the track and do NOT inject. A genuinely-stuck
-                // agent produces nothing AND can't call clear → the inject fires.
+                // agent produces nothing AND fires no fresh hook → the inject fires.
                 if retry_tracks.remove(name).is_some() {
                     tracing::info!(
                         agent = %name,
                         productive_silent_secs = productive_silence.as_secs(),
-                        recovered_via = if self_cleared {
-                            "agent_self_clear"
-                        } else if recovered {
+                        recovered_via = if recovered {
                             "productive_output"
                         } else {
                             "hook_active" // #t-26795: fresh post-onset claude hook

--- a/src/daemon/supervisor/tests.rs
+++ b/src/daemon/supervisor/tests.rs
@@ -1446,31 +1446,27 @@ fn phase1_detects_rate_limit_and_schedules_retry() {
 
 /// PURE truth table for the work-turn throttle arm predicate. The arm fires ONLY with the
 /// full conjunction; dropping any guard (the primary `blocked_rl`, the `throttle_hint`
-/// corroboration, or the `!recovered`/`!self_cleared` liveness) must turn it off. NEUTER for
+/// corroboration, or the `!recovered` liveness) must turn it off. NEUTER for
 /// the integration arm below.
 #[test]
 fn work_turn_throttle_arm_truth_table_2466() {
     // Full conjunction → arm.
     assert!(
-        super::work_turn_throttle_arm(true, true, false, false),
-        "blocked_rl + throttle_hint + !recovered + !self_cleared → arm"
+        super::work_turn_throttle_arm(true, true, false),
+        "blocked_rl + throttle_hint + !recovered → arm"
     );
     // Each guard is load-bearing.
     assert!(
-        !super::work_turn_throttle_arm(false, true, false, false),
+        !super::work_turn_throttle_arm(false, true, false),
         "no blocked_reason=RateLimit (a bare throttle-token mention) → must NOT arm"
     );
     assert!(
-        !super::work_turn_throttle_arm(true, false, false, false),
+        !super::work_turn_throttle_arm(true, false, false),
         "no throttle hint on screen → must NOT arm"
     );
     assert!(
-        !super::work_turn_throttle_arm(true, true, true, false),
+        !super::work_turn_throttle_arm(true, true, true),
         "recovered (productive output) → must NOT arm"
-    );
-    assert!(
-        !super::work_turn_throttle_arm(true, true, false, true),
-        "self_cleared (agent awake) → must NOT arm"
     );
 }
 
@@ -1985,15 +1981,81 @@ fn server_rate_limit_recent_productive_output_clears_and_skips_inject() {
     std::fs::remove_dir_all(&home).ok();
 }
 
-/// #2232 (a)+(c): an agent self-clearing its rate-limit block (MCP
-/// `clear_blocked_reason`, here the `rate_limit_self_cleared` latch) is
-/// ground-truth recovery even WITHOUT recent productive output (the pure-text
-/// fast-reply gap where `recovered_within` misses). Its retry track must clear
-/// and NO `continue` may be injected across repeated ticks (no over-inject).
+/// #26795-3 (was #2232 (a)+(c)): the `self_cleared` agent-driven recovery signal
+/// was removed (2746/2746 telemetry: agents never set it). Its unique role —
+/// clearing the SRL retry track on recovery even WITHOUT productive output (the
+/// pure-text fast-reply gap where `recovered_within` misses) — is now carried by
+/// the surviving `hook_recovered` signal. This pins the supervisor SRL clear
+/// composition `recovered || hook_recovered`: a fresh post-onset claude hook
+/// clears the track and injects NO `continue` across repeated ticks, with no
+/// productive-output marker. (Complements `srl_hook_override_kills_flap`, which
+/// pins the floor-advance; this pins the no-over-inject guarantee.)
 #[test]
-fn server_rate_limit_self_clear_clears_track_and_skips_inject_2232() {
+#[serial_test::serial]
+fn server_rate_limit_hook_recovered_clears_track_and_skips_inject_26795_3() {
     let registry: AgentRegistry = Arc::new(parking_lot::Mutex::new(HashMap::new()));
-    let home = tmp_home("srl-self-clear");
+    let home = tmp_home("srl-hook-recovered");
+    let name = "srl-hook-recovered-agent";
+    let mut tracks: HashMap<String, RateLimitRetry> = HashMap::new();
+    tracks.insert(
+        name.to_string(),
+        RateLimitRetry {
+            retry_count: 2,
+            next_retry_at: Instant::now(), // DUE — would inject absent recovery
+            exhausted: false,
+            inject_failures: 0,
+            abort_pending: false,
+        },
+    );
+    let mut last_inject: HashMap<String, Instant> = HashMap::new();
+    let mut srl_floor: HashMap<crate::types::InstanceId, u64> = HashMap::new();
+
+    let (handle, _reader) = mock_agent_handle(name, crate::state::AgentState::ServerRateLimit);
+    let id = handle.id;
+    // NOT recovered: last_productive_output stays None (the pure-text gap).
+    registry.lock().insert(handle.id, handle);
+    // Onset baseline pins the floor BELOW the recovery hooks.
+    crate::daemon::hook_shadow::record_event(name, "Stop", None);
+    let floor = crate::daemon::hook_shadow::latest_hook_seq(name);
+    srl_floor.insert(id, floor);
+
+    // A fresh post-onset tool-call hook each tick (seq > floor) = hook_recovered:
+    // ground-truth the agent is alive even with no productive-output marker.
+    for _ in 0..3 {
+        crate::daemon::hook_shadow::record_event(name, "PreToolUse", None);
+        super::process_error_recovery(
+            &home,
+            &registry,
+            &mut tracks,
+            &mut Default::default(),
+            &mut Default::default(),
+            &mut last_inject,
+            &mut srl_floor,
+            past_boot_grace(),
+        );
+    }
+
+    assert!(
+        !tracks.contains_key(name),
+        "#26795-3: a hook-recovered SRL agent's retry track must be dropped even \
+             with no recent productive output (the pure-text gap self_cleared covered)"
+    );
+    assert!(
+        !last_inject.contains_key(name),
+        "#26795-3: no `continue` may be injected into a hook-recovered agent"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// #26795-3 (a): a NON-CLAUDE backend has no state hooks, so `hook_recovered` is
+/// always false — its only SRL retry-exit is the productive-output heuristic
+/// (`recovered`). Removing the dead `self_cleared` signal must leave that path
+/// unchanged: a recovered (recent productive output) non-claude agent still has
+/// its retry track cleared and no `continue` injected.
+#[test]
+fn non_claude_srl_retry_exit_unchanged_after_self_clear_removal_26795_3() {
+    let registry: AgentRegistry = Arc::new(parking_lot::Mutex::new(HashMap::new()));
+    let home = tmp_home("srl-nonclaude-exit");
     let mut tracks: HashMap<String, RateLimitRetry> = HashMap::new();
     tracks.insert(
         "test-agent".to_string(),
@@ -2007,11 +2069,13 @@ fn server_rate_limit_self_clear_clears_track_and_skips_inject_2232() {
     );
     let mut last_inject: HashMap<String, Instant> = HashMap::new();
 
-    let (handle, _reader) =
+    let (mut handle, _reader) =
         mock_agent_handle("test-agent", crate::state::AgentState::ServerRateLimit);
-    // NOT recovered (last_productive_output stays None — the fast-text gap), but
-    // the agent self-cleared its rate-limit block: the #2232 ground-truth signal.
-    handle.core.lock().health.rate_limit_self_cleared = true;
+    // NON-CLAUDE: codex has no state hooks (`has_state_hooks()` false) → the hook
+    // recovery path can never fire; only the productive-output heuristic can exit.
+    handle.backend_command = "codex".to_string();
+    // Recovered via the heuristic: recent productive output.
+    handle.core.lock().state.last_productive_output = Some(Instant::now());
     registry.lock().insert(handle.id, handle);
 
     for _ in 0..3 {
@@ -2029,31 +2093,32 @@ fn server_rate_limit_self_clear_clears_track_and_skips_inject_2232() {
 
     assert!(
         !tracks.contains_key("test-agent"),
-        "#2232: an agent that self-cleared its rate-limit block must have its \
-             retry track dropped even with no recent productive output"
+        "#26795-3 (a): a recovered non-claude agent's SRL retry track must clear \
+             via the productive-output heuristic (unchanged by the signal removal)"
     );
     assert!(
         !last_inject.contains_key("test-agent"),
-        "#2232: no `continue` may be re-injected into a self-cleared agent \
-             (the over-inject the issue reports)"
+        "#26795-3 (a): no `continue` injected into a recovered non-claude agent"
     );
     std::fs::remove_dir_all(&home).ok();
 }
 
-/// #2232 D1(b): when the supervisor tracks/injects a rate-limit retry it
-/// ALREADY knows the agent is rate-limited, so it marks the agent
-/// `RateLimit`-blocked — guaranteeing the agent's later filtered
-/// `clear_blocked_reason(reason=rate_limit)` matches and latches (reliable
-/// ground-truth, not tick-window best-effort).
+/// #26795-3 (was #2232 D1(b)): when the supervisor tracks/injects a rate-limit
+/// retry it ALREADY knows the agent is rate-limited, so it marks the agent
+/// `RateLimit`-blocked. The `self_cleared` consumer this originally fed was
+/// removed (dead signal, 2746/2746 never set), but the `set_blocked_reason` is
+/// RETAINED: it surfaces the block in the operator-visible health status and
+/// feeds the loose-arm `blocked_rl` read on the next tick. This pins that
+/// retained behaviour (unchanged by the signal removal).
 #[test]
-fn server_rate_limit_inject_schedule_marks_ratelimit_block_2232() {
+fn server_rate_limit_inject_schedule_marks_ratelimit_block_26795_3() {
     let registry: AgentRegistry = Arc::new(parking_lot::Mutex::new(HashMap::new()));
     let home = tmp_home("srl-mark-block");
     let mut tracks: HashMap<String, RateLimitRetry> = HashMap::new();
 
     let (handle, _reader) =
         mock_agent_handle("test-agent", crate::state::AgentState::ServerRateLimit);
-    // No prior blocked_reason, not recovered, not self-cleared.
+    // No prior blocked_reason, not recovered.
     assert!(handle.core.lock().health.current_reason.is_none());
     registry.lock().insert(handle.id, handle);
 
@@ -2075,124 +2140,10 @@ fn server_rate_limit_inject_schedule_marks_ratelimit_block_2232() {
             h.core.lock().health.current_reason,
             Some(crate::health::BlockedReason::RateLimit { .. })
         ),
-        "#2232 D1(b): inject-schedule must mark the agent RateLimit-blocked so a \
-             later filtered self-clear reliably matches"
+        "#26795-3: inject-schedule must still mark the agent RateLimit-blocked \
+             (retained health-status marking after the self_cleared signal removal)"
     );
     drop(reg);
-    std::fs::remove_dir_all(&home).ok();
-}
-
-/// #2232 cross-episode: the self-clear latch resets on a genuine ServerRateLimit
-/// EXIT, so a FUTURE rate-limit episode re-arms the retry path (no stale latch
-/// permanently disabling auto-recovery).
-#[test]
-fn server_rate_limit_self_clear_latch_resets_on_exit_then_rearms_2232() {
-    let registry: AgentRegistry = Arc::new(parking_lot::Mutex::new(HashMap::new()));
-    let home = tmp_home("srl-rearm");
-    let mut tracks: HashMap<String, RateLimitRetry> = HashMap::new();
-
-    let (handle, _reader) =
-        mock_agent_handle("test-agent", crate::state::AgentState::ServerRateLimit);
-    handle.core.lock().health.rate_limit_self_cleared = true;
-    registry.lock().insert(handle.id, handle);
-    let tick = |tracks: &mut HashMap<String, RateLimitRetry>| {
-        super::process_error_recovery(
-            &home,
-            &registry,
-            tracks,
-            &mut Default::default(),
-            &mut Default::default(),
-            &mut Default::default(),
-            &mut Default::default(),
-            past_boot_grace(),
-        );
-    };
-
-    // Self-cleared SRL → no track armed.
-    tick(&mut tracks);
-    assert!(
-        !tracks.contains_key("test-agent"),
-        "self-cleared SRL must not re-arm"
-    );
-
-    // Agent genuinely leaves ServerRateLimit → latch resets.
-    {
-        let reg = registry.lock();
-        reg.values()
-            .next()
-            .expect("agent present")
-            .core
-            .lock()
-            .state
-            .current = crate::state::AgentState::Idle;
-    }
-    tick(&mut tracks);
-    assert!(
-        !registry
-            .lock()
-            .values()
-            .next()
-            .expect("agent present")
-            .core
-            .lock()
-            .health
-            .rate_limit_self_cleared,
-        "#2232: a genuine ServerRateLimit exit resets the self-clear latch"
-    );
-
-    // A NEW rate-limit episode (no productive output, latch now reset) re-arms.
-    {
-        let reg = registry.lock();
-        reg.values()
-            .next()
-            .expect("agent present")
-            .core
-            .lock()
-            .state
-            .current = crate::state::AgentState::ServerRateLimit;
-    }
-    tick(&mut tracks);
-    assert!(
-        tracks.contains_key("test-agent"),
-        "#2232: a future rate-limit episode must re-arm after the latch reset"
-    );
-    std::fs::remove_dir_all(&home).ok();
-}
-
-/// #2232 (d): the self-clear signal is an idempotent no-op when there is no
-/// active retry track — the supervisor consumes it safely (no panic, no
-/// inject, and a self-cleared agent is not re-armed).
-#[test]
-fn server_rate_limit_self_clear_no_track_is_noop_2232() {
-    let registry: AgentRegistry = Arc::new(parking_lot::Mutex::new(HashMap::new()));
-    let home = tmp_home("srl-noop");
-    let mut tracks: HashMap<String, RateLimitRetry> = HashMap::new(); // empty
-    let mut last_inject: HashMap<String, Instant> = HashMap::new();
-
-    let (handle, _reader) =
-        mock_agent_handle("test-agent", crate::state::AgentState::ServerRateLimit);
-    handle.core.lock().health.rate_limit_self_cleared = true;
-    registry.lock().insert(handle.id, handle);
-
-    super::process_error_recovery(
-        &home,
-        &registry,
-        &mut tracks,
-        &mut Default::default(),
-        &mut Default::default(),
-        &mut last_inject,
-        &mut Default::default(),
-        past_boot_grace(),
-    );
-
-    assert!(
-        !tracks.contains_key("test-agent"),
-        "#2232: a self-cleared agent is not re-armed even from an empty track set"
-    );
-    assert!(
-        !last_inject.contains_key("test-agent"),
-        "#2232: no inject for a self-cleared agent"
-    );
     std::fs::remove_dir_all(&home).ok();
 }
 

--- a/src/health.rs
+++ b/src/health.rs
@@ -351,18 +351,6 @@ pub struct HealthTracker {
     /// so it lives alongside `current_reason` rather than inside the enum. Reset
     /// when a new reason is set and cleared with the reason.
     pub current_note: Option<String>,
-    /// #2232: ground-truth rate-limit recovery latch. Set true ONLY when the
-    /// AGENT itself clears a `RateLimit`/`QuotaExceeded` block via the MCP
-    /// `clear_blocked_reason` action (proof it is awake and read the inject) —
-    /// the watchdog's heuristic auto-clear does NOT set it. The supervisor's
-    /// `process_error_recovery` reads it (under the lock it already holds) as a
-    /// reliable recovery signal to drop the `ServerRateLimit` retry track when
-    /// the narrow `recovered_within` heuristic misses a pure-text fast reply, and
-    /// resets it on a genuine `ServerRateLimit` exit so a future episode re-arms.
-    /// In-memory only (resets to false on restart, like the retry tracks).
-    /// (`RecoverySignal::RateLimitLifted` is the would-be typed equivalent but
-    /// stays unwired — a bool is sufficient here, #2232 D2.)
-    pub rate_limit_self_cleared: bool,
     /// `#685` sub-task 7a: per-agent recovery dispatcher state machine.
     /// Mutated only by `src/daemon/per_tick/recovery_dispatcher.rs`;
     /// `health.rs` ships it as a field to keep all per-agent state in
@@ -468,7 +456,6 @@ impl HealthTracker {
             last_output: Instant::now(),
             current_reason: None,
             current_note: None,
-            rate_limit_self_cleared: false,
             recovery_stage_state: RecoveryStageState::None,
             last_stage1_fired_at: None,
             last_stage3_fired_at: None,


### PR DESCRIPTION
## What

PR ① of the #26795-3 SRL self-clear convergence (② = #2674, merges the payload copy). Removes the **dead `rate_limit_self_cleared` recovery SIGNAL** and **keeps the `clear_blocked_reason` VERB**.

## Why

The #26795-3 spike quantified that the MCP self-clear recovery *exit* is a design dead-path: **2746/2746** `recovery_shadow` entries had `self_cleared=false` — agents essentially never call `health clear_blocked_reason` to self-clear a rate-limit block, so the signal never fired in production. Its one real value — closing the pure-text fast-reply gap that the `recovered_within` heuristic misses — is now carried by `hook_recovered` (#t-26795, claude backend has state hooks).

## Scope (latch/signal surface only — the verb is untouched)

| File | Change |
|---|---|
| `health.rs` | Drop the `rate_limit_self_cleared` field |
| `api/handlers/instance.rs` | Drop the latch-SET after `clear_blocked_reason` (+ orphaned `was_rate_limit_block`) |
| `api/handlers/hook_event.rs` | Drop the #t-3558 apierror-hook latch RESET (+ orphaned `is_apierror_hook`) |
| `daemon/supervisor.rs` | Drop `self_cleared` from `work_turn_throttle_arm`, the capture tuple, and the recovery composition → `recovered \|\| hook_recovered` |

**Verb surface untouched** (all legit callers): `operator_gate.rs` AlwaysAllow, `api/mod.rs`, the `instance.rs` handler + `health.rs::clear_blocked_reason()`, `instance_metadata.rs`, `dispatch.rs`, `tools.rs`, doc in `instructions.rs`, and the daemon direct callers (`watchdog.rs`, `supervisor.rs:971`).

## Two judgment calls (flagging for the reviewer)

1. **`set_blocked_reason` is RETAINED** (not removed). Its original comment framed it as "so the agent's later self-clear reliably matches", but it writes to the shared `current_reason` health field — consumed by the operator-visible health status and the next-tick loose-arm `blocked_rl` read. So I kept it and only dropped the `&& !self_cleared` guard, which is a **no-op in practice** (`self_cleared` was always false). The cross-episode latch *reset* (`else` branch) is removed — nothing left to reset.
2. **Ruling (c) — the composition test is re-pointed to `hook_recovered`.** The removed `self_clear_clears_track` test uniquely covered "clears the track *without productive output*" (the pure-text gap). `recovered` requires productive output, so the only surviving signal that covers that gap is `hook_recovered` — I re-pointed the test there rather than duplicating the existing `recovered` test. If the intent was a simpler `recovered` re-point, easy to redirect.

## Tests (per lead ruling)

- **(a) NEW** `non_claude_srl_retry_exit_unchanged_...` — a non-claude backend (no hooks → `hook_recovered` always false) still exits via the productive-output heuristic, unchanged by the removal.
- **(b)** #t-26795 `hook_recovered` regressions untouched, stay green.
- **(c)** `self_clear_clears_track` **updated** → re-pointed to `hook_recovered`, pinning `recovered || hook_recovered`.
- **(d)** **Deleted** the tests that ONLY exercised the removed latch/reset (hook_event StopFailure-reset pair + T3558 helpers; instance rl-latch test; supervisor latch-reset-on-exit + no-track-noop). Plain verb-clears test kept.

## Serde back-compat

`HealthTracker` derives **`Clone` only** (not `Serialize`/`Deserialize`) — the field was in-memory only, so removal has **zero on-disk schema / serde back-compat impact**.

## Gate (all green)

`fmt --check` · `file_size` + `src_file_size` invariants (by binary) · `clippy --workspace --all-targets -D warnings` · `nextest` (170 affected + 7 targeted, incl. both new tests + the untouched hook_recovered regression).
