### PR TITLE
feat(worktree-gc PR-D·D3): sweep delegates occupancy(L0)+branch(L4) to the shared classifier

### DIFF
--- a/src/worktree/disposition.rs
+++ b/src/worktree/disposition.rs
@@ -22,13 +22,13 @@
 //! `evaluate_candidate` classification. It re-encodes NONE of that logic; it only
 //! adds the cross-system routing that unifies the three decision systems.
 //!
-//! PR-D · D2 (#2711) narrowed D1's blanket `#![allow(dead_code)]`: the L0–L2
-//! auto-release path now has a real production caller
-//! ([`crate::daemon::auto_release::should_release_now`]), so `terminal_disposition`
-//! + `DispositionInput` are live. Only the still-unwired L3 GC reclaim states
-//! (`ReclaimState`) and the L4 branch-ref decision (`branch_disposition` +
-//! `BranchSignal` / `BranchDisposition`) carry targeted `#[allow(dead_code)]`,
-//! until D3/D4 land their call sites.
+//! PR-D narrows D1's blanket `#![allow(dead_code)]` as each call site lands: D2
+//! (#2713) wired the L0–L2 auto-release path
+//! ([`crate::daemon::auto_release::should_release_now`]); D3 wired the shared L0
+//! gate ([`l0_protected`]) + the L4 branch decision ([`branch_disposition`]) into
+//! the sweep ([`crate::worktree_cleanup`]). Only the still-unwired L3 GC reclaim
+//! states (`ReclaimState`'s non-`NotEligible` variants) carry a targeted
+//! `#[allow(dead_code)]`, until D4 lands the GC `evaluate_candidate` call site.
 
 use crate::daemon::auto_release::ReleaseDecision;
 
