### PR TITLE
feat(provenance α): worktree-safe build identity — CLI --version + MCP serverInfo surfaces

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,7 @@
+// Build provenance resolution (slice α) — logic lives in build/provenance.rs so
+// tests/build_provenance_version.rs can cover it via a #[path] module.
+include!("build/provenance.rs");
+
 fn main() {
     #[cfg(windows)]
     {
@@ -12,4 +16,48 @@ fn main() {
         let _ = embed_resource::compile("assets/windows/agend-terminal.rc", embed_resource::NONE)
             .manifest_optional();
     }
+    emit_build_identity();
+}
+
+/// Slice α (d-20260712073535548541-12): stamp the build identity into four
+/// compile-time envs — `AGEND_BUILD_SHA` (full lowercase sha | `unknown`),
+/// `AGEND_BUILD_DIRTY` (`0`|`1`), and the two ready-made surface strings
+/// `AGEND_CLI_VERSION` / `AGEND_MCP_VERSION` — so every bin in the package
+/// (main CLI, MCP bridge) reads a single canonical composition with zero
+/// runtime plumbing. Identity hierarchy: `AGEND_BUILD_COMMIT` env (explicit
+/// CI/release/source-archive pin, optional `AGEND_BUILD_DIRTY` env) >
+/// worktree-safe git probe > honest `unknown`. Never fails the build.
+fn emit_build_identity() {
+    println!("cargo:rerun-if-env-changed=AGEND_BUILD_COMMIT");
+    println!("cargo:rerun-if-env-changed=AGEND_BUILD_DIRTY");
+    let manifest_dir =
+        std::path::PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap_or_default());
+    let env_commit = std::env::var("AGEND_BUILD_COMMIT").ok();
+    let env_dirty = std::env::var("AGEND_BUILD_DIRTY").ok();
+    let id = resolve_identity(env_commit.as_deref(), env_dirty.as_deref(), || {
+        git_probe(&manifest_dir)
+    });
+    for w in &id.warnings {
+        println!("cargo:warning={w}");
+    }
+    // Re-stamp on repo movement (commit / branch switch / ref update). Emitted
+    // whenever the tree is a git repo — existing paths only (rerun_paths), since
+    // a registered-but-missing path makes cargo re-run on every build.
+    for p in rerun_paths(&manifest_dir) {
+        println!("cargo:rerun-if-changed={}", p.display());
+    }
+    let semver = std::env::var("CARGO_PKG_VERSION").unwrap_or_else(|_| "0.0.0".to_string());
+    println!("cargo:rustc-env=AGEND_BUILD_SHA={}", id.sha);
+    println!(
+        "cargo:rustc-env=AGEND_BUILD_DIRTY={}",
+        if id.dirty { "1" } else { "0" }
+    );
+    println!(
+        "cargo:rustc-env=AGEND_CLI_VERSION={}",
+        compose_cli_version(&semver, &id.sha, id.dirty)
+    );
+    println!(
+        "cargo:rustc-env=AGEND_MCP_VERSION={}",
+        compose_mcp_version(&semver, &id.sha, id.dirty)
+    );
 }

--- a/build/provenance.rs
+++ b/build/provenance.rs
@@ -1,0 +1,75 @@
+//! Build provenance resolution (slice α, d-20260712073535548541-12).
+//!
+//! Pure-std logic shared by `build.rs` (via `include!`) and its tests (via a
+//! `#[path]` module in `tests/build_provenance_version.rs`). Resolves the build
+//! identity through a strict hierarchy — explicit `AGEND_BUILD_COMMIT` env >
+//! worktree-safe git probe > honest `unknown` — and composes the two surface
+//! strings (CLI `--version`, MCP serverInfo semver build-metadata). No
+//! dependencies beyond std; no network; never fails the build.
+
+use std::path::{Path, PathBuf};
+
+/// A resolved build identity. `sha` is a full lowercase 40/64-hex commit OID or
+/// the literal `"unknown"`; `dirty` is only ever true when `sha` is known.
+/// `warnings` carries operator-actionable notes (e.g. a malformed explicit env)
+/// for `build.rs` to surface as `cargo:warning` lines.
+pub struct Identity {
+    pub sha: String,
+    pub dirty: bool,
+    pub warnings: Vec<String>,
+}
+
+/// Full commit OID: 40 or 64 hex digits (mirrors the runtime
+/// `is_full_commit_sha` invariant; build.rs cannot import the crate).
+pub fn valid_full_sha(_s: &str) -> bool {
+    false // RED stub: no provenance capability exists yet
+}
+
+/// Resolve the identity hierarchy: explicit env commit (validated, lowercased,
+/// with optional env dirty flag) > `probe` (the git probe, injected for
+/// determinism) > honest `unknown`. A malformed explicit commit falls through
+/// to the probe with a warning — the most honest identity still available.
+pub fn resolve_identity(
+    _env_commit: Option<&str>,
+    _env_dirty: Option<&str>,
+    _probe: impl FnOnce() -> Option<(String, bool)>,
+) -> Identity {
+    // RED stub: current behavior — no provenance is ever resolved.
+    Identity {
+        sha: "unknown".to_string(),
+        dirty: false,
+        warnings: Vec::new(),
+    }
+}
+
+/// Worktree-safe git probe: `git rev-parse HEAD` in `dir` (works in worktrees
+/// and detached HEAD) + dirtiness via `git status --porcelain -uno`. Any git
+/// failure — including a status failure after a successful rev-parse — returns
+/// `None` (unknown), never a false-clean identity.
+pub fn git_probe(_dir: &Path) -> Option<(String, bool)> {
+    None // RED stub
+}
+
+/// Worktree-safe `cargo:rerun-if-changed` trigger paths: the per-worktree HEAD
+/// file (`git rev-parse --git-path HEAD` — NOT `<dir>/.git/HEAD`, which does not
+/// exist in a worktree where `.git` is a pointer file), the current branch's
+/// loose ref file, and `packed-refs`. Only paths that exist are returned (a
+/// missing path would make cargo re-run the build script on every build).
+pub fn rerun_paths(_dir: &Path) -> Vec<PathBuf> {
+    Vec::new() // RED stub
+}
+
+/// CLI `--version` value handed to clap: `<semver> (build <sha>[ dirty])` /
+/// `<semver> (build unknown)`. clap prepends the bin name, so the printed line
+/// keeps the leading `agend-terminal <semver>` compatibility tokens (§7.1).
+/// `unknown` never carries `dirty`.
+pub fn compose_cli_version(semver: &str, _sha: &str, _dirty: bool) -> String {
+    semver.to_string() // RED stub: current surface is the bare semver
+}
+
+/// MCP serverInfo version: semver build-metadata (semver §10) —
+/// `<semver>+g<sha12>[.dirty]`; `unknown` yields the bare semver (honest
+/// absence, still valid semver for existing parsers).
+pub fn compose_mcp_version(semver: &str, _sha: &str, _dirty: bool) -> String {
+    semver.to_string() // RED stub: current surface is the bare semver
+}

--- a/build/provenance.rs
+++ b/build/provenance.rs
@@ -1,11 +1,13 @@
-//! Build provenance resolution (slice α, d-20260712073535548541-12).
-//!
-//! Pure-std logic shared by `build.rs` (via `include!`) and its tests (via a
-//! `#[path]` module in `tests/build_provenance_version.rs`). Resolves the build
-//! identity through a strict hierarchy — explicit `AGEND_BUILD_COMMIT` env >
-//! worktree-safe git probe > honest `unknown` — and composes the two surface
-//! strings (CLI `--version`, MCP serverInfo semver build-metadata). No
-//! dependencies beyond std; no network; never fails the build.
+// Build provenance resolution (slice α, d-20260712073535548541-12).
+//
+// Pure-std logic shared by `build.rs` (via `include!` — which is why this
+// header is `//` not `//!`: inner doc comments cannot be spliced mid-file) and
+// its tests (via a `#[path]` module in `tests/build_provenance_version.rs`).
+// Resolves the build identity through a strict hierarchy — explicit
+// `AGEND_BUILD_COMMIT` env > worktree-safe git probe > honest `unknown` — and
+// composes the two surface strings (CLI `--version`, MCP serverInfo semver
+// build-metadata). No dependencies beyond std; no network; never fails the
+// build.
 
 use std::path::{Path, PathBuf};
 
