### PR TITLE
feat(worktree-gc PR-D·D2): auto_release delegates release gate to terminal_disposition

### DIFF
--- a/src/daemon/auto_release.rs
+++ b/src/daemon/auto_release.rs
@@ -403,6 +403,51 @@ pub(crate) fn decide_release(
     }
 }
 
+/// PR-D · D2 (#2711): the bound-path release gate, delegated to the unified
+/// [`crate::worktree::disposition::terminal_disposition`] classifier (D1) instead
+/// of an inline boolean. Pure, so the equivalence pin can lock it exhaustively.
+///
+/// The classifier owns the normal L1/L2 invariant — release only on a POSITIVE
+/// PR-invariant, for both the clean-`Release` and the #2697 dirty-but-releasable
+/// (`SkipDirtyWorktree`) arms. The auto-release path exercises only L0+L1/L2, so
+/// the L0 protection fields are fed pass-through values (the pre-D2 gate never
+/// consulted `.agend-managed` / `.agend-pinned` / occupancy) and the L3 (GC)
+/// fields are inert — with `binding_present=true` the classifier never reaches the
+/// binding-absent branch that reads them.
+///
+/// `reviewer_bypassed` (the #2010 2a reviewer-binding release) is `releasable ==
+/// false` BY CONSTRUCTION (it is only ever set inside the `!releasable` block), so
+/// the classifier keeps it. The bypass therefore releases a CLEAN reviewer
+/// worktree via a SEPARATE explicit arm; a DIRTY one still retains (protecting
+/// review WIP). This reproduces the pre-D2
+/// `matches!(Release) || (matches!(SkipDirtyWorktree) && releasable)` expression
+/// byte-for-byte on every reachable `(decision, releasable, reviewer_bypassed)` —
+/// locked by [`tests::should_release_now_equals_pre_d2_gate`].
+fn should_release_now(
+    decision: &ReleaseDecision,
+    releasable: bool,
+    reviewer_bypassed: bool,
+) -> bool {
+    use crate::worktree::disposition::{
+        terminal_disposition, Disposition, DispositionInput, ReclaimState,
+    };
+    let input = DispositionInput {
+        // L0 pass-through: the pre-D2 auto-release gate never consulted these.
+        daemon_managed: true,
+        pinned: false,
+        in_use: Some(false),
+        // L1/L2: the real sub-verdicts the classifier composes.
+        binding_present: true,
+        release_decision: decision.clone(),
+        releasable_by_invariant: releasable,
+        // L3 (GC) inert on the bound path — never read when binding_present.
+        agent_alive: Some(false),
+        reclaim: ReclaimState::NotEligible,
+    };
+    matches!(terminal_disposition(&input), Disposition::Release)
+        || (reviewer_bypassed && matches!(decision, ReleaseDecision::Release))
+}
+
 /// Return the queue directory path. Caller is responsible for ensuring
 /// it exists before reading; [`enqueue_intent`] handles creation on
 /// the write side.
@@ -680,7 +725,7 @@ fn process_intent(home: &Path, intent: &AutoReleaseIntent) -> IntentOutcome {
             }
         }
     }
