### PR TITLE
fix(auto-release): release never-had-a-PR worktrees — verdict-auto-close enqueue + gh no-PR confirmation (+scm mock seam)

### DIFF
--- a/src/daemon/auto_release.rs
+++ b/src/daemon/auto_release.rs
@@ -242,6 +242,28 @@ fn all_branch_tasks_done(home: &Path, repo: &str, branch: &str) -> bool {
         })
 }
 
+/// #t-…24962-7: positively confirm a branch NEVER had any PR — `gh pr list
+/// --state all --head <branch>` returns empty. Branch-delete-immune (queries by
+/// head-branch name, not a live ref). `Some(true)` = confirmed never-PR;
+/// `Some(false)` = a PR exists/existed; `None` = gh failed (cannot confirm — the
+/// caller must NOT release, #986 transient-failure convention). Routed through
+/// `make_scm_provider` so the crate-wide test seam can drive it without gh.
+fn branch_never_had_pr(repo: &str, branch: &str) -> Option<bool> {
+    match crate::scm::make_scm_provider(repo, None).pr_list(
+        repo,
+        &crate::scm::ListFilter {
+            state: Some("all"),
+            head: Some(branch.to_string()),
+            ..Default::default()
+        },
+        &["number"],
+        None,
+    ) {
+        Ok(prs) => Some(prs.is_empty()),
+        Err(_) => None,
+    }
+}
+
 /// t-worktree-leak (PR-1): the unified release invariant (must-fix #2/#3/#4),
 /// repo+branch scoped. `releasable ⟺ PR-terminal ∨ (no-PR ∧ all branch tasks
 /// done)`. Returns (releasable_per_invariant, confidence). The dirty / opt-out /
@@ -645,6 +667,16 @@ fn process_intent(home: &Path, intent: &AutoReleaseIntent) -> IntentOutcome {
                 confidence = PrConfidence::ObservedTerminal;
                 tracing::info!(agent = %assignee, repo = %repo, branch = %branch,
                     "auto_release: pr_state absent but branch confirmed merged (post --delete-branch) — treating as terminal");
+            } else if branch_never_had_pr(&repo, &branch) == Some(true) {
+                // #t-…24962-7: no pr_state AND gh positively confirms the branch
+                // never had ANY PR (review/spike/design worktrees that produce no
+                // PR of their own) AND all tasks are done → releasable via the
+                // no-PR invariant. A transient gh failure returns None → NOT
+                // released (retain for a later sweep, #986 convention).
+                releasable = true;
+                confidence = PrConfidence::QueriedNone;
+                tracing::info!(agent = %assignee, repo = %repo, branch = %branch,
+                    "auto_release: pr_state absent, gh confirms branch never had a PR + all tasks done — releasable (no-PR)");
             }
         }
     }
