### PR TITLE
fix(task-gov): per-key plan-governance ACL closes plan-ack self-weaken + forged-ack (t-…-74)

### DIFF
--- a/src/tasks/acl.rs
+++ b/src/tasks/acl.rs
@@ -92,6 +92,23 @@ pub fn is_system_identity(caller: &str) -> bool {
     SYSTEM_IDENTITIES.contains(&caller)
 }
 
+/// t-…-74 (decision d-…-22, Root ruling m-1087): the ONLY identity with
+/// governance authority over a task's plan-ack metadata (`plan` +
+/// `plan_ack_required`) is EXACTLY the task's creator (`created_by`) — or a
+/// recognized system identity. This is deliberately narrower than
+/// [`can_mutate_record`]: it is NOT the assignee/owner, NOT the team
+/// orchestrator, and NOT any transitive dispatch-authority. Keeping it a
+/// pure `created_by`/`system` check is the whole point — it must never expand
+/// authority transitively (the gate this protects can otherwise be self-weakened
+/// by the very agent it constrains). Operational authority (done / update /
+/// non-governance metadata) stays with [`can_mutate_record`], unchanged.
+pub(super) fn is_plan_governance_author(
+    caller: &str,
+    record: &crate::task_events::TaskRecord,
+) -> bool {
+    is_system_identity(caller) || record.created_by.0.as_str() == caller
+}
+
 pub(super) fn can_mutate_record(
     home: &Path,
     caller: &str,

--- a/src/tasks/handler.rs
+++ b/src/tasks/handler.rs
@@ -1561,6 +1561,28 @@ fn handle_metadata_set(
                     "id": id, "event": "metadata_set", "task": task, "noop": true
                 });
             }
+            // Fail-closed status policy (PR #2761 r1): a content-CHANGING plan
+            // write is permitted ONLY in the pre-work window {Backlog, Open,
+            // Claimed} — where no work is active because the →in_progress ack gate
+            // has not yet been passed. At in_progress and every later/terminal/
+            // blocked state the plan is FROZEN for EVERY identity, creator
+            // included. Reopening the gate would require an
+            // in_progress→claimed/open transition that this handler deliberately
+            // does NOT grant (I5: no creator status authority); silently resetting
+            // plan_acks WITHOUT a transition (the r0 defect) leaves work running
+            // under an unacked replacement plan. metadata_set never mutates status
+            // — the remedy for a wrong plan mid-work is cancel + recreate.
+            if !matches!(
+                record.status,
+                crate::task_events::TaskStatus::Backlog
+                    | crate::task_events::TaskStatus::Open
+                    | crate::task_events::TaskStatus::Claimed
+            ) {
+                return serde_json::json!({
+                    "error": "the plan is frozen once work has started (in_progress or later); cancel + recreate the task to re-plan — it cannot be hot-swapped under running work",
+                    "code": "plan_frozen_work_started",
+                });
+            }
             let acks_present = record
                 .metadata
                 .get("plan_acks")