-    if !releasable {
+    let reviewer_bypassed = if !releasable {
         // #2010 2a: the open-PR invariant holds an IMPLEMENTER's worktree until
         // the PR is terminal (correct — it may be needed for rework/merge), but
         // it must NOT hold a REVIEWER's binding once the reviewer's own review
@@ -699,11 +744,14 @@ fn process_intent(home: &Path, intent: &AutoReleaseIntent) -> IntentOutcome {
         if reviewer_binding_release_bypass(intent, task.as_ref(), &assignee, sender_role.as_deref())
         {
             tracing::info!(agent = %assignee, repo = %repo, branch = %branch, event, ?confidence, role = ?sender_role, "auto_release: reviewer-binding bypass — reviewer verdict + review task terminal, releasing if clean (#2010 2a)");
+            true
         } else {
             tracing::debug!(agent = %assignee, repo = %repo, branch = %branch, event, ?confidence, "auto_release: invariant not yet satisfied — retaining for retry");
             return IntentOutcome::Retry;
         }
-    }
+    } else {
+        false
+    };
 
     // ── final gate (dirty / opt-out / bound), must-fix #6.
     let worktree_dirty = binding
@@ -720,8 +768,11 @@ fn process_intent(home: &Path, intent: &AutoReleaseIntent) -> IntentOutcome {
     // AND notifies (wip_notice_recipient → team orchestrator, #2696) before
     // removing, so no WIP is lost. A NON-releasable dirty worktree (open PR /
     // Unknown / reviewer-bypass) still retains — that WIP may be active work.
-    let release_now = matches!(decision, ReleaseDecision::Release)
-        || (matches!(decision, ReleaseDecision::SkipDirtyWorktree) && releasable);
+    // PR-D · D2 (#2711): delegate this gate to the unified `terminal_disposition`
+    // classifier instead of the inline boolean. `reviewer_bypassed` carries the
+    // #2010 clean-reviewer release the classifier can't encode (releasable=false by
+    // construction). Byte-identical — `should_release_now` + its equivalence pin.
+    let release_now = should_release_now(&decision, releasable, reviewer_bypassed);
     if release_now {
         // codex gap ②: CAS+release must be ONE atomic critical section under
         // `.binding.json.lock` — the same lock `bind_full` holds (binding.rs:67)
@@ -1096,6 +1147,48 @@ mod tests {
             !reviewer_binding_release_bypass(&intent, None, "reviewer-1", rev),
             "missing task must not bypass"
         );
+    }
+
+    /// PR-D · D2 (#2711) equivalence pin: `should_release_now` — the classifier
+    /// delegation — must reproduce the pre-D2 inline gate
+    /// `matches!(Release) || (matches!(SkipDirtyWorktree) && releasable)`
+    /// byte-for-byte on EVERY reachable `(decision, releasable, reviewer_bypassed)`.
+    ///
+    /// Reachability at the gate (`process_intent`): the code returns `Retry` before
+    /// the gate unless `releasable || reviewer_bypassed`, and `reviewer_bypassed` is
+    /// only ever set inside the `!releasable` block — so at the gate EXACTLY ONE of
+    /// the two is true. The reviewer-bypass arm (releasable=false) is where the
+    /// classifier ALONE would drift: it keeps a clean reviewer worktree the pre-D2
+    /// gate released, so the explicit bypass arm restores it — and must NOT release
+    /// a dirty one (review-WIP protection). This pin locks BOTH directions. (The
+    /// two unreachable combos — (false,false) already returned Retry; (true,true)
+    /// can't arise since bypass ⟹ !releasable — are deliberately not asserted.)
+    #[test]
+    fn should_release_now_equals_pre_d2_gate() {
+        // The pre-D2 inline expression, verbatim (main 8ddf26f1) — the baseline.
+        fn pre_d2(decision: &ReleaseDecision, releasable: bool) -> bool {
+            matches!(decision, ReleaseDecision::Release)
+                || (matches!(decision, ReleaseDecision::SkipDirtyWorktree) && releasable)
+        }
+        let decisions = [
+            ReleaseDecision::Release,
+            ReleaseDecision::SkipDirtyWorktree,
+            ReleaseDecision::SkipOptOut,
+            ReleaseDecision::SkipNotBound,
+            ReleaseDecision::SkipNoAssignee,
+            ReleaseDecision::SkipTaskMissing,
+        ];
+        for d in &decisions {
+            // Reachable gate states: exactly one of {releasable, reviewer_bypassed}.
+            for &(releasable, reviewer_bypassed) in &[(true, false), (false, true)] {
+                assert_eq!(
+                    should_release_now(d, releasable, reviewer_bypassed),
+                    pre_d2(d, releasable),
+                    "release_now DRIFT: decision={d:?} releasable={releasable} \
+                     reviewer_bypassed={reviewer_bypassed}",
+                );
+            }
+        }
     }
 
     /// #2010 codex-r1 §3.9 — the implementer self-verdict EXPLOIT must not

--- a/src/worktree/disposition.rs
+++ b/src/worktree/disposition.rs
@@ -21,7 +21,14 @@
 //! from `auto_release::releasable_by_invariant`, a [`ReclaimState`] from the GC
 //! `evaluate_candidate` classification. It re-encodes NONE of that logic; it only
 //! adds the cross-system routing that unifies the three decision systems.
-#![allow(dead_code)] // D1 additive: no production caller until D2–D4 wire the call sites.
+//!
+//! PR-D · D2 (#2711) narrowed D1's blanket `#![allow(dead_code)]`: the L0–L2
+//! auto-release path now has a real production caller
+//! ([`crate::daemon::auto_release::should_release_now`]), so `terminal_disposition`
+//! + `DispositionInput` are live. Only the still-unwired L3 GC reclaim states
+//! (`ReclaimState`) and the L4 branch-ref decision (`branch_disposition` +
+//! `BranchSignal` / `BranchDisposition`) carry targeted `#[allow(dead_code)]`,
+//! until D3/D4 land their call sites.
 
 use crate::daemon::auto_release::ReleaseDecision;
 
@@ -47,6 +54,9 @@ pub(crate) enum Disposition {
 /// L3 (binding-absent, GC) reclaim classification. Produced by the GC system's
 /// `evaluate_candidate` (D4 wires it); the pure part the classifier routes on.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+// L3 GC states: only `NotEligible` is constructed so far (by the auto-release
+// caller); D4 wires the constructors for the reclaim variants.
+#[allow(dead_code)]
 pub(crate) enum ReclaimState {
     /// Not a GC candidate (in grace, not aged, or spared) → Keep.
     NotEligible,
@@ -66,6 +76,8 @@ pub(crate) enum ReclaimState {
 /// may be reclaimed while its branch ref is KEPT (CR-2026-06-14 — remote-gone
 /// alone is never a `branch -D` trigger).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+// L4 branch-ref axis: D3/D4 wire `branch_disposition` into the sweep/GC paths.
+#[allow(dead_code)]
 pub(crate) enum BranchSignal {
     /// Merged-ancestor, squash-merged past the age floor, or an authoritative
     /// merged PR (#2698) → the work is provably in `default`.
@@ -79,6 +91,8 @@ pub(crate) enum BranchSignal {
 
 /// Branch-ref disposition (spike §1 L4).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+// L4 branch-ref axis: D3/D4 wire `branch_disposition` into the sweep/GC paths.
+#[allow(dead_code)]
 pub(crate) enum BranchDisposition {
     KeepBranch,
     DeleteBranch,
@@ -159,6 +173,8 @@ pub(crate) fn terminal_disposition(input: &DispositionInput) -> Disposition {
 
 /// The branch-ref decision (spike §1 L4), independent of the worktree dir.
 /// Delete only on provable-in-default; remote-gone alone never deletes.
+// L4 branch-ref axis: no production caller until D3/D4 wire the sweep/GC paths.
+#[allow(dead_code)]
 pub(crate) fn branch_disposition(signal: BranchSignal) -> BranchDisposition {
     match signal {
         BranchSignal::ProvablyInDefault => BranchDisposition::DeleteBranch,


### PR DESCRIPTION
## PR-D · D2 — auto_release delegates its release gate to `terminal_disposition`

2nd baton of the janitor-disposition migration (spike §6). `process_intent`'s
bound-path release decision now delegates to the unified D1 classifier
(`src/worktree/disposition.rs`, merged in #2711) instead of the inline
`Release || (SkipDirtyWorktree && releasable)` boolean. **Behavior byte-identical
— only the decision source changes.**

### ⚠ The one correctness point (reviewer: read this first)
`terminal_disposition` requires `releasable_by_invariant == true` for **both** the
clean-`Release` and the #2697 dirty-`SkipDirtyWorktree` arms. But `process_intent`
reaches the `release_now` gate when `releasable || reviewer_bypassed`, and the
**#2010 reviewer-binding bypass** *falls through* with `releasable == false`:

| decision | releasable | reviewer_bypass | pre-D2 `release_now` |
|---|---|---|---|
| Release (clean) | true | — | release |
| SkipDirtyWorktree (dirty) | true | — | release (#2697) |
| Release (clean) | **false** | true | **release** ← fires without `releasable` |
| SkipDirtyWorktree (dirty) | **false** | true | **retain** (review-WIP protection) |

So neither raw-`releasable` (would drop row 3 = revert #2010) nor "gate-passed=true"
(would release row 4 = lose review WIP) is byte-identical. The delegation feeds the
classifier the **raw** `releasable` and keeps the reviewer-bypass-clean release as a
**separate explicit arm**:
`terminal_disposition(input)==Release || (reviewer_bypassed && decision==Release)`.
The classifier's `releasable_by_invariant` field stays honest (the bypass is
`releasable=false` by construction; D1 classifier is untouched).

### Guard
`should_release_now_equals_pre_d2_gate` — an **exhaustive** equivalence pin asserting
`new == pre-D2 inline expr` over every reachable `(decision × releasable ×
reviewer_bypassed)`. Removing the bypass arm fails it on `(Release,false,true)`;
loosening the SkipDirty arm fails it on `(SkipDirtyWorktree,false,true)`.

### Changes
- `src/daemon/auto_release.rs`: `should_release_now` (pure classifier delegation) +
  capture `reviewer_bypassed` + replace the inline gate + the equivalence pin.
- `src/worktree/disposition.rs`: narrow D1's blanket `#![allow(dead_code)]` — L0–L2
  now have a real caller; targeted allows remain only on the still-unwired L3
  (`ReclaimState`) / L4 (`branch_disposition` + `BranchSignal`/`BranchDisposition`).

### Verification
- Full census **5455/5455 green** (baseline 5447/5447 green pre-change; delta = tray
  feature-gated tests + the new pin). 41 auto_release pins (incl. #2697/#2700
  integration) + 19 disposition fail-direction pins all green.
- fmt + clippy (`--features tray -D warnings`) clean.

Refs #2711 (D1). Parent: PR-D umbrella.
