### PR TITLE
feat(#2342 P0a): control-socket per-method capability auth + operator full-cap token (close dev2 A1)

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -271,6 +271,16 @@ pub fn serve(
             return;
         }
     };
+    // P0a security-posture surface (dev2 A1 residual, task
+    // t-20260709010037959088-61315-1): the operator token is 0600 in run_dir,
+    // which isolates cross-USER only — a same-uid agent can read it. Until this
+    // is `Resolved`, a Conversational responder that accepts inbound MUST NOT
+    // ship (enforced by the `responder_inbound_requires_same_uid_isolation`
+    // invariant). Surfaced here so the posture is visible in daemon logs.
+    tracing::debug!(
+        isolation = ?crate::auth_cookie::SAME_UID_OPERATOR_ISOLATION,
+        "operator/agent same-uid secret-isolation status"
+    );
     tracing::info!(port, "API listening");
 
     // #1189: write `.ready` in app (TUI) mode after confirmed bind success.
@@ -629,10 +639,12 @@ fn handle_session(
 
         // P0a (#2342 B4): per-method CAPABILITY gate FIRST — authority is proven
         // by the authenticated principal (which secret was presented), not by
-        // method-shape (dev2 A1). This is a HARD default-DENY: an Agent-cookie
-        // holder reaching any direct method (inject/send/spawn/kill/…) is refused
-        // outright here, before the operator-mode gate. Distinct `denied_by`
-        // ("capability", not queued) keeps the security denial legible in audit.
+        // method-shape. Closes the method-shape / sidecar-agent-cookie subcase of
+        // dev2 A1 (the same-user-agent subcase — a same-uid agent reading
+        // `api.operator` — is a HARD Phase-2 prereq: `auth_cookie::SAME_UID_OPERATOR_ISOLATION`).
+        // HARD default-DENY: an Agent-cookie holder reaching any direct method
+        // (inject/send/spawn/kill/…) is refused here, before the operator-mode gate.
+        // Distinct `denied_by` ("capability", not queued) keeps the denial legible in audit.
         //
         // #1339: the operator-mode authority gate then covers the `mcp_tool`
         // tunnel (per-tool authority) at the one ingress choke point. By here an

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -258,6 +258,19 @@ pub fn serve(
             return;
         }
     };
+    // P0a (#2342 B4): the operator full-capability token is minted alongside the
+    // cookie by `auth_cookie::issue` (every boot path), so it is on disk before
+    // this accept loop starts (publish-before-accept). Fail CLOSED if it is
+    // missing: serving without the operator secret would either lock the operator
+    // out (no full-cap principal possible) or force a default-allow fallback —
+    // both worse than not serving.
+    let operator_token = match crate::auth_cookie::read_operator_token(&run_dir) {
+        Ok(t) => t,
+        Err(e) => {
+            tracing::error!(error = %e, "api.operator token missing; aborting serve");
+            return;
+        }
+    };
     tracing::info!(port, "API listening");
 
     // #1189: write `.ready` in app (TUI) mode after confirmed bind success.
