### PR TITLE
feat(worktree-gc PR-D·D4): GC evaluate_candidate delegates L3 reclaim judgment to terminal_disposition

### DIFF
--- a/src/worktree/disposition.rs
+++ b/src/worktree/disposition.rs
@@ -26,9 +26,12 @@
 //! (#2713) wired the L0–L2 auto-release path
 //! ([`crate::daemon::auto_release::should_release_now`]); D3 wired the shared L0
 //! gate ([`l0_protected`]) + the L4 branch decision ([`branch_disposition`]) into
-//! the sweep ([`crate::worktree_cleanup`]). Only the still-unwired L3 GC reclaim
-//! states (`ReclaimState`'s non-`NotEligible` variants) carry a targeted
-//! `#[allow(dead_code)]`, until D4 lands the GC `evaluate_candidate` call site.
+//! the sweep ([`crate::worktree_cleanup`]); D4 wired the L3 GC reclaim judgment
+//! (the GC `evaluate_candidate` produces a [`ReclaimState`] + `agent_alive` and
+//! delegates the Keep/Delete/Archive routing here). The ONLY remaining
+//! `#[allow(dead_code)]` is on [`ReclaimState::CleanReleaseArchive`] — the
+//! removal-time archive-belt outcome the disposition ladder (D5) still routes
+//! natively, matched here but not yet constructed outside tests.
 
 use crate::daemon::auto_release::ReleaseDecision;
 
