### PR TITLE
fix(inbox): settle answered parent row after successful parented inter-agent send

### DIFF
--- a/src/agent_ops.rs
+++ b/src/agent_ops.rs
@@ -826,6 +826,79 @@ mod tests {
         std::fs::remove_dir_all(&home).ok();
     }
 
+    /// #2730: the API-down fallback fork must NOT settle the sender's parent row
+    /// when the fallback enqueue itself fails. Mirror of the normal-fork test
+    /// (`messaging/tests.rs::failed_parented_send_does_not_settle_sender_parent`)
+    /// through `fallback_deliver`: the settle seam is wired only past the enqueue
+    /// Ok, so a lost fallback message must leave the parent unprocessed.
+    #[test]
+    fn failed_fallback_delivery_does_not_settle_sender_parent() {
+        let home = tmp_home("fallback-fail-no-settle");
+        let (sender, target) = ("ffns-worker", "ffns-peer");
+        std::fs::write(
+            crate::fleet::fleet_yaml_path(&home),
+            format!("instances:\n  {target}:\n    backend: claude\n"),
+        )
+        .unwrap();
+        // Seed + drain a real delivering parent row in the SENDER's own inbox.
+        let pid = "m-ffns-parent";
+        crate::inbox::enqueue(
+            &home,
+            sender,
+            crate::inbox::InboxMessage {
+                schema_version: 1,
+                id: Some(pid.to_string()),
+                from: "codex".to_string(),
+                text: "q".to_string(),
+                kind: Some("query".to_string()),
+                timestamp: chrono::Utc::now().to_rfc3339(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        crate::inbox::drain(&home, sender); // parent: unread → delivering
+
+        // Break ONLY the target's inbox jsonl (dir) so the fallback enqueue fails.
+        std::fs::create_dir_all(home.join("inbox").join(format!("{target}.jsonl"))).unwrap();
+
+        let reply = crate::inbox::InboxMessage {
+            schema_version: 1,
+            id: Some("m-ffns-reply".to_string()),
+            from: sender.to_string(),
+            text: "answered".to_string(),
+            kind: Some("report".to_string()),
+            timestamp: chrono::Utc::now().to_rfc3339(),
+            parent_id: Some(pid.to_string()),
+            ..Default::default()
+        };
+        let resp = fallback_deliver(
+            &home,
+            sender,
+            target,
+            "answered",
+            reply,
+            &anyhow::anyhow!("api down"),
+        );
+        assert!(
+            resp.get("error").is_some(),
+            "the fallback enqueue must fail when the target inbox is broken: {resp}"
+        );
+
+        // The sender's parent row must remain unprocessed — settle must NOT fire.
+        let path = crate::inbox::storage::inbox_path_resolved(&home, sender);
+        let body = std::fs::read_to_string(&path).unwrap();
+        let row = body
+            .lines()
+            .filter_map(|l| serde_json::from_str::<serde_json::Value>(l).ok())
+            .find(|v| v.get("id").and_then(|x| x.as_str()) == Some(pid))
+            .expect("sender parent row must still exist");
+        assert!(
+            row.get("read_at").is_none_or(|r| r.is_null()),
+            "a FAILED fallback delivery must not settle the sender parent: {row}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
     /// t-20260705005551919287-14440-22: `send_to`'s API-down fallback hardcoded
     /// `kind: None` when handing off to `inbox::deliver` — losing the ORIGINAL
     /// message kind (`"query"`/`"task"`/etc, threaded through fine on the

--- a/src/agent_ops.rs
+++ b/src/agent_ops.rs
@@ -38,6 +38,8 @@ pub fn fallback_deliver(
     if !in_fleet {
         return json!({"error": format!("target instance '{target}' not found in fleet.yaml (API unavailable: {api_error})")});
     }
+    // Capture the answered parent before `msg` is moved into enqueue below.
+    let parent_id = msg.parent_id.clone();
     // #bughunt2: this is the last-resort path (the daemon API is already down),
     // so the inbox is the SOLE channel. A swallowed enqueue here is total,
     // unrecoverable message loss reported as success — surface it instead.
@@ -48,6 +50,10 @@ pub fn fallback_deliver(
             )
         });
     }
+    // Confirmed-successful fallback delivery: settle the SENDER's own parent row
+    // so an answered obligation stops re-nagging via poll-reminder. No-ops when
+    // parent_id is None; the failed-enqueue early return above skips it.
+    crate::inbox::settle_parent_after_successful_send(home, from, parent_id.as_deref());
     crate::inbox::notify_agent(home, target, &crate::inbox::NotifySource::Agent(from), text);
     json!({"target": target, "delivery_mode": "inbox_fallback", "note": format!("API unavailable: {api_error}")})
 }

--- a/src/agent_ops.rs
+++ b/src/agent_ops.rs
@@ -858,8 +858,14 @@ mod tests {
         .unwrap();
         crate::inbox::drain(&home, sender); // parent: unread → delivering
 
-        // Break ONLY the target's inbox jsonl (dir) so the fallback enqueue fails.
-        std::fs::create_dir_all(home.join("inbox").join(format!("{target}.jsonl"))).unwrap();
+        // Break ONLY the target's RESOLVED inbox path (dir) so the fallback
+        // enqueue fails. Must be the RESOLVED (not raw-name) path — on Windows
+        // inbox_path_resolved migrates name→UUID, so a raw-name-path directory is
+        // bypassed and the UUID path succeeds (#2730 r2 Windows failure). Breaking
+        // the resolved path makes enqueue hit the id_path-exists branch on BOTH
+        // platforms (no symlink/copy migration divergence).
+        let target_path = crate::inbox::storage::inbox_path_resolved(&home, target);
+        std::fs::create_dir_all(&target_path).unwrap();
 
         let reply = crate::inbox::InboxMessage {
             schema_version: 1,

--- a/src/api/handlers/messaging.rs
+++ b/src/api/handlers/messaging.rs
@@ -732,6 +732,10 @@ pub(crate) fn handle_send(params: &Value, ctx: &HandlerCtx) -> Value {
             });
         }
     };
+    // Answered-parent settlement: a confirmed-successful parented send discharges
+    // the SENDER's own parent row so it stops re-nagging via poll-reminder. Runs
+    // only past the failed-send early return above; no-ops when parent_id is None.
+    crate::inbox::settle_parent_after_successful_send(ctx.home, vs.from, msg.parent_id.as_deref());
     inject_provenance(params, vs.from, vs.target);
     let branch_checked_out = checkout_branch_if_requested(params, ctx.home, vs.target);
     process_verdicts(ctx.home, vs.from, &msg);

--- a/src/api/handlers/messaging/tests.rs
+++ b/src/api/handlers/messaging/tests.rs
@@ -108,10 +108,15 @@ fn failed_parented_send_does_not_settle_sender_parent() {
     .unwrap();
     crate::inbox::drain(&home, sender); // parent: unread → delivering
 
-    // Force ONLY the target's enqueue to fail: its inbox jsonl as a DIRECTORY
-    // makes the append inside route_and_deliver error, without touching the
-    // sender's inbox.
-    std::fs::create_dir_all(home.join("inbox").join(format!("{target}.jsonl"))).unwrap();
+    // Force ONLY the target's enqueue to fail, without touching the sender's
+    // inbox: make the target's RESOLVED inbox path a directory so the append
+    // inside route_and_deliver errors. Must be the RESOLVED (not raw-name) path —
+    // on Windows inbox_path_resolved migrates name→UUID, so a raw-name-path
+    // directory is bypassed and the UUID path succeeds (#2730 r2 Windows failure).
+    // Breaking the resolved path makes enqueue hit the id_path-exists branch on
+    // BOTH platforms (no symlink/copy migration divergence).
+    let target_path = crate::inbox::storage::inbox_path_resolved(&home, target);
+    std::fs::create_dir_all(&target_path).unwrap();
 
     let ctx = test_ctx(&home);
     let resp = handle_send(

--- a/src/api/handlers/messaging/tests.rs
+++ b/src/api/handlers/messaging/tests.rs
@@ -75,6 +75,70 @@ fn send_surfaces_enqueue_failure_not_fake_ok() {
     std::fs::remove_dir_all(&home).ok();
 }
 
+/// #2730: a FAILED parented send must NOT settle the sender's parent row. The
+/// settle seam is wired only past a successful `route_and_deliver`; a delivery
+/// failure early-returns before it. Seed + drain a real delivering parent row in
+/// the SENDER's own inbox, force ONLY the target's enqueue to fail (its inbox
+/// jsonl is made a directory, so the sender's inbox stays usable), then prove the
+/// parent row is still unprocessed (`read_at` unset) — settle did not fire.
+#[test]
+fn failed_parented_send_does_not_settle_sender_parent() {
+    let home = tmp_home("failed-send-no-settle");
+    let (sender, target) = ("fsns-worker", "fsns-peer");
+    std::fs::write(
+        crate::fleet::fleet_yaml_path(&home),
+        format!("instances:\n  {target}:\n    backend: claude\n"),
+    )
+    .unwrap();
+    // Seed + drain a real delivering parent row in the SENDER's own inbox.
+    let pid = "m-fsns-parent";
+    crate::inbox::enqueue(
+        &home,
+        sender,
+        crate::inbox::InboxMessage {
+            schema_version: 1,
+            id: Some(pid.to_string()),
+            from: "codex".to_string(),
+            text: "q".to_string(),
+            kind: Some("query".to_string()),
+            timestamp: chrono::Utc::now().to_rfc3339(),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    crate::inbox::drain(&home, sender); // parent: unread → delivering
+
+    // Force ONLY the target's enqueue to fail: its inbox jsonl as a DIRECTORY
+    // makes the append inside route_and_deliver error, without touching the
+    // sender's inbox.
+    std::fs::create_dir_all(home.join("inbox").join(format!("{target}.jsonl"))).unwrap();
+
+    let ctx = test_ctx(&home);
+    let resp = handle_send(
+        &json!({"from": sender, "target": target, "kind": "report", "parent_id": pid, "text": "answered"}),
+        &ctx,
+    );
+    assert_eq!(
+        resp["ok"], false,
+        "the send must fail when the target enqueue is broken: {resp}"
+    );
+
+    // The sender's parent row must remain unprocessed — settle must NOT fire on
+    // the failure path.
+    let path = crate::inbox::storage::inbox_path_resolved(&home, sender);
+    let body = std::fs::read_to_string(&path).unwrap();
+    let row = body
+        .lines()
+        .filter_map(|l| serde_json::from_str::<serde_json::Value>(l).ok())
+        .find(|v| v.get("id").and_then(|x| x.as_str()) == Some(pid))
+        .expect("sender parent row must still exist");
+    assert!(
+        row.get("read_at").is_none_or(|r| r.is_null()),
+        "a FAILED send must not settle the sender parent (read_at must stay unset): {row}"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
 #[test]
 fn test_send_to_fleet_defined_instance_succeeds() {
     let home = tmp_home("fleet-defined");

--- a/src/daemon/poll_reminder.rs
+++ b/src/daemon/poll_reminder.rs
@@ -360,6 +360,209 @@ mod tests {
         std::fs::remove_dir_all(&home).ok();
     }
 
+    // ── #interagent-parent-settlement RED anchor ───────────────────────────
+    // A successful parented inter-agent send must settle the SENDER's own
+    // parent inbox row so the answered obligation stops cycling
+    // delivering→unread (reclaim 600s TTL) and re-nagging via poll-reminder.
+    // These drive the REAL send entries (handle_send / fallback_deliver /
+    // real task-send record_dispatch) → age the parent row past the reclaim
+    // TTL → real reclaim_stale_delivering → real collect_poll_reminders, and
+    // assert the sender is NOT nagged. RED (pre-fix): the sender IS nagged, so
+    // each `assert!(!nagged)` FAILS behaviorally. GREEN wires the settle seam.
+
+    fn write_fleet(home: &Path, names: &[&str]) {
+        let mut s = String::from("instances:\n");
+        for n in names {
+            s.push_str(&format!("  {n}:\n    backend: claude\n"));
+        }
+        std::fs::write(crate::fleet::fleet_yaml_path(home), s).ok();
+    }
+
+    fn inbox_msg(
+        id: &str,
+        from: &str,
+        kind: &str,
+        parent_id: Option<&str>,
+    ) -> crate::inbox::InboxMessage {
+        crate::inbox::InboxMessage {
+            schema_version: 1,
+            id: Some(id.to_string()),
+            from: from.to_string(),
+            text: "x".to_string(),
+            kind: Some(kind.to_string()),
+            timestamp: chrono::Utc::now().to_rfc3339(),
+            parent_id: parent_id.map(String::from),
+            ..Default::default()
+        }
+    }
+
+    fn empty_registry() -> AgentRegistry {
+        Arc::new(Mutex::new(HashMap::new()))
+    }
+
+    fn handler_ctx<'a>(
+        home: &'a Path,
+        registry: &'a AgentRegistry,
+    ) -> crate::api::handlers::HandlerCtx<'a> {
+        // Leak the auxiliary registries for 'static — acceptable in tests
+        // (mirrors messaging/tests.rs::test_ctx).
+        let configs: &'static crate::api::ConfigRegistry =
+            Box::leak(Box::new(Arc::new(Mutex::new(HashMap::new()))));
+        let externals: &'static crate::agent::ExternalRegistry =
+            Box::leak(Box::new(Arc::new(Mutex::new(HashMap::new()))));
+        crate::api::handlers::HandlerCtx {
+            registry,
+            configs,
+            externals,
+            notifier: None,
+            home,
+        }
+    }
+
+    fn aged_601s() -> String {
+        (chrono::Utc::now() - chrono::Duration::seconds(601)).to_rfc3339()
+    }
+
+    fn sender_is_nagged(home: &Path, registry: &AgentRegistry, sender: &str) -> bool {
+        reset_dedup(sender);
+        collect_poll_reminders(home, registry)
+            .iter()
+            .any(|(n, _)| n == sender)
+    }
+
+    /// Q: a bare query answered via the REAL `handle_send` (kind=report,
+    /// parent_id) must not re-nag its sender.
+    #[test]
+    fn answered_query_parent_not_nagged_via_handle_send() {
+        let home = tmp_home("psq");
+        let (a, b) = ("psq-worker", "psq-peer");
+        write_fleet(&home, &[b]);
+        let qid = "m-psq-query";
+        crate::inbox::enqueue(&home, a, inbox_msg(qid, "codex", "query", None)).unwrap();
+        crate::inbox::drain(&home, a); // Q: unread → delivering
+        let registry = mock_registry(a, AgentState::Idle);
+        let ctx = handler_ctx(&home, &registry);
+        let resp = crate::api::handlers::messaging::handle_send(
+            &serde_json::json!({"from": a, "target": b, "kind": "report", "parent_id": qid, "text": "answered"}),
+            &ctx,
+        );
+        assert_eq!(resp["ok"], true, "real send must succeed: {resp}");
+        crate::inbox::storage::set_row_delivering_at_for_test(&home, a, qid, &aged_601s());
+        crate::inbox::reclaim_stale_delivering(&home);
+        assert!(
+            !sender_is_nagged(&home, &registry, a),
+            "answered query parent must not re-nag via poll-reminder"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// F: same as Q but the reply is delivered through the API-down
+    /// `fallback_deliver` entry.
+    #[test]
+    fn answered_query_parent_not_nagged_via_fallback_deliver() {
+        let home = tmp_home("psf");
+        let (a, b) = ("psf-worker", "psf-peer");
+        write_fleet(&home, &[b]);
+        let qid = "m-psf-query";
+        crate::inbox::enqueue(&home, a, inbox_msg(qid, "codex", "query", None)).unwrap();
+        crate::inbox::drain(&home, a);
+        let registry = mock_registry(a, AgentState::Idle);
+        let reply = inbox_msg("m-psf-reply", a, "report", Some(qid));
+        let resp = crate::agent_ops::fallback_deliver(
+            &home,
+            a,
+            b,
+            "answered",
+            reply,
+            &anyhow::anyhow!("api down"),
+        );
+        assert!(
+            resp.get("error").is_none(),
+            "fallback delivery must succeed: {resp}"
+        );
+        crate::inbox::storage::set_row_delivering_at_for_test(&home, a, qid, &aged_601s());
+        crate::inbox::reclaim_stale_delivering(&home);
+        assert!(
+            !sender_is_nagged(&home, &registry, a),
+            "answered query parent (fallback path) must not re-nag"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// T: a REAL task send (handle_send kind=task) creates BOTH the task inbox
+    /// row on the worker AND the PendingDispatch sidecar. After the worker
+    /// answers with a parented `handle_send` (kind=update, parent_id=D), the
+    /// task row must stop nagging AND the original sidecar must stay Pending
+    /// (settlement is orthogonal to the dispatch-idle nudge input).
+    #[test]
+    fn answered_task_parent_not_nagged_and_real_sidecar_stays_pending() {
+        use crate::daemon::dispatch_idle::{list_pending, DispatchStatus};
+        let home = tmp_home("pst");
+        let (a, lead) = ("pst-worker", "pst-lead");
+        write_fleet(&home, &[a, lead]);
+        let corr = "t-pst-1";
+
+        // First REAL task send lead→A: inbox delivery (A not in this send's
+        // registry) enqueues the task row AND track_dispatch records the sidecar.
+        let empty = empty_registry();
+        let ctx1 = handler_ctx(&home, &empty);
+        let dispatch = crate::api::handlers::messaging::handle_send(
+            &serde_json::json!({
+                "from": lead, "target": a, "kind": "task",
+                "task_id": corr, "expect_reply_within_secs": 1800,
+                "text": "do the thing"
+            }),
+            &ctx1,
+        );
+        assert_eq!(
+            dispatch["ok"], true,
+            "task dispatch must succeed: {dispatch}"
+        );
+        assert!(
+            list_pending(&home)
+                .iter()
+                .any(|d| d.correlation_id.as_deref() == Some(corr)),
+            "the REAL task send must create a PendingDispatch sidecar (setup precondition)"
+        );
+
+        // A receives the task row (unread → delivering) and learns its id.
+        let drained = crate::inbox::drain(&home, a);
+        let d_id = drained
+            .iter()
+            .find(|m| m.kind.as_deref() == Some("task"))
+            .and_then(|m| m.id.clone())
+            .expect("task row must have been delivered to the worker");
+
+        // Second REAL send A→lead answering the dispatch row (kind=update, no
+        // correlation_id → does NOT resolve the sidecar).
+        let registry = mock_registry(a, AgentState::Idle);
+        let ctx2 = handler_ctx(&home, &registry);
+        let reply = crate::api::handlers::messaging::handle_send(
+            &serde_json::json!({"from": a, "target": lead, "kind": "update", "parent_id": d_id, "text": "progress"}),
+            &ctx2,
+        );
+        assert_eq!(reply["ok"], true, "parented reply must succeed: {reply}");
+
+        // The dispatch-idle sidecar (sole nudge input) must be UNCHANGED by the
+        // parent-row settle.
+        assert!(
+            list_pending(&home)
+                .iter()
+                .any(|d| d.correlation_id.as_deref() == Some(corr)
+                    && matches!(d.status, DispatchStatus::Pending)),
+            "the REAL PendingDispatch must remain Pending after the parent inbox row is settled"
+        );
+
+        // The answered task-dispatch row must not re-nag via poll-reminder.
+        crate::inbox::storage::set_row_delivering_at_for_test(&home, a, &d_id, &aged_601s());
+        crate::inbox::reclaim_stale_delivering(&home);
+        assert!(
+            !sender_is_nagged(&home, &registry, a),
+            "answered task parent must not re-nag via poll-reminder"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
     /// Restore an env var to its pre-test value on drop. The shadow-observer tests mutate
     /// `AGEND_SHADOW_OBSERVER` / `AGEND_OBSERVED_DISPATCH` process-globally, so they run
     /// `#[serial_test::serial(shadow_observer)]` (same group as the snapshot operated-state

--- a/src/inbox/mod.rs
+++ b/src/inbox/mod.rs
@@ -60,6 +60,23 @@ pub use notify::{
     PENDING_HEADER_PREFIX,
 };
 
+/// Settle the SENDER's own parent inbox row after a confirmed-successful
+/// parented inter-agent send, so an answered obligation stops cycling
+/// delivering→unread (reclaim TTL) and re-nagging via poll-reminder. Mirrors
+/// the channel targeted-reply path (`mcp/handlers/channel.rs` #2622 Fork C).
+/// Kind-independent, sender-scoped, idempotent. NO warn on the returned bool
+/// (`false` = already-read/not-found/no-transition, all benign); genuine
+/// lock/write failures are already warned inside `storage::settle_read_by_id`.
+pub(crate) fn settle_parent_after_successful_send(
+    home: &std::path::Path,
+    sender: &str,
+    parent_id: Option<&str>,
+) {
+    if let Some(pid) = parent_id {
+        let _ = storage::settle_read_by_id(home, sender, pid);
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 #[path = "tests.rs"]

--- a/src/inbox/storage.rs
+++ b/src/inbox/storage.rs
@@ -988,6 +988,40 @@ pub fn settle_read_by_id(home: &Path, name: &str, msg_id: &str) -> bool {
     })
 }
 
+/// Test-only: force one row's `delivering_at` to an explicit rfc3339 timestamp so
+/// a test can age a `delivering` row past [`RECLAIM_TTL_SECS`] deterministically
+/// (no wall-clock sleep) and then exercise the real [`reclaim_stale_delivering`]
+/// path. Rewrites via raw JSON so forward-schema fields survive.
+#[cfg(test)]
+pub(crate) fn set_row_delivering_at_for_test(
+    home: &Path,
+    name: &str,
+    msg_id: &str,
+    ts_rfc3339: &str,
+) {
+    let path = inbox_path_resolved(home, name);
+    let Ok(content) = std::fs::read_to_string(&path) else {
+        return;
+    };
+    let mut out = String::new();
+    for line in content.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<serde_json::Value>(line) {
+            Ok(mut v) => {
+                if v.get("id").and_then(|x| x.as_str()) == Some(msg_id) {
+                    v["delivering_at"] = serde_json::Value::String(ts_rfc3339.to_string());
+                }
+                out.push_str(&serde_json::to_string(&v).unwrap_or_else(|_| line.to_string()));
+            }
+            Err(_) => out.push_str(line),
+        }
+        out.push('\n');
+    }
+    let _ = std::fs::write(&path, out);
+}
+
 /// Session-reset settle: stamp `read_at` on ALL `delivering` rows for `name`,
 /// transitioning them to `processed` so [`reclaim_stale_delivering`] will not
 /// revert them to `unread` for re-delivery.

--- a/src/inbox/storage.rs
+++ b/src/inbox/storage.rs
@@ -2281,10 +2281,18 @@ pub(crate) fn set_row_delivering_at_for_test(
     ts_rfc3339: &str,
 ) {
     let path = inbox_path_resolved(home, name);
-    let Ok(content) = std::fs::read_to_string(&path) else {
-        return;
+    // Fail loudly, never silently no-op: a read failure, wrong id/inbox, or a
+    // setup regression that ages ZERO rows would leave the parent freshly
+    // delivering — reclaim would skip it and a positive poll-reminder test could
+    // pass WITHOUT exercising aged reclaim (false GREEN). #2730 reviewer boundary.
+    let content = match std::fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(e) => {
+            panic!("set_row_delivering_at_for_test: cannot read {name}'s inbox at {path:?}: {e}")
+        }
     };
     let mut out = String::new();
+    let mut aged = 0usize;
     for line in content.lines() {
         if line.trim().is_empty() {
             continue;
@@ -2293,6 +2301,7 @@ pub(crate) fn set_row_delivering_at_for_test(
             Ok(mut v) => {
                 if v.get("id").and_then(|x| x.as_str()) == Some(msg_id) {
                     v["delivering_at"] = serde_json::Value::String(ts_rfc3339.to_string());
+                    aged += 1;
                 }
                 out.push_str(&serde_json::to_string(&v).unwrap_or_else(|_| line.to_string()));
             }
@@ -2300,7 +2309,13 @@ pub(crate) fn set_row_delivering_at_for_test(
         }
         out.push('\n');
     }
-    let _ = std::fs::write(&path, out);
+    assert_eq!(
+        aged, 1,
+        "set_row_delivering_at_for_test: expected exactly one row with id={msg_id} in {name}'s inbox, aged {aged} — the aging seam would silently no-op and could produce a false GREEN"
+    );
+    if let Err(e) = std::fs::write(&path, out) {
+        panic!("set_row_delivering_at_for_test: cannot write {name}'s inbox at {path:?}: {e}");
+    }
 }
 
 #[cfg(test)]

--- a/src/inbox/storage.rs
+++ b/src/inbox/storage.rs
@@ -988,40 +988,6 @@ pub fn settle_read_by_id(home: &Path, name: &str, msg_id: &str) -> bool {
     })
 }
 
-/// Test-only: force one row's `delivering_at` to an explicit rfc3339 timestamp so
-/// a test can age a `delivering` row past [`RECLAIM_TTL_SECS`] deterministically
-/// (no wall-clock sleep) and then exercise the real [`reclaim_stale_delivering`]
-/// path. Rewrites via raw JSON so forward-schema fields survive.
-#[cfg(test)]
-pub(crate) fn set_row_delivering_at_for_test(
-    home: &Path,
-    name: &str,
-    msg_id: &str,
-    ts_rfc3339: &str,
-) {
-    let path = inbox_path_resolved(home, name);
-    let Ok(content) = std::fs::read_to_string(&path) else {
-        return;
-    };
-    let mut out = String::new();
-    for line in content.lines() {
-        if line.trim().is_empty() {
-            continue;
-        }
-        match serde_json::from_str::<serde_json::Value>(line) {
-            Ok(mut v) => {
-                if v.get("id").and_then(|x| x.as_str()) == Some(msg_id) {
-                    v["delivering_at"] = serde_json::Value::String(ts_rfc3339.to_string());
-                }
-                out.push_str(&serde_json::to_string(&v).unwrap_or_else(|_| line.to_string()));
-            }
-            Err(_) => out.push_str(line),
-        }
-        out.push('\n');
-    }
-    let _ = std::fs::write(&path, out);
-}
-
 /// Session-reset settle: stamp `read_at` on ALL `delivering` rows for `name`,
 /// transitioning them to `processed` so [`reclaim_stale_delivering`] will not
 /// revert them to `unread` for re-delivery.
@@ -2296,6 +2262,45 @@ pub(super) fn msg_already_drained_in_jsonl(home: &Path, agent_name: &str, msg_id
         }
     }
     false
+}
+
+/// Test-only: force one row's `delivering_at` to an explicit rfc3339 timestamp so
+/// a test can age a `delivering` row past [`RECLAIM_TTL_SECS`] deterministically
+/// (no wall-clock sleep) and then exercise the real [`reclaim_stale_delivering`]
+/// path. Rewrites via raw JSON so forward-schema fields survive.
+///
+/// Placed here (below the production fns) so its `#[cfg(test)]` attribute never
+/// becomes the first one in the file — the #1617 source-scan invariant test
+/// slices production up to the first `#[cfg(test)]`, so a test helper above
+/// `reclaim_stale_delivering` would truncate its scan region.
+#[cfg(test)]
+pub(crate) fn set_row_delivering_at_for_test(
+    home: &Path,
+    name: &str,
+    msg_id: &str,
+    ts_rfc3339: &str,
+) {
+    let path = inbox_path_resolved(home, name);
+    let Ok(content) = std::fs::read_to_string(&path) else {
+        return;
+    };
+    let mut out = String::new();
+    for line in content.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<serde_json::Value>(line) {
+            Ok(mut v) => {
+                if v.get("id").and_then(|x| x.as_str()) == Some(msg_id) {
+                    v["delivering_at"] = serde_json::Value::String(ts_rfc3339.to_string());
+                }
+                out.push_str(&serde_json::to_string(&v).unwrap_or_else(|_| line.to_string()));
+            }
+            Err(_) => out.push_str(line),
+        }
+        out.push('\n');
+    }
+    let _ = std::fs::write(&path, out);
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What

A confirmed-successful **parented inter-agent send** now settles the **sender's own** parent inbox row, so an answered obligation stops cycling `delivering → unread` (reclaim TTL) and re-nagging via the poll-reminder. Fixes the silent-failure RCA `t-20260711093334407213-85213-0` / decision `d-20260711095706702437-3`.

Root cause: after answering a `query`/`task`/`update` parent via `send`, the sender's parent row stayed `delivering`. The 600s reclaim TTL reverted it to `unread`, and `collect_poll_reminders` then re-nagged the sender about an obligation it had already discharged. The channel targeted-reply path already settles (`mcp/handlers/channel.rs`, #2622 Fork C); inter-agent send did not.

## RED → GREEN

- **RED** `9511bfe1` (preserved): 3 real-path tests + a deterministic `#[cfg(test)]` ager. All 3 fail behaviorally (sender IS re-nagged) through the real `send → aged reclaim_stale_delivering → collect_poll_reminders` path — no wall-clock, no `is_err`/compile-fail.
- **GREEN** `25de102a`: one helper + exactly two success callsites flips them to pass.

## Production surface (minimal — 1 helper + 2 callsites)

- `src/inbox/mod.rs`: `pub(crate) settle_parent_after_successful_send(home, sender, parent_id)` — no-ops on `None`, delegates to the idempotent `storage::settle_read_by_id` (only stamps `read_at` when `None`; internal warns cover genuine lock/write failures, so no warn on the benign `false`).
- `src/api/handlers/messaging.rs` `handle_send`: settle **after** `route_and_deliver` returns `Ok`, past the failed-send early return — a failed send never settles.
- `src/agent_ops.rs` `fallback_deliver` (API-down path): capture `parent_id` **before** `msg` is moved into `enqueue`, settle **after** the enqueue `Ok`.

Plus a **test-infra relocation** in `storage.rs`: the RED-added `#[cfg(test)] set_row_delivering_at_for_test` was placed above `reclaim_stale_delivering`, making it the file's first `#[cfg(test)]` and truncating the #1617 source-scan invariant test (`reclaim_renudge_classifier_runs_unlocked_not_under_inbox_lock`) before its target fn. Moved to the bottom with the other `#[cfg(test)]` items — no production behavior change; restores the file convention and greens the invariant.

**LOC-EST:** ~21 production LOC (helper + 2 callsites incl. comments). `storage.rs` `+39/−34` is a net-zero relocation of a test helper, not new behavior.

## Race class (SOP-1)

Sender-scoped, idempotent write. `settle_read_by_id` takes the same per-agent inbox lock every other inbox writer uses; both callsites invoke it while holding **no** inbox lock, so no new lock-ordering edge is introduced. Concurrent settle vs. reclaim/drain on the same row is safe: settle only transitions `read_at: None → Some`, reclaim/drain no-op on an already-`read` row, and the write is a lock-guarded tmp+rename rewrite. The dispatch-idle `PendingDispatch` sidecar is orthogonal — the T-case test asserts it stays `Pending` after settle.

## Verification

- 3 target tests **PASS** + **20× serial stress** clean.
- Full neighbor suite (`poll_reminder|inbox|messaging|agent_ops|dispatch_idle`) **474/474**.
- `cargo fmt --check` clean (own files; pre-existing `vendor/agentic-git` noise is CI-excluded).
- Strict clippy exact CI gate (`--lib --bin agend-terminal --bin agend-git --bin agend-mcp-bridge --tests --examples --features tray -- -D warnings`) clean.
- Full `cargo nextest run` **5395/5395** (no `AGEND_GIT_BYPASS`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
