### PR TITLE
fix(task-board): persist auto-close result + honest result/depends_on update

### DIFF
--- a/src/api/handlers/messaging/tests.rs
+++ b/src/api/handlers/messaging/tests.rs
@@ -2576,3 +2576,42 @@ fn verdict_reverse_lookup_skips_when_reporter_has_multiple_open_dispatches_t127(
     );
     std::fs::remove_dir_all(&home).ok();
 }
+
+/// F1 real-entry (spike t-…19288-1): a terminal correlated report driven through
+/// the REAL report handler (`track_dispatch`, the fn `handle_send` invokes) must
+/// end with the report body in the task's replayed `result`. Complements the
+/// helper-level `auto_close.rs` projection test — this covers the messaging entry.
+#[test]
+fn terminal_report_projects_result_via_track_dispatch() {
+    let home = tmp_home("f1-track-dispatch");
+    seed_review_task(&home, "t-f1e", "dev-agent"); // Created + Claimed(owner=dev-agent)
+    let report = "RESULT: shipped; PR #456 merged.";
+    let msg = crate::inbox::InboxMessage {
+        from: "dev-agent".into(),
+        text: report.into(),
+        kind: Some("report".into()),
+        correlation_id: Some("t-f1e".into()),
+        terminal: Some(true),
+        timestamp: "2026-07-12T00:00:00Z".into(),
+        ..Default::default()
+    };
+    // Real report entry (params unused on the report branch).
+    track_dispatch(&home, &json!({}), "dev-agent", "lead", &msg);
+
+    assert_eq!(
+        task_status_of(&home, "t-f1e"),
+        Some(crate::task_events::TaskStatus::Done),
+        "precondition: the real report entry auto-closed the task"
+    );
+    let result = crate::task_events::replay(&home)
+        .unwrap()
+        .tasks
+        .get(&crate::task_events::TaskId("t-f1e".into()))
+        .and_then(|r| r.result.clone());
+    assert_eq!(
+        result.as_deref(),
+        Some(report),
+        "F1(real): terminal report via track_dispatch must persist `result` (was null)"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}

--- a/src/task_events.rs
+++ b/src/task_events.rs
@@ -342,6 +342,15 @@ pub enum TaskEvent {
         task_id: TaskId,
         tags: Vec<String>,
     },
+    /// Set/replace a task's free-text `result` after creation — e.g. an owner or
+    /// orchestrator backfilling the outcome on a done task. Additive variant
+    /// (mirrors `TagsSet`); the `update` MCP arm emits it. `depends_on` has NO
+    /// analogous variant by design — it is create-only/immutable.
+    ResultSet {
+        task_id: TaskId,
+        by: InstanceName,
+        result: String,
+    },
     /// Metadata KV bag update — set one key-value pair on a task.
     MetadataSet {
         task_id: TaskId,
@@ -398,6 +407,7 @@ impl TaskEvent {
             | TaskEvent::PriorityChanged { task_id, .. }
             | TaskEvent::DescriptionUpdated { task_id, .. }
             | TaskEvent::TagsSet { task_id, .. }
+            | TaskEvent::ResultSet { task_id, .. }
             | TaskEvent::MetadataSet { task_id, .. }
             | TaskEvent::BranchLinked { task_id, .. } => task_id,
         }
@@ -423,6 +433,7 @@ impl TaskEvent {
             TaskEvent::PriorityChanged { .. } => "priority_changed",
             TaskEvent::DescriptionUpdated { .. } => "description_updated",
             TaskEvent::TagsSet { .. } => "tags_set",
+            TaskEvent::ResultSet { .. } => "result_set",
             TaskEvent::MetadataSet { .. } => "metadata_set",
             TaskEvent::BranchLinked { .. } => "branch_linked",
         }
@@ -783,6 +794,12 @@ impl TaskBoardState {
                     t.updated_at = touch_at.to_string();
                 }
             }
+            TaskEvent::ResultSet { result, .. } => {
+                if let Some(t) = self.tasks.get_mut(task_id) {
+                    t.result = Some(result.clone());
+                    t.updated_at = touch_at.to_string();
+                }
+            }
             TaskEvent::BranchLinked { branch, .. } => {
                 if let Some(t) = self.tasks.get_mut(task_id) {
                     t.branch = Some(branch.clone());
@@ -886,8 +903,18 @@ impl TaskBoardState {
         if let Some(t) = self.tasks.get_mut(task_id) {
             t.status = TaskStatus::Done;
             t.updated_at = touch_at.to_string();
-            if let DoneSource::OperatorManual { result, .. } = source {
-                t.result = result.clone();
+            match source {
+                DoneSource::OperatorManual { result, .. } => t.result = result.clone(),
+                // F1: project the terminal auto-close report body into `result`
+                // when the task has no explicit result yet — never overwrite an
+                // operator-set result. Purely read-model; replay backfills
+                // historical ReportAutoClose logs. (PrMerged / AutoCloseOnPrMerge
+                // are deliberately NOT projected — out of the witnessed scope; add
+                // an arm here if a case surfaces.)
+                DoneSource::ReportAutoClose { report_summary, .. } if t.result.is_none() => {
+                    t.result = Some(report_summary.clone());
+                }
+                _ => {}
             }
         }
     }

--- a/src/tasks/auto_close.rs
+++ b/src/tasks/auto_close.rs
@@ -552,4 +552,36 @@ mod tests {
             Some(crate::task_events::TaskStatus::Done)
         );
     }
+
+    fn task_result(home: &Path, task_id: &str) -> Option<String> {
+        crate::task_events::replay(home)
+            .unwrap()
+            .tasks
+            .get(&TaskId(task_id.into()))
+            .and_then(|r| r.result.clone())
+    }
+
+    /// F1 (spike t-…19288-1): a terminal report auto-close must project the
+    /// report body into the task's `result`. Pre-fix `apply_done` set `result`
+    /// only from `DoneSource::OperatorManual`, so `ReportAutoClose.report_summary`
+    /// was dropped and the closed task's `result` stayed null.
+    #[test]
+    fn report_auto_close_projects_report_into_result() {
+        let home = tmp_home("f1_result");
+        seed_claimed_task(&home, "t-f1-result", "dev-agent");
+        let report = "RESULT: fixed the parser; PR #123 merged; all suites green.";
+        let closed =
+            auto_close_on_report(&home, "report", "t-f1-result", "dev-agent", report, true).unwrap();
+        assert!(closed, "precondition: terminal assignee report auto-closes");
+        assert_eq!(
+            task_status(&home, "t-f1-result"),
+            Some(crate::task_events::TaskStatus::Done),
+            "precondition: task is Done"
+        );
+        assert_eq!(
+            task_result(&home, "t-f1-result").as_deref(),
+            Some(report),
+            "F1: auto-close must persist the report into `result` (was null)"
+        );
+    }
 }

--- a/src/tasks/auto_close.rs
+++ b/src/tasks/auto_close.rs
@@ -571,7 +571,8 @@ mod tests {
         seed_claimed_task(&home, "t-f1-result", "dev-agent");
         let report = "RESULT: fixed the parser; PR #123 merged; all suites green.";
         let closed =
-            auto_close_on_report(&home, "report", "t-f1-result", "dev-agent", report, true).unwrap();
+            auto_close_on_report(&home, "report", "t-f1-result", "dev-agent", report, true)
+                .unwrap();
         assert!(closed, "precondition: terminal assignee report auto-closes");
         assert_eq!(
             task_status(&home, "t-f1-result"),
@@ -582,6 +583,58 @@ mod tests {
             task_result(&home, "t-f1-result").as_deref(),
             Some(report),
             "F1: auto-close must persist the report into `result` (was null)"
+        );
+    }
+
+    /// F1 guard: a `ReportAutoClose` must NOT overwrite an already-set `result`
+    /// (e.g. an operator-manual result). Only a null result is backfilled.
+    #[test]
+    fn report_auto_close_does_not_overwrite_explicit_result() {
+        let home = tmp_home("f1_guard");
+        let tid = TaskId("t-f1-guard".into());
+        crate::task_events::append_batch(
+            &home,
+            &InstanceName::from("test:seed"),
+            vec![
+                TaskEvent::Created {
+                    task_id: tid.clone(),
+                    title: "t".into(),
+                    description: String::new(),
+                    priority: "normal".into(),
+                    owner: None,
+                    due_at: None,
+                    depends_on: Vec::new(),
+                    routed_to: None,
+                    branch: None,
+                    bind: None,
+                    eta_secs: None,
+                    tags: vec![],
+                    parent_id: None,
+                },
+                TaskEvent::Done {
+                    task_id: tid.clone(),
+                    by: InstanceName::from("op"),
+                    source: crate::task_events::DoneSource::OperatorManual {
+                        authored_at: "2026-01-01T00:00:00Z".into(),
+                        result: Some("explicit operator result".into()),
+                    },
+                },
+                // A later ReportAutoClose on the same task must be a no-op for `result`.
+                TaskEvent::Done {
+                    task_id: tid,
+                    by: InstanceName::from("dev"),
+                    source: crate::task_events::DoneSource::ReportAutoClose {
+                        report_summary: "auto summary".into(),
+                        closed_at: "2026-01-02T00:00:00Z".into(),
+                    },
+                },
+            ],
+        )
+        .expect("seed");
+        assert_eq!(
+            task_result(&home, "t-f1-guard").as_deref(),
+            Some("explicit operator result"),
+            "F1 guard: ReportAutoClose must not overwrite an explicit result"
         );
     }
 }

--- a/src/tasks/handler.rs
+++ b/src/tasks/handler.rs
@@ -926,6 +926,18 @@ fn handle_update(
             base.to_string()
         }
     };
+    // F3: `depends_on` is set at `Created` and is immutable via `update` — there
+    // is no post-create event that carries it, by design (circular-dependency
+    // containment; see the contract in `tasks/tests.rs`). Reject it explicitly
+    // instead of the historical silent no-op that falsely reported "updated".
+    if args.get("depends_on").is_some_and(|v| !v.is_null()) {
+        return serde_json::json!({
+            "error": format!(
+                "'depends_on' is set at creation and is immutable via update (task {id})"
+            ),
+            "code": "immutable_field",
+        });
+    }
     // PR4 F1 — collect transitions into a Vec then emit via
     // single `append_batch` so updates are atomic at the F7 batch
     // level (all-or-nothing fsync window).
@@ -1115,9 +1127,26 @@ fn handle_update(
                 .map(|s| crate::task_events::InstanceName(s.clone())),
         });
     }
