### PR TITLE
feat(embedder-p3): package agend-git + agentic-git shims in release archives (close tarball distribution gap)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,6 +166,7 @@ jobs:
         if: matrix.archive == 'tar.gz'
         shell: bash
         run: |
+          set -euo pipefail
           cd target/${{ matrix.target }}/release
           # Sprint 56 Track I-Phase2a (#531): bundle agend-mcp-bridge
           # alongside agend-terminal so backends spawned by the daemon's
@@ -173,18 +174,38 @@ jobs:
           # this, mcp_config::bridge_binary_path falls back to
           # `agend-terminal mcp` and reply / react / download_attachment
           # land on the daemon-state-unreachable error path on Windows.
-          tar czf ../../../agend-terminal-${{ matrix.target }}.tar.gz agend-terminal agend-mcp-bridge
+          # #2524 P3: also bundle the git/kill shims (agend-git + agentic-git)
+          # AT THE SAME LAYER — the daemon's symlink_shim resolves siblings via
+          # current_exe().with_file_name(), so a release-tarball install must
+          # place them beside agend-terminal or the git guard silently falls
+          # back / breaks (the cargo-install path already gets all 4, #2691).
+          bins="agend-terminal agend-mcp-bridge agend-git agentic-git"
+          tar czf ../../../agend-terminal-${{ matrix.target }}.tar.gz $bins
+          # Fail-loud: the archive MUST contain every expected sibling binary.
+          for b in $bins; do
+            tar tzf ../../../agend-terminal-${{ matrix.target }}.tar.gz | grep -qx "$b" \
+              || { echo "::error::release tarball missing $b"; exit 1; }
+          done
 
       - name: Package (Windows)
         if: matrix.archive == 'zip'
         shell: pwsh
         run: |
-          # Sprint 56 Track I-Phase2a (#531): same dual-binary packaging
-          # as the Unix tar arm. PowerShell's Compress-Archive `-Path`
-          # accepts a comma-separated array of file paths.
-          Compress-Archive `
-            -Path "target/${{ matrix.target }}/release/agend-terminal.exe","target/${{ matrix.target }}/release/agend-mcp-bridge.exe" `
-            -DestinationPath agend-terminal-${{ matrix.target }}.zip
+          $ErrorActionPreference = "Stop"
+          # Sprint 56 Track I-Phase2a (#531): same dual-binary packaging as the
+          # Unix tar arm. #2524 P3: also ship the git/kill shims (agend-git +
+          # agentic-git) beside agend-terminal — symlink_shim finds siblings via
+          # current_exe().with_file_name() (see the Unix arm for the rationale).
+          $rel = "target/${{ matrix.target }}/release"
+          $bins = @("agend-terminal","agend-mcp-bridge","agend-git","agentic-git")
+          $paths = $bins | ForEach-Object { "$rel/$_.exe" }
+          Compress-Archive -Path $paths -DestinationPath agend-terminal-${{ matrix.target }}.zip -Force
+          # Fail-loud: the archive MUST contain every expected sibling binary.
+          Expand-Archive -Path agend-terminal-${{ matrix.target }}.zip -DestinationPath _verify -Force
+          foreach ($b in $bins) {
+            if (!(Test-Path "_verify/$b.exe")) { Write-Error "release zip missing $b.exe"; exit 1 }
+          }
+          Remove-Item -Recurse -Force _verify
 
       - name: Upload artifact
         uses: actions/upload-artifact@v5
@@ -237,6 +258,13 @@ jobs:
           # operators hit the same #531 fallback-to-`agend-terminal
           # mcp` failure mode for daemon-state-required tools.
           cp target/release/agend-mcp-bridge AppDir/usr/bin/agend-mcp-bridge
+          # #2524 P3: ship the git/kill shims beside agend-terminal in the
+          # AppImage too — symlink_shim resolves siblings via
+          # current_exe().with_file_name(), which inside the AppImage is
+          # AppDir/usr/bin. `set -euo pipefail` (above) makes a missing source
+          # binary fail-loud; without these the git guard silently degrades.
+          cp target/release/agend-git AppDir/usr/bin/agend-git
+          cp target/release/agentic-git AppDir/usr/bin/agentic-git
           cp assets/appimage/agend-terminal.desktop AppDir/usr/share/applications/agend-terminal.desktop
           # Resize 1024x1024 master → 256x256 for hicolor + AppImage root
           convert assets/appimage/agend-terminal.png -resize 256x256 AppDir/usr/share/icons/hicolor/256x256/apps/agend-terminal.png

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,10 +179,13 @@ jobs:
           # current_exe().with_file_name(), so a release-tarball install must
           # place them beside agend-terminal or the git guard silently falls
           # back / breaks (the cargo-install path already gets all 4, #2691).
