### PR TITLE
feat: Add persistent context thresholds in RuntimeConfig

### DIFF
--- a/src/daemon/per_tick/context_alert.rs
+++ b/src/daemon/per_tick/context_alert.rs
@@ -25,7 +25,7 @@ use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
 /// Default alert threshold (percent). Override: `AGEND_CONTEXT_ALERT_PCT`.
-const DEFAULT_ALERT_PCT: f32 = 80.0;
+pub(crate) const DEFAULT_ALERT_PCT: f32 = 80.0;
 /// Re-arm requires dropping this far below the threshold (compact/restart),
 /// so boundary noise can't re-fire.
 const HYSTERESIS_PCT: f32 = 5.0;
@@ -36,7 +36,7 @@ fn alert_threshold() -> f32 {
     std::env::var("AGEND_CONTEXT_ALERT_PCT")
         .ok()
         .and_then(|v| v.parse().ok())
-        .unwrap_or(DEFAULT_ALERT_PCT)
+        .unwrap_or_else(|| crate::runtime_config::get().context_alert_pct)
 }
 
 /// Per-agent alert latch.
@@ -183,6 +183,7 @@ impl PerTickHandler for ContextAlertHandler {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     const T: f32 = 80.0;
 
@@ -322,5 +323,41 @@ mod tests {
              UNCONDITIONAL, not gated on resolved_context()"
         );
         std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    #[serial(runtime_config)]
+    fn alert_threshold_precedence() {
+        // Clear global runtime config to defaults to prevent test contamination
+        let temp_dir = std::env::temp_dir().join("agend-test-clean-alert");
+        std::fs::create_dir_all(&temp_dir).ok();
+        std::fs::write(temp_dir.join("runtime-config.json"), r#"{"schema_version": 1}"#).unwrap();
+        crate::runtime_config::reload(&temp_dir);
+        std::fs::remove_dir_all(&temp_dir).ok();
+
+        // Isolate env var to prevent pollution from/to the host process
+        let old_env = std::env::var("AGEND_CONTEXT_ALERT_PCT").ok();
+        std::env::remove_var("AGEND_CONTEXT_ALERT_PCT");
+
+        // 1. Env var unset, runtime config default
+        assert_eq!(alert_threshold(), 80.0);
+
+        // 2. Env var set overrides config
+        std::env::set_var("AGEND_CONTEXT_ALERT_PCT", "55.5");
+        assert_eq!(alert_threshold(), 55.5);
+
+        // Restore env var
+        if let Some(val) = old_env {
+            std::env::set_var("AGEND_CONTEXT_ALERT_PCT", val);
+        } else {
+            std::env::remove_var("AGEND_CONTEXT_ALERT_PCT");
+        }
+
+        // Clean up global config back to default
+        let temp_dir = std::env::temp_dir().join("agend-test-clean-alert");
+        std::fs::create_dir_all(&temp_dir).ok();
+        std::fs::write(temp_dir.join("runtime-config.json"), r#"{"schema_version": 1}"#).unwrap();
+        crate::runtime_config::reload(&temp_dir);
+        std::fs::remove_dir_all(&temp_dir).ok();
     }
 }

--- a/src/daemon/per_tick/context_alert.rs
+++ b/src/daemon/per_tick/context_alert.rs
@@ -181,6 +181,7 @@ impl PerTickHandler for ContextAlertHandler {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use serial_test::serial;

--- a/src/daemon/per_tick/context_alert.rs
+++ b/src/daemon/per_tick/context_alert.rs
@@ -24,9 +24,6 @@ use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
-/// Re-arm requires dropping this far below the threshold (compact/restart),
-/// so boundary noise can't re-fire.
-const HYSTERESIS_PCT: f32 = 5.0;
 /// Re-alert cadence while usage stays continuously above the threshold.
 const REALERT_AFTER: Duration = Duration::from_secs(30 * 60);
 
@@ -67,7 +64,7 @@ fn decide(state: &mut AlertState, pct: f32, threshold: f32, now: Instant) -> boo
         }
         return false;
     }
-    if pct < threshold - HYSTERESIS_PCT {
+    if pct < threshold - crate::runtime_config::HYSTERESIS_PCT {
         state.armed = true;
     }
     false

--- a/src/daemon/per_tick/context_alert.rs
+++ b/src/daemon/per_tick/context_alert.rs
@@ -331,7 +331,11 @@ mod tests {
         // Clear global runtime config to defaults to prevent test contamination
         let temp_dir = std::env::temp_dir().join("agend-test-clean-alert");
         std::fs::create_dir_all(&temp_dir).ok();
-        std::fs::write(temp_dir.join("runtime-config.json"), r#"{"schema_version": 1}"#).unwrap();
+        std::fs::write(
+            temp_dir.join("runtime-config.json"),
+            r#"{"schema_version": 1}"#,
+        )
+        .unwrap();
         crate::runtime_config::reload(&temp_dir);
         std::fs::remove_dir_all(&temp_dir).ok();
 
@@ -356,7 +360,11 @@ mod tests {
         // Clean up global config back to default
         let temp_dir = std::env::temp_dir().join("agend-test-clean-alert");
         std::fs::create_dir_all(&temp_dir).ok();
-        std::fs::write(temp_dir.join("runtime-config.json"), r#"{"schema_version": 1}"#).unwrap();
+        std::fs::write(
+            temp_dir.join("runtime-config.json"),
+            r#"{"schema_version": 1}"#,
+        )
+        .unwrap();
         crate::runtime_config::reload(&temp_dir);
         std::fs::remove_dir_all(&temp_dir).ok();
     }

--- a/src/daemon/per_tick/context_alert.rs
+++ b/src/daemon/per_tick/context_alert.rs
@@ -24,8 +24,6 @@ use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
-/// Default alert threshold (percent). Override: `AGEND_CONTEXT_ALERT_PCT`.
-pub(crate) const DEFAULT_ALERT_PCT: f32 = 80.0;
 /// Re-arm requires dropping this far below the threshold (compact/restart),
 /// so boundary noise can't re-fire.
 const HYSTERESIS_PCT: f32 = 5.0;
@@ -33,10 +31,8 @@ const HYSTERESIS_PCT: f32 = 5.0;
 const REALERT_AFTER: Duration = Duration::from_secs(30 * 60);
 
 fn alert_threshold() -> f32 {
-    std::env::var("AGEND_CONTEXT_ALERT_PCT")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or_else(|| crate::runtime_config::get().context_alert_pct)
+    let (alert, _, _) = crate::runtime_config::resolve_effective_thresholds();
+    alert
 }
 
 /// Per-agent alert latch.
@@ -329,27 +325,31 @@ mod tests {
     #[test]
     #[serial(runtime_config)]
     fn alert_threshold_precedence() {
-        // Clear global runtime config to defaults to prevent test contamination
         let temp_dir = std::env::temp_dir().join("agend-test-clean-alert");
         std::fs::create_dir_all(&temp_dir).ok();
+
+        // 1. Write non-default valid config to check loader/consumer fallback
         std::fs::write(
             temp_dir.join("runtime-config.json"),
-            r#"{"schema_version": 1}"#,
+            r#"{"schema_version": 1, "context_alert_pct": 60.0, "context_handoff_pct": 70.0, "context_handoff_escalate_pct": 80.0}"#,
         )
         .unwrap();
         crate::runtime_config::reload(&temp_dir);
-        std::fs::remove_dir_all(&temp_dir).ok();
 
-        // Isolate env var to prevent pollution from/to the host process
         let old_env = std::env::var("AGEND_CONTEXT_ALERT_PCT").ok();
         std::env::remove_var("AGEND_CONTEXT_ALERT_PCT");
 
-        // 1. Env var unset, runtime config default
-        assert_eq!(alert_threshold(), 80.0);
+        // Runtime config non-default value resolved
+        assert_eq!(alert_threshold(), 60.0);
 
         // 2. Env var set overrides config
         std::env::set_var("AGEND_CONTEXT_ALERT_PCT", "55.5");
         assert_eq!(alert_threshold(), 55.5);
+
+        // 3. Invalid env var resolved combination falls back to config value
+        // alert 95.0, handoff in config is 70.0 -> invalid triplet combination (alert >= handoff), should fallback to config (60.0)
+        std::env::set_var("AGEND_CONTEXT_ALERT_PCT", "95.0");
+        assert_eq!(alert_threshold(), 60.0);
 
         // Restore env var
         if let Some(val) = old_env {
@@ -359,8 +359,6 @@ mod tests {
         }
 
         // Clean up global config back to default
-        let temp_dir = std::env::temp_dir().join("agend-test-clean-alert");
-        std::fs::create_dir_all(&temp_dir).ok();
         std::fs::write(
             temp_dir.join("runtime-config.json"),
             r#"{"schema_version": 1}"#,

--- a/src/daemon/per_tick/context_handoff.rs
+++ b/src/daemon/per_tick/context_handoff.rs
@@ -33,10 +33,6 @@ use super::{PerTickHandler, TickContext};
 use parking_lot::Mutex;
 use std::collections::HashMap;
 
-/// Re-arm requires dropping this far below the handoff threshold
-/// (compact/restart), so boundary wobble can't start a second episode.
-const HYSTERESIS_PCT: f32 = 5.0;
-
 /// The handoff file the injection asks for, relative to the agent's
 /// working directory. Matches the manual-rescue convention from the 6/10
 /// incident.
@@ -101,7 +97,7 @@ fn decide(
     escalate_pct: f32,
 ) -> Option<Action> {
     // Auto-resolve (silent): compact/restart dropped the usage — re-arm.
-    if pct < handoff_pct - HYSTERESIS_PCT {
+    if pct < handoff_pct - crate::runtime_config::HYSTERESIS_PCT {
         state.phase = Phase::Armed;
         return None;
     }

--- a/src/daemon/per_tick/context_handoff.rs
+++ b/src/daemon/per_tick/context_handoff.rs
@@ -568,7 +568,11 @@ mod tests {
         // Clear global runtime config to defaults to prevent test contamination
         let temp_dir = std::env::temp_dir().join("agend-test-clean-handoff");
         std::fs::create_dir_all(&temp_dir).ok();
-        std::fs::write(temp_dir.join("runtime-config.json"), r#"{"schema_version": 1}"#).unwrap();
+        std::fs::write(
+            temp_dir.join("runtime-config.json"),
+            r#"{"schema_version": 1}"#,
+        )
+        .unwrap();
         crate::runtime_config::reload(&temp_dir);
         std::fs::remove_dir_all(&temp_dir).ok();
 
@@ -603,7 +607,11 @@ mod tests {
         // Clean up global config back to default
         let temp_dir = std::env::temp_dir().join("agend-test-clean-handoff");
         std::fs::create_dir_all(&temp_dir).ok();
-        std::fs::write(temp_dir.join("runtime-config.json"), r#"{"schema_version": 1}"#).unwrap();
+        std::fs::write(
+            temp_dir.join("runtime-config.json"),
+            r#"{"schema_version": 1}"#,
+        )
+        .unwrap();
         crate::runtime_config::reload(&temp_dir);
         std::fs::remove_dir_all(&temp_dir).ok();
     }

--- a/src/daemon/per_tick/context_handoff.rs
+++ b/src/daemon/per_tick/context_handoff.rs
@@ -33,10 +33,6 @@ use super::{PerTickHandler, TickContext};
 use parking_lot::Mutex;
 use std::collections::HashMap;
 
-pub(crate) const DEFAULT_HANDOFF_PCT: f32 = 85.0;
-/// Operator-escalation threshold (percent). Override:
-/// `AGEND_CONTEXT_HANDOFF_ESCALATE_PCT`.
-pub(crate) const DEFAULT_ESCALATE_PCT: f32 = 92.0;
 /// Re-arm requires dropping this far below the handoff threshold
 /// (compact/restart), so boundary wobble can't start a second episode.
 const HYSTERESIS_PCT: f32 = 5.0;
@@ -47,17 +43,13 @@ const HYSTERESIS_PCT: f32 = 5.0;
 pub(crate) const HANDOFF_FILENAME: &str = "SESSION-HANDOFF.md";
 
 fn handoff_threshold() -> f32 {
-    std::env::var("AGEND_CONTEXT_HANDOFF_PCT")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or_else(|| crate::runtime_config::get().context_handoff_pct)
+    let (_, handoff, _) = crate::runtime_config::resolve_effective_thresholds();
+    handoff
 }
 
 fn escalate_threshold() -> f32 {
-    std::env::var("AGEND_CONTEXT_HANDOFF_ESCALATE_PCT")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or_else(|| crate::runtime_config::get().context_handoff_escalate_pct)
+    let (_, _, escalate) = crate::runtime_config::resolve_effective_thresholds();
+    escalate
 }
 
 /// Episode phase per agent. One episode = one continuous stay above the
@@ -565,32 +557,38 @@ mod tests {
     #[test]
     #[serial(runtime_config)]
     fn handoff_threshold_precedence() {
-        // Clear global runtime config to defaults to prevent test contamination
         let temp_dir = std::env::temp_dir().join("agend-test-clean-handoff");
         std::fs::create_dir_all(&temp_dir).ok();
+
+        // 1. Write non-default valid config to check loader/consumer fallback
         std::fs::write(
             temp_dir.join("runtime-config.json"),
-            r#"{"schema_version": 1}"#,
+            r#"{"schema_version": 1, "context_alert_pct": 60.0, "context_handoff_pct": 70.0, "context_handoff_escalate_pct": 80.0}"#,
         )
         .unwrap();
         crate::runtime_config::reload(&temp_dir);
-        std::fs::remove_dir_all(&temp_dir).ok();
 
-        // Isolate env vars to prevent pollution from/to the host process
         let old_handoff = std::env::var("AGEND_CONTEXT_HANDOFF_PCT").ok();
         let old_escalate = std::env::var("AGEND_CONTEXT_HANDOFF_ESCALATE_PCT").ok();
         std::env::remove_var("AGEND_CONTEXT_HANDOFF_PCT");
         std::env::remove_var("AGEND_CONTEXT_HANDOFF_ESCALATE_PCT");
 
-        // 1. Env var unset, runtime config default
-        assert_eq!(handoff_threshold(), 85.0);
-        assert_eq!(escalate_threshold(), 92.0);
+        // Runtime config non-default value resolved
+        assert_eq!(handoff_threshold(), 70.0);
+        assert_eq!(escalate_threshold(), 80.0);
 
         // 2. Env var set overrides config
         std::env::set_var("AGEND_CONTEXT_HANDOFF_PCT", "65.5");
         std::env::set_var("AGEND_CONTEXT_HANDOFF_ESCALATE_PCT", "75.5");
         assert_eq!(handoff_threshold(), 65.5);
         assert_eq!(escalate_threshold(), 75.5);
+
+        // 3. Invalid env var resolved combination falls back to config value
+        // handoff 90.0, escalate 85.0 -> invalid triplet combination (handoff >= escalate), should fallback to config (handoff=70.0, escalate=80.0)
+        std::env::set_var("AGEND_CONTEXT_HANDOFF_PCT", "90.0");
+        std::env::set_var("AGEND_CONTEXT_HANDOFF_ESCALATE_PCT", "85.0");
+        assert_eq!(handoff_threshold(), 70.0);
+        assert_eq!(escalate_threshold(), 80.0);
 
         // Restore env vars
         if let Some(val) = old_handoff {
@@ -605,8 +603,6 @@ mod tests {
         }
 
         // Clean up global config back to default
-        let temp_dir = std::env::temp_dir().join("agend-test-clean-handoff");
-        std::fs::create_dir_all(&temp_dir).ok();
         std::fs::write(
             temp_dir.join("runtime-config.json"),
             r#"{"schema_version": 1}"#,

--- a/src/daemon/per_tick/context_handoff.rs
+++ b/src/daemon/per_tick/context_handoff.rs
@@ -38,14 +38,13 @@ use std::collections::HashMap;
 /// incident.
 pub(crate) const HANDOFF_FILENAME: &str = "SESSION-HANDOFF.md";
 
-fn handoff_threshold() -> f32 {
-    let (_, handoff, _) = crate::runtime_config::resolve_effective_thresholds();
-    handoff
-}
-
-fn escalate_threshold() -> f32 {
-    let (_, _, escalate) = crate::runtime_config::resolve_effective_thresholds();
-    escalate
+/// One resolve per tick: handoff and escalate must come from the SAME
+/// effective-triplet snapshot, so a config reload / env change between two
+/// separate resolves can't hand `decide` a torn pair. Overrides:
+/// `AGEND_CONTEXT_HANDOFF_PCT` / `AGEND_CONTEXT_HANDOFF_ESCALATE_PCT`.
+fn tick_thresholds() -> (f32, f32) {
+    let (_, handoff, escalate) = crate::runtime_config::resolve_effective_thresholds();
+    (handoff, escalate)
 }
 
 /// Episode phase per agent. One episode = one continuous stay above the
@@ -243,8 +242,7 @@ impl PerTickHandler for ContextHandoffHandler {
             live
         };
 
-        let handoff_pct = handoff_threshold();
-        let escalate_pct = escalate_threshold();
+        let (handoff_pct, escalate_pct) = tick_thresholds();
         let now_ms = chrono::Utc::now().timestamp_millis();
         let mut states = self.states.lock();
         for (name, pct, is_idle) in snapshot {
@@ -570,21 +568,18 @@ mod tests {
         std::env::remove_var("AGEND_CONTEXT_HANDOFF_ESCALATE_PCT");
 
         // Runtime config non-default value resolved
-        assert_eq!(handoff_threshold(), 70.0);
-        assert_eq!(escalate_threshold(), 80.0);
+        assert_eq!(tick_thresholds(), (70.0, 80.0));
 
         // 2. Env var set overrides config
         std::env::set_var("AGEND_CONTEXT_HANDOFF_PCT", "65.5");
         std::env::set_var("AGEND_CONTEXT_HANDOFF_ESCALATE_PCT", "75.5");
-        assert_eq!(handoff_threshold(), 65.5);
-        assert_eq!(escalate_threshold(), 75.5);
+        assert_eq!(tick_thresholds(), (65.5, 75.5));
 
         // 3. Invalid env var resolved combination falls back to config value
         // handoff 90.0, escalate 85.0 -> invalid triplet combination (handoff >= escalate), should fallback to config (handoff=70.0, escalate=80.0)
         std::env::set_var("AGEND_CONTEXT_HANDOFF_PCT", "90.0");
         std::env::set_var("AGEND_CONTEXT_HANDOFF_ESCALATE_PCT", "85.0");
-        assert_eq!(handoff_threshold(), 70.0);
-        assert_eq!(escalate_threshold(), 80.0);
+        assert_eq!(tick_thresholds(), (70.0, 80.0));
 
         // Restore env vars
         if let Some(val) = old_handoff {
@@ -605,6 +600,35 @@ mod tests {
         )
         .unwrap();
         crate::runtime_config::reload(&temp_dir);
+        std::fs::remove_dir_all(&temp_dir).ok();
+    }
+
+    /// #2753 final review: handoff+escalate must come from ONE
+    /// `resolve_effective_thresholds` snapshot per tick — two separate resolves
+    /// can tear the pair when a config reload / env change lands between them,
+    /// handing `decide` a handoff from one triplet and an escalate from another.
+    #[test]
+    #[serial(runtime_config)]
+    fn tick_resolves_one_threshold_snapshot() {
+        let temp_dir = std::env::temp_dir().join("agend-test-handoff-snapshot");
+        std::fs::create_dir_all(&temp_dir).ok();
+        std::fs::write(
+            temp_dir.join("runtime-config.json"),
+            r#"{"schema_version": 1}"#,
+        )
+        .unwrap();
+        crate::runtime_config::reload(&temp_dir);
+
+        let before = crate::runtime_config::resolve_calls_this_thread();
+        let (handoff, escalate) = tick_thresholds();
+        let resolves = crate::runtime_config::resolve_calls_this_thread() - before;
+        assert_eq!(
+            resolves, 1,
+            "handoff and escalate must be read from the SAME effective-triplet resolve"
+        );
+        // Any resolve output is a validated triplet (or the validated fallback),
+        // so the pair is ordered by construction.
+        assert!(handoff < escalate);
         std::fs::remove_dir_all(&temp_dir).ok();
     }
 }

--- a/src/daemon/per_tick/context_handoff.rs
+++ b/src/daemon/per_tick/context_handoff.rs
@@ -33,11 +33,10 @@ use super::{PerTickHandler, TickContext};
 use parking_lot::Mutex;
 use std::collections::HashMap;
 
-/// Handoff-injection threshold (percent). Override: `AGEND_CONTEXT_HANDOFF_PCT`.
-const DEFAULT_HANDOFF_PCT: f32 = 85.0;
+pub(crate) const DEFAULT_HANDOFF_PCT: f32 = 85.0;
 /// Operator-escalation threshold (percent). Override:
 /// `AGEND_CONTEXT_HANDOFF_ESCALATE_PCT`.
-const DEFAULT_ESCALATE_PCT: f32 = 92.0;
+pub(crate) const DEFAULT_ESCALATE_PCT: f32 = 92.0;
 /// Re-arm requires dropping this far below the handoff threshold
 /// (compact/restart), so boundary wobble can't start a second episode.
 const HYSTERESIS_PCT: f32 = 5.0;
@@ -51,14 +50,14 @@ fn handoff_threshold() -> f32 {
     std::env::var("AGEND_CONTEXT_HANDOFF_PCT")
         .ok()
         .and_then(|v| v.parse().ok())
-        .unwrap_or(DEFAULT_HANDOFF_PCT)
+        .unwrap_or_else(|| crate::runtime_config::get().context_handoff_pct)
 }
 
 fn escalate_threshold() -> f32 {
     std::env::var("AGEND_CONTEXT_HANDOFF_ESCALATE_PCT")
         .ok()
         .and_then(|v| v.parse().ok())
-        .unwrap_or(DEFAULT_ESCALATE_PCT)
+        .unwrap_or_else(|| crate::runtime_config::get().context_handoff_escalate_pct)
 }
 
 /// Episode phase per agent. One episode = one continuous stay above the
@@ -353,6 +352,7 @@ impl PerTickHandler for ContextHandoffHandler {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     const HP: f32 = 85.0;
     const EP: f32 = 92.0;
@@ -560,5 +560,51 @@ mod tests {
              must be UNCONDITIONAL, not gated on resolved_context()"
         );
         std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    #[serial(runtime_config)]
+    fn handoff_threshold_precedence() {
+        // Clear global runtime config to defaults to prevent test contamination
+        let temp_dir = std::env::temp_dir().join("agend-test-clean-handoff");
+        std::fs::create_dir_all(&temp_dir).ok();
+        std::fs::write(temp_dir.join("runtime-config.json"), r#"{"schema_version": 1}"#).unwrap();
+        crate::runtime_config::reload(&temp_dir);
+        std::fs::remove_dir_all(&temp_dir).ok();
+
+        // Isolate env vars to prevent pollution from/to the host process
+        let old_handoff = std::env::var("AGEND_CONTEXT_HANDOFF_PCT").ok();
+        let old_escalate = std::env::var("AGEND_CONTEXT_HANDOFF_ESCALATE_PCT").ok();
+        std::env::remove_var("AGEND_CONTEXT_HANDOFF_PCT");
+        std::env::remove_var("AGEND_CONTEXT_HANDOFF_ESCALATE_PCT");
+
+        // 1. Env var unset, runtime config default
+        assert_eq!(handoff_threshold(), 85.0);
+        assert_eq!(escalate_threshold(), 92.0);
+
+        // 2. Env var set overrides config
+        std::env::set_var("AGEND_CONTEXT_HANDOFF_PCT", "65.5");
+        std::env::set_var("AGEND_CONTEXT_HANDOFF_ESCALATE_PCT", "75.5");
+        assert_eq!(handoff_threshold(), 65.5);
+        assert_eq!(escalate_threshold(), 75.5);
+
+        // Restore env vars
+        if let Some(val) = old_handoff {
+            std::env::set_var("AGEND_CONTEXT_HANDOFF_PCT", val);
+        } else {
+            std::env::remove_var("AGEND_CONTEXT_HANDOFF_PCT");
+        }
+        if let Some(val) = old_escalate {
+            std::env::set_var("AGEND_CONTEXT_HANDOFF_ESCALATE_PCT", val);
+        } else {
+            std::env::remove_var("AGEND_CONTEXT_HANDOFF_ESCALATE_PCT");
+        }
+
+        // Clean up global config back to default
+        let temp_dir = std::env::temp_dir().join("agend-test-clean-handoff");
+        std::fs::create_dir_all(&temp_dir).ok();
+        std::fs::write(temp_dir.join("runtime-config.json"), r#"{"schema_version": 1}"#).unwrap();
+        crate::runtime_config::reload(&temp_dir);
+        std::fs::remove_dir_all(&temp_dir).ok();
     }
 }

--- a/src/runtime_config.rs
+++ b/src/runtime_config.rs
@@ -110,6 +110,14 @@ pub const DEFAULT_ALERT_PCT: f32 = 80.0;
 pub const DEFAULT_HANDOFF_PCT: f32 = 85.0;
 pub const DEFAULT_ESCALATE_PCT: f32 = 92.0;
 
+/// Re-arm requires the usage to drop this far below a threshold (compact/restart)
+/// before a handler's latch re-arms — the single source of truth shared by the
+/// per-tick consumers (`context_alert`/`context_handoff`) AND by
+/// `validate_thresholds`' lower bound: a threshold <= this floor makes the
+/// re-arm condition `pct < threshold - HYSTERESIS_PCT` impossible, so such
+/// values are rejected as invalid.
+pub const HYSTERESIS_PCT: f32 = 5.0;
+
 fn default_dev_idle() -> i64 {
     3600
 }
@@ -225,18 +233,21 @@ pub fn validate_thresholds(alert: f32, handoff: f32, escalate: f32) -> Result<()
     if !alert.is_finite() || !handoff.is_finite() || !escalate.is_finite() {
         return Err("values must be finite".to_string());
     }
-    // Hysteresis is 5.0, so values <= 5.0 are invalid.
-    if alert <= 5.0 || alert > 100.0 {
-        return Err(format!("alert_pct must be in (5.0, 100.0], got {alert}"));
-    }
-    if handoff <= 5.0 || handoff > 100.0 {
+    // Values <= HYSTERESIS_PCT are invalid: the re-arm condition
+    // `pct < threshold - HYSTERESIS_PCT` would be impossible, wedging the latch.
+    if alert <= HYSTERESIS_PCT || alert > 100.0 {
         return Err(format!(
-            "handoff_pct must be in (5.0, 100.0], got {handoff}"
+            "alert_pct must be in ({HYSTERESIS_PCT}, 100.0], got {alert}"
         ));
     }
-    if escalate <= 5.0 || escalate > 100.0 {
+    if handoff <= HYSTERESIS_PCT || handoff > 100.0 {
         return Err(format!(
-            "escalate_pct must be in (5.0, 100.0], got {escalate}"
+            "handoff_pct must be in ({HYSTERESIS_PCT}, 100.0], got {handoff}"
+        ));
+    }
+    if escalate <= HYSTERESIS_PCT || escalate > 100.0 {
+        return Err(format!(
+            "escalate_pct must be in ({HYSTERESIS_PCT}, 100.0], got {escalate}"
         ));
     }
     if alert >= handoff {
@@ -844,5 +855,35 @@ mod tests {
         assert_eq!(get_key("context_handoff_escalate_pct").unwrap(), "70.2");
 
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// Pins the single-source-of-truth coupling: `validate_thresholds`' lower
+    /// bound IS `HYSTERESIS_PCT` and is exclusive. A threshold exactly at the
+    /// floor is rejected (the re-arm condition `pct < threshold - HYSTERESIS_PCT`
+    /// would be impossible); a value just above it (with valid ordered
+    /// handoff/escalate) is accepted. If someone re-tunes `HYSTERESIS_PCT`, the
+    /// validate bound moves with it — they cannot drift apart.
+    #[test]
+    fn validate_lower_bound_is_hysteresis_pct_single_source() {
+        // Exactly at the floor is out of the exclusive lower bound → Err.
+        assert!(
+            validate_thresholds(
+                HYSTERESIS_PCT,
+                HYSTERESIS_PCT + 10.0,
+                HYSTERESIS_PCT + 20.0
+            )
+            .is_err(),
+            "a threshold == HYSTERESIS_PCT must be rejected (exclusive lower bound)"
+        );
+        // Just above the floor, ordered handoff/escalate → Ok.
+        assert!(
+            validate_thresholds(
+                HYSTERESIS_PCT + 0.1,
+                HYSTERESIS_PCT + 10.0,
+                HYSTERESIS_PCT + 20.0
+            )
+            .is_ok(),
+            "a threshold just above HYSTERESIS_PCT (ordered) must be accepted"
+        );
     }
 }

--- a/src/runtime_config.rs
+++ b/src/runtime_config.rs
@@ -84,6 +84,15 @@ pub struct RuntimeConfig {
     /// bump — only a non-additive change to an existing field does.
     #[serde(default)]
     pub schema_version: u32,
+    /// Context-window usage percent at which the per-tick context-alert watchdog notifies.
+    #[serde(default = "default_context_alert")]
+    pub context_alert_pct: f32,
+    /// Context-window usage percent at which the context-handoff watchdog injects a handoff request.
+    #[serde(default = "default_context_handoff")]
+    pub context_handoff_pct: f32,
+    /// Higher context-window percent at which the handoff watchdog escalates to the operator.
+    #[serde(default = "default_context_handoff_escalate")]
+    pub context_handoff_escalate_pct: f32,
 }
 
 impl SchemaVersioned for RuntimeConfig {
@@ -106,6 +115,15 @@ fn default_fleet_idle() -> i64 {
 fn default_fleet_ack_ttl() -> i64 {
     2700
 }
+fn default_context_alert() -> f32 {
+    crate::daemon::per_tick::context_alert::DEFAULT_ALERT_PCT
+}
+fn default_context_handoff() -> f32 {
+    crate::daemon::per_tick::context_handoff::DEFAULT_HANDOFF_PCT
+}
+fn default_context_handoff_escalate() -> f32 {
+    crate::daemon::per_tick::context_handoff::DEFAULT_ESCALATE_PCT
+}
 
 impl Default for RuntimeConfig {
     fn default() -> Self {
@@ -120,6 +138,9 @@ impl Default for RuntimeConfig {
             copy_on_select: true,
             dim_unfocused_panes: true,
             observed_badge: true,
+            context_alert_pct: default_context_alert(),
+            context_handoff_pct: default_context_handoff(),
+            context_handoff_escalate_pct: default_context_handoff_escalate(),
             schema_version: RuntimeConfig::CURRENT,
         }
     }
@@ -300,6 +321,21 @@ pub fn set(home: &Path, key: &str, value: &str) -> Result<String, String> {
                 _ => return Err(format!("invalid boolean: {value} (use on/off)")),
             };
         }
+        "context_alert_pct" => {
+            config.context_alert_pct = value
+                .parse()
+                .map_err(|_| format!("invalid float: {value}"))?;
+        }
+        "context_handoff_pct" => {
+            config.context_handoff_pct = value
+                .parse()
+                .map_err(|_| format!("invalid float: {value}"))?;
+        }
+        "context_handoff_escalate_pct" => {
+            config.context_handoff_escalate_pct = value
+                .parse()
+                .map_err(|_| format!("invalid float: {value}"))?;
+        }
         _ => return Err(format!("unknown config key: {key}")),
     }
     let path = home.join("runtime-config.json");
@@ -345,6 +381,9 @@ pub fn get_key(key: &str) -> Result<String, String> {
         "copy_on_select" => Ok(config.copy_on_select.to_string()),
         "dim_unfocused_panes" => Ok(config.dim_unfocused_panes.to_string()),
         "observed_badge" => Ok(config.observed_badge.to_string()),
+        "context_alert_pct" => Ok(config.context_alert_pct.to_string()),
+        "context_handoff_pct" => Ok(config.context_handoff_pct.to_string()),
+        "context_handoff_escalate_pct" => Ok(config.context_handoff_escalate_pct.to_string()),
         _ => Err(format!("unknown config key: {key}")),
     }
 }
@@ -674,6 +713,26 @@ mod tests {
             disk.contains("999"),
             "the future-version file must be left intact, not downgraded: {disk}"
         );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    #[serial(runtime_config)]
+    fn context_pcts_default_and_toggleable() {
+        let c = RuntimeConfig::default();
+        assert_eq!(c.context_alert_pct, 80.0);
+        assert_eq!(c.context_handoff_pct, 85.0);
+        assert_eq!(c.context_handoff_escalate_pct, 92.0);
+
+        let dir = std::env::temp_dir().join("agend-test-runtime-config-ctxpct");
+        std::fs::create_dir_all(&dir).ok();
+        set(&dir, "context_alert_pct", "60").unwrap();
+        set(&dir, "context_handoff_pct", "65.5").unwrap();
+        set(&dir, "context_handoff_escalate_pct", "70.2").unwrap();
+        reload(&dir);
+        assert_eq!(get_key("context_alert_pct").unwrap(), "60");
+        assert_eq!(get_key("context_handoff_pct").unwrap(), "65.5");
+        assert_eq!(get_key("context_handoff_escalate_pct").unwrap(), "70.2");
         std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/src/runtime_config.rs
+++ b/src/runtime_config.rs
@@ -106,6 +106,10 @@ fn default_true() -> bool {
     true
 }
 
+pub const DEFAULT_ALERT_PCT: f32 = 80.0;
+pub const DEFAULT_HANDOFF_PCT: f32 = 85.0;
+pub const DEFAULT_ESCALATE_PCT: f32 = 92.0;
+
 fn default_dev_idle() -> i64 {
     3600
 }
@@ -116,13 +120,13 @@ fn default_fleet_ack_ttl() -> i64 {
     2700
 }
 fn default_context_alert() -> f32 {
-    crate::daemon::per_tick::context_alert::DEFAULT_ALERT_PCT
+    DEFAULT_ALERT_PCT
 }
 fn default_context_handoff() -> f32 {
-    crate::daemon::per_tick::context_handoff::DEFAULT_HANDOFF_PCT
+    DEFAULT_HANDOFF_PCT
 }
 fn default_context_handoff_escalate() -> f32 {
-    crate::daemon::per_tick::context_handoff::DEFAULT_ESCALATE_PCT
+    DEFAULT_ESCALATE_PCT
 }
 
 impl Default for RuntimeConfig {
@@ -192,8 +196,16 @@ pub fn reload(home: &Path) {
                 ),
             ),
             Ok(config) => {
-                *global().write() = config;
-                CORRUPT_WARNED.store(false, Ordering::Relaxed);
+                if let Err(msg) = validate_thresholds(
+                    config.context_alert_pct,
+                    config.context_handoff_pct,
+                    config.context_handoff_escalate_pct,
+                ) {
+                    fail_closed(is_startup, &format!("invalid context thresholds: {msg}"));
+                } else {
+                    *global().write() = config;
+                    CORRUPT_WARNED.store(false, Ordering::Relaxed);
+                }
             }
             Err(e) => fail_closed(is_startup, &format!("unparseable: {e}")),
         },
@@ -204,6 +216,78 @@ pub fn reload(home: &Path) {
         Err(_) => {
             // Vanished at runtime — keep last-known-good rather than resetting.
             fail_closed(false, "runtime-config.json disappeared");
+        }
+    }
+}
+
+/// Validate the context threshold values triplet semantically.
+pub fn validate_thresholds(alert: f32, handoff: f32, escalate: f32) -> Result<(), String> {
+    if !alert.is_finite() || !handoff.is_finite() || !escalate.is_finite() {
+        return Err("values must be finite".to_string());
+    }
+    // Hysteresis is 5.0, so values <= 5.0 are invalid.
+    if alert <= 5.0 || alert > 100.0 {
+        return Err(format!("alert_pct must be in (5.0, 100.0], got {alert}"));
+    }
+    if handoff <= 5.0 || handoff > 100.0 {
+        return Err(format!(
+            "handoff_pct must be in (5.0, 100.0], got {handoff}"
+        ));
+    }
+    if escalate <= 5.0 || escalate > 100.0 {
+        return Err(format!(
+            "escalate_pct must be in (5.0, 100.0], got {escalate}"
+        ));
+    }
+    if alert >= handoff {
+        return Err(format!(
+            "alert_pct ({alert}) must be less than handoff_pct ({handoff})"
+        ));
+    }
+    if handoff >= escalate {
+        return Err(format!(
+            "handoff_pct ({handoff}) must be less than escalate_pct ({escalate})"
+        ));
+    }
+    Ok(())
+}
+
+/// Resolve and validate the effective context threshold triplet.
+/// Checks the environment variables first, falling back to RuntimeConfig, then to defaults.
+pub fn resolve_effective_thresholds() -> (f32, f32, f32) {
+    let config = get();
+    let alert = std::env::var("AGEND_CONTEXT_ALERT_PCT")
+        .ok()
+        .and_then(|v| v.parse::<f32>().ok())
+        .unwrap_or(config.context_alert_pct);
+    let handoff = std::env::var("AGEND_CONTEXT_HANDOFF_PCT")
+        .ok()
+        .and_then(|v| v.parse::<f32>().ok())
+        .unwrap_or(config.context_handoff_pct);
+    let escalate = std::env::var("AGEND_CONTEXT_HANDOFF_ESCALATE_PCT")
+        .ok()
+        .and_then(|v| v.parse::<f32>().ok())
+        .unwrap_or(config.context_handoff_escalate_pct);
+
+    if validate_thresholds(alert, handoff, escalate).is_ok() {
+        (alert, handoff, escalate)
+    } else {
+        tracing::warn!(
+            alert,
+            handoff,
+            escalate,
+            config_alert = config.context_alert_pct,
+            config_handoff = config.context_handoff_pct,
+            config_escalate = config.context_handoff_escalate_pct,
+            "effective context thresholds combination is invalid. falling back to runtime config values."
+        );
+        let fallback_alert = config.context_alert_pct;
+        let fallback_handoff = config.context_handoff_pct;
+        let fallback_escalate = config.context_handoff_escalate_pct;
+        if validate_thresholds(fallback_alert, fallback_handoff, fallback_escalate).is_ok() {
+            (fallback_alert, fallback_handoff, fallback_escalate)
+        } else {
+            (DEFAULT_ALERT_PCT, DEFAULT_HANDOFF_PCT, DEFAULT_ESCALATE_PCT)
         }
     }
 }
@@ -338,6 +422,11 @@ pub fn set(home: &Path, key: &str, value: &str) -> Result<String, String> {
         }
         _ => return Err(format!("unknown config key: {key}")),
     }
+    validate_thresholds(
+        config.context_alert_pct,
+        config.context_handoff_pct,
+        config.context_handoff_escalate_pct,
+    )?;
     let path = home.join("runtime-config.json");
     // #1990 (reviewer-2 P1): `config` comes from in-memory `get()` (the
     // keep-last-good snapshot), NOT the disk file — so a blind write here would
@@ -726,6 +815,8 @@ mod tests {
 
         let dir = std::env::temp_dir().join("agend-test-runtime-config-ctxpct");
         std::fs::create_dir_all(&dir).ok();
+
+        // Test valid setting
         set(&dir, "context_alert_pct", "60").unwrap();
         set(&dir, "context_handoff_pct", "65.5").unwrap();
         set(&dir, "context_handoff_escalate_pct", "70.2").unwrap();
@@ -733,6 +824,25 @@ mod tests {
         assert_eq!(get_key("context_alert_pct").unwrap(), "60");
         assert_eq!(get_key("context_handoff_pct").unwrap(), "65.5");
         assert_eq!(get_key("context_handoff_escalate_pct").unwrap(), "70.2");
+
+        // Test invalid setting (setting a value that breaks order or bounds must return Err)
+        assert!(set(&dir, "context_alert_pct", "80.0").is_err()); // alert 80.0 >= handoff 65.5
+        assert!(set(&dir, "context_handoff_pct", "4.0").is_err()); // handoff <= 5.0 (hysteresis)
+        assert!(set(&dir, "context_handoff_escalate_pct", "NaN").is_err()); // NaN is not finite
+
+        // Test invalid disk configuration reload keeps last known good
+        // Write invalid reload file directly
+        std::fs::write(
+            dir.join("runtime-config.json"),
+            r#"{"schema_version": 1, "context_alert_pct": 95.0, "context_handoff_pct": 70.0, "context_handoff_escalate_pct": 80.0}"#,
+        )
+        .unwrap();
+        reload(&dir);
+        // Kept last good (60.0 / 65.5 / 70.2)
+        assert_eq!(get_key("context_alert_pct").unwrap(), "60");
+        assert_eq!(get_key("context_handoff_pct").unwrap(), "65.5");
+        assert_eq!(get_key("context_handoff_escalate_pct").unwrap(), "70.2");
+
         std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/src/runtime_config.rs
+++ b/src/runtime_config.rs
@@ -886,4 +886,50 @@ mod tests {
             "a threshold just above HYSTERESIS_PCT (ordered) must be accepted"
         );
     }
+
+    /// Reviewer follow-up: `set()`'s NaN rejection is tested, but the ENV path
+    /// wasn't. `"NaN".parse::<f32>()` returns `Ok(NaN)`, so a NaN env override
+    /// must NOT silently poison the effective threshold (which would disable the
+    /// watchdog) — `resolve_effective_thresholds` must fall back to the config
+    /// value because `validate_thresholds` rejects the non-finite triplet.
+    #[test]
+    #[serial(runtime_config)]
+    fn nan_env_override_falls_back_not_poisons() {
+        let dir = std::env::temp_dir().join("agend-test-runtime-config-nanenv");
+        std::fs::create_dir_all(&dir).ok();
+
+        // Known-good config so the fallback value is deterministic.
+        std::fs::write(
+            dir.join("runtime-config.json"),
+            r#"{"schema_version": 1, "context_alert_pct": 60.0, "context_handoff_pct": 70.0, "context_handoff_escalate_pct": 80.0}"#,
+        )
+        .unwrap();
+        reload(&dir);
+
+        let old_env = std::env::var("AGEND_CONTEXT_ALERT_PCT").ok();
+        std::env::set_var("AGEND_CONTEXT_ALERT_PCT", "NaN");
+
+        let (alert, _, _) = resolve_effective_thresholds();
+        assert!(
+            alert.is_finite(),
+            "a NaN env override must not poison the effective alert threshold"
+        );
+        assert_eq!(
+            alert, 60.0,
+            "NaN env value is rejected → falls back to the config value"
+        );
+
+        if let Some(val) = old_env {
+            std::env::set_var("AGEND_CONTEXT_ALERT_PCT", val);
+        } else {
+            std::env::remove_var("AGEND_CONTEXT_ALERT_PCT");
+        }
+        std::fs::write(
+            dir.join("runtime-config.json"),
+            r#"{"schema_version": 1}"#,
+        )
+        .unwrap();
+        reload(&dir);
+        std::fs::remove_dir_all(&dir).ok();
+    }
 }

--- a/src/runtime_config.rs
+++ b/src/runtime_config.rs
@@ -867,12 +867,8 @@ mod tests {
     fn validate_lower_bound_is_hysteresis_pct_single_source() {
         // Exactly at the floor is out of the exclusive lower bound → Err.
         assert!(
-            validate_thresholds(
-                HYSTERESIS_PCT,
-                HYSTERESIS_PCT + 10.0,
-                HYSTERESIS_PCT + 20.0
-            )
-            .is_err(),
+            validate_thresholds(HYSTERESIS_PCT, HYSTERESIS_PCT + 10.0, HYSTERESIS_PCT + 20.0)
+                .is_err(),
             "a threshold == HYSTERESIS_PCT must be rejected (exclusive lower bound)"
         );
         // Just above the floor, ordered handoff/escalate → Ok.
@@ -924,11 +920,7 @@ mod tests {
         } else {
             std::env::remove_var("AGEND_CONTEXT_ALERT_PCT");
         }
-        std::fs::write(
-            dir.join("runtime-config.json"),
-            r#"{"schema_version": 1}"#,
-        )
-        .unwrap();
+        std::fs::write(dir.join("runtime-config.json"), r#"{"schema_version": 1}"#).unwrap();
         reload(&dir);
         std::fs::remove_dir_all(&dir).ok();
     }

--- a/src/runtime_config.rs
+++ b/src/runtime_config.rs
@@ -165,6 +165,23 @@ static RUNTIME_CONFIG: OnceLock<RwLock<RuntimeConfig>> = OnceLock::new();
 static INITIALIZED: AtomicBool = AtomicBool::new(false);
 /// #1576: de-dupes the corrupt-config warning across 10s ticks.
 static CORRUPT_WARNED: AtomicBool = AtomicBool::new(false);
+/// #2753: de-dupes the invalid-effective-thresholds warning across per-tick
+/// resolves — warn on the FIRST invalid resolution of an episode, stay silent
+/// while it persists, re-arm as soon as a valid triplet resolves. Mirrors
+/// `CORRUPT_WARNED`.
+static INVALID_THRESHOLDS_WARNED: AtomicBool = AtomicBool::new(false);
+
+#[cfg(test)]
+thread_local! {
+    /// Test-only probe: per-thread count of `resolve_effective_thresholds`
+    /// calls, pinning the per-tick consumers' one-resolve-per-tick contract.
+    static RESOLVE_CALLS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+#[cfg(test)]
+pub(crate) fn resolve_calls_this_thread() -> usize {
+    RESOLVE_CALLS.with(std::cell::Cell::get)
+}
 
 fn global() -> &'static RwLock<RuntimeConfig> {
     RUNTIME_CONFIG.get_or_init(|| RwLock::new(RuntimeConfig::default()))
@@ -263,9 +280,23 @@ pub fn validate_thresholds(alert: f32, handoff: f32, escalate: f32) -> Result<()
     Ok(())
 }
 
+/// Latch step for the once-per-invalid-episode warning: records this
+/// resolution's validity and returns whether the invalid warning should be
+/// emitted NOW (true only on the first invalid resolution after a valid one).
+fn note_thresholds_validity(valid: bool) -> bool {
+    if valid {
+        INVALID_THRESHOLDS_WARNED.store(false, Ordering::Relaxed);
+        false
+    } else {
+        !INVALID_THRESHOLDS_WARNED.swap(true, Ordering::Relaxed)
+    }
+}
+
 /// Resolve and validate the effective context threshold triplet.
 /// Checks the environment variables first, falling back to RuntimeConfig, then to defaults.
 pub fn resolve_effective_thresholds() -> (f32, f32, f32) {
+    #[cfg(test)]
+    RESOLVE_CALLS.with(|c| c.set(c.get() + 1));
     let config = get();
     let alert = std::env::var("AGEND_CONTEXT_ALERT_PCT")
         .ok()
@@ -280,9 +311,8 @@ pub fn resolve_effective_thresholds() -> (f32, f32, f32) {
         .and_then(|v| v.parse::<f32>().ok())
         .unwrap_or(config.context_handoff_escalate_pct);
 
-    if validate_thresholds(alert, handoff, escalate).is_ok() {
-        (alert, handoff, escalate)
-    } else {
+    let valid = validate_thresholds(alert, handoff, escalate).is_ok();
+    if note_thresholds_validity(valid) {
         tracing::warn!(
             alert,
             handoff,
@@ -292,6 +322,10 @@ pub fn resolve_effective_thresholds() -> (f32, f32, f32) {
             config_escalate = config.context_handoff_escalate_pct,
             "effective context thresholds combination is invalid. falling back to runtime config values."
         );
+    }
+    if valid {
+        (alert, handoff, escalate)
+    } else {
         let fallback_alert = config.context_alert_pct;
         let fallback_handoff = config.context_handoff_pct;
         let fallback_escalate = config.context_handoff_escalate_pct;
@@ -919,6 +953,69 @@ mod tests {
             std::env::set_var("AGEND_CONTEXT_ALERT_PCT", val);
         } else {
             std::env::remove_var("AGEND_CONTEXT_ALERT_PCT");
+        }
+        std::fs::write(dir.join("runtime-config.json"), r#"{"schema_version": 1}"#).unwrap();
+        reload(&dir);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// #2753 final review: the invalid-effective-thresholds warning must fire
+    /// once per invalid EPISODE, not once per resolve —
+    /// `resolve_effective_thresholds` runs every tick from the per-tick
+    /// consumers, so an un-latched warn floods the log for as long as the
+    /// invalid override persists. A valid resolution ends the episode and
+    /// re-arms the latch.
+    #[test]
+    #[serial(runtime_config)]
+    fn invalid_thresholds_warning_latches_once_per_episode() {
+        // Normalize: a valid resolution re-arms the latch.
+        assert!(!note_thresholds_validity(true));
+        // First invalid resolution of an episode warns...
+        assert!(note_thresholds_validity(false));
+        // ...further invalid resolutions in the same episode stay silent.
+        assert!(!note_thresholds_validity(false));
+        assert!(!note_thresholds_validity(false));
+        // A valid triplet ends the episode without warning...
+        assert!(!note_thresholds_validity(true));
+        // ...and the next invalid episode warns exactly once again.
+        assert!(note_thresholds_validity(false));
+        assert!(!note_thresholds_validity(false));
+    }
+
+    /// Wiring counterpart of the latch-semantics test:
+    /// `resolve_effective_thresholds` itself must drive the latch — an invalid
+    /// env override latches it, a valid resolution re-arms it.
+    #[test]
+    #[serial(runtime_config)]
+    fn resolve_effective_thresholds_drives_warn_latch() {
+        let dir = std::env::temp_dir().join("agend-test-runtime-config-warnlatch");
+        std::fs::create_dir_all(&dir).ok();
+        std::fs::write(
+            dir.join("runtime-config.json"),
+            r#"{"schema_version": 1, "context_alert_pct": 60.0, "context_handoff_pct": 70.0, "context_handoff_escalate_pct": 80.0}"#,
+        )
+        .unwrap();
+        reload(&dir);
+
+        let old_env = std::env::var("AGEND_CONTEXT_ALERT_PCT").ok();
+        std::env::remove_var("AGEND_CONTEXT_ALERT_PCT");
+
+        // Valid resolution → latch re-armed.
+        resolve_effective_thresholds();
+        assert!(!INVALID_THRESHOLDS_WARNED.load(Ordering::Relaxed));
+
+        // Invalid override (alert >= handoff) → latch set after first resolve.
+        std::env::set_var("AGEND_CONTEXT_ALERT_PCT", "95.0");
+        resolve_effective_thresholds();
+        assert!(INVALID_THRESHOLDS_WARNED.load(Ordering::Relaxed));
+
+        // Back to valid → latch re-armed for the next episode.
+        std::env::remove_var("AGEND_CONTEXT_ALERT_PCT");
+        resolve_effective_thresholds();
+        assert!(!INVALID_THRESHOLDS_WARNED.load(Ordering::Relaxed));
+
+        if let Some(val) = old_env {
+            std::env::set_var("AGEND_CONTEXT_ALERT_PCT", val);
         }
         std::fs::write(dir.join("runtime-config.json"), r#"{"schema_version": 1}"#).unwrap();
         reload(&dir);

--- a/src/runtime_config.rs
+++ b/src/runtime_config.rs
@@ -237,17 +237,17 @@ pub fn validate_thresholds(alert: f32, handoff: f32, escalate: f32) -> Result<()
     // `pct < threshold - HYSTERESIS_PCT` would be impossible, wedging the latch.
     if alert <= HYSTERESIS_PCT || alert > 100.0 {
         return Err(format!(
-            "alert_pct must be in ({HYSTERESIS_PCT}, 100.0], got {alert}"
+            "alert_pct must be in ({HYSTERESIS_PCT:.1}, 100.0], got {alert}"
         ));
     }
     if handoff <= HYSTERESIS_PCT || handoff > 100.0 {
         return Err(format!(
-            "handoff_pct must be in ({HYSTERESIS_PCT}, 100.0], got {handoff}"
+            "handoff_pct must be in ({HYSTERESIS_PCT:.1}, 100.0], got {handoff}"
         ));
     }
     if escalate <= HYSTERESIS_PCT || escalate > 100.0 {
         return Err(format!(
-            "escalate_pct must be in ({HYSTERESIS_PCT}, 100.0], got {escalate}"
+            "escalate_pct must be in ({HYSTERESIS_PCT:.1}, 100.0], got {escalate}"
         ));
     }
     if alert >= handoff {

--- a/tests/attached_path_mcp_invariants.rs
+++ b/tests/attached_path_mcp_invariants.rs
@@ -109,9 +109,9 @@ fn api_port_published_before_agent_spawn_loop_completes() {
         .args(["--agents", "t3:/bin/sh"])
         .env("AGEND_HOME", &tmp)
         // Pin the stagger so the legacy agents-first ordering takes a
-        // deterministic ~4 s; the C1 reorder makes `api.port` appear
+        // deterministic ~2 s; the C1 reorder makes `api.port` appear
         // independently of this.
-        .env("AGEND_SPAWN_STAGGER_MS", "2000")
+        .env("AGEND_SPAWN_STAGGER_MS", "1000")
         // Disable any background work that could compete for startup time
         // and inflate the legacy budget (false positives), and silence
         // logs going to a real $HOME log dir.
@@ -121,11 +121,10 @@ fn api_port_published_before_agent_spawn_loop_completes() {
         .spawn()
         .expect("spawn agend-terminal daemon");
 
-    // Budget: well below 4 s (legacy wall time with N=3 + 2000 ms stagger)
+    // Budget: well below 2 s (legacy wall time with N=3 + 1000 ms stagger)
     // and well above the C1-reordered actual wall time (~50-200 ms even on
-    // slow CI, which can take up to ~1.6s). Poll cheaply so we don't add
-    // measurement noise.
-    let deadline = start + Duration::from_millis(3000);
+    // slow CI). Poll cheaply so we don't add measurement noise.
+    let deadline = start + Duration::from_millis(1500);
     let mut api_port_path: Option<PathBuf> = None;
     while Instant::now() < deadline {
         if let Some(p) = find_api_port(&tmp) {

--- a/tests/attached_path_mcp_invariants.rs
+++ b/tests/attached_path_mcp_invariants.rs
@@ -109,9 +109,9 @@ fn api_port_published_before_agent_spawn_loop_completes() {
         .args(["--agents", "t3:/bin/sh"])
         .env("AGEND_HOME", &tmp)
         // Pin the stagger so the legacy agents-first ordering takes a
-        // deterministic ~2 s; the C1 reorder makes `api.port` appear
+        // deterministic ~4 s; the C1 reorder makes `api.port` appear
         // independently of this.
-        .env("AGEND_SPAWN_STAGGER_MS", "1000")
+        .env("AGEND_SPAWN_STAGGER_MS", "2000")
         // Disable any background work that could compete for startup time
         // and inflate the legacy budget (false positives), and silence
         // logs going to a real $HOME log dir.
@@ -121,10 +121,11 @@ fn api_port_published_before_agent_spawn_loop_completes() {
         .spawn()
         .expect("spawn agend-terminal daemon");
 
-    // Budget: well below 2 s (legacy wall time with N=3 + 1000 ms stagger)
+    // Budget: well below 4 s (legacy wall time with N=3 + 2000 ms stagger)
     // and well above the C1-reordered actual wall time (~50-200 ms even on
-    // slow CI). Poll cheaply so we don't add measurement noise.
-    let deadline = start + Duration::from_millis(1500);
+    // slow CI, which can take up to ~1.6s). Poll cheaply so we don't add
+    // measurement noise.
+    let deadline = start + Duration::from_millis(3000);
     let mut api_port_path: Option<PathBuf> = None;
     while Instant::now() < deadline {
         if let Some(p) = find_api_port(&tmp) {


### PR DESCRIPTION
## What
Proposes persistent configuration of context watchdog thresholds inside RuntimeConfig.

## How
1. Added `context_alert_pct`, `context_handoff_pct`, and `context_handoff_escalate_pct` to `RuntimeConfig` struct in `src/runtime_config.rs` with `#[serde(default)]` pointing to helper functions that return defaults.
2. Updated handlers in `src/daemon/per_tick/context_alert.rs` and `src/daemon/per_tick/context_handoff.rs` to query the environment variable first. If empty or unparseable, fallback to calling `crate::runtime_config::get().<field>`.
3. Linked the helper defaults in `src/runtime_config.rs` back to the module constants to preserve single-source definition.
4. Added sequential/isolated unit tests verifying precedence fallback (Env Var > RuntimeConfig > Compile-time default) for all context watchdog thresholds.

## Scope
Follows the requirements: persistent configuration of context thresholds without bumping RuntimeConfig::CURRENT schema version (additive change).

## Lessons
When testing process-global singleton config (`RuntimeConfig`) and process environment variables concurrently, tests must be serialized under the same key (`#[serial(runtime_config)]`) and environment variables must be isolated and restored to prevent contamination.

Closes #2752