### PR TITLE
feat(worktree-gc PR-D·D1): terminal_disposition classifier + fail-direction pins

### DIFF
--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -12,6 +12,10 @@
 use crate::agent_ops::validate_branch;
 use std::path::{Path, PathBuf};
 
+/// PR-D · D1: the unified `terminal_disposition` classifier seam (spike §1).
+/// Additive — no production caller yet; D2–D4 wire the call sites.
+pub(crate) mod disposition;
+
 /// Sprint 57 Wave 4 (#546 Item 4) canonical worktree path:
 /// `$AGEND_HOME/worktrees/<agent>/<branch>/`. Single source of truth
 /// — every site that needs to know "where does agent X's branch Y

--- a/src/worktree/disposition.rs
+++ b/src/worktree/disposition.rs
@@ -1,0 +1,398 @@
+//! PR-D · D1 — the single `terminal_disposition` classifier (janitor spike §1).
+//!
+//! Today the worktree-cleanup / GC-retention / auto-release paths each run their
+//! OWN "is this terminal?" decision (spike §0: three decision systems over six
+//! kill-paths). This module is the unified DECISION seam they will share: one
+//! pure classifier that maps a worktree's resolved signals to one of four
+//! dispositions. It is **pure by construction** — every I/O-derived signal is an
+//! INPUT, computed by the caller. The impure signal-gathering stays in each
+//! system; D2–D4 wire the call sites (this D1 slice is purely additive and has
+//! ZERO production callers).
+//!
+//! The one invariant every layer preserves (spike §0): **every ambiguity fails
+//! toward NOT destroying.** `Keep` is the safe default; the classifier only
+//! reaches `Release`/`Delete`/`Archive` on a POSITIVE terminal signal, never on
+//! the mere absence of a keep signal. The fail-direction of each row is pinned
+//! by the tests below.
+//!
+//! Extract-and-delegate (spike §5): the classifier COMPOSES sub-verdicts already
+//! produced by each system's existing fn — `ReleaseDecision` from
+//! [`crate::daemon::auto_release::decide_release`], `releasable_by_invariant`
+//! from `auto_release::releasable_by_invariant`, a [`ReclaimState`] from the GC
+//! `evaluate_candidate` classification. It re-encodes NONE of that logic; it only
+//! adds the cross-system routing that unifies the three decision systems.
+#![allow(dead_code)] // D1 additive: no production caller until D2–D4 wire the call sites.
+
+use crate::daemon::auto_release::ReleaseDecision;
+
+/// The four terminal dispositions of a worktree (spike §1). Orthogonal to the
+/// branch decision ([`BranchDisposition`], spike §1 L4, which is worktree-
+/// independent per the CR-2026-06-14 dir-vs-branch decoupling).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Disposition {
+    /// Not terminal, or ambiguous → leave it alone (the fail-closed default).
+    Keep,
+    /// Binding present + terminal → full managed release (`release_full`:
+    /// WIP-preserve → remove → unbind → branch cleanup).
+    Release,
+    /// No binding, confirmed-clean terminal → historical hard remove
+    /// (CleanRelease, decision Q3 — ungated).
+    Delete,
+    /// Reclaim-worthy but the git state is untrustworthy/unverifiable → atomic
+    /// archive to `.trash` (recoverable): ForceReclaim always, or a CleanRelease
+    /// the hard-delete couldn't act on.
+    Archive,
+}
+
+/// L3 (binding-absent, GC) reclaim classification. Produced by the GC system's
+/// `evaluate_candidate` (D4 wires it); the pure part the classifier routes on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ReclaimState {
+    /// Not a GC candidate (in grace, not aged, or spared) → Keep.
+    NotEligible,
+    /// `released_at` present, past the 24h grace, worktree clean → hard delete.
+    CleanReleaseHardDelete,
+    /// `released_at` present + past grace, but the hard delete is unactionable
+    /// (lock contention / owning-repo unresolved / remove failed) and the
+    /// archive gate is on → archive instead.
+    CleanReleaseArchive,
+    /// Never-released OR malformed `released_at`, dead agent, past the age cap →
+    /// ForceReclaim: ALWAYS archived, never hard-deleted (t-worktree-leak PR-2).
+    ForceReclaim,
+}
+
+/// Whether a branch's work is provably in `default` (spike §1 L4). This axis is
+/// SEPARATE from the worktree-dir disposition: a remote-gone branch's worktree
+/// may be reclaimed while its branch ref is KEPT (CR-2026-06-14 — remote-gone
+/// alone is never a `branch -D` trigger).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BranchSignal {
+    /// Merged-ancestor, squash-merged past the age floor, or an authoritative
+    /// merged PR (#2698) → the work is provably in `default`.
+    ProvablyInDefault,
+    /// The remote-tracking ref is gone but the branch is NOT proven merged —
+    /// may hold unpushed local work (CR-2026-06-14). Never a delete trigger.
+    RemoteGoneOnly,
+    /// Not merged and not remote-gone → keep.
+    NotMerged,
+}
+
+/// Branch-ref disposition (spike §1 L4).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BranchDisposition {
+    KeepBranch,
+    DeleteBranch,
+}
+
+/// Pre-computed, caller-gathered signals for [`terminal_disposition`]. Ambiguity
+/// is preserved as `Option::None` on the dimensions where the DECISION (not the
+/// I/O) owns the fail-direction, so the classifier can route it to `Keep`.
+pub(crate) struct DispositionInput {
+    // ── L0: protection layer (any hit → Keep) ──
+    /// `.agend-managed` marker present. `false` = operator-created, not ours.
+    pub daemon_managed: bool,
+    /// `.agend-pinned` present.
+    pub pinned: bool,
+    /// In-use / occupancy. `None` = could not be determined (corrupt
+    /// binding.json, un-canonicalizable ancestor) → fail-closed Keep;
+    /// `Some(true)` = in use → Keep.
+    pub in_use: Option<bool>,
+
+    // ── L1/L2: binding present — the auto-release system ──
+    /// Whether a binding is present. Drives the L2 (present) vs L3 (absent)
+    /// split — kept explicit because `ReleaseDecision::SkipNotBound` conflates
+    /// "no binding" with "dirty undetermined".
+    pub binding_present: bool,
+    /// The auto-release gate verdict (`decide_release`: task/opt-out/bound/dirty).
+    pub release_decision: ReleaseDecision,
+    /// The PR-invariant half (`releasable_by_invariant`): PR-terminal OR
+    /// (no-PR ∧ branch tasks done). Ambiguity (Unknown / open PR / pending
+    /// task) already collapses to `false` upstream → the classifier keeps.
+    pub releasable_by_invariant: bool,
+
+    // ── L3: binding absent — the GC system ──
+    /// Agent liveness. `None` = liveness could not be read → fail-toward-alive
+    /// Keep; `Some(true)` = alive → Keep.
+    pub agent_alive: Option<bool>,
+    /// GC reclaim classification.
+    pub reclaim: ReclaimState,
+}
+
+/// The unified worktree-disposition decision (spike §1, layers L0–L3). Pure:
+/// routes over pre-computed sub-verdicts, duplicating none of their logic.
+pub(crate) fn terminal_disposition(input: &DispositionInput) -> Disposition {
+    // ── L0 — protection. Any ambiguity or protection hit → Keep. ──
+    if !input.daemon_managed || input.pinned {
+        return Disposition::Keep;
+    }
+    match input.in_use {
+        None | Some(true) => return Disposition::Keep, // unresolvable or in use
+        Some(false) => {}
+    }
+
+    if input.binding_present {
+        // ── L1/L2 — binding present. Delegate the gate to `decide_release`'s
+        // verdict; release only on a POSITIVE PR-invariant. Every other case
+        // (dirty-not-releasable, undetermined dirty, opt-out, open PR, …) keeps. ──
+        match input.release_decision {
+            // Clean + bound + PR-releasable → release.
+            ReleaseDecision::Release if input.releasable_by_invariant => Disposition::Release,
+            // #2697: a dirty-but-releasable worktree still releases (release_full
+            // WIP-preserves the dirty tree first) rather than living forever.
+            ReleaseDecision::SkipDirtyWorktree if input.releasable_by_invariant => {
+                Disposition::Release
+            }
+            _ => Disposition::Keep,
+        }
+    } else {
+        // ── L3 — binding absent (GC). Liveness fails toward alive. ──
+        if input.agent_alive != Some(false) {
+            return Disposition::Keep; // alive, or liveness unreadable → spare
+        }
+        match input.reclaim {
+            ReclaimState::NotEligible => Disposition::Keep,
+            ReclaimState::CleanReleaseHardDelete => Disposition::Delete,
+            ReclaimState::CleanReleaseArchive | ReclaimState::ForceReclaim => Disposition::Archive,
+        }
+    }
+}
+
+/// The branch-ref decision (spike §1 L4), independent of the worktree dir.
+/// Delete only on provable-in-default; remote-gone alone never deletes.
+pub(crate) fn branch_disposition(signal: BranchSignal) -> BranchDisposition {
+    match signal {
+        BranchSignal::ProvablyInDefault => BranchDisposition::DeleteBranch,
+        BranchSignal::RemoteGoneOnly | BranchSignal::NotMerged => BranchDisposition::KeepBranch,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Base input: daemon-managed, not pinned, not in use, no binding, not a GC
+    /// candidate, agent dead. A no-op `Keep` — each test perturbs ONE dimension.
+    fn base() -> DispositionInput {
+        DispositionInput {
+            daemon_managed: true,
+            pinned: false,
+            in_use: Some(false),
+            binding_present: false,
+            release_decision: ReleaseDecision::SkipNotBound,
+            releasable_by_invariant: false,
+            agent_alive: Some(false),
+            reclaim: ReclaimState::NotEligible,
+        }
+    }
+
+    // ── L0 protection — fail-direction pins ──
+
+    #[test]
+    fn l0_unmanaged_worktree_is_kept() {
+        // A worktree WITHOUT the `.agend-managed` marker is operator-created —
+        // never ours to reclaim, whatever the other signals say.
+        let input = DispositionInput {
+            daemon_managed: false,
+            binding_present: true,
+            release_decision: ReleaseDecision::Release,
+            releasable_by_invariant: true,
+            ..base()
+        };
+        assert_eq!(terminal_disposition(&input), Disposition::Keep);
+    }
+
+    #[test]
+    fn l0_pinned_worktree_is_kept() {
+        let input = DispositionInput {
+            pinned: true,
+            ..base()
+        };
+        assert_eq!(terminal_disposition(&input), Disposition::Keep);
+    }
+
+    #[test]
+    fn l0_in_use_unresolvable_is_kept() {
+        // Occupancy could not be determined (corrupt binding.json / un-
+        // canonicalizable ancestor) → AMBIGUITY, not "not in use" → fail-closed.
+        let input = DispositionInput {
+            in_use: None,
+            ..base()
+        };
+        assert_eq!(terminal_disposition(&input), Disposition::Keep);
+    }
+
+    #[test]
+    fn l0_in_use_is_kept() {
+        let input = DispositionInput {
+            in_use: Some(true),
+            ..base()
+        };
+        assert_eq!(terminal_disposition(&input), Disposition::Keep);
+    }
+
+    // ── L1/L2 binding-present — fail-direction pins ──
+
+    #[test]
+    fn l1_undetermined_dirty_is_kept() {
+        // `decide_release` maps dirty=None → SkipNotBound (fail-safe). With a
+        // binding present that is NOT "no binding" — it is "dirty undetermined",
+        // and an undetermined dirty state must never release.
+        let input = DispositionInput {
+            binding_present: true,
+            release_decision: ReleaseDecision::SkipNotBound,
+            releasable_by_invariant: true,
+            ..base()
+        };
+        assert_eq!(terminal_disposition(&input), Disposition::Keep);
+    }
+
+    #[test]
+    fn l1_dirty_not_releasable_is_kept() {
+        // Dirty worktree, PR not terminal → WIP protection, keep.
+        let input = DispositionInput {
+            binding_present: true,
+            release_decision: ReleaseDecision::SkipDirtyWorktree,
+            releasable_by_invariant: false,
+            ..base()
+        };
+        assert_eq!(terminal_disposition(&input), Disposition::Keep);
+    }
+
+    #[test]
+    fn l2_bound_clean_not_releasable_is_kept() {
+        // Clean + bound but the PR is open / Unknown / tasks pending →
+        // releasable_by_invariant=false upstream → keep (sweeper retries).
+        let input = DispositionInput {
+            binding_present: true,
+            release_decision: ReleaseDecision::Release,
+            releasable_by_invariant: false,
+            ..base()
+        };
+        assert_eq!(terminal_disposition(&input), Disposition::Keep);
+    }
+
+    #[test]
+    fn l2_opt_out_is_kept() {
+        let input = DispositionInput {
+            binding_present: true,
+            release_decision: ReleaseDecision::SkipOptOut,
+            releasable_by_invariant: true,
+            ..base()
+        };
+        assert_eq!(terminal_disposition(&input), Disposition::Keep);
+    }
+
+    #[test]
+    fn l2_bound_clean_releasable_releases() {
+        // The one release path: clean + bound + PR-releasable.
+        let input = DispositionInput {
+            binding_present: true,
+            release_decision: ReleaseDecision::Release,
+            releasable_by_invariant: true,
+            ..base()
+        };
+        assert_eq!(terminal_disposition(&input), Disposition::Release);
+    }
+
+    #[test]
+    fn l2_dirty_but_releasable_releases_2697() {
+        // #2697: a releasable dirty worktree is no longer immortal — it releases
+        // (release_full WIP-preserves first), not retains forever.
+        let input = DispositionInput {
+            binding_present: true,
+            release_decision: ReleaseDecision::SkipDirtyWorktree,
+            releasable_by_invariant: true,
+            ..base()
+        };
+        assert_eq!(terminal_disposition(&input), Disposition::Release);
+    }
+
+    // ── L3 binding-absent (GC) — fail-direction pins ──
+
+    #[test]
+    fn l3_liveness_unreadable_fails_toward_alive() {
+        // Liveness could not be read → treat as alive → spare (fail-toward-alive),
+        // even for an otherwise force-reclaimable candidate.
+        let input = DispositionInput {
+            agent_alive: None,
+            reclaim: ReclaimState::ForceReclaim,
+            ..base()
+        };
+        assert_eq!(terminal_disposition(&input), Disposition::Keep);
+    }
+
+    #[test]
+    fn l3_agent_alive_is_kept() {
+        let input = DispositionInput {
+            agent_alive: Some(true),
+            reclaim: ReclaimState::ForceReclaim,
+            ..base()
+        };
+        assert_eq!(terminal_disposition(&input), Disposition::Keep);
+    }
+
+    #[test]
+    fn l3_not_eligible_is_kept() {
+        let input = DispositionInput {
+            reclaim: ReclaimState::NotEligible,
+            ..base()
+        };
+        assert_eq!(terminal_disposition(&input), Disposition::Keep);
+    }
+
+    #[test]
+    fn l3_clean_release_hard_deletes() {
+        let input = DispositionInput {
+            reclaim: ReclaimState::CleanReleaseHardDelete,
+            ..base()
+        };
+        assert_eq!(terminal_disposition(&input), Disposition::Delete);
+    }
+
+    #[test]
+    fn l3_clean_release_archive_archives() {
+        let input = DispositionInput {
+            reclaim: ReclaimState::CleanReleaseArchive,
+            ..base()
+        };
+        assert_eq!(terminal_disposition(&input), Disposition::Archive);
+    }
+
+    #[test]
+    fn l3_force_reclaim_archives_never_deletes() {
+        // t-worktree-leak PR-2: ForceReclaim is ALWAYS archived, never hard-deleted.
+        let input = DispositionInput {
+            reclaim: ReclaimState::ForceReclaim,
+            ..base()
+        };
+        assert_eq!(terminal_disposition(&input), Disposition::Archive);
+    }
+
+    // ── L4 branch — fail-direction pins ──
+
+    #[test]
+    fn l4_remote_gone_alone_keeps_branch() {
+        // CR-2026-06-14: remote-gone alone is NEVER a `branch -D` trigger — the
+        // branch may hold unpushed local work.
+        assert_eq!(
+            branch_disposition(BranchSignal::RemoteGoneOnly),
+            BranchDisposition::KeepBranch
+        );
+    }
+
+    #[test]
+    fn l4_not_merged_keeps_branch() {
+        assert_eq!(
+            branch_disposition(BranchSignal::NotMerged),
+            BranchDisposition::KeepBranch
+        );
+    }
+
+    #[test]
+    fn l4_provably_in_default_deletes_branch() {
+        assert_eq!(
+            branch_disposition(BranchSignal::ProvablyInDefault),
+            BranchDisposition::DeleteBranch
+        );
+    }
+}


### PR DESCRIPTION
## PR-D · D1 — `terminal_disposition` classifier + fail-direction pins

First slice of the janitor-unification refactor (spike vet-approved 2026-07-09, operator-greenlit 2026-07-10). See `JANITOR-DISPOSITION-SPIKE-20260709.md` §1/§6.

**Purely additive — NO production caller.** D2–D4 wire the three decision systems (auto_release / sweep / GC) onto this seam; this PR only establishes the classifier + its fail-direction contract. The module carries `#![allow(dead_code)]` for the interim.

### Code (`src/worktree/disposition.rs`)
- `terminal_disposition(&DispositionInput) -> Disposition` (Keep / Release / Delete / Archive) — spike §1 layers **L0–L3**.
- `branch_disposition(BranchSignal) -> BranchDisposition` — spike §1 **L4** (worktree-independent; remote-gone alone never deletes, CR-2026-06-14).
- **Pure combinators over pre-computed sub-verdicts** — `ReleaseDecision` from `daemon::auto_release::decide_release`, `releasable_by_invariant`, a `ReclaimState` (from GC `evaluate_candidate`), and liveness. It re-encodes **none** of that logic; it only adds the cross-system routing that unifies the three decision systems (extract-and-delegate, spike §5).

The one invariant every layer preserves: **every ambiguity fails toward NOT destroying.** `Keep` is the default; the classifier reaches Release/Delete/Archive only on a POSITIVE terminal signal.

### Tests — 19 fail-direction pins (spike success-criterion ①)
The spike §1 table has 11 layer rows (L0×4, L1×1, L2×2, L3×3, L4×1); the 19 pins cover every one, with both the fail-direction and the positive outcome per row:
- **L0**: unmanaged / pinned / in-use-unresolvable / in-use → Keep.
- **L1/L2**: undetermined-dirty → Keep, dirty-not-releasable → Keep, bound-clean-not-releasable → Keep, opt-out → Keep; bound-clean-releasable → Release; dirty-but-releasable → Release (#2697 WIP-preserve).
- **L3**: liveness-unreadable → fail-toward-alive Keep, agent-alive → Keep, not-eligible → Keep, clean-release → Delete, clean-release-archive → Archive, force-reclaim → Archive-never-delete (t-worktree-leak PR-2).
- **L4**: remote-gone-alone → KeepBranch (CR-2026-06-14), not-merged → KeepBranch, provably-in-default → DeleteBranch.

### Verification
- Baseline census **5424/5424** green (pre-change record).
- Post-change **5443/5443** green (census + 19 new pins, `--retries 2`; 5424 → 5443 = +19).
- `cargo fmt --check` clean; `cargo clippy --bin agend-terminal --features tray -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
