### PR TITLE
fix(reply-settle): plain reply settles the current turn's inbox rows (stop reclaim double-reply)

### DIFF
--- a/src/mcp/handlers/channel.rs
+++ b/src/mcp/handlers/channel.rs
@@ -174,6 +174,19 @@ pub(super) fn handle_reply(home: &Path, args: &Value, instance_name: &str) -> Va
         },
     ) {
         Ok(msg) => {
+            // A plain reply (no explicit `message_id`) answers the CURRENT user turn.
+            // Capture that turn's persistent inbox-row ids NOW — BEFORE
+            // `record_reply_outcome` below, which `take()`s `pending_user_turn` — so we
+            // can settle them. The daemon drain armed the real delivery ids into
+            // `group_msg_ids` (#2042: replying to any id settles the whole logical turn).
+            let plain_reply_group_ids: Vec<String> = if message_id.is_none() {
+                crate::daemon::heartbeat_pair::snapshot_for(instance_name)
+                    .pending_user_turn
+                    .map(|t| t.group_msg_ids)
+                    .unwrap_or_default()
+            } else {
+                Vec::new()
+            };
             // #1665: reply delivered — closes the user-turn (no warn at sweep).
             crate::reply_ledger::record_reply_outcome(instance_name, true);
             // #2622 PR-3 Fork C: a targeted reply also settles the persistent
@@ -182,6 +195,14 @@ pub(super) fn handle_reply(home: &Path, args: &Value, instance_name: &str) -> Va
             // stops redelivering once it's actually been answered.
             if let Some(msg_id) = message_id {
                 crate::inbox::storage::settle_read_by_id(home, instance_name, msg_id);
+            } else {
+                // Plain-reply path: settle the whole turn's group so the row can't stay
+                // `delivering` and get reverted-to-unread + RE-DELIVERED by
+                // `reclaim_stale_delivering` after the 600s TTL — the telegram
+                // double-reply. Same action as the `message_id` path; id source differs.
+                for id in &plain_reply_group_ids {
+                    crate::inbox::storage::settle_read_by_id(home, instance_name, id);
+                }
             }
             // Sprint 59 Wave 1 PR-4: surface the pending-decision /
             // resolved-decision IDs so caller observability is

--- a/src/mcp/handlers/channel_p0a_tests.rs
+++ b/src/mcp/handlers/channel_p0a_tests.rs
@@ -863,3 +863,74 @@ fn reply_with_message_id_missing_channel_on_row_errors_2622() {
     );
     std::fs::remove_dir_all(&home).ok();
 }
+
+/// reply auto-settle: a PLAIN reply (no explicit `message_id`) must SETTLE the
+/// current user turn's persistent inbox row(s). Pre-fix, only the
+/// `message_id`-carrying branch settled — a plain reply left the row `delivering`,
+/// so `reclaim_stale_delivering` reverted it to unread after the 600s TTL and
+/// RE-DELIVERED it, producing the telegram DOUBLE reply. RED before the
+/// channel.rs `else` branch that settles `pending_user_turn.group_msg_ids`.
+#[test]
+fn plain_reply_settles_turn_group_so_reclaim_cannot_redeliver() {
+    let _g = registry_guard();
+    crate::channel::reset_active_channel_for_test();
+    let home = tmp_home("reply-settle");
+    // A delivered channel message in alpha's inbox, in the reclaim-vulnerable
+    // `delivering` state with a stale `delivering_at` (past RECLAIM_TTL=600s).
+    let stale = (chrono::Utc::now() - chrono::Duration::seconds(1000)).to_rfc3339();
+    let row = crate::inbox::message::InboxMessage {
+        schema_version: 1,
+        id: Some("m-turn-1".into()),
+        from: "user:op".into(),
+        text: "a long question".into(),
+        channel: Some(crate::channel::ChannelKind::Telegram),
+        timestamp: stale.clone(),
+        delivering_at: Some(stale),
+        ..Default::default()
+    };
+    // Arm the turn the way the drain does (reply_to_channel + group_msg_ids); this
+    // also establishes alpha's resolved (UUID-keyed, #2622) inbox path.
+    crate::reply_ledger::arm_channel_turn(
+        &home,
+        "alpha",
+        crate::channel::ChannelKind::Telegram,
+        Some("m-turn-1".into()),
+        None,
+        None,
+        Some("user:op"),
+        Some("a long question"),
+    );
+    // Insert the delivering row via `enqueue` so it lands in the RESOLVED inbox file
+    // (the same one settle_read_by_id / reclaim operate on).
+    crate::inbox::storage::enqueue(&home, "alpha", row).expect("enqueue");
+    crate::channel::register_active_channel(MockChannel::arc("telegram", ReplyOutcome::Ok));
+
+    // Plain reply — NO message_id.
+    let result = super::handle_reply(&home, &serde_json::json!({"message": "answer"}), "alpha");
+    assert_eq!(
+        result["message_id"], "mock-msg-1",
+        "reply must succeed: {result}"
+    );
+
+    let inbox_path = crate::inbox::storage::inbox_path_resolved(&home, "alpha");
+    let read_at_of = |p: &std::path::Path| -> Option<String> {
+        std::fs::read_to_string(p).ok().and_then(|c| {
+            c.lines()
+                .filter_map(|l| serde_json::from_str::<serde_json::Value>(l).ok())
+                .find(|v| v["id"] == "m-turn-1")
+                .and_then(|v| v["read_at"].as_str().map(String::from))
+        })
+    };
+    assert!(
+        read_at_of(&inbox_path).is_some(),
+        "plain reply must SETTLE the turn's inbox row (read_at set), else reclaim re-delivers"
+    );
+    // A settled (read) row is immune to reclaim_stale_delivering (it only reverts
+    // `delivering` rows with read_at None) → no double-delivery.
+    crate::inbox::storage::reclaim_stale_delivering(&home);
+    assert!(
+        read_at_of(&inbox_path).is_some(),
+        "settled row must survive reclaim (no revert-to-unread / double-delivery)"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}


### PR DESCRIPTION
## Telegram double-reply — root fix

`handle_reply` settled the persistent inbox row only on the explicit-`message_id` branch. A **plain reply** (no `message_id` — the common telegram path) left the row `delivering`, so `reclaim_stale_delivering` reverted it to unread after the 600s TTL and **re-delivered** it → a **double reply**. The in-memory `settled_reply_groups` TTL and the reclaim window are both 600s, so both suppression layers expire together.

## Fix (channel.rs, ~15 lines)

In the `Ok` branch, when `message_id` is None, capture the current turn's persistent delivery ids from `pending_user_turn.group_msg_ids` **before** `record_reply_outcome` `take()`s the turn, then settle each via `settle_read_by_id` — the same action as the `message_id` path; only the id source differs. #2042: replying to any id in the group settles the whole logical turn.

- **Chose direction (a)** over (b) (reclaim correlating reply↔inbound by fuzzy timestamp — over-suppresses genuinely-unanswered messages, cross-layer pollution).
- **Scope**: only enqueue-path channel messages (long / attachments / quote-reply / pointer-only) build a persistent row; <200-char short messages are PTY-only, unaffected.
- **Key subtlety**: the capture MUST precede `record_reply_outcome` (which clears the turn) — found via the test.

## Test (RED-first)

A `delivering` channel row (stale `delivering_at`) + armed turn + plain reply → assert the row is settled (`read_at` set) **and** survives `reclaim_stale_delivering`. Proven RED (settle neutered → fail) → GREEN; fixture uses the resolved (UUID-keyed, #2622) inbox path. `channel` p0a_tests **21/21**; CI-scoped clippy + rustfmt clean.

Note: touches `channel.rs` only (+ its test file) — disjoint from the AUDIT3-005 PR #2717 (`storage.rs`); no merge conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)