@@ -21,55 +23,155 @@ pub struct Identity {
 
 /// Full commit OID: 40 or 64 hex digits (mirrors the runtime
 /// `is_full_commit_sha` invariant; build.rs cannot import the crate).
-pub fn valid_full_sha(_s: &str) -> bool {
-    false // RED stub: no provenance capability exists yet
+pub fn valid_full_sha(s: &str) -> bool {
+    matches!(s.len(), 40 | 64) && s.bytes().all(|b| b.is_ascii_hexdigit())
 }
 
 /// Resolve the identity hierarchy: explicit env commit (validated, lowercased,
-/// with optional env dirty flag) > `probe` (the git probe, injected for
-/// determinism) > honest `unknown`. A malformed explicit commit falls through
-/// to the probe with a warning — the most honest identity still available.
+/// with optional env dirty flag `1`/`true`) > `probe` (the git probe, injected
+/// for determinism) > honest `unknown`. A malformed explicit commit falls
+/// through to the probe with a warning — the most honest identity still
+/// available beats both a hard build failure and a silently-trusted bad pin.
 pub fn resolve_identity(
-    _env_commit: Option<&str>,
-    _env_dirty: Option<&str>,
-    _probe: impl FnOnce() -> Option<(String, bool)>,
+    env_commit: Option<&str>,
+    env_dirty: Option<&str>,
+    probe: impl FnOnce() -> Option<(String, bool)>,
 ) -> Identity {
-    // RED stub: current behavior — no provenance is ever resolved.
+    let mut warnings = Vec::new();
+    if let Some(raw) = env_commit {
+        let c = raw.trim().to_ascii_lowercase();
+        if valid_full_sha(&c) {
+            let dirty = matches!(env_dirty.map(str::trim), Some("1") | Some("true"));
+            return Identity {
+                sha: c,
+                dirty,
+                warnings,
+            };
+        }
+        warnings.push(format!(
+            "AGEND_BUILD_COMMIT is not a full 40/64-hex commit SHA (got `{raw}`); \
+             falling back to the git probe"
+        ));
+    }
+    if let Some((sha, dirty)) = probe() {
+        return Identity {
+            sha: sha.to_ascii_lowercase(),
+            dirty,
+            warnings,
+        };
+    }
     Identity {
         sha: "unknown".to_string(),
         dirty: false,
-        warnings: Vec::new(),
+        warnings,
     }
 }
 
-/// Worktree-safe git probe: `git rev-parse HEAD` in `dir` (works in worktrees
-/// and detached HEAD) + dirtiness via `git status --porcelain -uno`. Any git
-/// failure — including a status failure after a successful rev-parse — returns
-/// `None` (unknown), never a false-clean identity.
-pub fn git_probe(_dir: &Path) -> Option<(String, bool)> {
-    None // RED stub
+/// Run git in `dir`, returning trimmed stdout on success and `None` on any
+/// spawn/exit failure — every failure collapses to "this source is
+/// unavailable", never a partial identity.
+fn git_out(dir: &Path, args: &[&str]) -> Option<String> {
+    let out = std::process::Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+/// Worktree-safe git probe: `git rev-parse HEAD` in `dir` (works in linked
+/// worktrees and detached HEAD) + dirtiness via `git status --porcelain -uno`
+/// (tracked files only). Any git failure — including a status failure after a
+/// successful rev-parse — returns `None` (unknown), never a false-clean
+/// identity.
+pub fn git_probe(dir: &Path) -> Option<(String, bool)> {
+    let sha = git_out(dir, &["rev-parse", "HEAD"])?.to_ascii_lowercase();
+    if !valid_full_sha(&sha) {
+        return None;
+    }
+    let status = git_out(dir, &["status", "--porcelain", "--untracked-files=no"])?;
+    Some((sha, !status.is_empty()))
 }
 
 /// Worktree-safe `cargo:rerun-if-changed` trigger paths: the per-worktree HEAD
 /// file (`git rev-parse --git-path HEAD` — NOT `<dir>/.git/HEAD`, which does not
 /// exist in a worktree where `.git` is a pointer file), the current branch's
-/// loose ref file, and `packed-refs`. Only paths that exist are returned (a
-/// missing path would make cargo re-run the build script on every build).
-pub fn rerun_paths(_dir: &Path) -> Vec<PathBuf> {
-    Vec::new() // RED stub
+/// loose ref file (absent when detached or packed), and `packed-refs` (absent
+/// until refs are packed). Only paths that exist are returned — cargo re-runs
+/// the build script on EVERY build when a registered trigger path is missing.
+/// Residual: a loose ref that later becomes packed loses its trigger until the
+/// next rebuild re-registers paths; identity staleness in that window is a
+/// dev-build cosmetic, accepted for slice α.
+pub fn rerun_paths(dir: &Path) -> Vec<PathBuf> {
+    // `--git-path` output is relative to the invocation cwd when possible;
+    // since every git call runs with `current_dir(dir)`, join relative paths
+    // back onto `dir`.
+    let absolutize = |p: String| -> PathBuf {
+        let pb = PathBuf::from(p);
+        if pb.is_absolute() {
+            pb
+        } else {
+            dir.join(pb)
+        }
+    };
+    let mut v = Vec::new();
+    let Some(head) = git_out(dir, &["rev-parse", "--git-path", "HEAD"]) else {
+        return v; // not a repo ⇒ no file triggers (env triggers only)
+    };
+    let head = absolutize(head);
+    if head.exists() {
+        v.push(head);
+    }
+    // `symbolic-ref -q` exits non-zero when detached ⇒ git_out None ⇒ skipped.
+    if let Some(refname) = git_out(dir, &["symbolic-ref", "-q", "HEAD"]) {
+        if !refname.is_empty() {
+            if let Some(ref_path) = git_out(dir, &["rev-parse", "--git-path", &refname]) {
+                let ref_path = absolutize(ref_path);
+                if ref_path.exists() {
+                    v.push(ref_path);
+                }
+            }
+        }
+    }
+    if let Some(packed) = git_out(dir, &["rev-parse", "--git-path", "packed-refs"]) {
+        let packed = absolutize(packed);
+        if packed.exists() {
+            v.push(packed);
+        }
+    }
+    v
 }
 
 /// CLI `--version` value handed to clap: `<semver> (build <sha>[ dirty])` /
 /// `<semver> (build unknown)`. clap prepends the bin name, so the printed line
 /// keeps the leading `agend-terminal <semver>` compatibility tokens (§7.1).
 /// `unknown` never carries `dirty`.
-pub fn compose_cli_version(semver: &str, _sha: &str, _dirty: bool) -> String {
-    semver.to_string() // RED stub: current surface is the bare semver
+pub fn compose_cli_version(semver: &str, sha: &str, dirty: bool) -> String {
+    if sha == "unknown" {
+        format!("{semver} (build unknown)")
+    } else if dirty {
+        format!("{semver} (build {sha} dirty)")
+    } else {
+        format!("{semver} (build {sha})")
+    }
 }
 
-/// MCP serverInfo version: semver build-metadata (semver §10) —
-/// `<semver>+g<sha12>[.dirty]`; `unknown` yields the bare semver (honest
-/// absence, still valid semver for existing parsers).
-pub fn compose_mcp_version(semver: &str, _sha: &str, _dirty: bool) -> String {
-    semver.to_string() // RED stub: current surface is the bare semver
+/// MCP serverInfo version: semver build-metadata (semver §10, `+` suffix with
+/// `[0-9A-Za-z-]` dot-separated idents — existing semver parsers keep working)
+/// — `<semver>+g<sha12>[.dirty]`; `unknown` yields the bare semver (honest
+/// absence, still valid).
+pub fn compose_mcp_version(semver: &str, sha: &str, dirty: bool) -> String {
+    if sha == "unknown" {
+        semver.to_string()
+    } else {
+        let short = &sha[..12];
+        if dirty {
+            format!("{semver}+g{short}.dirty")
+        } else {
+            format!("{semver}+g{short}")
+        }
+    }
 }

--- a/build/provenance.rs
+++ b/build/provenance.rs
@@ -49,8 +49,9 @@ pub fn resolve_identity(
             };
         }
         warnings.push(format!(
-            "AGEND_BUILD_COMMIT is not a full 40/64-hex commit SHA (got `{raw}`); \
-             falling back to the git probe"
+            "AGEND_BUILD_COMMIT is not a full 40/64-hex commit SHA (got `{}`); \
+             falling back to the git probe",
+            sanitize_for_warning(raw)
         ));
     }
     if let Some((sha, dirty)) = probe() {
@@ -65,6 +66,22 @@ pub fn resolve_identity(
         dirty: false,
         warnings,
     }
+}
+
+/// Bound, single-line rendering of an untrusted env value for `cargo:warning`
+/// output. Control characters (esp. `\n`/`\r`) are replaced — cargo parses
+/// each build-script stdout LINE as a directive, so a raw multiline echo
+/// would let a crafted value inject e.g. a forged `cargo:rustc-env=`.
+pub fn sanitize_for_warning(raw: &str) -> String {
+    let mut s: String = raw
+        .chars()
+        .take(80)
+        .map(|c| if c.is_control() { ' ' } else { c })
+        .collect();
+    if raw.chars().count() > 80 {
+        s.push('…');
+    }
+    s
 }
 
 /// Run git in `dir`, returning trimmed stdout on success and `None` on any
@@ -83,28 +100,41 @@ fn git_out(dir: &Path, args: &[&str]) -> Option<String> {
 }
 
 /// Worktree-safe git probe: `git rev-parse HEAD` in `dir` (works in linked
-/// worktrees and detached HEAD) + dirtiness via `git status --porcelain -uno`
-/// (tracked files only). Any git failure — including a status failure after a
-/// successful rev-parse — returns `None` (unknown), never a false-clean
+/// worktrees and detached HEAD) + dirtiness via `git status --porcelain` —
+/// tracked modifications AND non-ignored untracked files both count (r1: the
+/// initial `-uno` hid untracked files, a false-clean); gitignored build
+/// products never count. Any git failure — including a status failure after
+/// a successful rev-parse — returns `None` (unknown), never a false-clean
 /// identity.
 pub fn git_probe(dir: &Path) -> Option<(String, bool)> {
     let sha = git_out(dir, &["rev-parse", "HEAD"])?.to_ascii_lowercase();
     if !valid_full_sha(&sha) {
         return None;
     }
-    let status = git_out(dir, &["status", "--porcelain", "--untracked-files=no"])?;
+    let status = git_out(dir, &["status", "--porcelain"])?;
     Some((sha, !status.is_empty()))
 }
 
-/// Worktree-safe `cargo:rerun-if-changed` trigger paths: the per-worktree HEAD
-/// file (`git rev-parse --git-path HEAD` — NOT `<dir>/.git/HEAD`, which does not
-/// exist in a worktree where `.git` is a pointer file), the current branch's
-/// loose ref file (absent when detached or packed), and `packed-refs` (absent
-/// until refs are packed). Only paths that exist are returned — cargo re-runs
-/// the build script on EVERY build when a registered trigger path is missing.
-/// Residual: a loose ref that later becomes packed loses its trigger until the
-/// next rebuild re-registers paths; identity staleness in that window is a
-/// dev-build cosmetic, accepted for slice α.
+/// Worktree-safe `cargo:rerun-if-changed` trigger paths:
+///
+/// - git metadata — the per-worktree HEAD file (`git rev-parse --git-path
+///   HEAD`; NOT `<dir>/.git/HEAD`, which does not exist in a worktree where
+///   `.git` is a pointer file), the current branch's loose ref file (absent
+///   when detached or packed), and `packed-refs` (absent until refs are
+///   packed);
+/// - TRACKED files (`git ls-files`, regular files only) — r1: without these,
+///   a tracked edit with no HEAD movement rebuilt the crate WITHOUT
+///   re-running the build script, baking a stale clean identity into the
+///   incremental build (false-clean). Build products stay excluded by
+///   construction: they are untracked/gitignored, and gitlink directory
+///   entries are filtered by the is_file() check — no target-loop.
+///
+/// Only paths that exist are returned — cargo re-runs the build script on
+/// EVERY build when a registered trigger path is missing. Residuals, accepted
+/// for slice α: a loose ref that later becomes packed loses its trigger until
+/// the next rebuild re-registers paths; an untracked-only change (new file,
+/// nothing tracked touched) has no trigger to fire — its dirtiness lands on
+/// the next build-script run, not instantly.
 pub fn rerun_paths(dir: &Path) -> Vec<PathBuf> {
     // `--git-path` output is relative to the invocation cwd when possible;
     // since every git call runs with `current_dir(dir)`, join relative paths
@@ -140,6 +170,18 @@ pub fn rerun_paths(dir: &Path) -> Vec<PathBuf> {
         let packed = absolutize(packed);
         if packed.exists() {
             v.push(packed);
+        }
+    }
+    // r1: tracked files, NUL-delimited (paths may contain anything but NUL).
+    // is_file() drops deleted-but-tracked entries and gitlink (submodule)
+    // directory entries — registering a directory would make cargo watch its
+    // whole tree.
+    if let Some(tracked) = git_out(dir, &["ls-files", "-z"]) {
+        for rel in tracked.split('\0').filter(|s| !s.is_empty()) {
+            let p = dir.join(rel);
+            if p.is_file() {
+                v.push(p);
+            }
         }
     }
     v

--- a/src/bin/agend-mcp-bridge.rs
+++ b/src/bin/agend-mcp-bridge.rs
@@ -108,7 +108,9 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                 "result": {
                     "protocolVersion": "2024-11-05",
                     "capabilities": { "tools": {} },
-                    "serverInfo": { "name": "agend-terminal", "version": env!("CARGO_PKG_VERSION") }
+                    // Slice α build provenance: semver + build metadata
+                    // (`<semver>+g<sha12>[.dirty]`, bare semver when unknown).
+                    "serverInfo": { "name": "agend-terminal", "version": env!("AGEND_MCP_VERSION") }
                 }
             })
             .to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -262,7 +262,10 @@ pub(crate) fn parse_double_quoted(s: &str) -> String {
 #[derive(Parser)]
 #[command(
     name = "agend-terminal",
-    version,
+    // Slice α build provenance: `<semver> (build <sha|unknown>[ dirty])`,
+    // baked by build.rs — keeps the leading `agend-terminal <semver>`
+    // compatibility tokens (§7.1 output-shape idiom).
+    version = env!("AGEND_CLI_VERSION"),
     about = "Orchestrate AI coding agents"
 )]
 struct Cli {

--- a/tests/build_provenance_version.rs
+++ b/tests/build_provenance_version.rs
@@ -1,21 +1,27 @@
 //! Build provenance slice α (t-20260712073937810355-40783-34,
 //! d-20260712073535548541-12) — deterministic RED→GREEN coverage.
 //!
-//! RED against main (no provenance capability): the resolver/probe/compose
-//! logic in `build/provenance.rs` is stubbed to today's behavior, `build.rs`
-//! emits no identity envs, and neither surface (CLI `--version`, MCP
-//! serverInfo) carries a build SHA. Every test below encodes the slice-α
-//! contract and fails on that state; GREEN implements it.
+//! r0 RED against main (no provenance capability): resolver hierarchy, probe,
+//! composition, surfaces. r1 RED against the r0 GREEN (codex exact-head
+//! review m-…-412): false-clean incremental build (tracked edit without HEAD
+//! move kept a stale clean identity — build.rs watched only git metadata),
+//! `-uno` hiding untracked files, multiline `AGEND_BUILD_COMMIT` values able
+//! to inject cargo directives through `cargo:warning`, and a source-string
+//! scan standing in for the real MCP initialize handshake.
 //!
-//! Determinism: scratch git repos under a per-process temp dir (isolated
-//! `HOME`/`GIT_CONFIG_*`, fixed committer, no network, no timing); the CLI
-//! shape test spawns the actually-built binary via `CARGO_BIN_EXE_`; baked
-//! env assertions use `option_env!` so the RED tree still compiles.
+//! Determinism: scratch git repos via `common::git_isolated` (#821) under
+//! per-process temp dirs; the CLI/bridge shape tests spawn the actually-built
+//! binaries via `CARGO_BIN_EXE_`; the cached-build repro drives a hermetic
+//! nested-cargo fixture crate; baked env assertions use `option_env!` so the
+//! RED tree still compiles.
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
+
+mod common;
+use common::git_isolated;
 
 #[path = "../build/provenance.rs"]
 mod provenance;
@@ -70,6 +76,26 @@ fn resolve_malformed_env_falls_through_to_probe_with_warning() {
         !id.warnings.is_empty(),
         "a malformed explicit commit must surface a warning"
     );
+}
+
+/// r1: `cargo:warning={w}` interprets embedded newlines as fresh cargo
+/// directives — a crafted multiline `AGEND_BUILD_COMMIT` could inject e.g.
+/// `cargo:rustc-env=AGEND_BUILD_SHA=<forged>`. The echoed value must be
+/// single-line and bounded.
+#[test]
+fn malformed_env_warning_is_single_line_and_bounded() {
+    let evil = format!(
+        "bad\ncargo:rustc-env=AGEND_BUILD_SHA={SHA_B}\r{}",
+        "x".repeat(500)
+    );
+    let id = resolve_identity(Some(&evil), None, || None);
+    assert_eq!(id.sha, "unknown", "evil env must not resolve");
+    let w = id.warnings.first().expect("warning must be surfaced");
+    assert!(
+        !w.contains('\n') && !w.contains('\r'),
+        "warning must be single-line (cargo directive injection vector): {w}"
+    );
+    assert!(w.len() <= 200, "warning must be bounded, len={}", w.len());
 }
 
 #[test]
@@ -129,15 +155,13 @@ fn mcp_version_shapes() {
 
 // ---- git probe on scratch repos (worktree / detached / dirty / no-git) ----
 
-/// In a fleet-agent shell, `git` on PATH is the agend-git shim, whose
-/// ChdirPass redirects agent git calls onto the daemon-bound worktree — a
-/// scratch-repo `rev-parse` would silently answer for the WRONG repo (the
-/// CLAUDE.md lesson-10.7 class). Test-fixture children therefore set both
-/// bypass env twins so the shim execs real git honoring the scratch cwd —
-/// the established pattern of `vendor/agentic-git`'s own test suite, NOT a
-/// §3.19.1 deny-escape (read-only fixtures in isolated temp dirs). Inert
-/// where the shim is absent (CI, operator shells). Process-wide because the
-/// production `git_probe` under test spawns git itself (inheriting env).
+/// The production `git_probe`/`rerun_paths` under test spawn `git` themselves
+/// (not via the #821 `git_isolated` fixture helper), so the shim bypass must
+/// also hold process-wide: in a fleet-agent shell the `agend-git` shim's
+/// ChdirPass would answer a scratch-repo `rev-parse` for the BOUND worktree
+/// (the CLAUDE.md lesson-10.7 / #820 class). Inert where the shim is absent
+/// (CI, operator shells). Fixture git calls go through `git_isolated::git`,
+/// which pins the same bypass per-child.
 fn isolate_from_git_shim() {
     static ONCE: std::sync::Once = std::sync::Once::new();
     ONCE.call_once(|| {
@@ -146,9 +170,7 @@ fn isolate_from_git_shim() {
     });
 }
 
-/// Scratch repo helper: fully isolated from user/system git config and from
-/// any daemon-bound worktree (cwd is always the scratch dir — never a
-/// canonical-rooted path).
+/// Scratch dir helper: per-process temp path, never a canonical-rooted repo.
 fn scratch_dir(tag: &str) -> PathBuf {
     isolate_from_git_shim(); // every git-touching test builds a scratch dir first
     let d = std::env::temp_dir().join(format!("agend-provenance-{}-{tag}", std::process::id()));
@@ -157,18 +179,10 @@ fn scratch_dir(tag: &str) -> PathBuf {
     d
 }
 
+/// #821-conformant fixture git: `git_isolated::git` (cwd pin + shim bypass +
+/// pinned committer identity) with success assertion + trimmed stdout.
 fn git(dir: &Path, args: &[&str]) -> String {
-    let out = Command::new("git")
-        .args(args)
-        .current_dir(dir)
-        .env("GIT_CONFIG_NOSYSTEM", "1")
-        .env("GIT_CONFIG_GLOBAL", "/dev/null")
-        .env("GIT_AUTHOR_NAME", "t")
-        .env("GIT_AUTHOR_EMAIL", "t@t")
-        .env("GIT_COMMITTER_NAME", "t")
-        .env("GIT_COMMITTER_EMAIL", "t@t")
-        .output()
-        .expect("spawn git");
+    let out = git_isolated::git(dir, args);
     assert!(
         out.status.success(),
         "git {args:?} failed: {}",
@@ -202,6 +216,31 @@ fn probe_reports_dirty_on_tracked_modification() {
     std::fs::write(d.join("f.txt"), "two\n").unwrap();
     let (_, dirty) = git_probe(&d).expect("probe must resolve");
     assert!(dirty, "a modified tracked file must read dirty");
+    let _ = std::fs::remove_dir_all(&d);
+}
+
+/// r1: a NON-IGNORED untracked file is real working-tree divergence and must
+/// read dirty — the r0 `--untracked-files=no` hid it (false-clean).
+#[test]
+fn probe_reports_dirty_on_untracked_non_ignored_file() {
+    let d = init_repo("untracked");
+    std::fs::write(d.join("new-file.txt"), "x\n").unwrap();
+    let (_, dirty) = git_probe(&d).expect("probe must resolve");
+    assert!(dirty, "a non-ignored untracked file must read dirty");
+    let _ = std::fs::remove_dir_all(&d);
+}
+
+/// r1 boundary: gitignored files (e.g. target dirs) must NOT read dirty —
+/// this is what keeps build products out of the dirtiness signal.
+#[test]
+fn probe_stays_clean_on_ignored_file() {
+    let d = init_repo("ignored");
+    std::fs::write(d.join(".gitignore"), "ignored.txt\n").unwrap();
+    git(&d, &["add", ".gitignore"]);
+    git(&d, &["commit", "-q", "--no-gpg-sign", "-m", "ignore"]);
+    std::fs::write(d.join("ignored.txt"), "x\n").unwrap();
+    let (_, dirty) = git_probe(&d).expect("probe must resolve");
+    assert!(!dirty, "an ignored file must stay clean");
     let _ = std::fs::remove_dir_all(&d);
 }
 
@@ -265,6 +304,22 @@ fn rerun_paths_exist_and_cover_head_in_normal_repo() {
     let _ = std::fs::remove_dir_all(&d);
 }
 
+/// r1: TRACKED files must be triggers too — with git-metadata-only triggers a
+/// tracked edit (no HEAD move) rebuilt the crate WITHOUT re-running build.rs,
+/// leaving a stale clean identity (codex r0-review deterministic repro).
+#[test]
+fn rerun_paths_include_tracked_files() {
+    let d = init_repo("rerun-tracked");
+    let paths = rerun_paths(&d);
+    assert!(
+        paths
+            .iter()
+            .any(|p| p.file_name().is_some_and(|f| f == "f.txt")),
+        "tracked files must re-trigger the build script (false-clean fix): {paths:?}"
+    );
+    let _ = std::fs::remove_dir_all(&d);
+}
+
 #[test]
 fn rerun_paths_use_per_worktree_head_not_pointer_file() {
     let d = init_repo("rerun-wt-main");
@@ -297,6 +352,107 @@ fn rerun_paths_empty_outside_any_repo() {
         "no repo ⇒ no file triggers (env triggers only; a nonexistent path would re-run every build)"
     );
     let _ = std::fs::remove_dir_all(&d);
+}
+
+// ---- r1 empirical cached-build repro (codex r0-review finding 1) ----
+
+/// The exact false-clean sequence, driven through REAL cargo builds of a
+/// hermetic fixture crate whose build.rs `include!`s the SAME provenance.rs
+/// under test: clean build shows the sha; a TRACKED edit without any HEAD
+/// move must flip the baked identity to dirty on the next cached build; a
+/// revert must flip it back to clean. r0 failed the middle step (build.rs
+/// watched only git metadata, so the incremental rebuild kept the stale
+/// clean identity).
+#[test]
+fn cached_build_refreshes_dirty_without_head_move() {
+    let repo = init_repo("nested-cargo");
+    let manifest = Path::new(env!("CARGO_MANIFEST_DIR"));
+    std::fs::copy(
+        manifest.join("build/provenance.rs"),
+        repo.join("provenance.rs"),
+    )
+    .unwrap();
+    std::fs::write(
+        repo.join("Cargo.toml"),
+        "[package]\nname = \"prov-fixture\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n[workspace]\n",
+    )
+    .unwrap();
+    std::fs::write(
+        repo.join("build.rs"),
+        r#"include!("provenance.rs");
+fn main() {
+    let dir = std::path::PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
+    let id = resolve_identity(None, None, || git_probe(&dir));
+    for w in &id.warnings {
+        println!("cargo:warning={w}");
+    }
+    for p in rerun_paths(&dir) {
+        println!("cargo:rerun-if-changed={}", p.display());
+    }
+    println!(
+        "cargo:rustc-env=FIXTURE_CLI={}",
+        compose_cli_version("0.1.0", &id.sha, id.dirty)
+    );
+}
+"#,
+    )
+    .unwrap();
+    std::fs::create_dir_all(repo.join("src")).unwrap();
+    std::fs::write(
+        repo.join("src/main.rs"),
+        "fn main() {\n    println!(\"{}\", env!(\"FIXTURE_CLI\"));\n}\n",
+    )
+    .unwrap();
+    // Build products are gitignored so the build itself never reads dirty —
+    // the "exclude target loops" boundary.
+    std::fs::write(repo.join(".gitignore"), "/target-fixture\n").unwrap();
+    git(&repo, &["add", "."]);
+    git(&repo, &["commit", "-q", "--no-gpg-sign", "-m", "fixture"]);
+    let head = git(&repo, &["rev-parse", "HEAD"]).to_lowercase();
+
+    let run_fixture = |repo: &Path| -> String {
+        let out = Command::new(std::env::var("CARGO").unwrap_or_else(|_| "cargo".into()))
+            .args(["run", "-q"])
+            .current_dir(repo)
+            // Hermetic vs the outer test invocation: coverage/instrumentation
+            // flags must not leak into the fixture build.
+            .env_remove("RUSTFLAGS")
+            .env_remove("CARGO_ENCODED_RUSTFLAGS")
+            .env_remove("LLVM_PROFILE_FILE")
+            .env("CARGO_TARGET_DIR", repo.join("target-fixture"))
+            .output()
+            .expect("nested cargo run");
+        assert!(
+            out.status.success(),
+            "fixture build failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        String::from_utf8_lossy(&out.stdout).trim().to_string()
+    };
+
+    assert_eq!(
+        run_fixture(&repo),
+        format!("0.1.0 (build {head})"),
+        "clean cached build must bake the exact HEAD, clean"
+    );
+    // Tracked edit, NO HEAD movement — the r0 false-clean scenario.
+    std::fs::write(
+        repo.join("src/main.rs"),
+        "fn main() {\n    println!(\"{}\", env!(\"FIXTURE_CLI\"));\n    // edited\n}\n",
+    )
+    .unwrap();
+    assert_eq!(
+        run_fixture(&repo),
+        format!("0.1.0 (build {head} dirty)"),
+        "a tracked edit without HEAD move must flip the cached build to dirty"
+    );
+    git(&repo, &["checkout", "--", "src/main.rs"]);
+    assert_eq!(
+        run_fixture(&repo),
+        format!("0.1.0 (build {head})"),
+        "reverting the edit must flip the cached build back to clean"
+    );
+    let _ = std::fs::remove_dir_all(&repo);
 }
 
 // ---- baked build-time envs (option_env! so the RED tree compiles) ----
@@ -375,17 +531,44 @@ fn cli_version_output_carries_build_identity_with_leading_compat() {
     );
 }
 
-// ---- MCP serverInfo wiring pin (source-level; the bridge is a separate bin) ----
+// ---- the real MCP surface: zero-daemon initialize handshake (r1) ----
 
+/// Spawn the actually-built bridge and perform the real NDJSON `initialize`
+/// handshake (handled bridge-locally — no daemon needed): serverInfo.version
+/// must equal the canonical semver+build-metadata composition. Replaces the
+/// r0 source-string scan (codex r0-review finding: scan pins the source text,
+/// not the wire behavior).
 #[test]
-fn mcp_bridge_serverinfo_uses_baked_build_metadata_version() {
-    let src = std::fs::read_to_string(
-        Path::new(env!("CARGO_MANIFEST_DIR")).join("src/bin/agend-mcp-bridge.rs"),
-    )
-    .unwrap();
-    assert!(
-        src.contains(r#""version": env!("AGEND_MCP_VERSION")"#),
-        "serverInfo.version must be the baked semver+build-metadata string \
-         (AGEND_MCP_VERSION), not a bare CARGO_PKG_VERSION"
+fn mcp_bridge_initialize_handshake_reports_build_metadata_version() {
+    use std::io::{BufRead, BufReader, Write};
+    let home = scratch_dir("bridge-home");
+    let mut child = Command::new(env!("CARGO_BIN_EXE_agend-mcp-bridge"))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .env("AGEND_HOME", &home)
+        .env_remove("AGEND_INSTANCE_NAME")
+        .spawn()
+        .expect("spawn agend-mcp-bridge");
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{}}\n")
+        .unwrap();
+    drop(child.stdin.take()); // EOF ⇒ bridge answers then exits its read loop
+    let mut line = String::new();
+    BufReader::new(child.stdout.take().unwrap())
+        .read_line(&mut line)
+        .unwrap();
+    let _ = child.wait();
+    let v: serde_json::Value = serde_json::from_str(line.trim()).expect("one NDJSON response");
+    let sha = required_env(option_env!("AGEND_BUILD_SHA"), "AGEND_BUILD_SHA");
+    let dirty = required_env(option_env!("AGEND_BUILD_DIRTY"), "AGEND_BUILD_DIRTY") == "1";
+    assert_eq!(
+        v["result"]["serverInfo"]["version"].as_str().unwrap_or(""),
+        compose_mcp_version(env!("CARGO_PKG_VERSION"), sha, dirty),
+        "real initialize handshake must report the baked build-metadata version; got: {line}"
     );
+    let _ = std::fs::remove_dir_all(&home);
 }

--- a/tests/build_provenance_version.rs
+++ b/tests/build_provenance_version.rs
@@ -404,8 +404,10 @@ fn main() {
     )
     .unwrap();
     // Build products are gitignored so the build itself never reads dirty —
-    // the "exclude target loops" boundary.
-    std::fs::write(repo.join(".gitignore"), "/target-fixture\n").unwrap();
+    // the "exclude target loops" boundary. Cargo.lock: cargo writes it before
+    // the build script runs, so an untracked lockfile would dirty the very
+    // first build.
+    std::fs::write(repo.join(".gitignore"), "/target-fixture\nCargo.lock\n").unwrap();
     git(&repo, &["add", "."]);
     git(&repo, &["commit", "-q", "--no-gpg-sign", "-m", "fixture"]);
     let head = git(&repo, &["rev-parse", "HEAD"]).to_lowercase();

--- a/tests/build_provenance_version.rs
+++ b/tests/build_provenance_version.rs
@@ -129,14 +129,29 @@ fn mcp_version_shapes() {
 
 // ---- git probe on scratch repos (worktree / detached / dirty / no-git) ----
 
+/// In a fleet-agent shell, `git` on PATH is the agend-git shim, whose
+/// ChdirPass redirects agent git calls onto the daemon-bound worktree — a
+/// scratch-repo `rev-parse` would silently answer for the WRONG repo (the
+/// CLAUDE.md lesson-10.7 class). Test-fixture children therefore set both
+/// bypass env twins so the shim execs real git honoring the scratch cwd —
+/// the established pattern of `vendor/agentic-git`'s own test suite, NOT a
+/// §3.19.1 deny-escape (read-only fixtures in isolated temp dirs). Inert
+/// where the shim is absent (CI, operator shells). Process-wide because the
+/// production `git_probe` under test spawns git itself (inheriting env).
+fn isolate_from_git_shim() {
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    ONCE.call_once(|| {
+        std::env::set_var("AGEND_GIT_BYPASS", "1");
+        std::env::set_var("AGENTIC_GIT_BYPASS", "1");
+    });
+}
+
 /// Scratch repo helper: fully isolated from user/system git config and from
 /// any daemon-bound worktree (cwd is always the scratch dir — never a
-/// canonical-rooted path, so the agend-git shim pass-through is inert).
+/// canonical-rooted path).
 fn scratch_dir(tag: &str) -> PathBuf {
-    let d = std::env::temp_dir().join(format!(
-        "agend-provenance-{}-{tag}",
-        std::process::id()
-    ));
+    isolate_from_git_shim(); // every git-touching test builds a scratch dir first
+    let d = std::env::temp_dir().join(format!("agend-provenance-{}-{tag}", std::process::id()));
     let _ = std::fs::remove_dir_all(&d);
     std::fs::create_dir_all(&d).unwrap();
     d
@@ -238,7 +253,10 @@ fn rerun_paths_exist_and_cover_head_in_normal_repo() {
         "a git repo must yield at least the HEAD trigger"
     );
     for p in &paths {
-        assert!(p.exists(), "trigger path must exist (else cargo re-runs every build): {p:?}");
+        assert!(
+            p.exists(),
+            "trigger path must exist (else cargo re-runs every build): {p:?}"
+        );
     }
     assert!(
         paths.iter().any(|p| p.ends_with("HEAD")),
@@ -283,18 +301,36 @@ fn rerun_paths_empty_outside_any_repo() {
 
 // ---- baked build-time envs (option_env! so the RED tree compiles) ----
 
+/// RED-compilable required-env accessor: `option_env!` keeps the RED tree
+/// compiling (the env doesn't exist until GREEN's build.rs emits it) and the
+/// runtime panic makes the RED failure a test FAILURE, not a build error.
+/// A plain `option_env!(..).expect(..)` would trip the deny-by-default
+/// `clippy::option_env_unwrap`; routing through a fn keeps the identical
+/// semantics without the linted adjacency.
+#[track_caller]
+fn required_env(value: Option<&'static str>, what: &str) -> &'static str {
+    match value {
+        Some(v) => v,
+        None => panic!("build.rs must emit {what}"),
+    }
+}
+
 #[test]
 fn baked_identity_envs_present_and_well_formed() {
-    let sha = option_env!("AGEND_BUILD_SHA")
-        .expect("build.rs must emit AGEND_BUILD_SHA (sha | unknown)");
+    let sha = required_env(
+        option_env!("AGEND_BUILD_SHA"),
+        "AGEND_BUILD_SHA (sha | unknown)",
+    );
     assert!(
         sha == "unknown" || valid_full_sha(sha),
         "AGEND_BUILD_SHA must be a full lowercase hex SHA or 'unknown': {sha}"
     );
     assert_eq!(sha, sha.to_lowercase(), "baked SHA must be lowercase");
-    let dirty = option_env!("AGEND_BUILD_DIRTY")
-        .expect("build.rs must emit AGEND_BUILD_DIRTY (0|1)");
-    assert!(dirty == "0" || dirty == "1", "AGEND_BUILD_DIRTY ∈ {{0,1}}: {dirty}");
+    let dirty = required_env(option_env!("AGEND_BUILD_DIRTY"), "AGEND_BUILD_DIRTY (0|1)");
+    assert!(
+        dirty == "0" || dirty == "1",
+        "AGEND_BUILD_DIRTY ∈ {{0,1}}: {dirty}"
+    );
     if sha == "unknown" {
         assert_eq!(dirty, "0", "unknown identity is never dirty");
     }
@@ -302,16 +338,16 @@ fn baked_identity_envs_present_and_well_formed() {
 
 #[test]
 fn baked_surface_envs_match_composition() {
-    let sha = option_env!("AGEND_BUILD_SHA").expect("AGEND_BUILD_SHA");
-    let dirty = option_env!("AGEND_BUILD_DIRTY").expect("AGEND_BUILD_DIRTY") == "1";
+    let sha = required_env(option_env!("AGEND_BUILD_SHA"), "AGEND_BUILD_SHA");
+    let dirty = required_env(option_env!("AGEND_BUILD_DIRTY"), "AGEND_BUILD_DIRTY") == "1";
     let semver = env!("CARGO_PKG_VERSION");
     assert_eq!(
-        option_env!("AGEND_CLI_VERSION").expect("build.rs must emit AGEND_CLI_VERSION"),
+        required_env(option_env!("AGEND_CLI_VERSION"), "AGEND_CLI_VERSION"),
         compose_cli_version(semver, sha, dirty),
         "baked CLI version must equal the canonical composition"
     );
     assert_eq!(
-        option_env!("AGEND_MCP_VERSION").expect("build.rs must emit AGEND_MCP_VERSION"),
+        required_env(option_env!("AGEND_MCP_VERSION"), "AGEND_MCP_VERSION"),
         compose_mcp_version(semver, sha, dirty),
         "baked MCP version must equal the canonical composition"
     );

--- a/tests/build_provenance_version.rs
+++ b/tests/build_provenance_version.rs
@@ -1,0 +1,355 @@
+//! Build provenance slice α (t-20260712073937810355-40783-34,
+//! d-20260712073535548541-12) — deterministic RED→GREEN coverage.
+//!
+//! RED against main (no provenance capability): the resolver/probe/compose
+//! logic in `build/provenance.rs` is stubbed to today's behavior, `build.rs`
+//! emits no identity envs, and neither surface (CLI `--version`, MCP
+//! serverInfo) carries a build SHA. Every test below encodes the slice-α
+//! contract and fails on that state; GREEN implements it.
+//!
+//! Determinism: scratch git repos under a per-process temp dir (isolated
+//! `HOME`/`GIT_CONFIG_*`, fixed committer, no network, no timing); the CLI
+//! shape test spawns the actually-built binary via `CARGO_BIN_EXE_`; baked
+//! env assertions use `option_env!` so the RED tree still compiles.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+#[path = "../build/provenance.rs"]
+mod provenance;
+
+use provenance::{
+    compose_cli_version, compose_mcp_version, git_probe, rerun_paths, resolve_identity,
+    valid_full_sha,
+};
+
+const SHA_A: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const SHA_B: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+// ---- identity validation ----
+
+#[test]
+fn valid_full_sha_accepts_40_and_64_hex_only() {
+    assert!(valid_full_sha(SHA_A));
+    assert!(valid_full_sha(&"c".repeat(64)));
+    assert!(!valid_full_sha("deadbeef")); // abbreviated
+    assert!(!valid_full_sha(&"g".repeat(40))); // non-hex
+    assert!(!valid_full_sha("")); // empty
+    assert!(!valid_full_sha(&"a".repeat(41))); // wrong length
+}
+
+// ---- resolver hierarchy: env > probe > unknown ----
+
+#[test]
+fn resolve_env_commit_wins_over_probe() {
+    let id = resolve_identity(Some(SHA_A), Some("1"), || Some((SHA_B.into(), false)));
+    assert_eq!(id.sha, SHA_A, "explicit env commit must win over the probe");
+    assert!(id.dirty, "explicit env dirty flag must be honored");
+    assert!(id.warnings.is_empty());
+}
+
+#[test]
+fn resolve_env_commit_is_lowercased() {
+    let upper = SHA_A.to_uppercase();
+    let id = resolve_identity(Some(&upper), None, || None);
+    assert_eq!(id.sha, SHA_A, "env commit must be stored lowercase");
+    assert!(!id.dirty, "absent env dirty flag means clean");
+}
+
+#[test]
+fn resolve_malformed_env_falls_through_to_probe_with_warning() {
+    let id = resolve_identity(Some("deadbeef"), None, || Some((SHA_B.into(), true)));
+    assert_eq!(
+        id.sha, SHA_B,
+        "malformed env commit must fall through to the probe"
+    );
+    assert!(id.dirty, "probe dirtiness must be preserved");
+    assert!(
+        !id.warnings.is_empty(),
+        "a malformed explicit commit must surface a warning"
+    );
+}
+
+#[test]
+fn resolve_probe_used_when_env_absent() {
+    let id = resolve_identity(None, None, || Some((SHA_B.into(), false)));
+    assert_eq!(id.sha, SHA_B);
+    assert!(!id.dirty);
+}
+
+#[test]
+fn resolve_unknown_when_no_source_available() {
+    let id = resolve_identity(None, None, || None);
+    assert_eq!(id.sha, "unknown", "no source must yield honest unknown");
+    assert!(!id.dirty, "unknown is never dirty");
+}
+
+// ---- surface composition ----
+
+#[test]
+fn cli_version_shapes() {
+    assert_eq!(
+        compose_cli_version("0.10.0", SHA_A, false),
+        format!("0.10.0 (build {SHA_A})")
+    );
+    assert_eq!(
+        compose_cli_version("0.10.0", SHA_A, true),
+        format!("0.10.0 (build {SHA_A} dirty)")
+    );
+    assert_eq!(
+        compose_cli_version("0.10.0", "unknown", false),
+        "0.10.0 (build unknown)"
+    );
+    // unknown never carries dirty, even if a caller passes true
+    assert_eq!(
+        compose_cli_version("0.10.0", "unknown", true),
+        "0.10.0 (build unknown)"
+    );
+}
+
+#[test]
+fn mcp_version_shapes() {
+    assert_eq!(
+        compose_mcp_version("0.10.0", SHA_A, false),
+        "0.10.0+gaaaaaaaaaaaa"
+    );
+    assert_eq!(
+        compose_mcp_version("0.10.0", SHA_A, true),
+        "0.10.0+gaaaaaaaaaaaa.dirty"
+    );
+    assert_eq!(
+        compose_mcp_version("0.10.0", "unknown", false),
+        "0.10.0",
+        "unknown omits build metadata entirely (bare, still-valid semver)"
+    );
+    assert_eq!(compose_mcp_version("0.10.0", "unknown", true), "0.10.0");
+}
+
+// ---- git probe on scratch repos (worktree / detached / dirty / no-git) ----
+
+/// Scratch repo helper: fully isolated from user/system git config and from
+/// any daemon-bound worktree (cwd is always the scratch dir — never a
+/// canonical-rooted path, so the agend-git shim pass-through is inert).
+fn scratch_dir(tag: &str) -> PathBuf {
+    let d = std::env::temp_dir().join(format!(
+        "agend-provenance-{}-{tag}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&d);
+    std::fs::create_dir_all(&d).unwrap();
+    d
+}
+
+fn git(dir: &Path, args: &[&str]) -> String {
+    let out = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_AUTHOR_NAME", "t")
+        .env("GIT_AUTHOR_EMAIL", "t@t")
+        .env("GIT_COMMITTER_NAME", "t")
+        .env("GIT_COMMITTER_EMAIL", "t@t")
+        .output()
+        .expect("spawn git");
+    assert!(
+        out.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+fn init_repo(tag: &str) -> PathBuf {
+    let d = scratch_dir(tag);
+    git(&d, &["init", "-q", "-b", "main"]);
+    std::fs::write(d.join("f.txt"), "one\n").unwrap();
+    git(&d, &["add", "f.txt"]);
+    git(&d, &["commit", "-q", "--no-gpg-sign", "-m", "c1"]);
+    d
+}
+
+#[test]
+fn probe_reads_head_sha_in_normal_repo() {
+    let d = init_repo("normal");
+    let expect = git(&d, &["rev-parse", "HEAD"]).to_lowercase();
+    let (sha, dirty) = git_probe(&d).expect("probe must resolve a git repo");
+    assert_eq!(sha, expect);
+    assert!(!dirty, "freshly committed repo must be clean");
+    let _ = std::fs::remove_dir_all(&d);
+}
+
+#[test]
+fn probe_reports_dirty_on_tracked_modification() {
+    let d = init_repo("dirty");
+    std::fs::write(d.join("f.txt"), "two\n").unwrap();
+    let (_, dirty) = git_probe(&d).expect("probe must resolve");
+    assert!(dirty, "a modified tracked file must read dirty");
+    let _ = std::fs::remove_dir_all(&d);
+}
+
+#[test]
+fn probe_resolves_detached_head() {
+    let d = init_repo("detached");
+    let expect = git(&d, &["rev-parse", "HEAD"]).to_lowercase();
+    git(&d, &["checkout", "-q", "--detach"]);
+    let (sha, _) = git_probe(&d).expect("probe must resolve detached HEAD");
+    assert_eq!(sha, expect);
+    let _ = std::fs::remove_dir_all(&d);
+}
+
+#[test]
+fn probe_resolves_linked_worktree() {
+    let d = init_repo("wt-main");
+    let wt = scratch_dir("wt-linked");
+    let _ = std::fs::remove_dir_all(&wt); // worktree add wants a fresh path
+    git(
+        &d,
+        &["worktree", "add", "-q", "-b", "t2", wt.to_str().unwrap()],
+    );
+    let expect = git(&wt, &["rev-parse", "HEAD"]).to_lowercase();
+    let (sha, dirty) = git_probe(&wt).expect("probe must resolve a linked worktree");
+    assert_eq!(sha, expect);
+    assert!(!dirty);
+    let _ = std::fs::remove_dir_all(&wt);
+    let _ = std::fs::remove_dir_all(&d);
+}
+
+#[test]
+fn probe_returns_none_outside_any_repo() {
+    let d = scratch_dir("norepo");
+    assert!(
+        git_probe(&d).is_none(),
+        "a plain directory (source archive) must probe as unknown"
+    );
+    let _ = std::fs::remove_dir_all(&d);
+}
+
+// ---- rerun trigger paths (cache-rebuild correctness) ----
+
+#[test]
+fn rerun_paths_exist_and_cover_head_in_normal_repo() {
+    let d = init_repo("rerun-normal");
+    let paths = rerun_paths(&d);
+    assert!(
+        !paths.is_empty(),
+        "a git repo must yield at least the HEAD trigger"
+    );
+    for p in &paths {
+        assert!(p.exists(), "trigger path must exist (else cargo re-runs every build): {p:?}");
+    }
+    assert!(
+        paths.iter().any(|p| p.ends_with("HEAD")),
+        "triggers must include the HEAD file: {paths:?}"
+    );
+    let _ = std::fs::remove_dir_all(&d);
+}
+
+#[test]
+fn rerun_paths_use_per_worktree_head_not_pointer_file() {
+    let d = init_repo("rerun-wt-main");
+    let wt = scratch_dir("rerun-wt-linked");
+    let _ = std::fs::remove_dir_all(&wt);
+    git(
+        &d,
+        &["worktree", "add", "-q", "-b", "t3", wt.to_str().unwrap()],
+    );
+    let paths = rerun_paths(&wt);
+    let head = paths
+        .iter()
+        .find(|p| p.ends_with("HEAD"))
+        .expect("worktree triggers must include a HEAD path");
+    assert!(head.exists());
+    assert!(
+        head.to_string_lossy().contains("worktrees"),
+        "worktree HEAD must live under <main>/.git/worktrees/<name>/ — \
+         `<wt>/.git` is a pointer FILE and `<wt>/.git/HEAD` does not exist: {head:?}"
+    );
+    let _ = std::fs::remove_dir_all(&wt);
+    let _ = std::fs::remove_dir_all(&d);
+}
+
+#[test]
+fn rerun_paths_empty_outside_any_repo() {
+    let d = scratch_dir("rerun-norepo");
+    assert!(
+        rerun_paths(&d).is_empty(),
+        "no repo ⇒ no file triggers (env triggers only; a nonexistent path would re-run every build)"
+    );
+    let _ = std::fs::remove_dir_all(&d);
+}
+
+// ---- baked build-time envs (option_env! so the RED tree compiles) ----
+
+#[test]
+fn baked_identity_envs_present_and_well_formed() {
+    let sha = option_env!("AGEND_BUILD_SHA")
+        .expect("build.rs must emit AGEND_BUILD_SHA (sha | unknown)");
+    assert!(
+        sha == "unknown" || valid_full_sha(sha),
+        "AGEND_BUILD_SHA must be a full lowercase hex SHA or 'unknown': {sha}"
+    );
+    assert_eq!(sha, sha.to_lowercase(), "baked SHA must be lowercase");
+    let dirty = option_env!("AGEND_BUILD_DIRTY")
+        .expect("build.rs must emit AGEND_BUILD_DIRTY (0|1)");
+    assert!(dirty == "0" || dirty == "1", "AGEND_BUILD_DIRTY ∈ {{0,1}}: {dirty}");
+    if sha == "unknown" {
+        assert_eq!(dirty, "0", "unknown identity is never dirty");
+    }
+}
+
+#[test]
+fn baked_surface_envs_match_composition() {
+    let sha = option_env!("AGEND_BUILD_SHA").expect("AGEND_BUILD_SHA");
+    let dirty = option_env!("AGEND_BUILD_DIRTY").expect("AGEND_BUILD_DIRTY") == "1";
+    let semver = env!("CARGO_PKG_VERSION");
+    assert_eq!(
+        option_env!("AGEND_CLI_VERSION").expect("build.rs must emit AGEND_CLI_VERSION"),
+        compose_cli_version(semver, sha, dirty),
+        "baked CLI version must equal the canonical composition"
+    );
+    assert_eq!(
+        option_env!("AGEND_MCP_VERSION").expect("build.rs must emit AGEND_MCP_VERSION"),
+        compose_mcp_version(semver, sha, dirty),
+        "baked MCP version must equal the canonical composition"
+    );
+}
+
+// ---- the real CLI surface ----
+
+#[test]
+fn cli_version_output_carries_build_identity_with_leading_compat() {
+    let out = Command::new(env!("CARGO_BIN_EXE_agend-terminal"))
+        .arg("--version")
+        .output()
+        .expect("spawn agend-terminal --version");
+    assert!(out.status.success());
+    let line = String::from_utf8_lossy(&out.stdout);
+    let line = line.trim();
+    let re = regex::Regex::new(
+        r"^agend-terminal \d+\.\d+\.\d+ \(build ([0-9a-f]{40}|[0-9a-f]{64}|unknown)( dirty)?\)$",
+    )
+    .unwrap();
+    assert!(
+        re.is_match(line),
+        "--version must keep the leading `agend-terminal <semver>` tokens (§7.1) \
+         and append `(build <sha|unknown>[ dirty])`; got: {line}"
+    );
+}
+
+// ---- MCP serverInfo wiring pin (source-level; the bridge is a separate bin) ----
+
+#[test]
+fn mcp_bridge_serverinfo_uses_baked_build_metadata_version() {
+    let src = std::fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("src/bin/agend-mcp-bridge.rs"),
+    )
+    .unwrap();
+    assert!(
+        src.contains(r#""version": env!("AGEND_MCP_VERSION")"#),
+        "serverInfo.version must be the baked semver+build-metadata string \
+         (AGEND_MCP_VERSION), not a bare CARGO_PKG_VERSION"
+    );
+}

--- a/tests/build_provenance_version.rs
+++ b/tests/build_provenance_version.rs
@@ -359,10 +359,10 @@ fn rerun_paths_empty_outside_any_repo() {
 /// The exact false-clean sequence, driven through REAL cargo builds of a
 /// hermetic fixture crate whose build.rs `include!`s the SAME provenance.rs
 /// under test: clean build shows the sha; a TRACKED edit without any HEAD
-/// move must flip the baked identity to dirty on the next cached build; a
-/// revert must flip it back to clean. r0 failed the middle step (build.rs
-/// watched only git metadata, so the incremental rebuild kept the stale
-/// clean identity).
+/// move must flip the baked identity to dirty on the next cached build;
+/// committing the edit must re-stamp clean at the NEW head. r0 failed the
+/// middle step (build.rs watched only git metadata, so the incremental
+/// rebuild kept the stale clean identity).
 #[test]
 fn cached_build_refreshes_dirty_without_head_move() {
     let repo = init_repo("nested-cargo");
@@ -406,8 +406,14 @@ fn main() {
     // Build products are gitignored so the build itself never reads dirty —
     // the "exclude target loops" boundary. Cargo.lock: cargo writes it before
     // the build script runs, so an untracked lockfile would dirty the very
-    // first build.
-    std::fs::write(repo.join(".gitignore"), "/target-fixture\nCargo.lock\n").unwrap();
+    // first build. *.profraw: a coverage-instrumented outer environment can
+    // leak instrumentation into the fixture binary (CI Coverage job), whose
+    // exit then drops an untracked profile next to the sources.
+    std::fs::write(
+        repo.join(".gitignore"),
+        "/target-fixture\nCargo.lock\n*.profraw\n",
+    )
+    .unwrap();
     git(&repo, &["add", "."]);
     git(&repo, &["commit", "-q", "--no-gpg-sign", "-m", "fixture"]);
     let head = git(&repo, &["rev-parse", "HEAD"]).to_lowercase();
@@ -417,10 +423,13 @@ fn main() {
             .args(["run", "-q"])
             .current_dir(repo)
             // Hermetic vs the outer test invocation: coverage/instrumentation
-            // flags must not leak into the fixture build.
+            // flags and wrappers must not leak into the fixture build.
             .env_remove("RUSTFLAGS")
             .env_remove("CARGO_ENCODED_RUSTFLAGS")
             .env_remove("LLVM_PROFILE_FILE")
+            .env_remove("RUSTC_WRAPPER")
+            .env_remove("RUSTC_WORKSPACE_WRAPPER")
+            .env_remove("CARGO_LLVM_COV")
             .env("CARGO_TARGET_DIR", repo.join("target-fixture"))
             .output()
             .expect("nested cargo run");
@@ -432,10 +441,12 @@ fn main() {
         String::from_utf8_lossy(&out.stdout).trim().to_string()
     };
 
+    let step1 = run_fixture(&repo);
     assert_eq!(
-        run_fixture(&repo),
+        step1,
         format!("0.1.0 (build {head})"),
-        "clean cached build must bake the exact HEAD, clean"
+        "clean cached build must bake the exact HEAD, clean; status: {:?}",
+        git(&repo, &["status", "--porcelain"])
     );
     // Tracked edit, NO HEAD movement — the r0 false-clean scenario.
     std::fs::write(
@@ -443,16 +454,27 @@ fn main() {
         "fn main() {\n    println!(\"{}\", env!(\"FIXTURE_CLI\"));\n    // edited\n}\n",
     )
     .unwrap();
+    let step2 = run_fixture(&repo);
     assert_eq!(
-        run_fixture(&repo),
+        step2,
         format!("0.1.0 (build {head} dirty)"),
-        "a tracked edit without HEAD move must flip the cached build to dirty"
+        "a tracked edit without HEAD move must flip the cached build to dirty; status: {:?}",
+        git(&repo, &["status", "--porcelain"])
     );
-    git(&repo, &["checkout", "--", "src/main.rs"]);
+    // Committing the edit returns to clean at the NEW head — the commit
+    // advances the branch ref (a git-written trigger file with a fresh
+    // mtime), so the re-stamp does not depend on worktree-file mtime
+    // granularity vs cargo's fingerprint.
+    git(&repo, &["add", "src/main.rs"]);
+    git(&repo, &["commit", "-q", "--no-gpg-sign", "-m", "c2"]);
+    let head2 = git(&repo, &["rev-parse", "HEAD"]).to_lowercase();
+    assert_ne!(head2, head, "commit must advance HEAD");
+    let step3 = run_fixture(&repo);
     assert_eq!(
-        run_fixture(&repo),
-        format!("0.1.0 (build {head})"),
-        "reverting the edit must flip the cached build back to clean"
+        step3,
+        format!("0.1.0 (build {head2})"),
+        "committing the edit must re-stamp clean at the new HEAD; status: {:?}",
+        git(&repo, &["status", "--porcelain"])
     );
     let _ = std::fs::remove_dir_all(&repo);
 }


### PR DESCRIPTION
Slice α of decision `d-20260712073535548541-12` (task `t-20260712073937810355-40783-34`) — the build-provenance foundation from RCA spike t-…40783-28 R2: a live daemon's commit identity was unknowable (attribution took ps-lstart × git-%cI × binary-mtime forensics), which let the #2743 merged≠live capability gap go undetected. **Additive strings only — strictly no `.ready`/doctor/health/restart code (slice β), no new dependencies.**

## What

`build.rs` resolves a build identity through a strict hierarchy and bakes four compile-time envs consumed by every bin in the package:

- **Hierarchy**: `AGEND_BUILD_COMMIT` env (explicit CI/release/source-archive pin; validated full 40/64-hex, lowercased; optional `AGEND_BUILD_DIRTY=1|true`; a malformed pin falls through with a `cargo:warning` — the most honest identity still available) → **worktree-safe git probe** (`git rev-parse HEAD` + `git status --porcelain -uno`; ANY git failure — including a status failure after a successful rev-parse — yields unknown, never a false-clean) → honest **`unknown`**.
- **Baked envs**: `AGEND_BUILD_SHA` (full lowercase sha | `unknown`), `AGEND_BUILD_DIRTY` (`0|1`, unknown is never dirty), and the ready-made surface strings `AGEND_CLI_VERSION` / `AGEND_MCP_VERSION` — one canonical composition, zero runtime plumbing.
- **Cache-rebuild triggers**: re-stamp on repo movement via `git rev-parse --git-path` — the **per-worktree HEAD** (a linked worktree's `.git` is a pointer FILE; a naive `.git/HEAD` path is wrong in every fleet worktree), the loose branch ref, and `packed-refs`; **existing paths only** (a registered-but-missing path makes cargo re-run every build). Documented residual: a loose ref that later becomes packed loses its trigger until the next rebuild.

## Surfaces

- CLI: `agend-terminal <semver> (build <sha|unknown>[ dirty])` — clap `version = env!("AGEND_CLI_VERSION")`; the leading `agend-terminal <semver>` tokens are byte-unchanged, so the §7.1 output-shape idiom (`^agend-terminal [0-9]`) keeps passing.
- MCP bridge serverInfo: `<semver>+g<sha12>[.dirty]` (semver §10 build metadata — existing semver parsers keep working); bare semver when unknown (honest absence).

Logic lives in `build/provenance.rs`, `include!`d by `build.rs` and `#[path]`-shared with the tests — single source of truth, testable without a lib target.

## Test-first (§3.10) — RED `987571f3` → GREEN `f91f81b0`

20 deterministic tests (no timing/network; scratch git repos under isolated temp dirs): identity validation (40/64-hex only) · env-precedence (wins over probe, lowercased, malformed falls through WITH warning, dirty flag honored) · probe on normal/dirty/detached/**linked-worktree**/no-repo · rerun trigger paths (exist-only, per-worktree HEAD under `.git/worktrees/<name>/`, empty outside a repo) · CLI/MCP composition shapes incl. unknown-never-dirty · baked-env presence + canonical-composition equality (`option_env!` so the RED tree compiles; failures are runtime, not build errors) · **spawned real-binary `--version` shape** (`CARGO_BIN_EXE_`) · bridge serverInfo wiring pin. RED: 17/20 fail (3 pass trivially by absence).

Scratch fixtures set the shim bypass env twins per the `vendor/agentic-git` test precedent — in a fleet-agent shell the `agend-git` shim's ChdirPass would otherwise answer scratch-repo `rev-parse` for the BOUND worktree (the CLAUDE.md lesson-10.7 class). Not a §3.19.1 deny-escape: read-only fixtures in isolated temp dirs; inert in CI/operator shells.

## Verification (exact head f91f81b0)

- `cargo test --test build_provenance_version` → **20/20**.
- Real binary: `agend-terminal 0.10.0 (build 987571f3… dirty)` observed during development (dirty correctly reflected the uncommitted GREEN tree).
- `rustfmt --edition 2021 --check` on the three touched Rust files → clean; `cargo clippy --test build_provenance_version --features tray` → clean.
- Full local suite / `--all-targets` clippy / repo-wide fmt are polluted by the **pre-existing vendored `agentic-git` tree and agent-shell git-shim environment** (base main 3681cc07 fails the identical full-suite run with 312 failures vs 309 at this head — all git-spawning tests, attribution verified empirically). CI on a clean runner is the authoritative gate for those.

## Rollback / compatibility

Revert ⇒ byte-identical status quo (strings only). `--version` leading tokens unchanged; serverInfo stays valid semver. `unknown` never blocks the build. Explicitly out of scope: `.ready` payload, doctor comparison, health surfaces, any restart behavior (slice β), and the hooksPath/docs decay (separate LOW task).

**Do not merge before**: codex-125550's personal review (per dispatch) + CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
