### PR TITLE
fix(AUDIT3-005): inbox runtime rewriters preserve unparseable lines, not silently drop

### DIFF
--- a/src/inbox/storage.rs
+++ b/src/inbox/storage.rs
@@ -288,6 +288,48 @@ fn parse_inbox_messages(content: &str) -> impl Iterator<Item = InboxMessage> + '
         .filter_map(|line| serde_json::from_str::<InboxMessage>(line).ok())
 }
 
+/// AUDIT3-005: the single parse step for EVERY read-modify-write rewriter
+/// (`drain` / `ack` / `settle_read_by_id` / `ack_by_correlation` / `clear_compact`
+/// / `sweep_expired` / `reclaim_stale_delivering`). Returns `Some(msg)` only for a
+/// row this daemon can process (parseable, schema ≤ current); the caller runs its
+/// own logic on it. A row the caller must NOT process but MUST NOT DELETE — a
+/// FORWARD-SCHEMA row (valid JSON a newer daemon wrote, downgrade-safe) OR an
+/// UNPARSEABLE line (a torn enqueue / external corruption) — is pushed VERBATIM to
+/// `preserved` (the caller re-emits it in its rewrite) and `None` returned.
+/// Centralizing this closes the runtime-rewrite silent-loss window: pre-fix each
+/// site's `Err(_) => continue` DROPPED the corrupt line on rewrite — before the
+/// startup-only `recover_half_writes` could quarantine it — with no log. Routing
+/// all sites through ONE helper (not per-site patches) prevents a missed/ drifted
+/// site (the #27 lesson). Blank-line handling stays the caller's concern. WARNs so
+/// the formerly-silent event is observable.
+fn parse_or_preserve_line(line: &str, preserved: &mut Vec<String>) -> Option<InboxMessage> {
+    match serde_json::from_str::<InboxMessage>(line) {
+        Ok(msg) if msg.schema_version <= InboxMessage::CURRENT_VERSION => Some(msg),
+        Ok(msg) => {
+            // Forward-schema: unknown newer fields — re-emit intact, never downgrade-delete.
+            tracing::warn!(
+                found = msg.schema_version,
+                supported = InboxMessage::CURRENT_VERSION,
+                "inbox rewrite: preserving forward-schema row verbatim"
+            );
+            preserved.push(line.to_string());
+            None
+        }
+        Err(e) => {
+            // AUDIT3-005: a torn enqueue / externally-corrupt line. Preserve verbatim
+            // so a runtime rewrite never destroys it before startup
+            // `recover_half_writes` quarantines it to inbox.recovery/.
+            tracing::warn!(
+                error = %e,
+                line_len = line.len(),
+                "inbox rewrite: preserving unparseable line verbatim (AUDIT3-005; was silently dropped)"
+            );
+            preserved.push(line.to_string());
+            None
+        }
+    }
+}
+
 /// Iterate `home/inbox`'s `*.jsonl` entry paths (the directory-walk +
 /// extension-filter shared by `sweep_expired` / `get_thread` / `find_message`).
 /// A `read_dir` error yields an empty iteration (callers historically
