### PR TITLE
feat(routing V1): cleanup-failure hygiene tasks; remove raw general residue alarm

### DIFF
--- a/src/daemon/hygiene_task.rs
+++ b/src/daemon/hygiene_task.rs
@@ -211,7 +211,7 @@ mod tests {
         let active: Vec<_> = state
             .tasks
             .values()
-            .filter(|t| t.metadata.get(ALERT_KEY_META).is_some())
+            .filter(|t| t.metadata.contains_key(ALERT_KEY_META))
             .collect();
         assert_eq!(active.len(), 1, "exactly one hygiene task after race");
         // One side must have created, the other updated (order free).

--- a/src/daemon/hygiene_task.rs
+++ b/src/daemon/hygiene_task.rs
@@ -60,6 +60,58 @@ fn find_active(state: &TaskBoardState, key: &str) -> Option<(TaskId, u64)> {
     })
 }
 
+/// r2 (§3.20 deterministic RED): test-only rendezvous at the stale-probe
+/// window — between capturing `(tid, n)` from a rejected create and issuing
+/// the update append. Lets a test hold N writers at the SAME probed `n`
+/// deterministically. Each participating thread waits at most once
+/// (thread-local latch), so CAS-retry loops can never re-block; unarmed =
+/// no-op; test-only compile (nextest = process-per-test, no cross-test leak).
+#[cfg(test)]
+pub(crate) mod test_sync {
+    use std::cell::Cell;
+    use std::sync::{Arc, Barrier, Mutex};
+
+    /// (generation, barrier): the generation makes a reused test-runner
+    /// thread distinguish "already rendezvoused THIS arming" from a fresh
+    /// arming by a later test in the same process (`cargo test` runs tests
+    /// as threads in one process; nextest is process-per-test).
+    static GATE: Mutex<Option<(u64, Arc<Barrier>)>> = Mutex::new(None);
+    static NEXT_GEN: Mutex<u64> = Mutex::new(1);
+    thread_local! {
+        static WAITED_GEN: Cell<u64> = const { Cell::new(0) };
+    }
+
+    /// Scoped arming: dropping the guard clears the gate, so an armed
+    /// barrier can never leak into later tests/threads (r3 blocker on
+    /// 8bf5b73e: static gate was set and never reset).
+    #[must_use = "the gate stays armed only while this guard lives"]
+    pub(crate) struct GateGuard;
+    impl Drop for GateGuard {
+        fn drop(&mut self) {
+            GATE.lock().expect("gate lock").take();
+        }
+    }
+
+    pub fn arm(parties: usize) -> GateGuard {
+        let mut next = NEXT_GEN.lock().expect("gen lock");
+        let gen = *next;
+        *next += 1;
+        *GATE.lock().expect("gate lock") = Some((gen, Arc::new(Barrier::new(parties))));
+        GateGuard
+    }
+
+    pub fn wait_if_armed() {
+        let gate = GATE.lock().expect("gate lock").clone();
+        if let Some((gen, b)) = gate {
+            if WAITED_GEN.with(Cell::get) == gen {
+                return; // this thread already rendezvoused this generation
+            }
+            WAITED_GEN.with(|w| w.set(gen));
+            b.wait();
+        }
+    }
+}
+
 static SEQ: AtomicU64 = AtomicU64::new(0);
 
 fn new_task_id() -> TaskId {
@@ -72,9 +124,10 @@ fn new_task_id() -> TaskId {
 
 /// Atomically create-or-update the hygiene task for `key`. `title` is used
 /// only on create; `evidence` (a JSON object with exact repo/branch/reason
-/// fields) replaces the previous evidence on update. Bounded retry: each
-/// attempt is individually atomic; a rejection returns the authoritative
-/// state that invalidated it, so the loop converges in ≤2 flips.
+/// fields) replaces the previous evidence on update. CAS loop: each attempt
+/// is individually atomic and validates the exact state its write assumes;
+/// rejections hand back the fresh state, so W concurrent writers converge in
+/// ≤W serialized rounds (bounded by `ATTEMPTS`, overrun = loud error).
 pub fn upsert_system_hygiene_task(
     home: &Path,
     key: &str,
@@ -88,72 +141,100 @@ pub fn upsert_system_hygiene_task(
         key: k.to_string(),
         value: v,
     };
-    // Each attempt is individually atomic (precondition + append under the
-    // board lock against a fresh replay). A rejection means the other shape
-    // won the race; ≤2 flips converge, 3rd is a hard error.
-    for _ in 0..3 {
+    // CAS loop. Every attempt validates its full assumption under the board
+    // lock against a fresh replay — "no active task" for create, the exact
+    // `(task id, occurrences)` pair for update — and every rejection hands the
+    // freshly observed state to the next attempt. An ID-only update check
+    // would let two stale probes both commit `n+1` (lost update, REJECTED
+    // verdict on 943cb54b). Each serialized round commits at least one
+    // writer, so W concurrent callers converge in ≤W rounds; the budget is a
+    // generous multiple and overrunning it is a loud error, never a silent
+    // drop.
+    const ATTEMPTS: usize = 16;
+    let mut probe: Option<(TaskId, u64)> = None;
+    for _ in 0..ATTEMPTS {
         let now = chrono::Utc::now().to_rfc3339();
-        let mut existing: Option<(TaskId, u64)> = None;
-        let task_id = new_task_id();
-        let create = vec![
-            TaskEvent::Created {
-                task_id: task_id.clone(),
-                title: title.to_string(),
-                description: format!(
-                    "system hygiene alert (episode key `{key}`) — evidence in \
-                     task metadata; close when resolved (a recurrence reopens \
-                     a fresh task)."
-                ),
-                priority: "normal".to_string(),
-                owner: None,
-                due_at: None,
-                depends_on: Vec::new(),
-                routed_to: None,
-                branch: None,
-                bind: Some(false),
-                eta_secs: None,
-                tags: vec!["system-hygiene".to_string()],
-                parent_id: None,
-            },
-            meta(&task_id, ALERT_KEY_META, key.into()),
-            meta(&task_id, EVIDENCE_META, evidence.clone()),
-            meta(&task_id, LAST_SEEN_META, now.clone().into()),
-            meta(&task_id, OCCURRENCES_META, 1u64.into()),
-        ];
-        match task_events::append_batch_checked(home, &emitter, create, |state| match find_active(
-            state, key,
-        ) {
-            Some(hit) => {
-                existing = Some(hit);
-                Err("active episode task already exists".to_string())
+        match probe.take() {
+            None => {
+                let task_id = new_task_id();
+                let mut seen: Option<(TaskId, u64)> = None;
+                let create = vec![
+                    TaskEvent::Created {
+                        task_id: task_id.clone(),
+                        title: title.to_string(),
+                        description: format!(
+                            "system hygiene alert (episode key `{key}`) — evidence in \
+                             task metadata; close when resolved (a recurrence reopens \
+                             a fresh task)."
+                        ),
+                        priority: "normal".to_string(),
+                        owner: None,
+                        due_at: None,
+                        depends_on: Vec::new(),
+                        routed_to: None,
+                        branch: None,
+                        bind: Some(false),
+                        eta_secs: None,
+                        tags: vec!["system-hygiene".to_string()],
+                        parent_id: None,
+                    },
+                    meta(&task_id, ALERT_KEY_META, key.into()),
+                    meta(&task_id, EVIDENCE_META, evidence.clone()),
+                    meta(&task_id, LAST_SEEN_META, now.clone().into()),
+                    meta(&task_id, OCCURRENCES_META, 1u64.into()),
+                ];
+                match task_events::append_batch_checked(home, &emitter, create, |state| {
+                    match find_active(state, key) {
+                        Some(hit) => {
+                            seen = Some(hit);
+                            Err("active episode task already exists".to_string())
+                        }
+                        None => Ok(()),
+                    }
+                })? {
+                    Ok(_) => return Ok(HygieneUpsert::Created(task_id)),
+                    Err(_) => {
+                        probe = seen;
+                        continue;
+                    }
+                }
             }
-            None => Ok(()),
-        })? {
-            Ok(_) => return Ok(HygieneUpsert::Created(task_id)),
-            Err(_) => {
-                let Some((tid, n)) = existing else {
-                    anyhow::bail!("hygiene upsert: rejected without an existing task");
-                };
+            Some((tid, n)) => {
+                // r2: deterministic stale-probe rendezvous — no-op in
+                // production, lets tests pin writers at the same probed `n`.
+                #[cfg(test)]
+                test_sync::wait_if_armed();
                 let update = vec![
                     meta(&tid, EVIDENCE_META, evidence.clone()),
                     meta(&tid, LAST_SEEN_META, now.into()),
                     meta(&tid, OCCURRENCES_META, (n + 1).into()),
                 ];
                 let tid_check = tid.clone();
+                let mut seen: Option<(TaskId, u64)> = None;
                 match task_events::append_batch_checked(home, &emitter, update, |state| {
                     match find_active(state, key) {
+                        // r2a RED state: identity-only check — the rendezvous
+                        // test above FAILS at this commit by construction
+                        // (two stale probes both commit n+1). Next commit
+                        // tightens this to a full CAS.
                         Some((t, _)) if t == tid_check => Ok(()),
-                        _ => Err("episode task closed since probe".to_string()),
+                        other => {
+                            seen = other;
+                            Err("episode state moved since probe".to_string())
+                        }
                     }
                 })? {
                     Ok(_) => return Ok(HygieneUpsert::Updated(tid)),
-                    // Closed between the two attempts — loop back to create.
-                    Err(_) => continue,
+                    // Fresh (tid, n) → CAS-retry; None (closed) → create path.
+                    Err(_) => {
+                        probe = seen;
+                        continue;
+                    }
                 }
             }
         }
     }
-    anyhow::bail!("hygiene upsert for `{key}`: state flipped 3 times, giving up")
+    anyhow::bail!("hygiene upsert for `{key}`: contention exceeded {ATTEMPTS} attempts, giving up")
 }
 
 #[cfg(test)]
@@ -253,6 +334,100 @@ mod tests {
             .filter(|t| t.metadata.contains_key(ALERT_KEY_META))
             .count();
         assert_eq!(hygiene_count, 1);
+    }
+
+    /// r2 (§3.20 deterministic RED): force the exact stale-probe interleaving
+    /// via the production-path rendezvous — TWO writers both create-reject
+    /// against the seeded task, both capture `n=1`, the armed barrier holds
+    /// them at the update window, then both race the append. CAS: exactly one
+    /// commit per observed `n`; the loser retries with fresh `n=2` → final
+    /// occurrences=3, always. Old ID-only predicate: both commit `n+1=2` →
+    /// final 2, always (deterministic loss — mutation-checked in the r2
+    /// report).
+    #[test]
+    fn stale_probe_rendezvous_cas_exactly_once() {
+        let home = tmp_home("cas-det");
+        let seed = upsert_system_hygiene_task(&home, "k:r:b", "residue", ev("seed")).unwrap();
+        assert!(matches!(seed, HygieneUpsert::Created(_)));
+        let gate = test_sync::arm(2);
+        let mk = |tag: &'static str| {
+            let home = home.clone();
+            std::thread::spawn(move || {
+                upsert_system_hygiene_task(&home, "k:r:b", "residue", ev(tag))
+            })
+        };
+        let (a, b) = (mk("obs-a"), mk("obs-b"));
+        let ra = a.join().unwrap().unwrap();
+        let rb = b.join().unwrap().unwrap();
+        assert!(matches!(ra, HygieneUpsert::Updated(_)), "{ra:?}");
+        assert!(matches!(rb, HygieneUpsert::Updated(_)), "{rb:?}");
+        let state = board_state(&home);
+        let t = state.tasks.get(seed.task_id()).unwrap();
+        assert_eq!(
+            t.metadata.get(OCCURRENCES_META).and_then(|v| v.as_u64()),
+            Some(3),
+            "both rendezvoused observations must land: 1 (seed) + 2"
+        );
+        // r3: same-process post-rendezvous regression — once the guard is
+        // dropped the gate is cleared, so an ordinary update must neither
+        // block on a stale barrier nor miscount.
+        drop(gate);
+        let after = upsert_system_hygiene_task(&home, "k:r:b", "residue", ev("post")).unwrap();
+        assert!(matches!(after, HygieneUpsert::Updated(_)), "{after:?}");
+        let state = board_state(&home);
+        let t = state.tasks.get(seed.task_id()).unwrap();
+        assert_eq!(
+            t.metadata.get(OCCURRENCES_META).and_then(|v| v.as_u64()),
+            Some(4),
+            "post-rendezvous ordinary update must count normally"
+        );
+    }
+
+    /// r1 contention/load coverage: N concurrent updaters against an EXISTING
+    /// episode must each be accounted exactly once — occurrences goes 1 →
+    /// 1+N, one active task, all callers report Updated. (The FINAL count is
+    /// deterministic post-fix regardless of scheduling; the deterministic
+    /// stale-probe interleaving itself is pinned by
+    /// `stale_probe_rendezvous_cas_exactly_once` above.)
+    #[test]
+    fn concurrent_updates_on_existing_episode_lose_nothing() {
+        const N: usize = 8;
+        let home = tmp_home("cas");
+        let seed = upsert_system_hygiene_task(&home, "k:r:b", "residue", ev("seed")).unwrap();
+        assert!(matches!(seed, HygieneUpsert::Created(_)));
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(N));
+        let handles: Vec<_> = (0..N)
+            .map(|i| {
+                let home = home.clone();
+                let b = std::sync::Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    b.wait();
+                    upsert_system_hygiene_task(&home, "k:r:b", "residue", ev(&format!("obs-{i}")))
+                })
+            })
+            .collect();
+        for h in handles {
+            let r = h.join().unwrap().unwrap();
+            assert!(
+                matches!(r, HygieneUpsert::Updated(_)),
+                "existing episode: {r:?}"
+            );
+        }
+        let state = board_state(&home);
+        let t = state.tasks.get(seed.task_id()).unwrap();
+        assert_eq!(
+            t.metadata.get(OCCURRENCES_META).and_then(|v| v.as_u64()),
+            Some(1 + N as u64),
+            "every concurrent observation must be accounted exactly once"
+        );
+        assert_eq!(
+            state
+                .tasks
+                .values()
+                .filter(|t| t.metadata.contains_key(ALERT_KEY_META))
+                .count(),
+            1
+        );
     }
 
     /// C2 (RED): a Done episode re-opens as a NEW task (fresh episode), the

--- a/src/daemon/hygiene_task.rs
+++ b/src/daemon/hygiene_task.rs
@@ -83,12 +83,20 @@ pub(crate) mod test_sync {
 
     /// Scoped arming: dropping the guard clears the gate, so an armed
     /// barrier can never leak into later tests/threads (r3 blocker on
-    /// 8bf5b73e: static gate was set and never reset).
+    /// 8bf5b73e: static gate was set and never reset). The guard OWNS its
+    /// generation and Drop compares before clearing (r4 blocker on
+    /// 1beac4e6: an unconditional take() let a stale guard A clear a newer
+    /// arming B). Overlapping-arm policy: `arm` safely REPLACES any active
+    /// gate — the superseded guard's Drop becomes a no-op via the gen
+    /// compare, pinned by `overlapping_arm_stale_guard_drop_is_noop`.
     #[must_use = "the gate stays armed only while this guard lives"]
-    pub(crate) struct GateGuard;
+    pub(crate) struct GateGuard(u64);
     impl Drop for GateGuard {
         fn drop(&mut self) {
-            GATE.lock().expect("gate lock").take();
+            let mut gate = GATE.lock().expect("gate lock");
+            if gate.as_ref().is_some_and(|(gen, _)| *gen == self.0) {
+                gate.take();
+            }
         }
     }
 
@@ -97,7 +105,12 @@ pub(crate) mod test_sync {
         let gen = *next;
         *next += 1;
         *GATE.lock().expect("gate lock") = Some((gen, Arc::new(Barrier::new(parties))));
-        GateGuard
+        GateGuard(gen)
+    }
+
+    /// Test-only observation for the overlap regression.
+    pub fn armed_gen() -> Option<u64> {
+        GATE.lock().expect("gate lock").as_ref().map(|(g, _)| *g)
     }
 
     pub fn wait_if_armed() {
@@ -334,6 +347,30 @@ mod tests {
             .filter(|t| t.metadata.contains_key(ALERT_KEY_META))
             .count();
         assert_eq!(hygiene_count, 1);
+    }
+
+    /// r4 (codex REJECTED@1beac4e6): overlapping arms — a STALE guard's Drop
+    /// must not clear a newer generation. Policy: arm() replaces; superseded
+    /// guard drop is a gen-compared no-op.
+    #[test]
+    fn overlapping_arm_stale_guard_drop_is_noop() {
+        let a = test_sync::arm(2);
+        let gen_a = test_sync::armed_gen().unwrap();
+        let b = test_sync::arm(2);
+        let gen_b = test_sync::armed_gen().unwrap();
+        assert_ne!(gen_a, gen_b, "re-arm must advance the generation");
+        drop(a);
+        assert_eq!(
+            test_sync::armed_gen(),
+            Some(gen_b),
+            "stale guard A must NOT clear newer arming B"
+        );
+        drop(b);
+        assert_eq!(
+            test_sync::armed_gen(),
+            None,
+            "owning guard clears its own gate"
+        );
     }
 
     /// r2 (§3.20 deterministic RED): force the exact stale-probe interleaving

--- a/src/daemon/hygiene_task.rs
+++ b/src/daemon/hygiene_task.rs
@@ -1,0 +1,244 @@
+//! V1 of d-20260712065632138568-7: durable system-hygiene alerts live ON the
+//! task board — one active task per episode key, created/updated atomically
+//! under the board JSONL lock via `append_batch_checked` (fresh-replay
+//! precondition). Task metadata is the ONLY durable episode authority: there
+//! is no separate receipt store to desync (create-then-crash or
+//! receipt-then-crash两store窗 impossible by construction).
+//!
+//! Key semantics:
+//! - active task (status != Done/Cancelled) with `system_alert_key` == key
+//!   already on the board → UPDATE it (evidence/last_seen/occurrences), no new
+//!   task.
+//! - no active task with the key (never existed, or prior episode Done) →
+//!   CREATE a fresh task; a Done episode re-opens as a NEW task.
+
+use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use crate::task_events::{
+    self, InstanceName, TaskBoardState, TaskEvent, TaskId, TaskStatus,
+};
+
+/// Metadata key carrying the stable episode identity.
+pub const ALERT_KEY_META: &str = "system_alert_key";
+/// Metadata key carrying the latest evidence payload (JSON object).
+pub const EVIDENCE_META: &str = "evidence";
+/// Metadata key carrying the RFC3339 time the episode was last observed.
+pub const LAST_SEEN_META: &str = "last_seen";
+/// Metadata key counting observations folded into this episode task.
+pub const OCCURRENCES_META: &str = "occurrences";
+
+const EMITTER: &str = "system:hygiene";
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum HygieneUpsert {
+    Created(TaskId),
+    Updated(TaskId),
+}
+
+impl HygieneUpsert {
+    pub fn task_id(&self) -> &TaskId {
+        match self {
+            HygieneUpsert::Created(t) | HygieneUpsert::Updated(t) => t,
+        }
+    }
+}
+
+/// Find the ACTIVE (not Done/Cancelled) task carrying `key` in
+/// `system_alert_key` metadata, plus its current occurrence count.
+fn find_active(state: &TaskBoardState, key: &str) -> Option<(TaskId, u64)> {
+    state.tasks.values().find_map(|t| {
+        if matches!(t.status, TaskStatus::Done | TaskStatus::Cancelled) {
+            return None;
+        }
+        (t.metadata.get(ALERT_KEY_META)? == key).then(|| {
+            let n = t
+                .metadata
+                .get(OCCURRENCES_META)
+                .and_then(|v| v.as_u64())
+                .unwrap_or(1);
+            (t.id.clone(), n)
+        })
+    })
+}
+
+static SEQ: AtomicU64 = AtomicU64::new(0);
+
+fn new_task_id() -> TaskId {
+    // Same shape as the MCP create path (messaging.rs): timestamp + pid +
+    // process-unique seq.
+    let ts = chrono::Utc::now().format("%Y%m%d%H%M%S%6f");
+    let seq = SEQ.fetch_add(1, Ordering::Relaxed);
+    TaskId(format!("t-{ts}-{}-h{seq}", std::process::id()))
+}
+
+/// Atomically create-or-update the hygiene task for `key`. `title` is used
+/// only on create; `evidence` (a JSON object with exact repo/branch/reason
+/// fields) replaces the previous evidence on update. Bounded retry: each
+/// attempt is individually atomic; a rejection returns the authoritative
+/// state that invalidated it, so the loop converges in ≤2 flips.
+pub fn upsert_system_hygiene_task(
+    home: &Path,
+    key: &str,
+    title: &str,
+    evidence: serde_json::Value,
+) -> anyhow::Result<HygieneUpsert> {
+    let _ = (home, key, title, evidence);
+    todo!("V1 GREEN: atomic checked-batch upsert (RED commit is stub-only)")
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn ev(reason: &str) -> serde_json::Value {
+        serde_json::json!({
+            "repo": "/tmp/fixture-repo",
+            "branch": "feat/x",
+            "reason": reason,
+        })
+    }
+
+    /// Bin crate has no `tempfile` dep — same pattern as
+    /// `worktree_cleanup::tests::tmp_home`.
+    fn tmp_home(tag: &str) -> std::path::PathBuf {
+        use std::sync::atomic::AtomicU32;
+        static C: AtomicU32 = AtomicU32::new(0);
+        let dir = std::env::temp_dir().join(format!(
+            "agend-hygiene-{}-{}-{}",
+            tag,
+            std::process::id(),
+            C.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn board_state(home: &Path) -> TaskBoardState {
+        task_events::replay(home).expect("replay")
+    }
+
+    /// C1 (RED): concurrent double-fire for the SAME key must yield exactly
+    /// one active task — one thread Creates, the other Updates.
+    #[test]
+    fn concurrent_double_fire_yields_one_active_task() {
+        let home = tmp_home("c1");
+        let h1 = {
+            let home = home.clone();
+            std::thread::spawn(move || {
+                upsert_system_hygiene_task(&home, "k:r:b", "residue", ev("remove failed"))
+            })
+        };
+        let h2 = {
+            let home = home.clone();
+            std::thread::spawn(move || {
+                upsert_system_hygiene_task(&home, "k:r:b", "residue", ev("remove failed"))
+            })
+        };
+        let r1 = h1.join().unwrap().unwrap();
+        let r2 = h2.join().unwrap().unwrap();
+        let state = board_state(&home);
+        let active: Vec<_> = state
+            .tasks
+            .values()
+            .filter(|t| t.metadata.get(ALERT_KEY_META).is_some())
+            .collect();
+        assert_eq!(active.len(), 1, "exactly one hygiene task after race");
+        // One side must have created, the other updated (order free).
+        let created = matches!(r1, HygieneUpsert::Created(_)) as u8
+            + matches!(r2, HygieneUpsert::Created(_)) as u8;
+        assert_eq!(created, 1, "exactly one Created among racers: {r1:?} {r2:?}");
+        assert_eq!(r1.task_id(), r2.task_id(), "both refer to the same task");
+    }
+
+    /// R2' (RED): re-observing the same episode is an UPDATE (occurrences
+    /// increments, last_seen moves, evidence replaced) — never a second task.
+    /// Restart-equivalence: there is no process state, so a fresh call after
+    /// daemon restart is byte-identical to this second call.
+    #[test]
+    fn same_episode_updates_not_duplicates() {
+        let home_buf = tmp_home("r2");
+        let home = home_buf.as_path();
+        let a = upsert_system_hygiene_task(home, "k:r:b", "residue", ev("first")).unwrap();
+        let b = upsert_system_hygiene_task(home, "k:r:b", "residue", ev("second")).unwrap();
+        assert!(matches!(a, HygieneUpsert::Created(_)));
+        assert!(matches!(b, HygieneUpsert::Updated(_)));
+        let state = board_state(home);
+        let t = state.tasks.get(b.task_id()).unwrap();
+        assert_eq!(
+            t.metadata.get(OCCURRENCES_META).and_then(|v| v.as_u64()),
+            Some(2)
+        );
+        assert_eq!(
+            t.metadata.get(EVIDENCE_META).unwrap()["reason"],
+            "second",
+            "latest evidence wins"
+        );
+        let hygiene_count = state
+            .tasks
+            .values()
+            .filter(|t| t.metadata.contains_key(ALERT_KEY_META))
+            .count();
+        assert_eq!(hygiene_count, 1);
+    }
+
+    /// C2 (RED): a Done episode re-opens as a NEW task (fresh episode), the
+    /// done task stays done.
+    #[test]
+    fn done_episode_reopens_as_new_task() {
+        let home_buf = tmp_home("c2");
+        let home = home_buf.as_path();
+        let a = upsert_system_hygiene_task(home, "k:r:b", "residue", ev("first")).unwrap();
+        let emitter = InstanceName::from(EMITTER);
+        task_events::append(
+            home,
+            &emitter,
+            TaskEvent::Done {
+                task_id: a.task_id().clone(),
+                by: emitter.clone(),
+                source: task_events::DoneSource::OperatorManual {
+                    authored_at: chrono::Utc::now().to_rfc3339(),
+                    result: Some("fixed".into()),
+                },
+            },
+        )
+        .unwrap();
+        let b = upsert_system_hygiene_task(home, "k:r:b", "residue", ev("again")).unwrap();
+        assert!(matches!(b, HygieneUpsert::Created(_)), "reopen = new task");
+        assert_ne!(a.task_id(), b.task_id());
+        let state = board_state(home);
+        assert_eq!(state.tasks.get(a.task_id()).unwrap().status, TaskStatus::Done);
+        assert_ne!(
+            state.tasks.get(b.task_id()).unwrap().status,
+            TaskStatus::Done
+        );
+    }
+
+    /// Evidence exactness (RED): created task carries the exact
+    /// repo/branch/reason payload + key + last_seen metadata.
+    #[test]
+    fn created_task_carries_exact_evidence() {
+        let home_buf = tmp_home("ev");
+        let home = home_buf.as_path();
+        let r = upsert_system_hygiene_task(
+            home,
+            "residue-remove-failed:/r/repo:feat/x",
+            "worktree remove failed",
+            ev("sweep worktree remove failed"),
+        )
+        .unwrap();
+        let state = board_state(home);
+        let t = state.tasks.get(r.task_id()).unwrap();
+        assert_eq!(
+            t.metadata.get(ALERT_KEY_META).unwrap(),
+            "residue-remove-failed:/r/repo:feat/x"
+        );
+        let e = t.metadata.get(EVIDENCE_META).unwrap();
+        assert_eq!(e["repo"], "/tmp/fixture-repo");
+        assert_eq!(e["branch"], "feat/x");
+        assert_eq!(e["reason"], "sweep worktree remove failed");
+        assert!(t.metadata.contains_key(LAST_SEEN_META));
+        assert_eq!(t.status, TaskStatus::Open);
+    }
+}

--- a/src/daemon/hygiene_task.rs
+++ b/src/daemon/hygiene_task.rs
@@ -15,9 +15,7 @@
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use crate::task_events::{
-    self, InstanceName, TaskBoardState, TaskEvent, TaskId, TaskStatus,
-};
+use crate::task_events::{self, InstanceName, TaskBoardState, TaskEvent, TaskId, TaskStatus};
 
 /// Metadata key carrying the stable episode identity.
 pub const ALERT_KEY_META: &str = "system_alert_key";
@@ -83,8 +81,79 @@ pub fn upsert_system_hygiene_task(
     title: &str,
     evidence: serde_json::Value,
 ) -> anyhow::Result<HygieneUpsert> {
-    let _ = (home, key, title, evidence);
-    todo!("V1 GREEN: atomic checked-batch upsert (RED commit is stub-only)")
+    let emitter = InstanceName::from(EMITTER);
+    let meta = |task_id: &TaskId, k: &str, v: serde_json::Value| TaskEvent::MetadataSet {
+        task_id: task_id.clone(),
+        by: emitter.clone(),
+        key: k.to_string(),
+        value: v,
+    };
+    // Each attempt is individually atomic (precondition + append under the
+    // board lock against a fresh replay). A rejection means the other shape
+    // won the race; ≤2 flips converge, 3rd is a hard error.
+    for _ in 0..3 {
+        let now = chrono::Utc::now().to_rfc3339();
+        let mut existing: Option<(TaskId, u64)> = None;
+        let task_id = new_task_id();
+        let create = vec![
+            TaskEvent::Created {
+                task_id: task_id.clone(),
+                title: title.to_string(),
+                description: format!(
+                    "system hygiene alert (episode key `{key}`) — evidence in \
+                     task metadata; close when resolved (a recurrence reopens \
+                     a fresh task)."
+                ),
+                priority: "normal".to_string(),
+                owner: None,
+                due_at: None,
+                depends_on: Vec::new(),
+                routed_to: None,
+                branch: None,
+                bind: Some(false),
+                eta_secs: None,
+                tags: vec!["system-hygiene".to_string()],
+                parent_id: None,
+            },
+            meta(&task_id, ALERT_KEY_META, key.into()),
+            meta(&task_id, EVIDENCE_META, evidence.clone()),
+            meta(&task_id, LAST_SEEN_META, now.clone().into()),
+            meta(&task_id, OCCURRENCES_META, 1u64.into()),
+        ];
+        match task_events::append_batch_checked(home, &emitter, create, |state| match find_active(
+            state, key,
+        ) {
+            Some(hit) => {
+                existing = Some(hit);
+                Err("active episode task already exists".to_string())
+            }
+            None => Ok(()),
+        })? {
+            Ok(_) => return Ok(HygieneUpsert::Created(task_id)),
+            Err(_) => {
+                let Some((tid, n)) = existing else {
+                    anyhow::bail!("hygiene upsert: rejected without an existing task");
+                };
+                let update = vec![
+                    meta(&tid, EVIDENCE_META, evidence.clone()),
+                    meta(&tid, LAST_SEEN_META, now.into()),
+                    meta(&tid, OCCURRENCES_META, (n + 1).into()),
+                ];
+                let tid_check = tid.clone();
+                match task_events::append_batch_checked(home, &emitter, update, |state| {
+                    match find_active(state, key) {
+                        Some((t, _)) if t == tid_check => Ok(()),
+                        _ => Err("episode task closed since probe".to_string()),
+                    }
+                })? {
+                    Ok(_) => return Ok(HygieneUpsert::Updated(tid)),
+                    // Closed between the two attempts — loop back to create.
+                    Err(_) => continue,
+                }
+            }
+        }
+    }
+    anyhow::bail!("hygiene upsert for `{key}`: state flipped 3 times, giving up")
 }
 
 #[cfg(test)]
@@ -148,7 +217,10 @@ mod tests {
         // One side must have created, the other updated (order free).
         let created = matches!(r1, HygieneUpsert::Created(_)) as u8
             + matches!(r2, HygieneUpsert::Created(_)) as u8;
-        assert_eq!(created, 1, "exactly one Created among racers: {r1:?} {r2:?}");
+        assert_eq!(
+            created, 1,
+            "exactly one Created among racers: {r1:?} {r2:?}"
+        );
         assert_eq!(r1.task_id(), r2.task_id(), "both refer to the same task");
     }
 
@@ -208,7 +280,10 @@ mod tests {
         assert!(matches!(b, HygieneUpsert::Created(_)), "reopen = new task");
         assert_ne!(a.task_id(), b.task_id());
         let state = board_state(home);
-        assert_eq!(state.tasks.get(a.task_id()).unwrap().status, TaskStatus::Done);
+        assert_eq!(
+            state.tasks.get(a.task_id()).unwrap().status,
+            TaskStatus::Done
+        );
         assert_ne!(
             state.tasks.get(b.task_id()).unwrap().status,
             TaskStatus::Done

--- a/src/daemon/hygiene_task.rs
+++ b/src/daemon/hygiene_task.rs
@@ -213,11 +213,11 @@ pub fn upsert_system_hygiene_task(
                 let mut seen: Option<(TaskId, u64)> = None;
                 match task_events::append_batch_checked(home, &emitter, update, |state| {
                     match find_active(state, key) {
-                        // r2a RED state: identity-only check — the rendezvous
-                        // test above FAILS at this commit by construction
-                        // (two stale probes both commit n+1). Next commit
-                        // tightens this to a full CAS.
-                        Some((t, _)) if t == tid_check => Ok(()),
+                        // CAS: identity AND the count our `n+1` was computed
+                        // from must both still hold — exactly one commit per
+                        // observed `n` can succeed (r2a commit replays the
+                        // identity-only lost-update RED).
+                        Some((t, cur)) if t == tid_check && cur == n => Ok(()),
                         other => {
                             seen = other;
                             Err("episode state moved since probe".to_string())

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -25,6 +25,7 @@ pub(crate) mod handoff_timeout_watchdog;
 pub(crate) mod heartbeat_pair;
 pub(crate) mod helper_staleness_watchdog;
 pub mod hook_shadow;
+pub(crate) mod hygiene_task;
 pub(crate) mod idle_watchdog;
 pub(crate) mod inbox_stuck_watchdog;
 pub(crate) mod inject_delivery;

--- a/src/daemon/per_tick/worktree_registry_sweep.rs
+++ b/src/daemon/per_tick/worktree_registry_sweep.rs
@@ -36,13 +36,6 @@ use std::sync::Arc;
 pub(crate) struct WorktreeRegistrySweepHandler {
     gate: crate::daemon::cadence_gate::CadenceGate,
     in_flight: Arc<AtomicBool>,
-    /// #P4 (branch-residue): episode-dedup for the >15 non-default-branch
-    /// residue alarm — flips false→true on the first over-threshold sweep so
-    /// the warn+operator-notify fires ONCE, resets when the count drops back to
-    /// ≤15. Process-lifetime state on this long-lived singleton handler (mirrors
-    /// `in_flight`); mutated through the Arc's interior mutability from the
-    /// spawned round.
-    count_warned: Arc<AtomicBool>,
 }
 
 impl WorktreeRegistrySweepHandler {
@@ -50,7 +43,6 @@ impl WorktreeRegistrySweepHandler {
         Self {
             gate: crate::daemon::cadence_gate::CadenceGate::new(every_n_ticks),
             in_flight: Arc::new(AtomicBool::new(false)),
-            count_warned: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -82,7 +74,6 @@ impl PerTickHandler for WorktreeRegistrySweepHandler {
         let home = ctx.home.to_path_buf();
         let configs = Arc::clone(ctx.configs);
         let in_flight = Arc::clone(&self.in_flight);
-        let count_warned = Arc::clone(&self.count_warned);
         // fire-and-forget: #P1-2607 — moves the potentially-slow sweep
         // (git subprocess per candidate branch) off the daemon's main tick
         // loop. No JoinHandle is kept; completion is signaled via `in_flight`,
@@ -101,7 +92,7 @@ impl PerTickHandler for WorktreeRegistrySweepHandler {
                 let _guard = super::ClearOnDrop::new(in_flight);
                 #[cfg(test)]
                 test_hooks::round_gate();
-                worktree_auto_cleanup(&home, &configs, &count_warned);
+                worktree_auto_cleanup(&home, &configs);
             }
             #[cfg(test)]
             test_hooks::signal_round_complete();
@@ -191,7 +182,7 @@ mod test_hooks {
 /// `AGEND_WORKTREE_AUTO_CLEANUP` ONLY — when the sweep returns candidates they
 /// were actually removed (the retired `AGEND_WORKTREE_PRUNE_LIVE` dry-run toggle
 /// is gone), so every returned entry is logged as a live removal.
-fn worktree_auto_cleanup(home: &Path, configs: &ConfigRegistry, count_warned: &AtomicBool) {
+fn worktree_auto_cleanup(home: &Path, configs: &ConfigRegistry) {
     let cfgs = configs.lock();
     let config_data: std::collections::HashMap<String, Option<std::path::PathBuf>> = cfgs
         .iter()
@@ -217,64 +208,14 @@ fn worktree_auto_cleanup(home: &Path, configs: &ConfigRegistry, count_warned: &A
         tracing::info!(branch, path, reason, "worktree auto-removed");
     }
 
-    // #P4 (branch-residue): end-of-sweep residue alarm. If any bound repo has
-    // accumulated more than 15 non-default local branches, worktree/branch GC is
-    // not keeping up (GC stalled, or AUTO_CLEANUP disabled). Warn + notify the
-    // operator ONCE per episode (de-duped via `count_warned`, reset when back
-    // under). The count is observational, independent of whether the sweep ran.
-    let max_count = max_nondefault_branch_count(home);
-    if branch_count_alert(max_count, count_warned) {
-        tracing::warn!(
-            count = max_count,
-            "non-default local branch count exceeds 15 — residue may be accumulating \
-             (is AGEND_WORKTREE_AUTO_CLEANUP=0 / GC stalled?)"
-        );
-        let text = format!(
-            "Local non-default branch count is {max_count} (>15) in a bound repo; \
-             worktree/branch GC is not keeping up. Investigate residue."
-        );
-        crate::inbox::notify_agent(
-            home,
-            "general",
-            &crate::inbox::NotifySource::System("branch-residue"),
-            &text,
-        );
-    }
-}
-
-/// #P4: max non-default local branch count across all repos bound under `home`
-/// (`git branch --format=%(refname:short)`, filtering out each repo's default
-/// branch). Fail-open on a git error — a transient enumeration failure counts as
-/// 0 for that repo rather than raising a false residue alarm.
-fn max_nondefault_branch_count(home: &Path) -> usize {
-    crate::binding::bound_source_repos(home)
-        .iter()
-        .map(|repo| {
-            let default = crate::git_helpers::default_branch(repo);
-            match crate::git_helpers::git_cmd(repo, &["branch", "--format=%(refname:short)"]) {
-                Ok(stdout) => stdout.lines().filter(|b| *b != default.as_str()).count(),
-                Err(_) => 0,
-            }
-        })
-        .max()
-        .unwrap_or(0)
-}
-
-/// #P4: pure episode-dedup decision for the residue alarm. Returns `true` iff
-/// the caller should fire the warn+operator-notify NOW: the count exceeds the
-/// threshold AND we haven't already warned this episode (`already_warned` flips
-/// false→true on the first fire, mirroring the `in_flight` swap idiom). Once the
-/// count drops back to ≤threshold the flag resets, so a later re-accumulation
-/// re-fires exactly once. Extracted so the fire/skip/reset transitions are
-/// unit-testable without asserting on tracing/inbox side effects (the RED8 seam).
-fn branch_count_alert(max_count: usize, already_warned: &AtomicBool) -> bool {
-    const BRANCH_COUNT_WARN_THRESHOLD: usize = 15;
-    if max_count > BRANCH_COUNT_WARN_THRESHOLD {
-        !already_warned.swap(true, Ordering::AcqRel)
-    } else {
-        already_warned.store(false, Ordering::Release);
-        false
-    }
+    // V1 (d-20260712065632138568-7): the former #P4 raw branch-count residue
+    // alarm (>15 non-default branches → notify "general") is REMOVED. Raw
+    // count conflated live scaffolding (active worktrees, TTL-fresh review/*
+    // branches) with genuine residue and pushed an unactionable page into a
+    // working agent's PTY. The actionable signal lives in
+    // `worktree_cleanup::sweep_from_registry` now: proven-eligible-but-failed
+    // removals and persistently failing fetches upsert durable, deduped
+    // hygiene tasks on the task board (exact repo/branch/reason).
 }
 
 #[cfg(test)]
@@ -413,91 +354,9 @@ mod tests {
         std::fs::remove_dir_all(&home).ok();
     }
 
-    /// #P4 (branch-residue) RED8 — pure episode-dedup transitions: >15 fires
-    /// once, a second >15 sweep in the same episode is suppressed, and dropping
-    /// back to ≤15 resets the flag so a later re-accumulation re-fires. Pins the
-    /// dedup contract without asserting on tracing/inbox side effects.
-    #[test]
-    fn branch_count_alert_fires_once_per_episode_red8() {
-        let flag = AtomicBool::new(false);
-        assert!(
-            branch_count_alert(16, &flag),
-            "first over-threshold sweep must fire"
-        );
-        assert!(
-            !branch_count_alert(16, &flag),
-            "a second >15 sweep in the same episode must NOT re-fire (deduped)"
-        );
-        assert!(
-            !branch_count_alert(15, &flag),
-            "exactly 15 is NOT over the >15 threshold and resets the episode"
-        );
-        assert!(
-            !branch_count_alert(10, &flag),
-            "further under-threshold sweeps stay quiet"
-        );
-        assert!(
-            branch_count_alert(20, &flag),
-            "after resetting under threshold, a fresh >15 sweep fires again"
-        );
-    }
-
-    /// #P4 RED8 — end-to-end count wiring: a bound source repo with 16
-    /// non-default branches makes `max_nondefault_branch_count` report >15, so
-    /// the alarm predicate fires on the first sweep. Real git fixture + a seeded
-    /// `binding.json` so `bound_source_repos` discovers the repo.
-    #[test]
-    fn sixteen_branches_trip_the_residue_alarm_red8() {
-        fn git(dir: &Path, args: &[&str]) {
-            std::process::Command::new("git")
-                .args(args)
-                .current_dir(dir)
-                .env("AGEND_GIT_BYPASS", "1")
-                .env("GIT_AUTHOR_NAME", "test")
-                .env("GIT_AUTHOR_EMAIL", "t@t")
-                .env("GIT_COMMITTER_NAME", "test")
-                .env("GIT_COMMITTER_EMAIL", "t@t")
-                .output()
-                .expect("git");
-        }
-        let tag = format!("{}-p4-red8", std::process::id());
-        let home = std::env::temp_dir().join(format!("agend-p4-home-{tag}"));
-        let repo = std::env::temp_dir().join(format!("agend-p4-repo-{tag}"));
-        std::fs::create_dir_all(&home).unwrap();
-        std::fs::create_dir_all(&repo).unwrap();
-        git(&repo, &["init", "-b", "main"]);
-        std::fs::write(repo.join("README.md"), "init").ok();
-        git(&repo, &["add", "."]);
-        git(&repo, &["commit", "-m", "init"]);
-        // 16 non-default branches → strictly greater than the 15 threshold.
-        for i in 0..16 {
-            git(&repo, &["branch", &format!("feat/b{i}")]);
-        }
-        // Seed binding so bound_source_repos(home) discovers this repo.
-        let bdir = crate::paths::runtime_dir(&home).join("agent-x");
-        std::fs::create_dir_all(&bdir).unwrap();
-        std::fs::write(
-            bdir.join("binding.json"),
-            serde_json::json!({ "source_repo": repo.display().to_string() }).to_string(),
-        )
-        .unwrap();
-
-        let n = max_nondefault_branch_count(&home);
-        assert!(
-            n > 15,
-            "16 non-default branches must count as >15 (got {n})"
-        );
-        let flag = AtomicBool::new(false);
-        assert!(
-            branch_count_alert(n, &flag),
-            "the residue alarm must fire on the first sweep for a >15 repo"
-        );
-        assert!(
-            !branch_count_alert(n, &flag),
-            "and must not re-fire on the immediately-following sweep"
-        );
-
-        std::fs::remove_dir_all(&home).ok();
-        std::fs::remove_dir_all(&repo).ok();
-    }
+    // V1 (d-20260712065632138568-7): the RED8 raw-count alarm tests
+    // (`branch_count_alert_fires_once_per_episode_red8`,
+    // `sixteen_branches_trip_the_residue_alarm_red8`) were deleted with the
+    // alarm they pinned. Replacement coverage lives in
+    // `worktree_cleanup::tests::*_v1` (failure producers + negative guards).
 }

--- a/src/worktree_cleanup.rs
+++ b/src/worktree_cleanup.rs
@@ -385,6 +385,16 @@ fn is_in_use(wt_path: &Path, active_dirs: &[PathBuf]) -> bool {
 /// candidate claims to be "merged" regardless of why it was really swept).
 /// `path` is `"(no worktree)"` for phase-2 orphan branches, which never had
 /// one — never an empty string standing in for a real value.
+/// V1 (d-20260712065632138568-7): best-effort durable hygiene alert — a board
+/// write failure must never abort the sweep itself.
+fn upsert_hygiene(home: &Path, key: String, title: String, evidence: serde_json::Value) {
+    if let Err(e) =
+        crate::daemon::hygiene_task::upsert_system_hygiene_task(home, &key, &title, evidence)
+    {
+        tracing::warn!(error = %e, key = %key, "hygiene task upsert failed");
+    }
+}
+
 pub fn sweep_from_registry(
     home: &Path,
     configs: &HashMap<String, Option<PathBuf>>,
@@ -440,14 +450,22 @@ pub fn sweep_from_registry(
         // failing fetch accumulates undeletable branches invisibly — surface
         // it. Pure logging, the sweep proceeds on local refs.
         let remote = crate::git_helpers::primary_remote(repo);
-        match crate::git_helpers::git_bypass(repo, &["fetch", "--prune", &remote]) {
+        // V1 (d-20260712065632138568-7): a failing fetch is a persistent-
+        // ambiguity signal (undeletable branches accumulate invisibly, #2004)
+        // — surfaced as a durable hygiene task, no longer log-only. The upsert
+        // dedups on the episode key, so a repo stuck failing every tick keeps
+        // ONE task (occurrences counts the ticks).
+        let fetch_fail = match crate::git_helpers::git_bypass(repo, &["fetch", "--prune", &remote])
+        {
             Ok(o) if !o.status.success() => {
+                let stderr = String::from_utf8_lossy(&o.stderr).trim().to_string();
                 tracing::warn!(
                     repo = %repo.display(),
                     remote = %remote,
-                    stderr = %String::from_utf8_lossy(&o.stderr).trim(),
+                    stderr = %stderr,
                     "fetch --prune failed during worktree/branch sweep — merge/gone checks run on possibly-stale local refs"
                 );
+                Some(format!("fetch --prune failed: {stderr}"))
             }
             Err(e) => {
                 tracing::warn!(
@@ -456,8 +474,21 @@ pub fn sweep_from_registry(
                     error = %e,
                     "fetch --prune could not run during worktree/branch sweep — merge/gone checks run on possibly-stale local refs"
                 );
+                Some(format!("fetch --prune could not run: {e}"))
             }
-            Ok(_) => {}
+            Ok(_) => None,
+        };
+        if let Some(reason) = fetch_fail {
+            upsert_hygiene(
+                home,
+                format!("residue-fetch-degraded:{}", repo.display()),
+                format!("[hygiene] fetch --prune failing: {}", repo.display()),
+                serde_json::json!({
+                    "repo": repo.display().to_string(),
+                    "remote": remote,
+                    "reason": reason,
+                }),
+            );
         }
 
         // CR-2026-06-14: needed to decide whether a stale worktree's branch is
@@ -538,30 +569,51 @@ pub fn sweep_from_registry(
             // direct call: same args, push on success. `agent`/`candidate` are inert
             // on the Delete arm; the Err reason is unused here (the sweep skips, it
             // does not archive-fallthrough).
-            let removed_ok = matches!(
-                crate::daemon::janitor::dispose(
-                    home,
-                    crate::worktree::disposition::Disposition::Delete,
-                    "",
-                    None,
-                    || {
-                        if remove_worktree(
-                            repo,
-                            &entry.path,
-                            &entry.branch,
-                            branch_safe_to_delete,
-                            false,
-                        ) {
-                            Ok(())
-                        } else {
-                            Err("sweep worktree remove failed".to_string())
-                        }
-                    },
-                ),
-                crate::daemon::janitor::DispositionOutcome::Deleted(Ok(()))
+            let outcome = crate::daemon::janitor::dispose(
+                home,
+                crate::worktree::disposition::Disposition::Delete,
+                "",
+                None,
+                || {
+                    if remove_worktree(
+                        repo,
+                        &entry.path,
+                        &entry.branch,
+                        branch_safe_to_delete,
+                        false,
+                    ) {
+                        Ok(())
+                    } else {
+                        Err("sweep worktree remove failed".to_string())
+                    }
+                },
             );
-            if removed_ok {
-                removed.push((entry.branch.clone(), entry.path.clone(), reason));
+            match outcome {
+                crate::daemon::janitor::DispositionOutcome::Deleted(Ok(())) => {
+                    removed.push((entry.branch.clone(), entry.path.clone(), reason));
+                }
+                // V1 (d-20260712065632138568-7): a PROVEN-eligible candidate
+                // whose removal failed may not be silently skipped — that is
+                // the actionable residue signal (replaces the raw-count alarm).
+                crate::daemon::janitor::DispositionOutcome::Deleted(Err(fail)) => {
+                    upsert_hygiene(
+                        home,
+                        format!("residue-remove-failed:{}:{}", repo.display(), entry.branch),
+                        format!("[hygiene] worktree remove failed: {}", entry.branch),
+                        serde_json::json!({
+                            "repo": repo.display().to_string(),
+                            "branch": entry.branch,
+                            "path": entry.path,
+                            "reason": fail,
+                            "eligibility": {
+                                "merged": merged,
+                                "remote_gone": gone,
+                                "delete_branch": branch_safe_to_delete,
+                            },
+                        }),
+                    );
+                }
+                _ => {}
             }
         }
 
@@ -2248,9 +2300,19 @@ mod tests {
         let removed = sweep_from_registry(&home, &configs, &[]);
         std::env::remove_var("AGEND_WORKTREE_AUTO_CLEANUP");
 
+        // The sabotaged WORKTREE dir must survive (its removal failed). The
+        // branch itself may legitimately be reaped by phase-2 as an orphan
+        // ("(no worktree)") once git dropped the admin entry — that layered
+        // self-heal is fine; the failure signal is about the stuck DIR.
         assert!(
-            !removed.iter().any(|(b, _, _)| b == "feat/done"),
-            "sabotaged removal must not be reported as removed: {removed:?}"
+            wt.exists(),
+            "sabotage must hold: the unremovable worktree dir survives"
+        );
+        assert!(
+            !removed
+                .iter()
+                .any(|(b, p, _)| b == "feat/done" && p != "(no worktree)"),
+            "the failed worktree removal itself may not be reported: {removed:?}"
         );
         let tasks = hygiene_tasks(&home);
         let key = format!("residue-remove-failed:{}:feat/done", repo.display());
@@ -2261,7 +2323,10 @@ mod tests {
         assert_eq!(evidence["repo"], repo.display().to_string());
         assert_eq!(evidence["branch"], "feat/done");
         assert!(
-            evidence["reason"].as_str().unwrap_or("").contains("remove failed"),
+            evidence["reason"]
+                .as_str()
+                .unwrap_or("")
+                .contains("remove failed"),
             "exact failure reason required: {evidence}"
         );
 
@@ -2319,7 +2384,9 @@ mod tests {
 
         let tasks = hygiene_tasks(&home);
         assert!(
-            !tasks.iter().any(|(k, _)| k.contains("review/2746-codex-r1")),
+            !tasks
+                .iter()
+                .any(|(k, _)| k.contains("review/2746-codex-r1")),
             "deliberately-kept branch must not be alerted: {tasks:?}"
         );
 

--- a/src/worktree_cleanup.rs
+++ b/src/worktree_cleanup.rs
@@ -388,10 +388,11 @@ fn is_in_use(wt_path: &Path, active_dirs: &[PathBuf]) -> bool {
 /// V1 (d-20260712065632138568-7): best-effort durable hygiene alert — a board
 /// write failure must never abort the sweep itself.
 fn upsert_hygiene(home: &Path, key: String, title: String, evidence: serde_json::Value) {
-    if let Err(e) =
-        crate::daemon::hygiene_task::upsert_system_hygiene_task(home, &key, &title, evidence)
-    {
-        tracing::warn!(error = %e, key = %key, "hygiene task upsert failed");
+    match crate::daemon::hygiene_task::upsert_system_hygiene_task(home, &key, &title, evidence) {
+        Ok(outcome) => {
+            tracing::info!(key = %key, task = %outcome.task_id().0, "hygiene task upserted");
+        }
+        Err(e) => tracing::warn!(error = %e, key = %key, "hygiene task upsert failed"),
     }
 }
 

--- a/src/worktree_cleanup.rs
+++ b/src/worktree_cleanup.rs
@@ -2194,6 +2194,173 @@ mod tests {
 
         std::fs::remove_dir_all(&repo).ok();
     }
+
+    // ── V1 (d-20260712065632138568-7): cleanup-failure hygiene producers ──
+
+    /// Board-side view of the hygiene tasks the sweep produced under `home`.
+    fn hygiene_tasks(home: &Path) -> Vec<(String, serde_json::Value)> {
+        crate::task_events::replay(home)
+            .map(|s| {
+                s.tasks
+                    .values()
+                    .filter_map(|t| {
+                        Some((
+                            t.metadata
+                                .get(crate::daemon::hygiene_task::ALERT_KEY_META)?
+                                .as_str()?
+                                .to_string(),
+                            t.metadata
+                                .get(crate::daemon::hygiene_task::EVIDENCE_META)
+                                .cloned()
+                                .unwrap_or(serde_json::Value::Null),
+                        ))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// V1 RED: an ELIGIBLE (merged) worktree whose removal FAILS must produce a
+    /// durable hygiene task with the exact repo/branch/reason — the sweep may
+    /// not silently skip a proven-eligible-but-undeletable candidate.
+    #[cfg(unix)]
+    #[test]
+    fn remove_failure_upserts_hygiene_task_v1() {
+        use std::os::unix::fs::PermissionsExt;
+        let _lock = ENV_LOCK.lock();
+        let repo = setup_test_repo("v1-remove-fail");
+        make_old_dated_branch(&repo, "feat/done", "2024-01-01T00:00:00 +0000");
+        let wt = repo.join("wt-done");
+        git_in(
+            &repo,
+            &["worktree", "add", wt.to_str().unwrap(), "feat/done"],
+        );
+        git_in(&repo, &["merge", "feat/done"]);
+        // Sabotage: strip write permission so the eligible worktree cannot be
+        // removed (children can't be unlinked from a non-writable dir).
+        std::fs::set_permissions(&wt, std::fs::Permissions::from_mode(0o555)).unwrap();
+
+        std::env::set_var("AGEND_WORKTREE_AUTO_CLEANUP", "1");
+        let home = tmp_home("v1-remove-fail");
+        let mut configs = HashMap::new();
+        configs.insert("other-agent".to_string(), Some(repo.join("other")));
+        write_source_repo_binding(&home, "other-agent", &repo);
+        let removed = sweep_from_registry(&home, &configs, &[]);
+        std::env::remove_var("AGEND_WORKTREE_AUTO_CLEANUP");
+
+        assert!(
+            !removed.iter().any(|(b, _, _)| b == "feat/done"),
+            "sabotaged removal must not be reported as removed: {removed:?}"
+        );
+        let tasks = hygiene_tasks(&home);
+        let key = format!("residue-remove-failed:{}:feat/done", repo.display());
+        let hit = tasks.iter().find(|(k, _)| *k == key);
+        let (_, evidence) = hit.unwrap_or_else(|| {
+            panic!("eligible-but-remove-failed must upsert a hygiene task; got {tasks:?}")
+        });
+        assert_eq!(evidence["repo"], repo.display().to_string());
+        assert_eq!(evidence["branch"], "feat/done");
+        assert!(
+            evidence["reason"].as_str().unwrap_or("").contains("remove failed"),
+            "exact failure reason required: {evidence}"
+        );
+
+        std::fs::set_permissions(&wt, std::fs::Permissions::from_mode(0o755)).ok();
+        std::fs::remove_dir_all(&repo).ok();
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// V1 RED: a failing `fetch --prune` (here: unreachable remote) must upsert
+    /// a fetch-degraded hygiene task — a persistently failing fetch accumulates
+    /// undeletable branches invisibly (#2004) and may no longer stay log-only.
+    #[test]
+    fn fetch_failure_upserts_ambiguity_task_v1() {
+        let _lock = ENV_LOCK.lock();
+        let repo = setup_test_repo("v1-fetch-fail");
+        git_in(
+            &repo,
+            &["remote", "add", "origin", "/nonexistent/agend-v1-fixture"],
+        );
+        std::env::set_var("AGEND_WORKTREE_AUTO_CLEANUP", "1");
+        let home = tmp_home("v1-fetch-fail");
+        let configs = HashMap::new();
+        write_source_repo_binding(&home, "other-agent", &repo);
+        let _ = sweep_from_registry(&home, &configs, &[]);
+        std::env::remove_var("AGEND_WORKTREE_AUTO_CLEANUP");
+
+        let tasks = hygiene_tasks(&home);
+        let key = format!("residue-fetch-degraded:{}", repo.display());
+        assert!(
+            tasks.iter().any(|(k, _)| *k == key),
+            "failing fetch must upsert a fetch-degraded hygiene task; got {tasks:?}"
+        );
+
+        std::fs::remove_dir_all(&repo).ok();
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// V1 negative guard (production datum m-20260712065850381686-207): a
+    /// deliberately KEPT branch — young review/* scaffolding, not merged, no
+    /// matching merged PR, not a squash orphan — is NOT eligible-but-failed and
+    /// must NOT produce any hygiene task.
+    #[test]
+    fn kept_review_branch_produces_no_hygiene_task_v1() {
+        let _lock = ENV_LOCK.lock();
+        let repo = setup_test_repo("v1-kept-review");
+        // Young review scaffolding branch, no worktree: phase-2 keeps it
+        // (inside its 72h TTL, unmerged, no remote counterpart).
+        git_in(&repo, &["branch", "review/2746-codex-r1"]);
+        std::env::set_var("AGEND_WORKTREE_AUTO_CLEANUP", "1");
+        let home = tmp_home("v1-kept-review");
+        let configs = HashMap::new();
+        write_source_repo_binding(&home, "other-agent", &repo);
+        let _ = sweep_from_registry(&home, &configs, &[]);
+        std::env::remove_var("AGEND_WORKTREE_AUTO_CLEANUP");
+
+        let tasks = hygiene_tasks(&home);
+        assert!(
+            !tasks.iter().any(|(k, _)| k.contains("review/2746-codex-r1")),
+            "deliberately-kept branch must not be alerted: {tasks:?}"
+        );
+
+        std::fs::remove_dir_all(&repo).ok();
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// V1 guard: `AGEND_WORKTREE_AUTO_CLEANUP=0` is an operator opt-out — the
+    /// sweep does not run, so NO hygiene task may appear even with a staged
+    /// failure candidate present.
+    #[cfg(unix)]
+    #[test]
+    fn auto_cleanup_opt_out_produces_no_tasks_v1() {
+        use std::os::unix::fs::PermissionsExt;
+        let _lock = ENV_LOCK.lock();
+        let repo = setup_test_repo("v1-optout");
+        make_old_dated_branch(&repo, "feat/done", "2024-01-01T00:00:00 +0000");
+        let wt = repo.join("wt-done");
+        git_in(
+            &repo,
+            &["worktree", "add", wt.to_str().unwrap(), "feat/done"],
+        );
+        git_in(&repo, &["merge", "feat/done"]);
+        std::fs::set_permissions(&wt, std::fs::Permissions::from_mode(0o555)).unwrap();
+
+        std::env::set_var("AGEND_WORKTREE_AUTO_CLEANUP", "0");
+        let home = tmp_home("v1-optout");
+        let configs = HashMap::new();
+        write_source_repo_binding(&home, "other-agent", &repo);
+        let _ = sweep_from_registry(&home, &configs, &[]);
+        std::env::remove_var("AGEND_WORKTREE_AUTO_CLEANUP");
+
+        assert!(
+            hygiene_tasks(&home).is_empty(),
+            "opt-out means quiet: no sweep, no producers, no tasks"
+        );
+
+        std::fs::set_permissions(&wt, std::fs::Permissions::from_mode(0o755)).ok();
+        std::fs::remove_dir_all(&repo).ok();
+        std::fs::remove_dir_all(&home).ok();
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What

V1 of decision d-20260712065632138568-7 (routing RCA, 3-round adversarial convergence — see ROUTING-RCA-R3-FINAL-20260712.md @ claude-aef7c0 workspace):

1. **Durable hygiene alerts = board tasks** — new `daemon::hygiene_task::upsert_system_hygiene_task`: one active task per episode key, atomic create/update via `task_events::append_batch_checked` (fresh-replay precondition under the board lock). Task metadata is the only episode authority (no separate receipt store → no two-store crash window). Done episode ⇒ same key reopens a NEW task.
2. **Actual-failure producers** (replaces count-threshold guessing): proven-eligible-but-remove-failed worktrees (janitor Delete arm `Err`) and failing `fetch --prune` (persistent-ambiguity, #2004) upsert tasks with exact repo/branch/path/reason evidence.
3. **Raw `>15` branch-count alarm removed** — hardcoded `notify_agent("general")`, `count_warned` process-local dedup, both counting helpers and their RED8 tests. Raw count conflated live scaffolding (active worktrees, TTL-fresh review/*) with residue and paged an unrelated agent's PTY; restart reset the dedup (24→24 duplicate pages).

## Scope discipline (V1 only)

No V2/V3/HMAC/generic recipient foundation. `AGEND_WORKTREE_AUTO_CLEANUP=0` = operator opt-out, quiet by construction. Helper extraction deferred to the second consumer (YAGNI per R3).

## Tests

RED base **e255ff7a** (6 fail / 2 guard): 4 upsert-contract REDs (concurrent double-fire ⇒ one task; same episode updates occurrences/evidence; Done reopens as new; exact evidence) + 2 producer REDs (remove-failure, fetch-failure). Guards: deliberately-kept young `review/*` branch ⇒ no task (production datum m-…207); opt-out ⇒ quiet.

GREEN: targeted 27/27; **full nextest 5448/5448**; fmt clean; clippy clean for this tree (4 pre-existing `unwrap_used` lints in `vendor/agentic-git` *tests* are out of scope — same submodule pointer was CI-green in #2724).

## Honest notes for review

- Alarm removal itself has NO runtime RED (`notify_agent` is PTY-inject + process-global heartbeat state, not fixture-assertable) — verify via source diff + the negative guards (accepted boundary, codex m-…248).
- `remove_failure_upserts_hygiene_task_v1` is `#[cfg(unix)]` (perm-sabotage fixture); the upsert contract tests are cross-platform.
- Phase-2 may legitimately branch-reap an orphaned merged branch even when the sabotaged worktree DIR removal failed — the hygiene task tracks the stuck dir; test asserts that layering explicitly.

Per task t-20260712065642553545-40783-21: independent exact-head review + GH verdict mirror required; merge by archfix orchestrator after gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)