### PR TITLE
fix(clippy)+docs: 1.97 stable denials; keep MSRV 1.88 floor

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,17 @@ cargo clippy -- -D warnings          # must be warning-free
 
 CI mirrors these steps on Ubuntu + macOS + Windows (`.github/workflows/ci.yml`).
 
+**Toolchain split (do not conflate):**
+
+- **MSRV 1.88** (`Cargo.toml` `rust-version`) — the supported install floor.
+  CI enforces it with a dedicated `MSRV check (1.88)` job (`cargo +1.88 check
+  --locked`). Do not raise it casually; see `docs/RELEASING.md`.
+- **CI Check uses current stable** (`dtolnay/rust-toolchain@stable`) for
+  fmt / clippy / tests. Develop with a recent rustup stable so local
+  `clippy -D warnings` matches CI. When stable advances and clippy newly
+  denies existing code, fix on `main` with a small PR — that is expected,
+  not a signal to bump MSRV.
+
 ### Before pushing: `scripts/preflight.sh`
 
 Run the one-shot CI-parity preflight to catch failures locally instead of after a push:

--- a/CONTRIBUTING.zh-TW.md
+++ b/CONTRIBUTING.zh-TW.md
@@ -20,6 +20,16 @@ cargo clippy -- -D warnings          # must be warning-free
 
 CI 會在 Ubuntu + macOS + Windows 上複製這些步驟（`.github/workflows/ci.yml`）。
 
+**Toolchain 分軌（不要混為一談）：**
+
+- **MSRV 1.88**（`Cargo.toml` `rust-version`）— 支援的安裝地板。
+  CI 用獨立 job `MSRV check (1.88)`（`cargo +1.88 check --locked`）強制。
+  不要隨便抬高；細節見 `docs/RELEASING.zh-TW.md`。
+- **CI Check 用當日 stable**（`dtolnay/rust-toolchain@stable`）跑
+  fmt／clippy／test。本機請用較新的 rustup stable，讓 `clippy -D warnings`
+  與 CI 對齊。stable 前進、clippy 新拒絕既有程式碼時，用小 PR 修到 `main`
+  即可——這是預期行為，**不是**該 bump MSRV 的信號。
+
 ### 推送前：`scripts/preflight.sh`
 
 執行這個一次到位、與 CI 對齊的 preflight，把失敗在本地就抓出來，而不是等到推送之後：

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -96,9 +96,24 @@ Also edit the GitHub Release: mark it as a pre-release or add a warning to
 the notes pointing at the fixed version. Then ship the fix as a new patch
 release through the normal flow — never reuse or move a published tag.
 
