### PR TITLE
feat(ci-watch S1): exact-head protected-main post-merge watch

### DIFF
--- a/src/daemon/ci_watch/mod.rs
+++ b/src/daemon/ci_watch/mod.rs
@@ -33,6 +33,21 @@ pub const WATCH_TTL_HOURS: i64 = 72;
 /// leaks, never a live watch.
 pub const MAX_WATCH_AGE_HOURS: i64 = 7 * 24;
 
+/// S1 exact-head watch: is `s` a full immutable commit SHA? Accepts a 40-hex
+/// (SHA-1) or 64-hex (SHA-256, future object-format repos) hash, case-insensitive.
+/// Rejects abbreviated / non-hex / empty — an exact-head protected watch requires
+/// an UNAMBIGUOUS immutable target so a later main push can never alias it.
+pub fn is_full_commit_sha(s: &str) -> bool {
+    matches!(s.len(), 40 | 64) && s.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+/// S1: canonical (lowercase) form of a commit SHA for storage + comparison, so a
+/// caller-supplied `HEAD_SHA` matches the provider's lowercase `head_sha`. Callers
+/// MUST have validated with [`is_full_commit_sha`] first (this only lowercases).
+pub fn normalize_head_sha(s: &str) -> String {
+    s.to_ascii_lowercase()
+}
+
 // Pre-#701 callers reached these names via `crate::daemon::ci_watch::X`.
 // The re-exports preserve that path even when the only in-tree use of
 // some items is via the trait object inside `watcher::check_ci_watches`.
@@ -52,7 +67,7 @@ pub use provider::{
 #[allow(unused_imports)]
 pub use registry::{
     ci_watches_dir, cleanup_watches_for_instance, has_instance_anywhere, reassign_next_after_ci,
-    remove_watch, watch_filename,
+    remove_watch, watch_filename, watch_filename_exact_head,
 };
 #[allow(unused_imports)]
 pub use sweep::{gc_stale_watches, startup_sweep};

--- a/src/daemon/ci_watch/poller.rs
+++ b/src/daemon/ci_watch/poller.rs
@@ -65,6 +65,26 @@ impl CiProvider for CachedCiProvider {
         Ok(result)
     }
 
+    /// S1 (#2743 r1, P0): forward the exact-head by-SHA fetch to `inner`. WITHOUT
+    /// this override the wrapper falls to the trait default (`ApiError 501
+    /// unsupported`), so EVERY production exact-head watch (which is always wrapped
+    /// in `CachedCiProvider` by the fan-out) hits 501, stays armed forever, and
+    /// never reaches `GitHubCiProvider::poll_runs_for_sha`. No tick-cache here: the
+    /// `poll_cache` is keyed by `(repo, branch)` and would alias distinct target
+    /// SHAs on the same branch; each exact-head watch is one-shot + low-frequency,
+    /// so a direct forward is correct and simplest.
+    /// S1 (#2743 r1, P0): forward the exact-head by-SHA fetch to `inner`. WITHOUT
+    /// this override the wrapper falls to the trait default (`ApiError 501
+    /// unsupported`), so EVERY production exact-head watch (which is always wrapped
+    /// in `CachedCiProvider` by the fan-out) hits 501, stays armed forever, and
+    /// never reaches `GitHubCiProvider::poll_runs_for_sha`. No tick-cache here: the
+    /// `poll_cache` is keyed by `(repo, branch)` and would alias distinct target
+    /// SHAs on the same branch; each exact-head watch is one-shot + low-frequency,
+    /// so a direct forward is correct and simplest.
+    async fn poll_runs_for_sha(&self, repo: &str, head_sha: &str) -> anyhow::Result<CiPollResult> {
+        self.inner.poll_runs_for_sha(repo, head_sha).await
+    }
+
     async fn check_pr_terminal(&self, repo: &str, branch: &str) -> PrState {
         self.inner.check_pr_terminal(repo, branch).await
     }

--- a/src/daemon/ci_watch/poller.rs
+++ b/src/daemon/ci_watch/poller.rs
@@ -73,14 +73,6 @@ impl CiProvider for CachedCiProvider {
     /// `poll_cache` is keyed by `(repo, branch)` and would alias distinct target
     /// SHAs on the same branch; each exact-head watch is one-shot + low-frequency,
     /// so a direct forward is correct and simplest.
-    /// S1 (#2743 r1, P0): forward the exact-head by-SHA fetch to `inner`. WITHOUT
-    /// this override the wrapper falls to the trait default (`ApiError 501
-    /// unsupported`), so EVERY production exact-head watch (which is always wrapped
-    /// in `CachedCiProvider` by the fan-out) hits 501, stays armed forever, and
-    /// never reaches `GitHubCiProvider::poll_runs_for_sha`. No tick-cache here: the
-    /// `poll_cache` is keyed by `(repo, branch)` and would alias distinct target
-    /// SHAs on the same branch; each exact-head watch is one-shot + low-frequency,
-    /// so a direct forward is correct and simplest.
     async fn poll_runs_for_sha(&self, repo: &str, head_sha: &str) -> anyhow::Result<CiPollResult> {
         self.inner.poll_runs_for_sha(repo, head_sha).await
     }

--- a/src/daemon/ci_watch/poller.rs
+++ b/src/daemon/ci_watch/poller.rs
@@ -1439,6 +1439,44 @@ struct NotifyOutcome {
 /// Single-load-per-tick entry point: receives the pre-loaded `WatchState`
 /// from the caller, passes `&mut` to sub-functions, and flushes once at
 /// the end when state has changed.
+/// S1 exact-head one-shot terminal-clear. An exact-head watch fires ONE post-merge
+/// notification for its pinned SHA, then must disappear. Once EVERY run at the
+/// target SHA has concluded (aggregate terminal), remove the watch so it doesn't
+/// linger to TTL. No-op for a non-exact-head watch or a still-pending / runless
+/// target (which stays armed). Returns true when it removed the watch — the caller
+/// must then NOT flush/refresh the now-deleted file.
+fn maybe_clear_exact_head_terminal(
+    ctx: &CiCheckCtx<'_>,
+    state: &WatchState,
+    pr: &PollResult,
+) -> bool {
+    if state.target_head_sha.is_none() {
+        return false;
+    }
+    let target = || pr.runs.iter().filter(|r| r.head_sha == pr.current_sha);
+    if target().next().is_none() || target().any(|r| r.conclusion.is_none()) {
+        // No run for the target yet, or a workflow at the target is still in
+        // progress — keep armed (matches the multi-workflow aggregate contract:
+        // never resolve while one workflow is pending).
+        return false;
+    }
+    super::remove_watch(
+        ctx.home,
+        ctx.watch_path,
+        &ctx.subscribers.join(","),
+        ctx.repo,
+        ctx.branch,
+        "exact_head_terminal",
+    );
+    tracing::info!(
+        repo = ctx.repo,
+        branch = ctx.branch,
+        sha = %pr.current_sha,
+        "ci_watch removed (exact-head post-merge check complete)"
+    );
+    true
+}
+
 async fn ci_check_repo(
     home: &Path,
     watch_path: &Path,
@@ -1546,6 +1584,11 @@ async fn ci_check_repo(
         )
     };
     if to_notify.is_empty() {
+        // S1 exact-head one-shot: a terminal target with nothing new to notify
+        // (already notified on a prior poll) is complete — remove and stop.
+        if maybe_clear_exact_head_terminal(&ctx, &state, &pr) {
+            return Ok(());
+        }
         // #1991: did anything actually change this cycle? A branch whose runs
         // are all terminal and all already-notified produces an UNCHANGED
         // quiet poll — pre-#1991 it still re-stamped `last_terminal_seen_at`
@@ -1595,6 +1638,11 @@ async fn ci_check_repo(
     let outcome =
         fan_out_notifications(&ctx, &state, &pr, &deduped, &tracking, registry, provider).await;
     persist_watch_state(&ctx, &pr, &outcome, &mut state);
+    // S1 exact-head one-shot: the pinned target SHA reached terminal and we've
+    // just notified — remove the watch instead of persisting/refreshing it.
+    if maybe_clear_exact_head_terminal(&ctx, &state, &pr) {
+        return Ok(());
+    }
     if state != snapshot {
         flush_watch_state(watch_path, &state);
     }
@@ -1727,7 +1775,13 @@ async fn poll_ci_runs(
     state: &mut WatchState,
     provider: &dyn CiProvider,
 ) -> anyhow::Result<Option<PollResult>> {
-    let poll_result = provider.poll_runs(ctx.repo, ctx.branch).await?;
+    // S1 exact-head: resolve the PINNED target SHA (GitHub `?head_sha=`) so a
+    // newer main push can't displace it off the branch's recent-runs page.
+    // Ordinary (branch-tracking) watches poll the branch exactly as before.
+    let poll_result = match state.target_head_sha.as_deref() {
+        Some(sha) => provider.poll_runs_for_sha(ctx.repo, sha).await?,
+        None => provider.poll_runs(ctx.repo, ctx.branch).await?,
+    };
     match poll_result {
         CiPollResult::ApiError {
             status,
@@ -1785,11 +1839,17 @@ async fn poll_ci_runs(
             if runs.is_empty() {
                 return Ok(None);
             }
-            let current_sha = runs
-                .first()
-                .map(|r| r.head_sha.as_str())
-                .unwrap_or("")
-                .to_string();
+            // S1 exact-head: pin current_sha to the target so the downstream
+            // aggregation (which filters runs by `head_sha == current_sha`) selects
+            // exactly the target SHA's runs — never a newer head.
+            let current_sha = match state.target_head_sha.as_deref() {
+                Some(sha) => sha.to_string(),
+                None => runs
+                    .first()
+                    .map(|r| r.head_sha.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+            };
             let head_moved = tracking
                 .prev_head_sha
                 .is_some_and(|prev| prev != current_sha);

--- a/src/daemon/ci_watch/poller_tests.rs
+++ b/src/daemon/ci_watch/poller_tests.rs
@@ -7227,3 +7227,72 @@ fn exact_head_provider_error_keeps_watch_armed() {
     );
     std::fs::remove_dir_all(&dir).ok();
 }
+
+/// #2743 r1 (P0): PRODUCTION wraps EVERY provider in `CachedCiProvider`
+/// (fan-out site poller.rs:611). Before the wrapper override, `poll_runs_for_sha`
+/// fell to the trait-default `ApiError 501` there, so every production exact-head
+/// watch stayed armed forever and never reached `GitHubCiProvider::poll_runs_for_sha`.
+/// This drives the exact-head resolution THROUGH `CachedCiProvider` deterministically
+/// (wrap the inner fake, run `ci_check_repo`) — the inner succeeds ONLY from
+/// `poll_runs_for_sha` (branch page empty), proving the wrapper forwards it.
+#[test]
+fn exact_head_resolves_through_cached_provider_wrapper() {
+    let dir = tmp_dir("s1-exact-head-cached");
+    let inner = ExactHeadMock::new(
+        vec![], // branch page: nothing (a raw poll_runs would find no target)
+        vec![wf_run("CI", 100, 1, Some("success"), S1_TARGET_SHA)], // by-SHA: target terminal
+    );
+    let cached = super::CachedCiProvider {
+        inner: Box::new(inner),
+        poll_cache: std::sync::Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+    };
+    run_ci_check(&dir, &exact_head_watch_json(), &cached).unwrap();
+    assert!(
+        !exact_head_watch_path(&dir).exists(),
+        "exact-head watch must resolve + clear THROUGH CachedCiProvider (not the 501 default)"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// #2743 r1 (P0): the FULL production fan-out through `check_ci_watches_with_provider`
+/// — which itself constructs the `CachedCiProvider` wrapper (proving the real wrapping
+/// applies, not just that the wrapper forwards). The inner fake succeeds ONLY from
+/// `poll_runs_for_sha`; the exact-head watch must resolve + one-shot-clear. The fan-out
+/// spawns a detached task, so we wait (bounded) for the clear.
+#[test]
+fn exact_head_resolves_through_production_fanout() {
+    let dir = tmp_dir("s1-exact-head-fanout");
+    let ci_dir = dir.join("ci-watches");
+    std::fs::create_dir_all(&ci_dir).unwrap();
+    let watch_path = ci_dir.join(watch_filename("o/r", "main"));
+    std::fs::write(
+        &watch_path,
+        serde_json::to_string_pretty(&exact_head_watch_json()).unwrap(),
+    )
+    .unwrap();
+
+    let registry: AgentRegistry =
+        std::sync::Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new()));
+    // make_provider yields the inner fake; check_ci_watches_with_provider wraps it in
+    // CachedCiProvider (the production wrapping site) before ci_check_repo.
+    super::check_ci_watches_with_provider(&dir, &registry, |_ws| {
+        Some(Box::new(ExactHeadMock::new(
+            vec![],
+            vec![wf_run("CI", 100, 1, Some("success"), S1_TARGET_SHA)],
+        )) as Box<dyn CiProvider>)
+    });
+    // Detached fan-out task → wait (bounded, ~2s) for the one-shot terminal-clear.
+    let mut cleared = false;
+    for _ in 0..200 {
+        if !watch_path.exists() {
+            cleared = true;
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+    assert!(
+        cleared,
+        "exact-head watch must resolve + clear through the real check_ci_watches fan-out (CachedCiProvider wrapping)"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}

--- a/src/daemon/ci_watch/poller_tests.rs
+++ b/src/daemon/ci_watch/poller_tests.rs
@@ -7075,3 +7075,155 @@ fn quiet_terminal_poll_does_not_refresh_expires_1991() {
     );
     std::fs::remove_dir_all(&dir).ok();
 }
+
+// ─────────────────────────────────────────────────────────────────────────
+// S1 exact-head watch — poller freshness (test-first).
+//
+// An exact-head watch (pinned `target_head_sha`) MUST resolve the target SHA via
+// `poll_runs_for_sha` and IGNORE newer/unrelated branch runs, so a later main
+// push can't falsely complete the wrong post-merge check. `ExactHeadMock` returns
+// DIFFERENT runs for the two provider paths to prove which one drives resolution.
+// ─────────────────────────────────────────────────────────────────────────
+
+struct ExactHeadMock {
+    branch_result: Mutex<CiPollResult>,
+    sha_result: Mutex<CiPollResult>,
+}
+
+impl ExactHeadMock {
+    fn runs(runs: Vec<CiRun>) -> CiPollResult {
+        CiPollResult::Runs {
+            runs,
+            rate_limit_remaining: None,
+            rate_limit_limit: None,
+        }
+    }
+    fn new(branch_runs: Vec<CiRun>, sha_runs: Vec<CiRun>) -> Self {
+        Self {
+            branch_result: Mutex::new(Self::runs(branch_runs)),
+            sha_result: Mutex::new(Self::runs(sha_runs)),
+        }
+    }
+    fn with_sha_api_error(branch_runs: Vec<CiRun>) -> Self {
+        Self {
+            branch_result: Mutex::new(Self::runs(branch_runs)),
+            sha_result: Mutex::new(CiPollResult::ApiError {
+                status: 502,
+                message: "upstream error".to_string(),
+                rate_limit_reset: None,
+            }),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl CiProvider for ExactHeadMock {
+    async fn poll_runs(&self, _repo: &str, _branch: &str) -> anyhow::Result<CiPollResult> {
+        Ok(self.branch_result.lock().clone())
+    }
+    async fn poll_runs_for_sha(&self, _repo: &str, _sha: &str) -> anyhow::Result<CiPollResult> {
+        Ok(self.sha_result.lock().clone())
+    }
+    async fn check_pr_terminal(&self, _repo: &str, _branch: &str) -> PrState {
+        PrState::Open // an exact-head main watch has no PR
+    }
+    async fn fetch_failure_summary(&self, _repo: &str, _run_id: u64) -> String {
+        "Build / Test".to_string()
+    }
+    fn token_warning(&self) -> Option<&'static str> {
+        None
+    }
+}
+
+const S1_TARGET_SHA: &str = "c4206950c4206950c4206950c4206950c4206950";
+const S1_NEWER_SHA: &str = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+
+fn exact_head_watch_json() -> serde_json::Value {
+    serde_json::json!({
+        "repo": "o/r",
+        "branch": "main",
+        "target_head_sha": S1_TARGET_SHA,
+        "subscribers": [{"instance": "reviewer-x"}],
+        "next_after_ci": ["reviewer-x"],
+        "expires_at": (chrono::Utc::now() + chrono::Duration::hours(24)).to_rfc3339(),
+    })
+}
+
+fn exact_head_watch_path(dir: &std::path::Path) -> std::path::PathBuf {
+    dir.join("ci-watches").join(watch_filename("o/r", "main"))
+}
+
+/// Target SHA success (via by-SHA) while the branch's recent page shows ONLY a
+/// NEWER unrelated green (target displaced off the page). The watch must resolve
+/// on the TARGET and terminal-clear (one-shot) — the newer green must NOT
+/// complete it. RED before the poller sources by-SHA + one-shot clears.
+#[test]
+fn exact_head_success_resolves_target_ignoring_newer_branch_run() {
+    let dir = tmp_dir("s1-exact-head-success");
+    let provider = ExactHeadMock::new(
+        vec![wf_run("CI", 999, 1, Some("success"), S1_NEWER_SHA)], // branch page: newer only
+        vec![wf_run("CI", 100, 1, Some("success"), S1_TARGET_SHA)], // by-SHA: target terminal
+    );
+    run_ci_check(&dir, &exact_head_watch_json(), &provider).unwrap();
+    assert!(
+        !exact_head_watch_path(&dir).exists(),
+        "exact-head watch must terminal-clear once the TARGET sha succeeds"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// Target SHA still PENDING (by-SHA) while the branch page shows a newer green.
+/// The watch must stay ARMED — a newer unrelated green never completes it.
+#[test]
+fn exact_head_pending_target_stays_armed_despite_newer_green() {
+    let dir = tmp_dir("s1-exact-head-pending");
+    let provider = ExactHeadMock::new(
+        vec![wf_run("CI", 999, 1, Some("success"), S1_NEWER_SHA)],
+        vec![wf_run("CI", 100, 1, None, S1_TARGET_SHA)], // target in progress
+    );
+    run_ci_check(&dir, &exact_head_watch_json(), &provider).unwrap();
+    assert!(
+        exact_head_watch_path(&dir).exists(),
+        "a pending target must keep the exact-head watch armed (newer green ignored)"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// Multi-workflow: one workflow terminal-green, another still pending at the
+/// TARGET sha. Aggregate is NOT terminal → the watch must NOT resolve/clear
+/// (codex locked detail: never resolve while another workflow pends).
+#[test]
+fn exact_head_partial_workflow_pending_does_not_clear() {
+    let dir = tmp_dir("s1-exact-head-partial");
+    let provider = ExactHeadMock::new(
+        vec![],
+        vec![
+            wf_run("CI", 100, 1, Some("success"), S1_TARGET_SHA),
+            wf_run("LOC", 101, 1, None, S1_TARGET_SHA), // still pending
+        ],
+    );
+    run_ci_check(&dir, &exact_head_watch_json(), &provider).unwrap();
+    assert!(
+        exact_head_watch_path(&dir).exists(),
+        "a target with one workflow still pending must NOT terminal-clear"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// Provider error on the by-SHA fetch must FAIL LOUD (Err) and NOT clear the
+/// watch — no false terminal-clear on an API error.
+#[test]
+fn exact_head_provider_error_keeps_watch_armed() {
+    let dir = tmp_dir("s1-exact-head-error");
+    let provider = ExactHeadMock::with_sha_api_error(vec![]);
+    let result = run_ci_check(&dir, &exact_head_watch_json(), &provider);
+    assert!(
+        result.is_err(),
+        "by-SHA API error must surface as Err (fail loud)"
+    );
+    assert!(
+        exact_head_watch_path(&dir).exists(),
+        "a provider error must NOT terminal-clear the exact-head watch"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}

--- a/src/daemon/ci_watch/provider.rs
+++ b/src/daemon/ci_watch/provider.rs
@@ -345,6 +345,24 @@ pub trait CiProvider: Send + Sync {
     /// Poll workflow/pipeline runs for `repo@branch`.
     async fn poll_runs(&self, repo: &str, branch: &str) -> anyhow::Result<CiPollResult>;
 
+    /// S1 exact-head: resolve CI runs for an EXACT immutable commit SHA (post-merge
+    /// exact-head watch on a protected ref). Unlike [`poll_runs`], which reads the
+    /// branch's recent-runs page, this resolves the target regardless of how far the
+    /// branch advanced. Default: UNSUPPORTED — returns `ApiError` so the poller keeps
+    /// the watch armed (never false-clears) on providers without a by-SHA fetch. The
+    /// handler restricts exact-head watches to GitHub, which overrides this.
+    async fn poll_runs_for_sha(
+        &self,
+        _repo: &str,
+        _head_sha: &str,
+    ) -> anyhow::Result<CiPollResult> {
+        Ok(CiPollResult::ApiError {
+            status: 501,
+            message: "poll_runs_for_sha unsupported for this provider (exact-head watch is GitHub-only this wave)".to_string(),
+            rate_limit_reset: None,
+        })
+    }
+
     /// #1705: poll ALL recent runs for `repo` in ONE query (`?per_page=100`, no
     /// branch filter); the caller groups by `head_branch` and fans out to each
     /// watched branch, collapsing N per-branch polls into one. `None` = the
@@ -479,6 +497,81 @@ impl GitHubCiProvider {
     }
 }
 
+/// S1: shared GitHub Actions `workflow_runs` response → `CiPollResult`. Extracted
+/// verbatim from `poll_runs` so `poll_runs` (branch page) and `poll_runs_for_sha`
+/// (exact-head `?head_sha=`) produce byte-identical result + rate-limit semantics
+/// from their one-line-different request URL.
+async fn parse_github_runs_response(resp: reqwest::Response) -> anyhow::Result<CiPollResult> {
+    let status = resp.status().as_u16();
+    let rate_limit_reset = resp
+        .headers()
+        .get("x-ratelimit-reset")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse::<u64>().ok());
+    // Sprint 54 P0-2: capture remaining/limit on every response, not just
+    // rate-limited ones. The watch loop feeds these into `adaptive_interval` so
+    // we widen the next poll BEFORE hitting the cap, instead of recovering from it.
+    let parse_u64_header = |name: &str| {
+        resp.headers()
+            .get(name)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.parse::<u64>().ok())
+    };
+    let rate_limit_remaining = parse_u64_header("x-ratelimit-remaining");
+    let rate_limit_limit = parse_u64_header("x-ratelimit-limit");
+    let body: serde_json::Value = resp.json().await?;
+
+    // Surface API errors (rate-limit, auth, server) instead of silently
+    // treating them as "no runs".
+    if !(200..300).contains(&status) {
+        let message = body["message"]
+            .as_str()
+            .unwrap_or("(no message)")
+            .to_string();
+        // Sprint 54 P0-4: hint via the unified token cache. Anything the cache
+        // treats as "no token available" (env unset AND gh not authed) gets the
+        // actionable hint. Reading the cache — not env — keeps behavior
+        // consistent with what auth_fn actually saw on the wire.
+        let hint = if status == 403
+            && crate::github_token::cached_token().is_none()
+            && message.to_lowercase().contains("rate limit")
+        {
+            " — set GITHUB_TOKEN or run `gh auth login` to raise the unauthenticated 60/hr cap"
+        } else {
+            ""
+        };
+        return Ok(CiPollResult::ApiError {
+            status,
+            message: format!("GH API {status}: {message}{hint}"),
+            rate_limit_reset,
+        });
+    }
+
+    // Parse GitHub-specific `workflow_runs` array into neutral CiRun structs.
+    let runs = body["workflow_runs"]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|r| {
+                    Some(CiRun {
+                        id: r["id"].as_u64()?,
+                        conclusion: r["conclusion"].as_str().map(String::from),
+                        head_sha: r["head_sha"].as_str()?.to_string(),
+                        url: r["html_url"].as_str().unwrap_or("").to_string(),
+                        name: r["name"].as_str().unwrap_or("").to_string(),
+                        run_attempt: r["run_attempt"].as_u64().unwrap_or(1),
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    Ok(CiPollResult::Runs {
+        runs,
+        rate_limit_remaining,
+        rate_limit_limit,
+    })
+}
+
 #[async_trait::async_trait]
 impl CiProvider for GitHubCiProvider {
     async fn poll_runs(&self, repo: &str, branch: &str) -> anyhow::Result<CiPollResult> {
@@ -490,76 +583,25 @@ impl CiProvider for GitHubCiProvider {
             ))
             .send()
             .await?;
-        let status = resp.status().as_u16();
-        let rate_limit_reset = resp
-            .headers()
-            .get("x-ratelimit-reset")
-            .and_then(|v| v.to_str().ok())
-            .and_then(|s| s.parse::<u64>().ok());
-        // Sprint 54 P0-2: capture remaining/limit on every response,
-        // not just rate-limited ones. The watch loop feeds these into
-        // `adaptive_interval` so we widen the next poll BEFORE hitting
-        // the cap, instead of recovering from it.
-        let parse_u64_header = |name: &str| {
-            resp.headers()
-                .get(name)
-                .and_then(|v| v.to_str().ok())
-                .and_then(|s| s.parse::<u64>().ok())
-        };
-        let rate_limit_remaining = parse_u64_header("x-ratelimit-remaining");
-        let rate_limit_limit = parse_u64_header("x-ratelimit-limit");
-        let body: serde_json::Value = resp.json().await?;
+        parse_github_runs_response(resp).await
+    }
 
-        // Surface API errors (rate-limit, auth, server) instead of
-        // silently treating them as "no runs".
-        if !(200..300).contains(&status) {
-            let message = body["message"]
-                .as_str()
-                .unwrap_or("(no message)")
-                .to_string();
-            // Sprint 54 P0-4: hint via the unified token cache. Anything
-            // the cache treats as "no token available" (env unset AND gh
-            // not authed) gets the actionable hint. Reading the cache —
-            // not env — keeps behavior consistent with what auth_fn
-            // actually saw on the wire.
-            let hint = if status == 403
-                && crate::github_token::cached_token().is_none()
-                && message.to_lowercase().contains("rate limit")
-            {
-                " — set GITHUB_TOKEN or run `gh auth login` to raise the unauthenticated 60/hr cap"
-            } else {
-                ""
-            };
-            return Ok(CiPollResult::ApiError {
-                status,
-                message: format!("GH API {status}: {message}{hint}"),
-                rate_limit_reset,
-            });
-        }
-
-        // Parse GitHub-specific `workflow_runs` array into neutral CiRun structs.
-        let runs = body["workflow_runs"]
-            .as_array()
-            .map(|arr| {
-                arr.iter()
-                    .filter_map(|r| {
-                        Some(CiRun {
-                            id: r["id"].as_u64()?,
-                            conclusion: r["conclusion"].as_str().map(String::from),
-                            head_sha: r["head_sha"].as_str()?.to_string(),
-                            url: r["html_url"].as_str().unwrap_or("").to_string(),
-                            name: r["name"].as_str().unwrap_or("").to_string(),
-                            run_attempt: r["run_attempt"].as_u64().unwrap_or(1),
-                        })
-                    })
-                    .collect()
-            })
-            .unwrap_or_default();
-        Ok(CiPollResult::Runs {
-            runs,
-            rate_limit_remaining,
-            rate_limit_limit,
-        })
+    /// S1 exact-head: resolve runs for an EXACT immutable commit SHA via GitHub's
+    /// documented `?head_sha=` filter — independent of the branch's recent-runs
+    /// page, so a newer main push can't displace the target off the page. The
+    /// same response parser as `poll_runs`, so result/aggregate semantics match.
+    /// `head_sha` is validated + lowercased upstream (`is_full_commit_sha` /
+    /// `normalize_head_sha`).
+    async fn poll_runs_for_sha(&self, repo: &str, head_sha: &str) -> anyhow::Result<CiPollResult> {
+        let resp = self
+            .http
+            .get(&format!(
+                "repos/{repo}/actions/runs?head_sha={}&per_page={POLL_RUNS_PAGE_SIZE}",
+                percent_encode_query(head_sha)
+            ))
+            .send()
+            .await?;
+        parse_github_runs_response(resp).await
     }
 
     async fn poll_repo_runs(&self, repo: &str) -> Option<anyhow::Result<RepoPollResult>> {

--- a/src/daemon/ci_watch/registry.rs
+++ b/src/daemon/ci_watch/registry.rs
@@ -264,6 +264,19 @@ pub fn watch_filename(repo: &str, branch: &str) -> String {
     )
 }
 
+/// S1 exact-head watch identity: keyed on `repo:branch:head_sha` so a pinned
+/// post-merge watch on a protected ref (a) never collides with a generic
+/// `repo:branch` watch and (b) lets multiple post-merge SHAs coexist and
+/// self-terminate independently. `head_sha` MUST already be lowercase-normalized
+/// (`normalize_head_sha`) so the filename is stable across mixed-case callers.
+pub fn watch_filename_exact_head(repo: &str, branch: &str, head_sha: &str) -> String {
+    let composite = format!("{repo}:{branch}:{head_sha}");
+    format!(
+        "{}.json",
+        crate::daemon::utils::sha256_hex(composite.as_bytes())
+    )
+}
+
 /// Persist updated tracking state (last_run_id + head_sha) to the watch file.
 /// Retained for tests that exercise the legacy per-field write path.
 #[cfg(test)]

--- a/src/daemon/ci_watch/sweep.rs
+++ b/src/daemon/ci_watch/sweep.rs
@@ -294,21 +294,31 @@ pub fn gc_stale_watches(home: &Path, sweep_origin: &str) -> usize {
         let branch = &watch.branch;
         let audit_label = watch.subscriber_names().join(",");
 
-        // (3) E4.5 protected-ref migration — applied first because a
-        // protected-ref watch is invalid regardless of TTL state.
+        // (3) E4.5 protected-ref migration — applied first because a GENERIC
+        // protected-ref watch is invalid regardless of TTL state. S1 narrows it:
+        // a VALID exact-head watch (well-formed `target_head_sha`) is a legitimate
+        // post-merge monitor and is PRESERVED (falls through to the normal TTL/
+        // age lifecycle below); a legacy generic protected watch (no target SHA)
+        // OR one with a malformed SHA is still removed here.
         if crate::agent_ops::is_protected_ref(branch) {
-            remove_watch(
-                home,
-                &path,
-                &audit_label,
-                repo,
-                branch,
-                &format!("{sweep_origin}_protected_branch_migration"),
-            );
-            tracing::info!(repo = %repo, branch = %branch, sweep = %sweep_origin,
-                "ci_watch removed (E4.5 protected-branch migration)");
-            removed += 1;
-            continue;
+            let valid_exact_head = watch
+                .target_head_sha
+                .as_deref()
+                .is_some_and(super::is_full_commit_sha);
+            if !valid_exact_head {
+                remove_watch(
+                    home,
+                    &path,
+                    &audit_label,
+                    repo,
+                    branch,
+                    &format!("{sweep_origin}_protected_branch_migration"),
+                );
+                tracing::info!(repo = %repo, branch = %branch, sweep = %sweep_origin,
+                    "ci_watch removed (E4.5 protected-branch migration)");
+                removed += 1;
+                continue;
+            }
         }
 
         // #1991 P6 (lead adjudication): an unwatch TOMBSTONE (auto_arm_optout,
@@ -1009,6 +1019,96 @@ mod tests {
             "after the lock is released, gc removes the expired watch"
         );
         assert_eq!(removed, 1, "exactly the one expired watch removed");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    // ── S1 exact-head protected-main watch: sweep preservation ──────────
+    //
+    // The E4.5-migration arm removes protected-ref (main/master) watches. S1
+    // narrows it: a VALID exact-head protected watch (well-formed `target_head_sha`)
+    // is PRESERVED across restart; a legacy GENERIC protected watch (no
+    // target_head_sha) or a malformed-SHA one is still removed.
+
+    fn write_raw_watch(ci_dir: &std::path::Path, name: &str, body: serde_json::Value) -> PathBuf {
+        let p = ci_dir.join(format!("{name}.json"));
+        std::fs::write(&p, serde_json::to_string_pretty(&body).unwrap()).unwrap();
+        p
+    }
+
+    /// RED→GREEN: a valid exact-head protected `main` watch must SURVIVE the
+    /// startup sweep (today the E4.5-migration arm removes every main watch).
+    #[test]
+    fn startup_sweep_preserves_valid_exact_head_main() {
+        let dir = tmp_dir("s1-preserve-exact-head");
+        let ci_dir = dir.join("ci-watches");
+        std::fs::create_dir_all(&ci_dir).unwrap();
+        let future = (chrono::Utc::now() + chrono::Duration::hours(24)).to_rfc3339();
+        let p = write_raw_watch(
+            &ci_dir,
+            "exact_head_main",
+            serde_json::json!({
+                "repo": "o/r", "branch": "main",
+                "target_head_sha": "c4206950c4206950c4206950c4206950c4206950",
+                "subscribers": [{"instance": "lead"}],
+                "expires_at": future,
+            }),
+        );
+        super::startup_sweep(&dir);
+        assert!(
+            p.exists(),
+            "a valid exact-head protected main watch must survive the restart sweep"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// Control/guard: a legacy GENERIC protected `main` watch (no target_head_sha)
+    /// is still removed by the E4.5 migration.
+    #[test]
+    fn startup_sweep_removes_legacy_generic_main() {
+        let dir = tmp_dir("s1-remove-legacy-generic");
+        let ci_dir = dir.join("ci-watches");
+        std::fs::create_dir_all(&ci_dir).unwrap();
+        let future = (chrono::Utc::now() + chrono::Duration::hours(24)).to_rfc3339();
+        let p = write_raw_watch(
+            &ci_dir,
+            "generic_main",
+            serde_json::json!({
+                "repo": "o/r", "branch": "main",
+                "subscribers": [{"instance": "dev"}],
+                "expires_at": future,
+            }),
+        );
+        super::startup_sweep(&dir);
+        assert!(
+            !p.exists(),
+            "a legacy generic protected main watch must still be removed (E4.5 migration)"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// Guard: a protected watch carrying a MALFORMED target_head_sha is NOT a
+    /// valid exact-head watch and must still be removed.
+    #[test]
+    fn startup_sweep_removes_exact_head_with_malformed_sha() {
+        let dir = tmp_dir("s1-remove-malformed-sha");
+        let ci_dir = dir.join("ci-watches");
+        std::fs::create_dir_all(&ci_dir).unwrap();
+        let future = (chrono::Utc::now() + chrono::Duration::hours(24)).to_rfc3339();
+        let p = write_raw_watch(
+            &ci_dir,
+            "malformed_main",
+            serde_json::json!({
+                "repo": "o/r", "branch": "main",
+                "target_head_sha": "not-a-sha",
+                "subscribers": [{"instance": "lead"}],
+                "expires_at": future,
+            }),
+        );
+        super::startup_sweep(&dir);
+        assert!(
+            !p.exists(),
+            "a protected watch with a malformed target_head_sha must still be removed"
+        );
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/src/daemon/ci_watch/watch_state.rs
+++ b/src/daemon/ci_watch/watch_state.rs
@@ -147,6 +147,18 @@ pub struct WatchState {
     pub task_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub review_class: Option<String>,
+    /// S1 exact-head protected-main watch: an IMMUTABLE full commit SHA this
+    /// watch is pinned to. When `Some`, this is a post-merge close-loop watch on
+    /// a protected ref (`main`/`master`) — the poller resolves runs for THIS SHA
+    /// only (via `poll_runs_for_sha`), never the branch's latest head, so a newer
+    /// unrelated main push can't falsely complete it. Set only by `handle_watch_ci`
+    /// under the exact-head authority gate (task_id + next_after_ci + orchestrator/
+    /// operator); dispatch auto-watch never sets it. Stored lowercase. `None` on
+    /// every ordinary (branch-tracking) watch — its absence is what distinguishes a
+    /// legitimate exact-head protected watch (kept by `gc_stale_watches`) from a
+    /// legacy generic protected watch (removed by the E4.5 migration sweep).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target_head_sha: Option<String>,
     /// #1151: when set, only these workflow names count toward the
     /// "CI passed" aggregate. Non-required checks (e.g. flaky Windows)
     /// are ignored. When absent, all checks must pass (backward compat).

--- a/src/mcp/handlers/ci/exact_head_watch_tests.rs
+++ b/src/mcp/handlers/ci/exact_head_watch_tests.rs
@@ -1,0 +1,237 @@
+//! S1 exact-head protected-main watch — handler gate tests (test-first).
+//!
+//! Contract (decision d-20260712033954660984-4): a watch on a protected ref
+//! (`main`/`master`) is accepted ONLY as an exact-head post-merge watch —
+//! full immutable `head_sha` + `task_id` + explicit `next_after_ci`, created
+//! by the target team orchestrator or operator, on a GitHub repo. A generic
+//! protected watch stays E4.5-rejected. These pin the handler gate; the
+//! poller-freshness + sweep behaviors are pinned in their own modules.
+
+use super::watch::handle_watch_ci;
+use serde_json::json;
+
+fn tmp_home(tag: &str) -> std::path::PathBuf {
+    use std::sync::atomic::{AtomicU32, Ordering};
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+    let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let h = std::env::temp_dir().join(format!(
+        "agend-exact-head-{}-{}-{}",
+        std::process::id(),
+        tag,
+        id
+    ));
+    std::fs::create_dir_all(&h).unwrap();
+    h
+}
+
+/// Seed a team where `orchestrator` orchestrates `member`, so
+/// `teams::is_orchestrator_of(home, orchestrator, member)` is true.
+fn seed_team(home: &std::path::Path, orchestrator: &str, member: &str) {
+    let yaml = format!(
+        "teams:\n  post-merge-team:\n    members:\n      - {member}\n    orchestrator: {orchestrator}\n    created_at: \"2026-01-01T00:00:00Z\"\n"
+    );
+    std::fs::write(crate::fleet::fleet_yaml_path(home), yaml).unwrap();
+}
+
+const FULL_SHA: &str = "c4206950c4206950c4206950c4206950c4206950"; // 40-hex
+
+fn exact_head_args(head_sha: &str) -> serde_json::Value {
+    json!({
+        "repository": "suzuke/agend-terminal",
+        "branch": "main",
+        "head_sha": head_sha,
+        "task_id": "t-1",
+        "next_after_ci": ["reviewer-x"],
+    })
+}
+
+/// Generic protected watch (no head_sha) stays E4.5-rejected — the exact-head
+/// path must NOT open a generic bypass.
+#[test]
+fn generic_main_watch_still_e4_5_rejected() {
+    let home = tmp_home("generic-reject");
+    seed_team(&home, "lead", "reviewer-x");
+    let r = handle_watch_ci(
+        &home,
+        &json!({"repository": "suzuke/agend-terminal", "branch": "main"}),
+        "lead",
+    );
+    assert_eq!(
+        r["code"].as_str(),
+        Some("e4_5_protected_branch"),
+        "generic main (no head_sha) must stay E4.5-rejected: {r}"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// Authorized orchestrator + full SHA + task_id + next_after_ci → accepted.
+/// RED today (E4.5 rejects everything on main); GREEN after the gate lands.
+#[test]
+fn exact_head_main_accepted_for_orchestrator() {
+    let home = tmp_home("accept-orch");
+    seed_team(&home, "lead", "reviewer-x");
+    let r = handle_watch_ci(&home, &exact_head_args(FULL_SHA), "lead");
+    assert_eq!(
+        r["watching"].as_bool(),
+        Some(true),
+        "authorized exact-head main watch must be accepted: {r}"
+    );
+    assert!(r.get("error").is_none(), "no error on accept: {r}");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// Operator (empty caller) bypasses the orchestrator check but still needs the
+/// full triple (SHA + task_id + next_after_ci).
+#[test]
+fn exact_head_main_accepted_for_operator() {
+    let home = tmp_home("accept-op");
+    // No team seeded — operator authority is caller-identity, not membership.
+    let r = handle_watch_ci(&home, &exact_head_args(FULL_SHA), "");
+    assert_eq!(
+        r["watching"].as_bool(),
+        Some(true),
+        "operator exact-head main watch must be accepted: {r}"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// A caller who is NOT the target team orchestrator (nor operator) is rejected
+/// on AUTHORITY — distinct from the generic E4.5 rejection.
+#[test]
+fn exact_head_main_rejected_for_unauthorized_caller() {
+    let home = tmp_home("reject-unauth");
+    seed_team(&home, "lead", "reviewer-x");
+    let r = handle_watch_ci(&home, &exact_head_args(FULL_SHA), "dev");
+    assert_eq!(
+        r["code"].as_str(),
+        Some("protected_watch_unauthorized"),
+        "a non-orchestrator caller must be rejected on authority: {r}"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// Missing task_id → rejected (exact-head requires the close-loop triple).
+#[test]
+fn exact_head_main_rejected_without_task_id() {
+    let home = tmp_home("reject-no-task");
+    seed_team(&home, "lead", "reviewer-x");
+    let mut args = exact_head_args(FULL_SHA);
+    args.as_object_mut().unwrap().remove("task_id");
+    let r = handle_watch_ci(&home, &args, "lead");
+    assert_eq!(
+        r["code"].as_str(),
+        Some("protected_watch_missing_requirements"),
+        "exact-head without task_id must be rejected: {r}"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// Missing next_after_ci → rejected.
+#[test]
+fn exact_head_main_rejected_without_next_after_ci() {
+    let home = tmp_home("reject-no-next");
+    seed_team(&home, "lead", "reviewer-x");
+    let mut args = exact_head_args(FULL_SHA);
+    args.as_object_mut().unwrap().remove("next_after_ci");
+    let r = handle_watch_ci(&home, &args, "lead");
+    assert_eq!(
+        r["code"].as_str(),
+        Some("protected_watch_missing_requirements"),
+        "exact-head without next_after_ci must be rejected: {r}"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// Abbreviated / non-full SHA → rejected (immutable-target requirement).
+#[test]
+fn exact_head_main_rejected_for_abbreviated_sha() {
+    let home = tmp_home("reject-shortsha");
+    seed_team(&home, "lead", "reviewer-x");
+    let r = handle_watch_ci(&home, &exact_head_args("c420695"), "lead"); // 7-hex
+    assert_eq!(
+        r["code"].as_str(),
+        Some("protected_watch_invalid_sha"),
+        "abbreviated SHA must be rejected: {r}"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// A non-GitHub repository can never arm an exact-head watch. Repo resolution
+/// (`canonicalize_repo_slug` / `derive_repo_from_remote`) already rejects every
+/// non-GitHub remote before the gate (the daemon only polls GitHub Actions), so
+/// the observable contract is "no exact-head watch for a non-GitHub repo". The
+/// handler's `detect_provider_from_remote != github` check is a backstop for the
+/// binding-derived edge. (Reported to codex: the upstream layer makes the backstop
+/// effectively unreachable — candidate for removal per KISS.)
+#[test]
+fn exact_head_main_rejected_for_non_github_repo() {
+    let home = tmp_home("reject-nongh");
+    seed_team(&home, "lead", "reviewer-x");
+    let mut args = exact_head_args(FULL_SHA);
+    args.as_object_mut().unwrap().insert(
+        "repository".to_string(),
+        json!("https://gitlab.com/suzuke/agend-terminal"),
+    );
+    let r = handle_watch_ci(&home, &args, "lead");
+    assert_ne!(
+        r["watching"].as_bool(),
+        Some(true),
+        "a non-GitHub repo must not arm an exact-head watch: {r}"
+    );
+    assert!(
+        r.get("error").is_some() && r.get("code").is_some(),
+        "non-GitHub repo must reject with a structured error+code: {r}"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// A non-protected branch is unaffected by the exact-head gate: `head_sha` is
+/// simply ignored and a normal branch watch is created.
+#[test]
+fn non_protected_branch_watch_unaffected_by_head_sha() {
+    let home = tmp_home("nonprot");
+    let r = handle_watch_ci(
+        &home,
+        &json!({"repository": "suzuke/agend-terminal", "branch": "feat/x", "head_sha": FULL_SHA}),
+        "dev",
+    );
+    assert_eq!(
+        r["watching"].as_bool(),
+        Some(true),
+        "non-protected branch watch must still work: {r}"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// Auto-watch guard (decision point 3): `head_sha` is INERT on a non-protected
+/// branch — `target_head_sha` is only ever persisted behind the protected-ref
+/// exact-head gate. The dispatch auto-arm path arms feature branches (never
+/// main/master — E4.5 rejects that at dispatch) and passes no head_sha, so it can
+/// never mint an exact-head watch; this pins that even a leaked head_sha stays inert.
+#[test]
+fn head_sha_inert_on_non_protected_branch_no_target_persisted() {
+    let home = tmp_home("nonprot-no-persist");
+    let r = handle_watch_ci(
+        &home,
+        &json!({
+            "repository": "suzuke/agend-terminal", "branch": "feat/x",
+            "head_sha": FULL_SHA, "task_id": "t-1", "next_after_ci": ["reviewer-x"],
+        }),
+        "dev",
+    );
+    assert_eq!(r["watching"].as_bool(), Some(true), "{r}");
+    // The single persisted watch file must NOT carry target_head_sha.
+    let ci_dir = home.join("ci-watches");
+    let entry = std::fs::read_dir(&ci_dir)
+        .unwrap()
+        .flatten()
+        .find(|e| e.path().extension().is_some_and(|x| x == "json"))
+        .expect("a watch file was written");
+    let watch: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(entry.path()).unwrap()).unwrap();
+    assert!(
+        watch.get("target_head_sha").is_none(),
+        "a non-protected-branch watch must never carry target_head_sha: {watch}"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}

--- a/src/mcp/handlers/ci/mod.rs
+++ b/src/mcp/handlers/ci/mod.rs
@@ -111,3 +111,10 @@ fn resolve_repo_or_error(home: &Path, instance_name: &str, args: &Value) -> Resu
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests;
+
+// S1 exact-head protected-main watch — handler gate tests in a sibling file
+// (test-named ⇒ file_size_invariant-exempt; keeps watch.rs under its ceiling).
+#[cfg(test)]
+#[path = "exact_head_watch_tests.rs"]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod exact_head_watch_tests;

--- a/src/mcp/handlers/ci/watch.rs
+++ b/src/mcp/handlers/ci/watch.rs
@@ -18,17 +18,66 @@ pub(crate) fn handle_watch_ci(home: &Path, args: &Value, instance_name: &str) ->
     let branch = args["branch"].as_str().unwrap_or("main");
     let interval = args["interval_secs"].as_u64().unwrap_or(60);
 
-    // Sprint 57 Wave 2 Track B (#546 Item 3) — E4.5 protected-ref
-    // gate. Closes the bypass that let any agent subscribe to `main`
-    // (or `master`) CI by calling `ci action=watch` directly. Mirrors
-    // the worktree-lease gate in `worktree_pool::lease`; both go
-    // through `agent_ops::is_protected_ref` so the protected set is
-    // edited in exactly one place. The "main" default at the line
-    // above is the backstop the gate catches when callers omit both
-    // `branch` and explicit-protected branch — both flows land here.
-    if let Err(e) = crate::agent_ops::ensure_not_protected_json(branch) {
-        return e;
-    }
+    // S1 exact-head protected-ref gate (decision d-20260712033954660984-4).
+    // A protected ref (main/master) is mutation-free to WATCH, but a GENERIC
+    // watch resolves on any later run and can falsely complete the wrong task —
+    // so it stays E4.5-rejected (via the shared `agent_ops::is_protected_ref`,
+    // same protected set as the worktree-lease gate). The ONLY allowed protected
+    // watch is an EXACT-HEAD post-merge watch: a full immutable target SHA +
+    // `task_id` + explicit `next_after_ci`, created by the target team
+    // orchestrator or operator, on a GitHub repo. The poller then resolves THAT
+    // SHA only (`poll_runs_for_sha`). Non-protected branches are unaffected;
+    // lease/bind/dispatch E4.5 gates are untouched.
+    let exact_head_sha: Option<String> = if crate::agent_ops::is_protected_ref(branch) {
+        let head_sha = match args["head_sha"].as_str().filter(|s| !s.is_empty()) {
+            // Generic protected watch (no pinned SHA) → unchanged E4.5 rejection.
+            None => match crate::agent_ops::ensure_not_protected_json(branch) {
+                Err(e) => return e,
+                Ok(()) => unreachable!("is_protected_ref ⇒ ensure_not_protected_json errs"),
+            },
+            Some(s) => s,
+        };
+        if !crate::daemon::ci_watch::is_full_commit_sha(head_sha) {
+            return json!({
+                "error": format!("exact-head protected watch requires a FULL immutable commit SHA (40- or 64-hex); got {head_sha:?}"),
+                "code": "protected_watch_invalid_sha",
+            });
+        }
+        let has_task_id = args["task_id"].as_str().is_some_and(|s| !s.is_empty());
+        let next_targets = crate::daemon::ci_watch::watch_state::normalize_next_after_ci(
+            args.get("next_after_ci").unwrap_or(&Value::Null),
+        );
+        if !has_task_id || next_targets.is_empty() {
+            return json!({
+                "error": "exact-head protected watch requires BOTH `task_id` and an explicit `next_after_ci` target",
+                "code": "protected_watch_missing_requirements",
+            });
+        }
+        // Authority: operator (anonymous CLI, empty caller) bypasses; otherwise
+        // the caller must be the orchestrator of EVERY next_after_ci target's team.
+        let authorized = instance_name.is_empty()
+            || next_targets
+                .iter()
+                .all(|m| crate::teams::is_orchestrator_of(home, instance_name, m));
+        if !authorized {
+            return json!({
+                "error": format!("'{instance_name}' may not arm a protected-branch exact-head watch — only the target team orchestrator or operator may"),
+                "code": "protected_watch_unauthorized",
+            });
+        }
+        // By-SHA resolution is GitHub-only this wave — fail loud rather than arm a
+        // watch the poller could never resolve.
+        let (provider_kind, _) = crate::daemon::ci_watch::detect_provider_from_remote(repo);
+        if provider_kind != "github" {
+            return json!({
+                "error": format!("exact-head protected watch is GitHub-only this wave (detected provider: {provider_kind})"),
+                "code": "protected_watch_provider_unsupported",
+            });
+        }
+        Some(crate::daemon::ci_watch::normalize_head_sha(head_sha))
+    } else {
+        None
+    };
 
     // Reject unsupported providers early with operator-actionable error.
     if args["ci_provider"].as_str() == Some("bitbucket_server") {
@@ -45,7 +94,12 @@ pub(crate) fn handle_watch_ci(home: &Path, args: &Value, instance_name: &str) ->
             "code": "ci_watches_dir_create_failed",
         });
     }
-    let filename = crate::daemon::ci_watch::watch_filename(repo, branch);
+    // Exact-head protected watches key on repo:branch:head_sha so they never
+    // collide with a generic branch watch and multiple post-merge SHAs coexist.
+    let filename = match exact_head_sha.as_deref() {
+        Some(sha) => crate::daemon::ci_watch::watch_filename_exact_head(repo, branch, sha),
+        None => crate::daemon::ci_watch::watch_filename(repo, branch),
+    };
     let watch_path = ci_dir.join(&filename);
 
     // H5 (CR-2026-06-14): flock the read→mutate→atomic_write window (mirrors
@@ -174,6 +228,13 @@ pub(crate) fn handle_watch_ci(home: &Path, args: &Value, instance_name: &str) ->
     // exposure.
     if let Some(rc) = args["review_class"].as_str().filter(|s| !s.is_empty()) {
         watch["review_class"] = json!(rc);
+    }
+    // S1: persist the (validated, lowercased) exact-head pin. Its PRESENCE marks
+    // this as a protected post-merge watch the poller resolves by target SHA and
+    // `gc_stale_watches` preserves across restart. Only reachable here after the
+    // exact-head gate above, so a non-protected watch never carries it.
+    if let Some(sha) = exact_head_sha.as_deref() {
+        watch["target_head_sha"] = json!(sha);
     }
 
     // #779 P2 Piece 3 site B: atomic_write failure (disk full,

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -317,7 +317,8 @@ pub(crate) fn def_ci() -> Value {
             "review_class": {"type": "string", "enum": ["single", "dual"], "description": "#972: review threshold for the daemon's PR-state aggregator. `single` (default) — §3.6 one VERIFIED unlocks the merge gate. `dual` — §3.5 two distinct VERIFIED required before `[pr-ready-for-merge]` fires."},
             "ci_provider": {"type": "string", "description": "watch: CI provider override — `github` (default) or `bitbucket_cloud`. `bitbucket_server` is rejected (not yet supported). Persisted on the watch sidecar."},
             "ci_provider_url": {"type": "string", "description": "watch: base URL for a self-hosted CI provider, persisted on the watch sidecar alongside `ci_provider`."},
-            "task_id": {"type": "string", "description": "watch: optional task id to bind this watch to. Persisted on the watch sidecar as a back-link so the `[ci-ready-for-action]` the daemon emits on CI pass carries a structured reference to the originating task. Normally injected by the dispatch auto-watch (dispatch_auto_bind_lease); a manual `ci action=watch` caller may also pass it to bind the watch to a specific task (#1031)."}
+            "task_id": {"type": "string", "description": "watch: optional task id to bind this watch to. Persisted on the watch sidecar as a back-link so the `[ci-ready-for-action]` the daemon emits on CI pass carries a structured reference to the originating task. Normally injected by the dispatch auto-watch (dispatch_auto_bind_lease); a manual `ci action=watch` caller may also pass it to bind the watch to a specific task (#1031)."},
+            "head_sha": {"type": "string", "description": "watch: full immutable commit SHA (40- or 64-hex) for an EXACT-HEAD post-merge watch on a protected ref (`main`/`master`). Generic protected-branch watches stay E4.5-rejected; a protected watch is accepted ONLY with `head_sha` PLUS `task_id` and explicit `next_after_ci`, and only from the target team orchestrator or operator. The poller resolves runs for THIS SHA only (GitHub `?head_sha=` fetch), ignoring newer main runs, so a later push can't falsely complete the post-merge check. Ignored on non-protected branches. GitHub-only this wave."}
         }, "required": ["action"]}})
 }
 
@@ -1021,6 +1022,7 @@ mod tests {
             ("ci", "ci_provider", "ci/mod.rs provider override"),
             ("ci", "ci_provider_url", "ci/mod.rs self-hosted base URL"),
             ("ci", "task_id", "ci/watch.rs:163 handle_watch_ci watch back-link (#1031)"),
+            ("ci", "head_sha", "ci/watch.rs handle_watch_ci exact-head protected-branch pin (S1)"),
             // ── repo ──
             ("repo", "action", "ci/mod.rs routing"),
             ("repo", "pr", "ci/mod.rs handle_merge_repo"),


### PR DESCRIPTION
## What & why

Implements decision **d-20260712033954660984-4** (task `t-…19288-3`, spike RCA `SPIKE-ci-watch-state-rca`). A watch on a protected ref (`main`/`master`) is accepted **only** as an **exact-head post-merge watch** — a full immutable `head_sha` + `task_id` + explicit `next_after_ci`, created by the target team orchestrator or operator, on GitHub. Generic protected watches stay E4.5-rejected.

**Problem it solves:** §5 requires post-merge main-CI verification, but a generic `main` watch was E4.5-rejected — forcing the §7-forbidden manual `gh` polling. A *generic* main watch is the wrong fix (it resolves on **any** later main run → could falsely complete the wrong task). This pins the watch to the exact merge SHA so a newer push can never alias it.

## Design (each guard is deliberate)

- **schema** (`tools.rs`): `ci` tool gains `head_sha` (+ audit-list parity entry).
- **state** (`watch_state.rs`): `WatchState.target_head_sha` — its *presence* marks an exact-head watch.
- **handler** (`ci/watch.rs`): exact-head gate replacing the E4.5 block — validate full SHA (40/64-hex, lowercased), require `task_id` + `next_after_ci`, authorize (operator bypass OR `teams::is_orchestrator_of` for **every** `next_after_ci` target), GitHub-only; identity `sha256(repo:branch:head_sha)`; persist `target_head_sha`. Reject codes: `protected_watch_invalid_sha` / `_missing_requirements` / `_unauthorized` / `_provider_unsupported`; generic → `e4_5_protected_branch`.
- **provider** (`provider.rs`): new `CiProvider::poll_runs_for_sha` — GitHub `?head_sha=` resolves the target regardless of branch advance (no recent-page dependence); default impl fails loud (`ApiError`, GitHub-only this wave). `poll_runs` refactored onto a shared `parse_github_runs_response` (behavior identical).
- **poller** (`poller.rs`): exact-head watches source `poll_runs_for_sha` + pin `current_sha` to the target, **reusing the existing multi-workflow aggregate** (never resolves while a workflow pends); `maybe_clear_exact_head_terminal` one-shot removal on target terminal; provider error keeps the watch armed (no false clear).
- **sweep** (`sweep.rs`): the E4.5-migration arm now **preserves** a valid exact-head watch, still removes legacy generic / malformed-SHA protected watches.

**Untouched by design:** lease/bind/dispatch E4.5 gates; #931 release persistence (no unsubscribe-on-release). Dispatch auto-watch cannot mint an exact-head watch (dispatch rejects `main`; `head_sha` is inert off protected refs — pinned by a test).

## Tests (test-first)

RED verified pre-gate (**7/9 handler tests failed** before the gate landed). To reproduce RED, revert the behavior hunks in `ci/watch.rs` (gate), `poller.rs` (sourcing + one-shot), `sweep.rs` (narrowing).

- `ci/exact_head_watch_tests.rs`: generic-reject, accept orchestrator/operator, reject unauthorized / no-task / no-next / short-sha / non-github, non-protected-unaffected, head_sha-inert-off-protected.
- `sweep.rs`: preserve valid exact-head / remove legacy generic / remove malformed-sha.
- `poller_tests.rs` (`ExactHeadMock` returns different runs for `poll_runs` vs `poll_runs_for_sha`): success resolves target ignoring a newer branch green; pending target stays armed; partial-workflow pending does not clear; provider error keeps armed (fail loud).

**Local verification:** `cargo clippy --bin agend-terminal --tests -- -D warnings` clean; S1 + `ci_watch::watch` + schema/audit-parity suites green.

## Reviewer notes (dual review requested)

- **Race-class / daemon-core** (§3.15/§3.20): the freshness behavior is covered by deterministic tests (no timing dependence).
- **Finding for discussion (KISS):** the handler's `detect_provider_from_remote != github` backstop is *effectively unreachable* — `canonicalize_repo_slug` / `derive_repo_from_remote` already reject every non-GitHub remote before the gate. Kept as defense-in-depth for the binding-derived edge; flagged as a candidate for removal. The non-github test asserts the observable contract (a non-GitHub repo never arms an exact-head watch) rather than that specific code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
