### PR TITLE
fix(#78445-2 PR-B): honest quota-wedge dispatch_idle message + durable one-shot

### DIFF
--- a/src/daemon/dispatch_idle/mod.rs
+++ b/src/daemon/dispatch_idle/mod.rs
@@ -118,14 +118,16 @@ pub(crate) struct PendingDispatch {
     /// Reset to `None` on re-dispatch (a fresh episode).
     #[serde(default)]
     pub(crate) reported_at: Option<String>,
-    /// #t-116: fire-once latch — the one-time escalation fired while the target is
-    /// QUOTA-WEDGED (backend usage-limit / quota-reached hard-block, snapshot
-    /// `agent_state == "usage_limit"`). Such an agent is EXPECTED to stay silent
-    /// until the quota resets (often hours/days), so re-nudging it every threshold
-    /// is pure noise (r5: agy quota wedged 6 days, pinged every 30 min). Escalate
-    /// ONCE, then suppress until recovery. Reset to `false` the moment the agent is
-    /// no longer quota-wedged (so a genuine later re-wedge re-escalates once) and on
-    /// re-dispatch. Mirrors the `long_running_escalated` fire-once latch.
+    /// #t-116/#78445-2: durable fire-once latch — the one-time escalation fired
+    /// while the target is QUOTA-WEDGED (backend usage-limit / quota-reached
+    /// hard-block, snapshot `agent_state == "usage_limit"`). Such an agent is
+    /// EXPECTED to stay silent until the quota resets (often hours/days), so
+    /// re-nudging it every threshold is pure noise (r5: agy quota wedged 6 days,
+    /// pinged every 30 min). Escalate ONCE, then suppress. #78445-2: this is a
+    /// ONE-SHOT per dispatch — it is NOT cleared on a non-wedged tick, so a
+    /// snapshot flicker can't re-fire it (the observed same-heads-up-twice noise);
+    /// only a re-dispatch (a genuinely new episode) resets it. Mirrors the
+    /// `long_running_escalated` fire-once latch.
     #[serde(default)]
     pub(crate) quota_escalated: bool,
 }
@@ -814,18 +816,6 @@ fn set_quota_escalated(home: &Path, dispatch_id: &str) {
     });
 }
 
-/// #t-116: clear the quota-wedge latch when the target RECOVERS (no longer
-/// quota-wedged), so a genuine later re-wedge re-escalates once.
-fn clear_quota_escalated(home: &Path, dispatch_id: &str) {
-    let path = pending_path(home, dispatch_id);
-    let _ = crate::store::with_json_state::<PendingDispatch, _, _>(&path, |cur| {
-        if cur.quota_escalated {
-            cur.quota_escalated = false;
-        }
-        Some(())
-    });
-}
-
 /// #t-116: is `target` QUOTA-WEDGED — i.e. its snapshot `agent_state` is
 /// `"usage_limit"` (the classifier's `AgentState::UsageLimit`, which maps to
 /// `BlockedReason::QuotaExceeded`)? Such an agent is hard-blocked on a backend
@@ -1059,15 +1049,18 @@ pub(crate) fn scan_and_emit(home: &Path) {
             continue;
         }
 
-        // #t-116: a backend quota / usage-limit hard-block (snapshot
+        // #t-116/#78445-2: a backend quota / usage-limit hard-block (snapshot
         // `agent_state == "usage_limit"`) is EXPECTED to stay silent until the
         // quota resets (often hours/days) — re-nudging every threshold is pure
         // noise (r5: agy quota wedged 6 days, pinged every 30 min). Escalate ONCE
