### PR TITLE
fix(#t-78445-3): SHA gate scans summary+artifacts + one-shot-actionable reject

### DIFF
--- a/src/mcp/handlers/comms.rs
+++ b/src/mcp/handlers/comms.rs
@@ -455,29 +455,29 @@ pub(super) fn handle_report_result(home: &Path, args: &Value, sender: &Option<Se
     let result = {
         let reviewed_head = args["reviewed_head"].as_str();
 
-        // M3: SHA-staleness gate — if reviewed_head is provided, verify against PR HEAD.
+        // #t-78445-3: shared scan surface for BOTH gates below — `summary +
+        // artifacts` (a PR URL / evidence token may live in either) — built once via
+        // one helper so the two can't drift (the drift that false-rejected verdicts).
+        let scan_body = super::comms_gates::report_scan_body(summary, args["artifacts"].as_str());
+
+        // M3: SHA-staleness gate — verify reviewed_head against PR HEAD; scans
+        // scan_body (keep the surface in sync with the evidence gate below).
         if let Some(rh) = reviewed_head {
             if let Err(e) = super::comms_gates::check_sha_gate(
                 rh,
-                summary,
+                &scan_body,
                 super::comms_gates::fetch_pr_head_sha,
             ) {
                 return json!({"error": e});
             }
         }
 
-        // #1666 Phase A: reviewer-evidence gate. Only fires on actual verdict
-        // reports (summary STARTS WITH VERIFIED/REJECTED/UNVERIFIED — §3.12
-        // convention, so non-verdict reports are never touched). VERIFIED/
-        // REJECTED must carry an evidence token; UNVERIFIED is exempt. Scans
-        // summary + artifacts (evidence may live in either) and reuses the
-        // sha_gate reject path (`json!({"error"})` → back to the reviewer).
+        // #1666 Phase A: reviewer-evidence gate. Only fires on actual verdict reports
+        // (summary STARTS WITH VERIFIED/REJECTED/UNVERIFIED — §3.12). VERIFIED/
+        // REJECTED must carry an evidence token; UNVERIFIED is exempt. Scans scan_body
+        // (in sync with the SHA gate above). Reuses the reject path back to the sender.
         if let Some(verdict) = super::comms_gates::detect_verdict(summary) {
-            let evidence_body = match args["artifacts"].as_str() {
-                Some(a) => format!("{summary}\n{a}"),
-                None => summary.to_string(),
-            };
-            if let Err(e) = super::comms_gates::check_evidence_gate(&evidence_body, verdict) {
+            if let Err(e) = super::comms_gates::check_evidence_gate(&scan_body, verdict) {
                 return json!({"error": e});
             }
 
@@ -487,7 +487,7 @@ pub(super) fn handle_report_result(home: &Path, args: &Value, sender: &Option<Se
                 home,
                 sender.as_str(),
                 summary,
-                &evidence_body,
+                &scan_body,
                 verdict,
             );
         }

--- a/src/mcp/handlers/comms_gates/mod.rs
+++ b/src/mcp/handlers/comms_gates/mod.rs
@@ -19,7 +19,7 @@ pub(super) use evidence_gate::{check_evidence_gate, cross_check_and_log};
 // dispatch tracker (the verdict→review-task bridge in `track_dispatch`), so they
 // are crate-visible, not just `pub(super)`.
 pub(crate) use evidence_gate::{detect_verdict, Verdict};
-pub(super) use sha_gate::{check_sha_gate, fetch_pr_head_sha};
+pub(super) use sha_gate::{check_sha_gate, fetch_pr_head_sha, report_scan_body};
 
 // Send-invariant gate (handle_unified_send).
 pub(super) use anti_stall::enforce_send_invariants;

--- a/src/mcp/handlers/comms_gates/sha_gate.rs
+++ b/src/mcp/handlers/comms_gates/sha_gate.rs
@@ -2,9 +2,14 @@
 
 /// Check that a reviewer's claimed SHA matches the current PR HEAD.
 /// Returns Ok(()) to proceed, Err(message) to reject the verdict.
+///
+/// `scan_text` is the reviewer's report body scanned for the PR URL — the caller
+/// MUST pass `summary + artifacts` (the PR URL may live in either), the SAME scan
+/// surface as the sibling evidence gate. Passing `summary` alone false-rejects a
+/// verdict whose URL is in `artifacts` (#t-78445-3).
 pub(crate) fn check_sha_gate(
     reviewed_head: &str,
-    summary: &str,
+    scan_text: &str,
     fetch: impl Fn(&str) -> Result<String, String>,
 ) -> Result<(), String> {
     if reviewed_head.len() < 7 {
@@ -14,14 +19,23 @@ pub(crate) fn check_sha_gate(
             reviewed_head.len()
         ));
     }
-    let pr_ref = match extract_pr_number(summary) {
+    let pr_ref = match extract_pr_number(scan_text) {
         Some(pr) => pr,
         None => {
-            // B2: reviewed_head provided but no PR URL → incomplete attestation
-            return Err("reviewed_head provided but no GitHub PR URL in summary; \
-                 include PR URL (https://github.com/owner/repo/pull/N) \
-                 so daemon can verify SHA against current PR head"
-                .to_string());
+            // B2: reviewed_head provided but no PR URL anywhere in the report body →
+            // incomplete attestation. One-shot-actionable message (a degraded model
+            // must be able to fix + resend from the text alone). We do NOT guess the
+            // repo from a bare `#N`: guessing could verify against the WRONG PR and
+            // silently pass a stale head — the anti-forgery this gate exists for.
+            return Err(
+                "reviewed_head was provided but no GitHub PR URL was found in the \
+                 report body (summary + artifacts). The daemon verifies reviewed_head against \
+                 the PR's current head, which needs the PR URL. FIX: add a line with the FULL \
+                 URL — `PR: https://github.com/<owner>/<repo>/pull/<N>` — to your message or \
+                 artifacts, then resend. A bare `#<N>` is not enough (the daemon will not guess \
+                 the repo)."
+                    .to_string(),
+            );
         }
     };
     let current_sha = fetch(&pr_ref)?;
@@ -38,6 +52,18 @@ pub(crate) fn check_sha_gate(
         ));
     }
     Ok(())
+}
+
+/// The report body scanned by BOTH the SHA gate (for the PR URL) and the sibling
+/// reviewer-evidence gate (for the evidence token): `summary + artifacts` — either
+/// field may carry it. Shared through this one helper so the two gates' scan
+/// surfaces can never drift apart (the drift that false-rejected reviewer verdicts
+/// whose URL was in `artifacts`, #t-78445-3).
+pub(crate) fn report_scan_body(summary: &str, artifacts: Option<&str>) -> String {
+    match artifacts {
+        Some(a) => format!("{summary}\n{a}"),
+        None => summary.to_string(),
+    }
 }
 
 /// Extract PR number from text containing a GitHub PR URL.
@@ -171,6 +197,41 @@ mod tests {
         assert!(
             result.is_ok(),
             "7-char reviewed_head should pass: {result:?}"
+        );
+    }
+
+    /// #t-78445-3: the caller passes `summary + "\n" + artifacts`; the PR URL may
+    /// live in the artifacts portion. The gate must find it there (not just in the
+    /// summary prefix) — the false-reject root cause.
+    #[test]
+    fn sha_gate_finds_url_in_appended_artifacts_78445_3() {
+        let sha = "abc123def456789012345678901234567890abcd";
+        let scan_text = "VERIFIED — looks correct\nPR: https://github.com/owner/repo/pull/42";
+        let result = check_sha_gate(sha, scan_text, |_| Ok(sha.to_string()));
+        assert!(
+            result.is_ok(),
+            "URL in the appended artifacts portion must be found: {result:?}"
+        );
+    }
+
+    /// #t-78445-3: a bare `#N` (no full URL) is STILL rejected — the daemon must not
+    /// guess the repo (anti-forgery) — but the message must be one-shot actionable.
+    #[test]
+    fn sha_gate_bare_pr_number_rejected_with_actionable_message_78445_3() {
+        let result = check_sha_gate("abc1234def", "VERIFIED — PR #42 only", |_| unreachable!());
+        let err = result.unwrap_err();
+        assert!(err.contains("no GitHub PR URL"), "still rejected: {err}");
+        assert!(
+            err.contains("PR: https://github.com/<owner>/<repo>/pull/<N>"),
+            "message must name the exact FULL-URL line to add: {err}"
+        );
+        assert!(
+            err.contains("summary + artifacts"),
+            "message must say both fields are scanned: {err}"
+        );
+        assert!(
+            err.contains("not guess the repo"),
+            "message must explain why a bare #N is insufficient: {err}"
         );
     }
 }

--- a/src/mcp/handlers/comms_p0c_tests.rs
+++ b/src/mcp/handlers/comms_p0c_tests.rs
@@ -109,3 +109,91 @@ fn report_with_correlation_auto_settles_dispatch_row_without_ack_inbox_35896_11(
     );
     std::fs::remove_dir_all(&home).ok();
 }
