### PR TITLE
feat(embedder-p2): flag-gated git-shim swap agend-git → agentic-git (build-together + kill-shim coexist + rollback=flip flag)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,20 @@ jobs:
       # the slow-timeout is KILLED and NAMED → a fast, attributed failure instead
       # of a 30-min mystery. The `ci` profile also serializes the heavy real-git
       # test cluster (`git-subprocess` test-group) so it can't race the suite.
+      # #2524 P2 (build-together, design §3.A): the flag-gated git-shim swap
+      # points `git` at a self-built `agentic-git` binary from the vendored
+      # submodule. It is NOT a workspace member (the submodule declares its OWN
+      # [workspace]), so `cargo build --release` above does not produce it — build
+      # it via the submodule manifest and expose its path so the runtime parity
+      # test (tests/agentic_git_shim_swap.rs) exercises the REAL binary instead of
+      # skipping. Unix-only: the shim swap + that test are `#[cfg(unix)]`.
+      - name: Build-together agentic-git shim (#2524 P2)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          ./scripts/build_agentic_git_shim.sh debug
+          echo "AGENTIC_GIT_SHIM_BIN=$PWD/target/debug/agentic-git" >> "$GITHUB_ENV"
+
       - name: Install nextest (#1784/#1893 — per-test terminate-after, all platforms)
         uses: taiki-e/install-action@v2
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -223,3 +223,9 @@ glob = "0.3"
 # §7 PR-C names `tracing-test` as the sanctioned approach for asserting
 # `tracing::warn!` records are actually emitted).
 tracing-test = "0.2"
+# #2524 P2 cross-build proof (tests/agentic_git_shim_swap.rs): sign a bound
+# binding with the SAME core the daemon links (agend-terminal's build) so the
+# test can assert the SUBMODULE-built agentic-git binary verifies + allows it.
+# SAME path as the normal dep (line ~137) → cargo unifies to ONE package, so the
+# single-source invariant (tests/agentic_core_single_source.rs) is preserved.
+agentic-git-core = { path = "vendor/agentic-git/crates/agentic-git-core" }

--- a/scripts/build_agentic_git_shim.sh
+++ b/scripts/build_agentic_git_shim.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Build-together (agentic-git migration, design §3.A / #2524 P2).
+#
+# Builds the vendored `agentic-git` shim binary from the PINNED submodule and
+# installs it as a sibling of the daemon exe, so the flag-gated git-shim swap
+# (fleet.yaml `use_agentic_git_shim: true`) can resolve it at daemon startup via
+# `current_exe().with_file_name("agentic-git")` (see src/binding/shim_install.rs).
+#
+# Why the submodule's OWN manifest (not a workspace `-p agentic-git`): the
+# vendored crate uses `edition.workspace = true` and lives under vendor/agentic-git,
+# which declares its own `[workspace]`. It therefore CANNOT be a member of
+# agend-terminal's package/workspace without editing the pinned submodule (a
+# revert-clean spike confirms cargo rejects it). Building via the submodule
+# manifest keeps agend-terminal's Cargo.lock with EXACTLY ONE agentic-git-core
+# (tests/agentic_core_single_source.rs) while the binary links the SAME vendored
+# core SOURCE dir the daemon links — structural same-version, no registry drift.
+#
+# Usage: scripts/build_agentic_git_shim.sh [debug|release]   (default: debug)
+set -euo pipefail
+
+PROFILE="${1:-debug}"
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SUB="$REPO/vendor/agentic-git"
+DEST_DIR="${CARGO_TARGET_DIR:-$REPO/target}/$PROFILE"
+
+case "$PROFILE" in
+  debug|release) ;;
+  *) echo "usage: $0 [debug|release]" >&2; exit 2 ;;
+esac
+
+if [ ! -f "$SUB/Cargo.toml" ]; then
+  echo "error: submodule not initialized at $SUB — run: git submodule update --init" >&2
+  exit 1
+fi
+
+# Build in the submodule's OWN target dir (its own Cargo.lock over the same
+# vendored source) to avoid sharing agend-terminal's target-dir — no
+# cross-workspace rebuild churn or target-lock contention. (No bash array for
+# the profile flag — keeps `set -u` happy on macOS's bash 3.2.)
+if [ "$PROFILE" = release ]; then
+  cargo build -p agentic-git --manifest-path "$SUB/Cargo.toml" --release
+else
+  cargo build -p agentic-git --manifest-path "$SUB/Cargo.toml"
+fi
+
+mkdir -p "$DEST_DIR"
+install -m 0755 "$SUB/target/$PROFILE/agentic-git" "$DEST_DIR/agentic-git"
+echo "build-together: installed agentic-git shim → $DEST_DIR/agentic-git"

--- a/src/binding.rs
+++ b/src/binding.rs
@@ -860,44 +860,13 @@ pub fn reconcile_hooks(home: &Path) {
     }
 }
 
