### PR TITLE
feat(#t-78445-1): agend-git shim — require --force-with-lease for feature-branch force-push (fleet-safety)

### DIFF
--- a/FORCE-PUSH-SHIM-SPIKE.md
+++ b/FORCE-PUSH-SHIM-SPIKE.md
@@ -1,0 +1,95 @@
+# Spike: agend-git shim force-push gap (t-…78445-1, #2673 follow-up)
+
+Spike-first (no production code except part (a) comment softening — done). DUAL-class
+(fleet-safety / data-loss-adjacent). All file:line in `src/bin/agend-git.rs` unless noted.
+
+## The gap (confirmed at file:line)
+`push_protected_violation` (`:2068-2103`, called from the push arm `:241-256`) treats
+force as "HOW not WHAT" (doc `:2066`). `push_dest_refs` (`:2035-2045`) does
+`a.strip_prefix('+')` and extracts only the DESTINATION ref; the gate denies only:
+bulk (`--all`/`--mirror`, `:2116-2121`), wildcard dest (`*`), an explicit protected
+dest, or a no-refspec push under `push.default=matching` (`:2133-2141`). A non-protected
+dest like `feat/x` matches none → `None` → **allow**. Force never enters the decision:
+`is_bulk_push_flag` explicitly excludes `--force`/`-f` (`:2116-2121`, test `:1013-1028`),
+and `push_dest_refs_normalizes_refspec_targets_s3` (`tests.rs:904-924`) *asserts*
+`push --force -u origin feat/x` is allowed. No `--force-with-lease` handling anywhere;
+push audit fires ONLY on deny (`deny_trust_root :224-231`, `deny_protected_ref :247-254`)
+— an allowed force-push emits no event.
+
+**Impact**: any agent, any time, can `git push --force origin <feature>` and overwrite
+existing commits on that origin branch (another agent's / another session's work, or a
+wrong-based branch — e.g. #2673 state-3's residual edge). Same fleet-safety family as
+#2662 (denylist/trust-root).
+
+## Step 1 — does command-authority (t-777-1) cover this? NO.
+The `t-777-1` proposal doc (`COMMAND-AUTHORITY-SPIKE*.md`, fixup-dev-2) is **not on disk**
+(searched repo + `workspace/*` + `worktrees/`; fixup-dev-2's workspace was GC'd; 777-1
+survives only in JSON logs). The accessible command-authority artifacts —
+`workspace/gapfix-dev2/INSTANCE-ACTIONIZE-SPIKE.md` + `P0-CLASSIFIER-DESIGN.md` (task
+14440-2) — are scoped to the 12 MCP **Instance-family tools** + `operator_gate` classify(),
+with ZERO git/push/force content. Command-authority gates MCP *tool* calls; the git shim
+is a *distinct enforcement layer* (intercepts the raw `git` subprocess). Force-push
+authority is therefore out of command-authority scope regardless of the missing doc →
+**proceed independently; nothing to defer to.**
+
+## Threat / context model (proportionate)
+Single-user single-machine fleet ([[feedback_security_single_user_single_machine]]).
+Defending TWO failure modes: (a) benign agent footgun — a wrong-based / stale-based
+`--force` overwrites real commits (this task's origin); (b) injected agent deliberately
+destroying an origin branch. Force-push is a CAPABLE op, not inherently a footgun
+([[feedback_restrict_only_footguns_not_capable_ops]]) — the footgun is specifically the
+UNCONDITIONAL overwrite. So the fix should remove the footgun WITHOUT removing the
+capability. Protected refs (main/master) are already hard-denied; this is only about
+feature branches.
+
+## Options (with cost / agent-workflow compat)
+- **(i) Require `--force-with-lease`** (RECOMMENDED). Deny `--force`/`-f`/`+<dest>` to a
+  non-protected feature dest UNLESS it carries `--force-with-lease[=…]` (or
+  `--force-if-includes`); deny message teaches the safe form. Rationale: `--force-with-lease`
+  refuses to overwrite if the remote moved since the pusher's last fetch — it kills the
+  "clobber unseen commits" footgun while KEEPING the legitimate rebase-then-force workflow.
+  · Compat: the common agent flow (rebase/amend → force-push) still works when the pusher
+    has fetched (lease baseline = its remote-tracking ref); if someone else pushed, the
+    lease FAILS loudly = exactly the footgun being caught. Friction = agents must switch
+    from `--force` to `--force-with-lease` (the deny msg guides them). `+<dest>` refspec
+    force has no lease form → deny it, steer to the flag form.
+  · Cost: localized edit to `push_protected_violation` (add a force-detect + lease-detect
+    arm) + tests (bare-force→deny, lease-force→allow, `+dest`→deny) + a `deny_force_no_lease`
+    audit event. ~1 function + test file. Blast radius contained (§ below).
+  · Risk: "擋太死逼 agent 繞 shim (AGEND_GIT_BYPASS)" — mitigated: lease is a 1-word change,
+    not a capability loss; the deny message makes the fix obvious.
+- **(ii) Warn + audit, allow.** Emit an `allowed_force_push` event + stderr warning on bare
+  force-to-feature, but allow. Zero workflow friction + gives traceability, but does NOT
+  prevent the data-loss. Good as a *complement* to (i) (audit the denies/allows) or a
+  weaker standalone first step.
+- **(iii) Status quo + docs.** Cheapest, zero safety. Not recommended given a merged PR
+  (#2673) already documents relying on a backstop this gap defeats.
+
+**Recommendation: (i) + the audit half of (ii)** — require `--force-with-lease` for
+feature-branch force-pushes (footgun removed, capability kept), and emit a deny audit
+event for observability. Proportionate to single-user context; mirrors the existing
+protected-ref deny pattern.
+
+## Blast radius (for the impl, if vetted)
+- Decision: `push_protected_violation` `:2068-2103` (+ maybe `push_dest_refs` to surface the
+  raw `+`/force flag instead of discarding it) — the force/lease detection needs the flag,
+  which `:2035-2045` currently strips.
+- Tests: `src/bin/agend-git/tests.rs:904-1028` (several ASSERT force-to-feature is allowed —
+  they must be updated to the new contract; add the deny/allow-lease cases). Per lead's
+  fixture guidance, adjust to the new semantics, don't weaken the rule.
+- Audit: add `deny_force_no_lease` via the existing `write_git_event_typed` (~`:2413`).
+
+## Part (a) — DONE
+Softened the two overstated state-3 comments in
+`src/mcp/handlers/dispatch_hook/branch_start_point.rs` (state table + inline): the non-ff
+"second line of defense" now reads as a PARTIAL backstop that a bare `git push --force`
+bypasses (cites t-…78445-1). Comment-only, no logic change.
+
+## Open questions for lead / operator
+1. Accept the `--force-with-lease` friction (hard deny, option i), or start with warn+audit
+   (ii) only? I recommend (i) — data-loss surface, lease keeps the capability.
+2. `--force-with-lease` baseline compat: confirm agents typically fetch before force-pushing
+   (else bare-lease can misbehave). If not, the deny msg should say `--force-with-lease=<ref>:<sha>`.
+3. Also cover `+<dest>` refspec force (I propose deny → steer to the flag form) — OK?
+4. Scope: this touches the SHIM only (not MCP-tool authority). Confirm we're not waiting on
+   the (missing) 777-1 doc.

--- a/src/bin/agend-git.rs
+++ b/src/bin/agend-git.rs
@@ -35,6 +35,11 @@ mod protected_refs;
 #[path = "agend-git/git_refs.rs"]
 mod git_refs;
 
+// #t-…78445-1: push-authority decisions (protected-ref guard + bare-force gate) live in this
+// submodule to keep agend-git.rs under the 2500-LOC anti-monolith ceiling.
+#[path = "agend-git/force_push.rs"]
+mod force_push;
+
 /// #1504 L3: max times the shim may re-enter before hard-failing. Healthy
 /// operation never exceeds 1 (real git ≠ shim → no re-entry), so a small cap
 /// has zero false-trip risk while containing a self-resolution spawn storm.
@@ -238,7 +243,7 @@ fn main() {
             // Shim-layer defense-in-depth (the remote's branch protection is the primary
             // gate); fail-closed (`load_protected_refs`). A normal push of the agent's own
             // branch is untouched.
-            if let Some(reason) = push_protected_violation(
+            if let Some(reason) = force_push::push_protected_violation(
                 &args,
                 &load_protected_refs(&home),
                 push_default_is_matching(&worktree),
@@ -249,6 +254,22 @@ fn main() {
                     &agent,
                     subcommand,
                     "deny_protected_ref",
+                    None,
+                    Some(&reason),
+                );
+                std::process::exit(1);
+            }
+            // #t-…78445-1: a bare force-push (`--force`/`-f`/`+refspec`) to a NON-protected
+            // feature branch can silently overwrite existing remote commits — require
+            // `--force-with-lease` (footgun removed, rebase-then-force workflow kept).
+            // Runs after the protected check so protected-ref force keeps `deny_protected_ref`.
+            if let Some(reason) = force_push::push_force_without_lease_violation(&args) {
+                emit_deny_error(subcommand, &reason, &agent, Some(&binding));
+                write_git_event_typed(
+                    &home,
+                    &agent,
+                    subcommand,
+                    "deny_force_no_lease",
                     None,
                     Some(&reason),
                 );
@@ -2042,64 +2063,6 @@ fn push_dest_refs(args: &[String]) -> Vec<String> {
             dest.strip_prefix("refs/heads/").unwrap_or(dest).to_string()
         })
         .collect()
-}
-
-/// #2379 S3: a `git push` is DENIED iff it could write a protected ref. COMPREHENSIVE over
-/// the push surface (r6: a positional-only parse let `--all`/`--mirror` slip through).
-/// Returns an actionable deny reason, or `None` to allow:
-/// - **`--all` / `--mirror`** (+ unambiguous abbreviations) push EVERY local head incl.
-///   protected ones → deny (a bound agent must push an explicit refspec of its OWN branch);
-/// - an **explicit refspec** whose DEST is a protected ref (exact, case-insensitive) → deny;
-/// - a **wildcard** refspec dest (`refs/heads/*`) could write a protected ref → deny
-///   (conservative — a bound agent pushes its explicit branch; glob-vs-protected refinement
-///   is a follow-up);
-/// - a **no-refspec** push (`git push` / `git push <remote>`) targets the CURRENT branch
-///   under the modern `push.default` (simple/current/upstream) = a bound agent's
-///   non-protected assigned branch (cross-branch deny) → allow; EXCEPT the deprecated
-///   `push.default=matching`, which would ALSO push a local `main`/`master` → deny.
-///
-/// `--tags` is TAGS-ONLY (`refs/tags/*`, never a branch) regardless of push.default, so it
-/// is exempt even from the matching deny (r6 dry-run: `git push --tags` under matching pushes
-/// only tags). `--follow-tags` is NOT exempt: it pushes the would-be-pushed BRANCHES *plus*
-/// tags, so under `push.default=matching` it pushes the matching heads incl. `main`
-/// (empirically confirmed via dry-run) → it correctly hits the matching deny. Force flags
-/// (`-f`/`--force-with-lease`/`+`) change HOW not WHAT — the refspec is still parsed above.
-/// Shim-layer defense-in-depth — the remote's branch protection is the primary gate.
-fn push_protected_violation(
-    args: &[String],
-    protected: &[String],
-    push_default_matching: bool,
-) -> Option<String> {
-    if let Some(flag) = args.iter().skip(1).find(|a| is_bulk_push_flag(a)) {
-        return Some(format!(
-            "`{flag}` pushes ALL local refs (including protected ones) — push an explicit \
-             refspec of your own task branch instead, not all refs at once"
-        ));
-    }
-    for dest in push_dest_refs(args) {
-        if dest.contains('*') {
-            return Some(format!(
-                "wildcard refspec dest `{dest}` could write a protected ref — push an \
-                 explicit, single-ref refspec instead"
-            ));
-        }
-        if protected.iter().any(|p| p.eq_ignore_ascii_case(&dest)) {
-            return Some(format!(
-                "protected ref — pushing to '{dest}' is denied (shim-layer guard; the \
-                 remote's branch protection is the primary gate). Push your own task branch \
-                 and open a PR; do NOT push directly to a protected ref."
-            ));
-        }
-    }
-    if push_default_matching && !has_explicit_refspec(args) && !is_tags_only_push(args) {
-        return Some(
-            "push.default=matching with no explicit refspec would push every same-named \
-             branch (including a local protected ref) — set push.default=current/simple, or \
-             push an explicit refspec of your own task branch"
-                .to_string(),
-        );
-    }
-    None
 }
 
 /// `--tags` makes the push TAGS-ONLY (`refs/tags/*`), regardless of `push.default` — so it is

--- a/src/bin/agend-git/force_push.rs
+++ b/src/bin/agend-git/force_push.rs
@@ -1,0 +1,141 @@
+/// #2379 S3: a `git push` is DENIED iff it could write a protected ref. COMPREHENSIVE over
+/// the push surface (r6: a positional-only parse let `--all`/`--mirror` slip through).
+/// Returns an actionable deny reason, or `None` to allow:
+/// - **`--all` / `--mirror`** (+ unambiguous abbreviations) push EVERY local head incl.
+///   protected ones → deny (a bound agent must push an explicit refspec of its OWN branch);
+/// - an **explicit refspec** whose DEST is a protected ref (exact, case-insensitive) → deny;
+/// - a **wildcard** refspec dest (`refs/heads/*`) could write a protected ref → deny
+///   (conservative — a bound agent pushes its explicit branch; glob-vs-protected refinement
+///   is a follow-up);
+/// - a **no-refspec** push (`git push` / `git push <remote>`) targets the CURRENT branch
+///   under the modern `push.default` (simple/current/upstream) = a bound agent's
+///   non-protected assigned branch (cross-branch deny) → allow; EXCEPT the deprecated
+///   `push.default=matching`, which would ALSO push a local `main`/`master` → deny.
+///
+/// `--tags` is TAGS-ONLY (`refs/tags/*`, never a branch) regardless of push.default, so it
+/// is exempt even from the matching deny (r6 dry-run: `git push --tags` under matching pushes
+/// only tags). `--follow-tags` is NOT exempt: it pushes the would-be-pushed BRANCHES *plus*
+/// tags, so under `push.default=matching` it pushes the matching heads incl. `main`
+/// (empirically confirmed via dry-run) → it correctly hits the matching deny. Force flags
+/// (`-f`/`--force-with-lease`/`+`) change HOW not WHAT — the refspec is still parsed above.
+/// Shim-layer defense-in-depth — the remote's branch protection is the primary gate.
+pub(crate) fn push_protected_violation(
+    args: &[String],
+    protected: &[String],
+    push_default_matching: bool,
+) -> Option<String> {
+    if let Some(flag) = args.iter().skip(1).find(|a| super::is_bulk_push_flag(a)) {
+        return Some(format!(
+            "`{flag}` pushes ALL local refs (including protected ones) — push an explicit \
+             refspec of your own task branch instead, not all refs at once"
+        ));
+    }
+    for dest in super::push_dest_refs(args) {
+        if dest.contains('*') {
+            return Some(format!(
+                "wildcard refspec dest `{dest}` could write a protected ref — push an \
+                 explicit, single-ref refspec instead"
+            ));
+        }
+        if protected.iter().any(|p| p.eq_ignore_ascii_case(&dest)) {
+            return Some(format!(
+                "protected ref — pushing to '{dest}' is denied (shim-layer guard; the \
+                 remote's branch protection is the primary gate). Push your own task branch \
+                 and open a PR; do NOT push directly to a protected ref."
+            ));
+        }
+    }
+    if push_default_matching
+        && !super::has_explicit_refspec(args)
+        && !super::is_tags_only_push(args)
+    {
+        return Some(
+            "push.default=matching with no explicit refspec would push every same-named \
+             branch (including a local protected ref) — set push.default=current/simple, or \
+             push an explicit refspec of your own task branch"
+                .to_string(),
+        );
+    }
+    None
+}
+
+/// #t-…78445-1 (fleet-safety, dev3 #2673 review): a BARE force-push
+/// (`--force`/`-f`/`+refspec`) to a NON-protected branch can silently overwrite commits
+/// already on the remote branch — another agent's or session's work, or a wrong-based
+/// branch (#2673 state-3's residual edge). `push_protected_violation` above intentionally
+/// ignores force ("HOW not WHAT") and only guards protected refs, so it never catches this.
+/// Require `--force-with-lease` instead: it refuses the push if the remote moved since the
+/// pusher's last fetch, which REMOVES the footgun while KEEPING the legitimate
+/// rebase-then-force workflow (footgun-removal, not capability-removal). Returns an
+/// actionable deny reason (with an executable retry sequence), or `None` to allow.
+///
+/// Runs AFTER `push_protected_violation` in the push arm, so a force-push to a protected ref
+/// is already denied (with `deny_protected_ref`) before reaching here. Deletions don't
+/// overwrite history → exempt. NB: git makes a trailing `--force` override a
+/// `--force-with-lease`, so ANY bare `--force`/`-f`/`+refspec` present = unconditional and is
+/// denied even if a lease flag co-occurs.
+pub(crate) fn push_force_without_lease_violation(args: &[String]) -> Option<String> {
+    if !push_has_bare_force(args) || is_delete_push(args) {
+        return None;
+    }
+    let (remote, branch) = force_push_target(args);
+    let seq = match (remote.as_deref(), branch.as_deref()) {
+        (Some(r), Some(b)) => {
+            format!("git fetch {r} {b} && git push --force-with-lease {r} {b}")
+        }
+        _ => "git fetch <remote> <branch> && git push --force-with-lease <remote> <branch>"
+            .to_string(),
+    };
+    Some(format!(
+        "bare force-push denied: `--force` / `-f` / a `+refspec` can SILENTLY OVERWRITE \
+         commits already on the remote branch (another agent's or session's work). Re-run \
+         with a lease — it refuses the push if the remote moved since your last fetch, so you \
+         cannot clobber commits you have not seen:\n  {seq}\nProtected refs stay hard-denied \
+         regardless; this guards feature branches (t-…78445-1). If you genuinely intend to \
+         discard remote commits, fetch first so the lease baseline is current."
+    ))
+}
+
+/// A push carries a BARE (unconditional) force: `--force`, a single-dash short cluster
+/// containing `f` (`-f`, `-fu`, `-uf`, …), or a `+`-prefixed refspec positional.
+/// `--force-with-lease[=…]` / `--force-if-includes` are the SAFE forms and are NOT bare
+/// force (they gate on the remote not having moved). `--force` is an exact match — git
+/// rejects an ambiguous abbreviation like `--forc` (shared with `--force-with-lease`), so no
+/// abbreviation handling is needed for the long form.
+fn push_has_bare_force(args: &[String]) -> bool {
+    args.iter().skip(1).any(|a| {
+        a == "--force"
+            || (a.starts_with('-') && !a.starts_with("--") && a.contains('f'))
+            || a.starts_with('+')
+    })
+}
+
+/// A deletion push (`--delete`, a short cluster containing `d`, or a `:<dest>` refspec with an
+/// empty source) removes a ref rather than overwriting history → exempt from the force gate.
+fn is_delete_push(args: &[String]) -> bool {
+    args.iter().skip(1).any(|a| {
+        a == "--delete"
+            || (a.starts_with('-') && !a.starts_with("--") && a.contains('d'))
+            || (!a.starts_with('-') && a.strip_prefix('+').unwrap_or(a).starts_with(':'))
+    })
+}
+
+/// Best-effort `(remote, branch)` for the deny message's retry sequence: the first positional
+/// after `push` is the remote, the second (if any) is the refspec whose dest is the branch.
+/// Absent → the message falls back to a `<remote> <branch>` template.
+fn force_push_target(args: &[String]) -> (Option<String>, Option<String>) {
+    let positionals: Vec<&String> = args
+        .iter()
+        .skip(1)
+        .filter(|a| !a.starts_with('-'))
+        .collect();
+    let remote = positionals
+        .first()
+        .map(|s| s.trim_start_matches('+').to_string());
+    let branch = positionals.get(1).map(|a| {
+        let a = a.strip_prefix('+').unwrap_or(a);
+        let dest = a.rsplit(':').next().unwrap_or(a);
+        dest.strip_prefix("refs/heads/").unwrap_or(dest).to_string()
+    });
+    (remote, branch)
+}

--- a/src/bin/agend-git/force_push.rs
+++ b/src/bin/agend-git/force_push.rs
@@ -110,28 +110,55 @@ fn push_has_bare_force(args: &[String]) -> bool {
     })
 }
 
-/// A deletion push (`--delete`, a short cluster containing `d`, or a `:<dest>` refspec with an
-/// empty source) removes a ref rather than overwriting history → exempt from the force gate.
+/// A PURE deletion push removes refs rather than overwriting history → exempt from the force
+/// gate. The `--delete` flag (or its short `-d` cluster) makes EVERY named ref a deletion, so
+/// it is unconditionally exempt. Otherwise a push is a pure deletion only when it names at
+/// least one refspec and EVERY refspec is a `:<dest>` deletion.
+///
+/// #t-…78445-1 F1 (dev2 review, CONFIRMED bypass): this MUST NOT use any-arg detection. A
+/// mixed `git push --force origin :del real` deletes `:del` AND force-overwrites `real`; an
+/// any-arg exemption would let `real`'s force through. Exempting only when ALL refspecs are
+/// deletions keeps a lone `:del` (or `--delete`) exempt while a mixed push stays gated.
 fn is_delete_push(args: &[String]) -> bool {
-    args.iter().skip(1).any(|a| {
-        a == "--delete"
-            || (a.starts_with('-') && !a.starts_with("--") && a.contains('d'))
-            || (!a.starts_with('-') && a.strip_prefix('+').unwrap_or(a).starts_with(':'))
-    })
+    // `--delete` / `-d` → all named refs are deletions.
+    if args
+        .iter()
+        .skip(1)
+        .any(|a| a == "--delete" || (a.starts_with('-') && !a.starts_with("--") && a.contains('d')))
+    {
+        return true;
+    }
+    // Otherwise inspect the refspec positionals. The first positional is the remote; a push
+    // is a pure deletion only when it names >=1 refspec and EVERY refspec is a `:<dest>`
+    // deletion (after an optional `+`). A single non-delete refspec means the force applies to
+    // a real overwrite and must stay gated.
+    let non_flag: Vec<&str> = args
+        .iter()
+        .skip(1)
+        .filter(|a| !a.starts_with('-'))
+        .map(|s| s.as_str())
+        .collect();
+    non_flag.len() > 1
+        && non_flag[1..]
+            .iter()
+            .all(|&a| a.strip_prefix('+').unwrap_or(a).starts_with(':'))
 }
 
-/// Best-effort `(remote, branch)` for the deny message's retry sequence: the first positional
-/// after `push` is the remote, the second (if any) is the refspec whose dest is the branch.
-/// Absent → the message falls back to a `<remote> <branch>` template.
+/// Best-effort `(remote, branch)` for the deny message's retry sequence. Only reported when
+/// BOTH are explicitly on the command line — i.e. >=2 positionals (a remote followed by a
+/// refspec). With fewer we cannot tell a remote from a refspec (dev2 NIT: a lone `+branch`
+/// was mistaken for the remote, yielding `git fetch mybranch mybranch`), so we return
+/// `(None, None)` and the caller falls back to the generic `<remote> <branch>` template.
 fn force_push_target(args: &[String]) -> (Option<String>, Option<String>) {
     let positionals: Vec<&String> = args
         .iter()
         .skip(1)
         .filter(|a| !a.starts_with('-'))
         .collect();
-    let remote = positionals
-        .first()
-        .map(|s| s.trim_start_matches('+').to_string());
+    if positionals.len() < 2 {
+        return (None, None);
+    }
+    let remote = Some(positionals[0].trim_start_matches('+').to_string());
     let branch = positionals.get(1).map(|a| {
         let a = a.strip_prefix('+').unwrap_or(a);
         let dest = a.rsplit(':').next().unwrap_or(a);

--- a/src/bin/agend-git/tests.rs
+++ b/src/bin/agend-git/tests.rs
@@ -926,7 +926,7 @@ fn push_dest_refs_normalizes_refspec_targets_s3() {
 #[test]
 fn push_protected_violation_explicit_refspec_s3() {
     let p = vargs(&["main", "master", "release-1.0"]);
-    let denied = |a: &[&str]| push_protected_violation(&vargs(a), &p, false);
+    let denied = |a: &[&str]| force_push::push_protected_violation(&vargs(a), &p, false);
     // explicit protected dest → deny (message names the ref).
     assert!(denied(&["push", "origin", "HEAD:main"])
         .unwrap()
@@ -950,7 +950,7 @@ fn push_protected_violation_bulk_and_wildcard_forms_s3() {
     // r6's bypass: `--all`/`--mirror` (and abbreviations) push EVERY local head — must
     // deny regardless of positionals. RM: drop the is_bulk_push_flag branch → RED.
     let p = vargs(&["main", "master"]);
-    let denied = |a: &[&str]| push_protected_violation(&vargs(a), &p, false);
+    let denied = |a: &[&str]| force_push::push_protected_violation(&vargs(a), &p, false);
     assert!(denied(&["push", "origin", "--all"]).is_some());
     assert!(denied(&["push", "--mirror", "origin"]).is_some());
     assert!(denied(&["push", "--all"]).is_some());
@@ -967,26 +967,100 @@ fn push_protected_violation_bulk_and_wildcard_forms_s3() {
 }
 
 #[test]
+fn push_force_without_lease_gate_t78445() {
+    // #t-…78445-1 (dev3 #2673 review): a BARE force-push to a non-protected feature branch
+    // is DENIED; `--force-with-lease` is the escape. RED on pre-gate code — before this the
+    // push arm allowed `push --force origin feat/x` (push_protected_violation ignores force).
+    let v = |a: &[&str]| force_push::push_force_without_lease_violation(&vargs(a));
+    // bare --force / -f / bundled -fu / +refspec (explicit or long) → DENY.
+    assert!(v(&["push", "--force", "origin", "feat/x"]).is_some());
+    assert!(v(&["push", "-f", "origin", "feat/x"]).is_some());
+    assert!(v(&["push", "-fu", "origin", "feat/x"]).is_some());
+    assert!(v(&["push", "origin", "+feat/x"]).is_some());
+    assert!(v(&["push", "origin", "+HEAD:refs/heads/feat/x"]).is_some());
+    // current-branch bare force (no explicit refspec) also overwrites → DENY.
+    assert!(v(&["push", "--force"]).is_some());
+    assert!(v(&["push", "--force", "origin"]).is_some());
+    // the SAFE forms → ALLOW (footgun removed, capability kept).
+    assert!(v(&["push", "--force-with-lease", "origin", "feat/x"]).is_none());
+    assert!(v(&[
+        "push",
+        "--force-with-lease=feat/x:abc123",
+        "origin",
+        "feat/x"
+    ])
+    .is_none());
+    assert!(v(&[
+        "push",
+        "--force-if-includes",
+        "--force-with-lease",
+        "origin",
+        "feat/x"
+    ])
+    .is_none());
+    // git makes a trailing bare --force OVERRIDE a lease → treat as unconditional → DENY.
+    assert!(v(&["push", "--force-with-lease", "--force", "origin", "feat/x"]).is_some());
+    // normal (non-force) pushes → ALLOW (zero regression).
+    assert!(v(&["push", "-u", "origin", "feat/x"]).is_none());
+    assert!(v(&["push", "origin", "feat/x"]).is_none());
+    assert!(v(&["push"]).is_none());
+    // deletions remove a ref, they don't overwrite history → EXEMPT even with force.
+    assert!(v(&["push", "--force", "--delete", "origin", "feat/x"]).is_none());
+    assert!(v(&["push", "--force", "origin", ":feat/x"]).is_none());
+    assert!(v(&["push", "-df", "origin", "feat/x"]).is_none());
+}
+
+#[test]
+fn push_force_deny_message_carries_executable_retry_sequence_t78445() {
+    // Lead req (#t-…78445-1): the deny must be ONE-SHOT fixable — a copy-pasteable retry
+    // sequence with the concrete remote+branch, for models weak at constructing retries.
+    let msg = force_push::push_force_without_lease_violation(&vargs(&[
+        "push", "--force", "origin", "feat/x",
+    ]))
+    .expect("bare force must deny");
+    assert!(
+        msg.contains("git fetch origin feat/x && git push --force-with-lease origin feat/x"),
+        "must carry the exact executable retry sequence: {msg}"
+    );
+    // no explicit remote/branch → the message still names the lease form via a template.
+    let generic = force_push::push_force_without_lease_violation(&vargs(&["push", "--force"]))
+        .expect("current-branch bare force must deny");
+    assert!(
+        generic.contains("--force-with-lease"),
+        "template must still name the safe form: {generic}"
+    );
+}
+
+#[test]
 fn push_protected_violation_push_default_matching_s3() {
     // no-refspec push under the DEPRECATED push.default=matching pushes every same-named
     // branch (incl. a local protected ref) → deny. simple/current (matching=false) →
     // allow (only the current/assigned branch). RM: drop the matching branch → first RED.
     let p = vargs(&["main", "master"]);
-    assert!(push_protected_violation(&vargs(&["push"]), &p, true).is_some());
-    assert!(push_protected_violation(&vargs(&["push", "origin"]), &p, true).is_some());
+    assert!(force_push::push_protected_violation(&vargs(&["push"]), &p, true).is_some());
+    assert!(force_push::push_protected_violation(&vargs(&["push", "origin"]), &p, true).is_some());
     // an EXPLICIT refspec governs even under matching → only that dest matters.
-    assert!(push_protected_violation(&vargs(&["push", "origin", "feat/x"]), &p, true).is_none());
+    assert!(
+        force_push::push_protected_violation(&vargs(&["push", "origin", "feat/x"]), &p, true)
+            .is_none()
+    );
     // not matching → no-refspec push is safe (current branch only).
-    assert!(push_protected_violation(&vargs(&["push"]), &p, false).is_none());
+    assert!(force_push::push_protected_violation(&vargs(&["push"]), &p, false).is_none());
     // r6: `--tags` is TAGS-ONLY (refs/tags/*) even under matching → MUST be allowed
     // (the previous cut wrongly denied it). RM: drop the is_tags_only_push exemption → RED.
-    assert!(push_protected_violation(&vargs(&["push", "--tags", "origin"]), &p, true).is_none());
-    assert!(push_protected_violation(&vargs(&["push", "--tags"]), &p, true).is_none());
+    assert!(
+        force_push::push_protected_violation(&vargs(&["push", "--tags", "origin"]), &p, true)
+            .is_none()
+    );
+    assert!(force_push::push_protected_violation(&vargs(&["push", "--tags"]), &p, true).is_none());
     // `--follow-tags` is NOT tags-only — under matching it pushes the matching branches
     // (incl. main, verified by dry-run) → MUST stay denied (no over-exemption).
-    assert!(
-        push_protected_violation(&vargs(&["push", "--follow-tags", "origin"]), &p, true).is_some()
-    );
+    assert!(force_push::push_protected_violation(
+        &vargs(&["push", "--follow-tags", "origin"]),
+        &p,
+        true
+    )
+    .is_some());
 }
 
 #[test]
@@ -996,11 +1070,13 @@ fn push_head_main_denied_by_hardcode_floor_even_without_policy_s3() {
     // push_protected_violation, OR load_protected_refs drop the floor → RED.
     let h = home_s3("e2e");
     let protected = load_protected_refs(h.to_str().unwrap());
-    assert!(
-        push_protected_violation(&vargs(&["push", "origin", "HEAD:main"]), &protected, false)
-            .is_some()
-    );
-    assert!(push_protected_violation(
+    assert!(force_push::push_protected_violation(
+        &vargs(&["push", "origin", "HEAD:main"]),
+        &protected,
+        false
+    )
+    .is_some());
+    assert!(force_push::push_protected_violation(
         &vargs(&["push", "-u", "origin", "feat/x"]),
         &protected,
         false

--- a/src/bin/agend-git/tests.rs
+++ b/src/bin/agend-git/tests.rs
@@ -1004,10 +1004,18 @@ fn push_force_without_lease_gate_t78445() {
     assert!(v(&["push", "-u", "origin", "feat/x"]).is_none());
     assert!(v(&["push", "origin", "feat/x"]).is_none());
     assert!(v(&["push"]).is_none());
-    // deletions remove a ref, they don't overwrite history → EXEMPT even with force.
+    // PURE deletions remove a ref, they don't overwrite history → EXEMPT even with force.
     assert!(v(&["push", "--force", "--delete", "origin", "feat/x"]).is_none());
     assert!(v(&["push", "--force", "origin", ":feat/x"]).is_none());
     assert!(v(&["push", "-df", "origin", "feat/x"]).is_none());
+    // F1 (dev2, CONFIRMED bypass) — a MIXED delete+overwrite push must NOT be exempted: the
+    // delete refspec used to trigger an any-arg exemption that let the overwrite's force
+    // through. All three of dev2's forms must DENY (RED against the pre-fix any-arg logic).
+    assert!(v(&["push", "--force", "origin", ":del", "real"]).is_some());
+    assert!(v(&["push", "--force", "origin", "+:del", "real"]).is_some());
+    assert!(v(&["push", "--force", "origin", "real", ":del"]).is_some());
+    // multi-delete (every refspec a deletion) stays EXEMPT.
+    assert!(v(&["push", "--force", "origin", ":del1", ":del2"]).is_none());
 }
 
 #[test]

--- a/src/mcp/handlers/dispatch_hook/branch_start_point.rs
+++ b/src/mcp/handlers/dispatch_hook/branch_start_point.rs
@@ -54,16 +54,18 @@ pub(super) fn create_new_branch(
     //          NOW + a stale (non-fresh) clone + the branch pushed to origin only
     //          AFTER this repo's last fetch. The incident is a FRESH clone (view
     //          complete → caught by state 1), so this edge is NOT the incident.
-    //        · it is NOT silent: a later push of the wrong-based branch to the
-    //          existing origin/<branch> is a non-fast-forward and is REJECTED — a
-    //          natural second line of defense + a loud signal.
+    //        · it is usually not silent: a later NORMAL push of the wrong-based
+    //          branch to the existing origin/<branch> is a non-fast-forward and is
+    //          rejected — a partial backstop + signal. CAVEAT (t-…78445-1): a bare
+    //          `git push --force` bypasses that rejection, and the agend-git shim
+    //          currently permits force-push to a non-protected branch, so the non-ff
+    //          "defense" holds only against a plain push, not a deliberate force.
     //   4. view none, fetch FAILED, view EMPTY (never synced with origin at all)
     //                                            → truly blind ⇒ REFUSE (Err).
     // Asymmetry vs the EXISTS arm (state 1): that arm update-refs the local ref to the
     // tip; here we base on the view SHA, which when OFFLINE may LAG origin's tip. Lag
-    // ≠ loss — the base is a real ancestor on the correct branch and the non-ff
-    // backstop covers the rest; when online the pre-fetch above advances the view to
-    // the tip anyway.
+    // ≠ loss — the base is a real ancestor on the correct branch; when online the
+    // pre-fetch above advances the view to the tip anyway.
     let work_tracking_ref = format!("refs/remotes/origin/{branch}");
     let work_fetch_ok = crate::git_helpers::git_bypass_timeout(
         source,
@@ -159,8 +161,9 @@ pub(super) fn create_new_branch(
         // origin is unreachable NOW but we DO have a remote-tracking view in which
         // origin/<branch> is absent. Create from `from_ref`. The residual data-loss
         // needs offline + stale-clone + a branch pushed since our last fetch to stack
-        // (non-incident — the incident is a fresh, complete clone), and a wrong-based
-        // push to an existing origin/<branch> is a rejected non-ff (loud 2nd defense).
+        // (non-incident — the incident is a fresh, complete clone); a wrong-based
+        // NORMAL push to the existing origin/<branch> is a rejected non-ff (partial
+        // backstop), but a bare `git push --force` bypasses it (see t-…78445-1).
         crate::event_log::log(
             home,
             "ensure_branch_fail_open",

--- a/tests/agend_git_shim_phase2.rs
+++ b/tests/agend_git_shim_phase2.rs
@@ -88,6 +88,26 @@ fn shim_deny_unbound_mutate_in_source() {
 }
 
 #[test]
+fn shim_force_push_requires_lease_wired_in_source() {
+    // #t-…78445-1: the push arm must gate bare force-push (require --force-with-lease) and
+    // emit its own audit event, distinct from deny_protected_ref. Guards against accidental
+    // removal of the wiring; the decision logic itself is unit-tested in agend-git/tests.rs.
+    let src = include_str!("../src/bin/agend-git.rs");
+    assert!(
+        src.contains("push_force_without_lease_violation"),
+        "force-push gate must be wired into the push arm"
+    );
+    assert!(
+        src.contains("deny_force_no_lease"),
+        "force-push deny must emit its own audit event type"
+    );
+    assert!(
+        src.contains("--force-with-lease"),
+        "deny message must steer to the safe --force-with-lease form"
+    );
+}
+
+#[test]
 fn shim_deny_worktree_management() {
     let src = include_str!("../src/bin/agend-git.rs");
     assert!(


### PR DESCRIPTION
## Summary
Fleet-safety follow-up to #2673 (dev3's review finding). The `agend-git` shim allowed a bare
`git push --force origin <feature>`: `push_protected_violation` treats force as "HOW not WHAT"
and only guards protected refs, so **any agent could silently overwrite existing commits on
any origin feature branch** — another agent's/session's work, or a wrong-based branch (#2673
state-3's residual edge). Same family as #2662.

**Lead-vetted option (i): require `--force-with-lease`.** It refuses the push if the remote
moved since the pusher's last fetch — removing the footgun while KEEPING the legitimate
rebase-then-force workflow (footgun-removal, not capability-removal). Protected refs keep
their existing hard-block; normal and lease-form pushes are unchanged.

## The gate
`force_push::push_force_without_lease_violation`, run in the push arm **after** the
protected-ref check (so a force-push to a protected ref still returns `deny_protected_ref`):
- Denies a bare `--force` / `-f` / a `+refspec` to a **non-protected** branch unless it
  carries `--force-with-lease` (or `--force-if-includes`).
- **Deletions are exempt** — they remove a ref, they don't overwrite history.
- A trailing bare `--force` **overrides** a lease in git, so any bare force present =
  unconditional = denied even if a lease flag co-occurs.
- Emits a distinct `deny_force_no_lease` audit event (mirrors `deny_protected_ref`).

### ⚠ Reviewers: the deny message is executable (lead requirement)
For models weak at constructing retries, the deny is **one-shot fixable** — it carries the
concrete sequence:
```
git fetch <remote> <branch> && git push --force-with-lease <remote> <branch>
```
with the real remote+branch when they're on the command line (template otherwise).

## Structure
The push-authority decisions (`push_protected_violation` + the new force gate) moved into a
`src/bin/agend-git/force_push.rs` submodule to keep `agend-git.rs` under its **2500-LOC
anti-monolith ceiling** (it sat at 2497). Pure move — the small arg-parsing helpers
(`push_dest_refs`, `is_bulk_push_flag`, …) stay in the root and are reached via `super::`.

## (a) #2673 comment softening (shipped here per lead)
`branch_start_point.rs` state-3 comments no longer call the non-ff rejection an absolute
"second line of defense" — it's a **partial** backstop that a bare `git push --force`
bypasses (exactly this gap). Comment-only.

## Step-1 finding (why this proceeds independently)
The command-authority spike (t-777-1) does **not** cover force-push: its deliverable doc is
absent (workspace GC'd), and the accessible artifacts are scoped to MCP Instance-family
tools + `operator_gate` with zero git content. Command-authority gates MCP *tool* calls; the
git shim is a distinct enforcement layer.

## Tests
- `push_force_without_lease_gate_t78445` — **verified RED** against the pre-gate allow
  (neutralizing the gate lets `push --force origin feat/x` through). Covers bare force / `-f`
  / bundled `-fu` / `+refspec` / current-branch → deny; `--force-with-lease`(=…) /
  `--force-if-includes` → allow; lease-then-bare-force → deny; normal + deletion → allow.
- `push_force_deny_message_carries_executable_retry_sequence_t78445` — pins the retry line.
- `shim_force_push_requires_lease_wired_in_source` (phase2) — pins the arm wiring + event.

## Gate
- `cargo fmt --check` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo nextest run --workspace`: **5410 passed** (incl. `src_file_size_invariant`,
  `file_size_invariant`, and all git invariants — the shim is on their scan surface).
  Excluded: 4 real-daemon/timing e2e (#1900 `e2e_workflow`, #1907
  `teardown_completeness_regression`, 2 `attached_path`) that fail environmentally in this
  sandbox, orthogonal to the shim (they never invoke it).

Task: `t-20260707032230285794-78445-1` · Spike: `FORCE-PUSH-SHIM-SPIKE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
