### PR TITLE
refactor(#2737): typed two-phase owner-service invariants (retire string masker)

### DIFF
--- a/src/api_activity_probe.rs
+++ b/src/api_activity_probe.rs
@@ -73,7 +73,7 @@ struct Socket {
 }
 
 /// Spawn the daemon-owned probe thread. Fire-and-forget.
-pub fn spawn(registry: AgentRegistry) {
+pub fn spawn(_permit: &crate::daemon::owner_services::OwnerServicePermit, registry: AgentRegistry) {
     // fire-and-forget: the probe loop is a read-only sampler that terminates on
     // process exit. Losing the thread on shutdown is harmless (next boot
     // re-samples); it owns no state another thread must join. (§10.5)

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -465,71 +465,71 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
     // attached); the owned-only maintenance tick REQUIRES it, so a run_app that
     // skips the seam fails to compile (structural I2, replacing the old
     // `owner_services_called_by_both_hosts` string-scan).
-    let owner_services: Option<crate::daemon::owner_services::OwnerServicesStarted> = if !attached_mode
-    {
-        crate::daemon::supervisor::spawn(home.clone(), Arc::clone(&registry));
-        // #2453 Stage 1a / #2737: owner monitoring (instance_monitor +
-        // api_activity_probe) via the typed phase-1 seam — identical position/args
-        // in run_core's build_tick_infrastructure, so a service can't be wired in
-        // one host and silently dead in the other (#982/#1002/#1720/#2434). The
-        // returned OwnerMonitoringStarted token is required by phase 2 below, so
-        // monitoring is compile-forced to precede the stream observers (exact
-        // order preserved: monitoring → shadow::start → stream).
-        let monitoring = crate::daemon::owner_services::start_owner_monitoring(
-            crate::daemon::owner_services::OwnerRole::Owned,
-            &home,
-            &registry,
-            &crate::daemon::owner_services::OwnerMonitoringStarters::real(),
-        );
-        // #2413 Phase B (live-fix): start the hook-event socket server in app mode too.
-        // The LIVE fleet daemon runs THIS `run_app`, never `run_core` (shadow::start's
-        // only other caller), so without this the whole Shadow Observer plane was dead in
-        // production (observed_status null on every agent under the flag — #1720/#685
-        // silent-dead-in-app class, mirrors recovery_dispatcher #1694(a)). No-op under
-        // `AGEND_SHADOW_OBSERVER=0` (default-ON; the =0 kill-switch ⇒ zero change). Owner-only
-        // (`!attached_mode`) like the probe: an attached TUI must not also bind the socket;
-        // the daemon that owns the fleet started it. Lifecycle mirrors run_core — a
-        // detached accept loop that exits with the process; the stale socket is cleared on
-        // next bind (start_unix removes it before binding).
-        crate::daemon::shadow::start(&home);
-        // #2453 Stage 1a / #2737: the three Shadow Observer stream planes (rollout
-        // + opencode + kiro) via the typed phase-2 seam. Requires the phase-1
-        // OwnerMonitoringStarted token (compile-enforced order). #2434: the live
-        // fleet daemon is app mode, so these must be app-wired (not run_core-only)
-        // or each backend's observer source is dead in production. Identical
-        // position/args in run_core's build_tick_infrastructure. shadow::start
-        // (the socket-ingest plane above) stays host-local — separate fork.
-        let owner_services = crate::daemon::owner_services::start_owner_stream_observers(
-            crate::daemon::owner_services::OwnerRole::Owned,
-            &monitoring,
-            &home,
-            &registry,
-            &crate::daemon::owner_services::OwnerStreamStarters::real(),
-        );
-        // Attached mode stays unwired: that process never owns the registry,
-        // and the Telegram bot (if any) runs under the other daemon which
-        // already did its own attach.
-        //
-        // #945 Phase 1: telegram_init is now backgrounded; `telegram_state`
-        // is always None at this point post-backgrounding. Publish registry
-        // to the pending slot so the background thread can attach when its
-        // ~6s HTTP init completes. The if-let path below covers the eager
-        // (fast/mocked init) case.
-        crate::agent::set_pending_registry(Arc::clone(&registry));
-        if let Some(tg) = telegram_state.as_ref() {
-            tg.attach_registry(Arc::clone(&registry));
-        } else if let Some(tg) = crate::channel::lookup_channel_by_name("telegram") {
-            // Multi-channel-safe (t-20260703164240502572-50899-11): this
-            // fallback is telegram-specific (the `tg`/`telegram_state`
-            // naming already assumed it); `active_channel()` would silently
-            // no-op here once discord is also registered.
-            tg.attach_registry(Arc::clone(&registry));
-        }
-        // #2737: hand the final witness to the owned-only maintenance tick below.
-        Some(owner_services)
-    } else {
-        None
-    };
+    let owner_services: Option<crate::daemon::owner_services::OwnerServicesStarted> =
+        if !attached_mode {
+            crate::daemon::supervisor::spawn(home.clone(), Arc::clone(&registry));
+            // #2453 Stage 1a / #2737: owner monitoring (instance_monitor +
+            // api_activity_probe) via the typed phase-1 seam — identical position/args
+            // in run_core's build_tick_infrastructure, so a service can't be wired in
+            // one host and silently dead in the other (#982/#1002/#1720/#2434). The
+            // returned OwnerMonitoringStarted token is required by phase 2 below, so
+            // monitoring is compile-forced to precede the stream observers (exact
+            // order preserved: monitoring → shadow::start → stream).
+            let monitoring = crate::daemon::owner_services::start_owner_monitoring(
+                crate::daemon::owner_services::OwnerRole::Owned,
+                &home,
+                &registry,
+                &crate::daemon::owner_services::OwnerMonitoringStarters::real(),
+            );
+            // #2413 Phase B (live-fix): start the hook-event socket server in app mode too.
+            // The LIVE fleet daemon runs THIS `run_app`, never `run_core` (shadow::start's
+            // only other caller), so without this the whole Shadow Observer plane was dead in
+            // production (observed_status null on every agent under the flag — #1720/#685
+            // silent-dead-in-app class, mirrors recovery_dispatcher #1694(a)). No-op under
+            // `AGEND_SHADOW_OBSERVER=0` (default-ON; the =0 kill-switch ⇒ zero change). Owner-only
+            // (`!attached_mode`) like the probe: an attached TUI must not also bind the socket;
+            // the daemon that owns the fleet started it. Lifecycle mirrors run_core — a
+            // detached accept loop that exits with the process; the stale socket is cleared on
+            // next bind (start_unix removes it before binding).
+            crate::daemon::shadow::start(&home);
+            // #2453 Stage 1a / #2737: the three Shadow Observer stream planes (rollout
+            // + opencode + kiro) via the typed phase-2 seam. Requires the phase-1
+            // OwnerMonitoringStarted token (compile-enforced order). #2434: the live
+            // fleet daemon is app mode, so these must be app-wired (not run_core-only)
+            // or each backend's observer source is dead in production. Identical
+            // position/args in run_core's build_tick_infrastructure. shadow::start
+            // (the socket-ingest plane above) stays host-local — separate fork.
+            let owner_services = crate::daemon::owner_services::start_owner_stream_observers(
+                crate::daemon::owner_services::OwnerRole::Owned,
+                &monitoring,
+                &home,
+                &registry,
+                &crate::daemon::owner_services::OwnerStreamStarters::real(),
+            );
+            // Attached mode stays unwired: that process never owns the registry,
+            // and the Telegram bot (if any) runs under the other daemon which
+            // already did its own attach.
+            //
+            // #945 Phase 1: telegram_init is now backgrounded; `telegram_state`
+            // is always None at this point post-backgrounding. Publish registry
+            // to the pending slot so the background thread can attach when its
+            // ~6s HTTP init completes. The if-let path below covers the eager
+            // (fast/mocked init) case.
+            crate::agent::set_pending_registry(Arc::clone(&registry));
+            if let Some(tg) = telegram_state.as_ref() {
+                tg.attach_registry(Arc::clone(&registry));
+            } else if let Some(tg) = crate::channel::lookup_channel_by_name("telegram") {
+                // Multi-channel-safe (t-20260703164240502572-50899-11): this
+                // fallback is telegram-specific (the `tg`/`telegram_state`
+                // naming already assumed it); `active_channel()` would silently
+                // no-op here once discord is also registered.
+                tg.attach_registry(Arc::clone(&registry));
+            }
+            // #2737: hand the final witness to the owned-only maintenance tick below.
+            Some(owner_services)
+        } else {
+            None
+        };
 
     // #2453: the five cohesive key/UI-interaction fields, owned by one type.
     // `name_counter` counts auto-dedup agent names.
@@ -2431,472 +2431,6 @@ mod tests {
              the app-mode live daemon. No 'crate::daemon::shadow::start(&home)' before the \
              #[cfg(test)] cutoff"
         );
-    }
-
-    /// #2413 Phase D + #2453 Stage 1a: the codex rollout-tail observer source
-    /// (Stream plane) must stay wired at the shared owner-service site
-    /// `start_shared_stream_observers`. This pin proves `rollout::spawn` remains
-    /// present in `owner_services` production (comments + string literals masked —
-    /// #2447 r6 — so a commented-out or literal call does NOT satisfy it).
-    /// REVERSE-MUTATION: deleting or commenting the real `rollout::spawn(...)` in
-    /// `owner_services` turns THIS test RED. That the helper is actually reached by
-    /// BOTH hosts (owned `run_app` + headless `run_core`) — the #1720/#685/#2434
-    /// "dead in the app-mode live daemon" class — is proven SEPARATELY by
-    /// `owner_services_called_by_both_hosts`; the two compose the full
-    /// "observer live in both hosts" invariant.
-    #[test]
-    fn run_app_wires_codex_rollout_tailer_2413() {
-        // #2453 Stage 1a: rollout::spawn moved into the shared helper both hosts
-        // call — scan owner_services (production region) instead of run_app.
-        let source = std::fs::read_to_string("src/daemon/owner_services.rs")
-            .or_else(|_| std::fs::read_to_string("agend-terminal/src/daemon/owner_services.rs"))
-            .expect("source file must be readable from test cwd");
-        let prod = &source[..source.find("#[cfg(test)]").unwrap_or(source.len())];
-        // Strip comments FIRST: a commented-out call must not pass the pin (#2447 r6 vacuity fix).
-        let prod_code = strip_comments_and_blank_strings(prod);
-        assert!(
-            prod_code.contains("crate::daemon::shadow::rollout::spawn("),
-            "owner_services::start_shared_stream_observers must spawn the codex rollout-tail \
-             observer (#2413 Phase D) — deleting or commenting it here leaves codex agents' \
-             Stream observer dead in every host that calls the helper (both do — see \
-             owner_services_called_by_both_hosts). No ACTIVE \
-             'crate::daemon::shadow::rollout::spawn(' (comments + string-literal contents masked) before the \
-             #[cfg(test)] cutoff"
-        );
-    }
-
-    /// #2413 opencode plane + #2453 Stage 1a: the opencode SSE `/event` observer
-    /// source (Stream plane) must stay wired at the shared owner-service site
-    /// `start_shared_stream_observers`. This pin proves `opencode::spawn` remains
-    /// present in `owner_services` production (comments + string literals masked —
-    /// #2447 r6 — so a commented-out or literal call does NOT satisfy it).
-    /// REVERSE-MUTATION: deleting or commenting the real `opencode::spawn(...)` in
-    /// `owner_services` turns THIS test RED. That both hosts (owned `run_app` +
-    /// headless `run_core`) actually reach the helper — the #2434 dead-in-app class
-    /// — is proven SEPARATELY by `owner_services_called_by_both_hosts`.
-    #[test]
-    fn run_app_wires_opencode_sse_observer_2413() {
-        // #2453 Stage 1a: opencode::spawn moved into the shared helper both hosts
-        // call — scan owner_services (production region) instead of run_app.
-        let source = std::fs::read_to_string("src/daemon/owner_services.rs")
-            .or_else(|_| std::fs::read_to_string("agend-terminal/src/daemon/owner_services.rs"))
-            .expect("source file must be readable from test cwd");
-        let prod = &source[..source.find("#[cfg(test)]").unwrap_or(source.len())];
-        // Strip comments FIRST: a commented-out call must not pass the pin (#2447 r6 vacuity fix).
-        let prod_code = strip_comments_and_blank_strings(prod);
-        assert!(
-            prod_code.contains("crate::daemon::shadow::opencode::spawn("),
-            "owner_services::start_shared_stream_observers must spawn the opencode SSE observer \
-             (#2413 opencode plane) — deleting or commenting it here leaves opencode agents' \
-             Stream observer dead in every host that calls the helper (both do — see \
-             owner_services_called_by_both_hosts). No ACTIVE \
-             'crate::daemon::shadow::opencode::spawn(' (comments + string-literal contents masked) before the \
-             #[cfg(test)] cutoff"
-        );
-    }
-
-    /// Strip `//` line + `/* */` block comments from Rust source so a wiring-pin
-    /// contains-check can't be satisfied by a COMMENTED-OUT call (#2447 r6: the raw
-    /// contains() was vacuous — commenting the production call left the text present and the
-    /// pin still passed, the exact #2434 dead-wiring class it must catch).
-    ///
-    /// **String-literal-aware** (#2447 r6 round-2): a `//` or `/*` INSIDE a string / char /
-    /// raw-string literal is NOT a comment and is preserved verbatim — so e.g. a
-    /// `"http://x"` URL or a `"/* x */"` payload on a line cannot make the stripper eat the
-    /// rest of that line (a false-RED for the pin). Handles `"..."` (with `\` escapes),
-    /// `'...'` char literals (escape + simple; lifetimes like `'a` are left as-is), and raw
-    /// strings `r"..."` / `r#"..."#` / `br"..."` (hash-count matched, no escapes). Unicode-
-    /// correct. Shared so the codex/opencode app-pins can adopt it (follow-up).
-    fn strip_rust_comments(src: &str) -> String {
-        let s: Vec<char> = src.chars().collect();
-        let n = s.len();
-        let mut out = String::with_capacity(src.len());
-        let mut i = 0;
-        while i < n {
-            let c = s[i];
-            // line comment → skip to (but keep) the newline.
-            if c == '/' && i + 1 < n && s[i + 1] == '/' {
-                i += 2;
-                while i < n && s[i] != '\n' {
-                    i += 1;
-                }
-                continue;
-            }
-            // block comment → skip to `*/`.
-            if c == '/' && i + 1 < n && s[i + 1] == '*' {
-                i += 2;
-                while i + 1 < n && !(s[i] == '*' && s[i + 1] == '/') {
-                    i += 1;
-                }
-                i = (i + 2).min(n);
-                continue;
-            }
-            // raw string `r"..."` / `r#"..."#` / `br"..."` — copy verbatim (no escapes;
-            // close on `"` + the same number of `#`).
-            if c == 'r' || (c == 'b' && i + 1 < n && s[i + 1] == 'r') {
-                let r_pos = if c == 'b' { i + 1 } else { i };
-                let mut k = r_pos + 1;
-                let mut hashes = 0;
-                while k < n && s[k] == '#' {
-                    hashes += 1;
-                    k += 1;
-                }
-                if k < n && s[k] == '"' {
-                    for ch in &s[i..=k] {
-                        out.push(*ch);
-                    }
-                    i = k + 1;
-                    loop {
-                        if i >= n {
-                            break;
-                        }
-                        if s[i] == '"' {
-                            let mut h = 0;
-                            while i + 1 + h < n && h < hashes && s[i + 1 + h] == '#' {
-                                h += 1;
-                            }
-                            if h == hashes {
-                                for ch in &s[i..i + 1 + hashes] {
-                                    out.push(*ch);
-                                }
-                                i += 1 + hashes;
-                                break;
-                            }
-                        }
-                        out.push(s[i]);
-                        i += 1;
-                    }
-                    continue;
-                }
-                // not a raw string (plain identifier starting with r/b) → fall through.
-            }
-            // normal / byte string `"..."` — copy verbatim, honoring `\` escapes.
-            if c == '"' {
-                out.push(c);
-                i += 1;
-                while i < n {
-                    if s[i] == '\\' && i + 1 < n {
-                        out.push(s[i]);
-                        out.push(s[i + 1]);
-                        i += 2;
-                        continue;
-                    }
-                    out.push(s[i]);
-                    let closing = s[i] == '"';
-                    i += 1;
-                    if closing {
-                        break;
-                    }
-                }
-                continue;
-            }
-            // char literal `'x'` / `'\n'` (vs a lifetime `'a`, left as a normal char).
-            if c == '\'' {
-                if i + 1 < n && s[i + 1] == '\\' {
-                    // escape char literal: `'`, `\`, escaped-char, …, `'`.
-                    out.push(s[i]);
-                    out.push(s[i + 1]);
-                    i += 2;
-                    if i < n {
-                        out.push(s[i]); // the escaped char (covers `'\''`)
-                        i += 1;
-                    }
-                    while i < n && s[i] != '\'' {
-                        out.push(s[i]);
-                        i += 1;
-                    }
-                    if i < n {
-                        out.push(s[i]); // closing `'`
-                        i += 1;
-                    }
-                    continue;
-                }
-                if i + 2 < n && s[i + 2] == '\'' {
-                    // simple char literal `'x'` (x may be `"` / `/`, must not start a string).
-                    out.push(s[i]);
-                    out.push(s[i + 1]);
-                    out.push(s[i + 2]);
-                    i += 3;
-                    continue;
-                }
-                // lifetime / stray `'` → normal char.
-            }
-            out.push(c);
-            i += 1;
-        }
-        out
-    }
-
-    /// Replace the CONTENTS of every string / raw-string literal with spaces (delimiters
-    /// kept) in ALREADY-comment-free Rust source; char literals are passed through verbatim
-    /// (they can't hold a multi-char needle, but must be consumed so a `"` inside `'"'`
-    /// doesn't mis-start a string scan). Sibling of [`strip_rust_comments`] used only by the
-    /// wiring pins via [`strip_comments_and_blank_strings`].
-    ///
-    /// #2450 reviewer-6: comment-stripping alone left the pins **string-literal-blind** — a
-    /// needle hidden in a string (`let _ = "…::spawn(";`) survived the strip, so the pin's
-    /// `contains()` still falsely passed (the exact #2434 dead-wiring vacuity, just relocated
-    /// from a comment into a string). Blanking string interiors closes that: the only place
-    /// the needle survives is an ACTIVE code call.
-    fn blank_string_contents(src: &str) -> String {
-        let s: Vec<char> = src.chars().collect();
-        let n = s.len();
-        let mut out = String::with_capacity(src.len());
-        let mut i = 0;
-        while i < n {
-            let c = s[i];
-            // raw string `r"..."` / `r#"..."#` / `br"..."` — blank interior, keep delimiters.
-            if c == 'r' || (c == 'b' && i + 1 < n && s[i + 1] == 'r') {
-                let r_pos = if c == 'b' { i + 1 } else { i };
-                let mut k = r_pos + 1;
-                let mut hashes = 0;
-                while k < n && s[k] == '#' {
-                    hashes += 1;
-                    k += 1;
-                }
-                if k < n && s[k] == '"' {
-                    for ch in &s[i..=k] {
-                        out.push(*ch); // opening `r#"` delimiter, verbatim
-                    }
-                    i = k + 1;
-                    loop {
-                        if i >= n {
-                            break;
-                        }
-                        if s[i] == '"' {
-                            let mut h = 0;
-                            while i + 1 + h < n && h < hashes && s[i + 1 + h] == '#' {
-                                h += 1;
-                            }
-                            if h == hashes {
-                                for ch in &s[i..i + 1 + hashes] {
-                                    out.push(*ch); // closing `"#`, verbatim
-                                }
-                                i += 1 + hashes;
-                                break;
-                            }
-                        }
-                        out.push(' '); // blank one interior char
-                        i += 1;
-                    }
-                    continue;
-                }
-                // not a raw string (identifier starting with r/b) → fall through.
-            }
-            // normal / byte string `"..."` — blank interior (honor `\` escapes), keep quotes.
-            if c == '"' {
-                out.push('"');
-                i += 1;
-                while i < n {
-                    if s[i] == '\\' && i + 1 < n {
-                        out.push(' ');
-                        out.push(' ');
-                        i += 2;
-                        continue;
-                    }
-                    if s[i] == '"' {
-                        out.push('"');
-                        i += 1;
-                        break;
-                    }
-                    out.push(' ');
-                    i += 1;
-                }
-                continue;
-            }
-            // char literal `'x'` / `'\n'` — pass through verbatim (consume so a `"` inside a
-            // char literal can't start a string scan); a lifetime `'a` is a normal char.
-            if c == '\'' {
-                if i + 1 < n && s[i + 1] == '\\' {
-                    out.push(s[i]);
-                    out.push(s[i + 1]);
-                    i += 2;
-                    if i < n {
-                        out.push(s[i]);
-                        i += 1;
-                    }
-                    while i < n && s[i] != '\'' {
-                        out.push(s[i]);
-                        i += 1;
-                    }
-                    if i < n {
-                        out.push(s[i]);
-                        i += 1;
-                    }
-                    continue;
-                }
-                if i + 2 < n && s[i + 2] == '\'' {
-                    out.push(s[i]);
-                    out.push(s[i + 1]);
-                    out.push(s[i + 2]);
-                    i += 3;
-                    continue;
-                }
-                // lifetime / stray `'` → normal char.
-            }
-            out.push(c);
-            i += 1;
-        }
-        out
-    }
-
-    /// The wiring-pin matcher: strip comments AND blank string-literal contents, so a
-    /// `…::spawn(` needle counts ONLY when it is an ACTIVE code call — not commented out
-    /// (#2447) and not hidden in a string literal (#2450 reviewer-6). Composition of the two
-    /// proven passes; `strip_rust_comments` body is left untouched.
-    fn strip_comments_and_blank_strings(src: &str) -> String {
-        blank_string_contents(&strip_rust_comments(src))
-    }
-
-    /// #2450 reviewer-6 regression: the wiring-pin matcher must treat a `…::spawn(` needle as
-    /// PRESENT only when it is ACTIVE code — not in a comment (#2447) and not hidden inside a
-    /// string / raw-string literal (#2450). Pins reviewer-6's exact false-green break-probe.
-    #[test]
-    fn strip_comments_and_blank_strings_masks_string_and_comment_needles() {
-        let needle = "crate::daemon::shadow::rollout::spawn(";
-        // ACTIVE code call → still present (must NOT false-kill the real wiring).
-        assert!(strip_comments_and_blank_strings(&format!("    {needle}x);")).contains(needle));
-        // reviewer-6 break-probe: needle hidden in a NORMAL string literal → masked.
-        assert!(
-            !strip_comments_and_blank_strings(&format!("let _p = \"{needle}\";")).contains(needle)
-        );
-        // needle hidden in a RAW string literal → masked.
-        assert!(
-            !strip_comments_and_blank_strings(&format!("let _p = r#\"{needle}\"#;"))
-                .contains(needle)
-        );
-        // needle in a comment → masked (the comment-strip pass still applies).
-        assert!(!strip_comments_and_blank_strings(&format!("// {needle}\n")).contains(needle));
-        // string-literal-AWARE preserved: a `"http://x"` URL must not eat the rest of its
-        // line, so real code after it survives (no false-RED).
-        assert!(
-            strip_comments_and_blank_strings("let u = \"http://x\"; keep_me();")
-                .contains("keep_me()")
-        );
-    }
-
-    /// #2447 r6 round-2: `strip_rust_comments` must strip REAL comments yet preserve
-    /// `//` / `/*` that live inside string / char / raw-string literals (else a `"http://x"`
-    /// URL would false-strip its line → a vacuity-fix that introduces a false-RED). Covers
-    /// r6's requested cases.
-    #[test]
-    fn strip_rust_comments_is_string_literal_aware() {
-        // Real comments ARE stripped.
-        assert!(!strip_rust_comments("keep // dropme\n").contains("dropme"));
-        let blk = strip_rust_comments("alpha /* dropme */ omega");
-        assert!(!blk.contains("dropme") && blk.contains("alpha") && blk.contains("omega"));
-        // `//` inside a normal string is NOT a comment.
-        assert!(strip_rust_comments(r#"let u = "http://example.com/a";"#)
-            .contains("http://example.com/a"));
-        // `/* */` inside a string is preserved.
-        assert!(strip_rust_comments(r#"let s = "/* not a comment */";"#)
-            .contains("/* not a comment */"));
-        // raw string content (incl. `//`) is preserved.
-        assert!(strip_rust_comments(r##"let r = r#"// not comment"#;"##).contains("// not comment"));
-        // a quote/slash inside a CHAR literal must not start a string / a comment.
-        assert!(strip_rust_comments(r#"let c = '"'; live_after_quote();"#)
-            .contains("live_after_quote()"));
-        assert!(
-            strip_rust_comments("let c = '/'; live_after_slash();").contains("live_after_slash()")
-        );
-        // escaped-quote char literal `'\''` must not desync the scanner.
-        assert!(
-            strip_rust_comments(r"let c = '\''; live_after_esc();").contains("live_after_esc()")
-        );
-        // a real trailing line comment AFTER an in-string `//` is still stripped.
-        let mixed = strip_rust_comments("let u = \"a//b\"; keep(); // dropme\n");
-        assert!(mixed.contains("a//b") && mixed.contains("keep()") && !mixed.contains("dropme"));
-        // the pin's own case: active call survives; commented-out does not.
-        assert!(
-            strip_rust_comments("    crate::daemon::shadow::kiro::spawn(x);")
-                .contains("crate::daemon::shadow::kiro::spawn(")
-        );
-        assert!(
-            !strip_rust_comments("    // crate::daemon::shadow::kiro::spawn(x);")
-                .contains("crate::daemon::shadow::kiro::spawn(")
-        );
-    }
-
-    /// #2413 kiro plane + #2453 Stage 1a: the kiro session-tail observer source
-    /// (Stream plane) must stay wired at the shared owner-service site
-    /// `start_shared_stream_observers`. This pin proves `kiro::spawn` remains
-    /// present in `owner_services` production (comments + string literals masked —
-    /// #2447 r6 — so a commented-out or literal call does NOT satisfy it).
-    /// REVERSE-MUTATION: deleting or commenting the real `kiro::spawn(...)` in
-    /// `owner_services` turns THIS test RED. That both hosts (owned `run_app` +
-    /// headless `run_core`) actually reach the helper — the #2434 dead-in-app class
-    /// — is proven SEPARATELY by `owner_services_called_by_both_hosts`.
-    #[test]
-    fn run_app_wires_kiro_session_tailer_2413() {
-        // #2453 Stage 1a: kiro::spawn moved into the shared helper both hosts
-        // call — scan owner_services (production region) instead of run_app.
-        let source = std::fs::read_to_string("src/daemon/owner_services.rs")
-            .or_else(|_| std::fs::read_to_string("agend-terminal/src/daemon/owner_services.rs"))
-            .expect("source file must be readable from test cwd");
-        let prod = &source[..source.find("#[cfg(test)]").unwrap_or(source.len())];
-        // Strip comments FIRST: a commented-out call must not pass the pin (r6 vacuity fix).
-        let prod_code = strip_comments_and_blank_strings(prod);
-        assert!(
-            prod_code.contains("crate::daemon::shadow::kiro::spawn("),
-            "owner_services::start_shared_stream_observers must spawn the kiro session-tail \
-             observer (#2413 kiro plane) — deleting or commenting it here leaves kiro agents' \
-             Stream observer dead in every host that calls the helper (both do — see \
-             owner_services_called_by_both_hosts). No ACTIVE \
-             'crate::daemon::shadow::kiro::spawn(' (comments + string-literal contents masked) before the \
-             #[cfg(test)] cutoff"
-        );
-    }
-
-    // ----- #2453 Stage 1a: shared owner-service wiring guards (STATIC) -----
-    // These reuse the module's existing `strip_comments_and_blank_strings`
-    // masker; no parser is duplicated. Source-scan only — no helper is called and
-    // no thread is spawned. Runtime-host coverage is intentionally ABSENT for
-    // this pure refactor (no non-invasive host entry exists).
-
-    const OWNER_MOVED_SPAWNS: [&str; 5] = [
-        "instance_monitor::spawn_monitor_tick(",
-        "api_activity_probe::spawn(",
-        "shadow::rollout::spawn(",
-        "shadow::opencode::spawn(",
-        "shadow::kiro::spawn(",
-    ];
-
-    /// A source file's production region (before its test module), comments
-    /// stripped and string literals blanked. Masks FIRST, then cuts at the first
-    /// `mod tests {` in masked source — robust to a stray item-level
-    /// `#[cfg(test)]` before the module (e.g. daemon's `test_env_lock`) and to an
-    /// attribute between `#[cfg(test)]` and the module (e.g. `#[allow(...)]`).
-    fn owner_wiring_prod(rel: &str) -> String {
-        let src = std::fs::read_to_string(rel)
-            .or_else(|_| std::fs::read_to_string(format!("agend-terminal/{rel}")))
-            .unwrap_or_else(|_| panic!("source file must be readable from test cwd: {rel}"));
-        let masked = strip_comments_and_blank_strings(&src);
-        let end = masked.find("mod tests {").unwrap_or(masked.len());
-        masked[..end].to_string()
-    }
-
-    /// STATIC: the five spawn calls are absent from BOTH host bodies and present
-    /// at the shared owner_services wiring site. Scope is the two run hosts + the
-    /// wiring module — NOT a global-uniqueness claim.
-    #[test]
-    fn owner_services_spawns_absent_from_hosts_present_at_wiring_site() {
-        for host in ["src/app/mod.rs", "src/daemon/mod.rs"] {
-            let code = owner_wiring_prod(host);
-            for spawn in OWNER_MOVED_SPAWNS {
-                assert!(
-                    !code.contains(spawn),
-                    "{host} host body must NOT call `{spawn}` — it moved to the shared \
-                     owner_services wiring site (a host-local copy reintroduces dual-host drift)"
-                );
-            }
-        }
-        let wiring = owner_wiring_prod("src/daemon/owner_services.rs");
-        for spawn in OWNER_MOVED_SPAWNS {
-            assert!(
-                wiring.contains(spawn),
-                "owner_services must contain `{spawn}` (the shared wiring site both hosts call)"
-            );
-        }
     }
 
     /// #1726 must-verify: app-standalone runs these handlers with EMPTY

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -460,13 +460,27 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
     // and pushes a vterm tail to the agent's Telegram topic. In Attached mode
     // the daemon already runs its own supervisor against the real registry, so
     // the app must not also poll a disjoint (empty) registry.
-    if !attached_mode {
+    // #2737: the owner-service composition is now a typed two-phase seam. This
+    // owned-only block yields the `OwnerServicesStarted` witness (None when
+    // attached); the owned-only maintenance tick REQUIRES it, so a run_app that
+    // skips the seam fails to compile (structural I2, replacing the old
+    // `owner_services_called_by_both_hosts` string-scan).
+    let owner_services: Option<crate::daemon::owner_services::OwnerServicesStarted> = if !attached_mode
+    {
         crate::daemon::supervisor::spawn(home.clone(), Arc::clone(&registry));
-        // #2453 Stage 1a: monitoring (instance_monitor + api_activity_probe)
-        // wired via the shared owner-services helper — identical call in
-        // run_core's build_tick_infrastructure, so a service can't be wired in
-        // one host and silently dead in the other (#982/#1002/#1720/#2434).
-        crate::daemon::owner_services::start_shared_monitoring_services(&home, &registry);
+        // #2453 Stage 1a / #2737: owner monitoring (instance_monitor +
+        // api_activity_probe) via the typed phase-1 seam — identical position/args
+        // in run_core's build_tick_infrastructure, so a service can't be wired in
+        // one host and silently dead in the other (#982/#1002/#1720/#2434). The
+        // returned OwnerMonitoringStarted token is required by phase 2 below, so
+        // monitoring is compile-forced to precede the stream observers (exact
+        // order preserved: monitoring → shadow::start → stream).
+        let monitoring = crate::daemon::owner_services::start_owner_monitoring(
+            crate::daemon::owner_services::OwnerRole::Owned,
+            &home,
+            &registry,
+            &crate::daemon::owner_services::OwnerMonitoringStarters::real(),
+        );
         // #2413 Phase B (live-fix): start the hook-event socket server in app mode too.
         // The LIVE fleet daemon runs THIS `run_app`, never `run_core` (shadow::start's
         // only other caller), so without this the whole Shadow Observer plane was dead in
@@ -478,13 +492,20 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
         // detached accept loop that exits with the process; the stale socket is cleared on
         // next bind (start_unix removes it before binding).
         crate::daemon::shadow::start(&home);
-        // #2453 Stage 1a: the three Shadow Observer stream planes (rollout +
-        // opencode + kiro) wired via the shared owner-services helper. #2434: the
-        // live fleet daemon is app mode, so these must be app-wired (not
-        // run_core-only) or each backend's observer source is dead in production.
-        // Identical call in run_core's build_tick_infrastructure. shadow::start
+        // #2453 Stage 1a / #2737: the three Shadow Observer stream planes (rollout
+        // + opencode + kiro) via the typed phase-2 seam. Requires the phase-1
+        // OwnerMonitoringStarted token (compile-enforced order). #2434: the live
+        // fleet daemon is app mode, so these must be app-wired (not run_core-only)
+        // or each backend's observer source is dead in production. Identical
+        // position/args in run_core's build_tick_infrastructure. shadow::start
         // (the socket-ingest plane above) stays host-local — separate fork.
-        crate::daemon::owner_services::start_shared_stream_observers(&home, &registry);
+        let owner_services = crate::daemon::owner_services::start_owner_stream_observers(
+            crate::daemon::owner_services::OwnerRole::Owned,
+            &monitoring,
+            &home,
+            &registry,
+            &crate::daemon::owner_services::OwnerStreamStarters::real(),
+        );
         // Attached mode stays unwired: that process never owns the registry,
         // and the Telegram bot (if any) runs under the other daemon which
         // already did its own attach.
@@ -504,7 +525,11 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
             // no-op here once discord is also registered.
             tg.attach_registry(Arc::clone(&registry));
         }
-    }
+        // #2737: hand the final witness to the owned-only maintenance tick below.
+        Some(owner_services)
+    } else {
+        None
+    };
 
     // #2453: the five cohesive key/UI-interaction fields, owned by one type.
     // `name_counter` counts auto-dedup agent names.
@@ -1160,6 +1185,12 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
                     &app_configs,
                     &app_handlers,
                     app_tick_progress.as_deref(),
+                    // #2737: owned tick only fires when `tick_rx` is Some (owned
+                    // mode), where `owner_services` is always `Some` (the seam ran
+                    // in the owned bootstrap block above).
+                    owner_services
+                        .as_ref()
+                        .expect("owned maintenance tick requires the owner-service witness"),
                 );
                 // PR4: back to Waiting between maintenance ticks so the monitor
                 // never attributes render/idle time to the maintenance host.
@@ -1369,6 +1400,11 @@ fn app_maintenance_tick(
     configs: &crate::api::ConfigRegistry,
     handlers: &[Box<dyn crate::daemon::per_tick::PerTickHandler>],
     progress: Option<&crate::daemon::tick_stall::TickProgress>,
+    // #2737: proof the owner-service seam ran. This owned-only tick is the
+    // witness consumer that makes app's dual-host reach a COMPILE property
+    // (structural I2) — run_app cannot reach here without an OwnerServicesStarted,
+    // which only the seam can mint. Unused at runtime (it is a capability witness).
+    _owner_services: &crate::daemon::owner_services::OwnerServicesStarted,
 ) {
     let tick_ctx = crate::daemon::per_tick::TickContext {
         home,
@@ -2817,10 +2853,6 @@ mod tests {
     // no thread is spawned. Runtime-host coverage is intentionally ABSENT for
     // this pure refactor (no non-invasive host entry exists).
 
-    const OWNER_HELPERS: [&str; 2] = [
-        "start_shared_monitoring_services(",
-        "start_shared_stream_observers(",
-    ];
     const OWNER_MOVED_SPAWNS: [&str; 5] = [
         "instance_monitor::spawn_monitor_tick(",
         "api_activity_probe::spawn(",
@@ -2843,22 +2875,6 @@ mod tests {
         masked[..end].to_string()
     }
 
-    /// STATIC: BOTH production hosts (owned `run_app`, headless
-    /// `build_tick_infrastructure`) call BOTH shared helpers — deleting either
-    /// host's call turns this RED (the dual-host wiring path is required).
-    #[test]
-    fn owner_services_called_by_both_hosts() {
-        for host in ["src/app/mod.rs", "src/daemon/mod.rs"] {
-            let code = owner_wiring_prod(host);
-            for helper in OWNER_HELPERS {
-                assert!(
-                    code.contains(helper),
-                    "{host} production must call `{helper}` (dual-host shared-wiring path)"
-                );
-            }
-        }
-    }
-
     /// STATIC: the five spawn calls are absent from BOTH host bodies and present
     /// at the shared owner_services wiring site. Scope is the two run hosts + the
     /// wiring module — NOT a global-uniqueness claim.
@@ -2879,41 +2895,6 @@ mod tests {
             assert!(
                 wiring.contains(spawn),
                 "owner_services must contain `{spawn}` (the shared wiring site both hosts call)"
-            );
-        }
-    }
-
-    /// STATIC: in app mode both helper calls sit INSIDE the `if !attached_mode`
-    /// owner guard — an attached TUI must never start the shared daemon services.
-    /// Moving a call outside the guard turns this RED.
-    #[test]
-    fn owner_services_calls_inside_attached_mode_guard() {
-        let code = owner_wiring_prod("src/app/mod.rs");
-        let start = code
-            .find("if !attached_mode {")
-            .expect("app production must contain the `if !attached_mode {` owner guard");
-        let after = &code[start..];
-        let mut depth = 0i32;
-        let mut end = after.len();
-        for (idx, ch) in after.char_indices() {
-            match ch {
-                '{' => depth += 1,
-                '}' => {
-                    depth -= 1;
-                    if depth == 0 {
-                        end = idx + ch.len_utf8();
-                        break;
-                    }
-                }
-                _ => {}
-            }
-        }
-        let block = &after[..end];
-        for helper in OWNER_HELPERS {
-            assert!(
-                block.contains(helper),
-                "app must call `{helper}` INSIDE the `if !attached_mode` owner guard \
-                 (attached TUI must not start shared services)"
             );
         }
     }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1227,6 +1227,11 @@ fn spawn_fleet_agents(home: &Path, agents: &[AgentDef], ctx: &DaemonContext) {
 /// until the main loop exits.
 struct TickKeepalive {
     _task_sweep: crate::daemon::task_sweep::TaskSweep,
+    // #2737: owner-service witness held for daemon lifetime. build_tick_infrastructure
+    // cannot construct TickKeepalive without calling the two-phase seam, so run_core's
+    // dual-host reach is a COMPILE property (structural I2, replacing the old
+    // `owner_services_called_by_both_hosts` string-scan).
+    _owner_services: crate::daemon::owner_services::OwnerServicesStarted,
 }
 
 fn build_tick_infrastructure(
@@ -1245,14 +1250,28 @@ fn build_tick_infrastructure(
         supervisor::spawn(home.to_path_buf(), Arc::clone(&ctx.registry));
     }
     router::spawn(home.to_path_buf(), Arc::clone(&ctx.registry));
-    // #2453 Stage 1a: monitoring (instance_monitor + api_activity_probe) via the
-    // shared owner-services helper — identical call in owned `run_app`.
-    crate::daemon::owner_services::start_shared_monitoring_services(home, &ctx.registry);
-    // #2453 Stage 1a: the three Shadow Observer stream planes (rollout + opencode
-    // + kiro) via the shared owner-services helper — identical call in owned
+    // #2453 Stage 1a / #2737: owner monitoring (instance_monitor +
+    // api_activity_probe) via the typed phase-1 seam — identical position/args to
+    // owned `run_app`. The daemon host always owns the fleet (no attached concept),
+    // so role = Owned. The returned token is required by phase 2 (compile-enforced
+    // order).
+    let monitoring = crate::daemon::owner_services::start_owner_monitoring(
+        crate::daemon::owner_services::OwnerRole::Owned,
+        home,
+        &ctx.registry,
+        &crate::daemon::owner_services::OwnerMonitoringStarters::real(),
+    );
+    // #2453 Stage 1a / #2737: the three Shadow Observer stream planes (rollout +
+    // opencode + kiro) via the typed phase-2 seam — identical call in owned
     // `run_app`. No-op under AGEND_SHADOW_OBSERVER=0 (default-ON). shadow::start
     // (the socket-ingest plane) stays host-local (separate fork).
-    crate::daemon::owner_services::start_shared_stream_observers(home, &ctx.registry);
+    let owner_services = crate::daemon::owner_services::start_owner_stream_observers(
+        crate::daemon::owner_services::OwnerRole::Owned,
+        &monitoring,
+        home,
+        &ctx.registry,
+        &crate::daemon::owner_services::OwnerStreamStarters::real(),
+    );
 
     crate::inbox::recover_half_writes(home);
     // #1988: same half-write recovery for the task-event log — quarantine a
@@ -1288,7 +1307,14 @@ fn build_tick_infrastructure(
         rx
     };
 
-    (TickKeepalive { _task_sweep }, handlers, tick_rx)
+    (
+        TickKeepalive {
+            _task_sweep,
+            _owner_services: owner_services,
+        },
+        handlers,
+        tick_rx,
+    )
 }
 
 fn log_residual_worktrees(home: &Path) {

--- a/src/daemon/owner_services.rs
+++ b/src/daemon/owner_services.rs
@@ -1,11 +1,10 @@
-//! #2453 Stage 1a: two host-agnostic helpers that own the WIRING (not the
+//! #2453 Stage 1a: a host-agnostic TWO-PHASE seam that owns the WIRING (not the
 //! JoinHandles) of the owner-only background services started identically by
 //! BOTH run hosts — the TUI owned-mode `app::run_app` and the headless
-//! `daemon::run_core` (via `build_tick_infrastructure`). Extracting the shared
-//! spawn calls into one place closes the dual-host drift class (#982/#1002/
-//! #1720/#2434: "wired in one host, silently dead in the other"). Pure,
-//! behavior-preserving: same calls, same order, same args, same cfg — no new
-//! threads/locks/state/channels.
+//! `daemon::run_core` (via `build_tick_infrastructure`). Centralizing the spawn
+//! calls closes the dual-host drift class (#982/#1002/#1720/#2434: "wired in one
+//! host, silently dead in the other"). Behavior-preserving: same calls, same
+//! order, same args, same cfg — no new threads/locks/state/channels.
 //!
 //! Deliberately EXCLUDED (each a separate decision fork, per d-20260711201257672833-2):
 //! `shadow::start` (different ordering per host), `supervisor::spawn` (`#[cfg(unix)]`
@@ -29,68 +28,39 @@ use crate::agent::AgentRegistry;
 use std::path::Path;
 use std::sync::Arc;
 
-/// Owner-only agent liveness/activity monitoring services. Each spawns a
-/// process-lifetime thread internally and returns `()` — this helper owns the
-/// WIRING, not a `JoinHandle`. Called identically by owned `run_app` and headless
-/// `build_tick_infrastructure`.
-pub(crate) fn start_shared_monitoring_services(home: &Path, registry: &AgentRegistry) {
-    crate::instance_monitor::spawn_monitor_tick(home.to_path_buf(), Arc::clone(registry));
-    // #2413 Phase 1: out-of-path lsof API-activity probe (feeds
-    // AgentCore::api_activity for false-idle detection). Self-disables if `lsof`
-    // is absent.
-    crate::api_activity_probe::spawn(Arc::clone(registry));
-}
-
-/// Owner-only Shadow Observer per-backend Evidence-SOURCE planes (Stream plane).
-/// Each is a no-op under `AGEND_SHADOW_OBSERVER=0` (default-ON). The live fleet
-/// daemon is app mode, so gating these run_core-only would leave each backend's
-/// observer source dead in production (#2434). `shadow::start` (the socket-ingest
-/// plane) is deliberately NOT here — its per-host ordering differs (separate fork).
-pub(crate) fn start_shared_stream_observers(home: &Path, registry: &AgentRegistry) {
-    // #2413 Phase D: codex rollout-tail — read-only tail of
-    // ~/.codex/sessions/.../rollout-*.jsonl → Evidence → shared buffer.
-    crate::daemon::shadow::rollout::spawn(Arc::clone(registry), home.to_path_buf());
-    // #2413 opencode plane: SSE `/event` observer (per-agent embedded server).
-    crate::daemon::shadow::opencode::spawn(Arc::clone(registry), home.to_path_buf());
-    // #2413 kiro plane: read-only tail of ~/.kiro/sessions/cli/<uuid>.jsonl.
-    crate::daemon::shadow::kiro::spawn(Arc::clone(registry), home.to_path_buf());
-}
-
-// ===================================================================
-// #2737 typed two-phase owner-service seam (RED scaffolding).
-// Commit A: declarations + stub phase bodies that start NOTHING, so the
-// call-level tests below are RED. Commit B fills in the real bodies, adds the
-// permit to the five low-level spawns, wires both hosts, and deletes the old
-// string-masker guards. The `#[allow(dead_code)]` marks below are removed in
-// commit B once production wires these items.
-// ===================================================================
-
 /// Which host role is composing the owner services. Owned → start them;
 /// Attached (a TUI connected to another daemon that owns the fleet) → start none.
-#[allow(dead_code)]
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub(crate) enum OwnerRole {
     Owned,
+    /// Production gates attached-exclusion via the unchanged `if !attached_mode`
+    /// wrapper in `run_app` (the seam is called with `Owned` INSIDE it, preserving
+    /// #2737's exact order), so this variant is constructed only by tests today —
+    /// it encodes the "attached starts none" contract that
+    /// `attached_two_phases_start_none` verifies behaviorally against the real seam.
+    #[cfg_attr(not(test), allow(dead_code))]
     Attached,
 }
 
 /// Capability token gating the five owner-service spawns. The single field is
 /// PRIVATE to this module, so only `owner_services` code can mint one: other
 /// modules may name `&OwnerServicePermit` in a signature but cannot construct it,
-/// which makes a host-body direct spawn fail to compile (structural I4).
-#[allow(dead_code)]
+/// which makes a host-body direct spawn fail to compile (structural I4 — the
+/// former `owner_services_spawns_absent_from_hosts…` masker guard, now a compile
+/// property).
 pub(crate) struct OwnerServicePermit(());
 
 /// Phase-1 witness — proof that the monitoring phase ran. Required as an argument
 /// by phase 2, so the compiler enforces monitoring-before-stream ordering.
 /// Ctor is private to this module.
-#[allow(dead_code)]
 #[must_use]
 pub(crate) struct OwnerMonitoringStarted(());
 
 /// Final witness — proof that BOTH owner-service phases ran. Retained by each
-/// owner host (structural I2). Ctor is private to this module.
-#[allow(dead_code)]
+/// owner host (app: required by owned-only `app_maintenance_tick`; daemon: held
+/// in `TickKeepalive`), so a host that skips the seam fails to compile
+/// (structural I2 — the former `owner_services_called_by_both_hosts` guard).
+/// Ctor is private to this module.
 #[must_use]
 pub(crate) struct OwnerServicesStarted(());
 
@@ -110,32 +80,92 @@ pub(crate) struct OwnerStreamStarters<'a> {
     pub kiro: &'a dyn Fn(&OwnerServicePermit, &Path, &AgentRegistry),
 }
 
-/// Phase 1: owner monitoring services. `Owned` starts them via the injected
-/// starters; `Attached` starts none. Returns the `OwnerMonitoringStarted` token
-/// phase 2 requires.
-#[allow(dead_code)]
+impl OwnerMonitoringStarters<'static> {
+    /// Production starters — forward to the real thread-spawning services.
+    /// `&fn_item` promotes to `&'static dyn Fn` (fn items are zero-sized consts).
+    pub(crate) fn real() -> Self {
+        OwnerMonitoringStarters {
+            monitor_tick: &real_monitor_tick,
+            api_activity_probe: &real_api_activity_probe,
+        }
+    }
+}
+
+impl OwnerStreamStarters<'static> {
+    /// Production starters — forward to the real thread-spawning observers.
+    pub(crate) fn real() -> Self {
+        OwnerStreamStarters {
+            rollout: &real_rollout,
+            opencode: &real_opencode,
+            kiro: &real_kiro,
+        }
+    }
+}
+
+fn real_monitor_tick(permit: &OwnerServicePermit, home: &Path, registry: &AgentRegistry) {
+    crate::instance_monitor::spawn_monitor_tick(permit, home.to_path_buf(), Arc::clone(registry));
+}
+
+/// #2413 Phase 1: out-of-path lsof API-activity probe (feeds AgentCore::api_activity
+/// for false-idle detection). Self-disables if `lsof` is absent.
+fn real_api_activity_probe(permit: &OwnerServicePermit, registry: &AgentRegistry) {
+    crate::api_activity_probe::spawn(permit, Arc::clone(registry));
+}
+
+/// #2413 Phase D: codex rollout-tail — read-only tail of
+/// ~/.codex/sessions/.../rollout-*.jsonl → Evidence → shared buffer.
+fn real_rollout(permit: &OwnerServicePermit, home: &Path, registry: &AgentRegistry) {
+    crate::daemon::shadow::rollout::spawn(permit, Arc::clone(registry), home.to_path_buf());
+}
+
+/// #2413 opencode plane: SSE `/event` observer (per-agent embedded server).
+fn real_opencode(permit: &OwnerServicePermit, home: &Path, registry: &AgentRegistry) {
+    crate::daemon::shadow::opencode::spawn(permit, Arc::clone(registry), home.to_path_buf());
+}
+
+/// #2413 kiro plane: read-only tail of ~/.kiro/sessions/cli/<uuid>.jsonl.
+fn real_kiro(permit: &OwnerServicePermit, home: &Path, registry: &AgentRegistry) {
+    crate::daemon::shadow::kiro::spawn(permit, Arc::clone(registry), home.to_path_buf());
+}
+
+/// Phase 1: owner monitoring services (`instance_monitor` + `api_activity_probe`).
+/// `Owned` starts them via the injected starters; `Attached` starts none. Returns
+/// the `OwnerMonitoringStarted` token phase 2 requires. No-op / no threads under
+/// `Attached`.
 pub(crate) fn start_owner_monitoring(
-    _role: OwnerRole,
-    _home: &Path,
-    _registry: &AgentRegistry,
-    _starters: &OwnerMonitoringStarters<'_>,
+    role: OwnerRole,
+    home: &Path,
+    registry: &AgentRegistry,
+    starters: &OwnerMonitoringStarters<'_>,
 ) -> OwnerMonitoringStarted {
-    // RED stub (commit A): starts nothing → the owned call-level test is RED.
+    if role == OwnerRole::Owned {
+        let permit = OwnerServicePermit(());
+        (starters.monitor_tick)(&permit, home, registry);
+        (starters.api_activity_probe)(&permit, registry);
+    }
     OwnerMonitoringStarted(())
 }
 
-/// Phase 2: owner stream observers. Requires `&OwnerMonitoringStarted` so it
-/// cannot be called before phase 1 (compile-enforced ordering). `Owned` starts
-/// them; `Attached` starts none. Returns the final `OwnerServicesStarted` witness.
-#[allow(dead_code)]
+/// Phase 2: owner Shadow-Observer stream planes (rollout + opencode + kiro).
+/// Requires `&OwnerMonitoringStarted` so it cannot be called before phase 1
+/// (compile-enforced ordering). `Owned` starts them; `Attached` starts none.
+/// Returns the final `OwnerServicesStarted` witness. Each observer is itself a
+/// no-op under `AGEND_SHADOW_OBSERVER=0` (default-ON). `shadow::start` (the
+/// socket-ingest plane) is deliberately NOT here — its per-host ordering differs
+/// (separate fork), so it stays host-local between the two phases in `run_app`.
 pub(crate) fn start_owner_stream_observers(
-    _role: OwnerRole,
+    role: OwnerRole,
     _monitoring: &OwnerMonitoringStarted,
-    _home: &Path,
-    _registry: &AgentRegistry,
-    _starters: &OwnerStreamStarters<'_>,
+    home: &Path,
+    registry: &AgentRegistry,
+    starters: &OwnerStreamStarters<'_>,
 ) -> OwnerServicesStarted {
-    // RED stub (commit A): starts nothing → the owned call-level test is RED.
+    if role == OwnerRole::Owned {
+        let permit = OwnerServicePermit(());
+        (starters.rollout)(&permit, home, registry);
+        (starters.opencode)(&permit, home, registry);
+        (starters.kiro)(&permit, home, registry);
+    }
     OwnerServicesStarted(())
 }
 

--- a/src/daemon/owner_services.rs
+++ b/src/daemon/owner_services.rs
@@ -11,9 +11,19 @@
 //! `shadow::start` (different ordering per host), `supervisor::spawn` (`#[cfg(unix)]`
 //! delta), `router`/`TaskSweep`/recovery (headless-only), bootstrap/restart/shutdown.
 //!
-//! The structural wiring guards for these helpers live in `app::tests`
-//! (`owner_services_*`), where the shared comment/string masker already exists —
-//! no masker is duplicated here and this module stays production-only.
+//! #2737 (decision d-20260712034336318886-6): the old app::tests string masker +
+//! source-scan guards are replaced by the TYPED two-phase seam below. Both hosts
+//! reach the owner services by construction/real call-level tests instead of by
+//! grepping source text:
+//! - `start_owner_monitoring` → `OwnerMonitoringStarted`, then (in app) `shadow::start`,
+//!   then `start_owner_stream_observers(…, &OwnerMonitoringStarted, …)` → `OwnerServicesStarted`.
+//!   The phase-2 `&OwnerMonitoringStarted` parameter makes "monitoring runs before stream
+//!   observers" a COMPILE dependency (you cannot call phase 2 without phase 1's token).
+//! - the five low-level spawns require a private `OwnerServicePermit`, so a host-body
+//!   direct spawn cannot compile (structural I4 — no host-local copy).
+//! - `OwnerServicesStarted` is retained by each owner host (app: required by the
+//!   owned-only `app_maintenance_tick`; daemon: held in `TickKeepalive`), so a host
+//!   that skips the seam fails to compile (structural I2 — dual-host reach).
 
 use crate::agent::AgentRegistry;
 use std::path::Path;
@@ -44,4 +54,154 @@ pub(crate) fn start_shared_stream_observers(home: &Path, registry: &AgentRegistr
     crate::daemon::shadow::opencode::spawn(Arc::clone(registry), home.to_path_buf());
     // #2413 kiro plane: read-only tail of ~/.kiro/sessions/cli/<uuid>.jsonl.
     crate::daemon::shadow::kiro::spawn(Arc::clone(registry), home.to_path_buf());
+}
+
+// ===================================================================
+// #2737 typed two-phase owner-service seam (RED scaffolding).
+// Commit A: declarations + stub phase bodies that start NOTHING, so the
+// call-level tests below are RED. Commit B fills in the real bodies, adds the
+// permit to the five low-level spawns, wires both hosts, and deletes the old
+// string-masker guards. The `#[allow(dead_code)]` marks below are removed in
+// commit B once production wires these items.
+// ===================================================================
+
+/// Which host role is composing the owner services. Owned → start them;
+/// Attached (a TUI connected to another daemon that owns the fleet) → start none.
+#[allow(dead_code)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum OwnerRole {
+    Owned,
+    Attached,
+}
+
+/// Capability token gating the five owner-service spawns. The single field is
+/// PRIVATE to this module, so only `owner_services` code can mint one: other
+/// modules may name `&OwnerServicePermit` in a signature but cannot construct it,
+/// which makes a host-body direct spawn fail to compile (structural I4).
+#[allow(dead_code)]
+pub(crate) struct OwnerServicePermit(());
+
+/// Phase-1 witness — proof that the monitoring phase ran. Required as an argument
+/// by phase 2, so the compiler enforces monitoring-before-stream ordering.
+/// Ctor is private to this module.
+#[allow(dead_code)]
+#[must_use]
+pub(crate) struct OwnerMonitoringStarted(());
+
+/// Final witness — proof that BOTH owner-service phases ran. Retained by each
+/// owner host (structural I2). Ctor is private to this module.
+#[allow(dead_code)]
+#[must_use]
+pub(crate) struct OwnerServicesStarted(());
+
+/// Injected phase-1 starters. Two REQUIRED fields → the struct literal (incl. the
+/// production `real()` ctor) fails to compile until every monitoring service is
+/// wired (I1 completeness for phase 1). Production uses `real()`; tests inject
+/// recording fakes that start no threads.
+pub(crate) struct OwnerMonitoringStarters<'a> {
+    pub monitor_tick: &'a dyn Fn(&OwnerServicePermit, &Path, &AgentRegistry),
+    pub api_activity_probe: &'a dyn Fn(&OwnerServicePermit, &AgentRegistry),
+}
+
+/// Injected phase-2 starters. Three REQUIRED fields (I1 completeness for phase 2).
+pub(crate) struct OwnerStreamStarters<'a> {
+    pub rollout: &'a dyn Fn(&OwnerServicePermit, &Path, &AgentRegistry),
+    pub opencode: &'a dyn Fn(&OwnerServicePermit, &Path, &AgentRegistry),
+    pub kiro: &'a dyn Fn(&OwnerServicePermit, &Path, &AgentRegistry),
+}
+
+/// Phase 1: owner monitoring services. `Owned` starts them via the injected
+/// starters; `Attached` starts none. Returns the `OwnerMonitoringStarted` token
+/// phase 2 requires.
+#[allow(dead_code)]
+pub(crate) fn start_owner_monitoring(
+    _role: OwnerRole,
+    _home: &Path,
+    _registry: &AgentRegistry,
+    _starters: &OwnerMonitoringStarters<'_>,
+) -> OwnerMonitoringStarted {
+    // RED stub (commit A): starts nothing → the owned call-level test is RED.
+    OwnerMonitoringStarted(())
+}
+
+/// Phase 2: owner stream observers. Requires `&OwnerMonitoringStarted` so it
+/// cannot be called before phase 1 (compile-enforced ordering). `Owned` starts
+/// them; `Attached` starts none. Returns the final `OwnerServicesStarted` witness.
+#[allow(dead_code)]
+pub(crate) fn start_owner_stream_observers(
+    _role: OwnerRole,
+    _monitoring: &OwnerMonitoringStarted,
+    _home: &Path,
+    _registry: &AgentRegistry,
+    _starters: &OwnerStreamStarters<'_>,
+) -> OwnerServicesStarted {
+    // RED stub (commit A): starts nothing → the owned call-level test is RED.
+    OwnerServicesStarted(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use parking_lot::Mutex;
+    use std::cell::RefCell;
+    use std::collections::HashMap;
+
+    fn empty_registry() -> AgentRegistry {
+        Arc::new(Mutex::new(HashMap::new()))
+    }
+
+    fn tmp() -> &'static Path {
+        Path::new("/tmp/owner-services-seam-test")
+    }
+
+    /// Drive both phases with recording fakes (no threads) under `role`, returning
+    /// the ordered labels of the services that were started. The fake closures are
+    /// locals here so they outlive the starter structs they are borrowed into.
+    fn run_both_phases(role: OwnerRole) -> Vec<&'static str> {
+        let log = RefCell::new(Vec::new());
+        let reg = empty_registry();
+        let monitoring = OwnerMonitoringStarters {
+            monitor_tick: &|_p, _h, _r| log.borrow_mut().push("monitor_tick"),
+            api_activity_probe: &|_p, _r| log.borrow_mut().push("api_activity_probe"),
+        };
+        let stream = OwnerStreamStarters {
+            rollout: &|_p, _h, _r| log.borrow_mut().push("rollout"),
+            opencode: &|_p, _h, _r| log.borrow_mut().push("opencode"),
+            kiro: &|_p, _h, _r| log.borrow_mut().push("kiro"),
+        };
+        let mon = start_owner_monitoring(role, tmp(), &reg, &monitoring);
+        let _services = start_owner_stream_observers(role, &mon, tmp(), &reg, &stream);
+        let started = log.borrow().clone();
+        started
+    }
+
+    /// I1 completeness + PHASE ORDER: owned mode starts exactly the five owner
+    /// services, monitoring pair BEFORE stream trio, in this exact order.
+    /// Reverse-mutation: omitting/reordering a starter, or a stub that starts
+    /// nothing, turns this RED. (Swapping the two phase CALLS won't even compile —
+    /// phase 2 requires the phase-1 token.)
+    #[test]
+    fn owned_two_phases_start_all_five_in_order() {
+        assert_eq!(
+            run_both_phases(OwnerRole::Owned),
+            [
+                "monitor_tick",
+                "api_activity_probe",
+                "rollout",
+                "opencode",
+                "kiro"
+            ],
+            "owned mode must start exactly the five owner services, monitoring before stream"
+        );
+    }
+
+    /// I3 attached exclusion: an attached TUI passes through both phases but
+    /// starts NONE. Reverse-mutation: dropping the `Owned` gate turns this RED.
+    #[test]
+    fn attached_two_phases_start_none() {
+        assert!(
+            run_both_phases(OwnerRole::Attached).is_empty(),
+            "attached mode must start no owner services"
+        );
+    }
 }

--- a/src/daemon/shadow/kiro.rs
+++ b/src/daemon/shadow/kiro.rs
@@ -152,7 +152,11 @@ struct Cursor {
 /// Spawn the kiro session tailer — a fire-and-forget daemon thread (mirrors
 /// `rollout::spawn` / `api_activity_probe::spawn`). No-op unless [`super::enabled`]. Wired
 /// into BOTH `run_core` AND `run_app` (the #2434 lesson: the live fleet daemon is app mode).
-pub fn spawn(registry: crate::agent::AgentRegistry, home: PathBuf) {
+pub fn spawn(
+    _permit: &crate::daemon::owner_services::OwnerServicePermit,
+    registry: crate::agent::AgentRegistry,
+    home: PathBuf,
+) {
     if !super::enabled() {
         return;
     }

--- a/src/daemon/shadow/opencode.rs
+++ b/src/daemon/shadow/opencode.rs
@@ -369,7 +369,11 @@ struct Sub {
 /// Spawn the opencode SSE observer supervisor — a fire-and-forget daemon thread (mirrors
 /// `rollout::spawn`). No-op unless [`super::enabled`]. Wired into BOTH `run_core` AND
 /// `run_app` (the #2434 lesson: the live fleet daemon is app mode).
-pub fn spawn(registry: crate::agent::AgentRegistry, _home: PathBuf) {
+pub fn spawn(
+    _permit: &crate::daemon::owner_services::OwnerServicePermit,
+    registry: crate::agent::AgentRegistry,
+    _home: PathBuf,
+) {
     if !super::enabled() {
         return;
     }

--- a/src/daemon/shadow/rollout.rs
+++ b/src/daemon/shadow/rollout.rs
@@ -235,7 +235,11 @@ struct Cursor {
 /// Spawn the codex rollout tailer — a fire-and-forget daemon thread (mirrors
 /// `api_activity_probe::spawn`). No-op unless [`super::enabled`]. Wired into BOTH
 /// `run_core` AND `run_app` (the #2434 lesson: the live fleet daemon is app mode).
-pub fn spawn(registry: crate::agent::AgentRegistry, home: PathBuf) {
+pub fn spawn(
+    _permit: &crate::daemon::owner_services::OwnerServicePermit,
+    registry: crate::agent::AgentRegistry,
+    home: PathBuf,
+) {
     if !super::enabled() {
         return;
     }

--- a/src/instance_monitor.rs
+++ b/src/instance_monitor.rs
@@ -63,7 +63,11 @@ pub fn latest_metrics() -> Vec<InstanceMetrics> {
 
 /// Spawn a dedicated monitor collection thread at 5s interval.
 /// Independent from the supervisor 10s tick to meet operator Q7 spec.
-pub fn spawn_monitor_tick(home: std::path::PathBuf, registry: crate::agent::AgentRegistry) {
+pub fn spawn_monitor_tick(
+    _permit: &crate::daemon::owner_services::OwnerServicePermit,
+    home: std::path::PathBuf,
+    registry: crate::agent::AgentRegistry,
+) {
     // fire-and-forget: monitor tick loop terminates on process exit. Sysinfo
     // collection is read-only sampling — losing one tick on shutdown is
     // harmless (next daemon start re-samples). Self-acknowledged Sprint 20


### PR DESCRIPTION
Implements the #2737 spike-approved design (decision `d-20260712034336318886-6`; spike manifest v3 on `spike/2737-typed-owner-invariants`): replace the handwritten Rust **string masker + source-scan guards** with a **typed two-phase owner-service seam** whose invariants hold by construction / real call-level test.

## Design (two typed phases — exact positions preserved)
`src/daemon/owner_services.rs`:
- `start_owner_monitoring(role, home, reg, &OwnerMonitoringStarters) -> OwnerMonitoringStarted`
- `start_owner_stream_observers(role, &OwnerMonitoringStarted, home, reg, &OwnerStreamStarters) -> OwnerServicesStarted`

Phase 2 **requires** the phase-1 token, so *monitoring-before-stream* is a compile dependency. Both hosts call the two phases at the **exact original positions** — app `run_app` at `:469` / `:487` with `shadow::start` untouched between them; daemon `build_tick_infrastructure` at `:1250` / `:1255`. No call site moved; order byte-identical to #2737.

## Invariants (all by construction / real test, no source scan)
- **I4 no host-local copy** — the five low-level spawns (`instance_monitor::spawn_monitor_tick`, `api_activity_probe::spawn`, `shadow::{rollout,opencode,kiro}::spawn`) now require a private-ctor `&OwnerServicePermit`. Only `owner_services` can mint one, so a host-body direct spawn **fails to compile**. (Sole callers were the seam → 5 signature + 5 call edits, zero test breakage.)
- **I2 dual-host reach** — `OwnerServicesStarted` witness (private ctor) is retained by each host: app's owned-only `app_maintenance_tick` **requires** `&OwnerServicesStarted`; daemon's `TickKeepalive` holds it. A host that skips the seam fails to compile.
- **I1 completeness** — the 2+3 required `OwnerServiceStarters` fields + `real()` + the exact-ordered-set test force a seam-routed new service to be acknowledged.
- **I3 attached exclusion** — production keeps the unchanged `if !attached_mode` wrapper; the `OwnerRole::Attached` path (seam starts none) is verified behaviorally.

## Test-first (§3.10) — one PR, three commits
1. **RED** (`dfcfd58f`) — typed seam + call-level tests with **stub** bodies; `owned_two_phases_start_all_five_in_order` **fails** (stub starts nothing).
2. **GREEN** (`49aa0d53`) — real phase bodies + permit + witnesses + host rewire at exact positions; deletes the coupled G1/G3 + orphaned `OWNER_HELPERS`.
3. **CLEANUP** (`9f9cac6f`) — deletes the ~295-LOC masker (`strip_rust_comments`/`blank_string_contents`/`strip_comments_and_blank_strings` + 2 self-tests), `owner_wiring_prod`, `OWNER_MOVED_SPAWNS`, and the now-redundant P2/P3/P4 + G2 scans.

The two call-level tests drive the **real** seam with recording fakes (no threads).

## Race-class question (§3.20 SOP1)
**Not race-class.** This is a behavior-preserving wiring refactor: the same five threads start in the same order with the same args; no new spawn sites, channels, locks, or timing. The RED→GREEN tests are fully deterministic (recording fakes, zero threads).

## Scope (per decision)
- **Out of scope, kept:** `run_app_wires_shadow_socket_server_2413` (P1) — `shadow::start` is host-local / a separate fork; #2738/#2739 cover its runtime ordering. Only the owner-service masker scans are removed, **not** all app static scans.
- A1 full host typestate: deferred.

## Verification
- `cargo nextest run --bin agend-terminal` → **5069 passed / 0 failed** (2 slow, 1 leaky, 12 skipped).
- `cargo clippy --bin agend-terminal --tests` → clean.
- `cargo fmt --check` → clean (my paths; vendored `agentic-git` pre-existing diffs untouched).
- RED→GREEN observed live: at `dfcfd58f` the owned seam test fails; at GREEN it passes.

Net: **−253 LOC** (359 insertions, 612 deletions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
