### PR TITLE
feat(backend): Grok Build CLI first-class backend (dispatch MVP)

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -20,6 +20,10 @@ pub enum Backend {
     /// project-local config at `<workdir>/.antigravitycli/mcp_config.json`.
     /// Added in #987.
     Agy,
+    /// xAI Grok Build CLI (`grok`). Full-screen TUI coding agent.
+    /// Project-local MCP at `<workdir>/.grok/config.toml` (`[mcp_servers.*]`).
+    /// MVP: typed inject + trust dismiss; no lifecycle hooks yet.
+    Grok,
     /// Generic shell (bash/zsh/sh). No preset wiring — inject/ready/resume are
     /// all no-ops. Command defaults to `$SHELL` or the platform default
     /// (`/bin/bash` on Unix, `cmd.exe` on Windows).
@@ -47,7 +51,8 @@ impl Backend {
             | Backend::KiroCli
             | Backend::Codex
             | Backend::OpenCode
-            | Backend::Agy => true,
+            | Backend::Agy
+            | Backend::Grok => true,
             Backend::Shell | Backend::Raw(_) => false,
         }
     }
@@ -110,6 +115,9 @@ impl Backend {
                 "OPENCODE_CONFIG",
                 "OPENCODE_API_KEY",
             ],
+            // OAuth also lives under ~/.grok/auth.json (file-based); the env
+            // key is the headless/CI path. GROK_HOME may be used for isolation.
+            Backend::Grok => &["XAI_API_KEY"],
             Backend::Shell | Backend::Raw(_) => &[],
         }
     }
@@ -127,6 +135,7 @@ impl Backend {
             "opencode" | "opencode-cli" => Backend::OpenCode,
             // #1580: "gemini"/"gemini-cli" retired → fall through to Raw.
             "agy" | "antigravity" | "antigravity-cli" => Backend::Agy,
+            "grok" | "grok-build" | "grok-cli" | "grok-build-cli" => Backend::Grok,
             "shell" | "bash" | "zsh" | "sh" => Backend::Shell,
             _ => Backend::Raw(trimmed.to_string()),
         }
@@ -145,6 +154,7 @@ impl Backend {
             // parse_str still accepts the "agy" alias for backward-compat with
             // any fleet.yaml entries written before #995.
             Backend::Agy => "antigravity-cli",
+            Backend::Grok => "grok",
             Backend::Shell => "shell",
             Backend::Raw(s) => s.as_str(),
         }
