### PR TITLE
fix(notify-routing): WIP-preserved notice → caller (not hardcoded general) + drop double [system:] prefix

### DIFF
--- a/src/bootstrap/canonical_hygiene.rs
+++ b/src/bootstrap/canonical_hygiene.rs
@@ -314,14 +314,21 @@ fn git_stash_push(canonical: &std::path::Path, message: &str) -> Result<(), Stri
 /// stash with recovery instructions. Delivery failures are silently
 /// dropped — the tracing::info above already records the canonical
 /// hygiene event for log audits.
-fn notify_operator_of_auto_stash(canonical: &std::path::Path, stash_message: &str) {
-    let home = crate::home_dir();
-    let text = format!(
-        "[system:canonical_auto_stash] Canonical at `{path}` was detached + dirty; \
+/// The canonical-auto-stash notice BODY. The `[system:canonical_auto_stash]`
+/// marker is added by the notify layer (`NotifySource::System`); the body must
+/// NOT embed a second (double-prefix bug, #t-…61315-2).
+fn canonical_auto_stash_notice(canonical: &std::path::Path, stash_message: &str) -> String {
+    format!(
+        "Canonical at `{path}` was detached + dirty; \
          auto-stashed WIP as `{stash_message}` and switched back to {DEFAULT_BRANCH}. \
          Recover via:\n  git -C {path} stash list\n  git -C {path} stash pop  # or: git stash apply <ref>\n#852.",
         path = canonical.display(),
-    );
+    )
+}
+
+fn notify_operator_of_auto_stash(canonical: &std::path::Path, stash_message: &str) {
+    let home = crate::home_dir();
+    let text = canonical_auto_stash_notice(canonical, stash_message);
     let source = crate::inbox::NotifySource::System("canonical_auto_stash");
     crate::inbox::notify_agent(&home, "general", &source, &text);
 }
@@ -332,9 +339,12 @@ fn notify_operator_of_auto_stash(canonical: &std::path::Path, stash_message: &st
 /// move scratch out) WITHOUT attributing it to any agent — we have no provenance.
 /// The notification body is bounded (first `MAX_LINES` porcelain entries + a
 /// count); the full porcelain list goes to the event log for audit.
-pub(crate) fn notify_operator_of_canonical_dirty(report: &CanonicalDirtyReport) {
+/// The canonical-dirty notice BODY. The `[system:canonical_dirty]` marker is added
+/// by the notify layer (`NotifySource::System`); the body must NOT embed a second
+/// (double-prefix bug, #t-…61315-2). Bounded to the first `MAX_LINES` porcelain
+/// entries + a count; the full list goes to the event log.
+fn canonical_dirty_notice(report: &CanonicalDirtyReport) -> String {
     const MAX_LINES: usize = 10;
-    let home = crate::home_dir();
     let total = report.porcelain_lines.len();
     let mut body: String = report
         .porcelain_lines
@@ -348,14 +358,19 @@ pub(crate) fn notify_operator_of_canonical_dirty(report: &CanonicalDirtyReport) 
             total - MAX_LINES
         ));
     }
-    let text = format!(
-        "[system:canonical_dirty] Managed canonical repo `{path}` is DIRTY on \
+    format!(
+        "Managed canonical repo `{path}` is DIRTY on \
          {branch} ({total} non-ignored change(s)). Canonical repos must stay clean \
          under AgEnD — work in a git worktree and move any scratch/handoff files \
          OUT of the canonical tree.{body}\nInspect: git -C {path} status",
         path = report.path.display(),
         branch = DEFAULT_BRANCH,
-    );
+    )
+}
+
+pub(crate) fn notify_operator_of_canonical_dirty(report: &CanonicalDirtyReport) {
+    let home = crate::home_dir();
+    let text = canonical_dirty_notice(report);
     let source = crate::inbox::NotifySource::System("canonical_dirty");
     crate::inbox::notify_agent(&home, "general", &source, &text);
 
@@ -429,6 +444,32 @@ pub fn decide_canonical_action(head_state: &str, working_tree_clean: bool) -> Ca
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+
+    /// #t-…61315-2 Bug2 (RED-first): the `[system:…]` marker is added exactly
+    /// once by the notify layer (`NotifySource::System`). The text builder must
+    /// NOT embed a second copy — else the delivered message double-prefixes.
+    #[test]
+    fn canonical_dirty_notice_no_embedded_marker() {
+        let report = CanonicalDirtyReport::from_status(
+            std::path::Path::new("/tmp/canon"),
+            " M src/foo.rs\n?? scratch.txt",
+        );
+        let notice = canonical_dirty_notice(&report);
+        assert!(
+            !notice.contains("[system:"),
+            "notice body must not embed a [system:…] marker (notify layer adds it): {notice}"
+        );
+    }
+
+    /// #t-…61315-2 Bug2 (RED-first): auto-stash notice builder — same invariant.
+    #[test]
+    fn canonical_auto_stash_notice_no_embedded_marker() {
+        let notice = canonical_auto_stash_notice(std::path::Path::new("/tmp/canon"), "wip-abc123");
+        assert!(
+            !notice.contains("[system:"),
+            "notice body must not embed a [system:…] marker (notify layer adds it): {notice}"
+        );
+    }
 
     /// Most-common boot path: HEAD is on `main`. No-op regardless of
     /// working-tree state (operator might have WIP that's expected).

--- a/src/mcp/handlers/force_release/mod.rs
+++ b/src/mcp/handlers/force_release/mod.rs
@@ -59,6 +59,7 @@ pub(super) fn rebase_clean_self(
     home: &Path,
     agent: &str,
     branch: &str,
+    sender: Option<&str>,
 ) -> Result<RebaseCleanOutcome, String> {
     let worktrees_root = home.join("worktrees");
     let target = worktrees_root.join(agent).join(branch);
@@ -83,7 +84,8 @@ pub(super) fn rebase_clean_self(
         // so the operator can recover it in place — even force_release must not
         // silently lose it.
         if let Some(reason) =
-            crate::worktree::preserve_dirty_worktree(home, agent, &target, branch).blocked_reason()
+            crate::worktree::preserve_dirty_worktree(home, agent, &target, branch, sender)
+                .blocked_reason()
         {
             return Err(format!(
                 "force_release refused: worktree at {} has uncommitted WIP that could not be \
@@ -175,7 +177,7 @@ mod tests {
         let home = tmp_home("rebase-clean-existing");
         let dir = seed_daemon_worktree(&home, "dev", "feat/rebase-x");
         assert!(dir.exists());
-        let outcome = rebase_clean_self(&home, "dev", "feat/rebase-x")
+        let outcome = rebase_clean_self(&home, "dev", "feat/rebase-x", None)
             .expect("clean state in pool must succeed");
         assert!(outcome.dir_existed);
         assert!(outcome.dir_removed);
@@ -192,7 +194,7 @@ mod tests {
         // No prior bind, no stale dir → helper still runs release_full
         // (idempotent) and reports dir_existed=false.
         let home = tmp_home("rebase-clean-idempotent");
-        let outcome = rebase_clean_self(&home, "dev", "feat/never-existed")
+        let outcome = rebase_clean_self(&home, "dev", "feat/never-existed", None)
             .expect("helper must not error on clean state");
         assert!(!outcome.dir_existed);
         assert!(!outcome.dir_removed);
@@ -214,7 +216,7 @@ mod tests {
         let home = tmp_home("rebase-outside-pool");
         // An empty branch resolves to <home>/worktrees/dev (the
         // agent-level dir) which the safety check rejects.
-        let r = rebase_clean_self(&home, "dev", "");
+        let r = rebase_clean_self(&home, "dev", "", None);
         assert!(r.is_err(), "empty branch must reject as path-unsafe");
         // A branch with `..` would also escape the pool — but
         // agent_ops::validate_branch already rejects those before this
@@ -340,7 +342,7 @@ mod tests {
         );
         std::fs::write(target.join("fr-wip.txt"), b"force-release WIP").unwrap();
 
-        let outcome = rebase_clean_self(&home, agent, branch).expect("rebase_clean_self ok");
+        let outcome = rebase_clean_self(&home, agent, branch, None).expect("rebase_clean_self ok");
         assert!(
             outcome.dir_existed && outcome.dir_removed,
             "dirty worktree removed by force_release: {outcome:?}"
@@ -412,7 +414,7 @@ mod tests {
         let gitdir = gitlink.strip_prefix("gitdir:").unwrap().trim();
         std::fs::write(Path::new(gitdir).join("index.lock"), b"").unwrap();
 
-        let result = rebase_clean_self(&home, agent, branch);
+        let result = rebase_clean_self(&home, agent, branch, None);
         assert!(
             result.is_err(),
             "force_release must FAIL-CLOSED (Err) when dirty WIP can't be preserved: {result:?}"

--- a/src/mcp/handlers/force_release/repair.rs
+++ b/src/mcp/handlers/force_release/repair.rs
@@ -153,7 +153,11 @@ pub(crate) fn attempt_safe_rebind_repair(
         {
             return Err(blocked);
         }
-        return match rebase_clean_self(home, agent, branch) {
+        // Stale-state cleanup: the recorded worktree is already GONE (no live WIP
+        // to preserve here), and this repair helper carries no caller identity →
+        // None routes any WIP-preserved notice to the agent's team orchestrator
+        // (fallback: operator inbox), never a hardcoded recipient.
+        return match rebase_clean_self(home, agent, branch, None) {
             Ok(_) => Ok(RepairAction::StaleStateCleared),
             Err(e) => Err(RepairBlocked::PathUnsafe(e)),
         };

--- a/src/mcp/handlers/worktree.rs
+++ b/src/mcp/handlers/worktree.rs
@@ -269,7 +269,12 @@ fn handle_release_worktree_force(
         .filter(|s| !s.is_empty())
         .map(std::path::PathBuf::from);
 
-    match crate::mcp::handlers::force_release::rebase_clean_self(home, agent, branch) {
+    match crate::mcp::handlers::force_release::rebase_clean_self(
+        home,
+        agent,
+        branch,
+        sender.as_ref().map(|s| s.as_str()),
+    ) {
         Ok(o) => {
             // #826 L2 GC: when the binding-clear path short-circuited on
             // "no binding" (the post-disband state), the

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -555,6 +555,7 @@ pub(crate) fn preserve_dirty_worktree(
     agent: &str,
     wt_path: &Path,
     branch: &str,
+    sender: Option<&str>,
 ) -> WipPreservation {
     use crate::git_helpers::git_cmd;
     if branch.is_empty() {
@@ -634,7 +635,7 @@ pub(crate) fn preserve_dirty_worktree(
     tracing::info!(agent, branch, %ref_name,
         "preserve dirty WIP: uncommitted worktree changes snapshotted before manual release");
     prune_recovery_refs(wt_path, branch);
-    notify_wip_preserved(home, agent, branch, &ref_name);
+    notify_wip_preserved(home, agent, branch, &ref_name, sender);
     WipPreservation::Preserved
 }
 
@@ -699,20 +700,44 @@ fn recovery_ref_expired(ref_name: &str, cutoff: chrono::DateTime<chrono::Utc>) -
     }
 }
 
-/// Notify the operator-mapped agent (`general`, per convention — mirrors
-/// canonical_hygiene's auto-stash notify) that a dirty worktree's WIP was
-/// preserved, with a one-line recovery command. Best-effort.
-fn notify_wip_preserved(home: &Path, agent: &str, branch: &str, ref_name: &str) {
-    let text = format!(
-        "[system:release_dirty_wip_preserved] Agent `{agent}` released a DIRTY worktree \
+/// Resolve the recipient for a WIP-preserved notice: the release's CALLER when
+/// known (`sender`), else the agent's team orchestrator, else the operator inbox
+/// (`general`) as a last resort — never a hardcoded recipient (#t-…61315-2 Bug1).
+fn wip_notice_recipient(home: &Path, agent: &str, sender: Option<&str>) -> String {
+    sender
+        .map(str::to_string)
+        .or_else(|| crate::teams::find_team_for(home, agent).and_then(|t| t.orchestrator))
+        .unwrap_or_else(|| "general".to_string())
+}
+
+/// The WIP-preserved notice BODY. The `[system:release_dirty_wip_preserved]`
+/// marker is added by the notify layer (`NotifySource::System`); the body must
+/// NOT embed a second (double-prefix bug, #t-…61315-2 Bug2).
+fn wip_preserved_notice(agent: &str, branch: &str, ref_name: &str) -> String {
+    format!(
+        "Agent `{agent}` released a DIRTY worktree \
          for branch `{branch}`; its uncommitted WIP (tracked + untracked) was snapshotted \
          to recovery ref:\n  {ref_name}\nRecover it from the canonical repo with:\n  \
          git worktree add ../wip-recover {ref_name}\n(or inspect: git log -p {ref_name}). \
          Auto-pruned after {RECOVERY_TTL_DAYS}d / max {RECOVERY_MAX_PER_BRANCH} per branch. \
          #2158-adjacent."
-    );
+    )
+}
+
+/// Notify the release's CALLER that a dirty worktree's WIP was preserved, with a
+/// one-line recovery command. Recipient + body per the pure helpers above.
+/// Best-effort.
+fn notify_wip_preserved(
+    home: &Path,
+    agent: &str,
+    branch: &str,
+    ref_name: &str,
+    sender: Option<&str>,
+) {
+    let recipient = wip_notice_recipient(home, agent, sender);
+    let text = wip_preserved_notice(agent, branch, ref_name);
     let source = crate::inbox::NotifySource::System("release_dirty_wip_preserved");
-    crate::inbox::notify_agent(home, "general", &source, &text);
+    crate::inbox::notify_agent(home, &recipient, &source, &text);
 }
 
 /// #2234 Phase 2: resolve the worktree dir to remove for `(agent, branch)`,
@@ -1034,7 +1059,7 @@ mod tests {
         // Untracked WIP — the loss-prone case (`clean -fd` would delete it).
         std::fs::write(info.path.join("scratch-wip.txt"), b"unsaved work").unwrap();
 
-        let outcome = preserve_dirty_worktree(&home, "agent1", &info.path, &info.branch);
+        let outcome = preserve_dirty_worktree(&home, "agent1", &info.path, &info.branch, None);
         assert!(
             matches!(outcome, WipPreservation::Preserved),
             "dirty worktree must be Preserved, got {}",
@@ -1061,7 +1086,7 @@ mod tests {
         // marker, which is not preservable) → helper must report Clean.
         assert!(
             matches!(
-                preserve_dirty_worktree(&home, "agent1", &info.path, &info.branch),
+                preserve_dirty_worktree(&home, "agent1", &info.path, &info.branch, None),
                 WipPreservation::Clean
             ),
             "clean worktree must be Clean (no recovery ref)"
@@ -1101,7 +1126,7 @@ mod tests {
         std::fs::write(info.path.join("precious-wip.txt"), b"must not vanish").unwrap();
         let lock = plant_index_lock(&info.path);
 
-        let outcome = preserve_dirty_worktree(&home, "agent1", &info.path, &info.branch);
+        let outcome = preserve_dirty_worktree(&home, "agent1", &info.path, &info.branch, None);
         assert!(
             outcome.blocked_reason().is_some(),
             "unpreservable WIP must be Blocked (fail-closed), got {}",
@@ -1114,6 +1139,62 @@ mod tests {
         std::fs::remove_file(&lock).ok();
         std::fs::remove_dir_all(&home).ok();
         std::fs::remove_dir_all(&repo).ok();
+    }
+
+    /// Bug1 (#t-…61315-2): a known caller is the notice recipient — never the
+    /// hardcoded `general` the pre-fix `notify_agent(home, "general", …)` used.
+    #[test]
+    fn wip_notice_recipient_prefers_the_caller() {
+        let home = tmp_home("wip-recipient-caller");
+        assert_eq!(
+            wip_notice_recipient(&home, "agent1", Some("lead-x")),
+            "lead-x",
+            "a known caller must be the recipient, not a hardcoded one"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Bug1 last-resort fallback: no caller AND no team → operator inbox
+    /// (`general`). This is the ONLY path that may legitimately use `general`.
+    #[test]
+    fn wip_notice_recipient_no_team_falls_back_to_general() {
+        let home = tmp_home("wip-recipient-no-team");
+        assert_eq!(
+            wip_notice_recipient(&home, "agent1", None),
+            "general",
+            "no caller and no team → operator inbox as last resort"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Bug1 middle fallback: no caller but the agent belongs to a team → route to
+    /// that team's ORCHESTRATOR, not the hardcoded `general`.
+    #[test]
+    fn wip_notice_recipient_no_caller_uses_team_orchestrator() {
+        let home = tmp_home("wip-recipient-team");
+        std::fs::write(
+            crate::fleet::fleet_yaml_path(&home),
+            "teams:\n  gapfix:\n    members: [agent1, lead-y]\n    orchestrator: lead-y\n",
+        )
+        .expect("write fleet.yaml");
+        assert_eq!(
+            wip_notice_recipient(&home, "agent1", None),
+            "lead-y",
+            "no caller but a team → the team orchestrator, not hardcoded general"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Bug2 (#t-…61315-2): the `[system:…]` marker is added exactly once by the
+    /// notify layer (`NotifySource::System`); the body builder must NOT embed a
+    /// second copy — else the delivered message double-prefixes.
+    #[test]
+    fn wip_preserved_notice_has_no_embedded_marker() {
+        let notice = wip_preserved_notice("agent1", "feat/x", "refs/agend-wip/agent1/x-1");
+        assert!(
+            !notice.contains("[system:"),
+            "notice body must not embed a [system:…] marker (notify layer adds it): {notice}"
+        );
     }
 
     /// Seed a recovery ref dated `days_ago` (distinct days → distinct names).

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -480,8 +480,11 @@ pub fn release_full(home: &Path, agent: &str, dry_run: bool) -> ReleaseOutcome {
             // callers of `remove_worktree` are intentionally left untouched.
             if is_daemon_managed(wt_path) {
                 let branch = binding["branch"].as_str().unwrap_or("");
+                // No caller identity on the background pool-sweep path → None
+                // routes the WIP-preserved notice to the agent's team orchestrator
+                // (fallback: operator inbox) rather than a hardcoded recipient.
                 let preservation =
-                    crate::worktree::preserve_dirty_worktree(home, agent, wt_path, branch);
+                    crate::worktree::preserve_dirty_worktree(home, agent, wt_path, branch, None);
                 if let Some(reason) = preservation.blocked_reason() {
                     // reviewer4 #2672 fix — FAIL-CLOSED: there IS uncommitted WIP
                     // but it could not be snapshotted (e.g. a contended


### PR DESCRIPTION
## What & why

Task `t-20260709010239838391-61315-2` — two real bugs in the dirty-worktree WIP-preserved notification (surfaced when the lead `release_worktree`'d a dirty worktree):

- **Bug1 — recipient hardcoded `general`.** `notify_wip_preserved` called `notify_agent(home, "general", …)`, ignoring the caller identity that IS available up the chain (`handle_release_worktree_force` holds `sender`). The `agent` argument only went into the message *body*, never the recipient.
- **Bug2 — double `[system:…]` prefix.** The body literal manually embedded `[system:release_dirty_wip_preserved]`, while the notify layer (`NotifySource::System`, Display = `system:{label}`) already prepends exactly that marker → the delivered message double-prefixed. `canonical_hygiene.rs`'s canonical-dirty and auto-stash notices shared the identical pattern.

## Changes

- **Thread `sender: Option<&str>`** down `handle_release_worktree_force → rebase_clean_self → preserve_dirty_worktree → notify_wip_preserved`. The two callers with no sender in scope pass `None`: the `worktree_pool` background sweep and `force_release/repair.rs` stale-cleanup.
- **Extract pure seams** in `worktree.rs`:
  - `wip_notice_recipient(home, agent, sender)` — resolves caller → **agent's team orchestrator** (`teams::find_team_for(home, agent).and_then(|t| t.orchestrator)`) → `general` **only as a last resort**. Never hardcoded.
  - `wip_preserved_notice(agent, branch, ref_name)` — body builder, no embedded marker.
- **Drop the manual `[system:…]` prefix** from all three notice builders (worktree WIP + canonical dirty + canonical auto-stash); the notify layer adds exactly one.
- `canonical_hygiene` keeps recipient=`general` **by design** (operator-facing boot hygiene, no agent caller) — only the double-prefix is fixed there.

## Tests (RED-first → GREEN)

Tests target the **pure seams** — deterministic, no delivery machinery (the earlier end-to-end-via-`inbox/*.jsonl` approach was wrong-layer: `notify_agent` delivers via `compose_aware_inject`, not inbox files).

RED (before fix), 4 failing:
```
wip_preserved (recipient=general; marker count 2)         ... FAILED ×2
canonical_dirty/auto_stash_notice_no_embedded_marker      ... FAILED ×2
```
GREEN (after fix):
```
running 6 tests ... test result: ok. 6 passed; 0 failed
```
- `wip_notice_recipient_prefers_the_caller` / `_no_team_falls_back_to_general` / `_no_caller_uses_team_orchestrator`
- `wip_preserved_notice_has_no_embedded_marker`
- `canonical_dirty_notice_no_embedded_marker` / `canonical_auto_stash_notice_no_embedded_marker`

Gate: `cargo fmt --check` ✓, `cargo clippy --workspace --lib --bins --tests -D warnings` ✓, `cargo nextest run worktree canonical_hygiene force_release` → **333/333 passed**.

Closes t-20260709010239838391-61315-2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
