### PR TITLE
feat(#2453 Stage R1): explicit restart host-capability dispatch seam

### DIFF
--- a/src/api/handlers/external.rs
+++ b/src/api/handlers/external.rs
@@ -126,6 +126,7 @@ mod tests {
             externals,
             notifier: None,
             home: home_ref,
+            capability: crate::api::RestartCapability::Unsupported,
         };
         (ctx, home)
     }

--- a/src/api/handlers/hook_event.rs
+++ b/src/api/handlers/hook_event.rs
@@ -91,6 +91,7 @@ mod tests {
             externals,
             notifier: None,
             home,
+            capability: crate::api::RestartCapability::Unsupported,
         }
     }
 

--- a/src/api/handlers/instance.rs
+++ b/src/api/handlers/instance.rs
@@ -556,6 +556,7 @@ mod tests {
             externals,
             notifier: None,
             home: home_ref,
+            capability: crate::api::RestartCapability::Unsupported,
         };
         (ctx, home)
     }
@@ -624,6 +625,7 @@ mod tests {
             externals,
             notifier: None,
             home: home_ref,
+            capability: crate::api::RestartCapability::Unsupported,
         };
         (ctx, home)
     }
@@ -707,6 +709,7 @@ mod tests {
             externals,
             notifier: None,
             home: home_ref,
+            capability: crate::api::RestartCapability::Unsupported,
         };
 
         let resp = handle_spawn(&json!({"name": "twin", "backend": "claude"}), &ctx);
@@ -1097,6 +1100,7 @@ mod tests {
             externals,
             notifier: None,
             home: home_ref,
+            capability: crate::api::RestartCapability::Unsupported,
         };
         (ctx, home)
     }