@@ -320,9 +362,12 @@ pub fn inbox_agent_names(home: &Path) -> Vec<String> {
 ///
 /// NOT crash-atomic: enqueue appends in place — no tmp+rename (only the
 /// read-modify-write rewriters drain/sweep/clear/supersede use that). A crash
-/// mid-write can leave a half-written trailing line; every read path skips an
-/// unparseable line and [`recover_half_writes`] quarantines it (to
-/// `inbox.recovery/`) at startup.
+/// mid-write can leave a half-written trailing line. Read-ONLY paths skip an
+/// unparseable line; the read-modify-write rewriters PRESERVE it verbatim
+/// (AUDIT3-005 — all route through [`parse_or_preserve_line`], which re-emits a
+/// forward-schema OR unparseable line instead of dropping it), so a RUNTIME
+/// rewrite can never silently destroy it before [`recover_half_writes`]
+/// quarantines it (to `inbox.recovery/`) at the next startup.
 ///
 /// Returns an error when the inbox is in readonly mode (disk full).
 /// Callers should invoke [`check_disk_space`] periodically (e.g. daemon tick);
@@ -612,24 +657,12 @@ pub fn drain(home: &Path, name: &str) -> Vec<InboxMessage> {
             if line.trim().is_empty() {
                 continue;
             }
-            let mut msg: InboxMessage = match serde_json::from_str(line) {
-                Ok(m) => m,
-                Err(_) => continue,
-            };
-            if msg.schema_version > InboxMessage::CURRENT_VERSION {
-                // CR-2026-06-14: a newer daemon wrote this row. We can't deliver
-                // it (forward-only fields are unknown to this struct), but we MUST
-                // NOT delete it on the rewrite below — that is downgrade data loss.
-                // Preserve the RAW line verbatim so the rewrite re-emits it intact
-                // (store.rs refuse-and-preserve).
-                tracing::warn!(
-                    found = msg.schema_version,
-                    supported = InboxMessage::CURRENT_VERSION,
-                    "skipping (preserving on disk) inbox message written by newer schema version"
-                );
-                preserved_forward.push(line.to_string());
+            // AUDIT3-005: parse-or-preserve — a forward-schema row (newer daemon) AND
+            // an unparseable line (torn enqueue / corruption) are preserved verbatim
+            // (re-emitted below), never silently dropped on the rewrite.
+            let Some(mut msg) = parse_or_preserve_line(line, &mut preserved_forward) else {
                 continue;
-            }
+            };
             if msg.read_at.is_none() {
                 if msg.superseded_by.is_some() {
                     // superseded obligations are retired (marked read) but never
@@ -843,16 +876,10 @@ pub fn ack(home: &Path, name: &str, msg_id: Option<&str>) -> usize {
             if line.trim().is_empty() {
                 continue;
             }
-            let mut msg: InboxMessage = match serde_json::from_str(line) {
-                Ok(m) => m,
-                Err(_) => continue,
-            };
-            if msg.schema_version > InboxMessage::CURRENT_VERSION {
-                // Mirror drain()/clear_compact(): never destroy a forward-schema
-                // row a newer daemon wrote — re-emit it verbatim.
-                preserved_forward.push(line.to_string());
+            // AUDIT3-005: forward-schema + unparseable lines preserved verbatim.
+            let Some(mut msg) = parse_or_preserve_line(line, &mut preserved_forward) else {
                 continue;
-            }
+            };
             // Only an in-flight `delivering` row is ackable. Match on id when given.
             let is_target = msg_id.is_none_or(|id| msg.id.as_deref() == Some(id));
             if is_target && msg.read_at.is_none() && msg.delivering_at.is_some() {
@@ -919,14 +946,10 @@ pub fn settle_read_by_id(home: &Path, name: &str, msg_id: &str) -> bool {
             if line.trim().is_empty() {
                 continue;
             }
-            let mut msg: InboxMessage = match serde_json::from_str(line) {
-                Ok(m) => m,
-                Err(_) => continue,
-            };
-            if msg.schema_version > InboxMessage::CURRENT_VERSION {
-                preserved_forward.push(line.to_string());
+            // AUDIT3-005: forward-schema + unparseable lines preserved verbatim.
+            let Some(mut msg) = parse_or_preserve_line(line, &mut preserved_forward) else {
                 continue;
-            }
+            };
             if msg.id.as_deref() == Some(msg_id) && msg.read_at.is_none() {
                 msg.read_at = Some(now.clone());
                 settled = true;
@@ -1025,14 +1048,10 @@ pub fn ack_by_correlation(home: &Path, name: &str, correlation_id: &str) -> usiz
             if line.trim().is_empty() {
                 continue;
             }
-            let mut msg: InboxMessage = match serde_json::from_str(line) {
-                Ok(m) => m,
-                Err(_) => continue,
-            };
-            if msg.schema_version > InboxMessage::CURRENT_VERSION {
-                preserved_forward.push(line.to_string());
+            // AUDIT3-005: forward-schema + unparseable lines preserved verbatim.
+            let Some(mut msg) = parse_or_preserve_line(line, &mut preserved_forward) else {
                 continue;
-            }
+            };
             // Only ack delivering rows whose task_id matches the correlation_id.
             let task_matches = msg
                 .task_id
@@ -1215,21 +1234,10 @@ pub fn clear_compact(
             if line.trim().is_empty() {
                 continue;
             }
-            let mut msg: InboxMessage = match serde_json::from_str(line) {
-                Ok(m) => m,
-                Err(_) => continue,
-            };
-            if msg.schema_version > InboxMessage::CURRENT_VERSION {
-                // CR-2026-06-14: preserve forward-schema rows verbatim — never
-                // delete a message a newer daemon wrote (downgrade data loss).
-                tracing::warn!(
-                    found = msg.schema_version,
-                    supported = InboxMessage::CURRENT_VERSION,
-                    "skipping (preserving on disk) inbox message written by newer schema version"
-                );
-                preserved_forward.push(line.to_string());
+            // AUDIT3-005: forward-schema + unparseable lines preserved verbatim.
+            let Some(mut msg) = parse_or_preserve_line(line, &mut preserved_forward) else {
                 continue;
-            }
+            };
             // Already-read rows are untouched (and not re-summarised).
             if msg.read_at.is_some() {
                 out.push(msg);
@@ -1776,14 +1784,17 @@ pub fn sweep_expired(home: &Path) {
                 read_non_blocker: bool,
             }
             let mut kept: Vec<Kept> = Vec::new();
+            // AUDIT3-005: forward-schema + unparseable lines to re-emit verbatim (never swept).
+            let mut preserved: Vec<String> = Vec::new();
             let mut changed = false;
             for line in content.lines() {
                 if line.trim().is_empty() {
                     continue;
                 }
-                let msg: InboxMessage = match serde_json::from_str(line) {
-                    Ok(m) => m,
-                    Err(_) => continue,
+                // AUDIT3-005: a corrupt line has no parseable TTL — preserve it
+                // verbatim, never sweep it away.
+                let Some(msg) = parse_or_preserve_line(line, &mut preserved) else {
+                    continue;
                 };
                 let ts = chrono::DateTime::parse_from_rfc3339(&msg.timestamp)
                     .map(|dt| dt.with_timezone(&chrono::Utc))
@@ -1844,7 +1855,9 @@ pub fn sweep_expired(home: &Path) {
             }
 
             if changed {
-                if kept.is_empty() {
+                // AUDIT3-005: only delete the file when NOTHING survives — a preserved
+                // (forward-schema / unparseable) line must keep the file alive.
+                if kept.is_empty() && preserved.is_empty() {
                     let _ = std::fs::remove_file(path);
                 } else {
                     let tmp = path.with_extension("jsonl.tmp");
@@ -1856,6 +1869,10 @@ pub fn sweep_expired(home: &Path) {
                             .open(&tmp)?;
                         for k in &kept {
                             writeln!(f, "{}", k.line)?;
+                        }
+                        // AUDIT3-005: re-emit forward-schema + unparseable lines verbatim.
+                        for raw in &preserved {
+                            writeln!(f, "{raw}")?;
                         }
                         f.sync_all()?;
                         std::fs::rename(&tmp, path)?;
@@ -1926,14 +1943,10 @@ pub fn reclaim_stale_delivering(home: &Path) {
                 if line.trim().is_empty() {
                     continue;
                 }
-                let mut msg: InboxMessage = match serde_json::from_str(line) {
-                    Ok(m) => m,
-                    Err(_) => continue,
-                };
-                if msg.schema_version > InboxMessage::CURRENT_VERSION {
-                    preserved_forward.push(line.to_string());
+                // AUDIT3-005: forward-schema + unparseable lines preserved verbatim.
+                let Some(mut msg) = parse_or_preserve_line(line, &mut preserved_forward) else {
                     continue;
-                }
+                };
                 // A `delivering` row = read_at None AND delivering_at Some.
                 if msg.read_at.is_none() {
                     if let Some(ref since) = msg.delivering_at {

--- a/src/inbox/tests.rs
+++ b/src/inbox/tests.rs
@@ -4883,3 +4883,167 @@ fn unread_obligation_summary_empty_inbox_is_default_2604() {
     assert!(s.oldest_obligation.is_none());
     fs::remove_dir_all(&home).ok();
 }
+
+// ── AUDIT3-005: every RUNTIME read-modify-write rewriter must PRESERVE an
+// unparseable line verbatim (re-emit it), NOT silently drop it — else a torn
+// enqueue / corrupt line is lost before startup `recover_half_writes` can
+// quarantine it. RED before the shared `parse_or_preserve_line` fix: each rewriter
+// drops the corrupt line when its rewrite fires (changed=true). One test per site
+// (mark_ci_watch_superseded already preserves via its else-branch, so it is a
+// control, not a fix target).
+const A3005_CORRUPT: &str = "{\"broken\":CORRUPT-005 unparseable torn line";
+
+fn a3005_read(home: &Path, name: &str) -> String {
+    fs::read_to_string(home.join("inbox").join(format!("{name}.jsonl"))).unwrap_or_default()
+}
+fn a3005_write(home: &Path, name: &str, good: &str) {
+    let dir = home.join("inbox");
+    fs::create_dir_all(&dir).ok();
+    fs::write(
+        dir.join(format!("{name}.jsonl")),
+        format!("{good}\n{A3005_CORRUPT}\n"),
+    )
+    .ok();
+}
+
+#[test]
+fn audit3_005_drain_preserves_corrupt_line() {
+    let home = tmp_home("a3005-drain");
+    a3005_write(
+        &home,
+        "ag",
+        &serde_json::to_string(&make_msg("s", "keep")).unwrap(),
+    );
+    let _ = drain(&home, "ag");
+    assert!(
+        a3005_read(&home, "ag").contains("CORRUPT-005"),
+        "drain must PRESERVE the unparseable line, not silently drop it"
+    );
+    fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn audit3_005_ack_preserves_corrupt_line() {
+    let home = tmp_home("a3005-ack");
+    let deliv = msg()
+        .sender("s")
+        .id("m-ack")
+        .delivering_at(&secs_ago(5))
+        .build();
+    a3005_write(&home, "ag", &serde_json::to_string(&deliv).unwrap());
+    ack(&home, "ag", Some("m-ack"));
+    assert!(
+        a3005_read(&home, "ag").contains("CORRUPT-005"),
+        "ack must PRESERVE the unparseable line"
+    );
+    fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn audit3_005_settle_read_by_id_preserves_corrupt_line() {
+    let home = tmp_home("a3005-settle");
+    let deliv = msg()
+        .sender("s")
+        .id("m-set")
+        .delivering_at(&secs_ago(5))
+        .build();
+    a3005_write(&home, "ag", &serde_json::to_string(&deliv).unwrap());
+    super::storage::settle_read_by_id(&home, "ag", "m-set");
+    assert!(
+        a3005_read(&home, "ag").contains("CORRUPT-005"),
+        "settle_read_by_id must PRESERVE the unparseable line"
+    );
+    fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn audit3_005_ack_by_correlation_preserves_corrupt_line() {
+    let home = tmp_home("a3005-ackcorr");
+    // ack_by_correlation matches on `task_id` (despite the name), delivering + unread.
+    let m = msg()
+        .sender("s")
+        .id("m-c")
+        .task_id("corr-1")
+        .delivering_at(&secs_ago(5))
+        .build();
+    a3005_write(&home, "ag", &serde_json::to_string(&m).unwrap());
+    ack_by_correlation(&home, "ag", "corr-1");
+    assert!(
+        a3005_read(&home, "ag").contains("CORRUPT-005"),
+        "ack_by_correlation must PRESERVE the unparseable line"
+    );
+    fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn audit3_005_clear_compact_preserves_corrupt_line() {
+    let home = tmp_home("a3005-clear");
+    a3005_write(
+        &home,
+        "ag",
+        &serde_json::to_string(&make_msg("s", "clear-me")).unwrap(),
+    );
+    let _ = clear_compact(&home, "ag", |_| None); // non-obligation → cleared (changed)
+    assert!(
+        a3005_read(&home, "ag").contains("CORRUPT-005"),
+        "clear_compact must PRESERVE the unparseable line"
+    );
+    fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn audit3_005_sweep_expired_preserves_corrupt_line() {
+    let home = tmp_home("a3005-sweep");
+    // Ancient unread message → expired (UNREAD_TTL) → sweep rewrites (changed=true),
+    // leaving ONLY the corrupt line — also exercises the empty-`kept` remove-file path.
+    let old = msg()
+        .sender("s")
+        .text("old")
+        .timestamp("2020-01-01T00:00:00Z")
+        .build();
+    a3005_write(&home, "ag", &serde_json::to_string(&old).unwrap());
+    sweep_expired(&home);
+    assert!(
+        a3005_read(&home, "ag").contains("CORRUPT-005"),
+        "sweep_expired must PRESERVE the unparseable line (it can't judge its TTL)"
+    );
+    fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn audit3_005_reclaim_stale_delivering_preserves_corrupt_line() {
+    let home = tmp_home("a3005-reclaim");
+    let stale = msg()
+        .sender("s")
+        .delivering_at(&secs_ago(1_000_000))
+        .build();
+    a3005_write(&home, "ag", &serde_json::to_string(&stale).unwrap());
+    reclaim_stale_delivering(&home);
+    assert!(
+        a3005_read(&home, "ag").contains("CORRUPT-005"),
+        "reclaim_stale_delivering must PRESERVE the unparseable line"
+    );
+    fs::remove_dir_all(&home).ok();
+}
+
+/// Control: `mark_ci_watch_superseded` ALREADY preserves (its `else` re-pushes the
+/// raw line). Pins that it stays correct.
+#[test]
+fn audit3_005_mark_ci_watch_superseded_preserves_corrupt_line_control() {
+    let home = tmp_home("a3005-supersede");
+    let ci = msg()
+        .sender("system:ci")
+        .kind("ci-watch")
+        .id("m-ci")
+        .build();
+    let mut ci = ci;
+    ci.correlation_id = Some("repo@feat/x".into());
+    ci.text = "ci-watch system:ci repo@feat/x".into();
+    a3005_write(&home, "ag", &serde_json::to_string(&ci).unwrap());
+    mark_ci_watch_superseded(&home, "ag", "repo@feat/x", "m-new");
+    assert!(
+        a3005_read(&home, "ag").contains("CORRUPT-005"),
+        "mark_ci_watch_superseded must keep preserving the unparseable line"
+    );
+    fs::remove_dir_all(&home).ok();
+}


### PR DESCRIPTION
## Silent inbox message-loss (AUDIT3-005) — CONFIRMED + fixed

All 7 inbox read-modify-write rewriters (`drain` / `ack` / `settle_read_by_id` / `ack_by_correlation` / `clear_compact` / `sweep_expired` / `reclaim_stale_delivering`) used `Err(_) => continue` — an unparseable JSONL line (a torn enqueue / external corruption) was **silently dropped** on rewrite (`changed==true`), with **no log**, *before* the startup-only `recover_half_writes` could quarantine it. `preserved_forward` only rescued forward-schema rows (valid JSON). Net: a runtime rewrite raced ahead of startup recovery and permanently lost the line — in practice a half-written **unread inbound message** (a sender blocked forever / a delegation silently dropped), undetectable.

## Fix

A shared **`parse_or_preserve_line`** helper is the single parse step for every rewriter: a forward-schema OR unparseable line is preserved **verbatim** (re-emitted in the rewrite) and WARNed, never dropped — so it survives on disk until the next startup `recover_half_writes` quarantines it to `inbox.recovery/`. One helper (not per-site patches) prevents a missed/drifted site (the #27 lesson).

**Verification corrected the audit's site list** (the payoff of checking each): `mark_ci_watch_superseded` **already preserves** (its `else`-branch — kept as a control test), while `settle_read_by_id` + `ack_by_correlation` **were buggy but unlisted**. `sweep_expired` also gains an empty-file guard so a preserved line keeps the file alive. The misleading `enqueue` doc (claimed startup quarantine covered it) is corrected.

## Tests (RED-first)

One per site asserting a corrupt line **survives** the runtime rewrite — via the daemon-up path (no prior `recover_half_writes`) that the existing `test_half_written_jsonl_preserves_good_messages` masks — plus a `mark_ci_watch_superseded` control. 7 RED → GREEN. `inbox` module **221/221**; CI-scoped clippy `-D warnings` + rustfmt clean.

Follow-up (flagged): reply-settle (same storage layer) is the natural next item.

Closes AUDIT3-005

🤖 Generated with [Claude Code](https://claude.com/claude-code)