@@ -76,8 +76,6 @@ pub(crate) enum ReclaimState {
 /// may be reclaimed while its branch ref is KEPT (CR-2026-06-14 — remote-gone
 /// alone is never a `branch -D` trigger).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-// L4 branch-ref axis: D3/D4 wire `branch_disposition` into the sweep/GC paths.
-#[allow(dead_code)]
 pub(crate) enum BranchSignal {
     /// Merged-ancestor, squash-merged past the age floor, or an authoritative
     /// merged PR (#2698) → the work is provably in `default`.
@@ -91,8 +89,6 @@ pub(crate) enum BranchSignal {
 
 /// Branch-ref disposition (spike §1 L4).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-// L4 branch-ref axis: D3/D4 wire `branch_disposition` into the sweep/GC paths.
-#[allow(dead_code)]
 pub(crate) enum BranchDisposition {
     KeepBranch,
     DeleteBranch,
@@ -132,16 +128,27 @@ pub(crate) struct DispositionInput {
     pub reclaim: ReclaimState,
 }
 
+/// Spike §1 L0 — the SHARED protection gate: a worktree is protected from ALL
+/// reclaim paths when it is operator-created (not `.agend-managed`), pinned,
+/// in-use, or its occupancy is unresolvable. This is the fail-closed prefix every
+/// terminal-detection system shares; extracting it (PR-D·D3) lets a system that
+/// owns its OWN terminal trigger — e.g. the sweep's `merged‖gone` — delegate the
+/// SAME occupancy/marker fail-direction instead of re-deriving it (the RCA
+/// "no-man's-land between policies" fix). `in_use == None` (unresolvable) fails
+/// CLOSED → protected, mirroring the sweep's `list_worktrees Err → skip`.
+pub(crate) fn l0_protected(daemon_managed: bool, pinned: bool, in_use: Option<bool>) -> bool {
+    !daemon_managed || pinned || !matches!(in_use, Some(false))
+}
+
 /// The unified worktree-disposition decision (spike §1, layers L0–L3). Pure:
 /// routes over pre-computed sub-verdicts, duplicating none of their logic.
 pub(crate) fn terminal_disposition(input: &DispositionInput) -> Disposition {
-    // ── L0 — protection. Any ambiguity or protection hit → Keep. ──
-    if !input.daemon_managed || input.pinned {
+    // ── L0 — protection. Any ambiguity or protection hit → Keep. The shared
+    // fail-direction lives in `l0_protected` so a system that owns its own
+    // terminal trigger (the sweep's merged‖gone, PR-D·D3) delegates the SAME
+    // occupancy/marker gate rather than re-deriving it. ──
+    if l0_protected(input.daemon_managed, input.pinned, input.in_use) {
         return Disposition::Keep;
-    }
-    match input.in_use {
-        None | Some(true) => return Disposition::Keep, // unresolvable or in use
-        Some(false) => {}
     }
 
     if input.binding_present {
@@ -173,8 +180,6 @@ pub(crate) fn terminal_disposition(input: &DispositionInput) -> Disposition {
 
 /// The branch-ref decision (spike §1 L4), independent of the worktree dir.
 /// Delete only on provable-in-default; remote-gone alone never deletes.
-// L4 branch-ref axis: no production caller until D3/D4 wire the sweep/GC paths.
-#[allow(dead_code)]
 pub(crate) fn branch_disposition(signal: BranchSignal) -> BranchDisposition {
     match signal {
         BranchSignal::ProvablyInDefault => BranchDisposition::DeleteBranch,
@@ -244,6 +249,42 @@ mod tests {
             ..base()
         };
         assert_eq!(terminal_disposition(&input), Disposition::Keep);
+    }
+
+    // ── PR-D·D3: the shared L0 protection predicate ──
+
+    #[test]
+    fn l0_protected_holds_the_l0_fail_directions() {
+        // `l0_protected` is the extracted L0 gate `terminal_disposition` now calls —
+        // it must hold the SAME fail directions (spike §1 L0).
+        assert!(
+            l0_protected(false, false, Some(false)),
+            "unmanaged → protected"
+        );
+        assert!(l0_protected(true, true, Some(false)), "pinned → protected");
+        assert!(l0_protected(true, false, Some(true)), "in-use → protected");
+        assert!(
+            l0_protected(true, false, None),
+            "occupancy unresolvable → fail-CLOSED protected"
+        );
+        assert!(
+            !l0_protected(true, false, Some(false)),
+            "managed + unpinned + not-in-use → NOT protected (the only reclaimable case)"
+        );
+    }
+
+    #[test]
+    fn l0_protected_is_the_sweep_occupancy_gate() {
+        // PR-D·D3: the sweep passes marker/pin as pass-through (it never consulted
+        // them) + `Some(is_in_use)`, so the delegated gate reduces EXACTLY to the
+        // pre-D3 `is_in_use` skip — byte-identical.
+        for in_use in [true, false] {
+            assert_eq!(
+                l0_protected(true, false, Some(in_use)),
+                in_use,
+                "sweep occupancy delegation must equal is_in_use (in_use={in_use})"
+            );
+        }
     }
 
     // ── L1/L2 binding-present — fail-direction pins ──

--- a/src/worktree_cleanup.rs
+++ b/src/worktree_cleanup.rs
@@ -472,8 +472,19 @@ pub fn sweep_from_registry(
         for entry in &entries {
             let wt_path = Path::new(&entry.path);
 
-            if is_in_use(wt_path, &active_dirs) {
-                tracing::debug!(branch = %entry.branch, path = %entry.path, "skipping worktree (in use by agent)");
+            // PR-D·D3: occupancy/marker protection (L0) delegated to the shared
+            // `disposition::l0_protected` — the SAME fail-direction the classifier
+            // applies (in-use `Some(true)` / unresolvable `None` → protected). The
+            // sweep never consulted the marker/pin dims, so they are pass-through
+            // (daemon_managed=true, pinned=false) → byte-identical to the prior
+            // `is_in_use`-only skip. (The tick-level `list_worktrees Err → continue`
+            // above is the `None`/unresolvable arm of the same L0 fail-direction.)
+            if crate::worktree::disposition::l0_protected(
+                true,
+                false,
+                Some(is_in_use(wt_path, &active_dirs)),
+            ) {
+                tracing::debug!(branch = %entry.branch, path = %entry.path, "skipping worktree (in use by agent — L0 protected)");
                 continue;
             }
 
@@ -495,8 +506,16 @@ pub fn sweep_from_registry(
             // committed-but-unpushed local work; deleting the ref would lose it
             // irrecoverably (phase-1 only skips *dirty* worktrees, not
             // committed-but-unpushed ones). The worktree dir is still reclaimed.
-            let branch_safe_to_delete =
-                merged || is_squash_gc_eligible(repo, &entry.branch, &default);
+            // PR-D·D3: the branch-safe-to-delete (L4) decision delegates to
+            // `branch_disposition` via `branch_reap_delete`. `merged || squash` is
+            // the ProvablyInDefault signal; `gone` alone keeps the branch
+            // (CR-2026-06-14). No scaffold-TTL arm here — that is phase-2's
+            // orphaned-branch concern (this entry still HAS a worktree).
+            let branch_safe_to_delete = branch_reap_delete(
+                merged || is_squash_gc_eligible(repo, &entry.branch, &default),
+                gone,
+                false,
+            );
             let reason = if merged { "merged" } else { "remote-gone" };
 
             tracing::info!(
@@ -581,6 +600,35 @@ fn is_stale_review_scaffold(repo_root: &Path, branch: &str) -> bool {
         .map(|d| d.as_secs())
         .unwrap_or(0);
     Duration::from_secs(now.saturating_sub(tip_ts)) >= REVIEW_SCAFFOLD_TTL
+}
+
+/// PR-D·D3: the branch-reap decision, delegated to the shared
+/// [`crate::worktree::disposition::branch_disposition`] classifier (L4). The
+/// SHARED "provably in default → delete" fail-direction lives in the classifier;
+/// this caller only gathers the signals and adds the one override the classifier
+/// does not encode.
+///
+/// - `provably_in_default` (merged-ancestor OR squash-merged past the age floor)
+///   → `BranchSignal::ProvablyInDefault → DeleteBranch`.
+/// - `remote_gone` alone → `BranchSignal::RemoteGoneOnly → KeepBranch`
+///   (CR-2026-06-14: remote-gone is NEVER an independent delete trigger — the
+///   branch may hold committed-but-unpushed local work).
+/// - `scaffold_ttl` is a review-scaffold branch that is `NotMerged` (the classifier
+///   KEEPS it) but has aged past its TTL — an EXPLICIT external arm reproduces the
+///   reap the classifier can't model. Same shape as D2's #2010 `reviewer_bypass`:
+///   an override the pure classifier deliberately does not encode, kept outside so
+///   the delegation stays honest. Locked byte-for-byte by
+///   [`tests::branch_reap_delete_equals_pre_d3_gate`].
+fn branch_reap_delete(provably_in_default: bool, remote_gone: bool, scaffold_ttl: bool) -> bool {
+    use crate::worktree::disposition::{branch_disposition, BranchDisposition, BranchSignal};
+    let signal = if provably_in_default {
+        BranchSignal::ProvablyInDefault
+    } else if remote_gone {
+        BranchSignal::RemoteGoneOnly
+    } else {
+        BranchSignal::NotMerged
+    };
+    matches!(branch_disposition(signal), BranchDisposition::DeleteBranch) || scaffold_ttl
 }
 
 /// #P1-2607: process-wide cache of the STRUCTURAL squash-merged check (git
@@ -755,7 +803,13 @@ fn prune_orphaned_branches(repo_root: &Path, dry_run: bool) -> Vec<(String, &'st
         // so the merged/squash paths never reap them — a TTL is their only live
         // terminal path (H1 in the RCA).
         let scaffold = !merged && !squash && is_stale_review_scaffold(repo_root, branch);
-        if !merged && !squash && !scaffold {
+        // PR-D·D3: the reap decision (L4) delegates to `branch_disposition` via
+        // `branch_reap_delete`. `merged || squash` = ProvablyInDefault → delete;
+        // `scaffold` is the explicit external-arm override (a NotMerged branch the
+        // classifier keeps, aged past its TTL). Phase-2 does not compute remote-gone
+        // (CR-2026-06-14 dropped it as a trigger) → remote_gone=false. Byte-identical
+        // to the prior `!merged && !squash && !scaffold` continue-gate.
+        if !branch_reap_delete(merged || squash, false, scaffold) {
             continue;
         }
         // The scaffolding path never merged, so its commits survive only in the
@@ -1626,6 +1680,30 @@ mod tests {
         git_in(repo, &["add", "."]);
         git_in(repo, &["commit", "-m", "main diverge"]);
         git_in(repo, &["cherry-pick", branch]);
+    }
+
+    /// PR-D·D3 equivalence pin: `branch_reap_delete` — the `branch_disposition`
+    /// delegation — must reproduce BOTH pre-D3 branch-reap gates byte-for-byte:
+    ///   phase-2 `prune_orphaned_branches`: delete iff `merged || squash || scaffold`
+    ///   phase-1 `branch_safe_to_delete`:   delete iff `merged || squash` (scaffold=false)
+    /// Both reduce to `provably_in_default || scaffold_ttl`. The CR-2026-06-14
+    /// invariant — remote-gone ALONE is never a delete trigger — is pinned by
+    /// asserting `remote_gone` NEVER changes the result across the full domain.
+    #[test]
+    fn branch_reap_delete_equals_pre_d3_gate() {
+        for provably_in_default in [true, false] {
+            for remote_gone in [true, false] {
+                for scaffold_ttl in [true, false] {
+                    assert_eq!(
+                        branch_reap_delete(provably_in_default, remote_gone, scaffold_ttl),
+                        provably_in_default || scaffold_ttl,
+                        "branch reap DRIFT: provably={provably_in_default} \
+                         remote_gone={remote_gone} scaffold={scaffold_ttl} \
+                         (remote-gone must NEVER flip the result — CR-2026-06-14)"
+                    );
+                }
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
## PR-D · D3 — sweep delegates occupancy(L0) + branch(L4) to the shared classifier

3rd baton of the janitor-disposition migration (spike §6), the **heaviest slice**.
The worktree sweep's SHARED decisions now delegate to the unified disposition
classifier; its genuinely-distinct terminal trigger stays sweep-native. **Behavior
byte-identical — only the decision SOURCE of the shared parts changes.**

### Design ruling — read first (scopes the review)
Per the lead's adjudication **(A)** (decision `d-20260710081647131915-4`): the
classifier delegates SHARED / overlapping fail-directions (occupancy, branch); each
system keeps its own terminal-detection. **The sweep's `merged‖gone` DIR trigger is
NOT routed through the classifier** — it is the sweep's *defining concept*, not a
shared reclaim state. Forcing it through the classifier's L3 would require
fabricating `agent_alive` + a synthetic `ReclaimState` (the "gaming the classifier
field" anti-pattern D2 flagged). **This partial delegation is a deliberate design
choice, not an omission** — "honest partial delegation > literal full delegation
with fabricated inputs."

### The override the delegation must NOT swallow (the D2-shaped trap)
`review/*` **scaffold-TTL** reaps a branch that is `NotMerged` — which
`branch_disposition` maps to `KeepBranch`. A naive `branch_disposition()==DeleteBranch`
would silently drop it. So it is an **explicit external arm** in `branch_reap_delete`,
the same shape as D2's #2010 `reviewer_bypass`. `remote-gone-alone` (CR-2026-06-14)
IS covered by `RemoteGoneOnly→KeepBranch`; half-orphan force-reclaim is DIR/GC axis
(kept off the branch path).

### Changes
- **`src/worktree/disposition.rs`**: extract `l0_protected(daemon_managed, pinned,
  in_use)` — the SHARED L0 occupancy/marker gate; `terminal_disposition` now calls
  it (behavior-identical, pinned by the existing L0 tests) so the sweep delegates
  the SAME fail-direction. Narrow the dead_code allow → only L3 `ReclaimState`
  remains (D4 wires it).
- **`src/worktree_cleanup.rs`**: phase-1 `sweep_from_registry` occupancy→`l0_protected`,
  branch-safe-to-delete→`branch_reap_delete`; phase-2 `prune_orphaned_branches` reap
  gate→`branch_reap_delete`. `merged‖gone` stays native.

### Equivalence guards (exhaustive over the reachable domain)
- `branch_reap_delete_equals_pre_d3_gate`: `new == provably_in_default || scaffold`
  over all `(provably × remote_gone × scaffold)`; pins that **remote-gone alone never
  deletes** (CR-2026-06-14 — `remote_gone` must never flip the result).
- `l0_protected_holds_the_l0_fail_directions` + `l0_protected_is_the_sweep_occupancy_gate`:
  the shared L0 fail-directions + `l0_protected(true,false,Some(x)) == x` (byte-identical
  to the pre-D3 `is_in_use` skip).

### Verification
- Full census **5458/5458 green** (baseline 5455 + 3 new pins). 56 sweep + 255
  GC-adjacent pins + D2 auto_release pins + 19 disposition fail-direction pins all green.
- fmt + clippy (`--features tray -D warnings`) clean.

Refs #2711 (D1), #2713 (D2). Parent: PR-D umbrella. **DUAL review.**