-          bins="agend-terminal agend-mcp-bridge agend-git agentic-git"
-          tar czf ../../../agend-terminal-${{ matrix.target }}.tar.gz $bins
+          # All 4 bins listed explicitly on the `tar czf` line + guard loop so
+          # tests/no_local_mcp_mode_invariant.rs (brackets forward from `tar czf`)
+          # asserts each is packaged.
+          tar czf ../../../agend-terminal-${{ matrix.target }}.tar.gz \
+            agend-terminal agend-mcp-bridge agend-git agentic-git
           # Fail-loud: the archive MUST contain every expected sibling binary.
-          for b in $bins; do
+          for b in agend-terminal agend-mcp-bridge agend-git agentic-git; do
             tar tzf ../../../agend-terminal-${{ matrix.target }}.tar.gz | grep -qx "$b" \
               || { echo "::error::release tarball missing $b"; exit 1; }
           done
@@ -197,12 +200,14 @@ jobs:
           # agentic-git) beside agend-terminal — symlink_shim finds siblings via
           # current_exe().with_file_name() (see the Unix arm for the rationale).
           $rel = "target/${{ matrix.target }}/release"
-          $bins = @("agend-terminal","agend-mcp-bridge","agend-git","agentic-git")
-          $paths = $bins | ForEach-Object { "$rel/$_.exe" }
-          Compress-Archive -Path $paths -DestinationPath agend-terminal-${{ matrix.target }}.zip -Force
+          # All 4 .exe listed explicitly on the Compress-Archive line + guard loop
+          # so tests/no_local_mcp_mode_invariant.rs asserts each is packaged.
+          Compress-Archive `
+            -Path "$rel/agend-terminal.exe","$rel/agend-mcp-bridge.exe","$rel/agend-git.exe","$rel/agentic-git.exe" `
+            -DestinationPath agend-terminal-${{ matrix.target }}.zip -Force
           # Fail-loud: the archive MUST contain every expected sibling binary.
           Expand-Archive -Path agend-terminal-${{ matrix.target }}.zip -DestinationPath _verify -Force