@@ -169,7 +179,7 @@ impl Backend {
     /// test (codex-44cea9, 2026-06-10) surfaced this.
     pub fn input_prompt_marker(&self) -> Option<&'static str> {
         match self {
-            Backend::ClaudeCode => Some("❯"),
+            Backend::ClaudeCode | Backend::Grok => Some("❯"),
             Backend::Agy => Some(">"),
             _ => None,
         }
@@ -224,7 +234,8 @@ impl Backend {
             | Backend::KiroCli
             | Backend::Codex
             | Backend::OpenCode
-            | Backend::Agy => self.preset().command.to_string(),
+            | Backend::Agy
+            | Backend::Grok => self.preset().command.to_string(),
             Backend::Shell => crate::shell_command(),
             Backend::Raw(path) => path.clone(),
         }
@@ -641,6 +652,44 @@ impl Backend {
                 fleet_mcp_supported: true,
                 ..DEFAULTS
             },
+            Backend::Grok => BackendPreset {
+                command: "grok",
+                // Unattended tool execution (fleet dispatch). Matches Claude's
+                // --dangerously-skip-permissions / Agy's same flag.
+                args: &["--always-approve"],
+                // Splash + empty prompt (smoke-verified against Grok 0.2.93).
+                ready_pattern: "Grok Build|❯|always-approve",
+                // Full-screen TUI: bulk write does not land; paced inject required
+                // (inject-focus smoke 2026-07-10).
+                typed_inject: true,
+                // Grok's `--continue` EXIT 2s when no session exists for cwd
+                // ("No session found for current directory"). Unlike Claude, it
+                // does not soft-fallback. Until has_resumable_session is wired
+                // to ~/.grok/sessions/<encoded-cwd>/, keep resume off so Fresh
+                // spawns (and the --agents path, which always appends resume
+                // flags) stay bootable. Operator can still /resume inside the
+                // TUI. Follow-up: encode-cwd session probe + ContinueInCwd.
+                resume_mode: ResumeMode::NotSupported,
+                quit_command: "/exit",
+                // Shared AGENTS.md (also Codex/OpenCode). Grok reads project rules
+                // from AGENTS.md / Claude.md automatically.
+                instructions_path: "AGENTS.md",
+                instructions_shared: true,
+                ready_timeout_secs: 30,
+                // Project trust modal fires on first tool use in a new workdir
+                // ("Run Grok Build in a project directory?"). Default cursor is
+                // the accept option → single Enter. Anchored per #468. The
+                // inject path submits with one CR; this dismiss covers the
+                // follow-up trust modal (empirically needed for a turn to run).
+                dismiss_patterns: &[DismissPattern {
+                    label: r"(?m)^[^A-Za-z\n]*Run Grok Build in a project directory\?",
+                    sequence: b"\r",
+                }],
+                // configure_grok writes <workdir>/.grok/config.toml
+                // [mcp_servers.agend-terminal] (project-scoped; no HOME write).
+                fleet_mcp_supported: true,
+                ..DEFAULTS
+            },
             // Shell and Raw have no preset behavior. `command` is `""` as a
             // sentinel — callers that need the actual spawn path should use
             // [`Backend::command_string`], which resolves Shell to `$SHELL`
@@ -681,6 +730,8 @@ impl Backend {
             // covers the user-facing "antigravity" alias for hand-edited
             // fleet.yaml entries.
             Some(Backend::Agy)
+        } else if basename == "grok" || basename.starts_with("grok-") {
+            Some(Backend::Grok)
         } else {
             None
         }
@@ -695,6 +746,7 @@ impl Backend {
             Backend::OpenCode,
             // #1580: Gemini retired; Agy (its successor) carries the Google engine.
             Backend::Agy,
+            Backend::Grok,
         ]
     }
 
@@ -769,6 +821,7 @@ impl Backend {
             Backend::OpenCode => Some("opencode"),
             Backend::KiroCli => Some("kiro"),
             Backend::Agy => Some("agy"),
+            Backend::Grok => Some("grok"),
             Backend::Shell | Backend::Raw(_) => None,
         }
     }
@@ -870,6 +923,8 @@ impl Backend {
             Backend::Codex => "0.118.0",
             Backend::OpenCode => "1.4.0",
             Backend::Agy => "1.0.0",
+            // Patterns + trust dismiss calibrated against live PTY smoke.
+            Backend::Grok => "0.2.93",
             Backend::Shell | Backend::Raw(_) => "n/a",
         }
     }
