### PR TITLE
refactor(w1.2): seal remaining helper-only git modules (production closeout)

### DIFF
--- a/docs/REFACTOR-PLAN.md
+++ b/docs/REFACTOR-PLAN.md
@@ -55,14 +55,16 @@ wanting raw control. Makes "forgot `AGEND_GIT_BYPASS`" structurally
 impossible daemon-side and kills a flaky-test class.
 **Effort** 0.5–1 day · **Risk** low, mechanical, reviewable per call-site ·
 **Source** survey 05-R1.
-**Status** ✅ First slice done — PR #2068. `git_cmd`/`git_ok` landed; 4 modules
-migrated + sealed (`branch_sweep`, `worktree_cleanup`, `worktree_pool`,
-`binding`) by the `tests/daemon_git_helper_invariant.rs` per-slice
-`MODULE_SCOPE` scanner (FAILs CI on an unmarked raw `Command::new("git")` in a
-sealed module). **Scope correction**: the daemon has **~150** raw git sites
-across **~25** modules (not the ~51 estimate above); `MODULE_SCOPE` grows
-monotonically as each later slice adds its module, so the seal never claims
-unearned coverage. Remaining-module migration is the backlog: task `t-…766-17`.
+**Status** ✅ Production closeout (2026-07). `git_cmd`/`git_ok` landed in
+#2068; subsequent slices sealed worktree lifecycle, claim/deploy, auto_release,
+`git_worktree` + pool GC (#2702), then every remaining daemon/MCP module that
+already used the helpers with **zero production raw** `Command::new("git")`
+(admin, conflict_notify, per-tick GC helpers, binding_state, ci/checkout,
+dispatch_hook, force_release). `MODULE_SCOPE` in
+`tests/daemon_git_helper_invariant.rs` is the authority list — grows
+monotonically. Intentional residual raw: `git_helpers` (implementation) and
+`bin/agend-git` (gated shim). Optional backlog: no-cwd bypass helper for
+`git_worktree::remove_force`'s empty-`source_repo` allow-marked branch.
 
 ### W1.3 Quick wins (one small PR each)
 - Unify the duplicated tool-timeout maps (`request_dedup.rs:465` ↔

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -245,17 +245,13 @@ entry; none is free to "just clean up" without the listed care.
 3. **Raw `Command::new("git")` vs `git_cmd`/`git_ok`/`git_bypass`**: W1.2
    (#2068) landed helpers and a per-slice seal in
    `tests/daemon_git_helper_invariant.rs` (`MODULE_SCOPE` grows
-   monotonically; never shrink). **Sealed modules as of 2026-07** (production
-   portion; `// git-raw-allowed:` markers exempt deliberate raw sites):
-
-   `worktree_pool.rs`, `worktree_cleanup.rs`, `branch_sweep.rs`,
-   `binding.rs`, `mcp_config.rs`, `instructions.rs`, `skills.rs`,
-   `claim_verifier.rs`, `deployments.rs`, `bootstrap/canonical_hygiene.rs`,
-   `agent_ops.rs`, `mcp/handlers/ci/release.rs`, `daemon/auto_release.rs`,
-   `daemon/retention/worktrees.rs`, `worktree.rs`.
-
-   Unsealed production callers (and all of `agend-git` itself, which is the
-   gated side) remain the backlog — the seal never claims unearned coverage.
+   monotonically; never shrink; authority list — do not duplicate it here).
+   **Production closeout (2026-07):** every daemon/MCP module that performs
+   LOCAL git is sealed (worktree lifecycle, pool GC, admin, conflict_notify,
+   dispatch_hook, force_release, …). Intentional residual raw:
+   `git_helpers` (bypass implementation) and `bin/agend-git` (gated shim).
+   Optional backlog: no-cwd bypass for `git_worktree::remove_force`'s empty-
+   `source_repo` allow-marked branch.
 4. **Size-driven extraction at the MCP cap**: `instance.rs`/`comms.rs` at
    the 750-LOC cap with "extracted for file_size_invariant" cross-file
    seams; `handle_delegate_task` is a 317-LOC god-fn with gates inlined.

--- a/docs/architecture.zh-TW.md
+++ b/docs/architecture.zh-TW.md
@@ -241,18 +241,13 @@ Release → crates.io publish（見 RELEASING.md）。
    decider 盲目改走 operated_state。
 3. **原始 `Command::new("git")` vs `git_cmd`/`git_ok`/`git_bypass`**：W1.2
    （#2068）導入 helper，並以 `tests/daemon_git_helper_invariant.rs` 做
-   per-slice 封印（`MODULE_SCOPE` 單調成長、永不縮小）。**截至 2026-07 已
-   seal 的 module**（只掃 production 區段；`// git-raw-allowed:` 標記豁免
-   刻意保留的 raw site）：
-
-   `worktree_pool.rs`、`worktree_cleanup.rs`、`branch_sweep.rs`、
-   `binding.rs`、`mcp_config.rs`、`instructions.rs`、`skills.rs`、
-   `claim_verifier.rs`、`deployments.rs`、`bootstrap/canonical_hygiene.rs`、
-   `agent_ops.rs`、`mcp/handlers/ci/release.rs`、`daemon/auto_release.rs`、
-   `daemon/retention/worktrees.rs`、`worktree.rs`。
-
-   尚未 seal 的 production 呼叫端（以及 `agend-git` 本體——那是 gated 端，
-   本來就該 raw）仍是 backlog——封印絕不宣稱尚未掙得的覆蓋率。
+   per-slice 封印（`MODULE_SCOPE` 單調成長、永不縮小；**權威列表在該檔，
+   此處不重複抄**）。**Production closeout（2026-07）：** 所有會跑 LOCAL
+   git 的 daemon/MCP module 皆已 seal（worktree 生命週期、pool GC、admin、
+   conflict_notify、dispatch_hook、force_release…）。刻意保留的 raw：
+   `git_helpers`（bypass 實作）與 `bin/agend-git`（gated 端）。可選
+   backlog：`git_worktree::remove_force` empty-`source_repo` 的
+   allow-marked 分支，若有「無 cwd 的 bypass helper」可再收掉。
 4. **MCP 上限處的 size-driven 拆分**：`instance.rs`/`comms.rs` 卡在
    750-LOC 上限，帶有「為了 file_size_invariant 而拆分」的 cross-file
    接縫；`handle_delegate_task` 是一個 317-LOC 的 god-fn，gate 都 inline 在裡頭。

--- a/tests/daemon_git_helper_invariant.rs
+++ b/tests/daemon_git_helper_invariant.rs
@@ -94,6 +94,22 @@ const MODULE_SCOPE: &[&str] = &[
     "git_worktree.rs",
     "worktree_pool/gc.rs",
     "worktree_pool/workspace.rs",
+    // W1.2 closeout: remaining daemon/MCP modules that already route LOCAL git
+    // through git_cmd/git_ok/git_bypass/git_worktree (zero production raw
+    // Command::new("git")). Seal so a reintroduced raw site fails CI. After this
+    // list, the only intentional production raw-git lives in git_helpers (the
+    // bypass implementation) and bin/agend-git (the gated shim side).
+    "admin/mod.rs",
+    "daemon/conflict_notify.rs",
+    "daemon/per_tick/canonical_heartbeat.rs",
+    "daemon/per_tick/tmp_review_gc.rs",
+    "mcp/handlers/binding_state.rs",
+    "mcp/handlers/ci/checkout.rs",
+    "mcp/handlers/dispatch_hook/branch_start_point.rs",
+    "mcp/handlers/dispatch_hook/from_ref.rs",
+    "mcp/handlers/dispatch_hook/mod.rs",
+    "mcp/handlers/force_release/gc.rs",
+    "mcp/handlers/force_release/repair.rs",
 ];
 
 /// One violation entry — `(file, line_number, snippet)`.


### PR DESCRIPTION
## Summary

Wave 1 / W1.2 **production closeout**: seal every remaining daemon/MCP module that already uses `git_cmd` / `git_ok` / `git_bypass` / `git_worktree` with **zero production raw** `Command::new("git")`.

### `MODULE_SCOPE` additions

- `admin/mod.rs`
- `daemon/conflict_notify.rs`
- `daemon/per_tick/canonical_heartbeat.rs`
- `daemon/per_tick/tmp_review_gc.rs`
- `mcp/handlers/binding_state.rs`
- `mcp/handlers/ci/checkout.rs`
- `mcp/handlers/dispatch_hook/{branch_start_point,from_ref,mod}.rs`
- `mcp/handlers/force_release/{gc,repair}.rs`

After this list, intentional residual production raw git is only:

- `src/git_helpers.rs` (bypass implementation)
- `src/bin/agend-git*` (gated shim side)

Optional backlog (not this PR): no-cwd bypass helper for `git_worktree::remove_force`'s empty-`source_repo` allow-marked branch.

### Docs

- `docs/REFACTOR-PLAN.md` W1.2 status → production closeout
- `docs/architecture.md` + zh-TW: point at `MODULE_SCOPE` as authority; describe residual raw

No runtime behavior change — seal only.

## Test plan

- [x] `cargo test --test daemon_git_helper_invariant` (4/4)
- [ ] CI `MSRV check (1.88)` + Check matrix