### PR TITLE
fix(branch-residue PR-B): PR-authoritative immediate delete (P3) + branch-count alarm (P4) + occupancy fail-closed

### DIFF
--- a/src/branch_sweep.rs
+++ b/src/branch_sweep.rs
@@ -210,37 +210,48 @@ fn is_squash_merged_cherry(repo: &Path, base: &str, branch: &str) -> bool {
     had_any
 }
 
-/// GitHub API based detection: query whether a merged PR exists for
-/// this branch with matching HEAD SHA. Most reliable — not affected
-/// by git history topology. SHA check prevents false positives from
-/// branch name reuse.
-fn is_squash_merged_diff(repo: &Path, base: &str, branch: &str) -> bool {
+/// Tri-state result of the PR-based (authoritative) merge check. `Unknown`
+/// means the check could NOT run — no github remote, `extract_github_repo`
+/// returned `None`, the tip couldn't be resolved, or the `gh`/scm call errored
+/// — as distinct from `NotMerged` (the check ran and found no matching merged
+/// PR). #P3 (branch-residue): callers that treat a merged PR as monotonic proof
+/// (delete NOW, no age gate) act ONLY on `Merged`; `Unknown` fails CLOSED
+/// (treated as not-merged) everywhere, so a gh outage never reaps a branch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PrMergeStatus {
+    Merged,
+    NotMerged,
+    Unknown,
+}
+
+/// GitHub API based detection: query whether a merged PR exists for this
+/// branch with matching HEAD SHA. Most reliable — not affected by git history
+/// topology. SHA check prevents false positives from branch name reuse.
+///
+/// #P3: returns a TRI-STATE (`PrMergeStatus`) so a caller can tell "detection
+/// couldn't run" (`Unknown`) apart from "ran, no matching merged PR"
+/// (`NotMerged`). The private `is_squash_merged_diff` wrapper below collapses
+/// `Merged → true` / else → false to keep `is_squash_merged`'s Method-2
+/// behavior byte-identical.
+pub(crate) fn pr_merge_status(repo: &Path, base: &str, branch: &str) -> PrMergeStatus {
     // Resolve owner/repo from git remote origin.
-    // W1.2 class-2: BEHAVIOR DELTA — adds AGEND_GIT_BYPASS (this site previously
-    // ran raw `git` with NO bypass env). Daemon-side git over a fleet repo is the
-    // forgot-bypass latent class (#821/#1463); always-bypass is the intended fix.
-    // git_cmd trims stdout → identical to the prior `.trim().to_string()`.
-    let remote = crate::git_helpers::git_cmd(repo, &["remote", "get-url", "origin"]).ok();
-    let Some(remote_url) = remote else {
-        return false;
+    // W1.2 class-2: git_cmd always adds AGEND_GIT_BYPASS + trims stdout (this
+    // site previously ran raw `git` — the forgot-bypass latent class #821/#1463).
+    let Ok(remote_url) = crate::git_helpers::git_cmd(repo, &["remote", "get-url", "origin"]) else {
+        return PrMergeStatus::Unknown;
     };
-    let gh_repo = extract_github_repo(&remote_url);
-    let Some(gh_repo) = gh_repo else {
-        return false;
+    let Some(gh_repo) = extract_github_repo(&remote_url) else {
+        return PrMergeStatus::Unknown;
     };
     // Get local branch tip SHA.
-    // W1.2 class-2: BEHAVIOR DELTA — adds AGEND_GIT_BYPASS (was raw, no bypass).
-    // Same forgot-bypass class as the remote read above; git_cmd trims → identical.
-    let local_sha = crate::git_helpers::git_cmd(repo, &["rev-parse", branch]).ok();
-    let Some(local_sha) = local_sha else {
-        return false;
+    let Ok(local_sha) = crate::git_helpers::git_cmd(repo, &["rev-parse", branch]) else {
+        return PrMergeStatus::Unknown;
     };
     // #PR-D: `gh pr list` via ScmProvider. argv is set-equal to the prior
     // inline `pr list --state merged --head B --base BASE --repo R --json
     // headRefOid` — flag ORDER is canonicalized (gh order-insensitive) per
     // decision d-20260601151209762922-0; same flags+values. Uses --repo
-    // (gh_repo derived above), no cwd. Any failure → false (unchanged from
-    // the prior gh-fail / parse-fail → false).
+    // (gh_repo derived above), no cwd. A gh/scm error → `Unknown` (fail-closed).
     let Ok(prs) = crate::scm::make_scm_provider(&gh_repo, None).pr_list(
         &gh_repo,
         &crate::scm::ListFilter {
@@ -252,16 +263,28 @@ fn is_squash_merged_diff(repo: &Path, base: &str, branch: &str) -> bool {
         &["headRefOid"],
         None,
     ) else {
-        return false;
+        return PrMergeStatus::Unknown;
     };
-    // True iff any merged PR's HEAD SHA matches the local branch tip, or the
+    // Merged iff any merged PR's HEAD SHA matches the local branch tip, or the
     // local tip is a strict ancestor of that HEAD SHA — see
     // `local_sha_matches_merged_head` for why the ancestor case matters.
-    prs.iter().any(|s| {
+    let merged = prs.iter().any(|s| {
         s.head_ref_oid
             .as_deref()
             .is_some_and(|oid| local_sha_matches_merged_head(repo, &local_sha, oid))
-    })
+    });
+    if merged {
+        PrMergeStatus::Merged
+    } else {
+        PrMergeStatus::NotMerged
+    }
+}
+
+/// Method-2 wrapper for [`is_squash_merged`]: `Merged → true`, else false.
+/// `Unknown` maps to NOT squash-merged — byte-identical to the pre-#P3
+/// `is_squash_merged_diff` (every non-`Merged` outcome was already `false`).
+fn is_squash_merged_diff(repo: &Path, base: &str, branch: &str) -> bool {
+    matches!(pr_merge_status(repo, base, branch), PrMergeStatus::Merged)
 }
 
 /// True iff `head_ref_oid` (a merged PR's recorded HEAD SHA) equals

--- a/src/daemon/per_tick/worktree_registry_sweep.rs
+++ b/src/daemon/per_tick/worktree_registry_sweep.rs
@@ -36,6 +36,13 @@ use std::sync::Arc;
 pub(crate) struct WorktreeRegistrySweepHandler {
     gate: crate::daemon::cadence_gate::CadenceGate,
     in_flight: Arc<AtomicBool>,
+    /// #P4 (branch-residue): episode-dedup for the >15 non-default-branch
+    /// residue alarm — flips false→true on the first over-threshold sweep so
+    /// the warn+operator-notify fires ONCE, resets when the count drops back to
+    /// ≤15. Process-lifetime state on this long-lived singleton handler (mirrors
+    /// `in_flight`); mutated through the Arc's interior mutability from the
+    /// spawned round.
+    count_warned: Arc<AtomicBool>,
 }
 
 impl WorktreeRegistrySweepHandler {
@@ -43,6 +50,7 @@ impl WorktreeRegistrySweepHandler {
         Self {
             gate: crate::daemon::cadence_gate::CadenceGate::new(every_n_ticks),
             in_flight: Arc::new(AtomicBool::new(false)),
+            count_warned: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -74,6 +82,7 @@ impl PerTickHandler for WorktreeRegistrySweepHandler {
         let home = ctx.home.to_path_buf();
         let configs = Arc::clone(ctx.configs);
         let in_flight = Arc::clone(&self.in_flight);
+        let count_warned = Arc::clone(&self.count_warned);
         // fire-and-forget: #P1-2607 — moves the potentially-slow sweep
         // (git subprocess per candidate branch) off the daemon's main tick
         // loop. No JoinHandle is kept; completion is signaled via `in_flight`,
@@ -92,7 +101,7 @@ impl PerTickHandler for WorktreeRegistrySweepHandler {
                 let _guard = super::ClearOnDrop::new(in_flight);
                 #[cfg(test)]
                 test_hooks::round_gate();
-                worktree_auto_cleanup(&home, &configs);
+                worktree_auto_cleanup(&home, &configs, &count_warned);
             }
             #[cfg(test)]
             test_hooks::signal_round_complete();
@@ -178,12 +187,11 @@ mod test_hooks {
 ///
 /// #2605: repo discovery moved to live `binding.json` state
 /// (`sweep_from_registry` reads it via `home`) instead of the removed
-/// `AgentConfig.worktree_source` cache. Real deletion is additionally gated by
-/// `worktree_cleanup::prune_live_enabled` (default off) — while off, the same
-/// candidates are identified but not deleted, and are logged under a distinct
-/// dry-run event kind so an operator can diff them against a fresh audit
-/// before opting in.
-fn worktree_auto_cleanup(home: &Path, configs: &ConfigRegistry) {
+/// `AgentConfig.worktree_source` cache. Real deletion is gated by
+/// `worktree_cleanup::prune_live_enabled` (default LIVE since #2695 — opt-out
+/// via `AGEND_WORKTREE_PRUNE_LIVE=0`, which keeps the same candidates identified
+/// but not deleted, logged under a distinct dry-run event kind).
+fn worktree_auto_cleanup(home: &Path, configs: &ConfigRegistry, count_warned: &AtomicBool) {
     let cfgs = configs.lock();
     let config_data: std::collections::HashMap<String, Option<std::path::PathBuf>> = cfgs
         .iter()
@@ -224,6 +232,66 @@ fn worktree_auto_cleanup(home: &Path, configs: &ConfigRegistry) {
         } else {
             tracing::info!(branch, path, reason, "worktree auto-removed");
         }
+    }
+
+    // #P4 (branch-residue): end-of-sweep residue alarm. If any bound repo has
+    // accumulated more than 15 non-default local branches, worktree/branch GC is
+    // not keeping up (GC stalled, or the prune gate opted out). Warn + notify the
+    // operator ONCE per episode (de-duped via `count_warned`, reset when back
+    // under). Independent of `dry_run` — the count is observational, so a
+    // dry-run daemon still surfaces accumulating residue.
+    let max_count = max_nondefault_branch_count(home);
+    if branch_count_alert(max_count, count_warned) {
+        tracing::warn!(
+            count = max_count,
+            "non-default local branch count exceeds 15 — residue may be accumulating \
+             (is AGEND_WORKTREE_PRUNE_LIVE=0 / GC stalled?)"
+        );
+        let text = format!(
+            "Local non-default branch count is {max_count} (>15) in a bound repo; \
+             worktree/branch GC is not keeping up. Investigate residue."
+        );
+        crate::inbox::notify_agent(
+            home,
+            "general",
+            &crate::inbox::NotifySource::System("branch-residue"),
+            &text,
+        );
+    }
+}
+
+/// #P4: max non-default local branch count across all repos bound under `home`
+/// (`git branch --format=%(refname:short)`, filtering out each repo's default
+/// branch). Fail-open on a git error — a transient enumeration failure counts as
+/// 0 for that repo rather than raising a false residue alarm.
+fn max_nondefault_branch_count(home: &Path) -> usize {
+    crate::binding::bound_source_repos(home)
+        .iter()
+        .map(|repo| {
+            let default = crate::git_helpers::default_branch(repo);
+            match crate::git_helpers::git_cmd(repo, &["branch", "--format=%(refname:short)"]) {
+                Ok(stdout) => stdout.lines().filter(|b| *b != default.as_str()).count(),
+                Err(_) => 0,
+            }
+        })
+        .max()
+        .unwrap_or(0)
+}
+
+/// #P4: pure episode-dedup decision for the residue alarm. Returns `true` iff
+/// the caller should fire the warn+operator-notify NOW: the count exceeds the
+/// threshold AND we haven't already warned this episode (`already_warned` flips
+/// false→true on the first fire, mirroring the `in_flight` swap idiom). Once the
+/// count drops back to ≤threshold the flag resets, so a later re-accumulation
+/// re-fires exactly once. Extracted so the fire/skip/reset transitions are
+/// unit-testable without asserting on tracing/inbox side effects (the RED8 seam).
+fn branch_count_alert(max_count: usize, already_warned: &AtomicBool) -> bool {
+    const BRANCH_COUNT_WARN_THRESHOLD: usize = 15;
+    if max_count > BRANCH_COUNT_WARN_THRESHOLD {
+        !already_warned.swap(true, Ordering::AcqRel)
+    } else {
+        already_warned.store(false, Ordering::Release);
+        false
     }
 }
 
@@ -361,5 +429,93 @@ mod tests {
         );
 
         std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #P4 (branch-residue) RED8 — pure episode-dedup transitions: >15 fires
+    /// once, a second >15 sweep in the same episode is suppressed, and dropping
+    /// back to ≤15 resets the flag so a later re-accumulation re-fires. Pins the
+    /// dedup contract without asserting on tracing/inbox side effects.
+    #[test]
+    fn branch_count_alert_fires_once_per_episode_red8() {
+        let flag = AtomicBool::new(false);
+        assert!(
+            branch_count_alert(16, &flag),
+            "first over-threshold sweep must fire"
+        );
+        assert!(
+            !branch_count_alert(16, &flag),
+            "a second >15 sweep in the same episode must NOT re-fire (deduped)"
+        );
+        assert!(
+            !branch_count_alert(15, &flag),
+            "exactly 15 is NOT over the >15 threshold and resets the episode"
+        );
+        assert!(
+            !branch_count_alert(10, &flag),
+            "further under-threshold sweeps stay quiet"
+        );
+        assert!(
+            branch_count_alert(20, &flag),
+            "after resetting under threshold, a fresh >15 sweep fires again"
+        );
+    }
+
+    /// #P4 RED8 — end-to-end count wiring: a bound source repo with 16
+    /// non-default branches makes `max_nondefault_branch_count` report >15, so
+    /// the alarm predicate fires on the first sweep. Real git fixture + a seeded
+    /// `binding.json` so `bound_source_repos` discovers the repo.
+    #[test]
+    fn sixteen_branches_trip_the_residue_alarm_red8() {
+        fn git(dir: &Path, args: &[&str]) {
+            std::process::Command::new("git")
+                .args(args)
+                .current_dir(dir)
+                .env("AGEND_GIT_BYPASS", "1")
+                .env("GIT_AUTHOR_NAME", "test")
+                .env("GIT_AUTHOR_EMAIL", "t@t")
+                .env("GIT_COMMITTER_NAME", "test")
+                .env("GIT_COMMITTER_EMAIL", "t@t")
+                .output()
+                .expect("git");
+        }
+        let tag = format!("{}-p4-red8", std::process::id());
+        let home = std::env::temp_dir().join(format!("agend-p4-home-{tag}"));
+        let repo = std::env::temp_dir().join(format!("agend-p4-repo-{tag}"));
+        std::fs::create_dir_all(&home).unwrap();
+        std::fs::create_dir_all(&repo).unwrap();
+        git(&repo, &["init", "-b", "main"]);
+        std::fs::write(repo.join("README.md"), "init").ok();
+        git(&repo, &["add", "."]);
+        git(&repo, &["commit", "-m", "init"]);
+        // 16 non-default branches → strictly greater than the 15 threshold.
+        for i in 0..16 {
+            git(&repo, &["branch", &format!("feat/b{i}")]);
+        }
+        // Seed binding so bound_source_repos(home) discovers this repo.
+        let bdir = crate::paths::runtime_dir(&home).join("agent-x");
+        std::fs::create_dir_all(&bdir).unwrap();
+        std::fs::write(
+            bdir.join("binding.json"),
+            serde_json::json!({ "source_repo": repo.display().to_string() }).to_string(),
+        )
+        .unwrap();
+
+        let n = max_nondefault_branch_count(&home);
+        assert!(
+            n > 15,
+            "16 non-default branches must count as >15 (got {n})"
+        );
+        let flag = AtomicBool::new(false);
+        assert!(
+            branch_count_alert(n, &flag),
+            "the residue alarm must fire on the first sweep for a >15 repo"
+        );
+        assert!(
+            !branch_count_alert(n, &flag),
+            "and must not re-fire on the immediately-following sweep"
+        );
+
+        std::fs::remove_dir_all(&home).ok();
+        std::fs::remove_dir_all(&repo).ok();
     }
 }

--- a/src/worktree_cleanup.rs
+++ b/src/worktree_cleanup.rs
@@ -11,14 +11,13 @@
 //! #2605: repo discovery used to come from `AgentConfig.worktree_source`, a
 //! spawn-time cache keyed on the LEGACY `{repo}/.worktrees/...` layout — under
 //! the current workspace-spawn + post-spawn-bind architecture this was always
-//! empty, so this module's git-mutating paths have never actually run against
+//! empty, so this module's git-mutating paths had never actually run against
 //! the canonical repo in production (see `BRANCH-AUDIT-20260704.md`). Fixing
-//! repo discovery activates a delete path with zero production track record,
-//! so real deletion is additionally gated **opt-in** via
-//! `AGEND_WORKTREE_PRUNE_LIVE=1` (see `prune_live_enabled`) — default is
-//! dry-run: candidates are logged (`tracing` + `event_log`), nothing is
-//! deleted, until an operator diffs the dry-run output against a fresh audit
-//! and flips the gate.
+//! repo discovery activated a delete path that was, for a rollout window,
+//! gated opt-in via `AGEND_WORKTREE_PRUNE_LIVE`. As of PR-A (branch-residue,
+//! #2695) that gate is **default-LIVE, opt-OUT**: real deletion runs unless
+//! `AGEND_WORKTREE_PRUNE_LIVE=0` (see `prune_live_enabled`); when opted out,
+//! candidates are only logged (`tracing` + `event_log`), nothing is deleted.
 
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -72,21 +71,53 @@ pub struct WorktreeEntry {
 /// exposed to that failure mode). Adds the #1897 60s LOCAL_GIT_TIMEOUT
 /// bound `git_bypass` provides — the raw `Command` this replaced had NO
 /// timeout, unlike the other 3 porcelain call sites already converged here.
-fn list_worktrees(repo_root: &Path) -> Vec<WorktreeEntry> {
-    crate::git_worktree::list_porcelain(repo_root)
-        .unwrap_or_default()
-        .into_iter()
-        .filter_map(|(path, branch)| {
-            let branch = branch?;
-            if branch == "main" || branch == "master" {
-                return None;
-            }
-            Some(WorktreeEntry {
-                path: path.display().to_string(),
-                branch,
+///
+/// PR-B rider (dev2 #2695 seat2): **fail-CLOSED**. A `git worktree list`
+/// failure is an AMBIGUITY, not "no worktrees" — swallowing it (the former
+/// `unwrap_or_default()`) collapsed the occupancy dimension to empty, so a
+/// caller's "not occupied → eligible to delete" check would fail-OPEN and could
+/// reap a branch whose worktree is merely un-enumerable. The error now
+/// propagates as `Err(())` (logged once here) and every caller skips its
+/// mutating work for this tick (mirrors the `bound_worktree_paths_or_ambiguous`
+/// fail-closed convention below).
+fn list_worktrees(repo_root: &Path) -> Result<Vec<WorktreeEntry>, ()> {
+    // Call git directly rather than `git_worktree::list_porcelain`, which
+    // collapses a NON-ZERO exit into `Ok(Vec::new())` (that swallow is exactly
+    // half of the fail-OPEN dev2 flagged). Here BOTH a spawn error AND a
+    // non-zero `git worktree list` exit surface as `Err(())` so the caller skips
+    // its removals this tick instead of proceeding on a collapsed occupancy view.
+    let out = crate::git_helpers::git_bypass(repo_root, &crate::git_worktree::LIST_PORCELAIN_ARGS)
+        .map_err(|e| {
+            tracing::warn!(
+                repo = %repo_root.display(),
+                error = %e,
+                "list_worktrees: git worktree enumeration failed to spawn — caller fails closed"
+            );
+        })?;
+    if !out.status.success() {
+        tracing::warn!(
+            repo = %repo_root.display(),
+            stderr = %String::from_utf8_lossy(&out.stderr).trim(),
+            "list_worktrees: git worktree list exited non-zero — occupancy dimension \
+             would collapse; caller fails closed (skips its removals this tick)"
+        );
+        return Err(());
+    }
+    Ok(
+        crate::git_worktree::parse_porcelain(&String::from_utf8_lossy(&out.stdout))
+            .into_iter()
+            .filter_map(|(path, branch)| {
+                let branch = branch?;
+                if branch == "main" || branch == "master" {
+                    return None;
+                }
+                Some(WorktreeEntry {
+                    path: path.display().to_string(),
+                    branch,
+                })
             })
-        })
-        .collect()
+            .collect(),
+    )
 }
 
 /// Check if a branch is merged into the default branch (local check, no API needed).
@@ -432,7 +463,12 @@ pub fn sweep_from_registry(
         let default = crate::git_helpers::default_branch(repo);
 
         // Phase 1: clean worktrees (existing logic + remote-gone)
-        let entries = list_worktrees(repo);
+        // PR-B rider: fail-closed — if worktree enumeration errors, skip this
+        // repo's reclaim this tick rather than proceed with a collapsed occupancy view.
+        let entries = match list_worktrees(repo) {
+            Ok(e) => e,
+            Err(()) => continue,
+        };
         for entry in &entries {
             let wt_path = Path::new(&entry.path);
 
@@ -499,7 +535,9 @@ pub fn sweep_from_registry(
 /// human may still follow up on locally) is left for a later tick. A
 /// genuinely-orphaned squash-merged branch's tip predates the merge, so it
 /// clears this floor on the next sweep.
-const SQUASH_GC_MIN_TIP_AGE: Duration = Duration::from_secs(24 * 60 * 60);
+// #P3 (branch-residue): `pub(crate)` so `worktree_pool::merged_branch_disposition`
+// can phrase its "younger than the {N}h GC floor" keep reason with the SAME N.
+pub(crate) const SQUASH_GC_MIN_TIP_AGE: Duration = Duration::from_secs(24 * 60 * 60);
 
 /// PR-A P1 (branch-residue RCA §3): a reviewer-checkout scaffolding branch
 /// (`review/*` etc. — see [`crate::branch_sweep::is_reviewer_checkout`]) whose
@@ -569,6 +607,20 @@ type SquashCacheKey = (PathBuf, String, String, String);
 static SQUASH_MERGED_CACHE: std::sync::OnceLock<parking_lot::Mutex<HashMap<SquashCacheKey, bool>>> =
     std::sync::OnceLock::new();
 
+/// #P3 (branch-residue): positive-only cache of a TRUE structural squash-merge,
+/// keyed WITHOUT `default_tip_sha` — `(repo, branch, tip_sha)`. A positive
+/// squash verdict is MONOTONIC (once a branch's patch is in `default`, `default`
+/// only ever advances further; it never "un-absorbs" the patch), so `default`
+/// advancing must NOT bust a cached TRUE and force the expensive cherry/tree-diff
+/// re-run. This set is checked BEFORE `default`'s tip is even resolved. The
+/// `default_tip`-keyed [`SQUASH_MERGED_CACHE`] above still holds FALSE verdicts,
+/// which are NOT monotonic (a false can flip to true once `default` advances to
+/// absorb the branch), so those MUST stay default-tip-keyed to re-evaluate.
+type SquashPositiveKey = (PathBuf, String, String);
+static SQUASH_MERGED_POSITIVE: std::sync::OnceLock<
+    parking_lot::Mutex<std::collections::HashSet<SquashPositiveKey>>,
+> = std::sync::OnceLock::new();
+
 /// #1750-B3: is `branch` a squash-merge orphan eligible for auto-GC? True when
 /// it is squash-merged into the default branch AND its tip is older than
 /// [`SQUASH_GC_MIN_TIP_AGE`]. Reuses `branch_sweep`'s detection (git cherry +
@@ -601,6 +653,17 @@ pub(crate) fn is_squash_gc_eligible(repo_root: &Path, branch: &str, default: &st
     if Duration::from_secs(now.saturating_sub(tip_ts)) < SQUASH_GC_MIN_TIP_AGE {
         return false;
     }
+
+    // #P3: a positive squash verdict is monotonic — check the default-tip-FREE
+    // positive set FIRST. A hit short-circuits to `true` without even resolving
+    // `default`'s tip (so `default` advancing can't needlessly bust it).
+    let pos_key = (repo_root.to_path_buf(), branch.to_string(), tip_sha.clone());
+    let positive = SQUASH_MERGED_POSITIVE
+        .get_or_init(|| parking_lot::Mutex::new(std::collections::HashSet::new()));
+    if positive.lock().contains(&pos_key) {
+        return true;
+    }
+
     let Some((default_tip_sha, _)) = branch_tip_info(repo_root, default) else {
         return false;
     };
@@ -616,6 +679,12 @@ pub(crate) fn is_squash_gc_eligible(repo_root: &Path, branch: &str, default: &st
         return cached;
     }
     let result = crate::branch_sweep::is_squash_merged(repo_root, default, branch);
+    // #P3: only TRUE is monotonic — record it in the positive set so a later
+    // `default` advance is a cheap positive-set hit. FALSE stays in the
+    // default-tip-keyed bool cache (it can flip to true when `default` advances).
+    if result {
+        positive.lock().insert(pos_key);
+    }
     cache.lock().insert(key, result);
     result
 }
@@ -631,10 +700,21 @@ pub(crate) fn is_squash_gc_eligible(repo_root: &Path, branch: &str, default: &st
 fn prune_orphaned_branches(repo_root: &Path, dry_run: bool) -> Vec<(String, &'static str)> {
     let default = crate::git_helpers::default_branch(repo_root);
     // Collect branches currently checked out in worktrees — cannot delete these
-    let wt_branches: HashSet<String> = list_worktrees(repo_root)
-        .into_iter()
-        .map(|e| e.branch)
-        .collect();
+    // PR-B rider (dev2 #2695 seat2): fail-CLOSED occupancy. If the worktree list
+    // can't be determined, the occupancy dimension would collapse to "nothing
+    // occupied" and a branch whose worktree is merely un-enumerable could be
+    // reaped — skip ALL branch pruning this tick instead (mirrors :382).
+    let wt_branches: HashSet<String> = match list_worktrees(repo_root) {
+        Ok(entries) => entries.into_iter().map(|e| e.branch).collect(),
+        Err(()) => {
+            tracing::warn!(
+                repo = %repo_root.display(),
+                "prune_orphaned_branches: worktree occupancy could not be determined — \
+                 skipping ALL branch pruning this tick (fail-closed)"
+            );
+            return Vec::new();
+        }
+    };
 
     // W1.2: git_cmd → trimmed stdout on success; spawn-error + non-zero collapse to `Err → []`.
     let branches: Vec<String> =
@@ -861,6 +941,43 @@ mod tests {
         std::env::set_var("AGEND_WORKTREE_PRUNE_LIVE", "1");
         assert!(prune_live_enabled());
         std::env::remove_var("AGEND_WORKTREE_PRUNE_LIVE");
+    }
+
+    // ── PR-B rider (dev2 #2695 seat2): occupancy fail-CLOSED ──
+
+    /// A `git worktree list` failure must surface as `Err` (fail-closed), NOT
+    /// collapse to an empty Vec — the former `unwrap_or_default()` fail-OPEN let
+    /// a caller treat "occupancy unknown" as "nothing occupied" and reap a branch
+    /// whose worktree is merely un-enumerable. A non-git-repo path makes the
+    /// enumeration fail; this is the fail-open path dev2 flagged as uncovered.
+    #[test]
+    fn list_worktrees_fails_closed_on_git_error() {
+        let non_repo = std::env::temp_dir().join(format!(
+            "agend-not-a-repo-{}-{}",
+            std::process::id(),
+            "riderfailclosed"
+        ));
+        let _ = std::fs::remove_dir_all(&non_repo);
+        std::fs::create_dir_all(&non_repo).unwrap();
+        assert!(
+            list_worktrees(&non_repo).is_err(),
+            "list_worktrees must fail-CLOSED (Err) when git worktree enumeration fails, \
+             not collapse to an empty Vec"
+        );
+        std::fs::remove_dir_all(&non_repo).ok();
+    }
+
+    /// Happy path: a valid repo (no extra worktrees) enumerates to `Ok` (empty
+    /// after excluding the main worktree) — the fail-closed change must not break
+    /// normal enumeration.
+    #[test]
+    fn list_worktrees_ok_on_valid_repo() {
+        let repo = setup_test_repo("rider-lw-ok");
+        assert!(
+            list_worktrees(&repo).is_ok(),
+            "a valid repo must enumerate worktrees as Ok"
+        );
+        std::fs::remove_dir_all(&repo).ok();
     }
 
     #[test]
@@ -1864,6 +1981,52 @@ mod tests {
              RECOMPUTED — `default`'s tip is part of the cache key, so a stale \
              entry keyed only on branch tip must not keep returning the old \
              (false) verdict forever"
+        );
+
+        std::fs::remove_dir_all(&repo).ok();
+    }
+
+    /// #P3 (branch-residue): a POSITIVE (true) squash verdict is monotonic —
+    /// once a branch's patch is in `default`, `default` only advances further,
+    /// so `default`'s tip changing must NOT bust the cached TRUE and force the
+    /// expensive cherry/tree-diff re-run. Proven by seeding the positive-only
+    /// set (keyed WITHOUT default_tip) for a branch that is structurally NOT
+    /// squash-merged, then advancing `default`'s tip: a genuine recompute would
+    /// return FALSE, so the call returning TRUE proves the positive set is
+    /// consulted first (before default_tip is even resolved). Pre-#P3 (no
+    /// positive set) this recomputes under the new 4-tuple key → returns FALSE.
+    #[test]
+    fn is_squash_gc_eligible_positive_cache_survives_default_advance_p3() {
+        let _lock = ENV_LOCK.lock();
+        let repo = setup_test_repo("p3-positive-cache");
+        // An OLD (age-floor-clearing) branch that is NOT actually squash-merged
+        // — a genuine recompute returns false.
+        make_unmerged_dated_branch(&repo, "feat/positive", "2024-01-01T00:00:00 +0000");
+        assert!(
+            !crate::branch_sweep::is_squash_merged(&repo, "main", "feat/positive"),
+            "precondition: structurally NOT squash-merged (recompute would say false)"
+        );
+        let (tip_sha, _) = branch_tip_info(&repo, "feat/positive").expect("tip info must resolve");
+
+        // Seed the positive-only set for (repo, branch, tip_sha) — simulating a
+        // prior sweep that computed TRUE and recorded the monotonic positive.
+        let positive =
+            SQUASH_MERGED_POSITIVE.get_or_init(|| Mutex::new(std::collections::HashSet::new()));
+        positive
+            .lock()
+            .insert((repo.clone(), "feat/positive".to_string(), tip_sha.clone()));
+
+        // Advance `default`'s tip (a fresh commit on main) so the 4-tuple bool
+        // cache key would differ — forcing a recompute absent the positive set.
+        std::fs::write(repo.join("advance.txt"), "main advances").ok();
+        git_in(&repo, &["add", "."]);
+        git_in(&repo, &["commit", "-m", "advance main"]);
+
+        assert!(
+            is_squash_gc_eligible(&repo, "feat/positive", "main"),
+            "#P3: the positive set (keyed without default_tip) must be consulted \
+             FIRST and return true without recompute, even though `default` \
+             advanced and the structural check would now say false"
         );
 
         std::fs::remove_dir_all(&repo).ok();

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -196,6 +196,54 @@ pub struct ReleaseOutcome {
 /// remote-gone yet carries committed-but-unpushed work `git branch -D` would
 /// destroy irrecoverably. Mirrors `worktree_cleanup.rs::prune_orphaned_branches`.
 ///
+/// #P3 (branch-residue): pure KEEP/DELETE decision for a released managed
+/// branch, split out of `cleanup_merged_branch` so the authoritative-PR-merge
+/// fast path and the fail-closed keep reasons are unit-testable without a live
+/// `gh`/scm (the RED6 seam). `Ok(())` = delete-eligible; `Err(reason)` = keep,
+/// with a reason that no longer blanket-blames "not merged" — the pre-#P3 text
+/// was misleading when the real cause was a gh-detection outage or the age floor.
+///
+/// - `is_merged`: `git merge-base --is-ancestor branch default`.
+/// - `pr_merged`: an authoritative merged PR matches the tip → delete NOW,
+///   no age gate (monotonic proof).
+/// - `squash_aged`: structurally squash-merged AND past the 24h tip-age floor.
+/// - `is_squash_structural`: `branch_sweep::is_squash_merged` (offline
+///   cherry+tree-diff) — used ONLY to phrase the "under the age floor" keep
+///   reason; the caller computes it lazily (keep path only) to avoid an extra
+///   git call on the delete path, passing `false` when eligible (never read).
+/// - `pr_detect_unknown`: the PR check could not run (no github remote / gh
+///   error) → fail-closed keep, retried next sweep.
+pub(crate) fn merged_branch_disposition(
+    branch: &str,
+    default: &str,
+    is_merged: bool,
+    pr_merged: bool,
+    squash_aged: bool,
+    is_squash_structural: bool,
+    pr_detect_unknown: bool,
+) -> Result<(), String> {
+    if is_merged || pr_merged || squash_aged {
+        return Ok(());
+    }
+    if pr_detect_unknown && !is_squash_structural {
+        return Err(format!(
+            "branch '{branch}': PR-merge detection unavailable (no github remote, \
+             or gh/scm error) — kept, fail-closed; retried next sweep"
+        ));
+    }
+    if is_squash_structural {
+        let hours = crate::worktree_cleanup::SQUASH_GC_MIN_TIP_AGE.as_secs() / 3600;
+        return Err(format!(
+            "branch '{branch}': squash-merged but tip younger than the {hours}h \
+             GC floor — kept; a later sweep will delete it"
+        ));
+    }
+    Err(format!(
+        "branch '{branch}' is not merged into '{default}' (no merged PR with a \
+         matching head SHA, not a squash-merge orphan) — kept"
+    ))
+}
+
 /// Returns `(deleted, skip_reason)`:
 /// - `(true, None)` — branch was deleted
 /// - `(false, Some(reason))` — branch was NOT deleted, reason explains why
@@ -251,20 +299,49 @@ fn cleanup_merged_branch(
         &["merge-base", "--is-ancestor", branch, &default],
     );
 
+    // #P3 (branch-residue): an authoritative PR-merge (a merged PR whose head
+    // SHA == this branch tip, or the tip is an ancestor of it) is MONOTONIC
+    // proof the work landed — delete NOW, no age margin. The 24h
+    // `SQUASH_GC_MIN_TIP_AGE` floor exists ONLY to stop the cherry/tree-diff
+    // HEURISTIC (`is_squash_gc_eligible`) from false-reaping a just-created
+    // branch that happens to be tree-equal to main; an authoritative PR needs
+    // no such belt. Skip the (network) PR check when already merged.
+    let pr_status = if is_merged {
+        crate::branch_sweep::PrMergeStatus::NotMerged
+    } else {
+        crate::branch_sweep::pr_merge_status(source_repo, &default, branch)
+    };
+    let pr_merged = matches!(pr_status, crate::branch_sweep::PrMergeStatus::Merged);
+
     // t-...50899-10 / CR-2026-06-14 parity: `is_gone` (remote-tracking ref
     // deleted) is no longer an independent delete trigger — a remote-gone
     // branch carrying commits NOT reachable from `default` (unpushed local
     // work) must be KEPT. Delete only when the branch's work is provably in
-    // `default`: merged (ancestor) or squash-merged (age-gated heuristic),
-    // same gate `worktree_cleanup.rs::prune_orphaned_branches` uses.
-    let squash =
-        !is_merged && crate::worktree_cleanup::is_squash_gc_eligible(source_repo, branch, &default);
+    // `default`: merged (ancestor), an authoritative merged PR (above), or
+    // squash-merged past the age floor (heuristic), same gate
+    // `worktree_cleanup.rs::prune_orphaned_branches` uses.
+    let squash_aged = !is_merged
+        && !pr_merged
+        && crate::worktree_cleanup::is_squash_gc_eligible(source_repo, branch, &default);
 
-    if !is_merged && !squash {
-        return (
-            false,
-            Some("branch not merged into main and not a squash-merge orphan".to_string()),
-        );
+    // #P3: split the KEEP/DELETE decision (+ the split skip reason) into a pure,
+    // unit-testable free function. Compute the offline structural-squash signal
+    // ONLY on the keep path (it's needed just to phrase the age-floor reason) —
+    // the delete path passes a dummy `false` the function never reads.
+    let eligible = is_merged || pr_merged || squash_aged;
+    let is_squash_structural =
+        !eligible && crate::branch_sweep::is_squash_merged(source_repo, &default, branch);
+    let pr_detect_unknown = matches!(pr_status, crate::branch_sweep::PrMergeStatus::Unknown);
+    if let Err(reason) = merged_branch_disposition(
+        branch,
+        &default,
+        is_merged,
+        pr_merged,
+        squash_aged,
+        is_squash_structural,
+        pr_detect_unknown,
+    ) {
+        return (false, Some(reason));
     }
 
     if dry_run {

--- a/src/worktree_pool/tests.rs
+++ b/src/worktree_pool/tests.rs
@@ -2024,9 +2024,16 @@ fn release_full_preserves_unmerged_branch() {
         !outcome.branch_deleted,
         "unmerged branch must NOT be deleted"
     );
+    // #P3: the fixture repo has NO github remote, so PR-merge detection is
+    // Unknown → the split fail-closed keep reason (the pre-#P3 blanket "not
+    // merged into main…" text was misleading — it implied a definitive verdict
+    // when the check could not actually run). Either way the branch is KEPT.
     assert_eq!(
         outcome.branch_cleanup_skipped_reason.as_deref(),
-        Some("branch not merged into main and not a squash-merge orphan")
+        Some(
+            "branch 'feat/unmerged': PR-merge detection unavailable (no github \
+             remote, or gh/scm error) — kept, fail-closed; retried next sweep"
+        )
     );
     // Verify branch still exists.
     let branch_exists = std::process::Command::new("git")
@@ -2143,9 +2150,18 @@ fn release_full_absent_worktree_unmerged_branch_preserved() {
         !outcome.branch_deleted,
         "unmerged branch must NOT be deleted"
     );
+    // #P3: the fixture repo has NO github remote, so PR-merge detection is
+    // Unknown → the split fail-closed keep reason (the pre-#P3 blanket "not
+    // merged into main…" text was misleading — it implied a definitive
+    // not-merged verdict when the check couldn't actually run). In production a
+    // bound repo has a github remote, so a genuinely-unmerged branch there gets
+    // the "is not merged into 'main'…" reason instead; either way it is KEPT.
     assert_eq!(
         outcome.branch_cleanup_skipped_reason.as_deref(),
-        Some("branch not merged into main and not a squash-merge orphan")
+        Some(
+            "branch 'feat/absent-unmerged': PR-merge detection unavailable \
+             (no github remote, or gh/scm error) — kept, fail-closed; retried next sweep"
+        )
     );
     let branch_exists = std::process::Command::new("git")
         .args(["rev-parse", "--verify", "feat/absent-unmerged"])
@@ -3689,5 +3705,102 @@ fn release_full_refuses_when_dirty_wip_unpreservable() {
         "no (partial) recovery ref on a Blocked release"
     );
     std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&repo).ok();
+}
+
+/// #P3 (branch-residue) RED6 — pure KEEP/DELETE decision, testable without a
+/// live gh/scm. An authoritative merged PR (`pr_merged=true`) makes the branch
+/// delete-eligible IMMEDIATELY (`Ok`), even though it is NOT age-gated
+/// (`squash_aged=false`) — the monotonic-PR fast path. Pre-#P3
+/// `cleanup_merged_branch` had NO PR path at all, so a PR-merged branch under
+/// the 24h floor was kept; this pins the new fast path plus the three SPLIT
+/// keep reasons (the old blanket "not merged" text was misleading).
+#[test]
+fn merged_branch_disposition_split_reasons_and_pr_fast_path_red6() {
+    // Authoritative merged PR → delete NOW, no age gate.
+    assert!(
+        merged_branch_disposition("feat/x", "main", false, true, false, false, false).is_ok(),
+        "an authoritative merged PR must be delete-eligible now, no age gate"
+    );
+    // A plain merged ancestor is likewise eligible.
+    assert!(
+        merged_branch_disposition("feat/x", "main", true, false, false, false, false).is_ok(),
+        "a merged ancestor stays delete-eligible"
+    );
+    // Nothing merged, no PR, not structural, detection ran → precise "not
+    // merged" keep reason (NOT a gh-outage or age-floor reason).
+    let err =
+        merged_branch_disposition("feat/x", "main", false, false, false, false, false).unwrap_err();
+    assert!(
+        err.contains("not merged into 'main'"),
+        "plain unmerged branch keeps with the 'not merged' reason: {err}"
+    );
+    // gh/detection unavailable (and not structurally squash) → fail-closed reason.
+    let err =
+        merged_branch_disposition("feat/x", "main", false, false, false, false, true).unwrap_err();
+    assert!(
+        err.contains("detection unavailable"),
+        "a gh/remote outage keeps with the fail-closed detection reason: {err}"
+    );
+    // Structurally squash-merged but under the age floor → age-floor reason.
+    let err =
+        merged_branch_disposition("feat/x", "main", false, false, false, true, false).unwrap_err();
+    assert!(
+        err.contains("younger than"),
+        "a young squash-merge keeps with the age-floor reason: {err}"
+    );
+}
+
+/// #P3 (branch-residue) RED7 — hermetic fail-closed: a fixture repo with NO
+/// github remote makes `pr_merge_status` return `Unknown` (extract_github_repo
+/// None), and `cleanup_merged_branch` on such a repo for a young, non-merged
+/// branch KEEPS it (falls back to the age-gated heuristic, which also declines)
+/// with the fail-closed detection reason. Proves gh-unavailable → fail-closed
+/// keep, never a delete. No real gh runs (no github remote to resolve).
+#[test]
+fn pr_merge_status_unknown_without_github_remote_keeps_branch_red7() {
+    fn git(dir: &Path, args: &[&str]) {
+        std::process::Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .env("AGEND_GIT_BYPASS", "1")
+            .env("GIT_AUTHOR_NAME", "test")
+            .env("GIT_AUTHOR_EMAIL", "t@t")
+            .env("GIT_COMMITTER_NAME", "test")
+            .env("GIT_COMMITTER_EMAIL", "t@t")
+            .output()
+            .expect("git");
+    }
+    let repo = tmp_repo("red7-no-remote");
+    // A young, non-merged branch with its OWN commit (diverges from main, so it
+    // is NOT an ancestor → is_merged=false; committed now → under the age floor).
+    git(&repo, &["checkout", "-b", "feat/red7"]);
+    std::fs::write(repo.join("red7.txt"), "young unmerged work").ok();
+    git(&repo, &["add", "."]);
+    git(&repo, &["commit", "-m", "young unmerged work"]);
+    git(&repo, &["checkout", "main"]);
+
+    // No github remote configured → detection is Unknown (fail-closed), NOT a
+    // NotMerged/Merged verdict.
+    assert_eq!(
+        crate::branch_sweep::pr_merge_status(&repo, "main", "feat/red7"),
+        crate::branch_sweep::PrMergeStatus::Unknown,
+        "no github remote → detection Unknown (fail-closed), not a merge verdict"
+    );
+
+    // And the release-path cleanup KEEPS the branch (never deletes on a
+    // gh-unavailable young unmerged branch), surfacing the fail-closed reason.
+    let (deleted, reason) = cleanup_merged_branch(&repo, "feat/red7", false);
+    assert!(
+        !deleted,
+        "a gh-unavailable young unmerged branch must be KEPT, never deleted"
+    );
+    assert!(
+        reason
+            .as_deref()
+            .is_some_and(|r| r.contains("detection unavailable")),
+        "keep must carry the fail-closed detection reason: {reason:?}"
+    );
+
     std::fs::remove_dir_all(&repo).ok();
 }


### PR DESCRIPTION
## PR-B — branch-residue P3 + P4 (+ two #2695 riders)

Closes RCA **H3** + adds recurrence observability (`BRANCH-RESIDUE-RCA-20260709.md` §P3/§P4). Continues #2695 (PR-A). Scope: **P3 + P4 + the two #2695 review riders** — P1b/P5 are separate.

### P3 — release deletes on authoritative PR evidence (no 24h wait)
- `branch_sweep`: new `PrMergeStatus{Merged,NotMerged,Unknown}` + `pr_merge_status`; `is_squash_merged_diff` is now a `matches!(…Merged)` wrapper (Method-2 behavior byte-identical).
- `worktree_pool::cleanup_merged_branch`: an authoritative merged PR (head SHA == tip, or tip is its ancestor) is **monotonic proof** → delete immediately, skipping the 24h `SQUASH_GC_MIN_TIP_AGE` floor (that floor exists only for the cherry/tree heuristic's false-positive safety). The KEEP/DELETE + **split skip-reason** decision is extracted into a pure, unit-testable `merged_branch_disposition` (too-young / not-merged / detection-unavailable — replacing the pre-P3 misleading blanket "not merged" text). `Unknown` (no github remote or gh error) **fails CLOSED** everywhere.
- `worktree_cleanup`: a positive squash-merge result is monotonic → a new `(repo,branch,tip)`-keyed positive cache, checked **before** `default_tip` is resolved, so `default` advancing no longer busts a cached TRUE and re-runs the expensive check (the #2614 default-tip-bust class, for the positive side).

### P4 — recurrence alarm
At sweep end, the max non-default local branch count across bound repos `> 15` → `warn` + **one** operator notification (via the #2696-fixed notify path to the operator inbox), **deduped** per over-threshold episode (resets on drop-back), and it **fires in dry-run too** (exactly when the flag was forgotten and GC silently stalled).

### Riders (#2695 non-blocking findings)
- **dev2 seat2 — occupancy fail-OPEN → fail-CLOSED.** `list_worktrees` was *doubly* fail-open: `unwrap_or_default()` **and** `list_porcelain` swallowing a non-zero exit into `Ok(empty)`. It now calls git directly and returns `Err` on a spawn error **or** a non-zero exit; both callers skip their removals this tick (mirrors the `:382` fail-closed convention). +RED (`list_worktrees_fails_closed_on_git_error`).
- **reviewer4 — two stale "default dry-run" doc comments** corrected to default-LIVE (`worktree_cleanup.rs`, `worktree_registry_sweep.rs`).

### Acceptance (RED6–8 + occupancy RED, red-then-green)
- **RED6** authoritative PR-merge → immediate delete (pure `merged_branch_disposition`; pre-P3 kept a young PR-merged branch).
- **RED7** gh/PR detection unavailable (no github remote) → **fail-closed keep** (age-gated fallback).
- **RED8** > 15 branches → alarm fires once per episode, resets on drop-back.
- occupancy RED (rider) + P3 positive-cache test (true-RED verified: neutralizing the positive-set check made it FAIL on a `default` advance).

> **gh testability / coordination:** `gh`/`ScmProvider` is not mockable without a shared test seam that **dev3's PR-C owns** (single-source in `src/scm/`). Per the lead's coordination, this PR does **not** invent one — RED6 uses the pure decision fn, RED7 uses the no-remote skip. A real gh-positive exact-SHA integration RED6 is a fast-follow once that seam merges.

### Gate
CI-style fmt (vendor-excluded) + clippy `-D warnings` + full nextest green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
