### PR TITLE
fix(#2703): dispatch/checkout auto-create base on repo default branch, not hardcoded origin/main

### DIFF
--- a/src/mcp/handlers/ci/checkout.rs
+++ b/src/mcp/handlers/ci/checkout.rs
@@ -98,8 +98,14 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
     let mut auto_created_branch = false;
     let mut fetch_attempted = false;
     if bind {
-        let from_ref = args["from_ref"].as_str().unwrap_or("origin/main");
         let src = Path::new(&source_path);
+        // #2703: when the caller omits `from_ref`, default to the repo's DEFAULT
+        // branch (origin/HEAD via `default_branch`), not a hard-coded origin/main —
+        // mirrors the dispatch-path fix (dispatch_hook/mod.rs). An explicit
+        // `from_ref` override is unchanged. Main-default repos: default_branch →
+        // "main" → "origin/main", byte-identical to the prior literal.
+        let default_base = format!("origin/{}", crate::git_helpers::default_branch(src));
+        let from_ref = args["from_ref"].as_str().unwrap_or(&default_base);
         match crate::mcp::handlers::dispatch_hook::ensure_branch_exists(
             home,
             src,

--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -1105,6 +1105,102 @@ fn checkout_bind_true_writes_binding_marker_and_no_longer_arms_watch_2158_gr1() 
     std::fs::remove_dir_all(&parent).ok();
 }
 
+/// #2703: `repo action=checkout bind:true` WITHOUT an explicit `from_ref` must
+/// default the new branch's base to the repo's DEFAULT branch (`origin/HEAD`),
+/// not a hard-coded `origin/main` (checkout.rs's `unwrap_or("origin/main")`).
+/// Same root as the dispatch-path fix (dispatch_hook/mod.rs:488). RED before the
+/// `default_branch()` swap (pre-fix the created branch tips at origin/main).
+#[test]
+#[cfg(unix)]
+fn checkout_bind_true_defaults_base_to_repo_default_branch_2703() {
+    let home = p778_tmp_home("2703-devdefault");
+    let parent = p778_tmp_home("2703-devdefault-src");
+    let origin = parent.join("o.git");
+    let source = parent.join("source-repo");
+
+    let git = |args: &[&str], dir: &std::path::Path| -> String {
+        let out = std::process::Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .env("AGEND_GIT_BYPASS", "1")
+            .output()
+            .expect("git spawn");
+        assert!(
+            out.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        String::from_utf8_lossy(&out.stdout).trim().to_string()
+    };
+
+    // Bare origin whose DEFAULT branch is `dev`, with main != dev tips.
+    std::fs::create_dir_all(&origin).ok();
+    git(&["init", "--bare", "-b", "main"], &origin);
+    std::fs::create_dir_all(&source).ok();
+    git(&["init", "-b", "main"], &source);
+    git(
+        &["remote", "add", "origin", origin.to_str().unwrap()],
+        &source,
+    );
+    git(
+        &[
+            "-c",
+            "user.name=t",
+            "-c",
+            "user.email=t@t",
+            "commit",
+            "--allow-empty",
+            "-m",
+            "MAIN",
+        ],
+        &source,
+    );
+    let main_sha = git(&["rev-parse", "HEAD"], &source);
+    git(&["push", "-q", "origin", "main"], &source);
+    git(&["checkout", "-b", "dev"], &source);
+    git(
+        &[
+            "-c",
+            "user.name=t",
+            "-c",
+            "user.email=t@t",
+            "commit",
+            "--allow-empty",
+            "-m",
+            "DEV",
+        ],
+        &source,
+    );
+    let dev_sha = git(&["rev-parse", "HEAD"], &source);
+    git(&["push", "-q", "origin", "dev"], &source);
+    git(&["symbolic-ref", "HEAD", "refs/heads/dev"], &origin);
+    git(&["fetch", "origin", "--quiet"], &source);
+    git(&["remote", "set-head", "origin", "dev"], &source);
+    assert_ne!(main_sha, dev_sha);
+
+    // No `from_ref` supplied → must default to the repo default (origin/dev).
+    let resp = super::handle_checkout_repo(
+        &home,
+        &serde_json::json!({
+            "repository_path": source.display().to_string(),
+            "branch": "feat/x-2703",
+            "bind": true,
+        }),
+        "checkout-2703-agent",
+    );
+    assert!(resp.get("error").is_none(), "checkout must succeed: {resp}");
+
+    let created = git(&["rev-parse", "refs/heads/feat/x-2703"], &source);
+    assert_eq!(
+        created, dev_sha,
+        "#2703: checkout bind:true default base must be repo default (origin/dev), \
+         got {created} (origin/main={main_sha})"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&parent).ok();
+}
+
 /// #2533: `repo action=checkout bind:true task_id=...` (the reviewer-workflow
 /// self-claim path, §3.19.1) must thread the caller-supplied `task_id` into
 /// `binding.json` — pre-fix, `handle_checkout_repo_inner` hardcoded `""`

--- a/src/mcp/handlers/dispatch_hook/mod.rs
+++ b/src/mcp/handlers/dispatch_hook/mod.rs
@@ -469,7 +469,12 @@ pub(crate) fn dispatch_auto_bind_lease_with_source_and_chain(
     // auto_created_branch / fetch_attempted) and shares one decision
     // tree with `repo action=checkout bind:true` (the #784 entry).
     //
-    // `from_ref` is hard-coded to `"origin/main"` (mirror #784 default).
+    // #2703: `from_ref` is the repo's DEFAULT branch (`origin/<default_branch>`
+    // via `git_helpers::default_branch`, reading `origin/HEAD`), NOT a hard-coded
+    // `origin/main` (the #784 default, which mis-based every dispatched branch in a
+    // dev-default repo). Invariant for main-default (and origin/HEAD-blind) repos:
+    // `default_branch` returns "main" → `origin/main`, byte-identical to the prior
+    // literal (pinned by `dispatch_auto_create_main_default_invariance_2703`).
     //
     // Strict error contract (#781 Phase 3 r1, Path A — restored after
     // initial fail-soft fix was found to weaken Piece 7's structured-
@@ -485,7 +490,15 @@ pub(crate) fn dispatch_auto_bind_lease_with_source_and_chain(
     let (auto_created_branch, fetch_attempted) = if reused {
         (false, false)
     } else {
-        ensure_branch_exists(home, &source_repo, branch, "origin/main", target)?
+        // #2703: base on the repo's default branch (origin/HEAD), not a literal
+        // origin/main. `default_branch` returns a bare branch name; qualify it with
+        // the push remote (`origin`, per #2047) so `resolve_from_ref_remote` splits
+        // it correctly for both the create base and the #1755 pre-create fetch.
+        let base = format!(
+            "origin/{}",
+            crate::git_helpers::default_branch(&source_repo)
+        );
+        ensure_branch_exists(home, &source_repo, branch, &base, target)?
     };
 
     // #2234 cure-(B): under the flag the agent's WORKSPACE dir IS its worktree

--- a/src/mcp/handlers/dispatch_hook/tests.rs
+++ b/src/mcp/handlers/dispatch_hook/tests.rs
@@ -173,6 +173,148 @@ fn ensure_branch_exists_refreshes_stale_origin_before_create_1755() {
     std::fs::remove_dir_all(&home).ok();
 }
 
+/// #2703: the dispatch auto-create path must base a NEW branch on the repo's
+/// DEFAULT branch (`origin/HEAD` via `git_helpers::default_branch`), NOT a
+/// hard-coded `origin/main`. External report (cheerc, 2/2 repro): a repo whose
+/// default is `dev` got every dispatched branch based on `origin/main`, forcing
+/// an impl-side `reset --hard origin/dev`. RED before the mod.rs:488
+/// `default_branch()` swap (pre-fix the created branch tips at origin/main).
+#[test]
+fn dispatch_auto_create_bases_on_repo_default_branch_2703() {
+    let home = std::env::temp_dir().join(format!("agend-2703-devdefault-{}", std::process::id()));
+    std::fs::create_dir_all(&home).ok();
+    let workspace = crate::paths::workspace_dir(&home);
+    std::fs::create_dir_all(&workspace).ok();
+    let origin = workspace.join("o.git");
+    let repo = workspace.join("dev-agent");
+
+    let git = |args: &[&str], dir: &std::path::Path| -> String {
+        let out = std::process::Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .env("AGEND_GIT_BYPASS", "1")
+            .output()
+            .expect("git spawn");
+        assert!(
+            out.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        String::from_utf8_lossy(&out.stdout).trim().to_string()
+    };
+
+    // Bare origin whose DEFAULT branch is `dev`, with main != dev tips.
+    std::fs::create_dir_all(&origin).ok();
+    git(&["init", "--bare", "-b", "main"], &origin);
+    std::fs::create_dir_all(&repo).ok();
+    git(&["init", "-b", "main"], &repo);
+    git(
+        &["remote", "add", "origin", origin.to_str().unwrap()],
+        &repo,
+    );
+    git(
+        &[
+            "-c",
+            "user.name=t",
+            "-c",
+            "user.email=t@t",
+            "commit",
+            "--allow-empty",
+            "-m",
+            "MAIN",
+        ],
+        &repo,
+    );
+    let main_sha = git(&["rev-parse", "HEAD"], &repo);
+    git(&["push", "-q", "origin", "main"], &repo);
+    git(&["checkout", "-b", "dev"], &repo);
+    git(
+        &[
+            "-c",
+            "user.name=t",
+            "-c",
+            "user.email=t@t",
+            "commit",
+            "--allow-empty",
+            "-m",
+            "DEV",
+        ],
+        &repo,
+    );
+    let dev_sha = git(&["rev-parse", "HEAD"], &repo);
+    git(&["push", "-q", "origin", "dev"], &repo);
+    // origin default → dev (bare HEAD + local remote-tracking `origin/HEAD`).
+    git(&["symbolic-ref", "HEAD", "refs/heads/dev"], &origin);
+    git(&["fetch", "origin", "--quiet"], &repo);
+    git(&["remote", "set-head", "origin", "dev"], &repo);
+    assert_ne!(main_sha, dev_sha);
+    assert_eq!(
+        crate::git_helpers::default_branch(&repo),
+        "dev",
+        "precondition: repo default must resolve to dev"
+    );
+
+    // fleet.yaml so dispatch resolves source_repo = repo.
+    std::fs::write(
+        crate::fleet::fleet_yaml_path(&home),
+        format!(
+            "instances:\n  dev-agent:\n    backend: claude\n    working_directory: {}\n",
+            repo.display()
+        ),
+    )
+    .ok();
+
+    // Call the PRODUCTION dispatch entry.
+    let r = super::dispatch_auto_bind_lease(&home, "dev-agent", "T-2703", "feat/x-2703", None);
+    assert!(r.is_ok(), "dispatch must succeed: {:?}", r.err());
+
+    // The created branch must base on origin/dev (the default), NOT origin/main.
+    let created_tip = git(&["rev-parse", "refs/heads/feat/x-2703"], &repo);
+    assert_eq!(
+        created_tip, dev_sha,
+        "#2703: dispatched branch must base on repo default (origin/dev), \
+         got {created_tip} (origin/main={main_sha})"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// #2703 invariance: a repo whose default IS `main` must stay byte-identical to
+/// the pre-fix literal — the dispatched branch still bases on `origin/main`.
+/// Guards the common case against regression when the `origin/main` literal
+/// became `format!("origin/{}", default_branch(src))` (default_branch → "main").
+#[test]
+fn dispatch_auto_create_main_default_invariance_2703() {
+    let home = std::env::temp_dir().join(format!("agend-2703-maininv-{}", std::process::id()));
+    std::fs::create_dir_all(&home).ok();
+    setup_test_repo(&home, "main-agent");
+    let repo = crate::paths::workspace_dir(&home).join("main-agent");
+    let git = |args: &[&str]| -> String {
+        let out = std::process::Command::new("git")
+            .args(args)
+            .current_dir(&repo)
+            .env("AGEND_GIT_BYPASS", "1")
+            .output()
+            .expect("git spawn");
+        String::from_utf8_lossy(&out.stdout).trim().to_string()
+    };
+    let origin_main = git(&["rev-parse", "refs/remotes/origin/main"]);
+    assert_eq!(
+        crate::git_helpers::default_branch(&repo),
+        "main",
+        "precondition: default must resolve to main"
+    );
+
+    let r = super::dispatch_auto_bind_lease(&home, "main-agent", "T-inv", "feat/inv-2703", None);
+    assert!(r.is_ok(), "dispatch must succeed: {:?}", r.err());
+
+    let created = git(&["rev-parse", "refs/heads/feat/inv-2703"]);
+    assert_eq!(
+        created, origin_main,
+        "#2703: main-default repo base must stay origin/main (byte-identical)"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
 #[test]
 fn dispatch_with_branch_creates_binding_and_worktree() {
     let home = std::env::temp_dir().join(format!("agend-s53-prod-{}-bind", std::process::id()));


### PR DESCRIPTION
## Problem (external report #2703, cheerc — 2/2 repro + event-log evidence)

`send(kind=task, branch=<new>)` dispatch auto-create hard-coded the new-branch base to `"origin/main"` (`dispatch_hook/mod.rs:488`); `repo action=checkout bind:true` defaulted the same via `unwrap_or("origin/main")` (`ci/checkout.rs`). In a **dev-default repo** (`origin/HEAD → dev`) every dispatched / checked-out branch based on `origin/main` — the wrong base — forcing an impl-side `reset --hard origin/dev`.

## Root cause: a single literal, cascading

The literal `"origin/main"` fed **both** the create base (`git branch <b> origin/main`) **and** the #1755 pre-create fetch refspec (`+main:refs/remotes/origin/main`) via `resolve_from_ref_remote`. One change fixes the whole chain. `git_helpers::default_branch()` (reads `origin/HEAD`, comment: *"do NOT blindly assume main"*) was already used by 4 other daemon sites — dispatch was the lone outlier.

## Fix

Both sites derive the base from `format!("origin/{}", git_helpers::default_branch(&source_repo))`.

- **Main-default / origin-HEAD-blind repos**: `default_branch` → `"main"` → `"origin/main"`, **byte-identical** to the prior literal (worst case of new code == the only case of old code → no regression).
- **dev-default repos**: base correctly becomes `origin/dev`.
- `repo checkout`'s explicit `from_ref` override is unchanged; only its *default* moved.

Out of scope (per triage): `clean_empty_init_commits`' `reset/rebase origin/main` (history-rewrite class — separate backlog); a `send` `from_ref` param (deferred until a real need).

## Tests (RED-first, proven)

- `dispatch_auto_create_bases_on_repo_default_branch_2703` — dev-default → base==origin/dev (pre-fix RED: based on origin/main).
- `checkout_bind_true_defaults_base_to_repo_default_branch_2703` — same for `repo checkout` default (pre-fix RED).
- `dispatch_auto_create_main_default_invariance_2703` — main-default → base stays origin/main (byte-identical guard).

Gate: fmt ✓, CI-scoped clippy `-D warnings` ✓, dispatch_hook+ci modules 166/166 ✓, file-size invariant ✓.

Closes #2703

🤖 Generated with [Claude Code](https://claude.com/claude-code)