-/// Symlink the agend-git binary into $AGEND_HOME/bin under every name it shadows (so the shims
-/// win over the real tools via PATH). Called at daemon startup. #t-…777-1: the binary is
-/// MULTIPLEXED on argv[0] — `git` = git shim; `pkill`/`killall`/`kill` = kill_guard.rs.
-pub fn symlink_shim(home: &Path) {
-    let bin_dir = home.join("bin");
-    std::fs::create_dir_all(&bin_dir).ok();
-
-    // Find the agend-git binary alongside the main binary.
-    let shim_name = if cfg!(windows) {
-        "agend-git.exe"
-    } else {
-        "agend-git"
-    };
-    let shim_src = std::env::current_exe().ok().and_then(|exe| {
-        let candidate = exe.with_file_name(shim_name);
-        candidate.exists().then_some(candidate)
-    });
-
-    let Some(src) = shim_src else { return };
-    let shadows: &[&str] = if cfg!(windows) {
-        &["git.exe", "pkill.exe", "killall.exe", "kill.exe"]
-    } else {
-        &["git", "pkill", "killall", "kill"]
-    };
-    for name in shadows {
-        let link_path = bin_dir.join(name);
-        // Remove stale symlink/file first.
-        let _ = std::fs::remove_file(&link_path);
-        #[cfg(unix)]
-        {
-            let _ = std::os::unix::fs::symlink(&src, &link_path);
-        }
-        #[cfg(not(unix))]
-        {
-            let _ = std::fs::copy(&src, &link_path);
-        }
-    }
-}
+/// Git/kill shim installation — see [`shim_install::symlink_shim`]. Homed in its
+/// own module so the #2524-P2 flag-gated backend-swap logic AND its unit tests
+/// don't push this core file past the anti-monolith LOC ceiling. Re-exported so
+/// the public path stays `crate::binding::symlink_shim` (call site + wiring
+/// invariant unchanged).
+mod shim_install;
+pub use shim_install::symlink_shim;
 
 /// Clear orphan bindings (agents no longer in registry).
 /// Called at daemon startup.