@@ -353,9 +366,10 @@ pub fn serve(
         let cfgs = Arc::clone(&configs);
         let ext = Arc::clone(&externals);
         let ntf = notifier.clone();
-        // Cookie is `[u8; 32]` (Copy), each session gets its own copy so the
-        // spawned closure satisfies `'static`.
+        // Cookie + operator token are `[u8; 32]` (Copy); each session gets its
+        // own copies so the spawned closure satisfies `'static`.
         let session_cookie = cookie;
+        let session_operator_token = operator_token;
         if std::thread::Builder::new()
             .name("api_handler".into())
             .spawn(move || {
@@ -372,6 +386,7 @@ pub fn serve(
                     &cfgs,
                     &ext,
                     ntf.as_deref(),
+                    session_operator_token,
                     session_cookie,
                 );
             })
@@ -506,6 +521,7 @@ fn handle_session(
     configs: &ConfigRegistry,
     externals: &ExternalRegistry,
     notifier: Option<&dyn ApiNotifier>,
+    operator_token: crate::auth_cookie::Cookie,
     cookie: crate::auth_cookie::Cookie,
 ) {
     let cloned = match stream.try_clone() {
@@ -531,15 +547,22 @@ fn handle_session(
     let _ = reader
         .get_ref()
         .set_read_timeout(Some(std::time::Duration::from_secs(5)));
-    // Sprint 25 P1 F1: extract optional peer PID for telemetry.
-    let peer_pid =
-        match crate::auth_cookie::server_handshake_ndjson(&mut reader, &mut writer, &cookie) {
-            Ok(pid) => pid,
-            Err(e) => {
-                tracing::warn!(error = %e, "API auth rejected");
-                return;
-            }
-        };
+    // P0a (#2342 B4): the handshake now also resolves WHICH principal
+    // authenticated (operator full-cap token vs shared agent cookie) — authority
+    // is proven by this principal, not by method-shape (dev2 A1). Sprint 25 P1 F1:
+    // the optional peer PID (telemetry) is still returned alongside.
+    let (principal, peer_pid) = match crate::auth_cookie::server_handshake_ndjson(
+        &mut reader,
+        &mut writer,
+        &operator_token,
+        &cookie,
+    ) {
+        Ok(pair) => pair,
+        Err(e) => {
+            tracing::warn!(error = %e, "API auth rejected");
+            return;
+        }
+    };
     // Restore no-timeout for authenticated sessions (on the read fd it was
     // armed on above — CR-2026-06-14).
     let _ = reader.get_ref().set_read_timeout(None);
@@ -604,11 +627,28 @@ fn handle_session(
             home,
         };
 
-        // #1339: single operator-mode authority gate. Covers every direct method
-        // AND the `mcp_tool` tunnel (all 36 tools) at the one ingress choke point.
-        // Operator-surface calls (no `instance`) are never denied; Active is a
-        // passthrough. A deny short-circuits before dispatch.
-        let response = if let Err(denied) =
+        // P0a (#2342 B4): per-method CAPABILITY gate FIRST — authority is proven
+        // by the authenticated principal (which secret was presented), not by
+        // method-shape (dev2 A1). This is a HARD default-DENY: an Agent-cookie
+        // holder reaching any direct method (inject/send/spawn/kill/…) is refused
+        // outright here, before the operator-mode gate. Distinct `denied_by`
+        // ("capability", not queued) keeps the security denial legible in audit.
+        //
+        // #1339: the operator-mode authority gate then covers the `mcp_tool`
+        // tunnel (per-tool authority) at the one ingress choke point. By here an
+        // Agent principal can only be on `mcp_tool`/`mcp_tools_list`; Operator has
+        // full authority (mode gate is a pass-through for direct methods). A deny
+        // short-circuits before dispatch.
+        let response = if !operator_gate::capability_allows(principal, method) {
+            json!({
+                "ok": false,
+                "error": format!(
+                    "method '{method}' is not permitted for this connection's token \
+                     (capability gate: default-deny)"
+                ),
+                "denied_by": "capability"
+            })
+        } else if let Err(denied) =
             operator_gate::check_operation_allowed(method, params, &crate::operator_mode::get())
         {
             json!({"ok": false, "error": denied, "denied_by": "operator_mode", "queued": true})
@@ -737,10 +777,15 @@ pub fn call_at(run_dir: &Path, request: &Value) -> anyhow::Result<Value> {
     stream
         .set_read_timeout(Some(std::time::Duration::from_secs(2)))
         .context("set call_at read timeout")?;
-    let cookie = crate::auth_cookie::read_cookie(run_dir)?;
+    // P0a (#2342 B4): the operator surface presents the operator full-capability
+    // token, NOT the shared agent cookie — so it authenticates as
+    // `Principal::Operator` (allow-all). Fail CLOSED if the token is missing
+    // (`?`): never silently fall back to the cookie, which would authenticate as
+    // a mere Agent and get every direct method denied (operator lockout).
+    let operator_token = crate::auth_cookie::read_operator_token(run_dir)?;
     let mut writer = stream.try_clone()?;
     let mut reader = BufReader::new(stream);
-    crate::auth_cookie::client_handshake_ndjson(&mut reader, &mut writer, &cookie)?;
+    crate::auth_cookie::client_handshake_ndjson(&mut reader, &mut writer, &operator_token)?;
     writeln!(writer, "{request}")?;
     writer.flush()?;
     let mut line = String::new();
@@ -779,12 +824,17 @@ pub fn call(home: &Path, request: &Value) -> anyhow::Result<Value> {
     stream
         .set_read_timeout(Some(timeout))
         .context("set api::call read timeout")?;
-    // Cookie from the SAME `run` resolution used for the port above (#2 fix).
-    let cookie = crate::auth_cookie::read_cookie(&run)?;
+    // P0a (#2342 B4): present the operator full-capability token (NOT the shared
+    // agent cookie) so this operator-surface call authenticates as
+    // `Principal::Operator` = allow-all. Read from the SAME `run` resolution used
+    // for the port above (#2 fix). Fail CLOSED if missing (`?`) — never fall back
+    // to the cookie (that would authenticate as Agent → direct methods denied →
+    // operator locked out of its own daemon).
+    let operator_token = crate::auth_cookie::read_operator_token(&run)?;
 
     let mut writer = stream.try_clone()?;
     let mut reader = BufReader::new(stream);
-    crate::auth_cookie::client_handshake_ndjson(&mut reader, &mut writer, &cookie)?;
+    crate::auth_cookie::client_handshake_ndjson(&mut reader, &mut writer, &operator_token)?;
 
     writeln!(writer, "{}", request)?;
     writer.flush()?;
@@ -1222,10 +1272,13 @@ mod tests {
         let mut writer = stream.try_clone().unwrap();
         let mut reader = std::io::BufReader::new(stream);
 
-        // Auth handshake
+        // Auth handshake — this helper drives operator-surface DIRECT methods
+        // (delete/create_team/…), so it presents the operator full-capability
+        // token (P0a), exactly as the real `api::call`/`call_at` now do.
         let run_dir = crate::daemon::run_dir(home);
-        let cookie = crate::auth_cookie::read_cookie(&run_dir).unwrap();
-        crate::auth_cookie::client_handshake_ndjson(&mut reader, &mut writer, &cookie).unwrap();
+        let operator_token = crate::auth_cookie::read_operator_token(&run_dir).unwrap();
+        crate::auth_cookie::client_handshake_ndjson(&mut reader, &mut writer, &operator_token)
+            .unwrap();
 
         writeln!(writer, "{}", request).unwrap();
         writer.flush().unwrap();

--- a/src/api/operator_gate.rs
+++ b/src/api/operator_gate.rs
@@ -134,9 +134,47 @@ pub(crate) fn classify(op: &str, action: Option<&str>) -> OpClass {
     }
 }
 
+/// P0a (#2342 B4) — per-method **capability** gate. Authority is proven by the
+/// AUTHENTICATED [`Principal`] (which per-daemon secret the connection presented
+/// at handshake), NEVER by the request's method-shape — that is the dev2 A1 fix.
+/// This runs at the socket-ingress choke point (`api::serve`) BEFORE the
+/// operator-mode gate ([`check_operation_allowed`]), as a HARD default-DENY:
+/// `false` ⇒ the caller's token has no capability for `method`, refuse outright
+/// (not a mode-deferred queue). The exhaustive `match` forces every principal to
+/// declare its capability, so a future `Principal::Sidecar` cannot be added
+/// without deciding what it may invoke.
+///
+/// [`Principal`]: crate::auth_cookie::Principal
+pub(crate) fn capability_allows(principal: crate::auth_cookie::Principal, method: &str) -> bool {
+    use crate::auth_cookie::Principal;
+    match principal {
+        // The boot-minted operator full-capability token — every control method
+        // (its CLI/TUI drive the direct methods; operator-mode gates AGENTS, not
+        // the operator, so the mode gate downstream is a pass-through for it).
+        Principal::Operator => true,
+        // The shared agent cookie — capability = the MCP tunnel ONLY. Every
+        // direct method (inject/send/spawn/kill/delete/mode/shutdown/…) is
+        // default-DENIED. (Closes dev2 A1: a shared-cookie holder could
+        // previously reach every injection-equivalent method by method-shape.)
+        // `mcp_tool`/`mcp_tools_list` then flow on to the operator-mode gate for
+        // per-tool authority; this gate only decides reachability.
+        Principal::Agent => {
+            method == super::method::MCP_TOOL || method == super::method::MCP_TOOLS_LIST
+        }
+    }
+}
+
 /// Decide whether `method` (+ `params`) is allowed under the current
 /// `state`. `Ok(())` = allowed; `Err(reason)` = denied (caller returns the
 /// reason to the requester). Pure — no I/O, fully unit-testable.
+///
+/// P0a note: this is the operator-**mode** gate. It runs AFTER
+/// [`capability_allows`] at the ingress, so by the time it is reached an Agent
+/// principal can only be on `mcp_tool`/`mcp_tools_list` (every direct method was
+/// already hard-denied by the capability gate) and an Operator principal has
+/// full authority. Its residual `is_agent_transport` method-shape check is thus
+/// only ever exercised by Operator+direct (allow) or Agent+mcp-tunnel (gate) —
+/// both correct — and is no longer an authority-establishing decision.
 pub(crate) fn check_operation_allowed(
     method: &str,
     params: &Value,
@@ -679,6 +717,61 @@ mod tests {
             assert!(
                 src.contains("DAEMON-AUTONOMIC, GATE-EXEMPT BY DESIGN"),
                 "{rel} must carry the #1339 gate-exempt marker"
+            );
+        }
+    }
+
+    // ── P0a (#2342 B4): per-method capability gate ───────────────────────────
+    use crate::api::method;
+    use crate::auth_cookie::Principal as P;
+
+    #[test]
+    fn capability_operator_may_invoke_every_method() {
+        // The operator full-capability token reaches every control method —
+        // direct AND the mcp tunnel (its CLI/TUI drive the direct methods).
+        for m in [
+            method::INJECT,
+            method::SEND,
+            method::SPAWN,
+            method::KILL,
+            method::DELETE,
+            method::CREATE_TEAM,
+            method::MODE,
+            method::SHUTDOWN,
+            method::LIST,
+            method::MCP_TOOL,
+            method::MCP_TOOLS_LIST,
+        ] {
+            assert!(
+                capability_allows(P::Operator, m),
+                "operator must be capable of '{m}'"
+            );
+        }
+    }
+
+    #[test]
+    fn capability_agent_is_mcp_tunnel_only_default_deny() {
+        // The shared agent cookie reaches ONLY the mcp tunnel.
+        assert!(capability_allows(P::Agent, method::MCP_TOOL));
+        assert!(capability_allows(P::Agent, method::MCP_TOOLS_LIST));
+        // Every injection-equivalent direct method is default-DENIED (dev2 A1).
+        for m in [
+            method::INJECT,
+            method::SEND,
+            method::SPAWN,
+            method::KILL,
+            method::DELETE,
+            method::CREATE_TEAM,
+            method::UPDATE_TEAM,
+            method::MODE,
+            method::SHUTDOWN,
+            method::LIST,
+            method::STATUS,
+            "some_unknown_future_method",
+        ] {
+            assert!(
+                !capability_allows(P::Agent, m),
+                "agent cookie must NOT be capable of direct method '{m}'"
             );
         }
     }

--- a/src/api/operator_gate.rs
+++ b/src/api/operator_gate.rs
@@ -154,8 +154,11 @@ pub(crate) fn capability_allows(principal: crate::auth_cookie::Principal, method
         Principal::Operator => true,
         // The shared agent cookie — capability = the MCP tunnel ONLY. Every
         // direct method (inject/send/spawn/kill/delete/mode/shutdown/…) is
-        // default-DENIED. (Closes dev2 A1: a shared-cookie holder could
-        // previously reach every injection-equivalent method by method-shape.)
+        // default-DENIED. (Closes the method-shape / sidecar-agent-cookie subcase
+        // of dev2 A1: a shared-cookie holder could previously reach every
+        // injection-equivalent method by method-shape. The same-user-agent subcase
+        // — a same-uid agent reading `api.operator` — is a HARD Phase-2 prereq, see
+        // `auth_cookie::SAME_UID_OPERATOR_ISOLATION`.)
         // `mcp_tool`/`mcp_tools_list` then flow on to the operator-mode gate for
         // per-tool authority; this gate only decides reachability.
         Principal::Agent => {

--- a/src/auth_cookie.rs
+++ b/src/auth_cookie.rs
@@ -21,21 +21,60 @@ use std::path::Path;
 
 pub const COOKIE_LEN: usize = 32;
 pub const COOKIE_FILE: &str = "api.cookie";
+/// P0a (#2342 B4): the operator full-capability token — a SECOND per-daemon
+/// secret, distinct from the shared agent `api.cookie`. The operator CLI/TUI
+/// present THIS token (see `api::call`/`call_at`); the agent MCP bridge presents
+/// only `api.cookie`. Holding it authenticates as [`Principal::Operator`] (full
+/// capability); the cookie authenticates as [`Principal::Agent`] (MCP tunnel
+/// only). 0600, per-boot fresh — see [`issue`].
+pub const OPERATOR_TOKEN_FILE: &str = "api.operator";
 
 pub type Cookie = [u8; COOKIE_LEN];
 
-/// Generate a fresh 32-byte cookie and write it atomically to
-/// `{run_dir}/api.cookie` with mode 0600 on Unix. Returns the bytes so the
-/// caller can keep an in-memory copy rather than re-reading on each connect.
+/// The authenticated principal a control-socket connection presented at
+/// handshake — i.e. WHICH per-daemon secret it holds. Authority is proven by
+/// this principal (a capability class), NEVER by the request's method-shape
+/// (this is the dev2 A1 fix). Consumed by `api::operator_gate::capability_allows`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Principal {
+    /// Holder of the boot-minted operator full-capability token
+    /// (`api.operator`) — the operator CLI/TUI. Full capability: every method.
+    Operator,
+    /// Holder of the shared agent cookie (`api.cookie`) — the MCP bridge.
+    /// Capability = the MCP tunnel ONLY; every direct method is default-DENIED.
+    Agent,
+    // Future (#2342 Phase 2): a `Sidecar` principal whose sole capability is
+    // `enqueue-to-responder-inbox`. Add the variant here — the exhaustive match
+    // in `capability_allows` will then force its capability decision.
+}
+
+/// Issue BOTH per-daemon control-socket secrets, fresh, into `run_dir`:
+///  - `api.cookie`   — the shared agent cookie (RETURNED so the caller can cache
+///    an in-memory copy rather than re-reading on each connect).
+///  - `api.operator` — the operator full-capability token (P0a #2342 B4).
+///
+/// Two INDEPENDENT 32-byte random secrets, each written 0600 (Unix) and fsynced
+/// before rename. Every daemon boot path funnels through `issue` before the API
+/// socket accepts, so both secrets are durably published before accept
+/// (publish-before-accept) and rotate per boot. Callers needing the operator
+/// token read it back via [`read_operator_token`].
 pub fn issue(run_dir: &Path) -> Result<Cookie> {
-    let mut cookie = [0u8; COOKIE_LEN];
-    // `getrandom::Error` implements `std::error::Error` in 0.3+.
-    getrandom::fill(&mut cookie).map_err(|e| anyhow!("getrandom: {e}"))?;
-    let path = run_dir.join(COOKIE_FILE);
-    let tmp = run_dir.join(format!(".{COOKIE_FILE}.tmp"));
-    write_restricted(&tmp, &cookie).context("write api.cookie tmp")?;
-    std::fs::rename(&tmp, &path).context("rename api.cookie")?;
+    let cookie = issue_secret(run_dir, COOKIE_FILE)?;
+    issue_secret(run_dir, OPERATOR_TOKEN_FILE)?;
     Ok(cookie)
+}
+
+/// Generate a fresh 32-byte secret and write it atomically to `{run_dir}/{file}`
+/// with mode 0600 on Unix (fsync-before-rename). Returns the bytes.
+fn issue_secret(run_dir: &Path, file: &str) -> Result<Cookie> {
+    let mut secret = [0u8; COOKIE_LEN];
+    // `getrandom::Error` implements `std::error::Error` in 0.3+.
+    getrandom::fill(&mut secret).map_err(|e| anyhow!("getrandom: {e}"))?;
+    let path = run_dir.join(file);
+    let tmp = run_dir.join(format!(".{file}.tmp"));
+    write_restricted(&tmp, &secret).with_context(|| format!("write {file} tmp"))?;
+    std::fs::rename(&tmp, &path).with_context(|| format!("rename {file}"))?;
+    Ok(secret)
 }
 
 #[cfg(unix)]
@@ -66,15 +105,29 @@ fn write_restricted(path: &Path, data: &[u8]) -> std::io::Result<()> {
     f.sync_all()
 }
 
-/// Read the cookie from `{run_dir}/api.cookie`. Enforces exact 32-byte size
-/// so a truncated or padded file can't match by coincidence.
+/// Read the shared agent cookie from `{run_dir}/api.cookie`. Enforces exact
+/// 32-byte size so a truncated or padded file can't match by coincidence.
 pub fn read_cookie(run_dir: &Path) -> Result<Cookie> {
-    let mut f = File::open(run_dir.join(COOKIE_FILE)).context("open api.cookie")?;
+    read_secret(run_dir, COOKIE_FILE)
+}
+
+/// Read the operator full-capability token from `{run_dir}/api.operator` (P0a
+/// #2342 B4). Same exact-size enforcement as [`read_cookie`]. Missing/unreadable
+/// → Err: operator clients fail CLOSED — they must refuse rather than silently
+/// fall back to the shared cookie (which would authenticate as a mere Agent and
+/// lock the operator out of its own direct methods).
+pub fn read_operator_token(run_dir: &Path) -> Result<Cookie> {
+    read_secret(run_dir, OPERATOR_TOKEN_FILE)
+}
+
+fn read_secret(run_dir: &Path, file: &str) -> Result<Cookie> {
+    let mut f = File::open(run_dir.join(file)).with_context(|| format!("open {file}"))?;
     let mut bytes = [0u8; COOKIE_LEN];
-    f.read_exact(&mut bytes).context("read api.cookie")?;
+    f.read_exact(&mut bytes)
+        .with_context(|| format!("read {file}"))?;
     let mut extra = [0u8; 1];
     if f.read(&mut extra).unwrap_or(0) != 0 {
-        return Err(anyhow!("api.cookie: unexpected trailing bytes"));
+        return Err(anyhow!("{file}: unexpected trailing bytes"));
     }
     Ok(bytes)
 }
@@ -129,14 +182,20 @@ fn hex_nibble(b: u8) -> Option<u8> {
     }
 }
 
-/// Server-side NDJSON handshake: reads the first line, verifies `auth`
-/// matches `expected`, writes `{"ok":true}` on success. Returns Err (and
-/// writes a JSON error reply) on mismatch or malformed input.
+/// Server-side NDJSON handshake: reads the first line and verifies the presented
+/// `auth` hex against the two per-daemon secrets, returning WHICH [`Principal`]
+/// authenticated (P0a #2342 B4). Writes `{"ok":true}` on a match; on mismatch or
+/// malformed input writes `{"ok":false,"error":"auth"}` and returns Err
+/// (fail-closed — a connection presenting NEITHER secret is refused before any
+/// method). Presented secret == `operator_token` → [`Principal::Operator`];
+/// == `agent_cookie` → [`Principal::Agent`]. Also returns the optional peer PID
+/// (telemetry only — the daemon does not poll it for liveness).
 pub fn server_handshake_ndjson<R: BufRead, W: Write>(
     reader: &mut R,
     writer: &mut W,
-    expected: &Cookie,
-) -> Result<Option<u32>> {
+    operator_token: &Cookie,
+    agent_cookie: &Cookie,
+) -> Result<(Principal, Option<u32>)> {
     let mut line = String::new();
     if reader.read_line(&mut line)? == 0 {
         return Err(anyhow!("auth: connection closed before handshake"));
@@ -150,18 +209,21 @@ pub fn server_handshake_ndjson<R: BufRead, W: Write>(
     };
     let hex = parsed.get("auth").and_then(|x| x.as_str()).unwrap_or("");
     let got = from_hex(hex);
-    let ok = matches!(&got, Some(c) if verify(expected, c));
-    if !ok {
-        let _ = writeln!(writer, r#"{{"ok":false,"error":"auth"}}"#);
-        return Err(anyhow!("auth: bad cookie"));
-    }
+    // Operator token checked first (a full-capability match wins). Both
+    // comparisons are constant-time (`verify`); a rejected attempt runs both.
+    let principal = match &got {
+        Some(c) if verify(operator_token, c) => Principal::Operator,
+        Some(c) if verify(agent_cookie, c) => Principal::Agent,
+        _ => {
+            let _ = writeln!(writer, r#"{{"ok":false,"error":"auth"}}"#);
+            return Err(anyhow!("auth: bad cookie"));
+        }
+    };
     writeln!(writer, r#"{{"ok":true}}"#)?;
     writer.flush().ok();
     // Sprint 25 P1 F1: extract optional peer PID for telemetry.
-    // Telemetry only: daemon does not poll this PID for liveness;
-    // see Sprint 25 P3 follow-up (active peer-process invalidation).
     let peer_pid = parsed.get("pid").and_then(|v| v.as_u64()).map(|v| v as u32);
-    Ok(peer_pid)
+    Ok((principal, peer_pid))
 }
 
 /// Client-side NDJSON handshake: sends `{"auth":"<hex>"}`, reads one-line
@@ -256,6 +318,34 @@ mod tests {
         std::fs::remove_dir_all(&dir).ok();
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn issued_operator_token_has_mode_0600() {
+        // P0a: the operator full-capability token is a secret — it MUST be 0600,
+        // same as the cookie (it is written via the same `write_restricted`).
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tmp_dir("op-mode");
+        issue(&dir).unwrap();
+        let meta = std::fs::metadata(dir.join(OPERATOR_TOKEN_FILE)).unwrap();
+        assert_eq!(meta.permissions().mode() & 0o777, 0o600);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn operator_token_and_cookie_are_independent_secrets() {
+        // If they collided, there would be no operator/agent separation.
+        let dir = tmp_dir("distinct");
+        let cookie = issue(&dir).unwrap();
+        let read_cookie_back = read_cookie(&dir).unwrap();
+        let operator = read_operator_token(&dir).unwrap();
+        assert_eq!(cookie, read_cookie_back, "issue returns the agent cookie");
+        assert_ne!(
+            operator, cookie,
+            "operator token must differ from the agent cookie"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
     #[test]
     fn read_cookie_rejects_short_file() {
         let dir = tmp_dir("short");
@@ -304,44 +394,56 @@ mod tests {
         assert_eq!(from_hex(&"z".repeat(64)), None);
     }
 
-    #[test]
-    fn ndjson_handshake_accepts_correct_cookie() {
-        let cookie: Cookie = [0x42; COOKIE_LEN];
-        let payload = format!("{{\"auth\":\"{}\"}}\n", to_hex(&cookie));
-        let mut reader = std::io::BufReader::new(payload.as_bytes());
+    // P0a: distinct operator token + agent cookie for the two-secret handshake.
+    const OPERATOR: Cookie = [0x42; COOKIE_LEN];
+    const AGENT: Cookie = [0x24; COOKIE_LEN];
+
+    fn run_handshake(auth_hex: &str) -> (Result<(Principal, Option<u32>)>, String) {
+        let payload = format!("{{\"auth\":\"{auth_hex}\"}}\n");
+        let mut reader = std::io::BufReader::new(std::io::Cursor::new(payload.into_bytes()));
         let mut writer: Vec<u8> = Vec::new();
-        server_handshake_ndjson(&mut reader, &mut writer, &cookie).unwrap();
-        assert!(String::from_utf8_lossy(&writer).contains("\"ok\":true"));
+        let res = server_handshake_ndjson(&mut reader, &mut writer, &OPERATOR, &AGENT);
+        (res, String::from_utf8_lossy(&writer).into_owned())
     }
 
     #[test]
-    fn ndjson_handshake_rejects_wrong_cookie() {
-        let expected: Cookie = [0x42; COOKIE_LEN];
-        let presented: Cookie = [0x43; COOKIE_LEN];
-        let payload = format!("{{\"auth\":\"{}\"}}\n", to_hex(&presented));
-        let mut reader = std::io::BufReader::new(payload.as_bytes());
-        let mut writer: Vec<u8> = Vec::new();
-        let err = server_handshake_ndjson(&mut reader, &mut writer, &expected).unwrap_err();
-        assert!(format!("{err}").contains("auth"));
-        assert!(String::from_utf8_lossy(&writer).contains("\"ok\":false"));
+    fn ndjson_handshake_maps_operator_token_to_operator_principal() {
+        let (res, reply) = run_handshake(&to_hex(&OPERATOR));
+        let (principal, _pid) = res.unwrap();
+        assert_eq!(principal, Principal::Operator);
+        assert!(reply.contains("\"ok\":true"));
+    }
+
+    #[test]
+    fn ndjson_handshake_maps_agent_cookie_to_agent_principal() {
+        let (res, reply) = run_handshake(&to_hex(&AGENT));
+        let (principal, _pid) = res.unwrap();
+        assert_eq!(principal, Principal::Agent);
+        assert!(reply.contains("\"ok\":true"));
+    }
+
+    #[test]
+    fn ndjson_handshake_rejects_secret_matching_neither() {
+        let stranger: Cookie = [0x99; COOKIE_LEN];
+        let (res, reply) = run_handshake(&to_hex(&stranger));
+        assert!(format!("{}", res.unwrap_err()).contains("auth"));
+        assert!(reply.contains("\"ok\":false"));
     }
 
     #[test]
     fn ndjson_handshake_rejects_missing_auth_field() {
-        let cookie: Cookie = [0x42; COOKIE_LEN];
         let mut reader = std::io::BufReader::new(&b"{\"method\":\"list\"}\n"[..]);
         let mut writer: Vec<u8> = Vec::new();
-        let err = server_handshake_ndjson(&mut reader, &mut writer, &cookie).unwrap_err();
+        let err = server_handshake_ndjson(&mut reader, &mut writer, &OPERATOR, &AGENT).unwrap_err();
         assert!(format!("{err}").contains("auth"));
         assert!(String::from_utf8_lossy(&writer).contains("\"ok\":false"));
     }
 
     #[test]
     fn ndjson_handshake_rejects_empty_stream() {
-        let cookie: Cookie = [0x42; COOKIE_LEN];
         let mut reader = std::io::BufReader::new(&b""[..]);
         let mut writer: Vec<u8> = Vec::new();
-        assert!(server_handshake_ndjson(&mut reader, &mut writer, &cookie).is_err());
+        assert!(server_handshake_ndjson(&mut reader, &mut writer, &OPERATOR, &AGENT).is_err());
     }
 
     #[test]
@@ -359,7 +461,13 @@ mod tests {
         to_server.extend_from_slice(&client_writer);
         let mut server_reader = std::io::BufReader::new(&to_server[..]);
         let mut server_writer: Vec<u8> = Vec::new();
-        server_handshake_ndjson(&mut server_reader, &mut server_writer, &cookie).unwrap();
+        // The client presents `cookie` as the agent cookie; a different value
+        // stands in for the operator token so the two secrets are distinct.
+        let operator: Cookie = [0x11; COOKIE_LEN];
+        let (principal, _) =
+            server_handshake_ndjson(&mut server_reader, &mut server_writer, &operator, &cookie)
+                .unwrap();
+        assert_eq!(principal, Principal::Agent);
         // Now feed server's reply back into client's reader.
         let mut client_reader = std::io::BufReader::new(&server_writer[..]);
         // Re-run client half against a fresh writer to exercise the success path.

--- a/src/auth_cookie.rs
+++ b/src/auth_cookie.rs
@@ -33,8 +33,10 @@ pub type Cookie = [u8; COOKIE_LEN];
 
 /// The authenticated principal a control-socket connection presented at
 /// handshake — i.e. WHICH per-daemon secret it holds. Authority is proven by
-/// this principal (a capability class), NEVER by the request's method-shape
-/// (this is the dev2 A1 fix). Consumed by `api::operator_gate::capability_allows`.
+/// this principal (a capability class), NEVER by the request's method-shape —
+/// this closes the **method-shape / sidecar-agent-cookie subcase** of dev2 A1.
+/// The **same-user-agent subcase** is NOT closed here — see
+/// [`SAME_UID_OPERATOR_ISOLATION`]. Consumed by `api::operator_gate::capability_allows`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Principal {
     /// Holder of the boot-minted operator full-capability token
@@ -47,6 +49,49 @@ pub enum Principal {
     // `enqueue-to-responder-inbox`. Add the variant here — the exhaustive match
     // in `capability_allows` will then force its capability decision.
 }
+
+/// Status of the same-uid operator/agent SECRET-ISOLATION residual — dev2's P0a
+/// review finding; tracking task `t-20260709010037959088-61315-1`.
+///
+/// P0a closes the **method-shape / sidecar-agent-cookie** subcase of dev2 A1 (an
+/// entity holding only the agent cookie cannot reach the direct methods). It does
+/// NOT close the **same-user-agent** subcase: `api.operator` lives in `run_dir`
+/// mode 0600, and 0600 isolates cross-USER only — a same-uid agent (the future
+/// #2342 Conversational **responder**, if prompt-injected) can
+/// `read(run_dir/api.operator)`, present it, authenticate as [`Principal::Operator`],
+/// and drive every direct method (`inject`/`spawn`/`delete`/…), bypassing the whole
+/// capability model + Conversational ACL. Root cause: the principal is bound to a
+/// *same-uid-readable secret*, not to caller IDENTITY (TCP loopback has no OS
+/// peer-cred; the handshake `pid` is client-supplied and unauthenticated).
+///
+/// Closing it requires binding the principal to caller identity — OS peer-cred
+/// (operator surface over a UDS + `SO_PEERCRED`), an out-of-band operator token
+/// (never written to agent-readable disk), or per-agent private capability cookies.
+/// It MUST NOT be considered satisfied by the no-tools sandbox alone (pillar-3 —
+/// manifest §0.2 explicitly forbids leaning on it).
+///
+/// This is a **HARD prerequisite** for shipping a Conversational responder that
+/// accepts inbound (Phase 2). The invariant test
+/// `responder_inbound_requires_same_uid_isolation` (tests/p0a_capability_auth.rs)
+/// couples the two: wiring a responder-inbound path while this is `Unresolved`
+/// fails loud, so the prerequisite cannot be shipped around silently.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IsolationStatus {
+    /// Same-uid operator/agent secret isolation is NOT yet enforced. Safe ONLY
+    /// while no same-uid Conversational responder accepts inbound.
+    Unresolved,
+    /// Caller identity is bound (peer-cred / out-of-band token / per-agent
+    /// cookie); a same-uid agent can no longer impersonate the operator. Not yet
+    /// constructed in production — the flip to this state lands with task
+    /// t-20260709010037959088-61315-1 (the Phase-2 hard prerequisite).
+    #[allow(dead_code)] // forward state: constructed when isolation is resolved (Phase 2).
+    Resolved,
+}
+
+/// Current status of the same-uid operator/agent secret isolation. Flip to
+/// [`IsolationStatus::Resolved`] ONLY when task `t-20260709010037959088-61315-1`
+/// actually lands (identity-bound auth). The responder-inbound guard reads this.
+pub const SAME_UID_OPERATOR_ISOLATION: IsolationStatus = IsolationStatus::Unresolved;
 
 /// Issue BOTH per-daemon control-socket secrets, fresh, into `run_dir`:
 ///  - `api.cookie`   — the shared agent cookie (RETURNED so the caller can cache
@@ -475,6 +520,61 @@ mod tests {
         client_handshake_ndjson(&mut client_reader, &mut ignored, &cookie).unwrap();
         // `dummy_reader` was unused; pacify the linter.
         let _ = dummy_reader.fill_buf();
+    }
+
+    /// Recursively test whether any `.rs` file under `dir` contains `needle`.
+    fn rs_files_contain(dir: &std::path::Path, needle: &str) -> bool {
+        let mut stack = vec![dir.to_path_buf()];
+        while let Some(d) = stack.pop() {
+            let Ok(entries) = std::fs::read_dir(&d) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let p = entry.path();
+                if p.is_dir() {
+                    stack.push(p);
+                } else if p.extension().and_then(|e| e.to_str()) == Some("rs") {
+                    if let Ok(txt) = std::fs::read_to_string(&p) {
+                        if txt.contains(needle) {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+        false
+    }
+
+    /// HARD-PREREQUISITE fail-loud guard (dev2's P0a review residual, tracking
+    /// task t-20260709010037959088-61315-1).
+    ///
+    /// P0a leaves the **same-user-agent** subcase of dev2 A1 OPEN: a same-uid
+    /// agent can read `api.operator` and impersonate the operator (see
+    /// [`SAME_UID_OPERATOR_ISOLATION`]). That is safe ONLY while no same-uid
+    /// Conversational responder accepts inbound. CONTRACT: any PR that wires such
+    /// a responder MUST (a) place the responder-inbound contract marker (the
+    /// `marker` value assembled below — split so this guard does not self-match)
+    /// at the wiring site, and (b) resolve the isolation, flipping
+    /// `SAME_UID_OPERATOR_ISOLATION` to `Resolved`. If the marker appears while
+    /// isolation is still `Unresolved`, this guard fails loud — so the
+    /// prerequisite cannot be shipped around silently, and in particular NOT by
+    /// leaning on the no-tools sandbox (manifest §0.2).
+    #[test]
+    fn responder_inbound_requires_same_uid_isolation() {
+        let marker = concat!("RESPONDER-", "INBOUND-LIVE");
+        let src = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let responder_inbound_wired = rs_files_contain(&src, marker);
+        if responder_inbound_wired && SAME_UID_OPERATOR_ISOLATION != IsolationStatus::Resolved {
+            panic!(
+                "HARD PREREQ VIOLATED: a Conversational responder inbound path is wired \
+                 (contract marker present) but SAME_UID_OPERATOR_ISOLATION is Unresolved. \
+                 A same-uid prompt-injected responder can read api.operator and impersonate \
+                 the operator, bypassing the whole capability model. Resolve tracking task \
+                 t-20260709010037959088-61315-1 (UDS peer-cred / out-of-band operator token / \
+                 per-agent capability cookie — NOT the no-tools sandbox, manifest §0.2), then \
+                 set SAME_UID_OPERATOR_ISOLATION = IsolationStatus::Resolved."
+            );
+        }
     }
 
     #[test]

--- a/tests/common/harness.rs
+++ b/tests/common/harness.rs
@@ -583,12 +583,16 @@ fn authed_api_call(
     let mut writer = stream.try_clone().map_err(|e| format!("clone: {e}"))?;
     let mut reader = BufReader::new(stream);
 
-    // Auth handshake
+    // Auth handshake — this helper drives OPERATOR-surface methods (list/status/
+    // inject/…), so it presents the operator full-capability token (P0a #2342 B4),
+    // exactly as the real operator CLI (`api::call`) now does. Presenting the
+    // shared agent cookie would authenticate as `Principal::Agent`, whose only
+    // capability is the mcp tunnel → every direct method denied.
     let run_dir = find_run_dir(home).ok_or("no run dir".to_string())?;
-    let cookie_bytes =
-        std::fs::read(run_dir.join("api.cookie")).map_err(|e| format!("read cookie: {e}"))?;
-    let cookie_hex: String = cookie_bytes.iter().map(|b| format!("{b:02x}")).collect();
-    writeln!(writer, r#"{{"auth":"{cookie_hex}"}}"#).map_err(|e| format!("write auth: {e}"))?;
+    let token_bytes = std::fs::read(run_dir.join("api.operator"))
+        .map_err(|e| format!("read operator token: {e}"))?;
+    let token_hex: String = token_bytes.iter().map(|b| format!("{b:02x}")).collect();
+    writeln!(writer, r#"{{"auth":"{token_hex}"}}"#).map_err(|e| format!("write auth: {e}"))?;
     writer.flush().map_err(|e| format!("flush: {e}"))?;
     let mut auth_resp = String::new();
     reader

--- a/tests/daemon_boot_gate_filter.txt
+++ b/tests/daemon_boot_gate_filter.txt
@@ -15,6 +15,7 @@ e2e_workflow
 harness_smoke
 migrated_scripts
 vte_gotchas
+p0a_capability_auth
 # Direct daemon-boot (start --foreground, not via AgendHarness) — manually listed;
 # add a new direct-boot daemon test here when you write one.
 restart_smoke

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -117,13 +117,17 @@ impl TestDaemon {
         None
     }
 
-    /// Read the 32-byte cookie the daemon published in its run dir. Tests
-    /// speak raw TCP so they must present it manually (unlike production
-    /// clients which go through `ipc::connect_api`/`auth_cookie`).
-    fn find_api_cookie(home: &Path) -> Option<Vec<u8>> {
+    /// Read the 32-byte operator full-capability token the daemon published in
+    /// its run dir. `TestDaemon` emulates the OPERATOR CLI (it drives direct
+    /// methods list/kill/delete/inject/shutdown), so it presents `api.operator`
+    /// (P0a #2342 B4) — the shared `api.cookie` would authenticate as a mere
+    /// Agent and get every direct method capability-denied. Tests speak raw TCP
+    /// so they present it manually (unlike production clients which go through
+    /// `api::call`/`auth_cookie::read_operator_token`).
+    fn find_operator_token(home: &Path) -> Option<Vec<u8>> {
         let run = home.join("run");
         for entry in std::fs::read_dir(&run).ok()?.flatten() {
-            let p = entry.path().join("api.cookie");
+            let p = entry.path().join("api.operator");
             if let Ok(bytes) = std::fs::read(&p) {
                 if bytes.len() == 32 {
                     return Some(bytes);
@@ -138,7 +142,7 @@ impl TestDaemon {
     /// request.
     fn connect_authed(&self) -> (BufReader<TcpStream>, TcpStream) {
         let port = Self::find_api_port(&self.home).expect("api port");
-        let cookie = Self::find_api_cookie(&self.home).expect("api.cookie");
+        let cookie = Self::find_operator_token(&self.home).expect("api.operator");
         let stream =
             TcpStream::connect(SocketAddr::from((Ipv4Addr::LOCALHOST, port))).expect("connect");
         stream.set_nodelay(true).ok();

--- a/tests/p0a_capability_auth.rs
+++ b/tests/p0a_capability_auth.rs
@@ -1,0 +1,150 @@
+//! #2342 P0a — control-socket per-method capability authorization (dev2 A1).
+//!
+//! The loopback control socket authenticates a SINGLE shared `api.cookie` that
+//! BOTH the operator CLI and the agent MCP bridge present identically; today the
+//! operator-vs-agent distinction is made purely by method-shape
+//! (`operator_gate::check_operation_allowed` short-circuits every non-`mcp_tool`
+//! method to full authority). So ANY holder of the shared cookie — the agent
+//! bridge, or any same-user process that can read the cookie file — can drive
+//! every injection-equivalent DIRECT method (`inject`/`send`/`spawn`/`kill`/…)
+//! by simply sending its method string. That is dev2 A1.
+//!
+//! P0a closes it: authority is proven by the AUTHENTICATED PRINCIPAL (which
+//! secret was presented at handshake), not by method-shape. A boot-minted
+//! operator full-capability token (`api.operator`) → allow-all; the shared agent
+//! cookie → the MCP tunnel ONLY, every direct method default-DENIED.
+//!
+//! Unix-only: mirrors the other socket-level harness tests.
+#![cfg(unix)]
+
+mod common;
+
+use common::harness::AgendHarness;
+use serde_json::{json, Value};
+use std::io::{BufRead, BufReader, Write};
+use std::net::TcpStream;
+use std::path::Path;
+use std::time::Duration;
+
+/// Minimal fleet: one idle instance so the daemon's API socket comes up.
+fn minimal_fleet() -> String {
+    "instances:\n  probe:\n    command: /bin/cat\n".to_string()
+}
+
+/// A hermetic /tmp home (NEVER ~/.agend-terminal).
+fn hermetic_home(tag: &str) -> std::path::PathBuf {
+    let home = std::env::temp_dir().join(format!(
+        "agend-p0a-{}-{}-{}",
+        tag,
+        std::process::id(),
+        // Monotonic-ish disambiguator without wall-clock (avoid Date::now bans in
+        // scripts; here in a test std::time is fine but keep it simple).
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    ));
+    assert!(
+        home.starts_with(std::env::temp_dir()),
+        "hermetic: home must be under tmp"
+    );
+    home
+}
+
+/// The daemon's run dir (the harness owns the only one under <home>/run/<pid>/).
+fn run_dir_of(h: &AgendHarness) -> std::path::PathBuf {
+    std::fs::read_dir(h.home.join("run"))
+        .expect("run dir")
+        .flatten()
+        .map(|e| e.path())
+        .find(|p| p.join("api.cookie").exists())
+        .expect("run dir with api.cookie")
+}
+
+fn hex_of_file(path: &Path) -> String {
+    let bytes = std::fs::read(path).expect("read secret file");
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+/// Outcome of one control-socket round-trip.
+enum Outcome {
+    /// The `{"auth":…}` handshake was rejected (connection refused pre-method).
+    AuthRejected(Value),
+    /// Handshake accepted; here is the method response.
+    Response(Value),
+}
+
+/// Connect, optionally send the `{"auth":"<hex>"}` handshake line, then the
+/// request. `auth_hex = None` sends NO handshake line (the request is the first
+/// line the server reads — i.e. a no-token connection).
+fn socket_call(port: u16, auth_hex: Option<&str>, request: &Value) -> Outcome {
+    let stream = TcpStream::connect(format!("127.0.0.1:{port}")).expect("connect api");
+    stream.set_read_timeout(Some(Duration::from_secs(15))).ok();
+    let mut writer = stream.try_clone().expect("clone stream");
+    let mut reader = BufReader::new(stream);
+
+    if let Some(hex) = auth_hex {
+        writeln!(writer, r#"{{"auth":"{hex}"}}"#).expect("write auth");
+        writer.flush().ok();
+        let mut auth_resp = String::new();
+        reader.read_line(&mut auth_resp).expect("read auth resp");
+        let parsed: Value = serde_json::from_str(auth_resp.trim())
+            .unwrap_or_else(|e| panic!("parse auth resp '{auth_resp}': {e}"));
+        if parsed.get("ok").and_then(Value::as_bool) != Some(true) {
+            return Outcome::AuthRejected(parsed);
+        }
+    }
+
+    writeln!(writer, "{}", serde_json::to_string(request).expect("serialize"))
+        .expect("write request");
+    writer.flush().ok();
+    let mut resp = String::new();
+    reader.read_line(&mut resp).expect("read response");
+    let parsed: Value =
+        serde_json::from_str(resp.trim()).unwrap_or_else(|e| panic!("parse resp '{resp}': {e}"));
+    // A no-token connection has its (unauth) first line parsed AS the handshake:
+    // the server replies `{"ok":false,"error":"auth"}` and closes. Classify it.
+    if auth_hex.is_none() && parsed.get("error").and_then(Value::as_str) == Some("auth") {
+        return Outcome::AuthRejected(parsed);
+    }
+    Outcome::Response(parsed)
+}
+
+/// RED-first (dev2 A1): a holder of the shared AGENT cookie must NOT be able to
+/// reach the injection-equivalent DIRECT methods. On the OLD (pre-P0a) code the
+/// gate short-circuits every non-`mcp_tool` method to full authority, so the
+/// cookie holder's `inject`/`send`/`spawn` reach the handler (NOT capability-
+/// denied) → this test FAILS. On P0a code the cookie authenticates as the Agent
+/// principal whose capability is the MCP tunnel ONLY → each direct method is
+/// hard-denied with `denied_by == "capability"`.
+#[test]
+fn agent_cookie_cannot_reach_direct_methods() {
+    let home = hermetic_home("red-direct");
+    let h = AgendHarness::spawn_with(home.clone(), &minimal_fleet(), "start")
+        .expect("daemon boot");
+    let cookie_hex = hex_of_file(&run_dir_of(&h).join("api.cookie"));
+
+    // Every injection-equivalent direct method the manifest names.
+    for (method, params) in [
+        ("inject", json!({"instance": "probe", "text": "x"})),
+        ("send", json!({"instance": "probe", "message": "x"})),
+        ("spawn", json!({"name": "evil", "command": "/bin/cat"})),
+    ] {
+        let req = json!({"method": method, "params": params});
+        let out = socket_call(h.api_port, Some(&cookie_hex), &req);
+        let resp = match out {
+            Outcome::Response(v) => v,
+            Outcome::AuthRejected(v) => {
+                panic!("cookie handshake unexpectedly rejected for {method}: {v}")
+            }
+        };
+        assert_eq!(
+            resp.get("denied_by").and_then(Value::as_str),
+            Some("capability"),
+            "dev2 A1: agent-cookie holder reached direct method '{method}' \
+             (expected capability-deny). response={resp}"
+        );
+    }
+
+    std::fs::remove_dir_all(&home).ok();
+}

--- a/tests/p0a_capability_auth.rs
+++ b/tests/p0a_capability_auth.rs
@@ -95,8 +95,12 @@ fn socket_call(port: u16, auth_hex: Option<&str>, request: &Value) -> Outcome {
         }
     }
 
-    writeln!(writer, "{}", serde_json::to_string(request).expect("serialize"))
-        .expect("write request");
+    writeln!(
+        writer,
+        "{}",
+        serde_json::to_string(request).expect("serialize")
+    )
+    .expect("write request");
     writer.flush().ok();
     let mut resp = String::new();
     reader.read_line(&mut resp).expect("read response");
@@ -120,8 +124,7 @@ fn socket_call(port: u16, auth_hex: Option<&str>, request: &Value) -> Outcome {
 #[test]
 fn agent_cookie_cannot_reach_direct_methods() {
     let home = hermetic_home("red-direct");
-    let h = AgendHarness::spawn_with(home.clone(), &minimal_fleet(), "start")
-        .expect("daemon boot");
+    let h = AgendHarness::spawn_with(home.clone(), &minimal_fleet(), "start").expect("daemon boot");
     let cookie_hex = hex_of_file(&run_dir_of(&h).join("api.cookie"));
 
     // Every injection-equivalent direct method the manifest names.
@@ -144,6 +147,108 @@ fn agent_cookie_cannot_reach_direct_methods() {
             "dev2 A1: agent-cookie holder reached direct method '{method}' \
              (expected capability-deny). response={resp}"
         );
+    }
+
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// Compat (the #1 load-bearing risk = operator lockout): the operator
+/// full-capability token MUST reach the direct methods its own CLI/TUI drive.
+/// This is the end-to-end "operator transport is NOT locked" proof.
+#[test]
+fn operator_token_reaches_direct_methods() {
+    let home = hermetic_home("op-allow");
+    let h = AgendHarness::spawn_with(home.clone(), &minimal_fleet(), "start").expect("daemon boot");
+    let op_hex = hex_of_file(&run_dir_of(&h).join("api.operator"));
+
+    // A read (`list`) and a structural op (`spawn`) — both must reach the handler
+    // (never capability-denied) for the operator principal.
+    for (method, params) in [
+        ("list", json!({})),
+        (
+            "spawn",
+            json!({"name": "p0a-op-spawned", "command": "/bin/cat"}),
+        ),
+    ] {
+        let req = json!({"method": method, "params": params});
+        let resp = match socket_call(h.api_port, Some(&op_hex), &req) {
+            Outcome::Response(v) => v,
+            Outcome::AuthRejected(v) => {
+                panic!("operator token handshake unexpectedly rejected for {method}: {v}")
+            }
+        };
+        assert_ne!(
+            resp.get("denied_by").and_then(Value::as_str),
+            Some("capability"),
+            "operator lockout regression: operator token was capability-denied for \
+             '{method}'. response={resp}"
+        );
+    }
+
+    // `list` specifically returns a successful handler result for the operator.
+    let list = match socket_call(
+        h.api_port,
+        Some(&op_hex),
+        &json!({"method": "list", "params": {}}),
+    ) {
+        Outcome::Response(v) => v,
+        Outcome::AuthRejected(v) => panic!("operator list rejected: {v}"),
+    };
+    assert_eq!(
+        list.get("ok").and_then(Value::as_bool),
+        Some(true),
+        "operator `list` should succeed. response={list}"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// Compat: the shared agent cookie must STILL reach the MCP tunnel — narrowing
+/// the sidecar/agent surface must not break the agent bridge's only real path.
+#[test]
+fn agent_cookie_still_reaches_mcp_tunnel() {
+    let home = hermetic_home("agent-mcp");
+    let h = AgendHarness::spawn_with(home.clone(), &minimal_fleet(), "start").expect("daemon boot");
+    let cookie_hex = hex_of_file(&run_dir_of(&h).join("api.cookie"));
+
+    let req = json!({
+        "method": "mcp_tool",
+        "params": {"tool": "list_instances", "arguments": {}, "instance": "probe"}
+    });
+    let resp = match socket_call(h.api_port, Some(&cookie_hex), &req) {
+        Outcome::Response(v) => v,
+        Outcome::AuthRejected(v) => panic!("agent cookie handshake rejected: {v}"),
+    };
+    assert_ne!(
+        resp.get("denied_by").and_then(Value::as_str),
+        Some("capability"),
+        "compat regression: agent cookie was capability-denied for the mcp tunnel. \
+         response={resp}"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// Regression guard: a connection presenting NEITHER secret is refused at the
+/// handshake (fail-closed), before any method is dispatched.
+#[test]
+fn unauthenticated_and_wrong_token_are_rejected() {
+    let home = hermetic_home("no-auth");
+    let h = AgendHarness::spawn_with(home.clone(), &minimal_fleet(), "start").expect("daemon boot");
+
+    let inject = json!({"method": "inject", "params": {"instance": "probe", "text": "x"}});
+
+    // No handshake line at all.
+    match socket_call(h.api_port, None, &inject) {
+        Outcome::AuthRejected(_) => {}
+        Outcome::Response(v) => panic!("no-token connection was NOT rejected: {v}"),
+    }
+
+    // A well-formed hex that matches neither the operator token nor the cookie.
+    let stranger_hex = "aa".repeat(32);
+    match socket_call(h.api_port, Some(&stranger_hex), &inject) {
+        Outcome::AuthRejected(_) => {}
+        Outcome::Response(v) => panic!("wrong-token connection was NOT rejected: {v}"),
     }
 
     std::fs::remove_dir_all(&home).ok();

--- a/tests/p0a_capability_auth.rs
+++ b/tests/p0a_capability_auth.rs
@@ -7,12 +7,20 @@
 //! method to full authority). So ANY holder of the shared cookie — the agent
 //! bridge, or any same-user process that can read the cookie file — can drive
 //! every injection-equivalent DIRECT method (`inject`/`send`/`spawn`/`kill`/…)
-//! by simply sending its method string. That is dev2 A1.
+//! by simply sending its method string. That is the method-shape subcase of dev2 A1.
 //!
-//! P0a closes it: authority is proven by the AUTHENTICATED PRINCIPAL (which
-//! secret was presented at handshake), not by method-shape. A boot-minted
-//! operator full-capability token (`api.operator`) → allow-all; the shared agent
-//! cookie → the MCP tunnel ONLY, every direct method default-DENIED.
+//! P0a closes the **method-shape / sidecar-agent-cookie** subcase: authority is
+//! proven by the AUTHENTICATED PRINCIPAL (which secret was presented at
+//! handshake), not by method-shape. A boot-minted operator full-capability token
+//! (`api.operator`) → allow-all; the shared agent cookie → the MCP tunnel ONLY,
+//! every direct method default-DENIED.
+//!
+//! NOT closed here — the **same-user-agent** subcase: `api.operator` is 0600 in
+//! run_dir, which isolates cross-USER only, so a same-uid agent (a future #2342
+//! responder, if prompt-injected) can read it and impersonate the operator. That
+//! is a HARD Phase-2 prerequisite tracked by task t-20260709010037959088-61315-1
+//! and pinned by the `responder_inbound_requires_same_uid_isolation` guard in
+//! `src/auth_cookie.rs` (see `auth_cookie::SAME_UID_OPERATOR_ISOLATION`).
 //!
 //! Unix-only: mirrors the other socket-level harness tests.
 #![cfg(unix)]


### PR DESCRIPTION
## #2342 P0a — control-socket per-method capability auth + operator full-cap token

**Load-bearing (Blocker 4).** Closes the **method-shape / sidecar-agent-cookie subcase** of
**dev2 A1**: the loopback control socket authenticated a SINGLE shared `api.cookie` that both the
operator CLI and the agent MCP bridge present identically, and operator-vs-agent authority was
decided purely by **method-shape** (`operator_gate::check_operation_allowed` short-circuited every
non-`mcp_tool` method to full authority). So anything holding only the cookie could drive every
injection-equivalent direct method (`inject`/`send`/`spawn`/`kill`/…) by sending its method string.

> ⚠️ **Scope honesty (dev2 r0 review).** This does **NOT** close the **same-user-agent** subcase of
> A1. `api.operator` is `0600` in `run_dir`, which isolates cross-**USER** only — a same-uid agent
> (a future #2342 Conversational **responder**, if prompt-injected) can `read(run_dir/api.operator)`,
> present it, authenticate as `Principal::Operator`, and drive every direct method. Root cause: the
> principal is bound to a *same-uid-readable secret*, not to caller **identity** (TCP loopback has no
> OS peer-cred; the handshake `pid` is client-supplied). That is a **HARD Phase-2 prerequisite**
> (tracking task **t-20260709010037959088-61315-1**; fix = UDS+SO_PEERCRED / out-of-band operator
> token / per-agent capability cookie) and **must NOT** be considered satisfied by the no-tools
> sandbox (manifest §0.2). It is **pinned in code** by the fail-loud guard
> `responder_inbound_requires_same_uid_isolation` + `auth_cookie::SAME_UID_OPERATOR_ISOLATION`.

### Fix: authority proven by the AUTHENTICATED PRINCIPAL, not method-shape
A second per-daemon secret — a boot-minted **operator full-capability token** (`api.operator`) — is
introduced. The handshake maps *which secret was presented* → a `Principal`:

| presented secret | principal | capability |
|---|---|---|
| `api.operator` | `Operator` | full — every method |
| `api.cookie`   | `Agent`    | the MCP tunnel ONLY — every direct method default-DENIED |
| neither        | —          | rejected at handshake (fail-closed) |

The per-method **capability gate** (`operator_gate::capability_allows`) is a HARD default-DENY that
runs at the socket-ingress choke point *before* the operator-mode gate. Exhaustive `match` leaves a
documented slot for a future `Principal::Sidecar` (Phase 2 = enqueue-only).

### Change set
- **`auth_cookie.rs`**: `OPERATOR_TOKEN_FILE`, `Principal`, operator-token mint folded into `issue`
  (every boot path publishes it 0600 before accept — publish-before-accept + per-boot rotation),
  `read_operator_token`, handshake → `(Principal, peer_pid)`. `IsolationStatus` +
  `SAME_UID_OPERATOR_ISOLATION` marker + the fail-loud responder-inbound guard.
- **`operator_gate.rs`**: `capability_allows(principal, method)`. `check_operation_allowed` + its 30
  unit tests **unchanged** (min-churn; capability gate is orthogonal, runs first).
- **`api/mod.rs`**: `serve` reads both secrets (fail-closed if the operator token is missing) + a
  security-posture boot log; `handle_session` threads the principal; ingress runs the capability gate
  first (`denied_by:"capability"`, not queued), then the mode gate; `call`/`call_at` present the
  operator token.

### Compat — the #1 load-bearing risk (operator lockout) — VERIFIED
- Agent bridge only ever sends `mcp_tool`/`mcp_tools_list` (the `send`/`list` at
  `agend-mcp-bridge.rs:589/612/625` are `#[cfg(test)]` fixtures) → Agent=mcp-only breaks nothing.
- Every operator-surface + daemon self-IPC path funnels through `api::call`/`call_at` → all present
  the operator token → Operator principal → allow-all.
- The agent PTY-attach path (`write_tui_auth`/`read_and_verify_tui`) is a separate socket/protocol,
  untouched — it keeps using `api.cookie`.

### Tests (RED-first + end-to-end)
- **RED proof** (commit 1) — socket-level: agent cookie reaches `inject`/`send`/`spawn` (asserts
  capability-deny) — FAILS on old code, GREEN after fix.
- Unit: principal mapping; `capability_allows`; operator-token 0600; operator/cookie independence;
  the fail-loud isolation guard (verified it panics when the responder-inbound marker is planted).
- Integration (real daemon): operator token reaches direct `list`+`spawn` (NOT locked out); agent
  cookie still reaches the mcp tunnel (compat); unauth/wrong-token rejected (fail-closed).
- Gate: `cargo fmt --check` clean; CI-scoped clippy `-D warnings` clean; full `nextest` green.

### Deferred to Phase 2 (per manifest §B4 / staging §7)
Sidecar enqueue-only capability + server-side conversation→responder enqueue-target resolution, AND
the same-uid operator/agent secret isolation (task t-20260709010037959088-61315-1) — a hard
prerequisite before any Conversational responder accepts inbound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
