### PR TITLE
feat(tick-stall): opt-in out-of-band per-host tick-stall diagnostics

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -774,6 +774,16 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
     // moved off the supervisor thread.
     let app_handlers = app_tick_handlers(Arc::clone(&daemon_binary_stale));
 
+    // PR4: opt-in out-of-band tick-stall diagnostics for the OWNED-app maintenance
+    // tick host. An attached app never ticks (tick_rx is `None` → never_rx), so it
+    // starts NO monitor. `_app_stall_monitor` lives across the render loop and
+    // stops+joins its thread on teardown; both are `None` when the env gate is off.
+    let (app_tick_progress, _app_stall_monitor) = if attached_mode {
+        (None, None)
+    } else {
+        crate::daemon::tick_stall::start_for_host("app-owned-tick", &app_handlers, &home)
+    };
+
     // #2057 milestone 3: just BEFORE the render loop. If this is < the baseline,
     // a startup phase shrank the controlling TTY; milestone 2 brackets whether
     // it was the fleet spawn/restore vs the post-spawn wiring (subscribers /
@@ -1185,7 +1195,13 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
                     &app_externals,
                     &app_configs,
                     &app_handlers,
+                    app_tick_progress.as_deref(),
                 );
+                // PR4: back to Waiting between maintenance ticks so the monitor
+                // never attributes render/idle time to the maintenance host.
+                if let Some(p) = app_tick_progress.as_deref() {
+                    p.enter_waiting();
+                }
             }
             default(select_timeout) => {
                 // #t-84833-10: periodic idle refresh — mark dirty so the cap above
@@ -1388,6 +1404,7 @@ fn app_maintenance_tick(
     externals: &crate::agent::ExternalRegistry,
     configs: &crate::api::ConfigRegistry,
     handlers: &[Box<dyn crate::daemon::per_tick::PerTickHandler>],
+    progress: Option<&crate::daemon::tick_stall::TickProgress>,
 ) {
     let tick_ctx = crate::daemon::per_tick::TickContext {
         home,
@@ -1395,7 +1412,9 @@ fn app_maintenance_tick(
         externals,
         configs,
     };
-    crate::daemon::per_tick::run_handlers_with_panic_guard(handlers, &tick_ctx);
+    // PR4: `progress` is `Some` only for an owned app with diagnostics enabled;
+    // `None` (attached or gate-off) runs the untracked path, byte-identical.
+    crate::daemon::per_tick::run_handlers_with_progress(handlers, &tick_ctx, progress);
 }
 
 /// App exit teardown: persist the on-screen layout, then (Owned mode only) sync

--- a/src/daemon/delivery_worker.rs
+++ b/src/daemon/delivery_worker.rs
@@ -63,6 +63,18 @@ enum DeliveryJob {
         agent: String,
         text: Vec<u8>,
     },
+    /// PR4: an out-of-band tick-stall page. The stall monitor thread `try_send`s
+    /// this (never blocking the tick host it watches); the worker — off that
+    /// thread — owns the escalation fan-out + `event_log` write. `host` / `phase`
+    /// / `handler` are the captured stall identity, `generation` the seqlock
+    /// progress marker at the time of the page.
+    TickStallAlert {
+        home: std::path::PathBuf,
+        host: String,
+        phase: String,
+        handler: String,
+        generation: u64,
+    },
 }
 
 /// Payload for an offloaded Telegram send. Carries the already-resolved channel
@@ -138,6 +150,41 @@ fn dispatch(job: DeliveryJob) {
                 tracing::debug!(agent = %agent, error = %e, "delivery_worker: cron inject failed");
             }
         }
+        DeliveryJob::TickStallAlert {
+            home,
+            host,
+            phase,
+            handler,
+            generation,
+        } => {
+            // PR4: the worker (NOT the monitor sampler) owns the escalation +
+            // event-log side effects, so the sampler never blocks on channel /
+            // disk I/O while the tick host it watches is wedged.
+            let msg = format!(
+                "[tick-stall] {host} made no progress for the configured threshold \
+                 while in phase '{phase}' (handler={handler}, generation={generation}). \
+                 The tick thread is wedged — hang-detection, recovery-dispatch and \
+                 crash handling on this host are stalled until it clears; \
+                 investigate the named handler."
+            );
+            let dispatched = crate::channel::notify_all_escalation_channels(
+                &host,
+                crate::channel::NotifySeverity::Error,
+                &msg,
+                false,
+            );
+            crate::event_log::log(&home, "tick_stall", &host, &msg);
+            tracing::error!(
+                host = %host,
+                phase = %phase,
+                handler = %handler,
+                generation,
+                channels = dispatched,
+                "tick_stall: tick host wedged — out-of-band page dispatched"
+            );
+            #[cfg(test)]
+            crate::daemon::tick_stall::test_probe::emit(&host, &handler);
+        }
     }
 }
 
@@ -177,6 +224,38 @@ pub(crate) fn enqueue_cron_inject(
         agent: agent.to_string(),
         text,
     })
+}
+
+/// PR4: offload an out-of-band tick-stall page. The stall monitor calls this; it
+/// `try_send`s and NEVER blocks. A full queue is the *observable drop path* —
+/// `Err(())` plus a `tracing::error` carrying host / phase / generation — because
+/// a wedged tick host is exactly when the operator must not silently lose the
+/// page. The monitor treats `Err` as "page dropped" and simply moves on.
+pub(crate) fn enqueue_tick_stall_alert(
+    home: &std::path::Path,
+    host: &str,
+    phase: &str,
+    handler: &str,
+    generation: u64,
+) -> Result<(), ()> {
+    let result = try_enqueue(DeliveryJob::TickStallAlert {
+        home: home.to_path_buf(),
+        host: host.to_string(),
+        phase: phase.to_string(),
+        handler: handler.to_string(),
+        generation,
+    });
+    if result.is_err() {
+        tracing::error!(
+            host = %host,
+            phase = %phase,
+            handler = %handler,
+            generation,
+            "tick_stall alert DROPPED: delivery queue full — the tick host is \
+             wedged and its out-of-band page was lost"
+        );
+    }
+    result
 }
 
 fn try_enqueue(job: DeliveryJob) -> Result<(), ()> {
@@ -249,6 +328,28 @@ mod tests {
         assert!(
             enqueue_pty_wake(std::path::Path::new("/tmp/aw"), "agentA", "ping").is_err(),
             "AUDIT2-006: a full delivery queue must drop (Err), never block the tick thread"
+        );
+        test_support::set_force_full(false);
+    }
+
+    /// PR4 (#8): a full delivery queue drops the tick-stall page (`Err`) — the
+    /// observable drop path (the enqueue also logs a `tracing::error` with
+    /// host/phase/generation) — instead of blocking the monitor thread.
+    #[test]
+    fn tick_stall_alert_drops_when_queue_full() {
+        let _ff = test_support::force_full_guard();
+        let home = std::env::temp_dir();
+
+        test_support::set_force_full(false);
+        assert!(
+            enqueue_tick_stall_alert(&home, "daemon-tick", "handler", "slow_handler", 7).is_ok(),
+            "a non-full delivery queue accepts the tick-stall page"
+        );
+
+        test_support::set_force_full(true);
+        assert!(
+            enqueue_tick_stall_alert(&home, "daemon-tick", "handler", "slow_handler", 7).is_err(),
+            "a full delivery queue must drop the page (Err), never block the monitor"
         );
         test_support::set_force_full(false);
     }

--- a/src/daemon/delivery_worker.rs
+++ b/src/daemon/delivery_worker.rs
@@ -160,6 +160,13 @@ fn dispatch(job: DeliveryJob) {
             // PR4: the worker (NOT the monitor sampler) owns the escalation +
             // event-log side effects, so the sampler never blocks on channel /
             // disk I/O while the tick host it watches is wedged.
+            //
+            // Observe the routed identity FIRST (tests only): the assertion is
+            // "the correct TickStallAlert reached the worker via the real
+            // monitor→enqueue path", which must not hinge on the downstream
+            // escalation/event-log I/O succeeding in a bare test $HOME.
+            #[cfg(test)]
+            crate::daemon::tick_stall::test_probe::emit(&host, &handler);
             let msg = format!(
                 "[tick-stall] {host} made no progress for the configured threshold \
                  while in phase '{phase}' (handler={handler}, generation={generation}). \
@@ -182,8 +189,6 @@ fn dispatch(job: DeliveryJob) {
                 channels = dispatched,
                 "tick_stall: tick host wedged — out-of-band page dispatched"
             );
-            #[cfg(test)]
-            crate::daemon::tick_stall::test_probe::emit(&host, &handler);
         }
     }
 }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -43,6 +43,7 @@ pub mod shadow;
 pub(crate) mod supervisor;
 pub(crate) mod task_progress;
 pub(crate) mod task_sweep;
