### PR TITLE
fix(#2755): transactional recursive submodule provisioning in repo checkout

### DIFF
--- a/src/binding.rs
+++ b/src/binding.rs
@@ -779,6 +779,59 @@ pub fn is_agent_in_managed_worktree(home: &Path, agent: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// #2755 R4: whether ANY agent's binding currently targets `worktree_path`. Checkout
+/// recovery MUST never delete a still-BOUND worktree (a crash after `bind_full` but
+/// before the Committed journal leaves the binding written yet the journal
+/// non-Committed) — the provision effectively succeeded and must be ADOPTED, not torn
+/// down. `Uncertain` (a binding dir/file exists but is unreadable) fails closed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WorktreeBindingState {
+    /// A binding maps this exact worktree path — adopt/keep it.
+    Bound,
+    /// No binding targets it — safe to reconcile/remove.
+    Unbound,
+    /// A runtime dir/binding could not be read — authority uncertain, fail closed.
+    Uncertain,
+}
+
+/// Scan `runtime/*/binding.json` for a binding whose `worktree` equals `worktree_path`.
+/// A NotFound runtime area or per-agent binding is `Unbound`; any other read error is
+/// `Uncertain` (fail-closed). A corrupt/newer-schema binding that does not match is
+/// simply not this worktree's binding.
+pub(crate) fn worktree_binding_state(home: &Path, worktree_path: &Path) -> WorktreeBindingState {
+    let rt = crate::paths::runtime_dir(home);
+    let entries = match std::fs::read_dir(&rt) {
+        Ok(e) => e,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return WorktreeBindingState::Unbound,
+        Err(_) => return WorktreeBindingState::Uncertain,
+    };
+    let target = worktree_path.to_string_lossy();
+    for entry in entries {
+        let Ok(entry) = entry else {
+            return WorktreeBindingState::Uncertain;
+        };
+        let bp = entry.path().join("binding.json");
+        match std::fs::read_to_string(&bp) {
+            Ok(c) => {
+                if parse_binding_guarded(&c)
+                    .and_then(|v| {
+                        v.get("worktree")
+                            .and_then(|w| w.as_str())
+                            .map(str::to_string)
+                    })
+                    .as_deref()
+                    == Some(target.as_ref())
+                {
+                    return WorktreeBindingState::Bound;
+                }
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(_) => return WorktreeBindingState::Uncertain,
+        }
+    }
+    WorktreeBindingState::Unbound
+}
+
 /// Install the prepare-commit-msg hook into a worktree via core.hooksPath.
 /// Points to `$AGEND_HOME/hooks/` unified directory.
 /// Installs bash hook on Unix, PowerShell hook on Windows.

--- a/src/binding.rs
+++ b/src/binding.rs
@@ -779,58 +779,10 @@ pub fn is_agent_in_managed_worktree(home: &Path, agent: &str) -> bool {
         .unwrap_or(false)
 }
 
-/// #2755 R4: whether ANY agent's binding currently targets `worktree_path`. Checkout
-/// recovery MUST never delete a still-BOUND worktree (a crash after `bind_full` but
-/// before the Committed journal leaves the binding written yet the journal
-/// non-Committed) — the provision effectively succeeded and must be ADOPTED, not torn
-/// down. `Uncertain` (a binding dir/file exists but is unreadable) fails closed.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum WorktreeBindingState {
-    /// A binding maps this exact worktree path — adopt/keep it.
-    Bound,
-    /// No binding targets it — safe to reconcile/remove.
-    Unbound,
-    /// A runtime dir/binding could not be read — authority uncertain, fail closed.
-    Uncertain,
-}
-
-/// Scan `runtime/*/binding.json` for a binding whose `worktree` equals `worktree_path`.
-/// A NotFound runtime area or per-agent binding is `Unbound`; any other read error is
-/// `Uncertain` (fail-closed). A corrupt/newer-schema binding that does not match is
-/// simply not this worktree's binding.
-pub(crate) fn worktree_binding_state(home: &Path, worktree_path: &Path) -> WorktreeBindingState {
-    let rt = crate::paths::runtime_dir(home);
-    let entries = match std::fs::read_dir(&rt) {
-        Ok(e) => e,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return WorktreeBindingState::Unbound,
-        Err(_) => return WorktreeBindingState::Uncertain,
-    };
-    let target = worktree_path.to_string_lossy();
-    for entry in entries {
-        let Ok(entry) = entry else {
-            return WorktreeBindingState::Uncertain;
-        };
-        let bp = entry.path().join("binding.json");
-        match std::fs::read_to_string(&bp) {
-            Ok(c) => {
-                if parse_binding_guarded(&c)
-                    .and_then(|v| {
-                        v.get("worktree")
-                            .and_then(|w| w.as_str())
-                            .map(str::to_string)
-                    })
-                    .as_deref()
-                    == Some(target.as_ref())
-                {
-                    return WorktreeBindingState::Bound;
-                }
-            }
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-            Err(_) => return WorktreeBindingState::Uncertain,
-        }
-    }
-    WorktreeBindingState::Unbound
-}
+/// #2755 R4: binding-adoption query for checkout recovery, extracted to the
+/// `worktree_state` submodule; re-exported for the stable `crate::binding` path.
+mod worktree_state;
+pub(crate) use worktree_state::{worktree_binding_state, WorktreeBindingState};
 
 /// Install the prepare-commit-msg hook into a worktree via core.hooksPath.
 /// Points to `$AGEND_HOME/hooks/` unified directory.

--- a/src/binding/worktree_state.rs
+++ b/src/binding/worktree_state.rs
@@ -12,21 +12,31 @@ use std::path::Path;
 /// recovery MUST never delete a still-BOUND worktree (a crash after `bind_full` but
 /// before the Committed journal leaves the binding written yet the journal
 /// non-Committed) — the provision effectively succeeded and must be ADOPTED, not torn
-/// down. `Uncertain` (a binding dir/file exists but is unreadable) fails closed.
+/// down. A binding that is PRESENT but cannot be confidently understood is `Uncertain`
+/// and also fails closed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum WorktreeBindingState {
     /// A binding maps this exact worktree path — adopt/keep it.
     Bound,
-    /// No binding targets it — safe to reconcile/remove.
+    /// No binding is present for this path — safe to reconcile/remove.
     Unbound,
-    /// A runtime dir/binding could not be read — authority uncertain, fail closed.
+    /// A binding is PRESENT but cannot be confidently understood — a read error, corrupt
+    /// JSON, a FUTURE schema this daemon can't parse, or a record with no usable `worktree`
+    /// field — so it MIGHT target this path. Authority uncertain: fail closed (never remove).
     Uncertain,
 }
 
 /// Scan `runtime/*/binding.json` for a binding whose `worktree` equals `worktree_path`.
-/// A NotFound runtime area or per-agent binding is `Unbound`; any other read error is
-/// `Uncertain` (fail-closed). A corrupt/newer-schema binding that does not match is
-/// simply not this worktree's binding.
+///
+/// A definitive match is [`Bound`](WorktreeBindingState::Bound). A genuinely ABSENT
+/// binding (no `binding.json`, or a NotFound runtime area) does not block removal. But a
+/// binding that is PRESENT yet cannot be confidently understood — a read error, corrupt
+/// JSON, a schema NEWER than this daemon supports (`parse_binding_guarded` → `None`), or a
+/// record missing a usable `worktree` field — is [`Uncertain`](WorktreeBindingState::Uncertain):
+/// a DESTRUCTIVE retention site must never reclaim a worktree a newer daemon may legitimately
+/// own just because this daemon can't parse the binding ("future ≠ absent"; see
+/// [`super::parse_binding_guarded`] / [`super::present_including_future`]). Only a clean scan —
+/// no present-but-unreadable binding AND no match — is [`Unbound`](WorktreeBindingState::Unbound).
 pub(crate) fn worktree_binding_state(home: &Path, worktree_path: &Path) -> WorktreeBindingState {
     let rt = crate::paths::runtime_dir(home);
     let entries = match std::fs::read_dir(&rt) {
@@ -35,28 +45,33 @@ pub(crate) fn worktree_binding_state(home: &Path, worktree_path: &Path) -> Workt
         Err(_) => return WorktreeBindingState::Uncertain,
     };
     let target = worktree_path.to_string_lossy();
+    // A present-but-unreadable binding could be THIS worktree's owner; remember we saw one
+    // and fail closed (Uncertain) at the end unless a definitive Bound match turns up first.
+    let mut uncertain = false;
     for entry in entries {
         let Ok(entry) = entry else {
             return WorktreeBindingState::Uncertain;
         };
         let bp = entry.path().join("binding.json");
         match std::fs::read_to_string(&bp) {
-            Ok(c) => {
-                if parse_binding_guarded(&c)
-                    .and_then(|v| {
-                        v.get("worktree")
-                            .and_then(|w| w.as_str())
-                            .map(str::to_string)
-                    })
-                    .as_deref()
-                    == Some(target.as_ref())
-                {
-                    return WorktreeBindingState::Bound;
-                }
-            }
+            // Corrupt JSON or a newer-than-supported schema ⇒ `None` ⇒ cannot rule out
+            // that it targets us. A well-formed binding for a DIFFERENT worktree IS ruled
+            // out (skip); one with no usable `worktree` field is uncertain.
+            Ok(c) => match parse_binding_guarded(&c) {
+                None => uncertain = true,
+                Some(v) => match v.get("worktree").and_then(|w| w.as_str()) {
+                    Some(w) if w == target.as_ref() => return WorktreeBindingState::Bound,
+                    Some(_) => {}
+                    None => uncertain = true,
+                },
+            },
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
             Err(_) => return WorktreeBindingState::Uncertain,
         }
     }
-    WorktreeBindingState::Unbound
+    if uncertain {
+        WorktreeBindingState::Uncertain
+    } else {
+        WorktreeBindingState::Unbound
+    }
 }

--- a/src/binding/worktree_state.rs
+++ b/src/binding/worktree_state.rs
@@ -1,0 +1,62 @@
+//! #2755 R4: binding-adoption query for checkout recovery.
+//!
+//! Extracted from `binding.rs` so the parent stays under the anti-monolith
+//! ceiling (`tests/src_file_size_invariant.rs`); the binding-format coupling
+//! (`parse_binding_guarded`, the `worktree` field) stays in the `binding`
+//! module rather than leaking into the checkout handlers that consume it.
+
+use super::parse_binding_guarded;
+use std::path::Path;
+
+/// #2755 R4: whether ANY agent's binding currently targets `worktree_path`. Checkout
+/// recovery MUST never delete a still-BOUND worktree (a crash after `bind_full` but
+/// before the Committed journal leaves the binding written yet the journal
+/// non-Committed) — the provision effectively succeeded and must be ADOPTED, not torn
+/// down. `Uncertain` (a binding dir/file exists but is unreadable) fails closed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WorktreeBindingState {
+    /// A binding maps this exact worktree path — adopt/keep it.
+    Bound,
+    /// No binding targets it — safe to reconcile/remove.
+    Unbound,
+    /// A runtime dir/binding could not be read — authority uncertain, fail closed.
+    Uncertain,
+}
+
+/// Scan `runtime/*/binding.json` for a binding whose `worktree` equals `worktree_path`.
+/// A NotFound runtime area or per-agent binding is `Unbound`; any other read error is
+/// `Uncertain` (fail-closed). A corrupt/newer-schema binding that does not match is
+/// simply not this worktree's binding.
+pub(crate) fn worktree_binding_state(home: &Path, worktree_path: &Path) -> WorktreeBindingState {
+    let rt = crate::paths::runtime_dir(home);
+    let entries = match std::fs::read_dir(&rt) {
+        Ok(e) => e,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return WorktreeBindingState::Unbound,
+        Err(_) => return WorktreeBindingState::Uncertain,
+    };
+    let target = worktree_path.to_string_lossy();
+    for entry in entries {
+        let Ok(entry) = entry else {
+            return WorktreeBindingState::Uncertain;
+        };
+        let bp = entry.path().join("binding.json");
+        match std::fs::read_to_string(&bp) {
+            Ok(c) => {
+                if parse_binding_guarded(&c)
+                    .and_then(|v| {
+                        v.get("worktree")
+                            .and_then(|w| w.as_str())
+                            .map(str::to_string)
+                    })
+                    .as_deref()
+                    == Some(target.as_ref())
+                {
+                    return WorktreeBindingState::Bound;
+                }
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(_) => return WorktreeBindingState::Uncertain,
+        }
+    }
+    WorktreeBindingState::Unbound
+}

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -297,6 +297,13 @@ pub(crate) fn boot_hygiene_sweeps(home: &Path) {
             );
         }
     });
+    // #2755: retry any checkout-transaction rollback left pending by a prior
+    // (possibly crashed) daemon — the SAME callable the per-tick handler runs, so
+    // a worktree whose rollback `remove --force` failed recovers at boot, not only
+    // on the next tick.
+    time_step("checkout_txn_recover", || {
+        crate::mcp::handlers::ci::checkout_txn::recover_pending_sweep_prod(home);
+    });
 }
 
 /// Result of [`resolve_fleet_and_reconcile`]: the normalized fleet config, the

--- a/src/daemon/per_tick/checkout_txn_recover.rs
+++ b/src/daemon/per_tick/checkout_txn_recover.rs
@@ -1,0 +1,38 @@
+//! #2755: periodic recovery of stuck `repo action=checkout` transaction
+//! rollbacks. A worktree whose `git worktree remove --force` failed during a
+//! provisioning rollback (Windows open-handle, transient FS) leaves a durably
+//! `rollback_pending` journal; this handler retries it on backoff cadence and,
+//! at the INTERVENTION ceiling, emits a deduped operator audit.
+//!
+//! It shares the SAME callable as boot-repair
+//! (`checkout_txn::recover_pending_sweep_prod`) — there is NO dedicated worker
+//! (§10.5); the per-tick host owns the cadence. Cadence-gated so the (cheap,
+//! filesystem-only) sweep does not run every tick.
+
+use super::{PerTickHandler, TickContext};
+
+pub(crate) struct CheckoutTxnRecoverHandler {
+    gate: crate::daemon::cadence_gate::CadenceGate,
+}
+
+impl CheckoutTxnRecoverHandler {
+    pub(crate) fn new(every_n_ticks: u64) -> Self {
+        Self {
+            gate: crate::daemon::cadence_gate::CadenceGate::new(every_n_ticks),
+        }
+    }
+}
+
+impl PerTickHandler for CheckoutTxnRecoverHandler {
+    fn name(&self) -> &'static str {
+        "checkout_txn_recover"
+    }
+
+    fn run(&self, ctx: &TickContext<'_>) {
+        if !self.gate.fire() {
+            return;
+        }
+        // Same shared callable as boot-repair (no dedicated worker).
+        let _ = crate::mcp::handlers::ci::checkout_txn::recover_pending_sweep_prod(ctx.home);
+    }
+}

--- a/src/daemon/per_tick/mod.rs
+++ b/src/daemon/per_tick/mod.rs
@@ -45,6 +45,7 @@ pub(crate) mod assignment_reconcile;
 pub(crate) mod backend_exit_detection;
 pub(crate) mod canonical_heartbeat;
 pub(crate) mod check_schedules;
+pub(crate) mod checkout_txn_recover;
 pub(crate) mod ci_watch_poll;
 pub(crate) mod context_alert;
 pub(crate) mod context_handoff;