-        // so the dispatcher knows, then LATCH-suppress until recovery. Mirrors the
-        // `long_running_escalated` fire-once idiom (emit the same long-running
-        // "expected delay, confirm" signal; do NOT flip to Exceeded — the agent is
-        // blocked, not stuck). The latch resets the moment the agent is no longer
-        // quota-wedged, so a genuine later re-wedge re-escalates once.
+        // with a quota-specific "blocked on usage_limit, expected silent" event
+        // (NOT the long-running "still showing activity" text — the target is NOT
+        // active), then LATCH-suppress. Do NOT flip to Exceeded — the agent is
+        // blocked, not stuck. #78445-2: `quota_escalated` is a DURABLE one-shot —
+        // it is NOT cleared on a non-wedged tick, so a snapshot flicker can't
+        // re-fire it (the observed same-heads-up-twice noise); a genuinely
+        // recovered-but-idle dispatch instead falls through to the stuck path
+        // below, and only a re-dispatch (new episode) resets the latch.
         if target_is_quota_wedged(snapshot.as_ref(), &d.target) {
             if !d.quota_escalated {
                 tracing::info!(
@@ -1076,15 +1069,10 @@ pub(crate) fn scan_and_emit(home: &Path) {
                     target = %d.target,
                     "#t-116 target quota-wedged (usage_limit) — escalating once then suppressing"
                 );
-                emit_long_running_event(home, &d, elapsed_secs);
+                emit_quota_wedged_event(home, &d, elapsed_secs);
                 set_quota_escalated(home, &d.dispatch_id);
             }
             continue;
-        }
-        // Recovered from a prior quota-wedge → clear the latch so a future re-wedge
-        // re-escalates once (genuine-recurrence-re-logs-once).
-        if d.quota_escalated {
-            clear_quota_escalated(home, &d.dispatch_id);
         }
 
         // #1516/#1694②: the dispatch-idle threshold is for "agent went silent
@@ -1306,8 +1294,24 @@ fn dispatch_idle_text(
     elapsed_secs: i64,
     threshold_secs: i64,
     long_running: bool,
+    quota_wedged: bool,
 ) -> String {
     let corr = correlation_id.unwrap_or("");
+    // #78445-2: the quota-wedge escalation — HONEST about the target being blocked
+    // on its provider quota (usage_limit), NOT "still showing activity" (which the
+    // long-running text below wrongly claimed for a usage_limit target).
+    if quota_wedged {
+        return format!(
+            "[dispatch_idle_quota_wedged] dispatch {dispatch_id} from '{dispatcher}' → '{target}' \
+             (kind={expected_kind}, correlation_id={corr}) has been unreplied for {elapsed_secs}s, and \
+             '{target}' is currently QUOTA-WEDGED (backend usage_limit / provider quota hard-block).\n\n\
+             This is NOT a stuck/silent alarm and NOT active work — '{target}' is blocked on its \
+             provider quota and is EXPECTED to stay silent until the quota resets (often hours/days). \
+             ONE heads-up (no repeats):\n\
+             - Expected → no action; it resolves when the quota lifts and the report arrives.\n\
+             - Can't wait → re-dispatch to a healthy same-role peer ('{target}' won't reply meanwhile).",
+        );
+    }
     // #2008-p2: the long-running escalation is DELIBERATELY worded to read nothing
     // like the stuck alarm — "active, just long, confirm" vs "went silent, may be
     // stuck/crashed" — so the dispatcher tells them apart at a glance.
@@ -1362,6 +1366,7 @@ fn deliver_dispatch_idle(
     elapsed_secs: i64,
     threshold_secs: i64,
     long_running: bool,
+    quota_wedged: bool,
 ) {
     let text = dispatch_idle_text(
         dispatch_id,
@@ -1372,6 +1377,7 @@ fn deliver_dispatch_idle(
         elapsed_secs,
         threshold_secs,
         long_running,
+        quota_wedged,
     );
     // #947: fall back to dispatch_id when upstream correlation_id is None so the
     // nudge is always traceable to its source sidecar.
@@ -1384,7 +1390,9 @@ fn deliver_dispatch_idle(
         "system:dispatch_idle",
         // #2008-p2: a distinct subtype so the dispatcher's inbox tooling can tell a
         // "still active, just long" confirm from a "went silent" stuck alarm.
-        if long_running {
+        if quota_wedged {
+            "dispatch_idle_quota_wedged"
+        } else if long_running {
             "dispatch_idle_long_running"
         } else {
             "dispatch_idle_threshold_exceeded"
@@ -1409,6 +1417,7 @@ fn handle_event(event: &crate::daemon::event_bus::Event) -> bool {
         threshold_secs,
         correlation_id,
         long_running,
+        quota_wedged,
     } = &event.kind
     {
         deliver_dispatch_idle(
@@ -1421,6 +1430,7 @@ fn handle_event(event: &crate::daemon::event_bus::Event) -> bool {
             *elapsed_secs,
             *threshold_secs,
             *long_running,
+            *quota_wedged,
         );
         true
     } else {
@@ -1435,7 +1445,7 @@ pub fn register_subscriber() {
 }
 
 fn emit_exceeded_event(home: &Path, d: &PendingDispatch, elapsed_secs: i64) {
-    emit_dispatch_idle_event(home, d, elapsed_secs, false);
+    emit_dispatch_idle_event(home, d, elapsed_secs, false, false);
 }
 
 /// #2008-p2: the "long-running WITH ACTIVITY — confirm expected" escalation fired
@@ -1444,7 +1454,14 @@ fn emit_exceeded_event(home: &Path, d: &PendingDispatch, elapsed_secs: i64) {
 /// wording. Does NOT flip the sidecar to Exceeded — the target is working, not
 /// stuck, so the stuck-alarm path still owns a later genuine idle.
 fn emit_long_running_event(home: &Path, d: &PendingDispatch, elapsed_secs: i64) {
-    emit_dispatch_idle_event(home, d, elapsed_secs, true);
+    emit_dispatch_idle_event(home, d, elapsed_secs, true, false);
+}
+
+/// #78445-2: the quota-wedge escalation — the target is blocked on its provider
+/// quota (usage_limit), NOT active. A distinct honest message + the
+/// `dispatch_idle_quota_wedged` tag, fired once per dispatch (durable one-shot).
+fn emit_quota_wedged_event(home: &Path, d: &PendingDispatch, elapsed_secs: i64) {
+    emit_dispatch_idle_event(home, d, elapsed_secs, false, true);
 }
 
 fn emit_dispatch_idle_event(
@@ -1452,11 +1469,14 @@ fn emit_dispatch_idle_event(
     d: &PendingDispatch,
     elapsed_secs: i64,
     long_running: bool,
+    quota_wedged: bool,
 ) {
     // Observability log runs regardless of the gate (it is not the notification).
     crate::event_log::log(
         home,
-        if long_running {
+        if quota_wedged {
+            "dispatch_idle_quota_wedged"
+        } else if long_running {
             "dispatch_idle_long_running"
         } else {
             "dispatch_idle_threshold_exceeded"
@@ -1485,6 +1505,7 @@ fn emit_dispatch_idle_event(
             threshold_secs: d.threshold_secs,
             correlation_id: d.correlation_id.clone(),
             long_running,
+            quota_wedged,
         },
     );
 }
@@ -1526,6 +1547,13 @@ impl DispatchIdleTracker {
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicU32, Ordering};
+
+    // #78445-2: quota-wedge tests homed in a sibling `*_tests.rs` (LOC-exempt) so
+    // `mod.rs` stays under the anti-monolith ceiling. Submodule of `tests`, so its
+    // `use super::*` inherits both these helpers and the production items. Lives in
+    // the `tests/` subdir a mod-in-inline-module `#[path]` resolves against.
+    #[path = "dispatch_idle_quota_78445_tests.rs"]
+    mod quota_78445_tests;
 
     /// #1636: the `DispatchStatus` enum MUST serialize to / deserialize from the
     /// exact lowercase wire strings the prior stringly-typed field used, so
@@ -2027,7 +2055,7 @@ mod tests {
         );
         let elog = std::fs::read_to_string(home.join("event-log.jsonl")).unwrap_or_default();
         assert_eq!(
-            elog.matches("dispatch_idle_long_running").count(),
+            elog.matches("dispatch_idle_quota_wedged").count(),
             1,
             "exactly one quota escalation: {elog}"
         );
@@ -2041,7 +2069,7 @@ mod tests {
         scan_and_emit(&home);
         let elog2 = std::fs::read_to_string(home.join("event-log.jsonl")).unwrap_or_default();
         assert_eq!(
-            elog2.matches("dispatch_idle_long_running").count(),
+            elog2.matches("dispatch_idle_quota_wedged").count(),
             1,
             "fire-once: still exactly one after repeat scans: {elog2}"
         );
@@ -2053,65 +2081,6 @@ mod tests {
             d.status,
             DispatchStatus::Pending,
             "still suppressed (Pending) across repeats, never Exceeded"
-        );
-        std::fs::remove_dir_all(&home).ok();
-    }
-
-    /// #t-116: when the target RECOVERS from a quota-wedge, the latch resets, so a
-    /// GENUINE later re-wedge re-escalates once (genuine-recurrence-re-logs-once),
-    /// rather than staying permanently silent.
-    #[test]
-    fn quota_recovery_resets_latch_then_rewedge_reescalates_t116() {
-        let home = tmp_home("t116-quota-recover");
-        let issued = chrono::Utc::now() - chrono::Duration::seconds(700);
-        let id = write_pending_at(&home, "lead", "dev", Some("t-qr"), "task", 600, issued);
-
-        // Episode 1 — wedged → escalate once + latch.
-        write_target_snapshot(&home, "dev", "usage_limit");
-        scan_and_emit(&home);
-        assert!(
-            list_pending(&home)
-                .into_iter()
-                .find(|d| d.dispatch_id == id)
-                .unwrap()
-                .quota_escalated,
-            "episode 1: latch set"
-        );
-
-        // Recover from the quota state (agent_state no longer "usage_limit") → the
-        // latch clears. Use "idle" (not a working state): a working state's
-        // suppress-gate refreshes `issued_at`, which would drop episode 2 below
-        // threshold; "idle" leaves the clock untouched and a single scan only bumps
-        // the debounce streak (no fire), isolating the latch-reset behaviour.
-        write_target_snapshot(&home, "dev", "idle");
-        scan_and_emit(&home);
-        let d = list_pending(&home)
-            .into_iter()
-            .find(|d| d.dispatch_id == id)
-            .unwrap();
-        assert!(!d.quota_escalated, "recovery must clear the quota latch");
-        assert_eq!(
-            d.status,
-            DispatchStatus::Pending,
-            "single idle scan defers (debounce), not Exceeded"
-        );
-
-        // Episode 2 — re-wedge → re-escalates once.
-        write_target_snapshot(&home, "dev", "usage_limit");
-        scan_and_emit(&home);
-        let d = list_pending(&home)
-            .into_iter()
-            .find(|d| d.dispatch_id == id)
-            .unwrap();
-        assert!(
-            d.quota_escalated,
-            "re-wedge after recovery re-sets the latch"
-        );
-        let elog = std::fs::read_to_string(home.join("event-log.jsonl")).unwrap_or_default();
-        assert_eq!(
-            elog.matches("dispatch_idle_long_running").count(),
-            2,
-            "two escalations across two distinct wedge episodes: {elog}"
         );
         std::fs::remove_dir_all(&home).ok();
     }
@@ -3903,6 +3872,7 @@ mod tests {
             elapsed,
             threshold,
             false,
+            false,
         );
 
         // Bus emit→subscriber delivery (the gate-ON path) — real fan-out.
@@ -3920,6 +3890,7 @@ mod tests {
                 threshold_secs: threshold,
                 correlation_id: corr.map(String::from),
                 long_running: false,
+                quota_wedged: false,
             },
         );
 

--- a/src/daemon/dispatch_idle/tests/dispatch_idle_quota_78445_tests.rs
+++ b/src/daemon/dispatch_idle/tests/dispatch_idle_quota_78445_tests.rs
@@ -1,0 +1,116 @@
+//! #78445-2 PR-B — quota-wedge dispatch_idle tests, homed in a sibling `*_tests.rs`
+//! file loaded via `#[path]` from the inline `mod tests` so `dispatch_idle/mod.rs`
+//! stays under the anti-monolith LOC ceiling (the `src_file_size_invariant`
+//! established split pattern). As a submodule of `mod tests`, `use super::*`
+//! inherits both the inline test helpers (`tmp_home` / `write_pending_at` /
+//! `write_target_snapshot`) and the production items under test.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use super::*;
+
+/// #78445-2 (c): the quota-wedge message is HONEST — it uses its own subtype tag,
+/// names the usage_limit / quota block, and does NOT reuse the long-running "still
+/// showing activity" text (which falsely claimed the usage_limit target was
+/// active). The long-running (activity) text itself is unchanged. (Supersedes the
+/// #t-116 recovery-reescalate test: #78445-2 made the quota latch a durable
+/// one-shot, so a recovery no longer clears it to re-escalate — see
+/// `quota_wedge_one_shot_persists_across_flicker_78445_2`.)
+#[test]
+fn quota_wedge_message_is_honest_not_activity_78445_2() {
+    let quota = dispatch_idle_text(
+        "di-q",
+        "lead",
+        "dev",
+        "task",
+        Some("t-q"),
+        900,
+        600,
+        false,
+        true,
+    );
+    assert!(
+        quota.contains("[dispatch_idle_quota_wedged]"),
+        "quota message uses its own subtype tag: {quota}"
+    );
+    assert!(
+        !quota.contains("still showing activity"),
+        "quota message must NOT claim the usage_limit target is active: {quota}"
+    );
+    assert!(
+        quota.contains("usage_limit") || quota.to_lowercase().contains("quota"),
+        "quota message names the usage_limit / quota block: {quota}"
+    );
+    // The long-running (activity) text is untouched — its own distinct wording.
+    let lr = dispatch_idle_text(
+        "di-l",
+        "lead",
+        "dev",
+        "task",
+        Some("t-l"),
+        900,
+        600,
+        true,
+        false,
+    );
+    assert!(
+        lr.contains("still showing activity") && lr.contains("[dispatch_idle_long_running]"),
+        "long-running text unchanged: {lr}"
+    );
+}
+
+/// #78445-2 PR-B (b)+(c) RED-first: the quota-wedge escalation is a ONE-SHOT per
+/// dispatch that SURVIVES a flicker, and it emits an HONEST quota event (its own
+/// tag), not the long-running "still showing activity" one. A brief non-usage_limit
+/// snapshot blip must NOT clear the latch and let a re-wedge re-fire — the observed
+/// "same heads-up twice, 4 min apart" noise on a quota-wedged reviewer.
+#[test]
+fn quota_wedge_one_shot_persists_across_flicker_78445_2() {
+    let home = tmp_home("78445-quota-flicker");
+    let issued = chrono::Utc::now() - chrono::Duration::seconds(700);
+    let id = write_pending_at(&home, "lead", "dev", Some("t-qf"), "task", 600, issued);
+
+    // Episode 1 — wedged → escalate once + latch.
+    write_target_snapshot(&home, "dev", "usage_limit");
+    scan_and_emit(&home);
+    assert!(
+        list_pending(&home)
+            .into_iter()
+            .find(|d| d.dispatch_id == id)
+            .unwrap()
+            .quota_escalated,
+        "wedged → one-shot latch set"
+    );
+
+    // FLICKER: one non-usage_limit tick (a snapshot blip, NOT a sustained
+    // recovery). "idle" leaves the clock untouched (a working state would refresh
+    // issued_at and drop the re-wedge below threshold) and a single scan only bumps
+    // the debounce streak (no stuck fire).
+    write_target_snapshot(&home, "dev", "idle");
+    scan_and_emit(&home);
+    assert!(
+        list_pending(&home)
+            .into_iter()
+            .find(|d| d.dispatch_id == id)
+            .unwrap()
+            .quota_escalated,
+        "#78445-2 (b): a flicker must NOT clear the quota one-shot latch"
+    );
+
+    // Re-wedge → still latched → NO second escalation.
+    write_target_snapshot(&home, "dev", "usage_limit");
+    scan_and_emit(&home);
+    let elog = std::fs::read_to_string(home.join("event-log.jsonl")).unwrap_or_default();
+    assert_eq!(
+        elog.matches("dispatch_idle_quota_wedged").count(),
+        1,
+        "#78445-2: exactly ONE quota escalation across wedge→flicker→re-wedge: {elog}"
+    );
+    assert_eq!(
+        elog.matches("dispatch_idle_long_running").count(),
+        0,
+        "#78445-2 (c): quota-wedge must NOT borrow the long-running 'still showing \
+         activity' event: {elog}"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}

--- a/src/daemon/event_bus.rs
+++ b/src/daemon/event_bus.rs
@@ -57,6 +57,11 @@ pub enum EventKind {
         /// activity), NOT the "went silent / stuck" alarm. Same delivery shape; the
         /// subscriber branches the message text so the dispatcher tells them apart.
         long_running: bool,
+        /// #78445-2: this escalation is because the TARGET is quota-wedged
+        /// (usage_limit / provider quota hard-block), NOT active work — a distinct
+        /// honest message from `long_running` (which claims activity). At most one
+        /// of `long_running` / `quota_wedged` is true.
+        quota_wedged: bool,
     },
     // #event-bus pattern #9 (supervisor member-state-change): the structured
     // {agent, team, from/to display} PLUS the fields the shared deliver needs to
@@ -525,6 +530,7 @@ mod tests {
                 threshold_secs: 300,
                 correlation_id: Some("t-1".into()),
                 long_running: false,
+                quota_wedged: false,
             },
             EventKind::MemberStateChanged {
                 agent: "dev".into(),

--- a/src/inbox/storage.rs
+++ b/src/inbox/storage.rs
@@ -1664,6 +1664,12 @@ fn known_fire_and_forget_kind(msg: &InboxMessage) -> bool {
                 | "pr-ready-for-merge"
                 | "review-verdict"
                 | "dispatch_idle_long_running"
+                // #78445-2: the quota-wedge escalation subtype — same one-shot daemon
+                // FYI shape as dispatch_idle_long_running (its source-side
+                // `quota_escalated` latch never re-fires the same notice). MUST be
+                // registered or reclaim classifies it unknown → renudge re-delivers it,
+                // defeating the source one-shot (reviewer4 #2678 F1).
+                | "dispatch_idle_quota_wedged"
                 | "dispatch_idle_nudge"
                 // #2622 PR-2: the operator-facing notice emitted when an agent
                 // self-discharges a channel-reply obligation. Pure FYI — no
@@ -1720,6 +1726,9 @@ fn auto_ack_on_drain_kind(msg: &InboxMessage) -> bool {
                 // above, means the row never enters `delivering` limbo
                 // long enough to race the reclaim-TTL in the first place.
                 | "dispatch_idle_long_running"
+                // #78445-2: the quota-wedge subtype — same one-shot daemon FYI; settle
+                // on first drain like its `dispatch_idle_long_running` sibling.
+                | "dispatch_idle_quota_wedged"
                 | "dispatch_idle_nudge"
                 // #2622 PR-2: the self-discharge operator notice — settle on
                 // first drain (same pure-daemon-notification shape). Paired

--- a/src/inbox/tests.rs
+++ b/src/inbox/tests.rs
@@ -876,6 +876,14 @@ fn drain_auto_acks_daemon_notifications() {
             "[dispatch_idle_long_running] dispatch d-1 from 'lead' -> 'dev' - \
              Long run EXPECTED -> no action; it resolves when the report arrives.",
         ),
+        // #78445-2: the quota-wedge subtype — same one-shot daemon FYI shape as
+        // dispatch_idle_long_running; must auto-ack on drain like its sibling.
+        (
+            "dispatch_idle_quota_wedged",
+            "system:dispatch_idle",
+            "[dispatch_idle_quota_wedged] dispatch d-1 from 'lead' -> 'dev' is \
+             QUOTA-WEDGED (usage_limit) - expected silent until the quota resets.",
+        ),
         (
             "dispatch_idle_nudge",
             "system:dispatch-watchdog",
@@ -1024,6 +1032,8 @@ fn reclaim_settles_legacy_stale_pr_merged_delivering_row() {
 fn reclaim_settles_stale_delivering_for_newly_audited_fire_and_forget_kinds() {
     for kind in [
         "dispatch_idle_long_running",
+        // #78445-2: the quota-wedge subtype — same one-shot daemon FYI class.
+        "dispatch_idle_quota_wedged",
         "dispatch_idle_nudge",
         "pr-ready-for-merge",
         "pr-closed-unmerged",


### PR DESCRIPTION
## What

PR-B of #78445-2 (PR-A #2676 already merged). Fixes defects **(b)** and **(c)** — both in the quota-wedge escalation branch (`#t-116`) of the dispatch_idle watchdog.

## (b) Same heads-up fires twice per dispatch

`quota_escalated` (the fire-once latch) was cleared on **any** non-`usage_limit` tick. A brief snapshot **flicker** (not a sustained recovery) reset the one-shot, so the next `usage_limit` tick re-escalated — the observed "same heads-up twice, 4 min apart" on a quota-wedged reviewer.

**Fix:** make `quota_escalated` a **durable one-shot per dispatch** — drop the flicker self-clear (and the now-orphaned `clear_quota_escalated`).

**Trade-off (deliberate):** the rare "re-escalate on a genuine later re-wedge of the *same still-pending* dispatch" is dropped. No detection is lost: a genuinely-recovered-but-idle dispatch still surfaces via the **stuck path** (fall-through), and a re-dispatch (a new episode) still resets the latch via `record_dispatch`. Only the flicker noise goes.

## (c) False "still showing activity" on a usage_limit target

The quota branch reused `emit_long_running_event`, whose text says *"'<target>' is still showing activity"* — false for a quota-blocked (`usage_limit`) target.

**Fix:** a distinct **honest** message + `dispatch_idle_quota_wedged` event/inbox subtype ("blocked on usage_limit, expected silent until the quota resets", not "active"). Threaded a `quota_wedged: bool` through the (in-memory, **non-serde** `#[derive(Debug, Clone)]`) `DispatchIdleExceeded` event → subscriber → `dispatch_idle_text`. `long_running` / `quota_wedged` are mutually exclusive; the long-running text is untouched.

## Tests (RED-first, verified red on pre-fix)

Homed in a sibling `tests/dispatch_idle_quota_78445_tests.rs` (`*_tests.rs` → LOC-exempt) so `dispatch_idle/mod.rs` stays under the anti-monolith ceiling (**3932 < 3962**; the invariant refuses to let a grandfathered file grow).

- `quota_wedge_one_shot_persists_across_flicker_78445_2` — wedge → **idle flicker** → re-wedge: asserts the latch **persists** and exactly **one** `dispatch_idle_quota_wedged` fires (zero `dispatch_idle_long_running`). Pre-fix: latch cleared → 2 fires.
- `quota_wedge_message_is_honest_not_activity_78445_2` — the quota text names the `usage_limit` block and never claims activity; the long-running text is unchanged.
- Updated `quota_wedged_escalates_once_then_latches_t116` (new tag); removed the `#t-116` recovery-reescalate test (it pinned the now-removed flicker-clear behavior).

## Scope / defect (d)

Defects (b)+(c) only. **Defect (d)** — the dispatch-stuck check being blind to **task-terminal** state (a task going done should cascade-settle its stale `dispatch_tracking` rows) — is a **different store/subsystem** (`dispatch_tracking` + task-terminal hook, not the `dispatch_idle` sidecar emit). Recommended as a **separate PR-C**, not folded in, to keep this PR's blast radius on the sidecar emit path (fix direction recorded in the task's `defect_d_20260707`).

## Gate (all green)

`fmt --check` · `file_size` + `src_file_size` invariants (by binary) · `clippy --workspace --all-targets -D warnings` · `nextest` (159 dispatch_idle/event_bus/reclaim + 3 quota, RED→GREEN).