@@ -54,17 +57,21 @@ pub(crate) enum Disposition {
 /// L3 (binding-absent, GC) reclaim classification. Produced by the GC system's
 /// `evaluate_candidate` (D4 wires it); the pure part the classifier routes on.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-// L3 GC states: only `NotEligible` is constructed so far (by the auto-release
-// caller); D4 wires the constructors for the reclaim variants.
-#[allow(dead_code)]
 pub(crate) enum ReclaimState {
     /// Not a GC candidate (in grace, not aged, or spared) → Keep.
     NotEligible,
     /// `released_at` present, past the 24h grace, worktree clean → hard delete.
     CleanReleaseHardDelete,
     /// `released_at` present + past grace, but the hard delete is unactionable
-    /// (lock contention / owning-repo unresolved / remove failed) and the
-    /// archive gate is on → archive instead.
+    /// (lock contention / owning-repo unresolved / remove failed) and the archive
+    /// gate is on → archive instead. PR-D·D4: this is a REMOVAL-time archive-belt
+    /// outcome (`gc_remove_one`'s #2550 W5 `AGEND_WORKTREE_GC` fall-through), NOT an
+    /// `evaluate_candidate` verdict — the candidate JUDGMENT D4 delegates only
+    /// produces `NotEligible`/`CleanReleaseHardDelete`/`ForceReclaim`. This belt
+    /// outcome routes natively still (the disposition LADDER is D5), so it is
+    /// matched by [`terminal_disposition`] but not yet constructed outside tests →
+    /// a targeted `dead_code` allow until D5 wires it.
+    #[allow(dead_code)]
     CleanReleaseArchive,
     /// Never-released OR malformed `released_at`, dead agent, past the age cap →
     /// ForceReclaim: ALWAYS archived, never hard-deleted (t-worktree-leak PR-2).

--- a/src/worktree_pool/gc.rs
+++ b/src/worktree_pool/gc.rs
@@ -456,6 +456,9 @@ pub(crate) fn evaluate_candidate(
     wt_path: &Path,
     live_agents: &std::collections::HashSet<String>,
 ) -> Option<GcCandidate> {
+    use crate::worktree::disposition::{
+        terminal_disposition, Disposition, DispositionInput, ReclaimState,
+    };
     // Must be daemon-managed (R14).
     if !is_daemon_managed(wt_path) {
         return None;
@@ -486,8 +489,14 @@ pub(crate) fn evaluate_candidate(
         .lines()
         .find_map(|l| l.strip_prefix("released_at="));
 
-    match released_at {
-        // ── Clean-release path: explicitly released, past the grace TTL. ──
+    // ── PR-D·D4: gather the L3 signals (native, impure — spike §5), reduce them to
+    // a `ReclaimState` + `agent_alive`, then delegate the Keep/Delete/Archive
+    // JUDGMENT to the shared `terminal_disposition` classifier (spike §1 L3). Only
+    // the disposition routing converges on the classifier; the signal-gathering
+    // stays here. Locked byte-identical by the behavioral pins +
+    // `tests::gc_l3_delegation_equals_pre_d4_disposition`. ──
+    let (reclaim, agent_alive, kind, reason) = match released_at {
+        // ── Clean-release: explicitly released, past the 24h grace, clean. ──
         Some(ts) => {
             // A released lease should already be unbound; if it is still bound,
             // that is a contradiction — leave it alone (conservative).
@@ -501,6 +510,17 @@ pub(crate) fn evaluate_candidate(
                     if age < chrono::Duration::hours(GC_GRACE_HOURS) {
                         return None; // still within grace
                     }
+                    // Past grace. Liveness is INAPPLICABLE to an explicit release
+                    // (the agent voluntarily gave up the lease) → feed `Some(false)`
+                    // so the classifier's L3 liveness gate PASSES, reproducing the
+                    // pre-D4 CleanRelease arm that hard-deleted regardless of
+                    // liveness. (Locked by the equivalence pin.)
+                    (
+                        ReclaimState::CleanReleaseHardDelete,
+                        Some(false),
+                        GcKind::CleanRelease,
+                        format!("daemon-tagged, released >{}h, not pinned", GC_GRACE_HOURS),
+                    )
                 }
                 // #1870 (H1): a malformed `released_at=` (e.g. a partial-write /
                 // crash-truncated marker) MUST NOT be treated as "past grace" — the
@@ -515,22 +535,16 @@ pub(crate) fn evaluate_candidate(
                 // worktree is reclaimed. This does NOT reintroduce the H1
                 // WIP-destruction (that was the grace-window bypass).
                 Err(_) => {
-                    return force_reclaim_candidate(
-                        home,
-                        wt_path,
-                        agent_name,
-                        &marker_content,
-                        live_agents,
-                        "malformed released_at marker",
-                    );
+                    let alive =
+                        force_reclaim_state(home, &agent_name, &marker_content, live_agents)?;
+                    (
+                        ReclaimState::ForceReclaim,
+                        Some(alive),
+                        GcKind::ForceReclaim,
+                        force_reclaim_reason("malformed released_at marker"),
+                    )
                 }
             }
-            Some(GcCandidate {
-                path: wt_path.to_path_buf(),
-                agent: agent_name,
-                reason: format!("daemon-tagged, released >{}h, not pinned", GC_GRACE_HOURS),
-                kind: GcKind::CleanRelease,
-            })
         }
         // ── t-worktree-leak PR-2 force-reclaim backstop: NEVER released. ──
         // This is ONLY the no-event-abandonment / dead-agent tail (the
@@ -538,56 +552,91 @@ pub(crate) fn evaluate_candidate(
         // merge/close/task-done event; the 7-day expired-intent path hands off
         // here). liveness-AND-age: ANY live signal → never reclaim (even past the
         // cap); otherwise require the per-agent-jittered age cap.
-        None => force_reclaim_candidate(
-            home,
-            wt_path,
-            agent_name,
-            &marker_content,
-            live_agents,
-            "never-released lease",
-        ),
+        None => {
+            let alive = force_reclaim_state(home, &agent_name, &marker_content, live_agents)?;
+            (
+                ReclaimState::ForceReclaim,
+                Some(alive),
+                GcKind::ForceReclaim,
+                force_reclaim_reason("never-released lease"),
+            )
+        }
+    };
+
+    // Delegate the disposition JUDGMENT (spike §1 L3). Binding-absent GC path: L0
+    // fed pass-through (a managed, unpinned, resolvable worktree already reached
+    // here); L1/L2 inert (binding_present=false → the classifier never reads them).
+    let disposition = terminal_disposition(&DispositionInput {
+        daemon_managed: true,
+        pinned: false,
+        in_use: Some(false),
+        binding_present: false,
+        release_decision: crate::daemon::auto_release::ReleaseDecision::SkipNotBound,
+        releasable_by_invariant: false,
+        agent_alive,
+        reclaim,
+    });
+
+    match disposition {
+        // Delete → the CleanRelease hard-delete tier; Archive → the ForceReclaim
+        // `.trash` tier. `gc_remove_one` routes each `GcKind` to its mechanism
+        // (the disposition LADDER stays native — D5). `reason`/`kind` come from the
+        // arm above; they are consistent with the classifier's verdict by
+        // construction (locked by the equivalence pin).
+        Disposition::Delete | Disposition::Archive => Some(GcCandidate {
+            path: wt_path.to_path_buf(),
+            agent: agent_name,
+            reason,
+            kind,
+        }),
+        // Keep (liveness-spared / not eligible) → not a candidate. Release is
+        // unreachable here (binding_present=false).
+        Disposition::Keep | Disposition::Release => None,
     }
 }
 
-/// t-worktree-leak PR-2 force-reclaim backstop: reclaim a worktree ONLY when it
-/// is genuinely abandoned — not in the daemon's post-boot grace window (#5), NO
-/// liveness signal for its agent, AND its `leased_at` is past the per-agent
-/// force-reclaim age cap. ANY live signal → never reclaim (even past the cap).
-/// Shared by the never-released (`released_at` absent) arm AND the #1882 WT-LEAK-1
-/// corrupt-`released_at` fall-through. `marker_state` names why we're here, for
-/// the candidate's reason. The liveness + age-cap guards (NOT the grace window)
-/// are what protect a just-leased / just-released worktree from premature reclaim.
-fn force_reclaim_candidate(
+/// t-worktree-leak PR-2 force-reclaim backstop: the NATIVE age/boot guards that
+/// gate the ForceReclaim `ReclaimState`. Returns the agent's liveness
+/// (`Some(alive)`) when the lease is past BOTH the daemon post-boot grace window
+/// (#5) AND its per-agent `leased_at` age cap, or `None` when those native guards
+/// rule it out (so the classifier never sees a non-candidate). Shared by the
+/// never-released (`released_at` absent) arm AND the #1882 WT-LEAK-1 corrupt-
+/// `released_at` fall-through.
+///
+/// PR-D·D4: liveness is NOT gated here — it is delegated to `terminal_disposition`'s
+/// L3 gate, fed the real `alive` this returns, so the byte-identical
+/// `liveness-AND-age` contract holds (past boot ∧ past age ∧ classifier keeps if
+/// alive). `agent_has_liveness` fails toward alive on any read error. The grace
+/// window is NOT the guard — the age cap + liveness are (protecting a just-leased /
+/// just-released worktree from premature reclaim).
+fn force_reclaim_state(
     home: &Path,
-    wt_path: &Path,
-    agent_name: String,
+    agent_name: &str,
     marker_content: &str,
     live_agents: &std::collections::HashSet<String>,
-    marker_state: &str,
-) -> Option<GcCandidate> {
+) -> Option<bool> {
     // reviewer-2 #5: suspend force-reclaim during the daemon's post-boot grace
     // window (the process-liveness signal is still re-establishing).
     if daemon_within_boot_grace(home) {
         return None;
     }
-    if agent_has_liveness(home, &agent_name, live_agents) {
-        return None;
-    }
     let leased_at = marker_content
         .lines()
         .find_map(|l| l.strip_prefix("leased_at="));
-    if !leased_at_force_reclaimable(leased_at, &agent_name) {
+    if !leased_at_force_reclaimable(leased_at, agent_name) {
         return None;
     }
-    Some(GcCandidate {
-        path: wt_path.to_path_buf(),
-        agent: agent_name,
-        reason: format!(
-            "force-reclaim: {marker_state}, no liveness signal, leased >{}d (abandoned)",
-            force_reclaim_age_days()
-        ),
-        kind: GcKind::ForceReclaim,
-    })
+    // Past boot + age. Liveness is the classifier's gate — return the real signal.
+    Some(agent_has_liveness(home, agent_name, live_agents))
+}
+
+/// The `reason` string for a force-reclaim candidate. `marker_state` names why we
+/// entered the backstop (never-released lease vs malformed `released_at` marker).
+fn force_reclaim_reason(marker_state: &str) -> String {
+    format!(
+        "force-reclaim: {marker_state}, no liveness signal, leased >{}d (abandoned)",
+        force_reclaim_age_days()
+    )
 }
 
 /// Dry-run: log candidates without deleting. Returns candidate list.

--- a/src/worktree_pool/tests.rs
+++ b/src/worktree_pool/tests.rs
@@ -2890,6 +2890,138 @@ fn gc_run_force_reclaim_archives_never_hard_deletes() {
     let _ = std::fs::remove_dir_all(&home);
 }
 
+/// PR-D·D4 (spike-vet, NON-NEGOTIABLE): the UNCONDITIONAL `gc_remove_one`
+/// archive-only invariant for ForceReclaim. t-worktree-leak PR-2's load-bearing
+/// safety property — a ForceReclaim MUST NEVER be hard-deleted — currently rests
+/// ONLY on the control-flow POSITION of the `kind == ForceReclaim` early-return
+/// (gc.rs:706, before the hard-delete code). That is too fragile. This pins it
+/// BEHAVIORALLY so it fail-LOUD even if the routing moves.
+///
+/// Unlike `gc_run_force_reclaim_archives_never_hard_deletes` (which uses a fresh
+/// lease → a moved early-return trips the CleanRelease re-validation SKIP, not a
+/// hard-delete), this backdates a dead-agent lease so EVERY hard-delete gate
+/// WOULD pass: `evaluate_candidate` re-validation succeeds, the worktree's real
+/// `.git` resolves its source repo, and `git worktree remove` would actually
+/// hard-delete it. The archive-only routing is therefore the SOLE thing keeping
+/// the dir recoverable — move it and the dir is hard-deleted → absent from
+/// `.trash` → this test goes RED.
+#[test]
+fn force_reclaim_gc_remove_one_is_archive_only_unconditional() {
+    let home = tmp_home("fr-archive-inv");
+    let repo = tmp_repo("fr-archive-inv-repo");
+    let lease = lease(&home, &repo, "fr-inv-agent", "feat/x").expect("lease");
+    // Backdated + dead agent → this candidate passes EVERY hard-delete gate
+    // (re-validation, source-repo resolve, `git worktree remove`). Only the
+    // archive-only routing prevents an irrecoverable hard-delete.
+    backdate_lease(&lease.path, force_reclaim_age_days() + 5);
+    let live: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let cand = evaluate_candidate(&home, &lease.path, &live)
+        .expect("backdated dead-agent never-released lease → ForceReclaim candidate");
+    assert_eq!(
+        cand.kind,
+        GcKind::ForceReclaim,
+        "precondition: the candidate must be a ForceReclaim"
+    );
+
+    let result = gc_remove_one(&home, &cand);
+    assert!(
+        result.removed,
+        "ForceReclaim gc_remove_one must archive (Removed): {:?}",
+        result.error
+    );
+    assert!(
+        !lease.path.exists(),
+        "worktree dir must leave its original path"
+    );
+    let trash = home.join(".trash").join("worktrees");
+    let archived = std::fs::read_dir(&trash)
+        .map(|d| d.flatten().count() > 0)
+        .unwrap_or(false);
+    assert!(
+        archived,
+        "INVARIANT: a ForceReclaim MUST be ARCHIVED to .trash (recoverable), NEVER \
+         hard-deleted — the gc.rs:706 archive-only routing is load-bearing \
+         (t-worktree-leak PR-2). An empty .trash ⇒ the dir was hard-deleted ⇒ the \
+         routing regressed."
+    );
+    assert!(
+        crate::binding::read(&home, "fr-inv-agent").is_none(),
+        "binding unbound after force-reclaim archive"
+    );
+    let _ = std::fs::remove_dir_all(&home);
+}
+
+/// PR-D·D4 equivalence pin: the GC L3 judgment `evaluate_candidate` now delegates
+/// to [`terminal_disposition`] reproduces the pre-D4 disposition table byte-for-
+/// byte over the reachable `(ReclaimState, agent_alive)` domain. This locks the
+/// exact `DispositionInput` `evaluate_candidate` builds (binding-absent GC path:
+/// L0 pass-through, L1/L2 inert) AND the `Disposition → Option<GcKind>` map, so a
+/// classifier drift fails LOUD here rather than silently changing which worktree
+/// GC reclaims.
+#[test]
+fn gc_l3_delegation_equals_pre_d4_disposition() {
+    use crate::worktree::disposition::{
+        terminal_disposition, Disposition, DispositionInput, ReclaimState,
+    };
+    // The DispositionInput `evaluate_candidate` builds for the binding-absent GC
+    // path — L0 pass-through, L1/L2 inert.
+    let gc_input = |reclaim, agent_alive| DispositionInput {
+        daemon_managed: true,
+        pinned: false,
+        in_use: Some(false),
+        binding_present: false,
+        release_decision: crate::daemon::auto_release::ReleaseDecision::SkipNotBound,
+        releasable_by_invariant: false,
+        agent_alive,
+        reclaim,
+    };
+    // The map `evaluate_candidate` applies: Delete→CleanRelease, Archive→
+    // ForceReclaim, Keep→None (Release is unreachable — binding_present=false).
+    let to_kind = |d| match d {
+        Disposition::Delete => Some(GcKind::CleanRelease),
+        Disposition::Archive => Some(GcKind::ForceReclaim),
+        Disposition::Keep | Disposition::Release => None,
+    };
+
+    // CleanRelease arm — past grace, clean, liveness INAPPLICABLE (Some(false)):
+    // pre-D4 hard-deleted → CleanRelease candidate, regardless of real liveness.
+    assert_eq!(
+        to_kind(terminal_disposition(&gc_input(
+            ReclaimState::CleanReleaseHardDelete,
+            Some(false)
+        ))),
+        Some(GcKind::CleanRelease),
+        "clean-release past grace → CleanRelease (hard-delete tier), the pre-D4 outcome"
+    );
+    // ForceReclaim arm — past boot+age. Dead → archive; live → spared (the L3
+    // liveness gate now reproduces the pre-D4 native liveness-AND-age spare).
+    assert_eq!(
+        to_kind(terminal_disposition(&gc_input(
+            ReclaimState::ForceReclaim,
+            Some(false)
+        ))),
+        Some(GcKind::ForceReclaim),
+        "abandoned (dead, past cap) → ForceReclaim archive tier, the pre-D4 outcome"
+    );
+    assert_eq!(
+        to_kind(terminal_disposition(&gc_input(
+            ReclaimState::ForceReclaim,
+            Some(true)
+        ))),
+        None,
+        "live agent past cap → spared (liveness-AND-age), the pre-D4 None"
+    );
+    // NotEligible (within grace / boot-grace / recent lease) → Keep → None.
+    assert_eq!(
+        to_kind(terminal_disposition(&gc_input(
+            ReclaimState::NotEligible,
+            Some(false)
+        ))),
+        None,
+        "not eligible → spared, the pre-D4 None"
+    );
+}
+
 #[test]
 fn collect_managed_worktrees_finds_slash_branch_nested() {
     // reviewer-2 #4: a slash-branch worktree nests an extra level


### PR DESCRIPTION
## PR-D · D4 — GC `evaluate_candidate` delegates the L3 reclaim judgment

The **4th and last "delegation" baton** of the janitor-disposition migration
(spike §6). The GC candidate **JUDGMENT** now delegates to the unified
`terminal_disposition` classifier (spike §1 L3, binding-absent); the disposition
**MECHANISM** (archive vs hard-delete tiering) stays native — that ladder is D5.
Behavior **byte-identical**: only the decision *source* of "which candidate /
which disposition" converges on the shared classifier.

### What changed
- **`src/worktree_pool/gc.rs`** — `evaluate_candidate` gathers the L3 signals
  natively (released_at + 24h grace, clean, binding-absent, malformed marker,
  dead agent, 7d age cap), reduces them to a `ReclaimState` + `agent_alive`, and
  delegates the Keep/Delete/Archive routing to `terminal_disposition`
  (`Delete→CleanRelease`, `Archive→ForceReclaim`, `Keep→None`; Release
  unreachable). `force_reclaim_candidate` → `force_reclaim_state` (liveness fed to
  the classifier's L3 gate, byte-identical liveness-AND-age). CleanRelease feeds
  `agent_alive=Some(false)` — liveness is inapplicable to an explicit release
  (the one explicit arm, locked by the equivalence pin).
- **`src/worktree/disposition.rs`** — narrow the `dead_code` allow to ONLY
  `ReclaimState::CleanReleaseArchive` (the removal-time archive-belt = D5);
  `CleanReleaseHardDelete` + `ForceReclaim` now have real production callers.

### Tests (RED-first: existing pins + 2 new)
- **`force_reclaim_gc_remove_one_is_archive_only_unconditional`** (spike-vet
  amendment, NON-NEGOTIABLE): a backdated dead-agent lease passes **every**
  hard-delete gate, so the gc.rs:706 archive-only routing is the **sole**
  protection. **Mutation-verified RED** when the ForceReclaim early-return is
  broken → catches a hard-delete regression, not just a skip. Locks
  t-worktree-leak PR-2's load-bearing "ForceReclaim only archives, never
  hard-deletes".
- **`gc_l3_delegation_equals_pre_d4_disposition`**: equivalence pin over the
  reachable `(ReclaimState, agent_alive)` domain + the `Disposition→GcKind` map.

### Preserved / audited
- **#2699 half-orphan** (broken gitlink → `git status` fails → force-reclaim
  archives anyway) preserved — only the JUDGMENT changed; `maybe_remove_candidate`
  (retention) untouched; the flat-layout pin stays green.
- **Override audit**: the `AGEND_WORKTREE_GC` archive-belt + archive/hard-delete
  trust tiering are removal-MECHANISM (D5), kept native — no unencoded override at
  the evaluate seam.

### Verification
- Full census **5460 passed / 0 failed** (+2 new over the 5458 baseline); 255
  GC-retention + #2699 + #1053/#1058 + disposition fail-direction pins green.
- `fmt --check` (excl vendor) + `clippy --features tray -D warnings` clean.

Refs: #2711 (D1), #2713 (D2), #2715 (D3). Parent: PR-D umbrella.

**DUAL review** requested — the ForceReclaim archive-only guarantee is a safety
invariant.
