### PR TITLE
fix(#2738): bind shadow socket post-flock/pre-fleet — failed-handoff pathname steal

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -775,10 +775,6 @@ fn run_core(home: &Path, source: FleetSource) -> anyhow::Result<()> {
 
     let ctx = init_daemon_services(home, telegram_pre)?;
 
-    // #2413 Shadow Observer — local plane: start the unix-socket hook-event server
-    // (no-op under AGEND_SHADOW_OBSERVER=0; default-ON). Observe-only side-channel; never blocks.
-    crate::daemon::shadow::start(home);
-
     // #event-bus Step 2 (legacy-zero): register the per-pattern delivery
     // subscribers once (the bus is the SOLE delivery path). Shared with
     // `app::run_app` so owned `agend-terminal app` mode wires the IDENTICAL
@@ -847,6 +843,18 @@ fn run_core(home: &Path, source: FleetSource) -> anyhow::Result<()> {
             (agents, Some(lock))
         }
     };
+
+    // #2413/#2738 Shadow Observer — local plane: start the unix-socket hook-event
+    // server (no-op under AGEND_SHADOW_OBSERVER=0; default-ON; observe-only side
+    // channel, never blocks). Placed HERE — after the source match confirms SOLE
+    // ownership (normal boot: `prepare`'s OwnedFleet flock; handoff: flock acquired
+    // above) and immediately BEFORE spawn_fleet_agents. #2738: `start_unix` does a
+    // destructive `remove_file(path)` + `bind(path)`; running it PRE-flock let a
+    // handoff successor unlink+steal a live predecessor's socket pathname, then (if
+    // it aborted before the flock) leave the predecessor orphaned — shadow plane
+    // silently dead. Post-flock/pre-fleet preserves the invariant "bind after sole
+    // ownership AND before this host forks its fleet" for both boot modes.
+    crate::daemon::shadow::start(home);
 
     spawn_fleet_agents(home, &agents, &ctx);
 

--- a/tests/self_respawn_handoff.rs
+++ b/tests/self_respawn_handoff.rs
@@ -73,6 +73,11 @@ fn boot(home: &Path, fault: SuccessorFault) -> Child {
     let mut cmd = Command::new(bin());
     cmd.env("AGEND_HOME", home)
         .env("AGEND_RESTART_HANDOFF", "1")
+        // #2738: pin the Shadow Observer ON (default-ON, but explicit removes any
+        // ambient AGEND_SHADOW_OBSERVER=0) so BOTH the predecessor AND the
+        // env-inheriting handoff successor deterministically bind the shadow hook
+        // socket — the precondition for the pathname-steal connectability probe.
+        .env("AGEND_SHADOW_OBSERVER", "1")
         // Strip any ambient supervisor signal so this is a genuine
         // "no external supervisor" environment (e.g. macOS GUI sets
         // XPC_SERVICE_NAME; CI/systemd may set INVOCATION_ID).
@@ -110,6 +115,26 @@ fn boot(home: &Path, fault: SuccessorFault) -> Child {
 fn pid_alive(pid: u32) -> bool {
     // SAFETY: signal 0 only checks existence/permission, never delivers.
     unsafe { libc::kill(pid as i32, 0) == 0 }
+}
+
+/// #2738: after a failed handoff the predecessor must still OWN + serve its
+/// shadow hook socket. Connect to the per-daemon socket and write ONE complete
+/// newline-terminated frame (an unknown token is fine — CONNECTABILITY is the
+/// invariant; the trailing `\n` lets the daemon's sequential accept loop's
+/// line-read return promptly instead of blocking on its 2s read timeout).
+/// Returns true iff the connect succeeds (a live listener owns the pathname).
+/// The path mirrors `daemon::shadow::socket_path` (src/daemon/shadow/mod.rs:124),
+/// inlined because it is not importable from this integration crate.
+fn shadow_socket_connectable(home: &Path) -> bool {
+    let path = home.join("shadow-events.sock");
+    match std::os::unix::net::UnixStream::connect(&path) {
+        Ok(mut stream) => {
+            let _ = stream
+                .write_all(b"{\"token\":\"probe-2738\",\"hook_event_name\":\"SessionStart\"}\n");
+            true
+        }
+        Err(_) => false,
+    }
 }
 
 /// Active daemon pids: a `run/<pid>` dir whose pid is alive AND has an
@@ -410,6 +435,12 @@ fn self_respawn_aborts_when_successor_dies_after_phase1_commit() {
     let still_old = active_pids(&home) == vec![old_pid] && pid_alive(old_pid);
     let still_serves = ls_lists_probe_within(&home, Duration::from_secs(10));
 
+    // #2738: with the old PID confirmed sole primary + serving, its shadow hook
+    // socket must still be connectable — a pre-flock successor that stole the
+    // pathname (unlink+rebind) then died must NOT brick the shadow plane. Probe
+    // BEFORE cleanup (the kill below tears down the listener).
+    let shadow_ok = shadow_socket_connectable(&home);
+
     let _ = d1.kill();
     let _ = d1.wait();
     cleanup_test_home(&home);
@@ -421,6 +452,11 @@ fn self_respawn_aborts_when_successor_dies_after_phase1_commit() {
     assert!(
         still_serves,
         "predecessor must keep serving its agents after the FIX2 abort"
+    );
+    assert!(
+        shadow_ok,
+        "#2738: predecessor must still own + serve the shadow hook socket after the FIX2 abort \
+         (a pre-flock successor that unlinked+rebound the pathname then died must not brick it)"
     );
 }
 
@@ -460,6 +496,11 @@ fn self_respawn_recovers_as_primary_when_successor_dies_during_teardown() {
     let still_old = active_pids(&home) == vec![old_pid] && pid_alive(old_pid);
     let still_serves = ls_lists_probe_within(&home, Duration::from_secs(15));
 
+    // #2738: same shadow-socket connectability invariant on the recover-as-primary
+    // path — the successor stole the pathname pre-flock, so after the predecessor
+    // recovers it must still own + serve the socket. Probe BEFORE cleanup.
+    let shadow_ok = shadow_socket_connectable(&home);
+
     let _ = d1.kill();
     let _ = d1.wait();
     cleanup_test_home(&home);
@@ -471,6 +512,11 @@ fn self_respawn_recovers_as_primary_when_successor_dies_during_teardown() {
     assert!(
         still_serves,
         "predecessor must re-spawn + keep serving its agent after recover-as-primary"
+    );
+    assert!(
+        shadow_ok,
+        "#2738: predecessor must still own + serve the shadow hook socket after recover-as-primary \
+         (a pre-flock successor that unlinked+rebound the pathname then died must not brick it)"
     );
 }
 


### PR DESCRIPTION
Closes #2738.

## Bug (race/failover)
On a self-respawn HANDOFF, run_core ran `crate::daemon::shadow::start(home)` at daemon:780 — **before** the successor acquires the flock. `start_unix` does a destructive `remove_file(path) + bind(path)` (src/daemon/shadow/mod.rs:311), so a successor unlinks a still-live predecessor's shadow-socket pathname and takes over all future one-shot `UnixStream::connect(path)` frames (src/main.rs:171 — no retry/buffer). If the successor then aborts before the flock (the commit point), the predecessor is left orphaned on the now-unlinked inode and **never rebinds** (its recover-as-primary path is a loop `continue`, not a re-entry; `shadow::start` has exactly two callers) → the shadow observer plane is silently dead until a full restart. This violated the daemon's own documented discipline ("block on the flock … and ONLY THEN run the destructive reconciles", daemon/mod.rs:788-794).

## Fix
Move the single `shadow::start(home)` from before the source match (pre-flock) to immediately **before `spawn_fleet_agents`** — after the match confirms **sole ownership** (normal boot: `prepare`'s OwnedFleet flock already held; handoff: flock acquired in the match arm) and still **before the fleet forks**. Uniform, host-agnostic invariant: *bind after sole ownership AND before this host forks its fleet.* Normal boot and successful handoff keep their pre-fleet ordering; owned app already satisfied the invariant and is **unchanged**. The recover-as-primary re-spawn needs no `shadow::start` — the recovering predecessor already bound at boot.

## Tests (RED → GREEN, real-entry)
Extends the two existing real-daemon-spawn handoff cases (`self_respawn_aborts_when_successor_dies_after_phase1_commit`, `self_respawn_recovers_as_primary_when_successor_dies_during_teardown`): after the old PID is confirmed sole primary + serving, before cleanup, a real `UnixStream::connect` + one complete newline-terminated frame to the shadow socket. `boot` pins `AGEND_SHADOW_OBSERVER=1` for determinism.
- **RED** commit (test-only, on base): both cases fail — successor stole the pathname pre-flock then died → `ConnectionRefused`.
- **GREEN** commit (daemon-only, the move): both pass **3/3** consecutively; full `cargo nextest` 5412 passed / 0 failed.

## Lock/order
No new locks/spawns/state/channels. The single destructive unlink/bind moves from pre-flock to **post-flock-commit**, respecting the existing flock ordering. The detached fire-and-forget accept loop is unchanged. **Bypass scope: zero** (normal git in the bound worktree; no `agend-git` bypass). Determinism: RED/GREEN splits on logic, not timing — no new sleeps (reuses the harness's existing settle waits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)