### PR TITLE
feat(worktree-gc PR-D·D5): unify the disposition ladder behind a shared janitor::dispose switch

### DIFF
--- a/src/daemon/auto_release.rs
+++ b/src/daemon/auto_release.rs
@@ -804,7 +804,21 @@ fn process_intent(home: &Path, intent: &AutoReleaseIntent) -> IntentOutcome {
             }
         }
         let dirty = worktree_dirty.unwrap_or(false);
-        let outcome = crate::worktree_pool::release_full(home, &assignee, false);
+        // PR-D·D5: route through the shared `janitor::dispose` Release arm
+        // (== `release_full(home, agent, false)`). The lock/CAS/re-validation above
+        // and the fail-closed retain-on-failure below stay in THIS caller (D5-Q1);
+        // dispose owns only the Release→release_full mechanism binding.
+        let crate::daemon::janitor::DispositionOutcome::Released(outcome) =
+            crate::daemon::janitor::dispose(
+                home,
+                crate::worktree::disposition::Disposition::Release,
+                &assignee,
+                None,
+                || Ok(()),
+            )
+        else {
+            unreachable!("Release disposition yields Released");
+        };
         if outcome.released {
             tracing::info!(agent = %assignee, task_id = %intent.task_id, event, ?confidence, dirty, outcome = ?outcome, "auto_release: released worktree (release invariant satisfied)");
             IntentOutcome::Done

--- a/src/daemon/janitor.rs
+++ b/src/daemon/janitor.rs
@@ -1,0 +1,161 @@
+//! PR-D · D5 — the shared janitor disposition core (spike §2/§3).
+//!
+//! D1-D4 unified the DECISION: every terminal-detection system delegates to the
+//! pure classifier [`crate::worktree::disposition::terminal_disposition`]. D5
+//! closes the RCA's "no-man's-land between policies" on the DISPOSITION side:
+//! the three worktree-destruction mechanisms (managed release, hard remove,
+//! `.trash` archive) now funnel through ONE switch, so "one policy, two
+//! schedules" holds for BOTH the decision and its execution.
+//!
+//! [`dispose`] is that switch. It maps a decided [`Disposition`] to its
+//! mechanism:
+//! - `Release`/`Archive` mechanisms are shared VERBATIM across callers
+//!   (`release_full` / `maybe_remove_candidate`).
+//! - `Delete` is PARAMETERIZED by the caller's `delete` remover — the sweep
+//!   (`git_ok` + windows-retry + `branch -D`) and GC (`git_bypass` + timeout)
+//!   deliberately keep different git-invocation wrappers (lead decision
+//!   m-20260703064336281447-62 / d-20260710112849030331-3). Unifying those two
+//!   wrappers is a separate behavior change with its own PR — NOT smuggled in
+//!   here (D5-Q3 ruling B; same honest-partial line as D3 ruling-A).
+//!
+//! Each caller keeps its own fail-closed pre/post — the binding lock, re-
+//! validation, WIP-preserve (#2672), and the #2550 archive-fallthrough — in the
+//! caller (D5-Q1). This module owns only the disposition→mechanism binding, not
+//! the tier-specific safety wrapping.
+
+use crate::worktree::disposition::Disposition;
+use crate::worktree_pool::{GcCandidate, ReleaseOutcome};
+use std::path::Path;
+
+/// The result of executing a [`Disposition`] via [`dispose`].
+pub(crate) enum DispositionOutcome {
+    /// `Keep` — nothing was touched.
+    Kept,
+    /// `Release` — the managed `release_full` ran; carries its full outcome (the
+    /// auto-release caller needs `released`/`error` for its fail-closed retry).
+    Released(ReleaseOutcome),
+    /// `Delete` — the caller's remover ran. `Ok(())` = removed; `Err(reason)` =
+    /// could not remove, so the caller decides what to do with it (GC hands the
+    /// reason to its #2550 archive-fallthrough; the sweep just skips).
+    Deleted(Result<(), String>),
+    /// `Archive` — the shared `.trash` archive path ran (archive-only, the D4
+    /// gc.rs:706 ForceReclaim invariant); carries its `RemovalOutcome`.
+    Archived(crate::daemon::retention::worktrees::RemovalOutcome),
+}
+
+/// The shared disposition-ladder SWITCH (spike §2). Both cadence tiers funnel
+/// their decided `disposition` here; see the module docs for the boundary.
+///
+/// `agent` is used by the `Release` arm; `candidate` by the `Archive` arm;
+/// `delete` by the `Delete` arm — each arm reads only what it needs, so a caller
+/// that never reaches an arm passes an inert value (`""` / `None` / `|| Ok(())`).
+pub(crate) fn dispose(
+    home: &Path,
+    disposition: Disposition,
+    agent: &str,
+    candidate: Option<&GcCandidate>,
+    delete: impl FnOnce() -> Result<(), String>,
+) -> DispositionOutcome {
+    match disposition {
+        Disposition::Keep => DispositionOutcome::Kept,
+        // Binding present + terminal → the full managed release (WIP-preserve →
+        // remove → unbind → branch cleanup; fail-closed on unpreservable WIP,
+        // #2672). Shared verbatim.
+        Disposition::Release => {
+            DispositionOutcome::Released(crate::worktree_pool::release_full(home, agent, false))
+        }
+        // No binding, confirmed-clean terminal → the caller's dir-remover. The
+        // wrapper choice stays with the caller (D5-Q3 ruling B).
+        Disposition::Delete => DispositionOutcome::Deleted(delete()),
+        // Reclaim-worthy but untrustworthy git state → atomic `.trash` archive.
+        // Shared verbatim. Only the GC tier produces `Archive`, and it always
+        // carries its candidate; a missing candidate is a caller bug → fail toward
+        // NOT destroying (keep + LOUD), never archive a phantom.
+        Disposition::Archive => match candidate {
+            Some(c) => DispositionOutcome::Archived(
+                crate::daemon::retention::worktrees::maybe_remove_candidate(home, c),
+            ),
+            None => {
+                tracing::error!(
+                    agent,
+                    "janitor::dispose: Archive disposition without a GcCandidate — \
+                     keeping (fail-closed); this is a caller bug"
+                );
+                DispositionOutcome::Kept
+            }
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+
+    // PR-D·D5 equivalence pins: the disposition SWITCH binds each `Disposition` to
+    // its mechanism and touches NO other. The mechanisms themselves (`release_full`
+    // / `maybe_remove_candidate` / the caller's remover) are locked by their own
+    // pin families, and the end-to-end "each tier's disposition == dispose(same
+    // signals)" is locked by the GC/sweep/auto caller pins staying green through
+    // the D5 refactor; these lock the switch's internal routing directly. The
+    // Keep/Delete/Archive-None arms exercised here perform no I/O, so `home` is inert.
+    fn inert_home() -> std::path::PathBuf {
+        std::path::PathBuf::from("/nonexistent-d5-janitor-test")
+    }
+
+    #[test]
+    fn dispose_delete_runs_only_the_caller_remover() {
+        let called = Cell::new(false);
+        let out = dispose(&inert_home(), Disposition::Delete, "", None, || {
+            called.set(true);
+            Ok(())
+        });
+        assert!(called.get(), "Delete must invoke the caller's remover");
+        assert!(matches!(out, DispositionOutcome::Deleted(Ok(()))));
+    }
+
+    #[test]
+    fn dispose_delete_forwards_remover_error_verbatim() {
+        // GC's #2550 archive-fallthrough keys on this exact reason string.
+        let out = dispose(&inert_home(), Disposition::Delete, "", None, || {
+            Err("git worktree remove failed: boom".to_string())
+        });
+        match out {
+            DispositionOutcome::Deleted(Err(reason)) => {
+                assert_eq!(reason, "git worktree remove failed: boom");
+            }
+            _ => panic!("Delete must forward the remover's Err verbatim"),
+        }
+    }
+
+    #[test]
+    fn dispose_keep_is_a_noop_and_never_removes() {
+        let called = Cell::new(false);
+        let out = dispose(&inert_home(), Disposition::Keep, "", None, || {
+            called.set(true);
+            Ok(())
+        });
+        assert!(
+            !called.get(),
+            "Keep must NOT invoke the remover (the fail-closed default)"
+        );
+        assert!(matches!(out, DispositionOutcome::Kept));
+    }
+
+    #[test]
+    fn dispose_archive_without_candidate_keeps_fail_closed() {
+        // Archive is GC-only + always carries a candidate; a missing one is a caller
+        // bug → fail toward NOT destroying (keep), never archive a phantom, and never
+        // fall into the Delete remover.
+        let called = Cell::new(false);
+        let out = dispose(&inert_home(), Disposition::Archive, "agent-x", None, || {
+            called.set(true);
+            Ok(())
+        });
+        assert!(!called.get(), "Archive must not invoke the Delete remover");
+        assert!(
+            matches!(out, DispositionOutcome::Kept),
+            "Archive without a candidate → fail-closed Keep"
+        );
+    }
+}

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -27,6 +27,7 @@ pub mod hook_shadow;
 pub(crate) mod idle_watchdog;
 pub(crate) mod inbox_stuck_watchdog;
 pub(crate) mod inject_delivery;
+pub(crate) mod janitor;
 pub(crate) mod lifecycle;
 pub(crate) mod mcp_registry_watcher;
 pub(crate) mod notification_dedup;

--- a/src/worktree_cleanup.rs
+++ b/src/worktree_cleanup.rs
@@ -526,13 +526,37 @@ pub fn sweep_from_registry(
                 dry_run,
                 "removing stale worktree"
             );
-            if remove_worktree(
-                repo,
-                &entry.path,
-                &entry.branch,
-                branch_safe_to_delete,
-                dry_run,
-            ) {
+            // PR-D·D5: route the dir-Delete through the shared `janitor::dispose`
+            // Delete arm — the sweep passes its OWN remover (`remove_worktree`:
+            // git_ok + windows-retry + `branch -D`), so its deliberate wrapper is
+            // preserved (D5-Q3 ruling B; the git_ok↔git_bypass unify is a separate
+            // PR, decision m-20260703064336281447-62). Byte-identical to the prior
+            // direct call: same args, push on success. `agent`/`candidate` are inert
+            // on the Delete arm; the Err reason is unused here (the sweep skips, it
+            // does not archive-fallthrough).
+            let removed_ok = matches!(
+                crate::daemon::janitor::dispose(
+                    home,
+                    crate::worktree::disposition::Disposition::Delete,
+                    "",
+                    None,
+                    || {
+                        if remove_worktree(
+                            repo,
+                            &entry.path,
+                            &entry.branch,
+                            branch_safe_to_delete,
+                            dry_run,
+                        ) {
+                            Ok(())
+                        } else {
+                            Err("sweep worktree remove failed".to_string())
+                        }
+                    },
+                ),
+                crate::daemon::janitor::DispositionOutcome::Deleted(Ok(()))
+            );
+            if removed_ok {
                 removed.push((entry.branch.clone(), entry.path.clone(), reason));
             }
         }

--- a/src/worktree_pool/gc.rs
+++ b/src/worktree_pool/gc.rs
@@ -753,8 +753,23 @@ pub(crate) fn gc_remove_one(home: &Path, candidate: &GcCandidate) -> GcResult {
     // irrecoverable delete. Clean-release candidates keep the historical
     // hard-delete below (ungated, unconditional — decision Q3).
     if candidate.kind == GcKind::ForceReclaim {
-        use crate::daemon::retention::worktrees::{maybe_remove_candidate, RemovalOutcome};
-        let outcome = maybe_remove_candidate(home, candidate);
+        // PR-D·D5: route through the shared `janitor::dispose` Archive arm — the
+        // ForceReclaim→Archive binding IS the D4 gc.rs:706 archive-only invariant,
+        // now expressed as the disposition switch. `maybe_remove_candidate`
+        // (archive-only: liveness re-check + atomic `.trash` + unbind + ALERT) is
+        // unchanged behind it.
+        use crate::daemon::janitor::{dispose, DispositionOutcome};
+        use crate::daemon::retention::worktrees::RemovalOutcome;
+        use crate::worktree::disposition::Disposition;
+        let DispositionOutcome::Archived(outcome) = dispose(
+            home,
+            Disposition::Archive,
+            &candidate.agent,
+            Some(candidate),
+            || Ok(()),
+        ) else {
+            unreachable!("Archive disposition yields Archived");
+        };
         return GcResult {
             path: wt_path.clone(),
             agent: candidate.agent.clone(),
@@ -834,50 +849,59 @@ pub(crate) fn gc_remove_one(home: &Path, candidate: &GcCandidate) -> GcResult {
     // the prior raw Command, plus the timeout bound the raw path lacked).
     // source_repo is Some after resolve above, so the empty-cwd raw branch is
     // never taken here.
-    match crate::git_worktree::remove_force(&source_repo, &wt_path.display().to_string()) {
-        Ok(o) if o.status.success() => GcResult {
+    // W1.2 / PR-D·D5: the CleanRelease dir-remove is the `janitor::dispose` Delete
+    // arm — GC passes `remove_force` (always-bypass + LOCAL_GIT_TIMEOUT) as its
+    // remover (D5-Q3 ruling B keeps the sweep's git_ok+windows-retry wrapper
+    // separate). The remover returns `Ok(())` on success (incl. the remove_dir_all
+    // fallback path) or `Err(reason)`; this wrapper keeps the #2550 archive-
+    // fallthrough on `Err` (deliberate fail-closed pre/post, D5-Q1). Every reason
+    // string is preserved byte-for-byte.
+    use crate::daemon::janitor::{dispose, DispositionOutcome};
+    use crate::worktree::disposition::Disposition;
+    let outcome = dispose(home, Disposition::Delete, &candidate.agent, None, || {
+        match crate::git_worktree::remove_force(&source_repo, &wt_path.display().to_string()) {
+            Ok(o) if o.status.success() => Ok(()),
+            Ok(o) => {
+                let stderr = String::from_utf8_lossy(&o.stderr).trim().to_string();
+                tracing::warn!(
+                    agent = %candidate.agent,
+                    path = %wt_path.display(),
+                    error = %stderr,
+                    "gc: git worktree remove failed — falling back to remove_dir_all"
+                );
+                let _ = std::fs::remove_dir_all(wt_path);
+                if !wt_path.exists() {
+                    // W1.2: best-effort prune (result already ignored).
+                    let _ = crate::git_helpers::git_ok(&source_repo, &["worktree", "prune"]);
+                    Ok(())
+                } else {
+                    // Both `git worktree remove` and `remove_dir_all` failed — the
+                    // worktree is still on disk and still eligible. Fall through.
+                    Err(format!("git worktree remove failed: {stderr}"))
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    agent = %candidate.agent,
+                    path = %wt_path.display(),
+                    error = %e,
+                    "gc: git command failed"
+                );
+                Err(format!("git command failed: {e}"))
+            }
+        }
+    });
+    match outcome {
+        DispositionOutcome::Deleted(Ok(())) => GcResult {
             path: wt_path.clone(),
             agent: candidate.agent.clone(),
             removed: true,
             error: None,
         },
-        Ok(o) => {
-            let stderr = String::from_utf8_lossy(&o.stderr).trim().to_string();
-            tracing::warn!(
-                agent = %candidate.agent,
-                path = %wt_path.display(),
-                error = %stderr,
-                "gc: git worktree remove failed — falling back to remove_dir_all"
-            );
-            let _ = std::fs::remove_dir_all(wt_path);
-            if !wt_path.exists() {
-                // W1.2: best-effort prune (result already ignored).
-                let _ = crate::git_helpers::git_ok(&source_repo, &["worktree", "prune"]);
-                GcResult {
-                    path: wt_path.clone(),
-                    agent: candidate.agent.clone(),
-                    removed: true,
-                    error: None,
-                }
-            } else {
-                // Both `git worktree remove` and `remove_dir_all` failed — the
-                // worktree is still on disk and still eligible. Fall through.
-                archive_fallthrough_result(
-                    home,
-                    candidate,
-                    format!("git worktree remove failed: {stderr}"),
-                )
-            }
+        DispositionOutcome::Deleted(Err(reason)) => {
+            archive_fallthrough_result(home, candidate, reason)
         }
-        Err(e) => {
-            tracing::warn!(
-                agent = %candidate.agent,
-                path = %wt_path.display(),
-                error = %e,
-                "gc: git command failed"
-            );
-            archive_fallthrough_result(home, candidate, format!("git command failed: {e}"))
-        }
+        _ => unreachable!("Delete disposition yields Deleted"),
     }
 }
 


### PR DESCRIPTION
## PR-D · D5 — unify the disposition ladder behind `janitor::dispose`

The **structural close-out** of the janitor-disposition migration (spike §6). D1–D4
unified the **decision** (every terminal-detection system delegates to
`terminal_disposition`); D5 closes the RCA's "no-man's-land between policies" on the
**disposition** side — the three worktree-destruction mechanisms now funnel through
ONE switch, so "one policy, two schedules" holds for both the decision and its
execution. **Behavior byte-identical** — only the disposition→mechanism *binding*
converges.

### The shared core — new `src/daemon/janitor.rs`
`dispose(home, disposition, agent, candidate, delete) -> DispositionOutcome`:
- **Release / Archive** mechanisms shared verbatim (`release_full` /
  `maybe_remove_candidate`).
- **Delete** *parameterized* by the caller's remover (**Q3 ruling B**,
  `d-20260710112849030331-3`): the sweep (`git_ok` + windows-retry + `branch -D`) and
  GC (`git_bypass` + timeout) deliberately keep different git wrappers — unifying
  those is a **separate PR** (`m-20260703064336281447-62`), NOT smuggled in here. Same
  honest-partial line as D3 ruling-A.
- Each caller keeps its own fail-closed pre/post (lock, revalidate, WIP-preserve
  #2672, #2550 archive-fallthrough) — **Q1**.

### Caller wirings (all byte-identical)
- **`gc_remove_one`**: ForceReclaim → `dispose(Archive)` (this binding *is* the D4
  gc.rs:706 archive-only invariant, now the switch); CleanRelease → `dispose(Delete,
  remove_force)` with lock/revalidate/#2550-fallthrough kept in the wrapper, every
  reason string verbatim.
- **sweep** (`worktree_cleanup.rs`): `remove_worktree` → `dispose(Delete,
  remove_worktree)` — the sweep passes its own remover.
- **auto_release**: `release_full` → `dispose(Release)` inside the unchanged lock/CAS.

### Deliberately NOT touched
- **Q2 DEFERRED** to a DX rider: the offload + `in_flight` + `ClearOnDrop` scaffolding
  copy-pasted across the two PerTickHandlers (cadence-wrapper infra, orthogonal).
- Cadence (10min/1h/30s), enumeration, panic-isolation (#2549 W1), offload (#P1-2607),
  and the /tmp GC sibling rule (**Q3**) — untouched.

### Verification
- Full census **5464 passed / 0 failed** (5460 baseline + 4 new `janitor` equivalence
  pins). The sweep 56 + GC 255 + auto 38 + retention pins staying green **through** the
  refactor is the byte-identical proof.
- `fmt --check` + `clippy --features tray -D warnings` (1.97) clean.

Refs: #2711 (D1), #2713 (D2), #2715 (D3), #2716 (D4). Parent: PR-D umbrella.

**DUAL review** — cross-subsystem structural refactor (sweep + GC + auto_release).