+## Toolchain policy (MSRV floor vs CI Check)
+
+Two different pins, on purpose (#1994 / #2339 / #2340):
+
+| Role | Toolchain | Where | Purpose |
+|------|-----------|--------|---------|
+| **MSRV floor** | **1.88** (declared) | `Cargo.toml` `rust-version`, `ci.yml` job `MSRV check (1.88)`, `release.yml` gate | Anyone on rustc ≥ 1.88 can `cargo install` / compile the locked tree. Blocks Dependabot from silently raising the floor (the sysinfo 0.39 → rustc 1.95 class). |
+| **CI Check** | **current stable** (floating) | `ci.yml` `check` matrix (`dtolnay/rust-toolchain@stable` + fmt/clippy/test) | Catch new clippy lints and compiler behavior. **Not** pinned to 1.88. |
+
+Do **not** bump `rust-version` just because stable advanced (e.g. 1.96 / 1.97).
+Clippy denials on a new stable are fixed with a small mechanical PR on `main`
+while leaving MSRV at 1.88. Raise MSRV only when a dependency **must** move
+and no 1.88-compatible pin exists — see below.
+
 ## MSRV bumps
 
 `rust-version` in `Cargo.toml` is the source of truth; the gate's
 `cargo +1.88 check` pin must be updated in the same PR that bumps it
-(grep release.yml for `1.88`). Treat an MSRV bump as a minor-version event
-and call it out in the changelog.
+(grep `ci.yml` and `release.yml` for `1.88`). Treat an MSRV bump as a
+minor-version event and call it out in the changelog. Prefer a still-
+conservative new floor over tracking the latest stable.

--- a/docs/RELEASING.zh-TW.md
+++ b/docs/RELEASING.zh-TW.md
@@ -92,8 +92,22 @@ cargo yank --version X.Y.Z --undo     # if yanked by mistake
 已修正的版本。然後透過正常流程把修正當成一個新的 patch release 發出去——絕不要
 重用或移動已發布的 tag。
 
+## Toolchain 政策（MSRV 地板 vs CI Check）
+
+兩條 pin，刻意分開（#1994 / #2339 / #2340）：
+
+| 角色 | Toolchain | 位置 | 目的 |
+|------|-----------|------|------|
+| **MSRV 地板** | **1.88**（宣告） | `Cargo.toml` `rust-version`、`ci.yml` 的 `MSRV check (1.88)`、`release.yml` gate | rustc ≥ 1.88 就能 `cargo install`／編譯 locked tree。擋住 Dependabot 靜默抬高地板（sysinfo 0.39 → rustc 1.95 那類）。 |
+| **CI Check** | **當日 stable**（浮動） | `ci.yml` `check` matrix（`dtolnay/rust-toolchain@stable` + fmt/clippy/test） | 抓新 clippy 與編譯器行為。**不**釘在 1.88。 |
+
+不要只因為 stable 前進（例如 1.96／1.97）就 bump `rust-version`。
+新 stable 上的 clippy 拒絕項用一個機械小 PR 修到 `main`，MSRV 維持 1.88。
+只有依賴**必須**升級且沒有 1.88 相容 pin 時才抬 MSRV——見下節。
+
 ## MSRV bumps
 
 `Cargo.toml` 裡的 `rust-version` 是唯一的真實來源；gate 的 `cargo +1.88 check`
-pin 必須在同一個做 bump 的 PR 裡一起更新（在 release.yml 裡 grep `1.88`）。把一次
-MSRV bump 當成一個 minor-version 事件來看待，並在 changelog 中特別點出來。
+pin 必須在同一個做 bump 的 PR 裡一起更新（在 `ci.yml` 與 `release.yml` 裡
+grep `1.88`）。把一次 MSRV bump 當成 minor-version 事件，並在 changelog 點出。
+新地板仍應偏保守，不要對齊「最新 stable」。

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -1566,10 +1566,9 @@ fn wait_for_idle_inject_target(
         }
         let core = {
             let reg = lock_registry(registry);
-            match reg.get(&instance_id) {
-                Some(h) => std::sync::Arc::clone(&h.core),
-                None => return None, // agent gone
-            }
+            // agent gone → abort bootstrap wait
+            let h = reg.get(&instance_id)?;
+            std::sync::Arc::clone(&h.core)
         };
         if bootstrap_core_is_idle(&core) {
             break;

--- a/src/token_cost.rs
+++ b/src/token_cost.rs
@@ -533,12 +533,9 @@ fn read_file_tail(path: &Path, max_bytes: u64) -> Option<String> {
     f.read_to_end(&mut bytes).ok()?;
     let mut text = String::from_utf8_lossy(&bytes).into_owned();
     if start > 0 {
-        match text.find('\n') {
-            Some(i) => {
-                text.drain(..=i);
-            }
-            None => return None,
-        }
+        // Mid-file start: drop the partial first line (no newline ⇒ unusable).
+        let i = text.find('\n')?;
+        text.drain(..=i);
     }
     Some(text)
 }

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -196,7 +196,7 @@ pub fn run(
     // Kill test agents
     {
         let reg = registry.lock();
-        for (_, handle) in reg.iter() {
+        for handle in reg.values() {
             let mut child = handle.child.lock();
             let _ = child.kill();
         }


### PR DESCRIPTION
## Summary

Implements the dual-track toolchain policy (keep **MSRV 1.88**, let **CI Check float on stable**):

1. **Clippy 1.97** — mechanical fixes for `question_mark` / `for_kv_map` that broke every PR after `dtolnay/rust-toolchain@stable` moved 1.96.1 → 1.97.0 (`agent/mod.rs`, `token_cost.rs`, `verify.rs`). Does **not** change `rust-version`.
2. **Docs** — spell out MSRV floor vs floating-stable Check in `docs/RELEASING.md` (+ zh-TW) and `CONTRIBUTING.md` (+ zh-TW), citing #1994 / #2339 / #2340 so maintainers do not bump MSRV when stable advances.

Same code fix already cherry-picked onto #2701 / #2702 so those PRs can green; landing here unblocks **main** and future branches without further cherry-picks.

## Policy (explicit non-goals)

- ❌ Do not raise `rust-version` to 1.96/1.97
- ❌ Do not pin Check clippy to 1.88
- ✅ Keep `MSRV check (1.88)` + sysinfo 0.38 pin as install floor
- ✅ Fix new stable clippy denials with small PRs

## Test plan

- [x] `cargo clippy --bin agend-terminal --features tray -- -D warnings` on rustc 1.97
- [ ] CI `MSRV check (1.88)` still green (unchanged gate)
- [ ] CI `Check` matrix green under stable 1.97