--- a/src/tasks/handler.rs
+++ b/src/tasks/handler.rs
@@ -1493,16 +1493,129 @@ fn handle_metadata_set(
     if let Some(deny) = cross_board_denied(home, instance_name, id, false) {
         return deny;
     }
-    if !can_mutate_record(home, instance_name, &record) {
-        return serde_json::json!({"error": "permission denied: caller is not owner/creator"});
+    // ── t-…-74 governance-key ACL (decision d-…-22, Root ruling m-1087) ──
+    // `plan`, `plan_ack_required`, and `plan_acks` gate the #2249 pre-work
+    // alignment chokepoint — they are NOT ordinary owner-writable metadata, so
+    // each gets per-key fail-closed validation BEFORE the generic owner-ACL.
+    // GOV_AUTHOR = EXACTLY created_by (+ system), never the assignee or the
+    // orchestrator (no transitive authority — otherwise the very agent the gate
+    // constrains could self-weaken it). Every other key falls through to
+    // `can_mutate_record` (I4), byte-identical to before.
+    let is_gov_author = super::acl::is_plan_governance_author(instance_name, &record);
+    let deny_counter = |detail: &str| {
+        serde_json::json!({
+            "error": format!("plan_ack_required is protected: {detail}"),
+            "code": "plan_ack_required_protected",
+        })
+    };
+    // Set when a GOV_AUTHOR plan content-change must also reset acks (I3).
+    let mut reset_acks = false;
+    match key {
+        // I1: plan_acks is system-managed. Only `handle_ack_plan` appends it (and
+        // the reopen-reset below emits its own []-event). A direct metadata_set is
+        // rejected for EVERY identity, GOV_AUTHOR and system included.
+        "plan_acks" => {
+            return serde_json::json!({
+                "error": "plan_acks is system-managed; record acks via action=ack_plan, never metadata_set",
+                "code": "plan_acks_immutable",
+            });
+        }
+        // I2: accept ONLY a GOV_AUTHOR monotonic raise (numeric, ≥ current, after
+        // the assignee has claimed). Everything else — non-author, lower,
+        // non-numeric, pre-claim — fails closed. (Typed field promotion = t-…-79.)
+        "plan_ack_required" => {
+            let proposed = match value.as_u64() {
+                Some(n) => n,
+                None => return deny_counter("value must be a non-negative integer"),
+            };
+            if !is_gov_author {
+                return deny_counter("only the task creator (created_by) may raise it");
+            }
+            // "after assignee claim" — an unclaimed task (backlog/open, incl. one
+            // released back to open) is not yet under an assignee, so a raise is
+            // premature and fails closed.
+            if matches!(
+                record.status,
+                crate::task_events::TaskStatus::Backlog | crate::task_events::TaskStatus::Open
+            ) {
+                return deny_counter("may only be raised after the assignee has claimed the task");
+            }
+            let current = record
+                .metadata
+                .get("plan_ack_required")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+            if proposed < current {
+                return deny_counter(&format!(
+                    "may only be raised, never lowered ({current} → {proposed})"
+                ));
+            }
+        }
+        // I3: idempotency FIRST (a same-content write is a no-op for anyone —
+        // no reject, no event, no ack reset), then owner-pre-ack /
+        // GOV_AUTHOR-content-change(reopens acks) / else deny.
+        "plan" => {
+            if record.metadata.get("plan") == Some(&value) {
+                let task = read_task_record_at(&board, id).map(|r| record_to_task(&r));
+                return serde_json::json!({
+                    "id": id, "event": "metadata_set", "task": task, "noop": true
+                });
+            }
+            let acks_present = record
+                .metadata
+                .get("plan_acks")
+                .and_then(|v| v.as_array())
+                .map(|a| !a.is_empty())
+                .unwrap_or(false);
+            let is_owner = record.owner.as_ref().map(|o| o.0.as_str()) == Some(instance_name);
+            if is_gov_author {
+                // Creator/system content-change reopens the gate: reset acks.
+                reset_acks = acks_present;
+            } else if is_owner {
+                // The assignee may author/revise the plan ONLY before the first
+                // ack; after that it is frozen (only the creator may change it).
+                if acks_present {
+                    return serde_json::json!({
+                        "error": "the plan is frozen once a reviewer has acked it; only the task creator may change it (which re-opens acks)",
+                        "code": "plan_frozen_after_ack",
+                    });
+                }
+            } else {
+                return serde_json::json!({
+                    "error": "permission denied: only the assignee (pre-ack) or the task creator may set the plan",
+                    "code": "plan_write_denied",
+                });
+            }
+        }
+        // I4: every other key keeps the unchanged owner/orchestrator ACL.
+        _ => {
+            if !can_mutate_record(home, instance_name, &record) {
+                return serde_json::json!({"error": "permission denied: caller is not owner/creator"});
+            }
+        }
     }
-    let event = crate::task_events::TaskEvent::MetadataSet {
+
+    let set_event = crate::task_events::TaskEvent::MetadataSet {
         task_id: crate::task_events::TaskId(id.to_string()),
         by: emitter.clone(),
         key: key.to_string(),
         value,
     };
-    match crate::task_events::append_at(&board, &emitter, event) {
+    let append_result = if reset_acks {
+        // I6: emit the plan change + an audit-visible plan_acks=[] reset as ONE
+        // atomic batch so replay re-derives the reopened gate deterministically.
+        let reset_event = crate::task_events::TaskEvent::MetadataSet {
+            task_id: crate::task_events::TaskId(id.to_string()),
+            by: emitter.clone(),
+            key: "plan_acks".to_string(),
+            value: serde_json::json!([]),
+        };
+        crate::task_events::append_batch_at(&board, &emitter, vec![set_event, reset_event])
+            .map(|_| 0u64)
+    } else {
+        crate::task_events::append_at(&board, &emitter, set_event)
+    };
+    match append_result {
         Ok(_) => {
             let task = read_task_record_at(&board, id).map(|r| record_to_task(&r));
             serde_json::json!({"id": id, "event": "metadata_set", "task": task})

--- a/src/tasks/handler/tests.rs
+++ b/src/tasks/handler/tests.rs
@@ -1877,3 +1877,181 @@ fn gov_r8_counter_write_denied_for_every_identity_t74() {
     std::fs::remove_dir_all(&home).ok();
     std::fs::remove_dir_all(&orch_home).ok();
 }
+
+/// Drive a task all the way to in_progress: create (gated at 1), claim, creator
+/// authors the plan, a non-assignee acks, assignee transitions to in_progress.
+/// Returns the task id, now with status == InProgress and 1 ack recorded.
+fn gov_seed_in_progress(home: &std::path::Path) -> String {
+    let id = gov_seed_claimed(home, 1);
+    handle(
+        home,
+        "lead",
+        &serde_json::json!({
+            "action": "metadata_set", "id": id,
+            "metadata_key": "plan", "metadata_value": "plan A"
+        }),
+    );
+    handle(
+        home,
+        "reviewer-a",
+        &serde_json::json!({"action": "ack_plan", "id": id}),
+    );
+    let started = handle(
+        home,
+        "worker",
+        &serde_json::json!({"action": "update", "id": id, "status": "in_progress"}),
+    );
+    assert!(
+        started["error"].is_null(),
+        "precondition: in_progress reached: {started}"
+    );
+    id
+}
+
+/// R9 (PR #2761 r1) — once WORK HAS STARTED (in_progress), the plan is frozen
+/// for EVERYONE, creator included. r0's bug: a GOV_AUTHOR content-change reset
+/// plan_acks but performed NO status transition, so work kept running under an
+/// unacked replacement plan. The fix rejects the content-change (no silent
+/// reset, no status mutation). Same-content stays an idempotent no-op.
+#[test]
+fn gov_r9_plan_frozen_once_in_progress_t74() {
+    let home = tmp_home("gov-r9");
+    let id = gov_seed_in_progress(&home);
+
+    // Creator content-change while in_progress → frozen (NOT reset).
+    let creator_change = handle(
+        &home,
+        "lead",
+        &serde_json::json!({
+            "action": "metadata_set", "id": id,
+            "metadata_key": "plan", "metadata_value": "plan B"
+        }),
+    );
+    assert_eq!(
+        creator_change["code"], "plan_frozen_work_started",
+        "creator must not content-change the plan once work started: {creator_change}"
+    );
+    // Owner content-change while in_progress → also frozen.
+    let owner_change = handle(
+        &home,
+        "worker",
+        &serde_json::json!({
+            "action": "metadata_set", "id": id,
+            "metadata_key": "plan", "metadata_value": "plan C"
+        }),
+    );
+    assert_eq!(
+        owner_change["code"], "plan_frozen_work_started",
+        "owner must not content-change the plan once work started: {owner_change}"
+    );
+
+    // No mutation: plan unchanged, acks NOT reset, status still in_progress.
+    assert_eq!(gov_plan_text(&home, &id).as_deref(), Some("plan A"));
+    assert_eq!(
+        gov_plan_acks_len(&home, &id),
+        1,
+        "a rejected in_progress content-change must NOT reset acks"
+    );
+    assert_eq!(
+        read_task_record(&home, &id).expect("exists").status,
+        crate::task_events::TaskStatus::InProgress,
+        "status must stay in_progress (metadata_set never transitions status)"
+    );
+
+    // Same-content write is STILL an idempotent no-op, even in_progress.
+    let noop = handle(
+        &home,
+        "lead",
+        &serde_json::json!({
+            "action": "metadata_set", "id": id,
+            "metadata_key": "plan", "metadata_value": "plan A"
+        }),
+    );
+    assert!(
+        noop["error"].is_null(),
+        "same-content plan write must remain a no-op in_progress: {noop}"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// R10 (PR #2761 r1) — the freeze holds in a later lifecycle state (in_review):
+/// a content-change past the pre-work window is rejected regardless of how far
+/// the task has progressed.
+#[test]
+fn gov_r10_plan_frozen_in_review_t74() {
+    let home = tmp_home("gov-r10");
+    let id = gov_seed_in_progress(&home);
+    let review = handle(
+        &home,
+        "worker",
+        &serde_json::json!({"action": "update", "id": id, "status": "in_review"}),
+    );
+    assert!(
+        review["error"].is_null(),
+        "precondition: in_review reached: {review}"
+    );
+
+    let change = handle(
+        &home,
+        "lead",
+        &serde_json::json!({
+            "action": "metadata_set", "id": id,
+            "metadata_key": "plan", "metadata_value": "plan B"
+        }),
+    );
+    assert_eq!(
+        change["code"], "plan_frozen_work_started",
+        "plan must stay frozen in in_review: {change}"
+    );
+    assert_eq!(gov_plan_text(&home, &id).as_deref(), Some("plan A"));
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// R11 (PR #2761 r1) — Blocked-ambiguity resolved fail-closed: a Blocked task
+/// has (in general) already started work, so the plan is frozen there too. A
+/// content-change while Blocked is rejected for every identity.
+#[test]
+fn gov_r11_plan_frozen_when_blocked_t74() {
+    let home = tmp_home("gov-r11");
+    let id = gov_seed_in_progress(&home);
+    let blocked = handle(
+        &home,
+        "worker",
+        &serde_json::json!({"action": "update", "id": id, "status": "blocked"}),
+    );
+    assert!(
+        blocked["error"].is_null(),
+        "precondition: blocked reached: {blocked}"
+    );
+
+    // Creator and owner both frozen while Blocked.
+    for who in ["lead", "worker"] {
+        let change = handle(
+            &home,
+            who,
+            &serde_json::json!({
+                "action": "metadata_set", "id": id,
+                "metadata_key": "plan", "metadata_value": "plan B"
+            }),
+        );
+        assert_eq!(
+            change["code"], "plan_frozen_work_started",
+            "{who} must not content-change the plan while Blocked: {change}"
+        );
+    }
+    assert_eq!(gov_plan_text(&home, &id).as_deref(), Some("plan A"));
+    // Same-content no-op still holds while Blocked.
+    let noop = handle(
+        &home,
+        "lead",
+        &serde_json::json!({
+            "action": "metadata_set", "id": id,
+            "metadata_key": "plan", "metadata_value": "plan A"
+        }),
+    );
+    assert!(
+        noop["error"].is_null(),
+        "same-content no-op must hold while Blocked: {noop}"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}

--- a/src/tasks/handler/tests.rs
+++ b/src/tasks/handler/tests.rs
@@ -1329,3 +1329,551 @@ fn update_idempotent_result_with_malformed_other_field_errors() {
         "equal result + malformed other field must fail loud, not unchanged: {resp}"
     );
 }
+
+// ── task-governance metadata ACL (t-…-74, decision d-…-22, Root m-1087) ──
+// RED-first through the REAL MCP handler entry `handle(home, caller, args)`.
+// Model: `create` sets created_by = caller, assignee → owner. So throughout:
+//   owner/assignee = "worker",  created_by/GOV_AUTHOR = "lead".
+// The owner can forge plan_acks, lower plan_ack_required, and rewrite the plan
+// after acks today (handle_metadata_set gates only on can_mutate_record then
+// writes ANY key). GOV_AUTHOR (created_by) has NO write authority today. These
+// tests pin the target behavior; they fail against current code (RED).
+
+fn gov_plan_acks_len(home: &std::path::Path, id: &str) -> usize {
+    read_task_record(home, id)
+        .and_then(|r| {
+            r.metadata
+                .get("plan_acks")
+                .and_then(|v| v.as_array())
+                .map(|a| a.len())
+        })
+        .unwrap_or(0)
+}
+
+fn gov_plan_ack_required(home: &std::path::Path, id: &str) -> u64 {
+    read_task_record(home, id)
+        .and_then(|r| r.metadata.get("plan_ack_required").and_then(|v| v.as_u64()))
+        .unwrap_or(0)
+}
+
+fn gov_plan_text(home: &std::path::Path, id: &str) -> Option<String> {
+    read_task_record(home, id).and_then(|r| {
+        r.metadata
+            .get("plan")
+            .and_then(|v| v.as_str().map(String::from))
+    })
+}
+
+/// Create a task owned by `worker`, created by `lead`, gated at N acks, then
+/// claim it so status == Claimed (satisfies I2's "after assignee claim").
+fn gov_seed_claimed(home: &std::path::Path, required: u64) -> String {
+    let created = handle(
+        home,
+        "lead",
+        &serde_json::json!({
+            "action": "create",
+            "title": "governed task",
+            "assignee": "worker",
+            "plan_ack_required": required,
+            "plan_ack_reason": "repairs the plan-ack gate itself",
+        }),
+    );
+    let id = created["id"].as_str().expect("id").to_string();
+    handle(
+        home,
+        "worker",
+        &serde_json::json!({"action": "claim", "id": id}),
+    );
+    id
+}
+
+/// R1 — the OWNER cannot self-weaken plan_ack_required (lower it or, being a
+/// non-author, raise it). The counter must stay at its created value.
+#[test]
+fn gov_r1_owner_cannot_lower_or_raise_plan_ack_required_t74() {
+    let home = tmp_home("gov-r1");
+    let id = gov_seed_claimed(&home, 2);
+
+    for bad in [0u64, 1] {
+        let r = handle(
+            &home,
+            "worker",
+            &serde_json::json!({
+                "action": "metadata_set", "id": id,
+                "metadata_key": "plan_ack_required", "metadata_value": bad
+            }),
+        );
+        assert_eq!(
+            r["code"], "plan_ack_required_protected",
+            "owner lowering plan_ack_required to {bad} must be rejected: {r}"
+        );
+    }
+    // Even a *raise* by the owner (non-author) is rejected — only GOV_AUTHOR raises.
+    let raise = handle(
+        &home,
+        "worker",
+        &serde_json::json!({
+            "action": "metadata_set", "id": id,
+            "metadata_key": "plan_ack_required", "metadata_value": 3
+        }),
+    );
+    assert_eq!(
+        raise["code"], "plan_ack_required_protected",
+        "owner (non-author) raising plan_ack_required must be rejected: {raise}"
+    );
+    assert_eq!(
+        gov_plan_ack_required(&home, &id),
+        2,
+        "plan_ack_required must be unchanged after every rejected write"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// R2 — the OWNER cannot forge plan_acks via metadata_set (only handle_ack_plan
+/// may append). plan_acks must stay empty and the gate stays shut.
+#[test]
+fn gov_r2_owner_cannot_forge_plan_acks_t74() {
+    let home = tmp_home("gov-r2");
+    let id = gov_seed_claimed(&home, 2);
+    // Owner may author the plan pre-ack (legit).
+    handle(
+        &home,
+        "worker",
+        &serde_json::json!({
+            "action": "metadata_set", "id": id,
+            "metadata_key": "plan", "metadata_value": "the plan"
+        }),
+    );
+
+    let forged = handle(
+        &home,
+        "worker",
+        &serde_json::json!({
+            "action": "metadata_set", "id": id,
+            "metadata_key": "plan_acks",
+            "metadata_value": ["reviewer-a", "reviewer-b"]
+        }),
+    );
+    assert_eq!(
+        forged["code"], "plan_acks_immutable",
+        "owner forging plan_acks must be rejected: {forged}"
+    );
+    assert_eq!(
+        gov_plan_acks_len(&home, &id),
+        0,
+        "plan_acks must remain empty after a rejected forge"
+    );
+    // Gate still shut: 0/2.
+    let blocked = handle(
+        &home,
+        "worker",
+        &serde_json::json!({"action": "update", "id": id, "status": "in_progress"}),
+    );
+    assert_eq!(
+        blocked["code"], "plan_ack_pending",
+        "forged acks must not have opened the gate: {blocked}"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// R3 — once an ack lands, the OWNER can no longer content-change the plan
+/// (owner-frozen). A same-content write stays an idempotent no-op.
+#[test]
+fn gov_r3_owner_plan_frozen_after_first_ack_t74() {
+    let home = tmp_home("gov-r3");
+    let id = gov_seed_claimed(&home, 2);
+    // Owner authors the plan pre-ack (ok).
+    let set = handle(
+        &home,
+        "worker",
+        &serde_json::json!({
+            "action": "metadata_set", "id": id,
+            "metadata_key": "plan", "metadata_value": "plan A"
+        }),
+    );
+    assert!(
+        set["error"].is_null(),
+        "owner pre-ack plan write must succeed: {set}"
+    );
+    // A non-assignee ack lands.
+    let ack = handle(
+        &home,
+        "reviewer-a",
+        &serde_json::json!({"action": "ack_plan", "id": id}),
+    );
+    assert_eq!(ack["acked"], 1, "reviewer-a ack must land: {ack}");
+
+    // Owner CONTENT-CHANGE after ack → frozen.
+    let frozen = handle(
+        &home,
+        "worker",
+        &serde_json::json!({
+            "action": "metadata_set", "id": id,
+            "metadata_key": "plan", "metadata_value": "plan B (sneaky rewrite)"
+        }),
+    );
+    assert_eq!(
+        frozen["code"], "plan_frozen_after_ack",
+        "owner rewriting the plan after an ack must be rejected: {frozen}"
+    );
+    assert_eq!(
+        gov_plan_text(&home, &id).as_deref(),
+        Some("plan A"),
+        "the acked plan content must be unchanged after a rejected rewrite"
+    );
+    assert_eq!(
+        gov_plan_acks_len(&home, &id),
+        1,
+        "a rejected owner rewrite must not disturb existing acks"
+    );
+
+    // Same-content owner write after ack → idempotent no-op (no reject, no reset).
+    let noop = handle(
+        &home,
+        "worker",
+        &serde_json::json!({
+            "action": "metadata_set", "id": id,
+            "metadata_key": "plan", "metadata_value": "plan A"
+        }),
+    );
+    assert!(
+        noop["error"].is_null(),
+        "same-content owner plan write must be an idempotent no-op, not a reject: {noop}"
+    );
+    assert_eq!(
+        gov_plan_acks_len(&home, &id),
+        1,
+        "idempotent same-content write must not reset acks"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// R4 — the CREATOR (created_by, cross-team, post-claim) MAY author the plan and
+/// MAY raise plan_ack_required monotonically. Both are denied today.
+#[test]
+fn gov_r4_creator_governance_writes_allowed_t74() {
+    let home = tmp_home("gov-r4");
+    let id = gov_seed_claimed(&home, 1);
+    // No fleet.yaml → "lead" is neither owner nor orchestrator of "worker"
+    // (cross-team). Authority comes ONLY from being created_by.
+    let plan = handle(
+        &home,
+        "lead",
+        &serde_json::json!({
+            "action": "metadata_set", "id": id,
+            "metadata_key": "plan", "metadata_value": "creator-authored plan"
+        }),
+    );
+    assert!(
+        plan["error"].is_null(),
+        "created_by must be able to author the plan: {plan}"
+    );
+    assert_eq!(
+        gov_plan_text(&home, &id).as_deref(),
+        Some("creator-authored plan")
+    );
+
+    let raise = handle(
+        &home,
+        "lead",
+        &serde_json::json!({
+            "action": "metadata_set", "id": id,
+            "metadata_key": "plan_ack_required", "metadata_value": 2
+        }),
+    );
+    assert!(
+        raise["error"].is_null(),
+        "created_by must be able to raise plan_ack_required monotonically: {raise}"
+    );
+    assert_eq!(gov_plan_ack_required(&home, &id), 2);
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// R5 — a CREATOR content-change resets plan_acks (reopening the gate) and
+/// blocks in_progress until re-acked; a same-content creator write is an
+/// idempotent no-op that preserves acks.
+#[test]
+fn gov_r5_creator_content_change_resets_acks_idempotent_preserves_t74() {
+    let home = tmp_home("gov-r5");
+    let id = gov_seed_claimed(&home, 2);
+    handle(
+        &home,
+        "lead",
+        &serde_json::json!({
+            "action": "metadata_set", "id": id,
+            "metadata_key": "plan", "metadata_value": "content A"
+        }),
+    );
+    handle(
+        &home,
+        "reviewer-a",
+        &serde_json::json!({"action": "ack_plan", "id": id}),
+    );
+    handle(
+        &home,
+        "reviewer-b",
+        &serde_json::json!({"action": "ack_plan", "id": id}),
+    );
+    assert_eq!(gov_plan_acks_len(&home, &id), 2, "precondition: 2/2 acked");
+
+    // Creator CONTENT-CHANGE → acks reset to [].
+    let changed = handle(
+        &home,
+        "lead",
+        &serde_json::json!({
+            "action": "metadata_set", "id": id,
+            "metadata_key": "plan", "metadata_value": "content B"
+        }),
+    );
+    assert!(
+        changed["error"].is_null(),
+        "creator content-change must succeed: {changed}"
+    );
+    assert_eq!(
+        gov_plan_acks_len(&home, &id),
+        0,
+        "a creator content-change must RESET plan_acks (reopen the gate)"
+    );
+    let blocked = handle(
+        &home,
+        "worker",
+        &serde_json::json!({"action": "update", "id": id, "status": "in_progress"}),
+    );
+    assert_eq!(
+        blocked["code"], "plan_ack_pending",
+        "in_progress must be blocked until the plan is re-acked: {blocked}"
+    );
+
+    // Re-ack, then a SAME-content creator write → idempotent no-op, acks preserved.
+    handle(
+        &home,
+        "reviewer-a",
+        &serde_json::json!({"action": "ack_plan", "id": id}),
+    );
+    handle(
+        &home,
+        "reviewer-b",
+        &serde_json::json!({"action": "ack_plan", "id": id}),
+    );
+    assert_eq!(gov_plan_acks_len(&home, &id), 2, "re-acked to 2/2");
+    let noop = handle(
+        &home,
+        "lead",
+        &serde_json::json!({
+            "action": "metadata_set", "id": id,
+            "metadata_key": "plan", "metadata_value": "content B"
+        }),
+    );
+    assert!(
+        noop["error"].is_null(),
+        "same-content creator write must be a no-op: {noop}"
+    );
+    assert_eq!(
+        gov_plan_acks_len(&home, &id),
+        2,
+        "idempotent same-content creator write must NOT reset acks"
+    );
+    let unblocked = handle(
+        &home,
+        "worker",
+        &serde_json::json!({"action": "update", "id": id, "status": "in_progress"}),
+    );
+    assert!(
+        unblocked["error"].is_null(),
+        "preserved acks must keep the gate open: {unblocked}"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// R6 — the CREATOR has governance authority ONLY. No done / status-update /
+/// non-governance metadata authority (I5, I4). Guard against GREEN over-grant.
+#[test]
+fn gov_r6_creator_has_no_operational_authority_t74() {
+    let home = tmp_home("gov-r6");
+    let id = gov_seed_claimed(&home, 1);
+
+    let done = handle(
+        &home,
+        "lead",
+        &serde_json::json!({"action": "done", "id": id, "result": "sneaky close"}),
+    );
+    assert!(
+        done.get("error").is_some(),
+        "creator must not be able to `done`: {done}"
+    );
+
+    let upd = handle(
+        &home,
+        "lead",
+        &serde_json::json!({"action": "update", "id": id, "status": "blocked"}),
+    );
+    assert!(
+        upd.get("error").is_some(),
+        "creator must not be able to update operational status: {upd}"
+    );
+
+    let meta = handle(
+        &home,
+        "lead",
+        &serde_json::json!({
+            "action": "metadata_set", "id": id,
+            "metadata_key": "priority_note", "metadata_value": "creator poking non-gov key"
+        }),
+    );
+    assert!(
+        meta.get("error").is_some(),
+        "creator must not write a non-governance metadata key: {meta}"
+    );
+    assert!(
+        read_task_record(&home, &id)
+            .map(|r| !r.metadata.contains_key("priority_note"))
+            .unwrap_or(false),
+        "the non-governance key must not have been written"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// R7 — the OWNER's pre-ack plan authoring workflow is preserved (I3 owner
+/// branch, zero acks). Guard that GREEN doesn't over-freeze.
+#[test]
+fn gov_r7_owner_pre_ack_authoring_preserved_t74() {
+    let home = tmp_home("gov-r7");
+    let id = gov_seed_claimed(&home, 2);
+    let first = handle(
+        &home,
+        "worker",
+        &serde_json::json!({
+            "action": "metadata_set", "id": id,
+            "metadata_key": "plan", "metadata_value": "draft 1"
+        }),
+    );
+    assert!(
+        first["error"].is_null(),
+        "owner pre-ack plan authoring must succeed: {first}"
+    );
+    // Owner may still revise the plan while zero acks exist.
+    let revise = handle(
+        &home,
+        "worker",
+        &serde_json::json!({
+            "action": "metadata_set", "id": id,
+            "metadata_key": "plan", "metadata_value": "draft 2"
+        }),
+    );
+    assert!(
+        revise["error"].is_null(),
+        "owner may revise the plan while zero acks exist: {revise}"
+    );
+    assert_eq!(gov_plan_text(&home, &id).as_deref(), Some("draft 2"));
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// R8 — a generic/invalid governance-counter write is denied for EVERY identity,
+/// including the strongest (owner, creator/GOV_AUTHOR, a SYSTEM identity, and a
+/// team ORCHESTRATOR who passes can_mutate_record). plan_acks is immutable for
+/// all; plan_ack_required rejects lower/non-numeric for all.
+#[test]
+fn gov_r8_counter_write_denied_for_every_identity_t74() {
+    let home = tmp_home("gov-r8");
+    let id = gov_seed_claimed(&home, 2);
+    handle(
+        &home,
+        "worker",
+        &serde_json::json!({
+            "action": "metadata_set", "id": id,
+            "metadata_key": "plan", "metadata_value": "the plan"
+        }),
+    );
+
+    // plan_acks is immutable via metadata_set for owner, creator, and system.
+    for who in ["worker", "lead", "system:task_sweep"] {
+        let r = handle(
+            &home,
+            who,
+            &serde_json::json!({
+                "action": "metadata_set", "id": id,
+                "metadata_key": "plan_acks", "metadata_value": ["x", "y"]
+            }),
+        );
+        assert_eq!(
+            r["code"], "plan_acks_immutable",
+            "{who} must not be able to raw-write plan_acks: {r}"
+        );
+    }
+    assert_eq!(gov_plan_acks_len(&home, &id), 0, "plan_acks stayed empty");
+
+    // plan_ack_required: lower (by GOV_AUTHOR creator, and by SYSTEM) → rejected.
+    for who in ["lead", "system:task_sweep"] {
+        let lower = handle(
+            &home,
+            who,
+            &serde_json::json!({
+                "action": "metadata_set", "id": id,
+                "metadata_key": "plan_ack_required", "metadata_value": 1
+            }),
+        );
+        assert_eq!(
+            lower["code"], "plan_ack_required_protected",
+            "{who} must not be able to LOWER plan_ack_required: {lower}"
+        );
+    }
+    // Non-numeric raise by the creator → rejected (typed validation).
+    let non_numeric = handle(
+        &home,
+        "lead",
+        &serde_json::json!({
+            "action": "metadata_set", "id": id,
+            "metadata_key": "plan_ack_required", "metadata_value": "lots"
+        }),
+    );
+    assert_eq!(
+        non_numeric["code"], "plan_ack_required_protected",
+        "non-numeric plan_ack_required must be rejected: {non_numeric}"
+    );
+    assert_eq!(gov_plan_ack_required(&home, &id), 2, "counter unchanged");
+
+    // A team ORCHESTRATOR who passes can_mutate_record but is NOT created_by is
+    // ALSO denied — no transitive authority expansion (Root m-1087).
+    let orch_home = tmp_home("gov-r8-orch");
+    write_fleet_yaml_with_team(&orch_home, "my-team", "team-lead");
+    let created = handle(
+        &orch_home,
+        "lead",
+        &serde_json::json!({
+            "action": "create", "title": "orch task", "assignee": "dev-a",
+            "plan_ack_required": 2, "plan_ack_reason": "gate repair"
+        }),
+    );
+    let oid = created["id"].as_str().expect("id").to_string();
+    handle(
+        &orch_home,
+        "dev-a",
+        &serde_json::json!({"action": "claim", "id": oid}),
+    );
+    let orch_forge = handle(
+        &orch_home,
+        "team-lead",
+        &serde_json::json!({
+            "action": "metadata_set", "id": oid,
+            "metadata_key": "plan_acks", "metadata_value": ["a", "b"]
+        }),
+    );
+    assert_eq!(
+        orch_forge["code"], "plan_acks_immutable",
+        "an orchestrator (non-created_by) must not forge plan_acks: {orch_forge}"
+    );
+    let orch_lower = handle(
+        &orch_home,
+        "team-lead",
+        &serde_json::json!({
+            "action": "metadata_set", "id": oid,
+            "metadata_key": "plan_ack_required", "metadata_value": 1
+        }),
+    );
+    assert_eq!(
+        orch_lower["code"], "plan_ack_required_protected",
+        "an orchestrator (non-created_by) must not lower plan_ack_required: {orch_lower}"
+    );
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&orch_home).ok();
+}


### PR DESCRIPTION
## What & why
`handle_metadata_set` gated only on `can_mutate_record` (owner/orchestrator/system) then wrote **any** key/value. That let the task **OWNER** self-weaken the #2249 pre-work alignment gate: forge `plan_acks`, lower `plan_ack_required`, or rewrite the `plan` after reviewers had acked it. `created_by` had no write authority at all.

Implements decision `d-…-22` (C-typed immediate slice), task `t-…-74`, Root ruling `m-1087`. **No schema promotion** (typed field = separate task `t-…-79`). **No transitive authority expansion.**

## Governance authority
`GOV_AUTHOR(caller, record) := caller == record.created_by || is_system_identity(caller)` — EXACTLY the creator (+ system). **Not** the assignee, **not** the team orchestrator. Deliberately narrower than `can_mutate_record` — the gate must not be self-weakenable by the agent it constrains.

## Invariants (per-key classifier before the raw write)
- **I1** `plan_acks` → immutable via `metadata_set` for *every* identity (only `ack_plan` appends; the reopen-reset emits its own `[]`-event). `code=plan_acks_immutable`
- **I2** `plan_ack_required` → only a **GOV_AUTHOR monotonic raise** (numeric, ≥ current, after assignee claim); lower / non-numeric / non-author / pre-claim fail closed. `code=plan_ack_required_protected`
- **I3** `plan` → **idempotency FIRST** (same-content = no-op for anyone). Owner may author/revise only **pre-first-ack** (after → frozen); GOV_AUTHOR content-change is allowed and **resets `plan_acks=[]` atomically** (`append_batch_at`) to reopen the gate. `codes=plan_frozen_after_ack / plan_write_denied`
- **I4** other keys → unchanged `can_mutate_record`
- **I5** GOV_AUTHOR has **no** operational (done/update/non-gov metadata) authority
- **I6** `plan_acks` stays list-of-names; `MetadataSet` events keep replay determinism

## Design notes (from plan review)
- The GOV_AUTHOR-reset **owner-freeze loop** is intentional and harmless: after a creator content-change resets acks, the owner regains pre-ack editability, but the in_progress gate still requires fresh acks for *any* final content — completeness cannot be bypassed.
- `GOV_AUTHOR` includes `is_system_identity`, so **R8 explicitly proves a system identity also cannot generic-write the counter** (per reviewer-5's addendum).

## Tests — RED-first through the real `handle()` MCP entry
`gov_r1..gov_r8` in `src/tasks/handler/tests.rs`. R1–R5, R8 failed before the fix (the live vulnerabilities); R6/R7 are regression guards. R8 spans owner + creator + **system** + a fleet **orchestrator** (who passes `can_mutate_record` but is denied — no transitive authority).

## Verification
- 8 `gov_r` RED→GREEN; `tasks::` 200 pass; `acl::` pass.
- Full main-bin suite w/ `AGENTIC_GIT_REAL_GIT`: **5180 pass** (1 pre-existing port-alloc flake, passes in isolation; unrelated to this diff).
- CI fmt gate (`git ls-files '*.rs' ':!:vendor/**' | rustfmt --edition 2021 --check`): clean.
- Exact CI clippy line (`--features tray -D warnings`, all bins/tests/examples): clean.
- Blast radius: the only user-reachable `metadata_set` writer of these keys is `handle_metadata_set` (`task.rs:79` → `tasks::handle`); create-seed + `ack_plan` are separate legit paths.

Requires exact-head root review + independent second review before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)