+pub(crate) mod tick_stall;
 pub(crate) mod ticker;
 mod tui_bridge;
 pub(crate) mod usage_limit;

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -862,6 +862,12 @@ fn run_core(home: &Path, source: FleetSource) -> anyhow::Result<()> {
 
     let (_keepalive, handlers, tick_rx) = build_tick_infrastructure(home, &ctx);
 
+    // PR4: opt-in out-of-band tick-stall diagnostics for the daemon tick host.
+    // `_stall_monitor` is `None` unless `AGEND_TICK_STALL_SECS` enables it; it
+    // lives for the whole `'serve` loop and stops+joins its thread on teardown.
+    let (tick_progress, _stall_monitor) =
+        crate::daemon::tick_stall::start_for_host("daemon-tick", &handlers, home);
+
     // #1814 round-2: `'serve` wraps the tick loop + teardown so the final
     // recover-as-primary gate (below) can `continue 'serve` to resume serving if
     // the successor dies during the predecessor's teardown — instead of exiting
@@ -878,6 +884,10 @@ fn run_core(home: &Path, source: FleetSource) -> anyhow::Result<()> {
                 continue;
             }
 
+            // PR4: idle, blocked awaiting the next tick/crash/shutdown signal.
+            if let Some(p) = &tick_progress {
+                p.enter_waiting();
+            }
             let exit_event: Option<crate::agent::AgentExitEvent>;
             crossbeam_channel::select! {
                 recv(ctx.crash_rx) -> msg => { exit_event = msg.ok(); }
@@ -891,11 +901,18 @@ fn run_core(home: &Path, source: FleetSource) -> anyhow::Result<()> {
                 externals: &ctx.externals,
                 configs: &ctx.configs,
             };
+            // PR4: Preflight — the per-tick config reloads run before the sweep.
+            if let Some(p) = &tick_progress {
+                p.enter_preflight();
+            }
             crate::runtime_config::reload(home);
             // #1339: operator-mode.json reloaded each tick — a mode change (via the
             // `mode` MCP tool) propagates fleet-wide without a restart (reload-coherent).
             crate::operator_mode::reload(home);
-            per_tick::run_handlers_with_panic_guard(&handlers, &tick_ctx);
+            // PR4: the tracked runner publishes Handler(i) per handler and closes
+            // with PostHandlers, which also covers the crash-dispatch below. When
+            // diagnostics are OFF, `tick_progress` is None → untracked (byte-identical).
+            per_tick::run_handlers_with_progress(&handlers, &tick_ctx, tick_progress.as_deref());
 
             let exit_event = match exit_event {
                 Some(e) => e,

--- a/src/daemon/per_tick/mod.rs
+++ b/src/daemon/per_tick/mod.rs
@@ -253,11 +253,43 @@ pub(crate) fn snapshot_handler_timings() -> HashMap<String, HandlerStats> {
 /// the unit test (`per_tick::tests::panicking_handler_does_not_skip_siblings`)
 /// constructs a fixture vec with a panicking handler in the middle and
 /// asserts the trailing handler runs.
+///
+/// PR4 (Q3): retained as the untracked entry point. Both tick hosts (daemon
+/// `run_core` + owned app) now call [`run_handlers_with_progress`] directly, so
+/// in a non-test build this wrapper is currently reached only by its unit test
+/// (`per_tick::tests::panicking_handler_does_not_skip_siblings`) — hence the
+/// `not(test)` dead-code allowance, not a `#[cfg(test)]` gate (it stays a real
+/// `pub(crate)` untracked entry for future callers).
+#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) fn run_handlers_with_panic_guard(
     handlers: &[Box<dyn PerTickHandler>],
     ctx: &TickContext<'_>,
 ) {
-    for handler in handlers {
+    run_handlers_with_progress(handlers, ctx, None);
+}
+
+/// PR4 companion: identical per-handler panic isolation to
+/// [`run_handlers_with_panic_guard`], plus optional out-of-band stall tracking.
+///
+/// When `progress` is `Some`, the current [`Phase::Handler`](crate::daemon::tick_stall)
+/// index is published BEFORE each handler runs and advanced AFTER its
+/// `catch_unwind` — on both the Ok and the panic paths, so a wedged/panicked
+/// handler never leaves stale identity (the next iteration's `enter_handler`, or
+/// the closing `enter_post`, IS that transition). The daemon `run_core` and the
+/// owned app pass `Some`; the untracked wrapper above and every existing caller
+/// pass `None` and are byte-for-byte unaffected.
+///
+/// The tracker is written ONLY here, on the tick thread; the stall monitor reads
+/// it lock-free (see [`crate::daemon::tick_stall`]).
+pub(crate) fn run_handlers_with_progress(
+    handlers: &[Box<dyn PerTickHandler>],
+    ctx: &TickContext<'_>,
+    progress: Option<&crate::daemon::tick_stall::TickProgress>,
+) {
+    for (index, handler) in handlers.iter().enumerate() {
+        if let Some(p) = progress {
+            p.enter_handler(index as u32);
+        }
         let start = std::time::Instant::now();
         let name = handler.name();
         let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -274,6 +306,12 @@ pub(crate) fn run_handlers_with_panic_guard(
                  in this tick continue; next tick re-invokes this handler"
             );
         }
+        // PR4: the handler-identity transition is the NEXT iteration's
+        // `enter_handler(index+1)`, or — after the last handler — the closing
+        // `enter_post()` below; both run AFTER this catch_unwind (Ok or panic).
+    }
+    if let Some(p) = progress {
+        p.enter_post();
     }
 }
 

--- a/src/daemon/per_tick/mod.rs
+++ b/src/daemon/per_tick/mod.rs
@@ -254,13 +254,13 @@ pub(crate) fn snapshot_handler_timings() -> HashMap<String, HandlerStats> {
 /// constructs a fixture vec with a panicking handler in the middle and
 /// asserts the trailing handler runs.
 ///
-/// PR4 (Q3): retained as the untracked entry point. Both tick hosts (daemon
-/// `run_core` + owned app) now call [`run_handlers_with_progress`] directly, so
-/// in a non-test build this wrapper is currently reached only by its unit test
-/// (`per_tick::tests::panicking_handler_does_not_skip_siblings`) — hence the
-/// `not(test)` dead-code allowance, not a `#[cfg(test)]` gate (it stays a real
-/// `pub(crate)` untracked entry for future callers).
-#[cfg_attr(not(test), allow(dead_code))]
+/// PR4: the untracked entry is now a `#[cfg(test)]` convenience wrapper. Both
+/// tick hosts (daemon `run_core` + owned app) call [`run_handlers_with_progress`]
+/// directly (with `None` when diagnostics are off), so the untracked form has no
+/// production caller — gating it to `cfg(test)` keeps the existing panic-isolation
+/// tests (`per_tick` + `canonical_heartbeat`) unchanged with zero production dead
+/// code.
+#[cfg(test)]
 pub(crate) fn run_handlers_with_panic_guard(
     handlers: &[Box<dyn PerTickHandler>],
     ctx: &TickContext<'_>,

--- a/src/daemon/tick_stall.rs
+++ b/src/daemon/tick_stall.rs
@@ -42,11 +42,12 @@ const ENV_VAR: &str = "AGEND_TICK_STALL_SECS";
 /// Minimum enabled threshold (seconds). Below this the diagnostics stay OFF — a
 /// sub-10s window would false-alarm on ordinary slow ticks.
 const MIN_THRESHOLD_SECS: u64 = 10;
-/// A single monitor sample gap larger than `sample_interval * SUSPEND_GAP_FACTOR`
-/// means the monitor thread itself was frozen (laptop sleep / gross CPU
-/// starvation) — the tick host was frozen too, so it is not a real stall. See
-/// [`StallDetector::observe`].
-const SUSPEND_GAP_FACTOR: u32 = 4;
+/// Extra slack added to the base threshold for the `Waiting` phase. A full tick
+/// period (10s) of `Waiting` between ticks is normal cadence, not a stall, so the
+/// waiting threshold must clear it. A host stuck in `Waiting` beyond
+/// `threshold + TICK_PERIOD_SLACK` (a dead tick producer) still pages as
+/// `<waiting>`.
+const TICK_PERIOD_SLACK: Duration = Duration::from_secs(10);
 
 /// The tick host's coarse lifecycle position within one tick. `Handler` carries
 /// the 0-based index into the host's immutable handler-name table.
@@ -191,8 +192,11 @@ struct Alert {
 /// monitor thread feeds it `(now, snapshot)` each sample; unit tests feed
 /// synthetic values for fully deterministic coverage.
 struct StallDetector {
+    /// Base threshold for the active phases (Preflight / Handler / PostHandlers).
     threshold: Duration,
-    sample_interval: Duration,
+    /// Threshold for the `Waiting` phase — `threshold + TICK_PERIOD_SLACK` — so
+    /// ordinary between-tick cadence never alerts but a dead tick producer does.
+    waiting_threshold: Duration,
     last_sample: Instant,
     /// Settled generation at the last observed progress (`None` before the first
     /// clean snapshot).
@@ -206,17 +210,27 @@ struct StallDetector {
 impl StallDetector {
     fn new(
         threshold: Duration,
-        sample_interval: Duration,
+        waiting_threshold: Duration,
         now: Instant,
         initial: Option<Snapshot>,
     ) -> Self {
         Self {
             threshold,
-            sample_interval,
+            waiting_threshold,
             last_sample: now,
             last_progress_gen: initial.map(|s| s.generation),
             last_progress_at: now,
             alerted_gen: None,
+        }
+    }
+
+    /// The stall threshold for a phase: `Waiting` gets the extra tick-period
+    /// slack, every other phase uses the base threshold.
+    fn phase_threshold(&self, phase: Phase) -> Duration {
+        if phase == Phase::Waiting {
+            self.waiting_threshold
+        } else {
+            self.threshold
         }
     }
 
@@ -225,10 +239,13 @@ impl StallDetector {
         let gap = now.duration_since(self.last_sample);
         self.last_sample = now;
 
-        // Suspend / sample-gap reset: the monitor thread was itself frozen far
-        // longer than its cadence, so the tick host was frozen too — not a stall.
-        // Re-baseline and skip alerting so wake never false-alarms.
-        if gap > self.sample_interval * SUSPEND_GAP_FACTOR {
+        // Suspend / gross-gap reset: a SINGLE monitor sample gap wider than the
+        // base threshold means the monitor thread itself was frozen for a whole
+        // stall window (laptop sleep / severe CPU starvation) — the tick host was
+        // frozen too, so any "no progress" reading is unreliable. Under normal or
+        // even CI-loaded sampling the gap is ~`sample_interval` (≤ `threshold/4`),
+        // so this never fires during a genuine tick stall. Re-baseline, no alert.
+        if gap > self.threshold {
             self.last_progress_at = now;
             self.alerted_gen = None;
             self.last_progress_gen = snap.map(|s| s.generation);
@@ -245,9 +262,10 @@ impl StallDetector {
             return None;
         }
 
-        // No progress since `last_progress_at`. Waiting is never a stall.
-        if snap.phase != Phase::Waiting
-            && now.duration_since(self.last_progress_at) >= self.threshold
+        // No progress since `last_progress_at`. Every phase can stall — even
+        // `Waiting` (a dead tick producer) — but Waiting uses the larger
+        // waiting_threshold so ordinary cadence stays silent.
+        if now.duration_since(self.last_progress_at) >= self.phase_threshold(snap.phase)
             && self.alerted_gen != Some(snap.generation)
         {
             self.alerted_gen = Some(snap.generation);
@@ -264,6 +282,7 @@ impl StallDetector {
 /// ([`MonitorConfig::from_env`]); tests build it directly with tiny durations.
 pub(crate) struct MonitorConfig {
     threshold: Duration,
+    waiting_threshold: Duration,
     sample_interval: Duration,
     home: PathBuf,
 }
@@ -273,6 +292,7 @@ impl MonitorConfig {
     pub(crate) fn from_env(home: &Path) -> Option<Self> {
         let threshold = threshold_from_env()?;
         Some(Self {
+            waiting_threshold: threshold + TICK_PERIOD_SLACK,
             sample_interval: sample_interval_for(threshold),
             threshold,
             home: home.to_path_buf(),
@@ -280,9 +300,15 @@ impl MonitorConfig {
     }
 
     #[cfg(test)]
-    fn for_test(threshold: Duration, sample_interval: Duration, home: PathBuf) -> Self {
+    fn for_test(
+        threshold: Duration,
+        waiting_threshold: Duration,
+        sample_interval: Duration,
+        home: PathBuf,
+    ) -> Self {
         Self {
             threshold,
+            waiting_threshold,
             sample_interval,
             home,
         }
@@ -339,25 +365,28 @@ pub(crate) struct TickStallMonitorGuard {
 
 impl TickStallMonitorGuard {
     /// Spawn the monitor for `progress`. Holds a clone of the `Arc` for reading;
-    /// the caller keeps its own clone for writing.
-    pub(crate) fn spawn(progress: Arc<TickProgress>, config: MonitorConfig) -> Self {
+    /// the caller keeps its own clone for writing. Returns `None` when the OS
+    /// refuses the thread (thread exhaustion) — the caller then leaves the host
+    /// UNTRACKED rather than pretending tracking is on with a dead handle.
+    pub(crate) fn spawn(progress: Arc<TickProgress>, config: MonitorConfig) -> Option<Self> {
         let (stop_tx, stop_rx) = std::sync::mpsc::channel();
         // store JoinHandle: the guard joins on drop (no fire-and-forget — a stall
         // monitor must not outlive the host it watches).
-        let handle = std::thread::Builder::new()
+        match std::thread::Builder::new()
             .name("agend-tick-stall".into())
             .spawn(move || monitor_loop(&progress, &config, &stop_rx))
-            .map_err(|e| {
+        {
+            Ok(handle) => Some(Self {
+                stop_tx: Some(stop_tx),
+                handle: Some(handle),
+            }),
+            Err(e) => {
                 tracing::error!(
                     error = %e,
                     "tick_stall: failed to spawn monitor thread — diagnostics inactive for this host"
                 );
-                e
-            })
-            .ok();
-        Self {
-            stop_tx: Some(stop_tx),
-            handle,
+                None
+            }
         }
     }
 }
@@ -381,7 +410,7 @@ impl Drop for TickStallMonitorGuard {
 fn monitor_loop(progress: &TickProgress, config: &MonitorConfig, stop_rx: &Receiver<()>) {
     let mut detector = StallDetector::new(
         config.threshold,
-        config.sample_interval,
+        config.waiting_threshold,
         Instant::now(),
         progress.snapshot(),
     );
@@ -392,11 +421,24 @@ fn monitor_loop(progress: &TickProgress, config: &MonitorConfig, stop_rx: &Recei
             Err(RecvTimeoutError::Timeout) => {}
         }
         if let Some(alert) = detector.observe(Instant::now(), progress.snapshot()) {
+            let handler = progress.handler_label(alert.phase);
+            // Log the detection on THIS thread first. The monitor thread is never
+            // wedged, so a stall stays locally observable even if the single
+            // delivery worker accepts the job but is stuck on prior channel I/O —
+            // detection must not depend on the escalation path draining.
+            tracing::error!(
+                host = progress.host,
+                phase = alert.phase.label(),
+                handler,
+                generation = alert.generation,
+                "tick_stall DETECTED — tick host made no progress past its threshold"
+            );
+            // Then hand the escalation off the tick+monitor threads to the worker.
             let _ = super::delivery_worker::enqueue_tick_stall_alert(
                 &config.home,
                 progress.host,
                 alert.phase.label(),
-                progress.handler_label(alert.phase),
+                handler,
                 alert.generation,
             );
         }
@@ -419,8 +461,13 @@ pub(crate) fn start_for_host(
     };
     let names: Arc<[&'static str]> = handlers.iter().map(|h| h.name()).collect();
     let progress = TickProgress::new(host, names);
-    let guard = TickStallMonitorGuard::spawn(Arc::clone(&progress), config);
-    (Some(progress), Some(guard))
+    match TickStallMonitorGuard::spawn(Arc::clone(&progress), config) {
+        // Enabled: hand the writer `Arc` back to the tick loop + keep the guard.
+        Some(guard) => (Some(progress), Some(guard)),
+        // Monitor thread failed to spawn: leave the host UNTRACKED (no orphan
+        // progress writes with nothing reading them), not enabled-with-dead-handle.
+        None => (None, None),
+    }
 }
 
 /// Process-global alert-observation seam (test-only). The production alert path
@@ -576,12 +623,17 @@ mod tests {
         let probe = test_probe::install();
         let names: Arc<[&'static str]> = handlers.iter().map(|h| h.name()).collect();
         let progress = TickProgress::new(host, names);
+        // Generous margins so ordinary CI scheduling jitter can't trip the
+        // suspend reset (gap > threshold) or blow the watchdog: detection is
+        // ~threshold + a sample (~220ms) vs the 2s watchdog.
         let config = super::MonitorConfig::for_test(
-            Duration::from_millis(40),
-            Duration::from_millis(5),
+            Duration::from_millis(200),
+            Duration::from_secs(5),
+            Duration::from_millis(20),
             std::env::temp_dir(),
         );
-        let monitor = super::TickStallMonitorGuard::spawn(Arc::clone(&progress), config);
+        let monitor = super::TickStallMonitorGuard::spawn(Arc::clone(&progress), config)
+            .expect("monitor thread must spawn in tests");
         let progress_for_runner = Arc::clone(&progress);
         let runner = std::thread::spawn(move || {
             let home = std::env::temp_dir();
@@ -684,7 +736,10 @@ mod tests {
     // ── #7: guard stop/join is prompt ──────────────────────────────────────
 
     /// Dropping the guard must wake the monitor's `recv_timeout` at once and
-    /// join — teardown far faster than the (deliberately long) sample interval.
+    /// join. Proven with a completion channel + watchdog (NOT a wall-clock speed
+    /// assertion): a helper thread drops the guard and signals when the join
+    /// returns. If Stop failed to wake `recv_timeout`, the join would block the
+    /// full 30s sample interval and the watchdog `recv_timeout` would fire first.
     #[test]
     fn monitor_guard_stops_and_joins_promptly() {
         let _serial = TEST_LOCK.lock();
@@ -692,15 +747,21 @@ mod tests {
         let progress = TickProgress::new(DAEMON_HOST, names);
         let config = super::MonitorConfig::for_test(
             Duration::from_secs(30),
-            Duration::from_secs(30), // long: a naive join would wait this long
+            Duration::from_secs(30),
+            Duration::from_secs(30), // long: a naive join would block this long
             std::env::temp_dir(),
         );
-        let guard = super::TickStallMonitorGuard::spawn(Arc::clone(&progress), config);
-        let start = Instant::now();
-        drop(guard);
+        let guard = super::TickStallMonitorGuard::spawn(Arc::clone(&progress), config)
+            .expect("monitor thread must spawn in tests");
+
+        let (done_tx, done_rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            drop(guard); // stop + join
+            let _ = done_tx.send(());
+        });
         assert!(
-            start.elapsed() < Duration::from_secs(2),
-            "Stop must wake recv_timeout + join promptly, not wait the 30s interval"
+            done_rx.recv_timeout(Duration::from_secs(5)).is_ok(),
+            "Stop must wake recv_timeout and join promptly; a hang would exceed the watchdog"
         );
     }
 
@@ -710,21 +771,59 @@ mod tests {
         Snapshot { generation, phase }
     }
 
-    /// #2: a host parked in `Waiting` between ticks is never a stall, no matter
-    /// how long it waits.
+    /// #2 + waiting-stall: ordinary Waiting cadence (a tick advances the
+    /// generation each period) never alerts, but a host frozen in Waiting past
+    /// the waiting-threshold (a dead tick producer) pages as `<waiting>`.
     #[test]
-    fn detector_never_alerts_while_waiting() {
+    fn detector_waiting_cadence_silent_but_dead_producer_alerts() {
         let thr = Duration::from_millis(40);
+        let wait_thr = Duration::from_millis(140);
         let si = Duration::from_millis(5);
+        let period_samples = 20u64; // 20 * 5ms = 100ms < wait_thr → ordinary cadence
         let t0 = Instant::now();
-        let mut d = StallDetector::new(thr, si, t0, Some(snap(0, Phase::Waiting)));
-        for k in 1..=40u64 {
-            let now = t0 + si * k as u32;
-            assert!(
-                d.observe(now, Some(snap(0, Phase::Waiting))).is_none(),
-                "Waiting is never a stall (sample {k})"
-            );
+        let mut d = StallDetector::new(thr, wait_thr, t0, Some(snap(0, Phase::Waiting)));
+
+        // Ordinary cadence: a tick advances the generation every ~100ms while the
+        // host sits in Waiting between ticks. Must never alert.
+        let mut gen = 0u64;
+        let mut k = 0u64;
+        for _cycle in 0..5 {
+            for _ in 0..period_samples {
+                k += 1;
+                assert!(
+                    d.observe(t0 + si * k as u32, Some(snap(gen, Phase::Waiting)))
+                        .is_none(),
+                    "ordinary Waiting cadence must not alert"
+                );
+            }
+            // A tick fired → generation advances (progress), resetting the clock.
+            gen += 2;
+            k += 1;
+            assert!(d
+                .observe(t0 + si * k as u32, Some(snap(gen, Phase::Waiting)))
+                .is_none());
         }
+
+        // The tick producer dies: Waiting with NO further generation advance. Past
+        // the waiting-threshold it must alert as <waiting>.
+        let mut fired = None;
+        for _ in 0..40 {
+            k += 1;
+            if let Some(a) = d.observe(t0 + si * k as u32, Some(snap(gen, Phase::Waiting))) {
+                fired = Some(a);
+                break;
+            }
+        }
+        assert!(
+            matches!(
+                fired,
+                Some(Alert {
+                    phase: Phase::Waiting,
+                    ..
+                })
+            ),
+            "an unchanged Waiting past the waiting-threshold pages as <waiting>"
+        );
     }
 
     /// #3: one alert per outage (dedup), then re-arm after progress and alert
@@ -732,9 +831,10 @@ mod tests {
     #[test]
     fn detector_alerts_once_dedups_then_rearms() {
         let thr = Duration::from_millis(40);
+        let wait_thr = Duration::from_millis(140);
         let si = Duration::from_millis(5);
         let t0 = Instant::now();
-        let mut d = StallDetector::new(thr, si, t0, Some(snap(2, Phase::Handler(0))));
+        let mut d = StallDetector::new(thr, wait_thr, t0, Some(snap(2, Phase::Handler(0))));
 
         // Step at the sampling cadence until the first alert.
         let mut first_at = None;
@@ -793,9 +893,10 @@ mod tests {
     #[test]
     fn detector_suspend_gap_resets_and_suppresses_false_alert() {
         let thr = Duration::from_millis(40);
+        let wait_thr = Duration::from_millis(140);
         let si = Duration::from_millis(5);
         let t0 = Instant::now();
-        let mut d = StallDetector::new(thr, si, t0, Some(snap(2, Phase::Handler(0))));
+        let mut d = StallDetector::new(thr, wait_thr, t0, Some(snap(2, Phase::Handler(0))));
 
         // One normal sample, still stuck, before threshold.
         assert!(d
@@ -830,9 +931,10 @@ mod tests {
     #[test]
     fn detector_skips_torn_snapshots() {
         let thr = Duration::from_millis(40);
+        let wait_thr = Duration::from_millis(140);
         let si = Duration::from_millis(5);
         let t0 = Instant::now();
-        let mut d = StallDetector::new(thr, si, t0, Some(snap(2, Phase::Handler(0))));
+        let mut d = StallDetector::new(thr, wait_thr, t0, Some(snap(2, Phase::Handler(0))));
         // Interleave torn reads with real stuck reads; still alerts once elapsed.
         let mut fired = None;
         for k in 1..=20u64 {
@@ -858,10 +960,11 @@ mod tests {
     #[test]
     fn detectors_two_hosts_are_independent() {
         let thr = Duration::from_millis(40);
+        let wait_thr = Duration::from_millis(140);
         let si = Duration::from_millis(5);
         let t0 = Instant::now();
-        let mut daemon = StallDetector::new(thr, si, t0, Some(snap(2, Phase::Handler(0))));
-        let mut app = StallDetector::new(thr, si, t0, Some(snap(2, Phase::Handler(0))));
+        let mut daemon = StallDetector::new(thr, wait_thr, t0, Some(snap(2, Phase::Handler(0))));
+        let mut app = StallDetector::new(thr, wait_thr, t0, Some(snap(2, Phase::Handler(0))));
 
         // The app host keeps progressing; the daemon host is stuck.
         let mut daemon_fired = false;
@@ -888,29 +991,44 @@ mod tests {
 
     // ── Seqlock concurrency stress (#3.9 concurrent-state) ─────────────────
 
-    /// Under a concurrent writer, every accepted snapshot is torn-free: settled
-    /// (even) generation, monotonic non-decreasing, and a valid phase.
+    /// Under a concurrent writer, every accepted snapshot is torn-free AND
+    /// coherent: the handler index corresponds to the generation of the SAME
+    /// publish (a torn read pairing phase-A with generation-B would mismatch).
+    /// A writer-start handshake guarantees the reader observes real concurrent
+    /// progress, not just the initial state.
     #[test]
-    fn seqlock_reader_never_sees_torn_state() {
-        let progress = TickProgress::new("stress-tick", Arc::from(vec!["h0", "h1", "h2"]));
+    fn seqlock_reader_sees_coherent_phase_generation_pairs() {
+        // Encode the write count in the handler index: publish #n sets
+        // generation = 2n and index = n % LIMIT, so a coherent read has
+        // Handler((generation / 2) % LIMIT).
+        const LIMIT: u64 = 1_000_000;
+        let progress = TickProgress::new("stress-tick", Arc::from(vec!["stress"]));
         let writer = Arc::clone(&progress);
         let stop = Arc::new(AtomicBool::new(false));
         let stop_w = Arc::clone(&stop);
+        let (started_tx, started_rx) = std::sync::mpsc::channel();
         let handle = std::thread::spawn(move || {
-            let mut i = 0u32;
-            while !stop_w.load(Ordering::Relaxed) {
-                match i % 4 {
-                    0 => writer.enter_waiting(),
-                    1 => writer.enter_preflight(),
-                    2 => writer.enter_handler(i % 3),
-                    _ => writer.enter_post(),
+            let mut count = 0u64;
+            loop {
+                count += 1;
+                writer.enter_handler((count % LIMIT) as u32);
+                if count == 1 {
+                    let _ = started_tx.send(()); // writer-start handshake
                 }
-                i = i.wrapping_add(1);
+                if stop_w.load(Ordering::Relaxed) {
+                    break;
+                }
             }
         });
+        // Progress handshake: don't read until the writer has published at least once.
+        started_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("writer must start publishing");
 
         let mut last_gen = 0u64;
-        for _ in 0..200_000 {
+        let mut first_gen: Option<u64> = None;
+        let mut coherent_reads = 0u64;
+        for _ in 0..500_000 {
             if let Some(s) = progress.snapshot() {
                 assert_eq!(
                     s.generation % 2,
@@ -922,12 +1040,25 @@ mod tests {
                     "generation is monotonic non-decreasing"
                 );
                 last_gen = s.generation;
-                // `unpack` always yields a valid variant — a torn tag can't panic.
-                let _ = s.phase.label();
+                first_gen.get_or_insert(s.generation);
+                match s.phase {
+                    Phase::Handler(idx) => assert_eq!(
+                        u64::from(idx),
+                        (s.generation / 2) % LIMIT,
+                        "phase index must correspond to the generation (coherent seqlock read)"
+                    ),
+                    other => panic!("writer only publishes Handler; torn variant {other:?}"),
+                }
+                coherent_reads += 1;
             }
         }
         stop.store(true, Ordering::Relaxed);
         let _ = handle.join();
+        assert!(coherent_reads > 0, "reader must observe concurrent writes");
+        assert!(
+            last_gen > first_gen.unwrap_or(0),
+            "the writer must make progress during the read window"
+        );
     }
 
     // ── Env gating (Q4) ────────────────────────────────────────────────────

--- a/src/daemon/tick_stall.rs
+++ b/src/daemon/tick_stall.rs
@@ -1,39 +1,433 @@
 //! PR4 — opt-in out-of-band tick-stall diagnostics.
 //!
-//! Decision d-20260711043612580372-4. A dedicated, joined per-host monitor
-//! watches the tick host's [`per_tick`](super::per_tick) runner make progress
-//! and pages the operator out-of-band when a handler wedges the tick thread —
-//! WITHOUT ever running on that thread or reusing the blocking bounded tick
-//! producer.
+//! A dedicated, joined per-host monitor watches the tick host's
+//! [`per_tick`](super::per_tick) runner make progress and pages the operator
+//! out-of-band when a handler (or a preflight / post-handler step) wedges the
+//! tick thread — WITHOUT ever running on that thread, blocking it, or reusing
+//! the blocking bounded tick producer. Decision d-20260711043612580372-4.
 //!
-//! ## RED anchor (this commit)
+//! Opt-in and default-OFF: enabled only when `AGEND_TICK_STALL_SECS` is set to a
+//! value `>= 10` (see [`threshold_from_env`]). The daemon `run_core` host and an
+//! *owned* app host each start their own monitor; an *attached* app never ticks,
+//! so it never starts one.
 //!
-//! The production tracker (`TickProgress`), the monitor thread
-//! (`TickStallMonitorGuard`), the `AGEND_TICK_STALL_SECS` env gate and the
-//! `delivery_worker` alert job are NOT wired yet — in a release build this
-//! module compiles to **nothing** (every item below is `#[cfg(test)]`), so the
-//! shipping binary is byte-identical to the pre-PR4 daemon.
+//! ## Consistent snapshot (odd/even seqlock)
 //!
-//! What lives here now is only the test scaffolding that pins the desired
-//! behavior:
+//! The tick thread is the sole writer of [`TickProgress`]; the monitor thread is
+//! a lock-free reader. `state` packs the current [`Phase`] (+ handler index);
+//! `generation` is an odd/even seqlock — odd while a write is in flight, even
+//! when settled — so the monitor reads a torn-free (phase, generation) pair and
+//! uses the *settled* generation as the host's progress signal. Both writer and
+//! reader touch only atomics, so the monitor never blocks on a lock the tick
+//! thread holds and can never itself be stalled by the stall it is watching.
 //!
-//! * [`test_probe`] — a process-global observation seam. The GREEN alert path
-//!   (the `delivery_worker` `TickStallAlert` dispatch arm) will emit the exact
-//!   escalated `(host, handler)` here under `#[cfg(test)]`, so a test observes
-//!   the real payload without a live Telegram / `event_log` side effect.
-//! * the focused harness `drive_stalled_tick` + the frozen assertion
-//!   `expect_stall_alert`. The harness drives the **real** per-tick runner with
-//!   a `Condvar`-stalled handler (a genuine, deterministic tick stall). In RED
-//!   there is no monitor, so nothing ever feeds the probe and the assertion
-//!   FAILS by watchdog timeout (a real runtime panic — not a compile error and
-//!   not an `is_err`/pass-on-old check). GREEN wires the tracker + monitor +
-//!   delivery job; the harness body starts the monitor and drives the tracked
-//!   runner, and the SAME assertion then receives `host + handler`.
+//! ## Alert path
+//!
+//! The monitor sampler performs NO network or shared-state-lock I/O. On a
+//! confirmed stall it `try_send`s a bounded
+//! [`DeliveryJob::TickStallAlert`](super::delivery_worker) through the existing
+//! `delivery_worker`; that worker (off the tick thread) owns the `event_log`
+//! write and the escalation-channel fan-out. A full delivery queue is a
+//! `tracing::error` observable drop, never a block.
 
-/// Process-global alert-observation seam (test-only). The GREEN production
-/// alert path emits the escalated identity here so tests can assert the exact
-/// out-of-band payload without a real escalation side effect. Mirrors the
-/// `canonical_heartbeat` `test_hooks` static-seam pattern.
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender};
+use std::sync::Arc;
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
+
+/// Env var gating the diagnostics. Unset / `0` = disabled.
+const ENV_VAR: &str = "AGEND_TICK_STALL_SECS";
+/// Minimum enabled threshold (seconds). Below this the diagnostics stay OFF — a
+/// sub-10s window would false-alarm on ordinary slow ticks.
+const MIN_THRESHOLD_SECS: u64 = 10;
+/// A single monitor sample gap larger than `sample_interval * SUSPEND_GAP_FACTOR`
+/// means the monitor thread itself was frozen (laptop sleep / gross CPU
+/// starvation) — the tick host was frozen too, so it is not a real stall. See
+/// [`StallDetector::observe`].
+const SUSPEND_GAP_FACTOR: u32 = 4;
+
+/// The tick host's coarse lifecycle position within one tick. `Handler` carries
+/// the 0-based index into the host's immutable handler-name table.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum Phase {
+    /// Idle, blocked awaiting the next tick signal — never alerted (a long wait
+    /// between ticks is normal, not a stall).
+    Waiting,
+    /// Per-tick config reloads before the handler sweep.
+    Preflight,
+    /// Running the handler at this index.
+    Handler(u32),
+    /// After the handler sweep — exit-event / crash-dispatch handling.
+    PostHandlers,
+}
+
+impl Phase {
+    // Packed u64 layout: [ tag : high 32 | handler_index : low 32 ].
+    fn pack(self) -> u64 {
+        match self {
+            Phase::Waiting => 0,
+            Phase::Preflight => 1 << 32,
+            Phase::Handler(i) => (2u64 << 32) | u64::from(i),
+            Phase::PostHandlers => 3u64 << 32,
+        }
+    }
+
+    fn unpack(v: u64) -> Phase {
+        match v >> 32 {
+            0 => Phase::Waiting,
+            1 => Phase::Preflight,
+            2 => Phase::Handler((v & 0xFFFF_FFFF) as u32),
+            _ => Phase::PostHandlers,
+        }
+    }
+
+    /// Stable phase label for the alert payload / event log.
+    fn label(self) -> &'static str {
+        match self {
+            Phase::Waiting => "waiting",
+            Phase::Preflight => "preflight",
+            Phase::Handler(_) => "handler",
+            Phase::PostHandlers => "post-handlers",
+        }
+    }
+}
+
+/// A consistent (settled-generation, phase) reading taken by the monitor.
+#[derive(Clone, Copy)]
+struct Snapshot {
+    generation: u64,
+    phase: Phase,
+}
+
+/// Per-host tick-progress tracker. One `Arc` is written by the tick thread; a
+/// clone is read by the monitor thread. See the module docs for the seqlock.
+pub(crate) struct TickProgress {
+    /// Stable payload label for this host (`daemon-tick` / `app-owned-tick`).
+    host: &'static str,
+    /// Immutable handler-name table, indexed by `Phase::Handler(i)`. Built once
+    /// at construction and never mutated, so the monitor reads it unsynchronized.
+    handler_names: Arc<[&'static str]>,
+    /// Packed [`Phase`] (+ handler index).
+    state: AtomicU64,
+    /// Odd/even seqlock: odd = write in flight, even = settled. The settled value
+    /// is the host's monotonic progress signal.
+    generation: AtomicU64,
+}
+
+impl TickProgress {
+    pub(crate) fn new(host: &'static str, handler_names: Arc<[&'static str]>) -> Arc<Self> {
+        Arc::new(Self {
+            host,
+            handler_names,
+            state: AtomicU64::new(Phase::Waiting.pack()),
+            generation: AtomicU64::new(0), // even → no write in flight
+        })
+    }
+
+    /// Publish a new phase via the odd/even seqlock write protocol: bump to odd
+    /// (write begins), store the packed state, bump to even (write settled).
+    fn publish(&self, phase: Phase) {
+        self.generation.fetch_add(1, Ordering::AcqRel); // → odd
+        self.state.store(phase.pack(), Ordering::Release);
+        self.generation.fetch_add(1, Ordering::Release); // → even
+    }
+
+    pub(crate) fn enter_waiting(&self) {
+        self.publish(Phase::Waiting);
+    }
+    pub(crate) fn enter_preflight(&self) {
+        self.publish(Phase::Preflight);
+    }
+    pub(crate) fn enter_handler(&self, index: u32) {
+        self.publish(Phase::Handler(index));
+    }
+    pub(crate) fn enter_post(&self) {
+        self.publish(Phase::PostHandlers);
+    }
+
+    /// Lock-free consistent read. Returns `None` if a write is in flight or the
+    /// read tore across a concurrent publish — the caller retries next sample.
+    fn snapshot(&self) -> Option<Snapshot> {
+        let g1 = self.generation.load(Ordering::Acquire);
+        if g1 & 1 == 1 {
+            return None; // writer mid-publish (odd)
+        }
+        let state = self.state.load(Ordering::Acquire);
+        let g2 = self.generation.load(Ordering::Acquire);
+        if g1 != g2 {
+            return None; // torn across a concurrent publish
+        }
+        Some(Snapshot {
+            generation: g1,
+            phase: Phase::unpack(state),
+        })
+    }
+
+    /// The alert `handler` label for a phase: the stalled handler's name for
+    /// `Handler`, else a phase descriptor.
+    fn handler_label(&self, phase: Phase) -> &str {
+        match phase {
+            Phase::Handler(i) => self
+                .handler_names
+                .get(i as usize)
+                .copied()
+                .unwrap_or("<unknown-handler>"),
+            Phase::Preflight => "<preflight>",
+            Phase::PostHandlers => "<post-handlers>",
+            Phase::Waiting => "<waiting>",
+        }
+    }
+}
+
+/// A stall the [`StallDetector`] decided to raise.
+struct Alert {
+    generation: u64,
+    phase: Phase,
+}
+
+/// Pure stall-decision state machine — no threads, no clock of its own. The
+/// monitor thread feeds it `(now, snapshot)` each sample; unit tests feed
+/// synthetic values for fully deterministic coverage.
+struct StallDetector {
+    threshold: Duration,
+    sample_interval: Duration,
+    last_sample: Instant,
+    /// Settled generation at the last observed progress (`None` before the first
+    /// clean snapshot).
+    last_progress_gen: Option<u64>,
+    last_progress_at: Instant,
+    /// Generation at which we last alerted — dedups one outage; cleared on
+    /// progress so a later stall re-arms.
+    alerted_gen: Option<u64>,
+}
+
+impl StallDetector {
+    fn new(
+        threshold: Duration,
+        sample_interval: Duration,
+        now: Instant,
+        initial: Option<Snapshot>,
+    ) -> Self {
+        Self {
+            threshold,
+            sample_interval,
+            last_sample: now,
+            last_progress_gen: initial.map(|s| s.generation),
+            last_progress_at: now,
+            alerted_gen: None,
+        }
+    }
+
+    /// Feed one sample. Returns `Some` exactly once per fresh stall outage.
+    fn observe(&mut self, now: Instant, snap: Option<Snapshot>) -> Option<Alert> {
+        let gap = now.duration_since(self.last_sample);
+        self.last_sample = now;
+
+        // Suspend / sample-gap reset: the monitor thread was itself frozen far
+        // longer than its cadence, so the tick host was frozen too — not a stall.
+        // Re-baseline and skip alerting so wake never false-alarms.
+        if gap > self.sample_interval * SUSPEND_GAP_FACTOR {
+            self.last_progress_at = now;
+            self.alerted_gen = None;
+            self.last_progress_gen = snap.map(|s| s.generation);
+            return None;
+        }
+
+        let snap = snap?; // torn / mid-publish → retry next sample
+
+        if Some(snap.generation) != self.last_progress_gen {
+            // The host advanced since we last saw it — record progress, re-arm.
+            self.last_progress_gen = Some(snap.generation);
+            self.last_progress_at = now;
+            self.alerted_gen = None;
+            return None;
+        }
+
+        // No progress since `last_progress_at`. Waiting is never a stall.
+        if snap.phase != Phase::Waiting
+            && now.duration_since(self.last_progress_at) >= self.threshold
+            && self.alerted_gen != Some(snap.generation)
+        {
+            self.alerted_gen = Some(snap.generation);
+            return Some(Alert {
+                generation: snap.generation,
+                phase: snap.phase,
+            });
+        }
+        None
+    }
+}
+
+/// Monitor timing + destination. Built from the environment for production hosts
+/// ([`MonitorConfig::from_env`]); tests build it directly with tiny durations.
+pub(crate) struct MonitorConfig {
+    threshold: Duration,
+    sample_interval: Duration,
+    home: PathBuf,
+}
+
+impl MonitorConfig {
+    /// Build from `AGEND_TICK_STALL_SECS`; `None` when disabled / invalid.
+    pub(crate) fn from_env(home: &Path) -> Option<Self> {
+        let threshold = threshold_from_env()?;
+        Some(Self {
+            sample_interval: sample_interval_for(threshold),
+            threshold,
+            home: home.to_path_buf(),
+        })
+    }
+
+    #[cfg(test)]
+    fn for_test(threshold: Duration, sample_interval: Duration, home: PathBuf) -> Self {
+        Self {
+            threshold,
+            sample_interval,
+            home,
+        }
+    }
+}
+
+/// Production sample cadence: ~4 samples per threshold window (detection latency
+/// ≤ ~1.25× threshold), floored at 1s so the monitor never busy-loops.
+fn sample_interval_for(threshold: Duration) -> Duration {
+    (threshold / 4).max(Duration::from_secs(1))
+}
+
+/// Parse `AGEND_TICK_STALL_SECS`. Unset / `0` → disabled (no warning). `1..=9` →
+/// **invalid**: warn and disable (never silently clamp). `>= 10` → enabled.
+/// Malformed → warn and disable.
+pub(crate) fn threshold_from_env() -> Option<Duration> {
+    parse_threshold(std::env::var(ENV_VAR).ok().as_deref())
+}
+
+fn parse_threshold(raw: Option<&str>) -> Option<Duration> {
+    let raw = raw?.trim();
+    if raw.is_empty() {
+        return None;
+    }
+    match raw.parse::<u64>() {
+        Ok(0) => None,
+        Ok(n) if n < MIN_THRESHOLD_SECS => {
+            tracing::warn!(
+                value = n,
+                min = MIN_THRESHOLD_SECS,
+                "{ENV_VAR}={n} is below the {MIN_THRESHOLD_SECS}s minimum — tick-stall \
+                 diagnostics DISABLED (set >= {MIN_THRESHOLD_SECS}, or 0/unset to disable)"
+            );
+            None
+        }
+        Ok(n) => Some(Duration::from_secs(n)),
+        Err(_) => {
+            tracing::warn!(
+                value = %raw,
+                "{ENV_VAR} is not a non-negative integer — tick-stall diagnostics DISABLED"
+            );
+            None
+        }
+    }
+}
+
+/// A running per-host stall monitor. Dropping the guard signals the thread to
+/// stop (waking its `recv_timeout` at once) and joins it — the thread never
+/// outlives the host.
+pub(crate) struct TickStallMonitorGuard {
+    stop_tx: Option<Sender<()>>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl TickStallMonitorGuard {
+    /// Spawn the monitor for `progress`. Holds a clone of the `Arc` for reading;
+    /// the caller keeps its own clone for writing.
+    pub(crate) fn spawn(progress: Arc<TickProgress>, config: MonitorConfig) -> Self {
+        let (stop_tx, stop_rx) = std::sync::mpsc::channel();
+        // store JoinHandle: the guard joins on drop (no fire-and-forget — a stall
+        // monitor must not outlive the host it watches).
+        let handle = std::thread::Builder::new()
+            .name("agend-tick-stall".into())
+            .spawn(move || monitor_loop(&progress, &config, &stop_rx))
+            .map_err(|e| {
+                tracing::error!(
+                    error = %e,
+                    "tick_stall: failed to spawn monitor thread — diagnostics inactive for this host"
+                );
+                e
+            })
+            .ok();
+        Self {
+            stop_tx: Some(stop_tx),
+            handle,
+        }
+    }
+}
+
+impl Drop for TickStallMonitorGuard {
+    fn drop(&mut self) {
+        // Signal stop first (wakes the monitor's recv_timeout immediately), then
+        // join so teardown is prompt.
+        if let Some(tx) = self.stop_tx.take() {
+            let _ = tx.send(());
+        }
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+/// The sampling loop. Runs on its own thread; touches only atomics, the stop
+/// channel, and `delivery_worker::enqueue_tick_stall_alert`. NO event_log /
+/// channel calls here — the delivery worker owns those off this thread.
+fn monitor_loop(progress: &TickProgress, config: &MonitorConfig, stop_rx: &Receiver<()>) {
+    let mut detector = StallDetector::new(
+        config.threshold,
+        config.sample_interval,
+        Instant::now(),
+        progress.snapshot(),
+    );
+    loop {
+        match stop_rx.recv_timeout(config.sample_interval) {
+            // Stop signalled, or the guard (sole sender) dropped: exit promptly.
+            Ok(()) | Err(RecvTimeoutError::Disconnected) => return,
+            Err(RecvTimeoutError::Timeout) => {}
+        }
+        if let Some(alert) = detector.observe(Instant::now(), progress.snapshot()) {
+            let _ = super::delivery_worker::enqueue_tick_stall_alert(
+                &config.home,
+                progress.host,
+                alert.phase.label(),
+                progress.handler_label(alert.phase),
+                alert.generation,
+            );
+        }
+    }
+}
+
+/// Start the tick-stall diagnostics for a host, IF `AGEND_TICK_STALL_SECS`
+/// enables them. Returns `(Some(progress), Some(guard))` when enabled and
+/// `(None, None)` when disabled — so the default-OFF tick loop stays byte-for-
+/// byte untracked (no atomic writes, no monitor thread). The progress `Arc` is
+/// the loop's writer handle; the guard stops+joins the monitor on drop. One-line
+/// wiring for the daemon `run_core` and owned-app tick loops.
+pub(crate) fn start_for_host(
+    host: &'static str,
+    handlers: &[Box<dyn super::per_tick::PerTickHandler>],
+    home: &Path,
+) -> (Option<Arc<TickProgress>>, Option<TickStallMonitorGuard>) {
+    let Some(config) = MonitorConfig::from_env(home) else {
+        return (None, None); // disabled → truly untracked
+    };
+    let names: Arc<[&'static str]> = handlers.iter().map(|h| h.name()).collect();
+    let progress = TickProgress::new(host, names);
+    let guard = TickStallMonitorGuard::spawn(Arc::clone(&progress), config);
+    (Some(progress), Some(guard))
+}
+
+/// Process-global alert-observation seam (test-only). The production alert path
+/// (the `delivery_worker` `TickStallAlert` dispatch arm) emits the escalated
+/// identity here so tests can assert the exact out-of-band payload without a
+/// real escalation side effect. Mirrors the `canonical_heartbeat` `test_hooks`
+/// static-seam pattern.
 #[cfg(test)]
 pub(crate) mod test_probe {
     use parking_lot::Mutex;
@@ -62,10 +456,10 @@ pub(crate) mod test_probe {
         ProbeGuard { rx }
     }
 
-    /// Emit an observed `(host, handler)` to the installed probe, if any.
-    /// The GREEN `delivery_worker` `TickStallAlert` dispatch arm calls this
-    /// (under `#[cfg(test)]`) with the exact escalated identity. No-op when no
-    /// probe is installed.
+    /// Emit an observed `(host, handler)` to the installed probe, if any. The
+    /// `delivery_worker` `TickStallAlert` dispatch arm calls this (under
+    /// `#[cfg(test)]`) with the exact escalated identity. No-op when no probe is
+    /// installed.
     pub(crate) fn emit(host: &str, handler: &str) {
         // Clone the sender out so we never hold the lock across `try_send`.
         let sink = SINK.lock().clone();
@@ -79,28 +473,32 @@ pub(crate) mod test_probe {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::test_probe;
+    use super::{Alert, Phase, Snapshot, StallDetector, TickProgress};
     use crate::agent::{AgentRegistry, ExternalRegistry};
-    use crate::daemon::per_tick::{run_handlers_with_panic_guard, PerTickHandler, TickContext};
+    use crate::daemon::per_tick::{run_handlers_with_progress, PerTickHandler, TickContext};
     use parking_lot::{Condvar, Mutex};
     use std::collections::HashMap;
+    use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::mpsc::Receiver;
     use std::sync::Arc;
     use std::thread::JoinHandle;
-    use std::time::Duration;
+    use std::time::{Duration, Instant};
 
-    /// The probe + delivery-worker force-full seams are process-global; serialize
-    /// stall-diagnostics tests so they don't observe each other's emissions.
+    /// The probe seam is process-global; serialize stall-diagnostics tests so
+    /// they don't observe each other's emissions.
     static TEST_LOCK: Mutex<()> = Mutex::new(());
 
     /// Failure ceiling for the frozen assertion. In RED nothing ever emits, so
     /// the RED test blocks the full watchdog then panics. In GREEN the monitor
-    /// emits within a few injected sample intervals (≪ watchdog), so the pass is
-    /// fast; the watchdog is only the timeout guard, never the happy path.
+    /// emits within a few injected sample intervals (≪ watchdog); the watchdog is
+    /// only the timeout guard, never the happy path.
     const WATCHDOG: Duration = Duration::from_secs(2);
     /// Stable handler identity the alert must name.
     const STALL_HANDLER: &str = "slow_handler";
     /// Stable daemon host label (matches the GREEN payload label — Q5).
     const DAEMON_HOST: &str = "daemon-tick";
+
+    // ── Shared test doubles ────────────────────────────────────────────────
 
     /// A per-tick handler whose `run` blocks on a `Condvar` until released — a
     /// real, deterministic stall of the runner thread (no sleeps, no timing).
@@ -121,33 +519,39 @@ mod tests {
         }
     }
 
-    /// The mutable RED↔GREEN SEAM (`drive_stalled_tick` + this struct).
-    ///
-    /// RED: install the probe and spawn the **real** untracked runner
-    /// ([`run_handlers_with_panic_guard`]) with a `Condvar`-stalled handler.
-    /// There is no monitor, so nothing ever feeds the probe.
-    ///
-    /// GREEN (follow-up commit): additionally build an `Arc<TickProgress>`,
-    /// start the joined `TickStallMonitorGuard` on a short injected interval,
-    /// and drive `run_handlers_with_progress` so the monitor samples the stall
-    /// and the delivery path feeds the probe. Only this seam changes — the
-    /// `#[test]` below and `expect_stall_alert` stay byte-identical.
-    struct StalledTick {
+    /// A handler that panics on its (only) run — proves the runner advances the
+    /// tracked identity after `catch_unwind`.
+    struct PanicHandler;
+    impl PerTickHandler for PanicHandler {
+        fn name(&self) -> &'static str {
+            "flaky_handler"
+        }
+        fn run(&self, _ctx: &TickContext<'_>) {
+            panic!("PR4 test: handler panics");
+        }
+    }
+
+    // ── e2e harness (the mutable RED↔GREEN seam) ───────────────────────────
+
+    /// A live monitored tick: the real runner drives `TickProgress`, a real
+    /// `TickStallMonitorGuard` samples it, and stall alerts flow through the real
+    /// `delivery_worker` to the probe. Dropping it releases the stalled handler,
+    /// joins the runner, and stops+joins the monitor.
+    struct MonitoredTick {
         probe: test_probe::ProbeGuard,
         gate: Arc<(Mutex<bool>, Condvar)>,
+        _monitor: super::TickStallMonitorGuard,
         runner: Option<JoinHandle<()>>,
     }
 
-    impl StalledTick {
+    impl MonitoredTick {
         fn rx(&self) -> &Receiver<(String, String)> {
             &self.probe.rx
         }
     }
 
-    impl Drop for StalledTick {
+    impl Drop for MonitoredTick {
         fn drop(&mut self) {
-            // Release the stalled handler so the runner thread can finish, then
-            // join it — no leaked thread even when the assertion panicked.
             {
                 let (lock, cv) = &*self.gate;
                 *lock.lock() = true;
@@ -156,16 +560,29 @@ mod tests {
             if let Some(handle) = self.runner.take() {
                 let _ = handle.join();
             }
+            // `_monitor` (field) drops after this body: stop + join.
         }
     }
 
-    fn drive_stalled_tick() -> StalledTick {
+    /// Spawn the real runner over `handlers` under a short-threshold monitor for
+    /// `host`. The runner drives the tracked companion `run_handlers_with_progress`
+    /// so the monitor sees phase/handler progress and, on a stall, the delivery
+    /// path feeds the probe.
+    fn spawn_monitored(
+        host: &'static str,
+        handlers: Vec<Box<dyn PerTickHandler>>,
+        gate: Arc<(Mutex<bool>, Condvar)>,
+    ) -> MonitoredTick {
         let probe = test_probe::install();
-        let gate = Arc::new((Mutex::new(false), Condvar::new()));
-        let gate_for_runner = Arc::clone(&gate);
-        // Owned fixture is moved into the runner thread; the borrowing
-        // `TickContext` is constructed INSIDE the closure so the closure is
-        // `'static` (a stalled runner outlives this function's frame).
+        let names: Arc<[&'static str]> = handlers.iter().map(|h| h.name()).collect();
+        let progress = TickProgress::new(host, names);
+        let config = super::MonitorConfig::for_test(
+            Duration::from_millis(40),
+            Duration::from_millis(5),
+            std::env::temp_dir(),
+        );
+        let monitor = super::TickStallMonitorGuard::spawn(Arc::clone(&progress), config);
+        let progress_for_runner = Arc::clone(&progress);
         let runner = std::thread::spawn(move || {
             let home = std::env::temp_dir();
             let registry: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
@@ -178,18 +595,22 @@ mod tests {
                 externals: &externals,
                 configs: &configs,
             };
-            let handlers: Vec<Box<dyn PerTickHandler>> = vec![Box::new(BlockingHandler {
-                gate: gate_for_runner,
-            })];
-            // RED: the real runner blocks inside `BlockingHandler::run`; no
-            // monitor is watching, so no out-of-band stall alert is emitted.
-            run_handlers_with_panic_guard(&handlers, &ctx);
+            run_handlers_with_progress(&handlers, &ctx, Some(&*progress_for_runner));
         });
-        StalledTick {
+        MonitoredTick {
             probe,
             gate,
+            _monitor: monitor,
             runner: Some(runner),
         }
+    }
+
+    fn drive_stalled_tick() -> MonitoredTick {
+        let gate = Arc::new((Mutex::new(false), Condvar::new()));
+        let handlers: Vec<Box<dyn PerTickHandler>> = vec![Box::new(BlockingHandler {
+            gate: Arc::clone(&gate),
+        })];
+        spawn_monitored(DAEMON_HOST, handlers, gate)
     }
 
     /// FROZEN assertion — byte-identical in RED and GREEN. While the real runner
@@ -211,10 +632,11 @@ mod tests {
         }
     }
 
+    // ── #1: probe seam sanity + frozen e2e assertion ───────────────────────
+
     /// The observation seam itself must faithfully route an emitted identity to
-    /// the installed receiver, so a GREEN stall-test failure can only mean "no
-    /// monitor emit", never "the probe is broken". (Also exercises the emit path
-    /// the GREEN `delivery_worker` dispatch arm will call.)
+    /// the installed receiver, so a stall-test failure can only mean "no monitor
+    /// emit", never "the probe is broken".
     #[test]
     fn probe_seam_roundtrips_host_and_handler() {
         let _serial = TEST_LOCK.lock();
@@ -238,5 +660,344 @@ mod tests {
         let st = drive_stalled_tick();
         expect_stall_alert(st.rx(), DAEMON_HOST, STALL_HANDLER);
         // `st` drops here → releases the stalled handler + joins the runner.
+    }
+
+    // ── #4/#9: panic advances identity; exact payload ──────────────────────
+
+    /// A panicking handler must not leave stale identity: after `catch_unwind`
+    /// the runner advances, so a LATER stalled handler is the one the alert
+    /// names (never the panicked predecessor).
+    #[test]
+    fn panicking_handler_advances_identity_then_alert_names_later_stall() {
+        let _serial = TEST_LOCK.lock();
+        let gate = Arc::new((Mutex::new(false), Condvar::new()));
+        let handlers: Vec<Box<dyn PerTickHandler>> = vec![
+            Box::new(PanicHandler),
+            Box::new(BlockingHandler {
+                gate: Arc::clone(&gate),
+            }),
+        ];
+        let st = spawn_monitored(DAEMON_HOST, handlers, gate);
+        expect_stall_alert(st.rx(), DAEMON_HOST, STALL_HANDLER);
+    }
+
+    // ── #7: guard stop/join is prompt ──────────────────────────────────────
+
+    /// Dropping the guard must wake the monitor's `recv_timeout` at once and
+    /// join — teardown far faster than the (deliberately long) sample interval.
+    #[test]
+    fn monitor_guard_stops_and_joins_promptly() {
+        let _serial = TEST_LOCK.lock();
+        let names: Arc<[&'static str]> = Arc::from(vec!["h0"]);
+        let progress = TickProgress::new(DAEMON_HOST, names);
+        let config = super::MonitorConfig::for_test(
+            Duration::from_secs(30),
+            Duration::from_secs(30), // long: a naive join would wait this long
+            std::env::temp_dir(),
+        );
+        let guard = super::TickStallMonitorGuard::spawn(Arc::clone(&progress), config);
+        let start = Instant::now();
+        drop(guard);
+        assert!(
+            start.elapsed() < Duration::from_secs(2),
+            "Stop must wake recv_timeout + join promptly, not wait the 30s interval"
+        );
+    }
+
+    // ── Detector unit tests (deterministic, no threads) ────────────────────
+
+    fn snap(generation: u64, phase: Phase) -> Snapshot {
+        Snapshot { generation, phase }
+    }
+
+    /// #2: a host parked in `Waiting` between ticks is never a stall, no matter
+    /// how long it waits.
+    #[test]
+    fn detector_never_alerts_while_waiting() {
+        let thr = Duration::from_millis(40);
+        let si = Duration::from_millis(5);
+        let t0 = Instant::now();
+        let mut d = StallDetector::new(thr, si, t0, Some(snap(0, Phase::Waiting)));
+        for k in 1..=40u64 {
+            let now = t0 + si * k as u32;
+            assert!(
+                d.observe(now, Some(snap(0, Phase::Waiting))).is_none(),
+                "Waiting is never a stall (sample {k})"
+            );
+        }
+    }
+
+    /// #3: one alert per outage (dedup), then re-arm after progress and alert
+    /// again on the next stall.
+    #[test]
+    fn detector_alerts_once_dedups_then_rearms() {
+        let thr = Duration::from_millis(40);
+        let si = Duration::from_millis(5);
+        let t0 = Instant::now();
+        let mut d = StallDetector::new(thr, si, t0, Some(snap(2, Phase::Handler(0))));
+
+        // Step at the sampling cadence until the first alert.
+        let mut first_at = None;
+        for k in 1..=20u64 {
+            let now = t0 + si * k as u32;
+            if let Some(a) = d.observe(now, Some(snap(2, Phase::Handler(0)))) {
+                assert!(matches!(
+                    a,
+                    Alert {
+                        generation: 2,
+                        phase: Phase::Handler(0)
+                    }
+                ));
+                first_at = Some(k);
+                break;
+            }
+        }
+        let first = first_at.expect("a >= threshold stall must alert");
+
+        // Dedup: further samples of the same stuck generation raise nothing.
+        for k in (first + 1)..(first + 5) {
+            let now = t0 + si * k as u32;
+            assert!(
+                d.observe(now, Some(snap(2, Phase::Handler(0)))).is_none(),
+                "only one alert per outage"
+            );
+        }
+
+        // Progress: generation advances → re-arm (no alert on the progress sample).
+        let p = first + 6;
+        assert!(d
+            .observe(t0 + si * p as u32, Some(snap(4, Phase::Handler(1))))
+            .is_none());
+
+        // A fresh stall at the new generation alerts again.
+        let mut re = None;
+        for k in (p + 1)..(p + 20) {
+            let now = t0 + si * k as u32;
+            if let Some(a) = d.observe(now, Some(snap(4, Phase::Handler(1)))) {
+                re = Some(a);
+                break;
+            }
+        }
+        assert!(matches!(
+            re.expect("re-armed stall alerts again"),
+            Alert {
+                generation: 4,
+                phase: Phase::Handler(1)
+            }
+        ));
+    }
+
+    /// #5: a monitor sample gap far larger than the cadence (laptop sleep / CPU
+    /// starvation) re-baselines instead of false-alarming — and detection still
+    /// works afterward.
+    #[test]
+    fn detector_suspend_gap_resets_and_suppresses_false_alert() {
+        let thr = Duration::from_millis(40);
+        let si = Duration::from_millis(5);
+        let t0 = Instant::now();
+        let mut d = StallDetector::new(thr, si, t0, Some(snap(2, Phase::Handler(0))));
+
+        // One normal sample, still stuck, before threshold.
+        assert!(d
+            .observe(t0 + si, Some(snap(2, Phase::Handler(0))))
+            .is_none());
+
+        // A single huge gap (>> sample_interval): the monitor itself was frozen.
+        let after_suspend = t0 + si + si * 8 + thr;
+        assert!(
+            d.observe(after_suspend, Some(snap(2, Phase::Handler(0))))
+                .is_none(),
+            "suspend gap must reset the baseline, not alert"
+        );
+
+        // Re-baselined from the wake instant: a genuine post-wake stall still fires.
+        let mut fired = None;
+        for k in 1..=20u64 {
+            let now = after_suspend + si * k as u32;
+            if let Some(a) = d.observe(now, Some(snap(2, Phase::Handler(0)))) {
+                fired = Some(a);
+                break;
+            }
+        }
+        assert!(
+            fired.is_some(),
+            "detector still works after a suspend reset"
+        );
+    }
+
+    /// #5b: a torn read (writer mid-publish → `None` snapshot) is skipped, not
+    /// mistaken for progress or a stall.
+    #[test]
+    fn detector_skips_torn_snapshots() {
+        let thr = Duration::from_millis(40);
+        let si = Duration::from_millis(5);
+        let t0 = Instant::now();
+        let mut d = StallDetector::new(thr, si, t0, Some(snap(2, Phase::Handler(0))));
+        // Interleave torn reads with real stuck reads; still alerts once elapsed.
+        let mut fired = None;
+        for k in 1..=20u64 {
+            let now = t0 + si * k as u32;
+            let s = if k % 2 == 0 {
+                None
+            } else {
+                Some(snap(2, Phase::Handler(0)))
+            };
+            if let Some(a) = d.observe(now, s) {
+                fired = Some(a);
+                break;
+            }
+        }
+        assert!(
+            matches!(fired, Some(Alert { generation: 2, .. })),
+            "torn reads are skipped but a persistent stall still alerts"
+        );
+    }
+
+    /// #10: two hosts track independently — a stall on one does not alert for the
+    /// other, and each keeps its own dedup/re-arm state.
+    #[test]
+    fn detectors_two_hosts_are_independent() {
+        let thr = Duration::from_millis(40);
+        let si = Duration::from_millis(5);
+        let t0 = Instant::now();
+        let mut daemon = StallDetector::new(thr, si, t0, Some(snap(2, Phase::Handler(0))));
+        let mut app = StallDetector::new(thr, si, t0, Some(snap(2, Phase::Handler(0))));
+
+        // The app host keeps progressing; the daemon host is stuck.
+        let mut daemon_fired = false;
+        for k in 1..=20u64 {
+            let now = t0 + si * k as u32;
+            // app advances its generation every sample (always progressing).
+            assert!(
+                app.observe(now, Some(snap(2 + 2 * k, Phase::Handler(k as u32 % 3))))
+                    .is_none(),
+                "a progressing host never alerts"
+            );
+            if daemon
+                .observe(now, Some(snap(2, Phase::Handler(0))))
+                .is_some()
+            {
+                daemon_fired = true;
+            }
+        }
+        assert!(
+            daemon_fired,
+            "the stuck daemon host must alert independently"
+        );
+    }
+
+    // ── Seqlock concurrency stress (#3.9 concurrent-state) ─────────────────
+
+    /// Under a concurrent writer, every accepted snapshot is torn-free: settled
+    /// (even) generation, monotonic non-decreasing, and a valid phase.
+    #[test]
+    fn seqlock_reader_never_sees_torn_state() {
+        let progress = TickProgress::new("stress-tick", Arc::from(vec!["h0", "h1", "h2"]));
+        let writer = Arc::clone(&progress);
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_w = Arc::clone(&stop);
+        let handle = std::thread::spawn(move || {
+            let mut i = 0u32;
+            while !stop_w.load(Ordering::Relaxed) {
+                match i % 4 {
+                    0 => writer.enter_waiting(),
+                    1 => writer.enter_preflight(),
+                    2 => writer.enter_handler(i % 3),
+                    _ => writer.enter_post(),
+                }
+                i = i.wrapping_add(1);
+            }
+        });
+
+        let mut last_gen = 0u64;
+        for _ in 0..200_000 {
+            if let Some(s) = progress.snapshot() {
+                assert_eq!(
+                    s.generation % 2,
+                    0,
+                    "a settled snapshot has even generation"
+                );
+                assert!(
+                    s.generation >= last_gen,
+                    "generation is monotonic non-decreasing"
+                );
+                last_gen = s.generation;
+                // `unpack` always yields a valid variant — a torn tag can't panic.
+                let _ = s.phase.label();
+            }
+        }
+        stop.store(true, Ordering::Relaxed);
+        let _ = handle.join();
+    }
+
+    // ── Env gating (Q4) ────────────────────────────────────────────────────
+
+    /// Unset/0 disable silently; 1..=9 are invalid (disable, never clamp);
+    /// >=10 enable at that value; malformed disables.
+    #[test]
+    fn env_threshold_parsing_matches_q4() {
+        use super::parse_threshold;
+        assert_eq!(parse_threshold(None), None, "unset → disabled");
+        assert_eq!(parse_threshold(Some("")), None, "empty → disabled");
+        assert_eq!(parse_threshold(Some("0")), None, "0 → disabled");
+        assert_eq!(
+            parse_threshold(Some("1")),
+            None,
+            "1 → invalid, disabled (no clamp)"
+        );
+        assert_eq!(
+            parse_threshold(Some("9")),
+            None,
+            "9 → invalid, disabled (no clamp)"
+        );
+        assert_eq!(
+            parse_threshold(Some("10")),
+            Some(Duration::from_secs(10)),
+            "10 → enabled at 10s"
+        );
+        assert_eq!(
+            parse_threshold(Some("  45 ")),
+            Some(Duration::from_secs(45)),
+            "whitespace-tolerant; enabled at 45s"
+        );
+        assert_eq!(parse_threshold(Some("nope")), None, "malformed → disabled");
+    }
+
+    // ── #6: attached app starts no monitor (structural source-pin) ─────────
+
+    /// An attached app never ticks, so it must never start a stall monitor. This
+    /// is a structural invariant of the app wiring (same idiom as
+    /// `per_tick::tests::notification_handlers_wire_boot_grace`): a future edit
+    /// that drops the `attached_mode` gate would silently start a monitor on a
+    /// host that never ticks. Also pins the daemon `run_core` host wiring.
+    #[test]
+    fn hosts_wired_daemon_yes_attached_app_no() {
+        let app = std::fs::read_to_string("src/app/mod.rs")
+            .or_else(|_| std::fs::read_to_string("agend-terminal/src/app/mod.rs"))
+            .expect("src/app/mod.rs must be readable");
+        let anchor = app
+            .find("let (app_tick_progress, _app_stall_monitor)")
+            .expect("app must bind the owned-app stall monitor");
+        let region = &app[anchor..(anchor + 600).min(app.len())];
+        assert!(
+            region.contains("if attached_mode"),
+            "the app monitor must be gated on attached_mode"
+        );
+        assert!(
+            region.contains("(None, None)"),
+            "an attached app must resolve to (None, None) — no monitor"
+        );
+        assert!(
+            region.contains("start_for_host(\"app-owned-tick\""),
+            "an owned app starts the app-owned-tick monitor"
+        );
+
+        let daemon = std::fs::read_to_string("src/daemon/mod.rs")
+            .or_else(|_| std::fs::read_to_string("agend-terminal/src/daemon/mod.rs"))
+            .expect("src/daemon/mod.rs must be readable");
+        assert!(
+            daemon.contains("start_for_host(\"daemon-tick\""),
+            "the daemon run_core host starts the daemon-tick monitor"
+        );
     }
 }

--- a/src/daemon/tick_stall.rs
+++ b/src/daemon/tick_stall.rs
@@ -1,0 +1,242 @@
+//! PR4 — opt-in out-of-band tick-stall diagnostics.
+//!
+//! Decision d-20260711043612580372-4. A dedicated, joined per-host monitor
+//! watches the tick host's [`per_tick`](super::per_tick) runner make progress
+//! and pages the operator out-of-band when a handler wedges the tick thread —
+//! WITHOUT ever running on that thread or reusing the blocking bounded tick
+//! producer.
+//!
+//! ## RED anchor (this commit)
+//!
+//! The production tracker (`TickProgress`), the monitor thread
+//! (`TickStallMonitorGuard`), the `AGEND_TICK_STALL_SECS` env gate and the
+//! `delivery_worker` alert job are NOT wired yet — in a release build this
+//! module compiles to **nothing** (every item below is `#[cfg(test)]`), so the
+//! shipping binary is byte-identical to the pre-PR4 daemon.
+//!
+//! What lives here now is only the test scaffolding that pins the desired
+//! behavior:
+//!
+//! * [`test_probe`] — a process-global observation seam. The GREEN alert path
+//!   (the `delivery_worker` `TickStallAlert` dispatch arm) will emit the exact
+//!   escalated `(host, handler)` here under `#[cfg(test)]`, so a test observes
+//!   the real payload without a live Telegram / `event_log` side effect.
+//! * the focused harness `drive_stalled_tick` + the frozen assertion
+//!   `expect_stall_alert`. The harness drives the **real** per-tick runner with
+//!   a `Condvar`-stalled handler (a genuine, deterministic tick stall). In RED
+//!   there is no monitor, so nothing ever feeds the probe and the assertion
+//!   FAILS by watchdog timeout (a real runtime panic — not a compile error and
+//!   not an `is_err`/pass-on-old check). GREEN wires the tracker + monitor +
+//!   delivery job; the harness body starts the monitor and drives the tracked
+//!   runner, and the SAME assertion then receives `host + handler`.
+
+/// Process-global alert-observation seam (test-only). The GREEN production
+/// alert path emits the escalated identity here so tests can assert the exact
+/// out-of-band payload without a real escalation side effect. Mirrors the
+/// `canonical_heartbeat` `test_hooks` static-seam pattern.
+#[cfg(test)]
+pub(crate) mod test_probe {
+    use parking_lot::Mutex;
+    use std::sync::mpsc::{sync_channel, Receiver, SyncSender};
+
+    /// Single install slot. `None` = no test is observing (emit is a no-op).
+    static SINK: Mutex<Option<SyncSender<(String, String)>>> = Mutex::new(None);
+
+    /// RAII install handle: emits are routed to [`ProbeGuard::rx`] until this
+    /// guard drops, which clears the global slot so the next test starts clean.
+    pub(crate) struct ProbeGuard {
+        pub(crate) rx: Receiver<(String, String)>,
+    }
+
+    impl Drop for ProbeGuard {
+        fn drop(&mut self) {
+            *SINK.lock() = None;
+        }
+    }
+
+    /// Begin observing stall-alert emissions. Emits go to the returned guard's
+    /// receiver until it drops.
+    pub(crate) fn install() -> ProbeGuard {
+        let (tx, rx) = sync_channel(16);
+        *SINK.lock() = Some(tx);
+        ProbeGuard { rx }
+    }
+
+    /// Emit an observed `(host, handler)` to the installed probe, if any.
+    /// The GREEN `delivery_worker` `TickStallAlert` dispatch arm calls this
+    /// (under `#[cfg(test)]`) with the exact escalated identity. No-op when no
+    /// probe is installed.
+    pub(crate) fn emit(host: &str, handler: &str) {
+        // Clone the sender out so we never hold the lock across `try_send`.
+        let sink = SINK.lock().clone();
+        if let Some(tx) = sink {
+            let _ = tx.try_send((host.to_string(), handler.to_string()));
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::test_probe;
+    use crate::agent::{AgentRegistry, ExternalRegistry};
+    use crate::daemon::per_tick::{run_handlers_with_panic_guard, PerTickHandler, TickContext};
+    use parking_lot::{Condvar, Mutex};
+    use std::collections::HashMap;
+    use std::sync::mpsc::Receiver;
+    use std::sync::Arc;
+    use std::thread::JoinHandle;
+    use std::time::Duration;
+
+    /// The probe + delivery-worker force-full seams are process-global; serialize
+    /// stall-diagnostics tests so they don't observe each other's emissions.
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Failure ceiling for the frozen assertion. In RED nothing ever emits, so
+    /// the RED test blocks the full watchdog then panics. In GREEN the monitor
+    /// emits within a few injected sample intervals (≪ watchdog), so the pass is
+    /// fast; the watchdog is only the timeout guard, never the happy path.
+    const WATCHDOG: Duration = Duration::from_secs(2);
+    /// Stable handler identity the alert must name.
+    const STALL_HANDLER: &str = "slow_handler";
+    /// Stable daemon host label (matches the GREEN payload label — Q5).
+    const DAEMON_HOST: &str = "daemon-tick";
+
+    /// A per-tick handler whose `run` blocks on a `Condvar` until released — a
+    /// real, deterministic stall of the runner thread (no sleeps, no timing).
+    struct BlockingHandler {
+        gate: Arc<(Mutex<bool>, Condvar)>,
+    }
+
+    impl PerTickHandler for BlockingHandler {
+        fn name(&self) -> &'static str {
+            STALL_HANDLER
+        }
+        fn run(&self, _ctx: &TickContext<'_>) {
+            let (lock, cv) = &*self.gate;
+            let mut released = lock.lock();
+            while !*released {
+                cv.wait(&mut released);
+            }
+        }
+    }
+
+    /// The mutable RED↔GREEN SEAM (`drive_stalled_tick` + this struct).
+    ///
+    /// RED: install the probe and spawn the **real** untracked runner
+    /// ([`run_handlers_with_panic_guard`]) with a `Condvar`-stalled handler.
+    /// There is no monitor, so nothing ever feeds the probe.
+    ///
+    /// GREEN (follow-up commit): additionally build an `Arc<TickProgress>`,
+    /// start the joined `TickStallMonitorGuard` on a short injected interval,
+    /// and drive `run_handlers_with_progress` so the monitor samples the stall
+    /// and the delivery path feeds the probe. Only this seam changes — the
+    /// `#[test]` below and `expect_stall_alert` stay byte-identical.
+    struct StalledTick {
+        probe: test_probe::ProbeGuard,
+        gate: Arc<(Mutex<bool>, Condvar)>,
+        runner: Option<JoinHandle<()>>,
+    }
+
+    impl StalledTick {
+        fn rx(&self) -> &Receiver<(String, String)> {
+            &self.probe.rx
+        }
+    }
+
+    impl Drop for StalledTick {
+        fn drop(&mut self) {
+            // Release the stalled handler so the runner thread can finish, then
+            // join it — no leaked thread even when the assertion panicked.
+            {
+                let (lock, cv) = &*self.gate;
+                *lock.lock() = true;
+                cv.notify_all();
+            }
+            if let Some(handle) = self.runner.take() {
+                let _ = handle.join();
+            }
+        }
+    }
+
+    fn drive_stalled_tick() -> StalledTick {
+        let probe = test_probe::install();
+        let gate = Arc::new((Mutex::new(false), Condvar::new()));
+        let gate_for_runner = Arc::clone(&gate);
+        // Owned fixture is moved into the runner thread; the borrowing
+        // `TickContext` is constructed INSIDE the closure so the closure is
+        // `'static` (a stalled runner outlives this function's frame).
+        let runner = std::thread::spawn(move || {
+            let home = std::env::temp_dir();
+            let registry: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
+            let externals: ExternalRegistry = Arc::new(Mutex::new(HashMap::new()));
+            let configs: Arc<Mutex<HashMap<String, crate::daemon::AgentConfig>>> =
+                Arc::new(Mutex::new(HashMap::new()));
+            let ctx = TickContext {
+                home: &home,
+                registry: &registry,
+                externals: &externals,
+                configs: &configs,
+            };
+            let handlers: Vec<Box<dyn PerTickHandler>> = vec![Box::new(BlockingHandler {
+                gate: gate_for_runner,
+            })];
+            // RED: the real runner blocks inside `BlockingHandler::run`; no
+            // monitor is watching, so no out-of-band stall alert is emitted.
+            run_handlers_with_panic_guard(&handlers, &ctx);
+        });
+        StalledTick {
+            probe,
+            gate,
+            runner: Some(runner),
+        }
+    }
+
+    /// FROZEN assertion — byte-identical in RED and GREEN. While the real runner
+    /// is stalled inside a handler, an out-of-band stall alert naming
+    /// `(host, handler)` must reach the probe within the watchdog. RED has no
+    /// monitor → `recv_timeout` expires → panic. GREEN's monitor + delivery job
+    /// feed the probe → the same recv succeeds and the identities match.
+    fn expect_stall_alert(rx: &Receiver<(String, String)>, want_host: &str, want_handler: &str) {
+        match rx.recv_timeout(WATCHDOG) {
+            Ok((host, handler)) => {
+                assert_eq!(host, want_host, "stall alert host label");
+                assert_eq!(handler, want_handler, "stall alert handler identity");
+            }
+            Err(_) => panic!(
+                "RED: expected an out-of-band tick-stall alert host={want_host} \
+                 handler={want_handler} while the real per-tick runner is \
+                 Condvar-stalled, but none arrived within {WATCHDOG:?}"
+            ),
+        }
+    }
+
+    /// The observation seam itself must faithfully route an emitted identity to
+    /// the installed receiver, so a GREEN stall-test failure can only mean "no
+    /// monitor emit", never "the probe is broken". (Also exercises the emit path
+    /// the GREEN `delivery_worker` dispatch arm will call.)
+    #[test]
+    fn probe_seam_roundtrips_host_and_handler() {
+        let _serial = TEST_LOCK.lock();
+        let probe = test_probe::install();
+        test_probe::emit(DAEMON_HOST, STALL_HANDLER);
+        let (host, handler) = probe
+            .rx
+            .recv_timeout(WATCHDOG)
+            .expect("installed probe must receive the emitted alert");
+        assert_eq!(host, DAEMON_HOST);
+        assert_eq!(handler, STALL_HANDLER);
+    }
+
+    /// A wedged handler must raise an out-of-band alert that names the daemon
+    /// host and the exact stalled handler. RED-anchor: FAILS by watchdog timeout
+    /// (no monitor emits); GREEN wires the monitor + delivery job and the same
+    /// assertion receives `daemon-tick` / `slow_handler`.
+    #[test]
+    fn stall_alert_names_blocked_handler_on_daemon_host() {
+        let _serial = TEST_LOCK.lock();
+        let st = drive_stalled_tick();
+        expect_stall_alert(st.rx(), DAEMON_HOST, STALL_HANDLER);
+        // `st` drops here → releases the stalled handler + joins the runner.
+    }
+}

--- a/src/daemon/tick_stall.rs
+++ b/src/daemon/tick_stall.rs
@@ -53,8 +53,9 @@ const TICK_PERIOD_SLACK: Duration = Duration::from_secs(10);
 /// the 0-based index into the host's immutable handler-name table.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub(crate) enum Phase {
-    /// Idle, blocked awaiting the next tick signal — never alerted (a long wait
-    /// between ticks is normal, not a stall).
+    /// Idle, blocked awaiting the next tick signal. Ordinary between-tick cadence
+    /// stays silent (the generation advances every tick); a host frozen here past
+    /// the larger waiting-threshold — a dead tick producer — pages as `<waiting>`.
     Waiting,
     /// Per-tick config reloads before the handler sweep.
     Preflight,
@@ -288,11 +289,20 @@ pub(crate) struct MonitorConfig {
 }
 
 impl MonitorConfig {
-    /// Build from `AGEND_TICK_STALL_SECS`; `None` when disabled / invalid.
+    /// Build from `AGEND_TICK_STALL_SECS`; `None` when disabled / invalid / so
+    /// large the waiting threshold would overflow `Duration`.
     pub(crate) fn from_env(home: &Path) -> Option<Self> {
         let threshold = threshold_from_env()?;
+        let Some(waiting_threshold) = waiting_threshold_for(threshold) else {
+            tracing::warn!(
+                threshold_secs = threshold.as_secs(),
+                "{ENV_VAR} is so large the waiting threshold overflows Duration — \
+                 tick-stall diagnostics DISABLED"
+            );
+            return None;
+        };
         Some(Self {
-            waiting_threshold: threshold + TICK_PERIOD_SLACK,
+            waiting_threshold,
             sample_interval: sample_interval_for(threshold),
             threshold,
             home: home.to_path_buf(),
@@ -319,6 +329,15 @@ impl MonitorConfig {
 /// ≤ ~1.25× threshold), floored at 1s so the monitor never busy-loops.
 fn sample_interval_for(threshold: Duration) -> Duration {
     (threshold / 4).max(Duration::from_secs(1))
+}
+
+/// The `Waiting`-phase threshold for a base threshold (`threshold + slack`).
+/// Returns `None` when the base is so large the add would overflow `Duration`
+/// (e.g. `AGEND_TICK_STALL_SECS=u64::MAX`): the caller disables the diagnostics
+/// with a warning rather than panicking at startup — `Duration + Duration` panics
+/// on overflow, so the addition MUST stay checked.
+fn waiting_threshold_for(threshold: Duration) -> Option<Duration> {
+    threshold.checked_add(TICK_PERIOD_SLACK)
 }
 
 /// Parse `AGEND_TICK_STALL_SECS`. Unset / `0` → disabled (no warning). `1..=9` →
@@ -446,18 +465,20 @@ fn monitor_loop(progress: &TickProgress, config: &MonitorConfig, stop_rx: &Recei
 }
 
 /// Start the tick-stall diagnostics for a host, IF `AGEND_TICK_STALL_SECS`
-/// enables them. Returns `(Some(progress), Some(guard))` when enabled and
-/// `(None, None)` when disabled — so the default-OFF tick loop stays byte-for-
-/// byte untracked (no atomic writes, no monitor thread). The progress `Arc` is
-/// the loop's writer handle; the guard stops+joins the monitor on drop. One-line
-/// wiring for the daemon `run_core` and owned-app tick loops.
+/// enables them. Returns `(Some(progress), Some(guard))` only when enabled AND
+/// the monitor thread spawned; `(None, None)` when the diagnostics are disabled
+/// (default OFF / invalid / overflowing value) OR the monitor thread failed to
+/// spawn — either way the tick loop stays untracked (no orphan atomic writes with
+/// nothing reading them). The progress `Arc` is the loop's writer handle; the
+/// guard stops+joins the monitor on drop. One-line wiring for the daemon
+/// `run_core` and owned-app tick loops.
 pub(crate) fn start_for_host(
     host: &'static str,
     handlers: &[Box<dyn super::per_tick::PerTickHandler>],
     home: &Path,
 ) -> (Option<Arc<TickProgress>>, Option<TickStallMonitorGuard>) {
     let Some(config) = MonitorConfig::from_env(home) else {
-        return (None, None); // disabled → truly untracked
+        return (None, None); // disabled / invalid / overflowing → truly untracked
     };
     let names: Arc<[&'static str]> = handlers.iter().map(|h| h.name()).collect();
     let progress = TickProgress::new(host, names);
@@ -755,7 +776,7 @@ mod tests {
             .expect("monitor thread must spawn in tests");
 
         let (done_tx, done_rx) = std::sync::mpsc::channel();
-        std::thread::spawn(move || {
+        let dropper = std::thread::spawn(move || {
             drop(guard); // stop + join
             let _ = done_tx.send(());
         });
@@ -763,6 +784,9 @@ mod tests {
             done_rx.recv_timeout(Duration::from_secs(5)).is_ok(),
             "Stop must wake recv_timeout and join promptly; a hang would exceed the watchdog"
         );
+        // Reached only on success (the assert panics on timeout before this): the
+        // dropper already signalled, so the join completes at once — no leaked thread.
+        let _ = dropper.join();
     }
 
     // ── Detector unit tests (deterministic, no threads) ────────────────────
@@ -1092,6 +1116,32 @@ mod tests {
             "whitespace-tolerant; enabled at 45s"
         );
         assert_eq!(parse_threshold(Some("nope")), None, "malformed → disabled");
+    }
+
+    /// r2 regression: `AGEND_TICK_STALL_SECS=u64::MAX` parses fine (>= 10) but the
+    /// waiting threshold (`base + 10s`) would overflow `Duration` and panic at
+    /// startup. The checked add must instead disable (`None`), never crash.
+    #[test]
+    fn oversized_threshold_disables_instead_of_overflowing() {
+        use super::{parse_threshold, waiting_threshold_for};
+        // The parser accepts any u64 >= 10, u64::MAX included (r1 semantics).
+        assert_eq!(
+            parse_threshold(Some("18446744073709551615")),
+            Some(Duration::from_secs(u64::MAX)),
+            "parser accepts u64::MAX"
+        );
+        // But composing the waiting threshold must NOT overflow-panic — it
+        // returns None so from_env disables the diagnostics.
+        assert_eq!(
+            waiting_threshold_for(Duration::from_secs(u64::MAX)),
+            None,
+            "u64::MAX base → overflow → disabled (no panic)"
+        );
+        // A normal value still composes to base + 10s.
+        assert_eq!(
+            waiting_threshold_for(Duration::from_secs(10)),
+            Some(Duration::from_secs(20))
+        );
     }
 
     // ── #6: attached app starts no monitor (structural source-pin) ─────────


### PR DESCRIPTION
<!-- LOC-EST: 950-1250 -->

## PR4 — opt-in out-of-band tick-stall diagnostics

Implements decision **d-20260711043612580372-4** (task `t-20260711043639920994-41952-6`). A dedicated, joined per-host monitor watches the tick host's `per_tick` runner make progress and pages the operator **out-of-band** when a handler (or a preflight / post-handler step) wedges the tick thread — without ever running on that thread, blocking it, or reusing the blocking bounded tick producer.

**Default OFF.** Enabled only when `AGEND_TICK_STALL_SECS >= 10`. When unset/`0`, `start_for_host` returns `None` and the tick loop is byte-identical to pre-PR4 (no atomic writes, no monitor thread).

### What it adds
- **`TickProgress`** — per-host `Arc`, packed `phase|handler_index` state + an **odd/even seqlock** `generation` giving the monitor a torn-free, lock-free `(phase, generation)` snapshot (`Release`/`Acquire`). Sole writer is the tick thread; the monitor only reads atomics, so it can never be stalled by the stall it watches.
- **`StallDetector`** — the stall decision extracted as a pure, clock-injected state machine (deterministically unit-tested): non-`Waiting` no-progress past threshold ⇒ one alert per outage; re-arms on progress; resets on a suspend/sample-gap.
- **`TickStallMonitorGuard`** — dedicated joined monitor thread with a stop channel + stored `JoinHandle`; `recv_timeout` sampling gives prompt stop+join on `Drop`; monitor-local `Instant` only.
- **`run_handlers_with_progress`** (per_tick companion) — publishes `Handler(i)` before each handler and advances after `catch_unwind` on **both** the Ok and panic paths (a panicked handler never leaves stale identity). `run_handlers_with_panic_guard` retained as the untracked wrapper.
- **`DeliveryJob::TickStallAlert`** — the monitor `try_send`s it; the delivery worker (off the tick thread) owns the `event_log` write + escalation fan-out. A full queue is a `tracing::error` observable drop carrying host/phase/generation — never a block.
- Wired into daemon `run_core` (Waiting → Preflight → Handler(i) → PostHandlers, PostHandlers also covering crash-dispatch) and the **owned** app maintenance host. An **attached** app never ticks, so it starts no monitor.

Host labels: `daemon-tick`, `app-owned-tick`.

### Race-class discipline (§3.20)
**SOP-1 answer — is there a race, and a deterministic test without timing dependence?** Yes and yes. The race is the tick-thread writer vs. monitor-thread reader of `TickProgress`, plus the monitor lifecycle. It is tested deterministically with **no sleeps/timing dependence**:
- The e2e assertion drives the **real** `run_handlers_with_progress` with a `Condvar`-gated handler (a genuine, deterministic stall) and asserts the real monitor→`delivery_worker`→probe path yields the exact `host+handler`.
- The decision logic is a pure `StallDetector` fed synthetic `(Instant, snapshot)` — waiting/dedup/re-arm/suspend-reset/torn-read/dual-host all deterministic.
- A concurrent writer/reader seqlock stress (200k reads) asserts every accepted snapshot is torn-free (even generation, monotonic, valid phase).
- **20× serial** run of the concurrency-sensitive tests: 20/20.

### Test-first (§3.10)
- RED anchor `dcc1e8fd` — tests + `cfg(test)` seams only, zero production behavior; `stall_alert_names_blocked_handler_on_daemon_host` FAILS by watchdog timeout while the real runner is Condvar-gated. (`git checkout dcc1e8fd` → fail.)
- GREEN `3a41aabc` — wires the tracker/monitor/env/delivery; the **same frozen assertion** now receives `daemon-tick`/`slow_handler`. (`git checkout 3a41aabc` → pass.)

### Scope
Touches only `src/daemon/tick_stall.rs` (new), `src/daemon/{mod,per_tick/mod,delivery_worker}.rs`, `src/app/mod.rs`. **Excludes** (per decision): ticker `try_send` conversion, app/run_core unification, `HeartbeatPair`, handler offloads, timeout-policy changes.

### Local evidence
- `cargo nextest run` (no bypass): **5391 passed, 36 skipped, 0 failed**.
- `cargo clippy --lib --bin agend-terminal --bin agend-git --bin agend-mcp-bridge --tests --examples --features tray -- -D warnings`: clean.
- `cargo fmt --check`: clean (own tracked sources).
- 20× serial race stress: 20/20.

### Scope-overage note (§5.2)
~1180 added LOC, but production is ~350; the remainder is the deterministic test matrix (12 tick-stall tests + delivery/queue-full) and doc comments — cohesive to this single feature, no unrelated changes.

---
*archfix-claude-opus* · claude-opus-4-8