-          foreach ($b in $bins) {
+          foreach ($b in @("agend-terminal","agend-mcp-bridge","agend-git","agentic-git")) {
             if (!(Test-Path "_verify/$b.exe")) { Write-Error "release zip missing $b.exe"; exit 1 }
           }
           Remove-Item -Recurse -Force _verify

--- a/tests/no_local_mcp_mode_invariant.rs
+++ b/tests/no_local_mcp_mode_invariant.rs
@@ -11,9 +11,15 @@
 //! platform.
 //!
 //! This test parses `.github/workflows/release.yml` and asserts the
-//! 3 packaging steps (Unix tar, Windows zip, AppImage stage) all
-//! reference the bridge. It catches release-workflow edits that
-//! drop the bridge — the regression that originally produced #531.
+//! 3 packaging steps (Unix tar, Windows zip, AppImage stage) ship
+//! EVERY binary the daemon expects as a sibling — the MCP bridge
+//! (#531) plus the #2524 P3 git/kill shims (`agend-git`,
+//! `agentic-git`). `symlink_shim` resolves those shims via
+//! `current_exe().with_file_name()`, so a release-download install
+//! missing one silently degrades the git guard. It catches
+//! release-workflow edits that drop any of them — the regression that
+//! originally produced #531, now generalized to the P3 distribution
+//! gap (the cargo-install path is covered by the `[[bin]]` in #2691).
 //!
 //! ## Why text-parse over shell-out
 //!
@@ -33,6 +39,17 @@
 
 const RELEASE_YML: &str = include_str!("../.github/workflows/release.yml");
 
+/// Every binary the daemon expects as a sibling of `agend-terminal`
+/// (`current_exe().with_file_name()`). Each packaging step must ship all of
+/// them at the same layer: the MCP bridge (#531) plus the #2524 P3 git/kill
+/// shims. A missing shim in a release download silently degrades the git guard.
+const REQUIRED_PACKAGED_BINS: [&str; 4] = [
+    "agend-terminal",
+    "agend-mcp-bridge",
+    "agend-git",
+    "agentic-git",
+];
+
 #[test]
 fn release_workflow_packages_bridge_in_unix_tar_step() {
     // The Unix tar packaging step (line 77+ at the time of writing)
@@ -50,12 +67,14 @@ fn release_workflow_packages_bridge_in_unix_tar_step() {
         .map(|n| tar_idx + n)
         .unwrap_or(RELEASE_YML.len());
     let section = &RELEASE_YML[tar_idx..section_end];
-    assert!(
-        section.contains("agend-mcp-bridge"),
-        "Unix tar packaging step must include `agend-mcp-bridge` so \
-         release tarballs ship both binaries — Phase 2a fix for #531. \
-         Section was:\n{section}"
-    );
+    for bin in REQUIRED_PACKAGED_BINS {
+        assert!(
+            section.contains(bin),
+            "Unix tar packaging step must include `{bin}` so release tarballs \
+             ship every daemon sibling (bridge #531 + P3 git/kill shims). \
+             Section was:\n{section}"
+        );
+    }
 }
 
 #[test]
@@ -70,12 +89,14 @@ fn release_workflow_packages_bridge_in_windows_zip_step() {
         .map(|n| zip_idx + n)
         .unwrap_or(RELEASE_YML.len());
     let section = &RELEASE_YML[zip_idx..section_end];
-    assert!(
-        section.contains("agend-mcp-bridge"),
-        "Windows zip packaging step must include `agend-mcp-bridge.exe` \
-         so the release zip ships both binaries — Phase 2a fix for #531. \
-         Section was:\n{section}"
-    );
+    for bin in REQUIRED_PACKAGED_BINS {
+        assert!(
+            section.contains(bin),
+            "Windows zip packaging step must include `{bin}.exe` so the \
+             release zip ships every daemon sibling (bridge #531 + P3 git/kill \
+             shims). Section was:\n{section}"
+        );
+    }
 }
 
 #[test]
@@ -93,12 +114,14 @@ fn release_workflow_includes_bridge_in_appimage_stage() {
         .map(|n| stage_idx + n)
         .unwrap_or(RELEASE_YML.len());
     let section = &RELEASE_YML[stage_idx..section_end];
-    assert!(
-        section.contains("agend-mcp-bridge"),
-        "AppImage stage must copy `agend-mcp-bridge` into \
-         AppDir/usr/bin/ so AppImage installs ship both binaries — \
-         Phase 2a fix for #531. Section was:\n{section}"
-    );
+    for bin in REQUIRED_PACKAGED_BINS {
+        assert!(
+            section.contains(bin),
+            "AppImage stage must copy `{bin}` into AppDir/usr/bin/ so AppImage \
+             installs ship every daemon sibling (bridge #531 + P3 git/kill \
+             shims). Section was:\n{section}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## What & why

#2524 P3 — closes the **last piece** of the agentic-git distribution gap. #2691 made `cargo install --git/--path` deliver all four bins; the **GitHub release download path** still shipped only `agend-terminal` + `agend-mcp-bridge`, NOT the git/kill shims (`agend-git`, `agentic-git`). The daemon's `symlink_shim` resolves shims via `current_exe().with_file_name()`, so a release-tarball / AppImage user got no sibling `agentic-git` → the flag-gated git guard silently fell back to `agend-git` or broke.

## Changes (release.yml only)
- **Package (Unix)** tar: bundle all 4 bins at the archive root (flat = same-layer siblings) + fail-loud guard (`tar tzf | grep -qx`).
- **Package (Windows)** zip: all 4 `.exe` + `Expand-Archive` / `Test-Path` guard.
- **AppImage** AppDir: `cp` the two shims into `AppDir/usr/bin` beside agend-terminal (`set -euo pipefail` makes a missing source fail-loud).

## Verification
- `#2691` (merged) proved all 4 bins build on ubuntu / macOS / Windows via `cargo build --release` (agentic-git is a `[[bin]]`).
- Guard logic verified locally under bash: all-present → passes; missing bin → RED (job would fail).
- **Note**: `release.yml` triggers only on tags, so this PR's `ci.yml` does not run it — the guard fires at release-tag time. That's why the fail-loud archive-content assertions matter.

Closes the release-tarball half of the distribution gap flagged in #2691. Gates setting the shim flag release-default-ON (external default-ON users must be able to get the shim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
