### PR TITLE
fix(merge): exact-head + base-identity merge precondition (P0)

### DIFF
--- a/src/mcp/handlers/ci/exact_head_merge_tests.rs
+++ b/src/mcp/handlers/ci/exact_head_merge_tests.rs
@@ -81,7 +81,11 @@ impl ScmProvider for MergeMock {
     }
 
     fn pr_checks(&self, _r: &str, _p: u64) -> anyhow::Result<Vec<CheckState>> {
-        let state = if self.checks_pass { "SUCCESS" } else { "FAILURE" };
+        let state = if self.checks_pass {
+            "SUCCESS"
+        } else {
+            "FAILURE"
+        };
         Ok(vec![CheckState {
             name: "CI".into(),
             state: state.into(),
@@ -148,7 +152,11 @@ fn normal_merge_pins_expected_head_sha() {
     let _g = crate::scm::set_test_scm_provider(Arc::new(MergeMock::new(recorded.clone())));
     let r = super::handle_merge_repo(&home, &base_args(), "dev");
     assert_eq!(r["merged"].as_bool(), Some(true), "should merge: {r}");
-    let opts = recorded.lock().unwrap().clone().expect("pr_merge was called");
+    let opts = recorded
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("pr_merge was called");
     assert_eq!(
         opts.expected_head_sha.as_deref(),
         Some(H0),
@@ -169,7 +177,10 @@ fn head_move_between_gate_and_write_refuses() {
     let _g = crate::scm::set_test_scm_provider(Arc::new(mock));
     let r = super::handle_merge_repo(&home, &base_args(), "dev");
     assert!(refused(&r), "P0-1: a moved head must REFUSE, got: {r}");
-    assert!(recorded.lock().unwrap().is_none(), "P0-1: pr_merge must NOT run");
+    assert!(
+        recorded.lock().unwrap().is_none(),
+        "P0-1: pr_merge must NOT run"
+    );
     std::fs::remove_dir_all(&home).ok();
 }
 
@@ -189,7 +200,10 @@ fn base_oid_move_with_clean_status_refuses() {
         refused(&r),
         "P0-2: a base-OID advance (status still CLEAN) must REFUSE, got: {r}"
     );
-    assert!(recorded.lock().unwrap().is_none(), "P0-2: pr_merge must NOT run");
+    assert!(
+        recorded.lock().unwrap().is_none(),
+        "P0-2: pr_merge must NOT run"
+    );
     std::fs::remove_dir_all(&home).ok();
 }
 
@@ -226,8 +240,14 @@ fn head_lookup_failure_with_force_fails_closed() {
     mock.head_err = true;
     let _g = crate::scm::set_test_scm_provider(Arc::new(mock));
     let r = super::handle_merge_repo(&home, &force_args(), "dev");
-    assert!(refused(&r), "P0-3: head unknown + force must fail closed, got: {r}");
-    assert!(recorded.lock().unwrap().is_none(), "P0-3: pr_merge must NOT run");
+    assert!(
+        refused(&r),
+        "P0-3: head unknown + force must fail closed, got: {r}"
+    );
+    assert!(
+        recorded.lock().unwrap().is_none(),
+        "P0-3: pr_merge must NOT run"
+    );
     std::fs::remove_dir_all(&home).ok();
 }
 

--- a/src/mcp/handlers/ci/exact_head_merge_tests.rs
+++ b/src/mcp/handlers/ci/exact_head_merge_tests.rs
@@ -296,7 +296,10 @@ fn assert_identity_refused(
     mock.bases = vec![base];
     let _g = crate::scm::set_test_scm_provider(Arc::new(mock));
     let r = super::handle_merge_repo(&home, &args, "dev");
-    assert!(refused(&r), "{tag}: malformed identity must REFUSE, got: {r}");
+    assert!(
+        refused(&r),
+        "{tag}: malformed identity must REFUSE, got: {r}"
+    );
     assert!(
         recorded.lock().unwrap().is_none(),
         "{tag}: pr_merge must NOT run on a malformed identity"

--- a/src/mcp/handlers/ci/exact_head_merge_tests.rs
+++ b/src/mcp/handlers/ci/exact_head_merge_tests.rs
@@ -134,10 +134,22 @@ fn force_args() -> serde_json::Value {
     json!({"pr": 4242, "repository": "suzuke/agend-terminal", "force": true, "force_reason": "emergency"})
 }
 
-const H0: &str = "h0h0h0h0h0h0h0h0h0h0h0h0h0h0h0h0h0h0h0h0";
-const H1: &str = "d1ffd1ffd1ffd1ffd1ffd1ffd1ffd1ffd1ffd1ff";
-const B0: &str = "ba5eba5eba5eba5eba5eba5eba5eba5eba5eba5e0";
-const B1: &str = "ba5eADVANCEba5eADVANCEba5eADVANCEba5eADV1";
+// All four are valid FULL 40-hex commit OIDs (`is_full_commit_sha`), distinct so
+// a head/base move is detected by EXACT identity. #merge-exact-head r1: the
+// pre-r1 fixtures padded with non-hex 'h'/'ADVANCE', which masked the full-
+// commit-OID invariant — a malformed provider identity was silently accepted as
+// valid. Real identities now exercise the invariant end-to-end.
+const H0: &str = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+const H1: &str = "feedfacefeedfacefeedfacefeedfacefeedface";
+const B0: &str = "0badf00d0badf00d0badf00d0badf00d0badf00d";
+const B1: &str = "cafebabecafebabecafebabecafebabecafebabe";
+
+// r1 malformed-identity fixtures. Each violates `is_full_commit_sha` on exactly
+// one axis: right length / wrong alphabet, and right alphabet / wrong length. A
+// provider that yields either MUST fail closed — never a silently unpinned
+// (`--match-head-commit`) or ambiguous-base merge.
+const NON_HEX_40: &str = "gggggggggggggggggggggggggggggggggggggggg";
+const ABBREV_HEX: &str = "deadbeef";
 
 fn refused(r: &serde_json::Value) -> bool {
     r.get("error").is_some() && r["merged"].as_bool() != Some(true)
@@ -264,4 +276,57 @@ fn head_unavailable_provider_fails_closed() {
     assert!(refused(&r), "erroring provider must fail closed, got: {r}");
     assert!(recorded.lock().unwrap().is_none(), "pr_merge must NOT run");
     std::fs::remove_dir_all(&home).ok();
+}
+
+/// r1 full-commit-OID invariant harness: a single (head, base) snapshot whose
+/// identity violates `is_full_commit_sha` MUST refuse without ever reaching
+/// `pr_merge`, under BOTH the normal and force paths (force relaxes CI/verdict/
+/// freshness POLICY only, never head/base identity acquisition). RED against
+/// ea23104f, whose `acquire_head_base` filtered only `!is_empty()`.
+fn assert_identity_refused(
+    tag: &str,
+    head: &'static str,
+    base: &'static str,
+    args: serde_json::Value,
+) {
+    let home = tmp_home(tag);
+    let recorded = Arc::new(Mutex::new(None));
+    let mut mock = MergeMock::new(recorded.clone());
+    mock.heads = vec![head];
+    mock.bases = vec![base];
+    let _g = crate::scm::set_test_scm_provider(Arc::new(mock));
+    let r = super::handle_merge_repo(&home, &args, "dev");
+    assert!(refused(&r), "{tag}: malformed identity must REFUSE, got: {r}");
+    assert!(
+        recorded.lock().unwrap().is_none(),
+        "{tag}: pr_merge must NOT run on a malformed identity"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// P0-5a: an abbreviated (valid-hex but too-short) HEAD OID fails closed — a
+/// `--match-head-commit` pin needs a FULL unambiguous SHA. Normal path.
+#[test]
+fn abbreviated_head_refuses_normal() {
+    assert_identity_refused("abbrev-head-normal", ABBREV_HEX, B0, base_args());
+}
+
+/// P0-5b: same abbreviated HEAD under force — force never relaxes identity.
+#[test]
+fn abbreviated_head_refuses_force() {
+    assert_identity_refused("abbrev-head-force", ABBREV_HEX, B0, force_args());
+}
+
+/// P0-6a: a non-hex (right length, wrong alphabet) BASE OID fails closed — a
+/// malformed base returned identically twice must NOT satisfy the exact-base
+/// recheck. Normal path.
+#[test]
+fn malformed_base_refuses_normal() {
+    assert_identity_refused("nonhex-base-normal", H0, NON_HEX_40, base_args());
+}
+
+/// P0-6b: same non-hex BASE under force.
+#[test]
+fn malformed_base_refuses_force() {
+    assert_identity_refused("nonhex-base-force", H0, NON_HEX_40, force_args());
 }

--- a/src/mcp/handlers/ci/exact_head_merge_tests.rs
+++ b/src/mcp/handlers/ci/exact_head_merge_tests.rs
@@ -1,0 +1,247 @@
+//! P0 exact-head merge precondition — production `handle_merge_repo` race tests
+//! (test-first). Deterministic race reproduction via an injected mock
+//! `ScmProvider` returning sequenced snapshots (no timing/sleep): the mock is
+//! installed at the shared `make_scm_provider` seam, so every provider call the
+//! handler makes hits the SAME instance and its per-call counter advances in
+//! order. RED against d68341a2 (handler does not yet acquire/recheck/pin the
+//! head+base); GREEN once `expected_head_sha` + one-shot head+base identity
+//! recheck + fail-closed land.
+//!
+//! Base freshness is proven by EXACT base identity (`baseRefOid`), NOT
+//! `mergeStateStatus` (derived + laggy): the base-move test advances the base OID
+//! while `mergeStateStatus` stays CLEAN, so a status-only check would miss it.
+
+use crate::scm::{
+    CheckState, CompareResult, IssueSummary, ListFilter, MergeOpts, MergeOutcome, PrSummary,
+    ScmProvider,
+};
+use serde_json::json;
+use std::path::Path;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+/// Sequenced, field-dispatched mock. Every `pr_view` that requests `headRefOid`
+/// walks `(heads, bases)` in lockstep (one shared counter; last value repeated).
+/// `compare` is constant-Fresh. `pr_merge` records its `MergeOpts`.
+struct MergeMock {
+    heads: Vec<&'static str>,
+    bases: Vec<&'static str>,
+    hb_calls: AtomicUsize,
+    head_err: bool,
+    merge_state: &'static str,
+    checks_pass: bool,
+    recorded: Arc<Mutex<Option<MergeOpts>>>,
+}
+
+impl MergeMock {
+    fn new(recorded: Arc<Mutex<Option<MergeOpts>>>) -> Self {
+        Self {
+            heads: vec![H0],
+            bases: vec![B0],
+            hb_calls: AtomicUsize::new(0),
+            head_err: false,
+            merge_state: "CLEAN",
+            checks_pass: true,
+            recorded,
+        }
+    }
+}
+
+impl ScmProvider for MergeMock {
+    fn pr_view(&self, _r: &str, _p: u64, fields: &[&str]) -> anyhow::Result<PrSummary> {
+        // verify_merge_landed reads state+mergeCommit → report a landed PR.
+        if fields.contains(&"state") {
+            return Ok(PrSummary {
+                state: Some("MERGED".into()),
+                merge_commit_oid: Some("mergecommit0".into()),
+                ..Default::default()
+            });
+        }
+        if fields.contains(&"headRefOid") {
+            if self.head_err {
+                anyhow::bail!("gh pr view headRefOid failed (simulated)");
+            }
+            let i = self
+                .hb_calls
+                .fetch_add(1, Ordering::SeqCst)
+                .min(self.heads.len().max(self.bases.len()) - 1);
+            return Ok(PrSummary {
+                head_ref_oid: Some(self.heads[i.min(self.heads.len() - 1)].to_string()),
+                base_ref_oid: Some(self.bases[i.min(self.bases.len() - 1)].to_string()),
+                ..Default::default()
+            });
+        }
+        if fields.contains(&"mergeStateStatus") {
+            return Ok(PrSummary {
+                merge_state_status: Some(self.merge_state.into()),
+                ..Default::default()
+            });
+        }
+        Ok(PrSummary::default())
+    }
+
+    fn pr_checks(&self, _r: &str, _p: u64) -> anyhow::Result<Vec<CheckState>> {
+        let state = if self.checks_pass { "SUCCESS" } else { "FAILURE" };
+        Ok(vec![CheckState {
+            name: "CI".into(),
+            state: state.into(),
+        }])
+    }
+
+    fn pr_list(
+        &self,
+        _r: &str,
+        _f: &ListFilter,
+        _fl: &[&str],
+        _c: Option<&Path>,
+    ) -> anyhow::Result<Vec<PrSummary>> {
+        unimplemented!("MergeMock::pr_list not used by the merge path")
+    }
+
+    fn pr_merge(&self, _r: &str, _p: u64, opts: &MergeOpts) -> anyhow::Result<MergeOutcome> {
+        *self.recorded.lock().unwrap() = Some(opts.clone());
+        Ok(MergeOutcome::Submitted)
+    }
+
+    fn issue_view(&self, _r: &str, _n: u64, _f: &[&str]) -> anyhow::Result<IssueSummary> {
+        unimplemented!("MergeMock::issue_view not used by the merge path")
+    }
+
+    fn compare(&self, _r: &str, _b: &str, _h: &str) -> anyhow::Result<CompareResult> {
+        Ok(CompareResult::default()) // behind_by 0 → merge_freshness Fresh
+    }
+}
+
+fn tmp_home(tag: &str) -> std::path::PathBuf {
+    let h = std::env::temp_dir().join(format!(
+        "agend-exact-head-merge-{}-{}",
+        std::process::id(),
+        tag
+    ));
+    std::fs::create_dir_all(&h).unwrap();
+    h
+}
+
+fn base_args() -> serde_json::Value {
+    json!({"pr": 4242, "repository": "suzuke/agend-terminal"})
+}
+
+fn force_args() -> serde_json::Value {
+    json!({"pr": 4242, "repository": "suzuke/agend-terminal", "force": true, "force_reason": "emergency"})
+}
+
+const H0: &str = "h0h0h0h0h0h0h0h0h0h0h0h0h0h0h0h0h0h0h0h0";
+const H1: &str = "d1ffd1ffd1ffd1ffd1ffd1ffd1ffd1ffd1ffd1ff";
+const B0: &str = "ba5eba5eba5eba5eba5eba5eba5eba5eba5eba5e0";
+const B1: &str = "ba5eADVANCEba5eADVANCEba5eADVANCEba5eADV1";
+
+fn refused(r: &serde_json::Value) -> bool {
+    r.get("error").is_some() && r["merged"].as_bool() != Some(true)
+}
+
+/// P0-4: a normal merge PINS the exact acquired head — `pr_merge` receives
+/// `expected_head_sha == acquired head`. RED: handler passes no pin.
+#[test]
+fn normal_merge_pins_expected_head_sha() {
+    let home = tmp_home("pin");
+    let recorded = Arc::new(Mutex::new(None));
+    let _g = crate::scm::set_test_scm_provider(Arc::new(MergeMock::new(recorded.clone())));
+    let r = super::handle_merge_repo(&home, &base_args(), "dev");
+    assert_eq!(r["merged"].as_bool(), Some(true), "should merge: {r}");
+    let opts = recorded.lock().unwrap().clone().expect("pr_merge was called");
+    assert_eq!(
+        opts.expected_head_sha.as_deref(),
+        Some(H0),
+        "P0-4: merge must be pinned to the acquired head; got {:?}",
+        opts.expected_head_sha
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// P0-1: head moves between gate read and write (H0 → H1) → REFUSE, no merge.
+#[test]
+fn head_move_between_gate_and_write_refuses() {
+    let home = tmp_home("headmove");
+    let recorded = Arc::new(Mutex::new(None));
+    let mut mock = MergeMock::new(recorded.clone());
+    mock.heads = vec![H0, H0, H1]; // acquire, merge_freshness, recheck → moved
+    mock.bases = vec![B0];
+    let _g = crate::scm::set_test_scm_provider(Arc::new(mock));
+    let r = super::handle_merge_repo(&home, &base_args(), "dev");
+    assert!(refused(&r), "P0-1: a moved head must REFUSE, got: {r}");
+    assert!(recorded.lock().unwrap().is_none(), "P0-1: pr_merge must NOT run");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// P0-2: base OID advances (B0 → B1) while mergeStateStatus stays CLEAN → REFUSE.
+/// Proves the recheck uses EXACT base identity, not the derived/laggy status.
+#[test]
+fn base_oid_move_with_clean_status_refuses() {
+    let home = tmp_home("basemove");
+    let recorded = Arc::new(Mutex::new(None));
+    let mut mock = MergeMock::new(recorded.clone());
+    mock.heads = vec![H0]; // head stable
+    mock.bases = vec![B0, B0, B1]; // acquire, merge_freshness, recheck → base moved
+    mock.merge_state = "CLEAN"; // status UNCHANGED — a status-only check would miss it
+    let _g = crate::scm::set_test_scm_provider(Arc::new(mock));
+    let r = super::handle_merge_repo(&home, &base_args(), "dev");
+    assert!(
+        refused(&r),
+        "P0-2: a base-OID advance (status still CLEAN) must REFUSE, got: {r}"
+    );
+    assert!(recorded.lock().unwrap().is_none(), "P0-2: pr_merge must NOT run");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// P0-2b: force must NOT bypass the base-identity recheck. Base OID advances under
+/// force (mergeStateStatus CLEAN) → REFUSE. Force relaxes freshness POLICY, never
+/// the head/base identity atomicity.
+#[test]
+fn base_oid_move_under_force_still_refuses() {
+    let home = tmp_home("basemove-force");
+    let recorded = Arc::new(Mutex::new(None));
+    let mut mock = MergeMock::new(recorded.clone());
+    mock.heads = vec![H0]; // head stable
+    mock.bases = vec![B0, B1]; // force skips merge_freshness → acquire, recheck
+    let _g = crate::scm::set_test_scm_provider(Arc::new(mock));
+    let r = super::handle_merge_repo(&home, &force_args(), "dev");
+    assert!(
+        refused(&r),
+        "P0-2b: force must NOT bypass the base-identity recheck, got: {r}"
+    );
+    assert!(
+        recorded.lock().unwrap().is_none(),
+        "P0-2b: pr_merge must NOT run under force when base moved"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// P0-3: head lookup fails AND force=true → fail-closed. Force relaxes policy,
+/// never the non-bypassable head acquisition/pin.
+#[test]
+fn head_lookup_failure_with_force_fails_closed() {
+    let home = tmp_home("headfail-force");
+    let recorded = Arc::new(Mutex::new(None));
+    let mut mock = MergeMock::new(recorded.clone());
+    mock.head_err = true;
+    let _g = crate::scm::set_test_scm_provider(Arc::new(mock));
+    let r = super::handle_merge_repo(&home, &force_args(), "dev");
+    assert!(refused(&r), "P0-3: head unknown + force must fail closed, got: {r}");
+    assert!(recorded.lock().unwrap().is_none(), "P0-3: pr_merge must NOT run");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// Unsupported/erroring provider (cannot yield the head) → fail-closed, never a
+/// silently-unpinned merge.
+#[test]
+fn head_unavailable_provider_fails_closed() {
+    let home = tmp_home("headfail-nonforce");
+    let recorded = Arc::new(Mutex::new(None));
+    let mut mock = MergeMock::new(recorded.clone());
+    mock.head_err = true;
+    let _g = crate::scm::set_test_scm_provider(Arc::new(mock));
+    let r = super::handle_merge_repo(&home, &base_args(), "dev");
+    assert!(refused(&r), "erroring provider must fail closed, got: {r}");
+    assert!(recorded.lock().unwrap().is_none(), "pr_merge must NOT run");
+    std::fs::remove_dir_all(&home).ok();
+}

--- a/src/mcp/handlers/ci/merge.rs
+++ b/src/mcp/handlers/ci/merge.rs
@@ -99,8 +99,19 @@ fn acquire_head_base(repo: &str, pr: u64) -> Option<(String, String)> {
     let s = crate::scm::make_scm_provider(repo, None)
         .pr_view(repo, pr, &["headRefOid", "baseRefOid"])
         .ok()?;
-    let head = s.head_ref_oid.filter(|x| !x.is_empty())?;
-    let base = s.base_ref_oid.filter(|x| !x.is_empty())?;
+    // Fail closed unless BOTH are FULL commit OIDs (40/64-hex). Non-empty is not
+    // a commit-identity invariant: an abbreviated/non-hex head would reach
+    // `--match-head-commit` ambiguously, and a malformed base returned identically
+    // across the gate+recheck reads would falsely satisfy the exact-base identity
+    // check. Reuses the canonical `is_full_commit_sha` (the same invariant that
+    // guards exact-head CI watches) so both acquire sites (gate + pre-merge
+    // recheck) and both paths (incl. force) enforce one unambiguous identity.
+    let head = s
+        .head_ref_oid
+        .filter(|x| crate::daemon::ci_watch::is_full_commit_sha(x))?;
+    let base = s
+        .base_ref_oid
+        .filter(|x| crate::daemon::ci_watch::is_full_commit_sha(x))?;
     Some((head, base))
 }
 

--- a/src/mcp/handlers/ci/merge.rs
+++ b/src/mcp/handlers/ci/merge.rs
@@ -229,6 +229,8 @@ pub(crate) fn handle_merge_repo(home: &Path, args: &Value, instance_name: &str) 
             admin: true,
             squash: true,
             delete_branch: true,
+            // RED scaffold: field present but unpinned; GREEN populates it.
+            expected_head_sha: None,
         },
     ) {
         // #1467: `gh pr merge` exit 0 is NECESSARY but not SUFFICIENT — a

--- a/src/mcp/handlers/ci/merge.rs
+++ b/src/mcp/handlers/ci/merge.rs
@@ -89,6 +89,21 @@ pub(crate) fn base_drift_refusal(merge_state_status: &str) -> Option<(&'static s
     }
 }
 
+/// P0 exact-head: read the PR's current `(head, base)` OIDs in one `gh pr view`.
+/// Returns `None` if either is missing or the read errors — the caller MUST fail
+/// closed (a merge that cannot identify its exact head+base is unsafe, even under
+/// `force`). `base_ref_oid` is the base BRANCH's current tip (it advances as the
+/// base moves), so comparing it gate-vs-pre-merge detects a base advance by EXACT
+/// identity — `mergeStateStatus` is derived + laggy and cannot prove base identity.
+fn acquire_head_base(repo: &str, pr: u64) -> Option<(String, String)> {
+    let s = crate::scm::make_scm_provider(repo, None)
+        .pr_view(repo, pr, &["headRefOid", "baseRefOid"])
+        .ok()?;
+    let head = s.head_ref_oid.filter(|x| !x.is_empty())?;
+    let base = s.base_ref_oid.filter(|x| !x.is_empty())?;
+    Some((head, base))
+}
+
 pub(crate) fn handle_merge_repo(home: &Path, args: &Value, instance_name: &str) -> Value {
     let pr = match args["pr"].as_u64() {
         Some(n) => n,
@@ -107,6 +122,22 @@ pub(crate) fn handle_merge_repo(home: &Path, args: &Value, instance_name: &str) 
     if force && force_reason.is_empty() {
         return json!({"error": "force=true requires non-empty force_reason"});
     }
+
+    // P0 exact-head precondition: acquire the exact (head, base) OIDs this merge
+    // will pin/validate against. NON-BYPASSABLE — even a force merge must land the
+    // head+base it INTENDS; if either can't be read, fail closed (never merge a
+    // head/base we cannot identify). `force` relaxes only the CI/verdict/freshness
+    // POLICY below, never this acquisition nor the pre-merge identity recheck.
+    let (gated_head, gated_base) = match acquire_head_base(&repo, pr) {
+        Some(hb) => hb,
+        None => {
+            return json!({
+                "error": "cannot determine PR head+base commit — merge refused (fail-closed exact-head precondition)",
+                "hint": "reading the current head+base OIDs is required to pin the merge; retry when the provider (GitHub) is reachable. force does NOT bypass this.",
+                "code": "exact_head_unavailable",
+            });
+        }
+    };
 
     if !force {
         // #PR-D site 2: `gh pr checks` via ScmProvider. argv byte-identical
@@ -215,9 +246,47 @@ pub(crate) fn handle_merge_repo(home: &Path, args: &Value, instance_name: &str) 
         }
     }
 
-    // #PR-Z site 3: the ONLY write — `gh pr merge` via ScmProvider. argv
-    // byte-identical (`pr merge <pr> --repo R --admin --squash
-    // --delete-branch`, pinned by scm::tests::pr_merge_args_match_existing_gh_call).
+    // P0 exact-head: one-shot immediate recheck (NO in-call retry loop). Re-read
+    // the current (head, base) and refuse if EITHER moved since the gate — the
+    // merge must land the exact head+base that passed validation. Non-bypassable
+    // (incl force). A residual ε remains between this read and the write: the HEAD
+    // side is additionally pinned at the GitHub API via `--match-head-commit`
+    // (below); the BASE side has NO GitHub pin primitive, so its ε is a documented
+    // residual — true base atomicity awaits a merge-queue (separate spike). Note:
+    // `verify_merge_landed` proves only that the PR LANDED, not that the merge was
+    // free of a semantic phantom-reversion; it is NOT a base-race backstop.
+    let (head_now, base_now) = match acquire_head_base(&repo, pr) {
+        Some(hb) => hb,
+        None => {
+            return json!({
+                "error": "cannot re-read PR head+base before merge — merge refused (fail-closed)",
+                "hint": "retry when the provider (GitHub) is reachable; no merge was attempted.",
+                "code": "exact_head_recheck_unavailable",
+            });
+        }
+    };
+    if head_now != gated_head {
+        return json!({
+            "error": "PR head moved during merge preparation — merge refused (exact-head)",
+            "gated_head": gated_head,
+            "current_head": head_now,
+            "hint": "re-run the merge; the exact-head precondition intentionally refuses a moved head. No changes were made.",
+            "code": "exact_head_moved",
+        });
+    }
+    if base_now != gated_base {
+        return json!({
+            "error": "base branch advanced during merge preparation — merge refused (exact base identity)",
+            "gated_base": gated_base,
+            "current_base": base_now,
+            "hint": "rebase onto current main and re-run: git fetch && git rebase origin/main && git push --force-with-lease. (Residual: a base advance within the recheck→merge window is uncovered — no GitHub base-pin primitive; true base atomicity awaits a merge-queue.)",
+            "code": "exact_base_moved",
+        });
+    }
+
+    // #PR-Z site 3: the ONLY write — `gh pr merge` via ScmProvider. argv now adds
+    // `--match-head-commit <gated_head>` (P0 pin) to the byte-identical
+    // `pr merge <pr> --repo R --admin --squash --delete-branch`.
     // MergeOutcome maps the original exit-status branches 1:1: Submitted =
     // exit-0 (→ verify_merge_landed post-condition, unchanged; retry loop
     // stays in that caller), Failed = non-zero (→ "gh pr merge failed" +
@@ -229,8 +298,8 @@ pub(crate) fn handle_merge_repo(home: &Path, args: &Value, instance_name: &str) 
             admin: true,
             squash: true,
             delete_branch: true,
-            // RED scaffold: field present but unpinned; GREEN populates it.
-            expected_head_sha: None,
+            // P0 pin: fail the merge at the API if the head moved in the ε window.
+            expected_head_sha: Some(gated_head.clone()),
         },
     ) {
         // #1467: `gh pr merge` exit 0 is NECESSARY but not SUFFICIENT — a

--- a/src/mcp/handlers/ci/mod.rs
+++ b/src/mcp/handlers/ci/mod.rs
@@ -118,3 +118,10 @@ mod tests;
 #[path = "exact_head_watch_tests.rs"]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod exact_head_watch_tests;
+
+// P0 exact-head MERGE precondition — production handle_merge_repo race tests in a
+// sibling file (test-named ⇒ file_size_invariant-exempt; keeps merge.rs small).
+#[cfg(test)]
+#[path = "exact_head_merge_tests.rs"]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod exact_head_merge_tests;

--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -2668,12 +2668,15 @@ fn handle_watch_ci_rejects_invalid_repo_format() {
 /// Minimal ScmProvider stub yielding a stable (head, base) so the P0 exact-head
 /// acquisition passes, letting the force-audit tests below reach the audit path
 /// they exercise. The force path returns at the audit-write failure BEFORE any
-/// merge/recheck, so only `pr_view` is ever called here.
+/// merge/recheck, so only `pr_view` is ever called here. #merge-exact-head r1:
+/// the OIDs MUST be valid FULL 40-hex (`is_full_commit_sha`) — the pre-r1 stub
+/// used non-hex `"h".repeat(40)`, which the tightened identity invariant now
+/// (correctly) fails closed on.
 struct MergeHeadBaseStub;
 impl crate::scm::ScmProvider for MergeHeadBaseStub {
     fn pr_view(&self, _r: &str, _p: u64, _f: &[&str]) -> anyhow::Result<crate::scm::PrSummary> {
         Ok(crate::scm::PrSummary {
-            head_ref_oid: Some("h".repeat(40)),
+            head_ref_oid: Some("a".repeat(40)),
             base_ref_oid: Some("b".repeat(40)),
             ..Default::default()
         })

--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -2665,6 +2665,52 @@ fn handle_watch_ci_rejects_invalid_repo_format() {
 
 // ----- #1244 PR-B: merge preflight CI gate -----
 
+/// Minimal ScmProvider stub yielding a stable (head, base) so the P0 exact-head
+/// acquisition passes, letting the force-audit tests below reach the audit path
+/// they exercise. The force path returns at the audit-write failure BEFORE any
+/// merge/recheck, so only `pr_view` is ever called here.
+struct MergeHeadBaseStub;
+impl crate::scm::ScmProvider for MergeHeadBaseStub {
+    fn pr_view(&self, _r: &str, _p: u64, _f: &[&str]) -> anyhow::Result<crate::scm::PrSummary> {
+        Ok(crate::scm::PrSummary {
+            head_ref_oid: Some("h".repeat(40)),
+            base_ref_oid: Some("b".repeat(40)),
+            ..Default::default()
+        })
+    }
+    fn pr_checks(&self, _r: &str, _p: u64) -> anyhow::Result<Vec<crate::scm::CheckState>> {
+        unimplemented!("force path fails at audit before pr_checks")
+    }
+    fn pr_list(
+        &self,
+        _r: &str,
+        _f: &crate::scm::ListFilter,
+        _fl: &[&str],
+        _c: Option<&std::path::Path>,
+    ) -> anyhow::Result<Vec<crate::scm::PrSummary>> {
+        unimplemented!()
+    }
+    fn pr_merge(
+        &self,
+        _r: &str,
+        _p: u64,
+        _o: &crate::scm::MergeOpts,
+    ) -> anyhow::Result<crate::scm::MergeOutcome> {
+        unimplemented!("force path fails at audit before pr_merge")
+    }
+    fn issue_view(
+        &self,
+        _r: &str,
+        _n: u64,
+        _f: &[&str],
+    ) -> anyhow::Result<crate::scm::IssueSummary> {
+        unimplemented!()
+    }
+    fn compare(&self, _r: &str, _b: &str, _h: &str) -> anyhow::Result<crate::scm::CompareResult> {
+        unimplemented!()
+    }
+}
+
 #[test]
 fn merge_missing_pr_returns_error() {
     let home = std::env::temp_dir().join(format!("agend-merge-test-{}", std::process::id()));
@@ -2696,6 +2742,9 @@ fn merge_force_audit_write_failure_refuses_merge() {
     let events_path = home.join("fleet_events.jsonl");
     std::fs::create_dir_all(&events_path).unwrap();
 
+    // P0: the exact-head acquisition now runs before the audit — stub a reachable
+    // head+base so the test still reaches the force-audit failure it exercises.
+    let _g = crate::scm::set_test_scm_provider(std::sync::Arc::new(MergeHeadBaseStub));
     let result = super::handle_merge_repo(
         &home,
         // #1619: explicit `repository` so resolution succeeds and the
@@ -2740,6 +2789,10 @@ fn merge_force_reaches_handler_through_full_dispatch_chain_2539() {
     let prev_home = std::env::var("AGEND_HOME").ok();
     std::env::set_var("AGEND_HOME", &home);
 
+    // P0: stub a reachable head+base so the exact-head acquisition passes and the
+    // test still reaches the force-audit failure (thread-local, same thread as
+    // handle_tool).
+    let _g = crate::scm::set_test_scm_provider(std::sync::Arc::new(MergeHeadBaseStub));
     let result = crate::mcp::handlers::handle_tool(
         "repo",
         &json!({

--- a/src/scm/mod.rs
+++ b/src/scm/mod.rs
@@ -41,6 +41,11 @@ pub(crate) struct PrSummary {
     pub author_login: Option<String>,
     pub head_ref: Option<String>,
     pub head_ref_oid: Option<String>,
+    /// P0 exact-head: the base branch's CURRENT tip OID (GitHub `baseRefOid`,
+    /// which advances as the base branch moves). Compared gate-vs-pre-merge to
+    /// detect a base advance by exact identity — `mergeStateStatus` is derived +
+    /// laggy and cannot prove `initial base == pre-merge base`.
+    pub base_ref_oid: Option<String>,
     /// #1750-B4: GitHub's `isCrossRepository` — true when the PR's head branch
     /// lives in a FORK, not the base repo. A cross-repo head_ref can collide
     /// with a base-repo branch name, so remote-orphan GC must never treat it as
@@ -90,6 +95,12 @@ pub(crate) struct MergeOpts {
     pub admin: bool,
     pub squash: bool,
     pub delete_branch: bool,
+    /// P0 exact-head precondition (#merge-exact-head): when `Some`, the merge is
+    /// pinned to this exact full commit SHA — GitHub's `--match-head-commit` (gh
+    /// ≥2.92) makes the merge FAIL if the PR head has moved, closing the residual
+    /// gate→write window. `None` = unpinned (legacy). The GitHub argv emits
+    /// `--match-head-commit <sha>` iff `Some`.
+    pub expected_head_sha: Option<String>,
 }
 
 /// Result of [`ScmProvider::pr_merge`]. `Submitted` means `gh pr merge`
@@ -300,6 +311,7 @@ fn parse_pr_summary(v: &Value) -> PrSummary {
         author_login: v["author"]["login"].as_str().map(String::from),
         head_ref: v["headRefName"].as_str().map(String::from),
         head_ref_oid: v["headRefOid"].as_str().map(String::from),
+        base_ref_oid: v["baseRefOid"].as_str().map(String::from),
         is_cross_repository: v["isCrossRepository"].as_bool(),
         is_draft: v["isDraft"].as_bool(),
         merged_at: nonempty("mergedAt"),
@@ -934,6 +946,7 @@ mod tests {
                     admin: true,
                     squash: true,
                     delete_branch: true,
+                    expected_head_sha: None,
                 }
             ),
             vec![

--- a/src/scm/mod.rs
+++ b/src/scm/mod.rs
@@ -266,6 +266,13 @@ fn pr_merge_args(repo: &str, pr: u64, opts: &MergeOpts) -> Vec<String> {
     if opts.delete_branch {
         a.push("--delete-branch".into());
     }
+    // P0 exact-head: pin the merge to the exact validated head. GitHub's
+    // `--match-head-commit` (gh ≥2.92) makes `gh pr merge` FAIL if the PR head
+    // has moved, closing the residual daemon-recheck→write window at the API.
+    if let Some(sha) = opts.expected_head_sha.as_deref() {
+        a.push("--match-head-commit".into());
+        a.push(sha.into());
+    }
     a
 }
 
@@ -964,6 +971,32 @@ mod tests {
         assert_eq!(
             pr_merge_args("o/r", 7, &MergeOpts::default()),
             vec!["pr", "merge", "7", "--repo", "o/r"]
+        );
+        // P0 exact-head: `expected_head_sha` appends `--match-head-commit <sha>`
+        // AFTER the existing flags (gh ≥2.92); `None` omits it (byte-identical).
+        assert_eq!(
+            pr_merge_args(
+                "o/r",
+                7,
+                &MergeOpts {
+                    admin: true,
+                    squash: true,
+                    delete_branch: true,
+                    expected_head_sha: Some("abcabcabcabcabcabcabcabcabcabcabcabcabc0".into()),
+                }
+            ),
+            vec![
+                "pr",
+                "merge",
+                "7",
+                "--repo",
+                "o/r",
+                "--admin",
+                "--squash",
+                "--delete-branch",
+                "--match-head-commit",
+                "abcabcabcabcabcabcabcabcabcabcabcabcabc0",
+            ]
         );
         // Per-flag MergeOpts → argv mapping (each flag independent).
         assert_eq!(


### PR DESCRIPTION
> **Rebased** onto current `origin/main` `388edfa9` (#2745) — conflict-free (zero file overlap). Exact head: **`2315eaa8`**. History: RED `876e8312` → GREEN `bc164ae2` → r1 RED `08ebc5c4` → r1 GREEN `2315eaa8`.

## What & why (P0, converged manifest e4d9f42e / decision d-20260712064113268052-6)

The canonical merge (`handle_merge_repo` → `gh pr merge --admin --squash`) was **unpinned**: it read PR/base state in the policy gates, then merged whatever the current head was — a TOCTOU where a concurrent force-push (head) or a `main` advance (base) between the gate reads and the write merges an **unvalidated** head/base. `--admin` bypasses branch protection, so GitHub does not catch it. Scope here is **strictly** the exact-head + base-identity precondition — no receipt gate, no merge queue, no auto-retry.

## Change

Every `handle_merge_repo` (including `force`) now:
1. **Acquires** the exact `(head, base)` OIDs up front via `pr_view(headRefOid, baseRefOid)`; either unreadable → **fail-closed** (never merge a head/base it cannot identify). Non-bypassable — `force` relaxes only the CI/verdict/freshness **policy**.
2. **One-shot pre-merge recheck** (no in-call loop): re-reads `(head, base)`; head moved → REFUSE `exact_head_moved`; base moved → REFUSE `exact_base_moved`. Non-bypassable, incl. `force`.
3. **Pins** the merge: `MergeOpts.expected_head_sha` → `pr_merge_args` emits `--match-head-commit <sha>` so GitHub itself fails the merge if the head moved in the recheck→write ε window.

**Base identity, not status**: base freshness is compared by the exact base-branch tip (`baseRefOid`, which advances as `main` moves), NOT `mergeStateStatus` (derived + laggy, cannot prove `initial base == pre-merge base`). A base-OID advance with `mergeStateStatus` still `CLEAN` is refused.

### Documented residuals (NOT claiming full base atomicity)
- A base advance **within** the recheck→write ε window is uncovered — GitHub has no base-pin merge primitive (only head, via `--match-head-commit`). True base atomicity awaits a merge-queue (separate merge-flow spike).
- `verify_merge_landed` proves only that the PR **landed**, not the absence of a semantic phantom-reversion — it is **not** a base-race backstop.

## Tests (RED→GREEN, deterministic, no timing)

RED `744a99dd` → GREEN `ea23104f`. Races are reproduced through **production** `handle_merge_repo` via an injected mock `ScmProvider` returning sequenced snapshots (the shared `set_test_scm_provider` seam; per-call counter advances in order):
- `normal_merge_pins_expected_head_sha` — merge pins `expected_head_sha`.
- `head_move_between_gate_and_write_refuses` — head H0→H1 → REFUSE.
- `base_oid_move_with_clean_status_refuses` — base B0→B1 while status stays CLEAN → REFUSE (exact identity).
- `base_oid_move_under_force_still_refuses` — force does NOT bypass base identity.
- `head_lookup_failure_with_force_fails_closed` — head unknown + force → fail-closed.
- `head_unavailable_provider_fails_closed` — erroring/unsupported provider → fail-closed.
- `scm::tests` — `--match-head-commit` argv plumbing (present iff `Some`, `None` byte-identical).

### r1: full-commit-OID identity invariant (reviewer-required, RED `08ebc5c4` → GREEN `2315eaa8`)

The initial GREEN's `acquire_head_base` filtered only `!is_empty()` — **not** a commit-identity invariant. A malformed/abbreviated head could reach `--match-head-commit`, and a malformed base returned identically across the gate+recheck reads falsely satisfied the exact-base check. `acquire_head_base` now **fails closed unless BOTH head+base are FULL commit OIDs (40/64-hex)**, reusing the canonical `crate::daemon::ci_watch::is_full_commit_sha` (the same invariant guarding exact-head CI watches). One choke point → covers both acquire sites (gate + recheck) and both paths (incl. `force`).
- `abbreviated_head_refuses_normal` / `_force` — valid-hex but too-short HEAD → fail-closed under both paths.
- `malformed_base_refuses_normal` / `_force` — right-length non-hex BASE → fail-closed under both paths.
- All race fixtures replaced with valid distinct 40-hex OIDs (the pre-r1 non-hex `h`/`ADVANCE` padding masked the gap); 6 prior guarantees preserved (10/10).

## Verification
- Runtime GH CLI capability: `gh version 2.92.0`; `gh pr merge --match-head-commit SHA "Commit SHA that the pull request head must match to allow merge"`.
- `rustfmt --edition 2021 --check` (vendor-excluded) — clean.
- `cargo clippy --lib --bin agend-terminal --bin agend-git --bin agend-mcp-bridge --tests --examples --features tray -- -D warnings` (rustup stable) — clean.
- `cargo check --features discord` — clean.
- `cargo test --test file_size_invariant` — green (`merge.rs` 359 LOC < 750; tests live in a sibling `exact_head_merge_tests.rs`).
- Merge + scm targeted suites green on the rebased tree (`exact_head_merge_tests` 10/10, `merge_force*` 3/3, `scm::tests` 15/15).

**Do not merge — high-risk merge chokepoint; requires dual independent exact-head review + GitHub verdict mirrors + main CI close-loop.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

