### PR TITLE
refactor(w1.2): git_bypass_no_cwd + Wave 1 complete / Wave 2 status

### DIFF
--- a/docs/REFACTOR-PLAN.md
+++ b/docs/REFACTOR-PLAN.md
@@ -55,16 +55,13 @@ wanting raw control. Makes "forgot `AGEND_GIT_BYPASS`" structurally
 impossible daemon-side and kills a flaky-test class.
 **Effort** 0.5–1 day · **Risk** low, mechanical, reviewable per call-site ·
 **Source** survey 05-R1.
-**Status** ✅ Production closeout (2026-07). `git_cmd`/`git_ok` landed in
-#2068; subsequent slices sealed worktree lifecycle, claim/deploy, auto_release,
-`git_worktree` + pool GC (#2702), then every remaining daemon/MCP module that
-already used the helpers with **zero production raw** `Command::new("git")`
-(admin, conflict_notify, per-tick GC helpers, binding_state, ci/checkout,
-dispatch_hook, force_release). `MODULE_SCOPE` in
-`tests/daemon_git_helper_invariant.rs` is the authority list — grows
-monotonically. Intentional residual raw: `git_helpers` (implementation) and
-`bin/agend-git` (gated shim). Optional backlog: no-cwd bypass helper for
-`git_worktree::remove_force`'s empty-`source_repo` allow-marked branch.
+**Status** ✅ Complete (2026-07). `git_cmd`/`git_ok` landed in #2068; modules
+sealed through #2702/#2705 (`MODULE_SCOPE` authority list). Closeout helper
+`git_bypass_no_cwd` (+ timeout) routes empty-`source_repo` worktree remove
+through the same bypass/timeout/process-group kill as cwd-bound calls —
+`git_worktree::remove_force` has zero production raw `Command::new("git")`.
+Intentional residual raw: only inside `git_helpers` (the spawn implementation)
+and `bin/agend-git` (gated shim).
 
 ### W1.3 Quick wins (one small PR each)
 - Unify the duplicated tool-timeout maps (`request_dedup.rs:465` ↔
@@ -96,6 +93,9 @@ existing size-driven `instance_spawn.rs` + `instance_lifecycle.rs` into a
 coherent module) / `instance_metadata` (metadata + pane + health).
 Zero API change; the three concerns share no state.
 **Effort** M · **Risk** low · **Source** survey 02-#1.
+**Status** ✅ Largely landed — `instance.rs` is a thin re-export; queries /
+metadata / `instance_state/{spawn,lifecycle}` already split. Further
+concept-driven cleanup optional if LOC pressure returns.
 
 ### W2.2 Break up `handle_delegate_task` + extract `comms_gates`
 comms.rs at cap; `handle_delegate_task` (317 LOC) inlines busy-gate,
@@ -107,6 +107,9 @@ evidence_gate / anti_stall sibling files).
 **Effort** M · **Risk** low-medium (failure ordering must be preserved —
 route failure must still suppress provenance/dispatch side-effects) ·
 **Source** survey 02-#2, 03-A.
+**Status** 🔶 Partial — `comms_gates::run_dispatch_pre_checks` extracted;
+`handle_delegate_task` still owns message build + lease + send choreography
+(~comms.rs still near the 750-LOC cap). Remaining split is Wave-2 backlog.
 
 ### W2.3 `feed_with_fg` gate-pipeline extraction
 Decompose the 549-LOC classifier method into named `apply_*_gate` steps in
@@ -114,6 +117,10 @@ an explicit call sequence (ordering stays encoded in one place). This is
 the legibility prerequisite for every other state-detection change,
 including #1523 phase-2.
 **Effort** M · **Risk** low (structure-only) · **Source** survey 04-#2.
+**Status** ✅ Done — `feed_with_fg` / `feed_with_lazy_fg` → hash-dedup gate +
+`feed_after_dedup` with named `apply_anchor_gate` / `apply_position_gate` /
+`apply_working_marker_override` / `apply_srl_phantom_gate` /
+`apply_usage_limit_lifecycle_gate` + `gate_on_heartbeat` sequence.
 
 ### W2.4 `CadenceGate` + `PerAgentLatch<T>` utilities
 Collapse ~15 hand-rolled cadence counters and ~10 per-agent latch maps;
