### PR TITLE
feat(ci-watch S2): additive binding_state ci_watches_detail

### DIFF
--- a/src/daemon/ci_watch/mod.rs
+++ b/src/daemon/ci_watch/mod.rs
@@ -71,6 +71,10 @@ pub use registry::{
 };
 #[allow(unused_imports)]
 pub use sweep::{gc_stale_watches, startup_sweep};
+// `ExpiryReason` is named only inside `sweep` (+ its tests); binding_state consumes
+// the classifier's result via `.as_str()` without naming the type, so only the fn
+// is re-exported here.
+pub(crate) use sweep::classify_subscribed_watch_expiry;
 pub use watcher::check_ci_watches;
 
 pub(crate) use registry::parse_subscribers;

--- a/src/daemon/ci_watch/sweep.rs
+++ b/src/daemon/ci_watch/sweep.rs
@@ -249,6 +249,72 @@ fn fan_out_health_event(
 ///
 /// Returns the number of watches removed. Best-effort: read/parse
 /// failures skip the entry rather than aborting the sweep.
+/// S2: the ordered TTL-family expiry reasons a SUBSCRIBED (non-tombstone,
+/// non-protected-migration) watch can be reaped for — the exact predicates
+/// `gc_stale_watches` uses, extracted so `binding_state`'s `ci_watches_detail`
+/// classifies lifecycle from the SAME source of truth (no drift). Order mirrors
+/// GC precedence: absolute TTL → terminal-inactivity TTL → max-age cap.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ExpiryReason {
+    AbsoluteTtl,
+    TerminalInactivityTtl,
+    MaxAge,
+}
+
+impl ExpiryReason {
+    /// Stable wire string for `ci_watches_detail.expiry_reason`.
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            ExpiryReason::AbsoluteTtl => "absolute_ttl",
+            ExpiryReason::TerminalInactivityTtl => "terminal_inactivity_ttl",
+            ExpiryReason::MaxAge => "max_age",
+        }
+    }
+}
+
+/// S2: classify whether a SUBSCRIBED watch is TTL-family reap-eligible, returning
+/// the reason (`None` = still polling). Single source of truth for BOTH
+/// `gc_stale_watches`' removal decision and `binding_state`'s lifecycle
+/// projection. `lazy_pr_open` is invoked ONLY when the max-age threshold is
+/// crossed (short-circuit &&), so ordinary active watches never trigger a
+/// per-watch pr_state read — preserving the GC's existing laziness. Callers MUST
+/// evaluate the protected-migration + tombstone branches FIRST; this covers only
+/// the TTL-family, in GC precedence order.
+pub(crate) fn classify_subscribed_watch_expiry(
+    watch: &super::watch_state::WatchState,
+    now_utc: chrono::DateTime<chrono::Utc>,
+    lazy_pr_open: impl FnOnce() -> bool,
+) -> Option<ExpiryReason> {
+    // (1) absolute TTL.
+    if let Some(expires_at) = watch.expires_at.as_deref() {
+        if let Ok(exp) = chrono::DateTime::parse_from_rfc3339(expires_at) {
+            if now_utc > exp.with_timezone(&chrono::Utc) {
+                return Some(ExpiryReason::AbsoluteTtl);
+            }
+        }
+    }
+    // (2) inactivity TTL.
+    if let Some(last_seen) = watch.last_terminal_seen_at.as_deref() {
+        if let Ok(ts) = chrono::DateTime::parse_from_rfc3339(last_seen) {
+            if now_utc.signed_duration_since(ts.with_timezone(&chrono::Utc))
+                > chrono::Duration::hours(WATCH_TTL_HOURS)
+            {
+                return Some(ExpiryReason::TerminalInactivityTtl);
+            }
+        }
+    }
+    // (2b) #1750 A2 absolute age cap — `lazy_pr_open` runs ONLY after the age
+    // threshold is exceeded (short-circuit); an open PR is EXEMPT per PR-3.
+    if let Some(created) = watch.earliest_subscribed_at() {
+        if now_utc.signed_duration_since(created) > chrono::Duration::hours(MAX_WATCH_AGE_HOURS)
+            && !lazy_pr_open()
+        {
+            return Some(ExpiryReason::MaxAge);
+        }
+    }
+    None
+}
+
 pub fn gc_stale_watches(home: &Path, sweep_origin: &str) -> usize {
     let ci_dir = ci_watches_dir(home);
     let Ok(entries) = std::fs::read_dir(&ci_dir) else {
@@ -368,65 +434,44 @@ pub fn gc_stale_watches(home: &Path, sweep_origin: &str) -> usize {
             continue;
         }
 
-        // (1) absolute TTL.
-        if let Some(expires_at) = watch.expires_at.as_deref() {
-            if let Ok(exp) = chrono::DateTime::parse_from_rfc3339(expires_at) {
-                if now_utc > exp.with_timezone(&chrono::Utc) {
-                    remove_watch(
-                        home,
-                        &path,
-                        &audit_label,
-                        repo,
-                        branch,
-                        &format!("{sweep_origin}_expired"),
-                    );
-                    tracing::info!(repo = %repo, branch = %branch, sweep = %sweep_origin,
-                        "ci_watch removed (absolute TTL elapsed)");
-                    removed += 1;
-                    continue;
-                }
+        // (1)/(2)/(2b) TTL-family reap — via the shared `classify_subscribed_watch_expiry`
+        // so `binding_state`'s ci_watches_detail (S2) classifies from the SAME
+        // predicates (no drift). Each reason maps to the EXACT prior remove/audit/log
+        // in the same precedence. `is_branch_open` stays lazy (invoked only inside the
+        // classifier's max-age branch, after the age threshold is crossed).
+        match classify_subscribed_watch_expiry(&watch, now_utc, || {
+            crate::daemon::pr_state::is_branch_open(home, repo, branch)
+        }) {
+            Some(ExpiryReason::AbsoluteTtl) => {
+                remove_watch(
+                    home,
+                    &path,
+                    &audit_label,
+                    repo,
+                    branch,
+                    &format!("{sweep_origin}_expired"),
+                );
+                tracing::info!(repo = %repo, branch = %branch, sweep = %sweep_origin,
+                    "ci_watch removed (absolute TTL elapsed)");
+                removed += 1;
+                continue;
             }
-        }
-
-        // (2) inactivity TTL.
-        if let Some(last_seen) = watch.last_terminal_seen_at.as_deref() {
-            if let Ok(ts) = chrono::DateTime::parse_from_rfc3339(last_seen) {
-                let elapsed = now_utc.signed_duration_since(ts.with_timezone(&chrono::Utc));
-                if elapsed > chrono::Duration::hours(WATCH_TTL_HOURS) {
-                    remove_watch(
-                        home,
-                        &path,
-                        &audit_label,
-                        repo,
-                        branch,
-                        &format!("{sweep_origin}_inactivity_ttl"),
-                    );
-                    tracing::info!(repo = %repo, branch = %branch, hours = WATCH_TTL_HOURS,
-                        sweep = %sweep_origin,
-                        "ci_watch removed (inactivity TTL elapsed)");
-                    removed += 1;
-                    continue;
-                }
+            Some(ExpiryReason::TerminalInactivityTtl) => {
+                remove_watch(
+                    home,
+                    &path,
+                    &audit_label,
+                    repo,
+                    branch,
+                    &format!("{sweep_origin}_inactivity_ttl"),
+                );
+                tracing::info!(repo = %repo, branch = %branch, hours = WATCH_TTL_HOURS,
+                    sweep = %sweep_origin,
+                    "ci_watch removed (inactivity TTL elapsed)");
+                removed += 1;
+                continue;
             }
-        }
-
-        // (2b) #1750 A2: absolute age cap — backstop against a watch kept
-        // perpetually young by `refresh_expires_at` on every active poll (so it
-        // never trips the refreshed `expires_at` or inactivity TTL above).
-        // Anchored on the earliest `subscribed_at`, the one timestamp polling
-        // never moves. A watch older than MAX_WATCH_AGE_HOURS never reached
-        // terminal (which would have removed it) → stale by definition.
-        if let Some(created) = watch.earliest_subscribed_at() {
-            if now_utc.signed_duration_since(created) > chrono::Duration::hours(MAX_WATCH_AGE_HOURS)
-            {
-                // PR-3 (t-ci-ready-pr3-arm-not-armed): exempt watches whose PR is
-                // still OPEN. An open PR should keep notifying on CI, and the
-                // PR-3 auto-arm would otherwise re-create this watch on the next
-                // gh-poll (remove→rearm churn every MAX_WATCH_AGE_HOURS). Only
-                // merged/closed/untracked branches age out here.
-                if crate::daemon::pr_state::is_branch_open(home, repo, branch) {
-                    continue;
-                }
+            Some(ExpiryReason::MaxAge) => {
                 remove_watch(
                     home,
                     &path,
@@ -441,6 +486,7 @@ pub fn gc_stale_watches(home: &Path, sweep_origin: &str) -> usize {
                 removed += 1;
                 continue;
             }
+            None => {}
         }
     }
 
@@ -1109,6 +1155,126 @@ mod tests {
             !p.exists(),
             "a protected watch with a malformed target_head_sha must still be removed"
         );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    // ── S2: shared expiry classifier (source of truth for GC + binding_state) ──
+
+    fn ws(j: serde_json::Value) -> crate::daemon::ci_watch::WatchState {
+        serde_json::from_value(j).unwrap()
+    }
+
+    /// Lazy PR-open: NOT called for an active (non-over-age) watch — preserves the
+    /// GC invariant of no per-watch pr_state read on ordinary polling watches.
+    #[test]
+    fn classify_lazy_pr_open_not_called_for_active_watch() {
+        use std::cell::Cell;
+        let calls = Cell::new(0u32);
+        let w = ws(serde_json::json!({
+            "repo": "o/r", "branch": "feat/x",
+            "subscribers": [{"instance": "dev", "subscribed_at": (chrono::Utc::now() - chrono::Duration::hours(1)).to_rfc3339()}],
+            "expires_at": (chrono::Utc::now() + chrono::Duration::hours(24)).to_rfc3339(),
+        }));
+        let r = classify_subscribed_watch_expiry(&w, chrono::Utc::now(), || {
+            calls.set(calls.get() + 1);
+            false
+        });
+        assert_eq!(r, None, "active watch is polling");
+        assert_eq!(calls.get(), 0, "lazy pr-open must NOT be called for an active watch");
+    }
+
+    /// Over-max-age + PR closed → MaxAge; PR-open callback invoked exactly once.
+    #[test]
+    fn classify_max_age_calls_pr_open_once_and_reaps_when_closed() {
+        use std::cell::Cell;
+        let calls = Cell::new(0u32);
+        let old = (chrono::Utc::now() - chrono::Duration::hours(MAX_WATCH_AGE_HOURS + 1)).to_rfc3339();
+        let w = ws(serde_json::json!({
+            "repo": "o/r", "branch": "feat/x",
+            "subscribers": [{"instance": "dev", "subscribed_at": old}],
+            "expires_at": (chrono::Utc::now() + chrono::Duration::hours(24)).to_rfc3339(),
+        }));
+        let r = classify_subscribed_watch_expiry(&w, chrono::Utc::now(), || {
+            calls.set(calls.get() + 1);
+            false
+        });
+        assert_eq!(r, Some(ExpiryReason::MaxAge));
+        assert_eq!(calls.get(), 1, "pr-open checked exactly once, only after the age threshold");
+    }
+
+    /// Over-max-age but PR OPEN → exempt (polling).
+    #[test]
+    fn classify_max_age_exempt_when_pr_open() {
+        let old = (chrono::Utc::now() - chrono::Duration::hours(MAX_WATCH_AGE_HOURS + 1)).to_rfc3339();
+        let w = ws(serde_json::json!({
+            "repo": "o/r", "branch": "feat/x",
+            "subscribers": [{"instance": "dev", "subscribed_at": old}],
+            "expires_at": (chrono::Utc::now() + chrono::Duration::hours(24)).to_rfc3339(),
+        }));
+        assert_eq!(
+            classify_subscribed_watch_expiry(&w, chrono::Utc::now(), || true),
+            None,
+            "an over-age watch with an OPEN pr is exempt (polling)"
+        );
+    }
+
+    /// Absolute TTL takes precedence — pr-open is never consulted when it fires.
+    #[test]
+    fn classify_absolute_ttl_precedence_no_pr_read() {
+        let old = (chrono::Utc::now() - chrono::Duration::hours(MAX_WATCH_AGE_HOURS + 1)).to_rfc3339();
+        let w = ws(serde_json::json!({
+            "repo": "o/r", "branch": "feat/x",
+            "subscribers": [{"instance": "dev", "subscribed_at": old}],
+            "expires_at": (chrono::Utc::now() - chrono::Duration::hours(1)).to_rfc3339(),
+        }));
+        assert_eq!(
+            classify_subscribed_watch_expiry(&w, chrono::Utc::now(), || {
+                panic!("pr-open must not be read when absolute TTL already fired")
+            }),
+            Some(ExpiryReason::AbsoluteTtl)
+        );
+    }
+
+    /// DRIFT GUARD: `classify_subscribed_watch_expiry` must predict `gc_stale_watches`'
+    /// actual removal for every subscribed feature-branch watch (the classifier's
+    /// domain). If the GC's TTL predicates ever drift from the classifier, this fails.
+    #[test]
+    fn classify_matches_gc_reap_decision_drift() {
+        let dir = tmp_dir("s2-drift");
+        let ci_dir = dir.join("ci-watches");
+        std::fs::create_dir_all(&ci_dir).unwrap();
+        let now = chrono::Utc::now();
+        let recent = (now - chrono::Duration::hours(1)).to_rfc3339();
+        let old = (now - chrono::Duration::hours(MAX_WATCH_AGE_HOURS + 1)).to_rfc3339();
+        let past = (now - chrono::Duration::hours(1)).to_rfc3339();
+        let future = (now + chrono::Duration::hours(24)).to_rfc3339();
+        let ancient = (now - chrono::Duration::hours(WATCH_TTL_HOURS + 10)).to_rfc3339();
+        let cases: Vec<(&str, serde_json::Value)> = vec![
+            ("polling", serde_json::json!({"repo":"o/r","branch":"feat/live","subscribers":[{"instance":"dev","subscribed_at":recent}],"expires_at":future})),
+            ("abs", serde_json::json!({"repo":"o/r","branch":"feat/abs","subscribers":[{"instance":"dev","subscribed_at":recent}],"expires_at":past})),
+            ("inact", serde_json::json!({"repo":"o/r","branch":"feat/inact","subscribers":[{"instance":"dev","subscribed_at":recent}],"expires_at":future,"last_terminal_seen_at":ancient})),
+            ("maxage", serde_json::json!({"repo":"o/r","branch":"feat/maxage","subscribers":[{"instance":"dev","subscribed_at":old}],"expires_at":future})),
+        ];
+        let mut predicted_removed = std::collections::HashMap::new();
+        for (name, j) in &cases {
+            let w = ws(j.clone());
+            let repo = w.repo.clone();
+            let branch = w.branch.clone();
+            let c = classify_subscribed_watch_expiry(&w, now, || {
+                crate::daemon::pr_state::is_branch_open(&dir, &repo, &branch)
+            });
+            predicted_removed.insert(*name, c.is_some());
+            std::fs::write(ci_dir.join(format!("{name}.json")), serde_json::to_string_pretty(j).unwrap()).unwrap();
+        }
+        gc_stale_watches(&dir, "drift_test");
+        for (name, _) in &cases {
+            let exists = ci_dir.join(format!("{name}.json")).exists();
+            assert_eq!(
+                predicted_removed[name], !exists,
+                "classify() must predict gc removal for '{name}' (predicted_removed={}, exists={exists})",
+                predicted_removed[name]
+            );
+        }
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/src/daemon/ci_watch/sweep.rs
+++ b/src/daemon/ci_watch/sweep.rs
@@ -1180,7 +1180,11 @@ mod tests {
             false
         });
         assert_eq!(r, None, "active watch is polling");
-        assert_eq!(calls.get(), 0, "lazy pr-open must NOT be called for an active watch");
+        assert_eq!(
+            calls.get(),
+            0,
+            "lazy pr-open must NOT be called for an active watch"
+        );
     }
 
     /// Over-max-age + PR closed → MaxAge; PR-open callback invoked exactly once.
@@ -1188,7 +1192,8 @@ mod tests {
     fn classify_max_age_calls_pr_open_once_and_reaps_when_closed() {
         use std::cell::Cell;
         let calls = Cell::new(0u32);
-        let old = (chrono::Utc::now() - chrono::Duration::hours(MAX_WATCH_AGE_HOURS + 1)).to_rfc3339();
+        let old =
+            (chrono::Utc::now() - chrono::Duration::hours(MAX_WATCH_AGE_HOURS + 1)).to_rfc3339();
         let w = ws(serde_json::json!({
             "repo": "o/r", "branch": "feat/x",
             "subscribers": [{"instance": "dev", "subscribed_at": old}],
@@ -1199,13 +1204,18 @@ mod tests {
             false
         });
         assert_eq!(r, Some(ExpiryReason::MaxAge));
-        assert_eq!(calls.get(), 1, "pr-open checked exactly once, only after the age threshold");
+        assert_eq!(
+            calls.get(),
+            1,
+            "pr-open checked exactly once, only after the age threshold"
+        );
     }
 
     /// Over-max-age but PR OPEN → exempt (polling).
     #[test]
     fn classify_max_age_exempt_when_pr_open() {
-        let old = (chrono::Utc::now() - chrono::Duration::hours(MAX_WATCH_AGE_HOURS + 1)).to_rfc3339();
+        let old =
+            (chrono::Utc::now() - chrono::Duration::hours(MAX_WATCH_AGE_HOURS + 1)).to_rfc3339();
         let w = ws(serde_json::json!({
             "repo": "o/r", "branch": "feat/x",
             "subscribers": [{"instance": "dev", "subscribed_at": old}],
@@ -1221,7 +1231,8 @@ mod tests {
     /// Absolute TTL takes precedence — pr-open is never consulted when it fires.
     #[test]
     fn classify_absolute_ttl_precedence_no_pr_read() {
-        let old = (chrono::Utc::now() - chrono::Duration::hours(MAX_WATCH_AGE_HOURS + 1)).to_rfc3339();
+        let old =
+            (chrono::Utc::now() - chrono::Duration::hours(MAX_WATCH_AGE_HOURS + 1)).to_rfc3339();
         let w = ws(serde_json::json!({
             "repo": "o/r", "branch": "feat/x",
             "subscribers": [{"instance": "dev", "subscribed_at": old}],
@@ -1250,10 +1261,22 @@ mod tests {
         let future = (now + chrono::Duration::hours(24)).to_rfc3339();
         let ancient = (now - chrono::Duration::hours(WATCH_TTL_HOURS + 10)).to_rfc3339();
         let cases: Vec<(&str, serde_json::Value)> = vec![
-            ("polling", serde_json::json!({"repo":"o/r","branch":"feat/live","subscribers":[{"instance":"dev","subscribed_at":recent}],"expires_at":future})),
-            ("abs", serde_json::json!({"repo":"o/r","branch":"feat/abs","subscribers":[{"instance":"dev","subscribed_at":recent}],"expires_at":past})),
-            ("inact", serde_json::json!({"repo":"o/r","branch":"feat/inact","subscribers":[{"instance":"dev","subscribed_at":recent}],"expires_at":future,"last_terminal_seen_at":ancient})),
-            ("maxage", serde_json::json!({"repo":"o/r","branch":"feat/maxage","subscribers":[{"instance":"dev","subscribed_at":old}],"expires_at":future})),
+            (
+                "polling",
+                serde_json::json!({"repo":"o/r","branch":"feat/live","subscribers":[{"instance":"dev","subscribed_at":recent}],"expires_at":future}),
+            ),
+            (
+                "abs",
+                serde_json::json!({"repo":"o/r","branch":"feat/abs","subscribers":[{"instance":"dev","subscribed_at":recent}],"expires_at":past}),
+            ),
+            (
+                "inact",
+                serde_json::json!({"repo":"o/r","branch":"feat/inact","subscribers":[{"instance":"dev","subscribed_at":recent}],"expires_at":future,"last_terminal_seen_at":ancient}),
+            ),
+            (
+                "maxage",
+                serde_json::json!({"repo":"o/r","branch":"feat/maxage","subscribers":[{"instance":"dev","subscribed_at":old}],"expires_at":future}),
+            ),
         ];
         let mut predicted_removed = std::collections::HashMap::new();
         for (name, j) in &cases {
@@ -1264,7 +1287,11 @@ mod tests {
                 crate::daemon::pr_state::is_branch_open(&dir, &repo, &branch)
             });
             predicted_removed.insert(*name, c.is_some());
-            std::fs::write(ci_dir.join(format!("{name}.json")), serde_json::to_string_pretty(j).unwrap()).unwrap();
+            std::fs::write(
+                ci_dir.join(format!("{name}.json")),
+                serde_json::to_string_pretty(j).unwrap(),
+            )
+            .unwrap();
         }
         gc_stale_watches(&dir, "drift_test");
         for (name, _) in &cases {

--- a/src/mcp/handlers/binding_state.rs
+++ b/src/mcp/handlers/binding_state.rs
@@ -163,7 +163,10 @@ pub(crate) fn handle_binding_state(home: &Path, args: &Value, _sender: &Option<S
         // the owner/repo slug from the binding source_repo so `current_binding` in
         // ci_watches_detail matches BOTH repo and branch (a same-branch watch on a
         // different repo is NOT current). Non-derivable remote ⇒ "" ⇒ nothing current.
-        let current_repo = crate::mcp::handlers::dispatch_hook::derive_repo_from_remote_pub(
+        // r2 (#2746): provider-neutral so a reachable Bitbucket-Cloud watch's own
+        // binding matches (a GitHub-only derivation regressed it to ""); MUST stay in
+        // lockstep with watch-storage canonicalization — see provider_neutral_slug.
+        let current_repo = crate::mcp::handlers::dispatch_hook::derive_repo_slug_any_forge_pub(
             Path::new(source_repo),
         )
         .unwrap_or_default();

--- a/src/mcp/handlers/binding_state.rs
+++ b/src/mcp/handlers/binding_state.rs
@@ -159,6 +159,14 @@ pub(crate) fn handle_binding_state(home: &Path, args: &Value, _sender: &Option<S
         // PR2 F2: diagnostic HMAC status (shim-parity; see binding::signature_valid).
         let signature_valid = crate::binding::signature_valid(home, agent);
 
+        // S2 finding-1: the agent's CURRENT binding identity is repo+branch. Derive
+        // the owner/repo slug from the binding source_repo so `current_binding` in
+        // ci_watches_detail matches BOTH repo and branch (a same-branch watch on a
+        // different repo is NOT current). Non-derivable remote ⇒ "" ⇒ nothing current.
+        let current_repo =
+            crate::mcp::handlers::dispatch_hook::derive_repo_from_remote_pub(Path::new(source_repo))
+                .unwrap_or_default();
+
         json!({
             "agent": agent,
             "bound": true,
@@ -174,6 +182,7 @@ pub(crate) fn handle_binding_state(home: &Path, args: &Value, _sender: &Option<S
             "marker_present": marker_present,
             "signature_valid": signature_valid,
             "ci_watches": ci_watches,
+            "ci_watches_detail": enumerate_ci_watches_detail_for_agent(home, agent, &current_repo, branch),
             "bind_in_flight": bind_in_flight,
             "cross_branch_holders": cross_branch_holders,
             "dispatched_waiting_for": dispatched_waiting_for,
@@ -185,6 +194,7 @@ pub(crate) fn handle_binding_state(home: &Path, args: &Value, _sender: &Option<S
             "bound": false,
             "bind_in_flight": bind_in_flight,
             "ci_watches": ci_watches,
+            "ci_watches_detail": enumerate_ci_watches_detail_for_agent(home, agent, "", ""),
             "cross_branch_holders": Vec::<String>::new(),
             "dispatched_waiting_for": dispatched_waiting_for,
             "pending_response_to": pending_response_to,
@@ -192,36 +202,13 @@ pub(crate) fn handle_binding_state(home: &Path, args: &Value, _sender: &Option<S
     }
 }
 
-/// Return the list of CI watches that include `agent` as a subscriber,
-/// formatted as `"<repo>:<branch>"` for terse human reading. Empty
-/// list when the watches dir doesn't exist or the agent isn't on any.
-fn enumerate_ci_watches_for_agent(home: &Path, agent: &str) -> Vec<String> {
-    let ci_dir = crate::daemon::ci_watch::ci_watches_dir(home);
-    let Ok(entries) = std::fs::read_dir(&ci_dir) else {
-        return Vec::new();
-    };
-    let mut out = Vec::new();
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.extension().and_then(|s| s.to_str()) != Some("json") {
-            continue;
-        }
-        let Ok(content) = std::fs::read_to_string(&path) else {
-            continue;
-        };
-        let Ok(watch) = serde_json::from_str::<Value>(&content) else {
-            continue;
-        };
-        let subs = crate::daemon::ci_watch::parse_subscribers(&watch);
-        if subs.iter().any(|s| s == agent) {
-            let repo = watch["repo"].as_str().unwrap_or("?");
-            let branch = watch["branch"].as_str().unwrap_or("?");
-            out.push(format!("{repo}:{branch}"));
-        }
-    }
-    out.sort();
-    out
-}
+// S2: the ci-watch enumerators (byte-for-byte `ci_watches` strings + the additive
+// `ci_watches_detail` projection) live in a sibling module so binding_state.rs
+// stays under the MCP-handler LOC ceiling (file_size_invariant — the same reason
+// the tests are `#[path]` siblings).
+#[path = "binding_state_ci_watches.rs"]
+mod ci_watches;
+use ci_watches::{enumerate_ci_watches_detail_for_agent, enumerate_ci_watches_for_agent};
 
 /// Return list of agent names (other than `exclude_agent`) whose
 /// binding currently references `branch`. P0-1.5 enforces uniqueness
@@ -256,6 +243,12 @@ mod liveness_tests;
 #[cfg(test)]
 #[path = "binding_state_signature_tests.rs"]
 mod signature_tests;
+
+// S2 additive ci_watches_detail projection matrix (sibling file — LOC-exempt).
+#[cfg(test)]
+#[path = "binding_state_detail_tests.rs"]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod detail_tests;
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]

--- a/src/mcp/handlers/binding_state.rs
+++ b/src/mcp/handlers/binding_state.rs
@@ -163,9 +163,10 @@ pub(crate) fn handle_binding_state(home: &Path, args: &Value, _sender: &Option<S
         // the owner/repo slug from the binding source_repo so `current_binding` in
         // ci_watches_detail matches BOTH repo and branch (a same-branch watch on a
         // different repo is NOT current). Non-derivable remote ⇒ "" ⇒ nothing current.
-        let current_repo =
-            crate::mcp::handlers::dispatch_hook::derive_repo_from_remote_pub(Path::new(source_repo))
-                .unwrap_or_default();
+        let current_repo = crate::mcp::handlers::dispatch_hook::derive_repo_from_remote_pub(
+            Path::new(source_repo),
+        )
+        .unwrap_or_default();
 
         json!({
             "agent": agent,

--- a/src/mcp/handlers/binding_state_ci_watches.rs
+++ b/src/mcp/handlers/binding_state_ci_watches.rs
@@ -71,7 +71,8 @@ pub(super) fn enumerate_ci_watches_detail_for_agent(
         let Ok(content) = std::fs::read_to_string(&path) else {
             continue;
         };
-        let Ok(watch) = serde_json::from_str::<crate::daemon::ci_watch::WatchState>(&content) else {
+        let Ok(watch) = serde_json::from_str::<crate::daemon::ci_watch::WatchState>(&content)
+        else {
             continue;
         };
         if !watch.subscriber_names().iter().any(|s| s == agent) {

--- a/src/mcp/handlers/binding_state_ci_watches.rs
+++ b/src/mcp/handlers/binding_state_ci_watches.rs
@@ -57,8 +57,67 @@ pub(super) fn enumerate_ci_watches_detail_for_agent(
     current_repo: &str,
     current_branch: &str,
 ) -> Vec<Value> {
-    // RED-STUB (finding-3 RED commit): the real projection lands in the GREEN
-    // commit; here ci_watches_detail is empty so the projection matrix fails RED.
-    let _ = (home, agent, current_repo, current_branch);
-    Vec::new()
+    let ci_dir = crate::daemon::ci_watch::ci_watches_dir(home);
+    let Ok(entries) = std::fs::read_dir(&ci_dir) else {
+        return Vec::new();
+    };
+    let now_utc = chrono::Utc::now();
+    let mut rows: Vec<(String, String, String, Value)> = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("json") {
+            continue;
+        }
+        let Ok(content) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let Ok(watch) = serde_json::from_str::<crate::daemon::ci_watch::WatchState>(&content) else {
+            continue;
+        };
+        if !watch.subscriber_names().iter().any(|s| s == agent) {
+            continue;
+        }
+        let repo = watch.repo.clone();
+        let branch = watch.branch.clone();
+        let target_head_sha = watch.target_head_sha.clone();
+        // GC removes a protected-ref watch that is NOT a valid exact-head BEFORE
+        // the TTL classifier (protected-migration). Such a row is pending deletion
+        // — exclude it so binding_state never reports it as `polling` (finding 2).
+        if crate::agent_ops::is_protected_ref(&branch) {
+            let valid_exact_head = target_head_sha
+                .as_deref()
+                .is_some_and(crate::daemon::ci_watch::is_full_commit_sha);
+            if !valid_exact_head {
+                continue;
+            }
+        }
+        // Same classifier + lazy PR-open as the GC (is_branch_open runs only if the
+        // max-age threshold is crossed) → binding_state never drifts from cleanup.
+        let (lifecycle, expiry_reason) =
+            match crate::daemon::ci_watch::classify_subscribed_watch_expiry(&watch, now_utc, || {
+                crate::daemon::pr_state::is_branch_open(home, &repo, &branch)
+            }) {
+                Some(r) => ("expired", Some(r.as_str())),
+                None => ("polling", None),
+            };
+        // Binding identity is repo+branch (finding 1): a same-branch watch on a
+        // DIFFERENT repo is NOT current.
+        let current_binding =
+            !current_repo.is_empty() && repo == current_repo && branch == current_branch;
+        let detail = json!({
+            "repo": &repo,
+            "branch": &branch,
+            "target_head_sha": &target_head_sha,
+            "expires_at": &watch.expires_at,
+            "current_binding": current_binding,
+            "last_terminal_seen_at": &watch.last_terminal_seen_at,
+            "lifecycle": lifecycle,
+            "expiry_reason": expiry_reason,
+        });
+        rows.push((repo, branch, target_head_sha.unwrap_or_default(), detail));
+    }
+    rows.sort_by(|a, b| {
+        (a.0.as_str(), a.1.as_str(), a.2.as_str()).cmp(&(b.0.as_str(), b.1.as_str(), b.2.as_str()))
+    });
+    rows.into_iter().map(|(_, _, _, d)| d).collect()
 }

--- a/src/mcp/handlers/binding_state_ci_watches.rs
+++ b/src/mcp/handlers/binding_state_ci_watches.rs
@@ -1,0 +1,64 @@
+//! S2: ci-watch enumeration for `binding_state` — the byte-for-byte `ci_watches`
+//! string list + the additive `ci_watches_detail` projection. Extracted from
+//! binding_state.rs to keep that file under the MCP-handler LOC ceiling.
+
+use serde_json::{json, Value};
+use std::path::Path;
+
+/// Subscriber-scoped `"<repo>:<branch>"` strings, sorted. UNCHANGED byte-for-byte
+/// from the pre-S2 inline version (`ci_watches` back-compat).
+pub(super) fn enumerate_ci_watches_for_agent(home: &Path, agent: &str) -> Vec<String> {
+    let ci_dir = crate::daemon::ci_watch::ci_watches_dir(home);
+    let Ok(entries) = std::fs::read_dir(&ci_dir) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("json") {
+            continue;
+        }
+        let Ok(content) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let Ok(watch) = serde_json::from_str::<Value>(&content) else {
+            continue;
+        };
+        let subs = crate::daemon::ci_watch::parse_subscribers(&watch);
+        if subs.iter().any(|s| s == agent) {
+            let repo = watch["repo"].as_str().unwrap_or("?");
+            let branch = watch["branch"].as_str().unwrap_or("?");
+            out.push(format!("{repo}:{branch}"));
+        }
+    }
+    out.sort();
+    out
+}
+
+/// S2 additive detail — one row per watch the agent subscribes to.
+///
+/// `current_repo`/`current_branch` are the agent's CURRENT binding identity (the
+/// owner/repo slug derived from its binding `source_repo` + branch). A watch is
+/// `current_binding` only when BOTH match — binding identity is repo+branch, not
+/// branch alone: a same-branch watch on a DIFFERENT repo is NOT current. Empty
+/// `current_repo` (unbound, or a non-derivable remote) ⇒ nothing is current.
+///
+/// Rows GC's protected-migration arm would remove — a protected-ref watch
+/// (`main`/`master`) that is NOT a valid exact-head (absent/malformed target SHA)
+/// — are EXCLUDED (pending deletion, out of per-agent scope; mirrors the GC order
+/// where protected-migration precedes the TTL classifier). A VALID exact-head
+/// protected watch is kept. `lifecycle`/`expiry_reason` come from the SAME
+/// `classify_subscribed_watch_expiry` the GC reaps on (no drift). A non-current
+/// but not-reap-eligible watch is `polling`, NOT stale (#931). Tombstones never
+/// appear (subscriber-scoped). Sorted by (repo, branch, target_head_sha).
+pub(super) fn enumerate_ci_watches_detail_for_agent(
+    home: &Path,
+    agent: &str,
+    current_repo: &str,
+    current_branch: &str,
+) -> Vec<Value> {
+    // RED-STUB (finding-3 RED commit): the real projection lands in the GREEN
+    // commit; here ci_watches_detail is empty so the projection matrix fails RED.
+    let _ = (home, agent, current_repo, current_branch);
+    Vec::new()
+}

--- a/src/mcp/handlers/binding_state_detail_tests.rs
+++ b/src/mcp/handlers/binding_state_detail_tests.rs
@@ -1,0 +1,242 @@
+//! S2 additive `ci_watches_detail` — binding_state projection matrix (test-first).
+//!
+//! Contract (task t-…19288-4): `ci_watches` strings stay byte-for-byte; the new
+//! `ci_watches_detail` array carries identity (repo/branch/target_head_sha),
+//! raw expires_at + last_terminal_seen_at, current_binding (repo+branch — NOT
+//! branch alone), and a polling|expired lifecycle + expiry_reason derived from
+//! the SAME `classify_subscribed_watch_expiry` predicates the GC reaps on. A
+//! non-current binding is `polling`, not stale (#931). Rows GC's protected-
+//! migration arm would remove (generic/malformed protected watches) are excluded.
+
+use super::handle_binding_state;
+use serde_json::{json, Value};
+
+fn tmp_home(tag: &str) -> std::path::PathBuf {
+    use std::sync::atomic::{AtomicU32, Ordering};
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+    let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let h = std::env::temp_dir().join(format!(
+        "agend-s2-detail-{}-{}-{}",
+        std::process::id(),
+        tag,
+        id
+    ));
+    std::fs::create_dir_all(&h).unwrap();
+    h
+}
+
+/// Bind `agent` to `repo_slug`@`branch`. Creates a REAL git repo with an origin
+/// remote so `derive_repo_from_remote` resolves the slug (current_binding needs
+/// the bound repo identity, not just the branch).
+fn write_binding(home: &std::path::Path, agent: &str, repo_slug: &str, branch: &str) {
+    let src = home.join(format!("src-{agent}"));
+    std::fs::create_dir_all(&src).unwrap();
+    let git = |args: &[&str]| {
+        std::process::Command::new("git")
+            .args(args)
+            .current_dir(&src)
+            .env("AGEND_GIT_BYPASS", "1")
+            .output()
+            .unwrap();
+    };
+    git(&["init", "-b", "main"]);
+    git(&["remote", "add", "origin", &format!("https://github.com/{repo_slug}.git")]);
+
+    let dir = crate::paths::runtime_dir(home).join(agent);
+    std::fs::create_dir_all(&dir).unwrap();
+    let wt = home.join(format!("wt-{agent}"));
+    std::fs::create_dir_all(&wt).unwrap();
+    std::fs::write(wt.join(".agend-managed"), "x").unwrap();
+    let payload = json!({
+        "version": 1, "agent": agent, "task_id": "t", "branch": branch,
+        "worktree": wt.to_str().unwrap(), "source_repo": src.to_str().unwrap(),
+        "issued_at": "2026-05-09T00:00:00Z",
+    });
+    std::fs::write(dir.join("binding.json"), serde_json::to_string_pretty(&payload).unwrap()).unwrap();
+}
+
+#[allow(clippy::too_many_arguments)]
+fn write_watch(
+    home: &std::path::Path,
+    name: &str,
+    repo: &str,
+    branch: &str,
+    agent: &str,
+    subscribed_at: &str,
+    expires_at: &str,
+    last_terminal_seen_at: Option<&str>,
+    target_head_sha: Option<&str>,
+) {
+    let dir = crate::daemon::ci_watch::ci_watches_dir(home);
+    std::fs::create_dir_all(&dir).unwrap();
+    let mut w = json!({
+        "repo": repo, "branch": branch,
+        "subscribers": [{"instance": agent, "subscribed_at": subscribed_at}],
+        "expires_at": expires_at,
+    });
+    if let Some(ts) = last_terminal_seen_at {
+        w["last_terminal_seen_at"] = json!(ts);
+    }
+    if let Some(sha) = target_head_sha {
+        w["target_head_sha"] = json!(sha);
+    }
+    std::fs::write(dir.join(format!("{name}.json")), serde_json::to_string_pretty(&w).unwrap()).unwrap();
+}
+
+fn recent() -> String {
+    (chrono::Utc::now() - chrono::Duration::hours(1)).to_rfc3339()
+}
+fn future() -> String {
+    (chrono::Utc::now() + chrono::Duration::hours(24)).to_rfc3339()
+}
+fn past() -> String {
+    (chrono::Utc::now() - chrono::Duration::hours(1)).to_rfc3339()
+}
+const FULL_SHA_A: &str = "aaaa000000000000000000000000000000000000";
+const FULL_SHA_B: &str = "bbbb000000000000000000000000000000000000";
+
+fn row<'a>(resp: &'a Value, branch: &str) -> &'a Value {
+    resp["ci_watches_detail"]
+        .as_array()
+        .expect("ci_watches_detail array")
+        .iter()
+        .find(|e| e["branch"] == json!(branch))
+        .unwrap_or_else(|| panic!("no detail for branch {branch}: {resp}"))
+}
+
+/// Current binding (repo+branch) → current_binding=true, polling. Non-current
+/// live watch → false, polling (NOT stale). `ci_watches` strings intact.
+#[test]
+fn detail_current_and_noncurrent_are_polling() {
+    let home = tmp_home("cur-noncur");
+    write_binding(&home, "dev", "o/r", "feat/cur");
+    write_watch(&home, "w_cur", "o/r", "feat/cur", "dev", &recent(), &future(), None, None);
+    write_watch(&home, "w_other", "o/r", "feat/other", "dev", &recent(), &future(), None, None);
+
+    let r = handle_binding_state(&home, &json!({"instance": "dev"}), &None);
+    let strings: Vec<&str> = r["ci_watches"].as_array().unwrap().iter().filter_map(|v| v.as_str()).collect();
+    assert_eq!(strings, vec!["o/r:feat/cur", "o/r:feat/other"], "ci_watches strings: {r}");
+
+    let cur = row(&r, "feat/cur");
+    assert_eq!(cur["current_binding"], json!(true), "{cur}");
+    assert_eq!(cur["lifecycle"], json!("polling"), "{cur}");
+    assert_eq!(cur["expiry_reason"], json!(null), "{cur}");
+    assert_eq!(cur["target_head_sha"], json!(null), "ordinary watch has no pin: {cur}");
+
+    let other = row(&r, "feat/other");
+    assert_eq!(other["current_binding"], json!(false), "{other}");
+    assert_eq!(other["lifecycle"], json!("polling"), "non-current live watch is polling, NOT stale: {other}");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// FINDING 1: `current_binding` is repo+branch. A same-branch watch on a DIFFERENT
+/// repo must be current_binding=false (binding identity is not branch alone).
+#[test]
+fn detail_current_binding_requires_matching_repo() {
+    let home = tmp_home("cross-repo");
+    write_binding(&home, "dev", "o/r", "feat/x");
+    write_watch(&home, "w_same", "o/r", "feat/x", "dev", &recent(), &future(), None, None);
+    // Same branch, DIFFERENT repo — must NOT be current.
+    write_watch(&home, "w_other_repo", "o/other", "feat/x", "dev", &recent(), &future(), None, None);
+
+    let r = handle_binding_state(&home, &json!({"instance": "dev"}), &None);
+    let same = r["ci_watches_detail"].as_array().unwrap().iter()
+        .find(|e| e["repo"] == json!("o/r")).unwrap();
+    let other = r["ci_watches_detail"].as_array().unwrap().iter()
+        .find(|e| e["repo"] == json!("o/other")).unwrap();
+    assert_eq!(same["current_binding"], json!(true), "same repo+branch is current: {same}");
+    assert_eq!(
+        other["current_binding"], json!(false),
+        "a same-BRANCH watch on a DIFFERENT repo must NOT be current_binding (finding 1): {other}"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// FINDING 2: rows GC's protected-migration arm would remove — a GENERIC main
+/// watch (no target SHA) and a MALFORMED exact-head main watch — must be ABSENT
+/// from detail (out of per-agent scope); a VALID exact-head main watch remains.
+#[test]
+fn detail_excludes_protected_migration_rows_keeps_valid_exact_head() {
+    let home = tmp_home("prot-mig");
+    write_binding(&home, "dev", "o/r", "feat/cur");
+    write_watch(&home, "generic_main", "o/r", "main", "dev", &recent(), &future(), None, None);
+    write_watch(&home, "malformed_main", "o/r", "main", "dev", &recent(), &future(), None, Some("not-a-sha"));
+    write_watch(&home, "valid_main", "o/r", "main", "dev", &recent(), &future(), None, Some(FULL_SHA_A));
+
+    let r = handle_binding_state(&home, &json!({"instance": "dev"}), &None);
+    let mains: Vec<&Value> = r["ci_watches_detail"].as_array().unwrap().iter()
+        .filter(|e| e["branch"] == json!("main")).collect();
+    assert_eq!(mains.len(), 1, "only the VALID exact-head main survives: {r}");
+    assert_eq!(mains[0]["target_head_sha"], json!(FULL_SHA_A), "{r}");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn detail_expired_absolute_ttl() {
+    let home = tmp_home("abs-ttl");
+    write_binding(&home, "dev", "o/r", "feat/cur");
+    write_watch(&home, "w", "o/r", "feat/x", "dev", &recent(), &past(), None, None);
+    let r = handle_binding_state(&home, &json!({"instance": "dev"}), &None);
+    let d = row(&r, "feat/x");
+    assert_eq!(d["lifecycle"], json!("expired"), "{d}");
+    assert_eq!(d["expiry_reason"], json!("absolute_ttl"), "{d}");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn detail_expired_terminal_inactivity_ttl() {
+    let home = tmp_home("inact-ttl");
+    write_binding(&home, "dev", "o/r", "feat/cur");
+    let ancient = (chrono::Utc::now() - chrono::Duration::hours(80)).to_rfc3339();
+    write_watch(&home, "w", "o/r", "feat/x", "dev", &recent(), &future(), Some(&ancient), None);
+    let r = handle_binding_state(&home, &json!({"instance": "dev"}), &None);
+    let d = row(&r, "feat/x");
+    assert_eq!(d["lifecycle"], json!("expired"), "{d}");
+    assert_eq!(d["expiry_reason"], json!("terminal_inactivity_ttl"), "{d}");
+    assert_eq!(d["last_terminal_seen_at"], json!(ancient), "raw timestamp surfaced: {d}");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn detail_expired_max_age() {
+    let home = tmp_home("max-age");
+    write_binding(&home, "dev", "o/r", "feat/cur");
+    let old_sub = (chrono::Utc::now() - chrono::Duration::hours(7 * 24 + 1)).to_rfc3339();
+    write_watch(&home, "w", "o/r", "feat/x", "dev", &old_sub, &future(), None, None);
+    let r = handle_binding_state(&home, &json!({"instance": "dev"}), &None);
+    let d = row(&r, "feat/x");
+    assert_eq!(d["lifecycle"], json!("expired"), "{d}");
+    assert_eq!(d["expiry_reason"], json!("max_age"), "{d}");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// Two exact-head watches on the SAME repo+branch → DISTINCT rows keyed by
+/// target_head_sha, sorted by (repo, branch, target_head_sha).
+#[test]
+fn detail_multiple_exact_head_same_branch_distinct_by_sha() {
+    let home = tmp_home("multi-exact");
+    write_binding(&home, "lead", "o/r", "feat/cur");
+    write_watch(&home, "w_a", "o/r", "main", "lead", &recent(), &future(), None, Some(FULL_SHA_A));
+    write_watch(&home, "w_b", "o/r", "main", "lead", &recent(), &future(), None, Some(FULL_SHA_B));
+    let r = handle_binding_state(&home, &json!({"instance": "lead"}), &None);
+    let rows: Vec<&Value> = r["ci_watches_detail"].as_array().unwrap().iter()
+        .filter(|e| e["branch"] == json!("main")).collect();
+    assert_eq!(rows.len(), 2, "two distinct exact-head rows on the same branch: {r}");
+    assert_eq!(rows[0]["target_head_sha"], json!(FULL_SHA_A), "{r}");
+    assert_eq!(rows[1]["target_head_sha"], json!(FULL_SHA_B), "{r}");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// Unbound agent → detail present, every current_binding=false.
+#[test]
+fn detail_unbound_all_noncurrent() {
+    let home = tmp_home("unbound");
+    write_watch(&home, "w", "o/r", "feat/x", "ghost", &recent(), &future(), None, None);
+    let r = handle_binding_state(&home, &json!({"instance": "ghost"}), &None);
+    assert_eq!(r["bound"], json!(false), "{r}");
+    let arr = r["ci_watches_detail"].as_array().expect("detail array (unbound)");
+    assert_eq!(arr.len(), 1, "{r}");
+    assert_eq!(arr[0]["current_binding"], json!(false), "unbound ⇒ nothing current: {r}");
+    assert_eq!(arr[0]["lifecycle"], json!("polling"), "{r}");
+    std::fs::remove_dir_all(&home).ok();
+}

--- a/src/mcp/handlers/binding_state_detail_tests.rs
+++ b/src/mcp/handlers/binding_state_detail_tests.rs
@@ -40,12 +40,7 @@ fn write_binding(home: &std::path::Path, agent: &str, repo_slug: &str, branch: &
 /// Creates a REAL git repo so `current_repo` derivation resolves (or, for a
 /// non-GitHub forge, fails to resolve) exactly as production would — the
 /// current_binding projection needs the bound repo identity, not just the branch.
-fn write_binding_with_origin(
-    home: &std::path::Path,
-    agent: &str,
-    branch: &str,
-    origin_url: &str,
-) {
+fn write_binding_with_origin(home: &std::path::Path, agent: &str, branch: &str, origin_url: &str) {
     let src = home.join(format!("src-{agent}"));
     std::fs::create_dir_all(&src).unwrap();
     let git = |args: &[&str]| {

--- a/src/mcp/handlers/binding_state_detail_tests.rs
+++ b/src/mcp/handlers/binding_state_detail_tests.rs
@@ -40,7 +40,12 @@ fn write_binding(home: &std::path::Path, agent: &str, repo_slug: &str, branch: &
             .unwrap();
     };
     git(&["init", "-b", "main"]);
-    git(&["remote", "add", "origin", &format!("https://github.com/{repo_slug}.git")]);
+    git(&[
+        "remote",
+        "add",
+        "origin",
+        &format!("https://github.com/{repo_slug}.git"),
+    ]);
 
     let dir = crate::paths::runtime_dir(home).join(agent);
     std::fs::create_dir_all(&dir).unwrap();
@@ -52,7 +57,11 @@ fn write_binding(home: &std::path::Path, agent: &str, repo_slug: &str, branch: &
         "worktree": wt.to_str().unwrap(), "source_repo": src.to_str().unwrap(),
         "issued_at": "2026-05-09T00:00:00Z",
     });
-    std::fs::write(dir.join("binding.json"), serde_json::to_string_pretty(&payload).unwrap()).unwrap();
+    std::fs::write(
+        dir.join("binding.json"),
+        serde_json::to_string_pretty(&payload).unwrap(),
+    )
+    .unwrap();
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -80,7 +89,11 @@ fn write_watch(
     if let Some(sha) = target_head_sha {
         w["target_head_sha"] = json!(sha);
     }
-    std::fs::write(dir.join(format!("{name}.json")), serde_json::to_string_pretty(&w).unwrap()).unwrap();
+    std::fs::write(
+        dir.join(format!("{name}.json")),
+        serde_json::to_string_pretty(&w).unwrap(),
+    )
+    .unwrap();
 }
 
 fn recent() -> String {
@@ -110,22 +123,59 @@ fn row<'a>(resp: &'a Value, branch: &str) -> &'a Value {
 fn detail_current_and_noncurrent_are_polling() {
     let home = tmp_home("cur-noncur");
     write_binding(&home, "dev", "o/r", "feat/cur");
-    write_watch(&home, "w_cur", "o/r", "feat/cur", "dev", &recent(), &future(), None, None);
-    write_watch(&home, "w_other", "o/r", "feat/other", "dev", &recent(), &future(), None, None);
+    write_watch(
+        &home,
+        "w_cur",
+        "o/r",
+        "feat/cur",
+        "dev",
+        &recent(),
+        &future(),
+        None,
+        None,
+    );
+    write_watch(
+        &home,
+        "w_other",
+        "o/r",
+        "feat/other",
+        "dev",
+        &recent(),
+        &future(),
+        None,
+        None,
+    );
 
     let r = handle_binding_state(&home, &json!({"instance": "dev"}), &None);
-    let strings: Vec<&str> = r["ci_watches"].as_array().unwrap().iter().filter_map(|v| v.as_str()).collect();
-    assert_eq!(strings, vec!["o/r:feat/cur", "o/r:feat/other"], "ci_watches strings: {r}");
+    let strings: Vec<&str> = r["ci_watches"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|v| v.as_str())
+        .collect();
+    assert_eq!(
+        strings,
+        vec!["o/r:feat/cur", "o/r:feat/other"],
+        "ci_watches strings: {r}"
+    );
 
     let cur = row(&r, "feat/cur");
     assert_eq!(cur["current_binding"], json!(true), "{cur}");
     assert_eq!(cur["lifecycle"], json!("polling"), "{cur}");
     assert_eq!(cur["expiry_reason"], json!(null), "{cur}");
-    assert_eq!(cur["target_head_sha"], json!(null), "ordinary watch has no pin: {cur}");
+    assert_eq!(
+        cur["target_head_sha"],
+        json!(null),
+        "ordinary watch has no pin: {cur}"
+    );
 
     let other = row(&r, "feat/other");
     assert_eq!(other["current_binding"], json!(false), "{other}");
-    assert_eq!(other["lifecycle"], json!("polling"), "non-current live watch is polling, NOT stale: {other}");
+    assert_eq!(
+        other["lifecycle"],
+        json!("polling"),
+        "non-current live watch is polling, NOT stale: {other}"
+    );
     std::fs::remove_dir_all(&home).ok();
 }
 
@@ -135,18 +185,51 @@ fn detail_current_and_noncurrent_are_polling() {
 fn detail_current_binding_requires_matching_repo() {
     let home = tmp_home("cross-repo");
     write_binding(&home, "dev", "o/r", "feat/x");
-    write_watch(&home, "w_same", "o/r", "feat/x", "dev", &recent(), &future(), None, None);
+    write_watch(
+        &home,
+        "w_same",
+        "o/r",
+        "feat/x",
+        "dev",
+        &recent(),
+        &future(),
+        None,
+        None,
+    );
     // Same branch, DIFFERENT repo — must NOT be current.
-    write_watch(&home, "w_other_repo", "o/other", "feat/x", "dev", &recent(), &future(), None, None);
+    write_watch(
+        &home,
+        "w_other_repo",
+        "o/other",
+        "feat/x",
+        "dev",
+        &recent(),
+        &future(),
+        None,
+        None,
+    );
 
     let r = handle_binding_state(&home, &json!({"instance": "dev"}), &None);
-    let same = r["ci_watches_detail"].as_array().unwrap().iter()
-        .find(|e| e["repo"] == json!("o/r")).unwrap();
-    let other = r["ci_watches_detail"].as_array().unwrap().iter()
-        .find(|e| e["repo"] == json!("o/other")).unwrap();
-    assert_eq!(same["current_binding"], json!(true), "same repo+branch is current: {same}");
+    let same = r["ci_watches_detail"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|e| e["repo"] == json!("o/r"))
+        .unwrap();
+    let other = r["ci_watches_detail"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|e| e["repo"] == json!("o/other"))
+        .unwrap();
     assert_eq!(
-        other["current_binding"], json!(false),
+        same["current_binding"],
+        json!(true),
+        "same repo+branch is current: {same}"
+    );
+    assert_eq!(
+        other["current_binding"],
+        json!(false),
         "a same-BRANCH watch on a DIFFERENT repo must NOT be current_binding (finding 1): {other}"
     );
     std::fs::remove_dir_all(&home).ok();
@@ -159,14 +242,52 @@ fn detail_current_binding_requires_matching_repo() {
 fn detail_excludes_protected_migration_rows_keeps_valid_exact_head() {
     let home = tmp_home("prot-mig");
     write_binding(&home, "dev", "o/r", "feat/cur");
-    write_watch(&home, "generic_main", "o/r", "main", "dev", &recent(), &future(), None, None);
-    write_watch(&home, "malformed_main", "o/r", "main", "dev", &recent(), &future(), None, Some("not-a-sha"));
-    write_watch(&home, "valid_main", "o/r", "main", "dev", &recent(), &future(), None, Some(FULL_SHA_A));
+    write_watch(
+        &home,
+        "generic_main",
+        "o/r",
+        "main",
+        "dev",
+        &recent(),
+        &future(),
+        None,
+        None,
+    );
+    write_watch(
+        &home,
+        "malformed_main",
+        "o/r",
+        "main",
+        "dev",
+        &recent(),
+        &future(),
+        None,
+        Some("not-a-sha"),
+    );
+    write_watch(
+        &home,
+        "valid_main",
+        "o/r",
+        "main",
+        "dev",
+        &recent(),
+        &future(),
+        None,
+        Some(FULL_SHA_A),
+    );
 
     let r = handle_binding_state(&home, &json!({"instance": "dev"}), &None);
-    let mains: Vec<&Value> = r["ci_watches_detail"].as_array().unwrap().iter()
-        .filter(|e| e["branch"] == json!("main")).collect();
-    assert_eq!(mains.len(), 1, "only the VALID exact-head main survives: {r}");
+    let mains: Vec<&Value> = r["ci_watches_detail"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|e| e["branch"] == json!("main"))
+        .collect();
+    assert_eq!(
+        mains.len(),
+        1,
+        "only the VALID exact-head main survives: {r}"
+    );
     assert_eq!(mains[0]["target_head_sha"], json!(FULL_SHA_A), "{r}");
     std::fs::remove_dir_all(&home).ok();
 }
@@ -175,7 +296,17 @@ fn detail_excludes_protected_migration_rows_keeps_valid_exact_head() {
 fn detail_expired_absolute_ttl() {
     let home = tmp_home("abs-ttl");
     write_binding(&home, "dev", "o/r", "feat/cur");
-    write_watch(&home, "w", "o/r", "feat/x", "dev", &recent(), &past(), None, None);
+    write_watch(
+        &home,
+        "w",
+        "o/r",
+        "feat/x",
+        "dev",
+        &recent(),
+        &past(),
+        None,
+        None,
+    );
     let r = handle_binding_state(&home, &json!({"instance": "dev"}), &None);
     let d = row(&r, "feat/x");
     assert_eq!(d["lifecycle"], json!("expired"), "{d}");
@@ -188,12 +319,26 @@ fn detail_expired_terminal_inactivity_ttl() {
     let home = tmp_home("inact-ttl");
     write_binding(&home, "dev", "o/r", "feat/cur");
     let ancient = (chrono::Utc::now() - chrono::Duration::hours(80)).to_rfc3339();
-    write_watch(&home, "w", "o/r", "feat/x", "dev", &recent(), &future(), Some(&ancient), None);
+    write_watch(
+        &home,
+        "w",
+        "o/r",
+        "feat/x",
+        "dev",
+        &recent(),
+        &future(),
+        Some(&ancient),
+        None,
+    );
     let r = handle_binding_state(&home, &json!({"instance": "dev"}), &None);
     let d = row(&r, "feat/x");
     assert_eq!(d["lifecycle"], json!("expired"), "{d}");
     assert_eq!(d["expiry_reason"], json!("terminal_inactivity_ttl"), "{d}");
-    assert_eq!(d["last_terminal_seen_at"], json!(ancient), "raw timestamp surfaced: {d}");
+    assert_eq!(
+        d["last_terminal_seen_at"],
+        json!(ancient),
+        "raw timestamp surfaced: {d}"
+    );
     std::fs::remove_dir_all(&home).ok();
 }
 
@@ -202,7 +347,17 @@ fn detail_expired_max_age() {
     let home = tmp_home("max-age");
     write_binding(&home, "dev", "o/r", "feat/cur");
     let old_sub = (chrono::Utc::now() - chrono::Duration::hours(7 * 24 + 1)).to_rfc3339();
-    write_watch(&home, "w", "o/r", "feat/x", "dev", &old_sub, &future(), None, None);
+    write_watch(
+        &home,
+        "w",
+        "o/r",
+        "feat/x",
+        "dev",
+        &old_sub,
+        &future(),
+        None,
+        None,
+    );
     let r = handle_binding_state(&home, &json!({"instance": "dev"}), &None);
     let d = row(&r, "feat/x");
     assert_eq!(d["lifecycle"], json!("expired"), "{d}");
@@ -216,12 +371,40 @@ fn detail_expired_max_age() {
 fn detail_multiple_exact_head_same_branch_distinct_by_sha() {
     let home = tmp_home("multi-exact");
     write_binding(&home, "lead", "o/r", "feat/cur");
-    write_watch(&home, "w_a", "o/r", "main", "lead", &recent(), &future(), None, Some(FULL_SHA_A));
-    write_watch(&home, "w_b", "o/r", "main", "lead", &recent(), &future(), None, Some(FULL_SHA_B));
+    write_watch(
+        &home,
+        "w_a",
+        "o/r",
+        "main",
+        "lead",
+        &recent(),
+        &future(),
+        None,
+        Some(FULL_SHA_A),
+    );
+    write_watch(
+        &home,
+        "w_b",
+        "o/r",
+        "main",
+        "lead",
+        &recent(),
+        &future(),
+        None,
+        Some(FULL_SHA_B),
+    );
     let r = handle_binding_state(&home, &json!({"instance": "lead"}), &None);
-    let rows: Vec<&Value> = r["ci_watches_detail"].as_array().unwrap().iter()
-        .filter(|e| e["branch"] == json!("main")).collect();
-    assert_eq!(rows.len(), 2, "two distinct exact-head rows on the same branch: {r}");
+    let rows: Vec<&Value> = r["ci_watches_detail"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|e| e["branch"] == json!("main"))
+        .collect();
+    assert_eq!(
+        rows.len(),
+        2,
+        "two distinct exact-head rows on the same branch: {r}"
+    );
     assert_eq!(rows[0]["target_head_sha"], json!(FULL_SHA_A), "{r}");
     assert_eq!(rows[1]["target_head_sha"], json!(FULL_SHA_B), "{r}");
     std::fs::remove_dir_all(&home).ok();
@@ -231,12 +414,28 @@ fn detail_multiple_exact_head_same_branch_distinct_by_sha() {
 #[test]
 fn detail_unbound_all_noncurrent() {
     let home = tmp_home("unbound");
-    write_watch(&home, "w", "o/r", "feat/x", "ghost", &recent(), &future(), None, None);
+    write_watch(
+        &home,
+        "w",
+        "o/r",
+        "feat/x",
+        "ghost",
+        &recent(),
+        &future(),
+        None,
+        None,
+    );
     let r = handle_binding_state(&home, &json!({"instance": "ghost"}), &None);
     assert_eq!(r["bound"], json!(false), "{r}");
-    let arr = r["ci_watches_detail"].as_array().expect("detail array (unbound)");
+    let arr = r["ci_watches_detail"]
+        .as_array()
+        .expect("detail array (unbound)");
     assert_eq!(arr.len(), 1, "{r}");
-    assert_eq!(arr[0]["current_binding"], json!(false), "unbound ⇒ nothing current: {r}");
+    assert_eq!(
+        arr[0]["current_binding"],
+        json!(false),
+        "unbound ⇒ nothing current: {r}"
+    );
     assert_eq!(arr[0]["lifecycle"], json!("polling"), "{r}");
     std::fs::remove_dir_all(&home).ok();
 }

--- a/src/mcp/handlers/binding_state_detail_tests.rs
+++ b/src/mcp/handlers/binding_state_detail_tests.rs
@@ -25,10 +25,27 @@ fn tmp_home(tag: &str) -> std::path::PathBuf {
     h
 }
 
-/// Bind `agent` to `repo_slug`@`branch`. Creates a REAL git repo with an origin
-/// remote so `derive_repo_from_remote` resolves the slug (current_binding needs
-/// the bound repo identity, not just the branch).
+/// Bind `agent` to `repo_slug`@`branch` with a GitHub HTTPS origin (the common
+/// case). Delegates to [`write_binding_with_origin`].
 fn write_binding(home: &std::path::Path, agent: &str, repo_slug: &str, branch: &str) {
+    write_binding_with_origin(
+        home,
+        agent,
+        branch,
+        &format!("https://github.com/{repo_slug}.git"),
+    );
+}
+
+/// Bind `agent`@`branch` with `origin_url` as the source-repo origin remote.
+/// Creates a REAL git repo so `current_repo` derivation resolves (or, for a
+/// non-GitHub forge, fails to resolve) exactly as production would — the
+/// current_binding projection needs the bound repo identity, not just the branch.
+fn write_binding_with_origin(
+    home: &std::path::Path,
+    agent: &str,
+    branch: &str,
+    origin_url: &str,
+) {
     let src = home.join(format!("src-{agent}"));
     std::fs::create_dir_all(&src).unwrap();
     let git = |args: &[&str]| {
@@ -40,12 +57,7 @@ fn write_binding(home: &std::path::Path, agent: &str, repo_slug: &str, branch: &
             .unwrap();
     };
     git(&["init", "-b", "main"]);
-    git(&[
-        "remote",
-        "add",
-        "origin",
-        &format!("https://github.com/{repo_slug}.git"),
-    ]);
+    git(&["remote", "add", "origin", origin_url]);
 
     let dir = crate::paths::runtime_dir(home).join(agent);
     std::fs::create_dir_all(&dir).unwrap();
@@ -437,5 +449,46 @@ fn detail_unbound_all_noncurrent() {
         "unbound ⇒ nothing current: {r}"
     );
     assert_eq!(arr[0]["lifecycle"], json!("polling"), "{r}");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// r2 (codex #2746): a Bitbucket-Cloud watch is reachable via the PUBLIC `ci`
+/// schema — `repository=owner/repo` is a bare, provider-blind slug that
+/// `canonicalize_repo_slug` accepts, and `ci_provider=bitbucket_cloud` on a
+/// NON-protected branch is not rejected (only `bitbucket_server` is; the
+/// `provider_kind=="github"` gate applies to exact-head PROTECTED watches only).
+/// r1 derived `current_repo` with a GitHub-only origin canonicalizer, so a
+/// Bitbucket-origin binding resolved current_repo="" and the agent's OWN watch
+/// row projected current_binding=false. PRODUCTION-PATH RED: the real
+/// `handle_watch_ci` creates the watch (no synthetic sidecar injection).
+#[test]
+fn detail_current_binding_bitbucket_cloud_origin_production_path() {
+    let home = tmp_home("bitbucket-cur");
+    write_binding_with_origin(&home, "dev", "feat/x", "https://bitbucket.org/o/r.git");
+    // Public sequence: ci watch on a feature branch, explicit bare slug + provider.
+    let watch_resp = crate::mcp::handlers::ci::handle_watch_ci(
+        &home,
+        &json!({
+            "action": "watch",
+            "repository": "o/r",
+            "branch": "feat/x",
+            "ci_provider": "bitbucket_cloud",
+        }),
+        "dev",
+    );
+    assert!(
+        watch_resp.get("error").is_none(),
+        "a bitbucket_cloud feature-branch watch is reachable and must be accepted: {watch_resp}"
+    );
+
+    let r = handle_binding_state(&home, &json!({"instance": "dev"}), &None);
+    let d = row(&r, "feat/x");
+    assert_eq!(d["repo"], json!("o/r"), "watch stored the bare slug: {d}");
+    assert_eq!(
+        d["current_binding"],
+        json!(true),
+        "the agent's OWN Bitbucket-Cloud-origin watch must be current_binding=true; \
+         a GitHub-only current_repo derivation regressed it to false: {d}"
+    );
     std::fs::remove_dir_all(&home).ok();
 }

--- a/src/mcp/handlers/dispatch_hook/mod.rs
+++ b/src/mcp/handlers/dispatch_hook/mod.rs
@@ -9,7 +9,12 @@ mod auto_watch;
 mod branch_start_point;
 mod from_ref;
 mod live_binding;
+// S2 r2 (#2746): provider-neutral binding-origin slug for the binding_state
+// current_binding projection (GitHub + Bitbucket + GitLab), sibling for LOC
+// relief. Watch-storage canonicalization stays GitHub-only in this file.
+mod provider_neutral_slug;
 pub(crate) use from_ref::resolve_from_ref_remote; // CR-2026-06-14 extraction
+pub(crate) use provider_neutral_slug::derive_repo_slug_any_forge_pub;
 
 /// #781 Piece 7: structured dispatch outcome. Mirrors the #784 success
 /// response shape for `repo action=checkout bind:true` so callers across
@@ -976,9 +981,18 @@ pub(crate) fn canonicalize_repo_slug(s: &str) -> Option<String> {
     ))
 }
 
-/// Returns `None` for non-GitHub remotes — `watch_ci` only knows how to poll
-/// GitHub Actions, so silently skipping non-GitHub repos is the right behavior
-/// (the alternative would be writing a stale watch entry the poller can't act on).
+/// Returns `None` for non-GitHub remotes. This GitHub-only derivation is the
+/// dispatch-time fallback that stamps a watch's stored `repo` when the caller
+/// omits an explicit `repository` (see `ci::resolve_repo_or_error`): a non-GitHub
+/// binding origin then fails loud (`non_github_remote_no_override`) rather than
+/// writing a slug the derive path can't canonicalize.
+///
+/// NOTE (#2746): this does NOT mean the whole subsystem is GitHub-only — the
+/// poller has (dormant) GitLab/Bitbucket providers, and an EXPLICIT bare
+/// `repository=owner/repo` + `ci_provider=bitbucket_cloud` reaches a Bitbucket
+/// watch. For deriving the CURRENT-BINDING identity from a binding origin
+/// (which must match such a stored slug), use the provider-neutral
+/// [`derive_repo_slug_any_forge_pub`], NOT this helper.
 ///
 /// Pre-#942 this was a separate stricter implementation; post-#942 it
 /// delegates to [`canonicalize_repo_slug`] so derived-from-remote URLs

--- a/src/mcp/handlers/dispatch_hook/provider_neutral_slug.rs
+++ b/src/mcp/handlers/dispatch_hook/provider_neutral_slug.rs
@@ -148,4 +148,22 @@ mod tests {
         assert_eq!(canon(""), None);
         assert_eq!(canon("   "), None);
     }
+
+    /// r3 (codex #2746): unknown/look-alike SCP + SSH transports must be `None`.
+    /// r2 did NOT strip these, and a `host:owner/repo` SCP form splits into exactly
+    /// two slash-parts → was wrongly ACCEPTED as the bogus slug `host:owner/repo`
+    /// (the false boundary-safety claim: earlier tests only exercised HTTPS shapes,
+    /// which split into >2 parts and were already `None`).
+    #[test]
+    fn unknown_scp_and_ssh_transports_rejected() {
+        // SCP form for an unknown host (the r2 gap): git@host:owner/repo.
+        assert_eq!(canon("git@example.com:o/r"), None);
+        // SCP look-alike host — github.com.evil.com is NOT github.com.
+        assert_eq!(canon("git@github.com.evil.com:o/r"), None);
+        // SCP without a user (host:path) is still an unknown-host transport.
+        assert_eq!(canon("example.com:o/r"), None);
+        // SSH URL + HTTPS look-alike (already >2 parts, kept for the boundary set).
+        assert_eq!(canon("ssh://git@example.com/o/r"), None);
+        assert_eq!(canon("https://github.com.evil.com/o/r"), None);
+    }
 }

--- a/src/mcp/handlers/dispatch_hook/provider_neutral_slug.rs
+++ b/src/mcp/handlers/dispatch_hook/provider_neutral_slug.rs
@@ -11,11 +11,14 @@
 //! binding whose OWN watch it should have matched.
 //!
 //! This strips the known forge hosts (GitHub + Bitbucket; GitLab included as
-//! characterization — the public schema does not yet advertise it) and applies
-//! the SAME owner/repo parse + lowercase + `.git`/trailing-slash trim as
-//! `canonicalize_repo_slug`, so for a `github.com` URL the output is BYTE-
-//! IDENTICAL. Watch-STORAGE canonicalization is unchanged — this only affects
-//! how the current-binding identity is derived from the binding origin.
+//! characterization — the public schema does not yet advertise it) and then
+//! DELEGATES the `owner/repo` parse/lowercase/`.git`-trim to
+//! `canonicalize_repo_slug` — the SINGLE parser authority, so there is no second
+//! parser to drift from the storage form. For a `github.com` URL the output is
+//! BYTE-IDENTICAL. An unstripped input is accepted only as a clean bare slug;
+//! an unknown/look-alike transport (`://`, SCP `host:path`, `user@host`) is
+//! rejected. Watch-STORAGE canonicalization is unchanged — this only affects how
+//! the current-binding identity is derived from the binding origin.
 //!
 //! LOCKSTEP INVARIANT: this MUST produce the same canonical form that watch
 //! creation stores in `watch.repo` (see `ci::mod::resolve_repo_or_error`). If
@@ -45,28 +48,32 @@ pub(crate) fn derive_repo_slug_any_forge_pub(source_repo: &Path) -> Option<Strin
     canonicalize_repo_slug_any_forge(&url)
 }
 
-/// Host-agnostic form of [`super::canonicalize_repo_slug`]: strips the known
-/// forge hosts (in the https/http/ssh/scp remote-URL shapes) then applies the
-/// identical owner/repo parse + `.git`/slash trim + lowercase. Byte-identical to
-/// `canonicalize_repo_slug` for a `github.com` URL or a bare slug.
+/// Host-agnostic front-end to [`super::canonicalize_repo_slug`] — the SINGLE
+/// owner/repo parser authority (no second parser to drift). Strips a known forge
+/// host, then DELEGATES the `owner/repo` parse/lowercase/trim to
+/// `canonicalize_repo_slug`. An UNSTRIPPED input is accepted only as a clean bare
+/// slug; an unknown/look-alike transport (`://` scheme, SCP `host:path`,
+/// `user@host`) is rejected. Byte-identical to `canonicalize_repo_slug` for a
+/// `github.com` URL or a bare slug.
 pub(crate) fn canonicalize_repo_slug_any_forge(s: &str) -> Option<String> {
     let s = s.trim();
     if s.is_empty() {
         return None;
     }
-    let stripped = strip_known_forge_host(s).unwrap_or(s);
-    let slug = stripped.trim_end_matches('/').trim_end_matches(".git");
-    let mut parts = slug.split('/');
-    let owner = parts.next()?;
-    let name = parts.next()?;
-    if parts.next().is_some() || owner.is_empty() || name.is_empty() {
+    // Known forge host → strip its transport prefix; the `owner/repo(.git)`
+    // remainder is parsed by the single storage canonicalizer.
+    if let Some(rest) = strip_known_forge_host(s) {
+        return super::canonicalize_repo_slug(rest);
+    }
+    // No known host: only a CLEAN bare `owner/repo` slug may pass. A valid slug
+    // never contains ':' or '@', so any scheme (`://`), SCP host (`host:path`), or
+    // user (`user@host`) is an unknown/look-alike transport we reject — without
+    // this gate, a two-part `host:owner/repo` SCP form would be accepted as a
+    // bogus slug (r2 boundary bug, codex #2746).
+    if s.contains(':') || s.contains('@') {
         return None;
     }
-    Some(format!(
-        "{}/{}",
-        owner.to_ascii_lowercase(),
-        name.to_ascii_lowercase()
-    ))
+    super::canonicalize_repo_slug(s)
 }
 
 /// Strip the leading `scheme://host/` (or `git@host:` / `ssh://git@host/`) for a

--- a/src/mcp/handlers/dispatch_hook/provider_neutral_slug.rs
+++ b/src/mcp/handlers/dispatch_hook/provider_neutral_slug.rs
@@ -1,0 +1,151 @@
+//! Provider-neutral `owner/repo` derivation for the binding_state
+//! `current_binding` projection (codex #2746 / S2 r2).
+//!
+//! A CI watch stores a HOST-INDEPENDENT `owner/repo` slug: the public `ci`
+//! schema accepts a bare `repository=owner/repo` (provider-blind) plus
+//! `ci_provider=bitbucket_cloud`, so a Bitbucket-Cloud watch on a non-protected
+//! branch is reachable (only `bitbucket_server` is rejected; the
+//! `provider_kind=="github"` gate is exact-head-PROTECTED-only). The GitHub-only
+//! [`super::canonicalize_repo_slug`] returns `None` for a Bitbucket/GitLab
+//! origin, which regressed `current_binding` to false for a non-GitHub-origin
+//! binding whose OWN watch it should have matched.
+//!
+//! This strips the known forge hosts (GitHub + Bitbucket; GitLab included as
+//! characterization — the public schema does not yet advertise it) and applies
+//! the SAME owner/repo parse + lowercase + `.git`/trailing-slash trim as
+//! `canonicalize_repo_slug`, so for a `github.com` URL the output is BYTE-
+//! IDENTICAL. Watch-STORAGE canonicalization is unchanged — this only affects
+//! how the current-binding identity is derived from the binding origin.
+//!
+//! LOCKSTEP INVARIANT: this MUST produce the same canonical form that watch
+//! creation stores in `watch.repo` (see `ci::mod::resolve_repo_or_error`). If
+//! the subscribe path's repo canonicalization ever changes (e.g. a future
+//! non-GitHub provider gains its own normalization), THIS derivation must change
+//! in step or `current_binding` silently drifts back to false.
+
+use std::path::Path;
+
+/// Forge hosts whose remote-URL prefixes are stripped to a bare `owner/repo`.
+/// GitHub + Bitbucket are the providers the public `ci` schema can reach today;
+/// GitLab is characterization (poller support exists but the schema does not
+/// advertise it).
+const KNOWN_FORGE_HOSTS: &[&str] = &["github.com", "bitbucket.org", "gitlab.com"];
+
+/// Provider-neutral sibling of [`super::derive_repo_from_remote_pub`], used ONLY
+/// by the binding_state `current_binding` projection. Runs
+/// `git remote get-url origin` in `source_repo` and canonicalizes across the
+/// known forge hosts. `None` on no origin / non-forge host / git failure.
+pub(crate) fn derive_repo_slug_any_forge_pub(source_repo: &Path) -> Option<String> {
+    let output =
+        crate::git_helpers::git_bypass(source_repo, &["remote", "get-url", "origin"]).ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let url = String::from_utf8(output.stdout).ok()?;
+    canonicalize_repo_slug_any_forge(&url)
+}
+
+/// Host-agnostic form of [`super::canonicalize_repo_slug`]: strips the known
+/// forge hosts (in the https/http/ssh/scp remote-URL shapes) then applies the
+/// identical owner/repo parse + `.git`/slash trim + lowercase. Byte-identical to
+/// `canonicalize_repo_slug` for a `github.com` URL or a bare slug.
+pub(crate) fn canonicalize_repo_slug_any_forge(s: &str) -> Option<String> {
+    let s = s.trim();
+    if s.is_empty() {
+        return None;
+    }
+    let stripped = strip_known_forge_host(s).unwrap_or(s);
+    let slug = stripped.trim_end_matches('/').trim_end_matches(".git");
+    let mut parts = slug.split('/');
+    let owner = parts.next()?;
+    let name = parts.next()?;
+    if parts.next().is_some() || owner.is_empty() || name.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "{}/{}",
+        owner.to_ascii_lowercase(),
+        name.to_ascii_lowercase()
+    ))
+}
+
+/// Strip the leading `scheme://host/` (or `git@host:` / `ssh://git@host/`) for a
+/// KNOWN forge host, returning the `owner/repo(.git)` remainder. The trailing
+/// `/` (or `:`) is part of every prefix, so a look-alike host such as
+/// `github.com.evil.com` never matches `github.com` — boundary-safe.
+fn strip_known_forge_host(s: &str) -> Option<&str> {
+    for host in KNOWN_FORGE_HOSTS {
+        for prefix in [
+            format!("https://{host}/"),
+            format!("http://{host}/"),
+            format!("git@{host}:"),
+            format!("ssh://git@{host}/"),
+        ] {
+            if let Some(rest) = s.strip_prefix(prefix.as_str()) {
+                return Some(rest);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::canonicalize_repo_slug_any_forge as canon;
+
+    /// For GitHub URLs and bare slugs the any-forge canonicalizer must be
+    /// byte-identical to the storage canonicalizer — GitHub behavior preserved.
+    #[test]
+    fn github_and_bare_are_byte_identical_to_storage_canonicalizer() {
+        for url in [
+            "https://github.com/Owner/Repo.git",
+            "https://github.com/owner/repo",
+            "http://github.com/owner/repo",
+            "git@github.com:Owner/Repo.git",
+            "ssh://git@github.com/owner/repo.git",
+            "owner/repo",
+            "Owner/Repo",
+        ] {
+            assert_eq!(
+                canon(url),
+                crate::mcp::handlers::dispatch_hook::canonicalize_repo_slug(url),
+                "any-forge must match the GitHub storage canonicalizer for {url:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn bitbucket_https_and_ssh_resolve() {
+        assert_eq!(
+            canon("https://bitbucket.org/o/r.git"),
+            Some("o/r".to_string())
+        );
+        assert_eq!(canon("https://bitbucket.org/O/R"), Some("o/r".to_string()));
+        assert_eq!(canon("git@bitbucket.org:o/r.git"), Some("o/r".to_string()));
+        assert_eq!(
+            canon("ssh://git@bitbucket.org/o/r.git"),
+            Some("o/r".to_string())
+        );
+    }
+
+    #[test]
+    fn gitlab_characterization() {
+        // Not advertised by the public ci schema; covered so a future enablement
+        // has a defined baseline rather than a silent None.
+        assert_eq!(canon("https://gitlab.com/o/r.git"), Some("o/r".to_string()));
+        assert_eq!(canon("git@gitlab.com:o/r.git"), Some("o/r".to_string()));
+    }
+
+    #[test]
+    fn unknown_host_and_lookalike_and_malformed_are_none() {
+        // Unknown host is not stripped → the scheme/host inflates the path parts.
+        assert_eq!(canon("https://example.com/o/r"), None);
+        // Boundary: a look-alike host must NOT be treated as GitHub.
+        assert_eq!(canon("https://github.com.evil.com/o/r"), None);
+        assert_eq!(canon("single"), None);
+        assert_eq!(canon("a/b/c"), None);
+        assert_eq!(canon(""), None);
+        assert_eq!(canon("   "), None);
+    }
+}


### PR DESCRIPTION
## What & why

S2 follow-up to the merged S1 exact-head watch (task `t-…19288-4`, decision `d-…54660984-4`). Adds a **backward-compatible `ci_watches_detail`** array to `binding_state` so operators can read per-watch lifecycle in one call — without the S1 spike's confusion where a subject-scoped `binding_state` looked contradictory next to a caller-scoped `ci status`. `ci_watches` strings stay **byte-for-byte** (separate untouched scan).

## Design (per codex's shape review)

- **Shared classifier (single source of truth, no drift):** extract `classify_subscribed_watch_expiry(watch, now, lazy_pr_open) -> Option<ExpiryReason>` (`sweep.rs`), used by **both** `gc_stale_watches`' TTL-family removal **and** binding_state's projection. `lazy_pr_open` is invoked **only after the max-age threshold is crossed** (short-circuit `&&`), preserving the GC's no-`pr_state`-read-on-active-watches invariant. GC keeps its **protected-migration + tombstone** arms *before* the classifier and maps each reason to the **exact** prior remove/audit/log in the same precedence — behavior byte-identical.
- **Detail fields:** `repo`, `branch`, `target_head_sha` (S1 pin — disambiguates same-branch exact-head watches; sorted by `(repo,branch,target_head_sha)`), `expires_at`, `current_binding` (**repo+branch** — a same-branch watch on a DIFFERENT repo is NOT current; false when unbound), `last_terminal_seen_at` (**raw timestamp, not a lifecycle value**), `lifecycle` (`polling`|`expired`), `expiry_reason` (`null`|`absolute_ttl`|`terminal_inactivity_ttl`|`max_age`).
- **Correctness (codex's rejects, fixed):** `current_binding` is repo+branch, not branch alone (r1 finding-1); a non-current-binding watch is `polling`, **not stale** (#931); `terminal`-seen is a timestamp not a lifecycle; **tombstones + protected-migration are out of scope** for this subscriber-scoped endpoint (tombstone = zero subscribers ⇒ never returned here).

## r2 — provider-neutral current-binding identity (codex #2746)

r1 derived the current-binding repo with a **GitHub-only** origin canonicalizer. But a **Bitbucket-Cloud** watch is reachable via the PUBLIC `ci` schema: `repository=owner/repo` is a bare, provider-blind slug that `canonicalize_repo_slug` accepts, and `ci_provider=bitbucket_cloud` on a non-protected branch is **not** rejected (only `bitbucket_server` is; the `provider_kind=="github"` gate is exact-head-**protected**-only). So a Bitbucket-origin binding resolved `current_repo=""` and the agent's **OWN** watch projected `current_binding=false`.

Fix: a **provider-neutral binding-origin canonicalizer** (`dispatch_hook/provider_neutral_slug.rs`) used **only** by the `current_binding` projection — strips the known forge hosts (GitHub + Bitbucket; GitLab characterization), then **delegates the `owner/repo` parse to `canonicalize_repo_slug`** (r3: the SINGLE parser authority — no second parser to drift from the storage form), so a `github.com` URL is **byte-identical** to the storage canonicalizer. An **unstripped** input is accepted only as a clean bare slug; an unknown/look-alike transport (`://` scheme, SCP `host:path`, `user@host`) is **rejected** (r3 boundary fix — r2 wrongly accepted a two-part `git@example.com:o/r` as a bogus slug). Watch-**storage** canonicalization is unchanged; the deriver stays in **lockstep** with the slug watch creation stores (`ci::resolve_repo_or_error`) — documented as an invariant at both sites. GitLab is withdrawn from scope (the public schema does not advertise it; poller support is dormant).

## Tests (test-first)

- **r1 matrix RED-verified** (8/8 fail without the field): `current`/`waiting-noncurrent` polling; `current_binding` requires matching **repo** (same-branch/different-repo ⇒ false); expired via **each** reason (`absolute_ttl`/`terminal_inactivity_ttl`/`max_age` incl. the `is_branch_open` exemption); protected-migration exclusion keeps only the valid exact-head main; ≥2 exact-head watches on the same branch distinguished by `target_head_sha`; unbound → all `current_binding=false`; **`ci_watches` exact equality**.
- **r2 production-path RED:** the real `handle_watch_ci` creates a Bitbucket-Cloud feature-branch watch (`repository=owner/repo` + `ci_provider=bitbucket_cloud`) against a Bitbucket-origin binding, then `binding_state` must project `current_binding=true` (RED before the fix: `false`). No synthetic sidecar injection.
- **Provider-neutral canonicalizer matrix:** GitHub HTTPS/SSH + bare slug **byte-identical** to `canonicalize_repo_slug`; Bitbucket HTTPS/SSH resolve; GitLab characterization; unknown/look-alike hosts ⇒ `None` across **HTTPS *and* SCP/SSH** shapes — `https://example.com/o/r`, `https://github.com.evil.com/o/r`, `git@example.com:o/r`, `git@github.com.evil.com:o/r`, `example.com:o/r`, malformed (r3 RED for the SCP cases r2 wrongly accepted).
- **Classifier guards:** lazy-callback (pr-open NOT read for an active watch; read exactly once only after max-age; never when absolute-TTL already fired) + **drift guard** (`classify_subscribed_watch_expiry` predicts `gc_stale_watches`' actual removal for every case).
- **Byte-identical GC preserved:** the full `daemon::ci_watch` suite passes unchanged after the refactor.

**Local:** `cargo clippy --lib --bin agend-terminal --tests --features tray -- -D warnings` clean; `cargo fmt --check` clean; `tests/file_size_invariant` green; all of the above green.

## Reviewer notes
Rebased onto current `main` (post-#2745). The load-bearing checks are the **drift guard** + the **byte-identical existing sweep suite** (extracted classifier didn't change cleanup), the **r2 production-path RED** (Bitbucket-Cloud current-binding reachable via the public schema), and the **r3 single-parser delegation + SCP/look-alike transport rejection**. Replayable history: r1 RED→GREEN → fmt → r2 RED(Bitbucket)→GREEN → r3 RED(SCP)→GREEN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