--- a/src/binding/shim_install.rs
+++ b/src/binding/shim_install.rs
@@ -1,0 +1,188 @@
+//! Git/kill PATH-shim installation for `$AGEND_HOME/bin` (#2524 P2).
+//!
+//! Homed out of `binding.rs` so the flag-gated git-shim backend-swap logic and
+//! its unit tests stay off that core file's anti-monolith LOC budget. The public
+//! entry [`symlink_shim`] is re-exported from `crate::binding`, so callers and
+//! the app-mode wiring invariant keep referring to `binding::symlink_shim`.
+
+use std::path::{Path, PathBuf};
+
+/// Symlink the guard shim binaries into `$AGEND_HOME/bin` under every name they
+/// shadow (so the shims win over the real tools via PATH). Called at daemon
+/// startup. #t-…777-1: the binaries are MULTIPLEXED on argv[0] — `git` = git
+/// shim; `pkill`/`killall`/`kill` = kill_guard.rs.
+///
+/// #2524 P2 (agentic-git migration, design §5-Phase-2): the `git` name is
+/// FLAG-GATED. When `use_agentic_git` is true and the self-built `agentic-git`
+/// sibling exists, `git` points at it (the vendored successor shim, whose git
+/// guard matrix is parity-equivalent to agend-git's); otherwise `git` stays on
+/// `agend-git`. The `{pkill,killall,kill}` kill-shim links ALWAYS point at
+/// `agend-git` (D1=A — agentic-git is git-only and has no process-kill guard,
+/// so it must never shadow the kill family). Rollback = flip the flag back to
+/// false + restart; the on-disk binding format is unchanged, so a rolled-back
+/// agend-git shim still verifies core-signed bindings (no rebind storm).
+pub fn symlink_shim(home: &Path, use_agentic_git: bool) {
+    let Ok(exe) = std::env::current_exe() else {
+        return;
+    };
+    symlink_shim_at(home, &exe, use_agentic_git);
+}
+
+/// Testable core of [`symlink_shim`]: the daemon-exe path is injected so unit
+/// tests can point it at a fixture directory holding fake sibling binaries,
+/// instead of the real `current_exe()`.
+fn symlink_shim_at(home: &Path, exe: &Path, use_agentic_git: bool) {
+    let bin_dir = home.join("bin");
+    std::fs::create_dir_all(&bin_dir).ok();
+
+    // Resolve a self-built sibling binary next to the daemon exe, .exists()-gated.
+    let sibling = |stem: &str| -> Option<PathBuf> {
+        let name = if cfg!(windows) {
+            format!("{stem}.exe")
+        } else {
+            stem.to_string()
+        };
+        let candidate = exe.with_file_name(name);
+        candidate.exists().then_some(candidate)
+    };
+
+    // agend-git is the mandatory floor: it owns the kill family AND is the git
+    // default/fallback. Absent → nothing to install (byte-identical to the
+    // pre-P2 early-return when the shim binary was missing).
+    let Some(agend_git) = sibling("agend-git") else {
+        return;
+    };
+
+    // Flag-gated git target. Fail-SAFE: flag on but the agentic-git sibling
+    // missing (build-together did not ship it) → fall back to agend-git so `git`
+    // is NEVER left unguarded, and WARN loudly so the drift is diagnosable.
+    let git_src = if use_agentic_git {
+        match sibling("agentic-git") {
+            Some(agentic) => agentic,
+            None => {
+                tracing::warn!(
+                    "use_agentic_git_shim=true but the agentic-git binary is missing next \
+                     to the daemon exe; falling back to agend-git for the git shim (run the \
+                     build-together step). git stays guarded."
+                );
+                agend_git.clone()
+            }
+        }
+    } else {
+        agend_git.clone()
+    };
+
+    let git_name = if cfg!(windows) { "git.exe" } else { "git" };
+    let kill_names: &[&str] = if cfg!(windows) {
+        &["pkill.exe", "killall.exe", "kill.exe"]
+    } else {
+        &["pkill", "killall", "kill"]
+    };
+
+    // (link_name, source): `git` → flag-selected; kill family → always agend-git.
+    let mut links: Vec<(&str, &Path)> = vec![(git_name, git_src.as_path())];
+    for name in kill_names {
+        links.push((name, agend_git.as_path()));
+    }
+
+    for (name, src) in links {
+        let link_path = bin_dir.join(name);
+        // Remove stale symlink/file first.
+        let _ = std::fs::remove_file(&link_path);
+        #[cfg(unix)]
+        {
+            let _ = std::os::unix::fs::symlink(src, &link_path);
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = std::fs::copy(src, &link_path);
+        }
+    }
+}
+
+// The target-resolution assertions read symlink targets, which is a unix
+// semantic (the `cfg(not(unix))` path uses `fs::copy` instead). Windows shim
+// wiring is advisory-only in this repo; parity there is covered by the
+// source-inspection + build tests in `tests/agentic_git_shim_swap.rs`.
+#[cfg(all(test, unix))]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    /// Build a fixture: an exe dir containing the requested fake sibling
+    /// binaries plus a separate empty home. Returns `(home, fake_exe_path)`.
+    fn fixture(tag: &str, siblings: &[&str]) -> (PathBuf, PathBuf) {
+        let base = std::env::temp_dir().join(format!("agend-p2-shim-{tag}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&base);
+        let exe_dir = base.join("exe");
+        std::fs::create_dir_all(&exe_dir).unwrap();
+        std::fs::create_dir_all(base.join("home")).unwrap();
+        for s in siblings {
+            std::fs::write(exe_dir.join(s), b"#!/bin/sh\n").unwrap();
+        }
+        (base.join("home"), exe_dir.join("agend-terminal"))
+    }
+
+    fn target_of(home: &Path, name: &str) -> PathBuf {
+        std::fs::read_link(home.join("bin").join(name)).unwrap()
+    }
+
+    #[test]
+    fn flag_off_git_points_agend_git() {
+        let (home, exe) = fixture("off", &["agend-git", "agentic-git"]);
+        symlink_shim_at(&home, &exe, false);
+        let agend = exe.with_file_name("agend-git");
+        assert_eq!(target_of(&home, "git"), agend, "flag off: git → agend-git");
+        for n in ["pkill", "killall", "kill"] {
+            assert_eq!(target_of(&home, n), agend, "kill family → agend-git");
+        }
+    }
+
+    #[test]
+    fn flag_on_git_points_agentic_git() {
+        // The P2 swap: flag on + both siblings present → git retargets to
+        // agentic-git while the kill family stays on agend-git. Pre-P2 this
+        // function always pointed git → agend-git (the RED baseline).
+        let (home, exe) = fixture("on", &["agend-git", "agentic-git"]);
+        symlink_shim_at(&home, &exe, true);
+        assert_eq!(
+            target_of(&home, "git"),
+            exe.with_file_name("agentic-git"),
+            "flag on: git → agentic-git"
+        );
+        let agend = exe.with_file_name("agend-git");
+        for n in ["pkill", "killall", "kill"] {
+            assert_eq!(
+                target_of(&home, n),
+                agend,
+                "D1=A: kill family stays on agend-git even with the flag on"
+            );
+        }
+    }
+
+    #[test]
+    fn flag_on_missing_agentic_falls_back_to_agend_git() {
+        // Fail-safe: flag on but agentic-git not shipped → git must NOT be left
+        // unguarded; it falls back to the agend-git floor.
+        let (home, exe) = fixture("fallback", &["agend-git"]);
+        symlink_shim_at(&home, &exe, true);
+        let agend = exe.with_file_name("agend-git");
+        assert_eq!(target_of(&home, "git"), agend, "fallback: git → agend-git");
+        for n in ["pkill", "killall", "kill"] {
+            assert_eq!(target_of(&home, n), agend);
+        }
+    }
+
+    #[test]
+    fn no_agend_git_floor_installs_nothing() {
+        // No kill-shim floor present → install nothing (pre-P2 early-return),
+        // even though an agentic-git sibling exists.
+        let (home, exe) = fixture("noop", &["agentic-git"]);
+        symlink_shim_at(&home, &exe, true);
+        assert!(
+            !home.join("bin").join("git").exists(),
+            "no agend-git floor → no git link installed"
+        );
+        assert!(!home.join("bin").join("pkill").exists());
+    }
+}

--- a/src/bootstrap/fleet_normalize.rs
+++ b/src/bootstrap/fleet_normalize.rs
@@ -141,6 +141,7 @@ mod tests {
             display_timezone: None,
             agy_workspace_link_base: None,
             watchdog: Default::default(),
+            use_agentic_git_shim: false,
             home: None,
         };
         c.instances.insert(

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -373,7 +373,8 @@ pub(crate) fn resolve_fleet_and_reconcile(
             .spawn(move || crate::binding::reconcile_hooks(&home_owned));
     }
     time_step("binding::symlink_shim", || {
-        crate::binding::symlink_shim(home);
+        // #2524 P2: flag-gated git-shim backend (default off = agend-git).
+        crate::binding::symlink_shim(home, config.use_agentic_git_shim);
     });
     time_step("binding::reconcile_orphans", || {
         crate::binding::reconcile_orphans(home);

--- a/src/fleet/mod.rs
+++ b/src/fleet/mod.rs
@@ -193,6 +193,19 @@ pub struct FleetConfig {
     /// [`watchdog::WatchdogConfig`].
     #[serde(default)]
     pub watchdog: WatchdogConfig,
+    /// #2524 P2 (agentic-git migration, design §5-Phase-2): flag-gated git-shim
+    /// backend. `false` (DEFAULT — byte-identical to today) → `$AGEND_HOME/bin/git`
+    /// symlinks to the in-tree `agend-git` shim. `true` → `git` points at the
+    /// self-built vendored `agentic-git` binary instead; the `{pkill,killall,kill}`
+    /// kill-shim links ALWAYS stay on `agend-git` (D1=A — agentic-git has no kill
+    /// guard). Consumed at daemon startup by [`crate::binding::symlink_shim`].
+    /// Rollback = flip back to `false` + restart: the on-disk binding format is
+    /// unchanged, so a rolled-back agend-git shim still verifies core-signed
+    /// bindings (no rebind storm). Additive optional field → no
+    /// [`FLEET_SCHEMA_VERSION`] bump; `skip_serializing_if` keeps a fleet.yaml
+    /// rewrite from injecting the default-off knob.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub use_agentic_git_shim: bool,
     #[serde(skip)]
     pub(crate) home: Option<PathBuf>,
 }

--- a/tests/agentic_git_shim_swap.rs
+++ b/tests/agentic_git_shim_swap.rs
@@ -1,0 +1,320 @@
+//! #2524 P2 (agentic-git migration, design §5-Phase-2): parity coverage for the
+//! flag-gated git-shim backend swap (`use_agentic_git_shim`).
+//!
+//! Three tiers:
+//!   1. SOURCE parity (hermetic, always runs): the vendored `agentic-git` shim
+//!      source must carry every git guard agend-terminal depends on AND read
+//!      every daemon-injected `AGEND_*` env var (legacy fallback), so pointing
+//!      `git` at it (flag on) preserves the guard matrix. Mirrors the existing
+//!      `shim_*_in_source` checks for agend-git (agend_git_shim_phase2.rs).
+//!   2. RUNTIME guard (gated on a prebuilt binary): run the real binary as `git`
+//!      and prove the unbound-mutation deny actually fires.
+//!   3. CROSS-BUILD HMAC byte-compat (gated): a binding SIGNED by the daemon's
+//!      core (agend-terminal build, via the dev-dep) is VERIFIED + ALLOWED by the
+//!      SUBMODULE-built binary — the load-bearing safety assumption of the flag
+//!      flip — plus a tamper negative-control so the ALLOW can't be a rubber-stamp.
+//!
+//! The gated tiers prebuild the binary via `scripts/build_agentic_git_shim.sh`
+//! (CI runs it before nextest; locally skip-loud if absent). We deliberately
+//! NEVER nested-`cargo build` inside a test — that reintroduced the windows
+//! target-lock deadlock removed in agend_git_shim_phase2.rs:42-48. The vendored
+//! source is already a hard build prerequisite (the daemon links
+//! `agentic-git-core` from this same submodule, P1b), so `include_str!` on it
+//! adds no new fragility.
+
+const VENDORED_SHIM: &str = include_str!("../vendor/agentic-git/crates/agentic-git/src/main.rs");
+
+/// Every git guard agend-terminal relies on must be present in the vendored
+/// successor shim (design §5 DUAL parity core). A missing one = a silent guard
+/// regression the moment the flag flips on.
+#[test]
+fn vendored_shim_carries_every_depended_on_git_guard() {
+    for (needle, why) in [
+        ("fn deny_unbound_else_chdir", "unbound → deny all mutations"),
+        (
+            "fn push_protected_violation",
+            "protected-ref (main/master) deny",
+        ),
+        (
+            "fn push_trust_root_denylist_violation",
+            "trust-root push denylist",
+        ),
+        (
+            "fn push_force_without_lease_violation",
+            "force-lease gate (P0)",
+        ),
+        (
+            "fn is_pure_delete_push",
+            "#2677 ALL-not-ANY mixed-refspec force fix",
+        ),
+        ("fn cwd_is_canonical_rooted", "canonical-repo protection"),
+        ("recursion_guard_or_exit", "self-resolution recursion guard"),
+        ("cross-branch", "checkout/switch cross-branch fence"),
+        (
+            "integrity_core::verify",
+            "HMAC binding verify (fail-closed)",
+        ),
+        ("fn read_binding", "fail-closed binding read"),
+    ] {
+        assert!(
+            VENDORED_SHIM.contains(needle),
+            "vendored agentic-git shim missing `{needle}` ({why}) — flipping \
+             use_agentic_git_shim on would regress this guard. Re-pin the submodule."
+        );
+    }
+}
+
+/// The daemon injects only `AGEND_*` names; the vendored shim must read every
+/// one (via its `AGENTIC_GIT_*`-primary + `AGEND_*`-legacy fallback), else the
+/// swap silently loses bypass / real-git / binding routing.
+#[test]
+fn vendored_shim_reads_every_daemon_injected_agend_env() {
+    assert!(
+        VENDORED_SHIM.contains("fn legacy_env_name"),
+        "vendored shim must map AGENTIC_GIT_* → AGEND_* legacy names"
+    );
+    for var in [
+        "AGEND_HOME",
+        "AGEND_INSTANCE_NAME",
+        "AGEND_REAL_GIT",
+        "AGEND_GIT_BYPASS",
+        "AGEND_GIT_BYPASS_AGENT",
+        "AGEND_GIT_BYPASS_UNTIL",
+        "AGEND_GIT_SHIM_DEPTH",
+        "AGEND_GIT_ALLOW_CANONICAL_MUTATE",
+    ] {
+        assert!(
+            VENDORED_SHIM.contains(&format!("\"{var}\"")),
+            "vendored shim does not read daemon-injected {var} under any name — \
+             swapping the git shim would drop it"
+        );
+    }
+}
+
+// ── Runtime tiers (gated on a prebuilt binary; unix-only) ────────────────────
+
+#[cfg(unix)]
+mod runtime {
+    use std::path::{Path, PathBuf};
+    use std::process::{Command, Output};
+
+    /// The prebuilt binary, or None (caller skips-loud). CI exports
+    /// AGENTIC_GIT_SHIM_BIN; otherwise fall back to the build script's install
+    /// path or the submodule target.
+    pub fn locate() -> Option<PathBuf> {
+        if let Some(p) = std::env::var_os("AGENTIC_GIT_SHIM_BIN") {
+            let p = PathBuf::from(p);
+            if p.exists() {
+                return Some(p);
+            }
+        }
+        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        [
+            root.join("target/debug/agentic-git"),
+            root.join("vendor/agentic-git/target/debug/agentic-git"),
+        ]
+        .into_iter()
+        .find(|c| c.exists())
+    }
+
+    /// First existing STANDARD absolute real-git path (never a PATH shim). The
+    /// test may run inside an agend session whose PATH `git` is itself a shim, so
+    /// we must not resolve real git via PATH — that would feed the shim its own
+    /// path (recursion) and let a shim intercept fixture setup.
+    pub fn real_git() -> PathBuf {
+        [
+            "/usr/bin/git",
+            "/opt/homebrew/bin/git",
+            "/usr/local/bin/git",
+        ]
+        .into_iter()
+        .map(PathBuf::from)
+        .find(|p| p.exists())
+        .unwrap_or_else(|| PathBuf::from("git"))
+    }
+
+    /// Build a throwaway git repo with one commit, using REAL git directly
+    /// (absolute path → bypasses any PATH shim; real git ignores AGEND_* env).
+    pub fn init_repo(dir: &Path) {
+        let git = real_git();
+        let run = |args: &[&str]| {
+            assert!(
+                Command::new(&git)
+                    .args(args)
+                    .current_dir(dir)
+                    .env("HOME", dir) // isolate from ~/.gitconfig
+                    .status()
+                    .expect("fixture git")
+                    .success(),
+                "fixture git {args:?} must succeed"
+            );
+        };
+        run(&["init", "-q"]);
+        run(&[
+            "-c",
+            "user.email=t@t",
+            "-c",
+            "user.name=t",
+            "commit",
+            "--allow-empty",
+            "-q",
+            "-m",
+            "seed",
+        ]);
+    }
+
+    /// Run the prebuilt binary as argv[0] `git`, as `agent` bound to `home`, in
+    /// `cwd`, with a HERMETIC env: `env_clear` so no inherited `AGEND_GIT_BYPASS`
+    /// / shim-depth leaks in and masks the real guard/verify path.
+    pub fn run_as_git(bin: &Path, home: &Path, agent: &str, args: &[&str], cwd: &Path) -> Output {
+        use std::os::unix::fs::symlink;
+        let git = home.join("git");
+        let _ = std::fs::remove_file(&git);
+        symlink(bin, &git).expect("symlink git → agentic-git");
+        let real = real_git();
+        let real_dir = real.parent().unwrap_or_else(|| Path::new("/usr/bin"));
+        Command::new(&git)
+            .args(args)
+            .current_dir(cwd)
+            .env_clear()
+            .env("PATH", real_dir)
+            .env("HOME", home)
+            .env("AGEND_HOME", home)
+            .env("AGEND_INSTANCE_NAME", agent)
+            .env("AGEND_REAL_GIT", &real)
+            .output()
+            .expect("run agentic-git as git")
+    }
+
+    fn scratch(tag: &str) -> PathBuf {
+        let base = std::env::temp_dir().join(format!("agentic-p2-{tag}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&base);
+        std::fs::create_dir_all(&base).expect("mkdir scratch");
+        base
+    }
+
+    /// Build a temp AGEND_HOME with a REAL bound worktree and a binding SIGNED by
+    /// agend-terminal's `agentic_git_core` (the daemon's signer, via the dev-dep).
+    /// Returns `(home, agent)`.
+    fn daemon_signed_bound_home(tag: &str) -> (PathBuf, String) {
+        let base = scratch(tag);
+        let agent = "bound-agent".to_owned();
+        let wt = base.join("wt");
+        std::fs::create_dir_all(&wt).expect("mkdir wt");
+        init_repo(&wt);
+
+        // The daemon's field shape; the shim only requires a non-empty task_id +
+        // an existing worktree. Sign the EXACT bytes written — sign_binding hashes
+        // raw bytes verbatim (no canonicalization).
+        let body = format!(
+            "{{\"version\":1,\"agent\":\"{agent}\",\"task_id\":\"T-xbuild-1\",\
+             \"branch\":\"feat/p2-shim-swap\",\"worktree\":\"{}\"}}",
+            wt.display()
+        );
+        let sig = agentic_git_core::integrity_core::sign_binding(&base, body.as_bytes())
+            .expect("agend-terminal-build core must sign");
+
+        let bdir = base.join("runtime").join(&agent);
+        std::fs::create_dir_all(&bdir).expect("mkdir runtime/agent");
+        std::fs::write(bdir.join("binding.json"), &body).expect("write binding.json");
+        std::fs::write(bdir.join("binding.json.sig"), &sig).expect("write sig");
+        (base, agent)
+    }
+
+    /// Runtime guard: unbound mutation is DENIED (exit != 0, "denied … unbound").
+    /// Proves flipping the flag routes `git` to a binary that actually guards.
+    #[test]
+    fn unbound_mutation_is_denied() {
+        let Some(bin) = locate() else {
+            eprintln!("SKIP unbound_mutation_is_denied: no prebuilt agentic-git binary");
+            return;
+        };
+        let base = scratch("unbound");
+        let repo = base.join("repo");
+        std::fs::create_dir_all(&repo).expect("mkdir repo");
+        init_repo(&repo);
+        // AGEND_HOME=base has no runtime/<agent> binding → unbound.
+        let out = run_as_git(
+            &bin,
+            &base,
+            "ghost-unbound",
+            &["commit", "--allow-empty", "-m", "x"],
+            &repo,
+        );
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            !out.status.success(),
+            "unbound `git commit` must be DENIED (nonzero exit). stderr={stderr}"
+        );
+        assert!(
+            stderr.contains("denied") && stderr.to_lowercase().contains("unbound"),
+            "deny message must name the unbound reason; stderr={stderr}"
+        );
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    /// Cross-build proof: a daemon-core-signed BOUND binding is verified and
+    /// ALLOWED by the submodule-built binary (`git add .` → exit 0), proving the
+    /// two independent `agentic-git-core` compiles are HMAC byte-compatible.
+    #[test]
+    fn daemon_signed_binding_allowed_across_core_builds() {
+        let Some(bin) = locate() else {
+            eprintln!("SKIP daemon_signed_binding_allowed_across_core_builds: no prebuilt binary");
+            return;
+        };
+        let (home, agent) = daemon_signed_bound_home("allow");
+        // `git add .` from a NON-git cwd (home) → bound → ChdirPass into the
+        // worktree → real `git add` (exit 0 on a clean tree). A non-git cwd
+        // avoids the foreign-repo passthrough that would mask the bound path.
+        let out = run_as_git(&bin, &home, &agent, &["add", "."], &home);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            out.status.success(),
+            "daemon-core-signed bound binding must be VERIFIED + ALLOWED by the submodule-built \
+             binary (cross-build HMAC byte-compat); exit={:?} stderr={stderr}",
+            out.status.code()
+        );
+        assert!(
+            !stderr.contains("denied"),
+            "a validly-bound agent must not be denied; stderr={stderr}"
+        );
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    /// Negative control: flipping one hex char of the daemon signature makes the
+    /// same bound `git add` DENY — proving the ALLOW above is the HMAC actually
+    /// verifying (fail-closed), not the binary rubber-stamping any binding.
+    #[test]
+    fn tampered_daemon_signature_is_denied() {
+        let Some(bin) = locate() else {
+            eprintln!("SKIP tampered_daemon_signature_is_denied: no prebuilt binary");
+            return;
+        };
+        let (home, agent) = daemon_signed_bound_home("tamper");
+        let sigpath = home.join("runtime").join(&agent).join("binding.json.sig");
+        let sig = std::fs::read_to_string(&sigpath).expect("read sig");
+        std::fs::write(&sigpath, flip_first_hex(&sig)).expect("write tampered sig");
+
+        let out = run_as_git(&bin, &home, &agent, &["add", "."], &home);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            !out.status.success(),
+            "a tampered signature must be DENIED (fail-closed); exit={:?} stderr={stderr}",
+            out.status.code()
+        );
+        assert!(
+            stderr.to_lowercase().contains("unbound") || stderr.contains("denied"),
+            "tampered sig → fail-closed unbound/deny; stderr={stderr}"
+        );
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    /// Flip the first hex digit of a bare-hex tag to a different value.
+    fn flip_first_hex(tag: &str) -> String {
+        let mut chars: Vec<char> = tag.trim().chars().collect();
+        if let Some(first) = chars.first_mut() {
+            *first = if *first == '0' { '1' } else { '0' };
+        }
+        chars.into_iter().collect()
+    }
+}


### PR DESCRIPTION
## P2 — flag-gated git-shim swap: agend-git → agentic-git

Phase 2 of the agentic-git migration (design `AGENTIC-GIT-EMBED-DESIGN` §5-Phase-2 / §3.A / §6, refs #2524). Makes the vendored `agentic-git` binary the **live git guard** behind an **OFF-by-default** flag, so its guard matrix actually goes live while `agend-git` stays the rollback target and keeps owning the `{pkill,killall,kill}` kill-shim (D1=A). P0/P1a/P1b are merged; this is the first stage that changes runtime behavior when the flag is flipped.

### What changed
1. **Flag** — `fleet.yaml` `use_agentic_git_shim: bool`, default `false` = byte-identical to today. Additive optional field (`skip_serializing_if` when false), no `FLEET_SCHEMA_VERSION` bump. Read at daemon startup (`bootstrap::resolve_fleet_and_reconcile`, where `FleetConfig` is already in scope).
2. **symlink_shim swap** — flag ON → `$AGEND_HOME/bin/git` → self-built `agentic-git`; flag OFF, or ON but the sibling is missing → `agend-git` (**fail-safe** + `tracing::warn`). The kill family **always** → `agend-git` (agentic-git has no process-kill guard, D1=A). Rehomed from `binding.rs` into `src/binding/shim_install.rs` and **re-exported** (`pub use`), so `crate::binding::symlink_shim`, the call site, and the app-mode wiring invariant are unchanged — `binding.rs` was pinned at the 2500-LOC anti-monolith ceiling, so the logic + its unit tests had to live elsewhere.
3. **build-together** (`scripts/build_agentic_git_shim.sh`) — builds the `agentic-git` binary from the pinned submodule manifest and installs it as a daemon-exe sibling. CI runs it (unix) before nextest.
4. **CI** — build-together step exports `AGENTIC_GIT_SHIM_BIN` so the runtime tests exercise the real binary.

### Key decision — build-together is a build-step, NOT a workspace member
Design §3.A's literal wording was "workspace member so `cargo build -p agentic-git` shares one lockfile". That is **empirically blocked**: `vendor/agentic-git` declares its **own** `[workspace]` and its crates use `edition.workspace = true` — a crate under a directory that declares `[workspace]` cannot be reassigned to an ancestor workspace without editing the pinned submodule. Verified by a revert-clean spike (`cargo metadata` errors `failed to parse manifest .../agentic-git-core/Cargo.toml`). So the binary is built via the **submodule's own manifest** and installed as a sibling — the dispatch explicitly allowed "xtask 或 build step". The anti-drift intent is preserved:
- agend-terminal's `Cargo.lock` still has **exactly one** `agentic-git-core` (`tests/agentic_core_single_source.rs` still green).
- The binary links the **same vendored core source dir** the daemon links (same submodule commit `5306c85`) → structural same-version, no registry drift.

Decision recorded: `d-20260708061543811250-0`.

### Test coverage
- **Unit** (`src/binding/shim_install.rs`): flag off / on / fail-safe fallback / no-floor. RED-demonstrated (reverting `git_src` to always-agend-git fails the flag-on test).
- **Source parity** (`tests/agentic_git_shim_swap.rs`): every git guard agend-terminal depends on (unbound-deny, protected-ref, trust-root, force-lease + #2677 fix, cross-branch fence, recursion, HMAC verify, canonical) + all 8 daemon-injected `AGEND_*` legacy env names are present in the vendored shim source.
- **Runtime guard**: real binary run as `git`, unbound mutation → denied (exit 1, "unbound").
- **Cross-build HMAC byte-compat** (the load-bearing swap-safety proof): a binding **signed by the daemon's core** (agend-terminal build, via a same-path dev-dep) is **verified + ALLOWED** by the **submodule-built binary** — proving the two independent `agentic-git-core` compiles are HMAC byte-compatible, so flipping the flag on does not break live bindings. Plus a **tamper negative-control** (flip one hex char of the signature → the same bound op is denied) so the ALLOW can't be a rubber-stamp.

Gates: `cargo fmt --check`, `cargo clippy --all-targets --features tray -- -D warnings`, and 255 targeted tests (fleet/bootstrap/binding/shim/invariants/parity/cross-build) all green locally.

### Rollback
Flip the flag back to `false` + restart. The on-disk binding format is **unchanged**, so a rolled-back `agend-git` shim still verifies core-signed bindings — no rebind storm (directly answers dev3's rollback axis).

### Out of scope (lead-owned)
- `release.yml` submodule/packaging of the new binary — pre-P2 the release workflow's checkouts already lack `submodules: true` (decision `d-20260708045535393482-2`). Flag defaults OFF, so a released daemon works without the binary until that lands.

### Requested review (DUAL)
- **reviewer4**: behavioral parity + the cross-build byte-identical proof + wiring.
- **dev3**: fail-open / bypass surface / rollback (no new bypass; kill family untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