+
+/// #t-78445-3: the SHA-staleness gate must scan `summary + artifacts` for the PR
+/// URL (not `summary` alone). A reviewer whose verdict carries the URL in the
+/// `artifacts` field was FALSE-REJECTED with "no GitHub PR URL" → verdict lost to
+/// fallback (root cause of reviewer4's #2674/#2611 fallbacks). RED on pre-fix code
+/// (gate scanned summary only), GREEN after the shared summary+artifacts scan.
+#[test]
+fn sha_gate_scans_artifacts_for_pr_url_78445_3() {
+    let home = std::env::temp_dir().join(format!(
+        "agend-78445-3-artifacts-url-{}-{}",
+        std::process::id(),
+        line!()
+    ));
+    let _ = std::fs::remove_dir_all(&home);
+    std::fs::create_dir_all(&home).unwrap();
+    let reporter = "reviewer-78445";
+    std::fs::write(
+        home.join("fleet.yaml"),
+        format!("instances:\n  lead:\n    backend: claude\n  {reporter}:\n    backend: claude\n"),
+    )
+    .unwrap();
+
+    let sender = crate::identity::Sender::new(reporter);
+    // Verdict prefix in `summary` (no URL); the PR URL lives ONLY in `artifacts`.
+    let result = super::handle_report_result(
+        &home,
+        &json!({
+            "instance": "lead",
+            "summary": "VERIFIED — looks correct",
+            "artifacts": "PR: https://github.com/nonexistent-org-xyz/nonexistent-repo/pull/1",
+            "reviewed_head": "abc1234def5678",
+        }),
+        &sender,
+    );
+    // The URL IS present in the envelope (artifacts) → it must NOT be rejected as
+    // missing. (Post-fix the gate then attempts a real fetch which fails for the
+    // fake repo — a DIFFERENT error; the point is the "no URL" false-reject is gone.)
+    let err = result["error"].as_str().unwrap_or("");
+    assert!(
+        !err.contains("no GitHub PR URL"),
+        "PR URL in artifacts must NOT be false-rejected as missing: {result}"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// #t-78445-3 companion: a bare `#N` reference with NO full URL in EITHER field is
+/// still rejected (the daemon must not guess the repo — anti-forgery), but the
+/// reject message must be one-shot actionable so a degraded model can fix + resend
+/// instead of looping (the fugu re-enter degradation this bug triggered). No fetch
+/// runs (deterministic).
+#[test]
+fn sha_gate_bare_pr_number_still_rejected_actionable_78445_3() {
+    let home = std::env::temp_dir().join(format!(
+        "agend-78445-3-bare-num-{}-{}",
+        std::process::id(),
+        line!()
+    ));
+    let _ = std::fs::remove_dir_all(&home);
+    std::fs::create_dir_all(&home).unwrap();
+    let reporter = "reviewer-78445b";
+    std::fs::write(
+        home.join("fleet.yaml"),
+        format!("instances:\n  lead:\n    backend: claude\n  {reporter}:\n    backend: claude\n"),
+    )
+    .unwrap();
+
+    let sender = crate::identity::Sender::new(reporter);
+    let result = super::handle_report_result(
+        &home,
+        &json!({
+            "instance": "lead",
+            "summary": "VERIFIED — PR #2674 looks good",
+            "artifacts": "ran: cargo test -> ok",
+            "reviewed_head": "abc1234def5678",
+        }),
+        &sender,
+    );
+    let err = result["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("no GitHub PR URL"),
+        "a bare #N with no full URL must still reject: {result}"
+    );
+    assert!(
+        err.contains("PR: https://github.com/<owner>/<repo>/pull/<N>"),
+        "reject must name the exact FULL-URL line to add: {err}"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}


### PR DESCRIPTION
## What & why

The reviewer **SHA-staleness gate** (`comms_gates::sha_gate::check_sha_gate`) scanned only `summary` for the PR URL, while the **sibling reviewer-evidence gate** scanned `summary + artifacts` ("evidence may live in either"). A reviewer whose verdict carried the PR URL in the `artifacts` field was **false-rejected** with `reviewed_head provided but no GitHub PR URL in summary`, and the whole verdict was lost to the fallback-inject path.

This is the **root cause of reviewer4's #2674 (and likely #2611) verdicts going to fallback** three times today — and the rejection further degraded the fugu model into repeated `exec_command` mis-selection, so the structured verdict channel was lost entirely.

## Root cause (scan-surface drift)

Two gates in `handle_report_result` that should scan the same body diverged:

| gate | scanned | 
|---|---|
| SHA-staleness (`check_sha_gate`) | `summary` only ❌ |
| reviewer-evidence (`check_evidence_gate`) | `summary + artifacts` ✅ |

A PR URL in `artifacts` was invisible to the SHA gate.

## Fix

1. **Shared scan surface.** Both gates now go through one helper, `sha_gate::report_scan_body(summary, artifacts)` = `summary + "\n" + artifacts`. `handle_report_result` builds it once and threads it into both gates; each gate carries a keep-in-sync comment pointing at the other, so the surfaces can't drift again.
2. **One-shot-actionable reject message.** The no-URL error now names the exact line to add — `PR: https://github.com/<owner>/<repo>/pull/<N>` — and states both fields are scanned, so a degraded model can fix + resend instead of looping.
3. **Bare `#N` is still rejected — deliberately.** The daemon must **not** guess the repo from a bare `#N`: a wrong guess would fetch the wrong PR and could silently pass a stale head. `(b)`'s message teaches the full-URL line instead.

### Anti-forgery preserved (#1666 §3.3)

The gate exists to stop a reviewer reporting a stale/fake head. This fix only **widens where the PR URL is found** — once found (in either field), the SHA is still fetched from that PR and compared. A fake URL in `artifacts` is caught by the SHA mismatch exactly as a fake URL in `summary` is today. Rejected option (c) (accept + mark `unverified_head`) was **not** taken — it would trade the anti-forgery away; (a) fixes the real miss while keeping it.

## Tests (RED-first)

- `sha_gate_scans_artifacts_for_pr_url_78445_3` — URL only in `artifacts` → no longer false-rejected (handler-level; **verified RED on pre-fix code**).
- `sha_gate_bare_pr_number_still_rejected_actionable_78445_3` — bare `#N` → still rejected, message content pinned (handler-level, deterministic — no fetch).
- `sha_gate_finds_url_in_appended_artifacts_78445_3` + `sha_gate_bare_pr_number_rejected_with_actionable_message_78445_3` — unit-level (mock fetch), pin the scan + the actionable message.
- All existing `sha_gate` tests kept green.

## Gate

`cargo fmt --check` · `cargo clippy --workspace --all-targets -- -D warnings` · `file_size_invariant` (comms.rs kept under the 750-LOC ceiling by extracting `report_scan_body` into `sha_gate`) · full `cargo nextest run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
