### PR TITLE
feat: classify review branch preservation evidence

### DIFF
--- a/src/branch_sweep.rs
+++ b/src/branch_sweep.rs
@@ -685,6 +685,228 @@ mod tests {
         sha
     }
 
+    fn bind_handler_repo(home: &Path, repo: &Path, agent: &str) {
+        let binding_dir = home.join("runtime").join(agent);
+        std::fs::create_dir_all(&binding_dir).expect("mkdir binding");
+        std::fs::write(
+            binding_dir.join("binding.json"),
+            serde_json::json!({
+                "source_repo": repo.display().to_string(),
+                "branch": "feature",
+                "worktree": repo.display().to_string(),
+            })
+            .to_string(),
+        )
+        .expect("write binding");
+    }
+
+    fn handler_dry_run(home: &Path, repo: &Path, agent: &str) -> serde_json::Value {
+        bind_handler_repo(home, repo, agent);
+        crate::mcp::handlers::ci::handle_cleanup_merged_branches(
+            home,
+            &serde_json::json!({"instance": agent}),
+            agent,
+        )
+    }
+
+    fn reviewer_candidate<'a>(
+        response: &'a serde_json::Value,
+        name: &str,
+    ) -> &'a serde_json::Value {
+        response["categories"]["reviewer_checkout"]
+            .as_array()
+            .expect("reviewer_checkout array")
+            .iter()
+            .find(|candidate| candidate["name"] == name)
+            .unwrap_or_else(|| panic!("missing reviewer candidate {name}: {response}"))
+    }
+
+    fn add_local_bare_origin(repo: &Path) -> PathBuf {
+        let origin = repo.parent().expect("repo parent").join("origin.git");
+        git_run(
+            repo,
+            &["init", "--bare", origin.to_str().expect("origin path")],
+        );
+        git_run(
+            repo,
+            &[
+                "remote",
+                "add",
+                "origin",
+                origin.to_str().expect("origin path"),
+            ],
+        );
+        origin
+    }
+
+    // PR-A RED: preservation evidence is returned through the real
+    // cleanup_merged_branches dry-run handler. These assertions deliberately
+    // use JSON fields so the RED commit compiles against the pre-feature
+    // Candidate type and fails at the actual public response boundary.
+    #[test]
+    fn review_preservation_main_reachable_is_observability_only() {
+        let repo = setup_repo("preservation_main");
+        let home = repo.parent().unwrap().to_path_buf();
+        add_local_bare_origin(&repo);
+        git_run(&repo, &["branch", "tmp_main_reachable", "main"]);
+
+        let response = handler_dry_run(&home, &repo, "preservation-main-agent");
+        let candidate = reviewer_candidate(&response, "tmp_main_reachable");
+        assert_eq!(
+            candidate["preservation"]["classification"], "MAIN_REACHABLE",
+            "main ancestry must be surfaced as current evidence: {response}"
+        );
+        assert_eq!(candidate["preservation"]["durable"], false);
+        assert!(
+            response["candidate_ids"]
+                .as_array()
+                .expect("candidate_ids")
+                .iter()
+                .any(|id| id == "tmp_main_reachable"),
+            "PR-A is observability-only: classification must not remove the existing reviewer candidate"
+        );
+
+        std::fs::remove_dir_all(repo.parent().unwrap()).ok();
+    }
+
+    #[test]
+    fn review_preservation_external_ancestor_uses_hermetic_pull_ref() {
+        let repo = setup_repo("preservation_external");
+        let home = repo.parent().unwrap().to_path_buf();
+        add_local_bare_origin(&repo);
+        let candidate_sha =
+            create_branch_with_commit(&repo, "tmp_external", "review work under inspection");
+        git_run(
+            &repo,
+            &["checkout", "-b", "external-descendant", &candidate_sha],
+        );
+        std::fs::write(repo.join("external-descendant.txt"), "sync commit\n").expect("write");
+        git_run(&repo, &["add", "external-descendant.txt"]);
+        git_run(&repo, &["commit", "-m", "external descendant"]);
+        let descendant_sha =
+            String::from_utf8_lossy(&git_run(&repo, &["rev-parse", "HEAD"]).stdout)
+                .trim()
+                .to_string();
+        git_run(
+            &repo,
+            &[
+                "push",
+                "origin",
+                &format!("{descendant_sha}:refs/pull/7/head"),
+            ],
+        );
+        git_run(&repo, &["checkout", "main"]);
+
+        let response = handler_dry_run(&home, &repo, "preservation-external-agent");
+        let candidate = reviewer_candidate(&response, "tmp_external");
+        assert_eq!(
+            candidate["preservation"]["classification"],
+            "EXTERNALLY_REACHABLE_UNGUARANTEED",
+            "candidate ancestor of a current pull head must be visible without claiming durability: {response}"
+        );
+        assert_eq!(candidate["preservation"]["durable"], false);
+
+        std::fs::remove_dir_all(repo.parent().unwrap()).ok();
+    }
+
+    #[test]
+    fn review_preservation_orphaned_reports_exact_unique_count() {
+        let repo = setup_repo("preservation_orphan");
+        let home = repo.parent().unwrap().to_path_buf();
+        add_local_bare_origin(&repo); // successful, empty external inventory
+        create_branch_with_commit(&repo, "tmp_orphan", "orphan commit one");
+        git_run(&repo, &["checkout", "tmp_orphan"]);
+        std::fs::write(repo.join("orphan-two.txt"), "second unique commit\n").expect("write");
+        git_run(&repo, &["add", "orphan-two.txt"]);
+        git_run(&repo, &["commit", "-m", "orphan commit two"]);
+        git_run(&repo, &["checkout", "main"]);
+
+        let response = handler_dry_run(&home, &repo, "preservation-orphan-agent");
+        let candidate = reviewer_candidate(&response, "tmp_orphan");
+        assert_eq!(
+            candidate["preservation"]["classification"], "ORPHANED_UNIQUE",
+            "orphan classification requires a successful external inventory: {response}"
+        );
+        assert_eq!(candidate["preservation"]["unique_commit_count"], 2);
+
+        std::fs::remove_dir_all(repo.parent().unwrap()).ok();
+    }
+
+    #[test]
+    fn review_preservation_external_failure_keeps_inventory_unknown() {
+        let repo = setup_repo("preservation_unknown");
+        let home = repo.parent().unwrap().to_path_buf();
+        create_branch_with_commit(&repo, "tmp_unknown", "review work with offline origin");
+        git_run(
+            &repo,
+            &[
+                "remote",
+                "add",
+                "origin",
+                "/definitely/missing/agend-origin.git",
+            ],
+        );
+
+        let response = handler_dry_run(&home, &repo, "preservation-unknown-agent");
+        assert_eq!(
+            response["dry_run"], true,
+            "local inventory must survive: {response}"
+        );
+        let candidate = reviewer_candidate(&response, "tmp_unknown");
+        assert_eq!(
+            candidate["preservation"]["classification"], "UNKNOWN_EXTERNAL_LOOKUP_FAILED",
+            "offline evidence must never fall through to ORPHANED: {response}"
+        );
+        assert_ne!(
+            candidate["preservation"]["classification"],
+            "ORPHANED_UNIQUE"
+        );
+
+        std::fs::remove_dir_all(repo.parent().unwrap()).ok();
+    }
+
+    #[test]
+    fn spike_residue_is_separate_annotation_not_candidate() {
+        let repo = setup_repo("preservation_spike");
+        let home = repo.parent().unwrap().to_path_buf();
+        add_local_bare_origin(&repo);
+        git_run(&repo, &["checkout", "-b", "spike/preservation-probe"]);
+        std::fs::write(repo.join("spike-probe.txt"), "analysis artifact\n").expect("write");
+        git_run(&repo, &["add", "spike-probe.txt"]);
+        git_run(&repo, &["commit", "-m", "spike artifact"]);
+        git_run(&repo, &["checkout", "main"]);
+
+        let response = handler_dry_run(&home, &repo, "preservation-spike-agent");
+        let annotations = response["annotations"]["spike_residue"]
+            .as_array()
+            .expect("separate spike_residue annotations");
+        assert!(
+            annotations.iter().any(|entry| {
+                entry["name"] == "spike/preservation-probe"
+                    && entry["annotation"] == "SPIKE_RESIDUE"
+            }),
+            "spike residue must be visible only as an annotation: {response}"
+        );
+        assert!(
+            !response["candidate_ids"]
+                .as_array()
+                .expect("candidate_ids")
+                .iter()
+                .any(|id| id == "spike/preservation-probe"),
+            "annotation must not add spike residue to candidate_ids"
+        );
+        assert!(
+            !response["categories"]["reviewer_checkout"]
+                .as_array()
+                .expect("reviewer_checkout")
+                .iter()
+                .any(|candidate| candidate["name"] == "spike/preservation-probe"),
+            "spike residue must remain outside reviewer_checkout"
+        );
+
+        std::fs::remove_dir_all(repo.parent().unwrap()).ok();
+    }
+
     #[test]
     fn test_branch_sweep_scan_categorizes_clean_merged() {
         // #817 RED 1: branch "feat-a" merged into main via a merge

--- a/src/branch_sweep.rs
+++ b/src/branch_sweep.rs
@@ -25,6 +25,34 @@
 
 use std::path::Path;
 
+/// PR-A preservation classification is dry-run observability only. None of
+/// these values participate in `candidate_ids`, confirmation, or apply.
+#[derive(Debug, serde::Serialize)]
+struct PreservationEvidence {
+    classification: &'static str,
+    durable: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    unique_commit_count: Option<usize>,
+    note: String,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub(crate) struct SpikeResidueAnnotation {
+    name: String,
+    tip_sha: String,
+    annotation: &'static str,
+}
+
+#[derive(Debug)]
+enum ExternalInventory {
+    Available(Vec<String>),
+    LookupFailed(String),
+}
+
+/// Keep a network-backed dry-run probe below the MCP proxy budget. The result
+/// is computed once and reused for every reviewer candidate in the scan.
+const EXTERNAL_REF_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
 /// Threshold for `stale_idle` category. Branches whose tip commit
 /// committer-date is older than this AND not merged AND not squash-
 /// merged land in `stale_idle`. Operator can override via
@@ -149,6 +177,268 @@ fn enumerate_branches(repo: &Path) -> Result<Vec<BranchInfo>, String> {
         })
         .collect();
     Ok(branches)
+}
+
+fn checked_is_ancestor(repo: &Path, ancestor: &str, descendant: &str) -> Result<bool, String> {
+    let output = crate::git_helpers::git_bypass_timeout(
+        repo,
+        &["merge-base", "--is-ancestor", ancestor, descendant],
+        crate::git_helpers::LOCAL_GIT_TIMEOUT,
+    )
+    .map_err(|e| format!("git merge-base --is-ancestor {ancestor} {descendant}: {e}"))?;
+    if output.status.success() {
+        Ok(true)
+    } else if output.status.code() == Some(1) {
+        Ok(false)
+    } else {
+        Err(format!(
+            "git merge-base --is-ancestor {ancestor} {descendant}: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ))
+    }
+}
+
+fn external_inventory(repo: &Path) -> ExternalInventory {
+    let local = match crate::git_helpers::git_cmd(
+        repo,
+        &["for-each-ref", "--format=%(objectname)", "refs/remotes/"],
+    ) {
+        Ok(stdout) => stdout,
+        Err(e) => {
+            return ExternalInventory::LookupFailed(format!(
+                "local remote-tracking ref enumeration failed: {e}"
+            ));
+        }
+    };
+
+    let remote = match crate::git_helpers::git_bypass_timeout(
+        repo,
+        &[
+            "ls-remote",
+            "--refs",
+            "origin",
+            "refs/heads/*",
+            "refs/pull/*/head",
+        ],
+        EXTERNAL_REF_PROBE_TIMEOUT,
+    ) {
+        Ok(output) if output.status.success() => {
+            String::from_utf8_lossy(&output.stdout).to_string()
+        }
+        Ok(output) => {
+            return ExternalInventory::LookupFailed(format!(
+                "origin refs/pull lookup failed: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            ));
+        }
+        Err(e) => {
+            return ExternalInventory::LookupFailed(format!(
+                "origin refs/pull lookup failed or timed out after {}s: {e}",
+                EXTERNAL_REF_PROBE_TIMEOUT.as_secs()
+            ));
+        }
+    };
+
+    let mut roots: Vec<String> = local
+        .lines()
+        .map(str::trim)
+        .filter(|sha| !sha.is_empty())
+        .map(String::from)
+        .chain(remote.lines().filter_map(|line| {
+            line.split_whitespace()
+                .next()
+                .filter(|sha| !sha.is_empty())
+                .map(String::from)
+        }))
+        .collect();
+    roots.sort();
+    roots.dedup();
+    ExternalInventory::Available(roots)
+}
+
+fn rev_list_count_excluding(
+    repo: &Path,
+    tip: &str,
+    exclusions: &[String],
+) -> Result<std::process::Output, String> {
+    let mut args = vec![
+        "rev-list".to_string(),
+        "--count".to_string(),
+        tip.to_string(),
+        "--not".to_string(),
+    ];
+    args.extend(exclusions.iter().cloned());
+    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    crate::git_helpers::git_bypass_timeout(repo, &arg_refs, crate::git_helpers::LOCAL_GIT_TIMEOUT)
+        .map_err(|e| format!("git rev-list --count {tip}: {e}"))
+}
+
+fn parse_rev_list_count(output: &std::process::Output, context: &str) -> Result<usize, String> {
+    if !output.status.success() {
+        return Err(format!(
+            "git rev-list {context}: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .parse::<usize>()
+        .map_err(|e| format!("invalid rev-list count for {context}: {e}"))
+}
+
+fn unique_commit_count(
+    repo: &Path,
+    candidate: &BranchInfo,
+    base: &str,
+    branches: &[BranchInfo],
+    external_roots: &[String],
+) -> Result<usize, String> {
+    let mut exclusions: Vec<String> = vec![base.to_string()];
+    exclusions.extend(
+        branches
+            .iter()
+            .filter(|branch| branch.name != candidate.name)
+            .map(|branch| branch.tip_sha.clone()),
+    );
+    exclusions.extend(external_roots.iter().cloned());
+    exclusions.sort();
+    exclusions.dedup();
+
+    let output = rev_list_count_excluding(repo, &candidate.tip_sha, &exclusions)?;
+    parse_rev_list_count(&output, &format!("unique count for {}", candidate.name))
+}
+
+fn classify_preservation(
+    repo: &Path,
+    base: &str,
+    candidate: &BranchInfo,
+    branches: &[BranchInfo],
+    external: &ExternalInventory,
+) -> Result<PreservationEvidence, String> {
+    if checked_is_ancestor(repo, &candidate.tip_sha, base)? {
+        return Ok(PreservationEvidence {
+            classification: "MAIN_REACHABLE",
+            durable: false,
+            unique_commit_count: None,
+            note: format!(
+                "tip is currently reachable from {base}; current reachability is not durable preservation"
+            ),
+        });
+    }
+
+    let roots = match external {
+        ExternalInventory::LookupFailed(error) => {
+            return Ok(PreservationEvidence {
+                classification: "UNKNOWN_EXTERNAL_LOOKUP_FAILED",
+                durable: false,
+                unique_commit_count: None,
+                note: error.clone(),
+            });
+        }
+        ExternalInventory::Available(roots) => roots,
+    };
+
+    if roots.iter().any(|root| root == &candidate.tip_sha) {
+        return Ok(PreservationEvidence {
+            classification: "EXTERNALLY_REACHABLE_UNGUARANTEED",
+            durable: false,
+            unique_commit_count: None,
+            note: "candidate tip exactly matches a current external ref; external reachability is not durable preservation".to_string(),
+        });
+    }
+
+    if !roots.is_empty() {
+        // One graph walk answers whether the candidate tip is reachable from
+        // ANY external root. This keeps local work O(candidates), not
+        // O(candidates × refs), after the single cached remote probe.
+        let output = rev_list_count_excluding(repo, &candidate.tip_sha, roots)?;
+        if !output.status.success() {
+            return Ok(PreservationEvidence {
+                classification: "UNKNOWN_EXTERNAL_LOOKUP_FAILED",
+                durable: false,
+                unique_commit_count: None,
+                note: format!(
+                    "external ref ancestry could not be proven from local objects: {}",
+                    String::from_utf8_lossy(&output.stderr).trim()
+                ),
+            });
+        }
+        if parse_rev_list_count(&output, "external reachability")? == 0 {
+            return Ok(PreservationEvidence {
+                classification: "EXTERNALLY_REACHABLE_UNGUARANTEED",
+                durable: false,
+                unique_commit_count: None,
+                note: "candidate tip is currently reachable from an external ref; external reachability is not durable preservation".to_string(),
+            });
+        }
+    }
+
+    let count = unique_commit_count(repo, candidate, base, branches, roots)?;
+    Ok(PreservationEvidence {
+        classification: "ORPHANED_UNIQUE",
+        durable: false,
+        unique_commit_count: Some(count),
+        note: "external inventory succeeded; count is current unique reachability, not deletion authorization"
+            .to_string(),
+    })
+}
+
+pub(crate) fn dry_run_observability(
+    repo: &Path,
+    base: &str,
+    categories: &Categories,
+) -> Result<(serde_json::Value, Vec<SpikeResidueAnnotation>), String> {
+    let branches = enumerate_branches(repo)?;
+    let by_name: std::collections::HashMap<&str, &BranchInfo> = branches
+        .iter()
+        .map(|branch| (branch.name.as_str(), branch))
+        .collect();
+    let spike_residue = branches
+        .iter()
+        .filter(|branch| branch.name.starts_with("spike/"))
+        .map(|branch| SpikeResidueAnnotation {
+            name: branch.name.clone(),
+            tip_sha: branch.tip_sha.clone(),
+            annotation: "SPIKE_RESIDUE",
+        })
+        .collect();
+
+    let mut needs_external = false;
+    for candidate in &categories.reviewer_checkout {
+        let branch = by_name.get(candidate.name.as_str()).ok_or_else(|| {
+            format!(
+                "review candidate {} missing from branch inventory",
+                candidate.name
+            )
+        })?;
+        if !checked_is_ancestor(repo, &branch.tip_sha, base)? {
+            needs_external = true;
+            break;
+        }
+    }
+    let external = if needs_external {
+        external_inventory(repo)
+    } else {
+        ExternalInventory::Available(Vec::new())
+    };
+
+    let mut serialized = serde_json::to_value(categories)
+        .map_err(|e| format!("serialize branch sweep categories: {e}"))?;
+    let reviewer_candidates = serialized["reviewer_checkout"]
+        .as_array_mut()
+        .ok_or_else(|| "serialized reviewer_checkout was not an array".to_string())?;
+    for candidate in reviewer_candidates {
+        let name = candidate["name"]
+            .as_str()
+            .ok_or_else(|| "serialized reviewer candidate missing name".to_string())?;
+        let branch = by_name
+            .get(name)
+            .ok_or_else(|| format!("review candidate {name} missing from branch inventory"))?;
+        let evidence = classify_preservation(repo, base, branch, &branches, &external)?;
+        candidate["preservation"] = serde_json::to_value(evidence)
+            .map_err(|e| format!("serialize preservation evidence for {name}: {e}"))?;
+    }
+    Ok((serialized, spike_residue))
 }
 
 /// Returns true if `branch` is reachable from `base` via a merge
@@ -856,6 +1146,57 @@ mod tests {
         assert_eq!(
             candidate["preservation"]["classification"], "UNKNOWN_EXTERNAL_LOOKUP_FAILED",
             "offline evidence must never fall through to ORPHANED: {response}"
+        );
+        assert_ne!(
+            candidate["preservation"]["classification"],
+            "ORPHANED_UNIQUE"
+        );
+
+        std::fs::remove_dir_all(repo.parent().unwrap()).ok();
+    }
+
+    #[test]
+    fn review_preservation_unavailable_non_equal_external_object_is_unknown() {
+        let repo = setup_repo("preservation_unavailable_object");
+        let home = repo.parent().unwrap().to_path_buf();
+        let origin = add_local_bare_origin(&repo);
+        let candidate_sha =
+            create_branch_with_commit(&repo, "tmp_unavailable", "locally available review tip");
+        git_run(
+            &repo,
+            &[
+                "push",
+                "origin",
+                &format!("{candidate_sha}:refs/heads/seed"),
+            ],
+        );
+
+        // Create the external descendant in a separate clone, then remove the
+        // seed ref. `ls-remote` can see the pull-head SHA, while the repository
+        // being classified has never fetched that descendant object.
+        let peer = repo.parent().unwrap().join("external-peer");
+        git_run(
+            &repo,
+            &[
+                "clone",
+                origin.to_str().expect("origin path"),
+                peer.to_str().expect("peer path"),
+            ],
+        );
+        git_run(&peer, &["config", "user.name", "test"]);
+        git_run(&peer, &["config", "user.email", "t@t"]);
+        git_run(&peer, &["checkout", "seed"]);
+        std::fs::write(peer.join("remote-only.txt"), "unfetched descendant\n").expect("write");
+        git_run(&peer, &["add", "remote-only.txt"]);
+        git_run(&peer, &["commit", "-m", "remote-only descendant"]);
+        git_run(&peer, &["push", "origin", "HEAD:refs/pull/9/head"]);
+        git_run(&repo, &["push", "origin", ":refs/heads/seed"]);
+
+        let response = handler_dry_run(&home, &repo, "preservation-unavailable-agent");
+        let candidate = reviewer_candidate(&response, "tmp_unavailable");
+        assert_eq!(
+            candidate["preservation"]["classification"], "UNKNOWN_EXTERNAL_LOOKUP_FAILED",
+            "a non-equal remote-only object cannot prove ancestry: {response}"
         );
         assert_ne!(
             candidate["preservation"]["classification"],

--- a/src/mcp/handlers/ci/cleanup.rs
+++ b/src/mcp/handlers/ci/cleanup.rs
@@ -90,9 +90,22 @@ pub(crate) fn handle_cleanup_merged_branches(
         }
     };
     if !apply {
+        let (categories_with_observability, spike_residue) =
+            match crate::branch_sweep::dry_run_observability(&source_repo, base, &categories) {
+                Ok(report) => report,
+                Err(e) => {
+                    return json!({
+                        "error": format!("branch sweep observability failed: {e}"),
+                        "code": "scan_failed",
+                    });
+                }
+            };
         return json!({
             "dry_run": true,
-            "categories": &categories,
+            "categories": categories_with_observability,
+            "annotations": {
+                "spike_residue": spike_residue,
+            },
             "candidate_ids": categories.deletable_ids(),
             "total_candidates": categories.total(),
             "to_apply_hint": "repo action=cleanup_merged_branches apply=true confirm_ids=<subset> audit_reason=<...>",


### PR DESCRIPTION
## Summary
- enrich cleanup_merged_branches dry-run reviewer candidates with MAIN_REACHABLE, EXTERNALLY_REACHABLE_UNGUARANTEED, ORPHANED_UNIQUE(count), or UNKNOWN_EXTERNAL_LOOKUP_FAILED current evidence
- expose spike/* in a separate SPIKE_RESIDUE annotation-only collection
- use one bounded, cached external refs/pull probe per dry-run and preserve local inventory on offline/auth/remote-only-object uncertainty

## Safety boundary
PR-A is observability only per decision d-20260712104648437544-23. candidate_ids, confirmation, apply authorization, emit_delete_batch, force, archives, scheduling, and deletion behavior are unchanged. Current reachability is explicitly not durable preservation.

## RED / GREEN
- RED 542e8446: real handler tests fail because preservation/annotation fields are absent
- GREEN 8a0fefd2: the same tests pass

## Verification
- cargo test --bin agend-terminal branch_sweep::tests:: -- --nocapture (24 passed)
- cargo clippy --bin agend-terminal -- -D warnings
- cargo fmt --check

Scope follows dispatch spec d-20260712104648437544-23; no other changes.

---
*archfix-codex-7* · codex/gpt-5