@@ -1283,6 +1338,7 @@ mod tests {
             Backend::Codex,
             Backend::OpenCode,
             Backend::KiroCli,
+            Backend::Grok,
             Backend::Shell,
             Backend::Raw("x".into()),
         ] {
@@ -1306,6 +1362,7 @@ mod tests {
             Backend::Codex,
             Backend::OpenCode,
             Backend::Agy,
+            Backend::Grok,
             Backend::Shell,
             Backend::Raw("x".to_string()),
         ] {
@@ -1346,6 +1403,7 @@ mod tests {
             Backend::Codex,
             Backend::OpenCode,
             Backend::Agy,
+            Backend::Grok,
             Backend::Shell,
             Backend::Raw("x".to_string()),
         ] {
@@ -1357,6 +1415,27 @@ mod tests {
     }
 
     #[test]
+    fn grok_preset_mvp_inject_and_trust() {
+        let p = Backend::Grok.preset();
+        assert_eq!(p.command, "grok");
+        assert_eq!(p.args, &["--always-approve"]);
+        assert!(p.typed_inject, "Grok TUI requires paced inject");
+        assert_eq!(p.submit_key, "\r");
+        assert_eq!(p.instructions_path, "AGENTS.md");
+        assert!(p.instructions_shared);
+        assert!(p.fleet_mcp_supported);
+        assert!(matches!(p.resume_mode, ResumeMode::NotSupported));
+        let trust = p
+            .dismiss_patterns
+            .iter()
+            .find(|dp| dp.label.contains("project directory"))
+            .expect("Grok must dismiss project-directory trust modal");
+        assert_eq!(trust.sequence, b"\r");
+        assert_eq!(Backend::Grok.input_prompt_marker(), Some("❯"));
+        assert_eq!(Backend::Grok.credential_env_keys(), &["XAI_API_KEY"]);
+    }
+
+    #[test]
     fn from_command_detection() {
         assert_eq!(Backend::from_command("claude"), Some(Backend::ClaudeCode));
         assert_eq!(Backend::from_command("kiro-cli"), Some(Backend::KiroCli));
@@ -1365,6 +1444,11 @@ mod tests {
         // #1580: gemini retired — `gemini` no longer maps to a managed backend.
         assert_eq!(Backend::from_command("gemini"), None);
         assert_eq!(Backend::from_command("agy"), Some(Backend::Agy));
+        assert_eq!(Backend::from_command("grok"), Some(Backend::Grok));
+        assert_eq!(
+            Backend::from_command("/Users/x/.grok/bin/grok"),
+            Some(Backend::Grok)
+        );
         // Case insensitive
         assert_eq!(Backend::from_command("Claude"), Some(Backend::ClaudeCode));
         assert_eq!(
@@ -1469,19 +1553,22 @@ mod tests {
             Backend::Codex,
             Backend::OpenCode,
             Backend::Agy,
+            Backend::Grok,
             Backend::Shell,
             Backend::Raw("/x".to_string()),
         ];
-        let submit_key = ["\r"; 7];
-        let inject_prefix = ["", "", "", "\r", "\r", "", ""];
-        let typed_inject = [false, false, true, true, true, false, false];
-        let quit_command = ["/exit", "/quit", "exit", "/exit", "/exit", "exit", "exit"];
-        let instructions_shared = [false, false, true, true, true, false, false];
-        let inject_on_ready = [false; 7];
-        let ready_timeout = [30u64, 30, 20, 45, 20, 10, 10];
-        let fresh_some = [false, false, true, false, false, false, false];
-        let fleet_mcp = [true, true, true, true, true, false, false];
-        let redraw = [false, true, false, false, false, false, false];
+        let submit_key = ["\r"; 8];
+        let inject_prefix = ["", "", "", "\r", "\r", "", "", ""];
+        let typed_inject = [false, false, true, true, true, true, false, false];
+        let quit_command = [
+            "/exit", "/quit", "exit", "/exit", "/exit", "/exit", "exit", "exit",
+        ];
+        let instructions_shared = [false, false, true, true, true, true, false, false];
+        let inject_on_ready = [false; 8];
+        let ready_timeout = [30u64, 30, 20, 45, 20, 30, 10, 10];
+        let fresh_some = [false, false, true, false, false, false, false, false];
+        let fleet_mcp = [true, true, true, true, true, true, false, false];
+        let redraw = [false, true, false, false, false, false, false, false];
         for (i, b) in backends.iter().enumerate() {
             let p = b.preset();
             assert_eq!(p.submit_key, submit_key[i], "submit_key {b:?}");
@@ -1625,11 +1712,11 @@ mod tests {
     }
 
     #[test]
-    fn all_backends_returns_five() {
-        // #987 bumped 5 → 6 with Backend::Agy (gemini-cli's successor); #1580
-        // drops back to 5 as gemini-cli is retired:
-        // ClaudeCode, KiroCli, Codex, OpenCode, Agy.
-        assert_eq!(Backend::all().len(), 5);
+    fn all_backends_returns_six() {
+        // #987: 5 → 6 with Agy; #1580: back to 5 (gemini retired); Grok MVP: 6.
+        // ClaudeCode, KiroCli, Codex, OpenCode, Agy, Grok.
+        assert_eq!(Backend::all().len(), 6);
+        assert!(Backend::all().contains(&Backend::Grok));
     }
 
     #[test]
@@ -1650,9 +1737,13 @@ mod tests {
         assert_eq!(Backend::parse_str("agy"), Backend::Agy);
         assert_eq!(Backend::parse_str("antigravity"), Backend::Agy);
         assert_eq!(Backend::parse_str("antigravity-cli"), Backend::Agy);
+        assert_eq!(Backend::parse_str("grok"), Backend::Grok);
+        assert_eq!(Backend::parse_str("grok-build"), Backend::Grok);
+        assert_eq!(Backend::parse_str("grok-cli"), Backend::Grok);
         // Case insensitive
         assert_eq!(Backend::parse_str("Claude"), Backend::ClaudeCode);
         assert_eq!(Backend::parse_str("AGY"), Backend::Agy);
+        assert_eq!(Backend::parse_str("GROK"), Backend::Grok);
         // Whitespace trim
         assert_eq!(Backend::parse_str("  claude  "), Backend::ClaudeCode);
     }

--- a/src/backend_harness.rs
+++ b/src/backend_harness.rs
@@ -52,6 +52,7 @@ impl CapabilityMatrix {
             ("claude", "LLM context not tied to PTY buffer (known gap)"),
             ("opencode", ""),
             ("agy", ""),
+            ("grok", "MVP: typed inject + project-trust dismiss"),
         ] {
             backends.insert(
                 name.into(),
@@ -358,8 +359,8 @@ mod tests {
     #[test]
     fn test_capability_matrix_serializes_with_split_columns() {
         let matrix = CapabilityMatrix::new();
-        // #1580: 6 → 5 (gemini-cli retired).
-        assert_eq!(matrix.backends.len(), 5);
+        // #1580: 6 → 5 (gemini retired); Grok MVP: 6.
+        assert_eq!(matrix.backends.len(), 6);
         // All start unverified
         for b in matrix.backends.values() {
             assert_eq!(b.esc_semantics_verified, CapabilityLevel::Unverified);

--- a/src/backend_profile.rs
+++ b/src/backend_profile.rs
@@ -111,6 +111,7 @@ pub fn profile(backend: &Backend) -> &'static BackendProfile {
     static OPENCODE: OnceLock<BackendProfile> = OnceLock::new();
     static CODEX: OnceLock<BackendProfile> = OnceLock::new();
     static CLAUDE: OnceLock<BackendProfile> = OnceLock::new();
+    static GROK: OnceLock<BackendProfile> = OnceLock::new();
     // Shell + Raw share one profile — every legacy source treats `Shell | Raw(_)`
     // identically (empty patterns, default behavioral, generic productivity, Idle).
     static EMPTY: OnceLock<BackendProfile> = OnceLock::new();
@@ -120,7 +121,51 @@ pub fn profile(backend: &Backend) -> &'static BackendProfile {
         Backend::OpenCode => OPENCODE.get_or_init(opencode_profile),
         Backend::Codex => CODEX.get_or_init(codex_profile),
         Backend::ClaudeCode => CLAUDE.get_or_init(claudecode_profile),
+        Backend::Grok => GROK.get_or_init(grok_profile),
         Backend::Shell | Backend::Raw(_) => EMPTY.get_or_init(empty_profile),
+    }
+}
+
+/// Grok Build CLI — MVP detection profile (calibrated against Grok 0.2.93 PTY
+/// smoke). Patterns are deliberately thin: enough for dispatch ready/idle/active
+/// and the project-trust modal. Finer states (rate-limit, auth, etc.) land with
+/// real fixtures later.
+fn grok_profile() -> BackendProfile {
+    BackendProfile {
+        patterns: vec![
+            // Trust / permission chrome — before Idle so a stuck trust modal
+            // is not misread as ready-to-dispatch Idle.
+            (
+                AgentState::PermissionPrompt,
+                r"Run Grok Build in a project directory\?|Do you trust",
+            ),
+            // Active turn chrome (smoke: Thinking… / Responding…).
+            (
+                AgentState::Active,
+                r"Thinking…|Thinking\.\.\.|Responding…|Responding\.\.\.|esc to interrupt",
+            ),
+            // Idle / ready chrome.
+            (
+                AgentState::Idle,
+                r"\? for shortcuts|Enter:send|always-approve",
+            ),
+            (AgentState::Idle, r"Grok Build|❯"),
+        ],
+        behavioral: BehavioralConfig {
+            silence_thinking_ms: 3000,
+            silence_idle_ms: 8000,
+        },
+        productivity: ProductivityConfig {
+            // Reuse generic save-banner markers; Grok-specific completion
+            // glyphs can be added once we have state-replay fixtures.
+            markers: crate::behavioral::GENERIC_PRODUCTIVE_MARKERS,
+            use_heartbeat: true,
+            heartbeat_fresh_window_ms: 10_000,
+            cache_id: Some(MarkerCacheId::Generic),
+        },
+        context_pattern: None,
+        input_line_markers: &["❯"],
+        initial_state: AgentState::Starting,
     }
 }
 
@@ -538,6 +583,7 @@ mod context_pattern_tests {
         assert!(!has(&Backend::Codex));
         assert!(!has(&Backend::OpenCode));
         assert!(!has(&Backend::Agy));
+        assert!(!has(&Backend::Grok));
         assert!(!has(&Backend::Shell));
         assert!(!has(&Backend::Raw("x".into())));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -819,16 +819,14 @@ fn main() -> anyhow::Result<()> {
                             .split_once(':')
                             .map(|(n, c)| (n.to_string(), c.to_string()))
                             .unwrap_or_else(|| (a.to_string(), a.to_string()));
-                        let (preset_args, submit_key) = backend::Backend::from_command(&cmd)
-                            .map(|b| {
-                                let p = b.preset();
-                                let mut a: Vec<String> =
-                                    p.args.iter().map(|s| s.to_string()).collect();
-                                a.extend(p.resume_mode.args_for());
-                                (a, p.submit_key.to_string())
-                            })
-                            .unwrap_or_else(|| (Vec::new(), "\r".to_string()));
-                        (name, cmd, preset_args, None, None, submit_key)
+                        // User-only args: empty. `agent::build_command` prepends
+                        // `preset_spawn_args(spawn_mode)` — callers must NOT also
+                        // stuff preset flags here or backends that reject
+                        // duplicate flags (e.g. Grok `--always-approve`) exit 2.
+                        let submit_key = backend::Backend::from_command(&cmd)
+                            .map(|b| b.preset().submit_key.to_string())
+                            .unwrap_or_else(|| "\r".to_string());
+                        (name, cmd, Vec::new(), None, None, submit_key)
                     })
                     .collect();
                 // #1441: managed spawns fail-fast unless the instance is in

--- a/src/mcp_config.rs
+++ b/src/mcp_config.rs
@@ -814,6 +814,72 @@ fn strip_agend_mcp_sections(content: &str) -> String {
     out
 }
 
+/// Grok Build: write project-scoped `<workdir>/.grok/config.toml` with
+/// `[mcp_servers.agend-terminal]`. Grok loads project MCP from that path
+/// (see `grok mcp add --scope project`). Scope rule: never write `~/.grok`.
+fn configure_grok(working_dir: &Path, instance_name: Option<&str>) -> Result<()> {
+    configure_grok_with_home(working_dir, &home_path(), instance_name)
+}
+
+fn configure_grok_with_home(
+    working_dir: &Path,
+    home: &str,
+    instance_name: Option<&str>,
+) -> Result<()> {
+    let (bridge_cmd, bridge_args) = bridge_binary_path();
+    let grok_dir = working_dir.join(".grok");
+    std::fs::create_dir_all(&grok_dir)?;
+    let config_path = grok_dir.join("config.toml");
+
+    let _lock = crate::store::acquire_file_lock(&config_lock_path(&config_path))?;
+
+    let existing = std::fs::read_to_string(&config_path).unwrap_or_default();
+    // Reuse the same section headers as Codex — Grok's native schema is also
+    // `[mcp_servers.<name>]` (+ optional `.env` subtable).
+    let mut stripped = strip_agend_mcp_sections(&existing);
+    while stripped.ends_with("\n\n") {
+        stripped.pop();
+    }
+    if !stripped.is_empty() && !stripped.ends_with('\n') {
+        stripped.push('\n');
+    }
+    let separator = if stripped.is_empty() { "" } else { "\n" };
+
+    let bin_lit = toml_string_value(&bridge_cmd);
+    let home_lit = toml_string_value(home);
+    let instance_line = instance_name
+        .map(|n| format!("AGEND_INSTANCE_NAME = {}\n", toml_string_value(n)))
+        .unwrap_or_default();
+    let args_toml = if bridge_args.is_empty() {
+        "[]".to_string()
+    } else {
+        format!(
+            "[{}]",
+            bridge_args
+                .iter()
+                .map(|a| format!("\"{a}\""))
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    };
+    let body = format!(
+        r#"{stripped}{separator}{CODEX_MCP_HEADER}
+command = {bin_lit}
+args = {args_toml}
+enabled = true
+
+{CODEX_MCP_ENV_HEADER}
+AGEND_HOME = {home_lit}
+{instance_line}"#
+    );
+
+    if existing != body {
+        crate::store::atomic_write(&config_path, body.as_bytes())?;
+    }
+    tracing::debug!(path = %config_path.display(), "configured Grok MCP");
+    Ok(())
+}
+
 /// Detect backend from command name and configure MCP.
 pub fn configure(working_dir: &Path, command: &str, instance_name: Option<&str>) {
     let backend = crate::backend::Backend::from_command(command);
@@ -823,6 +889,7 @@ pub fn configure(working_dir: &Path, command: &str, instance_name: Option<&str>)
         Some(crate::backend::Backend::Agy) => configure_agy(working_dir, instance_name),
         Some(crate::backend::Backend::OpenCode) => configure_opencode(working_dir, instance_name),
         Some(crate::backend::Backend::Codex) => configure_codex(working_dir, instance_name),
+        Some(crate::backend::Backend::Grok) => configure_grok(working_dir, instance_name),
         // Non-preset backends (Shell, Raw) have no MCP wiring.
         Some(crate::backend::Backend::Shell) | Some(crate::backend::Backend::Raw(_)) | None => {
             return
@@ -1140,6 +1207,50 @@ mod tests {
         configure(&dir, "opencode", None);
         assert!(dir.join("opencode.json").exists());
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn configure_dispatches_grok_writes_project_toml() {
+        let dir = tmp_dir("dispatch_grok");
+        let home_scratch = tmp_dir("dispatch_grok_home");
+        configure_grok_with_home(&dir, home_scratch.to_str().unwrap(), Some("grok-1"))
+            .expect("configure_grok");
+
+        let cfg = dir.join(".grok").join("config.toml");
+        assert!(cfg.exists(), "configure_grok must write .grok/config.toml");
+        let body = std::fs::read_to_string(&cfg).unwrap();
+        assert!(
+            body.contains("[mcp_servers.agend-terminal]"),
+            "missing mcp server table: {body}"
+        );
+        assert!(
+            body.contains("AGEND_INSTANCE_NAME"),
+            "missing instance env: {body}"
+        );
+        assert!(
+            body.contains("enabled = true"),
+            "server must be enabled: {body}"
+        );
+        // Scope rule: nothing under the home_scratch arg except what we pass as AGEND_HOME value
+        let home_entries: Vec<_> = std::fs::read_dir(&home_scratch)
+            .map(|rd| rd.filter_map(|e| e.ok()).collect())
+            .unwrap_or_default();
+        assert!(
+            home_entries.is_empty(),
+            "configure_grok must not write under home, found: {home_entries:?}"
+        );
+        // Second call is idempotent (no double-append).
+        configure_grok_with_home(&dir, home_scratch.to_str().unwrap(), Some("grok-1"))
+            .expect("configure_grok 2");
+        let body2 = std::fs::read_to_string(&cfg).unwrap();
+        assert_eq!(
+            body.matches("[mcp_servers.agend-terminal]").count(),
+            1,
+            "must not duplicate sections"
+        );
+        assert_eq!(body, body2);
+        std::fs::remove_dir_all(&dir).ok();
+        std::fs::remove_dir_all(&home_scratch).ok();
     }
 
     /// #987: configure dispatches Backend::Agy to write the standard

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -49,6 +49,7 @@ pub const BACKEND_SKILL_DIRS: &[(&str, &str)] = &[
     ("opencode", ".opencode/skills"),
     ("kiro", ".kiro/skills"),
     ("agy", ".agents/skills"),
+    ("grok", ".grok/skills"),
 ];
 
 /// Unified skill source root: `<home>/skills/`.

--- a/src/state/patterns.rs
+++ b/src/state/patterns.rs
@@ -193,6 +193,7 @@ impl StatePatterns {
         static CODEX: OnceLock<StatePatterns> = OnceLock::new();
         static OPENCODE: OnceLock<StatePatterns> = OnceLock::new();
         static AGY: OnceLock<StatePatterns> = OnceLock::new();
+        static GROK: OnceLock<StatePatterns> = OnceLock::new();
         static EMPTY: OnceLock<StatePatterns> = OnceLock::new();
 
         let lock = match backend {
@@ -201,6 +202,7 @@ impl StatePatterns {
             Backend::Codex => &CODEX,
             Backend::OpenCode => &OPENCODE,
             Backend::Agy => &AGY,
+            Backend::Grok => &GROK,
             Backend::Shell | Backend::Raw(_) => &EMPTY,
         };
         // #1580: every backend now routes through its co-located BackendProfile —


### PR DESCRIPTION
## Summary

Adds **Grok Build CLI** (`grok`) as a first-class `Backend` so fleet instances can set `backend: grok` and participate in dispatch.

- **Spawn**: `grok --always-approve`
- **Inject**: `typed_inject` (PTY smoke: bulk write does not land)
- **Trust dismiss**: auto-Enter on `Run Grok Build in a project directory?`
- **Instructions**: shared `AGENTS.md`
- **MCP**: project-local `<workdir>/.grok/config.toml` `[mcp_servers.agend-terminal]` (no `~/.grok` writes)
- **State**: thin Idle/Active/Permission patterns (MVP)
- **Resume**: off for now — bare `--continue` with no session **exits 2**
- **Fix**: `--agents` no longer double-applies preset flags (Grok rejects duplicate `--always-approve`)

Aliases: `grok`, `grok-build`, `grok-cli`. Credential allowlist: `XAI_API_KEY`.

## Test plan

- [x] `cargo test --bin agend-terminal grok` (preset + configure_grok)
- [x] Isolated daemon smoke: `AGEND_HOME=… start --agents g:grok` → healthy idle, single `--always-approve`
- [ ] CI green on this PR
- [ ] Optional dogfood: fleet.yaml instance `backend: grok` + inject / send

## Out of scope (follow-ups)

- Session resume via `~/.grok/sessions` probe
- Richer state-replay fixtures / productivity markers
- Hook / shadow observer plane
- Production fleet.yaml opt-in (operator choice)

Claim: grok-backend-mvp