@@ -2024,7 +2056,12 @@ mod tests {
         itest_git(&wt, &["add", "feature.txt"]);
         itest_git(&wt, &["commit", "-m", "unmerged feat"]);
         std::fs::write(wt.join("build-artifact.txt"), "dirty").unwrap();
-        // No pr_state → Unknown; branch NOT squash-merged → fallback must decline.
+        // No pr_state → Unknown; NOT squash-merged; gh reports an existing (open)
+        // PR → branch_never_had_pr = Some(false) → the no-PR path also declines →
+        // RETAIN. Deterministic mock avoids a real gh call in the test.
+        let _scm = crate::scm::set_test_scm_provider(crate::scm::MockScmProvider::with_pr_list(
+            crate::scm::MockPrList::Prs(1),
+        ));
         task_done_via_handler(&home, "dev", "t-pg");
         assert_eq!(queue_len(&home), 1, "task-done enqueued the intent");
         drain_queue(&home);
@@ -2033,6 +2070,91 @@ mod tests {
             "Unknown + NOT merged + dirty → binding preserved (no false-release)"
         );
         assert_eq!(queue_len(&home), 1, "unmerged intent RETAINED for retry");
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    /// #t-…24962-7 (a): a verdict-auto-closed task must ENQUEUE a release-recompute
+    /// (mirroring the MCP task-done handler) so the reporter's review worktree gets
+    /// released. RED against pre-fix `auto_close_on_report`, which appended Done
+    /// WITHOUT enqueueing → the review-worktree binding leaked (intent never
+    /// existed = the specimens' empty queue).
+    #[test]
+    fn auto_close_on_report_enqueues_release_recompute() {
+        let home = tmp_home("itest-autoclose-enq");
+        write_fleet(&home, "reviewer");
+        let repo = itest_source_repo(&home, "owner/repo");
+        itest_lease(&home, &repo, "reviewer", "review/x", "t-rev", false);
+        assert_eq!(queue_len(&home), 0, "no intent before the terminal report");
+        let closed = crate::tasks::auto_close::auto_close_on_report(
+            &home,
+            "report",
+            "t-rev",
+            "reviewer",
+            "VERIFIED — clean",
+            true,
+        )
+        .expect("auto_close ok");
+        assert!(closed, "terminal report auto-closes the review task");
+        assert_eq!(
+            queue_len(&home),
+            1,
+            "verdict auto-close must enqueue a release-recompute intent"
+        );
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    /// #t-…24962-7 (b): a done task on a branch that NEVER had a PR (review / spike
+    /// / design worktree), no pr_state, dirty → gh positively confirms no PR →
+    /// WIP-preserve + release. RED (pre-fix): Unknown → retain FOREVER (immortal
+    /// review worktree — the specimen class).
+    #[test]
+    fn integration_no_pr_ever_dirty_releases_via_gh_confirm() {
+        let home = tmp_home("itest-nopr-ever");
+        write_fleet(&home, "reviewer");
+        let repo = itest_source_repo(&home, "owner/repo");
+        let wt = itest_lease(&home, &repo, "reviewer", "review/y", "t-revy", false);
+        std::fs::write(wt.join("build-artifact.txt"), "dirty").unwrap();
+        // gh confirms the branch never had ANY PR (empty pr list).
+        let _scm = crate::scm::set_test_scm_provider(crate::scm::MockScmProvider::with_pr_list(
+            crate::scm::MockPrList::Prs(0),
+        ));
+        task_done_via_handler(&home, "reviewer", "t-revy");
+        assert_eq!(queue_len(&home), 1, "task-done enqueued the intent");
+        drain_queue(&home);
+        assert!(
+            !bound(&home, "reviewer"),
+            "no-PR-ever + dirty → WIP-preserved + released (not immortal)"
+        );
+        assert_eq!(
+            queue_len(&home),
+            0,
+            "released intent is done (queue drained)"
+        );
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    /// #t-…24962-7 guard: a transient gh failure during the no-PR confirmation
+    /// must NOT release (branch_never_had_pr = None) — the worktree is RETAINED for
+    /// a later sweep (#986 convention), never false-released on an unconfirmed query.
+    #[test]
+    fn integration_no_pr_transient_gh_fail_retains() {
+        let home = tmp_home("itest-nopr-ghfail");
+        write_fleet(&home, "reviewer");
+        let repo = itest_source_repo(&home, "owner/repo");
+        let wt = itest_lease(&home, &repo, "reviewer", "review/z", "t-revz", false);
+        std::fs::write(wt.join("build-artifact.txt"), "dirty").unwrap();
+        // gh fails → cannot confirm no-PR.
+        let _scm = crate::scm::set_test_scm_provider(crate::scm::MockScmProvider::with_pr_list(
+            crate::scm::MockPrList::Fail("gh: rate limited".into()),
+        ));
+        task_done_via_handler(&home, "reviewer", "t-revz");
+        assert_eq!(queue_len(&home), 1, "task-done enqueued the intent");
+        drain_queue(&home);
+        assert!(
+            bound(&home, "reviewer"),
+            "transient gh failure → binding preserved (no false-release)"
+        );
+        assert_eq!(queue_len(&home), 1, "unconfirmed intent RETAINED for retry");
         let _ = std::fs::remove_dir_all(&home);
     }
 }

--- a/src/scm/mod.rs
+++ b/src/scm/mod.rs
@@ -562,6 +562,14 @@ not_supported_provider!(BitbucketScmProvider, "bitbucket");
 // ---------------------------------------------------------------------------
 
 pub(crate) fn make_scm_provider(repo: &str, scm_override: Option<&str>) -> Box<dyn ScmProvider> {
+    // #t-…24962-7 test seam: a thread-local mock (installed via
+    // `set_test_scm_provider`) short-circuits `gh` for unit/integration tests.
+    // No effect in production (`#[cfg(test)]`); the single source of truth for
+    // gh mocking across the crate.
+    #[cfg(test)]
+    if let Some(p) = TEST_SCM_PROVIDER.with(|c| c.borrow().clone()) {
+        return Box::new(TestScmHandle(p));
+    }
     let kind = match scm_override {
         Some(k) => k,
         None => crate::daemon::ci_watch::detect_provider_from_remote(repo).0,
@@ -572,6 +580,133 @@ pub(crate) fn make_scm_provider(repo: &str, scm_override: Option<&str>) -> Box<d
         // `detect_provider_from_remote` already defaults unknown/short-form
         // remotes to "github", so this arm is GitHub + any explicit "github".
         _ => Box::new(GitHubScmProvider),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// #t-…24962-7 test seam: mock `gh` at the `make_scm_provider` boundary so any
+// call site can be driven without a live `gh` in unit/integration tests. Single
+// source of truth for gh mocking across the crate (lead seam-ownership ruling).
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+thread_local! {
+    static TEST_SCM_PROVIDER: std::cell::RefCell<Option<std::sync::Arc<dyn ScmProvider>>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+/// Test-only: install `provider` as the ScmProvider for the current thread until
+/// the returned guard drops; `make_scm_provider` then returns it verbatim
+/// (ignoring repo/override). Nextest runs each test on its own thread, so the
+/// override is isolated per test.
+#[cfg(test)]
+pub(crate) fn set_test_scm_provider(provider: std::sync::Arc<dyn ScmProvider>) -> TestScmGuard {
+    TEST_SCM_PROVIDER.with(|c| *c.borrow_mut() = Some(provider));
+    TestScmGuard
+}
+
+#[cfg(test)]
+#[must_use = "the mock provider is uninstalled when this guard is dropped"]
+pub(crate) struct TestScmGuard;
+
+#[cfg(test)]
+impl Drop for TestScmGuard {
+    fn drop(&mut self) {
+        TEST_SCM_PROVIDER.with(|c| *c.borrow_mut() = None);
+    }
+}
+
+/// Adapts the thread-local `Arc<dyn ScmProvider>` back into the `Box<dyn
+/// ScmProvider>` that `make_scm_provider` returns (a `dyn` value can't be moved
+/// out of the `Arc`). Delegates every method.
+#[cfg(test)]
+struct TestScmHandle(std::sync::Arc<dyn ScmProvider>);
+
+#[cfg(test)]
+impl ScmProvider for TestScmHandle {
+    fn pr_view(&self, r: &str, p: u64, f: &[&str]) -> anyhow::Result<PrSummary> {
+        self.0.pr_view(r, p, f)
+    }
+    fn pr_checks(&self, r: &str, p: u64) -> anyhow::Result<Vec<CheckState>> {
+        self.0.pr_checks(r, p)
+    }
+    fn pr_list(
+        &self,
+        r: &str,
+        f: &ListFilter,
+        fl: &[&str],
+        c: Option<&Path>,
+    ) -> anyhow::Result<Vec<PrSummary>> {
+        self.0.pr_list(r, f, fl, c)
+    }
+    fn pr_merge(&self, r: &str, p: u64, o: &MergeOpts) -> anyhow::Result<MergeOutcome> {
+        self.0.pr_merge(r, p, o)
+    }
+    fn issue_view(&self, r: &str, n: u64, f: &[&str]) -> anyhow::Result<IssueSummary> {
+        self.0.issue_view(r, n, f)
+    }
+    fn compare(&self, r: &str, b: &str, h: &str) -> anyhow::Result<CompareResult> {
+        self.0.compare(r, b, h)
+    }
+}
+
+/// Reusable [`ScmProvider`] test double. Only the methods a test configures are
+/// implemented; the rest panic to surface an unexpected call. Extend as new call
+/// sites need mocking (this is the single shared mock).
+#[cfg(test)]
+#[derive(Default)]
+pub(crate) struct MockScmProvider {
+    pr_list: Option<MockPrList>,
+}
+
+/// Configured `pr_list` behavior for [`MockScmProvider`].
+#[cfg(test)]
+#[derive(Clone)]
+pub(crate) enum MockPrList {
+    /// Return this many default PRs — non-empty ⇒ "the branch has/had a PR".
+    Prs(usize),
+    /// Return an `Err` ⇒ a transient gh failure (a no-PR confirm must NOT release).
+    Fail(String),
+}
+
+#[cfg(test)]
+impl MockScmProvider {
+    pub(crate) fn with_pr_list(behavior: MockPrList) -> std::sync::Arc<Self> {
+        std::sync::Arc::new(Self {
+            pr_list: Some(behavior),
+        })
+    }
+}
+
+#[cfg(test)]
+impl ScmProvider for MockScmProvider {
+    fn pr_list(
+        &self,
+        _repo: &str,
+        _filter: &ListFilter,
+        _fields: &[&str],
+        _cwd: Option<&Path>,
+    ) -> anyhow::Result<Vec<PrSummary>> {
+        match &self.pr_list {
+            Some(MockPrList::Prs(n)) => Ok(vec![PrSummary::default(); *n]),
+            Some(MockPrList::Fail(msg)) => Err(anyhow::anyhow!(msg.clone())),
+            None => Ok(vec![]),
+        }
+    }
+    fn pr_view(&self, _r: &str, _p: u64, _f: &[&str]) -> anyhow::Result<PrSummary> {
+        unimplemented!("MockScmProvider::pr_view not configured")
+    }
+    fn pr_checks(&self, _r: &str, _p: u64) -> anyhow::Result<Vec<CheckState>> {
+        unimplemented!("MockScmProvider::pr_checks not configured")
+    }
+    fn pr_merge(&self, _r: &str, _p: u64, _o: &MergeOpts) -> anyhow::Result<MergeOutcome> {
+        unimplemented!("MockScmProvider::pr_merge not configured")
+    }
+    fn issue_view(&self, _r: &str, _n: u64, _f: &[&str]) -> anyhow::Result<IssueSummary> {
+        unimplemented!("MockScmProvider::issue_view not configured")
+    }
+    fn compare(&self, _r: &str, _b: &str, _h: &str) -> anyhow::Result<CompareResult> {
+        unimplemented!("MockScmProvider::compare not configured")
     }
 }
 

--- a/src/tasks/auto_close.rs
+++ b/src/tasks/auto_close.rs
@@ -72,6 +72,23 @@ pub fn auto_close_on_report(
     if closed {
         // #1018/#78445-2 (d): terminal auto-close — shared cleanup of both stores.
         super::task_terminal_cleanup(home, correlation_id);
+        // #t-…24962-7: a verdict-auto-closed task is a terminal task-done event
+        // too — enqueue a release-invariant recompute so the reporter's worktree is
+        // released, mirroring the MCP task-done handler (tasks/handler.rs). Without
+        // this, a review task closed by a terminal verdict (which has no PR of its
+        // own) never enqueues an intent → its binding leaks (immortal review
+        // worktree). `assignee == reporter` was enforced above; repo="" → the
+        // sweeper derives it from the binding's source_repo.
+        if let Some(binding) = crate::binding::read(home, reporter) {
+            if let Some(branch) = binding["branch"].as_str() {
+                crate::daemon::auto_release::enqueue_release_recompute(
+                    home,
+                    "",
+                    branch,
+                    "task_done",
+                );
+            }
+        }
     }
     Ok(closed)
 }


### PR DESCRIPTION
## What & why

The #2697 terminal-merge fallback only catches **merged** branches. A worktree on a branch that **never had a PR of its own** — a reviewer's `review/*` worktree, a spike, a design task — stayed immortal. Two gaps (both closed here). Live specimen: `reviewer4` → `review/2342-secmodel` (task done, no PR, binding still bound, queue empty).

### Gap A — the release intent never existed
`tasks::auto_close::auto_close_on_report` appended `TaskEvent::Done` **directly** and did **not** enqueue a release-recompute (unlike the MCP task-done handler, `tasks/handler.rs`). A review task closed by a terminal verdict has no PR, so `messaging.rs`'s `reviewed_head`-gated verdict-enqueue also skips it → **no intent** → the binding leaked (the specimens' empty queue). **Fix:** `enqueue_release_recompute` after the auto-close, mirroring the handler.

### Gap B — even enqueued, the drain retained forever
No pr_state → `Unknown` → not releasable. **Fix:** extend the `auto_release` Unknown fallback — when all branch tasks are done and the branch is not squash-merged, positively confirm via gh `pr_list --state all --head <branch>` that the branch **never had any PR** (`branch_never_had_pr`). Confirmed no-PR → releasable (`QueriedNone`): clean → release, dirty → WIP-preserve + release (#2697 semantics). A **transient gh failure returns `None` → NOT released** (retain for a later sweep, #986 convention).

## Test infrastructure — crate-wide gh mock seam

`src/scm/mod.rs` gains `set_test_scm_provider` (a thread-local override at the `make_scm_provider` boundary) + a reusable `MockScmProvider`, so any `ScmProvider` call site can be driven without a live `gh`. Single source of truth for gh mocking (per the lead's seam-ownership ruling; dev's #2698 touched 0 `scm/` files — no rebase dependency, file surfaces are disjoint).

## Tests (RED→GREEN)

- `auto_close_on_report_enqueues_release_recompute` — verdict auto-close now enqueues (RED: it didn't).
- `integration_no_pr_ever_dirty_releases_via_gh_confirm` — no-PR-ever + dirty → WIP-preserve + release (RED: retained forever).
- `integration_no_pr_transient_gh_fail_retains` — **guard:** gh failure → retain (no false-release).
- `integration_unmerged_unknown_dirty_retains` — **guard:** has-a-PR + dirty → retain.

Gate: `cargo fmt --check` ✓, `cargo clippy --workspace --lib --bins --tests -D warnings` ✓ (scoped), `cargo nextest run auto_release auto_close scm worktree_pool branch_sweep` → all green.

End-to-end acceptance: after this lands + a daemon restart, the `reviewer4` / `review/2342-secmodel` specimen should be auto-collected (lead coordinates the restart).

Refs t-20260709061939501126-24962-7 (sibling of #2697 merged-type + `t-…24962-6` flat-layout-GC — three types cover the no-owner worktree window)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