@@ -140,11 +147,14 @@ is a separate behaviour-fix backlog item (the #1923 G5 cleanup-on-delete class);
 `backend.rs preset()` 300-LOC 6-arm factory with repeated fields → table /
 default-merge. Adding a profile field currently means 7 edits.
 **Effort** M · **Risk** low · **Source** survey 04-#3.
+**Status** ✅ Done — `DEFAULTS` + `..DEFAULTS` per-arm overrides; pinned by
+`preset_default_merged_fields_byte_identical_w2_5`.
 
 ### W2.6 Name the resize contract
 Keep both resize chokepoints (#2048), extract a shared
 `PaneContentRect`/`ResizeDecision` helper, and document the invariant:
 layout pre-computes, render is authoritative for the final inner rect.
+**Status** ⏳ Open.
 **Effort** S-M · **Risk** medium — do NOT remove render-time resize
 without PTY tests · **Source** survey 03-C.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -247,11 +247,10 @@ entry; none is free to "just clean up" without the listed care.
    `tests/daemon_git_helper_invariant.rs` (`MODULE_SCOPE` grows
    monotonically; never shrink; authority list — do not duplicate it here).
    **Production closeout (2026-07):** every daemon/MCP module that performs
-   LOCAL git is sealed (worktree lifecycle, pool GC, admin, conflict_notify,
-   dispatch_hook, force_release, …). Intentional residual raw:
-   `git_helpers` (bypass implementation) and `bin/agend-git` (gated shim).
-   Optional backlog: no-cwd bypass for `git_worktree::remove_force`'s empty-
-   `source_repo` allow-marked branch.
+   LOCAL git is sealed; empty-`source_repo` worktree remove goes through
+   `git_helpers::git_bypass_no_cwd` (timeout-bounded). Intentional residual
+   raw: only inside `git_helpers` (spawn implementation) and `bin/agend-git`
+   (gated shim).
 4. **Size-driven extraction at the MCP cap**: `instance.rs`/`comms.rs` at
    the 750-LOC cap with "extracted for file_size_invariant" cross-file
    seams; `handle_delegate_task` is a 317-LOC god-fn with gates inlined.

--- a/docs/architecture.zh-TW.md
+++ b/docs/architecture.zh-TW.md
@@ -243,11 +243,9 @@ Release → crates.io publish（見 RELEASING.md）。
    （#2068）導入 helper，並以 `tests/daemon_git_helper_invariant.rs` 做
    per-slice 封印（`MODULE_SCOPE` 單調成長、永不縮小；**權威列表在該檔，
    此處不重複抄**）。**Production closeout（2026-07）：** 所有會跑 LOCAL
-   git 的 daemon/MCP module 皆已 seal（worktree 生命週期、pool GC、admin、
-   conflict_notify、dispatch_hook、force_release…）。刻意保留的 raw：
-   `git_helpers`（bypass 實作）與 `bin/agend-git`（gated 端）。可選
-   backlog：`git_worktree::remove_force` empty-`source_repo` 的
-   allow-marked 分支，若有「無 cwd 的 bypass helper」可再收掉。
+   git 的 daemon/MCP module 皆已 seal；empty-`source_repo` 的 worktree
+   remove 走 `git_helpers::git_bypass_no_cwd`（含 timeout）。刻意保留的 raw：
+   只在 `git_helpers`（spawn 實作）與 `bin/agend-git`（gated 端）。
 4. **MCP 上限處的 size-driven 拆分**：`instance.rs`/`comms.rs` 卡在
    750-LOC 上限，帶有「為了 file_size_invariant 而拆分」的 cross-file
    接縫；`handle_delegate_task` 是一個 317-LOC 的 god-fn，gate 都 inline 在裡頭。

--- a/src/git_helpers.rs
+++ b/src/git_helpers.rs
@@ -37,6 +37,47 @@ pub(crate) fn git_bypass(cwd: &Path, args: &[&str]) -> std::io::Result<std::proc
     git_bypass_timeout(cwd, args, LOCAL_GIT_TIMEOUT)
 }
 
+/// W1.2 closeout: always-bypass + [`LOCAL_GIT_TIMEOUT`] git spawn with **no**
+/// `current_dir`. Use when git must resolve the repo from absolute path args
+/// alone (e.g. `git worktree remove --force /abs/path` with empty owning-repo
+/// cwd). Same timeout + process-group kill as [`git_bypass`]; only the cwd
+/// binding differs.
+pub(crate) fn git_bypass_no_cwd(args: &[&str]) -> std::io::Result<std::process::Output> {
+    git_bypass_no_cwd_timeout(args, LOCAL_GIT_TIMEOUT)
+}
+
+/// Like [`git_bypass_no_cwd`] with an explicit timeout bound.
+pub(crate) fn git_bypass_no_cwd_timeout(
+    args: &[&str],
+    timeout: Duration,
+) -> std::io::Result<std::process::Output> {
+    if let Some(sub) = args.first() {
+        if matches!(
+            *sub,
+            "worktree" | "branch" | "checkout" | "switch" | "reset" | "clean" | "commit" | "push"
+        ) {
+            tracing::info!(
+                target: "agend_git_bypass",
+                op = %sub,
+                args = ?args,
+                cwd = "(none)",
+                ctx = %crate::event_log::caller_process_context(),
+                "#2158 AGEND_GIT_BYPASS mutating git op (no-cwd)"
+            );
+        }
+    }
+    // git-raw-allowed: no-cwd path is the single intentional raw Command in
+    // git_helpers outside the cwd-bound git_bypass_timeout chokepoint — still
+    // always AGEND_GIT_BYPASS + spawn_group_bounded timeout/kill.
+    let mut cmd = std::process::Command::new("git");
+    cmd.args(args).env("AGEND_GIT_BYPASS", "1");
+    spawn_group_bounded(
+        cmd,
+        &format!("git {:?}", &args[..1.min(args.len())]),
+        timeout,
+    )
+}
+
 /// Like `git_bypass` but with a process-level timeout. Spawns the git
 /// subprocess and polls `try_wait` until either the process exits or the
 /// deadline is reached, at which point the git process group is killed.

--- a/src/git_worktree.rs
+++ b/src/git_worktree.rs
@@ -20,12 +20,9 @@
 //!   this shared core — the core does NOT bake in any one caller's filter.
 //! - `git worktree remove --force`: [`remove_force`] extracts the
 //!   INTENTIONALLY-duplicated empty-`source_repo` dual-cwd branch shared
-//!   verbatim by `worktree_pool.rs::remove_worktree` and
-//!   `worktree_pool/workspace.rs::teardown_workspace_worktree` (both
-//!   already had matching comments citing the same "lead ruling": git
-//!   needs a resolvable cwd, and an empty `source_repo` means the ONLY
-//!   correct move is a bypass-enabled raw `Command` with NO `current_dir`,
-//!   never `git_bypass`/`git_cmd` — those both require a cwd).
+//!   by `worktree_pool` callers. Empty `source_repo` uses
+//!   [`crate::git_helpers::git_bypass_no_cwd`] (always-bypass + timeout,
+//!   no `current_dir`); non-empty uses [`crate::git_helpers::git_bypass`].
 //! - Wrapper/error-handling-granularity CHOICE (`git_bypass` vs `git_ok` vs
 //!   `git_cmd`) stays with each existing caller — this module does not
 //!   force a uniform return type onto call sites that currently rely on
@@ -106,27 +103,18 @@ pub(crate) fn list_porcelain(repo: &Path) -> std::io::Result<Vec<(PathBuf, Optio
 
 /// `git worktree remove --force <wt_path>`.
 ///
-/// `source_repo` empty → runs with NO `current_dir` (git resolves the repo
-/// from the absolute `wt_path` itself; `AGEND_GIT_BYPASS=1` still set via
-/// `env`) — the documented exception both original call sites shared
-/// verbatim (see module doc: `git_bypass`/`git_cmd` both REQUIRE a cwd, and
-/// the worktrees-pool parent dir is NOT the owning repo).
-/// `source_repo` non-empty → `git_helpers::git_bypass(source_repo, ...)`.
+/// `source_repo` empty → [`git_helpers::git_bypass_no_cwd`] (no `current_dir`;
+/// git resolves the repo from the absolute `wt_path`; still always-bypass +
+/// timeout-bounded). `source_repo` non-empty → [`git_helpers::git_bypass`].
 pub(crate) fn remove_force(
     source_repo: &Path,
     wt_path: &str,
 ) -> std::io::Result<std::process::Output> {
+    let args = ["worktree", "remove", "--force", wt_path];
     if source_repo.as_os_str().is_empty() {
-        // git-raw-allowed: empty source_repo — MUST NOT set current_dir (git
-        // resolves the repo from the absolute wt_path). `git_bypass`/`git_cmd`
-        // both require a cwd, so this branch stays a raw always-bypass Command
-        // (documented exception; see module doc + #2550 W2).
-        std::process::Command::new("git")
-            .args(["worktree", "remove", "--force", wt_path])
-            .env("AGEND_GIT_BYPASS", "1")
-            .output()
+        crate::git_helpers::git_bypass_no_cwd(&args)
     } else {
-        crate::git_helpers::git_bypass(source_repo, &["worktree", "remove", "--force", wt_path])
+        crate::git_helpers::git_bypass(source_repo, &args)
     }
 }
 


### PR DESCRIPTION
## Summary

Finishes the last W1.2 optional backlog and syncs the refactor map.

### Code
- **`git_helpers::git_bypass_no_cwd` / `git_bypass_no_cwd_timeout`** — always `AGEND_GIT_BYPASS`, process-group + `LOCAL_GIT_TIMEOUT`, **no** `current_dir`.
- **`git_worktree::remove_force`** — empty `source_repo` uses no-cwd helper; non-empty still uses `git_bypass`. **Zero production raw** `Command::new("git")` in `git_worktree.rs` (test fixture git stays under `#[cfg(test)]`).

Behavioral note: empty-cwd path gains the same 60s timeout/process-group kill as other local git (strict improvement vs unbounded `.output()`).

### Docs
- W1.2 → **Complete**
- W2.1 largely landed, W2.3/W2.5 done, W2.2 partial, W2.6 still open
- architecture EN/zh-TW residual-raw wording updated

## Test plan
- [x] `cargo test --test daemon_git_helper_invariant`
- [x] `cargo test --bin agend-terminal remove_force`
- [ ] CI Check + MSRV 1.88