### PR TITLE
fix(grok): recalibrate Active/Idle patterns — close systemic false-idle (N1+N3)

### DIFF
--- a/src/backend_profile.rs
+++ b/src/backend_profile.rs
@@ -126,10 +126,13 @@ pub fn profile(backend: &Backend) -> &'static BackendProfile {
     }
 }
 
-/// Grok Build CLI — MVP detection profile (calibrated against Grok 0.2.93 PTY
-/// smoke). Patterns are deliberately thin: enough for dispatch ready/idle/active
-/// and the project-trust modal. Finer states (rate-limit, auth, etc.) land with
-/// real fixtures later.
+/// Grok Build CLI — detection profile. Active/Idle chrome RECALIBRATED against
+/// a live grok 0.2.93 soak (#2707, t-…64079-13) after the original one-shot
+/// smoke mis-anchored the busy state → systemic false-idle (see the Active
+/// pattern note below). Patterns stay deliberately thin: dispatch
+/// ready/idle/active + the project-trust modal. Finer states (rate-limit, auth)
+/// have NO reliable screen signature and are deferred to the structured-log
+/// detector follow-up (`~/.grok/logs/unified.jsonl`), not screen regex.
 fn grok_profile() -> BackendProfile {
     BackendProfile {
         patterns: vec![
@@ -139,17 +142,28 @@ fn grok_profile() -> BackendProfile {
                 AgentState::PermissionPrompt,
                 r"Run Grok Build in a project directory\?|Do you trust",
             ),
-            // Active turn chrome (smoke: Thinking… / Responding…).
-            (
-                AgentState::Active,
-                r"Thinking…|Thinking\.\.\.|Responding…|Responding\.\.\.|esc to interrupt",
-            ),
-            // Idle / ready chrome.
+            // Active turn chrome. #2707 (soak t-…64079-13): grok 0.2.93's real
+            // busy UI shows NEITHER `Thinking…`/`Responding…` NOR `esc to
+            // interrupt` — it renders the `[stop]` button + a `Ctrl+c:cancel`
+            // hint, both present across every busy sub-phase (thinking /
+            // responding / tool_running). These are busy-EXCLUSIVE; and because
+            // Active is checked before Idle (first-match-wins, `state/patterns.rs`
+            // `detect_with_match`), a correct Active match PREEMPTS the Idle
+            // fall-through that used to latch the permanent `always-approve`
+            // footer → the systemic false-idle (busy 席 mis-read idle → dispatch).
+            (AgentState::Active, r"\[stop\]|Ctrl\+c:cancel"),
+            // Idle / ready chrome. Keys on idle-ASSOCIATED anchors only: the
+            // turn-completion line and the resting prompt affordances.
+            // Deliberately NOT `always-approve` (a PERMANENT footer mode
+            // indicator with zero state semantics — present during busy too, N1)
+            // nor a bare `❯` (the input box renders during busy as well). On an
+            // unrecognized screen this yields `None`, not a confident Idle — the
+            // SAFE direction (a missed idle just delays dispatch; a false idle
+            // mis-dispatches a working 席).
             (
                 AgentState::Idle,
-                r"\? for shortcuts|Enter:send|always-approve",
+                r"Turn completed in \d|Space:prompt|Enter:open",
             ),
-            (AgentState::Idle, r"Grok Build|❯"),
         ],
         behavioral: BehavioralConfig {
             silence_thinking_ms: 3000,

--- a/src/state/tests.rs
+++ b/src/state/tests.rs
@@ -774,6 +774,89 @@ fn pattern_does_not_cross_backends() {
 }
 
 #[test]
+fn grok_busy_screen_fires_active_not_false_idle() {
+    // #2707 N1+N3 false-idle live fix. REAL grok 0.2.93 PTY capture (soak
+    // t-20260710050344357464-64079-13): a BUSY turn (tool_running) whose footer
+    // STILL shows the PERMANENT `always-approve` mode indicator + a bare `❯`
+    // input box. Pre-fix the Active pattern (Thinking…/Responding…/esc to
+    // interrupt) matched NOTHING on grok's real busy chrome, while the Idle
+    // pattern matched the permanent `always-approve` → first-match-wins returned
+    // Idle → the daemon mis-read an 18s busy turn as idle (observed_status idle
+    // throughout) → a working席 is eligible for dispatch. RED pre-fix.
+    let patterns = StatePatterns::for_backend(&Backend::Grok);
+    let busy = "◆ Thought for 1.0s
+收到 gapfix-dev3 的說明請求，撰寫完整回覆並回傳。
+◆ Agend-terminal Send
+⠧ Run (Agend-terminal) Send 0.0s                       14s ⇣25.5k [stop]
+│ ❯                                                    │
+╰──────────── Grok 4.5 (high) · always-approve ─╯
+Shift+Tab:mode  │  Ctrl+c:cancel  │  Ctrl+.:shortcuts";
+    assert_eq!(
+        patterns.detect(busy),
+        Some(AgentState::Active),
+        "grok busy screen (has [stop] / Ctrl+c:cancel) must fire Active — \
+         NOT false-idle via the permanent always-approve footer",
+    );
+}
+
+#[test]
+fn grok_idle_screen_fires_idle() {
+    // REAL grok 0.2.93 idle capture (same soak): a completed turn at rest — no
+    // busy chrome. Idle keys on idle-associated anchors (`Turn completed in …` /
+    // `Space:prompt` / `Enter:open`), NOT the permanent `always-approve` footer
+    // (removed as an Idle marker, N1) nor the bare `❯` (present during busy too).
+    let patterns = StatePatterns::for_backend(&Backend::Grok);
+    let idle = "已處理 gapfix-dev3 的純推理題：
+Turn completed in 14s.
+│ ❯ Build anything                                     │
+╰──────────── Grok 4.5 (high) · always-approve ─╯
+Space:prompt  │  Enter:open  │  Ctrl+e:expand thinking  │  Ctrl+.:shortcuts";
+    assert_eq!(
+        patterns.detect(idle),
+        Some(AgentState::Idle),
+        "grok idle screen must fire Idle",
+    );
+}
+
+#[test]
+fn grok_responding_phase_fires_active() {
+    // Second busy sub-phase, a distinct LIVE grok-soak capture (#2707 soak):
+    // the `responding` phase renders `⠴ Responding… <t>` on the status line
+    // AND `[stop]` + a `Ctrl+c:cancel` hint. Unlike `tool_running`, the old
+    // pattern's `Responding…` DID match here — but the FIX keys on the
+    // busy-EXCLUSIVE `[stop]`/`Ctrl+c:cancel` present across ALL busy
+    // sub-phases, so both responding and tool_running land on Active uniformly.
+    let patterns = StatePatterns::for_backend(&Backend::Grok);
+    let responding = "◆ Thought for 1.2s
+直接撰寫 ACID 說明並回
+⠴ Responding… 0.1s                                     4.1s ⇣27.3k [stop]
+│ ❯                                                    │
+╰──────────── Grok 4.5 (high) · always-approve ─╯
+Shift+Tab:mode  │  Ctrl+c:cancel  │  Ctrl+.:shortcuts";
+    assert_eq!(
+        patterns.detect(responding),
+        Some(AgentState::Active),
+        "grok responding-phase screen must fire Active",
+    );
+}
+
+#[test]
+fn grok_always_approve_footer_is_not_an_idle_marker() {
+    // N1: `always-approve` is a PERMANENT footer mode indicator (present during
+    // BUSY too, see grok_busy_screen_fires_active_not_false_idle), so it carries
+    // ZERO state semantics. A fragment whose only idle-ish token is the footer
+    // (no completion line, no prompt affordance, no busy chrome) must NOT fire
+    // Idle — else it re-opens the false-idle hole. RED pre-fix. #2707 N1.
+    let patterns = StatePatterns::for_backend(&Backend::Grok);
+    let footer_only = "╰──────────── Grok 4.5 (high) · always-approve ─╯";
+    assert_ne!(
+        patterns.detect(footer_only),
+        Some(AgentState::Idle),
+        "#N1: bare always-approve footer must NOT fire Idle",
+    );
+}
+
+#[test]
 fn empty_input_no_change() {
     let mut t = tracker_at(&Backend::ClaudeCode, AgentState::Starting, 0);
     t.feed("");


### PR DESCRIPTION
## Problem (live correctness bug)
Grok 0.2.93's real busy UI shows **neither** `Thinking…`/`Responding…` **nor** `esc to interrupt` on the `tool_running`/`thinking` phases — it renders the `[stop]` button + a `Ctrl+c:cancel` hint. The old Active pattern (`backend_profile.rs` `grok_profile`) matched **nothing** on those busy screens, so `detect_with_match`'s first-match-wins fell through to the Idle pattern, which latched the **permanent** `always-approve` footer → every such busy screen was classified **Idle**.

Hard evidence (soak `t-…64079-13`): an 18s busy turn showed `observed_status.state = idle` the entire time (`since_ms` never advanced). A busy 席 read as idle is dispatch-eligible → mis-dispatch onto a working agent.

## Fix (N1+N3 merged)
Merged deliberately — splitting would leave false-idle live after "N1 done" (removing `always-approve` alone doesn't fix it; the Active gap is the root cause).

- **Active** → `\[stop\]|Ctrl\+c:cancel` — busy-**exclusive**, present across all busy sub-phases (thinking / responding / tool_running). Because Active is checked before Idle, a correct Active match **preempts** the Idle fall-through. (`Ctrl+c:cancel` sits on the bottom hint line — the same always-scanned region as `always-approve` — so it's caught even if the detector reads only the bottom rows.)
- **Idle** → `Turn completed in \d|Space:prompt|Enter:open`. Drops the permanent `always-approve` (**N1** — zero state semantics, present during busy too), the stale `? for shortcuts` / `Enter:send` / `Grok Build`, and the non-exclusive bare `❯`. An unrecognized screen now yields `None` (→ silence-based idle fallback) — the **false-idle-safe** direction.

## Tests (RED-first, real soak captures)
`src/state/tests.rs`:
- `grok_busy_screen_fires_active_not_false_idle` — real tool_running capture (has permanent `always-approve` + bare `❯`). **RED pre-fix** (returned `Idle`).
- `grok_responding_phase_fires_active` — real responding-phase capture (distinct busy sub-phase).
- `grok_idle_screen_fires_idle` — real idle capture.
- `grok_always_approve_footer_is_not_an_idle_marker` — **N1** guard, **RED pre-fix** (footer alone returned `Idle`).

## Verification
- 6 grok tests green; `state::` + `backend_profile::` (455 tests) no regression; full suite 5425/5427 (2 fails = known always-fail-locally `attached_path_mcp_invariants` infra tests).
- CI-exact `rustfmt --check` (own sources) clean; CI-exact strict clippy (`-D warnings`) clean.

## Scope / follow-up
Screen-pattern calibration only. `rate-limit`/`auth` have no reliable screen signature (deferred to the `~/.grok/logs/unified.jsonl` structured-log detector follow-up). Live `observed_status` flip on the running fleet requires the daemon to run this patched binary (rebuild+restart) — not done here.