@@ -484,6 +485,9 @@ pub(crate) fn build_default_handlers(
         // already-dead workers. Runs in app mode too (not allowlisted out); the
         // live daemon is app-mode. Idle cost: one read of a usually-tiny JSON sidecar.
         Box::new(EphemeralReapHandler::new(6)),
+        // #2755: retry stuck checkout-transaction rollbacks (backoff-governed;
+        // shares the boot-repair callable — no dedicated worker).
+        Box::new(checkout_txn_recover::CheckoutTxnRecoverHandler::new(60)),
         // #2549 W5: ContextAlertHandler (operator-directed: every 6 ticks
         // ~1min, ≥80% orchestrator alert) and ContextHandoffHandler (#2007
         // context-full safety net: every 6 ticks, 85% one-shot

--- a/src/mcp/handlers/ci/checkout.rs
+++ b/src/mcp/handlers/ci/checkout.rs
@@ -3,6 +3,26 @@ use crate::git_helpers::git_bypass;
 use serde_json::{json, Value};
 use std::path::Path;
 
+/// #2755 structured redaction: replace absolute filesystem paths (and Windows
+/// drive paths) in an error string RETURNED over the wire with `<path>`. The
+/// structured `code`/`stage`/`branch` stay actionable for the caller, but raw
+/// paths / git stderr — which leak the local layout, usernames, or submodule
+/// URLs — are stripped. The FULL, un-redacted detail is still recorded in the
+/// daemon event-log (`log_checkout_outcome`), so operators keep debuggability.
+pub(super) fn redact_paths(s: &str) -> String {
+    use std::sync::OnceLock;
+    static RE: OnceLock<regex::Regex> = OnceLock::new();
+    let re = RE.get_or_init(|| {
+        // A Windows drive path (`C:\…`), OR a POSIX path of ≥2 segments starting
+        // at a non-word boundary — the `≥2` + boundary avoid mangling "and/or"
+        // and a URL's "//host". Rust's regex has no lookbehind, so the leading
+        // boundary char is captured (`b`) and restored in the replacement.
+        regex::Regex::new(r"(?P<b>^|[^\w])(?P<p>[A-Za-z]:\\[\w.\\@~%+-]+|(?:/[\w.@~%+-]+){2,})")
+            .expect("valid redaction regex")
+    });
+    re.replace_all(s, "${b}<path>").into_owned()
+}
+
 /// #1447: resolve the checkout source repo from `repository_path` — the
 /// cross-tool standard name used by bind_self / team update. Returns `None`
 /// when absent or empty.
@@ -244,7 +264,10 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
         Ok(g) => g,
         Err(e) => {
             return json!({
-                "error": format!("could not acquire provisioning lock for '{branch}': {e}"),
+                "error": format!(
+                    "could not acquire provisioning lock for '{branch}': {}",
+                    redact_paths(&e.to_string())
+                ),
                 "code": "path_lock",
                 "branch": branch,
             })
@@ -335,7 +358,10 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
                     || {}, // no binding written before SubmodulesReady
                 );
                 let mut err = json!({
-                    "error": format!("submodule init failed, worktree rolled back: {e}"),
+                    "error": format!(
+                        "submodule init failed, worktree rolled back: {}",
+                        redact_paths(&e)
+                    ),
                     "code": "submodule_init_failed",
                     "stage": "submodules_ready",
                     "branch": branch,
@@ -390,7 +416,10 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
                         || {},
                     );
                     return json!({
-                        "error": format!("bind_full failed, worktree rolled back: {e}"),
+                        "error": format!(
+                            "bind_full failed, worktree rolled back: {}",
+                            redact_paths(&e.to_string())
+                        ),
                         "code": "bind_rollback",
                         "branch": branch,
                     });
@@ -453,11 +482,12 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
             // back; drop the journal.
             super::checkout_txn::Journal::clear(home, &mangled);
             let stderr = String::from_utf8_lossy(&o.stderr).to_string();
+            let redacted = redact_paths(stderr.trim());
             let mut err = json!({
-                "error": format!("git worktree add failed: {}", stderr.trim()),
+                "error": format!("git worktree add failed: {redacted}"),
                 "code": "worktree_add_failed",
                 "stage": "worktree_add",
-                "raw": stderr,
+                "raw": redacted,
             });
             if bind {
                 err["fetch_attempted"] = json!(fetch_attempted);
@@ -467,11 +497,12 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
         }
         Err(e) => {
             super::checkout_txn::Journal::clear(home, &mangled);
+            let spawn_err = redact_paths(&e.to_string());
             let mut err = json!({
-                "error": format!("git worktree add spawn failed: {e}"),
+                "error": format!("git worktree add spawn failed: {spawn_err}"),
                 "code": "worktree_add_failed",
                 "stage": "worktree_add",
-                "raw": e.to_string(),
+                "raw": spawn_err,
             });
             if bind {
                 err["fetch_attempted"] = json!(fetch_attempted);

--- a/src/mcp/handlers/ci/checkout.rs
+++ b/src/mcp/handlers/ci/checkout.rs
@@ -250,6 +250,32 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
             ) {
                 warnings.push(format!("marker: {e}"));
             }
+            // #2755 SubmodulesReady phase: `git worktree add` materializes the
+            // superproject (`.gitmodules` + gitlinks) but leaves submodule dirs
+            // EMPTY, so a build with path-dependency submodules (e.g.
+            // vendor/agentic-git) fails on a freshly provisioned worktree.
+            // Recursively init them; a failure ABORTS the transaction — roll the
+            // worktree back with `remove --force` (a mere prune can't remove a
+            // still-present dir) and return a structured error, never a
+            // half-provisioned tree. Runs for bind AND non-bind (a reviewer/triage
+            // inspection worktree needs its submodule content too).
+            if let Err(e) = crate::worktree::init_submodules_strict(&worktree_dir) {
+                let _ = crate::git_helpers::git_bypass(
+                    Path::new(&source_path),
+                    &["worktree", "remove", "--force", &worktree_path_str],
+                );
+                let mut err = json!({
+                    "error": format!("submodule init failed, worktree rolled back: {e}"),
+                    "code": "submodule_init_failed",
+                    "stage": "submodules_ready",
+                    "branch": branch,
+                });
+                if bind {
+                    err["fetch_attempted"] = json!(fetch_attempted);
+                    err["auto_created_branch"] = json!(auto_created_branch);
+                }
+                return err;
+            }
             if bind {
                 // #2533: optional caller-supplied task_id — attributes this self-claim
                 // to a task (§3.19.1 reviewer checkout is the common case) so `bind_full`

--- a/src/mcp/handlers/ci/checkout.rs
+++ b/src/mcp/handlers/ci/checkout.rs
@@ -289,16 +289,21 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
     let txn_now = chrono::Utc::now();
     // Replay a journal left by a CRASHED prior provision of this path (removes a
     // stale worktree so a fresh add — or the reuse check below — sees clean state).
-    if let Err(e) =
-        super::checkout_txn::recover_stale(home, &mangled, &worktree_dir, txn_now, || {
+    if let Err(e) = super::checkout_txn::recover_stale(
+        home,
+        &mangled,
+        &worktree_dir,
+        &source_canonical.display().to_string(),
+        txn_now,
+        || {
             crate::git_helpers::git_bypass(
                 Path::new(&source_path),
                 &["worktree", "remove", "--force", &worktree_path_str],
             )
             .map(|o| o.status.success())
             .unwrap_or(false)
-        })
-    {
+        },
+    ) {
         return json!({"error": redact_paths(&e), "code": "stale_txn_rollback", "branch": branch});
     }
     if bind {

--- a/src/mcp/handlers/ci/checkout.rs
+++ b/src/mcp/handlers/ci/checkout.rs
@@ -228,6 +228,51 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
     // branch — subsequent commits write to the right ref without the
     // extra `git switch` that triggered the #778 chicken-and-egg.
     let worktree_path_str = worktree_dir.display().to_string();
+    // #2755 INNER provisioning lock + transaction journal (d-20260713024125724636-10).
+    // The branch-lease (`_lease_lock`, OUTER, bind-only) is already held above;
+    // this per-worktree-path flock (bind AND non-bind) serializes two attempts on
+    // the SAME mangled path and releases INNER-first — declared AFTER `_lease_lock`
+    // so it drops first at fn exit. Journal + lock live OUTSIDE the worktree
+    // (home/checkout_txn/…) so a rollback `remove --force` can never delete the
+    // recovery record.
+    let mangled = worktree_dir
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or_default()
+        .to_string();
+    let _path_lock = match super::checkout_txn::acquire_path_lock(home, &mangled) {
+        Ok(g) => g,
+        Err(e) => {
+            return json!({
+                "error": format!("could not acquire provisioning lock for '{branch}': {e}"),
+                "code": "path_lock",
+                "branch": branch,
+            })
+        }
+    };
+    let txn_now = chrono::Utc::now();
+    // Replay a journal left by a CRASHED prior provision of this path so the fresh
+    // `git worktree add` below cannot collide with a stale worktree.
+    if let Err(e) = super::checkout_txn::recover_stale(home, &mangled, txn_now, |_j| {
+        crate::git_helpers::git_bypass(
+            Path::new(&source_path),
+            &["worktree", "remove", "--force", &worktree_path_str],
+        )
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+    }) {
+        return json!({"error": e, "code": "stale_txn_rollback", "branch": branch});
+    }
+    // Prepared: durably journal the intent BEFORE any filesystem side effect.
+    let mut journal = super::checkout_txn::Journal::prepared(
+        super::checkout_txn::new_nonce(),
+        worktree_path_str.clone(),
+        source_canonical.display().to_string(),
+        branch,
+        bind,
+        txn_now.to_rfc3339(),
+    );
+    let _ = journal.save(home, &mangled);
     let git_args: Vec<&str> = if bind {
         vec!["worktree", "add", &worktree_path_str, branch]
     } else {
@@ -235,6 +280,8 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
     };
     match git_bypass(Path::new(&source_path), &git_args) {
         Ok(o) if o.status.success() => {
+            journal.advance(super::checkout_txn::Phase::WorktreeAdded);
+            let _ = journal.save(home, &mangled);
             let mut resp =
                 json!({"path": worktree_path_str, "source": source_path, "branch": branch});
             // #1275: write .agend-managed unconditionally so
@@ -250,19 +297,32 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
             ) {
                 warnings.push(format!("marker: {e}"));
             }
+            journal.advance(super::checkout_txn::Phase::MarkerDurable);
+            let _ = journal.save(home, &mangled);
             // #2755 SubmodulesReady phase: `git worktree add` materializes the
             // superproject (`.gitmodules` + gitlinks) but leaves submodule dirs
             // EMPTY, so a build with path-dependency submodules (e.g.
             // vendor/agentic-git) fails on a freshly provisioned worktree.
             // Recursively init them; a failure ABORTS the transaction — roll the
-            // worktree back with `remove --force` (a mere prune can't remove a
-            // still-present dir) and return a structured error, never a
-            // half-provisioned tree. Runs for bind AND non-bind (a reviewer/triage
-            // inspection worktree needs its submodule content too).
+            // worktree back (arm retained intent + `remove --force`; a mere prune
+            // can't remove a still-present dir) and return a structured error,
+            // never a half-provisioned tree. Runs for bind AND non-bind (a
+            // reviewer/triage inspection worktree needs its submodule content too).
             if let Err(e) = crate::worktree::init_submodules_strict(&worktree_dir) {
-                let _ = crate::git_helpers::git_bypass(
-                    Path::new(&source_path),
-                    &["worktree", "remove", "--force", &worktree_path_str],
+                super::checkout_txn::rollback_failed(
+                    home,
+                    &mangled,
+                    &mut journal,
+                    txn_now,
+                    || {
+                        crate::git_helpers::git_bypass(
+                            Path::new(&source_path),
+                            &["worktree", "remove", "--force", &worktree_path_str],
+                        )
+                        .map(|o| o.status.success())
+                        .unwrap_or(false)
+                    },
+                    || {}, // no binding written before SubmodulesReady
                 );
                 let mut err = json!({
                     "error": format!("submodule init failed, worktree rolled back: {e}"),
@@ -276,6 +336,8 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
                 }
                 return err;
             }
+            journal.advance(super::checkout_txn::Phase::SubmodulesReady);
+            let _ = journal.save(home, &mangled);
             if bind {
                 // #2533: optional caller-supplied task_id — attributes this self-claim
                 // to a task (§3.19.1 reviewer checkout is the common case) so `bind_full`
@@ -300,10 +362,22 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
                         error = %e,
                         "bind_full failed after worktree add — rolling back worktree"
                     );
-                    // #1899: bounded via git_bypass (LOCAL 60s) — best-effort rollback.
-                    let _ = crate::git_helpers::git_bypass(
-                        Path::new(&source_path),
-                        &["worktree", "remove", "--force", &worktree_path_str],
+                    // #1899 + #2755: retained-intent rollback (arm journal + bounded
+                    // `remove --force`; bind_full failed ⇒ no binding to unbind).
+                    super::checkout_txn::rollback_failed(
+                        home,
+                        &mangled,
+                        &mut journal,
+                        txn_now,
+                        || {
+                            crate::git_helpers::git_bypass(
+                                Path::new(&source_path),
+                                &["worktree", "remove", "--force", &worktree_path_str],
+                            )
+                            .map(|o| o.status.success())
+                            .unwrap_or(false)
+                        },
+                        || {},
                     );
                     return json!({
                         "error": format!("bind_full failed, worktree rolled back: {e}"),
@@ -326,12 +400,48 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
                 resp["auto_created_branch"] = json!(auto_created_branch);
                 resp["fetch_attempted"] = json!(fetch_attempted);
             }
+            // #2755 Committed: the durable linearization point. Success is returned
+            // ONLY after this journal write lands; a store::atomic_write failure
+            // aborts into rollback (worktree + binding), never a half-visible
+            // provision.
+            journal.advance(super::checkout_txn::Phase::Committed);
+            if journal.save(home, &mangled).is_err() {
+                super::checkout_txn::rollback_failed(
+                    home,
+                    &mangled,
+                    &mut journal,
+                    txn_now,
+                    || {
+                        crate::git_helpers::git_bypass(
+                            Path::new(&source_path),
+                            &["worktree", "remove", "--force", &worktree_path_str],
+                        )
+                        .map(|o| o.status.success())
+                        .unwrap_or(false)
+                    },
+                    || {
+                        if bind {
+                            crate::binding::unbind(home, instance_name);
+                        }
+                    },
+                );
+                return json!({
+                    "error": "commit journal write failed, worktree rolled back",
+                    "code": "commit_failed",
+                    "branch": branch,
+                });
+            }
+            // Committed durable ⇒ transaction resolved; drop the journal tombstone.
+            super::checkout_txn::Journal::clear(home, &mangled);
             if !warnings.is_empty() {
                 resp["warnings"] = json!(warnings);
             }
             resp
         }
         Ok(o) => {
+            // Prepared journal but `git worktree add` failed ⇒ no worktree to roll
+            // back; drop the journal.
+            super::checkout_txn::Journal::clear(home, &mangled);
             let stderr = String::from_utf8_lossy(&o.stderr).to_string();
             let mut err = json!({
                 "error": format!("git worktree add failed: {}", stderr.trim()),
@@ -346,6 +456,7 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
             err
         }
         Err(e) => {
+            super::checkout_txn::Journal::clear(home, &mangled);
             let mut err = json!({
                 "error": format!("git worktree add spawn failed: {e}"),
                 "code": "worktree_add_failed",

--- a/src/mcp/handlers/ci/checkout.rs
+++ b/src/mcp/handlers/ci/checkout.rs
@@ -76,6 +76,33 @@ pub(super) fn rollback_response(
     }
 }
 
+/// #2755 R3 (independent P1.4): fsync the `.agend-managed` marker file's CONTENTS
+/// durable — `std::fs::write` + a parent-dir fsync makes the DIRENT durable but not
+/// the bytes, so a crash/power loss could leave a durable journal phase (or Committed
+/// success) with an empty/torn marker. Open + `sync_all()` and OBSERVE the result; a
+/// failure aborts the transaction fail-closed. A `cfg(test)` thread-local seam forces
+/// the sync error so the crash/durability rollback path is testable cross-platform.
+pub(super) fn sync_marker_contents(path: &Path) -> std::io::Result<()> {
+    #[cfg(test)]
+    if FAIL_MARKER_SYNC.with(std::cell::Cell::get) {
+        return Err(std::io::Error::other(
+            "test seam: forced marker sync_all failure",
+        ));
+    }
+    std::fs::File::open(path)?.sync_all()
+}
+
+#[cfg(test)]
+thread_local! {
+    static FAIL_MARKER_SYNC: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+/// Test-only: arm/disarm the [`sync_marker_contents`] failure seam (current thread).
+#[cfg(test)]
+pub(super) fn set_fail_marker_sync(fail: bool) {
+    FAIL_MARKER_SYNC.with(|c| c.set(fail));
+}
+
 pub(crate) fn handle_checkout_repo(home: &Path, args: &Value, instance_name: &str) -> Value {
     let result = handle_checkout_repo_inner(home, args, instance_name);
     log_checkout_outcome(home, args, instance_name, &result);
@@ -438,7 +465,28 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
                     branch,
                 );
             }
-            crate::store::fsync_parent_dir(&marker_path); // best-effort durability
+            // #2755 R3 (independent P1.4): make the marker CONTENTS durable BEFORE the
+            // parent-dir fsync and the MarkerDurable phase advance. A sync failure rolls
+            // back fail-closed — never record MarkerDurable (or later Committed success)
+            // over a non-durable marker.
+            if let Err(e) = sync_marker_contents(&marker_path) {
+                let outcome = super::checkout_txn::rollback_failed(
+                    home,
+                    &mangled,
+                    &mut journal,
+                    txn_now,
+                    remove_worktree,
+                    || {},
+                );
+                return rollback_response(
+                    outcome,
+                    &format!("marker fsync failed: {}", redact_paths(&e.to_string())),
+                    "marker_fsync_failed",
+                    "marker_durable",
+                    branch,
+                );
+            }
+            crate::store::fsync_parent_dir(&marker_path); // dirent durability
             journal.advance(super::checkout_txn::Phase::MarkerDurable);
             if journal.save(home, &mangled).is_err() {
                 let outcome = super::checkout_txn::rollback_failed(

--- a/src/mcp/handlers/ci/checkout.rs
+++ b/src/mcp/handlers/ci/checkout.rs
@@ -2,6 +2,9 @@ use crate::agent_ops::validate_branch;
 use crate::git_helpers::git_bypass;
 use serde_json::{json, Value};
 use std::path::Path;
+// #2755 R3: response-mapping + marker-durability helpers live in a sibling module to
+// keep this handler under the LOC ceiling (call sites below are unchanged).
+use super::checkout_helpers::{rollback_response, sync_marker_contents};
 
 /// #2755 structured redaction: replace absolute filesystem paths (and Windows
 /// drive paths) in an error string RETURNED over the wire with `<path>`. The
@@ -30,77 +33,6 @@ pub(crate) fn checkout_source(args: &Value) -> Option<&str> {
     args.get("repository_path")
         .and_then(Value::as_str)
         .filter(|s| !s.is_empty())
-}
-
-/// #2755 R3 (root + independent review): map a post-`git worktree add`
-/// [`RollbackOutcome`](super::checkout_txn::RollbackOutcome) to the checkout error
-/// response, reporting the ACTUAL cleanup state. `Removed` → the historical
-/// "worktree rolled back" text. `RollbackPending` → a STRUCTURED pending state
-/// (`code: "rollback_pending"`, `rollback_pending: true`) that NEVER claims the
-/// worktree was rolled back — the remove failed (Windows open-handle / transient
-/// FS) and the worktree survives for the recovery sweep. `intent_durable=false`
-/// (the retained-intent journal save ALSO failed) is surfaced for intervention.
-/// The original failure `code`/`stage` are preserved (`failed_code`/`stage`) so
-/// machine consumers keep the root cause. Pure — unit-tested cross-platform.
-pub(super) fn rollback_response(
-    outcome: super::checkout_txn::RollbackOutcome,
-    reason: &str,
-    code: &str,
-    stage: &str,
-    branch: &str,
-) -> Value {
-    use super::checkout_txn::RollbackOutcome;
-    match outcome {
-        RollbackOutcome::Removed => json!({
-            "error": format!("{reason}, worktree rolled back"),
-            "code": code,
-            "stage": stage,
-            "branch": branch,
-        }),
-        RollbackOutcome::RollbackPending { intent_durable } => json!({
-            "error": format!(
-                "{reason}; worktree REMOVE FAILED — rollback pending, recovery sweep will retry{}",
-                if intent_durable {
-                    ""
-                } else {
-                    " (retained-intent journal save ALSO failed — operator intervention needed)"
-                }
-            ),
-            "code": "rollback_pending",
-            "rollback_pending": true,
-            "intent_durable": intent_durable,
-            "failed_code": code,
-            "stage": stage,
-            "branch": branch,
-        }),
-    }
-}
-
-/// #2755 R3 (independent P1.4): fsync the `.agend-managed` marker file's CONTENTS
-/// durable — `std::fs::write` + a parent-dir fsync makes the DIRENT durable but not
-/// the bytes, so a crash/power loss could leave a durable journal phase (or Committed
-/// success) with an empty/torn marker. Open + `sync_all()` and OBSERVE the result; a
-/// failure aborts the transaction fail-closed. A `cfg(test)` thread-local seam forces
-/// the sync error so the crash/durability rollback path is testable cross-platform.
-pub(super) fn sync_marker_contents(path: &Path) -> std::io::Result<()> {
-    #[cfg(test)]
-    if FAIL_MARKER_SYNC.with(std::cell::Cell::get) {
-        return Err(std::io::Error::other(
-            "test seam: forced marker sync_all failure",
-        ));
-    }
-    std::fs::File::open(path)?.sync_all()
-}
-
-#[cfg(test)]
-thread_local! {
-    static FAIL_MARKER_SYNC: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
-}
-
-/// Test-only: arm/disarm the [`sync_marker_contents`] failure seam (current thread).
-#[cfg(test)]
-pub(super) fn set_fail_marker_sync(fail: bool) {
-    FAIL_MARKER_SYNC.with(|c| c.set(fail));
 }
 
 pub(crate) fn handle_checkout_repo(home: &Path, args: &Value, instance_name: &str) -> Value {

--- a/src/mcp/handlers/ci/checkout.rs
+++ b/src/mcp/handlers/ci/checkout.rs
@@ -339,21 +339,110 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
                         instance = instance_name,
                         %branch,
                         path = %wt_str,
-                        "repo checkout bind:true idempotent — agent already bound to this branch, returning existing worktree"
+                        "repo checkout bind:true idempotent — agent already bound to this branch, revalidating + self-healing existing worktree"
                     );
-                    // #2755: a reused worktree may have EMPTY submodules (a prior
-                    // provision predating this fix, or a partial init) — self-heal
-                    // recursively under the held path-lock before returning, else the
-                    // reuse hands back a broken tree. Best-effort: the existing bound
-                    // worktree is still returned if a transient init fails.
-                    if let Err(e) = crate::worktree::init_submodules_strict(&wt) {
-                        tracing::warn!(
-                            path = %wt_str, error = %e,
-                            "#2755 idempotent reuse: recursive submodule init failed (best-effort)"
-                        );
+                    // #2755 R3 (B4): the binding's worktree `wt` may be a DIFFERENT path
+                    // than the DERIVED `worktree_dir` the path-lock A guards (normal
+                    // dispatch layout worktrees/<agent>/<branch> vs the derived
+                    // <agent>-<source>). Mutating `wt` under A is a lock-for-the-wrong-
+                    // path hole. Under the OUTER branch-lease (held), DROP A and acquire
+                    // the EXACT lock B for `wt` (no A→B inversion → no deadlock), then CAS
+                    // re-read the binding + validate provenance BEFORE any destructive
+                    // sync/reset/init.
+                    drop(path_lock); // release A; the branch-lease still serializes us
+                    let wt_mangled = wt
+                        .file_name()
+                        .and_then(|s| s.to_str())
+                        .unwrap_or_default()
+                        .to_string();
+                    let wt_lock = match super::checkout_txn::acquire_path_lock(
+                        home,
+                        &wt,
+                        &wt_mangled,
+                    ) {
+                        Ok(g) => g,
+                        Err(e) => {
+                            return json!({
+                                "error": format!(
+                                    "reuse: could not acquire provisioning lock for the bound worktree: {}",
+                                    redact_paths(&e.to_string())
+                                ),
+                                "code": "reuse_path_lock",
+                                "branch": branch,
+                            })
+                        }
+                    };
+                    if !wt_lock.guards(&wt) {
+                        return json!({
+                            "error": "reuse: provisioning lock identity does not match the bound worktree path",
+                            "code": "reuse_path_lock_identity",
+                            "branch": branch,
+                        });
                     }
-                    // #2115: idempotent reuse bypasses worktree::create — force-sync the stale tree to HEAD here too (rationale: sync_worktree_to_head doc).
-                    crate::worktree::sync_worktree_to_head(&wt);
+                    // CAS re-read + provenance from ONE fresh read under lock B. The
+                    // binding must STILL map this exact branch+worktree (a concurrent
+                    // release/rebind may have changed it), AND — fail closed (decision
+                    // d-…38; signature verification is out of #2755 scope) — the bound
+                    // worktree must be a DAEMON-MANAGED worktree (`.agend-managed` marker,
+                    // within the daemon worktree area) of the REQUESTED source.
+                    let reread = crate::binding::read(home, instance_name);
+                    let maps_exact = reread.as_ref().is_some_and(|r| {
+                        r.get("branch").and_then(|v| v.as_str()) == Some(branch)
+                            && r.get("worktree").and_then(|v| v.as_str()) == Some(wt_str.as_str())
+                    });
+                    if !maps_exact {
+                        return json!({
+                            "error": "reuse: binding changed while acquiring the worktree lock — retry",
+                            "code": "reuse_binding_race",
+                            "branch": branch,
+                        });
+                    }
+                    let bound_source_ok = reread
+                        .as_ref()
+                        .and_then(|r| r.get("source_repo").and_then(|v| v.as_str()))
+                        .and_then(|s| Path::new(s).canonicalize().ok())
+                        .map(|c| c == source_canonical)
+                        .unwrap_or(false);
+                    let managed = wt.join(crate::worktree_pool::MANAGED_MARKER).is_file()
+                        && wt.starts_with(home.join("worktrees"));
+                    if !bound_source_ok || !managed {
+                        return json!({
+                            "error": "reuse refused: the bound worktree is not a daemon-managed worktree of the requested source at the exact bound path",
+                            "code": "reuse_provenance",
+                            "branch": branch,
+                        });
+                    }
+                    // #2755 R3 (B1): sync to the FINAL HEAD FIRST (an externally advanced
+                    // branch may change/add gitlinks), THEN strict recursive init, THEN
+                    // verify EXACT gitlink commits — any sync/init/verify failure returns
+                    // NO success (fail closed), never a bound:true over a broken tree.
+                    if let Err(e) = crate::worktree::sync_worktree_to_head_strict(&wt) {
+                        return json!({
+                            "error": format!("reuse: sync to HEAD failed: {}", redact_paths(&e)),
+                            "code": "reuse_sync_failed",
+                            "branch": branch,
+                        });
+                    }
+                    if let Err(e) = crate::worktree::init_submodules_strict(&wt) {
+                        return json!({
+                            "error": format!(
+                                "reuse: recursive submodule init failed: {}",
+                                redact_paths(&e)
+                            ),
+                            "code": "reuse_submodule_init_failed",
+                            "branch": branch,
+                        });
+                    }
+                    if let Err(e) = crate::worktree::verify_submodules_at_gitlinks(&wt) {
+                        return json!({
+                            "error": format!(
+                                "reuse: submodule gitlink verification failed: {}",
+                                redact_paths(&e)
+                            ),
+                            "code": "reuse_gitlink_mismatch",
+                            "branch": branch,
+                        });
+                    }
                     return json!({
                         "path": wt_str,
                         "source": source_path,

--- a/src/mcp/handlers/ci/checkout.rs
+++ b/src/mcp/handlers/ci/checkout.rs
@@ -240,7 +240,7 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
         .and_then(|s| s.to_str())
         .unwrap_or_default()
         .to_string();
-    let _path_lock = match super::checkout_txn::acquire_path_lock(home, &mangled) {
+    let path_lock = match super::checkout_txn::acquire_path_lock(home, &worktree_dir, &mangled) {
         Ok(g) => g,
         Err(e) => {
             return json!({
@@ -250,6 +250,16 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
             })
         }
     };
+    // #2755: revalidate the held lock still maps to the EXACT target path we are
+    // about to mutate, BEFORE any side effect (fail-closed; the pattern Slice A
+    // extends to bind_full). The authority is the guard's normalized path.
+    if !path_lock.guards(&worktree_dir) {
+        return json!({
+            "error": "provisioning lock identity does not match the target worktree path",
+            "code": "path_lock_identity",
+            "branch": branch,
+        });
+    }
     let txn_now = chrono::Utc::now();
     // Replay a journal left by a CRASHED prior provision of this path so the fresh
     // `git worktree add` below cannot collide with a stale worktree.

--- a/src/mcp/handlers/ci/checkout.rs
+++ b/src/mcp/handlers/ci/checkout.rs
@@ -181,6 +181,55 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
     } else {
         None
     };
+    // #2755 INNER provisioning lock — acquired BEFORE the idempotent-reuse check
+    // and any provision so reuse AND fresh provision are both serialized on the
+    // worktree PATH (a reuse must not bypass the lock or the recursive submodule
+    // init). Declared AFTER `_lease_lock` ⇒ drops (releases) INNER-first. Journal +
+    // lock live OUTSIDE the worktree so a rollback `remove --force` can't delete
+    // the recovery record.
+    let worktree_path_str = worktree_dir.display().to_string();
+    let mangled = worktree_dir
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or_default()
+        .to_string();
+    let path_lock = match super::checkout_txn::acquire_path_lock(home, &worktree_dir, &mangled) {
+        Ok(g) => g,
+        Err(e) => {
+            return json!({
+                "error": format!(
+                    "could not acquire provisioning lock for '{branch}': {}",
+                    redact_paths(&e.to_string())
+                ),
+                "code": "path_lock",
+                "branch": branch,
+            })
+        }
+    };
+    // Revalidate the held lock maps to the EXACT target path before any side effect
+    // (fail-closed; the authority is the guard's normalized path).
+    if !path_lock.guards(&worktree_dir) {
+        return json!({
+            "error": "provisioning lock identity does not match the target worktree path",
+            "code": "path_lock_identity",
+            "branch": branch,
+        });
+    }
+    let txn_now = chrono::Utc::now();
+    // Replay a journal left by a CRASHED prior provision of this path (removes a
+    // stale worktree so a fresh add — or the reuse check below — sees clean state).
+    if let Err(e) =
+        super::checkout_txn::recover_stale(home, &mangled, &worktree_dir, txn_now, || {
+            crate::git_helpers::git_bypass(
+                Path::new(&source_path),
+                &["worktree", "remove", "--force", &worktree_path_str],
+            )
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+        })
+    {
+        return json!({"error": redact_paths(&e), "code": "stale_txn_rollback", "branch": branch});
+    }
     if bind {
         // #1882: cross-agent P0-1.5 reject UNDER the lock — another agent holding
         // this branch is refused (mirrors the dispatch path's scan), rather than
@@ -216,6 +265,17 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
                         path = %wt_str,
                         "repo checkout bind:true idempotent — agent already bound to this branch, returning existing worktree"
                     );
+                    // #2755: a reused worktree may have EMPTY submodules (a prior
+                    // provision predating this fix, or a partial init) — self-heal
+                    // recursively under the held path-lock before returning, else the
+                    // reuse hands back a broken tree. Best-effort: the existing bound
+                    // worktree is still returned if a transient init fails.
+                    if let Err(e) = crate::worktree::init_submodules_strict(&wt) {
+                        tracing::warn!(
+                            path = %wt_str, error = %e,
+                            "#2755 idempotent reuse: recursive submodule init failed (best-effort)"
+                        );
+                    }
                     // #2115: idempotent reuse bypasses worktree::create — force-sync the stale tree to HEAD here too (rationale: sync_worktree_to_head doc).
                     crate::worktree::sync_worktree_to_head(&wt);
                     return json!({
@@ -244,59 +304,21 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
             }
         }
     }
-    // When `bind:true`, omit `--detach` so HEAD lands on the named
-    // branch — subsequent commits write to the right ref without the
-    // extra `git switch` that triggered the #778 chicken-and-egg.
-    let worktree_path_str = worktree_dir.display().to_string();
-    // #2755 INNER provisioning lock + transaction journal (d-20260713024125724636-10).
-    // The branch-lease (`_lease_lock`, OUTER, bind-only) is already held above;
-    // this per-worktree-path flock (bind AND non-bind) serializes two attempts on
-    // the SAME mangled path and releases INNER-first — declared AFTER `_lease_lock`
-    // so it drops first at fn exit. Journal + lock live OUTSIDE the worktree
-    // (home/checkout_txn/…) so a rollback `remove --force` can never delete the
-    // recovery record.
-    let mangled = worktree_dir
-        .file_name()
-        .and_then(|s| s.to_str())
-        .unwrap_or_default()
-        .to_string();
-    let path_lock = match super::checkout_txn::acquire_path_lock(home, &worktree_dir, &mangled) {
-        Ok(g) => g,
-        Err(e) => {
-            return json!({
-                "error": format!(
-                    "could not acquire provisioning lock for '{branch}': {}",
-                    redact_paths(&e.to_string())
-                ),
-                "code": "path_lock",
-                "branch": branch,
-            })
-        }
-    };
-    // #2755: revalidate the held lock still maps to the EXACT target path we are
-    // about to mutate, BEFORE any side effect (fail-closed; the pattern Slice A
-    // extends to bind_full). The authority is the guard's normalized path.
-    if !path_lock.guards(&worktree_dir) {
-        return json!({
-            "error": "provisioning lock identity does not match the target worktree path",
-            "code": "path_lock_identity",
-            "branch": branch,
-        });
-    }
-    let txn_now = chrono::Utc::now();
-    // Replay a journal left by a CRASHED prior provision of this path so the fresh
-    // `git worktree add` below cannot collide with a stale worktree.
-    if let Err(e) = super::checkout_txn::recover_stale(home, &mangled, txn_now, |_j| {
+    // (INNER path-lock, identity revalidation, and stale-txn recovery were done
+    // ABOVE — before the reuse check. `bind:true` omits `--detach` below so HEAD
+    // lands on the named branch, #778.)
+    // Bounded worktree rollback (LOCAL git via bypass), reused by every failure
+    // path below so each checked-save failure leaves no orphan.
+    let remove_worktree = || {
         crate::git_helpers::git_bypass(
             Path::new(&source_path),
             &["worktree", "remove", "--force", &worktree_path_str],
         )
         .map(|o| o.status.success())
         .unwrap_or(false)
-    }) {
-        return json!({"error": e, "code": "stale_txn_rollback", "branch": branch});
-    }
-    // Prepared: durably journal the intent BEFORE any filesystem side effect.
+    };
+    // Prepared: durably journal the intent BEFORE any filesystem side effect. A
+    // failed save here is fatal-but-clean (no side effect yet).
     let mut journal = super::checkout_txn::Journal::prepared(
         super::checkout_txn::new_nonce(),
         worktree_path_str.clone(),
@@ -305,7 +327,14 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
         bind,
         txn_now.to_rfc3339(),
     );
-    let _ = journal.save(home, &mangled);
+    if journal.save(home, &mangled).is_err() {
+        return json!({
+            "error": "could not persist checkout transaction journal",
+            "code": "journal_write",
+            "stage": "prepared",
+            "branch": branch,
+        });
+    }
     let git_args: Vec<&str> = if bind {
         vec!["worktree", "add", &worktree_path_str, branch]
     } else {
@@ -313,25 +342,74 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
     };
     match git_bypass(Path::new(&source_path), &git_args) {
         Ok(o) if o.status.success() => {
+            // WorktreeAdded — CHECKED save: the worktree now EXISTS, so a save
+            // failure must roll it back or the durable record under-reports on-disk
+            // state (a crash would then orphan it).
             journal.advance(super::checkout_txn::Phase::WorktreeAdded);
-            let _ = journal.save(home, &mangled);
+            if journal.save(home, &mangled).is_err() {
+                super::checkout_txn::rollback_failed(
+                    home,
+                    &mangled,
+                    &mut journal,
+                    txn_now,
+                    remove_worktree,
+                    || {},
+                );
+                return json!({
+                    "error": "could not persist WorktreeAdded journal, worktree rolled back",
+                    "code": "journal_write",
+                    "stage": "worktree_added",
+                    "branch": branch,
+                });
+            }
             let mut resp =
                 json!({"path": worktree_path_str, "source": source_path, "branch": branch});
-            // #1275: write .agend-managed unconditionally so
-            // release_worktree and GC can always clean up.
-            let mut warnings: Vec<String> = Vec::new();
+            // #1275 + #2755: write `.agend-managed` FAIL-CLOSED — a missing marker
+            // breaks release_worktree/GC cleanup, so a write failure rolls back
+            // rather than returning a half-managed worktree.
             let marker_path = worktree_dir.join(crate::worktree_pool::MANAGED_MARKER);
-            if let Err(e) = std::fs::write(
+            if std::fs::write(
                 &marker_path,
                 format!(
                     "agent={instance_name}\nbranch={branch}\nleased_at={}\n",
                     chrono::Utc::now().to_rfc3339()
                 ),
-            ) {
-                warnings.push(format!("marker: {e}"));
+            )
+            .is_err()
+            {
+                super::checkout_txn::rollback_failed(
+                    home,
+                    &mangled,
+                    &mut journal,
+                    txn_now,
+                    remove_worktree,
+                    || {},
+                );
+                return json!({
+                    "error": "marker write failed, worktree rolled back",
+                    "code": "marker_failed",
+                    "stage": "marker_durable",
+                    "branch": branch,
+                });
             }
+            crate::store::fsync_parent_dir(&marker_path); // best-effort durability
             journal.advance(super::checkout_txn::Phase::MarkerDurable);
-            let _ = journal.save(home, &mangled);
+            if journal.save(home, &mangled).is_err() {
+                super::checkout_txn::rollback_failed(
+                    home,
+                    &mangled,
+                    &mut journal,
+                    txn_now,
+                    remove_worktree,
+                    || {},
+                );
+                return json!({
+                    "error": "could not persist MarkerDurable journal, worktree rolled back",
+                    "code": "journal_write",
+                    "stage": "marker_durable",
+                    "branch": branch,
+                });
+            }
             // #2755 SubmodulesReady phase: `git worktree add` materializes the
             // superproject (`.gitmodules` + gitlinks) but leaves submodule dirs
             // EMPTY, so a build with path-dependency submodules (e.g.
@@ -347,15 +425,8 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
                     &mangled,
                     &mut journal,
                     txn_now,
-                    || {
-                        crate::git_helpers::git_bypass(
-                            Path::new(&source_path),
-                            &["worktree", "remove", "--force", &worktree_path_str],
-                        )
-                        .map(|o| o.status.success())
-                        .unwrap_or(false)
-                    },
-                    || {}, // no binding written before SubmodulesReady
+                    remove_worktree,
+                    || {},
                 );
                 let mut err = json!({
                     "error": format!(
@@ -373,7 +444,22 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
                 return err;
             }
             journal.advance(super::checkout_txn::Phase::SubmodulesReady);
-            let _ = journal.save(home, &mangled);
+            if journal.save(home, &mangled).is_err() {
+                super::checkout_txn::rollback_failed(
+                    home,
+                    &mangled,
+                    &mut journal,
+                    txn_now,
+                    remove_worktree,
+                    || {},
+                );
+                return json!({
+                    "error": "could not persist SubmodulesReady journal, worktree rolled back",
+                    "code": "journal_write",
+                    "stage": "submodules_ready",
+                    "branch": branch,
+                });
+            }
             if bind {
                 // #2533: optional caller-supplied task_id — attributes this self-claim
                 // to a task (§3.19.1 reviewer checkout is the common case) so `bind_full`
@@ -405,14 +491,7 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
                         &mangled,
                         &mut journal,
                         txn_now,
-                        || {
-                            crate::git_helpers::git_bypass(
-                                Path::new(&source_path),
-                                &["worktree", "remove", "--force", &worktree_path_str],
-                            )
-                            .map(|o| o.status.success())
-                            .unwrap_or(false)
-                        },
+                        remove_worktree,
                         || {},
                     );
                     return json!({
@@ -450,14 +529,7 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
                     &mangled,
                     &mut journal,
                     txn_now,
-                    || {
-                        crate::git_helpers::git_bypass(
-                            Path::new(&source_path),
-                            &["worktree", "remove", "--force", &worktree_path_str],
-                        )
-                        .map(|o| o.status.success())
-                        .unwrap_or(false)
-                    },
+                    remove_worktree,
                     || {
                         if bind {
                             crate::binding::unbind(home, instance_name);
@@ -472,9 +544,6 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
             }
             // Committed durable ⇒ transaction resolved; drop the journal tombstone.
             super::checkout_txn::Journal::clear(home, &mangled);
-            if !warnings.is_empty() {
-                resp["warnings"] = json!(warnings);
-            }
             resp
         }
         Ok(o) => {

--- a/src/mcp/handlers/ci/checkout.rs
+++ b/src/mcp/handlers/ci/checkout.rs
@@ -266,124 +266,21 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
                 .filter(|p| p.exists());
             if same_branch {
                 if let Some(wt) = live_wt {
-                    let wt_str = wt.display().to_string();
-                    tracing::info!(
-                        instance = instance_name,
-                        %branch,
-                        path = %wt_str,
-                        "repo checkout bind:true idempotent — agent already bound to this branch, revalidating + self-healing existing worktree"
-                    );
-                    // #2755 R3 (B4): the binding's worktree `wt` may be a DIFFERENT path
-                    // than the DERIVED `worktree_dir` the path-lock A guards (normal
-                    // dispatch layout worktrees/<agent>/<branch> vs the derived
-                    // <agent>-<source>). Mutating `wt` under A is a lock-for-the-wrong-
-                    // path hole. Under the OUTER branch-lease (held), DROP A and acquire
-                    // the EXACT lock B for `wt` (no A→B inversion → no deadlock), then CAS
-                    // re-read the binding + validate provenance BEFORE any destructive
-                    // sync/reset/init.
-                    drop(path_lock); // release A; the branch-lease still serializes us
-                    let wt_mangled = wt
-                        .file_name()
-                        .and_then(|s| s.to_str())
-                        .unwrap_or_default()
-                        .to_string();
-                    let wt_lock = match super::checkout_txn::acquire_path_lock(
+                    // #2755: the full fail-closed reuse contract (deadlock-safe exact-path
+                    // lock transfer, CAS re-read, canonical daemon-managed provenance, then
+                    // sync-to-final-HEAD → strict init → gitlink verify) lives in the sibling
+                    // `checkout_reuse` module to keep this handler under the LOC ceiling.
+                    return super::checkout_reuse::try_reuse_bound_worktree(
                         home,
-                        &wt,
-                        &wt_mangled,
-                    ) {
-                        Ok(g) => g,
-                        Err(e) => {
-                            return json!({
-                                "error": format!(
-                                    "reuse: could not acquire provisioning lock for the bound worktree: {}",
-                                    redact_paths(&e.to_string())
-                                ),
-                                "code": "reuse_path_lock",
-                                "branch": branch,
-                            })
-                        }
-                    };
-                    if !wt_lock.guards(&wt) {
-                        return json!({
-                            "error": "reuse: provisioning lock identity does not match the bound worktree path",
-                            "code": "reuse_path_lock_identity",
-                            "branch": branch,
-                        });
-                    }
-                    // CAS re-read + provenance from ONE fresh read under lock B. The
-                    // binding must STILL map this exact branch+worktree (a concurrent
-                    // release/rebind may have changed it), AND — fail closed (decision
-                    // d-…38; signature verification is out of #2755 scope) — the bound
-                    // worktree must be a DAEMON-MANAGED worktree (`.agend-managed` marker,
-                    // within the daemon worktree area) of the REQUESTED source.
-                    let reread = crate::binding::read(home, instance_name);
-                    let maps_exact = reread.as_ref().is_some_and(|r| {
-                        r.get("branch").and_then(|v| v.as_str()) == Some(branch)
-                            && r.get("worktree").and_then(|v| v.as_str()) == Some(wt_str.as_str())
-                    });
-                    if !maps_exact {
-                        return json!({
-                            "error": "reuse: binding changed while acquiring the worktree lock — retry",
-                            "code": "reuse_binding_race",
-                            "branch": branch,
-                        });
-                    }
-                    let bound_source_ok = reread
-                        .as_ref()
-                        .and_then(|r| r.get("source_repo").and_then(|v| v.as_str()))
-                        .and_then(|s| Path::new(s).canonicalize().ok())
-                        .map(|c| c == source_canonical)
-                        .unwrap_or(false);
-                    let managed = wt.join(crate::worktree_pool::MANAGED_MARKER).is_file()
-                        && wt.starts_with(home.join("worktrees"));
-                    if !bound_source_ok || !managed {
-                        return json!({
-                            "error": "reuse refused: the bound worktree is not a daemon-managed worktree of the requested source at the exact bound path",
-                            "code": "reuse_provenance",
-                            "branch": branch,
-                        });
-                    }
-                    // #2755 R3 (B1): sync to the FINAL HEAD FIRST (an externally advanced
-                    // branch may change/add gitlinks), THEN strict recursive init, THEN
-                    // verify EXACT gitlink commits — any sync/init/verify failure returns
-                    // NO success (fail closed), never a bound:true over a broken tree.
-                    if let Err(e) = crate::worktree::sync_worktree_to_head_strict(&wt) {
-                        return json!({
-                            "error": format!("reuse: sync to HEAD failed: {}", redact_paths(&e)),
-                            "code": "reuse_sync_failed",
-                            "branch": branch,
-                        });
-                    }
-                    if let Err(e) = crate::worktree::init_submodules_strict(&wt) {
-                        return json!({
-                            "error": format!(
-                                "reuse: recursive submodule init failed: {}",
-                                redact_paths(&e)
-                            ),
-                            "code": "reuse_submodule_init_failed",
-                            "branch": branch,
-                        });
-                    }
-                    if let Err(e) = crate::worktree::verify_submodules_at_gitlinks(&wt) {
-                        return json!({
-                            "error": format!(
-                                "reuse: submodule gitlink verification failed: {}",
-                                redact_paths(&e)
-                            ),
-                            "code": "reuse_gitlink_mismatch",
-                            "branch": branch,
-                        });
-                    }
-                    return json!({
-                        "path": wt_str,
-                        "source": source_path,
-                        "branch": branch,
-                        "bound": true,
-                        "idempotent": true,
-                        "auto_created_branch": auto_created_branch,
-                        "fetch_attempted": fetch_attempted,
-                    });
+                        instance_name,
+                        branch,
+                        &source_canonical,
+                        &source_path,
+                        wt,
+                        path_lock,
+                        auto_created_branch,
+                        fetch_attempted,
+                    );
                 }
                 let existing_task_id = existing
                     .get("task_id")
@@ -512,7 +409,28 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
                     branch,
                 );
             }
-            crate::store::fsync_parent_dir(&marker_path); // dirent durability
+            // #2755 R4 (item 5): OBSERVE the parent-dir (dirent) durability on Unix — a
+            // failure must NOT advance MarkerDurable over a non-durable directory entry.
+            if let Err(e) = crate::store::fsync_parent_dir_checked(&marker_path) {
+                let outcome = super::checkout_txn::rollback_failed(
+                    home,
+                    &mangled,
+                    &mut journal,
+                    txn_now,
+                    remove_worktree,
+                    || {},
+                );
+                return rollback_response(
+                    outcome,
+                    &format!(
+                        "marker dirent fsync failed: {}",
+                        redact_paths(&e.to_string())
+                    ),
+                    "marker_fsync_failed",
+                    "marker_durable",
+                    branch,
+                );
+            }
             journal.advance(super::checkout_txn::Phase::MarkerDurable);
             if journal.save(home, &mangled).is_err() {
                 let outcome = super::checkout_txn::rollback_failed(
@@ -553,6 +471,36 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
                     outcome,
                     &format!("submodule init failed: {}", redact_paths(&e)),
                     "submodule_init_failed",
+                    "submodules_ready",
+                    branch,
+                );
+                if bind {
+                    err["fetch_attempted"] = json!(fetch_attempted);
+                    err["auto_created_branch"] = json!(auto_created_branch);
+                }
+                return err;
+            }
+            // #2755 R4 (item 2): a successful `submodule update --init --recursive` is NOT
+            // proof the tree is buildable — `submodule.<name>.update=none` makes it exit 0
+            // while leaving the submodule uninitialized (`-` in status). Verify the EXACT
+            // gitlink commits BEFORE advancing SubmodulesReady; a mismatch rolls back
+            // fail-closed (mirrors the reuse path's verify).
+            if let Err(e) = crate::worktree::verify_submodules_at_gitlinks(&worktree_dir) {
+                let outcome = super::checkout_txn::rollback_failed(
+                    home,
+                    &mangled,
+                    &mut journal,
+                    txn_now,
+                    remove_worktree,
+                    || {},
+                );
+                let mut err = rollback_response(
+                    outcome,
+                    &format!(
+                        "submodule gitlink verification failed after init: {}",
+                        redact_paths(&e)
+                    ),
+                    "submodule_gitlink_mismatch",
                     "submodules_ready",
                     branch,
                 );

--- a/src/mcp/handlers/ci/checkout.rs
+++ b/src/mcp/handlers/ci/checkout.rs
@@ -32,6 +32,50 @@ pub(crate) fn checkout_source(args: &Value) -> Option<&str> {
         .filter(|s| !s.is_empty())
 }
 
+/// #2755 R3 (root + independent review): map a post-`git worktree add`
+/// [`RollbackOutcome`](super::checkout_txn::RollbackOutcome) to the checkout error
+/// response, reporting the ACTUAL cleanup state. `Removed` → the historical
+/// "worktree rolled back" text. `RollbackPending` → a STRUCTURED pending state
+/// (`code: "rollback_pending"`, `rollback_pending: true`) that NEVER claims the
+/// worktree was rolled back — the remove failed (Windows open-handle / transient
+/// FS) and the worktree survives for the recovery sweep. `intent_durable=false`
+/// (the retained-intent journal save ALSO failed) is surfaced for intervention.
+/// The original failure `code`/`stage` are preserved (`failed_code`/`stage`) so
+/// machine consumers keep the root cause. Pure — unit-tested cross-platform.
+pub(super) fn rollback_response(
+    outcome: super::checkout_txn::RollbackOutcome,
+    reason: &str,
+    code: &str,
+    stage: &str,
+    branch: &str,
+) -> Value {
+    use super::checkout_txn::RollbackOutcome;
+    match outcome {
+        RollbackOutcome::Removed => json!({
+            "error": format!("{reason}, worktree rolled back"),
+            "code": code,
+            "stage": stage,
+            "branch": branch,
+        }),
+        RollbackOutcome::RollbackPending { intent_durable } => json!({
+            "error": format!(
+                "{reason}; worktree REMOVE FAILED — rollback pending, recovery sweep will retry{}",
+                if intent_durable {
+                    ""
+                } else {
+                    " (retained-intent journal save ALSO failed — operator intervention needed)"
+                }
+            ),
+            "code": "rollback_pending",
+            "rollback_pending": true,
+            "intent_durable": intent_durable,
+            "failed_code": code,
+            "stage": stage,
+            "branch": branch,
+        }),
+    }
+}
+
 pub(crate) fn handle_checkout_repo(home: &Path, args: &Value, instance_name: &str) -> Value {
     let result = handle_checkout_repo_inner(home, args, instance_name);
     log_checkout_outcome(home, args, instance_name, &result);
@@ -347,7 +391,7 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
             // state (a crash would then orphan it).
             journal.advance(super::checkout_txn::Phase::WorktreeAdded);
             if journal.save(home, &mangled).is_err() {
-                super::checkout_txn::rollback_failed(
+                let outcome = super::checkout_txn::rollback_failed(
                     home,
                     &mangled,
                     &mut journal,
@@ -355,12 +399,13 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
                     remove_worktree,
                     || {},
                 );
-                return json!({
-                    "error": "could not persist WorktreeAdded journal, worktree rolled back",
-                    "code": "journal_write",
-                    "stage": "worktree_added",
-                    "branch": branch,
-                });
+                return rollback_response(
+                    outcome,
+                    "could not persist WorktreeAdded journal",
+                    "journal_write",
+                    "worktree_added",
+                    branch,
+                );
             }
             let mut resp =
                 json!({"path": worktree_path_str, "source": source_path, "branch": branch});
@@ -377,7 +422,7 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
             )
             .is_err()
             {
-                super::checkout_txn::rollback_failed(
+                let outcome = super::checkout_txn::rollback_failed(
                     home,
                     &mangled,
                     &mut journal,
@@ -385,17 +430,18 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
                     remove_worktree,
                     || {},
                 );
-                return json!({
-                    "error": "marker write failed, worktree rolled back",
-                    "code": "marker_failed",
-                    "stage": "marker_durable",
-                    "branch": branch,
-                });
+                return rollback_response(
+                    outcome,
+                    "marker write failed",
+                    "marker_failed",
+                    "marker_durable",
+                    branch,
+                );
             }
             crate::store::fsync_parent_dir(&marker_path); // best-effort durability
             journal.advance(super::checkout_txn::Phase::MarkerDurable);
             if journal.save(home, &mangled).is_err() {
-                super::checkout_txn::rollback_failed(
+                let outcome = super::checkout_txn::rollback_failed(
                     home,
                     &mangled,
                     &mut journal,
@@ -403,12 +449,13 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
                     remove_worktree,
                     || {},
                 );
-                return json!({
-                    "error": "could not persist MarkerDurable journal, worktree rolled back",
-                    "code": "journal_write",
-                    "stage": "marker_durable",
-                    "branch": branch,
-                });
+                return rollback_response(
+                    outcome,
+                    "could not persist MarkerDurable journal",
+                    "journal_write",
+                    "marker_durable",
+                    branch,
+                );
             }
             // #2755 SubmodulesReady phase: `git worktree add` materializes the
             // superproject (`.gitmodules` + gitlinks) but leaves submodule dirs
@@ -420,7 +467,7 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
             // never a half-provisioned tree. Runs for bind AND non-bind (a
             // reviewer/triage inspection worktree needs its submodule content too).
             if let Err(e) = crate::worktree::init_submodules_strict(&worktree_dir) {
-                super::checkout_txn::rollback_failed(
+                let outcome = super::checkout_txn::rollback_failed(
                     home,
                     &mangled,
                     &mut journal,
@@ -428,15 +475,13 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
                     remove_worktree,
                     || {},
                 );
-                let mut err = json!({
-                    "error": format!(
-                        "submodule init failed, worktree rolled back: {}",
-                        redact_paths(&e)
-                    ),
-                    "code": "submodule_init_failed",
-                    "stage": "submodules_ready",
-                    "branch": branch,
-                });
+                let mut err = rollback_response(
+                    outcome,
+                    &format!("submodule init failed: {}", redact_paths(&e)),
+                    "submodule_init_failed",
+                    "submodules_ready",
+                    branch,
+                );
                 if bind {
                     err["fetch_attempted"] = json!(fetch_attempted);
                     err["auto_created_branch"] = json!(auto_created_branch);
@@ -445,7 +490,7 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
             }
             journal.advance(super::checkout_txn::Phase::SubmodulesReady);
             if journal.save(home, &mangled).is_err() {
-                super::checkout_txn::rollback_failed(
+                let outcome = super::checkout_txn::rollback_failed(
                     home,
                     &mangled,
                     &mut journal,
@@ -453,12 +498,13 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
                     remove_worktree,
                     || {},
                 );
-                return json!({
-                    "error": "could not persist SubmodulesReady journal, worktree rolled back",
-                    "code": "journal_write",
-                    "stage": "submodules_ready",
-                    "branch": branch,
-                });
+                return rollback_response(
+                    outcome,
+                    "could not persist SubmodulesReady journal",
+                    "journal_write",
+                    "submodules_ready",
+                    branch,
+                );
             }
             if bind {
                 // #2533: optional caller-supplied task_id — attributes this self-claim
@@ -486,7 +532,7 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
                     );
                     // #1899 + #2755: retained-intent rollback (arm journal + bounded
                     // `remove --force`; bind_full failed ⇒ no binding to unbind).
-                    super::checkout_txn::rollback_failed(
+                    let outcome = super::checkout_txn::rollback_failed(
                         home,
                         &mangled,
                         &mut journal,
@@ -494,14 +540,13 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
                         remove_worktree,
                         || {},
                     );
-                    return json!({
-                        "error": format!(
-                            "bind_full failed, worktree rolled back: {}",
-                            redact_paths(&e.to_string())
-                        ),
-                        "code": "bind_rollback",
-                        "branch": branch,
-                    });
+                    return rollback_response(
+                        outcome,
+                        &format!("bind_full failed: {}", redact_paths(&e.to_string())),
+                        "bind_rollback",
+                        "bind_full",
+                        branch,
+                    );
                 }
                 // #2158 GR1 (operator-approved): a self-claimed `repo action=checkout
                 // bind=true` no longer SILENTLY arms a ci_watch — neither here (this
@@ -524,7 +569,7 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
             // provision.
             journal.advance(super::checkout_txn::Phase::Committed);
             if journal.save(home, &mangled).is_err() {
-                super::checkout_txn::rollback_failed(
+                let outcome = super::checkout_txn::rollback_failed(
                     home,
                     &mangled,
                     &mut journal,
@@ -536,11 +581,13 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
                         }
                     },
                 );
-                return json!({
-                    "error": "commit journal write failed, worktree rolled back",
-                    "code": "commit_failed",
-                    "branch": branch,
-                });
+                return rollback_response(
+                    outcome,
+                    "commit journal write failed",
+                    "commit_failed",
+                    "committed",
+                    branch,
+                );
             }
             // Committed durable ⇒ transaction resolved; drop the journal tombstone.
             super::checkout_txn::Journal::clear(home, &mangled);

--- a/src/mcp/handlers/ci/checkout_helpers.rs
+++ b/src/mcp/handlers/ci/checkout_helpers.rs
@@ -55,6 +55,11 @@ pub(super) fn rollback_response(
 /// success) with an empty/torn marker. Open + `sync_all()` and OBSERVE the result; a
 /// failure aborts the transaction fail-closed. A `cfg(test)` thread-local seam forces
 /// the sync error so the crash/durability rollback path is testable cross-platform.
+///
+/// The handle is opened for WRITE (not read-only): on Windows `sync_all` maps to
+/// `FlushFileBuffers`, which requires `GENERIC_WRITE` and returns ACCESS_DENIED on a
+/// read-only handle (`File::open`). `write(true)` (no truncate) preserves the bytes and
+/// yields a flushable handle on every platform.
 pub(super) fn sync_marker_contents(path: &Path) -> std::io::Result<()> {
     #[cfg(test)]
     if FAIL_MARKER_SYNC.with(std::cell::Cell::get) {
@@ -62,7 +67,10 @@ pub(super) fn sync_marker_contents(path: &Path) -> std::io::Result<()> {
             "test seam: forced marker sync_all failure",
         ));
     }
-    std::fs::File::open(path)?.sync_all()
+    std::fs::OpenOptions::new()
+        .write(true)
+        .open(path)?
+        .sync_all()
 }
 
 #[cfg(test)]

--- a/src/mcp/handlers/ci/checkout_helpers.rs
+++ b/src/mcp/handlers/ci/checkout_helpers.rs
@@ -1,0 +1,77 @@
+//! #2755 R3 provisioning helpers extracted from `checkout.rs` to keep that handler
+//! under the MCP-handler LOC ceiling (the same split pattern as `source_resolve.rs`):
+//! the post-rollback response mapping and the marker content-durability fsync.
+
+use super::checkout_txn::RollbackOutcome;
+use serde_json::{json, Value};
+use std::path::Path;
+
+/// #2755 R3 (root + independent review): map a post-`git worktree add`
+/// [`RollbackOutcome`] to the checkout error response, reporting the ACTUAL cleanup
+/// state. `Removed` → the historical "worktree rolled back" text. `RollbackPending`
+/// → a STRUCTURED pending state (`code: "rollback_pending"`, `rollback_pending: true`)
+/// that NEVER claims the worktree was rolled back — the remove failed (Windows
+/// open-handle / transient FS) and the worktree survives for the recovery sweep.
+/// `intent_durable=false` (the retained-intent journal save ALSO failed) is surfaced
+/// for intervention. The original failure `code`/`stage` are preserved
+/// (`failed_code`/`stage`) so machine consumers keep the root cause. Pure —
+/// unit-tested cross-platform.
+pub(super) fn rollback_response(
+    outcome: RollbackOutcome,
+    reason: &str,
+    code: &str,
+    stage: &str,
+    branch: &str,
+) -> Value {
+    match outcome {
+        RollbackOutcome::Removed => json!({
+            "error": format!("{reason}, worktree rolled back"),
+            "code": code,
+            "stage": stage,
+            "branch": branch,
+        }),
+        RollbackOutcome::RollbackPending { intent_durable } => json!({
+            "error": format!(
+                "{reason}; worktree REMOVE FAILED — rollback pending, recovery sweep will retry{}",
+                if intent_durable {
+                    ""
+                } else {
+                    " (retained-intent journal save ALSO failed — operator intervention needed)"
+                }
+            ),
+            "code": "rollback_pending",
+            "rollback_pending": true,
+            "intent_durable": intent_durable,
+            "failed_code": code,
+            "stage": stage,
+            "branch": branch,
+        }),
+    }
+}
+
+/// #2755 R3 (independent P1.4): fsync the `.agend-managed` marker file's CONTENTS
+/// durable — `std::fs::write` + a parent-dir fsync makes the DIRENT durable but not
+/// the bytes, so a crash/power loss could leave a durable journal phase (or Committed
+/// success) with an empty/torn marker. Open + `sync_all()` and OBSERVE the result; a
+/// failure aborts the transaction fail-closed. A `cfg(test)` thread-local seam forces
+/// the sync error so the crash/durability rollback path is testable cross-platform.
+pub(super) fn sync_marker_contents(path: &Path) -> std::io::Result<()> {
+    #[cfg(test)]
+    if FAIL_MARKER_SYNC.with(std::cell::Cell::get) {
+        return Err(std::io::Error::other(
+            "test seam: forced marker sync_all failure",
+        ));
+    }
+    std::fs::File::open(path)?.sync_all()
+}
+
+#[cfg(test)]
+thread_local! {
+    static FAIL_MARKER_SYNC: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+/// Test-only: arm/disarm the [`sync_marker_contents`] failure seam (current thread).
+#[cfg(test)]
+pub(super) fn set_fail_marker_sync(fail: bool) {
+    FAIL_MARKER_SYNC.with(|c| c.set(fail));
+}

--- a/src/mcp/handlers/ci/checkout_recovery.rs
+++ b/src/mcp/handlers/ci/checkout_recovery.rs
@@ -1,0 +1,173 @@
+//! #2755 R3/R4 crash-recovery sweep for checkout transactions — extracted from
+//! `checkout_txn.rs` to keep both modules under the MCP-handler LOC ceiling. The Journal
+//! state machine + `recover_stale` (checkout-start replay) stay in `checkout_txn`; this
+//! module is the boot + per-tick recovery DRIVER (`recover_pending_sweep[_prod]`).
+
+use super::checkout_txn::{
+    load_typed, quarantine_corrupt, try_acquire_path_lock, txn_root, Journal, JournalLoad, Phase,
+};
+use std::path::Path;
+
+/// Drive recovery of CRASHED (orphaned) checkout-transaction journals — the ONE shared
+/// callable for boot-repair AND a periodic tick (no dedicated worker; the caller sets
+/// cadence). Race-safe against a concurrent live checkout:
+///
+///   1. read the journal (unlocked) for its path + nonce;
+///   2. `try_lock` its EXACT normalized path — SKIP if held (an ACTIVE checkout owns it;
+///      not crashed) so a live provision is never disturbed;
+///   3. RE-READ under the lock and CAS the nonce — SKIP if the record changed (a NEWER
+///      checkout generation took over) so its worktree is never deleted;
+///   4. `Committed` ⇒ clear the tombstone; a still-BOUND worktree ⇒ adopt (never delete);
+///      any other non-Committed record with a real UNBOUND worktree ⇒ `remove` it
+///      (respecting backoff) then clear; on remove failure re-arm + deduped `audit`.
+///
+/// Handles EVERY non-Committed phase (not just `rollback_pending`), incl. the
+/// Prepared-with-real-worktree crash window. `try_lock`/`remove`/`audit` are injected so
+/// the sweep is unit-testable without live git or flocks. Returns the count resolved.
+pub(crate) fn recover_pending_sweep<G>(
+    home: &Path,
+    now: chrono::DateTime<chrono::Utc>,
+    try_lock: impl Fn(&Journal) -> Option<G>,
+    remove: impl Fn(&Journal) -> bool,
+    mut audit: impl FnMut(&Journal),
+) -> usize {
+    let Ok(entries) = std::fs::read_dir(txn_root(home)) else {
+        return 0; // no transaction area yet ⇒ nothing pending
+    };
+    let mut resolved = 0;
+    for entry in entries.flatten() {
+        let Some(mangled) = entry.file_name().to_str().map(str::to_string) else {
+            continue;
+        };
+        // (1) Unlocked read for path + nonce. Sibling `<key>.lock` files load as Absent
+        // (skipped); a corrupt record is QUARANTINED (retained as intervention authority —
+        // #2755 R3), NOT cleared; an unreadable record fails closed (#2755 R4).
+        let seen = match load_typed(home, &mangled) {
+            JournalLoad::Loaded(j) => j,
+            JournalLoad::Unreadable => {
+                // #2755 R4 (item 3a): unreadable ≠ absent — authority uncertain; skip this
+                // tick (fail closed), NEVER treat as nothing-to-recover.
+                tracing::warn!(mangled = %mangled, "checkout-txn journal unreadable — skipping sweep this tick (fail closed)");
+                continue;
+            }
+            JournalLoad::Corrupt => {
+                tracing::warn!(mangled = %mangled, "corrupt checkout-txn journal — quarantined for intervention");
+                crate::event_log::log(
+                    home,
+                    "checkout_txn_corrupt_quarantine",
+                    "checkout_txn",
+                    &format!("corrupt checkout-txn journal quarantined (manual intervention; managed worktree may remain): {mangled}"),
+                );
+                if !quarantine_corrupt(home, &mangled) {
+                    tracing::warn!(mangled = %mangled, "corrupt-journal quarantine rename failed — retained, will retry next tick");
+                }
+                continue;
+            }
+            JournalLoad::Absent => continue,
+        };
+        // (2) Acquire the EXACT path-lock; a held lock ⇒ a live checkout ⇒ skip.
+        let Some(_lock) = try_lock(&seen) else {
+            continue;
+        };
+        // (3) Re-read UNDER the lock + nonce CAS.
+        let j = match load_typed(home, &mangled) {
+            JournalLoad::Loaded(j) if j.nonce == seen.nonce => j,
+            JournalLoad::Loaded(_) => continue, // newer generation took over
+            JournalLoad::Unreadable => {
+                tracing::warn!(mangled = %mangled, "checkout-txn journal unreadable under lock — skipping (fail closed)");
+                continue;
+            }
+            JournalLoad::Corrupt => {
+                // Corrupt after the unlocked read (crashed mid-provision) — QUARANTINE +
+                // surface, never clear: same recovery-authority retention as arm (1).
+                tracing::warn!(mangled = %mangled, "corrupt checkout-txn journal (under lock) — quarantined for intervention");
+                crate::event_log::log(
+                    home,
+                    "checkout_txn_corrupt_quarantine",
+                    "checkout_txn",
+                    &format!("corrupt checkout-txn journal quarantined under lock (manual intervention): {mangled}"),
+                );
+                if !quarantine_corrupt(home, &mangled) {
+                    tracing::warn!(mangled = %mangled, "corrupt-journal quarantine rename failed under lock — retained, will retry");
+                }
+                continue;
+            }
+            JournalLoad::Absent => continue, // cleared concurrently
+        };
+        // (4) Resolve.
+        if j.phase == Phase::Committed {
+            Journal::clear(home, &mangled); // completed attempt's tombstone
+            continue;
+        }
+        if !Path::new(&j.worktree_path).exists() {
+            Journal::clear(home, &mangled); // crashed with no worktree on disk
+            continue;
+        }
+        if j.rollback_pending && !j.rollback_due(now) {
+            continue; // backoff pacing for an already-armed stuck retry
+        }
+        // #2755 R4 (item 1): NEVER remove a still-BOUND worktree (crash after bind_full,
+        // before Committed) — adopt it as committed. An UNCERTAIN binding fails closed.
+        match crate::binding::worktree_binding_state(home, Path::new(&j.worktree_path)) {
+            crate::binding::WorktreeBindingState::Bound => {
+                Journal::clear(home, &mangled); // effectively committed — keep worktree + binding
+                continue;
+            }
+            crate::binding::WorktreeBindingState::Uncertain => {
+                tracing::warn!(mangled = %mangled, "worktree binding unreadable — skipping removal (fail closed)");
+                continue;
+            }
+            crate::binding::WorktreeBindingState::Unbound => {}
+        }
+        if remove(&j) {
+            Journal::clear(home, &mangled);
+            resolved += 1;
+        } else {
+            let mut j = j;
+            let was_intervention = j.intervention;
+            j.arm_rollback(now);
+            if j.intervention && !was_intervention {
+                audit(&j); // deduped: only on ENTERING intervention
+            }
+            let _ = j.save(home, &mangled);
+        }
+    }
+    resolved
+}
+
+/// Production entry to [`recover_pending_sweep`] — the ONE shared callable invoked from
+/// BOTH boot-repair (`bootstrap::boot_hygiene_sweeps`) and the per-tick recovery handler
+/// (no dedicated worker). Supplies the real `git worktree remove --force` (run in each
+/// journal's recorded source repo) and the operator-visible INTERVENTION audit
+/// (`event_log`). Returns the count resolved this pass.
+pub(crate) fn recover_pending_sweep_prod(home: &Path) -> usize {
+    recover_pending_sweep(
+        home,
+        chrono::Utc::now(),
+        |j| {
+            // Non-blocking exact path-lock; None (a live checkout holds it) ⇒ skip.
+            let wt = Path::new(&j.worktree_path);
+            let mangled = wt.file_name().and_then(|s| s.to_str()).unwrap_or_default();
+            try_acquire_path_lock(home, wt, mangled)
+        },
+        |j| {
+            crate::git_helpers::git_bypass(
+                Path::new(&j.source_repo),
+                &["worktree", "remove", "--force", &j.worktree_path],
+            )
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+        },
+        |j| {
+            crate::event_log::log(
+                home,
+                "checkout_txn_intervention",
+                "checkout_txn",
+                &format!(
+                    "stuck checkout-worktree rollback entered INTERVENTION after {} attempts: {}",
+                    j.attempts, j.worktree_path
+                ),
+            );
+        },
+    )
+}

--- a/src/mcp/handlers/ci/checkout_reuse.rs
+++ b/src/mcp/handlers/ci/checkout_reuse.rs
@@ -1,0 +1,143 @@
+//! #2755 idempotent bind-reuse for `repo action=checkout`, extracted from `checkout.rs`
+//! to keep that handler under the MCP-handler LOC ceiling (same split pattern as
+//! `source_resolve.rs`). The full fail-closed reuse contract lives here: deadlock-safe
+//! exact-path lock transfer, CAS re-read, canonical daemon-managed provenance, then
+//! sync-to-final-HEAD → strict recursive init → exact gitlink verification.
+
+use super::checkout::redact_paths;
+use super::checkout_txn::PathLockGuard;
+use serde_json::{json, Value};
+use std::path::{Path, PathBuf};
+
+/// Reconcile + return an EXISTING bound worktree for THIS agent+branch (idempotent
+/// `bind:true` re-checkout), or a structured fail-closed error. Consumes `path_lock`
+/// (the DERIVED-path lock A) — it is dropped so the EXACT bound-path lock B can be taken
+/// without an A→B inversion. Always returns a response (never falls through).
+#[allow(clippy::too_many_arguments)]
+pub(super) fn try_reuse_bound_worktree(
+    home: &Path,
+    instance_name: &str,
+    branch: &str,
+    source_canonical: &Path,
+    source_path: &str,
+    wt: PathBuf,
+    path_lock: PathLockGuard,
+    auto_created_branch: bool,
+    fetch_attempted: bool,
+) -> Value {
+    let wt_str = wt.display().to_string();
+    tracing::info!(
+        instance = instance_name,
+        %branch,
+        path = %wt_str,
+        "repo checkout bind:true idempotent — agent already bound to this branch, revalidating + self-healing existing worktree"
+    );
+    // #2755 R3 (B4): the binding's worktree `wt` may be a DIFFERENT path than the DERIVED
+    // `worktree_dir` the path-lock A guards (dispatch layout worktrees/<agent>/<branch> vs
+    // the derived <agent>-<source>). Mutating `wt` under A is a lock-for-the-wrong-path
+    // hole. Under the OUTER branch-lease (held by the caller), DROP A and acquire the
+    // EXACT lock B for `wt` (no A→B inversion → no deadlock), then CAS re-read + validate
+    // provenance BEFORE any destructive sync/reset/init.
+    drop(path_lock);
+    let wt_mangled = wt
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or_default()
+        .to_string();
+    let wt_lock = match super::checkout_txn::acquire_path_lock(home, &wt, &wt_mangled) {
+        Ok(g) => g,
+        Err(e) => {
+            return json!({
+                "error": format!(
+                    "reuse: could not acquire provisioning lock for the bound worktree: {}",
+                    redact_paths(&e.to_string())
+                ),
+                "code": "reuse_path_lock",
+                "branch": branch,
+            })
+        }
+    };
+    if !wt_lock.guards(&wt) {
+        return json!({
+            "error": "reuse: provisioning lock identity does not match the bound worktree path",
+            "code": "reuse_path_lock_identity",
+            "branch": branch,
+        });
+    }
+    // CAS re-read + provenance from ONE fresh read under lock B. The binding must STILL
+    // map this exact branch+worktree (a concurrent release/rebind may have changed it),
+    // AND — fail closed (decision d-…38; signature verification is out of #2755 scope) —
+    // the bound worktree must be a DAEMON-MANAGED worktree of the REQUESTED source.
+    let reread = crate::binding::read(home, instance_name);
+    let maps_exact = reread.as_ref().is_some_and(|r| {
+        r.get("branch").and_then(|v| v.as_str()) == Some(branch)
+            && r.get("worktree").and_then(|v| v.as_str()) == Some(wt_str.as_str())
+    });
+    if !maps_exact {
+        return json!({
+            "error": "reuse: binding changed while acquiring the worktree lock — retry",
+            "code": "reuse_binding_race",
+            "branch": branch,
+        });
+    }
+    let bound_source_ok = reread
+        .as_ref()
+        .and_then(|r| r.get("source_repo").and_then(|v| v.as_str()))
+        .and_then(|s| Path::new(s).canonicalize().ok())
+        .map(|c| c.as_path() == source_canonical)
+        .unwrap_or(false);
+    // #2755 R4 (item 4): CANONICALIZE both the bound worktree and the pool — a symlink or
+    // `..` path inside the pool can otherwise point at an EXTERNAL worktree yet pass a
+    // lexical `starts_with`, and the sync/reset/init below would then mutate the resolved
+    // external target. Require the CANONICAL worktree to be a strict descendant of the
+    // CANONICAL pool (fail closed if either cannot be canonicalized) AND carry the marker.
+    let managed = wt.join(crate::worktree_pool::MANAGED_MARKER).is_file()
+        && match (wt.canonicalize(), home.join("worktrees").canonicalize()) {
+            (Ok(cwt), Ok(cpool)) => cwt.starts_with(&cpool) && cwt != cpool,
+            _ => false,
+        };
+    if !bound_source_ok || !managed {
+        return json!({
+            "error": "reuse refused: the bound worktree is not a daemon-managed worktree of the requested source at the exact bound path",
+            "code": "reuse_provenance",
+            "branch": branch,
+        });
+    }
+    // #2755 R3 (B1): sync to the FINAL HEAD FIRST (an externally advanced branch may
+    // change/add gitlinks), THEN strict recursive init, THEN verify EXACT gitlink commits
+    // — any sync/init/verify failure returns NO success (fail closed), never a bound:true
+    // over a broken tree.
+    if let Err(e) = crate::worktree::sync_worktree_to_head_strict(&wt) {
+        return json!({
+            "error": format!("reuse: sync to HEAD failed: {}", redact_paths(&e)),
+            "code": "reuse_sync_failed",
+            "branch": branch,
+        });
+    }
+    if let Err(e) = crate::worktree::init_submodules_strict(&wt) {
+        return json!({
+            "error": format!("reuse: recursive submodule init failed: {}", redact_paths(&e)),
+            "code": "reuse_submodule_init_failed",
+            "branch": branch,
+        });
+    }
+    if let Err(e) = crate::worktree::verify_submodules_at_gitlinks(&wt) {
+        return json!({
+            "error": format!(
+                "reuse: submodule gitlink verification failed: {}",
+                redact_paths(&e)
+            ),
+            "code": "reuse_gitlink_mismatch",
+            "branch": branch,
+        });
+    }
+    json!({
+        "path": wt_str,
+        "source": source_path,
+        "branch": branch,
+        "bound": true,
+        "idempotent": true,
+        "auto_created_branch": auto_created_branch,
+        "fetch_attempted": fetch_attempted,
+    })
+}

--- a/src/mcp/handlers/ci/checkout_submodule_tests.rs
+++ b/src/mcp/handlers/ci/checkout_submodule_tests.rs
@@ -618,3 +618,163 @@ fn txn_normalize_target_aliases_share_identity() {
     );
     std::fs::remove_dir_all(&home).ok();
 }
+
+// ─── frozen-scope remaining: redaction + real-entry recovery (deterministic) ──
+
+use super::checkout::redact_paths;
+
+/// Structured redaction strips absolute paths / git stderr from returned errors
+/// while keeping the actionable non-path text; "and/or" and plain words are not
+/// mangled (the ≥2-segment + boundary rule).
+#[test]
+fn redact_paths_strips_absolute_paths_only() {
+    let s = "fatal: could not clone /Users/alice/.agend/worktrees/x into /private/tmp/y";
+    let r = redact_paths(s);
+    assert!(!r.contains("/Users/alice"), "unix home redacted: {r}");
+    assert!(!r.contains("/private/tmp"), "temp path redacted: {r}");
+    assert!(
+        r.contains("<path>") && r.contains("could not clone"),
+        "placeholder + non-path text kept: {r}"
+    );
+    assert!(
+        !redact_paths(r"at C:\Users\bob\wt\x").contains(r"C:\Users"),
+        "windows drive path redacted"
+    );
+    assert_eq!(
+        redact_paths("retry and/or wait"),
+        "retry and/or wait",
+        "relative token untouched"
+    );
+    assert_eq!(
+        redact_paths("git worktree add failed"),
+        "git worktree add failed",
+        "no false positive on plain words"
+    );
+}
+
+/// The `(instance, source)` → worktree-dir mangling `handle_checkout_repo` uses.
+fn mangled_for(instance: &str, source: &Path) -> String {
+    format!(
+        "{}-{}",
+        instance,
+        source
+            .display()
+            .to_string()
+            .replace(['/', '\\', ':'], "_")
+            .replace('~', "")
+    )
+}
+
+/// Committed-write-FAILURE seam: force the durable Committed journal write to fail
+/// (its path pre-created as a DIRECTORY so `store::atomic_write`'s rename fails) →
+/// the real checkout ABORTS into rollback (worktree removed) and returns the
+/// structured `commit_failed`, never success.
+#[test]
+fn checkout_commit_write_failure_rolls_back_2755() {
+    let home = tmp_home("commitfail");
+    let repo = tmp_repo_with_file("commitfail", "readme.txt", "x\n");
+    let instance = "agent-cf";
+    let mangled = mangled_for(instance, &repo);
+    let jpath = home
+        .join("checkout_txn")
+        .join(&mangled)
+        .join("journal.json");
+    std::fs::create_dir_all(&jpath).unwrap(); // seam: journal.json is a DIR
+
+    let args =
+        json!({"repository_path": repo.display().to_string(), "branch": "main", "bind": false});
+    let resp = super::checkout::handle_checkout_repo(&home, &args, instance);
+    assert_eq!(
+        resp["code"].as_str(),
+        Some("commit_failed"),
+        "Committed-write failure ⇒ commit_failed: {resp}"
+    );
+    assert!(
+        !home.join("worktrees").join(&mangled).exists(),
+        "worktree rolled back on Committed-write failure"
+    );
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&repo).ok();
+}
+
+/// Restart-replay: a crashed prior attempt left a REAL stale worktree + a
+/// non-Committed journal at this path; a fresh real checkout REPLAYS it (removes
+/// the stale worktree under the path-lock) then provisions cleanly.
+#[test]
+fn checkout_restart_replays_stale_worktree_2755() {
+    let home = tmp_home("replay");
+    let repo = tmp_repo_with_file("replay", "readme.txt", "x\n");
+    let instance = "agent-rp";
+    let mangled = mangled_for(instance, &repo);
+    let wt = home.join("worktrees").join(&mangled);
+    std::fs::create_dir_all(wt.parent().unwrap()).unwrap();
+    // Crashed attempt: a REAL stale worktree at the target path + its
+    // non-Committed journal (WorktreeAdded ⇒ recover_stale must remove it).
+    git_run_ok(
+        &repo,
+        &[
+            "worktree",
+            "add",
+            "--detach",
+            &wt.display().to_string(),
+            "main",
+        ],
+        false,
+    );
+    let mut j = Journal::prepared(
+        "stale-nonce",
+        wt.display().to_string(),
+        repo.display().to_string(),
+        "main",
+        false,
+        fixed_now().to_rfc3339(),
+    );
+    j.advance(Phase::WorktreeAdded);
+    j.save(&home, &mangled).unwrap();
+
+    let args =
+        json!({"repository_path": repo.display().to_string(), "branch": "main", "bind": false});
+    let resp = super::checkout::handle_checkout_repo(&home, &args, instance);
+    assert!(
+        resp.get("error").is_none(),
+        "checkout succeeds after replaying the stale attempt: {resp}"
+    );
+    assert!(
+        wt.join("readme.txt").is_file(),
+        "freshly provisioned worktree materialized"
+    );
+    assert!(
+        Journal::load(&home, &mangled).is_none(),
+        "journal cleared on Committed"
+    );
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&repo).ok();
+}
+
+/// Windows/open-handle: a rollback whose `git worktree remove --force` FAILS
+/// (an open handle pins the dir) RETAINS intent (armed + backoff); a later sweep,
+/// once the handle is released (remove succeeds), resolves and clears it.
+/// Deterministic via injected remove — a real held OS handle is platform-specific.
+#[test]
+fn txn_open_handle_remove_failure_retained_then_recovered() {
+    let home = tmp_home("openhandle");
+    let mangled = "agent-oh";
+    let mut j = sample_journal();
+    j.advance(Phase::SubmodulesReady);
+    j.save(&home, mangled).unwrap();
+    // Handle held open ⇒ remove fails ⇒ intent retained (not cleared).
+    rollback_failed(&home, mangled, &mut j, fixed_now(), || false, || {});
+    let stuck = Journal::load(&home, mangled).expect("retained while handle open");
+    assert!(stuck.rollback_pending && stuck.next_attempt_at.is_some());
+    // Make it due; handle released ⇒ the sweep removes + clears.
+    let mut s = Journal::load(&home, mangled).unwrap();
+    s.next_attempt_at = Some((fixed_now() - chrono::Duration::seconds(1)).to_rfc3339());
+    s.save(&home, mangled).unwrap();
+    let resolved = recover_pending_sweep(&home, fixed_now(), |_| true, |_| {});
+    assert_eq!(resolved, 1, "handle released ⇒ recovered");
+    assert!(
+        Journal::load(&home, mangled).is_none(),
+        "cleared after successful remove"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}

--- a/src/mcp/handlers/ci/checkout_submodule_tests.rs
+++ b/src/mcp/handlers/ci/checkout_submodule_tests.rs
@@ -454,3 +454,167 @@ fn txn_rollback_failed_remove_fail_retains() {
     );
     std::fs::remove_dir_all(&home).ok();
 }
+
+// ─── recover_pending_sweep (shared boot+periodic callable — injected closures) ─
+
+use super::checkout_txn::recover_pending_sweep;
+
+fn save_pending_journal(
+    home: &std::path::Path,
+    mangled: &str,
+    attempts: u32,
+    deadline: chrono::DateTime<chrono::Utc>,
+) {
+    let mut j = sample_journal();
+    j.advance(Phase::SubmodulesReady);
+    j.rollback_pending = true;
+    j.attempts = attempts;
+    j.next_attempt_at = Some(deadline.to_rfc3339());
+    j.save(home, mangled).unwrap();
+}
+
+/// No transaction area ⇒ sweep resolves nothing.
+#[test]
+fn txn_sweep_empty_area_is_zero() {
+    let home = tmp_home("sweep-empty");
+    let n = recover_pending_sweep(&home, fixed_now(), |_| true, |_| {});
+    assert_eq!(n, 0);
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// A DUE pending rollback whose worktree removes is resolved + cleared.
+#[test]
+fn txn_sweep_due_remove_ok_clears() {
+    let home = tmp_home("sweep-ok");
+    save_pending_journal(&home, "m", 1, fixed_now() - chrono::Duration::seconds(1));
+    let n = recover_pending_sweep(&home, fixed_now(), |_| true, |_| {});
+    assert_eq!(n, 1);
+    assert!(Journal::load(&home, "m").is_none());
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// A NOT-yet-due pending rollback is left untouched (backoff respected).
+#[test]
+fn txn_sweep_not_due_is_skipped() {
+    let home = tmp_home("sweep-notdue");
+    save_pending_journal(&home, "m", 1, fixed_now() + chrono::Duration::seconds(60));
+    let removed = std::cell::Cell::new(false);
+    let n = recover_pending_sweep(
+        &home,
+        fixed_now(),
+        |_| {
+            removed.set(true);
+            true
+        },
+        |_| {},
+    );
+    assert_eq!(n, 0);
+    assert!(!removed.get(), "not-due journal is not touched");
+    assert!(Journal::load(&home, "m").is_some(), "journal retained");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// A due rollback whose remove FAILS is re-armed (attempts bump) and not cleared.
+#[test]
+fn txn_sweep_remove_fail_rearms() {
+    let home = tmp_home("sweep-fail");
+    save_pending_journal(&home, "m", 0, fixed_now() - chrono::Duration::seconds(1));
+    let n = recover_pending_sweep(&home, fixed_now(), |_| false, |_| {});
+    assert_eq!(n, 0);
+    let j = Journal::load(&home, "m").expect("retained");
+    assert!(
+        j.rollback_pending && j.attempts >= 1,
+        "re-armed for a later retry"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// The INTERVENTION audit fires ONCE when a stuck journal crosses the ceiling and
+/// is NOT re-emitted on subsequent sweeps of the same still-stuck journal.
+#[test]
+fn txn_sweep_intervention_audit_deduped() {
+    let home = tmp_home("sweep-audit");
+    // attempts=9 ⇒ next arm's backoff hits the ceiling ⇒ flips into intervention.
+    save_pending_journal(&home, "m", 9, fixed_now() - chrono::Duration::seconds(1));
+    let count = std::cell::Cell::new(0);
+    recover_pending_sweep(
+        &home,
+        fixed_now(),
+        |_| false,
+        |_| count.set(count.get() + 1),
+    );
+    assert_eq!(count.get(), 1, "audit once on ENTERING intervention");
+
+    // Make it due again; still stuck + already in intervention ⇒ no re-audit.
+    let mut j = Journal::load(&home, "m").unwrap();
+    assert!(j.intervention, "now in intervention");
+    j.next_attempt_at = Some((fixed_now() - chrono::Duration::seconds(1)).to_rfc3339());
+    j.save(&home, "m").unwrap();
+    recover_pending_sweep(
+        &home,
+        fixed_now(),
+        |_| false,
+        |_| count.set(count.get() + 1),
+    );
+    assert_eq!(
+        count.get(),
+        1,
+        "deduped — no re-audit while already in intervention"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// The typed path-lock guard carries the normalized TARGET-PATH identity and
+/// revalidates against a path (the forward API Slice A will require on bind_full).
+#[test]
+fn txn_path_lock_guard_carries_identity() {
+    let home = tmp_home("pathlock");
+    let wt = home.join("worktrees").join("agent-src");
+    std::fs::create_dir_all(&wt).unwrap();
+    let g = super::checkout_txn::acquire_path_lock(&home, &wt, "agent-src").expect("acquire");
+    assert_eq!(g.mangled(), "agent-src", "mangled metadata preserved");
+    assert_eq!(g.target(), super::checkout_txn::normalize_target(&wt));
+    assert!(g.guards(&wt), "revalidates its own target path");
+    assert!(
+        !g.guards(&home.join("worktrees").join("other")),
+        "rejects a different target path"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// Alias spellings (`.`-containing, symlink) of the SAME real worktree normalize
+/// to the SAME lock identity, so checkout/bind/release/GC mutually exclude on that
+/// path however it is spelled; distinct paths key distinctly. (Under the old
+/// (instance,source) mangled key these aliases would key DIFFERENTLY — the RED.)
+#[test]
+fn txn_normalize_target_aliases_share_identity() {
+    use super::checkout_txn::normalize_target;
+    let home = tmp_home("alias");
+    let real = home.join("worktrees").join("realwt");
+    std::fs::create_dir_all(&real).unwrap();
+
+    let via_dot = home.join("worktrees").join(".").join("realwt");
+    assert_eq!(
+        normalize_target(&real),
+        normalize_target(&via_dot),
+        "`.`-alias normalizes to the same identity"
+    );
+    #[cfg(unix)]
+    {
+        let link = home.join("worktrees").join("linkwt");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+        assert_eq!(
+            normalize_target(&real),
+            normalize_target(&link),
+            "symlink normalizes to its canonical target ⇒ same lock identity"
+        );
+    }
+    let other = home.join("worktrees").join("otherwt");
+    std::fs::create_dir_all(&other).unwrap();
+    assert_ne!(
+        normalize_target(&real),
+        normalize_target(&other),
+        "distinct paths keep distinct identities"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}

--- a/src/mcp/handlers/ci/checkout_submodule_tests.rs
+++ b/src/mcp/handlers/ci/checkout_submodule_tests.rs
@@ -389,6 +389,22 @@ fn write_corrupt_journal(home: &Path, mangled: &str) {
     std::fs::write(&jp, b"{ not valid json").unwrap();
 }
 
+/// #2755 R4: a corrupt journal is quarantined to a COLLISION-SAFE sidecar
+/// (`journal.json.corrupt-<hash>`), so evidence is asserted by prefix, not a fixed name.
+fn has_corrupt_evidence(home: &Path, mangled: &str) -> bool {
+    super::checkout_txn::journal_path(home, mangled)
+        .parent()
+        .and_then(|d| std::fs::read_dir(d).ok())
+        .map(|rd| {
+            rd.flatten().any(|e| {
+                e.file_name()
+                    .to_string_lossy()
+                    .starts_with("journal.json.corrupt")
+            })
+        })
+        .unwrap_or(false)
+}
+
 /// A Committed tombstone → cleared, NO worktree removal (the provision completed;
 /// its worktree is valid for reuse).
 #[test]
@@ -489,9 +505,7 @@ fn txn_recover_corrupt_removes_worktree() {
     assert!(r.is_ok());
     assert!(removed.get(), "corrupt + real worktree ⇒ removed");
     assert!(
-        super::checkout_txn::journal_path(&home, "m")
-            .with_file_name("journal.json.corrupt")
-            .exists(),
+        has_corrupt_evidence(&home, "m"),
         "torn record quarantined (evidence retained), not silently cleared"
     );
     assert!(
@@ -514,9 +528,7 @@ fn txn_recover_corrupt_remove_fail_arms_replacement() {
     let r = recover_stale(&home, "m", &wt, "/src-xyz", fixed_now(), || false);
     assert!(r.is_err(), "corrupt + remove fail ⇒ Err (caller aborts)");
     assert!(
-        super::checkout_txn::journal_path(&home, "m")
-            .with_file_name("journal.json.corrupt")
-            .exists(),
+        has_corrupt_evidence(&home, "m"),
         "torn record quarantined (evidence retained)"
     );
     let replacement = Journal::load(&home, "m").expect("synthesized replacement armed");
@@ -912,9 +924,7 @@ fn txn_sweep_corrupt_quarantined_not_cleared() {
     let n = recover_pending_sweep(&home, fixed_now(), |_| Some(()), |_| true, |_| {});
     assert_eq!(n, 0, "corrupt is not an auto-resolved removal");
     assert!(
-        super::checkout_txn::journal_path(&home, "m")
-            .with_file_name("journal.json.corrupt")
-            .exists(),
+        has_corrupt_evidence(&home, "m"),
         "corrupt journal quarantined (evidence retained), NOT cleared"
     );
     assert!(
@@ -1038,16 +1048,22 @@ fn checkout_prepared_write_failure_fails_clean_2755() {
     let home = tmp_home("prepfail");
     let repo = tmp_repo_with_file("prepfail", "readme.txt", "x\n");
     let instance = "agent-pf";
+    use std::os::unix::fs::PermissionsExt;
     let mangled = mangled_for(instance, &repo);
-    let jpath = home
-        .join("checkout_txn")
-        .join(&mangled)
-        .join("journal.json");
-    std::fs::create_dir_all(&jpath).unwrap(); // seam: journal.json is a DIR
+    // Seam: the checkout_txn/<mangled>/ dir EXISTS but is READ-ONLY. recover_stale then
+    // sees journal.json genuinely ABSENT (NotFound ⇒ proceeds), and the Prepared
+    // `atomic_write` into the read-only dir FAILS ⇒ journal_write fatal-but-clean. (A
+    // journal.json-as-DIR seam no longer works: R4 recover_stale reads it as Unreadable
+    // and fails closed before the Prepared save.)
+    let jdir = home.join("checkout_txn").join(&mangled);
+    std::fs::create_dir_all(&jdir).unwrap();
+    std::fs::set_permissions(&jdir, std::fs::Permissions::from_mode(0o555)).unwrap();
 
     let args =
         json!({"repository_path": repo.display().to_string(), "branch": "main", "bind": false});
     let resp = super::checkout::handle_checkout_repo(&home, &args, instance);
+    // Restore perms so cleanup (and any assertion failure path) can remove the tree.
+    std::fs::set_permissions(&jdir, std::fs::Permissions::from_mode(0o755)).ok();
     assert_eq!(
         resp["code"].as_str(),
         Some("journal_write"),

--- a/src/mcp/handlers/ci/checkout_submodule_tests.rs
+++ b/src/mcp/handlers/ci/checkout_submodule_tests.rs
@@ -611,6 +611,29 @@ fn rollback_response_pending_never_claims_rolled_back() {
     );
 }
 
+/// #2755 R3 (marker durability): `sync_marker_contents` opens + fsyncs the marker
+/// CONTENTS and OBSERVES failure — a `std::fs::write` + parent-dir fsync makes only the
+/// dirent durable, not the bytes. The seam forces the `sync_all` error (crash/power-loss
+/// surrogate); disarmed it durably syncs a real file. Cross-platform (no real checkout).
+#[test]
+fn marker_sync_contents_observes_failure_via_seam() {
+    let home = tmp_home("marker-sync");
+    let f = home.join(".agend-managed");
+    std::fs::write(&f, "agent=x\n").unwrap();
+    super::checkout::set_fail_marker_sync(true);
+    let armed = super::checkout::sync_marker_contents(&f);
+    super::checkout::set_fail_marker_sync(false);
+    assert!(
+        armed.is_err(),
+        "armed seam ⇒ marker fsync observed as failure"
+    );
+    assert!(
+        super::checkout::sync_marker_contents(&f).is_ok(),
+        "disarmed ⇒ real marker contents fsync succeeds"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
 // ─── recover_pending_sweep (shared boot+periodic — injected try_lock/remove) ───
 // try_lock: Some(_) ⇒ path-lock free (crashed, safe to recover); None ⇒ held (a
 // live checkout owns the path — skip).
@@ -1007,6 +1030,44 @@ fn checkout_commit_write_failure_rolls_back_2755() {
     assert!(
         !home.join("worktrees").join(&mangled).exists(),
         "worktree rolled back on Committed-write failure"
+    );
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&repo).ok();
+}
+
+/// #2755 R3 (marker durability, real entry): a marker CONTENTS fsync failure during
+/// provisioning ABORTS the transaction — the worktree is rolled back and a structured
+/// `marker_fsync_failed` error returned, never a success with a non-durable marker.
+/// Seam forces `sync_all` err at the MarkerDurable stage.
+///
+/// `#[cfg(unix)]`: absolute temp `repository_path` — Unix-only source contract
+/// (see `checkout_initializes_nested_submodules_2755`). The cross-platform durability
+/// observation is covered by `marker_sync_contents_observes_failure_via_seam`.
+#[cfg(unix)]
+#[test]
+fn checkout_marker_fsync_failure_rolls_back_2755() {
+    let home = tmp_home("markerfail");
+    let repo = tmp_repo_with_file("markerfail", "readme.txt", "x\n");
+    let instance = "agent-mf";
+    let mangled = mangled_for(instance, &repo);
+    super::checkout::set_fail_marker_sync(true);
+    let args =
+        json!({"repository_path": repo.display().to_string(), "branch": "main", "bind": false});
+    let resp = super::checkout::handle_checkout_repo(&home, &args, instance);
+    super::checkout::set_fail_marker_sync(false);
+    assert_eq!(
+        resp["stage"].as_str(),
+        Some("marker_durable"),
+        "aborts at marker durability: {resp}"
+    );
+    assert_eq!(
+        resp["code"].as_str(),
+        Some("marker_fsync_failed"),
+        "marker fsync failure ⇒ structured marker_fsync_failed (worktree removable ⇒ rolled back): {resp}"
+    );
+    assert!(
+        !home.join("worktrees").join(&mangled).exists(),
+        "worktree rolled back on marker fsync failure"
     );
     std::fs::remove_dir_all(&home).ok();
     std::fs::remove_dir_all(&repo).ok();

--- a/src/mcp/handlers/ci/checkout_submodule_tests.rs
+++ b/src/mcp/handlers/ci/checkout_submodule_tests.rs
@@ -1281,6 +1281,13 @@ fn checkout_idempotent_bound_reuse_inits_empty_submodules_2755() {
         &["worktree", "add", &wt.display().to_string(), branch],
         false,
     );
+    // A daemon-managed worktree carries the `.agend-managed` marker; the R3 reuse
+    // provenance gate requires it (+ within the daemon worktree area + matching source).
+    std::fs::write(
+        wt.join(crate::worktree_pool::MANAGED_MARKER),
+        "agent=agent-reuse\nbranch=feat/reuse\n",
+    )
+    .unwrap();
     let nested_b = wt.join("vendor/mid/nested/nested_b.txt");
     assert!(
         !nested_b.exists(),
@@ -1327,6 +1334,86 @@ fn checkout_idempotent_bound_reuse_inits_empty_submodules_2755() {
     if let Some(root) = super_repo.parent() {
         std::fs::remove_dir_all(root).ok();
     }
+}
+
+/// #2755 R3 (B4, indep P0.1 + codex m-…736): a `bind:true` reuse whose binding points
+/// at a worktree of a DIFFERENT repository than the requested source MUST fail closed —
+/// the bound tree is never mutated (sync/reset/init) or returned as success. The
+/// provenance gate requires bound `source_repo` canonical == requested source_canonical.
+///
+/// `#[cfg(unix)]`: absolute temp `repository_path` — Unix-only source contract.
+#[cfg(unix)]
+#[test]
+fn checkout_reuse_different_source_fails_closed_2755() {
+    let home = tmp_home("reuse-diff");
+    let requested = tmp_repo_with_file("reuse-req", "readme.txt", "requested\n");
+    let bound = tmp_repo_with_file("reuse-bound", "readme.txt", "bound\n");
+    let instance = "agent-diff";
+    let branch = "feat/diff";
+    // Both repos carry the (non-protected) branch so ensure_branch_exists is a no-op and
+    // the flow reaches the reuse block rather than failing earlier.
+    git_run_ok(&requested, &["branch", branch, "main"], false);
+    git_run_ok(&bound, &["branch", branch, "main"], false);
+
+    // A REAL daemon-managed worktree OF THE OTHER (bound) repo, with a sentinel file.
+    let wt = home.join("worktrees").join("agent-diff-bound");
+    std::fs::create_dir_all(wt.parent().unwrap()).unwrap();
+    git_run_ok(
+        &bound,
+        &["worktree", "add", &wt.display().to_string(), branch],
+        false,
+    );
+    std::fs::write(
+        wt.join(crate::worktree_pool::MANAGED_MARKER),
+        "agent=agent-diff\n",
+    )
+    .unwrap();
+    let sentinel = wt.join("sentinel.txt");
+    std::fs::write(&sentinel, "UNTOUCHED").unwrap();
+
+    // Binding maps instance → (branch, wt-of-bound-repo, source=bound).
+    let bdir = home.join("runtime").join(instance);
+    std::fs::create_dir_all(&bdir).unwrap();
+    std::fs::write(
+        bdir.join("binding.json"),
+        json!({
+            "version": 1,
+            "agent": instance,
+            "task_id": "T-test",
+            "branch": branch,
+            "worktree": wt.display().to_string(),
+            "source_repo": bound.display().to_string(),
+            "issued_at": "2026-01-01T00:00:00+00:00",
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    // Checkout requests the OTHER (requested) source on the same branch ⇒ provenance fail.
+    let args = json!({
+        "repository_path": requested.display().to_string(),
+        "branch": branch,
+        "bind": true,
+    });
+    let resp = super::checkout::handle_checkout_repo(&home, &args, instance);
+    assert_eq!(
+        resp["code"].as_str(),
+        Some("reuse_provenance"),
+        "reuse of a worktree with a DIFFERENT source must fail closed: {resp}"
+    );
+    assert!(
+        resp.get("idempotent").is_none(),
+        "must NOT return idempotent success: {resp}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&sentinel).unwrap(),
+        "UNTOUCHED",
+        "the bound worktree must NOT be mutated (no sync/reset/clean/init)"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&requested).ok();
+    std::fs::remove_dir_all(&bound).ok();
 }
 
 /// Windows/open-handle: a rollback whose `git worktree remove --force` FAILS

--- a/src/mcp/handlers/ci/checkout_submodule_tests.rs
+++ b/src/mcp/handlers/ci/checkout_submodule_tests.rs
@@ -986,6 +986,146 @@ fn checkout_restart_replays_stale_worktree_2755() {
     std::fs::remove_dir_all(&repo).ok();
 }
 
+/// #2755 item 1 (codex R2): the PRODUCTION recovery entry
+/// `checkout_txn::recover_pending_sweep_prod` — the ONE callable run from
+/// boot-repair AND the per-tick handler — invoked DIRECTLY (not via another
+/// checkout) removes a crashed attempt's REAL stale worktree under the real
+/// path-lock via a real `git worktree remove --force`, then clears its journal.
+/// The restart-replay test above drives recovery THROUGH a second checkout; this
+/// pins the boot / per-tick standalone path codex flagged as untested.
+#[cfg(unix)]
+#[test]
+fn recover_pending_sweep_prod_removes_stale_worktree_directly_2755() {
+    let home = tmp_home("prod-sweep");
+    let repo = tmp_repo_with_file("prod-sweep", "readme.txt", "x\n");
+    let instance = "agent-ps";
+    let mangled = mangled_for(instance, &repo);
+    let wt = home.join("worktrees").join(&mangled);
+    std::fs::create_dir_all(wt.parent().unwrap()).unwrap();
+    // A crashed attempt: a REAL registered worktree + a non-Committed journal.
+    git_run_ok(
+        &repo,
+        &[
+            "worktree",
+            "add",
+            "--detach",
+            &wt.display().to_string(),
+            "main",
+        ],
+        false,
+    );
+    assert!(
+        wt.join("readme.txt").is_file(),
+        "fixture: stale worktree materialized"
+    );
+    let mut j = Journal::prepared(
+        "crashed-nonce",
+        wt.display().to_string(),
+        repo.display().to_string(),
+        "main",
+        false,
+        fixed_now().to_rfc3339(),
+    );
+    j.advance(Phase::WorktreeAdded);
+    j.save(&home, &mangled).unwrap();
+
+    // DIRECT production entry — no second checkout drives this.
+    let resolved = super::checkout_txn::recover_pending_sweep_prod(&home);
+    assert_eq!(
+        resolved, 1,
+        "prod sweep resolves exactly the one crashed worktree"
+    );
+    assert!(
+        !wt.exists(),
+        "stale worktree removed by the real `git worktree remove --force`"
+    );
+    assert!(
+        Journal::load(&home, &mangled).is_none(),
+        "journal cleared after successful recovery"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&repo).ok();
+}
+
+/// #2755 item 2 (codex R2): a `bind:true` idempotent reuse (THIS agent already
+/// bound to this branch, worktree still on disk) must recursively INIT submodules
+/// on the reused worktree before returning it. A worktree provisioned before this
+/// fix — or partially inited — can have EMPTY submodule dirs; reuse must self-heal
+/// rather than hand back a broken tree. RED before the reuse-path
+/// `init_submodules_strict` (the short-circuit returned the stale worktree as-is).
+///
+/// Feasible without daemon signing: `binding::read` is an unsigned read (no HMAC
+/// verify) and the reuse short-circuit returns BEFORE `bind_full`, so a hand-seeded
+/// `binding.json` drives the path. The branch is non-protected (E4.5 rejects `main`
+/// under `bind:true`).
+#[cfg(unix)]
+#[test]
+fn checkout_idempotent_bound_reuse_inits_empty_submodules_2755() {
+    let home = tmp_home("reuse-submod");
+    let super_repo = tmp_super_with_nested_submodules("reuse-submod");
+    let instance = "agent-reuse";
+    let branch = "feat/reuse"; // non-protected (main is E4.5-protected for bind)
+    git_run_ok(&super_repo, &["branch", branch, "main"], false);
+
+    // A pre-existing bound worktree whose submodules are EMPTY: `git worktree add`
+    // does NOT recurse submodules, so vendor/mid/ starts uninitialized.
+    let mangled = mangled_for(instance, &super_repo);
+    let wt = home.join("worktrees").join(&mangled);
+    std::fs::create_dir_all(wt.parent().unwrap()).unwrap();
+    git_run_ok(
+        &super_repo,
+        &["worktree", "add", &wt.display().to_string(), branch],
+        false,
+    );
+    let nested_b = wt.join("vendor/mid/nested/nested_b.txt");
+    assert!(
+        !nested_b.exists(),
+        "fixture: reused worktree must start with EMPTY submodules"
+    );
+
+    // Seed THIS agent's binding pointing at the existing worktree (unsigned; the
+    // reuse short-circuit reads branch+worktree and returns before bind_full).
+    let bdir = home.join("runtime").join(instance);
+    std::fs::create_dir_all(&bdir).unwrap();
+    std::fs::write(
+        bdir.join("binding.json"),
+        json!({
+            "version": 1,
+            "agent": instance,
+            "task_id": "T-test",
+            "branch": branch,
+            "worktree": wt.display().to_string(),
+            "source_repo": super_repo.display().to_string(),
+            "issued_at": "2026-01-01T00:00:00+00:00",
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    let args = json!({
+        "repository_path": super_repo.display().to_string(),
+        "branch": branch,
+        "bind": true,
+    });
+    let resp = super::checkout::handle_checkout_repo(&home, &args, instance);
+    assert_eq!(
+        resp.get("idempotent").and_then(|v| v.as_bool()),
+        Some(true),
+        "must take the idempotent bound-reuse path: {resp}"
+    );
+    assert!(
+        nested_b.is_file(),
+        "#2755: idempotent reuse must recursively init submodules so {} exists",
+        nested_b.display()
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+    if let Some(root) = super_repo.parent() {
+        std::fs::remove_dir_all(root).ok();
+    }
+}
+
 /// Windows/open-handle: a rollback whose `git worktree remove --force` FAILS
 /// (an open handle pins the dir) RETAINS intent (armed + backoff); a later sweep,
 /// once the handle is released (remove succeeds), resolves and clears it.

--- a/src/mcp/handlers/ci/checkout_submodule_tests.rs
+++ b/src/mcp/handlers/ci/checkout_submodule_tests.rs
@@ -548,6 +548,90 @@ fn txn_recover_corrupt_remove_fail_arms_replacement() {
     std::fs::remove_dir_all(&home).ok();
 }
 
+/// #2755 R4 (item 1): recover_stale must NOT delete a still-BOUND worktree (a crash after
+/// bind_full but before the Committed journal) — it ADOPTS it (keeps the worktree, drops
+/// the stale journal) rather than tearing down a live binding's worktree.
+#[test]
+fn txn_recover_stale_adopts_bound_worktree() {
+    let home = tmp_home("rec-bound");
+    let wt = home.join("worktrees").join("agent-b-src");
+    save_journal_at(&home, "m", &wt, Phase::SubmodulesReady, true);
+    let bdir = home.join("runtime").join("agent-b");
+    std::fs::create_dir_all(&bdir).unwrap();
+    std::fs::write(
+        bdir.join("binding.json"),
+        serde_json::json!({
+            "version": 1,
+            "agent": "agent-b",
+            "branch": "b",
+            "worktree": wt.display().to_string(),
+        })
+        .to_string(),
+    )
+    .unwrap();
+    let removed = std::cell::Cell::new(false);
+    let r = recover_stale(&home, "m", &wt, "/src", fixed_now(), || {
+        removed.set(true);
+        true
+    });
+    assert!(r.is_ok(), "bound worktree adopted, not an error: {r:?}");
+    assert!(!removed.get(), "a still-BOUND worktree must NOT be removed");
+    assert!(wt.exists(), "bound worktree kept (adopted as committed)");
+    assert!(
+        Journal::load(&home, "m").is_none(),
+        "stale journal dropped on adopt"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// #2755 R4 (item 3a): an UNREADABLE journal (exists but the read errors — NOT NotFound)
+/// leaves recovery authority uncertain — recover_stale aborts FAIL-CLOSED, never treating
+/// it as Absent (nothing-to-recover).
+#[test]
+fn txn_recover_stale_unreadable_fails_closed() {
+    let home = tmp_home("rec-unread");
+    // A DIRECTORY at journal.json ⇒ `std::fs::read` errors (not NotFound) ⇒ Unreadable.
+    std::fs::create_dir_all(super::checkout_txn::journal_path(&home, "m")).unwrap();
+    let r = recover_stale(&home, "m", &home.join("wt"), "/src", fixed_now(), || true);
+    assert!(
+        r.is_err(),
+        "unreadable journal ⇒ recover_stale fails closed (not Ok/Absent): {r:?}"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// #2755 R4 (item 3c): a corrupt record whose worktree can't be removed AND whose
+/// replacement SAVE also fails must leave journal.json still CORRUPT — a durable BLOCKING
+/// record — so the next recovery attempt sees Corrupt, NEVER Absent (never fail-open).
+/// `#[cfg(unix)]`: forces the save failure via a read-only journal dir (fs permissions).
+#[cfg(unix)]
+#[test]
+fn txn_recover_stale_corrupt_save_failure_stays_blocking() {
+    use std::os::unix::fs::PermissionsExt;
+    let home = tmp_home("rec-corrupt-saveblock");
+    let wt = home.join("wt");
+    std::fs::create_dir_all(&wt).unwrap();
+    write_corrupt_journal(&home, "m");
+    let jdir = super::checkout_txn::journal_path(&home, "m")
+        .parent()
+        .unwrap()
+        .to_path_buf();
+    // Read-only dir ⇒ the evidence copy + replacement save both fail, but the corrupt
+    // journal.json remains (readable) as a blocking record.
+    std::fs::set_permissions(&jdir, std::fs::Permissions::from_mode(0o555)).unwrap();
+    let r = recover_stale(&home, "m", &wt, "/src", fixed_now(), || false);
+    std::fs::set_permissions(&jdir, std::fs::Permissions::from_mode(0o755)).ok();
+    assert!(r.is_err(), "remove+save failure ⇒ Err (fail closed): {r:?}");
+    assert!(
+        matches!(
+            super::checkout_txn::load_typed(&home, "m"),
+            super::checkout_txn::JournalLoad::Corrupt
+        ),
+        "journal.json stays CORRUPT (durable blocking) — the next attempt never sees Absent"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
 /// rollback_failed: worktree removed ⇒ unbind runs and the journal is cleared.
 #[test]
 fn txn_rollback_failed_remove_ok_unbinds_and_clears() {
@@ -1514,6 +1598,128 @@ fn checkout_reuse_stale_branch_syncs_final_head_then_inits_2755() {
     if let Some(root) = super_repo.parent() {
         std::fs::remove_dir_all(root).ok();
     }
+}
+
+/// #2755 R4 (item 2): a FRESH checkout must FAIL CLOSED when `submodule.<name>.update=none`
+/// makes `submodule update --init --recursive` exit 0 while SKIPPING the submodule (a `-`
+/// in `git submodule status`). The fresh-path `verify_submodules_at_gitlinks` catches it.
+///
+/// `#[cfg(unix)]`: absolute temp `repository_path` — Unix-only source contract.
+#[cfg(unix)]
+#[test]
+fn checkout_fresh_update_none_gitlink_mismatch_fails_closed_2755() {
+    let home = tmp_home("update-none");
+    let super_repo = tmp_super_with_nested_submodules("update-none");
+    // Pin vendor/mid to update=none so the init command registers but SKIPS it.
+    git_run_ok(
+        &super_repo,
+        &[
+            "config",
+            "-f",
+            ".gitmodules",
+            "submodule.vendor/mid.update",
+            "none",
+        ],
+        false,
+    );
+    git_run_ok(&super_repo, &["add", ".gitmodules"], false);
+    git_run_ok(
+        &super_repo,
+        &["commit", "-m", "vendor/mid update=none"],
+        false,
+    );
+
+    let args = json!({
+        "repository_path": super_repo.display().to_string(),
+        "branch": "main",
+        "bind": false,
+    });
+    let resp = super::checkout::handle_checkout_repo(&home, &args, "agent-un");
+    assert_eq!(
+        resp["code"].as_str(),
+        Some("submodule_gitlink_mismatch"),
+        "fresh init that leaves a submodule uninitialized (update=none) must fail closed: {resp}"
+    );
+    assert_eq!(resp["stage"].as_str(), Some("submodules_ready"));
+
+    std::fs::remove_dir_all(&home).ok();
+    if let Some(root) = super_repo.parent() {
+        std::fs::remove_dir_all(root).ok();
+    }
+}
+
+/// #2755 R4 (item 4): a reuse whose bound worktree is a SYMLINK inside the pool pointing
+/// at an EXTERNAL directory must FAIL CLOSED — the canonical-descendant confinement
+/// rejects it (a lexical `starts_with` would have passed), and the external target is
+/// never synced/reset/inited.
+///
+/// `#[cfg(unix)]`: symlink mechanics + absolute temp source.
+#[cfg(unix)]
+#[test]
+fn checkout_reuse_symlink_out_of_pool_fails_closed_2755() {
+    let home = tmp_home("reuse-symlink");
+    let repo = tmp_repo_with_file("reuse-symlink", "readme.txt", "x\n");
+    let instance = "agent-sym";
+    let branch = "feat/sym";
+    git_run_ok(&repo, &["branch", branch, "main"], false);
+
+    // A REAL worktree OUTSIDE the pool, with a sentinel + marker.
+    let external = home.join("external-wt");
+    git_run_ok(
+        &repo,
+        &["worktree", "add", &external.display().to_string(), branch],
+        false,
+    );
+    std::fs::write(
+        external.join(crate::worktree_pool::MANAGED_MARKER),
+        "agent=agent-sym\n",
+    )
+    .unwrap();
+    let sentinel = external.join("sentinel.txt");
+    std::fs::write(&sentinel, "UNTOUCHED").unwrap();
+
+    // A symlink INSIDE the pool → the external worktree (lexically "within worktrees/").
+    let pool = home.join("worktrees");
+    std::fs::create_dir_all(&pool).unwrap();
+    let link = pool.join("agent-sym-link");
+    std::os::unix::fs::symlink(&external, &link).unwrap();
+
+    let bdir = home.join("runtime").join(instance);
+    std::fs::create_dir_all(&bdir).unwrap();
+    std::fs::write(
+        bdir.join("binding.json"),
+        json!({
+            "version": 1,
+            "agent": instance,
+            "task_id": "T",
+            "branch": branch,
+            "worktree": link.display().to_string(),
+            "source_repo": repo.display().to_string(),
+            "issued_at": "2026-01-01T00:00:00+00:00",
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    let args = json!({
+        "repository_path": repo.display().to_string(),
+        "branch": branch,
+        "bind": true,
+    });
+    let resp = super::checkout::handle_checkout_repo(&home, &args, instance);
+    assert_eq!(
+        resp["code"].as_str(),
+        Some("reuse_provenance"),
+        "a symlink escaping the canonical pool must fail closed: {resp}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&sentinel).unwrap(),
+        "UNTOUCHED",
+        "the external symlink target must NOT be mutated"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&repo).ok();
 }
 
 /// Windows/open-handle: a rollback whose `git worktree remove --force` FAILS

--- a/src/mcp/handlers/ci/checkout_submodule_tests.rs
+++ b/src/mcp/handlers/ci/checkout_submodule_tests.rs
@@ -353,7 +353,7 @@ fn txn_nonce_distinguishes_attempts() {
 
 // ─── recover_stale / rollback_failed (injected remove/unbind — no live git) ──
 
-use super::checkout_txn::{recover_stale, rollback_failed};
+use super::checkout_txn::{recover_stale, rollback_failed, RollbackOutcome};
 
 /// Save a journal at `phase` whose `worktree_path` is `wt`, optionally creating a
 /// real `wt` dir on disk (recovery now decides remove-vs-clear by on-disk
@@ -498,7 +498,7 @@ fn txn_rollback_failed_remove_ok_unbinds_and_clears() {
     j.advance(Phase::SubmodulesReady);
     j.save(&home, "m").unwrap();
     let unbound = std::cell::Cell::new(false);
-    rollback_failed(
+    let outcome = rollback_failed(
         &home,
         "m",
         &mut j,
@@ -506,6 +506,7 @@ fn txn_rollback_failed_remove_ok_unbinds_and_clears() {
         || true,
         || unbound.set(true),
     );
+    assert_eq!(outcome, RollbackOutcome::Removed, "remove ok ⇒ Removed");
     assert!(unbound.get(), "unbind runs");
     assert!(Journal::load(&home, "m").is_none(), "removed ⇒ cleared");
     std::fs::remove_dir_all(&home).ok();
@@ -518,13 +519,96 @@ fn txn_rollback_failed_remove_fail_retains() {
     let mut j = sample_journal();
     j.advance(Phase::SubmodulesReady);
     j.save(&home, "m").unwrap();
-    rollback_failed(&home, "m", &mut j, fixed_now(), || false, || {});
+    // #2755 R3: a failed remove (Windows open-handle / transient FS) ⇒ RollbackPending,
+    // NEVER Removed — the caller must not claim "rolled back". intent_durable=true here
+    // (the armed journal saved cleanly). Cross-platform (injected remove) — this is the
+    // genuine Windows/open-handle rollback-pending row.
+    let outcome = rollback_failed(&home, "m", &mut j, fixed_now(), || false, || {});
+    assert_eq!(
+        outcome,
+        RollbackOutcome::RollbackPending {
+            intent_durable: true
+        },
+        "remove fail ⇒ RollbackPending with durably-saved intent"
+    );
     let retained = Journal::load(&home, "m").expect("retained");
     assert!(
         retained.rollback_pending && retained.next_attempt_at.is_some(),
         "armed retained intent survives a failed remove"
     );
     std::fs::remove_dir_all(&home).ok();
+}
+
+/// #2755 R3: when the worktree remove AND the retained-intent journal SAVE both fail,
+/// RollbackPending surfaces `intent_durable: false` — a worse durability state the
+/// response flags for intervention (indep P1.3: the save result must be observed).
+/// Seam: journal.json pre-created as a DIR so `store::atomic_write` can't rename over
+/// it. Cross-platform.
+#[test]
+fn txn_rollback_failed_pending_flags_nondurable_intent() {
+    let home = tmp_home("rb-nondurable");
+    let mut j = sample_journal();
+    j.advance(Phase::SubmodulesReady);
+    // Make the armed-intent save fail: its journal.json path is a directory.
+    std::fs::create_dir_all(super::checkout_txn::journal_path(&home, "m")).unwrap();
+    let outcome = rollback_failed(&home, "m", &mut j, fixed_now(), || false, || {});
+    assert_eq!(
+        outcome,
+        RollbackOutcome::RollbackPending {
+            intent_durable: false
+        },
+        "remove fail + save fail ⇒ pending with non-durable intent"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// #2755 R3 (public response): the checkout error response reports the ACTUAL cleanup
+/// state. `Removed` keeps the historical "worktree rolled back" text + original code.
+/// `RollbackPending` NEVER claims rolled back — a structured pending state (code
+/// `rollback_pending`, `rollback_pending:true`, `intent_durable`, original
+/// `failed_code` preserved). Pure mapping, cross-platform.
+#[test]
+fn rollback_response_pending_never_claims_rolled_back() {
+    let removed = super::checkout::rollback_response(
+        RollbackOutcome::Removed,
+        "submodule init failed",
+        "submodule_init_failed",
+        "submodules_ready",
+        "feat/x",
+    );
+    assert_eq!(removed["code"], "submodule_init_failed");
+    assert!(removed["error"].as_str().unwrap().contains("rolled back"));
+    assert!(removed.get("rollback_pending").is_none());
+
+    let pending = super::checkout::rollback_response(
+        RollbackOutcome::RollbackPending {
+            intent_durable: false,
+        },
+        "submodule init failed",
+        "submodule_init_failed",
+        "submodules_ready",
+        "feat/x",
+    );
+    assert_eq!(
+        pending["code"], "rollback_pending",
+        "pending ⇒ distinct code"
+    );
+    assert_eq!(pending["rollback_pending"], true);
+    assert_eq!(
+        pending["failed_code"], "submodule_init_failed",
+        "root-cause code preserved"
+    );
+    assert_eq!(pending["intent_durable"], false);
+    let err = pending["error"].as_str().unwrap();
+    assert!(
+        !err.contains("worktree rolled back"),
+        "must NOT claim rolled back: {err}"
+    );
+    assert!(err.contains("rollback pending"), "surfaces pending: {err}");
+    assert!(
+        err.contains("intervention"),
+        "non-durable intent flagged: {err}"
+    );
 }
 
 // ─── recover_pending_sweep (shared boot+periodic — injected try_lock/remove) ───
@@ -1147,7 +1231,13 @@ fn txn_open_handle_remove_failure_retained_then_recovered() {
     j.advance(Phase::SubmodulesReady);
     j.save(&home, mangled).unwrap();
     // Handle held open ⇒ remove fails ⇒ intent retained (not cleared).
-    rollback_failed(&home, mangled, &mut j, fixed_now(), || false, || {});
+    assert!(
+        matches!(
+            rollback_failed(&home, mangled, &mut j, fixed_now(), || false, || {}),
+            RollbackOutcome::RollbackPending { .. }
+        ),
+        "open handle ⇒ remove fails ⇒ RollbackPending"
+    );
     let stuck = Journal::load(&home, mangled).expect("retained while handle open");
     assert!(stuck.rollback_pending && stuck.next_attempt_at.is_some());
     // Make it due; handle released ⇒ the sweep removes + clears.

--- a/src/mcp/handlers/ci/checkout_submodule_tests.rs
+++ b/src/mcp/handlers/ci/checkout_submodule_tests.rs
@@ -600,6 +600,102 @@ fn txn_recover_stale_unreadable_fails_closed() {
     std::fs::remove_dir_all(&home).ok();
 }
 
+/// #2755 R5 (codex REJECT of 7ac7e281 — destructive-recovery gap): a binding written by a
+/// FUTURE schema is PRESENT (`parse_binding_guarded` → None). Recovery must treat it as
+/// possibly-ours and fail closed, NEVER skip it to `Unbound` and destroy a newer daemon's
+/// live worktree ("future ≠ absent").
+#[test]
+fn txn_recover_stale_future_schema_binding_not_removed() {
+    let home = tmp_home("rec-future-binding");
+    let wt = home.join("worktrees").join("agent-b-src");
+    save_journal_at(&home, "m", &wt, Phase::SubmodulesReady, true);
+    let bdir = home.join("runtime").join("agent-b");
+    std::fs::create_dir_all(&bdir).unwrap();
+    std::fs::write(
+        bdir.join("binding.json"),
+        serde_json::json!({
+            "version": 99_999, // beyond this daemon's schema ⇒ parse_binding_guarded None
+            "agent": "agent-b",
+            "worktree": wt.display().to_string(),
+        })
+        .to_string(),
+    )
+    .unwrap();
+    let removed = std::cell::Cell::new(false);
+    let r = recover_stale(&home, "m", &wt, "/src", fixed_now(), || {
+        removed.set(true);
+        true
+    });
+    assert!(
+        r.is_err(),
+        "future-schema binding ⇒ Uncertain ⇒ fail closed: {r:?}"
+    );
+    assert!(
+        !removed.get(),
+        "a possibly-bound (future-schema) worktree must NOT be removed"
+    );
+    assert!(wt.exists(), "worktree retained");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// #2755 R5: a CORRUPT (non-JSON) binding.json is present — a torn write during the very
+/// crash-after-bind window item 1 targets. Same fail-closed contract: never remove.
+#[test]
+fn txn_recover_stale_corrupt_binding_not_removed() {
+    let home = tmp_home("rec-corrupt-binding");
+    let wt = home.join("worktrees").join("agent-c-src");
+    save_journal_at(&home, "m", &wt, Phase::SubmodulesReady, true);
+    let bdir = home.join("runtime").join("agent-c");
+    std::fs::create_dir_all(&bdir).unwrap();
+    std::fs::write(bdir.join("binding.json"), "}{ not valid json").unwrap();
+    let removed = std::cell::Cell::new(false);
+    let r = recover_stale(&home, "m", &wt, "/src", fixed_now(), || {
+        removed.set(true);
+        true
+    });
+    assert!(
+        r.is_err(),
+        "corrupt binding ⇒ Uncertain ⇒ fail closed: {r:?}"
+    );
+    assert!(
+        !removed.get(),
+        "a possibly-bound (corrupt-binding) worktree must NOT be removed"
+    );
+    assert!(wt.exists(), "worktree retained");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// #2755 R5: a binding that PARSES but has no usable `worktree` field (future/invalid
+/// shape) is uncertain, not absent — must not authorize removal.
+#[test]
+fn txn_recover_stale_binding_without_worktree_field_not_removed() {
+    let home = tmp_home("rec-noworktree-binding");
+    let wt = home.join("worktrees").join("agent-d-src");
+    save_journal_at(&home, "m", &wt, Phase::SubmodulesReady, true);
+    let bdir = home.join("runtime").join("agent-d");
+    std::fs::create_dir_all(&bdir).unwrap();
+    std::fs::write(
+        bdir.join("binding.json"),
+        serde_json::json!({ "version": 1, "agent": "agent-d" }).to_string(), // no `worktree`
+    )
+    .unwrap();
+    let removed = std::cell::Cell::new(false);
+    let r = recover_stale(&home, "m", &wt, "/src", fixed_now(), || {
+        removed.set(true);
+        true
+    });
+    assert!(
+        r.is_err(),
+        "no-worktree-field binding ⇒ Uncertain ⇒ fail closed: {r:?}"
+    );
+    assert!(
+        !removed.get(),
+        "worktree must NOT be removed on an unusable binding shape"
+    );
+    assert!(wt.exists(), "worktree retained");
+    std::fs::remove_dir_all(&home).ok();
+}
+
 /// #2755 R4 (item 3c): a corrupt record whose worktree can't be removed AND whose
 /// replacement SAVE also fails must leave journal.json still CORRUPT — a durable BLOCKING
 /// record — so the next recovery attempt sees Corrupt, NEVER Absent (never fail-open).

--- a/src/mcp/handlers/ci/checkout_submodule_tests.rs
+++ b/src/mcp/handlers/ci/checkout_submodule_tests.rs
@@ -1416,6 +1416,90 @@ fn checkout_reuse_different_source_fails_closed_2755() {
     std::fs::remove_dir_all(&bound).ok();
 }
 
+/// #2755 R3 (B1, decision d-…37): a reused worktree whose branch ref ADVANCED past its
+/// checked-out commit must be synced to the FINAL HEAD FIRST, then recursively inited at
+/// that HEAD, then gitlink-verified — never inited at the stale tree. Advance feat/reuse
+/// to C2 (adds a file + keeps the submodule) via `update-ref` while the worktree sits at
+/// C1; after reuse the worktree carries C2's content AND its materialized submodule.
+///
+/// `#[cfg(unix)]`: absolute temp `repository_path` — Unix-only source contract.
+#[cfg(unix)]
+#[test]
+fn checkout_reuse_stale_branch_syncs_final_head_then_inits_2755() {
+    let home = tmp_home("reuse-stale");
+    let super_repo = tmp_super_with_nested_submodules("reuse-stale");
+    let instance = "agent-stale";
+    let branch = "feat/reuse";
+    git_run_ok(&super_repo, &["branch", branch, "main"], false); // C1
+
+    let mangled = mangled_for(instance, &super_repo);
+    let wt = home.join("worktrees").join(&mangled);
+    std::fs::create_dir_all(wt.parent().unwrap()).unwrap();
+    git_run_ok(
+        &super_repo,
+        &["worktree", "add", &wt.display().to_string(), branch],
+        false,
+    ); // wt at C1 (submodule vendor/mid EMPTY)
+    std::fs::write(
+        wt.join(crate::worktree_pool::MANAGED_MARKER),
+        "agent=agent-stale\n",
+    )
+    .unwrap();
+
+    // Advance the branch to C2 (a new file) WITHOUT touching the worktree — `update-ref`
+    // moves the checked-out branch at the plumbing level. wt now trails its own HEAD.
+    std::fs::write(super_repo.join("c2_only.txt"), "final-head\n").unwrap();
+    git_run_ok(&super_repo, &["add", "c2_only.txt"], false);
+    git_run_ok(&super_repo, &["commit", "-m", "C2 advance"], false); // main = C2
+    git_run_ok(
+        &super_repo,
+        &["update-ref", "refs/heads/feat/reuse", "main"],
+        false,
+    ); // feat/reuse = C2
+
+    let bdir = home.join("runtime").join(instance);
+    std::fs::create_dir_all(&bdir).unwrap();
+    std::fs::write(
+        bdir.join("binding.json"),
+        json!({
+            "version": 1,
+            "agent": instance,
+            "task_id": "T-test",
+            "branch": branch,
+            "worktree": wt.display().to_string(),
+            "source_repo": super_repo.display().to_string(),
+            "issued_at": "2026-01-01T00:00:00+00:00",
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    let args = json!({
+        "repository_path": super_repo.display().to_string(),
+        "branch": branch,
+        "bind": true,
+    });
+    let resp = super::checkout::handle_checkout_repo(&home, &args, instance);
+    assert_eq!(
+        resp.get("idempotent").and_then(|v| v.as_bool()),
+        Some(true),
+        "reuse must succeed after syncing the stale worktree to its final HEAD: {resp}"
+    );
+    assert!(
+        wt.join("c2_only.txt").is_file(),
+        "sync-first must materialize the FINAL HEAD (C2) content before init"
+    );
+    assert!(
+        wt.join("vendor/mid/nested/nested_b.txt").is_file(),
+        "recursive init must run against the final HEAD's gitlinks"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+    if let Some(root) = super_repo.parent() {
+        std::fs::remove_dir_all(root).ok();
+    }
+}
+
 /// Windows/open-handle: a rollback whose `git worktree remove --force` FAILS
 /// (an open handle pins the dir) RETAINS intent (armed + backoff); a later sweep,
 /// once the handle is released (remove succeeds), resolves and clears it.

--- a/src/mcp/handlers/ci/checkout_submodule_tests.rs
+++ b/src/mcp/handlers/ci/checkout_submodule_tests.rs
@@ -8,6 +8,10 @@
 //! (that module's helpers are private); a two-level super→A→B nest pins that
 //! the fix inits submodules RECURSIVELY, not just one level.
 
+// `#[cfg(unix)]`: `json!` is used only by the real-checkout tests below, which are
+// Unix-only (absolute-source contract — see the first such test). Windows would
+// otherwise warn `unused_imports` under strict clippy.
+#[cfg(unix)]
 use serde_json::json;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -17,6 +21,10 @@ static COUNTER: AtomicU32 = AtomicU32::new(0);
 /// Run git with `AGEND_GIT_BYPASS` (skip the shim); panic on non-zero. When
 /// `allow_file`, set `protocol.file.allow=always` so local-path submodule
 /// fixtures clone (git's submodule helper ignores repo-stored config).
+///
+/// `#[cfg(unix)]`: consumed only by the Unix-only real-checkout fixtures/tests
+/// below; gating avoids a `dead_code` warning on Windows under strict clippy.
+#[cfg(unix)]
 fn git_run_ok(dir: &Path, args: &[&str], allow_file: bool) {
     let mut cmd = std::process::Command::new("git");
     cmd.env("AGEND_GIT_BYPASS", "1").current_dir(dir);
@@ -35,6 +43,7 @@ fn git_run_ok(dir: &Path, args: &[&str], allow_file: bool) {
 }
 
 /// A committed local repo with one file at `rel` (the innermost submodule).
+#[cfg(unix)] // Unix-only real-checkout fixture (see `git_run_ok`).
 fn tmp_repo_with_file(name: &str, rel: &str, body: &str) -> PathBuf {
     let id = COUNTER.fetch_add(1, Ordering::Relaxed);
     let dir = std::env::temp_dir().join(format!(
@@ -60,6 +69,7 @@ fn tmp_repo_with_file(name: &str, rel: &str, body: &str) -> PathBuf {
 
 /// Hermetic superproject with two submodule levels:
 ///   super → `vendor/mid` (A) → `nested` (B, holds `nested_b.txt`).
+#[cfg(unix)] // Unix-only real-checkout fixture (see `git_run_ok`).
 fn tmp_super_with_nested_submodules(name: &str) -> PathBuf {
     let root = std::env::temp_dir().join(format!(
         "agend-co-nest-root-{}-{}-{}",
@@ -126,6 +136,13 @@ fn tmp_home(name: &str) -> PathBuf {
 /// must leave the submodule CONTENT materialized in the provisioned worktree.
 /// Pre-fix the handler runs `git worktree add` and skips `--init --recursive`,
 /// so the level-B file is missing and the assert fails.
+///
+/// `#[cfg(unix)]`: drives the real entry with an ABSOLUTE temp `repository_path`.
+/// The #2158 source guard's absolute arm is `/`-prefixed (Unix-only by design —
+/// a `C:\`-rooted Windows path routes to the agent-name arm and fails closed with
+/// `ambiguous_source_path`). Same Unix-only contract as
+/// `source_resolve.rs::absolute_existing_path_still_resolves_2158`.
+#[cfg(unix)]
 #[test]
 fn checkout_initializes_nested_submodules_2755() {
     let home = tmp_home("co-submod");
@@ -831,6 +848,7 @@ fn redact_paths_strips_absolute_paths_only() {
 }
 
 /// The `(instance, source)` → worktree-dir mangling `handle_checkout_repo` uses.
+#[cfg(unix)] // Used only by the Unix-only real-checkout tests below.
 fn mangled_for(instance: &str, source: &Path) -> String {
     format!(
         "{}-{}",
@@ -846,6 +864,10 @@ fn mangled_for(instance: &str, source: &Path) -> String {
 /// BLOCKER 1 — a checked PREPARED-save failure is fatal-but-CLEAN: no worktree is
 /// created (no side effect yet), so nothing to roll back. (journal.json
 /// pre-created as a DIR ⇒ the first `store::atomic_write` rename fails.)
+///
+/// `#[cfg(unix)]`: absolute temp `repository_path` — Unix-only source contract
+/// (see `checkout_initializes_nested_submodules_2755`).
+#[cfg(unix)]
 #[test]
 fn checkout_prepared_write_failure_fails_clean_2755() {
     let home = tmp_home("prepfail");
@@ -878,6 +900,10 @@ fn checkout_prepared_write_failure_fails_clean_2755() {
 /// BLOCKER 1 — a COMMITTED-write failure (all earlier phase saves succeed) ABORTS
 /// into rollback: the worktree is removed and the structured `commit_failed`
 /// returned, never success. Uses the checkout_txn `set_fail_committed_save` seam.
+///
+/// `#[cfg(unix)]`: absolute temp `repository_path` — Unix-only source contract
+/// (see `checkout_initializes_nested_submodules_2755`).
+#[cfg(unix)]
 #[test]
 fn checkout_commit_write_failure_rolls_back_2755() {
     let home = tmp_home("commitfail");
@@ -905,6 +931,10 @@ fn checkout_commit_write_failure_rolls_back_2755() {
 /// Restart-replay: a crashed prior attempt left a REAL stale worktree + a
 /// non-Committed journal at this path; a fresh real checkout REPLAYS it (removes
 /// the stale worktree under the path-lock) then provisions cleanly.
+///
+/// `#[cfg(unix)]`: absolute temp `repository_path` — Unix-only source contract
+/// (see `checkout_initializes_nested_submodules_2755`).
+#[cfg(unix)]
 #[test]
 fn checkout_restart_replays_stale_worktree_2755() {
     let home = tmp_home("replay");

--- a/src/mcp/handlers/ci/checkout_submodule_tests.rs
+++ b/src/mcp/handlers/ci/checkout_submodule_tests.rs
@@ -1,0 +1,175 @@
+//! #2755 real-entry RED: `repo action=checkout` must recursively initialize
+//! submodules. The MCP entry `handle_checkout_repo` runs `git worktree add`
+//! but (pre-fix) skips `submodule update --init --recursive`, so a
+//! path-dependency submodule (e.g. `vendor/agentic-git`) is left EMPTY on the
+//! provisioned worktree — the build then fails on missing nested content.
+//!
+//! Fixtures mirror `src/worktree/tests.rs::tmp_super_with_nested_submodules`
+//! (that module's helpers are private); a two-level super→A→B nest pins that
+//! the fix inits submodules RECURSIVELY, not just one level.
+
+use serde_json::json;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU32, Ordering};
+
+static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+/// Run git with `AGEND_GIT_BYPASS` (skip the shim); panic on non-zero. When
+/// `allow_file`, set `protocol.file.allow=always` so local-path submodule
+/// fixtures clone (git's submodule helper ignores repo-stored config).
+fn git_run_ok(dir: &Path, args: &[&str], allow_file: bool) {
+    let mut cmd = std::process::Command::new("git");
+    cmd.env("AGEND_GIT_BYPASS", "1").current_dir(dir);
+    if allow_file {
+        cmd.args(["-c", "protocol.file.allow=always"]);
+    }
+    cmd.args(args);
+    let out = cmd.output().expect("spawn git");
+    assert!(
+        out.status.success(),
+        "git {:?} in {} failed: {}",
+        args,
+        dir.display(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// A committed local repo with one file at `rel` (the innermost submodule).
+fn tmp_repo_with_file(name: &str, rel: &str, body: &str) -> PathBuf {
+    let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!(
+        "agend-co-subfix-{}-{}-{}",
+        std::process::id(),
+        name,
+        id
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    git_run_ok(&dir, &["init", "-b", "main"], false);
+    git_run_ok(&dir, &["config", "user.email", "test@test"], false);
+    git_run_ok(&dir, &["config", "user.name", "test"], false);
+    if let Some(parent) = Path::new(rel).parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(dir.join(parent)).unwrap();
+        }
+    }
+    std::fs::write(dir.join(rel), body).unwrap();
+    git_run_ok(&dir, &["add", rel], false);
+    git_run_ok(&dir, &["commit", "-m", "init"], false);
+    dir
+}
+
+/// Hermetic superproject with two submodule levels:
+///   super → `vendor/mid` (A) → `nested` (B, holds `nested_b.txt`).
+fn tmp_super_with_nested_submodules(name: &str) -> PathBuf {
+    let root = std::env::temp_dir().join(format!(
+        "agend-co-nest-root-{}-{}-{}",
+        std::process::id(),
+        name,
+        COUNTER.fetch_add(1, Ordering::Relaxed)
+    ));
+    std::fs::create_dir_all(&root).unwrap();
+
+    // Level B (innermost)
+    let b = tmp_repo_with_file(&format!("{name}-b"), "nested_b.txt", "level-b-payload\n");
+
+    // Level A: depends on B at nested/
+    let a = {
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = root.join(format!("a-{id}"));
+        std::fs::create_dir_all(&dir).unwrap();
+        git_run_ok(&dir, &["init", "-b", "main"], false);
+        git_run_ok(&dir, &["config", "user.email", "test@test"], false);
+        git_run_ok(&dir, &["config", "user.name", "test"], false);
+        git_run_ok(
+            &dir,
+            &["submodule", "add", &b.display().to_string(), "nested"],
+            true,
+        );
+        git_run_ok(&dir, &["commit", "-m", "A with nested B"], false);
+        dir
+    };
+
+    // Super: depends on A at vendor/mid/
+    let super_repo = {
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = root.join(format!("super-{id}"));
+        std::fs::create_dir_all(&dir).unwrap();
+        git_run_ok(&dir, &["init", "-b", "main"], false);
+        git_run_ok(&dir, &["config", "user.email", "test@test"], false);
+        git_run_ok(&dir, &["config", "user.name", "test"], false);
+        git_run_ok(
+            &dir,
+            &["submodule", "add", &a.display().to_string(), "vendor/mid"],
+            true,
+        );
+        git_run_ok(&dir, &["commit", "-m", "super with A->B nest"], false);
+        dir
+    };
+
+    let _ = (b, a);
+    super_repo
+}
+
+fn tmp_home(name: &str) -> PathBuf {
+    let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!(
+        "agend-co-home-{}-{}-{}",
+        std::process::id(),
+        name,
+        id
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+/// #2755 RED: a real `repo action=checkout` of a repo with (nested) submodules
+/// must leave the submodule CONTENT materialized in the provisioned worktree.
+/// Pre-fix the handler runs `git worktree add` and skips `--init --recursive`,
+/// so the level-B file is missing and the assert fails.
+#[test]
+fn checkout_initializes_nested_submodules_2755() {
+    let home = tmp_home("co-submod");
+    let super_repo = tmp_super_with_nested_submodules("co-submod");
+    assert!(
+        super_repo.join(".gitmodules").is_file(),
+        "fixture: super must have .gitmodules"
+    );
+
+    // Real MCP entry. bind:false is the minimal materialization path (no
+    // lease/bind_full/signing confounds); the `git worktree add` it runs is the
+    // exact site that skips submodule init.
+    let args = json!({
+        "repository_path": super_repo.display().to_string(),
+        "branch": "main",
+        "bind": false,
+    });
+    let resp = super::checkout::handle_checkout_repo(&home, &args, "agent-co");
+    assert!(resp.get("error").is_none(), "checkout errored: {resp}");
+    let wt = PathBuf::from(
+        resp["path"]
+            .as_str()
+            .unwrap_or_else(|| panic!("checkout must return a path: {resp}")),
+    );
+
+    // Decisive pin: the level-B file exists inside the provisioned worktree.
+    // `git worktree add` alone leaves vendor/mid (and its nested/) empty.
+    let nested_b = wt.join("vendor/mid/nested/nested_b.txt");
+    assert!(
+        nested_b.is_file(),
+        "#2755: repo checkout must recursively init submodules so {} exists; \
+         `git worktree add` alone leaves submodule dirs empty",
+        nested_b.display()
+    );
+    // Windows git may rewrite LF→CRLF on checkout; pin payload only.
+    let body = std::fs::read_to_string(&nested_b).unwrap();
+    assert_eq!(
+        body.trim_end_matches(['\r', '\n']),
+        "level-b-payload",
+        "nested submodule payload must match regardless of CRLF vs LF"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+    if let Some(root) = super_repo.parent() {
+        std::fs::remove_dir_all(root).ok();
+    }
+}

--- a/src/mcp/handlers/ci/checkout_submodule_tests.rs
+++ b/src/mcp/handlers/ci/checkout_submodule_tests.rs
@@ -397,7 +397,7 @@ fn txn_recover_committed_clears_without_remove() {
     let wt = home.join("wt");
     save_journal_at(&home, "m", &wt, Phase::Committed, true);
     let removed = std::cell::Cell::new(false);
-    let r = recover_stale(&home, "m", &wt, fixed_now(), || {
+    let r = recover_stale(&home, "m", &wt, "/src", fixed_now(), || {
         removed.set(true);
         true
     });
@@ -413,7 +413,7 @@ fn txn_recover_inflight_remove_ok_clears() {
     let home = tmp_home("rec-ok");
     let wt = home.join("wt");
     save_journal_at(&home, "m", &wt, Phase::WorktreeAdded, true);
-    let r = recover_stale(&home, "m", &wt, fixed_now(), || true);
+    let r = recover_stale(&home, "m", &wt, "/src", fixed_now(), || true);
     assert!(r.is_ok());
     assert!(Journal::load(&home, "m").is_none(), "removed ⇒ cleared");
     std::fs::remove_dir_all(&home).ok();
@@ -425,7 +425,7 @@ fn txn_recover_inflight_remove_fail_retains_intent() {
     let home = tmp_home("rec-fail");
     let wt = home.join("wt");
     save_journal_at(&home, "m", &wt, Phase::SubmodulesReady, true);
-    let r = recover_stale(&home, "m", &wt, fixed_now(), || false);
+    let r = recover_stale(&home, "m", &wt, "/src", fixed_now(), || false);
     assert!(r.is_err(), "remove failed ⇒ Err");
     let retained = Journal::load(&home, "m").expect("journal retained");
     assert!(retained.rollback_pending && retained.next_attempt_at.is_some());
@@ -440,7 +440,7 @@ fn txn_recover_no_worktree_clears_without_remove() {
     let wt = home.join("wt"); // NOT created
     save_journal_at(&home, "m", &wt, Phase::WorktreeAdded, false);
     let removed = std::cell::Cell::new(false);
-    let r = recover_stale(&home, "m", &wt, fixed_now(), || {
+    let r = recover_stale(&home, "m", &wt, "/src", fixed_now(), || {
         removed.set(true);
         true
     });
@@ -458,7 +458,7 @@ fn txn_recover_prepared_with_real_worktree_removes() {
     let wt = home.join("wt");
     save_journal_at(&home, "m", &wt, Phase::Prepared, true);
     let removed = std::cell::Cell::new(false);
-    let r = recover_stale(&home, "m", &wt, fixed_now(), || {
+    let r = recover_stale(&home, "m", &wt, "/src", fixed_now(), || {
         removed.set(true);
         true
     });
@@ -471,8 +471,10 @@ fn txn_recover_prepared_with_real_worktree_removes() {
     std::fs::remove_dir_all(&home).ok();
 }
 
-/// A CORRUPT (torn) journal + a real worktree → the worktree is removed and the
-/// torn record cleared (treated as a crashed attempt).
+/// A CORRUPT (torn) journal + a real worktree that REMOVES cleanly: the worktree is
+/// removed, and the torn record is QUARANTINED (retained as forensic evidence — #2755
+/// R3), never silently cleared. `Journal::load` is None only because journal.json was
+/// renamed aside to journal.json.corrupt.
 #[test]
 fn txn_recover_corrupt_removes_worktree() {
     let home = tmp_home("rec-corrupt");
@@ -480,13 +482,57 @@ fn txn_recover_corrupt_removes_worktree() {
     std::fs::create_dir_all(&wt).unwrap();
     write_corrupt_journal(&home, "m");
     let removed = std::cell::Cell::new(false);
-    let r = recover_stale(&home, "m", &wt, fixed_now(), || {
+    let r = recover_stale(&home, "m", &wt, "/src", fixed_now(), || {
         removed.set(true);
         true
     });
     assert!(r.is_ok());
     assert!(removed.get(), "corrupt + real worktree ⇒ removed");
-    assert!(Journal::load(&home, "m").is_none());
+    assert!(
+        super::checkout_txn::journal_path(&home, "m")
+            .with_file_name("journal.json.corrupt")
+            .exists(),
+        "torn record quarantined (evidence retained), not silently cleared"
+    );
+    assert!(
+        Journal::load(&home, "m").is_none(),
+        "no live journal.json remains"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// #2755 R3 (indep P0.2): a CORRUPT record + a real worktree whose remove FAILS must
+/// NOT drop recovery authority. recover_stale quarantines the torn record AND arms a
+/// SYNTHESIZED durable replacement (carrying the caller-known source) so the sweep can
+/// later drive `git worktree remove` — never orphan a worktree with no recovery record.
+#[test]
+fn txn_recover_corrupt_remove_fail_arms_replacement() {
+    let home = tmp_home("rec-corrupt-fail");
+    let wt = home.join("wt");
+    std::fs::create_dir_all(&wt).unwrap();
+    write_corrupt_journal(&home, "m");
+    let r = recover_stale(&home, "m", &wt, "/src-xyz", fixed_now(), || false);
+    assert!(r.is_err(), "corrupt + remove fail ⇒ Err (caller aborts)");
+    assert!(
+        super::checkout_txn::journal_path(&home, "m")
+            .with_file_name("journal.json.corrupt")
+            .exists(),
+        "torn record quarantined (evidence retained)"
+    );
+    let replacement = Journal::load(&home, "m").expect("synthesized replacement armed");
+    assert!(
+        replacement.rollback_pending && replacement.next_attempt_at.is_some(),
+        "replacement armed for the recovery sweep"
+    );
+    assert_eq!(
+        replacement.source_repo, "/src-xyz",
+        "replacement carries the caller source so the sweep can git-remove"
+    );
+    assert_eq!(
+        replacement.worktree_path,
+        wt.to_string_lossy(),
+        "replacement targets this worktree path"
+    );
     std::fs::remove_dir_all(&home).ok();
 }
 
@@ -855,14 +901,26 @@ fn txn_sweep_recovers_unarmed_crash() {
     std::fs::remove_dir_all(&home).ok();
 }
 
-/// A corrupt journal is cleared by the sweep (any orphan worktree ⇒ worktree GC).
+/// #2755 R3: the sweep QUARANTINES a corrupt journal (rename → journal.json.corrupt)
+/// instead of CLEARING it — a torn record still carries recovery AUTHORITY (a managed
+/// worktree may remain) and is the only source/path/nonce evidence. n stays 0 (nothing
+/// auto-resolved); the sweep surfaces intervention rather than destroying the evidence.
 #[test]
-fn txn_sweep_corrupt_cleared() {
+fn txn_sweep_corrupt_quarantined_not_cleared() {
     let home = tmp_home("sweep-corrupt");
     write_corrupt_journal(&home, "m");
     let n = recover_pending_sweep(&home, fixed_now(), |_| Some(()), |_| true, |_| {});
-    assert_eq!(n, 0);
-    assert!(Journal::load(&home, "m").is_none(), "corrupt cleared");
+    assert_eq!(n, 0, "corrupt is not an auto-resolved removal");
+    assert!(
+        super::checkout_txn::journal_path(&home, "m")
+            .with_file_name("journal.json.corrupt")
+            .exists(),
+        "corrupt journal quarantined (evidence retained), NOT cleared"
+    );
+    assert!(
+        Journal::load(&home, "m").is_none(),
+        "no live journal.json remains (renamed aside)"
+    );
     std::fs::remove_dir_all(&home).ok();
 }
 

--- a/src/mcp/handlers/ci/checkout_submodule_tests.rs
+++ b/src/mcp/handlers/ci/checkout_submodule_tests.rs
@@ -615,7 +615,7 @@ fn txn_rollback_failed_pending_flags_nondurable_intent() {
 /// `failed_code` preserved). Pure mapping, cross-platform.
 #[test]
 fn rollback_response_pending_never_claims_rolled_back() {
-    let removed = super::checkout::rollback_response(
+    let removed = super::checkout_helpers::rollback_response(
         RollbackOutcome::Removed,
         "submodule init failed",
         "submodule_init_failed",
@@ -626,7 +626,7 @@ fn rollback_response_pending_never_claims_rolled_back() {
     assert!(removed["error"].as_str().unwrap().contains("rolled back"));
     assert!(removed.get("rollback_pending").is_none());
 
-    let pending = super::checkout::rollback_response(
+    let pending = super::checkout_helpers::rollback_response(
         RollbackOutcome::RollbackPending {
             intent_durable: false,
         },
@@ -666,15 +666,15 @@ fn marker_sync_contents_observes_failure_via_seam() {
     let home = tmp_home("marker-sync");
     let f = home.join(".agend-managed");
     std::fs::write(&f, "agent=x\n").unwrap();
-    super::checkout::set_fail_marker_sync(true);
-    let armed = super::checkout::sync_marker_contents(&f);
-    super::checkout::set_fail_marker_sync(false);
+    super::checkout_helpers::set_fail_marker_sync(true);
+    let armed = super::checkout_helpers::sync_marker_contents(&f);
+    super::checkout_helpers::set_fail_marker_sync(false);
     assert!(
         armed.is_err(),
         "armed seam ⇒ marker fsync observed as failure"
     );
     assert!(
-        super::checkout::sync_marker_contents(&f).is_ok(),
+        super::checkout_helpers::sync_marker_contents(&f).is_ok(),
         "disarmed ⇒ real marker contents fsync succeeds"
     );
     std::fs::remove_dir_all(&home).ok();
@@ -1108,11 +1108,11 @@ fn checkout_marker_fsync_failure_rolls_back_2755() {
     let repo = tmp_repo_with_file("markerfail", "readme.txt", "x\n");
     let instance = "agent-mf";
     let mangled = mangled_for(instance, &repo);
-    super::checkout::set_fail_marker_sync(true);
+    super::checkout_helpers::set_fail_marker_sync(true);
     let args =
         json!({"repository_path": repo.display().to_string(), "branch": "main", "bind": false});
     let resp = super::checkout::handle_checkout_repo(&home, &args, instance);
-    super::checkout::set_fail_marker_sync(false);
+    super::checkout_helpers::set_fail_marker_sync(false);
     assert_eq!(
         resp["stage"].as_str(),
         Some("marker_durable"),

--- a/src/mcp/handlers/ci/checkout_submodule_tests.rs
+++ b/src/mcp/handlers/ci/checkout_submodule_tests.rs
@@ -173,3 +173,284 @@ fn checkout_initializes_nested_submodules_2755() {
         std::fs::remove_dir_all(root).ok();
     }
 }
+
+// ─── #2755 transaction journal (pure state machine — no live git) ────────────
+// These pin the durable-transaction invariants from d-20260713024125724636-10
+// deterministically (fixed clock, temp home), independent of `git worktree add`
+// — the vendored shim's agent-ancestry stray-worktree guard flakes live
+// concurrent worktree adds under an agent process tree (CI-safe, but not a
+// reliable seam for unit tests).
+
+use super::checkout_txn::{backoff_secs, Journal, Phase, INTERVENTION_CEILING_SECS};
+
+fn fixed_now() -> chrono::DateTime<chrono::Utc> {
+    chrono::DateTime::parse_from_rfc3339("2026-07-13T00:00:00+00:00")
+        .unwrap()
+        .with_timezone(&chrono::Utc)
+}
+
+fn sample_journal() -> Journal {
+    Journal::prepared(
+        "nonce-abc",
+        "/wt/agent-src",
+        "/src",
+        "feat/x",
+        true,
+        fixed_now().to_rfc3339(),
+    )
+}
+
+/// Phases advance monotonically; only Prepared has no on-disk worktree.
+#[test]
+fn txn_phase_order_and_worktree_existence() {
+    let order = [
+        Phase::Prepared,
+        Phase::WorktreeAdded,
+        Phase::MarkerDurable,
+        Phase::SubmodulesReady,
+        Phase::Committed,
+    ];
+    for w in order.windows(2) {
+        assert!(w[0].rank() < w[1].rank(), "{:?} < {:?}", w[0], w[1]);
+    }
+    assert!(!Phase::Prepared.worktree_exists());
+    assert!(Phase::WorktreeAdded.worktree_exists());
+    assert!(Phase::Committed.worktree_exists());
+}
+
+/// save → load round-trips durably (via store::atomic_write).
+#[test]
+fn txn_journal_persists_and_loads() {
+    let home = tmp_home("txn-persist");
+    let mangled = "agent-co-_src";
+    let mut j = sample_journal();
+    j.advance(Phase::WorktreeAdded);
+    j.save(&home, mangled).expect("save");
+    let loaded = Journal::load(&home, mangled).expect("load");
+    assert_eq!(loaded.nonce, "nonce-abc");
+    assert_eq!(loaded.phase, Phase::WorktreeAdded);
+    assert_eq!(loaded.schema_version, 1);
+    Journal::clear(&home, mangled);
+    assert!(
+        Journal::load(&home, mangled).is_none(),
+        "clear removes journal"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// A minimal on-disk record (pre-rollback fields absent) loads with defaults —
+/// forward/back compat via serde(default).
+#[test]
+fn txn_journal_serde_back_compat_defaults() {
+    let home = tmp_home("txn-compat");
+    let mangled = "agent-co-_src";
+    let path = super::checkout_txn::journal_path(&home, mangled);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    // No rollback_pending / attempts / next_attempt_at / intervention keys.
+    let minimal = r#"{"schema_version":1,"nonce":"n","phase":"submodules_ready",
+        "worktree_path":"/wt","source_repo":"/src","branch":"b","bind":false,
+        "created_at":"2026-07-13T00:00:00+00:00"}"#;
+    std::fs::write(&path, minimal).unwrap();
+    let j = Journal::load(&home, mangled).expect("loads minimal record");
+    assert_eq!(j.phase, Phase::SubmodulesReady);
+    assert!(!j.rollback_pending);
+    assert_eq!(j.attempts, 0);
+    assert!(j.next_attempt_at.is_none());
+    assert!(!j.intervention);
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// backoff doubles per attempt and is capped at the intervention ceiling.
+#[test]
+fn txn_backoff_doubles_then_caps_at_ceiling() {
+    assert_eq!(backoff_secs(0), 1);
+    assert_eq!(backoff_secs(1), 2);
+    assert_eq!(backoff_secs(4), 16);
+    assert_eq!(backoff_secs(8), 256);
+    assert_eq!(
+        backoff_secs(9),
+        INTERVENTION_CEILING_SECS,
+        "2^9=512 capped to 300"
+    );
+    assert_eq!(
+        backoff_secs(40),
+        INTERVENTION_CEILING_SECS,
+        "huge attempts stay capped, no overflow"
+    );
+}
+
+/// arm_rollback sets pending + a future deadline, increments attempts, and flips
+/// intervention once the backoff reaches the ceiling; retained intent persists.
+#[test]
+fn txn_arm_rollback_backoff_and_intervention() {
+    let now = fixed_now();
+    let mut j = sample_journal();
+    j.advance(Phase::SubmodulesReady);
+
+    j.arm_rollback(now);
+    assert!(j.rollback_pending, "rollback owed");
+    assert_eq!(j.attempts, 1);
+    assert!(!j.intervention, "first failure is under the ceiling");
+    // Deadline is now + backoff(0) = 1s.
+    let deadline = chrono::DateTime::parse_from_rfc3339(j.next_attempt_at.as_deref().unwrap())
+        .unwrap()
+        .with_timezone(&chrono::Utc);
+    assert_eq!(
+        deadline,
+        now + chrono::Duration::seconds(1),
+        "backoff(0)=1s deadline"
+    );
+
+    // Drive attempts up to the ceiling → intervention, still retrying.
+    for _ in 0..9 {
+        j.arm_rollback(now);
+    }
+    assert!(
+        j.intervention,
+        "backoff reached the 300s ceiling ⇒ operator intervention"
+    );
+    assert!(
+        j.rollback_pending,
+        "intervention keeps retrying, never abandons"
+    );
+}
+
+/// A stale journal (different nonce) is distinguishable from the in-flight attempt.
+#[test]
+fn txn_nonce_distinguishes_attempts() {
+    let a = Journal::prepared(
+        "nonce-1",
+        "/wt",
+        "/src",
+        "b",
+        false,
+        fixed_now().to_rfc3339(),
+    );
+    let b = Journal::prepared(
+        "nonce-2",
+        "/wt",
+        "/src",
+        "b",
+        false,
+        fixed_now().to_rfc3339(),
+    );
+    assert_ne!(a.nonce, b.nonce);
+}
+
+// ─── recover_stale / rollback_failed (injected remove/unbind — no live git) ──
+
+use super::checkout_txn::{recover_stale, rollback_failed};
+
+fn save_at_phase(home: &std::path::Path, mangled: &str, phase: Phase) {
+    let mut j = sample_journal();
+    // advance from Prepared up to `phase`
+    for p in [
+        Phase::WorktreeAdded,
+        Phase::MarkerDurable,
+        Phase::SubmodulesReady,
+        Phase::Committed,
+    ] {
+        if p.rank() <= phase.rank() {
+            j.advance(p);
+        }
+    }
+    j.save(home, mangled).unwrap();
+}
+
+/// A Committed tombstone left by a crashed cleanup is cleared, and no worktree
+/// removal is attempted (the provision had completed).
+#[test]
+fn txn_recover_committed_clears_without_remove() {
+    let home = tmp_home("rec-committed");
+    save_at_phase(&home, "m", Phase::Committed);
+    let removed = std::cell::Cell::new(false);
+    let r = recover_stale(&home, "m", fixed_now(), |_j| {
+        removed.set(true);
+        true
+    });
+    assert!(r.is_ok());
+    assert!(!removed.get(), "Committed ⇒ no worktree removal");
+    assert!(Journal::load(&home, "m").is_none(), "tombstone cleared");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// A crashed in-flight attempt whose worktree is successfully removed clears.
+#[test]
+fn txn_recover_inflight_remove_ok_clears() {
+    let home = tmp_home("rec-ok");
+    save_at_phase(&home, "m", Phase::WorktreeAdded);
+    let r = recover_stale(&home, "m", fixed_now(), |_j| true);
+    assert!(r.is_ok());
+    assert!(Journal::load(&home, "m").is_none(), "removed ⇒ cleared");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// A crashed in-flight attempt whose worktree CANNOT be removed retains intent
+/// (armed + backoff) and returns Err so the caller aborts rather than colliding.
+#[test]
+fn txn_recover_inflight_remove_fail_retains_intent() {
+    let home = tmp_home("rec-fail");
+    save_at_phase(&home, "m", Phase::SubmodulesReady);
+    let r = recover_stale(&home, "m", fixed_now(), |_j| false);
+    assert!(r.is_err(), "remove failed ⇒ Err");
+    let retained = Journal::load(&home, "m").expect("journal retained");
+    assert!(retained.rollback_pending, "retained intent armed");
+    assert!(
+        retained.next_attempt_at.is_some(),
+        "backoff deadline persisted"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// A Prepared journal (no worktree materialized) is cleared without a remove.
+#[test]
+fn txn_recover_prepared_clears_without_remove() {
+    let home = tmp_home("rec-prepared");
+    sample_journal().save(&home, "m").unwrap(); // Prepared
+    let removed = std::cell::Cell::new(false);
+    let r = recover_stale(&home, "m", fixed_now(), |_j| {
+        removed.set(true);
+        true
+    });
+    assert!(r.is_ok());
+    assert!(!removed.get(), "Prepared has no worktree ⇒ no remove");
+    assert!(Journal::load(&home, "m").is_none());
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// rollback_failed: worktree removed ⇒ unbind runs and the journal is cleared.
+#[test]
+fn txn_rollback_failed_remove_ok_unbinds_and_clears() {
+    let home = tmp_home("rb-ok");
+    let mut j = sample_journal();
+    j.advance(Phase::SubmodulesReady);
+    j.save(&home, "m").unwrap();
+    let unbound = std::cell::Cell::new(false);
+    rollback_failed(
+        &home,
+        "m",
+        &mut j,
+        fixed_now(),
+        || true,
+        || unbound.set(true),
+    );
+    assert!(unbound.get(), "unbind runs");
+    assert!(Journal::load(&home, "m").is_none(), "removed ⇒ cleared");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// rollback_failed: worktree NOT removed ⇒ journal retained (armed) for recovery.
+#[test]
+fn txn_rollback_failed_remove_fail_retains() {
+    let home = tmp_home("rb-fail");
+    let mut j = sample_journal();
+    j.advance(Phase::SubmodulesReady);
+    j.save(&home, "m").unwrap();
+    rollback_failed(&home, "m", &mut j, fixed_now(), || false, || {});
+    let retained = Journal::load(&home, "m").expect("retained");
+    assert!(
+        retained.rollback_pending && retained.next_attempt_at.is_some(),
+        "armed retained intent survives a failed remove"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}

--- a/src/mcp/handlers/ci/checkout_submodule_tests.rs
+++ b/src/mcp/handlers/ci/checkout_submodule_tests.rs
@@ -213,9 +213,6 @@ fn txn_phase_order_and_worktree_existence() {
     for w in order.windows(2) {
         assert!(w[0].rank() < w[1].rank(), "{:?} < {:?}", w[0], w[1]);
     }
-    assert!(!Phase::Prepared.worktree_exists());
-    assert!(Phase::WorktreeAdded.worktree_exists());
-    assert!(Phase::Committed.worktree_exists());
 }
 
 /// save → load round-trips durably (via store::atomic_write).
@@ -341,9 +338,21 @@ fn txn_nonce_distinguishes_attempts() {
 
 use super::checkout_txn::{recover_stale, rollback_failed};
 
-fn save_at_phase(home: &std::path::Path, mangled: &str, phase: Phase) {
-    let mut j = sample_journal();
-    // advance from Prepared up to `phase`
+/// Save a journal at `phase` whose `worktree_path` is `wt`, optionally creating a
+/// real `wt` dir on disk (recovery now decides remove-vs-clear by on-disk
+/// existence, not the phase alone).
+fn save_journal_at(home: &std::path::Path, mangled: &str, wt: &Path, phase: Phase, real: bool) {
+    if real {
+        std::fs::create_dir_all(wt).unwrap();
+    }
+    let mut j = Journal::prepared(
+        "nonce-x",
+        wt.display().to_string(),
+        "/src",
+        "b",
+        false,
+        fixed_now().to_rfc3339(),
+    );
     for p in [
         Phase::WorktreeAdded,
         Phase::MarkerDurable,
@@ -357,14 +366,21 @@ fn save_at_phase(home: &std::path::Path, mangled: &str, phase: Phase) {
     j.save(home, mangled).unwrap();
 }
 
-/// A Committed tombstone left by a crashed cleanup is cleared, and no worktree
-/// removal is attempted (the provision had completed).
+fn write_corrupt_journal(home: &Path, mangled: &str) {
+    let jp = super::checkout_txn::journal_path(home, mangled);
+    std::fs::create_dir_all(jp.parent().unwrap()).unwrap();
+    std::fs::write(&jp, b"{ not valid json").unwrap();
+}
+
+/// A Committed tombstone → cleared, NO worktree removal (the provision completed;
+/// its worktree is valid for reuse).
 #[test]
 fn txn_recover_committed_clears_without_remove() {
     let home = tmp_home("rec-committed");
-    save_at_phase(&home, "m", Phase::Committed);
+    let wt = home.join("wt");
+    save_journal_at(&home, "m", &wt, Phase::Committed, true);
     let removed = std::cell::Cell::new(false);
-    let r = recover_stale(&home, "m", fixed_now(), |_j| {
+    let r = recover_stale(&home, "m", &wt, fixed_now(), || {
         removed.set(true);
         true
     });
@@ -374,46 +390,85 @@ fn txn_recover_committed_clears_without_remove() {
     std::fs::remove_dir_all(&home).ok();
 }
 
-/// A crashed in-flight attempt whose worktree is successfully removed clears.
+/// A crashed non-Committed attempt whose REAL worktree removes → cleared.
 #[test]
 fn txn_recover_inflight_remove_ok_clears() {
     let home = tmp_home("rec-ok");
-    save_at_phase(&home, "m", Phase::WorktreeAdded);
-    let r = recover_stale(&home, "m", fixed_now(), |_j| true);
+    let wt = home.join("wt");
+    save_journal_at(&home, "m", &wt, Phase::WorktreeAdded, true);
+    let r = recover_stale(&home, "m", &wt, fixed_now(), || true);
     assert!(r.is_ok());
     assert!(Journal::load(&home, "m").is_none(), "removed ⇒ cleared");
     std::fs::remove_dir_all(&home).ok();
 }
 
-/// A crashed in-flight attempt whose worktree CANNOT be removed retains intent
-/// (armed + backoff) and returns Err so the caller aborts rather than colliding.
+/// A crashed attempt whose REAL worktree CANNOT be removed retains intent and Errs.
 #[test]
 fn txn_recover_inflight_remove_fail_retains_intent() {
     let home = tmp_home("rec-fail");
-    save_at_phase(&home, "m", Phase::SubmodulesReady);
-    let r = recover_stale(&home, "m", fixed_now(), |_j| false);
+    let wt = home.join("wt");
+    save_journal_at(&home, "m", &wt, Phase::SubmodulesReady, true);
+    let r = recover_stale(&home, "m", &wt, fixed_now(), || false);
     assert!(r.is_err(), "remove failed ⇒ Err");
     let retained = Journal::load(&home, "m").expect("journal retained");
-    assert!(retained.rollback_pending, "retained intent armed");
-    assert!(
-        retained.next_attempt_at.is_some(),
-        "backoff deadline persisted"
-    );
+    assert!(retained.rollback_pending && retained.next_attempt_at.is_some());
     std::fs::remove_dir_all(&home).ok();
 }
 
-/// A Prepared journal (no worktree materialized) is cleared without a remove.
+/// A non-Committed journal with NO worktree on disk (crashed before/without add) →
+/// cleared, no remove.
 #[test]
-fn txn_recover_prepared_clears_without_remove() {
-    let home = tmp_home("rec-prepared");
-    sample_journal().save(&home, "m").unwrap(); // Prepared
+fn txn_recover_no_worktree_clears_without_remove() {
+    let home = tmp_home("rec-nowt");
+    let wt = home.join("wt"); // NOT created
+    save_journal_at(&home, "m", &wt, Phase::WorktreeAdded, false);
     let removed = std::cell::Cell::new(false);
-    let r = recover_stale(&home, "m", fixed_now(), |_j| {
+    let r = recover_stale(&home, "m", &wt, fixed_now(), || {
         removed.set(true);
         true
     });
     assert!(r.is_ok());
-    assert!(!removed.get(), "Prepared has no worktree ⇒ no remove");
+    assert!(!removed.get(), "no worktree on disk ⇒ no remove");
+    assert!(Journal::load(&home, "m").is_none());
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// Prepared-with-REAL-worktree (crash after `git worktree add`, before the
+/// WorktreeAdded save): the on-disk worktree is removed even though phase=Prepared.
+#[test]
+fn txn_recover_prepared_with_real_worktree_removes() {
+    let home = tmp_home("rec-prep-wt");
+    let wt = home.join("wt");
+    save_journal_at(&home, "m", &wt, Phase::Prepared, true);
+    let removed = std::cell::Cell::new(false);
+    let r = recover_stale(&home, "m", &wt, fixed_now(), || {
+        removed.set(true);
+        true
+    });
+    assert!(r.is_ok());
+    assert!(
+        removed.get(),
+        "Prepared-with-real-worktree ambiguity ⇒ removed"
+    );
+    assert!(Journal::load(&home, "m").is_none());
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// A CORRUPT (torn) journal + a real worktree → the worktree is removed and the
+/// torn record cleared (treated as a crashed attempt).
+#[test]
+fn txn_recover_corrupt_removes_worktree() {
+    let home = tmp_home("rec-corrupt");
+    let wt = home.join("wt");
+    std::fs::create_dir_all(&wt).unwrap();
+    write_corrupt_journal(&home, "m");
+    let removed = std::cell::Cell::new(false);
+    let r = recover_stale(&home, "m", &wt, fixed_now(), || {
+        removed.set(true);
+        true
+    });
+    assert!(r.is_ok());
+    assert!(removed.get(), "corrupt + real worktree ⇒ removed");
     assert!(Journal::load(&home, "m").is_none());
     std::fs::remove_dir_all(&home).ok();
 }
@@ -455,17 +510,28 @@ fn txn_rollback_failed_remove_fail_retains() {
     std::fs::remove_dir_all(&home).ok();
 }
 
-// ─── recover_pending_sweep (shared boot+periodic callable — injected closures) ─
+// ─── recover_pending_sweep (shared boot+periodic — injected try_lock/remove) ───
+// try_lock: Some(_) ⇒ path-lock free (crashed, safe to recover); None ⇒ held (a
+// live checkout owns the path — skip).
 
 use super::checkout_txn::recover_pending_sweep;
 
-fn save_pending_journal(
-    home: &std::path::Path,
+fn save_pending(
+    home: &Path,
     mangled: &str,
+    wt: &Path,
     attempts: u32,
     deadline: chrono::DateTime<chrono::Utc>,
 ) {
-    let mut j = sample_journal();
+    std::fs::create_dir_all(wt).unwrap();
+    let mut j = Journal::prepared(
+        "nonce-x",
+        wt.display().to_string(),
+        "/src",
+        "b",
+        false,
+        fixed_now().to_rfc3339(),
+    );
     j.advance(Phase::SubmodulesReady);
     j.rollback_pending = true;
     j.attempts = attempts;
@@ -473,35 +539,50 @@ fn save_pending_journal(
     j.save(home, mangled).unwrap();
 }
 
-/// No transaction area ⇒ sweep resolves nothing.
+/// No transaction area ⇒ nothing.
 #[test]
 fn txn_sweep_empty_area_is_zero() {
     let home = tmp_home("sweep-empty");
-    let n = recover_pending_sweep(&home, fixed_now(), |_| true, |_| {});
+    let n = recover_pending_sweep(&home, fixed_now(), |_| Some(()), |_| true, |_| {});
     assert_eq!(n, 0);
     std::fs::remove_dir_all(&home).ok();
 }
 
-/// A DUE pending rollback whose worktree removes is resolved + cleared.
+/// Due + real worktree + lock free ⇒ removed + cleared.
 #[test]
 fn txn_sweep_due_remove_ok_clears() {
     let home = tmp_home("sweep-ok");
-    save_pending_journal(&home, "m", 1, fixed_now() - chrono::Duration::seconds(1));
-    let n = recover_pending_sweep(&home, fixed_now(), |_| true, |_| {});
+    let wt = home.join("wt");
+    save_pending(
+        &home,
+        "m",
+        &wt,
+        1,
+        fixed_now() - chrono::Duration::seconds(1),
+    );
+    let n = recover_pending_sweep(&home, fixed_now(), |_| Some(()), |_| true, |_| {});
     assert_eq!(n, 1);
     assert!(Journal::load(&home, "m").is_none());
     std::fs::remove_dir_all(&home).ok();
 }
 
-/// A NOT-yet-due pending rollback is left untouched (backoff respected).
+/// Not-yet-due ⇒ skipped (backoff respected).
 #[test]
 fn txn_sweep_not_due_is_skipped() {
     let home = tmp_home("sweep-notdue");
-    save_pending_journal(&home, "m", 1, fixed_now() + chrono::Duration::seconds(60));
+    let wt = home.join("wt");
+    save_pending(
+        &home,
+        "m",
+        &wt,
+        1,
+        fixed_now() + chrono::Duration::seconds(60),
+    );
     let removed = std::cell::Cell::new(false);
     let n = recover_pending_sweep(
         &home,
         fixed_now(),
+        |_| Some(()),
         |_| {
             removed.set(true);
             true
@@ -509,58 +590,155 @@ fn txn_sweep_not_due_is_skipped() {
         |_| {},
     );
     assert_eq!(n, 0);
-    assert!(!removed.get(), "not-due journal is not touched");
-    assert!(Journal::load(&home, "m").is_some(), "journal retained");
+    assert!(!removed.get());
+    assert!(Journal::load(&home, "m").is_some());
     std::fs::remove_dir_all(&home).ok();
 }
 
-/// A due rollback whose remove FAILS is re-armed (attempts bump) and not cleared.
+/// Due, remove FAILS ⇒ re-armed, not cleared.
 #[test]
 fn txn_sweep_remove_fail_rearms() {
     let home = tmp_home("sweep-fail");
-    save_pending_journal(&home, "m", 0, fixed_now() - chrono::Duration::seconds(1));
-    let n = recover_pending_sweep(&home, fixed_now(), |_| false, |_| {});
+    let wt = home.join("wt");
+    save_pending(
+        &home,
+        "m",
+        &wt,
+        0,
+        fixed_now() - chrono::Duration::seconds(1),
+    );
+    let n = recover_pending_sweep(&home, fixed_now(), |_| Some(()), |_| false, |_| {});
     assert_eq!(n, 0);
     let j = Journal::load(&home, "m").expect("retained");
-    assert!(
-        j.rollback_pending && j.attempts >= 1,
-        "re-armed for a later retry"
-    );
+    assert!(j.rollback_pending && j.attempts >= 1);
     std::fs::remove_dir_all(&home).ok();
 }
 
-/// The INTERVENTION audit fires ONCE when a stuck journal crosses the ceiling and
-/// is NOT re-emitted on subsequent sweeps of the same still-stuck journal.
+/// INTERVENTION audit fires ONCE on entering the ceiling; deduped after.
 #[test]
 fn txn_sweep_intervention_audit_deduped() {
     let home = tmp_home("sweep-audit");
-    // attempts=9 ⇒ next arm's backoff hits the ceiling ⇒ flips into intervention.
-    save_pending_journal(&home, "m", 9, fixed_now() - chrono::Duration::seconds(1));
+    let wt = home.join("wt");
+    save_pending(
+        &home,
+        "m",
+        &wt,
+        9,
+        fixed_now() - chrono::Duration::seconds(1),
+    );
     let count = std::cell::Cell::new(0);
     recover_pending_sweep(
         &home,
         fixed_now(),
+        |_| Some(()),
         |_| false,
         |_| count.set(count.get() + 1),
     );
-    assert_eq!(count.get(), 1, "audit once on ENTERING intervention");
-
-    // Make it due again; still stuck + already in intervention ⇒ no re-audit.
+    assert_eq!(count.get(), 1, "audit once on entering intervention");
     let mut j = Journal::load(&home, "m").unwrap();
-    assert!(j.intervention, "now in intervention");
+    assert!(j.intervention);
     j.next_attempt_at = Some((fixed_now() - chrono::Duration::seconds(1)).to_rfc3339());
     j.save(&home, "m").unwrap();
     recover_pending_sweep(
         &home,
         fixed_now(),
+        |_| Some(()),
         |_| false,
         |_| count.set(count.get() + 1),
     );
-    assert_eq!(
-        count.get(),
+    assert_eq!(count.get(), 1, "deduped");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// BLOCKER 2 — sweep-vs-new-generation: the journal's nonce CHANGES under the lock
+/// (a newer checkout re-provisioned this path) ⇒ the sweep skips it, so a NEWER
+/// generation's worktree is never deleted.
+#[test]
+fn txn_sweep_nonce_cas_skips_newer_generation() {
+    let home = tmp_home("sweep-nonce");
+    let wt = home.join("wt");
+    save_pending(
+        &home,
+        "m",
+        &wt,
         1,
-        "deduped — no re-audit while already in intervention"
+        fixed_now() - chrono::Duration::seconds(1),
     );
+    let removed = std::cell::Cell::new(false);
+    let home2 = home.clone();
+    let n = recover_pending_sweep(
+        &home,
+        fixed_now(),
+        |seen| {
+            // Newer generation takes over between the unlocked read and the
+            // under-lock re-read: overwrite with a DIFFERENT nonce.
+            let mut newer = seen.clone();
+            newer.nonce = "NEWER-GEN".into();
+            newer.save(&home2, "m").unwrap();
+            Some(())
+        },
+        |_| {
+            removed.set(true);
+            true
+        },
+        |_| {},
+    );
+    assert_eq!(n, 0, "nonce changed ⇒ skip");
+    assert!(!removed.get(), "NEWER generation's worktree never removed");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// BLOCKER 2 — a HELD path-lock (an active checkout) ⇒ the sweep skips: a live
+/// provision is never disturbed.
+#[test]
+fn txn_sweep_skips_live_locked_checkout() {
+    let home = tmp_home("sweep-locked");
+    let wt = home.join("wt");
+    save_pending(
+        &home,
+        "m",
+        &wt,
+        1,
+        fixed_now() - chrono::Duration::seconds(1),
+    );
+    let removed = std::cell::Cell::new(false);
+    let n = recover_pending_sweep(
+        &home,
+        fixed_now(),
+        |_| None::<()>,
+        |_| {
+            removed.set(true);
+            true
+        },
+        |_| {},
+    );
+    assert_eq!(n, 0);
+    assert!(!removed.get(), "locked (live) checkout not touched");
+    assert!(Journal::load(&home, "m").is_some(), "journal retained");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// BLOCKER 4 — a crashed NON-rollback_pending journal (crashed before arming) is
+/// still recovered: every non-Committed phase with a real worktree is handled.
+#[test]
+fn txn_sweep_recovers_unarmed_crash() {
+    let home = tmp_home("sweep-unarmed");
+    let wt = home.join("wt");
+    save_journal_at(&home, "m", &wt, Phase::WorktreeAdded, true); // rollback_pending=false
+    let n = recover_pending_sweep(&home, fixed_now(), |_| Some(()), |_| true, |_| {});
+    assert_eq!(n, 1, "unarmed crash recovered");
+    assert!(Journal::load(&home, "m").is_none());
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// A corrupt journal is cleared by the sweep (any orphan worktree ⇒ worktree GC).
+#[test]
+fn txn_sweep_corrupt_cleared() {
+    let home = tmp_home("sweep-corrupt");
+    write_corrupt_journal(&home, "m");
+    let n = recover_pending_sweep(&home, fixed_now(), |_| Some(()), |_| true, |_| {});
+    assert_eq!(n, 0);
+    assert!(Journal::load(&home, "m").is_none(), "corrupt cleared");
     std::fs::remove_dir_all(&home).ok();
 }
 
@@ -665,15 +843,14 @@ fn mangled_for(instance: &str, source: &Path) -> String {
     )
 }
 
-/// Committed-write-FAILURE seam: force the durable Committed journal write to fail
-/// (its path pre-created as a DIRECTORY so `store::atomic_write`'s rename fails) →
-/// the real checkout ABORTS into rollback (worktree removed) and returns the
-/// structured `commit_failed`, never success.
+/// BLOCKER 1 — a checked PREPARED-save failure is fatal-but-CLEAN: no worktree is
+/// created (no side effect yet), so nothing to roll back. (journal.json
+/// pre-created as a DIR ⇒ the first `store::atomic_write` rename fails.)
 #[test]
-fn checkout_commit_write_failure_rolls_back_2755() {
-    let home = tmp_home("commitfail");
-    let repo = tmp_repo_with_file("commitfail", "readme.txt", "x\n");
-    let instance = "agent-cf";
+fn checkout_prepared_write_failure_fails_clean_2755() {
+    let home = tmp_home("prepfail");
+    let repo = tmp_repo_with_file("prepfail", "readme.txt", "x\n");
+    let instance = "agent-pf";
     let mangled = mangled_for(instance, &repo);
     let jpath = home
         .join("checkout_txn")
@@ -684,6 +861,34 @@ fn checkout_commit_write_failure_rolls_back_2755() {
     let args =
         json!({"repository_path": repo.display().to_string(), "branch": "main", "bind": false});
     let resp = super::checkout::handle_checkout_repo(&home, &args, instance);
+    assert_eq!(
+        resp["code"].as_str(),
+        Some("journal_write"),
+        "Prepared save failure ⇒ journal_write: {resp}"
+    );
+    assert_eq!(resp["stage"].as_str(), Some("prepared"));
+    assert!(
+        !home.join("worktrees").join(&mangled).exists(),
+        "no worktree created (fatal-but-clean)"
+    );
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&repo).ok();
+}
+
+/// BLOCKER 1 — a COMMITTED-write failure (all earlier phase saves succeed) ABORTS
+/// into rollback: the worktree is removed and the structured `commit_failed`
+/// returned, never success. Uses the checkout_txn `set_fail_committed_save` seam.
+#[test]
+fn checkout_commit_write_failure_rolls_back_2755() {
+    let home = tmp_home("commitfail");
+    let repo = tmp_repo_with_file("commitfail", "readme.txt", "x\n");
+    let instance = "agent-cf";
+    let mangled = mangled_for(instance, &repo);
+    super::checkout_txn::set_fail_committed_save(true);
+    let args =
+        json!({"repository_path": repo.display().to_string(), "branch": "main", "bind": false});
+    let resp = super::checkout::handle_checkout_repo(&home, &args, instance);
+    super::checkout_txn::set_fail_committed_save(false);
     assert_eq!(
         resp["code"].as_str(),
         Some("commit_failed"),
@@ -759,7 +964,16 @@ fn checkout_restart_replays_stale_worktree_2755() {
 fn txn_open_handle_remove_failure_retained_then_recovered() {
     let home = tmp_home("openhandle");
     let mangled = "agent-oh";
-    let mut j = sample_journal();
+    let wt = home.join("wt");
+    std::fs::create_dir_all(&wt).unwrap();
+    let mut j = Journal::prepared(
+        "nonce-x",
+        wt.display().to_string(),
+        "/src",
+        "b",
+        false,
+        fixed_now().to_rfc3339(),
+    );
     j.advance(Phase::SubmodulesReady);
     j.save(&home, mangled).unwrap();
     // Handle held open ⇒ remove fails ⇒ intent retained (not cleared).
@@ -770,7 +984,7 @@ fn txn_open_handle_remove_failure_retained_then_recovered() {
     let mut s = Journal::load(&home, mangled).unwrap();
     s.next_attempt_at = Some((fixed_now() - chrono::Duration::seconds(1)).to_rfc3339());
     s.save(&home, mangled).unwrap();
-    let resolved = recover_pending_sweep(&home, fixed_now(), |_| true, |_| {});
+    let resolved = recover_pending_sweep(&home, fixed_now(), |_| Some(()), |_| true, |_| {});
     assert_eq!(resolved, 1, "handle released ⇒ recovered");
     assert!(
         Journal::load(&home, mangled).is_none(),

--- a/src/mcp/handlers/ci/checkout_txn.rs
+++ b/src/mcp/handlers/ci/checkout_txn.rs
@@ -1,0 +1,288 @@
+//! #2755: durable transaction journal + provisioning lock for
+//! `repo action=checkout`, per decision d-20260713024125724636-10.
+//!
+//! `git worktree add` + marker + submodule init + `bind_full` is a multi-step
+//! side-effecting provision. A crash / init failure between steps must never
+//! leave a half-provisioned worktree that later reads as "leased". This module
+//! makes the provision a **journalled transaction**:
+//!
+//! - Phases advance `Prepared → WorktreeAdded → MarkerDurable → SubmodulesReady
+//!   → Committed`; each transition is durably persisted BEFORE the next
+//!   side effect, so a replay after a crash knows exactly how far it got.
+//! - **Committed is the durable linearization point**: the caller returns
+//!   success ONLY after a `Committed` journal is durably written
+//!   ([`store::atomic_write`]); a write failure aborts into rollback.
+//! - The journal + its provisioning lock live OUTSIDE the worktree, in a
+//!   daemon-owned area keyed by the SAME mangled `<instance>-<source>` path the
+//!   worktree uses — so a `remove --force` of the worktree can never delete the
+//!   recovery record, and a stable key lets a restart find pending work.
+//! - **CAS-by-nonce**: each provisioning attempt stamps a unique `nonce`; a
+//!   replayer compares it to distinguish "my in-flight attempt" from a stale
+//!   record left by a previous process.
+//! - Rollback that fails (Windows open-handle, transient FS) RETAINS intent:
+//!   `rollback_pending` stays set with an exponential-backoff `next_attempt_at`;
+//!   at the [`INTERVENTION_CEILING_SECS`] cap it enters operator-visible
+//!   `intervention` and keeps retrying at ceiling cadence rather than orphaning
+//!   a recoverable worktree.
+//!
+//! This module is pure state + filesystem journal (no live git), so every
+//! invariant above is unit-testable without a real `git worktree add`.
+
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+/// Bumped if the on-disk journal shape changes incompatibly.
+pub(crate) const JOURNAL_SCHEMA_VERSION: u32 = 1;
+
+/// Rollback-retry backoff ceiling. Once the exponential backoff reaches this many
+/// seconds the transaction is operator-visible (`intervention`) and keeps
+/// retrying at this cadence — a recoverable open-handle worktree is never
+/// permanently abandoned.
+pub(crate) const INTERVENTION_CEILING_SECS: i64 = 300;
+
+/// The five provisioning phases (durably advanced in order).
+#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Debug)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum Phase {
+    /// Journal written; NO filesystem side effect yet.
+    Prepared,
+    /// `git worktree add` succeeded.
+    WorktreeAdded,
+    /// `.agend-managed` marker written + durable.
+    MarkerDurable,
+    /// Recursive submodule init succeeded.
+    SubmodulesReady,
+    /// Durable linearization point — success may be returned.
+    Committed,
+}
+
+impl Phase {
+    /// Rank for ordering assertions (monotonic advance only).
+    pub(crate) fn rank(self) -> u8 {
+        match self {
+            Phase::Prepared => 0,
+            Phase::WorktreeAdded => 1,
+            Phase::MarkerDurable => 2,
+            Phase::SubmodulesReady => 3,
+            Phase::Committed => 4,
+        }
+    }
+
+    /// Has a worktree been created on disk at this phase (⇒ rollback must
+    /// `git worktree remove --force`)? False only at `Prepared`.
+    pub(crate) fn worktree_exists(self) -> bool {
+        self.rank() >= Phase::WorktreeAdded.rank()
+    }
+}
+
+/// The durable transaction record for one checkout provisioning attempt.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub(crate) struct Journal {
+    pub schema_version: u32,
+    /// CAS-by-nonce: unique per provisioning attempt.
+    pub nonce: String,
+    pub phase: Phase,
+    /// The mangled worktree directory being provisioned.
+    pub worktree_path: String,
+    /// Canonical source repo (the `git worktree remove` cwd on rollback).
+    pub source_repo: String,
+    pub branch: String,
+    pub bind: bool,
+    pub created_at: String,
+    /// A phase failed and a `git worktree remove --force` rollback is owed.
+    #[serde(default)]
+    pub rollback_pending: bool,
+    /// Count of rollback attempts so far (drives backoff + intervention).
+    #[serde(default)]
+    pub attempts: u32,
+    /// Earliest rfc3339 time the next rollback retry may run.
+    #[serde(default)]
+    pub next_attempt_at: Option<String>,
+    /// Backoff reached the ceiling — operator-visible, still retrying.
+    #[serde(default)]
+    pub intervention: bool,
+}
+
+impl Journal {
+    /// A fresh `Prepared` journal for a new provisioning attempt.
+    pub(crate) fn prepared(
+        nonce: impl Into<String>,
+        worktree_path: impl Into<String>,
+        source_repo: impl Into<String>,
+        branch: impl Into<String>,
+        bind: bool,
+        created_at: impl Into<String>,
+    ) -> Self {
+        Self {
+            schema_version: JOURNAL_SCHEMA_VERSION,
+            nonce: nonce.into(),
+            phase: Phase::Prepared,
+            worktree_path: worktree_path.into(),
+            source_repo: source_repo.into(),
+            branch: branch.into(),
+            bind,
+            created_at: created_at.into(),
+            rollback_pending: false,
+            attempts: 0,
+            next_attempt_at: None,
+            intervention: false,
+        }
+    }
+
+    /// Advance to `next` (must be a strictly higher rank — monotonic).
+    pub(crate) fn advance(&mut self, next: Phase) {
+        debug_assert!(
+            next.rank() > self.phase.rank(),
+            "phase must advance monotonically: {:?} -> {:?}",
+            self.phase,
+            next
+        );
+        self.phase = next;
+    }
+
+    /// Mark that rollback is owed and (re)compute the next backoff deadline from
+    /// `now`. `attempts` increments; once the backoff hits the ceiling the record
+    /// is flagged `intervention`.
+    pub(crate) fn arm_rollback(&mut self, now: chrono::DateTime<chrono::Utc>) {
+        self.rollback_pending = true;
+        let backoff = backoff_secs(self.attempts);
+        self.next_attempt_at = Some((now + chrono::Duration::seconds(backoff)).to_rfc3339());
+        if backoff >= INTERVENTION_CEILING_SECS {
+            self.intervention = true;
+        }
+        self.attempts = self.attempts.saturating_add(1);
+    }
+
+    /// Durably persist (temp+fsync+rename+dir-fsync via [`store::atomic_write`]).
+    pub(crate) fn save(&self, home: &Path, mangled: &str) -> anyhow::Result<()> {
+        crate::store::save_atomic(&journal_path(home, mangled), self)
+    }
+
+    /// Load the journal for `mangled`, or `None` if absent/unparseable.
+    pub(crate) fn load(home: &Path, mangled: &str) -> Option<Journal> {
+        let bytes = std::fs::read(journal_path(home, mangled)).ok()?;
+        serde_json::from_slice(&bytes).ok()
+    }
+
+    /// Delete the journal (transaction fully resolved — Committed cleanup or
+    /// completed rollback). Best-effort.
+    pub(crate) fn clear(home: &Path, mangled: &str) {
+        let _ = std::fs::remove_file(journal_path(home, mangled));
+    }
+}
+
+/// The daemon-owned transaction area (sibling of `worktrees/`, NOT inside any
+/// worktree — a `remove --force` can never delete the recovery record).
+fn txn_root(home: &Path) -> PathBuf {
+    home.join("checkout_txn")
+}
+
+/// Journal file for `mangled` (the `<instance>-<source>` worktree key).
+pub(crate) fn journal_path(home: &Path, mangled: &str) -> PathBuf {
+    txn_root(home).join(mangled).join("journal.json")
+}
+
+/// Provisioning lock file for `mangled` — the INNER per-worktree-path flock
+/// (branch-lease is the OUTER lock). Kept outside the mangled subdir so it is
+/// not swept with the journal.
+pub(crate) fn lock_path(home: &Path, mangled: &str) -> PathBuf {
+    txn_root(home).join(format!("{mangled}.lock"))
+}
+
+/// Acquire the INNER per-worktree-path provisioning flock (blocking). Held across
+/// the whole provision so two attempts on the SAME mangled path serialize.
+/// Released before the OUTER branch-lease (inner-first) by dropping this guard
+/// first at the call site.
+pub(crate) fn acquire_path_lock(
+    home: &Path,
+    mangled: &str,
+) -> anyhow::Result<crate::store::FileFlockGuard> {
+    crate::store::acquire_file_lock(&lock_path(home, mangled))
+}
+
+/// Exponential rollback backoff for retry `attempts` (0-based): 2^attempts
+/// seconds, capped at [`INTERVENTION_CEILING_SECS`] so a persistently-stuck
+/// worktree retries forever at the ceiling cadence rather than growing
+/// unbounded.
+pub(crate) fn backoff_secs(attempts: u32) -> i64 {
+    let doubled = 1i64.checked_shl(attempts.min(31)).unwrap_or(i64::MAX);
+    doubled.min(INTERVENTION_CEILING_SECS)
+}
+
+/// A unique-per-attempt nonce (pid + wall-clock nanos) for CAS-by-nonce.
+pub(crate) fn new_nonce() -> String {
+    let now = chrono::Utc::now();
+    format!(
+        "{}-{}",
+        std::process::id(),
+        now.timestamp_nanos_opt()
+            .unwrap_or_else(|| now.timestamp_millis())
+    )
+}
+
+/// Roll back a provisioning attempt that failed AFTER `git worktree add`: arm the
+/// journal with retained-intent + backoff (durably), release any partial lease
+/// (`unbind`, a no-op when no binding was written), then attempt the worktree
+/// `remove` (returns true on success). The journal is CLEARED only when the
+/// worktree is actually gone; otherwise it survives with `rollback_pending` +
+/// `next_attempt_at` so recovery retries (up to the INTERVENTION ceiling), never
+/// orphaning a recoverable worktree. `remove`/`unbind` are injected for tests.
+pub(crate) fn rollback_failed(
+    home: &Path,
+    mangled: &str,
+    journal: &mut Journal,
+    now: chrono::DateTime<chrono::Utc>,
+    remove: impl Fn() -> bool,
+    unbind: impl Fn(),
+) {
+    journal.arm_rollback(now);
+    let _ = journal.save(home, mangled);
+    unbind();
+    if remove() {
+        Journal::clear(home, mangled);
+    }
+}
+
+/// Resolve any journal left by a CRASHED prior provisioning of THIS mangled path
+/// (called under the INNER path-lock, before a fresh `git worktree add`).
+///
+/// - No journal → nothing to do.
+/// - `Committed` → a completed attempt whose tombstone wasn't cleared: clear it.
+/// - Any earlier phase WITH a worktree on disk → a crashed in-flight attempt:
+///   roll it back via `remove` (returns true on success) then clear; if `remove`
+///   FAILS, RETAIN intent (armed + exponential backoff persisted) and return
+///   `Err` so the caller aborts rather than colliding with the stale worktree.
+/// - `Prepared` (no worktree materialized) → just clear.
+///
+/// `remove` is injected so the recovery logic is unit-testable without live git.
+pub(crate) fn recover_stale(
+    home: &Path,
+    mangled: &str,
+    now: chrono::DateTime<chrono::Utc>,
+    remove: impl Fn(&Journal) -> bool,
+) -> Result<(), String> {
+    let Some(mut j) = Journal::load(home, mangled) else {
+        return Ok(());
+    };
+    if j.phase == Phase::Committed {
+        Journal::clear(home, mangled);
+        return Ok(());
+    }
+    if !j.phase.worktree_exists() {
+        Journal::clear(home, mangled);
+        return Ok(());
+    }
+    if remove(&j) {
+        Journal::clear(home, mangled);
+        Ok(())
+    } else {
+        j.arm_rollback(now);
+        let _ = j.save(home, mangled);
+        Err(format!(
+            "a prior checkout of this path left a worktree that could not be rolled back \
+             (retained for retry; attempts={}{})",
+            j.attempts,
+            if j.intervention { ", INTERVENTION" } else { "" }
+        ))
+    }
+}

--- a/src/mcp/handlers/ci/checkout_txn.rs
+++ b/src/mcp/handlers/ci/checkout_txn.rs
@@ -36,13 +36,18 @@ use std::path::{Path, PathBuf};
 // Test seam: when set on the current thread, `Journal::save` fails ONLY the
 // `Committed` write, so a real-entry test can exercise the Committed-write-failure
 // abort (earlier phase saves still succeed).
-#[cfg(test)]
+// `all(test, unix)`: this seam is exercised only by the Unix-only
+// `checkout_commit_write_failure_rolls_back_2755` real-entry test (the #2158
+// source guard's absolute arm is `/`-prefixed — see checkout_submodule_tests.rs).
+// Gating the whole seam (thread_local + setter + `save` check) to `unix` keeps it
+// physically absent on Windows tests, so there is no dead-code to suppress.
+#[cfg(all(test, unix))]
 thread_local! {
     static FAIL_COMMITTED_SAVE: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
 }
 
 /// Test-only: arm/disarm the [`FAIL_COMMITTED_SAVE`] seam for the current thread.
-#[cfg(test)]
+#[cfg(all(test, unix))]
 pub(crate) fn set_fail_committed_save(fail: bool) {
     FAIL_COMMITTED_SAVE.with(|c| c.set(fail));
 }
@@ -182,7 +187,7 @@ impl Journal {
 
     /// Durably persist (temp+fsync+rename+dir-fsync via [`store::atomic_write`]).
     pub(crate) fn save(&self, home: &Path, mangled: &str) -> anyhow::Result<()> {
-        #[cfg(test)]
+        #[cfg(all(test, unix))]
         if self.phase == Phase::Committed && FAIL_COMMITTED_SAVE.with(|c| c.get()) {
             return Err(anyhow::anyhow!(
                 "test seam: forced Committed journal save failure"

--- a/src/mcp/handlers/ci/checkout_txn.rs
+++ b/src/mcp/handlers/ci/checkout_txn.rs
@@ -394,13 +394,31 @@ pub(crate) fn new_nonce() -> String {
     )
 }
 
+/// The observable outcome of a post-`git worktree add` rollback, so a caller reports
+/// the ACTUAL cleanup state and never claims the worktree was removed while it is
+/// still present awaiting the recovery sweep (#2755 R3 — root + independent review).
+#[must_use = "the checkout response must reflect Removed vs RollbackPending — never claim rolled back while cleanup is pending"]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RollbackOutcome {
+    /// Worktree removed and the journal cleared — cleanup complete.
+    Removed,
+    /// Worktree remove FAILED (Windows open-handle / transient FS); the retained-
+    /// intent journal is armed for the recovery sweep to retry. `intent_durable` is
+    /// whether that armed journal was durably persisted — `false` means the save
+    /// ALSO failed, a worse state the response must surface for intervention.
+    RollbackPending { intent_durable: bool },
+}
+
 /// Roll back a provisioning attempt that failed AFTER `git worktree add`: arm the
 /// journal with retained-intent + backoff (durably), release any partial lease
 /// (`unbind`, a no-op when no binding was written), then attempt the worktree
-/// `remove` (returns true on success). The journal is CLEARED only when the
-/// worktree is actually gone; otherwise it survives with `rollback_pending` +
-/// `next_attempt_at` so recovery retries (up to the INTERVENTION ceiling), never
-/// orphaning a recoverable worktree. `remove`/`unbind` are injected for tests.
+/// `remove`. Returns [`RollbackOutcome`]: `Removed` (journal cleared) ONLY when the
+/// worktree is actually gone; otherwise `RollbackPending` — the journal survives with
+/// `rollback_pending` + `next_attempt_at` so recovery retries (up to the INTERVENTION
+/// ceiling), never orphaning a recoverable worktree, and the caller MUST report
+/// pending, not "rolled back". The armed-intent SAVE result is surfaced as
+/// `intent_durable` (a save failure is a durability regression the response flags).
+/// `remove`/`unbind` are injected for tests.
 pub(crate) fn rollback_failed(
     home: &Path,
     mangled: &str,
@@ -408,12 +426,15 @@ pub(crate) fn rollback_failed(
     now: chrono::DateTime<chrono::Utc>,
     remove: impl Fn() -> bool,
     unbind: impl Fn(),
-) {
+) -> RollbackOutcome {
     journal.arm_rollback(now);
-    let _ = journal.save(home, mangled);
+    let intent_durable = journal.save(home, mangled).is_ok();
     unbind();
     if remove() {
         Journal::clear(home, mangled);
+        RollbackOutcome::Removed
+    } else {
+        RollbackOutcome::RollbackPending { intent_durable }
     }
 }
 

--- a/src/mcp/handlers/ci/checkout_txn.rs
+++ b/src/mcp/handlers/ci/checkout_txn.rs
@@ -33,6 +33,20 @@
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
+// Test seam: when set on the current thread, `Journal::save` fails ONLY the
+// `Committed` write, so a real-entry test can exercise the Committed-write-failure
+// abort (earlier phase saves still succeed).
+#[cfg(test)]
+thread_local! {
+    static FAIL_COMMITTED_SAVE: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+/// Test-only: arm/disarm the [`FAIL_COMMITTED_SAVE`] seam for the current thread.
+#[cfg(test)]
+pub(crate) fn set_fail_committed_save(fail: bool) {
+    FAIL_COMMITTED_SAVE.with(|c| c.set(fail));
+}
+
 /// Bumped if the on-disk journal shape changes incompatibly.
 pub(crate) const JOURNAL_SCHEMA_VERSION: u32 = 1;
 
@@ -68,12 +82,6 @@ impl Phase {
             Phase::SubmodulesReady => 3,
             Phase::Committed => 4,
         }
-    }
-
-    /// Has a worktree been created on disk at this phase (⇒ rollback must
-    /// `git worktree remove --force`)? False only at `Prepared`.
-    pub(crate) fn worktree_exists(self) -> bool {
-        self.rank() >= Phase::WorktreeAdded.rank()
     }
 }
 
@@ -174,19 +182,50 @@ impl Journal {
 
     /// Durably persist (temp+fsync+rename+dir-fsync via [`store::atomic_write`]).
     pub(crate) fn save(&self, home: &Path, mangled: &str) -> anyhow::Result<()> {
+        #[cfg(test)]
+        if self.phase == Phase::Committed && FAIL_COMMITTED_SAVE.with(|c| c.get()) {
+            return Err(anyhow::anyhow!(
+                "test seam: forced Committed journal save failure"
+            ));
+        }
         crate::store::save_atomic(&journal_path(home, mangled), self)
     }
 
-    /// Load the journal for `mangled`, or `None` if absent/unparseable.
+    /// Load the journal for `mangled`, or `None` if absent/corrupt. Production
+    /// recovery uses [`load_typed`] (which distinguishes the two); this Option
+    /// convenience is test-only.
+    #[cfg(test)]
     pub(crate) fn load(home: &Path, mangled: &str) -> Option<Journal> {
-        let bytes = std::fs::read(journal_path(home, mangled)).ok()?;
-        serde_json::from_slice(&bytes).ok()
+        match load_typed(home, mangled) {
+            JournalLoad::Loaded(j) => Some(j),
+            JournalLoad::Absent | JournalLoad::Corrupt => None,
+        }
     }
 
     /// Delete the journal (transaction fully resolved — Committed cleanup or
     /// completed rollback). Best-effort.
     pub(crate) fn clear(home: &Path, mangled: &str) {
         let _ = std::fs::remove_file(journal_path(home, mangled));
+    }
+}
+
+/// The result of reading a journal file — recovery must distinguish a genuinely
+/// ABSENT record from a CORRUPT one (a torn/partial write from a crash), since a
+/// corrupt journal must not be silently treated as "nothing to recover".
+pub(crate) enum JournalLoad {
+    Absent,
+    Corrupt,
+    Loaded(Journal),
+}
+
+/// Read the journal for `mangled`, distinguishing Absent / Corrupt / Loaded.
+pub(crate) fn load_typed(home: &Path, mangled: &str) -> JournalLoad {
+    match std::fs::read(journal_path(home, mangled)) {
+        Err(_) => JournalLoad::Absent,
+        Ok(bytes) => match serde_json::from_slice::<Journal>(&bytes) {
+            Ok(j) => JournalLoad::Loaded(j),
+            Err(_) => JournalLoad::Corrupt,
+        },
     }
 }
 
@@ -310,6 +349,26 @@ pub(crate) fn acquire_path_lock(
     })
 }
 
+/// NON-BLOCKING variant for the recovery sweep: `None` when the path-lock is held
+/// (an ACTIVE checkout owns this path — leave its journal alone) instead of
+/// blocking a daemon tick. `Some` only when the lock is free (⇒ any non-Committed
+/// journal here is from a CRASHED, not a live, provision — safe to recover).
+pub(crate) fn try_acquire_path_lock(
+    home: &Path,
+    worktree_dir: &Path,
+    mangled: &str,
+) -> Option<PathLockGuard> {
+    let target = normalize_target(worktree_dir);
+    let flock = crate::store::try_acquire_file_lock(&lock_path(home, &target))
+        .ok()
+        .flatten()?;
+    Some(PathLockGuard {
+        target,
+        mangled: mangled.to_string(),
+        _flock: flock,
+    })
+}
+
 /// Exponential rollback backoff for retry `attempts` (0-based): 2^attempts
 /// seconds, capped at [`INTERVENTION_CEILING_SECS`] so a persistently-stuck
 /// worktree retries forever at the ceiling cadence rather than growing
@@ -353,63 +412,79 @@ pub(crate) fn rollback_failed(
     }
 }
 
-/// Resolve any journal left by a CRASHED prior provisioning of THIS mangled path
-/// (called under the INNER path-lock, before a fresh `git worktree add`).
+/// Called at checkout START, UNDER the freshly-acquired path-lock, to resolve a
+/// journal left by a CRASHED prior attempt at THIS path so the fresh provision (or
+/// idempotent reuse) can proceed without colliding with a stale worktree.
 ///
-/// - No journal → nothing to do.
-/// - `Committed` → a completed attempt whose tombstone wasn't cleared: clear it.
-/// - Any earlier phase WITH a worktree on disk → a crashed in-flight attempt:
-///   roll it back via `remove` (returns true on success) then clear; if `remove`
-///   FAILS, RETAIN intent (armed + exponential backoff persisted) and return
-///   `Err` so the caller aborts rather than colliding with the stale worktree.
-/// - `Prepared` (no worktree materialized) → just clear.
+/// - Absent → nothing to do.
+/// - `Committed` tombstone → leave any (valid) worktree for the caller's reuse;
+///   just drop the stale record.
+/// - Corrupt OR any non-Committed phase → a crashed attempt: remove a real
+///   worktree if one EXISTS at `worktree_dir` (covers the Prepared-with-real-
+///   worktree window — a crash after `git worktree add` but before the
+///   WorktreeAdded save), then clear. If `remove` FAILS, arm+retain the journal
+///   and return `Err` (the sweep retries; the caller aborts rather than collide).
 ///
-/// `remove` is injected so the recovery logic is unit-testable without live git.
+/// `remove` (prod: `git worktree remove --force worktree_dir`) is injected so the
+/// logic is unit-testable without live git.
 pub(crate) fn recover_stale(
     home: &Path,
     mangled: &str,
+    worktree_dir: &Path,
     now: chrono::DateTime<chrono::Utc>,
-    remove: impl Fn(&Journal) -> bool,
+    remove: impl Fn() -> bool,
 ) -> Result<(), String> {
-    let Some(mut j) = Journal::load(home, mangled) else {
-        return Ok(());
+    let existing = match load_typed(home, mangled) {
+        JournalLoad::Absent => return Ok(()),
+        JournalLoad::Corrupt => None, // torn record — treat like a crashed attempt
+        JournalLoad::Loaded(j) => Some(j),
     };
-    if j.phase == Phase::Committed {
+    if matches!(&existing, Some(j) if j.phase == Phase::Committed) {
+        Journal::clear(home, mangled); // completed attempt's tombstone
+        return Ok(());
+    }
+    if !worktree_dir.exists() {
+        Journal::clear(home, mangled); // crashed before/without a worktree on disk
+        return Ok(());
+    }
+    if remove() {
         Journal::clear(home, mangled);
         return Ok(());
     }
-    if !j.phase.worktree_exists() {
-        Journal::clear(home, mangled);
-        return Ok(());
-    }
-    if remove(&j) {
-        Journal::clear(home, mangled);
-        Ok(())
-    } else {
+    if let Some(mut j) = existing {
         j.arm_rollback(now);
         let _ = j.save(home, mangled);
-        Err(format!(
-            "a prior checkout of this path left a worktree that could not be rolled back \
-             (retained for retry; attempts={}{})",
-            j.attempts,
-            if j.intervention { ", INTERVENTION" } else { "" }
-        ))
     }
+    Err(
+        "a prior checkout of this path left a worktree that could not be rolled \
+         back (retained for recovery)"
+            .into(),
+    )
 }
 
-/// Drive every DUE pending rollback across all checkout-transaction journals.
+/// Drive recovery of CRASHED (orphaned) checkout-transaction journals — the ONE
+/// shared callable for boot-repair AND a periodic tick (no dedicated worker; the
+/// caller sets cadence). Race-safe against a concurrent live checkout:
 ///
-/// The ONE shared callable for BOTH boot-repair and a periodic tick (there is no
-/// dedicated worker — the caller decides cadence). For each journal that is
-/// `rollback_pending` and past its `next_attempt_at`, re-attempt the worktree
-/// `remove`: clear on success; otherwise re-arm (exponential backoff) and, the
-/// FIRST time a journal crosses into the INTERVENTION ceiling, emit a deduped
-/// operator-visible `audit` (subsequent sweeps of the same stuck journal do NOT
-/// re-emit). `remove`/`audit` are injected so the sweep is unit-testable without
-/// live git. Returns the count of journals resolved (worktree removed) this pass.
-pub(crate) fn recover_pending_sweep(
+///   1. read the journal (unlocked) for its path + nonce;
+///   2. `try_lock` its EXACT normalized path — SKIP if held (an ACTIVE checkout
+///      owns it; not crashed) so a live provision is never disturbed;
+///   3. RE-READ under the lock and CAS the nonce — SKIP if the record changed
+///      (a NEWER checkout generation took over) so its worktree is never deleted;
+///   4. `Committed` ⇒ clear the tombstone; any other (non-Committed / corrupt-now)
+///      record with a real worktree on disk ⇒ `remove` it (respecting backoff for
+///      an already-armed retry) then clear; on remove failure re-arm backoff and
+///      emit a deduped INTERVENTION `audit`.
+///
+/// Handles EVERY non-Committed phase (not just `rollback_pending`), incl. the
+/// Prepared-with-real-worktree crash window (the on-disk-worktree check, not the
+/// phase, decides whether there is anything to remove). `try_lock`/`remove`/
+/// `audit` are injected so the sweep is unit-testable without live git or flocks.
+/// Returns the count of journals resolved this pass.
+pub(crate) fn recover_pending_sweep<G>(
     home: &Path,
     now: chrono::DateTime<chrono::Utc>,
+    try_lock: impl Fn(&Journal) -> Option<G>,
     remove: impl Fn(&Journal) -> bool,
     mut audit: impl FnMut(&Journal),
 ) -> usize {
@@ -418,21 +493,53 @@ pub(crate) fn recover_pending_sweep(
     };
     let mut resolved = 0;
     for entry in entries.flatten() {
-        // Journal lives at <root>/<mangled>/journal.json; the sibling
-        // <mangled>.lock files load as None and are skipped.
         let Some(mangled) = entry.file_name().to_str().map(str::to_string) else {
             continue;
         };
-        let Some(mut j) = Journal::load(home, &mangled) else {
+        // (1) Unlocked read for path + nonce. Sibling `<key>.lock` files load as
+        // Absent (skipped); a corrupt record is cleared (any orphaned worktree dir
+        // is left to worktree GC — a torn record has no source repo to drive
+        // `git worktree remove` from).
+        let seen = match load_typed(home, &mangled) {
+            JournalLoad::Loaded(j) => j,
+            JournalLoad::Corrupt => {
+                tracing::warn!(mangled = %mangled, "corrupt checkout-txn journal — clearing");
+                Journal::clear(home, &mangled);
+                continue;
+            }
+            JournalLoad::Absent => continue,
+        };
+        // (2) Acquire the EXACT path-lock; a held lock ⇒ a live checkout ⇒ skip.
+        let Some(_lock) = try_lock(&seen) else {
             continue;
         };
-        if !j.rollback_pending || !j.rollback_due(now) {
+        // (3) Re-read UNDER the lock + nonce CAS.
+        let j = match load_typed(home, &mangled) {
+            JournalLoad::Loaded(j) if j.nonce == seen.nonce => j,
+            JournalLoad::Loaded(_) => continue, // newer generation took over
+            JournalLoad::Corrupt => {
+                Journal::clear(home, &mangled);
+                continue;
+            }
+            JournalLoad::Absent => continue, // cleared concurrently
+        };
+        // (4) Resolve.
+        if j.phase == Phase::Committed {
+            Journal::clear(home, &mangled); // completed attempt's tombstone
             continue;
+        }
+        if !Path::new(&j.worktree_path).exists() {
+            Journal::clear(home, &mangled); // crashed with no worktree on disk
+            continue;
+        }
+        if j.rollback_pending && !j.rollback_due(now) {
+            continue; // backoff pacing for an already-armed stuck retry
         }
         if remove(&j) {
             Journal::clear(home, &mangled);
             resolved += 1;
         } else {
+            let mut j = j;
             let was_intervention = j.intervention;
             j.arm_rollback(now);
             if j.intervention && !was_intervention {
@@ -453,6 +560,12 @@ pub(crate) fn recover_pending_sweep_prod(home: &Path) -> usize {
     recover_pending_sweep(
         home,
         chrono::Utc::now(),
+        |j| {
+            // Non-blocking exact path-lock; None (a live checkout holds it) ⇒ skip.
+            let wt = Path::new(&j.worktree_path);
+            let mangled = wt.file_name().and_then(|s| s.to_str()).unwrap_or_default();
+            try_acquire_path_lock(home, wt, mangled)
+        },
         |j| {
             crate::git_helpers::git_bypass(
                 Path::new(&j.source_repo),

--- a/src/mcp/handlers/ci/checkout_txn.rs
+++ b/src/mcp/handlers/ci/checkout_txn.rs
@@ -12,10 +12,12 @@
 //! - **Committed is the durable linearization point**: the caller returns
 //!   success ONLY after a `Committed` journal is durably written
 //!   ([`store::atomic_write`]); a write failure aborts into rollback.
-//! - The journal + its provisioning lock live OUTSIDE the worktree, in a
-//!   daemon-owned area keyed by the SAME mangled `<instance>-<source>` path the
-//!   worktree uses — so a `remove --force` of the worktree can never delete the
-//!   recovery record, and a stable key lets a restart find pending work.
+//! - The journal (keyed by the `<instance>-<source>` mangled name) and its
+//!   provisioning lock (keyed by the NORMALIZED target PATH, so any consumer —
+//!   checkout/bind/release/GC — derives the same domain from the path alone) live
+//!   OUTSIDE the worktree in a daemon-owned area — so a `remove --force` of the
+//!   worktree can never delete the recovery record, and a stable key lets a
+//!   restart find pending work.
 //! - **CAS-by-nonce**: each provisioning attempt stamps a unique `nonce`; a
 //!   replayer compares it to distinguish "my in-flight attempt" from a stale
 //!   record left by a previous process.
@@ -153,6 +155,23 @@ impl Journal {
         self.attempts = self.attempts.saturating_add(1);
     }
 
+    /// Is a pending rollback due to retry at `now`? A deadline that is absent or
+    /// unparseable is treated as due (fail-forward — never strand a recoverable
+    /// worktree behind a corrupt timestamp).
+    pub(crate) fn rollback_due(&self, now: chrono::DateTime<chrono::Utc>) -> bool {
+        if !self.rollback_pending {
+            return false;
+        }
+        match self
+            .next_attempt_at
+            .as_deref()
+            .and_then(|ts| chrono::DateTime::parse_from_rfc3339(ts).ok())
+        {
+            Some(d) => now >= d.with_timezone(&chrono::Utc),
+            None => true,
+        }
+    }
+
     /// Durably persist (temp+fsync+rename+dir-fsync via [`store::atomic_write`]).
     pub(crate) fn save(&self, home: &Path, mangled: &str) -> anyhow::Result<()> {
         crate::store::save_atomic(&journal_path(home, mangled), self)
@@ -182,22 +201,113 @@ pub(crate) fn journal_path(home: &Path, mangled: &str) -> PathBuf {
     txn_root(home).join(mangled).join("journal.json")
 }
 
-/// Provisioning lock file for `mangled` — the INNER per-worktree-path flock
-/// (branch-lease is the OUTER lock). Kept outside the mangled subdir so it is
-/// not swept with the journal.
-pub(crate) fn lock_path(home: &Path, mangled: &str) -> PathBuf {
-    txn_root(home).join(format!("{mangled}.lock"))
+/// Normalize an absolute worktree TARGET path into the stable identity used as
+/// the CROSS-CONSUMER lock domain (checkout / bind / release / GC all key off the
+/// same real path, regardless of naming scheme). Canonicalize when the path
+/// EXISTS (release/GC — resolves symlinks / `.` / `..`); otherwise (checkout,
+/// pre-creation) canonicalize the PARENT and re-append the basename, so the same
+/// real path yields the same identity whether or not the worktree is
+/// materialized yet.
+pub(crate) fn normalize_target(target: &Path) -> String {
+    if let Ok(c) = target.canonicalize() {
+        return c.to_string_lossy().into_owned();
+    }
+    match (target.parent(), target.file_name()) {
+        (Some(parent), Some(name)) => {
+            let base = parent
+                .canonicalize()
+                .unwrap_or_else(|_| parent.to_path_buf());
+            base.join(name).to_string_lossy().into_owned()
+        }
+        _ => target.to_string_lossy().into_owned(),
+    }
 }
 
-/// Acquire the INNER per-worktree-path provisioning flock (blocking). Held across
-/// the whole provision so two attempts on the SAME mangled path serialize.
-/// Released before the OUTER branch-lease (inner-first) by dropping this guard
-/// first at the call site.
+/// A filesystem-safe, bounded lock-file NAME for a normalized target path —
+/// STABLE (same across processes of one binary, so any consumer derives the same
+/// lock file from the path alone) and collision-RESISTANT (a hash, not a
+/// bijection — the AUTHORITATIVE path identity is the guard's `normalize_target`
+/// string, revalidated on use; the hash only names the lock file). A hash reseed
+/// across a binary upgrade merely orphans idle lock files; the DURABLE journal is
+/// keyed separately by the human-readable `mangled`.
+fn path_lock_key(normalized: &str) -> String {
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    std::hash::Hasher::write(&mut h, normalized.as_bytes());
+    format!("wtpath-{:016x}", std::hash::Hasher::finish(&h))
+}
+
+/// The CANONICAL per-worktree-path lock file, keyed by the NORMALIZED target
+/// PATH (not the naming scheme). Kept outside the journal subdir so it is not
+/// swept with the journal. The single shared lock file for any op that mutates
+/// the worktree at this path — checkout today; a follow-up repo-release reuses it
+/// to serialize delete against checkout on the SAME path. Do not fork a private
+/// per-op lock file.
+pub(crate) fn lock_path(home: &Path, normalized_target: &str) -> PathBuf {
+    txn_root(home).join(format!("{}.lock", path_lock_key(normalized_target)))
+}
+
+/// A held per-worktree-path provisioning lock PLUS the NORMALIZED target-path
+/// identity it guards — a TYPED proof, not a bare flock, so a holder can
+/// REVALIDATE that the lock it holds matches the exact path it is about to
+/// mutate. The flock releases when this guard drops (RAII), so simply holding it
+/// serializes the path. `mangled` is retained as `(instance, source)` metadata
+/// (the journal key), but the lock DOMAIN is the normalized path (`target`).
+///
+/// #2755's checkout only HOLDS this guard. The identity/revalidate accessors are
+/// the forward API that Slice A (t-20260713082228621780-70517-26) will require on
+/// `bind_full` (pass the proof, assert identity before writing the binding);
+/// `allow(dead_code)` stands until that consumer lands.
+#[allow(dead_code)] // fields/accessors consumed by Slice A (t-…70517-26)
+pub(crate) struct PathLockGuard {
+    target: String,
+    mangled: String,
+    _flock: crate::store::FileFlockGuard,
+}
+
+#[allow(dead_code)] // accessors consumed by Slice A (t-…70517-26); #2755 holds only
+impl PathLockGuard {
+    /// The normalized absolute target-path lock domain this guard holds.
+    pub(crate) fn target(&self) -> &str {
+        &self.target
+    }
+
+    /// The `(instance, source)` mangled journal key (metadata; NOT the lock domain).
+    pub(crate) fn mangled(&self) -> &str {
+        &self.mangled
+    }
+
+    /// Re-resolve / revalidate: does this held lock guard the worktree at
+    /// `target_path`? A holder normalizes the path it is about to mutate and
+    /// asserts identity before mutating.
+    pub(crate) fn guards(&self, target_path: &Path) -> bool {
+        normalize_target(target_path) == self.target
+    }
+}
+
+/// Acquire the canonical per-worktree-path provisioning lock (blocking), keyed by
+/// the NORMALIZED `worktree_dir` PATH — crate-reusable across worktree-mutating
+/// ops on the same real path (checkout now; repo-release next — do NOT duplicate
+/// this API privately). `mangled` is carried as the journal metadata key.
+///
+/// Fleet lock order (acquire outer→inner, release inner→outer):
+/// branch-lease flock (`binding::acquire_branch_lease_lock`, OUTER, bind-only) →
+/// THIS per-path flock (serializes one worktree PATH for bind AND non-bind; the
+/// SOLE lock when `bind:false`) → binding-write lock (`.binding.json.lock`,
+/// inside `bind_full`, INNER). Held across the whole provision; the caller
+/// declares this guard AFTER the branch-lease guard so it drops (releases) first
+/// — inner-first.
 pub(crate) fn acquire_path_lock(
     home: &Path,
+    worktree_dir: &Path,
     mangled: &str,
-) -> anyhow::Result<crate::store::FileFlockGuard> {
-    crate::store::acquire_file_lock(&lock_path(home, mangled))
+) -> anyhow::Result<PathLockGuard> {
+    let target = normalize_target(worktree_dir);
+    let flock = crate::store::acquire_file_lock(&lock_path(home, &target))?;
+    Ok(PathLockGuard {
+        target,
+        mangled: mangled.to_string(),
+        _flock: flock,
+    })
 }
 
 /// Exponential rollback backoff for retry `attempts` (0-based): 2^attempts
@@ -285,4 +395,82 @@ pub(crate) fn recover_stale(
             if j.intervention { ", INTERVENTION" } else { "" }
         ))
     }
+}
+
+/// Drive every DUE pending rollback across all checkout-transaction journals.
+///
+/// The ONE shared callable for BOTH boot-repair and a periodic tick (there is no
+/// dedicated worker — the caller decides cadence). For each journal that is
+/// `rollback_pending` and past its `next_attempt_at`, re-attempt the worktree
+/// `remove`: clear on success; otherwise re-arm (exponential backoff) and, the
+/// FIRST time a journal crosses into the INTERVENTION ceiling, emit a deduped
+/// operator-visible `audit` (subsequent sweeps of the same stuck journal do NOT
+/// re-emit). `remove`/`audit` are injected so the sweep is unit-testable without
+/// live git. Returns the count of journals resolved (worktree removed) this pass.
+pub(crate) fn recover_pending_sweep(
+    home: &Path,
+    now: chrono::DateTime<chrono::Utc>,
+    remove: impl Fn(&Journal) -> bool,
+    mut audit: impl FnMut(&Journal),
+) -> usize {
+    let Ok(entries) = std::fs::read_dir(txn_root(home)) else {
+        return 0; // no transaction area yet ⇒ nothing pending
+    };
+    let mut resolved = 0;
+    for entry in entries.flatten() {
+        // Journal lives at <root>/<mangled>/journal.json; the sibling
+        // <mangled>.lock files load as None and are skipped.
+        let Some(mangled) = entry.file_name().to_str().map(str::to_string) else {
+            continue;
+        };
+        let Some(mut j) = Journal::load(home, &mangled) else {
+            continue;
+        };
+        if !j.rollback_pending || !j.rollback_due(now) {
+            continue;
+        }
+        if remove(&j) {
+            Journal::clear(home, &mangled);
+            resolved += 1;
+        } else {
+            let was_intervention = j.intervention;
+            j.arm_rollback(now);
+            if j.intervention && !was_intervention {
+                audit(&j); // deduped: only on ENTERING intervention
+            }
+            let _ = j.save(home, &mangled);
+        }
+    }
+    resolved
+}
+
+/// Production entry to [`recover_pending_sweep`] — the ONE shared callable invoked
+/// from BOTH boot-repair (`bootstrap::boot_hygiene_sweeps`) and the per-tick
+/// recovery handler (no dedicated worker). Supplies the real `git worktree remove
+/// --force` (run in each journal's recorded source repo) and the operator-visible
+/// INTERVENTION audit (`event_log`). Returns the count resolved this pass.
+pub(crate) fn recover_pending_sweep_prod(home: &Path) -> usize {
+    recover_pending_sweep(
+        home,
+        chrono::Utc::now(),
+        |j| {
+            crate::git_helpers::git_bypass(
+                Path::new(&j.source_repo),
+                &["worktree", "remove", "--force", &j.worktree_path],
+            )
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+        },
+        |j| {
+            crate::event_log::log(
+                home,
+                "checkout_txn_intervention",
+                "checkout_txn",
+                &format!(
+                    "stuck checkout-worktree rollback entered INTERVENTION after {} attempts: {}",
+                    j.attempts, j.worktree_path
+                ),
+            );
+        },
+    )
 }

--- a/src/mcp/handlers/ci/checkout_txn.rs
+++ b/src/mcp/handlers/ci/checkout_txn.rs
@@ -203,7 +203,7 @@ impl Journal {
     pub(crate) fn load(home: &Path, mangled: &str) -> Option<Journal> {
         match load_typed(home, mangled) {
             JournalLoad::Loaded(j) => Some(j),
-            JournalLoad::Absent | JournalLoad::Corrupt => None,
+            JournalLoad::Absent | JournalLoad::Corrupt | JournalLoad::Unreadable => None,
         }
     }
 
@@ -219,14 +219,22 @@ impl Journal {
 /// corrupt journal must not be silently treated as "nothing to recover".
 pub(crate) enum JournalLoad {
     Absent,
+    /// #2755 R4: the file EXISTS but could not be READ (permission / transient I/O).
+    /// Recovery authority is UNCERTAIN, so consumers MUST fail closed — never conflate
+    /// this with `Absent` (which is a genuine NotFound = nothing to recover).
+    Unreadable,
     Corrupt,
     Loaded(Journal),
 }
 
-/// Read the journal for `mangled`, distinguishing Absent / Corrupt / Loaded.
+/// Read the journal for `mangled`, distinguishing Absent / Unreadable / Corrupt /
+/// Loaded. #2755 R4: ONLY `NotFound` is `Absent`; any other read error is `Unreadable`
+/// (fail-closed authority), so a permission/transient error can't silently bypass a
+/// still-outstanding recovery record.
 pub(crate) fn load_typed(home: &Path, mangled: &str) -> JournalLoad {
     match std::fs::read(journal_path(home, mangled)) {
-        Err(_) => JournalLoad::Absent,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => JournalLoad::Absent,
+        Err(_) => JournalLoad::Unreadable,
         Ok(bytes) => match serde_json::from_slice::<Journal>(&bytes) {
             Ok(j) => JournalLoad::Loaded(j),
             Err(_) => JournalLoad::Corrupt,
@@ -236,7 +244,7 @@ pub(crate) fn load_typed(home: &Path, mangled: &str) -> JournalLoad {
 
 /// The daemon-owned transaction area (sibling of `worktrees/`, NOT inside any
 /// worktree — a `remove --force` can never delete the recovery record).
-fn txn_root(home: &Path) -> PathBuf {
+pub(crate) fn txn_root(home: &Path) -> PathBuf {
     home.join("checkout_txn")
 }
 
@@ -254,9 +262,27 @@ pub(crate) fn journal_path(home: &Path, mangled: &str) -> PathBuf {
 /// torn record is not reprocessed every tick. Safe WITHOUT a lock: journal writes are
 /// atomic (`store::save_atomic` = temp+rename), so a *corrupt* `journal.json` is
 /// always a genuine crash/corruption artifact, never a live checkout's mid-write.
-pub(crate) fn quarantine_corrupt(home: &Path, mangled: &str) {
+pub(crate) fn quarantine_corrupt(home: &Path, mangled: &str) -> bool {
     let jp = journal_path(home, mangled);
-    let _ = std::fs::rename(&jp, jp.with_file_name("journal.json.corrupt"));
+    // #2755 R4: collision-safe evidence name (hash the corrupt bytes) so two distinct
+    // torn records at this path don't clobber each other's evidence; OBSERVE the rename.
+    let dest = match std::fs::read(&jp) {
+        Ok(bytes) => corrupt_evidence_path(home, mangled, &bytes),
+        Err(_) => jp.with_file_name("journal.json.corrupt"), // unreadable ⇒ stable fallback
+    };
+    std::fs::rename(&jp, &dest).is_ok()
+}
+
+/// #2755 R4: collision-safe sidecar path for a corrupt journal's retained evidence —
+/// the corrupt BYTES are hashed so distinct torn records don't overwrite each other's
+/// evidence, and re-quarantining the SAME bytes is idempotent.
+fn corrupt_evidence_path(home: &Path, mangled: &str, bytes: &[u8]) -> PathBuf {
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    std::hash::Hasher::write(&mut h, bytes);
+    journal_path(home, mangled).with_file_name(format!(
+        "journal.json.corrupt-{:016x}",
+        std::hash::Hasher::finish(&h)
+    ))
 }
 
 /// Normalize an absolute worktree TARGET path into the stable identity used as
@@ -480,36 +506,74 @@ pub(crate) fn recover_stale(
     now: chrono::DateTime<chrono::Utc>,
     remove: impl Fn() -> bool,
 ) -> Result<(), String> {
+    // #2755 R4 (item 3a): NotFound ⇒ Absent (nothing to do); UNREADABLE (permission /
+    // transient I/O) leaves recovery authority UNCERTAIN ⇒ abort fail-closed, never
+    // silently proceed as if there were nothing to recover.
     let existing = match load_typed(home, mangled) {
         JournalLoad::Absent => return Ok(()),
-        JournalLoad::Corrupt => {
-            quarantine_corrupt(home, mangled); // retain recovery authority — never drop
-            None
+        JournalLoad::Unreadable => {
+            return Err(
+                "checkout journal storage is unreadable — recovery authority \
+                 uncertain, aborting fail-closed"
+                    .into(),
+            )
         }
+        JournalLoad::Corrupt => None, // evidence-retain + fail-closed arm handled below
         JournalLoad::Loaded(j) => Some(j),
+    };
+    let is_corrupt = existing.is_none();
+    // For a corrupt record, retire it to a collision-safe evidence sidecar whenever the
+    // path is otherwise resolved (no worktree / adopted / removed).
+    let retire = |home: &Path| {
+        if is_corrupt {
+            quarantine_corrupt(home, mangled);
+        } else {
+            Journal::clear(home, mangled);
+        }
     };
     if matches!(&existing, Some(j) if j.phase == Phase::Committed) {
         Journal::clear(home, mangled); // completed attempt's tombstone
         return Ok(());
     }
     if !worktree_dir.exists() {
-        // No worktree to reconcile; drop a loaded record (corrupt already quarantined).
-        if existing.is_some() {
-            Journal::clear(home, mangled);
-        }
+        retire(home); // no worktree ⇒ nothing to reconcile
         return Ok(());
+    }
+    // #2755 R4 (item 1): NEVER delete a still-BOUND worktree (a crash after `bind_full`
+    // but before the Committed journal leaves the binding written yet the journal
+    // non-Committed). Under the caller's path lock, ADOPT a bound worktree as committed;
+    // an UNCERTAIN binding fails closed.
+    match crate::binding::worktree_binding_state(home, worktree_dir) {
+        crate::binding::WorktreeBindingState::Bound => {
+            retire(home); // provision effectively committed — keep the worktree + binding
+            return Ok(());
+        }
+        crate::binding::WorktreeBindingState::Uncertain => {
+            return Err(
+                "a prior checkout left a worktree whose binding could not be read \
+                 — refusing to remove a possibly-bound worktree (fail closed)"
+                    .into(),
+            )
+        }
+        crate::binding::WorktreeBindingState::Unbound => {}
     }
     if remove() {
-        if existing.is_some() {
-            Journal::clear(home, mangled);
-        }
+        retire(home);
         return Ok(());
     }
-    // Remove FAILED with a worktree still on disk ⇒ arm a DURABLE recovery record the
-    // sweep retries. Loaded ⇒ arm it; corrupt/absent-but-worktree-present ⇒ SYNTHESIZE a
-    // replacement from the caller-known source + this path so the sweep drives
-    // `git worktree remove` with a valid source — never orphan a worktree without
-    // recovery authority (indep P0.2).
+    // Remove FAILED, worktree on disk, UNBOUND ⇒ arm a DURABLE recovery record.
+    // #2755 R4 (item 3c): the arm-save is OBSERVED. For a corrupt record, COPY the
+    // evidence aside FIRST, then the atomic replacement save OVERWRITES journal.json; if
+    // that save FAILS, journal.json stays the (corrupt or loaded) record — a durable
+    // BLOCKING state — so the next attempt never sees Absent (never fail-open).
+    if is_corrupt {
+        if let Ok(bytes) = std::fs::read(journal_path(home, mangled)) {
+            let _ = std::fs::copy(
+                journal_path(home, mangled),
+                corrupt_evidence_path(home, mangled, &bytes),
+            );
+        }
+    }
     let mut j = existing.unwrap_or_else(|| {
         Journal::prepared(
             new_nonce(),
@@ -521,7 +585,14 @@ pub(crate) fn recover_stale(
         )
     });
     j.arm_rollback(now);
-    let _ = j.save(home, mangled);
+    if j.save(home, mangled).is_err() {
+        return Err(
+            "a prior checkout left an un-removable worktree AND its recovery \
+             record could not be persisted — the original journal is retained as a durable \
+             blocking record; aborting fail-closed"
+                .into(),
+        );
+    }
     Err(
         "a prior checkout of this path left a worktree that could not be rolled \
          back (retained for recovery)"
@@ -529,143 +600,12 @@ pub(crate) fn recover_stale(
     )
 }
 
-/// Drive recovery of CRASHED (orphaned) checkout-transaction journals — the ONE
-/// shared callable for boot-repair AND a periodic tick (no dedicated worker; the
-/// caller sets cadence). Race-safe against a concurrent live checkout:
-///
-///   1. read the journal (unlocked) for its path + nonce;
-///   2. `try_lock` its EXACT normalized path — SKIP if held (an ACTIVE checkout
-///      owns it; not crashed) so a live provision is never disturbed;
-///   3. RE-READ under the lock and CAS the nonce — SKIP if the record changed
-///      (a NEWER checkout generation took over) so its worktree is never deleted;
-///   4. `Committed` ⇒ clear the tombstone; any other (non-Committed / corrupt-now)
-///      record with a real worktree on disk ⇒ `remove` it (respecting backoff for
-///      an already-armed retry) then clear; on remove failure re-arm backoff and
-///      emit a deduped INTERVENTION `audit`.
-///
-/// Handles EVERY non-Committed phase (not just `rollback_pending`), incl. the
-/// Prepared-with-real-worktree crash window (the on-disk-worktree check, not the
-/// phase, decides whether there is anything to remove). `try_lock`/`remove`/
-/// `audit` are injected so the sweep is unit-testable without live git or flocks.
-/// Returns the count of journals resolved this pass.
-pub(crate) fn recover_pending_sweep<G>(
-    home: &Path,
-    now: chrono::DateTime<chrono::Utc>,
-    try_lock: impl Fn(&Journal) -> Option<G>,
-    remove: impl Fn(&Journal) -> bool,
-    mut audit: impl FnMut(&Journal),
-) -> usize {
-    let Ok(entries) = std::fs::read_dir(txn_root(home)) else {
-        return 0; // no transaction area yet ⇒ nothing pending
-    };
-    let mut resolved = 0;
-    for entry in entries.flatten() {
-        let Some(mangled) = entry.file_name().to_str().map(str::to_string) else {
-            continue;
-        };
-        // (1) Unlocked read for path + nonce. Sibling `<key>.lock` files load as
-        // Absent (skipped); a corrupt record is QUARANTINED (retained as intervention
-        // authority — #2755 R3), NOT cleared: a torn record still marks a path where a
-        // managed worktree may remain, and it is the only source/path/nonce evidence.
-        let seen = match load_typed(home, &mangled) {
-            JournalLoad::Loaded(j) => j,
-            JournalLoad::Corrupt => {
-                tracing::warn!(mangled = %mangled, "corrupt checkout-txn journal — quarantined for intervention");
-                crate::event_log::log(
-                    home,
-                    "checkout_txn_corrupt_quarantine",
-                    "checkout_txn",
-                    &format!("corrupt checkout-txn journal quarantined (manual intervention; managed worktree may remain): {mangled}"),
-                );
-                quarantine_corrupt(home, &mangled);
-                continue;
-            }
-            JournalLoad::Absent => continue,
-        };
-        // (2) Acquire the EXACT path-lock; a held lock ⇒ a live checkout ⇒ skip.
-        let Some(_lock) = try_lock(&seen) else {
-            continue;
-        };
-        // (3) Re-read UNDER the lock + nonce CAS.
-        let j = match load_typed(home, &mangled) {
-            JournalLoad::Loaded(j) if j.nonce == seen.nonce => j,
-            JournalLoad::Loaded(_) => continue, // newer generation took over
-            JournalLoad::Corrupt => {
-                // Corrupt after the unlocked read (crashed mid-provision) — QUARANTINE +
-                // surface, never clear: same recovery-authority retention as arm (1).
-                tracing::warn!(mangled = %mangled, "corrupt checkout-txn journal (under lock) — quarantined for intervention");
-                crate::event_log::log(
-                    home,
-                    "checkout_txn_corrupt_quarantine",
-                    "checkout_txn",
-                    &format!("corrupt checkout-txn journal quarantined under lock (manual intervention): {mangled}"),
-                );
-                quarantine_corrupt(home, &mangled);
-                continue;
-            }
-            JournalLoad::Absent => continue, // cleared concurrently
-        };
-        // (4) Resolve.
-        if j.phase == Phase::Committed {
-            Journal::clear(home, &mangled); // completed attempt's tombstone
-            continue;
-        }
-        if !Path::new(&j.worktree_path).exists() {
-            Journal::clear(home, &mangled); // crashed with no worktree on disk
-            continue;
-        }
-        if j.rollback_pending && !j.rollback_due(now) {
-            continue; // backoff pacing for an already-armed stuck retry
-        }
-        if remove(&j) {
-            Journal::clear(home, &mangled);
-            resolved += 1;
-        } else {
-            let mut j = j;
-            let was_intervention = j.intervention;
-            j.arm_rollback(now);
-            if j.intervention && !was_intervention {
-                audit(&j); // deduped: only on ENTERING intervention
-            }
-            let _ = j.save(home, &mangled);
-        }
-    }
-    resolved
-}
-
-/// Production entry to [`recover_pending_sweep`] — the ONE shared callable invoked
-/// from BOTH boot-repair (`bootstrap::boot_hygiene_sweeps`) and the per-tick
-/// recovery handler (no dedicated worker). Supplies the real `git worktree remove
-/// --force` (run in each journal's recorded source repo) and the operator-visible
-/// INTERVENTION audit (`event_log`). Returns the count resolved this pass.
-pub(crate) fn recover_pending_sweep_prod(home: &Path) -> usize {
-    recover_pending_sweep(
-        home,
-        chrono::Utc::now(),
-        |j| {
-            // Non-blocking exact path-lock; None (a live checkout holds it) ⇒ skip.
-            let wt = Path::new(&j.worktree_path);
-            let mangled = wt.file_name().and_then(|s| s.to_str()).unwrap_or_default();
-            try_acquire_path_lock(home, wt, mangled)
-        },
-        |j| {
-            crate::git_helpers::git_bypass(
-                Path::new(&j.source_repo),
-                &["worktree", "remove", "--force", &j.worktree_path],
-            )
-            .map(|o| o.status.success())
-            .unwrap_or(false)
-        },
-        |j| {
-            crate::event_log::log(
-                home,
-                "checkout_txn_intervention",
-                "checkout_txn",
-                &format!(
-                    "stuck checkout-worktree rollback entered INTERVENTION after {} attempts: {}",
-                    j.attempts, j.worktree_path
-                ),
-            );
-        },
-    )
-}
+// #2755 R4: the crash-recovery SWEEP (boot + per-tick driver, `recover_pending_sweep`
+// [`_prod`]) lives in the sibling `checkout_recovery` module to keep both files under the
+// LOC ceiling; re-exported so every `checkout_txn::recover_pending_sweep[_prod]` caller
+// and test path is unchanged.
+pub(crate) use super::checkout_recovery::recover_pending_sweep_prod;
+// `recover_pending_sweep` (the injected-closure core) is only reached from tests;
+// `recover_pending_sweep_prod` is its sole production caller (inside checkout_recovery).
+#[cfg(test)]
+pub(crate) use super::checkout_recovery::recover_pending_sweep;

--- a/src/mcp/handlers/ci/checkout_txn.rs
+++ b/src/mcp/handlers/ci/checkout_txn.rs
@@ -245,6 +245,20 @@ pub(crate) fn journal_path(home: &Path, mangled: &str) -> PathBuf {
     txn_root(home).join(mangled).join("journal.json")
 }
 
+/// #2755 R3 (root + independent review): QUARANTINE a corrupt journal instead of
+/// CLEARING it. A torn/disk-corrupted record still carries recovery AUTHORITY (a
+/// managed worktree may remain at this path), so the ONLY durable source/path/nonce
+/// evidence must be retained for operator intervention — never destroyed. Renames
+/// `journal.json` → `journal.json.corrupt` (best-effort, idempotent): the evidence
+/// survives AND a later sweep sees `load_typed` = Absent (no `journal.json`), so the
+/// torn record is not reprocessed every tick. Safe WITHOUT a lock: journal writes are
+/// atomic (`store::save_atomic` = temp+rename), so a *corrupt* `journal.json` is
+/// always a genuine crash/corruption artifact, never a live checkout's mid-write.
+pub(crate) fn quarantine_corrupt(home: &Path, mangled: &str) {
+    let jp = journal_path(home, mangled);
+    let _ = std::fs::rename(&jp, jp.with_file_name("journal.json.corrupt"));
+}
+
 /// Normalize an absolute worktree TARGET path into the stable identity used as
 /// the CROSS-CONSUMER lock domain (checkout / bind / release / GC all key off the
 /// same real path, regardless of naming scheme). Canonicalize when the path
@@ -445,11 +459,16 @@ pub(crate) fn rollback_failed(
 /// - Absent → nothing to do.
 /// - `Committed` tombstone → leave any (valid) worktree for the caller's reuse;
 ///   just drop the stale record.
-/// - Corrupt OR any non-Committed phase → a crashed attempt: remove a real
-///   worktree if one EXISTS at `worktree_dir` (covers the Prepared-with-real-
-///   worktree window — a crash after `git worktree add` but before the
-///   WorktreeAdded save), then clear. If `remove` FAILS, arm+retain the journal
-///   and return `Err` (the sweep retries; the caller aborts rather than collide).
+/// - Corrupt → a torn/disk-corrupted record still carries recovery AUTHORITY:
+///   QUARANTINE it (retain evidence — #2755 R3), never silently drop it, then treat
+///   the path as a crashed attempt below. The caller-known `source_repo` lets a
+///   remove-failure arm a SYNTHESIZED replacement record the sweep can retry.
+/// - Any non-Committed phase → a crashed attempt: remove a real worktree if one
+///   EXISTS at `worktree_dir` (covers the Prepared-with-real-worktree window — a
+///   crash after `git worktree add` but before the WorktreeAdded save), then clear.
+///   If `remove` FAILS, arm+retain a DURABLE journal (loaded, or synthesized from
+///   `source_repo`+`worktree_dir` for a corrupt/absent record) and return `Err` so
+///   the sweep retries and the caller aborts rather than collide.
 ///
 /// `remove` (prod: `git worktree remove --force worktree_dir`) is injected so the
 /// logic is unit-testable without live git.
@@ -457,12 +476,16 @@ pub(crate) fn recover_stale(
     home: &Path,
     mangled: &str,
     worktree_dir: &Path,
+    source_repo: &str,
     now: chrono::DateTime<chrono::Utc>,
     remove: impl Fn() -> bool,
 ) -> Result<(), String> {
     let existing = match load_typed(home, mangled) {
         JournalLoad::Absent => return Ok(()),
-        JournalLoad::Corrupt => None, // torn record — treat like a crashed attempt
+        JournalLoad::Corrupt => {
+            quarantine_corrupt(home, mangled); // retain recovery authority — never drop
+            None
+        }
         JournalLoad::Loaded(j) => Some(j),
     };
     if matches!(&existing, Some(j) if j.phase == Phase::Committed) {
@@ -470,17 +493,35 @@ pub(crate) fn recover_stale(
         return Ok(());
     }
     if !worktree_dir.exists() {
-        Journal::clear(home, mangled); // crashed before/without a worktree on disk
+        // No worktree to reconcile; drop a loaded record (corrupt already quarantined).
+        if existing.is_some() {
+            Journal::clear(home, mangled);
+        }
         return Ok(());
     }
     if remove() {
-        Journal::clear(home, mangled);
+        if existing.is_some() {
+            Journal::clear(home, mangled);
+        }
         return Ok(());
     }
-    if let Some(mut j) = existing {
-        j.arm_rollback(now);
-        let _ = j.save(home, mangled);
-    }
+    // Remove FAILED with a worktree still on disk ⇒ arm a DURABLE recovery record the
+    // sweep retries. Loaded ⇒ arm it; corrupt/absent-but-worktree-present ⇒ SYNTHESIZE a
+    // replacement from the caller-known source + this path so the sweep drives
+    // `git worktree remove` with a valid source — never orphan a worktree without
+    // recovery authority (indep P0.2).
+    let mut j = existing.unwrap_or_else(|| {
+        Journal::prepared(
+            new_nonce(),
+            worktree_dir.to_string_lossy().into_owned(),
+            source_repo.to_string(),
+            String::new(),
+            false,
+            now.to_rfc3339(),
+        )
+    });
+    j.arm_rollback(now);
+    let _ = j.save(home, mangled);
     Err(
         "a prior checkout of this path left a worktree that could not be rolled \
          back (retained for recovery)"
@@ -523,14 +564,20 @@ pub(crate) fn recover_pending_sweep<G>(
             continue;
         };
         // (1) Unlocked read for path + nonce. Sibling `<key>.lock` files load as
-        // Absent (skipped); a corrupt record is cleared (any orphaned worktree dir
-        // is left to worktree GC — a torn record has no source repo to drive
-        // `git worktree remove` from).
+        // Absent (skipped); a corrupt record is QUARANTINED (retained as intervention
+        // authority — #2755 R3), NOT cleared: a torn record still marks a path where a
+        // managed worktree may remain, and it is the only source/path/nonce evidence.
         let seen = match load_typed(home, &mangled) {
             JournalLoad::Loaded(j) => j,
             JournalLoad::Corrupt => {
-                tracing::warn!(mangled = %mangled, "corrupt checkout-txn journal — clearing");
-                Journal::clear(home, &mangled);
+                tracing::warn!(mangled = %mangled, "corrupt checkout-txn journal — quarantined for intervention");
+                crate::event_log::log(
+                    home,
+                    "checkout_txn_corrupt_quarantine",
+                    "checkout_txn",
+                    &format!("corrupt checkout-txn journal quarantined (manual intervention; managed worktree may remain): {mangled}"),
+                );
+                quarantine_corrupt(home, &mangled);
                 continue;
             }
             JournalLoad::Absent => continue,
@@ -544,7 +591,16 @@ pub(crate) fn recover_pending_sweep<G>(
             JournalLoad::Loaded(j) if j.nonce == seen.nonce => j,
             JournalLoad::Loaded(_) => continue, // newer generation took over
             JournalLoad::Corrupt => {
-                Journal::clear(home, &mangled);
+                // Corrupt after the unlocked read (crashed mid-provision) — QUARANTINE +
+                // surface, never clear: same recovery-authority retention as arm (1).
+                tracing::warn!(mangled = %mangled, "corrupt checkout-txn journal (under lock) — quarantined for intervention");
+                crate::event_log::log(
+                    home,
+                    "checkout_txn_corrupt_quarantine",
+                    "checkout_txn",
+                    &format!("corrupt checkout-txn journal quarantined under lock (manual intervention): {mangled}"),
+                );
+                quarantine_corrupt(home, &mangled);
                 continue;
             }
             JournalLoad::Absent => continue, // cleared concurrently

--- a/src/mcp/handlers/ci/mod.rs
+++ b/src/mcp/handlers/ci/mod.rs
@@ -125,3 +125,10 @@ mod exact_head_watch_tests;
 #[path = "exact_head_merge_tests.rs"]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod exact_head_merge_tests;
+
+// #2755 repo-checkout transactional submodule provisioning — real-entry tests in
+// a sibling file (test-named ⇒ file_size_invariant-exempt; keeps checkout.rs small).
+#[cfg(test)]
+#[path = "checkout_submodule_tests.rs"]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod checkout_submodule_tests;

--- a/src/mcp/handlers/ci/mod.rs
+++ b/src/mcp/handlers/ci/mod.rs
@@ -20,7 +20,10 @@ mod source_resolve;
 // the re-exports below preserve EVERY `ci::handle_*` path used by dispatch.rs and
 // every `super::*` path used by the child `tests` module (zero caller/test edits).
 mod checkout;
-mod checkout_txn;
+// #2755: pub(crate) so the daemon per-tick + boot-repair recovery can reach the
+// shared `recover_pending_sweep_prod` (checkout provisioning is in `ci`, the
+// recovery driver is in `daemon`/`bootstrap`).
+pub(crate) mod checkout_txn;
 mod cleanup;
 mod merge;
 mod release;

--- a/src/mcp/handlers/ci/mod.rs
+++ b/src/mcp/handlers/ci/mod.rs
@@ -23,10 +23,16 @@ mod checkout;
 // #2755 R3: response-mapping + marker-durability helpers extracted from checkout.rs
 // to keep that handler under the LOC ceiling (same relief pattern as source_resolve).
 mod checkout_helpers;
+// #2755 R4: the idempotent bind-reuse contract, extracted from checkout.rs for the LOC
+// ceiling (deadlock-safe lock transfer + canonical provenance + sync/init/verify).
+mod checkout_reuse;
 // #2755: pub(crate) so the daemon per-tick + boot-repair recovery can reach the
 // shared `recover_pending_sweep_prod` (checkout provisioning is in `ci`, the
 // recovery driver is in `daemon`/`bootstrap`).
 pub(crate) mod checkout_txn;
+// #2755 R4: the crash-recovery sweep driver, split out of checkout_txn for the LOC
+// ceiling (re-exported from checkout_txn so caller paths are unchanged).
+pub(crate) mod checkout_recovery;
 mod cleanup;
 mod merge;
 mod release;

--- a/src/mcp/handlers/ci/mod.rs
+++ b/src/mcp/handlers/ci/mod.rs
@@ -20,6 +20,9 @@ mod source_resolve;
 // the re-exports below preserve EVERY `ci::handle_*` path used by dispatch.rs and
 // every `super::*` path used by the child `tests` module (zero caller/test edits).
 mod checkout;
+// #2755 R3: response-mapping + marker-durability helpers extracted from checkout.rs
+// to keep that handler under the LOC ceiling (same relief pattern as source_resolve).
+mod checkout_helpers;
 // #2755: pub(crate) so the daemon per-tick + boot-repair recovery can reach the
 // shared `recover_pending_sweep_prod` (checkout provisioning is in `ci`, the
 // recovery driver is in `daemon`/`bootstrap`).

--- a/src/mcp/handlers/ci/mod.rs
+++ b/src/mcp/handlers/ci/mod.rs
@@ -20,6 +20,7 @@ mod source_resolve;
 // the re-exports below preserve EVERY `ci::handle_*` path used by dispatch.rs and
 // every `super::*` path used by the child `tests` module (zero caller/test edits).
 mod checkout;
+mod checkout_txn;
 mod cleanup;
 mod merge;
 mod release;

--- a/src/store.rs
+++ b/src/store.rs
@@ -215,6 +215,23 @@ pub fn fsync_parent_dir(path: &Path) {
 #[cfg(not(unix))]
 pub fn fsync_parent_dir(_path: &Path) {}
 
+/// #2755 R4 (item 5): CHECKED variant of [`fsync_parent_dir`] — OBSERVES the
+/// directory-entry durability result so a caller can fail closed (e.g. MarkerDurable
+/// must not advance over a non-durable dirent). On Unix, opens the parent + `sync_all`
+/// and returns the result; on non-Unix it is a no-op success (no clean std equivalent).
+#[cfg(unix)]
+pub fn fsync_parent_dir_checked(path: &Path) -> std::io::Result<()> {
+    match path.parent().filter(|p| !p.as_os_str().is_empty()) {
+        Some(parent) => std::fs::File::open(parent)?.sync_all(),
+        None => Ok(()),
+    }
+}
+
+#[cfg(not(unix))]
+pub fn fsync_parent_dir_checked(_path: &Path) -> std::io::Result<()> {
+    Ok(())
+}
+
 /// Serialize `data` as pretty JSON and [`atomic_write`] it to `path`.
 pub fn save_atomic<T: Serialize>(path: &Path, data: &T) -> anyhow::Result<()> {
     let body = serde_json::to_string_pretty(data)?;

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -410,6 +410,58 @@ pub(crate) fn init_submodules_strict(wt_dir: &Path) -> Result<(), String> {
     .map_err(|e| e.to_string())
 }
 
+/// #2755 R3 (root review): after a recursive init, PROVE the working tree's submodules
+/// are at the EXACT commits the superproject's gitlinks record. `git worktree add` +
+/// init succeeding is NOT sufficient for a REUSED tree whose branch ref advanced (or a
+/// partial init) — a submodule can be left at a stale commit. `git submodule status
+/// --recursive` prefixes each line: ` ` = at the recorded commit, `-` = not initialized,
+/// `+` = a DIFFERENT commit than the gitlink, `U` = merge conflict. Any of `-`/`+`/`U`
+/// ⇒ the final tree is NOT proven buildable ⇒ Err (fail closed). No `.gitmodules` ⇒ Ok.
+pub(crate) fn verify_submodules_at_gitlinks(wt_dir: &Path) -> Result<(), String> {
+    if !wt_dir.join(".gitmodules").is_file() {
+        return Ok(());
+    }
+    let status = crate::git_helpers::git_cmd(
+        wt_dir,
+        &[
+            "-c",
+            "protocol.file.allow=always",
+            "submodule",
+            "status",
+            "--recursive",
+        ],
+    )
+    .map_err(|e| e.to_string())?;
+    for line in status.lines() {
+        if matches!(line.chars().next(), Some('-' | '+' | 'U')) {
+            return Err(format!(
+                "submodule not at its recorded gitlink commit: {}",
+                line.trim()
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// #2755 R3 (root review / decision d-…37): FAIL-CLOSED variant of
+/// [`sync_worktree_to_head`] for idempotent reuse — the reused tree must be synced to
+/// the FINAL HEAD (an externally advanced branch may change gitlinks) BEFORE recursive
+/// init, and a sync failure must ABORT the reuse (return no success), not be swallowed.
+/// A clean tree is a no-op (never a destructive reset on a clean worktree); a
+/// reset/clean failure returns `Err`.
+pub(crate) fn sync_worktree_to_head_strict(worktree_dir: &Path) -> Result<(), String> {
+    use crate::git_helpers::git_cmd;
+    match git_cmd(worktree_dir, &["status", "--porcelain"]) {
+        Ok(status) if status.is_empty() => return Ok(()), // clean ⇒ nothing to sync
+        Ok(_) => {}
+        Err(e) => return Err(format!("status probe failed: {e}")),
+    }
+    git_cmd(worktree_dir, &["reset", "--hard", "HEAD"])
+        .map_err(|e| format!("reset failed: {e}"))?;
+    git_cmd(worktree_dir, &["clean", "-fd"]).map_err(|e| format!("clean failed: {e}"))?;
+    Ok(())
+}
+
 /// #888 affirmative-signal predicate: does this instance opt into a per-agent
 /// worktree? `worktree: false` is a hard veto; otherwise `source_repo` OR
 /// `git_branch` is the opt-in. Pure (no filesystem) so the truth table can be

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -361,18 +361,8 @@ fn init_submodules_after_create(wt_dir: &Path) {
     if !wt_dir.join(".gitmodules").is_file() {
         return;
     }
-    match crate::git_helpers::git_cmd(
-        wt_dir,
-        &[
-            "-c",
-            "protocol.file.allow=always",
-            "submodule",
-            "update",
-            "--init",
-            "--recursive",
-        ],
-    ) {
-        Ok(_) => {
+    match init_submodules_strict(wt_dir) {
+        Ok(()) => {
             tracing::info!(
                 path = %wt_dir.display(),
                 "initialized submodules after worktree create"
@@ -388,6 +378,36 @@ fn init_submodules_after_create(wt_dir: &Path) {
             );
         }
     }
+}
+
+/// #2755: recursively initialize submodules in a freshly-added worktree, returning
+/// the git error string on failure (a HARD variant of the soft-warn
+/// [`init_submodules_after_create`]). `repo action=checkout`'s SubmodulesReady
+/// phase uses this so a failed init ABORTS into rollback instead of returning a
+/// worktree with missing path-dependency content. No-op (`Ok`) when `.gitmodules`
+/// is absent.
+///
+/// `-c protocol.file.allow=always` is intentional: git's submodule clone helper
+/// ignores the superproject's stored `protocol.file.allow` (security default
+/// post-2.38), so hermetic file-path submodule fixtures — and rare local-path
+/// submodules — need the command-line override. https/ssh remotes are unaffected.
+pub(crate) fn init_submodules_strict(wt_dir: &Path) -> Result<(), String> {
+    if !wt_dir.join(".gitmodules").is_file() {
+        return Ok(());
+    }
+    crate::git_helpers::git_cmd(
+        wt_dir,
+        &[
+            "-c",
+            "protocol.file.allow=always",
+            "submodule",
+            "update",
+            "--init",
+            "--recursive",
+        ],
+    )
+    .map(|_| ())
+    .map_err(|e| e.to_string())
 }
 
 /// #888 affirmative-signal predicate: does this instance opt into a per-agent


### PR DESCRIPTION
Fixes #2755. `repo action=checkout` ran `git worktree add` and **skipped recursive submodule init**, leaving path-dependency submodules (e.g. `vendor/agentic-git`) empty on the provisioned worktree. This makes provisioning a durable, phased, rollback-safe transaction that always initializes submodules before returning success.

Per decision `d-20260713024125724636-10` (+ adversarial R2 rulings). Scope: **repo checkout only**.

## What changed
- **SubmodulesReady**: `worktree::init_submodules_strict` (HARD Result variant) recursively inits submodules after `git worktree add`; failure aborts.
- **Journalled transaction** (`checkout_txn.rs`): CAS-by-nonce journal, 5 phases (Prepared→WorktreeAdded→MarkerDurable→SubmodulesReady→Committed), durable via `store::atomic_write`. **Committed is the durable linearization point** — success is never returned without a durable Committed; a write failure aborts into rollback (worktree + binding).
- **Locks**: branch-lease OUTER, per-path INNER (released inner-first; `bind:false` = path-lock only). The path-lock is a typed `PathLockGuard` keyed by the **normalized target PATH** (canonicalize existing, else canonical-parent+basename), so checkout/bind/release/GC key off the same real path regardless of naming scheme; `guards()` revalidates before mutation.
- **Retained-intent rollback**: `git worktree remove --force` (not prune); on cleanup failure the journal retains intent with exponential backoff → 300s INTERVENTION ceiling + deduped operator audit.
- **Recovery**: `recover_pending_sweep_prod` — ONE shared callable run from both a per-tick handler and boot-repair (no dedicated worker).
- **Redacted structured errors**: absolute paths / git stderr stripped from returned errors; full detail stays in the event-log.

## RED → GREEN evidence
- Core RED: `checkout_initializes_nested_submodules_2755` — real `handle_checkout_repo` vs a 2-level nested-submodule super; level-B file missing (pre-fix) → present (post-fix).
- Lock-identity (alias/symlink/layout) RED→GREEN: `txn_normalize_target_aliases_share_identity` — a `.`-alias and a symlink of the same real worktree get the SAME lock identity; distinct paths distinct. Under the prior `(instance,source)` mangled key these aliased differently (the RED).
- `checkout_commit_write_failure_rolls_back_2755` (Committed-write-failure abort), `checkout_restart_replays_stale_worktree_2755` (restart-replay), `txn_open_handle_remove_failure_retained_then_recovered` (open-handle recovery).

## Gates (local, on pushed head f61f3da4)
- 24 #2755 tests pass; `mcp::handlers::ci::` 134/134; `worktree::` 114/114
- clippy (prod + `--tests`) clean; rustfmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)