### PR TITLE
fix(#78445-2 PR-C): settle a task's dispatch_tracking rows when it closes (defect d)

### DIFF
--- a/src/daemon/task_sweep.rs
+++ b/src/daemon/task_sweep.rs
@@ -495,6 +495,10 @@ fn sweep_board_with_prs(
             // out of `open_ids` next cycle, so no re-attempt).
             let closed = task_events::append_done_if_legal_at(&board, &emitter, &marker, events)?;
             if closed {
+                // #78445-2 (d): merged-PR auto-close is a terminal transition — clear
+                // BOTH obligation stores (this path previously cleared NEITHER, so a
+                // sweep-closed task's stuck-dispatch rows nagged the reviewer).
+                crate::tasks::task_terminal_cleanup(home, &marker);
                 tracing::info!(
                     pr = pr.number,
                     marker = %marker,
@@ -1165,6 +1169,59 @@ mod tests {
             "board B's task must NOT be closed by repo A's PR (#2105 isolation)"
         );
 
+        fs::remove_dir_all(&home).ok();
+    }
+
+    /// #78445-2 (d): a merged-PR sweep auto-close is a terminal transition — it must
+    /// settle the closed task's obligation stores (dispatch_idle sidecar AND
+    /// dispatch_tracking rows) via `task_terminal_cleanup`. This path previously
+    /// cleared NEITHER (reviewer4 #2679).
+    #[test]
+    fn sweep_close_settles_obligation_stores_78445_2() {
+        let home = tmp_home("sweep-close-settle");
+        let ta = crate::tasks::handle(
+            &home,
+            "test-user",
+            &serde_json::json!({"action": "create", "title": "t", "assignee": "test-user", "project": "orgA/projA"}),
+        )["id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        // Obligation rows for the task the merged PR will close.
+        crate::daemon::dispatch_idle::record_dispatch(
+            &home,
+            "lead",
+            "rev-a",
+            Some(&ta),
+            "task",
+            900,
+        );
+        crate::dispatch_tracking::track_dispatch(
+            &home,
+            crate::dispatch_tracking::DispatchEntry {
+                task_id: Some(ta.clone()),
+                from: "lead".into(),
+                to: "rev-a".into(),
+                from_id: None,
+                to_id: None,
+                delegated_at: chrono::Utc::now().to_rfc3339(),
+                status: "pending".into(),
+            },
+        );
+
+        let pr = make_pr_meta(1, "fix", &format!("Closes {ta}"));
+        sweep_board_with_prs(&home, "orgA/projA", std::slice::from_ref(&pr), None, false).unwrap();
+
+        assert!(
+            crate::daemon::dispatch_idle::list_pending(&home)
+                .iter()
+                .all(|d| d.correlation_id.as_deref() != Some(ta.as_str())),
+            "merged-PR close must clear the dispatch_idle sidecar"
+        );
+        assert!(
+            !crate::dispatch_tracking::active_target_names(&home).contains(&"rev-a".to_string()),
+            "merged-PR close must settle the dispatch_tracking row"
+        );
         fs::remove_dir_all(&home).ok();
     }
 

--- a/src/tasks/auto_close.rs
+++ b/src/tasks/auto_close.rs
@@ -70,10 +70,8 @@ pub fn auto_close_on_report(
     let closed =
         crate::task_events::append_done_if_legal_at(&board, &emitter, correlation_id, vec![event])?;
     if closed {
-        let _ = crate::daemon::dispatch_idle::cleanup_pending_for_task_id(home, correlation_id);
-        // #78445-2 (d): also settle this task's dispatch_tracking rows (by task_id)
-        // so the stuck-dispatch sweep stops nagging about the now-closed task.
-        crate::dispatch_tracking::mark_completed(home, Some(correlation_id), "");
+        // #1018/#78445-2 (d): terminal auto-close — shared cleanup of both stores.
+        super::task_terminal_cleanup(home, correlation_id);
     }
     Ok(closed)
 }

--- a/src/tasks/auto_close.rs
+++ b/src/tasks/auto_close.rs
@@ -71,6 +71,9 @@ pub fn auto_close_on_report(
         crate::task_events::append_done_if_legal_at(&board, &emitter, correlation_id, vec![event])?;
     if closed {
         let _ = crate::daemon::dispatch_idle::cleanup_pending_for_task_id(home, correlation_id);
+        // #78445-2 (d): also settle this task's dispatch_tracking rows (by task_id)
+        // so the stuck-dispatch sweep stops nagging about the now-closed task.
+        crate::dispatch_tracking::mark_completed(home, Some(correlation_id), "");
     }
     Ok(closed)
 }
@@ -225,6 +228,64 @@ mod tests {
             Some(crate::task_events::TaskStatus::Done),
             "task status should be Done after auto-close"
         );
+    }
+
+    /// #78445-2 PR-C (defect d) RED-first: closing a task must SETTLE its
+    /// `dispatch_tracking` rows (matched by task_id) so the stuck-dispatch sweep
+    /// stops nagging about a dispatch whose task the board already closed (the
+    /// reviewer4 double "dispatch stuck check"). Isolation (lead reminder): a
+    /// DIFFERENT task's row — even from the SAME dispatcher — must SURVIVE.
+    /// Pre-fix: the closed task's row lingered → still active/nagged.
+    #[test]
+    fn task_close_settles_dispatch_tracking_rows_78445_2() {
+        use crate::dispatch_tracking::{active_target_names, track_dispatch, DispatchEntry};
+        let home = tmp_home("pc_settle_dispatch");
+        let now = chrono::Utc::now().to_rfc3339();
+        // A review dispatch (lead → rev-a) for the task we will close …
+        track_dispatch(
+            &home,
+            DispatchEntry {
+                task_id: Some("t-close-me".into()),
+                from: "lead".into(),
+                to: "rev-a".into(),
+                from_id: None,
+                to_id: None,
+                delegated_at: now.clone(),
+                status: "pending".into(),
+            },
+        );
+        // … and one for a DIFFERENT task from the SAME dispatcher (isolation guard).
+        track_dispatch(
+            &home,
+            DispatchEntry {
+                task_id: Some("t-keep-me".into()),
+                from: "lead".into(),
+                to: "rev-b".into(),
+                from_id: None,
+                to_id: None,
+                delegated_at: now,
+                status: "pending".into(),
+            },
+        );
+
+        seed_claimed_task(&home, "t-close-me", "dev-agent");
+        let closed =
+            auto_close_on_report(&home, "report", "t-close-me", "dev-agent", "done", true).unwrap();
+        assert!(
+            closed,
+            "precondition: assignee terminal report auto-closes the task"
+        );
+
+        let active = active_target_names(&home);
+        assert!(
+            !active.contains(&"rev-a".to_string()),
+            "#78445-2 (d): closing the task must settle its dispatch_tracking row (rev-a): {active:?}"
+        );
+        assert!(
+            active.contains(&"rev-b".to_string()),
+            "#78445-2 (d) isolation: a DIFFERENT task's row (rev-b, same dispatcher) must SURVIVE: {active:?}"
+        );
+        std::fs::remove_dir_all(&home).ok();
     }
 
     #[test]

--- a/src/tasks/handler.rs
+++ b/src/tasks/handler.rs
@@ -769,6 +769,12 @@ fn handle_done(
             // `dispatch_idle_threshold_exceeded` later for
             // work the task board already confirmed done.
             let _ = crate::daemon::dispatch_idle::cleanup_pending_for_task_id(home, &id);
+            // #78445-2 (d): mirror the sidecar clear for the OTHER obligation store —
+            // settle this task's dispatch_tracking rows (matched by task_id) so the
+            // stuck-dispatch sweep stops nagging about a dispatch whose task the board
+            // already closed (a fallback-inject verdict never fires the kind=report
+            // auto-settle). task_id-scoped → a co-dispatcher's other task rows survive.
+            crate::dispatch_tracking::mark_completed(home, Some(id.as_str()), "");
             // #807 Item 1: see create arm note.
             let task = read_task_record_at(&board, &id).map(|r| record_to_task(&r));
             serde_json::json!({
@@ -1180,6 +1186,9 @@ fn handle_update(
         if let Some(ref s) = new_status {
             if matches!(s.as_str(), "done" | "cancelled") {
                 let _ = crate::daemon::dispatch_idle::cleanup_pending_for_task_id(home, &id);
+                // #78445-2 (d): also settle this task's dispatch_tracking rows (by
+                // task_id) so the stuck-dispatch sweep stops nagging a closed task.
+                crate::dispatch_tracking::mark_completed(home, Some(id.as_str()), "");
             }
             if s == "cancelled" {
                 cascade_cancel_children(home, &board, &id, &emitter);

--- a/src/tasks/handler.rs
+++ b/src/tasks/handler.rs
@@ -763,18 +763,10 @@ fn handle_done(
                     );
                 }
             }
-            // #1018 (B): eager cleanup of pending dispatch
-            // sidecars whose correlation_id matches this
-            // closed task. Prevents the watchdog from firing
-            // `dispatch_idle_threshold_exceeded` later for
-            // work the task board already confirmed done.
-            let _ = crate::daemon::dispatch_idle::cleanup_pending_for_task_id(home, &id);
-            // #78445-2 (d): mirror the sidecar clear for the OTHER obligation store —
-            // settle this task's dispatch_tracking rows (matched by task_id) so the
-            // stuck-dispatch sweep stops nagging about a dispatch whose task the board
-            // already closed (a fallback-inject verdict never fires the kind=report
-            // auto-settle). task_id-scoped → a co-dispatcher's other task rows survive.
-            crate::dispatch_tracking::mark_completed(home, Some(id.as_str()), "");
+            // #1018/#78445-2 (d): a task reaching Done is terminal — clear BOTH
+            // obligation stores (dispatch_idle sidecar + dispatch_tracking rows) via
+            // the shared seam so no watchdog nags about the board-confirmed-done work.
+            super::task_terminal_cleanup(home, &id);
             // #807 Item 1: see create arm note.
             let task = read_task_record_at(&board, &id).map(|r| record_to_task(&r));
             serde_json::json!({
@@ -1185,10 +1177,9 @@ fn handle_update(
         // the task and should clear pending sidecars.
         if let Some(ref s) = new_status {
             if matches!(s.as_str(), "done" | "cancelled") {
-                let _ = crate::daemon::dispatch_idle::cleanup_pending_for_task_id(home, &id);
-                // #78445-2 (d): also settle this task's dispatch_tracking rows (by
-                // task_id) so the stuck-dispatch sweep stops nagging a closed task.
-                crate::dispatch_tracking::mark_completed(home, Some(id.as_str()), "");
+                // #1018/#78445-2 (d): terminal via update — shared cleanup of both
+                // obligation stores.
+                super::task_terminal_cleanup(home, &id);
             }
             if s == "cancelled" {
                 cascade_cancel_children(home, &board, &id, &emitter);
@@ -1617,6 +1608,7 @@ fn cascade_cancel_children(
     };
     let parent_tid = crate::task_events::TaskId(parent_id.to_string());
     let mut cancel_events = Vec::new();
+    let mut cancelled_ids = Vec::new();
     let mut notify_ids = Vec::new();
     for (child_id, child) in &state.tasks {
         if child.parent_id.as_ref() != Some(&parent_tid) {
@@ -1629,6 +1621,7 @@ fn cascade_cancel_children(
                     by: emitter.clone(),
                     reason: format!("cascade: parent {parent_id} cancelled"),
                 });
+                cancelled_ids.push(child_id.0.clone());
             }
             crate::task_events::TaskStatus::InProgress => {
                 notify_ids.push((child_id.clone(), child.owner.clone()));
@@ -1636,8 +1629,15 @@ fn cascade_cancel_children(
             _ => {}
         }
     }
-    if !cancel_events.is_empty() {
-        let _ = crate::task_events::append_batch_at(board, emitter, cancel_events);
+    if !cancel_events.is_empty()
+        && crate::task_events::append_batch_at(board, emitter, cancel_events).is_ok()
+    {
+        // #78445-2 (d): each cascaded child-cancel is terminal — clear BOTH obligation
+        // stores for EACH child (plural). task_id-scoped, so non-child rows are
+        // untouched. (This path previously cleared NEITHER.)
+        for cid in &cancelled_ids {
+            super::task_terminal_cleanup(home, cid);
+        }
     }
     for (child_id, owner) in notify_ids {
         if let Some(ref owner_name) = owner {

--- a/src/tasks/handler/tests.rs
+++ b/src/tasks/handler/tests.rs
@@ -46,6 +46,76 @@ fn create_task(home: &std::path::Path, task_id: &str) {
     let _ = args;
 }
 
+/// #78445-2 (d): a cascade parent-cancel is terminal for EACH child — every
+/// cancelled child's dispatch_tracking rows must settle (plural), while a NON-child
+/// task's rows (even the same dispatcher) survive. This path previously cleared
+/// NEITHER store (reviewer4 #2679).
+#[test]
+fn cascade_cancel_settles_each_child_dispatch_tracking_78445_2() {
+    let home = tmp_home("cascade-settle");
+    let seed = |tid: &str, parent: Option<&str>| {
+        crate::task_events::append(
+            &home,
+            &crate::task_events::InstanceName::from("test:seed"),
+            crate::task_events::TaskEvent::Created {
+                task_id: crate::task_events::TaskId(tid.into()),
+                title: "task".into(),
+                description: String::new(),
+                priority: "normal".into(),
+                owner: None,
+                due_at: None,
+                depends_on: Vec::new(),
+                routed_to: None,
+                branch: None,
+                bind: None,
+                eta_secs: None,
+                tags: vec![],
+                parent_id: parent.map(|p| crate::task_events::TaskId(p.into())),
+            },
+        )
+        .expect("seed");
+    };
+    seed("t-parent", None);
+    seed("t-c1", Some("t-parent"));
+    seed("t-c2", Some("t-parent"));
+    seed("t-x", None); // unrelated — NOT a child of t-parent
+
+    // dispatch_tracking rows for both children + the unrelated task (same dispatcher).
+    let now = chrono::Utc::now().to_rfc3339();
+    for (tid, to) in [("t-c1", "rev-c1"), ("t-c2", "rev-c2"), ("t-x", "rev-x")] {
+        crate::dispatch_tracking::track_dispatch(
+            &home,
+            crate::dispatch_tracking::DispatchEntry {
+                task_id: Some(tid.into()),
+                from: "lead".into(),
+                to: to.into(),
+                from_id: None,
+                to_id: None,
+                delegated_at: now.clone(),
+                status: "pending".into(),
+            },
+        );
+    }
+
+    cascade_cancel_children(
+        &home,
+        &home,
+        "t-parent",
+        &crate::task_events::InstanceName::from("test:cancel"),
+    );
+
+    let active = crate::dispatch_tracking::active_target_names(&home);
+    assert!(
+        !active.contains(&"rev-c1".to_string()) && !active.contains(&"rev-c2".to_string()),
+        "#78445-2 (d): EACH cascaded child's dispatch_tracking row must settle: {active:?}"
+    );
+    assert!(
+        active.contains(&"rev-x".to_string()),
+        "#78445-2 (d) isolation: a NON-child task's row must survive: {active:?}"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
 /// Simulate a concurrent reassignment landing between handle_update's
 /// out-of-lock read and its in-lock append.
 fn reassign(home: &std::path::Path, task_id: &str, new_owner: &str) {

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -16,6 +16,24 @@ mod tests;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
+/// #78445-2 (d): the SINGLE terminal-cleanup seam for a task reaching a terminal
+/// state (done / cancelled) via ANY writer — interactive done/update, auto-close,
+/// the merged-PR sweep, the batch-cancel sweep, and the cascade child-cancel.
+/// Clears BOTH obligation stores so no watchdog nags about closed work:
+/// - the dispatch_idle sidecar (#1018 `cleanup_pending_for_task_id`), and
+/// - the dispatch_tracking rows that drive the stuck-dispatch sweep
+///   (`mark_completed`, matched by task_id → a co-dispatcher's OTHER task rows
+///   survive).
+///
+/// Centralized (reviewer4 #2679): before this, only 3 of the 6 terminal writers
+/// cleared even the sidecar and none cleared dispatch_tracking. Routing every
+/// writer through one call means a new terminal path wires ONE line and cannot
+/// silently leak either store.
+pub(crate) fn task_terminal_cleanup(home: &Path, task_id: &str) {
+    let _ = crate::daemon::dispatch_idle::cleanup_pending_for_task_id(home, task_id);
+    crate::dispatch_tracking::mark_completed(home, Some(task_id), "");
+}
+
 pub use handler::handle;
 pub use handler::register_subscriber as register_cascade_subscriber;
 // #2117 P2: resolution helpers for the out-of-`tasks` callers — comms dispatch

--- a/src/tasks/sweep.rs
+++ b/src/tasks/sweep.rs
@@ -450,6 +450,12 @@ pub(super) fn emit_cancelled_batch(
     });
     match checked {
         Ok(Ok(_)) => {
+            // #78445-2 (d): each batch-cancelled task is terminal — clear BOTH
+            // obligation stores (this path previously cleared NEITHER). task_id-scoped
+            // → a co-dispatcher's other task rows survive.
+            for id in confirm_ids {
+                super::task_terminal_cleanup(home, id);
+            }
             for (id, category) in &audit {
                 crate::event_log::log(
                     home,

--- a/src/tasks/tests.rs
+++ b/src/tasks/tests.rs
@@ -20,6 +20,60 @@ fn tmp_home(name: &str) -> std::path::PathBuf {
     dir
 }
 
+/// #78445-2 (d): the central `task_terminal_cleanup` seam clears BOTH obligation
+/// stores for the closed task — the dispatch_idle sidecar AND the dispatch_tracking
+/// rows — and is task_id-scoped so a co-dispatcher's OTHER task rows survive. All
+/// six terminal writers route through this one call.
+#[test]
+fn task_terminal_cleanup_clears_both_stores_isolated_78445_2() {
+    let home = tmp_home("terminal-cleanup-both");
+    // A dispatch_idle sidecar for the task to close (record_dispatch is kind=task).
+    crate::daemon::dispatch_idle::record_dispatch(
+        &home,
+        "lead",
+        "rev-a",
+        Some("t-close"),
+        "task",
+        900,
+    );
+    // dispatch_tracking rows: one for the task to close (→rev-a), one for a DIFFERENT
+    // task from the SAME dispatcher (→rev-b, isolation guard).
+    let now = chrono::Utc::now().to_rfc3339();
+    for (tid, to) in [("t-close", "rev-a"), ("t-keep", "rev-b")] {
+        crate::dispatch_tracking::track_dispatch(
+            &home,
+            crate::dispatch_tracking::DispatchEntry {
+                task_id: Some(tid.into()),
+                from: "lead".into(),
+                to: to.into(),
+                from_id: None,
+                to_id: None,
+                delegated_at: now.clone(),
+                status: "pending".into(),
+            },
+        );
+    }
+
+    task_terminal_cleanup(&home, "t-close");
+
+    assert!(
+        crate::daemon::dispatch_idle::list_pending(&home)
+            .iter()
+            .all(|d| d.correlation_id.as_deref() != Some("t-close")),
+        "the closed task's dispatch_idle sidecar must be cleared"
+    );
+    let active = crate::dispatch_tracking::active_target_names(&home);
+    assert!(
+        !active.contains(&"rev-a".to_string()),
+        "the closed task's dispatch_tracking row must settle: {active:?}"
+    );
+    assert!(
+        active.contains(&"rev-b".to_string()),
+        "a DIFFERENT task's row (same dispatcher) must survive: {active:?}"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
 /// Sprint 23 P0 r2 F2 helper — minimal Task with assignee for
 /// `can_mutate_task` predicate tests. Mirrors decisions.rs
 /// `make_test_decision` fixture pattern.
@@ -4124,6 +4178,50 @@ fn test_sweep_stale_open_apply_labels_category() {
     assert!(
         log.contains("category=stale_open"),
         "audit line must label the category stale_open (not the fallback), got: {log}"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// #78445-2 (d): the batch-cancel sweep is terminal for EACH cancelled task — it
+/// must settle each cancelled task's dispatch_tracking rows, while a NON-cancelled
+/// task's row (same dispatcher) survives. This path previously cleared NEITHER
+/// obligation store (reviewer4 #2679).
+#[test]
+fn sweep_cancel_settles_dispatch_tracking_78445_2() {
+    let home = tmp_home("sweep_cancel_settle");
+    write_fleet_yaml(&home, &["alive"]);
+    let id = create_open_task(&home, "ref-less stale task to cancel");
+    // dispatch_tracking rows: one for the task to cancel (→rev-a), one for an
+    // unrelated task from the SAME dispatcher (→rev-b, isolation guard).
+    let now_ts = chrono::Utc::now().to_rfc3339();
+    for (tid, to) in [(id.as_str(), "rev-a"), ("t-unrelated", "rev-b")] {
+        crate::dispatch_tracking::track_dispatch(
+            &home,
+            crate::dispatch_tracking::DispatchEntry {
+                task_id: Some(tid.into()),
+                from: "lead".into(),
+                to: to.into(),
+                from_id: None,
+                to_id: None,
+                delegated_at: now_ts.clone(),
+                status: "pending".into(),
+            },
+        );
+    }
+    let live: std::collections::HashSet<String> = ["alive".to_string()].into_iter().collect();
+    let now = chrono::Utc::now() + chrono::Duration::days(20);
+    let cats = sweep::scan_categories(&home, &live, &stub_pr_lookup, &stub_issue_lookup, None, now);
+    let confirm: std::collections::HashSet<String> = [id.clone()].into_iter().collect();
+    sweep::emit_cancelled_batch(&home, &cats, &confirm, "sweep settle test").expect("emit");
+
+    let active = crate::dispatch_tracking::active_target_names(&home);
+    assert!(
+        !active.contains(&"rev-a".to_string()),
+        "the batch-cancelled task's dispatch_tracking row must settle: {active:?}"
+    );
+    assert!(
+        active.contains(&"rev-b".to_string()),
+        "an unrelated task's row (same dispatcher) must survive: {active:?}"
     );
     std::fs::remove_dir_all(&home).ok();
 }


### PR DESCRIPTION
## What

PR-C of #78445-2 (**defect d**). PR-A #2676 merged; PR-B #2678 in review. Same root pattern as PR-A — a **termination event** (a task going done/cancelled) blind to a parallel obligation **tracker**.

## Root cause

When a task closes, `#1018` already clears its `dispatch_idle` sidecars — but the **separate `dispatch_tracking` store** (which drives the 15/30-min "dispatch stuck check" warn/ask sweep) was **not** settled. A review dispatch whose verdict arrived via **fallback inject** (no structured `kind=report` → the `#2670` auto-settle never fired) left its `dispatch_tracking` row pending, so `sweep_stuck` kept nagging the reviewer about a dispatch whose task the board had already closed (observed: reviewer4 double "dispatch stuck check" after `t-26795-3` went done).

## Fix

At each task-terminal hook — `tasks/handler.rs` (done arm + update→done/cancelled arm) and `tasks/auto_close.rs` — alongside the existing `cleanup_pending_for_task_id`, also call:

```rust
crate::dispatch_tracking::mark_completed(home, Some(task_id), "");
```

which removes the rows keyed by that `task_id`.

**Isolation (lead reminder):** `mark_completed` matches on `row.task_id == <closing task>`, so a **different** task's row — even from the **same dispatcher** — survives. A co-dispatcher's other work is untouched.

Reassign (`OwnerAssigned`) is **not** a terminal close and is left to the existing `dispatch_tracking::reassign_to` retarget (unchanged).

## Test (RED-first, verified red on pre-fix)

`task_close_settles_dispatch_tracking_rows_78445_2` — seed a dispatch row for the task-to-close (→`rev-a`) **and** one for a different task from the **same** dispatcher (→`rev-b`); auto-close the first; assert `rev-a` is settled (gone from `active_target_names`) **and** `rev-b` survives. Pre-fix: both linger.

## Scope / design choice

Defect (d) only — a **different store/subsystem** from PR-B's (b)+(c) (the `dispatch_idle` sidecar emit). Chosen approach: **eager cascade at task-close** (consistent with `#1018`), not a lazy task-status query inside `sweep_stuck`.

## Gate (all green)

`fmt --check` · `src_file_size` invariant · `clippy --workspace --all-targets -D warnings` · `nextest` (64 tasks/dispatch_tracking, RED→GREEN).
