### PR TITLE
feat(binding_state): expose signature_valid diagnostic field

### DIFF
--- a/src/binding.rs
+++ b/src/binding.rs
@@ -565,10 +565,11 @@ fn binding_sig_path(dir: &Path) -> PathBuf {
 }
 
 /// Diagnostic: does `runtime/<agent>/binding.json.sig` verify against the
-/// **on-disk** binding body? Same sidecar name + `integrity_core::verify` as
-/// the shim (`agentic-git` `read_binding`). Tag is passed raw (no call-site
-/// trim). Missing/malformed/mismatched → `false`. Does **not** alter
-/// [`read`] / auth paths — observability only (`binding_state`).
+/// **on-disk** binding body? Same sidecar + `integrity_core::verify` as the
+/// shim (`agentic-git` `read_binding`). Passes the tag raw (call-site parity
+/// with the shim); `integrity_core` owns tag parsing/whitespace policy
+/// (`tag_to_hex` trims). Missing/malformed/mismatched → `false`. Does **not**
+/// alter [`read`] / auth paths — observability only (`binding_state`).
 pub(crate) fn signature_valid(home: &Path, agent: &str) -> bool {
     let dir = crate::paths::runtime_dir(home).join(agent);
     let body = match std::fs::read(dir.join("binding.json")) {

--- a/src/binding.rs
+++ b/src/binding.rs
@@ -255,14 +255,15 @@ pub(crate) fn branch_has_active_task(home: &Path, branch: &str) -> bool {
 /// the git registry leaves a stale prunable entry after a manual `remove_dir_all`
 /// fallback. Pass an empty path when unknown — `release_full` falls back to
 /// deriving the source from the worktree path's `.worktrees/<agent>` ancestor.
-/// #779 P2 (Option B): hard-break signature now returns `Result<(), String>`
-/// so callers can surface partial-failure diagnostics. The two pre-existing
-/// silent failure points (`create_dir_all` + `atomic_write`) become explicit
-/// `Err` cases. Two non-target callers (`worktree_pool::lease`,
-/// `dispatch_auto_bind_lease`) preserve their pre-#779-P2 silent semantic
-/// via `let _ = bind_full(...).ok();` — zero observable behavior change to
-/// the dispatch path. Only `ci::handle_checkout_repo` consumes the Result
-/// to populate its new `warnings` array.
+/// #779 P2 (Option B): hard-break API now returns `Result<(), String>` so
+/// callers can surface partial-failure diagnostics. I/O failures
+/// (`create_dir_all`, lock, `atomic_write`) are explicit `Err` cases.
+///
+/// Production callers match the Result (they do **not** swallow with
+/// `.ok()`): `dispatch_auto_bind_lease` rolls back a fresh lease on `Err`
+/// (`dispatch_hook`); `ci::handle_checkout_repo` hard-fails + rolls back;
+/// `binding::bind` logs and stays fail-closed. `worktree_pool::lease` no
+/// longer writes bindings — the authoritative caller binds after lease.
 pub fn bind_full(
     home: &Path,
     agent: &str,

--- a/src/binding.rs
+++ b/src/binding.rs
@@ -564,6 +564,24 @@ fn binding_sig_path(dir: &Path) -> PathBuf {
     dir.join("binding.json.sig")
 }
 
+/// Diagnostic: does `runtime/<agent>/binding.json.sig` verify against the
+/// **on-disk** binding body? Same sidecar name + `integrity_core::verify` as
+/// the shim (`agentic-git` `read_binding`). Tag is passed raw (no call-site
+/// trim). Missing/malformed/mismatched → `false`. Does **not** alter
+/// [`read`] / auth paths — observability only (`binding_state`).
+pub(crate) fn signature_valid(home: &Path, agent: &str) -> bool {
+    let dir = crate::paths::runtime_dir(home).join(agent);
+    let body = match std::fs::read(dir.join("binding.json")) {
+        Ok(b) => b,
+        Err(_) => return false,
+    };
+    let tag = match std::fs::read_to_string(binding_sig_path(&dir)) {
+        Ok(t) => t,
+        Err(_) => return false,
+    };
+    agentic_git_core::integrity_core::verify(home, &body, &tag).is_ok()
+}
+
 /// Clear a binding for an agent (task completed/released).
 pub fn unbind(home: &Path, agent: &str) {
     let dir = crate::paths::runtime_dir(home).join(agent);

--- a/src/mcp/handlers/binding_state.rs
+++ b/src/mcp/handlers/binding_state.rs
@@ -245,6 +245,11 @@ fn cross_branch_holders_for(home: &Path, branch: &str, exclude_agent: &str) -> V
 #[path = "binding_state_liveness_tests.rs"]
 mod liveness_tests;
 
+// PR2 architecture F2: signature_valid observability pins (sibling file).
+#[cfg(test)]
+#[path = "binding_state_signature_tests.rs"]
+mod signature_tests;
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {

--- a/src/mcp/handlers/binding_state.rs
+++ b/src/mcp/handlers/binding_state.rs
@@ -60,10 +60,7 @@ use std::path::Path;
 /// }
 /// ```
 ///
-/// `signature_valid` is **diagnostic only**: whether `runtime/<agent>/binding.json.sig`
-/// verifies against the on-disk binding body via the same
-/// `agentic_git_core::integrity_core::verify` primitive the agend-git shim uses.
-/// It does **not** change daemon `binding::read` or shim fail-closed auth.
+/// `signature_valid` is diagnostic only (on-disk body+sig via shim-same verify).
 ///
 /// Returns (unbound case):
 /// ```json
@@ -159,9 +156,8 @@ pub(crate) fn handle_binding_state(home: &Path, args: &Value, _sender: &Option<S
         let branch = b["branch"].as_str().unwrap_or("");
         let cross_branch_holders = cross_branch_holders_for(home, branch, agent);
 
-        // PR2 F2: diagnostic HMAC status. Read on-disk body+sidecar bytes
-        // (shim contract) — never re-serialize the in-memory index value.
-        let signature_valid = binding_signature_valid(home, agent);
+        // PR2 F2: diagnostic HMAC status (shim-parity; see binding::signature_valid).
+        let signature_valid = crate::binding::signature_valid(home, agent);
 
         json!({
             "agent": agent,
@@ -194,26 +190,6 @@ pub(crate) fn handle_binding_state(home: &Path, args: &Value, _sender: &Option<S
             "pending_response_to": pending_response_to,
         })
     }
-}
-
-/// Whether `runtime/<agent>/binding.json.sig` verifies against the on-disk
-/// binding body. Same sidecar name + `integrity_core::verify` as the shim
-/// (`agentic-git` `read_binding`). Missing/malformed/mismatched → `false`.
-/// Does not alter daemon auth paths — observability only.
-fn binding_signature_valid(home: &Path, agent: &str) -> bool {
-    let dir = crate::paths::runtime_dir(home).join(agent);
-    let body = match std::fs::read(dir.join("binding.json")) {
-        Ok(b) => b,
-        Err(_) => return false,
-    };
-    // Pass the sidecar tag byte-for-byte (no trim). The shim's `read_binding`
-    // does the same — a trailing newline on an otherwise-valid MAC must fail
-    // closed here so binding_state does not diverge from shim unbound.
-    let tag = match std::fs::read_to_string(dir.join("binding.json.sig")) {
-        Ok(t) => t,
-        Err(_) => return false,
-    };
-    agentic_git_core::integrity_core::verify(home, &body, &tag).is_ok()
 }
 
 /// Return the list of CI watches that include `agent` as a subscriber,

--- a/src/mcp/handlers/binding_state.rs
+++ b/src/mcp/handlers/binding_state.rs
@@ -206,11 +206,14 @@ fn binding_signature_valid(home: &Path, agent: &str) -> bool {
         Ok(b) => b,
         Err(_) => return false,
     };
+    // Pass the sidecar tag byte-for-byte (no trim). The shim's `read_binding`
+    // does the same — a trailing newline on an otherwise-valid MAC must fail
+    // closed here so binding_state does not diverge from shim unbound.
     let tag = match std::fs::read_to_string(dir.join("binding.json.sig")) {
         Ok(t) => t,
         Err(_) => return false,
     };
-    agentic_git_core::integrity_core::verify(home, &body, tag.trim()).is_ok()
+    agentic_git_core::integrity_core::verify(home, &body, &tag).is_ok()
 }
 
 /// Return the list of CI watches that include `agent` as a subscriber,

--- a/src/mcp/handlers/binding_state.rs
+++ b/src/mcp/handlers/binding_state.rs
@@ -53,11 +53,17 @@ use std::path::Path;
 ///   "worktree_exists_on_disk": true,
 ///   "worktree_valid": true,
 ///   "marker_present": true,
+///   "signature_valid": true,
 ///   "ci_watches": ["repo:branch", ...],
 ///   "bind_in_flight": false,
 ///   "cross_branch_holders": []
 /// }
 /// ```
+///
+/// `signature_valid` is **diagnostic only**: whether `runtime/<agent>/binding.json.sig`
+/// verifies against the on-disk binding body via the same
+/// `agentic_git_core::integrity_core::verify` primitive the agend-git shim uses.
+/// It does **not** change daemon `binding::read` or shim fail-closed auth.
 ///
 /// Returns (unbound case):
 /// ```json
@@ -153,6 +159,10 @@ pub(crate) fn handle_binding_state(home: &Path, args: &Value, _sender: &Option<S
         let branch = b["branch"].as_str().unwrap_or("");
         let cross_branch_holders = cross_branch_holders_for(home, branch, agent);
 
+        // PR2 F2: diagnostic HMAC status. Read on-disk body+sidecar bytes
+        // (shim contract) — never re-serialize the in-memory index value.
+        let signature_valid = binding_signature_valid(home, agent);
+
         json!({
             "agent": agent,
             "bound": true,
@@ -166,6 +176,7 @@ pub(crate) fn handle_binding_state(home: &Path, args: &Value, _sender: &Option<S
             "worktree_resolves": worktree_resolves,
             "invalid_reason": invalid_reason,
             "marker_present": marker_present,
+            "signature_valid": signature_valid,
             "ci_watches": ci_watches,
             "bind_in_flight": bind_in_flight,
             "cross_branch_holders": cross_branch_holders,
@@ -183,6 +194,23 @@ pub(crate) fn handle_binding_state(home: &Path, args: &Value, _sender: &Option<S
             "pending_response_to": pending_response_to,
         })
     }
+}
+
+/// Whether `runtime/<agent>/binding.json.sig` verifies against the on-disk
+/// binding body. Same sidecar name + `integrity_core::verify` as the shim
+/// (`agentic-git` `read_binding`). Missing/malformed/mismatched → `false`.
+/// Does not alter daemon auth paths — observability only.
+fn binding_signature_valid(home: &Path, agent: &str) -> bool {
+    let dir = crate::paths::runtime_dir(home).join(agent);
+    let body = match std::fs::read(dir.join("binding.json")) {
+        Ok(b) => b,
+        Err(_) => return false,
+    };
+    let tag = match std::fs::read_to_string(dir.join("binding.json.sig")) {
+        Ok(t) => t,
+        Err(_) => return false,
+    };
+    agentic_git_core::integrity_core::verify(home, &body, tag.trim()).is_ok()
 }
 
 /// Return the list of CI watches that include `agent` as a subscriber,

--- a/src/mcp/handlers/binding_state_signature_tests.rs
+++ b/src/mcp/handlers/binding_state_signature_tests.rs
@@ -1,0 +1,111 @@
+//! PR2 — `binding_state.signature_valid` pins (architecture F2 / d-20260711000700914571-1).
+//!
+//! Loaded via `#[path]` from `binding_state.rs` so the production handler file
+//! stays under the MCP-handler LOC ceiling.
+//!
+//! Exercises the **real** production entry `handle_binding_state` (not a
+//! reimplemented matcher). Cases:
+//! - valid bind_full-signed binding → signature_valid true
+//! - tampered body with stale sidecar → signature_valid false (still bound)
+//! - missing sidecar → signature_valid false
+//!
+//! RED against pre-PR2: the key is absent → as_bool() is None.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use super::handle_binding_state;
+use serde_json::json;
+use std::path::{Path, PathBuf};
+
+fn tmp_home(suffix: &str) -> PathBuf {
+    let h = std::env::temp_dir().join(format!(
+        "agend-binding-sig-{}-{}-{}",
+        std::process::id(),
+        suffix,
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&h).unwrap();
+    h
+}
+
+fn binding_dir(home: &Path, agent: &str) -> PathBuf {
+    crate::paths::runtime_dir(home).join(agent)
+}
+
+/// Cold-load a body (+ optional sidecar) after clearing the process-global
+/// binding index via `unbind` (which also deletes files).
+fn plant_binding(home: &Path, agent: &str, body: &str, sig: Option<&str>) {
+    crate::binding::unbind(home, agent);
+    let dir = binding_dir(home, agent);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("binding.json"), body.as_bytes()).unwrap();
+    if let Some(s) = sig {
+        std::fs::write(dir.join("binding.json.sig"), s.as_bytes()).unwrap();
+    }
+}
+
+/// RED: production binding_state must surface whether the HMAC sidecar verifies
+/// against the on-disk binding body — same primitive/tag/sidecar contract as
+/// the shim (`agentic_git_core::integrity_core::verify` / `binding.json.sig`).
+#[test]
+fn binding_state_signature_valid_true_false_missing() {
+    let home = tmp_home("sig");
+    let agent = "sig-agent";
+    let wt = home.join("wt");
+    let src = home.join("src");
+    std::fs::create_dir_all(&wt).unwrap();
+    std::fs::create_dir_all(&src).unwrap();
+
+    // Happy path: bind_full issues body + sidecar via the production signer.
+    crate::binding::bind_full(&home, agent, "t-sig", "feat/sig", &wt, &src, false)
+        .expect("bind_full must succeed for hermetic home");
+
+    let dir = binding_dir(&home, agent);
+    assert!(
+        dir.join("binding.json.sig").is_file(),
+        "fixture: bind_full must write binding.json.sig"
+    );
+    let original_body = std::fs::read_to_string(dir.join("binding.json")).unwrap();
+    let original_sig = std::fs::read_to_string(dir.join("binding.json.sig")).unwrap();
+
+    let r = handle_binding_state(&home, &json!({"instance": agent}), &None);
+    assert_eq!(r["bound"].as_bool(), Some(true), "bound: {r}");
+    assert_eq!(
+        r["signature_valid"].as_bool(),
+        Some(true),
+        "valid daemon-signed binding must report signature_valid=true: {r}"
+    );
+
+    // Tamper body, keep original sidecar.
+    let mut body: serde_json::Value = serde_json::from_str(&original_body).unwrap();
+    body["branch"] = json!("feat/tampered");
+    let tampered = serde_json::to_string_pretty(&body).unwrap();
+    plant_binding(&home, agent, &tampered, Some(&original_sig));
+
+    let r_tampered = handle_binding_state(&home, &json!({"instance": agent}), &None);
+    assert_eq!(
+        r_tampered["bound"].as_bool(),
+        Some(true),
+        "daemon binding_state still bound on parseable body (observability): {r_tampered}"
+    );
+    assert_eq!(
+        r_tampered["signature_valid"].as_bool(),
+        Some(false),
+        "tampered body with stale sig must report signature_valid=false: {r_tampered}"
+    );
+
+    // Missing sidecar.
+    plant_binding(&home, agent, &original_body, None);
+    let r_missing = handle_binding_state(&home, &json!({"instance": agent}), &None);
+    assert_eq!(r_missing["bound"].as_bool(), Some(true), "{r_missing}");
+    assert_eq!(
+        r_missing["signature_valid"].as_bool(),
+        Some(false),
+        "missing sidecar must report signature_valid=false: {r_missing}"
+    );
+
+    let _ = std::fs::remove_dir_all(&home);
+}

--- a/src/mcp/handlers/binding_state_signature_tests.rs
+++ b/src/mcp/handlers/binding_state_signature_tests.rs
@@ -107,5 +107,27 @@ fn binding_state_signature_valid_true_false_missing() {
         "missing sidecar must report signature_valid=false: {r_missing}"
     );
 
+    // Malformed sidecar: valid MAC + non-hex suffix. Call site passes the tag
+    // raw like the shim; integrity_core::tag_to_hex trims whitespace (so a bare
+    // trailing "\n" is NOT a divergence), but a non-hex character is MalformedTag
+    // for both paths — signature_valid must stay false while bound stays true.
+    plant_binding(
+        &home,
+        agent,
+        &original_body,
+        Some(&format!("{original_sig}x")),
+    );
+    let r_mal = handle_binding_state(&home, &json!({"instance": agent}), &None);
+    assert_eq!(
+        r_mal["bound"].as_bool(),
+        Some(true),
+        "malformed sidecar still leaves parseable body bound: {r_mal}"
+    );
+    assert_eq!(
+        r_mal["signature_valid"].as_bool(),
+        Some(false),
+        "valid MAC + non-hex suffix must be signature_valid=false (shim-parity): {r_mal}"
+    );
+
     let _ = std::fs::remove_dir_all(&home);
 }

--- a/src/mcp/handlers/dispatch_hook/mod.rs
+++ b/src/mcp/handlers/dispatch_hook/mod.rs
@@ -543,8 +543,9 @@ pub(crate) fn dispatch_auto_bind_lease_with_source_and_chain(
         lease.path
     };
 
-    // Bind with worktree + source-repo paths. Bind file write error stays graceful (Q1).
-    // #779 P2: bind_full returns Result; preserves pre-#779-P2 silent semantic.
+    // Bind with worktree + source-repo paths.
+    // #779 P2: bind_full returns Result — on Err roll back a *fresh* lease
+    // (below); reused/live trees are never removed. Not a silent `.ok()` swallow.
     // #2158 GR1: the only `arm_ci_watch=false` path through this sink is `bind_self`
     // (an agent self-claim → operator notify); dispatch wrappers pass true. So
     // self-claim ⟺ !arm_ci_watch — reuse the dispatch-intent, no task_id heuristic.

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -390,7 +390,7 @@ pub(crate) fn def_release_worktree() -> Value {
 }
 
 pub(crate) fn def_binding_state() -> Value {
-    json!({"name": "binding_state", "description": "Report the structured daemon-side bind state for an agent: binding.json content, worktree existence + .agend-managed marker, ci-watch subscriptions, bind-in-flight guard, and cross-branch holders. Operator + agent introspection surface; non-destructive. Pairs with release_worktree.",
+    json!({"name": "binding_state", "description": "Report the structured daemon-side bind state for an agent: binding.json content, worktree existence + .agend-managed marker, HMAC signature_valid (diagnostic; same verify as agend-git shim), ci-watch subscriptions, bind-in-flight guard, and cross-branch holders. Operator + agent introspection surface; non-destructive. Pairs with release_worktree.",
         "inputSchema": {"type": "object", "properties": {
             "instance": {"type": "string", "description": "Name of the existing instance to inspect"}
         }, "required": ["instance"]}})


### PR DESCRIPTION
## Summary
- Bound `binding_state` responses now include **`signature_valid: bool`** — whether `runtime/<agent>/binding.json.sig` verifies against the **on-disk** binding body via `agentic_git_core::integrity_core::verify` (same primitive/tag/sidecar as the agend-git shim).
- Missing / malformed / mismatched signature → `false`. Valid daemon-signed binding → `true`.
- **Fail-closed auth behavior unchanged**: daemon `binding::read` still does not HMAC-verify; shim still fail-closed on bad/missing sig. This field is diagnostic only (architecture F2 observability).
- Correct two proven-stale comments: `binding.rs` bind_full call-site docs; `dispatch_hook` “silent semantic” note.
- Tool description documents the new field.

## RED → green
| | SHA |
|---|---|
| base | `8ddf87f1dbffc1fc1c182443167a26d96e276b6f` |
| RED | `e420e202` — `binding_state_signature_valid_true_false_missing` fails (key absent) |
| green | `33619daa` — test passes |

```
cargo test --bin agend-terminal binding_state_signature_valid
# RED @ e420e202 → FAILED (signature_valid: None)
# green @ 33619daa → ok
cargo test --bin agend-terminal binding_state  # 18 ok
cargo clippy --package agend-terminal --lib --bins --tests --examples --features tray -- -D warnings  # ok
```

## Scope / non-goals
- No `signature_present` field
- No HeartbeatPair fake cleanup
- No `binding::read` fail-closed change
- No shim/signer policy change
- No heartbeat/tick/app surfaces

Task: `t-20260711000720647519-41952-1`
Decision: `d-20260711000700914571-1`