+    // F2: result backfill via the additive `ResultSet` event. Emitted only when
+    // the supplied value actually differs from the current record — an equal
+    // value produces no event, so the response below reports an honest
+    // `unchanged` rather than a false `updated`. Rides the same atomic
+    // `append_batch` + ownership ACL as every other update event (no separate
+    // authority surface). Allowed on any state so an owner/orchestrator can
+    // backfill the outcome on an already-done task (the witnessed case).
+    if let Some(new_result) = args.get("result").and_then(|v| v.as_str()) {
+        if record.result.as_deref() != Some(new_result) {
+            pending_events.push(crate::task_events::TaskEvent::ResultSet {
+                task_id: crate::task_events::TaskId(id.clone()),
+                by: crate::task_events::InstanceName::from(caller.as_str()),
+                result: new_result.to_string(),
+            });
+        }
+    }
     // F1: single atomic append_batch over all the update arm's
     // queued events. Either all land or none do.
-    if !pending_events.is_empty() {
+    let had_events = !pending_events.is_empty();
+    if had_events {
         // #1868: re-validate the status transition UNDER the append lock against
         // FRESH committed state (mirrors `handle_claim`/`handle_done`). The
         // out-of-lock `can_transition_to` check above is a fast-reject; a
@@ -1204,13 +1233,45 @@ fn handle_update(
     }
     // #807 Item 1: see create arm note.
     let task = read_task_record_at(&board, &id).map(|r| record_to_task(&r));
-    serde_json::json!({
-        "id": id,
-        "event": "updated",
-        "task": task,
-        // #807 deprecated alias kept for back-compat — see task.status for lifecycle.
-        "status": "updated",
-    })
+    if had_events {
+        serde_json::json!({
+            "id": id,
+            "event": "updated",
+            "task": task,
+            // #807 deprecated alias kept for back-compat — see task.status for lifecycle.
+            "status": "updated",
+        })
+    } else if [
+        "status",
+        "priority",
+        "assignee",
+        "description",
+        "tags",
+        "result",
+    ]
+    .iter()
+    .any(|k| args.get(*k).is_some_and(|v| !v.is_null()))
+    {
+        // A recognized field was supplied but equalled the current value (only
+        // `result` can reach here — status/priority/description/tags/owner always
+        // emit an event). Honest idempotent no-op instead of a false "updated".
+        serde_json::json!({
+            "id": id,
+            "event": "unchanged",
+            "task": task,
+            "status": "unchanged",
+        })
+    } else {
+        // No supported mutable field supplied (`depends_on` was already rejected
+        // above). Fail loud rather than the historical false "updated".
+        serde_json::json!({
+            "error": format!(
+                "no updatable field supplied for task {id} \
+                 (supported: status, priority, assignee, description, tags, result)"
+            ),
+            "code": "no_op",
+        })
+    }
 }
 
 fn handle_sweep(home: &Path, args: &Value) -> Value {
@@ -1581,6 +1642,7 @@ fn summarize_event(env: &crate::task_events::TaskEventEnvelope) -> (&str, String
             "description updated".to_string(),
         ),
         TaskEvent::TagsSet { tags, .. } => ("tags_set", actor, format!("tags → {tags:?}")),
+        TaskEvent::ResultSet { by, .. } => ("result_set", by.0.clone(), "result set".to_string()),
         TaskEvent::MetadataSet { key, value, by, .. } => (
             "metadata_set",
             by.0.clone(),

--- a/src/tasks/handler.rs
+++ b/src/tasks/handler.rs
@@ -950,19 +950,40 @@ fn handle_update(
     // "updated" so callers don't need to special-case.
     if let Some(ref s) = new_status {
         let prev_status = record.status;
+        // Reject an UNKNOWN status value outright — previously `from_str` returning
+        // None fell through to a silent no-op that falsely reported success
+        // (#task-result-rca review).
+        let Some(target) = crate::task_events::TaskStatus::from_str(s) else {
+            return serde_json::json!({
+                "error": format!(
+                    "unknown status '{s}' (task {id}); valid: backlog, open, claimed, \
+                     in_progress, in_review, blocked, verified, done, cancelled"
+                ),
+                "code": "unknown_status",
+            });
+        };
+        // `verified` is produced by the reviewer VERDICT path, not an operator
+        // update — return an actionable error rather than inventing a verdict.
+        if target == crate::task_events::TaskStatus::Verified {
+            return serde_json::json!({
+                "error": format!(
+                    "status 'verified' is set by the review/verdict path (send kind=report \
+                     with a VERIFIED verdict), not task update (task {id})"
+                ),
+                "code": "unsupported_status_transition",
+            });
+        }
         // #1265: transition enforcement — reject illegal status changes.
-        if let Some(target) = crate::task_events::TaskStatus::from_str(s) {
-            if !prev_status.can_transition_to(target) {
-                return serde_json::json!({
-                    "error": format!(
-                        "illegal transition: {} → {} (task {})",
-                        crate::tasks::status_to_legacy_str(prev_status),
-                        s,
-                        id
-                    ),
-                    "code": "illegal_transition",
-                });
-            }
+        if !prev_status.can_transition_to(target) {
+            return serde_json::json!({
+                "error": format!(
+                    "illegal transition: {} → {} (task {})",
+                    crate::tasks::status_to_legacy_str(prev_status),
+                    s,
+                    id
+                ),
+                "code": "illegal_transition",
+            });
         }
         // #2249 pre-work alignment gate: the ONE live chokepoint for the
         // claimed→in_progress transition (verified during the #2524 P2a
@@ -1075,13 +1096,20 @@ fn handle_update(
                 }),
                 _ => None,
             };
-        // PR4 F1 (PR3 r1 reviewer-2 LOW) — collect events into
-        // a Vec and emit via `append_batch` so all transitions
-        // produced by a single update call land under one fsync.
-        // F7 atomic-batch contract: either all land or none do
-        // (a partial-write window can't surface to readers).
-        if let Some(ev) = event_for_transition {
-            pending_events.push(ev);
+        // PR4 F1 (PR3 r1 reviewer-2 LOW) — collect events into a Vec and emit via
+        // `append_batch` so all transitions produced by a single update call land
+        // under one fsync. F7 atomic-batch contract: either all land or none do.
+        match event_for_transition {
+            Some(ev) => pending_events.push(ev),
+            // A parseable, legal status with no `update`-arm mapping must fail loud
+            // rather than silently no-op. Defensive: today only `verified` is
+            // unmapped, and it is already rejected above.
+            None => {
+                return serde_json::json!({
+                    "error": format!("status '{s}' is not settable via task update (task {id})"),
+                    "code": "unsupported_status_transition",
+                });
+            }
         }
     }
     // Priority change without status transition: queue
@@ -1127,15 +1155,23 @@ fn handle_update(
                 .map(|s| crate::task_events::InstanceName(s.clone())),
         });
     }
-    // F2: result backfill via the additive `ResultSet` event. Emitted only when
-    // the supplied value actually differs from the current record — an equal
-    // value produces no event, so the response below reports an honest
-    // `unchanged` rather than a false `updated`. Rides the same atomic
-    // `append_batch` + ownership ACL as every other update event (no separate
-    // authority surface). Allowed on any state so an owner/orchestrator can
-    // backfill the outcome on an already-done task (the witnessed case).
-    if let Some(new_result) = args.get("result").and_then(|v| v.as_str()) {
-        if record.result.as_deref() != Some(new_result) {
+    // F2: result backfill via the additive `ResultSet` event. A present-but-
+    // non-string `result` fails loud (was: silently ignored → false "unchanged").
+    // An equal string value emits no event (honest "unchanged" below); a differing
+    // value emits `ResultSet`. Rides the same atomic `append_batch` + ownership ACL
+    // as every other update event. Allowed on any state so an owner/orchestrator
+    // can backfill the outcome on an already-done task (the witnessed case).
+    let mut result_idempotent = false;
+    if let Some(result_val) = args.get("result") {
+        let Some(new_result) = result_val.as_str() else {
+            return serde_json::json!({
+                "error": format!("'result' must be a string (task {id})"),
+                "code": "invalid_result",
+            });
+        };
+        if record.result.as_deref() == Some(new_result) {
+            result_idempotent = true;
+        } else {
             pending_events.push(crate::task_events::TaskEvent::ResultSet {
                 task_id: crate::task_events::TaskId(id.clone()),
                 by: crate::task_events::InstanceName::from(caller.as_str()),
@@ -1241,20 +1277,13 @@ fn handle_update(
             // #807 deprecated alias kept for back-compat — see task.status for lifecycle.
             "status": "updated",
         })
-    } else if [
-        "status",
-        "priority",
-        "assignee",
-        "description",
-        "tags",
-        "result",
-    ]
-    .iter()
-    .any(|k| args.get(*k).is_some_and(|v| !v.is_null()))
-    {
-        // A recognized field was supplied but equalled the current value (only
-        // `result` can reach here — status/priority/description/tags/owner always
-        // emit an event). Honest idempotent no-op instead of a false "updated".
+    } else if result_idempotent {
+        // The ONLY zero-event success: `result` was supplied as a string equal to
+        // the current value, and no other mutable field was supplied (every other
+        // field emits an event when supplied, so it would be in `had_events`).
+        // Every other zero-event request — unknown/unmapped status, non-string
+        // result, or no recognized field — already returned a structured error
+        // above. Honest idempotent no-op instead of a false "updated".
         serde_json::json!({
             "id": id,
             "event": "unchanged",

--- a/src/tasks/handler.rs
+++ b/src/tasks/handler.rs
@@ -1277,13 +1277,17 @@ fn handle_update(
             // #807 deprecated alias kept for back-compat — see task.status for lifecycle.
             "status": "updated",
         })
-    } else if result_idempotent {
+    } else if result_idempotent
+        && !["status", "priority", "assignee", "description", "tags"]
+            .iter()
+            .any(|k| args.get(*k).is_some_and(|v| !v.is_null()))
+    {
         // The ONLY zero-event success: `result` was supplied as a string equal to
-        // the current value, and no other mutable field was supplied (every other
-        // field emits an event when supplied, so it would be in `had_events`).
-        // Every other zero-event request — unknown/unmapped status, non-string
-        // result, or no recognized field — already returned a structured error
-        // above. Honest idempotent no-op instead of a false "updated".
+        // the current value AND no OTHER mutable key was supplied. The
+        // presence-not-emission check is load-bearing: a malformed other field
+        // (e.g. `description: 123`, a non-string that emits no event) must NOT be
+        // silently absorbed into a false "unchanged" — it falls through to the
+        // fail-loud branch below. Honest idempotent no-op.
         serde_json::json!({
             "id": id,
             "event": "unchanged",
@@ -1291,12 +1295,15 @@ fn handle_update(
             "status": "unchanged",
         })
     } else {
-        // No supported mutable field supplied (`depends_on` was already rejected
-        // above). Fail loud rather than the historical false "updated".
+        // Zero events and not the idempotent-result case: either nothing updatable
+        // was supplied, or a supplied field produced no change (e.g. a malformed
+        // non-string value that emits no event). Fail loud rather than the
+        // historical false "updated" / a value-absorbing false "unchanged".
+        // (`depends_on` was already rejected above.)
         serde_json::json!({
             "error": format!(
-                "no updatable field supplied for task {id} \
-                 (supported: status, priority, assignee, description, tags, result)"
+                "no effective update for task {id}: no supported mutable field produced \
+                 a change (supported: status, priority, assignee, description, tags, result)"
             ),
             "code": "no_op",
         })

--- a/src/tasks/handler/tests.rs
+++ b/src/tasks/handler/tests.rs
@@ -1249,3 +1249,57 @@ fn update_with_no_supported_fields_errors() {
         "an update with no updatable field must fail loudly, not report success: {resp}"
     );
 }
+
+/// Review correction (#task-result-rca): an update with an UNKNOWN status string
+/// must fail loud, not silently no-op / report "unchanged".
+#[test]
+fn update_unknown_status_errors() {
+    let home = tmp_home("bad-status");
+    create_task(&home, "t-bs");
+    let resp = handle(
+        &home,
+        "dev-agent",
+        &serde_json::json!({"action": "update", "id": "t-bs", "status": "foo"}),
+    );
+    assert!(
+        resp.get("error").is_some(),
+        "unknown status must error, not unchanged/updated: {resp}"
+    );
+}
+
+/// Review correction: `verified` is produced by the reviewer verdict path, not an
+/// operator update — `update(status=verified)` must error (never invent a verdict).
+#[test]
+fn update_status_verified_is_rejected() {
+    let home = tmp_home("verified");
+    create_task(&home, "t-vf");
+    let resp = handle(
+        &home,
+        "dev-agent",
+        &serde_json::json!({"action": "update", "id": "t-vf", "status": "verified"}),
+    );
+    // Must be the ACTIONABLE verdict-path error — not the generic illegal_transition
+    // that `open → verified` happens to raise. (codex review: "do not invent a
+    // verdict — direct callers to the review/verdict path".)
+    assert_eq!(
+        resp["code"], "unsupported_status_transition",
+        "status=verified must return the actionable verdict-path error: {resp}"
+    );
+}
+
+/// Review correction: a non-string `result` must fail loud, not be silently
+/// ignored and reported as "unchanged".
+#[test]
+fn update_non_string_result_errors() {
+    let home = tmp_home("bad-result");
+    create_task(&home, "t-br");
+    let resp = handle(
+        &home,
+        "dev-agent",
+        &serde_json::json!({"action": "update", "id": "t-br", "result": 123}),
+    );
+    assert!(
+        resp.get("error").is_some(),
+        "non-string result must fail loud, not unchanged/updated: {resp}"
+    );
+}

--- a/src/tasks/handler/tests.rs
+++ b/src/tasks/handler/tests.rs
@@ -1108,3 +1108,130 @@ fn plan_ack_idempotent_reack_does_not_double_count_2249() {
     assert_eq!(second["already_acked"], true);
     std::fs::remove_dir_all(&home).ok();
 }
+
+// ── Result / depends_on update semantics (spike t-…19288-1, fix t-…46182-4) ──
+
+fn task_result(home: &std::path::Path, task_id: &str) -> Option<String> {
+    crate::task_events::replay(home)
+        .unwrap()
+        .tasks
+        .get(&crate::task_events::TaskId(task_id.into()))
+        .and_then(|r| r.result.clone())
+}
+
+fn seed_claimed(home: &std::path::Path, task_id: &str, owner: &str) {
+    use crate::task_events::{InstanceName, TaskEvent, TaskId};
+    let tid = TaskId(task_id.into());
+    crate::task_events::append_batch(
+        home,
+        &InstanceName::from("test:seed"),
+        vec![
+            TaskEvent::Created {
+                task_id: tid.clone(),
+                title: "t".into(),
+                description: String::new(),
+                priority: "normal".into(),
+                owner: None,
+                due_at: None,
+                depends_on: Vec::new(),
+                routed_to: None,
+                branch: None,
+                bind: None,
+                eta_secs: None,
+                tags: vec![],
+                parent_id: None,
+            },
+            TaskEvent::Claimed { task_id: tid, by: InstanceName::from(owner) },
+        ],
+    )
+    .expect("seed claimed");
+}
+
+/// F2 (witnessed backfill): after a terminal auto-close (owner=dev-agent,
+/// result null), the OWNER's `update(result=…)` must persist the result. Pre-fix
+/// `handle_update` never read `args["result"]`, so it was a silent no-op.
+#[test]
+fn update_result_backfills_done_task() {
+    let home = tmp_home("f2-backfill");
+    seed_claimed(&home, "t-f2", "dev-agent");
+    crate::tasks::auto_close::auto_close_on_report(
+        &home, "report", "t-f2", "dev-agent", "auto summary", true,
+    )
+    .expect("auto_close");
+    assert_eq!(
+        read_task_record(&home, "t-f2").unwrap().status,
+        crate::task_events::TaskStatus::Done,
+        "precondition: Done"
+    );
+    let resp = handle(
+        &home,
+        "dev-agent",
+        &serde_json::json!({"action": "update", "id": "t-f2", "result": "final: shipped in PR #77"}),
+    );
+    assert!(resp.get("error").is_none(), "update must not error: {resp}");
+    assert_eq!(
+        task_result(&home, "t-f2").as_deref(),
+        Some("final: shipped in PR #77"),
+        "F2: owner update(result=…) on a done task must persist `result`"
+    );
+}
+
+/// F2 honest idempotent: `update(result=X)` when the result already equals X
+/// must report `unchanged`, not a false `updated`.
+#[test]
+fn update_result_idempotent_reports_unchanged() {
+    let home = tmp_home("f2-idempotent");
+    seed_claimed(&home, "t-f2i", "dev-agent");
+    let first = handle(
+        &home,
+        "dev-agent",
+        &serde_json::json!({"action": "update", "id": "t-f2i", "result": "X"}),
+    );
+    assert_eq!(first["status"], "updated", "first result set is a real change: {first}");
+    let second = handle(
+        &home,
+        "dev-agent",
+        &serde_json::json!({"action": "update", "id": "t-f2i", "result": "X"}),
+    );
+    assert_eq!(
+        second["status"], "unchanged",
+        "F2: an equal-value result update must report `unchanged`, not `updated`: {second}"
+    );
+    assert_eq!(task_result(&home, "t-f2i").as_deref(), Some("X"));
+}
+
+/// F3: `depends_on` is create-only/immutable (tests.rs:1888). `update(depends_on=…)`
+/// must return an explicit error, never a false `updated`, and never mutate deps.
+#[test]
+fn update_depends_on_is_rejected_not_silently_accepted() {
+    let home = tmp_home("f3-reject");
+    create_task(&home, "t-f3");
+    let resp = handle(
+        &home,
+        "dev-agent",
+        &serde_json::json!({"action": "update", "id": "t-f3", "depends_on": ["t-up-1"]}),
+    );
+    assert!(
+        resp.get("error").is_some(),
+        "F3: update(depends_on=…) must return an explicit create-only error: {resp}"
+    );
+    let deps = read_task_record(&home, "t-f3").unwrap().depends_on;
+    assert!(deps.is_empty(), "depends_on must stay as created (immutable): {deps:?}");
+}
+
+/// Fail-loud: an update with no supported mutable field is not a success. Pre-fix
+/// it returned `updated` (empty pending_events → unconditional success).
+#[test]
+fn update_with_no_supported_fields_errors() {
+    let home = tmp_home("no-fields");
+    create_task(&home, "t-nf");
+    let resp = handle(
+        &home,
+        "dev-agent",
+        &serde_json::json!({"action": "update", "id": "t-nf"}),
+    );
+    assert!(
+        resp.get("error").is_some(),
+        "an update with no updatable field must fail loudly, not report success: {resp}"
+    );
+}

--- a/src/tasks/handler/tests.rs
+++ b/src/tasks/handler/tests.rs
@@ -1303,3 +1303,29 @@ fn update_non_string_result_errors() {
         "non-string result must fail loud, not unchanged/updated: {resp}"
     );
 }
+
+/// Review correction R3 (codex): an idempotent (equal) `result` must NOT absorb a
+/// malformed second field. `result=<current>` + a non-emitting `description` (wrong
+/// type) is a zero-event request that must fail loud, never "unchanged".
+#[test]
+fn update_idempotent_result_with_malformed_other_field_errors() {
+    let home = tmp_home("combo");
+    seed_claimed(&home, "t-combo", "dev-agent");
+    // Establish result = "X".
+    let set = handle(
+        &home,
+        "dev-agent",
+        &serde_json::json!({"action": "update", "id": "t-combo", "result": "X"}),
+    );
+    assert_eq!(set["status"], "updated", "precondition: result set: {set}");
+    // Equal result + a malformed (non-string) description → zero events.
+    let resp = handle(
+        &home,
+        "dev-agent",
+        &serde_json::json!({"action": "update", "id": "t-combo", "result": "X", "description": 123}),
+    );
+    assert!(
+        resp.get("error").is_some(),
+        "equal result + malformed other field must fail loud, not unchanged: {resp}"
+    );
+}

--- a/src/tasks/handler/tests.rs
+++ b/src/tasks/handler/tests.rs
@@ -1141,7 +1141,10 @@ fn seed_claimed(home: &std::path::Path, task_id: &str, owner: &str) {
                 tags: vec![],
                 parent_id: None,
             },
-            TaskEvent::Claimed { task_id: tid, by: InstanceName::from(owner) },
+            TaskEvent::Claimed {
+                task_id: tid,
+                by: InstanceName::from(owner),
+            },
         ],
     )
     .expect("seed claimed");
@@ -1155,7 +1158,12 @@ fn update_result_backfills_done_task() {
     let home = tmp_home("f2-backfill");
     seed_claimed(&home, "t-f2", "dev-agent");
     crate::tasks::auto_close::auto_close_on_report(
-        &home, "report", "t-f2", "dev-agent", "auto summary", true,
+        &home,
+        "report",
+        "t-f2",
+        "dev-agent",
+        "auto summary",
+        true,
     )
     .expect("auto_close");
     assert_eq!(
@@ -1187,7 +1195,10 @@ fn update_result_idempotent_reports_unchanged() {
         "dev-agent",
         &serde_json::json!({"action": "update", "id": "t-f2i", "result": "X"}),
     );
-    assert_eq!(first["status"], "updated", "first result set is a real change: {first}");
+    assert_eq!(
+        first["status"], "updated",
+        "first result set is a real change: {first}"
+    );
     let second = handle(
         &home,
         "dev-agent",
@@ -1216,7 +1227,10 @@ fn update_depends_on_is_rejected_not_silently_accepted() {
         "F3: update(depends_on=…) must return an explicit create-only error: {resp}"
     );
     let deps = read_task_record(&home, "t-f3").unwrap().depends_on;
-    assert!(deps.is_empty(), "depends_on must stay as created (immutable): {deps:?}");
+    assert!(
+        deps.is_empty(),
+        "depends_on must stay as created (immutable): {deps:?}"
+    );
 }
 
 /// Fail-loud: an update with no supported mutable field is not a success. Pre-fix


### PR DESCRIPTION
## What & why

Fixes task-result / dependency persistence losses on the daemon task board
(spike `t-20260712031654081407-19288-1`, fix `t-20260712025304522838-46182-4`).
Two root causes, three witnessed symptoms:

- **F1** — a terminal correlated report auto-closed a task but left `result` **null**.
  `apply_done` projected `result` only from `DoneSource::OperatorManual`;
  `ReportAutoClose.report_summary` was dropped.
- **F2** — `task update(result=…)` returned `"updated"` but was a **silent no-op**
  (the handler never read `args["result"]`; no event carried it).
- **F3** — `task update(depends_on=…)` returned `"updated"` but `depends_on` stayed
  `[]`. `depends_on` is **intentionally create-only/immutable** (circular-dep
  containment, `tasks/tests.rs:1888`); the defect was the *false success*, not the
  immutability.

## Approach (approved v2 contract, per cross-arch review)

- **F1** — `apply_done` now projects `ReportAutoClose.report_summary` into `result`
  **only when `result.is_none()`** (never overwrites an operator-set result).
  Read-model only; replay backfills historical auto-closed tasks. `PrMerged` /
  `AutoCloseOnPrMerge` deliberately excluded (out of witnessed scope).
- **F2** — additive `TaskEvent::ResultSet` (mirrors `TagsSet`); `handle_update`
  reads `args["result"]` and emits `ResultSet` **only when the value differs**,
  riding the existing atomic `append_batch` + ownership ACL. Allowed on any state so
  an owner/orchestrator can backfill a done task.
- **F3** — `handle_update` rejects `args["depends_on"]` with an explicit
  `immutable_field` error. `depends_on` stays create-only (no mutate event added).
- **Honest update response** — real change → `"updated"`; a recognized field
  supplied at its current value → `"unchanged"`; no supported mutable field →
  fail-loud `no_op` error (was: unconditional `"updated"`).

## Tests (RED-first)

First commit (`test:`) adds the RED suite **before** any implementation, merged into
existing modules; all fail on `c4206950`:

- `tasks::auto_close` — `report_auto_close_projects_report_into_result` (F1 helper)
- `api::handlers::messaging` — `terminal_report_projects_result_via_track_dispatch`
  (F1 through the **real report entry** `handle_send → track_dispatch`)
- `tasks::handler` — `update_result_backfills_done_task` (F2 owner backfill),
  `update_result_idempotent_reports_unchanged` (honest unchanged),
  `update_depends_on_is_rejected_not_silently_accepted` (F3),
  `update_with_no_supported_fields_errors` (fail-loud)

Second commit (`fix:`) implements F1/F2/F3 → all green, plus
`report_auto_close_does_not_overwrite_explicit_result` (F1 `is_none` guard).

## Verification

- `git ls-files '*.rs' ':!:vendor/**' | xargs rustfmt --edition 2021 --check` → clean
- `cargo clippy --lib --bin agend-terminal --bin agend-git --bin agend-mcp-bridge --tests --examples --features tray -- -D warnings` (rustup stable) → clean
- `cargo check --features discord` → clean
- `cargo test --bin agend-terminal -- tasks:: task_events:: api::handlers::messaging::` → **292 passed, 0 failed**

Do **not** merge — pending review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