--- a/src/api/handlers/mcp_proxy.rs
+++ b/src/api/handlers/mcp_proxy.rs
@@ -147,6 +147,7 @@ pub(crate) fn handle_mcp_tool(params: &Value, ctx: &HandlerCtx) -> Value {
     let runtime = crate::mcp::handlers::dispatch::RuntimeContext {
         registry: ctx.registry.clone(),
         externals: ctx.externals.clone(),
+        capability: ctx.capability,
     };
     handle_mcp_tool_inner(
         tool,
@@ -506,6 +507,7 @@ mod tests {
             externals: &externals,
             notifier: None,
             home: &dir,
+            capability: crate::api::RestartCapability::Unsupported,
         };
 
         let full = crate::mcp::tools::tool_definitions()["tools"]
@@ -562,6 +564,7 @@ mod tests {
             externals: &externals,
             notifier: None,
             home: &dir,
+            capability: crate::api::RestartCapability::Unsupported,
         };
 
         let resp = handle_mcp_tool(
@@ -606,6 +609,7 @@ mod tests {
             externals: &externals,
             notifier: None,
             home: &dir,
+            capability: crate::api::RestartCapability::Unsupported,
         };
 
         let resp = handle_mcp_tool(
@@ -653,6 +657,7 @@ mod tests {
             externals: &externals,
             notifier: None,
             home: &dir,
+            capability: crate::api::RestartCapability::Unsupported,
         };
 
         let resp = handle_mcp_tools_list(&json!({"instance": "bad"}), &ctx);
@@ -692,6 +697,7 @@ mod tests {
             externals: &externals,
             notifier: None,
             home: &dir,
+            capability: crate::api::RestartCapability::Unsupported,
         };
 
         let full = crate::mcp::tools::tool_definitions()["tools"]

--- a/src/api/handlers/messaging/tests.rs
+++ b/src/api/handlers/messaging/tests.rs
@@ -17,6 +17,7 @@ fn test_ctx(home: &std::path::Path) -> HandlerCtx<'_> {
         externals,
         notifier: None,
         home,
+        capability: crate::api::RestartCapability::Unsupported,
     }
 }
 
@@ -217,6 +218,7 @@ fn test_send_to_active_registry_target_returns_pty() {
         externals,
         notifier: None,
         home: home_ref,
+        capability: crate::api::RestartCapability::Unsupported,
     };
     let result = handle_send(
         &json!({"from": "sender", "target": "active-agent", "text": "hi"}),
@@ -808,6 +810,7 @@ fn same_team_codex_update_absorbed() {
         externals,
         notifier: None,
         home: home_ref,
+        capability: crate::api::RestartCapability::Unsupported,
     };
     let result = handle_send(
         &json!({"from": "sender", "target": "codex-agent", "text": "status update", "kind": "update"}),
@@ -884,6 +887,7 @@ fn cross_team_message_not_absorbed() {
         externals,
         notifier: None,
         home: home_ref,
+        capability: crate::api::RestartCapability::Unsupported,
     };
     // general can send cross-team; codex update should still inject (not absorbed)
     let result = handle_send(
@@ -952,6 +956,7 @@ fn same_team_codex_update_orchestrator_not_skipped() {
         externals,
         notifier: None,
         home: home_ref,
+        capability: crate::api::RestartCapability::Unsupported,
     };
     let result = handle_send(
         &json!({"from": "sender", "target": "codex-agent", "text": "status update", "kind": "update"}),
@@ -1016,6 +1021,7 @@ fn same_team_codex_update_non_orchestrator_skipped() {
         externals,
         notifier: None,
         home: home_ref,
+        capability: crate::api::RestartCapability::Unsupported,
     };
     let result = handle_send(
         &json!({"from": "sender", "target": "codex-agent", "text": "status update", "kind": "update"}),
@@ -1081,6 +1087,7 @@ fn cross_team_codex_update_orchestrator_not_skipped() {
         externals,
         notifier: None,
         home: home_ref,
+        capability: crate::api::RestartCapability::Unsupported,
     };
     let result = handle_send(
         &json!({"from": "general", "target": "codex-agent", "text": "cross-team update", "kind": "update"}),
@@ -1568,6 +1575,7 @@ fn make_codex_ctx(
         externals,
         notifier: None,
         home: home_ref,
+        capability: crate::api::RestartCapability::Unsupported,
     };
     (registry, ctx, home.to_path_buf())
 }
@@ -1817,6 +1825,7 @@ fn b6_non_codex_backend_pty_path_unchanged_by_override() {
         externals,
         notifier: None,
         home: home_ref,
+        capability: crate::api::RestartCapability::Unsupported,
     };
     seed_drained_blocker(&home, "claude-agent", "query", "corr-b6");
 
@@ -2019,6 +2028,7 @@ fn kind_report_cross_team_codex_via_general_still_injects() {
         externals,
         notifier: None,
         home: home_ref,
+        capability: crate::api::RestartCapability::Unsupported,
     };
     let result = handle_send(
         &json!({

--- a/src/api/handlers/mod.rs
+++ b/src/api/handlers/mod.rs
@@ -117,4 +117,8 @@ pub(crate) struct HandlerCtx<'a> {
     pub externals: &'a ExternalRegistry,
     pub notifier: Option<&'a dyn ApiNotifier>,
     pub home: &'a Path,
+    /// #2453 Stage R1: the API-server owner's restart capability, injected at
+    /// [`crate::api::serve`] from the composition root and carried into the MCP
+    /// `RuntimeContext` so `restart_daemon` dispatches on an injected value.
+    pub capability: crate::api::RestartCapability,
 }

--- a/src/api/handlers/team.rs
+++ b/src/api/handlers/team.rs
@@ -435,6 +435,7 @@ mod tests {
             externals,
             notifier: None,
             home,
+            capability: crate::api::RestartCapability::Unsupported,
         }
     }
 
@@ -524,6 +525,7 @@ mod tests_1964 {
             externals,
             notifier: None,
             home,
+            capability: crate::api::RestartCapability::Unsupported,
         }
     }
 
@@ -697,6 +699,7 @@ mod tests_2525 {
             externals,
             notifier: None,
             home,
+            capability: crate::api::RestartCapability::Unsupported,
         }
     }
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -212,11 +212,34 @@ pub mod method {
     pub const PANE_SNAPSHOT: &str = "pane_snapshot";
 }
 
+/// #2453 Stage R1: which host owns this API server, and therefore which restart
+/// strategy `restart_daemon` dispatches to. Injected at [`serve`] from the
+/// composition root (daemon / app / verify) — the explicit replacement for the
+/// former implicit `RUN_CORE_ACTIVE` global proxy. Threaded through the API
+/// [`handlers::HandlerCtx`] → MCP `RuntimeContext` so the restart handler
+/// dispatches on an injected value, never a process-global (decision
+/// d-20260712012329422433-1).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RestartCapability {
+    /// Headless `run_core` daemon: owns the in-process self-respawn / legacy
+    /// exit(42) machinery (the `RESTART_PENDING` consumer). Restart proceeds.
+    Daemon,
+    /// `agend-terminal app` (combined TUI+daemon, `run_app`): fail-closed in R1.
+    /// The staged owner-restart strategy is a later slice (decision d-…2329422433-1).
+    App,
+    /// Any other API-server owner (e.g. `verify`) — default-deny. A DISTINCT
+    /// value from `App` even though R1 routes both to a fail-closed response.
+    Unsupported,
+}
+
 /// Start API socket server (blocks calling thread).
 ///
 /// `notifier`: when running inside the TUI app, `Some(notifier)` to notify the
 /// event loop about instance/team creation and deletion. Daemon mode passes
 /// `None` and events are silently dropped.
+///
+/// `host`: the [`RestartCapability`] of this API-server owner, injected from the
+/// composition root so `restart_daemon` dispatches to the owner's strategy.
 pub fn serve(
     home: &Path,
     registry: AgentRegistry,
@@ -224,6 +247,7 @@ pub fn serve(
     configs: ConfigRegistry,
     externals: ExternalRegistry,
     notifier: Option<Arc<dyn ApiNotifier>>,
+    host: RestartCapability,
 ) {
     // #945 Phase 0: time the bind+port-publish step directly (not the
     // spawn of api::serve thread — that's sub-ms). Operators care about
@@ -380,6 +404,9 @@ pub fn serve(
         // own copies so the spawned closure satisfies `'static`.
         let session_cookie = cookie;
         let session_operator_token = operator_token;
+        // #2453: `host` is a `Copy` enum; each session gets its own copy so the
+        // spawned `move` closure satisfies `'static` (mirrors the cookie/token).
+        let session_host = host;
         if std::thread::Builder::new()
             .name("api_handler".into())
             .spawn(move || {
@@ -398,6 +425,7 @@ pub fn serve(
                     ntf.as_deref(),
                     session_operator_token,
                     session_cookie,
+                    session_host,
                 );
             })
             .is_err()
@@ -533,6 +561,7 @@ fn handle_session(
     notifier: Option<&dyn ApiNotifier>,
     operator_token: crate::auth_cookie::Cookie,
     cookie: crate::auth_cookie::Cookie,
+    host: RestartCapability,
 ) {
     let cloned = match stream.try_clone() {
         Ok(c) => c,
@@ -635,6 +664,7 @@ fn handle_session(
             externals,
             notifier,
             home,
+            capability: host,
         };
 
         // P0a (#2342 B4): per-method CAPABILITY gate FIRST — authority is proven
@@ -1243,7 +1273,15 @@ mod tests {
         std::thread::Builder::new()
             .name(format!("test_api_{label}"))
             .spawn(move || {
-                serve(&h, r, s, c, e, notifier);
+                serve(
+                    &h,
+                    r,
+                    s,
+                    c,
+                    e,
+                    notifier,
+                    crate::api::RestartCapability::Unsupported,
+                );
             })
             .unwrap();
 

--- a/src/app/api_server.rs
+++ b/src/app/api_server.rs
@@ -68,6 +68,7 @@ pub(super) fn start_api_server(
                 configs,
                 externals,
                 Some(notifier),
+                crate::api::RestartCapability::App,
             );
         })
         .ok();

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -165,21 +165,6 @@ pub(crate) static SHUTDOWN_REASON: AtomicU8 = AtomicU8::new(0);
 /// without API-layer plumbing.
 pub(crate) static RESTART_PENDING: AtomicBool = AtomicBool::new(false);
 
-/// #2098: positive "this process's `run_core` loop is the active restart
-/// consumer" marker. Set true at `run_core` entry; stays false in every other
-/// mode — notably `agend-terminal app` (combined TUI+daemon, `run_app`), which
-/// brings up the api server under an `OwnedFleet`/`ApiGuard` but NEVER enters
-/// `run_core`. Only `run_core` consumes `RESTART_PENDING` (the tail
-/// `confirm_shutdown_or_abort_respawn` + post-serve exit/promote); app mode has
-/// NO consumer, so setting `RESTART_PENDING` there bricks the control plane
-/// permanently (api/mod.rs breaks every session, the held-flock successor
-/// 30s-times-out and dies, the flag stays latched). The `restart_daemon` MCP
-/// handler reads this fail-SAFE: it proceeds with the restart machinery ONLY
-/// when run_core is the active loop, and fail-closes otherwise (default-deny —
-/// any future non-run_core mode is blocked without code change). See
-/// `mcp::handlers::restart::handle_restart_daemon`.
-pub(crate) static RUN_CORE_ACTIVE: AtomicBool = AtomicBool::new(false);
-
 /// #1814 FIX2 (reviewer race High): the spawned successor's child handle, parked
 /// by `handle_self_respawn` at commit so the run_core loop can do a FINAL
 /// liveness recheck (`try_wait`, which also reaps) before the irreversible
@@ -752,14 +737,6 @@ fn handle_clean_exit(
 fn run_core(home: &Path, source: FleetSource) -> anyhow::Result<()> {
     let started_at = std::time::Instant::now();
 
-    // #2098: mark run_core as the active restart consumer. Set at entry (before
-    // the api server is brought up below, so it is always true by the time any
-    // `restart_daemon` MCP call can arrive) — once we are in run_core we will
-    // reach the tail that consumes RESTART_PENDING, so an in-process self-respawn
-    // is safe here. The handoff successor also runs through run_core, so it
-    // inherits this and can restart normally in turn.
-    RUN_CORE_ACTIVE.store(true, Ordering::Release);
-
     // PR-D6: fail LOUD if the retired `AGEND_WORKTREE_PRUNE_LIVE` is still set —
     // sweep gating is now `AGEND_WORKTREE_AUTO_CLEANUP` only. One warn at boot so
     // an operator carrying the stale flag learns it is ignored (not silent).
@@ -1136,6 +1113,7 @@ fn init_daemon_services(
                 api_configs,
                 api_externals,
                 None,
+                crate::api::RestartCapability::Daemon,
             )
         })?;
 

--- a/src/daemon/poll_reminder.rs
+++ b/src/daemon/poll_reminder.rs
@@ -416,6 +416,7 @@ mod tests {
             externals,
             notifier: None,
             home,
+            capability: crate::api::RestartCapability::Unsupported,
         }
     }
 

--- a/src/mcp/handlers/dispatch.rs
+++ b/src/mcp/handlers/dispatch.rs
@@ -48,6 +48,10 @@ pub(crate) struct HandlerCtx<'a> {
 pub(crate) struct RuntimeContext {
     pub registry: crate::agent::AgentRegistry,
     pub externals: crate::agent::ExternalRegistry,
+    /// #2453 Stage R1: the API-server owner's restart capability, injected at
+    /// `crate::api::serve` and carried here from the API `HandlerCtx` so
+    /// `dispatch_restart_daemon` routes on an injected value, not a global.
+    pub capability: crate::api::RestartCapability,
 }
 
 /// One MCP tool's dispatcher. Function pointer (not `Box<dyn …>`) so
@@ -267,7 +271,13 @@ adapter!(dispatch_reply, hai, channel::handle_reply);
 pub(crate) fn dispatch_pane_snapshot(ctx: &HandlerCtx<'_>) -> Value {
     instance::handle_pane_snapshot(ctx.home, ctx.args, ctx.runtime)
 }
-adapter!(dispatch_restart_daemon, h, restart::handle_restart_daemon);
+/// #2453 Stage R1: custom (not `adapter!`) so the restart handler receives the
+/// INJECTED host capability from the `RuntimeContext`. An absent runtime (a
+/// standalone bridge call that never traversed the api `mcp_tool` ingress) maps
+/// to `None` → default-deny in the handler.
+pub(crate) fn dispatch_restart_daemon(ctx: &HandlerCtx<'_>) -> Value {
+    restart::handle_restart_daemon(ctx.home, ctx.runtime.map(|r| r.capability))
+}
 
 // ---------------------------------------------------------------------
 // Action-based adapters — match on args["action"], route to per-action
@@ -411,6 +421,58 @@ mod tests {
             sender: &EMPTY_SENDER,
             runtime: None,
         }
+    }
+
+    /// #2453 Stage R1: the restart adapter routes on the INJECTED runtime
+    /// capability, not a process-global. `Some(App)` → the app fail-close arm.
+    #[test]
+    fn dispatch_restart_daemon_app_capability_routes_app_fail_close() {
+        static EMPTY_SENDER: Option<Sender> = None;
+        let home = std::env::temp_dir();
+        let args = json!({});
+        let runtime = RuntimeContext {
+            registry: std::sync::Arc::new(
+                parking_lot::Mutex::new(std::collections::HashMap::new()),
+            ),
+            externals: std::sync::Arc::new(parking_lot::Mutex::new(
+                std::collections::HashMap::new(),
+            )),
+            capability: crate::api::RestartCapability::App,
+        };
+        let ctx = HandlerCtx {
+            home: &home,
+            args: &args,
+            instance_name: "",
+            sender: &EMPTY_SENDER,
+            runtime: Some(&runtime),
+        };
+        let resp = dispatch_restart_daemon(&ctx);
+        assert_eq!(
+            resp["ok"], false,
+            "App capability must route to app fail-close, got {resp}"
+        );
+        assert!(
+            resp["error"].as_str().unwrap_or("").contains("app"),
+            "App route must return the app-mode fail-close message — got {resp}"
+        );
+    }
+
+    /// #2453 Stage R1: an ABSENT runtime (standalone bridge, no api ingress) →
+    /// `None` → default-deny, and must NOT take the app arm.
+    #[test]
+    fn dispatch_restart_daemon_absent_runtime_default_deny() {
+        let home = std::env::temp_dir();
+        let args = json!({});
+        let ctx = ctx_for(&home, &args, ""); // runtime: None
+        let resp = dispatch_restart_daemon(&ctx);
+        assert_eq!(
+            resp["ok"], false,
+            "absent runtime must default-deny, got {resp}"
+        );
+        assert!(
+            !resp["error"].as_str().unwrap_or("").contains("agend-terminal app"),
+            "absent runtime must take the Unsupported/default-deny arm, not the app arm — got {resp}"
+        );
     }
 
     #[test]

--- a/src/mcp/handlers/instance_metadata.rs
+++ b/src/mcp/handlers/instance_metadata.rs
@@ -407,6 +407,7 @@ mod blocked_reason_runtime_2454_tests {
         let rt = RuntimeContext {
             registry: Arc::new(Mutex::new(HashMap::from([(id, handle)]))),
             externals: Arc::new(Mutex::new(HashMap::new())),
+            capability: crate::api::RestartCapability::Unsupported,
         };
         (rt, home)
     }

--- a/src/mcp/handlers/instance_queries.rs
+++ b/src/mcp/handlers/instance_queries.rs
@@ -196,6 +196,7 @@ mod tests {
         let runtime = RuntimeContext {
             registry,
             externals,
+            capability: crate::api::RestartCapability::Unsupported,
         };
 
         let result =
@@ -221,6 +222,7 @@ mod tests {
                     pid: 4242,
                 },
             )]))),
+            capability: crate::api::RestartCapability::Unsupported,
         }
     }
 

--- a/src/mcp/handlers/restart.rs
+++ b/src/mcp/handlers/restart.rs
@@ -1,40 +1,75 @@
 use serde_json::{json, Value};
 use std::path::Path;
 
-pub(super) fn handle_restart_daemon(home: &Path) -> Value {
-    // #2098 app/owned-mode fail-closed (FIRST, before any path selection): the
-    // restart machinery below — BOTH the #1814 self-respawn handoff AND the
-    // legacy exit(42) path — only completes when `run_core` is the active loop,
-    // because it is run_core's tail that consumes `RESTART_PENDING`
-    // (confirm_shutdown_or_abort_respawn + post-serve exit/promote). In
-    // `agend-terminal app` (combined TUI+daemon, run_app) run_core is NEVER
-    // entered: the api server runs under an OwnedFleet/ApiGuard that holds the
-    // flock for the whole TUI lifetime and there is NO RESTART_PENDING consumer.
-    // Under the #2094 self-respawn DEFAULT the successor writes control-ready
-    // (passing Phase-1) BEFORE blocking on the held flock, so the handler would
-    // set RESTART_PENDING, brick every api session (api/mod.rs), and the
-    // successor would 30s-time-out on the flock and die — latching the brick
-    // permanently. So fail CLOSED whenever run_core is not the active loop
-    // (fail-safe default-deny via the positive RUN_CORE_ACTIVE marker), and
-    // NEVER set RESTART_PENDING here — mirroring the unsupervised
-    // fail-closed-no-flag invariant below.
-    if !crate::daemon::RUN_CORE_ACTIVE.load(std::sync::atomic::Ordering::Acquire) {
-        tracing::warn!(
-            target: "handoff",
-            event = "fail_closed_app_mode",
-            "#2098 restart_daemon refused: run_core is not the active loop (app/owned mode) — no in-process restart consumer"
-        );
-        return json!({
-            "ok": false,
-            "error": "restart_daemon is not supported in `agend-terminal app` (combined TUI+daemon) \
-                      mode: that process runs no in-process restart consumer, so an in-process \
-                      self-respawn would brick the control plane. To restart, quit the app (the TUI \
-                      owns the daemon) and relaunch `agend-terminal app` — or send the process \
-                      SIGTERM and start it again. (A standalone `agend-terminal start` daemon \
-                      restarts in-process as normal.)"
-        });
+/// #2453 Stage R1: explicit active-host restart capability dispatch.
+///
+/// Replaces the implicit `RUN_CORE_ACTIVE` global proxy with an exhaustive match
+/// on the [`crate::api::RestartCapability`] INJECTED at `api::serve` from the
+/// composition root (daemon / app / verify) and carried through the
+/// `RuntimeContext`. An absent capability (`None` — a standalone bridge call that
+/// never traversed the api `mcp_tool` ingress, so has no `RuntimeContext`) is
+/// default-DENY. `App` and `Unsupported` are DISTINCT arms even though R1 routes
+/// both to a fail-closed response; a future staged app strategy becomes the
+/// `App` arm (decision d-20260712012329422433-1) with the compiler forcing every
+/// dispatch site to handle it — no god-object switch.
+pub(super) fn handle_restart_daemon(
+    home: &Path,
+    capability: Option<crate::api::RestartCapability>,
+) -> Value {
+    use crate::api::RestartCapability;
+    match capability {
+        Some(RestartCapability::Daemon) => daemon_restart_strategy(home),
+        Some(RestartCapability::App) => app_fail_closed(),
+        Some(RestartCapability::Unsupported) | None => unsupported_fail_closed(),
     }
+}
 
+/// #2453 Stage R1 (was the #2098 leading gate): the `agend-terminal app`
+/// (combined TUI+daemon, `run_app`) host has NO in-process `RESTART_PENDING`
+/// consumer — an in-process self-respawn would set `RESTART_PENDING`, brick every
+/// api session (api/mod.rs), and the held-flock successor would 30s-time-out and
+/// die, latching the brick permanently. Fail CLOSED with an actionable error and
+/// NEVER set `RESTART_PENDING`. The staged owner-restart strategy is a later
+/// slice (decision d-20260712012329422433-1).
+fn app_fail_closed() -> Value {
+    tracing::warn!(
+        target: "handoff",
+        event = "fail_closed_app_mode",
+        "#2098 restart_daemon refused: app host has no in-process restart consumer"
+    );
+    json!({
+        "ok": false,
+        "error": "restart_daemon is not supported in `agend-terminal app` (combined TUI+daemon) \
+                  mode: that process runs no in-process restart consumer, so an in-process \
+                  self-respawn would brick the control plane. To restart, quit the app (the TUI \
+                  owns the daemon) and relaunch `agend-terminal app` — or send the process \
+                  SIGTERM and start it again. (A standalone `agend-terminal start` daemon \
+                  restarts in-process as normal.)"
+    })
+}
+
+/// #2453 Stage R1: any other API-server owner (e.g. `verify`) or an ABSENT
+/// injected capability — default-DENY. A DISTINCT `RestartCapability` value from
+/// `App`; NEVER sets `RESTART_PENDING` and cannot reach the daemon strategy.
+fn unsupported_fail_closed() -> Value {
+    tracing::warn!(
+        target: "handoff",
+        event = "fail_closed_unsupported_host",
+        "#2453 restart_daemon refused: this API host provides no in-process restart capability"
+    );
+    json!({
+        "ok": false,
+        "error": "restart_daemon is not available: this API-server host provides no in-process \
+                  restart capability (default-deny). A standalone `agend-terminal start` daemon \
+                  restarts in-process as normal."
+    })
+}
+
+/// #2453 Stage R1: the daemon (`run_core`) host owns the in-process restart. The
+/// body below is the pre-Stage-R1 handler VERBATIM (self-respawn default /
+/// legacy exit(42) opt-out) — byte-semantically unchanged; only the app-mode
+/// gate that used to precede it moved out to the capability dispatch above.
+fn daemon_restart_strategy(home: &Path) -> Value {
     // #1814: self-respawn is the DEFAULT (Stage 4). By default the daemon owns
     // its own respawn (spawn successor → Phase-1 health gate → abort-stay-alive
     // on failure), so restart never hinges on an external supervisor being
@@ -100,10 +135,10 @@ pub(super) fn handle_restart_daemon(home: &Path) -> Value {
 /// shutdown if the successor is confirmed up. On failure the predecessor is
 /// never signalled → it stays fully alive with its agents intact.
 ///
-/// #2098 precondition: only ever reached via `handle_restart_daemon`, whose
-/// leading guard guarantees `RUN_CORE_ACTIVE` (run_core is the active
-/// RESTART_PENDING consumer) — so this never runs in app/owned mode and the
-/// `RESTART_PENDING.store(true)` on commit always has a consumer.
+/// #2098/#2453 precondition: only ever reached via the `Daemon` arm of
+/// `handle_restart_daemon`'s capability dispatch (`RestartCapability::Daemon`) —
+/// so this never runs in app/owned mode and the `RESTART_PENDING.store(true)` on
+/// commit always has a run_core consumer.
 fn handle_self_respawn(home: &Path) -> Value {
     let old_pid = std::process::id();
     let handoff_value = crate::daemon::restart::make_handoff_value(old_pid);
@@ -261,11 +296,6 @@ mod tests {
             .map(|k| (k.to_string(), std::env::var(k).ok()))
             .collect();
         let prior_restart_pending = crate::daemon::RESTART_PENDING.load(Ordering::Acquire);
-        // #2098: the new app-mode guard reads `RUN_CORE_ACTIVE`, a process-global
-        // static. Save + restore it so these tests (which set it per-case to
-        // pick the mode under test) don't leak into sibling tests sharing this
-        // process under plain `cargo test`.
-        let prior_run_core_active = crate::daemon::RUN_CORE_ACTIVE.load(Ordering::Acquire);
 
         // SAFETY: test-only mutation, serialised via the mutex above.
         unsafe {
@@ -289,7 +319,6 @@ mod tests {
             }
         }
         crate::daemon::RESTART_PENDING.store(prior_restart_pending, Ordering::Release);
-        crate::daemon::RUN_CORE_ACTIVE.store(prior_run_core_active, Ordering::Release);
 
         result
     }
@@ -315,12 +344,9 @@ mod tests {
                 "XPC_SERVICE_NAME",
             ],
             || {
-                // #2098: the legacy supervisor-detection branch under test is
-                // only reachable in run_core mode — the leading app-mode guard
-                // fail-closes first otherwise. Simulate run_core so this test
-                // reaches the branch it pins (positive control: the app guard
-                // does NOT over-block run_core).
-                crate::daemon::RUN_CORE_ACTIVE.store(true, Ordering::Release);
+                // #2453: inject the Daemon capability so this test drives the
+                // daemon strategy — which reaches the legacy supervisor-detection
+                // branch under test — with no process-global host state.
                 // Manual tempdir — matches the std::env::temp_dir pattern
                 // used elsewhere in this crate (e.g. claim_verifier.rs
                 // tests). Avoids adding tempfile as a dev-dep just for
@@ -334,7 +360,8 @@ mod tests {
                         .unwrap_or(0),
                 ));
                 std::fs::create_dir_all(&tmp).expect("create tempdir");
-                let response = handle_restart_daemon(&tmp);
+                let response =
+                    handle_restart_daemon(&tmp, Some(crate::api::RestartCapability::Daemon));
                 assert_eq!(
                     response["ok"], false,
                     "unsupervised invocation must return ok:false, got {response}"
@@ -380,9 +407,8 @@ mod tests {
             &[("XPC_SERVICE_NAME", "0"), ("AGEND_RESTART_HANDOFF", "0")],
             &["AGEND_WRAPPED", "AGEND_SUPERVISED", "INVOCATION_ID"],
             || {
-                // #2098: run_core mode so the legacy XPC false-positive guard is
-                // reached (the app-mode guard fail-closes first otherwise).
-                crate::daemon::RUN_CORE_ACTIVE.store(true, Ordering::Release);
+                // #2453: inject the Daemon capability so the legacy XPC
+                // false-positive guard under test is reached (no host global).
                 let tmp = std::env::temp_dir().join(format!(
                     "agend-restart-gui-test-{}-{}",
                     std::process::id(),
@@ -392,7 +418,8 @@ mod tests {
                         .unwrap_or(0),
                 ));
                 std::fs::create_dir_all(&tmp).expect("create tempdir");
-                let response = handle_restart_daemon(&tmp);
+                let response =
+                    handle_restart_daemon(&tmp, Some(crate::api::RestartCapability::Daemon));
                 assert_eq!(
                     response["ok"], false,
                     "ambient XPC_SERVICE_NAME alone must NOT be accepted as a \
@@ -417,9 +444,9 @@ mod tests {
     /// api session loop (api/mod.rs), and the held-flock successor would
     /// 30s-time-out and die — latching the brick permanently. With self-respawn
     /// the DEFAULT (#2094: `AGEND_RESTART_HANDOFF=1`), the handler MUST fail-closed
-    /// whenever run_core is not the active loop — BEFORE selecting any path or
-    /// spawning a successor, and WITHOUT setting RESTART_PENDING. Drives the
-    /// production `handle_restart_daemon` with `RUN_CORE_ACTIVE=false` (the real
+    /// for the App capability — BEFORE selecting any path or spawning a successor,
+    /// and WITHOUT setting RESTART_PENDING. Drives the production
+    /// `handle_restart_daemon` with the injected `RestartCapability::App` (the real
     /// app-mode state); the §3.9 `app_mode_restart_fails_closed_no_brick_2098`
     /// PTY test in tests/self_respawn_handoff.rs is the end-to-end reproduction.
     #[test]
@@ -435,10 +462,8 @@ mod tests {
                 "XPC_SERVICE_NAME",
             ],
             || {
-                // App/owned mode: run_core was never entered in this process, so
-                // RUN_CORE_ACTIVE is false (its default, set here explicitly so
-                // the test is order-independent).
-                crate::daemon::RUN_CORE_ACTIVE.store(false, Ordering::Release);
+                // App host: inject the App capability (the real app-mode state)
+                // so the handler dispatches to the app fail-close arm.
                 let tmp = std::env::temp_dir().join(format!(
                     "agend-restart-appmode-{}-{}",
                     std::process::id(),
@@ -448,7 +473,8 @@ mod tests {
                         .unwrap_or(0),
                 ));
                 std::fs::create_dir_all(&tmp).expect("create tempdir");
-                let response = handle_restart_daemon(&tmp);
+                let response =
+                    handle_restart_daemon(&tmp, Some(crate::api::RestartCapability::App));
                 assert_eq!(
                     response["ok"], false,
                     "app-mode (no run_core consumer) restart must fail-closed, got {response}"
@@ -470,5 +496,134 @@ mod tests {
                 let _ = std::fs::remove_dir_all(&tmp);
             },
         );
+    }
+
+    /// #2453 Stage R1: unique per-test tempdir (matches the std::env::temp_dir
+    /// pattern used above; avoids a tempfile dev-dep).
+    fn unique_tmp(tag: &str) -> std::path::PathBuf {
+        let tmp = std::env::temp_dir().join(format!(
+            "agend-restart-{tag}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0),
+        ));
+        std::fs::create_dir_all(&tmp).expect("create tempdir");
+        tmp
+    }
+
+    /// #2453 Stage R1: an INJECTED `RestartCapability::Daemon` reaches the real
+    /// restart machinery (the daemon strategy), NOT the app fail-close. With the
+    /// legacy path forced (`AGEND_RESTART_HANDOFF=0`) and no supervisor present,
+    /// the Daemon arm returns the supervisor-required error — proving dispatch
+    /// routed to the daemon strategy (whose error names "supervisor"), not the
+    /// app arm (whose error names `agend-terminal app`). No process-global.
+    #[test]
+    fn daemon_capability_reaches_restart_machinery_not_app() {
+        with_env_and_reset(
+            &[("AGEND_RESTART_HANDOFF", "0")],
+            &[
+                "AGEND_WRAPPED",
+                "AGEND_SUPERVISED",
+                "INVOCATION_ID",
+                "XPC_SERVICE_NAME",
+            ],
+            || {
+                let tmp = unique_tmp("daemon-cap");
+                let response =
+                    handle_restart_daemon(&tmp, Some(crate::api::RestartCapability::Daemon));
+                assert_eq!(
+                    response["ok"], false,
+                    "unsupervised daemon restart fails closed on the supervisor check, got {response}"
+                );
+                let error = response["error"].as_str().unwrap_or("");
+                assert!(
+                    error.contains("supervisor"),
+                    "Daemon capability must REACH the daemon strategy (supervisor-required error) — got {error:?}"
+                );
+                assert!(
+                    !error.contains("agend-terminal app"),
+                    "Daemon capability must NOT return the app fail-close message — got {error:?}"
+                );
+                let _ = std::fs::remove_dir_all(&tmp);
+            },
+        );
+    }
+
+    /// #2453 Stage R1: an INJECTED `RestartCapability::App` fail-closes with the
+    /// app-specific message and MUST NOT set `RESTART_PENDING` or write the
+    /// restart-requested marker (the successor-spawn path lives ONLY in the
+    /// Daemon strategy, unreachable from this arm).
+    #[test]
+    fn app_capability_fails_closed_leaves_restart_pending_false() {
+        with_env_and_reset(&[("AGEND_RESTART_HANDOFF", "1")], &[], || {
+            let tmp = unique_tmp("app-cap");
+            let response = handle_restart_daemon(&tmp, Some(crate::api::RestartCapability::App));
+            assert_eq!(
+                response["ok"], false,
+                "app-capability restart must fail closed, got {response}"
+            );
+            let error = response["error"].as_str().unwrap_or("");
+            assert!(
+                error.contains("app"),
+                "app fail-close error must name `app` mode (actionable) — got {error:?}"
+            );
+            assert!(
+                !crate::daemon::RESTART_PENDING.load(Ordering::Acquire),
+                "app capability must NOT set RESTART_PENDING"
+            );
+            assert!(
+                !tmp.join("restart-requested").exists(),
+                "app capability must NOT write restart-requested (no successor spawned)"
+            );
+            let _ = std::fs::remove_dir_all(&tmp);
+        });
+    }
+
+    /// #2453 Stage R1: an INJECTED `RestartCapability::Unsupported` (e.g. the
+    /// `verify` host) is default-deny — fail-closed, no `RESTART_PENDING`, and it
+    /// CANNOT reach the daemon strategy. A DISTINCT value/arm from `App` even
+    /// though both currently share a fail-closed helper.
+    #[test]
+    fn unsupported_capability_default_deny_cannot_reach_daemon() {
+        with_env_and_reset(&[("AGEND_RESTART_HANDOFF", "1")], &[], || {
+            let tmp = unique_tmp("unsupported-cap");
+            let response =
+                handle_restart_daemon(&tmp, Some(crate::api::RestartCapability::Unsupported));
+            assert_eq!(
+                response["ok"], false,
+                "unsupported-host restart must default-deny, got {response}"
+            );
+            assert!(
+                !crate::daemon::RESTART_PENDING.load(Ordering::Acquire),
+                "unsupported capability must NOT set RESTART_PENDING"
+            );
+            assert!(
+                !tmp.join("restart-requested").exists(),
+                "unsupported capability must NOT write restart-requested"
+            );
+            let _ = std::fs::remove_dir_all(&tmp);
+        });
+    }
+
+    /// #2453 Stage R1: an ABSENT capability (`None` — a standalone bridge call
+    /// that never traversed the api `mcp_tool` ingress, so carries no
+    /// `RuntimeContext`) default-denies exactly like `Unsupported`.
+    #[test]
+    fn absent_capability_none_default_deny() {
+        with_env_and_reset(&[("AGEND_RESTART_HANDOFF", "1")], &[], || {
+            let tmp = unique_tmp("none-cap");
+            let response = handle_restart_daemon(&tmp, None);
+            assert_eq!(
+                response["ok"], false,
+                "absent capability (None) must default-deny, got {response}"
+            );
+            assert!(
+                !crate::daemon::RESTART_PENDING.load(Ordering::Acquire),
+                "None capability must NOT set RESTART_PENDING"
+            );
+            let _ = std::fs::remove_dir_all(&tmp);
+        });
     }
 }

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -162,7 +162,15 @@ pub fn run(
                 let shutdown = Arc::new(std::sync::atomic::AtomicBool::new(false));
                 let configs = Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new()));
                 let externals = Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new()));
-                api::serve(&api_home, api_reg, shutdown, configs, externals, None)
+                api::serve(
+                    &api_home,
+                    api_reg,
+                    shutdown,
+                    configs,
+                    externals,
+                    None,
+                    api::RestartCapability::Unsupported,
+                )
             })
             .ok();
 


### PR DESCRIPTION
## #2453 Stage R1 — explicit restart host-capability dispatch seam

First behavior-preserving slice of decision **d-20260712012329422433-1** (adopt owner-host restart as the product contract via a thin host restart-capability dispatch). This PR only establishes the **injected dispatch boundary**; it does NOT implement the staged app restart.

### What changed
Replaces the implicit `RUN_CORE_ACTIVE` global-bool gate in `restart_daemon` with an **injected** `crate::api::RestartCapability { Daemon, App, Unsupported }`, supplied at each `api::serve` composition root and threaded through the existing runtime-context plumbing:

```
api::serve(host)  ->  api HandlerCtx.capability  ->  mcp RuntimeContext.capability
                  ->  custom dispatch_restart_daemon  ->  handle_restart_daemon(home, Option<RestartCapability>)
```

Composition roots (host known at construction time):
- `daemon/mod.rs` (headless `run_core`) → `Daemon`
- `app/api_server.rs` (`agend-terminal app`) → `App`
- `verify.rs` → `Unsupported`

Handler is an **exhaustive match** — a future staged app strategy becomes the `App` arm, compiler-forced at every dispatch site (no god-object switch):
- `Daemon` → the existing self-respawn / legacy `exit(42)` machinery, **byte-semantically unchanged** (moved verbatim into `daemon_restart_strategy`).
- `App` → fail-closed (same actionable message as before).
- `Unsupported | None` → default-deny. `None` = an absent runtime (a standalone bridge call with no api ingress). A **distinct value/arm** from `App`.

`RUN_CORE_ACTIVE` (static + set-site + doc) is **removed** — the restart handler was its sole consumer (`rg`-confirmed).

### Scope boundaries (per dispatch)
- Daemon self-respawn state machine **untouched** (not moved/shared).
- **No** feature flags, **no** TTY handoff, **no** app restart intent/channel in this slice.
- The `capability` field is propagation-only for unrelated handlers (every non-restart construction site is a test scaffold defaulting to `Unsupported`; the sole production ctx carries the injected host).

### Evidence (RED → GREEN)
**RED** (tests written first, against the not-yet-existing API): `cargo check --tests` → 9 focused errors (`cannot find RestartCapability in api` ×4, `RuntimeContext has no field capability`, `handle_restart_daemon takes 1 argument but 2 supplied` ×4).

**GREEN**:
- Targeted unit + adapter tests: **15/15 pass** — incl. `daemon_capability_reaches_restart_machinery_not_app`, `app_capability_fails_closed_leaves_restart_pending_false`, `unsupported_capability_default_deny_cannot_reach_daemon`, `absent_capability_none_default_deny`, and adapter-level `dispatch_restart_daemon_app_capability_routes_app_fail_close` / `dispatch_restart_daemon_absent_runtime_default_deny`. The three pre-existing fail-closed tests were rewritten to **inject** the capability (no process-global).
- Real-entry integration (`tests/self_respawn_handoff.rs`): **6/6 pass** — incl. `app_mode_restart_fails_closed_no_brick_2098` (app fail-close end-to-end via injected `App`) and `self_respawn_succeeds_with_no_external_supervisor` (daemon self-respawn end-to-end via injected `Daemon`).
- Broader module sweep (api + mcp handlers): **122/122 pass**.
- `cargo fmt --check` clean; strict CI clippy (`--lib --bin agend-terminal --bin agend-git --bin agend-mcp-bridge --tests --examples --features tray -- -D warnings`) clean.

Prepares the staged app strategy (a later slice) without a god-object.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
