### PR TITLE
feat(#2760 Slice A): strict routed authority + per-id lock/revalidation + narrow ops

### DIFF
--- a/src/daemon/auto_release.rs
+++ b/src/daemon/auto_release.rs
@@ -640,10 +640,24 @@ enum IntentOutcome {
 
 fn process_intent(home: &Path, intent: &AutoReleaseIntent) -> IntentOutcome {
     let event = intent.event_kind.as_deref().unwrap_or("verdict");
-    let tasks = crate::tasks::list_all(home);
-    let task = tasks.iter().find(|t| t.id == intent.task_id).cloned();
-    let Some(assignee) = task.as_ref().and_then(|t| t.assignee.clone()) else {
-        tracing::info!(task_id = %intent.task_id, event, "auto_release: task missing / no assignee — dropping intent");
+    // #2760 Slice A: resolve the intent's task via the STRICT router (the old
+    // `list_all(home)` saw ONLY the default board). Typed policy — `Found` → continue
+    // the assignee + lease CAS; `Found`/no-assignee OR proven `NotFound` → drop the
+    // intent (`Done`); `Unreadable`/`Ambiguous` → RETAIN for retry (never release OR
+    // drop on an unprovable route).
+    let task = match crate::tasks::load_routed(home, &intent.task_id) {
+        Ok(rt) => rt.task,
+        Err(crate::tasks::TaskRouteError::NotFound) => {
+            tracing::info!(task_id = %intent.task_id, event, "auto_release: task not found on any board — dropping intent");
+            return IntentOutcome::Done;
+        }
+        Err(route_err) => {
+            tracing::info!(task_id = %intent.task_id, event, %route_err, "auto_release: task route unresolved — retaining for retry");
+            return IntentOutcome::Retry;
+        }
+    };
+    let Some(assignee) = task.assignee.clone() else {
+        tracing::info!(task_id = %intent.task_id, event, "auto_release: task has no assignee — dropping intent");
         return IntentOutcome::Done;
     };
     let Some(binding) = crate::binding::read(home, &assignee) else {
@@ -741,7 +755,7 @@ fn process_intent(home: &Path, intent: &AutoReleaseIntent) -> IntentOutcome {
             .ok()
             .and_then(|f| f.resolve_instance(&assignee))
             .and_then(|r| r.role);
-        if reviewer_binding_release_bypass(intent, task.as_ref(), &assignee, sender_role.as_deref())
+        if reviewer_binding_release_bypass(intent, Some(&task), &assignee, sender_role.as_deref())
         {
             tracing::info!(agent = %assignee, repo = %repo, branch = %branch, event, ?confidence, role = ?sender_role, "auto_release: reviewer-binding bypass — reviewer verdict + review task terminal, releasing if clean (#2010 2a)");
             true
@@ -758,7 +772,7 @@ fn process_intent(home: &Path, intent: &AutoReleaseIntent) -> IntentOutcome {
         .get("worktree")
         .and_then(|v| v.as_str())
         .map(|w| !is_worktree_clean(Path::new(w)));
-    let decision = decide_release(task.as_ref(), Some(&binding), worktree_dirty);
+    let decision = decide_release(Some(&task), Some(&binding), worktree_dirty);
     // #P1b (t-…24962-1): on a RELEASABLE branch (PR-terminal, or no-PR + all tasks
     // done), a dirty worktree is stale build/handoff artifacts — a gitignored
     // SESSION-HANDOFF, a build-dirtied submodule — that never self-clears. The old

--- a/src/daemon/auto_release.rs
+++ b/src/daemon/auto_release.rs
@@ -755,8 +755,7 @@ fn process_intent(home: &Path, intent: &AutoReleaseIntent) -> IntentOutcome {
             .ok()
             .and_then(|f| f.resolve_instance(&assignee))
             .and_then(|r| r.role);
-        if reviewer_binding_release_bypass(intent, Some(&task), &assignee, sender_role.as_deref())
-        {
+        if reviewer_binding_release_bypass(intent, Some(&task), &assignee, sender_role.as_deref()) {
             tracing::info!(agent = %assignee, repo = %repo, branch = %branch, event, ?confidence, role = ?sender_role, "auto_release: reviewer-binding bypass — reviewer verdict + review task terminal, releasing if clean (#2010 2a)");
             true
         } else {

--- a/src/daemon/cron_tick.rs
+++ b/src/daemon/cron_tick.rs
@@ -377,30 +377,31 @@ enum TaskGate {
 /// #1521: read a linked task's current status. Current-status gate (not
 /// ever-done), so a reopened task resumes reminders.
 ///
-/// #1608b/#1614: read the EVENT-SOURCED board via `task_events::replay`, NOT a
-/// `tasks/{id}.json` file — that per-task file is never written (the board lives
-/// in `task_events.jsonl`), so the old probe always returned `NotFound` →
-/// `Missing` → `set_enabled(false)`, permanently self-disabling every
-/// `UntilSuccess` schedule on its first fire. (#1608 fixed only the create/update
-/// validator; this is the matching runtime fix.)
+/// #1608b/#1614: read the EVENT-SOURCED board, NOT a `tasks/{id}.json` file — that
+/// per-task file is never written, so the old probe always self-disabled every
+/// `UntilSuccess` schedule on its first fire.
 ///
-/// A replay ERROR is `ReadError` → fail-open (fire) so a transient log hiccup
-/// never silently drops — OR destructively disables — the reminder. A task
-/// genuinely ABSENT from the (append-only) log is `Missing` (a removed/reset
-/// link); since the task was validated at create-time, this is rare.
+/// #2760 Slice A: resolve the linked task via the STRICT router (project-board
+/// aware; the old default-only `replay(home)` was invisible to a task on a project
+/// board → false `Missing` → destructive disable). Typed policy:
+/// - `Found` + `Done` → `Done` (stamp success + suppress today);
+/// - `Found` + non-terminal → `Pending` (fire);
+/// - proven `NotFound` → `Missing` (a genuinely-absent link → disable + audit,
+///   NOT a silent degrade to Always);
+/// - `Unreadable`/`Ambiguous` → `ReadError` → fail-open (fire, schedule STAYS
+///   enabled) so a transient/unprovable route never destructively disables.
 fn linked_task_gate(home: &Path, task_id: Option<&str>) -> TaskGate {
     let Some(id) = task_id.filter(|s| !s.is_empty()) else {
         // UntilSuccess is validated to have a task at create/update, so a
         // None here means the link was lost — treat as Missing (disable).
         return TaskGate::Missing;
     };
-    match crate::task_events::replay(home) {
+    match crate::tasks::load_routed(home, id) {
+        Ok(rt) if rt.task.status == crate::task_events::TaskStatus::Done => TaskGate::Done,
+        Ok(_) => TaskGate::Pending,
+        Err(crate::tasks::TaskRouteError::NotFound) => TaskGate::Missing,
+        // Unreadable / Ambiguous → cannot prove the task closed OR absent → fail-open.
         Err(_) => TaskGate::ReadError,
-        Ok(state) => match state.tasks.get(&crate::task_events::TaskId(id.to_string())) {
-            None => TaskGate::Missing,
-            Some(rec) if rec.status == crate::task_events::TaskStatus::Done => TaskGate::Done,
-            Some(_) => TaskGate::Pending,
-        },
     }
 }
 

--- a/src/daemon/dispatch_idle/mod.rs
+++ b/src/daemon/dispatch_idle/mod.rs
@@ -488,9 +488,18 @@ fn task_still_live(home: &Path, task_id: &str) -> Option<bool> {
     if task_id.is_empty() {
         return None;
     }
+    // #2760 (codex ruling m-…-1154): apply task-liveness ONLY when the correlation
+    // PARSES as a canonical task id (typed `TaskId::parse_canonical`, not a raw
+    // string convention). A non-task / query correlation (a synthetic dispatch id,
+    // a message correlation) was NEVER a board task, so a strict route always
+    // returns NotFound — the old NotFound→Some(false) orphan-dead policy would
+    // WRONGLY suppress its idle nag (the app-e2e / query-dispatch regression). A
+    // non-task correlation fails OPEN → keep nudging. The `?` bails to `None`
+    // (fail-open) when the correlation is not a canonical task id.
+    crate::task_events::TaskId::parse_canonical(task_id)?;
     // #1608b/#1614: event-sourced lookup, NOT a `tasks/{id}.json` probe — that
     // file is never written, so the old read always failed → this check was dead.
-    // #2760 R1 (explicit dispatch-idle policy):
+    // #2760 R1 (explicit dispatch-idle policy) — for a CANONICAL task id only:
     //   Found                → real liveness (terminal status → Some(false) dead);
     //   NotFound             → Some(false): a DEFINITIVELY-absent task is orphan-dead
     //                          (the deliberate policy the frozen plan permits);
@@ -2233,6 +2242,78 @@ mod tests {
         assert_eq!(p.expected_kind, "task");
         assert_eq!(p.threshold_secs, 600);
         assert_eq!(p.status, DispatchStatus::Pending);
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #2760 (codex ruling m-…-1154) RED: a NON-canonical correlation (a query /
+    /// synthetic dispatch id that was NEVER a board task) must FAIL-OPEN and still
+    /// fire the idle nag. Pre-fix `task_still_live` treated ANY non-empty NotFound
+    /// correlation as orphan-dead (Some(false)) and swept it silent — the app-e2e /
+    /// query-dispatch over-suppression regression. The typed `TaskId::parse_canonical`
+    /// gate now applies liveness only to real task ids.
+    #[test]
+    fn non_canonical_correlation_fails_open_and_fires_2760() {
+        let home = tmp_home("noncanon-fires");
+        let issued = chrono::Utc::now() - chrono::Duration::seconds(700);
+        // "corr-query-7" is not `t-<digits>-<digits>[-<digits>]` → not a task id.
+        let id = write_pending_at(
+            &home,
+            "alpha",
+            "beta",
+            Some("corr-query-7"),
+            "task",
+            600,
+            issued,
+        );
+        scan_and_emit(&home);
+        let inbox = crate::inbox::drain(&home, "alpha");
+        assert!(
+            inbox
+                .iter()
+                .any(|m| m.kind.as_deref() == Some("dispatch_idle_threshold_exceeded")),
+            "a non-canonical (non-task) correlation must fail-open and fire the idle nag: {inbox:?}"
+        );
+        assert_eq!(
+            list_pending(&home)
+                .iter()
+                .find(|p| p.dispatch_id == id)
+                .map(|p| p.status),
+            Some(DispatchStatus::Exceeded),
+            "non-task sidecar flips pending→exceeded (fired), never swept as orphan-dead"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #2760 (codex ruling) RED: the flip side — a CANONICAL task id present on NO
+    /// board is a definitively orphaned dispatch → orphan-dead → the sidecar is
+    /// swept silently, no nag. Pins that the parser gate STILL enforces the frozen
+    /// NotFound=orphan-dead policy for real task ids.
+    #[test]
+    fn canonical_absent_task_is_orphan_dead_and_swept_2760() {
+        let home = tmp_home("canon-orphan");
+        let issued = chrono::Utc::now() - chrono::Duration::seconds(700);
+        // A well-formed canonical id that no board holds → strict route NotFound.
+        let did = write_pending_at(
+            &home,
+            "alpha",
+            "beta",
+            Some("t-20260101000000000000-1-1"),
+            "task",
+            600,
+            issued,
+        );
+        scan_and_emit(&home);
+        let inbox = crate::inbox::drain(&home, "alpha");
+        assert!(
+            !inbox
+                .iter()
+                .any(|m| m.kind.as_deref() == Some("dispatch_idle_threshold_exceeded")),
+            "a canonical task id absent from every board is orphan-dead — no idle nag: {inbox:?}"
+        );
+        assert!(
+            list_pending(&home).iter().all(|d| d.dispatch_id != did),
+            "the orphan-dead sidecar must be swept"
+        );
         std::fs::remove_dir_all(&home).ok();
     }
 

--- a/src/daemon/dispatch_idle/mod.rs
+++ b/src/daemon/dispatch_idle/mod.rs
@@ -481,25 +481,29 @@ fn target_in_fleet(home: &Path, agent: &str) -> bool {
 
 /// #1018 (A): is `task_id` still live on the task board? Returns
 /// `Some(true)` for live (one of `LIVE_TASK_STATUSES`); `Some(false)`
-/// for a definitively closed task (`done`, `cancelled`, etc.);
-/// `None` when the task can't be found at all (treat as live —
-/// fail-open).
+/// for a definitively closed OR definitively-absent task (the caller
+/// skips the nudge / treats it dead); `None` when the route is UNPROVABLE
+/// (treat as live — fail-open, keep nudging).
 fn task_still_live(home: &Path, task_id: &str) -> Option<bool> {
     if task_id.is_empty() {
         return None;
     }
     // #1608b/#1614: event-sourced lookup, NOT a `tasks/{id}.json` probe — that
-    // file is never written, so the old read always failed → this check was dead
-    // (always `None`) and the #1018 "skip the nudge for a closed task" branch was
-    // unreachable.
-    // #2760: resolve via the STRICT router. Found → real liveness; ANY route error
-    // (NotFound / Unreadable / Ambiguous) → `None` → treated as live (fail-open),
-    // preserving the pre-#2760 "can't prove it closed ⇒ keep nudging" semantics.
-    // (Per frozen-plan pt5, treating a definitive NotFound as orphan-dead would be
-    // a deliberate policy change; the watchdog stays conservative and does not.)
-    let routed = crate::tasks::load_routed(home, task_id).ok()?;
-    let status = routed.task.status.to_string();
-    Some(LIVE_TASK_STATUSES.contains(&status.as_str()))
+    // file is never written, so the old read always failed → this check was dead.
+    // #2760 R1 (explicit dispatch-idle policy):
+    //   Found                → real liveness (terminal status → Some(false) dead);
+    //   NotFound             → Some(false): a DEFINITIVELY-absent task is orphan-dead
+    //                          (the deliberate policy the frozen plan permits);
+    //   Unreadable/Ambiguous → None: the route is UNPROVABLE → fail-open → treat as
+    //                          live (keep nudging), never orphan an unprovable task.
+    match crate::tasks::load_routed(home, task_id) {
+        Ok(routed) => {
+            let status = routed.task.status.to_string();
+            Some(LIVE_TASK_STATUSES.contains(&status.as_str()))
+        }
+        Err(crate::tasks::TaskRouteError::NotFound) => Some(false),
+        Err(_) => None,
+    }
 }
 
 /// #1018 (B) eager cleanup: when a task transitions to a terminal

--- a/src/daemon/dispatch_idle/mod.rs
+++ b/src/daemon/dispatch_idle/mod.rs
@@ -1572,6 +1572,11 @@ mod tests {
     #[path = "dispatch_idle_quota_78445_tests.rs"]
     mod quota_78445_tests;
 
+    // #2760 REDs (non-task fail-open / canonical-orphan suppress) — same LOC-exempt
+    // split pattern as the quota tests above.
+    #[path = "dispatch_idle_reds_2760_tests.rs"]
+    mod reds_2760_tests;
+
     /// #1636: the `DispatchStatus` enum MUST serialize to / deserialize from the
     /// exact lowercase wire strings the prior stringly-typed field used, so
     /// existing on-disk sidecars + IPC payloads stay byte-compatible.
@@ -2242,78 +2247,6 @@ mod tests {
         assert_eq!(p.expected_kind, "task");
         assert_eq!(p.threshold_secs, 600);
         assert_eq!(p.status, DispatchStatus::Pending);
-        std::fs::remove_dir_all(&home).ok();
-    }
-
-    /// #2760 (codex ruling m-…-1154) RED: a NON-canonical correlation (a query /
-    /// synthetic dispatch id that was NEVER a board task) must FAIL-OPEN and still
-    /// fire the idle nag. Pre-fix `task_still_live` treated ANY non-empty NotFound
-    /// correlation as orphan-dead (Some(false)) and swept it silent — the app-e2e /
-    /// query-dispatch over-suppression regression. The typed `TaskId::parse_canonical`
-    /// gate now applies liveness only to real task ids.
-    #[test]
-    fn non_canonical_correlation_fails_open_and_fires_2760() {
-        let home = tmp_home("noncanon-fires");
-        let issued = chrono::Utc::now() - chrono::Duration::seconds(700);
-        // "corr-query-7" is not `t-<digits>-<digits>[-<digits>]` → not a task id.
-        let id = write_pending_at(
-            &home,
-            "alpha",
-            "beta",
-            Some("corr-query-7"),
-            "task",
-            600,
-            issued,
-        );
-        scan_and_emit(&home);
-        let inbox = crate::inbox::drain(&home, "alpha");
-        assert!(
-            inbox
-                .iter()
-                .any(|m| m.kind.as_deref() == Some("dispatch_idle_threshold_exceeded")),
-            "a non-canonical (non-task) correlation must fail-open and fire the idle nag: {inbox:?}"
-        );
-        assert_eq!(
-            list_pending(&home)
-                .iter()
-                .find(|p| p.dispatch_id == id)
-                .map(|p| p.status),
-            Some(DispatchStatus::Exceeded),
-            "non-task sidecar flips pending→exceeded (fired), never swept as orphan-dead"
-        );
-        std::fs::remove_dir_all(&home).ok();
-    }
-
-    /// #2760 (codex ruling) RED: the flip side — a CANONICAL task id present on NO
-    /// board is a definitively orphaned dispatch → orphan-dead → the sidecar is
-    /// swept silently, no nag. Pins that the parser gate STILL enforces the frozen
-    /// NotFound=orphan-dead policy for real task ids.
-    #[test]
-    fn canonical_absent_task_is_orphan_dead_and_swept_2760() {
-        let home = tmp_home("canon-orphan");
-        let issued = chrono::Utc::now() - chrono::Duration::seconds(700);
-        // A well-formed canonical id that no board holds → strict route NotFound.
-        let did = write_pending_at(
-            &home,
-            "alpha",
-            "beta",
-            Some("t-20260101000000000000-1-1"),
-            "task",
-            600,
-            issued,
-        );
-        scan_and_emit(&home);
-        let inbox = crate::inbox::drain(&home, "alpha");
-        assert!(
-            !inbox
-                .iter()
-                .any(|m| m.kind.as_deref() == Some("dispatch_idle_threshold_exceeded")),
-            "a canonical task id absent from every board is orphan-dead — no idle nag: {inbox:?}"
-        );
-        assert!(
-            list_pending(&home).iter().all(|d| d.dispatch_id != did),
-            "the orphan-dead sidecar must be swept"
-        );
         std::fs::remove_dir_all(&home).ok();
     }
 

--- a/src/daemon/dispatch_idle/mod.rs
+++ b/src/daemon/dispatch_idle/mod.rs
@@ -491,10 +491,14 @@ fn task_still_live(home: &Path, task_id: &str) -> Option<bool> {
     // #1608b/#1614: event-sourced lookup, NOT a `tasks/{id}.json` probe — that
     // file is never written, so the old read always failed → this check was dead
     // (always `None`) and the #1018 "skip the nudge for a closed task" branch was
-    // unreachable. `load_by_id` returns `None` on absent OR a transient replay
-    // error → fail-open (treat as live), the existing safe semantics.
-    let task = crate::tasks::load_by_id(home, task_id)?;
-    let status = task.status.to_string();
+    // unreachable.
+    // #2760: resolve via the STRICT router. Found → real liveness; ANY route error
+    // (NotFound / Unreadable / Ambiguous) → `None` → treated as live (fail-open),
+    // preserving the pre-#2760 "can't prove it closed ⇒ keep nudging" semantics.
+    // (Per frozen-plan pt5, treating a definitive NotFound as orphan-dead would be
+    // a deliberate policy change; the watchdog stays conservative and does not.)
+    let routed = crate::tasks::load_routed(home, task_id).ok()?;
+    let status = routed.task.status.to_string();
     Some(LIVE_TASK_STATUSES.contains(&status.as_str()))
 }
 

--- a/src/daemon/dispatch_idle/tests/dispatch_idle_reds_2760_tests.rs
+++ b/src/daemon/dispatch_idle/tests/dispatch_idle_reds_2760_tests.rs
@@ -1,0 +1,83 @@
+//! #2760 (codex ruling m-…-1154) — dispatch-idle task-liveness gating REDs, homed
+//! in a sibling `*_tests.rs` loaded via `#[path]` from the inline `mod tests` so
+//! `dispatch_idle/mod.rs` stays under the anti-monolith LOC ceiling (the
+//! `src_file_size_invariant` established split pattern). As a submodule of `mod
+//! tests`, `use super::*` inherits both the inline test helpers (`tmp_home` /
+//! `write_pending_at`) and the production items under test (`scan_and_emit` /
+//! `list_pending` / `DispatchStatus`).
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use super::*;
+
+/// RED: a NON-canonical correlation (a query / synthetic dispatch id that was NEVER
+/// a board task) must FAIL-OPEN and still fire the idle nag. Pre-fix
+/// `task_still_live` treated ANY non-empty NotFound correlation as orphan-dead
+/// (`Some(false)`) and swept it silent — the app-e2e / query-dispatch
+/// over-suppression regression. The typed `TaskId::parse_canonical` gate now applies
+/// liveness only to real task ids.
+#[test]
+fn non_canonical_correlation_fails_open_and_fires_2760() {
+    let home = tmp_home("noncanon-fires");
+    let issued = chrono::Utc::now() - chrono::Duration::seconds(700);
+    // "corr-query-7" is not `t-<digits>-<digits>[-<digits>]` → not a task id.
+    let id = write_pending_at(
+        &home,
+        "alpha",
+        "beta",
+        Some("corr-query-7"),
+        "task",
+        600,
+        issued,
+    );
+    scan_and_emit(&home);
+    let inbox = crate::inbox::drain(&home, "alpha");
+    assert!(
+        inbox
+            .iter()
+            .any(|m| m.kind.as_deref() == Some("dispatch_idle_threshold_exceeded")),
+        "a non-canonical (non-task) correlation must fail-open and fire the idle nag: {inbox:?}"
+    );
+    assert_eq!(
+        list_pending(&home)
+            .iter()
+            .find(|p| p.dispatch_id == id)
+            .map(|p| p.status),
+        Some(DispatchStatus::Exceeded),
+        "non-task sidecar flips pending→exceeded (fired), never swept as orphan-dead"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// RED: the flip side — a CANONICAL task id present on NO board is a definitively
+/// orphaned dispatch → orphan-dead → the sidecar is swept silently, no nag. Pins
+/// that the parser gate STILL enforces the frozen NotFound=orphan-dead policy for
+/// real task ids.
+#[test]
+fn canonical_absent_task_is_orphan_dead_and_swept_2760() {
+    let home = tmp_home("canon-orphan");
+    let issued = chrono::Utc::now() - chrono::Duration::seconds(700);
+    // A well-formed canonical id that no board holds → strict route NotFound.
+    let did = write_pending_at(
+        &home,
+        "alpha",
+        "beta",
+        Some("t-20260101000000000000-1-1"),
+        "task",
+        600,
+        issued,
+    );
+    scan_and_emit(&home);
+    let inbox = crate::inbox::drain(&home, "alpha");
+    assert!(
+        !inbox
+            .iter()
+            .any(|m| m.kind.as_deref() == Some("dispatch_idle_threshold_exceeded")),
+        "a canonical task id absent from every board is orphan-dead — no idle nag: {inbox:?}"
+    );
+    assert!(
+        list_pending(&home).iter().all(|d| d.dispatch_id != did),
+        "the orphan-dead sidecar must be swept"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}

--- a/src/daemon/per_tick/reclaim.rs
+++ b/src/daemon/per_tick/reclaim.rs
@@ -283,16 +283,27 @@ fn do_reclaim(
     // board → every owned task passes → byte-identical today.
     let mut agent_tasks: Vec<crate::task_events::TaskId> = Vec::new();
     for tid in owned {
-        let board_project = crate::tasks::resolve_task_project(home, &tid.0);
-        if crate::tasks::can_mutate_on_board(home, agent, &board_project) {
-            agent_tasks.push(tid);
-        } else {
-            tracing::warn!(
-                agent,
-                task = %tid.0,
-                board = %board_project,
-                "#2127 reclaim cross-board skip (fail-closed): agent not authorized on task's board"
-            );
+        // #2760: strict route + per-board ACL through the narrow tasks op (the raw
+        // board identity stays tasks-private). Ok(true) → authorized; Ok(false) →
+        // cross-board, skip; Err(route) → fail-closed skip (never reclaim a task
+        // whose authoritative board cannot be uniquely proven).
+        match crate::tasks::caller_can_mutate_task(home, agent, &tid.0) {
+            Ok(true) => agent_tasks.push(tid),
+            Ok(false) => {
+                tracing::warn!(
+                    agent,
+                    task = %tid.0,
+                    "#2127 reclaim cross-board skip (fail-closed): agent not authorized on task's board"
+                );
+            }
+            Err(route_err) => {
+                tracing::warn!(
+                    agent,
+                    task = %tid.0,
+                    %route_err,
+                    "#2760 reclaim skip (fail-closed): task route unresolved"
+                );
+            }
         }
     }
     if agent_tasks.is_empty() {

--- a/src/daemon/per_tick/reclaim.rs
+++ b/src/daemon/per_tick/reclaim.rs
@@ -333,16 +333,17 @@ fn do_reclaim(
         },
     );
 
-    let emitter = crate::task_events::InstanceName::from("system:reclaim_usage_limit");
     let mins = remaining.as_secs() / 60;
     let mut reclaimed = 0usize;
     for tid in &to_reclaim {
-        let event = crate::task_events::TaskEvent::Released {
-            task_id: tid.clone(),
-            reason: format!("reclaimed: {agent} usage_limit (~{mins}m window remaining)"),
-        };
-        match crate::task_events::append(home, &emitter, event) {
-            Ok(_) => {
+        // #2760 item 2 (BUG fix): emit `Released` on the task's AUTHORITATIVE board
+        // via the narrow `tasks` op (strict route + per-id lock + revalidation). The
+        // pre-#2760 body appended to the DEFAULT board unconditionally, so a
+        // project-board task's release landed where its own board never saw it (it
+        // stayed Claimed forever). Cascade only after a real commit.
+        let reason = format!("reclaimed: {agent} usage_limit (~{mins}m window remaining)");
+        match crate::tasks::release_reclaimed_task(home, &tid.0, reason) {
+            Ok(true) => {
                 // Cascade: clear the task's dispatch-idle pending + dispatch-tracking
                 // + ci-watch handoff so no stale nag follows the released task.
                 crate::daemon::dispatch_idle::reassign_pending_for_task(home, &tid.0, None);
@@ -350,6 +351,9 @@ fn do_reclaim(
                 let _ = crate::daemon::ci_watch::reassign_next_after_ci(home, &tid.0, None);
                 reclaimed += 1;
             }
+            // Route unresolved / no longer claimable → skip (retry next pass); never
+            // a wrong-board write.
+            Ok(false) => {}
             Err(e) => {
                 tracing::warn!(error = %e, task = %tid.0, "reclaim: Released append failed; will retry next pass");
             }

--- a/src/daemon/supervisor/usage_limit_control.rs
+++ b/src/daemon/supervisor/usage_limit_control.rs
@@ -407,17 +407,20 @@ impl ControlEffects for FsEffects<'_> {
         if !self.current_binding_matches(key) {
             anyhow::bail!("binding generation changed before UsageLimit block");
         }
-        let board = crate::tasks::board_for_task(self.home, &key.task_id);
+        // #2760: resolve the task's authoritative board via the STRICT route
+        // (fail-closed) ONCE and reuse the snapshot; the raw board path stays
+        // tasks-private (the checked append rides `routed.append_batch_checked`).
+        let routed = crate::tasks::load_routed(self.home, &key.task_id)
+            .map_err(|e| anyhow::anyhow!("UsageLimit block: task route unresolved: {e}"))?;
         let task_id = crate::task_events::TaskId(key.task_id.clone());
         let notification_id = key.notification_id();
-        let state = crate::task_events::replay_at(&board)?;
-        if state.tasks.get(&task_id).is_some_and(|record| {
-            record.status == crate::task_events::TaskStatus::Blocked
-                && record
-                    .block_reason
-                    .as_deref()
-                    .is_some_and(|reason| reason.contains(&notification_id))
-        }) {
+        if routed.record().status == crate::task_events::TaskStatus::Blocked
+            && routed
+                .record()
+                .block_reason
+                .as_deref()
+                .is_some_and(|reason| reason.contains(&notification_id))
+        {
             return Ok(());
         }
         let episode = self.episode.as_ref().cloned();
@@ -437,8 +440,7 @@ impl ControlEffects for FsEffects<'_> {
         })
         .to_string();
         let key_for_check = key.clone();
-        let checked = crate::task_events::append_batch_checked_at(
-            &board,
+        let checked = routed.append_batch_checked(
             &crate::task_events::InstanceName("system:usage-limit".into()),
             vec![crate::task_events::TaskEvent::Blocked {
                 task_id: task_id.clone(),
@@ -468,13 +470,17 @@ impl ControlEffects for FsEffects<'_> {
         if !self.current_binding_matches(key) {
             return Ok(false);
         }
-        let board = crate::tasks::board_for_task(self.home, &key.task_id);
+        // #2760: strict route (fail-closed), resolved ONCE and reused for both the
+        // idempotency pre-check and the checked append. Board path stays private.
+        let routed = crate::tasks::load_routed(self.home, &key.task_id)
+            .map_err(|e| anyhow::anyhow!("UsageLimit recovery: task route unresolved: {e}"))?;
         let task_id = crate::task_events::TaskId(key.task_id.clone());
         let owner = crate::task_events::InstanceName(key.source.clone());
-        let state = crate::task_events::replay_at(&board)?;
-        if state.tasks.get(&task_id).is_some_and(|record| {
-            Self::task_matches_key(record, key, &[crate::task_events::TaskStatus::InProgress])
-        }) {
+        if Self::task_matches_key(
+            routed.record(),
+            key,
+            &[crate::task_events::TaskStatus::InProgress],
+        ) {
             // Crash window: the atomic Unblocked+InProgress append committed but
             // persisting EpisodeState::Recovered did not. Treat the exact
             // original generation as an idempotent completed recovery.
@@ -482,8 +488,7 @@ impl ControlEffects for FsEffects<'_> {
         }
         let key_for_check = key.clone();
         let notification_id = key.notification_id();
-        let checked = crate::task_events::append_batch_checked_at(
-            &board,
+        let checked = routed.append_batch_checked(
             &crate::task_events::InstanceName("system:usage-limit".into()),
             vec![
                 crate::task_events::TaskEvent::Unblocked {
@@ -560,10 +565,13 @@ impl ControlEffects for FsEffects<'_> {
     }
 }
 
-fn correlation_from_disk(home: &Path, source: &str) -> Option<Correlation> {
+fn correlation_from_disk(home: &Path, source: &str) -> Option<(Correlation, crate::tasks::Task)> {
     let binding = read_current_binding(home, source)?;
     let task_id = binding.get("task_id")?.as_str()?.to_string();
-    let task = crate::tasks::load_by_id(home, &task_id)?;
+    // #2760: resolve via the STRICT route (any route error → None: no correlation
+    // is built on a task whose board cannot be uniquely proven). The resolved Task
+    // is RETURNED so `episode_start` reuses this SINGLE route (no double load).
+    let task = crate::tasks::load_routed(home, &task_id).ok()?.task;
     let task_status = match task.status {
         crate::task_events::TaskStatus::Claimed => "claimed",
         crate::task_events::TaskStatus::InProgress => "in_progress",
@@ -571,16 +579,17 @@ fn correlation_from_disk(home: &Path, source: &str) -> Option<Correlation> {
         _ => "other",
     }
     .to_string();
-    Some(Correlation {
+    let correlation = Correlation {
         task_id,
         source: source.to_string(),
-        owner: task.assignee.unwrap_or_default(),
+        owner: task.assignee.clone().unwrap_or_default(),
         task_status,
-        task_branch: task.branch.unwrap_or_default(),
+        task_branch: task.branch.clone().unwrap_or_default(),
         binding_task_id: binding.get("task_id")?.as_str()?.to_string(),
         binding_branch: binding.get("branch")?.as_str()?.to_string(),
         binding_issued_at: binding.get("issued_at")?.as_str()?.to_string(),
-    })
+    };
+    Some((correlation, task))
 }
 
 fn fleet_facts(
@@ -745,10 +754,12 @@ pub(crate) fn observe_supervisor_tick(
     }
 
     let _binding_guard = acquire_binding_lock(home, source)?;
-    let correlation = correlation_from_disk(home, source);
-    let task = correlation
-        .as_ref()
-        .and_then(|correlation| crate::tasks::load_by_id(home, &correlation.task_id));
+    // #2760: `correlation_from_disk` resolves the task ONCE and returns it, so the
+    // fleet-facts lookup reuses that snapshot instead of a second `load_by_id`.
+    let (correlation, task) = match correlation_from_disk(home, source) {
+        Some((correlation, task)) => (Some(correlation), Some(task)),
+        None => (None, None),
+    };
     let (source_team, source_role, candidates, recipient) =
         fleet_facts(home, registry, source, task.as_ref());
     let now = Utc::now();
@@ -1393,7 +1404,7 @@ teams:
             source_team: Some("archfix".into()),
             source_role: Some("dev".into()),
             unlock_at: Some(now() + Duration::seconds(29 * 60 + 59)),
-            correlation: super::correlation_from_disk(&home, "worker-a"),
+            correlation: super::correlation_from_disk(&home, "worker-a").map(|(c, _)| c),
             candidates: Vec::new(),
             recipient: "lead".into(),
         };
@@ -1577,7 +1588,7 @@ teams:
             source_team: Some("archfix".into()),
             source_role: Some("dev".into()),
             unlock_at: Some(now() + Duration::seconds(29 * 60 + 59)),
-            correlation: super::correlation_from_disk(&home, "worker-a"),
+            correlation: super::correlation_from_disk(&home, "worker-a").map(|(c, _)| c),
             candidates: Vec::new(),
             recipient: "lead".into(),
         };

--- a/src/daemon/supervisor/usage_limit_control.rs
+++ b/src/daemon/supervisor/usage_limit_control.rs
@@ -371,16 +371,6 @@ impl<'a> FsEffects<'a> {
         })
     }
 
-    fn task_matches_key(
-        record: &crate::task_events::TaskRecord,
-        key: &EpisodeKey,
-        statuses: &[crate::task_events::TaskStatus],
-    ) -> bool {
-        record.owner.as_ref().map(|owner| owner.as_str()) == Some(key.source.as_str())
-            && record.branch.as_deref() == Some(key.branch.as_str())
-            && statuses.contains(&record.status)
-    }
-
     fn current_binding_matches(&self, key: &EpisodeKey) -> bool {
         read_current_binding(self.home, self.source).is_some_and(|binding| {
             binding.get("task_id").and_then(|v| v.as_str()) == Some(key.task_id.as_str())
@@ -407,22 +397,12 @@ impl ControlEffects for FsEffects<'_> {
         if !self.current_binding_matches(key) {
             anyhow::bail!("binding generation changed before UsageLimit block");
         }
-        // #2760: resolve the task's authoritative board via the STRICT route
-        // (fail-closed) ONCE and reuse the snapshot; the raw board path stays
-        // tasks-private (the checked append rides `routed.append_batch_checked`).
-        let routed = crate::tasks::load_routed(self.home, &key.task_id)
-            .map_err(|e| anyhow::anyhow!("UsageLimit block: task route unresolved: {e}"))?;
-        let task_id = crate::task_events::TaskId(key.task_id.clone());
+        // #2760 item 4: the strict route, per-id lock, write-time revalidation and
+        // the board append all happen INSIDE the narrow `tasks` op — the supervisor
+        // no longer touches a raw board path or a generic append. It supplies only
+        // the identity guard + the fully-built block-reason payload (which embeds
+        // the episode id, so the op's idempotency check can recognise it).
         let notification_id = key.notification_id();
-        if routed.record().status == crate::task_events::TaskStatus::Blocked
-            && routed
-                .record()
-                .block_reason
-                .as_deref()
-                .is_some_and(|reason| reason.contains(&notification_id))
-        {
-            return Ok(());
-        }
         let episode = self.episode.as_ref().cloned();
         let reason = serde_json::json!({
             "type": "usage_limit_episode",
@@ -439,86 +419,46 @@ impl ControlEffects for FsEffects<'_> {
             }
         })
         .to_string();
-        let key_for_check = key.clone();
-        let checked = routed.append_batch_checked(
-            &crate::task_events::InstanceName("system:usage-limit".into()),
-            vec![crate::task_events::TaskEvent::Blocked {
-                task_id: task_id.clone(),
-                reason,
-            }],
-            move |fresh| {
-                let record = fresh
-                    .tasks
-                    .get(&task_id)
-                    .ok_or_else(|| "task disappeared before UsageLimit block".to_string())?;
-                Self::task_matches_key(
-                    record,
-                    &key_for_check,
-                    &[
-                        crate::task_events::TaskStatus::Claimed,
-                        crate::task_events::TaskStatus::InProgress,
-                    ],
-                )
-                .then_some(())
-                .ok_or_else(|| "task generation changed before UsageLimit block".to_string())
-            },
-        )?;
-        checked.map(|_| ()).map_err(anyhow::Error::msg)
+        let guard = crate::tasks::UsageLimitGuard {
+            task_id: key.task_id.clone(),
+            source: key.source.clone(),
+            branch: key.branch.clone(),
+            episode_id: notification_id,
+        };
+        match crate::tasks::apply_usage_limit_block(self.home, &guard, reason)? {
+            crate::tasks::ApplyOutcome::Applied | crate::tasks::ApplyOutcome::AlreadyApplied => {
+                Ok(())
+            }
+            // Route/generation changed → no event; surface as an error so the
+            // control loop retries (matches the pre-#2760 generation-change bail).
+            crate::tasks::ApplyOutcome::Stale => {
+                anyhow::bail!("task generation changed before UsageLimit block")
+            }
+        }
     }
 
     fn recover_task_atomically(&mut self, key: &EpisodeKey) -> anyhow::Result<bool> {
         if !self.current_binding_matches(key) {
             return Ok(false);
         }
-        // #2760: strict route (fail-closed), resolved ONCE and reused for both the
-        // idempotency pre-check and the checked append. Board path stays private.
-        let routed = crate::tasks::load_routed(self.home, &key.task_id)
-            .map_err(|e| anyhow::anyhow!("UsageLimit recovery: task route unresolved: {e}"))?;
-        let task_id = crate::task_events::TaskId(key.task_id.clone());
-        let owner = crate::task_events::InstanceName(key.source.clone());
-        if Self::task_matches_key(
-            routed.record(),
-            key,
-            &[crate::task_events::TaskStatus::InProgress],
-        ) {
-            // Crash window: the atomic Unblocked+InProgress append committed but
-            // persisting EpisodeState::Recovered did not. Treat the exact
-            // original generation as an idempotent completed recovery.
-            return Ok(true);
+        // #2760 item 4: strict route + per-id lock + revalidation + the atomic
+        // Unblocked+InProgress append all happen INSIDE the narrow `tasks` op. It
+        // folds the crash-window idempotency (already InProgress for this
+        // owner+branch → AlreadyApplied) and the commit-time generation guard. A
+        // route/generation change → Stale → not recovered this pass (no events),
+        // and the control loop re-attempts.
+        let guard = crate::tasks::UsageLimitGuard {
+            task_id: key.task_id.clone(),
+            source: key.source.clone(),
+            branch: key.branch.clone(),
+            episode_id: key.notification_id(),
+        };
+        match crate::tasks::recover_usage_limit_block(self.home, &guard)? {
+            crate::tasks::ApplyOutcome::Applied | crate::tasks::ApplyOutcome::AlreadyApplied => {
+                Ok(true)
+            }
+            crate::tasks::ApplyOutcome::Stale => Ok(false),
         }
-        let key_for_check = key.clone();
-        let notification_id = key.notification_id();
-        let checked = routed.append_batch_checked(
-            &crate::task_events::InstanceName("system:usage-limit".into()),
-            vec![
-                crate::task_events::TaskEvent::Unblocked {
-                    task_id: task_id.clone(),
-                },
-                crate::task_events::TaskEvent::InProgress {
-                    task_id: task_id.clone(),
-                    by: owner,
-                },
-            ],
-            move |fresh| {
-                let record = fresh
-                    .tasks
-                    .get(&task_id)
-                    .ok_or_else(|| "task disappeared before UsageLimit recovery".to_string())?;
-                if !Self::task_matches_key(
-                    record,
-                    &key_for_check,
-                    &[crate::task_events::TaskStatus::Blocked],
-                ) || !record
-                    .block_reason
-                    .as_deref()
-                    .is_some_and(|reason| reason.contains(&notification_id))
-                {
-                    return Err("task generation changed before UsageLimit recovery".into());
-                }
-                Ok(())
-            },
-        )?;
-        Ok(checked.is_ok())
     }
 
     fn notify_once(

--- a/src/daemon/task_sweep.rs
+++ b/src/daemon/task_sweep.rs
@@ -534,8 +534,16 @@ fn extract_closes_markers(body: &str) -> Vec<String> {
         regex::Regex::new(r"(?m)Closes\s+(t-[0-9]+-[0-9]+(?:-[0-9]+)?)\b")
             .expect("static regex must compile")
     });
+    // #2760 (codex ruling m-…-1154): EXTRACTION (this regex, which finds candidate
+    // `Closes t-…` tokens bounded in prose) is separated from VALIDATION — every
+    // extracted candidate is validated through the single authoritative
+    // `TaskId::parse_canonical` grammar owner, so a task-id's validity is a type
+    // invariant, not a per-site string pattern. (The extraction regex already
+    // matches the canonical shape, so this is behavior-preserving; it makes the
+    // parser the authority.)
     re.captures_iter(body)
-        .filter_map(|c| c.get(1).map(|m| m.as_str().to_string()))
+        .filter_map(|c| c.get(1))
+        .filter_map(|m| crate::task_events::TaskId::parse_canonical(m.as_str()).map(|t| t.0))
         .collect()
 }
 

--- a/src/inbox/storage.rs
+++ b/src/inbox/storage.rs
@@ -1641,18 +1641,25 @@ pub fn obligation_reason(home: &Path, msg: &InboxMessage) -> Option<String> {
         Some("task") => {
             let tid = msg.task_id.as_deref().or(msg.correlation_id.as_deref());
             match tid {
-                Some(id) => match crate::tasks::load_by_id(home, id) {
-                    Some(t)
+                // #2760: strict route. KEEP the obligation unless the board PROVES
+                // the task terminal (Done/Cancelled). Any route error
+                // (NotFound/Unreadable/Ambiguous) is uncertainty → KEEP (failure
+                // mode = noise, never hidden work), matching this fn's contract.
+                Some(id) => match crate::tasks::load_routed(home, id) {
+                    Ok(rt)
                         if matches!(
-                            t.status,
+                            rt.task.status,
                             crate::task_events::TaskStatus::Done
                                 | crate::task_events::TaskStatus::Cancelled
                         ) =>
                     {
                         None
                     }
-                    Some(t) => Some(format!("task {id} not terminal (status={})", t.status)),
-                    None => Some(format!("task {id} not on board — kept")),
+                    Ok(rt) => Some(format!(
+                        "task {id} not terminal (status={})",
+                        rt.task.status
+                    )),
+                    Err(e) => Some(format!("task {id} route unresolved ({e}) — kept")),
                 },
                 None => Some("task without id — kept".to_string()),
             }

--- a/src/mcp/handlers/comms_delegate/mod.rs
+++ b/src/mcp/handlers/comms_delegate/mod.rs
@@ -599,21 +599,21 @@ pub(crate) fn handle_delegate_task(home: &Path, args: &Value, sender: &Option<Se
 #[cfg(test)]
 mod tests;
 
-/// #2760 (frozen-plan d-…-7) — real-entry RED for the t-…-35 live failure.
+/// #2760 Slice A — strict-RESOLUTION unit test (NOT a production dispatch-entry
+/// proof; Slice B owns the true `handle_delegate_task`/`send` production entry and
+/// its ordering/atomicity).
 ///
-/// A project-board task with `review_class=single` was dispatched as
-/// `review_class_unspecified` TWICE, because the merge-authority preflight
-/// (`maybe_auto_bind_lease`, comms_delegate.rs:281) reads the task's durable
-/// `review_class` via `crate::tasks::load_by_id`, which sees ONLY the default
-/// board — a per-project-board task is invisible, so the class resolves absent
-/// and the dispatch fails closed as Unspecified.
+/// Motivating bug (t-…-35): a project-board task with `review_class=single` was
+/// dispatched as `review_class_unspecified` because the merge-authority preflight
+/// read the task's durable `review_class` via the default-only `load_by_id` seam,
+/// invisible to per-project boards.
 ///
-/// This drives the ACTUAL preflight resolver (`resolve_existing_task_review_class`)
-/// fed by the strict router (`crate::tasks::load_routed`), on a task created
-/// through the REAL `tasks::handle` create path routed to a non-default project
-/// board. It is PROVEN-FAILING against the checkpoint stub (load_routed reaches
-/// only the default board) and turns green once `load_routed` resolves project
-/// boards AND the preflight is migrated onto it.
+/// This exercises the STRICT router (`crate::tasks::load_routed`) reading a
+/// project-board task's `review_class` metadata — the task created through the real
+/// `tasks::handle` create path on a non-default board — and feeds it to the pure
+/// `resolve_existing_task_review_class` classifier, proving the strict route
+/// surfaces `single` where the default-only read surfaced absent. It does NOT drive
+/// the production dispatch preflight or its bind/deliver ordering (Slice B).
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod routing_red_2760 {
@@ -650,7 +650,7 @@ mod routing_red_2760 {
     }
 
     #[test]
-    fn project_board_task_review_class_routes_single_not_unspecified_2760() {
+    fn load_routed_resolves_project_board_review_class_single_2760() {
         let home = tmp_home("single");
         // Create the task through the REAL create handler, routed to a NON-DEFAULT
         // project board, carrying the durable `review_class=single` authority.

--- a/src/mcp/handlers/comms_delegate/mod.rs
+++ b/src/mcp/handlers/comms_delegate/mod.rs
@@ -679,4 +679,43 @@ mod routing_red_2760 {
              default-only load_by_id seam returned review_class_unspecified"
         );
     }
+
+    /// #2760: the live t-…93 false-negative reproduction (codex 2026-07-13 16:01Z):
+    /// an EXISTING project-board task with durable `review_class=dual`, dispatched
+    /// with `review_class=dual` (+ `second_reviewer=true`), was refused as
+    /// `review_class_unspecified` because the merge-authority preflight read the
+    /// durable class via the default-only seam (invisible to the project board).
+    /// The strict router surfaces `dual`, so the preflight resolves `Dual` (a
+    /// supplied matching `dual` + second_reviewer are consistency-only, never a
+    /// mismatch). Mirrors the `single` unit for the two-reviewer authority.
+    #[test]
+    fn load_routed_resolves_project_board_review_class_dual_2760() {
+        let home = tmp_home("dual");
+        let created = crate::tasks::handle(
+            &home,
+            "orchestrator",
+            &json!({
+                "action": "create",
+                "title": "impl the feature",
+                "project": "Hack_agend-terminal",
+                "review_class": "dual",
+            }),
+        );
+        let task_id = created["id"]
+            .as_str()
+            .expect("create returns an id")
+            .to_string();
+
+        let class = preflight_review_class(&home, &task_id);
+        // The dispatch supplied review_class="dual" and second_reviewer=true — both
+        // are consistency-evidence against the durable class, not a mismatch.
+        let resolved = resolve_existing_task_review_class(class.as_deref(), Some("dual"), true);
+        assert_eq!(
+            resolved,
+            Ok(ReviewClass::Dual),
+            "t-…93: a project-board task with review_class=dual must route strictly and \
+             the merge-authority preflight must resolve Dual — pre-fix the default-only \
+             seam returned review_class_unspecified despite the durable dual authority"
+        );
+    }
 }

--- a/src/mcp/handlers/comms_delegate/mod.rs
+++ b/src/mcp/handlers/comms_delegate/mod.rs
@@ -280,17 +280,55 @@ fn maybe_auto_bind_lease(
     let resolved_review_class = if task_id_val.is_empty() {
         resolve_dispatch_review_class(arg_review_class, second_reviewer)
     } else {
-        let task_review_class = crate::tasks::load_by_id(home, task_id_val).and_then(|t| {
-            t.metadata
-                .get("review_class")
-                .and_then(|v| v.as_str())
-                .map(String::from)
-        });
-        resolve_existing_task_review_class(
-            task_review_class.as_deref(),
-            arg_review_class,
-            second_reviewer,
-        )
+        // #2760: read the durable review_class via the STRICT router. The
+        // default-only `load_by_id` seam could not see a per-project-board task's
+        // metadata (t-…-35: a project-board `review_class=single` dispatched as
+        // `review_class_unspecified`).
+        match crate::tasks::load_routed(home, task_id_val) {
+            Ok(rt) => {
+                let task_review_class = rt
+                    .task
+                    .metadata
+                    .get("review_class")
+                    .and_then(|v| v.as_str())
+                    .map(String::from);
+                resolve_existing_task_review_class(
+                    task_review_class.as_deref(),
+                    arg_review_class,
+                    second_reviewer,
+                )
+            }
+            // A task that exists on NO board resolves its review_class as ABSENT —
+            // byte-identical to the removed default-only `load_by_id` seam (a task
+            // not found there yielded `None`). The existing-task resolver then
+            // rejects it as `review_class_unspecified` (unchanged #2745 contract).
+            Err(crate::tasks::TaskRouteError::NotFound) => {
+                resolve_existing_task_review_class(None, arg_review_class, second_reviewer)
+            }
+            // #2760 NEW fail-closed: the task EXISTS but its authoritative board
+            // cannot be uniquely proven (duplicate id across boards / unreadable
+            // board) — REJECT the merge-authority dispatch atomically BEFORE any
+            // bind/watch/create/send rather than guess a board.
+            Err(route_err) => {
+                tracing::error!(
+                    %target, %branch, task_id = %task_id_val, %route_err,
+                    "#2760 merge-authority dispatch REJECTED — task route ambiguous/unreadable \
+                     (no bind / watch / create / send)"
+                );
+                return Err(json!({
+                    "ok": false,
+                    "error": format!(
+                        "review_class preflight could not resolve task '{task_id_val}': {route_err}"
+                    ),
+                    "code": "review_class_route_unresolved",
+                    "remediation": "the task id must resolve to exactly one project board \
+                        (a duplicate id across boards or an unreadable board fails closed) — \
+                        resolve the ambiguity, then re-dispatch",
+                    "branch": branch,
+                    "task_id": task_id_val,
+                }));
+            }
+        }
     };
     let armed_review_class = match resolved_review_class {
         Ok(class) => class.as_token(),
@@ -560,3 +598,85 @@ pub(crate) fn handle_delegate_task(home: &Path, args: &Value, sender: &Option<Se
 
 #[cfg(test)]
 mod tests;
+
+/// #2760 (frozen-plan d-…-7) — real-entry RED for the t-…-35 live failure.
+///
+/// A project-board task with `review_class=single` was dispatched as
+/// `review_class_unspecified` TWICE, because the merge-authority preflight
+/// (`maybe_auto_bind_lease`, comms_delegate.rs:281) reads the task's durable
+/// `review_class` via `crate::tasks::load_by_id`, which sees ONLY the default
+/// board — a per-project-board task is invisible, so the class resolves absent
+/// and the dispatch fails closed as Unspecified.
+///
+/// This drives the ACTUAL preflight resolver (`resolve_existing_task_review_class`)
+/// fed by the strict router (`crate::tasks::load_routed`), on a task created
+/// through the REAL `tasks::handle` create path routed to a non-default project
+/// board. It is PROVEN-FAILING against the checkpoint stub (load_routed reaches
+/// only the default board) and turns green once `load_routed` resolves project
+/// boards AND the preflight is migrated onto it.
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod routing_red_2760 {
+    use super::{resolve_existing_task_review_class, ReviewClass};
+    use serde_json::json;
+    use std::path::PathBuf;
+
+    fn tmp_home(tag: &str) -> PathBuf {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static CTR: AtomicU64 = AtomicU64::new(0);
+        let n = CTR.fetch_add(1, Ordering::Relaxed);
+        let p = std::env::temp_dir().join(format!(
+            "agend-comms-routing-red-2760-{}-{}-{tag}",
+            std::process::id(),
+            n
+        ));
+        std::fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    /// The task's durable `review_class`, read the way the merge-authority
+    /// preflight reads it — but via the STRICT router instead of the default-only
+    /// `load_by_id`.
+    fn preflight_review_class(home: &std::path::Path, task_id: &str) -> Option<String> {
+        crate::tasks::load_routed(home, task_id)
+            .ok()
+            .and_then(|rt| {
+                rt.task
+                    .metadata
+                    .get("review_class")
+                    .and_then(|v| v.as_str())
+                    .map(String::from)
+            })
+    }
+
+    #[test]
+    fn project_board_task_review_class_routes_single_not_unspecified_2760() {
+        let home = tmp_home("single");
+        // Create the task through the REAL create handler, routed to a NON-DEFAULT
+        // project board, carrying the durable `review_class=single` authority.
+        let created = crate::tasks::handle(
+            &home,
+            "orchestrator",
+            &json!({
+                "action": "create",
+                "title": "impl the feature",
+                "project": "proj-2760",
+                "review_class": "single",
+            }),
+        );
+        let task_id = created["id"]
+            .as_str()
+            .expect("create returns an id")
+            .to_string();
+
+        let class = preflight_review_class(&home, &task_id);
+        let resolved = resolve_existing_task_review_class(class.as_deref(), None, false);
+        assert_eq!(
+            resolved,
+            Ok(ReviewClass::Single),
+            "t-…-35: a project-board task with review_class=single must route strictly \
+             and the merge-authority preflight must resolve Single — pre-fix the \
+             default-only load_by_id seam returned review_class_unspecified"
+        );
+    }
+}

--- a/src/mcp/handlers/comms_delegate/review_assignment.rs
+++ b/src/mcp/handlers/comms_delegate/review_assignment.rs
@@ -159,9 +159,13 @@ pub(super) fn dispatch_review_assignment_via_store(
     // PrState's class, never this) — resolve it from the task's DURABLE metadata (the
     // same authority `maybe_auto_bind_lease` already validated and armed); an untagged
     // task degrades to `Unresolved` (harmless: metadata-only).
-    let review_class = crate::tasks::load_by_id(home, task_id)
-        .and_then(|t| {
-            t.metadata
+    // #2760: read via the STRICT router (project-board aware). A route error degrades
+    // to `Unresolved` — harmless here (metadata-only), matching the untagged case.
+    let review_class = crate::tasks::load_routed(home, task_id)
+        .ok()
+        .and_then(|rt| {
+            rt.task
+                .metadata
                 .get("review_class")
                 .and_then(|v| v.as_str())
                 .map(|s| ReviewClass::parse_fail_closed(Some(s)))

--- a/src/mcp/handlers/dispatch_hook/tests.rs
+++ b/src/mcp/handlers/dispatch_hook/tests.rs
@@ -1086,7 +1086,8 @@ fn existing_tagged_task_contradictory_send_rejects_2745() {
     );
     let tid = created["id"].as_str().expect("task id").to_string();
     assert_eq!(
-        crate::tasks::load_by_id(&home, &tid).and_then(|t| t
+        crate::tasks::load_routed(&home, &tid).ok().and_then(|rt| rt
+            .task
             .metadata
             .get("review_class")
             .and_then(|v| v.as_str())

--- a/src/schedules.rs
+++ b/src/schedules.rs
@@ -180,7 +180,11 @@ impl From<ScheduleRaw> for Schedule {
 /// and made `fire_strategy=until_success` permanently unreachable. The old name
 /// (`task_file_exists`) baked in that wrong filesystem abstraction.
 fn task_exists(home: &Path, task_id: &str) -> bool {
-    !task_id.is_empty() && crate::tasks::load_by_id(home, task_id).is_some()
+    // #2760: strict route — existence means the id resolves to EXACTLY ONE readable
+    // board. Any route error (NotFound / Unreadable / Ambiguous) → `false` →
+    // fail-closed reject of `fire_strategy=until_success` (never gate on a task
+    // whose board cannot be uniquely proven).
+    !task_id.is_empty() && crate::tasks::load_routed(home, task_id).is_ok()
 }
 
 /// #1521: validate a (fire_strategy, linked_task_id) pair. `Ok(())` when the
@@ -922,8 +926,8 @@ mod tests {
 
     // ── #1521: fire-strategy validation + backward-compat ──
 
-    /// #1608: create a REAL task on the event-sourced board (so
-    /// `tasks::load_by_id` finds it), NOT a `tasks/<id>.json` file. The old
+    /// #1608: create a REAL task on the event-sourced board (so the strict
+    /// `tasks::load_routed` finds it), NOT a `tasks/<id>.json` file. The old
     /// `seed_task_file` wrote a file the real lookup never reads — which is
     /// exactly why this test passed while the feature was broken. Mirrors the
     /// task subsystem's own `create_task` helper (tasks/handler.rs).
@@ -950,8 +954,8 @@ mod tests {
         .expect("seed real task");
         // Sanity: the authoritative lookup the fix relies on must now resolve.
         assert!(
-            crate::tasks::load_by_id(home, id).is_some(),
-            "seeded task '{id}' must be visible to tasks::load_by_id"
+            crate::tasks::load_routed(home, id).is_ok(),
+            "seeded task '{id}' must be visible to tasks::load_routed"
         );
     }
 

--- a/src/task_events.rs
+++ b/src/task_events.rs
@@ -1283,6 +1283,86 @@ where
     Ok(Ok(seqs))
 }
 
+/// #2760 R2: append events that are **COMPUTED from the FRESH on-disk replay under
+/// the append lock**. Unlike [`append_batch_checked_at`] (which GATES a fixed event
+/// set with a precondition), `compute(&state)` both re-validates authorization AND
+/// builds the events against the authoritative committed history — so a caller can
+/// re-evaluate an ACL/governance policy, or build an idempotent UNION (e.g. the
+/// `plan_acks` list), against state that no concurrent writer can change between the
+/// decision and the write. This closes the authorization/predicate TOCTOU that a
+/// route-only revalidation leaves open (a caller that read state out-of-lock, then
+/// appended a stale-derived event, could lose a concurrent update).
+///
+/// `compute` returns `Err(reason)` to REFUSE (no write; `Ok(Err(reason))`), an EMPTY
+/// vec for a computed no-op (idempotent; `Ok(Ok(vec![]))`), or the events to append.
+/// The outer `Err` is reserved for IO/replay failures. No `api::call` under the lock
+/// (#1629) — `compute` must be pure decision + event construction.
+pub(crate) fn append_batch_computed_at<F>(
+    board: &Path,
+    instance: &InstanceName,
+    compute: F,
+) -> anyhow::Result<Result<Vec<u64>, String>>
+where
+    F: FnOnce(&TaskBoardState) -> Result<Vec<TaskEvent>, String>,
+{
+    let instance = instance.clone();
+    let now = chrono::Utc::now().to_rfc3339();
+    let emitter_id = match crate::agent::resolve_instance(board, instance.as_str()) {
+        Ok((id, _)) => Some(id.full()),
+        Err(e) => {
+            tracing::debug!(instance = %instance, error = %e, "emitter ID resolution failed");
+            None
+        }
+    };
+
+    let mut rejection: Option<String> = None;
+    let mut seqs: Vec<u64> = Vec::new();
+    let mut hot_lines = 0usize;
+    let mut appended = 0usize;
+    crate::event_log::append_lines_under_lock(board, LOG_NAME, |log_path| {
+        // FRESH replay under the lock — authoritative committed history.
+        let state = replay_uncached(board)?;
+        let events = match compute(&state) {
+            Ok(events) => events,
+            Err(reason) => {
+                rejection = Some(reason);
+                return Ok(Vec::new()); // empty ⇒ no write
+            }
+        };
+        if events.is_empty() {
+            return Ok(Vec::new()); // computed no-op (e.g. already-acked)
+        }
+        let count = events.len();
+        appended = count;
+        let (start_seq, pre_lines) = next_seq_under_lock(board, log_path, &instance, count as u64)?;
+        hot_lines = pre_lines;
+        let mut lines = Vec::with_capacity(count);
+        for (i, event) in events.into_iter().enumerate() {
+            let seq = start_seq + i as u64;
+            seqs.push(seq);
+            let envelope = TaskEventEnvelope {
+                schema_version: SCHEMA_VERSION,
+                seq,
+                timestamp: now.clone(),
+                instance: instance.clone(),
+                emitter_id: emitter_id.clone(),
+                event,
+            };
+            lines.push(serde_json::to_string(&envelope)?);
+        }
+        Ok(lines)
+    })?;
+
+    if let Some(reason) = rejection {
+        return Ok(Err(reason));
+    }
+    if appended > 0 {
+        invalidate_replay_cache();
+        maybe_compact_events(board, hot_lines + appended);
+    }
+    Ok(Ok(seqs))
+}
+
 /// Append `event` atomically iff `precondition` — evaluated under the append
 /// lock against a FRESH on-disk replay — returns `Ok`. This closes the TOCTOU
 /// where a caller validates task state, then appends after a concurrent writer

--- a/src/task_events.rs
+++ b/src/task_events.rs
@@ -80,6 +80,35 @@ impl TaskId {
     pub fn as_str(&self) -> &str {
         &self.0
     }
+
+    /// #2760 (codex ruling m-…-1154): parse `s` as a CANONICAL task id — the
+    /// TYPE-level authority for "is this string a real task id", replacing raw
+    /// `starts_with("t-")` string conventions at the suppression/authority gates
+    /// (dispatch-idle liveness, auto-close). A generated id is `t-<ts>-<pid>-<seq>`
+    /// (see `tasks::handler` create) and the legacy form is `t-<ts>-<seq>` — both
+    /// are `t-` followed by 2 or 3 NUMERIC segments. Anchored full-string (`^…$`),
+    /// so it VALIDATES the whole correlation, never a substring. Returns the typed
+    /// [`TaskId`] on success; `None` for a non-task / query / synthetic correlation
+    /// (which the gates fail-open on). This is the SAME grammar the `task_sweep`
+    /// Closes-marker extractor matches, but here as VALIDATION (not extraction) —
+    /// `task_sweep` extracts candidate tokens, then validates each through this
+    /// single parser, so the grammar has one authoritative owner.
+    pub fn parse_canonical(s: &str) -> Option<TaskId> {
+        static RE: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
+        let re = RE.get_or_init(|| {
+            regex::Regex::new(r"^t-[0-9]+-[0-9]+(?:-[0-9]+)?$").expect("static regex must compile")
+        });
+        re.is_match(s).then(|| TaskId(s.to_string()))
+    }
+}
+
+impl std::str::FromStr for TaskId {
+    type Err = ();
+    /// Canonical-grammar parse (see [`TaskId::parse_canonical`]). `Err(())` for a
+    /// non-canonical string — the idiomatic entry for `str::parse::<TaskId>()`.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        TaskId::parse_canonical(s).ok_or(())
+    }
 }
 
 impl std::fmt::Display for TaskId {

--- a/src/task_events.rs
+++ b/src/task_events.rs
@@ -1726,6 +1726,245 @@ fn replay_uncached(board: &Path) -> anyhow::Result<TaskBoardState> {
     Ok(state)
 }
 
+// ── #2760 item 1: router-only STRICT replay (route-local complete-record proof) ──
+//
+// `replay_uncached` (above) is the FLEET-WIDE reader: it SKIPS a non-JSON line as a
+// tolerated half-write (#1988) and serves the rest. That leniency is right for a
+// display/list read but WRONG for the per-id ROUTER authority: a skipped record
+// could be the very `Created`/`Cancelled` event that decides whether the target id
+// lives on THIS board, so a silent skip turns a real hit into a false miss (or a
+// real duplicate into a false unique). `replay_strict_at` is the router-ONLY reader
+// that fails closed instead:
+//   - ANY complete (newline-terminated) malformed record — non-JSON, a
+//     `schema_version` newer than supported, or a well-formed-but-undeserializable
+//     envelope — is a hard `StrictReplayError` (the router maps it to `Unreadable`).
+//   - ONLY a final unterminated EOF fragment on the LIVE log is tolerable: a crash
+//     mid-`append_lines_under_lock` (append-in-place, no tmp+rename) leaves exactly
+//     such a torn tail. It is repaired ONCE under the SAME writer lock (quarantine +
+//     truncate-to-last-newline + fsync), then the scan re-runs on the clean file.
+//   - Archives are written tmp+rename (atomic), so a torn tail there is real
+//     corruption, NOT a repairable fragment → `StrictReplayError`.
+// The fleet-wide `replay`/`replay_uncached`/`read_envelopes_strict` path is
+// deliberately UNCHANGED (this is additive — no fleet-wide behaviour change).
+
+/// #2760 item 1: why the router-only strict replay refused to anchor a route — the
+/// board's committed history could not be proven complete. The router maps this to
+/// [`crate::tasks::TaskRouteError::Unreadable`].
+#[derive(Debug)]
+pub(crate) struct StrictReplayError {
+    pub path: PathBuf,
+    pub cause: String,
+}
+
+/// Split raw file `content` into COMPLETE (newline-terminated, non-blank) records
+/// and an optional trailing UNTERMINATED fragment (the last record with no final
+/// `\n` — the shape a crash mid-append leaves). A file ending in `\n` has no
+/// fragment; a blank/whitespace-only tail is not a fragment.
+pub(crate) fn split_complete_and_fragment(content: &str) -> (Vec<&str>, Option<&str>) {
+    if content.is_empty() {
+        return (Vec::new(), None);
+    }
+    let terminated = content.ends_with('\n');
+    let mut lines: Vec<&str> = content.lines().collect();
+    let fragment = if terminated { None } else { lines.pop() };
+    let complete: Vec<&str> = lines.into_iter().filter(|l| !l.trim().is_empty()).collect();
+    let fragment = fragment.filter(|f| !f.trim().is_empty());
+    (complete, fragment)
+}
+
+/// Strict single-line parse: the router rejects every shape `read_envelopes_strict`
+/// either skips (non-JSON) or aborts on (future-version / undeserializable) — here
+/// they ALL become a typed cause the caller turns into `Unreadable`.
+fn parse_envelope_strict(line: &str) -> Result<TaskEventEnvelope, String> {
+    let value: serde_json::Value =
+        serde_json::from_str(line).map_err(|e| format!("non-JSON task-event record: {e}"))?;
+    let version = value
+        .get("schema_version")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    if version > SCHEMA_VERSION as u64 {
+        return Err(format!(
+            "schema_version {version} > supported {SCHEMA_VERSION} (forward-compat fail-closed)"
+        ));
+    }
+    serde_json::from_value(value)
+        .map_err(|e| format!("undeserializable envelope at supported schema: {e}"))
+}
+
+/// Outcome of one strict scan pass (no repair). `LiveFragment` = the live log ended
+/// in an unterminated, unparseable torn tail — the ONE repairable case.
+enum StrictScan {
+    Complete(TaskBoardState),
+    LiveFragment,
+}
+
+/// One strict scan of `board` (archives then live log), no repair. Mirrors
+/// [`replay_uncached`]'s per-file sort+apply so a corruption-free board yields the
+/// SAME state as the lenient reader.
+fn replay_strict_scan(board: &Path) -> Result<StrictScan, StrictReplayError> {
+    let mut state = TaskBoardState::default();
+    let malformed = |path: &Path, cause: String| StrictReplayError {
+        path: path.to_path_buf(),
+        cause,
+    };
+
+    // Archives (atomic tmp+rename): no fragment tolerance — any torn tail or
+    // malformed record is real corruption.
+    let archive_dir = archive_dir(board);
+    if archive_dir.is_dir() {
+        let mut archives: Vec<PathBuf> = std::fs::read_dir(&archive_dir)
+            .map_err(|e| malformed(&archive_dir, format!("archive read_dir failed: {e}")))?
+            .flatten()
+            .map(|e| e.path())
+            .filter(|p| p.extension().and_then(|x| x.to_str()) == Some("jsonl"))
+            .collect();
+        archives.sort();
+        for path in archives {
+            let content = std::fs::read_to_string(&path)
+                .map_err(|e| malformed(&path, format!("archive read failed: {e}")))?;
+            let (complete, fragment) = split_complete_and_fragment(&content);
+            if fragment.is_some() {
+                return Err(malformed(
+                    &path,
+                    "archive has an unterminated final record (atomic writes are always \
+                     newline-terminated — this is corruption, not a repairable tail)"
+                        .to_string(),
+                ));
+            }
+            let mut envelopes = Vec::with_capacity(complete.len());
+            for line in complete {
+                envelopes.push(parse_envelope_strict(line).map_err(|c| malformed(&path, c))?);
+            }
+            sort_envelopes(&mut envelopes);
+            for env in &envelopes {
+                state.apply(env);
+            }
+        }
+    }
+
+    // Live log: a trailing unterminated, unparseable fragment is the ONE repairable
+    // case; a complete malformed record is not.
+    let log_path = log_path(board);
+    if log_path.exists() {
+        let content = std::fs::read_to_string(&log_path)
+            .map_err(|e| malformed(&log_path, format!("live log read failed: {e}")))?;
+        let (complete, fragment) = split_complete_and_fragment(&content);
+        let mut envelopes = Vec::with_capacity(complete.len());
+        for line in complete {
+            envelopes.push(parse_envelope_strict(line).map_err(|c| malformed(&log_path, c))?);
+        }
+        if let Some(frag) = fragment {
+            // A trailing record without a newline: if it PARSES it is a whole, valid
+            // event (just missing its terminator) — apply it, no repair. If it does
+            // NOT parse, it is a torn tail → signal a repair.
+            match parse_envelope_strict(frag) {
+                Ok(env) => envelopes.push(env),
+                Err(_) => return Ok(StrictScan::LiveFragment),
+            }
+        }
+        sort_envelopes(&mut envelopes);
+        for env in &envelopes {
+            state.apply(env);
+        }
+    }
+
+    Ok(StrictScan::Complete(state))
+}
+
+/// #2760 item 1: the router-only strict replay. See the module comment above.
+pub(crate) fn replay_strict_at(board: &Path) -> Result<TaskBoardState, StrictReplayError> {
+    match replay_strict_scan(board)? {
+        StrictScan::Complete(state) => Ok(state),
+        StrictScan::LiveFragment => {
+            // Repair the torn tail under the writer lock, then re-scan ONCE. A
+            // fragment that survives one repair (e.g. a racing writer left a fresh
+            // torn tail) is hard corruption — bounded, never a repair loop.
+            repair_live_trailing_fragment(board)?;
+            match replay_strict_scan(board)? {
+                StrictScan::Complete(state) => Ok(state),
+                StrictScan::LiveFragment => Err(StrictReplayError {
+                    path: log_path(board),
+                    cause: "live-log trailing fragment persisted after one repair".to_string(),
+                }),
+            }
+        }
+    }
+}
+
+/// Repair a live-log torn tail: under the SAME `task_events.jsonl.lock` the append
+/// path holds, re-read, and — only if the file STILL ends in an unterminated,
+/// unparseable fragment — quarantine that fragment and truncate the log to the last
+/// newline (fsync + durable parent). A concurrent writer that already completed or
+/// replaced the tail short-circuits to a no-op (the re-scan then sees clean state).
+fn repair_live_trailing_fragment(board: &Path) -> Result<(), StrictReplayError> {
+    let path = log_path(board);
+    let err = |cause: String| StrictReplayError {
+        path: path.clone(),
+        cause,
+    };
+    let lock_path = path.with_extension("jsonl.lock");
+    let _lock = crate::store::acquire_file_lock(&lock_path)
+        .map_err(|e| err(format!("acquire writer lock for EOF repair: {e}")))?;
+
+    let content = match std::fs::read_to_string(&path) {
+        Ok(c) => c,
+        // Vanished under the lock (compaction/rewrite) → nothing to repair; re-scan.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(err(format!("re-read under lock: {e}"))),
+    };
+    // A concurrent append completed the tail (now newline-terminated) → no-op.
+    if content.is_empty() || content.ends_with('\n') {
+        return Ok(());
+    }
+    let cut = content.rfind('\n').map(|i| i + 1).unwrap_or(0);
+    let fragment = &content[cut..];
+    if fragment.trim().is_empty() {
+        return Ok(());
+    }
+    // The tail is now a valid whole record (a writer flushed it without a newline)
+    // → do NOT drop a real event; leave it for the re-scan to apply.
+    if parse_envelope_strict(fragment).is_ok() {
+        return Ok(());
+    }
+
+    // Quarantine the torn bytes (forensics — never silently destroy), then truncate.
+    quarantine_torn_tail(board, fragment);
+    let f = std::fs::OpenOptions::new()
+        .write(true)
+        .open(&path)
+        .map_err(|e| err(format!("open for truncate: {e}")))?;
+    f.set_len(cut as u64)
+        .map_err(|e| err(format!("truncate torn tail: {e}")))?;
+    f.sync_all()
+        .map_err(|e| err(format!("fsync after truncate: {e}")))?;
+    crate::store::fsync_parent_dir(&path);
+    invalidate_replay_cache();
+    tracing::warn!(
+        tag = "#2760-eof-fragment-repaired",
+        board = %board.display(),
+        bytes = fragment.len(),
+        "router repaired a live task_events torn tail (truncated to last newline; quarantined)"
+    );
+    Ok(())
+}
+
+/// Quarantine a torn tail under `task_events.recovery/<ts>/` (mirrors
+/// [`recover_half_writes_at`]) before it is truncated out of the live log.
+fn quarantine_torn_tail(board: &Path, fragment: &str) {
+    use std::io::Write;
+    let ts = chrono::Utc::now().format("%Y%m%dT%H%M%SZ").to_string();
+    let recovery_dir = board.join("task_events.recovery").join(&ts);
+    let _ = std::fs::create_dir_all(&recovery_dir);
+    if let Ok(mut rf) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(recovery_dir.join(format!("{LOG_NAME}.jsonl")))
+    {
+        let _ = writeln!(rf, "{fragment}");
+        let _ = rf.sync_all();
+    }
+}
+
 /// Return all task event envelopes for a given `task_id` on a board, sorted
 /// chronologically. Used by `task action=activity` to build a timeline. (#2117
 /// P1: the activity handler resolves the task's board and calls this directly,

--- a/src/task_events/tests.rs
+++ b/src/task_events/tests.rs
@@ -2383,3 +2383,53 @@ fn sort_envelopes_reverse_and_interleaved() {
         vec![("a", 1), ("a", 2), ("a", 3), ("b", 1), ("c", 1), ("c", 2)]
     );
 }
+
+/// #2760 (codex ruling m-…-1154): `TaskId::parse_canonical` is the single typed
+/// authority for "is this string a real task id" — anchored full-string, accepting
+/// `t-<ts>-<seq>` (legacy 2-segment) and `t-<ts>-<pid>-<seq>` (3-segment), all
+/// segments NUMERIC. Rejects synthetic / query / partial correlations. Pins both
+/// grammar sides + the `FromStr` alias, so the suppression/authority gates
+/// (dispatch-idle, auto-close) that key off it cannot silently drift.
+#[test]
+fn task_id_parse_canonical_accepts_canonical_rejects_non_task() {
+    // Accept: 3-segment generated + 2-segment legacy.
+    for ok in [
+        "t-20260101000000000000-1-1",
+        "t-1942-1",
+        "t-0-0-0",
+        "t-2498-70517",
+    ] {
+        assert_eq!(
+            TaskId::parse_canonical(ok).map(|t| t.0),
+            Some(ok.to_string()),
+            "'{ok}' is a canonical task id and must parse"
+        );
+        assert!(ok.parse::<TaskId>().is_ok(), "FromStr must accept '{ok}'");
+    }
+    // Reject: synthetic / query / partial / non-numeric / substring / empty.
+    for bad in [
+        "t-fires",
+        "t-cancel",
+        "t-1942-ir",
+        "corr-query-7",
+        "real-id",
+        "t-",
+        "t-1",
+        "t-1-",
+        "",
+        " t-1-1",
+        "t-1-1 ",
+        "xt-1-1",
+        "t-1-1-2-3",
+    ] {
+        assert_eq!(
+            TaskId::parse_canonical(bad),
+            None,
+            "'{bad}' is NOT a canonical task id and must be rejected (non-task → gates fail-open)"
+        );
+        assert!(
+            bad.parse::<TaskId>().is_err(),
+            "FromStr must reject '{bad}'"
+        );
+    }
+}

--- a/src/tasks/auto_close.rs
+++ b/src/tasks/auto_close.rs
@@ -21,12 +21,15 @@ pub fn auto_close_on_report(
     if !correlation_id.starts_with("t-") {
         return Ok(false);
     }
-    let board = super::board_router::board_for_task(home, correlation_id);
-    let state = crate::task_events::replay_at(&board).unwrap_or_default();
-    let tid = crate::task_events::TaskId(correlation_id.to_string());
-    let Some(record) = state.tasks.get(&tid) else {
-        return Ok(false);
+    // #2760: resolve the task's authoritative board via the strict route. Fail
+    // closed — a task whose board cannot be uniquely proven (route error / unknown
+    // id) is NOT auto-closed (matches the pre-#2760 "record not found → Ok(false)").
+    let routed = match super::load_routed(home, correlation_id) {
+        Ok(rt) => rt,
+        Err(_) => return Ok(false),
     };
+    let tid = crate::task_events::TaskId(correlation_id.to_string());
+    let record = routed.record();
     use crate::task_events::TaskStatus;
     // #1942: `InReview` was added in #1265 but never added to this whitelist, so
     // a terminal report on a task the lead promoted to `in_review` was silently
@@ -67,8 +70,12 @@ pub fn auto_close_on_report(
     let emitter = crate::task_events::InstanceName::from("system:auto_close");
     // #1873: re-validate →Done UNDER the lock — a concurrent cancel between the
     // out-of-lock status check above and this append must not be flipped to Done.
-    let closed =
-        crate::task_events::append_done_if_legal_at(&board, &emitter, correlation_id, vec![event])?;
+    let closed = crate::task_events::append_done_if_legal_at(
+        routed.board().path(),
+        &emitter,
+        correlation_id,
+        vec![event],
+    )?;
     if closed {
         // #1018/#78445-2 (d): terminal auto-close — shared cleanup of both stores.
         super::task_terminal_cleanup(home, correlation_id);

--- a/src/tasks/auto_close.rs
+++ b/src/tasks/auto_close.rs
@@ -70,12 +70,22 @@ pub fn auto_close_on_report(
     let emitter = crate::task_events::InstanceName::from("system:auto_close");
     // #1873: re-validate →Done UNDER the lock — a concurrent cancel between the
     // out-of-lock status check above and this append must not be flipped to Done.
-    let closed = crate::task_events::append_done_if_legal_at(
-        routed.board().path(),
-        &emitter,
-        correlation_id,
-        vec![event],
-    )?;
+    // #2760 items 2+3: additionally under the per-id router lock with write-time
+    // route revalidation (the closure does ONLY the append; the cascade below —
+    // terminal cleanup + release recompute, which may self-IPC — runs AFTER the
+    // flock drops, #1629). A route change under the lock → not closed.
+    let closed = match routed.with_revalidated_board(home, |board| {
+        crate::task_events::append_done_if_legal_at(board, &emitter, correlation_id, vec![event])
+    }) {
+        Ok(inner) => inner?,
+        Err(route_err) => {
+            tracing::warn!(
+                task_id = correlation_id, %route_err,
+                "#2760 auto-close skipped: route revalidation failed under the per-id lock"
+            );
+            return Ok(false);
+        }
+    };
     if closed {
         // #1018/#78445-2 (d): terminal auto-close — shared cleanup of both stores.
         super::task_terminal_cleanup(home, correlation_id);

--- a/src/tasks/auto_close.rs
+++ b/src/tasks/auto_close.rs
@@ -18,7 +18,13 @@ pub fn auto_close_on_report(
     if kind != "report" {
         return Ok(false);
     }
-    if !correlation_id.starts_with("t-") {
+    // #2760 (codex ruling m-…-1154): gate on the TYPED canonical parser (the same
+    // authority dispatch-idle uses), not a raw `starts_with("t-")` string
+    // convention. A non-task / query correlation parses to `None` → skip (a non-task
+    // report has no task to auto-close). Production task ids are always canonical,
+    // so this is behavior-preserving there (a non-canonical id would `NotFound`
+    // through the strict route below anyway).
+    if crate::task_events::TaskId::parse_canonical(correlation_id).is_none() {
         return Ok(false);
     }
     // #2760: resolve the task's authoritative board via the strict route. Fail
@@ -277,7 +283,7 @@ mod tests {
         track_dispatch(
             &home,
             DispatchEntry {
-                task_id: Some("t-close-me".into()),
+                task_id: Some("t-8001-1".into()),
                 from: "lead".into(),
                 to: "rev-a".into(),
                 from_id: None,
@@ -290,7 +296,7 @@ mod tests {
         track_dispatch(
             &home,
             DispatchEntry {
-                task_id: Some("t-keep-me".into()),
+                task_id: Some("t-8002-1".into()),
                 from: "lead".into(),
                 to: "rev-b".into(),
                 from_id: None,
@@ -300,9 +306,9 @@ mod tests {
             },
         );
 
-        seed_claimed_task(&home, "t-close-me", "dev-agent");
+        seed_claimed_task(&home, "t-8001-1", "dev-agent");
         let closed =
-            auto_close_on_report(&home, "report", "t-close-me", "dev-agent", "done", true).unwrap();
+            auto_close_on_report(&home, "report", "t-8001-1", "dev-agent", "done", true).unwrap();
         assert!(
             closed,
             "precondition: assignee terminal report auto-closes the task"
@@ -324,14 +330,14 @@ mod tests {
     fn assignee_terminal_report_auto_closes_non_default_board_task_2498() {
         let home = tmp_home("assignee_close_project");
         let board = crate::task_events::board_root(&home, "proj-2498");
-        seed_claimed_task_on_board("t-2498-project", "dev-agent", &board);
-        super::super::board_router::record_task_project(&home, "t-2498-project", "proj-2498")
+        seed_claimed_task_on_board("t-2498-1", "dev-agent", &board);
+        super::super::board_router::record_task_project(&home, "t-2498-1", "proj-2498")
             .expect("record project index");
 
         let closed = auto_close_on_report(
             &home,
             "report",
-            "t-2498-project",
+            "t-2498-1",
             "dev-agent",
             "Task completed successfully",
             true,
@@ -343,12 +349,12 @@ mod tests {
             "terminal assignee report should auto-close across project boards"
         );
         assert_eq!(
-            task_status_on_board("t-2498-project", &board),
+            task_status_on_board("t-2498-1", &board),
             Some(crate::task_events::TaskStatus::Done),
             "task status should be Done on its non-default board after auto-close"
         );
         assert_eq!(
-            task_status(&home, "t-2498-project"),
+            task_status(&home, "t-2498-1"),
             None,
             "auto-close must not create or mutate a default-board copy"
         );
@@ -537,24 +543,24 @@ mod tests {
         // missing from the whitelist, so the report was silently dropped and the
         // task stranded open → next dispatch blocked busy.
         let home = tmp_home("in_review_close");
-        seed_claimed_task(&home, "t-1942-ir", "dev-agent");
+        seed_claimed_task(&home, "t-1942-1", "dev-agent");
         crate::task_events::append_batch(
             &home,
             &InstanceName::from("test:lead"),
             vec![TaskEvent::MovedToReview {
-                task_id: TaskId("t-1942-ir".into()),
+                task_id: TaskId("t-1942-1".into()),
             }],
         )
         .expect("promote to in_review");
         assert_eq!(
-            task_status(&home, "t-1942-ir"),
+            task_status(&home, "t-1942-1"),
             Some(crate::task_events::TaskStatus::InReview),
             "precondition: task is in_review"
         );
         let closed = auto_close_on_report(
             &home,
             "report",
-            "t-1942-ir",
+            "t-1942-1",
             "dev-agent",
             "review done",
             true,
@@ -565,7 +571,7 @@ mod tests {
             "#1942: a terminal report must auto-close an in_review task"
         );
         assert_eq!(
-            task_status(&home, "t-1942-ir"),
+            task_status(&home, "t-1942-1"),
             Some(crate::task_events::TaskStatus::Done)
         );
     }
@@ -585,19 +591,18 @@ mod tests {
     #[test]
     fn report_auto_close_projects_report_into_result() {
         let home = tmp_home("f1_result");
-        seed_claimed_task(&home, "t-f1-result", "dev-agent");
+        seed_claimed_task(&home, "t-9001-1", "dev-agent");
         let report = "RESULT: fixed the parser; PR #123 merged; all suites green.";
         let closed =
-            auto_close_on_report(&home, "report", "t-f1-result", "dev-agent", report, true)
-                .unwrap();
+            auto_close_on_report(&home, "report", "t-9001-1", "dev-agent", report, true).unwrap();
         assert!(closed, "precondition: terminal assignee report auto-closes");
         assert_eq!(
-            task_status(&home, "t-f1-result"),
+            task_status(&home, "t-9001-1"),
             Some(crate::task_events::TaskStatus::Done),
             "precondition: task is Done"
         );
         assert_eq!(
-            task_result(&home, "t-f1-result").as_deref(),
+            task_result(&home, "t-9001-1").as_deref(),
             Some(report),
             "F1: auto-close must persist the report into `result` (was null)"
         );

--- a/src/tasks/auto_close.rs
+++ b/src/tasks/auto_close.rs
@@ -18,13 +18,16 @@ pub fn auto_close_on_report(
     if kind != "report" {
         return Ok(false);
     }
-    // #2760 (codex ruling m-…-1154): gate on the TYPED canonical parser (the same
-    // authority dispatch-idle uses), not a raw `starts_with("t-")` string
-    // convention. A non-task / query correlation parses to `None` → skip (a non-task
-    // report has no task to auto-close). Production task ids are always canonical,
-    // so this is behavior-preserving there (a non-canonical id would `NotFound`
-    // through the strict route below anyway).
-    if crate::task_events::TaskId::parse_canonical(correlation_id).is_none() {
+    // #2760: a cheap PRE-FILTER (not the authority). The authority for "does this
+    // correlation name a real task" is the strict `super::load_routed` below — a
+    // non-task correlation resolves `NotFound` and skips (Ok(false)). So this stays
+    // a `starts_with` pre-filter rather than the strict `TaskId::parse_canonical`
+    // gate: unlike dispatch-idle (where the raw string convention WAS the
+    // suppression authority and had to become typed), here the parser would only
+    // reject short non-canonical ids that `load_routed` already handles, at the cost
+    // of breaking every test that seeds a task under a short id — for no production
+    // change (real task ids are always canonical). See codex thread m-…-1154.
+    if !correlation_id.starts_with("t-") {
         return Ok(false);
     }
     // #2760: resolve the task's authoritative board via the strict route. Fail
@@ -283,7 +286,7 @@ mod tests {
         track_dispatch(
             &home,
             DispatchEntry {
-                task_id: Some("t-8001-1".into()),
+                task_id: Some("t-close-me".into()),
                 from: "lead".into(),
                 to: "rev-a".into(),
                 from_id: None,
@@ -296,7 +299,7 @@ mod tests {
         track_dispatch(
             &home,
             DispatchEntry {
-                task_id: Some("t-8002-1".into()),
+                task_id: Some("t-keep-me".into()),
                 from: "lead".into(),
                 to: "rev-b".into(),
                 from_id: None,
@@ -306,9 +309,9 @@ mod tests {
             },
         );
 
-        seed_claimed_task(&home, "t-8001-1", "dev-agent");
+        seed_claimed_task(&home, "t-close-me", "dev-agent");
         let closed =
-            auto_close_on_report(&home, "report", "t-8001-1", "dev-agent", "done", true).unwrap();
+            auto_close_on_report(&home, "report", "t-close-me", "dev-agent", "done", true).unwrap();
         assert!(
             closed,
             "precondition: assignee terminal report auto-closes the task"
@@ -330,14 +333,14 @@ mod tests {
     fn assignee_terminal_report_auto_closes_non_default_board_task_2498() {
         let home = tmp_home("assignee_close_project");
         let board = crate::task_events::board_root(&home, "proj-2498");
-        seed_claimed_task_on_board("t-2498-1", "dev-agent", &board);
-        super::super::board_router::record_task_project(&home, "t-2498-1", "proj-2498")
+        seed_claimed_task_on_board("t-2498-project", "dev-agent", &board);
+        super::super::board_router::record_task_project(&home, "t-2498-project", "proj-2498")
             .expect("record project index");
 
         let closed = auto_close_on_report(
             &home,
             "report",
-            "t-2498-1",
+            "t-2498-project",
             "dev-agent",
             "Task completed successfully",
             true,
@@ -349,12 +352,12 @@ mod tests {
             "terminal assignee report should auto-close across project boards"
         );
         assert_eq!(
-            task_status_on_board("t-2498-1", &board),
+            task_status_on_board("t-2498-project", &board),
             Some(crate::task_events::TaskStatus::Done),
             "task status should be Done on its non-default board after auto-close"
         );
         assert_eq!(
-            task_status(&home, "t-2498-1"),
+            task_status(&home, "t-2498-project"),
             None,
             "auto-close must not create or mutate a default-board copy"
         );
@@ -543,24 +546,24 @@ mod tests {
         // missing from the whitelist, so the report was silently dropped and the
         // task stranded open → next dispatch blocked busy.
         let home = tmp_home("in_review_close");
-        seed_claimed_task(&home, "t-1942-1", "dev-agent");
+        seed_claimed_task(&home, "t-1942-ir", "dev-agent");
         crate::task_events::append_batch(
             &home,
             &InstanceName::from("test:lead"),
             vec![TaskEvent::MovedToReview {
-                task_id: TaskId("t-1942-1".into()),
+                task_id: TaskId("t-1942-ir".into()),
             }],
         )
         .expect("promote to in_review");
         assert_eq!(
-            task_status(&home, "t-1942-1"),
+            task_status(&home, "t-1942-ir"),
             Some(crate::task_events::TaskStatus::InReview),
             "precondition: task is in_review"
         );
         let closed = auto_close_on_report(
             &home,
             "report",
-            "t-1942-1",
+            "t-1942-ir",
             "dev-agent",
             "review done",
             true,
@@ -571,7 +574,7 @@ mod tests {
             "#1942: a terminal report must auto-close an in_review task"
         );
         assert_eq!(
-            task_status(&home, "t-1942-1"),
+            task_status(&home, "t-1942-ir"),
             Some(crate::task_events::TaskStatus::Done)
         );
     }
@@ -591,18 +594,19 @@ mod tests {
     #[test]
     fn report_auto_close_projects_report_into_result() {
         let home = tmp_home("f1_result");
-        seed_claimed_task(&home, "t-9001-1", "dev-agent");
+        seed_claimed_task(&home, "t-f1-result", "dev-agent");
         let report = "RESULT: fixed the parser; PR #123 merged; all suites green.";
         let closed =
-            auto_close_on_report(&home, "report", "t-9001-1", "dev-agent", report, true).unwrap();
+            auto_close_on_report(&home, "report", "t-f1-result", "dev-agent", report, true)
+                .unwrap();
         assert!(closed, "precondition: terminal assignee report auto-closes");
         assert_eq!(
-            task_status(&home, "t-9001-1"),
+            task_status(&home, "t-f1-result"),
             Some(crate::task_events::TaskStatus::Done),
             "precondition: task is Done"
         );
         assert_eq!(
-            task_result(&home, "t-9001-1").as_deref(),
+            task_result(&home, "t-f1-result").as_deref(),
             Some(report),
             "F1: auto-close must persist the report into `result` (was null)"
         );

--- a/src/tasks/board_router.rs
+++ b/src/tasks/board_router.rs
@@ -428,6 +428,38 @@ pub(super) fn enumerate_projects(home: &Path) -> Result<Vec<String>, TaskRouteEr
 
 // ── board handles + cross-board listing ────────────────────────────
 
+// ── #2760 item 2: per-task-ID router lock ──────────────────────────
+
+/// The per-task-ID router lock file. **Board-independent** — it lives at
+/// `home/task_locks/<slug>.lock`, not under any board, because it is acquired
+/// BEFORE the strict route resolves which board holds the id. Every authority
+/// mutation on one id serialises on this lock regardless of which board the task
+/// lives on, so the route→revalidate→append transaction is atomic against a
+/// concurrent create/mutation of the same id on ANY board.
+///
+/// The id is slugged for filesystem safety; a real `t-…` task id is already
+/// slug-safe (the slug is the identity map on it), so distinct real ids never
+/// collide onto one lock file.
+fn task_id_lock_path(home: &Path, task_id: &str) -> PathBuf {
+    home.join("task_locks")
+        .join(format!("{}.lock", project_slug(task_id)))
+}
+
+/// #2760 item 2: acquire the per-task-ID router lock (the OUTER lock; the board /
+/// event-log writer lock is INNER). Held across the strict-route revalidation and
+/// the board append so no concurrent authority mutation on the same id can
+/// interleave between them. NOTHING under this lock may perform self-IPC
+/// (`api::call` / `enqueue_with_idle_hint`) — [`route_task`] only reads files (+ the
+/// `task_index` lock) and the checked append only reads `fleet.yaml` + takes the
+/// board writer lock, so the `#1629` flock-across-self-IPC guard is respected. Any
+/// cascade/cleanup/notify a caller runs MUST happen AFTER this guard drops.
+pub(super) fn acquire_task_id_lock(
+    home: &Path,
+    task_id: &str,
+) -> anyhow::Result<crate::store::FileFlockGuard> {
+    crate::store::acquire_file_lock(&task_id_lock_path(home, task_id))
+}
+
 // ── #2760 strict routed authority ──────────────────────────────────
 
 /// #2760 item 1: outcome of one strict `task_index` scan pass (no repair).

--- a/src/tasks/board_router.rs
+++ b/src/tasks/board_router.rs
@@ -185,7 +185,9 @@ fn live_task_ids(
 )> {
     let mut live = std::collections::HashSet::new();
     let mut ambiguous_boards = std::collections::HashSet::new();
-    for project in enumerate_projects(home) {
+    // #2760 R1: enumeration failure → None → skip pruning (conservative, matches
+    // this fn's None-on-uncertainty fail-safe; never false-prune a live entry).
+    for project in enumerate_projects(home).ok()? {
         let board = board_root(home, &project);
         let state = crate::task_events::replay_at(&board).ok()?;
         if state.tasks.is_empty() {
@@ -380,126 +382,155 @@ pub(crate) fn resolve_target_project(home: &Path, target: &str) -> String {
 /// unlike `list_all_boards`, which applies list-time dep derivation and would
 /// silently relabel an InProgress task's persisted status to `Blocked` before
 /// the detective ever sees it.
-pub(super) fn enumerate_projects(home: &Path) -> Vec<String> {
+///
+/// #2760 R1: FALLIBLE. A MISSING `boards/` dir is legacy/single-project →
+/// `Ok([DEFAULT])`. But a `boards/` dir that EXISTS yet cannot be fully
+/// enumerated — a `read_dir` I/O error, an unreadable directory entry, an entry
+/// whose file-type can't be stat'd, or a non-UTF-8 (thus un-sluggable) board name
+/// — makes the project-board set UNPROVABLE → `TaskRouteError::Unreadable`. This
+/// closes the fail-OPEN hole where a swallowed enumeration error would let a task
+/// living on a project board mis-resolve to `NotFound`/default. Entry errors are
+/// NEVER flattened away.
+pub(super) fn enumerate_projects(home: &Path) -> Result<Vec<String>, TaskRouteError> {
     let mut out = vec![DEFAULT_PROJECT.to_string()];
-    if let Ok(entries) = std::fs::read_dir(home.join("boards")) {
-        for e in entries.flatten() {
-            if e.path().is_dir() {
-                if let Some(name) = e.file_name().to_str() {
-                    out.push(name.to_string());
-                }
+    let boards = home.join("boards");
+    let unreadable = |cause: String| TaskRouteError::Unreadable {
+        path: boards.clone(),
+        cause,
+    };
+    let entries = match std::fs::read_dir(&boards) {
+        Ok(entries) => entries,
+        // No boards/ dir → single-project/legacy → default board only.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(out),
+        Err(e) => return Err(unreadable(format!("boards dir read_dir failed: {e}"))),
+    };
+    for entry in entries {
+        let entry = entry.map_err(|e| unreadable(format!("boards dir entry unreadable: {e}")))?;
+        let file_type = entry
+            .file_type()
+            .map_err(|e| unreadable(format!("boards dir entry file_type unreadable: {e}")))?;
+        if !file_type.is_dir() {
+            continue;
+        }
+        match entry.file_name().to_str() {
+            Some(name) => out.push(name.to_string()),
+            // A board dir whose name is not UTF-8 can't be slugged/enumerated, yet
+            // it EXISTS — it might hold the id, so uniqueness is unprovable.
+            None => {
+                return Err(unreadable(
+                    "boards dir contains a non-UTF-8 board name".to_string(),
+                ))
             }
         }
     }
-    out
+    Ok(out)
 }
 
 // ── board handles + cross-board listing ────────────────────────────
 
 // ── #2760 strict routed authority ──────────────────────────────────
 
-/// Result of reading the append-only `task_index.jsonl` for one task id.
-enum IndexLookup {
-    /// The index file exists but a hard I/O error prevented reading it, so the
-    /// route cannot be proven → [`route_task`] fails closed as `Unreadable`. A
-    /// *missing* file is deliberately NOT this variant: it is a legacy/pre-index
-    /// task → `Projects(vec![])` → the full-board scan proves the route instead.
+/// The `task_index.jsonl` signal for one id: the distinct project ids recorded for
+/// it, plus whether any non-empty line was CORRUPT (unparseable). The index is a
+/// CACHE — [`route_task`] proves uniqueness by a physical board scan, NOT by
+/// trusting this — but a corrupt line that could be a hidden entry for the target
+/// is surfaced (never silently skipped) so an *absent* physical scan fails closed
+/// rather than falsely reporting `NotFound`.
+enum IndexSignal {
+    /// The index file exists but a hard I/O error prevented reading it → the route
+    /// cannot be proven → `Unreadable`. A *missing* file is legacy/pre-index, NOT
+    /// this variant.
     Io(String),
-    /// The distinct `project_id`s the index records for the id, in first-seen
-    /// order. Empty = no entry (→ legacy scan); more than one = conflicting
-    /// distinct entries (→ `Ambiguous`).
-    Projects(Vec<String>),
+    Read {
+        /// Distinct `project_id`s the index records for the target id (first-seen
+        /// order). More than one = conflicting entries.
+        projects: Vec<String>,
+        /// A non-empty index line failed to parse — it MIGHT be a hidden entry for
+        /// the target id, so it is not silently ignored where uniqueness depends on
+        /// it (the absent case).
+        corrupt: bool,
+    },
 }
 
-/// Every distinct `project_id` the index records for `task_id`. Torn/corrupt lines
-/// are skipped (the #1988 half-write tolerance [`lookup_task_project`] already
-/// has); a missing index is legacy (not an error); a hard read failure is `Io`.
-fn index_projects_for(home: &Path, task_id: &str) -> IndexLookup {
+/// Read the index signal for `task_id`. A missing index is legacy → `Read{[],false}`;
+/// a hard read failure is `Io`; a non-empty unparseable line sets `corrupt`.
+fn index_signal(home: &Path, task_id: &str) -> IndexSignal {
     let content = match std::fs::read_to_string(index_path(home)) {
         Ok(c) => c,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            return IndexLookup::Projects(Vec::new());
+            return IndexSignal::Read {
+                projects: Vec::new(),
+                corrupt: false,
+            };
         }
-        Err(e) => return IndexLookup::Io(e.to_string()),
+        Err(e) => return IndexSignal::Io(e.to_string()),
     };
     let mut projects: Vec<String> = Vec::new();
+    let mut corrupt = false;
     for line in content.lines() {
-        if let Ok(entry) = serde_json::from_str::<IndexEntry>(line) {
-            if entry.task_id == task_id && !projects.contains(&entry.project_id) {
-                projects.push(entry.project_id);
+        if line.trim().is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<IndexEntry>(line) {
+            Ok(entry) => {
+                if entry.task_id == task_id && !projects.contains(&entry.project_id) {
+                    projects.push(entry.project_id);
+                }
             }
+            // A non-empty line that won't parse — could be a torn/half-written entry
+            // for ANY id (possibly the target). Recorded, not silently dropped.
+            Err(_) => corrupt = true,
         }
     }
-    IndexLookup::Projects(projects)
+    IndexSignal::Read { projects, corrupt }
 }
 
-/// #2760 STRICT resolution: the ONE board that authoritatively holds `task_id`
-/// plus its replay-derived record, or a fail-closed [`TaskRouteError`] that NEVER
-/// means "assume the default board". The strict replacement for the lenient
-/// [`resolve_task_project`]/[`board_for_task`] pair on every per-id authority path.
+/// #2760 STRICT resolution: the ONE board that authoritatively holds `task_id` plus
+/// its replay-derived record, or a fail-closed [`TaskRouteError`] that NEVER means
+/// "assume the default board". The strict replacement for the lenient
+/// `resolve_task_project`/`board_for_task` pair on every per-id authority path.
 ///
-/// - **Indexed route:** a single indexed project is REPLAY-VERIFIED on its board —
-///   present → `Ok`; that board's replay errors → `Unreadable`; indexed-but-absent
-///   → `Unreadable` (a hard index/board inconsistency, NEVER NotFound/default).
-///   Conflicting distinct index entries → `Ambiguous`. A hard index read error →
-///   `Unreadable`.
-/// - **Legacy (no index entry / missing index):** a checked scan of the default
-///   board + every project board. ANY board whose replay errors → `Unreadable`
-///   (a uniqueness proof is impossible), even if a hit was already seen. Exactly
-///   one hit → `Ok` (and the index is repaired, absent-guarded); zero → `NotFound`;
-///   more than one → `Ambiguous`.
+/// **Uniqueness is proven by a PHYSICAL scan, not by trusting the index cache**
+/// (#2760 R1 — the old indexed short-circuit returned after checking one board and
+/// missed an unindexed duplicate left by a create whose index-write failed):
+/// - hard index read error → `Unreadable`; conflicting distinct index entries →
+///   `Ambiguous` (a cache-integrity red flag, surfaced before the scan).
+/// - a checked scan of the default board + EVERY project board (any enumeration or
+///   replay error → `Unreadable`, even after a hit — the id might ALSO live on the
+///   unreadable board): >1 physical board → `Ambiguous`; exactly one → `Ok` (index
+///   repaired, absent-guarded) UNLESS a lone index entry names a DIFFERENT board
+///   than the id physically occupies → `Unreadable`; zero physical boards →
+///   `NotFound`, UNLESS the index claims the id exists (or a corrupt line might) →
+///   `Unreadable` (indexed-but-absent is NEVER NotFound/default).
 pub(super) fn route_task(
     home: &Path,
     task_id: &str,
 ) -> Result<(String, PathBuf, crate::task_events::TaskRecord), TaskRouteError> {
     let tid = TaskId(task_id.to_string());
 
-    // ── indexed route ──
-    match index_projects_for(home, task_id) {
-        IndexLookup::Io(cause) => {
+    // ── index cache: hard-read + conflict signals (NOT the uniqueness authority) ──
+    let (indexed_projects, index_corrupt) = match index_signal(home, task_id) {
+        IndexSignal::Io(cause) => {
             return Err(TaskRouteError::Unreadable {
                 path: index_path(home),
                 cause,
             });
         }
-        IndexLookup::Projects(mut projects) => {
-            if projects.len() > 1 {
-                return Err(TaskRouteError::Ambiguous {
-                    candidates: projects,
-                    cause: "conflicting distinct task_index entries".to_string(),
-                });
-            }
-            // 0 or 1 element after the guard above → `pop` yields the single
-            // indexed project or `None` (fall through to the legacy scan).
-            if let Some(project) = projects.pop() {
-                let board = board_root(home, &project);
-                let state = crate::task_events::replay_at(&board).map_err(|e| {
-                    TaskRouteError::Unreadable {
-                        path: board.clone(),
-                        cause: e.to_string(),
-                    }
-                })?;
-                return match state.tasks.get(&tid) {
-                    Some(record) => Ok((project, board, record.clone())),
-                    None => Err(TaskRouteError::Unreadable {
-                        path: board,
-                        cause: format!(
-                            "task_index routes '{task_id}' to project '{project}' but that \
-                             board does not hold it"
-                        ),
-                    }),
-                };
-            }
-        }
+        IndexSignal::Read { projects, corrupt } => (projects, corrupt),
+    };
+    if indexed_projects.len() > 1 {
+        return Err(TaskRouteError::Ambiguous {
+            candidates: indexed_projects,
+            cause: "conflicting distinct task_index entries".to_string(),
+        });
     }
 
-    // ── legacy checked scan (no index entry) ──
+    // ── authoritative physical scan of default + EVERY project board ──
+    // Enumeration failure (unreadable boards/ dir) → Unreadable; a board that cannot
+    // be replayed → Unreadable even after a hit (the id might ALSO live there).
     let mut hits: Vec<(String, PathBuf, crate::task_events::TaskRecord)> = Vec::new();
-    for project in enumerate_projects(home) {
+    for project in enumerate_projects(home)? {
         let board = board_root(home, &project);
-        // A board that cannot be replayed makes uniqueness unprovable — fail
-        // closed immediately (even if a hit was already collected: the id might
-        // ALSO live on this unreadable board).
         let state =
             crate::task_events::replay_at(&board).map_err(|e| TaskRouteError::Unreadable {
                 path: board.clone(),
@@ -512,24 +543,58 @@ pub(super) fn route_task(
     if hits.len() > 1 {
         return Err(TaskRouteError::Ambiguous {
             candidates: hits.into_iter().map(|(p, _, _)| p).collect(),
-            cause: "task id present on multiple boards".to_string(),
+            cause: "task id physically present on multiple boards".to_string(),
         });
     }
     match hits.pop() {
         Some((project, board, record)) => {
-            // Repair the index so the next resolve is O(1) + indexed. Absent-guarded
-            // so a concurrent repair cannot append a duplicate (#2168 Phase-2a).
+            // Index/physical consistency: a lone index entry naming a DIFFERENT
+            // board than the id physically occupies is a hard inconsistency — fail
+            // closed rather than trust either side.
+            if let Some(indexed) = indexed_projects.first() {
+                if *indexed != project {
+                    return Err(TaskRouteError::Unreadable {
+                        path: board,
+                        cause: format!(
+                            "task_index routes '{task_id}' to project '{indexed}' but the id \
+                             physically resides on '{project}'"
+                        ),
+                    });
+                }
+            }
+            // Repair the index (absent-guarded) so the next resolve is indexed.
             let _ = record_task_project_if_absent(home, task_id, &project);
             Ok((project, board, record))
         }
-        None => Err(TaskRouteError::NotFound),
+        None => {
+            // Zero physical boards hold the id. If the index CLAIMS it exists (a
+            // parseable entry) OR a corrupt line MIGHT be a hidden entry for it, the
+            // absence is unprovable → Unreadable (indexed-but-absent is NEVER
+            // NotFound/default). Only a clean, entry-free, corruption-free index
+            // yields a definitive NotFound.
+            if !indexed_projects.is_empty() || index_corrupt {
+                Err(TaskRouteError::Unreadable {
+                    path: index_path(home),
+                    cause: format!(
+                        "task_index claims '{task_id}' exists (or a corrupt line may) but no \
+                         board holds it"
+                    ),
+                })
+            } else {
+                Err(TaskRouteError::NotFound)
+            }
+        }
     }
 }
 
 /// All tasks across every board, tagged with their project id — for the
 /// `list project=all` / `scope=fleet` aggregate view.
 pub(crate) fn list_all_boards(home: &Path) -> Vec<(String, Vec<Task>)> {
+    // #2760 R1: the aggregate `list project=all` view is OUTSIDE the strict-route
+    // authority scope; on an unreadable boards/ dir it degrades to the default
+    // board rather than failing (a display path, not a per-id authority decision).
     enumerate_projects(home)
+        .unwrap_or_else(|_| vec![DEFAULT_PROJECT.to_string()])
         .into_iter()
         .map(|project| {
             let tasks = super::list_all_at(home, &board_root(home, &project));
@@ -550,7 +615,8 @@ pub(crate) fn list_all_boards(home: &Path) -> Vec<(String, Vec<Task>)> {
 /// single-project replay error is unchanged).
 pub(super) fn replay_all_boards(home: &Path) -> anyhow::Result<crate::task_events::TaskBoardState> {
     let mut merged = crate::task_events::TaskBoardState::default();
-    for project in enumerate_projects(home) {
+    // #2760 R1: enumeration failure fails closed (like the per-board replay below).
+    for project in enumerate_projects(home).map_err(|e| anyhow::anyhow!("enumerate boards: {e}"))? {
         let state = crate::task_events::replay_at(&board_root(home, &project))?;
         merged.tasks.extend(state.tasks);
     }

--- a/src/tasks/board_router.rs
+++ b/src/tasks/board_router.rs
@@ -430,59 +430,150 @@ pub(super) fn enumerate_projects(home: &Path) -> Result<Vec<String>, TaskRouteEr
 
 // ── #2760 strict routed authority ──────────────────────────────────
 
-/// The `task_index.jsonl` signal for one id: the distinct project ids recorded for
-/// it, plus whether any non-empty line was CORRUPT (unparseable). The index is a
-/// CACHE — [`route_task`] proves uniqueness by a physical board scan, NOT by
-/// trusting this — but a corrupt line that could be a hidden entry for the target
-/// is surfaced (never silently skipped) so an *absent* physical scan fails closed
-/// rather than falsely reporting `NotFound`.
-enum IndexSignal {
-    /// The index file exists but a hard I/O error prevented reading it → the route
-    /// cannot be proven → `Unreadable`. A *missing* file is legacy/pre-index, NOT
-    /// this variant.
-    Io(String),
-    Read {
-        /// Distinct `project_id`s the index records for the target id (first-seen
-        /// order). More than one = conflicting entries.
-        projects: Vec<String>,
-        /// A non-empty index line failed to parse — it MIGHT be a hidden entry for
-        /// the target id, so it is not silently ignored where uniqueness depends on
-        /// it (the absent case).
-        corrupt: bool,
-    },
+/// #2760 item 1: outcome of one strict `task_index` scan pass (no repair).
+/// `Fragment` = the file ended in an unterminated, unparseable torn tail — the ONE
+/// repairable case.
+enum IndexScan {
+    /// The DISTINCT project ids the index records for the target id (0, or >1 =
+    /// conflicting), first-seen order.
+    Projects(Vec<String>),
+    Fragment,
 }
 
-/// Read the index signal for `task_id`. A missing index is legacy → `Read{[],false}`;
-/// a hard read failure is `Io`; a non-empty unparseable line sets `corrupt`.
-fn index_signal(home: &Path, task_id: &str) -> IndexSignal {
-    let content = match std::fs::read_to_string(index_path(home)) {
-        Ok(c) => c,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            return IndexSignal::Read {
-                projects: Vec::new(),
-                corrupt: false,
-            };
+/// #2760 item 1: STRICT `task_index` read for the router. Unlike the advisory read
+/// it replaced (which flagged a corrupt line and pressed on), a COMPLETE
+/// (newline-terminated) malformed record is a hard [`TaskRouteError::Unreadable`]:
+/// it could be a hidden CONFLICTING entry for the target id, so tolerating it would
+/// let an `Ambiguous` route slip through as unique. ONLY a final unterminated EOF
+/// fragment is tolerable — repaired ONCE under the SAME `task_index.jsonl.lock`,
+/// then re-read (a fragment that survives one repair is hard corruption; bounded,
+/// never a repair loop). The index is still a CACHE — [`route_task`] proves
+/// uniqueness by the physical board scan — but its integrity must be provable.
+fn index_projects_strict(home: &Path, task_id: &str) -> Result<Vec<String>, TaskRouteError> {
+    match index_scan_once(home, task_id)? {
+        IndexScan::Projects(p) => Ok(p),
+        IndexScan::Fragment => {
+            repair_index_trailing_fragment(home)?;
+            match index_scan_once(home, task_id)? {
+                IndexScan::Projects(p) => Ok(p),
+                IndexScan::Fragment => Err(TaskRouteError::Unreadable {
+                    path: index_path(home),
+                    cause: "task_index trailing fragment persisted after one repair".to_string(),
+                }),
+            }
         }
-        Err(e) => return IndexSignal::Io(e.to_string()),
+    }
+}
+
+/// One strict scan of `task_index.jsonl` (no repair). A missing index is legacy →
+/// `Projects([])`; a hard read failure or any complete-malformed record →
+/// `Unreadable`; a trailing unparseable fragment → `Fragment`.
+fn index_scan_once(home: &Path, task_id: &str) -> Result<IndexScan, TaskRouteError> {
+    let path = index_path(home);
+    let unreadable = |cause: String| TaskRouteError::Unreadable {
+        path: path.clone(),
+        cause,
     };
-    let mut projects: Vec<String> = Vec::new();
-    let mut corrupt = false;
-    for line in content.lines() {
-        if line.trim().is_empty() {
-            continue;
+    let content = match std::fs::read_to_string(&path) {
+        Ok(c) => c,
+        // A MISSING index is legacy/pre-index — not an error (the physical scan is
+        // the authority); an existing-but-unreadable index fails closed.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(IndexScan::Projects(Vec::new()))
         }
-        match serde_json::from_str::<IndexEntry>(line) {
+        Err(e) => return Err(unreadable(format!("task_index read failed: {e}"))),
+    };
+    let (complete, fragment) = crate::task_events::split_complete_and_fragment(&content);
+    let mut projects: Vec<String> = Vec::new();
+    for line in complete {
+        let entry = serde_json::from_str::<IndexEntry>(line).map_err(|e| {
+            unreadable(format!(
+                "complete-malformed task_index record (could hide a conflicting entry): {e}"
+            ))
+        })?;
+        if entry.task_id == task_id && !projects.contains(&entry.project_id) {
+            projects.push(entry.project_id);
+        }
+    }
+    if let Some(frag) = fragment {
+        match serde_json::from_str::<IndexEntry>(frag) {
+            // A whole entry missing only its newline — apply it.
             Ok(entry) => {
                 if entry.task_id == task_id && !projects.contains(&entry.project_id) {
                     projects.push(entry.project_id);
                 }
             }
-            // A non-empty line that won't parse — could be a torn/half-written entry
-            // for ANY id (possibly the target). Recorded, not silently dropped.
-            Err(_) => corrupt = true,
+            // A torn tail → repairable.
+            Err(_) => return Ok(IndexScan::Fragment),
         }
     }
-    IndexSignal::Read { projects, corrupt }
+    Ok(IndexScan::Projects(projects))
+}
+
+/// Repair a `task_index.jsonl` torn tail: under the SAME `task_index.jsonl.lock`
+/// [`record_task_project`] holds, re-read, and — only if the file STILL ends in an
+/// unterminated, unparseable fragment — quarantine it and truncate to the last
+/// newline (fsync + durable parent). Mirrors the task_events EOF repair.
+fn repair_index_trailing_fragment(home: &Path) -> Result<(), TaskRouteError> {
+    let path = index_path(home);
+    let unreadable = |cause: String| TaskRouteError::Unreadable {
+        path: path.clone(),
+        cause,
+    };
+    let lock_path = path.with_extension("jsonl.lock");
+    let _lock = crate::store::acquire_file_lock(&lock_path)
+        .map_err(|e| unreadable(format!("acquire task_index lock for EOF repair: {e}")))?;
+    let content = match std::fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(unreadable(format!("re-read task_index under lock: {e}"))),
+    };
+    if content.is_empty() || content.ends_with('\n') {
+        return Ok(());
+    }
+    let cut = content.rfind('\n').map(|i| i + 1).unwrap_or(0);
+    let fragment = &content[cut..];
+    if fragment.trim().is_empty() {
+        return Ok(());
+    }
+    // A valid entry missing only its newline — keep it.
+    if serde_json::from_str::<IndexEntry>(fragment).is_ok() {
+        return Ok(());
+    }
+    quarantine_index_torn_tail(home, fragment);
+    let f = std::fs::OpenOptions::new()
+        .write(true)
+        .open(&path)
+        .map_err(|e| unreadable(format!("open task_index for truncate: {e}")))?;
+    f.set_len(cut as u64)
+        .map_err(|e| unreadable(format!("truncate task_index torn tail: {e}")))?;
+    f.sync_all()
+        .map_err(|e| unreadable(format!("fsync task_index after truncate: {e}")))?;
+    crate::store::fsync_parent_dir(&path);
+    tracing::warn!(
+        tag = "#2760-index-eof-fragment-repaired",
+        home = %home.display(),
+        bytes = fragment.len(),
+        "router repaired a task_index torn tail (truncated to last newline; quarantined)"
+    );
+    Ok(())
+}
+
+/// Quarantine a `task_index` torn tail under `task_index.recovery/<ts>/` before it
+/// is truncated out of the index.
+fn quarantine_index_torn_tail(home: &Path, fragment: &str) {
+    use std::io::Write;
+    let ts = chrono::Utc::now().format("%Y%m%dT%H%M%SZ").to_string();
+    let dir = home.join("task_index.recovery").join(&ts);
+    let _ = std::fs::create_dir_all(&dir);
+    if let Ok(mut rf) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(dir.join("task_index.jsonl"))
+    {
+        let _ = writeln!(rf, "{fragment}");
+        let _ = rf.sync_all();
+    }
 }
 
 /// #2760 STRICT resolution: the ONE board that authoritatively holds `task_id` plus
@@ -509,15 +600,10 @@ pub(super) fn route_task(
     let tid = TaskId(task_id.to_string());
 
     // ── index cache: hard-read + conflict signals (NOT the uniqueness authority) ──
-    let (indexed_projects, index_corrupt) = match index_signal(home, task_id) {
-        IndexSignal::Io(cause) => {
-            return Err(TaskRouteError::Unreadable {
-                path: index_path(home),
-                cause,
-            });
-        }
-        IndexSignal::Read { projects, corrupt } => (projects, corrupt),
-    };
+    // #2760 item 1: STRICT read — a hard I/O error or any complete-malformed record
+    // is `Unreadable`, not an advisory flag (a corrupt line could hide a conflicting
+    // entry for the target id). Only a final EOF fragment is repaired-and-retried.
+    let indexed_projects = index_projects_strict(home, task_id)?;
     if indexed_projects.len() > 1 {
         return Err(TaskRouteError::Ambiguous {
             candidates: indexed_projects,
@@ -526,16 +612,21 @@ pub(super) fn route_task(
     }
 
     // ── authoritative physical scan of default + EVERY project board ──
-    // Enumeration failure (unreadable boards/ dir) → Unreadable; a board that cannot
-    // be replayed → Unreadable even after a hit (the id might ALSO live there).
+    // #2760 item 1: the STRICT router-only replay proves each board's history is
+    // complete — a complete-malformed task-event record is `Unreadable` (never
+    // silently skipped, unlike the fleet-wide `replay_at`), tolerating only a final
+    // EOF fragment (repaired under the writer lock). Enumeration failure (unreadable
+    // boards/ dir) → Unreadable; a board that cannot be replayed → Unreadable even
+    // after a hit (the id might ALSO live there).
     let mut hits: Vec<(String, PathBuf, crate::task_events::TaskRecord)> = Vec::new();
     for project in enumerate_projects(home)? {
         let board = board_root(home, &project);
-        let state =
-            crate::task_events::replay_at(&board).map_err(|e| TaskRouteError::Unreadable {
-                path: board.clone(),
-                cause: e.to_string(),
-            })?;
+        let state = crate::task_events::replay_strict_at(&board).map_err(|e| {
+            TaskRouteError::Unreadable {
+                path: e.path,
+                cause: e.cause,
+            }
+        })?;
         if let Some(record) = state.tasks.get(&tid) {
             hits.push((project, board, record.clone()));
         }
@@ -568,17 +659,15 @@ pub(super) fn route_task(
         }
         None => {
             // Zero physical boards hold the id. If the index CLAIMS it exists (a
-            // parseable entry) OR a corrupt line MIGHT be a hidden entry for it, the
-            // absence is unprovable → Unreadable (indexed-but-absent is NEVER
-            // NotFound/default). Only a clean, entry-free, corruption-free index
-            // yields a definitive NotFound.
-            if !indexed_projects.is_empty() || index_corrupt {
+            // parseable entry), the absence is unprovable → Unreadable
+            // (indexed-but-absent is NEVER NotFound/default). A complete-malformed
+            // index line already failed closed as Unreadable in
+            // `index_projects_strict`, so only a clean, entry-free index reaches the
+            // definitive NotFound here.
+            if !indexed_projects.is_empty() {
                 Err(TaskRouteError::Unreadable {
                     path: index_path(home),
-                    cause: format!(
-                        "task_index claims '{task_id}' exists (or a corrupt line may) but no \
-                         board holds it"
-                    ),
+                    cause: format!("task_index claims '{task_id}' exists but no board holds it"),
                 })
             } else {
                 Err(TaskRouteError::NotFound)

--- a/src/tasks/board_router.rs
+++ b/src/tasks/board_router.rs
@@ -23,7 +23,7 @@
 use crate::task_events::{board_root, project_slug, TaskId, DEFAULT_PROJECT};
 use std::path::{Path, PathBuf};
 
-use super::Task;
+use super::{Task, TaskRouteError};
 
 // ── task_index (home/task_index.jsonl) ─────────────────────────────
 
@@ -270,6 +270,10 @@ fn index_contains(index_path: &Path, task_id: &str) -> bool {
     })
 }
 
+/// #2760: index first-match lookup. Production resolution now goes through
+/// [`route_task`]'s `index_projects_for` (which also surfaces conflicting entries);
+/// this remains only as a verification helper for the compaction tests below.
+#[cfg(test)]
 fn lookup_task_project(home: &Path, task_id: &str) -> Option<String> {
     let content = std::fs::read_to_string(index_path(home)).ok()?;
     content.lines().find_map(|line| {
@@ -363,30 +367,9 @@ pub(crate) fn resolve_target_project(home: &Path, target: &str) -> String {
     resolve_current_project(home, target)
 }
 
-/// The project a task lives in: the `task_index` entry, else a full-board scan
-/// that repairs the index on a hit, else [`DEFAULT_PROJECT`] (the `home` board)
-/// when the task is unknown — which keeps a missing/legacy task resolving to the
-/// historical board.
-pub(crate) fn resolve_task_project(home: &Path, task_id: &str) -> String {
-    if let Some(p) = lookup_task_project(home, task_id) {
-        return p;
-    }
-    let tid = TaskId(task_id.to_string());
-    for project in enumerate_projects(home) {
-        let found = crate::task_events::replay_at(&board_root(home, &project))
-            .map(|state| state.tasks.contains_key(&tid))
-            .unwrap_or(false);
-        if found {
-            // Repair the index so the next lookup is O(1). #2168 Phase-2a: use
-            // the absent-guarded variant so a concurrent repair (or a repair
-            // after a transient index loss) cannot append a duplicate entry —
-            // the existence check is atomic under the index lock.
-            let _ = record_task_project_if_absent(home, task_id, &project);
-            return project;
-        }
-    }
-    DEFAULT_PROJECT.to_string()
-}
+// #2760: the lenient `resolve_task_project` (index → scan → DEFAULT fallback) is
+// GONE — every per-id authority path now routes through [`route_task`], which
+// fails closed (NotFound / Unreadable / Ambiguous) instead of silently defaulting.
 
 /// Every project with an on-disk board: the default (fleet) project plus each
 /// `home/boards/<project_id>` subdir (the dir name IS the project id).
@@ -413,9 +396,134 @@ pub(super) fn enumerate_projects(home: &Path) -> Vec<String> {
 
 // ── board handles + cross-board listing ────────────────────────────
 
-/// Board root for an existing task (via [`resolve_task_project`]).
-pub(crate) fn board_for_task(home: &Path, task_id: &str) -> PathBuf {
-    board_root(home, &resolve_task_project(home, task_id))
+// ── #2760 strict routed authority ──────────────────────────────────
+
+/// Result of reading the append-only `task_index.jsonl` for one task id.
+enum IndexLookup {
+    /// The index file exists but a hard I/O error prevented reading it, so the
+    /// route cannot be proven → [`route_task`] fails closed as `Unreadable`. A
+    /// *missing* file is deliberately NOT this variant: it is a legacy/pre-index
+    /// task → `Projects(vec![])` → the full-board scan proves the route instead.
+    Io(String),
+    /// The distinct `project_id`s the index records for the id, in first-seen
+    /// order. Empty = no entry (→ legacy scan); more than one = conflicting
+    /// distinct entries (→ `Ambiguous`).
+    Projects(Vec<String>),
+}
+
+/// Every distinct `project_id` the index records for `task_id`. Torn/corrupt lines
+/// are skipped (the #1988 half-write tolerance [`lookup_task_project`] already
+/// has); a missing index is legacy (not an error); a hard read failure is `Io`.
+fn index_projects_for(home: &Path, task_id: &str) -> IndexLookup {
+    let content = match std::fs::read_to_string(index_path(home)) {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return IndexLookup::Projects(Vec::new());
+        }
+        Err(e) => return IndexLookup::Io(e.to_string()),
+    };
+    let mut projects: Vec<String> = Vec::new();
+    for line in content.lines() {
+        if let Ok(entry) = serde_json::from_str::<IndexEntry>(line) {
+            if entry.task_id == task_id && !projects.contains(&entry.project_id) {
+                projects.push(entry.project_id);
+            }
+        }
+    }
+    IndexLookup::Projects(projects)
+}
+
+/// #2760 STRICT resolution: the ONE board that authoritatively holds `task_id`
+/// plus its replay-derived record, or a fail-closed [`TaskRouteError`] that NEVER
+/// means "assume the default board". The strict replacement for the lenient
+/// [`resolve_task_project`]/[`board_for_task`] pair on every per-id authority path.
+///
+/// - **Indexed route:** a single indexed project is REPLAY-VERIFIED on its board —
+///   present → `Ok`; that board's replay errors → `Unreadable`; indexed-but-absent
+///   → `Unreadable` (a hard index/board inconsistency, NEVER NotFound/default).
+///   Conflicting distinct index entries → `Ambiguous`. A hard index read error →
+///   `Unreadable`.
+/// - **Legacy (no index entry / missing index):** a checked scan of the default
+///   board + every project board. ANY board whose replay errors → `Unreadable`
+///   (a uniqueness proof is impossible), even if a hit was already seen. Exactly
+///   one hit → `Ok` (and the index is repaired, absent-guarded); zero → `NotFound`;
+///   more than one → `Ambiguous`.
+pub(super) fn route_task(
+    home: &Path,
+    task_id: &str,
+) -> Result<(String, PathBuf, crate::task_events::TaskRecord), TaskRouteError> {
+    let tid = TaskId(task_id.to_string());
+
+    // ── indexed route ──
+    match index_projects_for(home, task_id) {
+        IndexLookup::Io(cause) => {
+            return Err(TaskRouteError::Unreadable {
+                path: index_path(home),
+                cause,
+            });
+        }
+        IndexLookup::Projects(mut projects) => {
+            if projects.len() > 1 {
+                return Err(TaskRouteError::Ambiguous {
+                    candidates: projects,
+                    cause: "conflicting distinct task_index entries".to_string(),
+                });
+            }
+            // 0 or 1 element after the guard above → `pop` yields the single
+            // indexed project or `None` (fall through to the legacy scan).
+            if let Some(project) = projects.pop() {
+                let board = board_root(home, &project);
+                let state = crate::task_events::replay_at(&board).map_err(|e| {
+                    TaskRouteError::Unreadable {
+                        path: board.clone(),
+                        cause: e.to_string(),
+                    }
+                })?;
+                return match state.tasks.get(&tid) {
+                    Some(record) => Ok((project, board, record.clone())),
+                    None => Err(TaskRouteError::Unreadable {
+                        path: board,
+                        cause: format!(
+                            "task_index routes '{task_id}' to project '{project}' but that \
+                             board does not hold it"
+                        ),
+                    }),
+                };
+            }
+        }
+    }
+
+    // ── legacy checked scan (no index entry) ──
+    let mut hits: Vec<(String, PathBuf, crate::task_events::TaskRecord)> = Vec::new();
+    for project in enumerate_projects(home) {
+        let board = board_root(home, &project);
+        // A board that cannot be replayed makes uniqueness unprovable — fail
+        // closed immediately (even if a hit was already collected: the id might
+        // ALSO live on this unreadable board).
+        let state =
+            crate::task_events::replay_at(&board).map_err(|e| TaskRouteError::Unreadable {
+                path: board.clone(),
+                cause: e.to_string(),
+            })?;
+        if let Some(record) = state.tasks.get(&tid) {
+            hits.push((project, board, record.clone()));
+        }
+    }
+    if hits.len() > 1 {
+        return Err(TaskRouteError::Ambiguous {
+            candidates: hits.into_iter().map(|(p, _, _)| p).collect(),
+            cause: "task id present on multiple boards".to_string(),
+        });
+    }
+    match hits.pop() {
+        Some((project, board, record)) => {
+            // Repair the index so the next resolve is O(1) + indexed. Absent-guarded
+            // so a concurrent repair cannot append a duplicate (#2168 Phase-2a).
+            let _ = record_task_project_if_absent(home, task_id, &project);
+            Ok((project, board, record))
+        }
+        None => Err(TaskRouteError::NotFound),
+    }
 }
 
 /// All tasks across every board, tagged with their project id — for the
@@ -667,21 +775,21 @@ mod tests {
         std::fs::remove_dir_all(&home).ok();
     }
 
-    /// Phase-2a (integration): a `resolve_task_project` repair, then a re-resolve
-    /// after the index is lost, never accumulates duplicates — the repair routes
-    /// through the absent-guarded variant.
+    /// Phase-2a (integration), #2760: the strict `route_task` repairs the index on
+    /// a legacy-scan hit, and a re-resolve after the entry exists never accumulates
+    /// duplicates — the repair routes through the absent-guarded variant.
     #[test]
-    fn resolve_repair_is_idempotent_across_index_loss() {
+    fn route_task_repair_is_idempotent_across_index_loss() {
         let home = tmp_home("repair-idem");
         seed_live_task(&home, DEFAULT_PROJECT, "T-r");
-        assert_eq!(resolve_task_project(&home, "T-r"), DEFAULT_PROJECT);
+        assert_eq!(route_task(&home, "T-r").unwrap().0, DEFAULT_PROJECT);
         assert_eq!(
             index_lines(&home),
             1,
             "first resolve repairs the index once"
         );
         // Re-resolve with the entry already present must not append again.
-        assert_eq!(resolve_task_project(&home, "T-r"), DEFAULT_PROJECT);
+        assert_eq!(route_task(&home, "T-r").unwrap().0, DEFAULT_PROJECT);
         assert_eq!(
             index_lines(&home),
             1,

--- a/src/tasks/board_router.rs
+++ b/src/tasks/board_router.rs
@@ -675,7 +675,13 @@ pub(super) fn route_task(
             // board than the id physically occupies is a hard inconsistency — fail
             // closed rather than trust either side.
             if let Some(indexed) = indexed_projects.first() {
-                if *indexed != project {
+                // #2760: compare on the canonical SLUG. The physical `project` is a
+                // board dir name (already slugged); a legacy index entry may hold the
+                // RAW project id (`orgA/projA`) whose board dir is the slug
+                // (`orgA_projA`) — those are the SAME board, not an inconsistency.
+                // Slugging both sides (idempotent on an already-safe id) avoids a
+                // false Unreadable for every raw-index task on a slug-unsafe project.
+                if project_slug(indexed) != project {
                     return Err(TaskRouteError::Unreadable {
                         path: board,
                         cause: format!(

--- a/src/tasks/handler.rs
+++ b/src/tasks/handler.rs
@@ -853,19 +853,27 @@ fn handle_done(
     // so the post-lock read-back reads the right board.
     let append_result = routed.with_revalidated_board(home, |board| {
         crate::task_events::append_checked_at(board, &emitter, event, |state| {
-            let tv = state
+            let rec = state
                 .tasks
-                .values()
-                .map(record_to_task)
-                .find(|t| t.id == done_id)
+                .get(&crate::task_events::TaskId(done_id.clone()))
                 .ok_or_else(|| format!("task '{done_id}' not found"))?;
-            if !tv
+            // #2760 R2 (root in-lock-authorization point): re-check the owner-ACL
+            // against FRESH state (force bypasses, mirroring the out-of-lock gate) so
+            // a concurrent ownership change cannot slip a stale-authorized done past
+            // the route-only revalidation.
+            if !force && !can_mutate_record(home, &caller, rec) {
+                return Err(format!(
+                    "task '{done_id}' ownership changed since authorization; caller \
+                     '{caller}' no longer authorized (retry)"
+                ));
+            }
+            if !rec
                 .status
                 .can_transition_to(crate::task_events::TaskStatus::Done)
             {
                 return Err(format!(
                     "illegal transition: {} → done (task {done_id})",
-                    status_to_legacy_str(tv.status)
+                    status_to_legacy_str(rec.status)
                 ));
             }
             Ok(())

--- a/src/tasks/handler.rs
+++ b/src/tasks/handler.rs
@@ -853,27 +853,19 @@ fn handle_done(
     // so the post-lock read-back reads the right board.
     let append_result = routed.with_revalidated_board(home, |board| {
         crate::task_events::append_checked_at(board, &emitter, event, |state| {
-            let rec = state
+            let tv = state
                 .tasks
-                .get(&crate::task_events::TaskId(done_id.clone()))
+                .values()
+                .map(record_to_task)
+                .find(|t| t.id == done_id)
                 .ok_or_else(|| format!("task '{done_id}' not found"))?;
-            // #2760 R2 (root in-lock-authorization point): re-check the owner-ACL
-            // against FRESH state (force bypasses, mirroring the out-of-lock gate) so
-            // a concurrent ownership change cannot slip a stale-authorized done past
-            // the route-only revalidation.
-            if !force && !can_mutate_record(home, &caller, rec) {
-                return Err(format!(
-                    "task '{done_id}' ownership changed since authorization; caller \
-                     '{caller}' no longer authorized (retry)"
-                ));
-            }
-            if !rec
+            if !tv
                 .status
                 .can_transition_to(crate::task_events::TaskStatus::Done)
             {
                 return Err(format!(
                     "illegal transition: {} → done (task {done_id})",
-                    status_to_legacy_str(rec.status)
+                    status_to_legacy_str(tv.status)
                 ));
             }
             Ok(())

--- a/src/tasks/handler.rs
+++ b/src/tasks/handler.rs
@@ -1865,7 +1865,7 @@ fn handle_ack_plan(
             "code": "plan_not_set",
         });
     }
-    let mut acks: Vec<String> = record
+    let acks: Vec<String> = record
         .metadata
         .get("plan_acks")
         .and_then(|v| v.as_array())
@@ -1881,23 +1881,74 @@ fn handle_ack_plan(
             "id": id, "event": "ack_plan", "acked": acks.len(), "already_acked": true,
         });
     }
-    acks.push(instance_name.to_string());
-    let acked_count = acks.len();
-    let event = crate::task_events::TaskEvent::MetadataSet {
-        task_id: crate::task_events::TaskId(id.to_string()),
-        by: emitter.clone(),
-        key: "plan_acks".to_string(),
-        value: serde_json::json!(acks),
-    };
-    // #2760 items 2+3: append the ack under the per-id router lock with write-time
-    // route revalidation.
-    let revalidated = routed.with_revalidated_board(home, |board| {
-        crate::task_events::append_at(board, &emitter, event)
+    // #2760 R2 (root+independent REJECT of a542517b): the `acks` list read above is
+    // an OUT-OF-LOCK snapshot — used only for the fast idempotent already-acked
+    // response. The AUTHORITATIVE ack is built as a UNION from the FRESH under-lock
+    // `plan_acks` (`with_revalidated_computed`). A route-only revalidation
+    // (board/incarnation) cannot see CONTENT staleness, so two acks that both read
+    // the pre-lock list would last-write-wins and silently LOSE one. Building the
+    // union (and re-checking self-ack / plan-present) against the committed state no
+    // concurrent writer can change closes that lost-update TOCTOU.
+    let caller = instance_name.to_string();
+    let tid = crate::task_events::TaskId(id.to_string());
+    let ack_emitter = emitter.clone();
+    // Test seam: inject a concurrent ack in the out-of-lock window to prove the
+    // union preserves it (no-op in production).
+    #[cfg(test)]
+    super::fire_before_mutation_commit_hook_for_test();
+    let revalidated = routed.with_revalidated_computed(home, &emitter, move |fresh| {
+        let rec = fresh
+            .tasks
+            .get(&tid)
+            .ok_or_else(|| "task disappeared before ack".to_string())?;
+        // Re-validate the ack authorization against FRESH state.
+        if rec.owner.as_ref().map(|o| o.0.as_str()) == Some(caller.as_str()) {
+            return Err("the task's assignee cannot ack their own plan".to_string());
+        }
+        if !rec.metadata.contains_key("plan") {
+            return Err("task has no plan set".to_string());
+        }
+        let mut fresh_acks: Vec<String> = rec
+            .metadata
+            .get("plan_acks")
+            .and_then(|v| v.as_array())
+            .map(|a| {
+                a.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+        if fresh_acks.iter().any(|a| a == &caller) {
+            return Ok(Vec::new()); // already acked under the lock → idempotent no-op
+        }
+        fresh_acks.push(caller.clone());
+        Ok(vec![crate::task_events::TaskEvent::MetadataSet {
+            task_id: tid.clone(),
+            by: ack_emitter.clone(),
+            key: "plan_acks".to_string(),
+            value: serde_json::json!(fresh_acks),
+        }])
     });
     match revalidated {
-        Ok(Ok(_)) => serde_json::json!({
-            "id": id, "event": "ack_plan", "acked": acked_count, "already_acked": false,
-        }),
+        Ok(Ok(Ok(seqs))) => {
+            // Empty seqs ⇒ the compute returned a no-op (already acked under lock).
+            let already = seqs.is_empty();
+            let count = read_task_record_at(routed.board().path(), id)
+                .and_then(|r| {
+                    r.metadata
+                        .get("plan_acks")
+                        .and_then(|v| v.as_array())
+                        .map(|a| a.len())
+                })
+                .unwrap_or(0);
+            serde_json::json!({
+                "id": id, "event": "ack_plan", "acked": count, "already_acked": already,
+            })
+        }
+        // The compute refused under the lock (self-ack / plan removed / owner drift).
+        Ok(Ok(Err(reason))) => {
+            serde_json::json!({"error": reason, "code": "ack_precondition_failed"})
+        }
         Ok(Err(e)) => serde_json::json!({"error": format!("{e}")}),
         Err(route_err) => serde_json::json!({
             "error": format!("task '{id}' route revalidation failed: {route_err}"),

--- a/src/tasks/handler.rs
+++ b/src/tasks/handler.rs
@@ -1653,36 +1653,122 @@ fn handle_metadata_set(
     {
         return deny;
     }
-    // ── t-…-74 governance-key ACL (decision d-…-22, Root ruling m-1087) ──
-    // `plan`, `plan_ack_required`, and `plan_acks` gate the #2249 pre-work
-    // alignment chokepoint — they are NOT ordinary owner-writable metadata, so
-    // each gets per-key fail-closed validation BEFORE the generic owner-ACL.
-    // GOV_AUTHOR = EXACTLY created_by (+ system), never the assignee or the
-    // orchestrator (no transitive authority — otherwise the very agent the gate
-    // constrains could self-weaken it). Every other key falls through to
-    // `can_mutate_record` (I4), byte-identical to before.
-    let is_gov_author = super::acl::is_plan_governance_author(instance_name, &record);
-    let deny_counter = |detail: &str| {
-        serde_json::json!({
-            "error": format!("plan_ack_required is protected: {detail}"),
-            "code": "plan_ack_required_protected",
-        })
-    };
-    // Set when a GOV_AUTHOR plan content-change must also reset acks (I3).
-    let mut reset_acks = false;
-    match key {
-        // I1: plan_acks is system-managed. Only `handle_ack_plan` appends it (and
-        // the reopen-reset below emits its own []-event). A direct metadata_set is
-        // rejected for EVERY identity, GOV_AUTHOR and system included.
-        "plan_acks" => {
+    // #2760 R2 (root+independent REJECT of a542517b): evaluate the plan-governance /
+    // ACL policy for the IMMEDIATE response (coded denials / idempotent no-op). It is
+    // RE-evaluated UNDER the per-id + board locks on FRESH state below, and the events
+    // are BUILT there — so a concurrent owner / status / plan / ack change cannot slip
+    // a stale-authorized write past a route-only (board+incarnation) revalidation.
+    match metadata_write_outcome(home, instance_name, &record, key, &value) {
+        MetadataWriteOutcome::Denied(e) => return e,
+        MetadataWriteOutcome::Noop => {
+            let task = read_task_record_at(&board, id).map(|r| record_to_task(&r));
             return serde_json::json!({
-                "error": "plan_acks is system-managed; record acks via action=ack_plan, never metadata_set",
-                "code": "plan_acks_immutable",
+                "id": id, "event": "metadata_set", "task": task, "noop": true
             });
         }
-        // I2: accept ONLY a GOV_AUTHOR monotonic raise (numeric, ≥ current, after
-        // the assignee has claimed). Everything else — non-author, lower,
-        // non-numeric, pre-claim — fails closed. (Typed field promotion = t-…-79.)
+        MetadataWriteOutcome::Write { .. } => {}
+    }
+    let caller = instance_name.to_string();
+    let key_owned = key.to_string();
+    let value_owned = value.clone();
+    let tid = crate::task_events::TaskId(id.to_string());
+    let meta_emitter = emitter.clone();
+    // Test seam: inject a concurrent owner/plan/ack change in the out-of-lock window
+    // to prove the under-lock re-evaluation refuses / recomputes (no-op in prod).
+    #[cfg(test)]
+    super::fire_before_mutation_commit_hook_for_test();
+    let append_result = routed.with_revalidated_computed(home, &emitter, move |fresh| {
+        let rec = fresh
+            .tasks
+            .get(&tid)
+            .ok_or_else(|| "task disappeared before metadata_set".to_string())?;
+        match metadata_write_outcome(home, &caller, rec, &key_owned, &value_owned) {
+            MetadataWriteOutcome::Write { reset_acks } => {
+                let mut events = vec![crate::task_events::TaskEvent::MetadataSet {
+                    task_id: tid.clone(),
+                    by: meta_emitter.clone(),
+                    key: key_owned.clone(),
+                    value: value_owned.clone(),
+                }];
+                if reset_acks {
+                    // I6: emit the plan change + an audit-visible plan_acks=[] reset
+                    // as ONE atomic batch so replay re-derives the reopened gate.
+                    events.push(crate::task_events::TaskEvent::MetadataSet {
+                        task_id: tid.clone(),
+                        by: meta_emitter.clone(),
+                        key: "plan_acks".to_string(),
+                        value: serde_json::json!([]),
+                    });
+                }
+                Ok(events)
+            }
+            // Became idempotent under the lock (a concurrent write set the same
+            // value) → no-op success.
+            MetadataWriteOutcome::Noop => Ok(Vec::new()),
+            // Authorization no longer holds on fresh state (owner/status/ack drift) →
+            // refuse; the caller retries against the new state.
+            MetadataWriteOutcome::Denied(_) => {
+                Err("metadata authorization changed under the lock — retry".to_string())
+            }
+        }
+    });
+    match append_result {
+        Ok(Ok(Ok(_))) => {
+            let task = read_task_record_at(&board, id).map(|r| record_to_task(&r));
+            serde_json::json!({"id": id, "event": "metadata_set", "task": task})
+        }
+        Ok(Ok(Err(reason))) => {
+            serde_json::json!({"error": reason, "code": "metadata_precondition_failed"})
+        }
+        Ok(Err(e)) => serde_json::json!({"error": format!("{e}")}),
+        Err(route_err) => serde_json::json!({
+            "error": format!("task '{id}' route revalidation failed: {route_err}"),
+            "code": "task_route_unresolved",
+        }),
+    }
+}
+
+/// #2760 R2: the outcome of the plan-governance / ACL policy for a `metadata_set`.
+enum MetadataWriteOutcome {
+    /// Fail-closed denial carrying the FULL coded JSON error (preserves the `code`).
+    Denied(Value),
+    /// Idempotent same-value write (`plan`) — no event.
+    Noop,
+    /// Allowed; `reset_acks` = a GOV_AUTHOR plan content-change that must also reset
+    /// `plan_acks` (I3).
+    Write { reset_acks: bool },
+}
+
+/// #2760 R2: the PURE plan-governance / ACL decision for `metadata_set`. Evaluated
+/// BOTH out-of-lock (immediate coded response) and again UNDER the per-id + board
+/// locks against FRESH state (`handle_metadata_set`), so a concurrent owner / status
+/// / plan / ack change cannot slip a stale-authorized write past a route-only
+/// revalidation. See the per-key invariants (t-…-74, decision d-…-22, PR #2761 r1).
+fn metadata_write_outcome(
+    home: &Path,
+    caller: &str,
+    record: &crate::task_events::TaskRecord,
+    key: &str,
+    value: &Value,
+) -> MetadataWriteOutcome {
+    use crate::task_events::TaskStatus;
+    // GOV_AUTHOR = EXACTLY created_by (+ system), never assignee/orchestrator (no
+    // transitive authority — else the very agent the gate constrains self-weakens it).
+    let is_gov_author = super::acl::is_plan_governance_author(caller, record);
+    let deny_counter = |detail: &str| {
+        MetadataWriteOutcome::Denied(serde_json::json!({
+            "error": format!("plan_ack_required is protected: {detail}"),
+            "code": "plan_ack_required_protected",
+        }))
+    };
+    match key {
+        // I1: plan_acks is system-managed (only `ack_plan` / the reopen-reset write
+        // it) — a direct metadata_set is rejected for EVERY identity.
+        "plan_acks" => MetadataWriteOutcome::Denied(serde_json::json!({
+            "error": "plan_acks is system-managed; record acks via action=ack_plan, never metadata_set",
+            "code": "plan_acks_immutable",
+        })),
+        // I2: accept ONLY a GOV_AUTHOR monotonic raise (numeric, ≥ current, post-claim).
         "plan_ack_required" => {
             let proposed = match value.as_u64() {
                 Some(n) => n,
@@ -1691,13 +1777,7 @@ fn handle_metadata_set(
             if !is_gov_author {
                 return deny_counter("only the task creator (created_by) may raise it");
             }
-            // "after assignee claim" — an unclaimed task (backlog/open, incl. one
-            // released back to open) is not yet under an assignee, so a raise is
-            // premature and fails closed.
-            if matches!(
-                record.status,
-                crate::task_events::TaskStatus::Backlog | crate::task_events::TaskStatus::Open
-            ) {
+            if matches!(record.status, TaskStatus::Backlog | TaskStatus::Open) {
                 return deny_counter("may only be raised after the assignee has claimed the task");
             }
             let current = record
@@ -1710,38 +1790,22 @@ fn handle_metadata_set(
                     "may only be raised, never lowered ({current} → {proposed})"
                 ));
             }
+            MetadataWriteOutcome::Write { reset_acks: false }
         }
-        // I3: idempotency FIRST (a same-content write is a no-op for anyone —
-        // no reject, no event, no ack reset), then owner-pre-ack /
-        // GOV_AUTHOR-content-change(reopens acks) / else deny.
+        // I3: idempotency FIRST (same-content = no-op), then status-frozen, then
+        // owner-pre-ack / GOV_AUTHOR-content-change(reopens acks) / else deny.
         "plan" => {
-            if record.metadata.get("plan") == Some(&value) {
-                let task = read_task_record_at(&board, id).map(|r| record_to_task(&r));
-                return serde_json::json!({
-                    "id": id, "event": "metadata_set", "task": task, "noop": true
-                });
+            if record.metadata.get("plan") == Some(value) {
+                return MetadataWriteOutcome::Noop;
             }
-            // Fail-closed status policy (PR #2761 r1): a content-CHANGING plan
-            // write is permitted ONLY in the pre-work window {Backlog, Open,
-            // Claimed} — where no work is active because the →in_progress ack gate
-            // has not yet been passed. At in_progress and every later/terminal/
-            // blocked state the plan is FROZEN for EVERY identity, creator
-            // included. Reopening the gate would require an
-            // in_progress→claimed/open transition that this handler deliberately
-            // does NOT grant (I5: no creator status authority); silently resetting
-            // plan_acks WITHOUT a transition (the r0 defect) leaves work running
-            // under an unacked replacement plan. metadata_set never mutates status
-            // — the remedy for a wrong plan mid-work is cancel + recreate.
             if !matches!(
                 record.status,
-                crate::task_events::TaskStatus::Backlog
-                    | crate::task_events::TaskStatus::Open
-                    | crate::task_events::TaskStatus::Claimed
+                TaskStatus::Backlog | TaskStatus::Open | TaskStatus::Claimed
             ) {
-                return serde_json::json!({
+                return MetadataWriteOutcome::Denied(serde_json::json!({
                     "error": "the plan is frozen once work has started (in_progress or later); cancel + recreate the task to re-plan — it cannot be hot-swapped under running work",
                     "code": "plan_frozen_work_started",
-                });
+                }));
             }
             let acks_present = record
                 .metadata
@@ -1749,71 +1813,37 @@ fn handle_metadata_set(
                 .and_then(|v| v.as_array())
                 .map(|a| !a.is_empty())
                 .unwrap_or(false);
-            let is_owner = record.owner.as_ref().map(|o| o.0.as_str()) == Some(instance_name);
+            let is_owner = record.owner.as_ref().map(|o| o.0.as_str()) == Some(caller);
             if is_gov_author {
-                // Creator/system content-change reopens the gate: reset acks.
-                reset_acks = acks_present;
+                MetadataWriteOutcome::Write {
+                    reset_acks: acks_present,
+                }
             } else if is_owner {
-                // The assignee may author/revise the plan ONLY before the first
-                // ack; after that it is frozen (only the creator may change it).
                 if acks_present {
-                    return serde_json::json!({
+                    MetadataWriteOutcome::Denied(serde_json::json!({
                         "error": "the plan is frozen once a reviewer has acked it; only the task creator may change it (which re-opens acks)",
                         "code": "plan_frozen_after_ack",
-                    });
+                    }))
+                } else {
+                    MetadataWriteOutcome::Write { reset_acks: false }
                 }
             } else {
-                return serde_json::json!({
+                MetadataWriteOutcome::Denied(serde_json::json!({
                     "error": "permission denied: only the assignee (pre-ack) or the task creator may set the plan",
                     "code": "plan_write_denied",
-                });
+                }))
             }
         }
         // I4: every other key keeps the unchanged owner/orchestrator ACL.
         _ => {
-            if !can_mutate_record(home, instance_name, &record) {
-                return serde_json::json!({"error": "permission denied: caller is not owner/creator"});
+            if !can_mutate_record(home, caller, record) {
+                MetadataWriteOutcome::Denied(
+                    serde_json::json!({"error": "permission denied: caller is not owner/creator"}),
+                )
+            } else {
+                MetadataWriteOutcome::Write { reset_acks: false }
             }
         }
-    }
-
-    let set_event = crate::task_events::TaskEvent::MetadataSet {
-        task_id: crate::task_events::TaskId(id.to_string()),
-        by: emitter.clone(),
-        key: key.to_string(),
-        value,
-    };
-    // #2760 items 2+3: the metadata append (previously an UNCHECKED default-board
-    // write via the pre-#2760 seam, now board-resolved) runs under the per-id
-    // router lock with write-time route revalidation — no self-IPC cascade, so the
-    // whole append can sit inside the closure. Read-back uses the `board` local
-    // (unchanged since the fingerprint matched).
-    let append_result = routed.with_revalidated_board(home, |board| {
-        if reset_acks {
-            // I6: emit the plan change + an audit-visible plan_acks=[] reset as ONE
-            // atomic batch so replay re-derives the reopened gate deterministically.
-            let reset_event = crate::task_events::TaskEvent::MetadataSet {
-                task_id: crate::task_events::TaskId(id.to_string()),
-                by: emitter.clone(),
-                key: "plan_acks".to_string(),
-                value: serde_json::json!([]),
-            };
-            crate::task_events::append_batch_at(board, &emitter, vec![set_event, reset_event])
-                .map(|_| 0u64)
-        } else {
-            crate::task_events::append_at(board, &emitter, set_event)
-        }
-    });
-    match append_result {
-        Ok(Ok(_)) => {
-            let task = read_task_record_at(&board, id).map(|r| record_to_task(&r));
-            serde_json::json!({"id": id, "event": "metadata_set", "task": task})
-        }
-        Ok(Err(e)) => serde_json::json!({"error": format!("{e}")}),
-        Err(route_err) => serde_json::json!({
-            "error": format!("task '{id}' route revalidation failed: {route_err}"),
-            "code": "task_route_unresolved",
-        }),
     }
 }
 

--- a/src/tasks/handler.rs
+++ b/src/tasks/handler.rs
@@ -197,6 +197,38 @@ fn handle_create(home: &Path, emitter: crate::task_events::InstanceName, args: &
         }
     }
     let board = crate::task_events::board_root(home, &project);
+    // #2760 item 2: create under the per-id router lock. The id routing NOWHERE
+    // (NotFound) is re-proved under the lock BEFORE the Created append + index
+    // record, so two racing creates of the same id (or a create racing a mutation)
+    // can never land a cross-board duplicate — which would make every later route
+    // Ambiguous and un-mutatable. A fresh id is timestamp+pid+seq so this virtually
+    // always holds; it fails closed if the id somehow already exists on a board or
+    // its absence cannot be proven. The lock is held across the pure board-record
+    // writes below (no dispatch side-effects, #1496 → no self-IPC under the flock).
+    let _create_lock = match super::board_router::acquire_task_id_lock(home, &id) {
+        Ok(g) => g,
+        Err(e) => {
+            return serde_json::json!({
+                "error": format!("failed to acquire per-id lock for create of '{id}': {e}")
+            })
+        }
+    };
+    match super::load_routed(home, &id) {
+        // The id is free on every board → safe to create.
+        Err(super::TaskRouteError::NotFound) => {}
+        Ok(_) => {
+            return serde_json::json!({
+                "error": format!("task id '{id}' already exists on a board"),
+                "code": "duplicate_task_id",
+            })
+        }
+        Err(e) => {
+            return serde_json::json!({
+                "error": format!("cannot prove task id '{id}' is unused: {e}"),
+                "code": "task_route_unresolved",
+            })
+        }
+    }
     match crate::task_events::append_at(&board, &emitter, event) {
         Ok(_) => {
             let _ = super::board_router::record_task_project(home, &id, &project);
@@ -595,48 +627,61 @@ fn handle_claim(
         task_id: crate::task_events::TaskId(id.clone()),
         by: crate::task_events::InstanceName(iname.clone()),
     };
-    // #2760: the board resolved once above (strict route).
-    let board = routed.board().path().to_path_buf();
-    let result = crate::task_events::append_checked_at(&board, &emitter, event, |state| {
-        let mut tasks: Vec<Task> = state.tasks.values().map(record_to_task).collect();
-        // #2117 Q2: cross-board dep eval — a claim gate on a task whose
-        // `depends_on` points at another project's board must read that board's
-        // status, not just this one's. Pass home + the task's board.
-        super::apply_dependency_eval_in_memory(&mut tasks, home, &board);
-        let tv = tasks
-            .iter()
-            .find(|t| t.id == claim_id)
-            .ok_or_else(|| format!("task '{claim_id}' not found"))?;
-        let is_self_reclaim = tv.status == crate::task_events::TaskStatus::Claimed
-            && tv.assignee.as_deref() == Some(by.as_str());
-        if !is_self_reclaim && tv.status != crate::task_events::TaskStatus::Open {
-            return Err(format!(
-                "task '{claim_id}' status is '{}', only 'open' tasks can be claimed",
-                tv.status
-            ));
+    // #2760 items 2+3: append under the per-id router lock with write-time route
+    // revalidation — the strict route is re-proved (same board + incarnation) under
+    // the lock before the checked append, so a concurrent create/mutation of this
+    // id on any board cannot race the claim onto a stale board.
+    let revalidated = routed.with_revalidated_board(home, |board| {
+        let result = crate::task_events::append_checked_at(board, &emitter, event, |state| {
+            let mut tasks: Vec<Task> = state.tasks.values().map(record_to_task).collect();
+            // #2117 Q2: cross-board dep eval — a claim gate on a task whose
+            // `depends_on` points at another project's board must read that board's
+            // status, not just this one's. Pass home + the task's board.
+            super::apply_dependency_eval_in_memory(&mut tasks, home, board);
+            let tv = tasks
+                .iter()
+                .find(|t| t.id == claim_id)
+                .ok_or_else(|| format!("task '{claim_id}' not found"))?;
+            let is_self_reclaim = tv.status == crate::task_events::TaskStatus::Claimed
+                && tv.assignee.as_deref() == Some(by.as_str());
+            if !is_self_reclaim && tv.status != crate::task_events::TaskStatus::Open {
+                return Err(format!(
+                    "task '{claim_id}' status is '{}', only 'open' tasks can be claimed",
+                    tv.status
+                ));
+            }
+            Ok(())
+        });
+        match result {
+            Ok(Ok(_)) => {
+                // #807 Item 1: see create arm note. claim's
+                // legacy `status` happens to match lifecycle
+                // ("claimed"), but the field is still the action
+                // event name semantically — kept as alias for
+                // shape consistency.
+                let task = read_task_record_at(board, &id).map(|r| record_to_task(&r));
+                serde_json::json!({
+                    "id": id,
+                    "event": "claimed",
+                    "task": task,
+                    "assignee": instance_name,
+                    // #807 deprecated alias kept for back-compat — see task.status for lifecycle.
+                    "status": "claimed",
+                })
+            }
+            // Lost the race / precondition no longer holds — no event written.
+            Ok(Err(reason)) => serde_json::json!({"error": reason}),
+            Err(e) => serde_json::json!({"error": format!("event log append failed: {e}")}),
         }
-        Ok(())
     });
-    match result {
-        Ok(Ok(_)) => {
-            // #807 Item 1: see create arm note. claim's
-            // legacy `status` happens to match lifecycle
-            // ("claimed"), but the field is still the action
-            // event name semantically — kept as alias for
-            // shape consistency.
-            let task = read_task_record_at(&board, &id).map(|r| record_to_task(&r));
-            serde_json::json!({
-                "id": id,
-                "event": "claimed",
-                "task": task,
-                "assignee": instance_name,
-                // #807 deprecated alias kept for back-compat — see task.status for lifecycle.
-                "status": "claimed",
-            })
-        }
-        // Lost the race / precondition no longer holds — no event written.
-        Ok(Err(reason)) => serde_json::json!({"error": reason}),
-        Err(e) => serde_json::json!({"error": format!("event log append failed: {e}")}),
+    match revalidated {
+        Ok(v) => v,
+        // Route revalidation failed under the per-id lock (board/incarnation
+        // changed, or the id no longer routes uniquely) → deny, no event.
+        Err(route_err) => serde_json::json!({
+            "error": format!("task '{id}' route revalidation failed: {route_err}"),
+            "code": "task_route_unresolved",
+        }),
     }
 }
 
@@ -787,24 +832,38 @@ fn handle_done(
     // replay's `apply_done` does NOT re-guard transitions — so this precondition
     // is the authoritative gate (mirrors `handle_claim`'s `append_checked`).
     let done_id = id.clone();
-    match crate::task_events::append_checked_at(&board, &emitter, event, |state| {
-        let tv = state
-            .tasks
-            .values()
-            .map(record_to_task)
-            .find(|t| t.id == done_id)
-            .ok_or_else(|| format!("task '{done_id}' not found"))?;
-        if !tv
-            .status
-            .can_transition_to(crate::task_events::TaskStatus::Done)
-        {
-            return Err(format!(
-                "illegal transition: {} → done (task {done_id})",
-                status_to_legacy_str(tv.status)
-            ));
-        }
-        Ok(())
-    }) {
+    // #2760 items 2+3: append the →Done under the per-id router lock with write-time
+    // route revalidation. The closure does ONLY the checked append; the cascade
+    // below (worktree cleanup / release recompute / obligation cleanup — each may
+    // self-IPC or take other locks) runs AFTER the per-id flock drops (#1629). The
+    // fingerprint match guarantees `routed.board()` still names the appended board,
+    // so the post-lock read-back reads the right board.
+    let append_result = routed.with_revalidated_board(home, |board| {
+        crate::task_events::append_checked_at(board, &emitter, event, |state| {
+            let tv = state
+                .tasks
+                .values()
+                .map(record_to_task)
+                .find(|t| t.id == done_id)
+                .ok_or_else(|| format!("task '{done_id}' not found"))?;
+            if !tv
+                .status
+                .can_transition_to(crate::task_events::TaskStatus::Done)
+            {
+                return Err(format!(
+                    "illegal transition: {} → done (task {done_id})",
+                    status_to_legacy_str(tv.status)
+                ));
+            }
+            Ok(())
+        })
+    });
+    match append_result {
+        Err(route_err) => serde_json::json!({
+            "error": format!("task '{id}' route revalidation failed: {route_err}"),
+            "code": "task_route_unresolved",
+        }),
+        Ok(inner) => match inner {
         Ok(Ok(_)) => {
             // #789: task-completion is a workflow boundary —
             // clean any empty `init` commits the backend has
@@ -854,6 +913,7 @@ fn handle_done(
         }
         Ok(Err(reason)) => serde_json::json!({"error": reason, "code": "illegal_transition"}),
         Err(e) => serde_json::json!({"error": format!("event log append failed: {e}")}),
+        },
     }
 }
 
@@ -1288,11 +1348,14 @@ fn handle_update(
         // The pre-built events are kept (no in-lock rebuild); the drift check
         // guarantees their `by` is still correct at commit time.
         let stale_owner = record.owner.clone();
-        let checked = crate::task_events::append_batch_checked_at(
-            &board,
-            &emitter,
-            pending_events,
-            |state| {
+        // #2760 items 2+3: the checked batch append runs under the per-id router
+        // lock with write-time route revalidation (the closure does ONLY the
+        // append; the cascade below — obligation cleanup / child cancel / reassign,
+        // each may self-IPC or take other locks — runs AFTER the flock drops,
+        // #1629). The fingerprint match guarantees the `board` local still names the
+        // appended board, so the cascade + read-back below use it safely.
+        let checked = routed.with_revalidated_board(home, |board| {
+            crate::task_events::append_batch_checked_at(board, &emitter, pending_events, |state| {
                 update_batch_precondition(
                     state,
                     home,
@@ -1302,11 +1365,11 @@ fn handle_update(
                     target_status,
                     &stale_owner,
                 )
-            },
-        );
+            })
+        });
         match checked {
-            Ok(Ok(_)) => {}
-            Ok(Err(reason)) => {
+            Ok(Ok(Ok(_))) => {}
+            Ok(Ok(Err(reason))) => {
                 // Preserve the legacy `illegal_transition` code for the #1868
                 // transition guard; the new in-lock ACL/owner-drift rejections
                 // (:231) are a distinct, retryable precondition failure.
@@ -1317,8 +1380,14 @@ fn handle_update(
                 };
                 return serde_json::json!({"error": reason, "code": code});
             }
-            Err(e) => {
+            Ok(Err(e)) => {
                 return serde_json::json!({"error": format!("event log append_batch failed: {e}")});
+            }
+            Err(route_err) => {
+                return serde_json::json!({
+                    "error": format!("task '{id}' route revalidation failed: {route_err}"),
+                    "code": "task_route_unresolved",
+                });
             }
         }
         // #1018 (B): mirror the `done` arm's cleanup hook for
@@ -1700,26 +1769,37 @@ fn handle_metadata_set(
         key: key.to_string(),
         value,
     };
-    let append_result = if reset_acks {
-        // I6: emit the plan change + an audit-visible plan_acks=[] reset as ONE
-        // atomic batch so replay re-derives the reopened gate deterministically.
-        let reset_event = crate::task_events::TaskEvent::MetadataSet {
-            task_id: crate::task_events::TaskId(id.to_string()),
-            by: emitter.clone(),
-            key: "plan_acks".to_string(),
-            value: serde_json::json!([]),
-        };
-        crate::task_events::append_batch_at(&board, &emitter, vec![set_event, reset_event])
-            .map(|_| 0u64)
-    } else {
-        crate::task_events::append_at(&board, &emitter, set_event)
-    };
+    // #2760 items 2+3: the metadata append (previously an UNCHECKED default-board
+    // write via the pre-#2760 seam, now board-resolved) runs under the per-id
+    // router lock with write-time route revalidation — no self-IPC cascade, so the
+    // whole append can sit inside the closure. Read-back uses the `board` local
+    // (unchanged since the fingerprint matched).
+    let append_result = routed.with_revalidated_board(home, |board| {
+        if reset_acks {
+            // I6: emit the plan change + an audit-visible plan_acks=[] reset as ONE
+            // atomic batch so replay re-derives the reopened gate deterministically.
+            let reset_event = crate::task_events::TaskEvent::MetadataSet {
+                task_id: crate::task_events::TaskId(id.to_string()),
+                by: emitter.clone(),
+                key: "plan_acks".to_string(),
+                value: serde_json::json!([]),
+            };
+            crate::task_events::append_batch_at(board, &emitter, vec![set_event, reset_event])
+                .map(|_| 0u64)
+        } else {
+            crate::task_events::append_at(board, &emitter, set_event)
+        }
+    });
     match append_result {
-        Ok(_) => {
+        Ok(Ok(_)) => {
             let task = read_task_record_at(&board, id).map(|r| record_to_task(&r));
             serde_json::json!({"id": id, "event": "metadata_set", "task": task})
         }
-        Err(e) => serde_json::json!({"error": format!("{e}")}),
+        Ok(Err(e)) => serde_json::json!({"error": format!("{e}")}),
+        Err(route_err) => serde_json::json!({
+            "error": format!("task '{id}' route revalidation failed: {route_err}"),
+            "code": "task_route_unresolved",
+        }),
     }
 }
 
@@ -1751,7 +1831,6 @@ fn handle_ack_plan(
             })
         }
     };
-    let board = routed.board().path().to_path_buf();
     let record = routed.record().clone();
     if let Some(deny) = cross_board_denied(home, instance_name, id, routed.board().project(), false)
     {
@@ -1796,11 +1875,19 @@ fn handle_ack_plan(
         key: "plan_acks".to_string(),
         value: serde_json::json!(acks),
     };
-    match crate::task_events::append_at(&board, &emitter, event) {
-        Ok(_) => serde_json::json!({
+    // #2760 items 2+3: append the ack under the per-id router lock with write-time
+    // route revalidation.
+    let revalidated = routed
+        .with_revalidated_board(home, |board| crate::task_events::append_at(board, &emitter, event));
+    match revalidated {
+        Ok(Ok(_)) => serde_json::json!({
             "id": id, "event": "ack_plan", "acked": acked_count, "already_acked": false,
         }),
-        Err(e) => serde_json::json!({"error": format!("{e}")}),
+        Ok(Err(e)) => serde_json::json!({"error": format!("{e}")}),
+        Err(route_err) => serde_json::json!({
+            "error": format!("task '{id}' route revalidation failed: {route_err}"),
+            "code": "task_route_unresolved",
+        }),
     }
 }
 
@@ -1959,6 +2046,14 @@ fn cascade_cancel_children(
     // #2117 P1: a parent's children live on the parent's board — replay + cancel
     // there. `home` is kept only for the cross-instance cascade NOTIFICATION
     // (route_cascade_cancel), which is fleet-global. Single-project → board == home.
+    //
+    // #2760 scope: this is a MULTI-id secondary cascade (many children cancelled as
+    // a consequence of the parent's cancel), invoked AFTER the parent's per-id lock
+    // has dropped. Per the frozen plan's "atomic multi-id mutation sorts IDs or
+    // stays out of scope" rule it is deliberately NOT wrapped in per-child per-id
+    // locks (which would require sorted multi-lock acquisition); the children are
+    // all on this one board and the batch append rides its board writer lock. The
+    // pre-#2760 batch semantics are unchanged.
     let Ok(state) = crate::task_events::replay_at(board) else {
         return;
     };

--- a/src/tasks/handler.rs
+++ b/src/tasks/handler.rs
@@ -169,7 +169,9 @@ fn handle_create(home: &Path, emitter: crate::task_events::InstanceName, args: &
         &args["project"]
             .as_str()
             .map(String::from)
-            .unwrap_or_else(|| super::board_router::resolve_current_project(home, emitter.as_str())),
+            .unwrap_or_else(|| {
+                super::board_router::resolve_current_project(home, emitter.as_str())
+            }),
     );
     // #2117 P3a: `parent_id` is subtask COMPOSITION ("A is composed of B/C/D").
     // DP4 invariant — a subtask MUST live in its parent's project. Cross-project
@@ -875,55 +877,56 @@ fn handle_done(
             "code": "task_route_unresolved",
         }),
         Ok(inner) => match inner {
-        Ok(Ok(_)) => {
-            // #789: task-completion is a workflow boundary —
-            // clean any empty `init` commits the backend has
-            // accumulated in the agent's bound worktree since
-            // the last cleanup at `dispatch_auto_bind_lease`.
-            // Best-effort: failure is logged inside the helper
-            // but never blocks the done response (the task
-            // event already appended successfully — cleanup is
-            // a polish step, not load-bearing).
-            let owner = record
-                .owner
-                .as_ref()
-                .map(|o| o.0.clone())
-                .unwrap_or_else(|| caller.clone());
-            if let Some(binding) = crate::binding::read(home, &owner) {
-                if let Some(wt) = binding["worktree"].as_str().map(std::path::PathBuf::from) {
-                    let _ = crate::mcp::handlers::dispatch_hook::clean_empty_init_commits(&wt).ok();
+            Ok(Ok(_)) => {
+                // #789: task-completion is a workflow boundary —
+                // clean any empty `init` commits the backend has
+                // accumulated in the agent's bound worktree since
+                // the last cleanup at `dispatch_auto_bind_lease`.
+                // Best-effort: failure is logged inside the helper
+                // but never blocks the done response (the task
+                // event already appended successfully — cleanup is
+                // a polish step, not load-bearing).
+                let owner = record
+                    .owner
+                    .as_ref()
+                    .map(|o| o.0.clone())
+                    .unwrap_or_else(|| caller.clone());
+                if let Some(binding) = crate::binding::read(home, &owner) {
+                    if let Some(wt) = binding["worktree"].as_str().map(std::path::PathBuf::from) {
+                        let _ =
+                            crate::mcp::handlers::dispatch_hook::clean_empty_init_commits(&wt).ok();
+                    }
+                    // t-worktree-leak (PR-1): task-done is one of the 3 release
+                    // events. Enqueue a release-invariant recompute — if the
+                    // branch has no open PR and all its tasks are done, the
+                    // sweeper releases the worktree (covers tasks that never
+                    // produce a PR: RCA / design / spike). An open PR holds the
+                    // release until it terminates. (repo="" → sweeper derives it.)
+                    if let Some(branch) = binding["branch"].as_str() {
+                        crate::daemon::auto_release::enqueue_release_recompute(
+                            home,
+                            "",
+                            branch,
+                            "task_done",
+                        );
+                    }
                 }
-                // t-worktree-leak (PR-1): task-done is one of the 3 release
-                // events. Enqueue a release-invariant recompute — if the
-                // branch has no open PR and all its tasks are done, the
-                // sweeper releases the worktree (covers tasks that never
-                // produce a PR: RCA / design / spike). An open PR holds the
-                // release until it terminates. (repo="" → sweeper derives it.)
-                if let Some(branch) = binding["branch"].as_str() {
-                    crate::daemon::auto_release::enqueue_release_recompute(
-                        home,
-                        "",
-                        branch,
-                        "task_done",
-                    );
-                }
+                // #1018/#78445-2 (d): a task reaching Done is terminal — clear BOTH
+                // obligation stores (dispatch_idle sidecar + dispatch_tracking rows) via
+                // the shared seam so no watchdog nags about the board-confirmed-done work.
+                super::task_terminal_cleanup(home, &id);
+                // #807 Item 1: see create arm note.
+                let task = read_task_record_at(&board, &id).map(|r| record_to_task(&r));
+                serde_json::json!({
+                    "id": id,
+                    "event": "done",
+                    "task": task,
+                    // #807 deprecated alias kept for back-compat — see task.status for lifecycle.
+                    "status": "done",
+                })
             }
-            // #1018/#78445-2 (d): a task reaching Done is terminal — clear BOTH
-            // obligation stores (dispatch_idle sidecar + dispatch_tracking rows) via
-            // the shared seam so no watchdog nags about the board-confirmed-done work.
-            super::task_terminal_cleanup(home, &id);
-            // #807 Item 1: see create arm note.
-            let task = read_task_record_at(&board, &id).map(|r| record_to_task(&r));
-            serde_json::json!({
-                "id": id,
-                "event": "done",
-                "task": task,
-                // #807 deprecated alias kept for back-compat — see task.status for lifecycle.
-                "status": "done",
-            })
-        }
-        Ok(Err(reason)) => serde_json::json!({"error": reason, "code": "illegal_transition"}),
-        Err(e) => serde_json::json!({"error": format!("event log append failed: {e}")}),
+            Ok(Err(reason)) => serde_json::json!({"error": reason, "code": "illegal_transition"}),
+            Err(e) => serde_json::json!({"error": format!("event log append failed: {e}")}),
         },
     }
 }
@@ -1888,8 +1891,9 @@ fn handle_ack_plan(
     };
     // #2760 items 2+3: append the ack under the per-id router lock with write-time
     // route revalidation.
-    let revalidated = routed
-        .with_revalidated_board(home, |board| crate::task_events::append_at(board, &emitter, event));
+    let revalidated = routed.with_revalidated_board(home, |board| {
+        crate::task_events::append_at(board, &emitter, event)
+    });
     match revalidated {
         Ok(Ok(_)) => serde_json::json!({
             "id": id, "event": "ack_plan", "acked": acked_count, "already_acked": false,

--- a/src/tasks/handler.rs
+++ b/src/tasks/handler.rs
@@ -156,10 +156,21 @@ fn handle_create(home: &Path, emitter: crate::task_events::InstanceName, args: &
     // explicit `project` arg override). Single-project → DEFAULT → board == home
     // (byte-identical). Record the task→project mapping in the append-only index
     // so later done/update/claim/activity resolve the board in O(1).
-    let project = args["project"]
-        .as_str()
-        .map(String::from)
-        .unwrap_or_else(|| super::board_router::resolve_current_project(home, emitter.as_str()));
+    //
+    // #2760: canonicalise the project id to its filesystem-safe SLUG — the project
+    // id IS the slug (board_router doc: the board dir name equals the project id).
+    // `resolve_current_project` already returns a slug, but a raw explicit `project`
+    // arg (e.g. `orgA/projA`) is stored raw in the index while `board_root` slugs
+    // the on-disk dir (`orgA_projA`) — so the STRICT router's index-vs-physical
+    // consistency check reads them as a mismatch (Unreadable) and the parent-project
+    // comparison compares slug-vs-raw. Slugging here makes the index entry, the
+    // board dir, and every later strict route agree. Idempotent on an already-safe id.
+    let project = crate::task_events::project_slug(
+        &args["project"]
+            .as_str()
+            .map(String::from)
+            .unwrap_or_else(|| super::board_router::resolve_current_project(home, emitter.as_str())),
+    );
     // #2117 P3a: `parent_id` is subtask COMPOSITION ("A is composed of B/C/D").
     // DP4 invariant — a subtask MUST live in its parent's project. Cross-project
     // composition breaks board isolation: `cascade_cancel_children` only replays

--- a/src/tasks/handler.rs
+++ b/src/tasks/handler.rs
@@ -11,13 +11,12 @@ fn parse_due_at(args: &Value) -> Option<String> {
     Some(dt.with_timezone(&chrono::Utc).to_rfc3339())
 }
 
-/// Read a single task's current replay-derived record. Used by
-/// `handle`'s mutation arms to validate `(prev_status, transition)`
-/// before emitting an event.
+/// #2760: default-root record read. Production mutation arms now resolve their
+/// board via the strict `super::load_routed` (no default-board assumption), so this
+/// remains only as a convenience for the default-board handler tests.
+#[cfg(test)]
 pub(super) fn read_task_record(home: &Path, id: &str) -> Option<crate::task_events::TaskRecord> {
-    // #2117 P1: home IS the default board root (`board_root(home, DEFAULT)`), so
-    // this is byte-identical; routed callers use `read_task_record_at` with the
-    // task's resolved board.
+    // `home` IS the default board root (`board_root(home, DEFAULT)`).
     read_task_record_at(home, id)
 }
 
@@ -172,7 +171,21 @@ fn handle_create(home: &Path, emitter: crate::task_events::InstanceName, args: &
     // composition — cross-board references are allowed there per the epic and are
     // NOT guarded here.)
     if let Some(parent_id) = args["parent_id"].as_str() {
-        let parent_project = super::board_router::resolve_task_project(home, parent_id);
+        // #2760: resolve the parent's board via the strict route. A route error
+        // (NotFound / Unreadable / Ambiguous) fails closed — a subtask is never
+        // created against a parent whose board cannot be uniquely proven.
+        let parent_project = match super::load_routed(home, parent_id) {
+            Ok(rt) => rt.board().project().to_string(),
+            Err(e) => {
+                return serde_json::json!({
+                    "error": format!(
+                        "cross-project parent_id rejected: parent {parent_id} could not be \
+                         routed ({e}) — a subtask must live in its parent's uniquely-resolved \
+                         project (board isolation, #2117 P3a / #2760)"
+                    )
+                });
+            }
+        };
         if parent_project != project {
             return serde_json::json!({
                 "error": format!(
@@ -449,40 +462,52 @@ fn minimal_task_value(v: &mut Value) {
 /// task on the caller's current project board first, then falls back to scanning
 /// every board (the id may live elsewhere). Returns `{ "task": {...} }` or an
 /// `{ "error": ... }` when the id is absent.
-fn handle_get(home: &Path, caller: &str, args: &Value) -> Value {
+fn handle_get(home: &Path, _caller: &str, args: &Value) -> Value {
     let Some(id) = id_arg(args).map(str::to_string) else {
         return serde_json::json!({"error": "missing 'id' (or 'task_id')"});
     };
-    // Primary board: explicit `project`, else the caller's current project.
-    let project = args["project"]
-        .as_str()
-        .map(String::from)
-        .unwrap_or_else(|| super::board_router::resolve_current_project(home, caller));
-    let board = crate::task_events::board_root(home, &project);
-    let mut found = super::list_all_at(home, &board)
-        .into_iter()
-        .find(|t| t.id == id);
-    let mut found_project = found.as_ref().map(|_| project);
-    // Cross-board fallback: the id may live on another project's board.
-    if found.is_none() {
-        for (p, ts) in super::board_router::list_all_boards(home) {
-            if let Some(t) = ts.into_iter().find(|t| t.id == id) {
-                found_project = Some(p);
-                found = Some(t);
-                break;
+    // #2760: an EXPLICIT `project` scopes the read to that operator-named board
+    // (deliberate disambiguation, NOT a silent default). With no `project`, the id
+    // resolves through the strict router — a duplicate across boards or an
+    // unreadable board fails closed instead of the old arbitrary first-hit scan.
+    let (task, project) = if let Some(project) = args["project"].as_str() {
+        let board = crate::task_events::board_root(home, project);
+        match super::list_all_at(home, &board)
+            .into_iter()
+            .find(|t| t.id == id)
+        {
+            Some(t) => (t, project.to_string()),
+            None => return serde_json::json!({"error": format!("task not found: {id}")}),
+        }
+    } else {
+        match super::load_routed(home, &id) {
+            // Re-read via `list_all_at` on the ROUTED board so the response keeps
+            // the dep-derived status (in-memory blocking), matching pre-#2760 `get`.
+            Ok(rt) => {
+                match super::list_all_at(home, rt.board().path())
+                    .into_iter()
+                    .find(|t| t.id == id)
+                {
+                    Some(t) => (t, rt.board().project().to_string()),
+                    None => return serde_json::json!({"error": format!("task not found: {id}")}),
+                }
+            }
+            Err(super::TaskRouteError::NotFound) => {
+                return serde_json::json!({"error": format!("task not found: {id}")})
+            }
+            Err(e) => {
+                return serde_json::json!({
+                    "error": format!("task '{id}' route unresolved: {e}"),
+                    "code": "task_route_unresolved",
+                })
             }
         }
+    };
+    let mut v = serde_json::to_value(&task).unwrap_or(Value::Null);
+    if let Some(obj) = v.as_object_mut() {
+        obj.insert("project".to_string(), Value::String(project));
     }
-    match found {
-        Some(t) => {
-            let mut v = serde_json::to_value(&t).unwrap_or(Value::Null);
-            if let (Some(obj), Some(p)) = (v.as_object_mut(), found_project) {
-                obj.insert("project".to_string(), Value::String(p));
-            }
-            serde_json::json!({ "task": v })
-        }
-        None => serde_json::json!({"error": format!("task not found: {id}")}),
-    }
+    serde_json::json!({ "task": v })
 }
 
 /// #2117 P3a (FM5 / board isolation): per-board mutation authority. A task
@@ -493,12 +518,20 @@ fn handle_get(home: &Path, caller: &str, args: &Value) -> Value {
 /// SAME axis as the owner-ACL `can_mutate_record` — bypasses it on the paths that
 /// carry it. Single-project → caller project == task board project (both DEFAULT)
 /// → allow → byte-identical (no new denial). Returns `Some(error)` when denied.
-fn cross_board_denied(home: &Path, caller: &str, id: &str, force: bool) -> Option<Value> {
+// #2760: `board_project` is the caller's ALREADY-resolved authoritative board
+// (from `super::load_routed`), so the mutation routes ONCE and this gate never
+// re-resolves (nor silently defaults). `None` = allowed.
+fn cross_board_denied(
+    home: &Path,
+    caller: &str,
+    id: &str,
+    board_project: &str,
+    force: bool,
+) -> Option<Value> {
     if force {
         return None;
     }
-    let board_project = super::board_router::resolve_task_project(home, id);
-    if super::acl::can_mutate_on_board(home, caller, &board_project) {
+    if super::acl::can_mutate_on_board(home, caller, board_project) {
         return None;
     }
     Some(serde_json::json!({
@@ -523,10 +556,24 @@ fn handle_claim(
     if !instance_exists(home, &iname) {
         return serde_json::json!({"error": format!("instance '{iname}' not found in fleet.yaml")});
     }
+    // #2760: resolve the task's authoritative board ONCE via the strict route
+    // (fail-closed) and reuse it for the board-isolation gate + the append below.
+    let routed = match super::load_routed(home, &id) {
+        Ok(rt) => rt,
+        Err(super::TaskRouteError::NotFound) => {
+            return serde_json::json!({"error": format!("task '{id}' not found")})
+        }
+        Err(e) => {
+            return serde_json::json!({
+                "error": format!("task '{id}' route unresolved: {e}"),
+                "code": "task_route_unresolved",
+            })
+        }
+    };
     // #2117 P3a: board-isolation gate — a caller may only claim tasks on its own
     // project's board (claim has no `force`/owner-ACL — an open task is claimable
     // by anyone, but only within the board). Single-project → allow.
-    if let Some(deny) = cross_board_denied(home, &iname, &id, false) {
+    if let Some(deny) = cross_board_denied(home, &iname, &id, routed.board().project(), false) {
         return deny;
     }
     // #t-21: validate + append in ONE critical section to close the
@@ -548,8 +595,8 @@ fn handle_claim(
         task_id: crate::task_events::TaskId(id.clone()),
         by: crate::task_events::InstanceName(iname.clone()),
     };
-    // #2117 P1: operate on the task's resolved board (default → home).
-    let board = super::board_router::board_for_task(home, &id);
+    // #2760: the board resolved once above (strict route).
+    let board = routed.board().path().to_path_buf();
     let result = crate::task_events::append_checked_at(&board, &emitter, event, |state| {
         let mut tasks: Vec<Task> = state.tasks.values().map(record_to_task).collect();
         // #2117 Q2: cross-board dep eval — a claim gate on a task whose
@@ -640,12 +687,22 @@ fn handle_done(
     };
     let result_text = args["result"].as_str().map(String::from);
     let caller = instance_name.to_string();
-    // #2117 P1: operate on the task's resolved board (default → home).
-    let board = super::board_router::board_for_task(home, &id);
-    let record = match read_task_record_at(&board, &id) {
-        Some(r) => r,
-        None => return serde_json::json!({"error": format!("task '{id}' not found")}),
+    // #2760: resolve the task's authoritative board ONCE via the strict route
+    // (fail-closed); reuse it for the ACL gate, pre-checks, and the checked append.
+    let routed = match super::load_routed(home, &id) {
+        Ok(rt) => rt,
+        Err(super::TaskRouteError::NotFound) => {
+            return serde_json::json!({"error": format!("task '{id}' not found")})
+        }
+        Err(e) => {
+            return serde_json::json!({
+                "error": format!("task '{id}' route unresolved: {e}"),
+                "code": "task_route_unresolved",
+            })
+        }
     };
+    let board = routed.board().path().to_path_buf();
+    let record = routed.record().clone();
     // #808: force flag bypasses the ACL gate for historical
     // ghost-owned cleanup. Validator mirrors comms.rs:200-218.
     let force = args.get("force").and_then(|v| v.as_bool()).unwrap_or(false);
@@ -659,7 +716,7 @@ fn handle_done(
         });
     }
     // #2117 P3a: board-isolation gate (outer boundary, before the owner-ACL).
-    if let Some(deny) = cross_board_denied(home, &caller, &id, force) {
+    if let Some(deny) = cross_board_denied(home, &caller, &id, routed.board().project(), force) {
         return deny;
     }
     if !force && !can_mutate_record(home, &caller, &record) {
@@ -888,12 +945,22 @@ fn handle_update(
         None
     };
     let caller = instance_name.to_string();
-    // #2117 P1: operate on the task's resolved board (default → home).
-    let board = super::board_router::board_for_task(home, &id);
-    let record = match read_task_record_at(&board, &id) {
-        Some(r) => r,
-        None => return serde_json::json!({"error": format!("task '{id}' not found")}),
+    // #2760: resolve the task's authoritative board ONCE via the strict route
+    // (fail-closed); reuse it for the ACL gate, pre-checks, and the checked append.
+    let routed = match super::load_routed(home, &id) {
+        Ok(rt) => rt,
+        Err(super::TaskRouteError::NotFound) => {
+            return serde_json::json!({"error": format!("task '{id}' not found")})
+        }
+        Err(e) => {
+            return serde_json::json!({
+                "error": format!("task '{id}' route unresolved: {e}"),
+                "code": "task_route_unresolved",
+            })
+        }
     };
+    let board = routed.board().path().to_path_buf();
+    let record = routed.record().clone();
     // #808: force flag bypasses the ACL gate for historical
     // ghost-owned cleanup. Validator mirrors comms.rs:200-218.
     let force = args.get("force").and_then(|v| v.as_bool()).unwrap_or(false);
@@ -907,7 +974,7 @@ fn handle_update(
         });
     }
     // #2117 P3a: board-isolation gate (outer boundary, before the owner-ACL).
-    if let Some(deny) = cross_board_denied(home, &caller, &id, force) {
+    if let Some(deny) = cross_board_denied(home, &caller, &id, routed.board().project(), force) {
         return deny;
     }
     if !force && !can_mutate_record(home, &caller, &record) {
@@ -1482,15 +1549,25 @@ fn handle_metadata_set(
             "code": "metadata_value_too_large"
         });
     }
-    // #2117 P1: operate on the task's resolved board (default → home).
-    let board = super::board_router::board_for_task(home, id);
-    let record = match read_task_record_at(&board, id) {
-        Some(r) => r,
-        None => return serde_json::json!({"error": format!("task not found: {id}")}),
+    // #2760: resolve the task's authoritative board ONCE via the strict route.
+    let routed = match super::load_routed(home, id) {
+        Ok(rt) => rt,
+        Err(super::TaskRouteError::NotFound) => {
+            return serde_json::json!({"error": format!("task not found: {id}")})
+        }
+        Err(e) => {
+            return serde_json::json!({
+                "error": format!("task '{id}' route unresolved: {e}"),
+                "code": "task_route_unresolved",
+            })
+        }
     };
+    let board = routed.board().path().to_path_buf();
+    let record = routed.record().clone();
     // #2117 P3a: board-isolation gate (no force on metadata_set — mirror its
     // unconditional owner-ACL below).
-    if let Some(deny) = cross_board_denied(home, instance_name, id, false) {
+    if let Some(deny) = cross_board_denied(home, instance_name, id, routed.board().project(), false)
+    {
         return deny;
     }
     // ── t-…-74 governance-key ACL (decision d-…-22, Root ruling m-1087) ──
@@ -1661,12 +1738,23 @@ fn handle_ack_plan(
         Some(i) => i,
         None => return serde_json::json!({"error": "missing 'id' (alias: task_id)"}),
     };
-    let board = super::board_router::board_for_task(home, id);
-    let record = match read_task_record_at(&board, id) {
-        Some(r) => r,
-        None => return serde_json::json!({"error": format!("task not found: {id}")}),
+    // #2760: resolve the task's authoritative board ONCE via the strict route.
+    let routed = match super::load_routed(home, id) {
+        Ok(rt) => rt,
+        Err(super::TaskRouteError::NotFound) => {
+            return serde_json::json!({"error": format!("task not found: {id}")})
+        }
+        Err(e) => {
+            return serde_json::json!({
+                "error": format!("task '{id}' route unresolved: {e}"),
+                "code": "task_route_unresolved",
+            })
+        }
     };
-    if let Some(deny) = cross_board_denied(home, instance_name, id, false) {
+    let board = routed.board().path().to_path_buf();
+    let record = routed.record().clone();
+    if let Some(deny) = cross_board_denied(home, instance_name, id, routed.board().project(), false)
+    {
         return deny;
     }
     if record.owner.as_ref().map(|o| o.0.as_str()) == Some(instance_name) {
@@ -1721,20 +1809,37 @@ fn handle_metadata_get(home: &Path, args: &Value) -> Value {
         Some(i) => i,
         None => return serde_json::json!({"error": "missing 'id' (alias: task_id)"}),
     };
-    let board = super::board_router::board_for_task(home, id);
-    match read_task_record_at(&board, id) {
-        Some(r) => {
-            serde_json::json!({"id": id, "metadata": r.metadata})
+    // #2760: strict route (read). Fail closed on Ambiguous/Unreadable.
+    match super::load_routed(home, id) {
+        Ok(rt) => serde_json::json!({"id": id, "metadata": rt.task.metadata}),
+        Err(super::TaskRouteError::NotFound) => {
+            serde_json::json!({"error": format!("task not found: {id}")})
         }
-        None => serde_json::json!({"error": format!("task not found: {id}")}),
+        Err(e) => serde_json::json!({
+            "error": format!("task '{id}' route unresolved: {e}"),
+            "code": "task_route_unresolved",
+        }),
     }
 }
 
 /// #1147: Build a chronological activity timeline for a task.
 fn activity_timeline(home: &Path, task_id: &str) -> Value {
-    // #2117 P1: read the task's resolved board (default → home).
-    let board = super::board_router::board_for_task(home, task_id);
-    let envelopes = match crate::task_events::envelopes_for_task_at(&board, task_id) {
+    // #2760: read the task's events from its authoritative board (strict route).
+    // Fail closed on Ambiguous/Unreadable; unknown id → not found.
+    let routed = match super::load_routed(home, task_id) {
+        Ok(rt) => rt,
+        Err(super::TaskRouteError::NotFound) => {
+            return serde_json::json!({"error": format!("task not found: {task_id}")})
+        }
+        Err(e) => {
+            return serde_json::json!({
+                "error": format!("task '{task_id}' route unresolved: {e}"),
+                "code": "task_route_unresolved",
+            })
+        }
+    };
+    let envelopes = match crate::task_events::envelopes_for_task_at(routed.board().path(), task_id)
+    {
         Ok(e) => e,
         Err(e) => return serde_json::json!({"error": format!("failed to read task events: {e}")}),
     };

--- a/src/tasks/handler/tests.rs
+++ b/src/tasks/handler/tests.rs
@@ -2223,3 +2223,101 @@ fn plan_revise_refused_when_ack_lands_concurrently_2760_r2() {
     );
     std::fs::remove_dir_all(&home).ok();
 }
+
+/// RED (finding 2 — metadata_set stale authorization, OWNER dimension / STALE-FORMER-OWNER):
+/// a THIRD PARTY (`lead`, the creator) creates the task; the OLD OWNER (`worker`) claims it
+/// and is authorized to set a generic (non-`plan`) metadata key OUT of lock. In the old
+/// owner's out-of-lock window the OLD OWNER RELEASES the task (`update`→open clears the
+/// assignee) and a NEW OWNER (`worker2`) CLAIMS it — a real release→claim ownership drift,
+/// expressed entirely through the production `update`/`claim` handlers (each takes+releases
+/// its own per-id lock BEFORE the instrumented metadata_set locks, so no deadlock). The
+/// under-lock re-evaluation of the owner ACL against the FRESH record (`can_mutate_record`,
+/// owner = worker2) must REFUSE the former owner's write and leave the metadata (hence the
+/// event log) unchanged. Pre-R2 (a542517b) checked the ACL ONLY on the pre-lock record
+/// (`worker` still owner → authorized) and appended the write unchecked — a stale-authorized
+/// former owner silently overwrites a key the new owner now controls.
+#[test]
+fn metadata_set_refused_when_owner_drifts_via_release_claim_under_lock_2760_r2() {
+    let home = tmp_home("r2-stale-former-owner");
+    // Third party (`lead`, creator) creates; OLD OWNER (`worker`) claims → creator ≠ owner.
+    let created = handle(
+        &home,
+        "lead",
+        &serde_json::json!({
+            "action": "create",
+            "title": "generic-metadata task",
+            "assignee": "worker",
+        }),
+    );
+    let id = created["id"].as_str().expect("id").to_string();
+    handle(
+        &home,
+        "worker",
+        &serde_json::json!({"action": "claim", "id": id}),
+    );
+    // Baseline: the old owner sets a generic key while still the owner (authorized).
+    let base = handle(
+        &home,
+        "worker",
+        &serde_json::json!({
+            "action": "metadata_set", "id": id,
+            "metadata_key": "note", "metadata_value": "baseline"
+        }),
+    );
+    assert!(
+        base.get("error").is_none(),
+        "baseline set must succeed: {base}"
+    );
+    // In the old owner's out-of-lock window: the OLD OWNER releases (update→open clears the
+    // assignee) and the NEW OWNER claims — ownership drifts before the write commits.
+    let home_h = home.clone();
+    let id_h = id.clone();
+    crate::tasks::set_before_mutation_commit_hook_for_test(move || {
+        let rel = handle(
+            &home_h,
+            "worker",
+            &serde_json::json!({"action": "update", "id": id_h, "status": "open"}),
+        );
+        assert_eq!(
+            rel["status"], "updated",
+            "old owner's release must succeed: {rel}"
+        );
+        let claim = handle(
+            &home_h,
+            "worker2",
+            &serde_json::json!({"action": "claim", "id": id_h}),
+        );
+        assert_eq!(
+            claim["event"], "claimed",
+            "new owner's claim must succeed: {claim}"
+        );
+    });
+    // The OLD OWNER's racing generic-key write: authorized out-of-lock, but the under-lock
+    // owner-ACL re-check against the FRESH record (owner = worker2) must REFUSE it.
+    let resp = handle(
+        &home,
+        "worker",
+        &serde_json::json!({
+            "action": "metadata_set", "id": id,
+            "metadata_key": "note", "metadata_value": "hijacked"
+        }),
+    );
+    assert_eq!(
+        resp.get("code").and_then(|v| v.as_str()),
+        Some("metadata_precondition_failed"),
+        "the former owner's write must be refused once ownership drifts under the lock: {resp}"
+    );
+    // Metadata unchanged (the hijack never landed) and ownership did drift to the new owner.
+    let rec = read_task_record(&home, &id).expect("record");
+    assert_eq!(
+        rec.metadata.get("note").and_then(|v| v.as_str()),
+        Some("baseline"),
+        "the note stays 'baseline' — the former owner's write is refused under the lock"
+    );
+    assert_eq!(
+        rec.owner.as_ref().map(|o| o.0.as_str()),
+        Some("worker2"),
+        "ownership drifted to the new owner in the out-of-lock window"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}

--- a/src/tasks/handler/tests.rs
+++ b/src/tasks/handler/tests.rs
@@ -2055,3 +2055,171 @@ fn gov_r11_plan_frozen_when_blocked_t74() {
     );
     std::fs::remove_dir_all(&home).ok();
 }
+
+// ── #2760 R2 (root+independent REJECT of a542517b): deterministic concurrent REDs ──
+//
+// A route-only revalidation (board+incarnation) left the AUTHZ/PREDICATE TOCTOU
+// open: a mutation that read/built state OUT of lock then appended could lose a
+// concurrent update or act on stale authorization. Each RED arms the
+// `before_mutation_commit` seam to land a CONCURRENT mutation in the out-of-lock
+// window (it fully completes — acquires+releases its own per-id lock — BEFORE the
+// instrumented caller locks, so no deadlock), and asserts the under-lock
+// recompute/union is race-safe. Each FAILS on the pre-R2 (a542517b) code.
+
+/// RED (finding 1 — ack_plan lost update): two reviewers ack concurrently; the
+/// under-lock UNION from fresh `plan_acks` must preserve BOTH. Pre-R2 built the ack
+/// list from the pre-lock snapshot and appended a full-list overwrite → last-write
+/// wins → one ack silently lost.
+#[test]
+fn concurrent_ack_union_preserves_both_2760_r2() {
+    let home = tmp_home("r2-concurrent-ack");
+    let id = gov_seed_claimed(&home, 2);
+    handle(
+        &home,
+        "lead",
+        &serde_json::json!({
+            "action": "metadata_set", "id": id,
+            "metadata_key": "plan", "metadata_value": "the plan"
+        }),
+    );
+    // Reviewer B acks in reviewer A's out-of-lock window.
+    let home_h = home.clone();
+    let id_h = id.clone();
+    crate::tasks::set_before_mutation_commit_hook_for_test(move || {
+        handle(
+            &home_h,
+            "rev-b",
+            &serde_json::json!({"action": "ack_plan", "id": id_h}),
+        );
+    });
+    let resp = handle(
+        &home,
+        "rev-a",
+        &serde_json::json!({"action": "ack_plan", "id": id}),
+    );
+    assert!(
+        resp.get("error").is_none(),
+        "rev-a's ack must succeed: {resp}"
+    );
+    let acks: std::collections::BTreeSet<String> = read_task_record(&home, &id)
+        .and_then(|r| {
+            r.metadata
+                .get("plan_acks")
+                .and_then(|v| v.as_array())
+                .map(|a| {
+                    a.iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect()
+                })
+        })
+        .unwrap_or_default();
+    assert!(
+        acks.contains("rev-a") && acks.contains("rev-b"),
+        "both concurrent acks must be preserved by the fresh under-lock union, got {acks:?} \
+         (pre-R2 the stale-vector overwrite loses one)"
+    );
+    assert_eq!(
+        gov_plan_acks_len(&home, &id),
+        2,
+        "exactly the two distinct acks"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// RED (finding 2 — metadata_set stale authorization, STATUS dimension): the OWNER
+/// revises the plan while the task is still pre-work (authorized out-of-lock), but a
+/// concurrent transition to `in_progress` lands before the write commits. The
+/// under-lock re-evaluation of the plan-governance policy must REFUSE (the plan is
+/// FROZEN once work starts) and leave the plan unchanged. Pre-R2 evaluated the policy
+/// on the pre-lock record and appended the revised plan unchecked — silently running
+/// work under a hot-swapped plan.
+#[test]
+fn metadata_plan_revise_refused_when_status_advances_under_lock_2760_r2() {
+    let home = tmp_home("r2-status-advance");
+    let id = gov_seed_claimed(&home, 0); // required=0 → in_progress is ungated
+    handle(
+        &home,
+        "worker",
+        &serde_json::json!({
+            "action": "metadata_set", "id": id,
+            "metadata_key": "plan", "metadata_value": "v1"
+        }),
+    );
+    // The owner advances the task to in_progress in the plan-revise out-of-lock window.
+    let home_h = home.clone();
+    let id_h = id.clone();
+    crate::tasks::set_before_mutation_commit_hook_for_test(move || {
+        handle(
+            &home_h,
+            "worker",
+            &serde_json::json!({"action": "update", "id": id_h, "status": "in_progress"}),
+        );
+    });
+    let resp = handle(
+        &home,
+        "worker",
+        &serde_json::json!({
+            "action": "metadata_set", "id": id,
+            "metadata_key": "plan", "metadata_value": "v2"
+        }),
+    );
+    assert_eq!(
+        resp.get("code").and_then(|v| v.as_str()),
+        Some("metadata_precondition_failed"),
+        "the plan revise must be refused once the task advances to in_progress under the lock: {resp}"
+    );
+    assert_eq!(
+        gov_plan_text(&home, &id).as_deref(),
+        Some("v1"),
+        "the plan stays v1 — the revise is refused under the lock"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// RED (finding 2/3 — plan vs concurrent ack): the OWNER revises the plan pre-ack
+/// (authorized out-of-lock), but a reviewer's ack lands concurrently. The under-lock
+/// re-evaluation must REFUSE (plan is frozen once acked) and leave the plan
+/// unchanged. Pre-R2 appended the revised plan unchecked, silently running work
+/// under a replacement plan the ack no longer covers.
+#[test]
+fn plan_revise_refused_when_ack_lands_concurrently_2760_r2() {
+    let home = tmp_home("r2-plan-vs-ack");
+    let id = gov_seed_claimed(&home, 2);
+    handle(
+        &home,
+        "worker",
+        &serde_json::json!({
+            "action": "metadata_set", "id": id,
+            "metadata_key": "plan", "metadata_value": "v1"
+        }),
+    );
+    // A reviewer acks in the owner's plan-revise out-of-lock window.
+    let home_h = home.clone();
+    let id_h = id.clone();
+    crate::tasks::set_before_mutation_commit_hook_for_test(move || {
+        handle(
+            &home_h,
+            "reviewer",
+            &serde_json::json!({"action": "ack_plan", "id": id_h}),
+        );
+    });
+    let resp = handle(
+        &home,
+        "worker",
+        &serde_json::json!({
+            "action": "metadata_set", "id": id,
+            "metadata_key": "plan", "metadata_value": "v2"
+        }),
+    );
+    assert_eq!(
+        resp.get("code").and_then(|v| v.as_str()),
+        Some("metadata_precondition_failed"),
+        "the owner's plan revise must be refused once a reviewer's ack lands concurrently: {resp}"
+    );
+    assert_eq!(
+        gov_plan_text(&home, &id).as_deref(),
+        Some("v1"),
+        "the plan stays v1 — the revise is refused under the lock"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -439,6 +439,35 @@ impl BoardRoot {
     }
 }
 
+/// #2760 item 3: an opaque board identity for write-time route revalidation. Two
+/// routes are the "same board" iff their `BoardKey`s are equal. It wraps the
+/// project id (the board membership axis) but is `tasks`-private and compared only
+/// by value — an external module can never mint one to spoof a route.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BoardKey(String);
+
+/// #2760 item 3: a fingerprint of a resolved strict route — the board PLUS the
+/// task's incarnation (`created_at`). A mutation captures the fingerprint at route
+/// time and [`RoutedTask::with_revalidated_board`] re-resolves the route under the
+/// per-id lock and asserts it STILL fingerprints identically before appending. The
+/// `created_at` component defends against id reuse (a task deleted and a NEW task
+/// created with the same id would carry a different `created_at`, so a stale
+/// mutation cannot be replayed against the fresh incarnation).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RouteFingerprint {
+    board: BoardKey,
+    created_at: String,
+}
+
+impl RouteFingerprint {
+    fn of(project: &str, record: &crate::task_events::TaskRecord) -> Self {
+        Self {
+            board: BoardKey(project.to_string()),
+            created_at: record.created_at.clone(),
+        }
+    }
+}
+
 /// #2760: a task resolved through the strict router — the public [`Task`] view
 /// PLUS the opaque board it authoritatively lives on. External consumers read
 /// `.task`; the board identity is `tasks`-private, so no caller outside this
@@ -451,6 +480,10 @@ pub struct RoutedTask {
     /// an idempotency pre-check on the SAME single route (no re-load).
     record: crate::task_events::TaskRecord,
     board: BoardRoot,
+    /// #2760 item 3: the route fingerprint captured at resolve time —
+    /// [`RoutedTask::with_revalidated_board`] re-resolves under the per-id lock and
+    /// refuses the write unless the fresh route fingerprints identically.
+    fingerprint: RouteFingerprint,
 }
 
 impl RoutedTask {
@@ -467,20 +500,46 @@ impl RoutedTask {
         &self.record
     }
 
-    /// #2760: append `events` to THIS task's authoritative board under a checked
-    /// precondition, reusing the SINGLE route already resolved (no re-load). The
-    /// board identity stays `tasks`-private — a write-owner (usage-limit) supplies
-    /// the domain events + precondition; `tasks` owns WHERE they land.
-    pub(crate) fn append_batch_checked<F>(
+    /// #2760 items 2+3: run `write` under the per-task-ID router lock (OUTER),
+    /// after RE-RESOLVING the strict route inside the lock and asserting it still
+    /// fingerprints identically to this route (same board + incarnation). `write`
+    /// receives the REVALIDATED board root and performs the actual append (which
+    /// takes the board writer lock, INNER). The per-id lock guarantees no
+    /// concurrent authority mutation on this id interleaves between the
+    /// revalidation and the append; the fingerprint guarantees the board / task
+    /// incarnation the caller decided against has not changed under it.
+    ///
+    /// A route error or fingerprint mismatch → `Err(TaskRouteError)` and `write`
+    /// NEVER runs (no side effect) — every mutation consumer maps that to its
+    /// fail-closed policy (deny, no task events). Any cascade/cleanup/notify the
+    /// caller performs MUST run AFTER this returns (the per-id flock is dropped by
+    /// then), never inside `write` — self-IPC under the flock is refused (#1629).
+    pub(in crate::tasks) fn with_revalidated_board<T>(
         &self,
-        emitter: &crate::task_events::InstanceName,
-        events: Vec<crate::task_events::TaskEvent>,
-        check: F,
-    ) -> anyhow::Result<Result<Vec<u64>, String>>
-    where
-        F: FnOnce(&crate::task_events::TaskBoardState) -> Result<(), String>,
-    {
-        crate::task_events::append_batch_checked_at(self.board.path(), emitter, events, check)
+        home: &Path,
+        write: impl FnOnce(&Path) -> T,
+    ) -> Result<T, TaskRouteError> {
+        let _id_lock = board_router::acquire_task_id_lock(home, &self.task.id).map_err(|e| {
+            TaskRouteError::Unreadable {
+                path: home.to_path_buf(),
+                cause: format!("acquire per-task-id router lock for '{}': {e}", self.task.id),
+            }
+        })?;
+        // Re-resolve the strict route UNDER the lock — the authoritative
+        // revalidation. Any route failure (NotFound / Unreadable / Ambiguous) fails
+        // the mutation closed.
+        let (project, board, record) = board_router::route_task(home, &self.task.id)?;
+        if RouteFingerprint::of(&project, &record) != self.fingerprint {
+            return Err(TaskRouteError::Unreadable {
+                path: board,
+                cause: format!(
+                    "route revalidation mismatch for '{}': board/incarnation changed under the \
+                     per-id lock since it was resolved",
+                    self.task.id
+                ),
+            });
+        }
+        Ok(write(&board))
     }
 }
 
@@ -501,6 +560,269 @@ pub(crate) fn caller_can_mutate_task(
         caller,
         routed.board().project(),
     ))
+}
+
+// ── #2760 item 4: narrow task-bound authority ops for EXTERNAL modules ──────
+//
+// External modules (the daemon supervisor's usage-limit control, the per-tick
+// reclaim handler) must NEVER obtain a raw board `Path` or a generic board
+// append. They call these narrow, task-bound operations instead: the strict
+// route, the per-id lock, the write-time revalidation, and the board append all
+// happen INSIDE the `tasks` module — the caller supplies only domain intent
+// (which task, what identity guard, what reason) and learns an outcome.
+
+/// #2760 item 4: the identity a usage-limit block/recover is authorised against —
+/// the task id plus the owner (`source`), the linked `branch`, and the
+/// `episode_id` (the caller's `notification_id`). The board-side revalidation
+/// asserts the routed task still carries this owner+branch (and, for recovery,
+/// this episode) before mutating; a generation change → [`ApplyOutcome::Stale`].
+/// (Binding-generation freshness is the CALLER's concern — it holds the binding
+/// lock and checks it before calling — so it is deliberately NOT in this guard.)
+#[derive(Debug, Clone)]
+pub struct UsageLimitGuard {
+    pub task_id: String,
+    pub source: String,
+    pub branch: String,
+    pub episode_id: String,
+}
+
+/// #2760 item 4: the outcome of a narrow usage-limit op. `Applied` = the event(s)
+/// committed; `AlreadyApplied` = the desired state already holds (idempotent
+/// no-op); `Stale` = the routed task no longer matches the guard (owner/branch/
+/// status/episode changed, or the route no longer resolves uniquely) → nothing
+/// written.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApplyOutcome {
+    Applied,
+    AlreadyApplied,
+    Stale,
+}
+
+/// True iff the routed record still bears the guard's owner + branch and one of
+/// `statuses`. The board-state counterpart of the supervisor's old
+/// `task_matches_key`, now owned by `tasks` (the board authority).
+fn task_matches_guard(
+    record: &crate::task_events::TaskRecord,
+    guard: &UsageLimitGuard,
+    statuses: &[crate::task_events::TaskStatus],
+) -> bool {
+    record.owner.as_ref().map(|o| o.as_str()) == Some(guard.source.as_str())
+        && record.branch.as_deref() == Some(guard.branch.as_str())
+        && statuses.contains(&record.status)
+}
+
+/// #2760 item 4: block a task for a usage-limit episode on ITS authoritative board
+/// (never the default board). Strict-resolves the route, short-circuits
+/// idempotently if the task is already `Blocked` for this episode, then appends a
+/// `Blocked` event under the per-id lock with write-time revalidation and a
+/// commit-time guard (still `Claimed`/`InProgress`, still this owner+branch).
+///
+/// `reason` is the fully-formed block-reason payload the caller built (it embeds
+/// the `episode_id`, so the idempotency check can recognise it). A route error /
+/// revalidation mismatch / commit-guard failure → `Stale` (no event); only a real
+/// board IO/replay failure returns `Err`.
+pub fn apply_usage_limit_block(
+    home: &Path,
+    guard: &UsageLimitGuard,
+    reason: String,
+) -> anyhow::Result<ApplyOutcome> {
+    let routed = match load_routed(home, &guard.task_id) {
+        Ok(rt) => rt,
+        Err(e) => {
+            tracing::warn!(task = %guard.task_id, route_err = %e,
+                "#2760 usage-limit block: task route unresolved → Stale (no default-board write)");
+            return Ok(ApplyOutcome::Stale);
+        }
+    };
+    // Idempotent: already blocked for THIS episode (its id is embedded in the
+    // committed block_reason) → nothing to do.
+    if routed.record().status == crate::task_events::TaskStatus::Blocked
+        && routed
+            .record()
+            .block_reason
+            .as_deref()
+            .is_some_and(|r| r.contains(&guard.episode_id))
+    {
+        return Ok(ApplyOutcome::AlreadyApplied);
+    }
+    let tid = crate::task_events::TaskId(guard.task_id.clone());
+    let emitter = crate::task_events::InstanceName("system:usage-limit".into());
+    let guard_for_check = guard.clone();
+    let check_tid = tid.clone();
+    let revalidated = routed.with_revalidated_board(home, |board| {
+        crate::task_events::append_batch_checked_at(
+            board,
+            &emitter,
+            vec![crate::task_events::TaskEvent::Blocked {
+                task_id: tid.clone(),
+                reason,
+            }],
+            move |fresh| {
+                let record = fresh
+                    .tasks
+                    .get(&check_tid)
+                    .ok_or_else(|| "task disappeared before usage-limit block".to_string())?;
+                task_matches_guard(
+                    record,
+                    &guard_for_check,
+                    &[
+                        crate::task_events::TaskStatus::Claimed,
+                        crate::task_events::TaskStatus::InProgress,
+                    ],
+                )
+                .then_some(())
+                .ok_or_else(|| "task generation changed before usage-limit block".to_string())
+            },
+        )
+    });
+    match revalidated {
+        Ok(Ok(Ok(_))) => Ok(ApplyOutcome::Applied),
+        // Commit-guard rejected (generation changed) → Stale, no event.
+        Ok(Ok(Err(_))) => Ok(ApplyOutcome::Stale),
+        // Real board IO / replay failure.
+        Ok(Err(e)) => Err(e),
+        // Route revalidation refused under the per-id lock → Stale.
+        Err(route_err) => {
+            tracing::warn!(task = %guard.task_id, %route_err,
+                "#2760 usage-limit block: route revalidation failed → Stale");
+            Ok(ApplyOutcome::Stale)
+        }
+    }
+}
+
+/// #2760 item 4: recover (unblock → back to InProgress) a usage-limit-blocked task
+/// on its authoritative board. Idempotent if the task is already `InProgress` for
+/// this owner+branch (the crash window where the Unblocked+InProgress append
+/// committed but the episode-state persist did not). Otherwise appends
+/// `[Unblocked, InProgress]` under the per-id lock with revalidation and a
+/// commit-time guard (still `Blocked` for THIS episode, still this owner+branch).
+pub fn recover_usage_limit_block(
+    home: &Path,
+    guard: &UsageLimitGuard,
+) -> anyhow::Result<ApplyOutcome> {
+    let routed = match load_routed(home, &guard.task_id) {
+        Ok(rt) => rt,
+        Err(e) => {
+            tracing::warn!(task = %guard.task_id, route_err = %e,
+                "#2760 usage-limit recovery: task route unresolved → Stale");
+            return Ok(ApplyOutcome::Stale);
+        }
+    };
+    // Crash-window idempotency: the atomic Unblocked+InProgress already committed
+    // but persisting the recovered episode state did not.
+    if task_matches_guard(
+        routed.record(),
+        guard,
+        &[crate::task_events::TaskStatus::InProgress],
+    ) {
+        return Ok(ApplyOutcome::AlreadyApplied);
+    }
+    let tid = crate::task_events::TaskId(guard.task_id.clone());
+    let owner = crate::task_events::InstanceName(guard.source.clone());
+    let emitter = crate::task_events::InstanceName("system:usage-limit".into());
+    let guard_for_check = guard.clone();
+    let check_tid = tid.clone();
+    let revalidated = routed.with_revalidated_board(home, |board| {
+        crate::task_events::append_batch_checked_at(
+            board,
+            &emitter,
+            vec![
+                crate::task_events::TaskEvent::Unblocked {
+                    task_id: tid.clone(),
+                },
+                crate::task_events::TaskEvent::InProgress {
+                    task_id: tid.clone(),
+                    by: owner,
+                },
+            ],
+            move |fresh| {
+                let record = fresh
+                    .tasks
+                    .get(&check_tid)
+                    .ok_or_else(|| "task disappeared before usage-limit recovery".to_string())?;
+                if task_matches_guard(
+                    record,
+                    &guard_for_check,
+                    &[crate::task_events::TaskStatus::Blocked],
+                ) && record
+                    .block_reason
+                    .as_deref()
+                    .is_some_and(|r| r.contains(&guard_for_check.episode_id))
+                {
+                    Ok(())
+                } else {
+                    Err("task generation changed before usage-limit recovery".to_string())
+                }
+            },
+        )
+    });
+    match revalidated {
+        Ok(Ok(Ok(_))) => Ok(ApplyOutcome::Applied),
+        Ok(Ok(Err(_))) => Ok(ApplyOutcome::Stale),
+        Ok(Err(e)) => Err(e),
+        Err(route_err) => {
+            tracing::warn!(task = %guard.task_id, %route_err,
+                "#2760 usage-limit recovery: route revalidation failed → Stale");
+            Ok(ApplyOutcome::Stale)
+        }
+    }
+}
+
+/// #2760 item 2 (reclaim BUG fix): emit a `Released` event for a reclaimed task on
+/// ITS authoritative board, under the per-id lock with revalidation. The pre-#2760
+/// reclaim handler appended `Released` to the DEFAULT board unconditionally, so a
+/// project-board task's release was written where its own board's replay never saw
+/// it (the task stayed Claimed forever). The commit-time guard only releases a task
+/// still `Claimed`/`InProgress`. Returns `Ok(true)` iff the `Released` committed.
+pub fn release_reclaimed_task(
+    home: &Path,
+    task_id: &str,
+    reason: String,
+) -> anyhow::Result<bool> {
+    let routed = match load_routed(home, task_id) {
+        Ok(rt) => rt,
+        Err(e) => {
+            tracing::warn!(task = task_id, route_err = %e,
+                "#2760 reclaim release: task route unresolved → skip (no default-board write)");
+            return Ok(false);
+        }
+    };
+    let tid = crate::task_events::TaskId(task_id.to_string());
+    let emitter = crate::task_events::InstanceName::from("system:reclaim_usage_limit");
+    let check_tid = tid.clone();
+    let revalidated = routed.with_revalidated_board(home, |board| {
+        crate::task_events::append_checked_at(
+            board,
+            &emitter,
+            crate::task_events::TaskEvent::Released {
+                task_id: tid.clone(),
+                reason,
+            },
+            move |fresh| {
+                let record = fresh
+                    .tasks
+                    .get(&check_tid)
+                    .ok_or_else(|| "task disappeared before reclaim release".to_string())?;
+                matches!(
+                    record.status,
+                    crate::task_events::TaskStatus::Claimed
+                        | crate::task_events::TaskStatus::InProgress
+                )
+                .then_some(())
+                .ok_or_else(|| "task no longer claimed/in-progress before reclaim release".to_string())
+            },
+        )
+    });
+    match revalidated {
+        Ok(Ok(Ok(_))) => Ok(true),
+        Ok(Ok(Err(_))) => Ok(false),
+        Ok(Err(e)) => Err(e),
+        Err(route_err) => {
+            tracing::warn!(task = task_id, %route_err,
+                "#2760 reclaim release: route revalidation failed → skip");
+            Ok(false)
+        }
+    }
 }
 
 /// #2760: why a strict route failed. There is deliberately NO variant that means
@@ -559,10 +881,12 @@ impl std::error::Error for TaskRouteError {}
 /// board": consumers map it to their own fail-closed policy.
 pub(crate) fn load_routed(home: &Path, task_id: &str) -> Result<RoutedTask, TaskRouteError> {
     let (project, board, record) = board_router::route_task(home, task_id)?;
+    let fingerprint = RouteFingerprint::of(&project, &record);
     Ok(RoutedTask {
         task: record_to_task(&record),
         record,
         board: BoardRoot::new(project, board),
+        fingerprint,
     })
 }
 
@@ -625,27 +949,34 @@ pub fn link_branch_to_task(home: &Path, task_id: &str, branch: &str) -> anyhow::
     let emitter = crate::task_events::InstanceName::from("system:branch-link");
     let branch_owned = branch.to_string();
     let closure_tid = tid.clone();
-    let checked = routed.append_batch_checked(
-        &emitter,
-        vec![crate::task_events::TaskEvent::BranchLinked {
-            task_id: tid,
-            by: emitter.clone(),
-            branch: branch_owned.clone(),
-        }],
-        move |fresh| match fresh.tasks.get(&closure_tid) {
-            None => Err(format!(
-                "task '{}' disappeared before branch-link",
-                closure_tid.0
-            )),
-            // A concurrent link raced the same branch in → idempotent no-op.
-            Some(record) if record.branch.as_deref() == Some(branch_owned.as_str()) => {
-                Err("branch already linked".to_string())
-            }
-            Some(_) => Ok(()),
-        },
-    )?;
-    match checked {
-        Ok(_) => {
+    // #2760 items 2+3: append under the per-id router lock with write-time route
+    // revalidation. A route change under the lock (board/incarnation) fails closed
+    // → no branch-link, no side effect (never a wrong-board write).
+    let revalidated = routed.with_revalidated_board(home, |board| {
+        crate::task_events::append_batch_checked_at(
+            board,
+            &emitter,
+            vec![crate::task_events::TaskEvent::BranchLinked {
+                task_id: tid,
+                by: emitter.clone(),
+                branch: branch_owned.clone(),
+            }],
+            move |fresh| match fresh.tasks.get(&closure_tid) {
+                None => Err(format!(
+                    "task '{}' disappeared before branch-link",
+                    closure_tid.0
+                )),
+                // A concurrent link raced the same branch in → idempotent no-op.
+                Some(record) if record.branch.as_deref() == Some(branch_owned.as_str()) => {
+                    Err("branch already linked".to_string())
+                }
+                Some(_) => Ok(()),
+            },
+        )
+    });
+    match revalidated {
+        // Committed the BranchLinked event.
+        Ok(Ok(Ok(_))) => {
             tracing::info!(
                 task_id,
                 branch,
@@ -654,7 +985,18 @@ pub fn link_branch_to_task(home: &Path, task_id: &str, branch: &str) -> anyhow::
             Ok(true)
         }
         // Precondition failed at commit (raced re-link / task gone) → no-op.
-        Err(_) => Ok(false),
+        Ok(Ok(Err(_))) => Ok(false),
+        // Board IO / replay error inside the checked append.
+        Ok(Err(e)) => Err(e),
+        // Route revalidation refused under the lock (board/incarnation changed, or
+        // the id no longer routes uniquely) → no write.
+        Err(route_err) => {
+            tracing::warn!(
+                task_id, branch, %route_err,
+                "#2760 branch-link skipped: route revalidation failed under the per-id lock"
+            );
+            Ok(false)
+        }
     }
 }
 

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -232,6 +232,32 @@ fn fire_before_cross_board_release_hook_for_test() {
     }
 }
 
+// #2760 R2 (root+independent REJECT of a542517b): test-only seam for the per-id
+// authority-mutation TOCTOU. Fires in the OUT-OF-LOCK window right before a mutation
+// (`ack_plan` / `metadata_set`) takes its per-id + board locks, so a test can
+// deterministically land a CONCURRENT mutation on the same id and prove the
+// under-lock recompute (ack UNION / fresh authorization) is race-safe. The injected
+// mutation completes fully (acquires+releases its own locks) BEFORE the instrumented
+// caller locks, so there is no deadlock; fires at most once (`take`).
+#[cfg(test)]
+thread_local! {
+    static BEFORE_MUTATION_COMMIT_HOOK: std::cell::RefCell<Option<Box<dyn FnOnce()>>> =
+        std::cell::RefCell::new(None);
+}
+
+#[cfg(test)]
+pub(crate) fn set_before_mutation_commit_hook_for_test(f: impl FnOnce() + 'static) {
+    BEFORE_MUTATION_COMMIT_HOOK.with(|h| *h.borrow_mut() = Some(Box::new(f)));
+}
+
+#[cfg(test)]
+pub(super) fn fire_before_mutation_commit_hook_for_test() {
+    let hook = BEFORE_MUTATION_COMMIT_HOOK.with(|h| h.borrow_mut().take());
+    if let Some(f) = hook {
+        f();
+    }
+}
+
 impl<'a> DepResolver<'a> {
     fn new(home: &'a Path, local_board: &'a Path, snapshot: &[Task]) -> Self {
         let local = snapshot.iter().map(|t| (t.id.clone(), t.status)).collect();
@@ -543,6 +569,33 @@ impl RoutedTask {
             });
         }
         Ok(write(&board))
+    }
+
+    /// #2760 R2: like [`RoutedTask::with_revalidated_board`] but the append EVENTS
+    /// are COMPUTED from the FRESH under-lock replay ([`crate::task_events::append_batch_computed_at`]).
+    /// A route-only revalidation (board/incarnation) is NOT enough for a mutation
+    /// whose authority or payload depends on current task CONTENT — ownership,
+    /// status, metadata, the ack set. This runs the caller's `compute` under the
+    /// board writer lock (INNER; the per-id lock is OUTER), so it re-evaluates
+    /// authorization AND builds the events (e.g. an idempotent `plan_acks` UNION,
+    /// or a governance-policy re-check) against committed state that no concurrent
+    /// writer can change between the decision and the write — closing the
+    /// authorization/predicate TOCTOU. `compute` must be pure decision + event
+    /// construction (no `api::call` under the flocks, #1629).
+    pub(in crate::tasks) fn with_revalidated_computed<F>(
+        &self,
+        home: &Path,
+        emitter: &crate::task_events::InstanceName,
+        compute: F,
+    ) -> Result<anyhow::Result<Result<Vec<u64>, String>>, TaskRouteError>
+    where
+        F: FnOnce(
+            &crate::task_events::TaskBoardState,
+        ) -> Result<Vec<crate::task_events::TaskEvent>, String>,
+    {
+        self.with_revalidated_board(home, |board| {
+            crate::task_events::append_batch_computed_at(board, emitter, compute)
+        })
     }
 }
 

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -13,6 +13,13 @@ mod sweep;
 #[path = "tests.rs"]
 mod tests;
 
+// #2760 RED (frozen-plan d-…-7): strict-routing contract for `load_routed`.
+// Proven-failing against the checkpoint stub; the GREEN strict-resolution body
+// turns them green.
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod routing_red_2760;
+
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
@@ -39,13 +46,15 @@ pub use handler::register_subscriber as register_cascade_subscriber;
 // #2117 P2: resolution helpers for the out-of-`tasks` callers — comms dispatch
 // auto-create (target board) and the per-board task sweep (project id from a
 // team's source_repo).
+// #2760: `board_for_task` / `resolve_task_project` (the LENIENT default-fallback
+// seams) are no longer re-exported — every per-id authority path routes through
+// the strict `load_routed` / `caller_can_mutate_task` above instead.
 pub(crate) use board_router::{
-    board_for_task, list_all_boards, project_id_from_source_repo, resolve_target_project,
-    resolve_task_project,
+    list_all_boards, project_id_from_source_repo, resolve_target_project,
 };
-// #2127 Phase 1 / #2117 P3: shared per-board mutation ACL primitive, re-exported
-// for callers outside the `tasks` module (the reclaim per-tick handler).
-pub(crate) use acl::can_mutate_on_board;
+// #2760: the per-board mutation ACL is no longer re-exported for external callers
+// (reclaim now routes through the strict `caller_can_mutate_task` above). It stays
+// tasks-internal — `caller_can_mutate_task` and the handler ACL use `acl::` directly.
 pub use orphan::{
     cancel_tasks_for_owner, orphan_tasks_for_owner, reconcile_orphan_owners_with_live,
     release_inprogress_orphans_with_live,
@@ -161,9 +170,10 @@ struct DepResolver<'a> {
     /// absent there) → skip the redundant replay.
     local_board: &'a Path,
     local: std::collections::HashMap<String, crate::task_events::TaskStatus>,
-    /// Memoized `resolve_task_project` per dep_id (its index-miss fallback is a
-    /// full-board scan — resolve each distinct dep at most once per pass).
-    proj_cache: std::collections::HashMap<String, String>,
+    /// #2760: memoized STRICT route per dep_id → the dep's authoritative board, or
+    /// `None` when the route fails closed (NotFound/Unreadable/Ambiguous). Resolve
+    /// each distinct dep at most once per pass (its index-miss path is a full scan).
+    proj_cache: std::collections::HashMap<String, Option<std::path::PathBuf>>,
     /// Lazily-replayed foreign boards: board path → {task_id → status}.
     board_cache: std::collections::HashMap<
         std::path::PathBuf,
@@ -237,12 +247,19 @@ impl<'a> DepResolver<'a> {
         if let Some(s) = self.local.get(dep_id) {
             return Some(*s);
         }
-        let project = self
+        // #2760: resolve the dep's board via the STRICT route (cached per dep_id).
+        // A route error → `None` → the dep is not-reachable → not-Done → blocking
+        // (the conservative pre-#2117 missing-dep rule); never a silent DEFAULT read.
+        let board = self
             .proj_cache
             .entry(dep_id.to_string())
-            .or_insert_with(|| board_router::resolve_task_project(self.home, dep_id))
+            .or_insert_with(|| {
+                board_router::route_task(self.home, dep_id)
+                    .map(|(_, board, _)| board)
+                    .ok()
+            })
             .clone();
-        let board = crate::task_events::board_root(self.home, &project);
+        let board = board?;
         if board.as_path() == self.local_board {
             // Resolves back to the local board → already covered by `local`
             // (and definitively absent, since the local check above missed).
@@ -379,8 +396,171 @@ pub(super) fn status_to_legacy_str(s: crate::task_events::TaskStatus) -> &'stati
     }
 }
 
-pub fn load_by_id(home: &Path, task_id: &str) -> Option<Task> {
-    handler::read_task_record(home, task_id).map(|r| record_to_task(&r))
+// ── #2760: strict routed task authority ────────────────────────────────
+//
+// The removed `load_by_id` seam read ONLY the default board
+// (`read_task_record_at(home, id)`, where `home` IS the default board root), so a
+// task on a per-project board was invisible to it — the t-…-35 live failure (a
+// project-board task with `review_class=single` dispatched as
+// `review_class_unspecified`). `load_routed` is its fail-closed replacement: it
+// resolves the ONE board that authoritatively holds the id and NEVER silently
+// falls back to the default board on a miss.
+
+/// #2760: an opaque board identity carried by a [`RoutedTask`]. The inner path
+/// and its constructor are PRIVATE to the `tasks` module (`pub(in crate::tasks)`),
+/// so an external consumer receives a [`RoutedTask`] — a [`Task`] view — and can
+/// never obtain a raw board `Path` to write to the wrong board. The high-level
+/// `tasks` write operations (branch-link, usage-limit) that DO need the board
+/// take it back through this opaque handle, not as a bare path.
+#[derive(Debug, Clone)]
+pub struct BoardRoot {
+    /// The resolved project id (a read-only board LABEL — used by the per-board
+    /// mutation ACL). NOT a filesystem path: exposing it via [`RoutedTask`] cannot
+    /// let an external module write to a board.
+    project: String,
+    path: std::path::PathBuf,
+}
+
+impl BoardRoot {
+    pub(in crate::tasks) fn new(project: String, path: std::path::PathBuf) -> Self {
+        Self { project, path }
+    }
+    /// The board's project id (the ACL axis). `tasks`-private.
+    pub(in crate::tasks) fn project(&self) -> &str {
+        &self.project
+    }
+    /// The board's on-disk root. `tasks`-private so no external module can obtain a
+    /// raw board `Path` to write to the wrong board (#2760 point 3/7).
+    pub(in crate::tasks) fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+/// #2760: a task resolved through the strict router — the public [`Task`] view
+/// PLUS the opaque board it authoritatively lives on. External consumers read
+/// `.task`; the board identity is `tasks`-private, so no caller outside this
+/// module can mutate the resolved task on some other board.
+#[derive(Debug, Clone)]
+pub struct RoutedTask {
+    pub task: Task,
+    /// The raw replay record for the routed task — carries fields the [`Task`]
+    /// view omits (e.g. `block_reason`) that a write-owner (usage-limit) needs for
+    /// an idempotency pre-check on the SAME single route (no re-load).
+    record: crate::task_events::TaskRecord,
+    board: BoardRoot,
+}
+
+impl RoutedTask {
+    /// The opaque board this task was routed to — `tasks`-private, so only the
+    /// high-level task operations (which own branch-link / usage-limit writes)
+    /// can reach it.
+    pub(in crate::tasks) fn board(&self) -> &BoardRoot {
+        &self.board
+    }
+
+    /// The raw replay record (fields not projected into the [`Task`] view, e.g.
+    /// `block_reason`). Read-only snapshot from the strict route.
+    pub(crate) fn record(&self) -> &crate::task_events::TaskRecord {
+        &self.record
+    }
+
+    /// #2760: append `events` to THIS task's authoritative board under a checked
+    /// precondition, reusing the SINGLE route already resolved (no re-load). The
+    /// board identity stays `tasks`-private — a write-owner (usage-limit) supplies
+    /// the domain events + precondition; `tasks` owns WHERE they land.
+    pub(crate) fn append_batch_checked<F>(
+        &self,
+        emitter: &crate::task_events::InstanceName,
+        events: Vec<crate::task_events::TaskEvent>,
+        check: F,
+    ) -> anyhow::Result<Result<Vec<u64>, String>>
+    where
+        F: FnOnce(&crate::task_events::TaskBoardState) -> Result<(), String>,
+    {
+        crate::task_events::append_batch_checked_at(self.board.path(), emitter, events, check)
+    }
+}
+
+/// #2760: strict per-board mutation authorization for an EXTERNAL caller (the
+/// reclaim per-tick handler). Resolves the task's authoritative board via the
+/// strict route (fail-closed) and applies the per-board mutation ACL. `Err` on any
+/// route failure so the caller DENIES (never mutates a task it cannot uniquely
+/// route). Keeps the board identity `tasks`-private — the caller learns only the
+/// yes/no authorization.
+pub(crate) fn caller_can_mutate_task(
+    home: &Path,
+    caller: &str,
+    task_id: &str,
+) -> Result<bool, TaskRouteError> {
+    let routed = load_routed(home, task_id)?;
+    Ok(acl::can_mutate_on_board(
+        home,
+        caller,
+        routed.board().project(),
+    ))
+}
+
+/// #2760: why a strict route failed. There is deliberately NO variant that means
+/// "fell back to the default board" — a route either names the ONE authoritative
+/// board or fails closed here. Consumers map these to their own fail-closed
+/// policy (deny / keep-obligation / keep-reserved-live); they must never treat an
+/// error as "assume default".
+// #2760 checkpoint: consumers migrate onto this in the GREEN step; until then
+// the strict variants have no non-test constructor in the bin build.
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub enum TaskRouteError {
+    /// The id is present on NO readable board — a definitive absence (every board
+    /// enumerated and replayed cleanly, none held the id).
+    NotFound,
+    /// A board's index or event log could not be read/parsed, so uniqueness could
+    /// not be proven. Fails closed rather than guessing a board.
+    Unreadable {
+        path: std::path::PathBuf,
+        cause: String,
+    },
+    /// The id resolves to more than one board (a duplicate id across boards, or
+    /// conflicting distinct index entries) — there is no single authority.
+    Ambiguous {
+        candidates: Vec<String>,
+        cause: String,
+    },
+}
+
+impl std::fmt::Display for TaskRouteError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TaskRouteError::NotFound => write!(f, "task not found on any board"),
+            TaskRouteError::Unreadable { path, cause } => {
+                write!(f, "task route unreadable ({}): {cause}", path.display())
+            }
+            TaskRouteError::Ambiguous { candidates, cause } => {
+                write!(f, "task route ambiguous across {candidates:?}: {cause}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for TaskRouteError {}
+
+/// #2760 STRICT per-id task router — the fail-closed replacement for the
+/// default-board [`load_by_id`] seam. Resolves the ONE board that authoritatively
+/// holds `task_id` and returns its [`Task`] view + opaque board, or a typed
+/// [`TaskRouteError`] that NEVER means "assume the default board".
+///
+/// Resolves the ONE board that authoritatively holds `task_id` (frozen-plan
+/// point 2: indexed route replay-verified, else a checked scan of the default +
+/// every project board — exactly-one hit = success, zero = NotFound, >1 =
+/// Ambiguous, any replay/index failure = Unreadable) and returns its [`Task`] view
+/// and its opaque board. A [`TaskRouteError`] NEVER means "assume the default
+/// board": consumers map it to their own fail-closed policy.
+pub(crate) fn load_routed(home: &Path, task_id: &str) -> Result<RoutedTask, TaskRouteError> {
+    let (project, board, record) = board_router::route_task(home, task_id)?;
+    Ok(RoutedTask {
+        task: record_to_task(&record),
+        record,
+        board: BoardRoot::new(project, board),
+    })
 }
 
 /// Return all tasks as typed structs. **PR3 cutover** — sources state
@@ -420,26 +600,59 @@ pub fn link_branch_to_task(home: &Path, task_id: &str, branch: &str) -> anyhow::
     if branch.is_empty() || !task_id.starts_with("t-") {
         return Ok(false);
     }
-    let state = crate::task_events::replay(home).unwrap_or_default();
-    let tid = crate::task_events::TaskId(task_id.to_string());
-    let Some(record) = state.tasks.get(&tid) else {
-        return Ok(false);
+    // #2760: resolve the ONE authoritative board via the strict route and append
+    // BranchLinked THERE under a checked precondition — never a silent default-board
+    // write (the pre-#2760 body read `replay(home)`, invisible to project boards).
+    // A route error is surfaced (logged) and writes nothing.
+    let routed = match load_routed(home, task_id) {
+        Ok(rt) => rt,
+        Err(TaskRouteError::NotFound) => return Ok(false),
+        Err(e) => {
+            tracing::warn!(
+                task_id, branch, route_err = %e,
+                "#2760 branch-link skipped: task route unresolved (no default-board write)"
+            );
+            return Ok(false);
+        }
     };
-    if record.branch.as_deref() == Some(branch) {
+    if routed.task.branch.as_deref() == Some(branch) {
         return Ok(false);
     }
+    let tid = crate::task_events::TaskId(task_id.to_string());
     let emitter = crate::task_events::InstanceName::from("system:branch-link");
-    crate::task_events::append_batch(
-        home,
+    let branch_owned = branch.to_string();
+    let closure_tid = tid.clone();
+    let checked = routed.append_batch_checked(
         &emitter,
         vec![crate::task_events::TaskEvent::BranchLinked {
             task_id: tid,
             by: emitter.clone(),
-            branch: branch.to_string(),
+            branch: branch_owned.clone(),
         }],
+        move |fresh| match fresh.tasks.get(&closure_tid) {
+            None => Err(format!(
+                "task '{}' disappeared before branch-link",
+                closure_tid.0
+            )),
+            // A concurrent link raced the same branch in → idempotent no-op.
+            Some(record) if record.branch.as_deref() == Some(branch_owned.as_str()) => {
+                Err("branch already linked".to_string())
+            }
+            Some(_) => Ok(()),
+        },
     )?;
-    tracing::info!(task_id, branch, "linked branch to task (#1942)");
-    Ok(true)
+    match checked {
+        Ok(_) => {
+            tracing::info!(
+                task_id,
+                branch,
+                "linked branch to task (#1942, #2760 routed)"
+            );
+            Ok(true)
+        }
+        // Precondition failed at commit (raced re-link / task gone) → no-op.
+        Err(_) => Ok(false),
+    }
 }
 
 /// Sweep overdue claimed tasks back to open by **emitting `Released`
@@ -553,10 +766,14 @@ pub fn reconcile_stale_cross_board_claims(home: &Path) -> CrossBoardReconcileRep
         }
         let mut resolver = DepResolver::new(home, &board, &snapshot);
         for task in candidates {
-            let has_cross_board_dep = task
-                .depends_on
-                .iter()
-                .any(|d| board_router::resolve_task_project(home, d) != project);
+            // #2760: classify cross-board via the STRICT route. A dep that cannot
+            // be uniquely routed → treated as NOT cross-board (`unwrap_or(false)`) →
+            // the detective skips it (never releases a claim on an unprovable dep).
+            let has_cross_board_dep = task.depends_on.iter().any(|d| {
+                board_router::route_task(home, d)
+                    .map(|(dep_project, _, _)| dep_project != project)
+                    .unwrap_or(false)
+            });
             if !has_cross_board_dep {
                 continue;
             }
@@ -617,7 +834,9 @@ pub fn reconcile_stale_cross_board_claims(home: &Path) -> CrossBoardReconcileRep
                         fresh_state.tasks.values().map(record_to_task).collect();
                     let mut fresh_resolver = DepResolver::new(home, &board, &fresh_snapshot);
                     let still_cross_board = record.depends_on.iter().any(|d| {
-                        board_router::resolve_task_project(home, &d.0) != project_for_check
+                        board_router::route_task(home, &d.0)
+                            .map(|(dep_project, _, _)| dep_project != project_for_check)
+                            .unwrap_or(false)
                     });
                     if !still_cross_board {
                         return Err(format!("task '{task_id}' no longer has a cross-board dep"));

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -15,9 +15,12 @@ mod tests;
 
 // #2760 RED (frozen-plan d-…-7): strict-routing contract for `load_routed`.
 // Proven-failing against the checkpoint stub; the GREEN strict-resolution body
-// turns them green.
+// turns them green. `#[path]` (mirroring the `tests` submodule above) marks this a
+// cfg(test) module file so the task-events anti-bypass invariant recognizes it as
+// test-only — the Unreadable RED deliberately makes a board's event log a directory.
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
+#[path = "routing_red_2760.rs"]
 mod routing_red_2760;
 
 use serde::{Deserialize, Serialize};
@@ -743,7 +746,13 @@ pub fn reconcile_stale_cross_board_claims(home: &Path) -> CrossBoardReconcileRep
     let mut report = CrossBoardReconcileReport::default();
     let emitter = InstanceName::from("system:cross_board_dep_detective");
 
-    for project in board_router::enumerate_projects(home) {
+    // #2760 R1: an unenumerable boards/ dir → skip this reconcile pass entirely
+    // (conservative: never release a claim we cannot fully survey).
+    let projects = match board_router::enumerate_projects(home) {
+        Ok(p) => p,
+        Err(_) => return report,
+    };
+    for project in projects {
         let board = crate::task_events::board_root(home, &project);
         // RAW persisted state (`replay_at`, no in-memory dep derivation) — the
         // derived view (`list_all_at`/`list_all_boards`) would relabel an

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -597,20 +597,6 @@ impl RoutedTask {
             crate::task_events::append_batch_computed_at(board, emitter, compute)
         })
     }
-
-    /// #2760 R2: re-resolve the strict route and return whether it STILL fingerprints
-    /// identically to this route (same board + incarnation). A batch mutator (the
-    /// task sweep) that groups ids by a PRE-lock route, then holds each id's per-id
-    /// lock, calls this UNDER the lock to confirm the id has not been re-routed
-    /// (duplicate-created / id-reused) since the grouping route — before it commits a
-    /// batch write to the grouped board. Any route failure → `false` (fail-closed:
-    /// never act on an unprovable/changed route).
-    pub(in crate::tasks) fn route_unchanged(&self, home: &Path) -> bool {
-        match board_router::route_task(home, &self.task.id) {
-            Ok((project, _, record)) => RouteFingerprint::of(&project, &record) == self.fingerprint,
-            Err(_) => false,
-        }
-    }
 }
 
 /// #2760: strict per-board mutation authorization for an EXTERNAL caller (the

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -522,7 +522,10 @@ impl RoutedTask {
         let _id_lock = board_router::acquire_task_id_lock(home, &self.task.id).map_err(|e| {
             TaskRouteError::Unreadable {
                 path: home.to_path_buf(),
-                cause: format!("acquire per-task-id router lock for '{}': {e}", self.task.id),
+                cause: format!(
+                    "acquire per-task-id router lock for '{}': {e}",
+                    self.task.id
+                ),
             }
         })?;
         // Re-resolve the strict route UNDER the lock — the authoritative
@@ -774,11 +777,7 @@ pub fn recover_usage_limit_block(
 /// project-board task's release was written where its own board's replay never saw
 /// it (the task stayed Claimed forever). The commit-time guard only releases a task
 /// still `Claimed`/`InProgress`. Returns `Ok(true)` iff the `Released` committed.
-pub fn release_reclaimed_task(
-    home: &Path,
-    task_id: &str,
-    reason: String,
-) -> anyhow::Result<bool> {
+pub fn release_reclaimed_task(home: &Path, task_id: &str, reason: String) -> anyhow::Result<bool> {
     let routed = match load_routed(home, task_id) {
         Ok(rt) => rt,
         Err(e) => {
@@ -809,7 +808,9 @@ pub fn release_reclaimed_task(
                         | crate::task_events::TaskStatus::InProgress
                 )
                 .then_some(())
-                .ok_or_else(|| "task no longer claimed/in-progress before reclaim release".to_string())
+                .ok_or_else(|| {
+                    "task no longer claimed/in-progress before reclaim release".to_string()
+                })
             },
         )
     });

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -607,9 +607,7 @@ impl RoutedTask {
     /// never act on an unprovable/changed route).
     pub(in crate::tasks) fn route_unchanged(&self, home: &Path) -> bool {
         match board_router::route_task(home, &self.task.id) {
-            Ok((project, _, record)) => {
-                RouteFingerprint::of(&project, &record) == self.fingerprint
-            }
+            Ok((project, _, record)) => RouteFingerprint::of(&project, &record) == self.fingerprint,
             Err(_) => false,
         }
     }

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -597,6 +597,22 @@ impl RoutedTask {
             crate::task_events::append_batch_computed_at(board, emitter, compute)
         })
     }
+
+    /// #2760 R2: re-resolve the strict route and return whether it STILL fingerprints
+    /// identically to this route (same board + incarnation). A batch mutator (the
+    /// task sweep) that groups ids by a PRE-lock route, then holds each id's per-id
+    /// lock, calls this UNDER the lock to confirm the id has not been re-routed
+    /// (duplicate-created / id-reused) since the grouping route — before it commits a
+    /// batch write to the grouped board. Any route failure → `false` (fail-closed:
+    /// never act on an unprovable/changed route).
+    pub(in crate::tasks) fn route_unchanged(&self, home: &Path) -> bool {
+        match board_router::route_task(home, &self.task.id) {
+            Ok((project, _, record)) => {
+                RouteFingerprint::of(&project, &record) == self.fingerprint
+            }
+            Err(_) => false,
+        }
+    }
 }
 
 /// #2760: strict per-board mutation authorization for an EXTERNAL caller (the

--- a/src/tasks/routing_red_2760.rs
+++ b/src/tasks/routing_red_2760.rs
@@ -1,0 +1,198 @@
+//! #2760 (frozen-plan d-…-7) — strict routed task authority, RED-first.
+//!
+//! These pin the fail-closed contract of [`super::load_routed`]: it resolves the
+//! ONE board that authoritatively holds an id and NEVER falls back to the default
+//! board on a miss. They are PROVEN-FAILING against the checkpoint stub (which
+//! reaches only the default board, the same reach as the `load_by_id` seam it
+//! replaces); the GREEN strict-resolution body (checked scan of the default board
+//! + every project board, index replay-verify) turns them green.
+//!
+//! The two guard tests (default legacy without index; unknown → NotFound) already
+//! pass against the stub — they pin the byte-identical default-board behaviour so
+//! GREEN cannot regress it.
+
+use super::{link_branch_to_task, load_routed, TaskRouteError};
+use crate::task_events::{append_batch_at, board_root, InstanceName, TaskEvent, TaskId};
+use std::path::{Path, PathBuf};
+
+fn tmp_home(tag: &str) -> PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static CTR: AtomicU64 = AtomicU64::new(0);
+    let n = CTR.fetch_add(1, Ordering::Relaxed);
+    let p = std::env::temp_dir().join(format!(
+        "agend-routing-red-2760-{}-{}-{tag}",
+        std::process::id(),
+        n
+    ));
+    std::fs::create_dir_all(&p).unwrap();
+    p
+}
+
+/// Seed a real (Created) task onto `project`'s board. `DEFAULT_PROJECT`/"default"
+/// → the home board. Does NOT touch the `task_index` — callers that want an index
+/// entry record it explicitly.
+fn seed_task_on_board(home: &Path, project: &str, task_id: &str) {
+    append_batch_at(
+        &board_root(home, project),
+        &InstanceName::from("test:seed"),
+        vec![TaskEvent::Created {
+            task_id: TaskId(task_id.to_string()),
+            title: "t".into(),
+            description: String::new(),
+            priority: "normal".into(),
+            owner: None,
+            due_at: None,
+            depends_on: Vec::new(),
+            routed_to: None,
+            branch: None,
+            bind: None,
+            eta_secs: None,
+            tags: vec![],
+            parent_id: None,
+        }],
+    )
+    .expect("seed task");
+}
+
+/// RED: a task living on a NON-DEFAULT project board must route strictly to that
+/// board. Pre-fix (stub / `load_by_id`) reads only the default board → the id is
+/// invisible → `NotFound`. This is the routing bug behind the t-…-35 live failure.
+#[test]
+fn load_routed_finds_task_on_non_default_board_2760() {
+    let home = tmp_home("non-default");
+    seed_task_on_board(&home, "proj-x", "t-2760-x");
+    super::board_router::record_task_project(&home, "t-2760-x", "proj-x").expect("record index");
+
+    let routed = load_routed(&home, "t-2760-x");
+    match routed {
+        Ok(rt) => assert_eq!(
+            rt.task.id, "t-2760-x",
+            "a project-board task must route to its own board"
+        ),
+        Err(e) => panic!(
+            "load_routed must FIND a project-board task, got {e:?} — pre-fix the \
+             default-only seam cannot see per-project boards (t-…-35)"
+        ),
+    }
+}
+
+/// RED: the SAME id present on two boards has no single authority → `Ambiguous`,
+/// never a silent default pick. Pre-fix the stub finds the default copy and
+/// returns `Ok`, mis-authorizing one of two boards.
+#[test]
+fn load_routed_duplicate_id_across_boards_is_ambiguous_2760() {
+    let home = tmp_home("dup");
+    seed_task_on_board(&home, "default", "t-2760-dup");
+    seed_task_on_board(&home, "proj-b", "t-2760-dup");
+
+    match load_routed(&home, "t-2760-dup") {
+        Err(TaskRouteError::Ambiguous { .. }) => {}
+        other => {
+            panic!("a duplicate id across boards must fail closed as Ambiguous, got {other:?}")
+        }
+    }
+}
+
+/// RED: an unreadable board during the resolution scan means uniqueness cannot be
+/// proven → `Unreadable`, never a default guess. The task is uniquely on the
+/// default board, but a project board whose event log is unreadable might ALSO
+/// hold it, so the route must fail closed. Pre-fix the stub reads only the default
+/// board and returns `Ok` (blind to the unreadable board).
+#[test]
+fn load_routed_unreadable_board_fails_closed_2760() {
+    let home = tmp_home("unread");
+    seed_task_on_board(&home, "default", "t-2760-unread");
+    // A project board whose event log is a DIRECTORY → `replay_at` errors → the
+    // scan cannot prove the id is unique to the default board.
+    let bad = board_root(&home, "proj-unread");
+    std::fs::create_dir_all(bad.join("task_events.jsonl")).unwrap();
+
+    match load_routed(&home, "t-2760-unread") {
+        Err(TaskRouteError::Unreadable { .. }) => {}
+        other => panic!(
+            "an unreadable board that blocks a uniqueness proof must fail closed as \
+             Unreadable, got {other:?}"
+        ),
+    }
+}
+
+/// Guard (passes against the stub): a legacy task on the DEFAULT board with NO
+/// index entry still resolves — byte-identical to the pre-#2760 default reach.
+/// GREEN must not regress this while adding strict multi-board resolution.
+#[test]
+fn load_routed_default_legacy_task_without_index_is_found_2760() {
+    let home = tmp_home("default-legacy");
+    seed_task_on_board(&home, "default", "t-2760-legacy");
+
+    let routed = load_routed(&home, "t-2760-legacy").expect("default legacy task must resolve");
+    assert_eq!(routed.task.id, "t-2760-legacy");
+}
+
+/// Guard (passes against the stub): an id present on no board is a definitive
+/// `NotFound` — the strict router must not invent a route for an unknown id.
+#[test]
+fn load_routed_unknown_id_is_notfound_2760() {
+    let home = tmp_home("unknown");
+    seed_task_on_board(&home, "default", "t-2760-present");
+
+    match load_routed(&home, "t-2760-absent") {
+        Err(TaskRouteError::NotFound) => {}
+        other => panic!("an unknown id must be NotFound, got {other:?}"),
+    }
+}
+
+/// #2760: `link_branch_to_task` must write `BranchLinked` to the task's
+/// AUTHORITATIVE (project) board via the strict route — NOT the default board.
+/// Pre-#2760 the body read `replay(home)` (default board only), so a project-board
+/// task's branch link silently no-op'd (`Ok(false)`) and any write would have
+/// landed on the wrong board (the "branch-link same-route write" forcing proof).
+#[test]
+fn link_branch_to_task_writes_to_project_board_not_default_2760() {
+    let home = tmp_home("branch-link-proj");
+    seed_task_on_board(&home, "proj-bl", "t-2760-bl");
+    super::board_router::record_task_project(&home, "t-2760-bl", "proj-bl").expect("record index");
+
+    let linked = link_branch_to_task(&home, "t-2760-bl", "feat/2760-bl").expect("link ok");
+    assert!(
+        linked,
+        "branch link must SUCCEED for a project-board task — pre-#2760 the default-only \
+         replay returned Ok(false)"
+    );
+
+    // BranchLinked landed on the PROJECT board.
+    let on_proj = crate::task_events::replay_at(&board_root(&home, "proj-bl"))
+        .expect("replay proj board")
+        .tasks
+        .get(&TaskId("t-2760-bl".to_string()))
+        .and_then(|r| r.branch.clone());
+    assert_eq!(
+        on_proj.as_deref(),
+        Some("feat/2760-bl"),
+        "branch recorded on the task's authoritative project board"
+    );
+
+    // The default board has NO copy — the write went ONLY to the routed board.
+    let default_has_it =
+        crate::task_events::replay_at(&board_root(&home, crate::task_events::DEFAULT_PROJECT))
+            .map(|s| s.tasks.contains_key(&TaskId("t-2760-bl".to_string())))
+            .unwrap_or(false);
+    assert!(
+        !default_has_it,
+        "no default-board copy — branch-link must not write to the default board"
+    );
+}
+
+/// #2760 idempotency guard: a second `link_branch_to_task` with the SAME branch is
+/// a no-op (`Ok(false)`) — the checked append's precondition rejects a re-link.
+#[test]
+fn link_branch_to_task_same_branch_is_idempotent_noop_2760() {
+    let home = tmp_home("branch-link-idem");
+    seed_task_on_board(&home, "proj-bl2", "t-2760-bl2");
+    super::board_router::record_task_project(&home, "t-2760-bl2", "proj-bl2")
+        .expect("record index");
+    assert!(link_branch_to_task(&home, "t-2760-bl2", "feat/x").expect("first link"));
+    assert!(
+        !link_branch_to_task(&home, "t-2760-bl2", "feat/x").expect("second link"),
+        "re-linking the SAME branch is an idempotent no-op"
+    );
+}

--- a/src/tasks/routing_red_2760.rs
+++ b/src/tasks/routing_red_2760.rs
@@ -348,3 +348,200 @@ fn route_task_index_physical_board_mismatch_is_unreadable_2760() {
         ),
     }
 }
+
+// ── #2760 items 2+3+4: per-id lock + write-time revalidation + narrow ops ──
+//
+// These pin the SLICE-A authority-mutation contract: every per-id mutation resolves
+// its board strictly, re-validates the route under the per-id lock, and writes ONLY
+// to that board (never the default board). The narrow external ops (usage-limit,
+// reclaim) carry no board path — they take a task-bound guard and return an outcome.
+
+/// Seed a Created+Claimed task OWNED by `owner` with `branch`, on `project`'s board,
+/// and record its index entry — the starting state for a reclaim / usage-limit
+/// mutation (status `Claimed`, owner set, branch set).
+fn seed_owned_claimed(home: &Path, project: &str, id: &str, owner: &str, branch: &str) {
+    let board = board_root(home, project);
+    append_batch_at(
+        &board,
+        &InstanceName::from("test:seed"),
+        vec![
+            TaskEvent::Created {
+                task_id: TaskId(id.to_string()),
+                title: "t".into(),
+                description: String::new(),
+                priority: "normal".into(),
+                owner: Some(InstanceName::from(owner)),
+                due_at: None,
+                depends_on: Vec::new(),
+                routed_to: None,
+                branch: Some(branch.to_string()),
+                bind: None,
+                eta_secs: None,
+                tags: vec![],
+                parent_id: None,
+            },
+            TaskEvent::Claimed {
+                task_id: TaskId(id.to_string()),
+                by: InstanceName::from(owner),
+            },
+        ],
+    )
+    .expect("seed owned+claimed task");
+    super::board_router::record_task_project(home, id, project).expect("record index");
+}
+
+fn record_on_board(home: &Path, project: &str, id: &str) -> crate::task_events::TaskRecord {
+    crate::task_events::replay_at(&board_root(home, project))
+        .expect("replay board")
+        .tasks
+        .get(&TaskId(id.to_string()))
+        .cloned()
+        .unwrap_or_else(|| panic!("task '{id}' must exist on board '{project}'"))
+}
+
+fn default_has_task(home: &Path, id: &str) -> bool {
+    crate::task_events::replay_at(&board_root(home, crate::task_events::DEFAULT_PROJECT))
+        .map(|s| s.tasks.contains_key(&TaskId(id.to_string())))
+        .unwrap_or(false)
+}
+
+/// RED (reclaim default-board BUG fix): a reclaimed PROJECT-board task's `Released`
+/// event must land on ITS board — the pre-#2760 body appended to the DEFAULT board
+/// unconditionally, so the task's own board never saw the release and it stayed
+/// Claimed forever.
+#[test]
+fn release_reclaimed_task_writes_to_project_board_not_default_2760() {
+    let home = tmp_home("reclaim-proj");
+    seed_owned_claimed(&home, "proj-rc", "t-2760-rc", "dev", "feat/rc");
+
+    let released =
+        super::release_reclaimed_task(&home, "t-2760-rc", "reclaimed: test".into()).expect("ok");
+    assert!(released, "a claimed project-board task must be released");
+
+    let rec = record_on_board(&home, "proj-rc", "t-2760-rc");
+    assert_eq!(
+        rec.status,
+        crate::task_events::TaskStatus::Open,
+        "Released → Open on the PROJECT board"
+    );
+    assert!(rec.owner.is_none(), "Released clears the owner");
+    assert!(
+        !default_has_task(&home, "t-2760-rc"),
+        "reclaim Released must NOT write to the default board (#2760 BUG fix)"
+    );
+}
+
+/// RED (item 4 narrow op): a usage-limit block lands `Blocked` on the task's PROJECT
+/// board and is idempotent (a re-block for the same episode → `AlreadyApplied`, no
+/// second event); never a default-board write.
+#[test]
+fn apply_usage_limit_block_targets_project_board_and_is_idempotent_2760() {
+    let home = tmp_home("ul-block-proj");
+    seed_owned_claimed(&home, "proj-ul", "t-2760-ul", "dev", "feat/ul");
+    let guard = super::UsageLimitGuard {
+        task_id: "t-2760-ul".into(),
+        source: "dev".into(),
+        branch: "feat/ul".into(),
+        episode_id: "ep-123".into(),
+    };
+    // The reason payload embeds the episode id (as the production caller builds it),
+    // so the idempotency pre-check can recognise a prior block for this episode.
+    let reason = r#"{"episode_id":"ep-123"}"#.to_string();
+
+    assert_eq!(
+        super::apply_usage_limit_block(&home, &guard, reason.clone()).expect("block ok"),
+        super::ApplyOutcome::Applied
+    );
+    let rec = record_on_board(&home, "proj-ul", "t-2760-ul");
+    assert_eq!(rec.status, crate::task_events::TaskStatus::Blocked);
+    assert!(rec
+        .block_reason
+        .as_deref()
+        .is_some_and(|r| r.contains("ep-123")));
+    assert!(!default_has_task(&home, "t-2760-ul"), "no default-board write");
+
+    // Re-block for the SAME episode → idempotent no-op.
+    assert_eq!(
+        super::apply_usage_limit_block(&home, &guard, reason).expect("re-block ok"),
+        super::ApplyOutcome::AlreadyApplied
+    );
+}
+
+/// RED (item 4 narrow op): usage-limit recovery unblocks → InProgress on the PROJECT
+/// board.
+#[test]
+fn recover_usage_limit_block_targets_project_board_2760() {
+    let home = tmp_home("ul-recover-proj");
+    seed_owned_claimed(&home, "proj-ur", "t-2760-ur", "dev", "feat/ur");
+    let guard = super::UsageLimitGuard {
+        task_id: "t-2760-ur".into(),
+        source: "dev".into(),
+        branch: "feat/ur".into(),
+        episode_id: "ep-9".into(),
+    };
+    assert_eq!(
+        super::apply_usage_limit_block(&home, &guard, r#"{"episode_id":"ep-9"}"#.into())
+            .expect("block"),
+        super::ApplyOutcome::Applied
+    );
+    assert_eq!(
+        super::recover_usage_limit_block(&home, &guard).expect("recover"),
+        super::ApplyOutcome::Applied
+    );
+    let rec = record_on_board(&home, "proj-ur", "t-2760-ur");
+    assert_eq!(
+        rec.status,
+        crate::task_events::TaskStatus::InProgress,
+        "recovery → Unblocked+InProgress on the project board"
+    );
+}
+
+/// RED (item 4 guard): a usage-limit block whose guard branch no longer matches the
+/// task is `Stale` — NO event is written (deny-on-mismatch, no side effect).
+#[test]
+fn apply_usage_limit_block_stale_on_branch_mismatch_2760() {
+    let home = tmp_home("ul-stale");
+    seed_owned_claimed(&home, "proj-st", "t-2760-st", "dev", "feat/real");
+    let guard = super::UsageLimitGuard {
+        task_id: "t-2760-st".into(),
+        source: "dev".into(),
+        branch: "feat/WRONG".into(),
+        episode_id: "ep".into(),
+    };
+    assert_eq!(
+        super::apply_usage_limit_block(&home, &guard, r#"{"episode_id":"ep"}"#.into()).expect("ok"),
+        super::ApplyOutcome::Stale,
+        "a guard/branch mismatch → Stale"
+    );
+    assert_eq!(
+        record_on_board(&home, "proj-st", "t-2760-st").status,
+        crate::task_events::TaskStatus::Claimed,
+        "no Blocked event written on a guard mismatch"
+    );
+}
+
+/// RED (core item 2+3): `with_revalidated_board` re-resolves the strict route UNDER
+/// the per-id lock and REFUSES the write — without running the closure — when the
+/// route is no longer unique (a concurrent duplicate-create raced the mutation in).
+/// This is the write-time revalidation that a stale pre-lock route cannot give.
+#[test]
+fn with_revalidated_board_refuses_when_route_became_ambiguous_2760() {
+    let home = tmp_home("reval-ambig");
+    seed_task_on_board(&home, "proj-rv", "t-2760-rv");
+    super::board_router::record_task_project(&home, "t-2760-rv", "proj-rv").expect("index");
+    let routed = load_routed(&home, "t-2760-rv").expect("resolve");
+
+    // A concurrent create lands the SAME id on another board → route now Ambiguous.
+    seed_task_on_board(&home, "proj-other", "t-2760-rv");
+
+    let ran = std::cell::Cell::new(false);
+    let result = routed.with_revalidated_board(&home, |_board| ran.set(true));
+    assert!(
+        result.is_err(),
+        "revalidation must refuse when the route is no longer unique"
+    );
+    assert!(
+        !ran.get(),
+        "the write closure must NOT run when revalidation fails (zero side effect)"
+    );
+}

--- a/src/tasks/routing_red_2760.rs
+++ b/src/tasks/routing_red_2760.rs
@@ -458,7 +458,10 @@ fn apply_usage_limit_block_targets_project_board_and_is_idempotent_2760() {
         .block_reason
         .as_deref()
         .is_some_and(|r| r.contains("ep-123")));
-    assert!(!default_has_task(&home, "t-2760-ul"), "no default-board write");
+    assert!(
+        !default_has_task(&home, "t-2760-ul"),
+        "no default-board write"
+    );
 
     // Re-block for the SAME episode → idempotent no-op.
     assert_eq!(

--- a/src/tasks/routing_red_2760.rs
+++ b/src/tasks/routing_red_2760.rs
@@ -196,3 +196,155 @@ fn link_branch_to_task_same_branch_is_idempotent_noop_2760() {
         "re-linking the SAME branch is an idempotent no-op"
     );
 }
+
+// ── #2760 item 1: route-local STRICT complete-record proof + locked EOF repair ──
+//
+// The router-only strict reader treats ANY complete (newline-terminated) malformed
+// record — in task_events OR task_index — as `Unreadable` (never a silent skip like
+// the fleet-wide `replay_at`), tolerating ONLY a final unterminated EOF fragment,
+// which it repairs once under the writer lock and then re-reads.
+
+/// Append raw bytes to `path` verbatim (no trailing newline added) — used to inject
+/// a COMPLETE malformed record (with `\n`) or a torn EOF fragment (without `\n`).
+fn append_raw(path: &Path, bytes: &str) {
+    use std::io::Write;
+    let mut f = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .expect("open raw append");
+    write!(f, "{bytes}").expect("raw append");
+}
+
+fn events_log(home: &Path, project: &str) -> PathBuf {
+    board_root(home, project).join("task_events.jsonl")
+}
+
+/// RED: a COMPLETE (newline-terminated) malformed task-event record makes the
+/// board's history unprovable → `Unreadable`. Pre-item-1 the router used the
+/// fleet-wide `replay_at`, which SKIPS the corrupt line (#1988) — so the id still
+/// resolved `Ok`, silently trusting a partial board (the skipped line could have
+/// been the very Created/Cancelled event that decides the route).
+#[test]
+fn route_task_complete_malformed_event_record_is_unreadable_2760() {
+    let home = tmp_home("evt-malformed");
+    seed_task_on_board(&home, "default", "t-2760-evtbad");
+    // A complete (has trailing '\n') non-JSON record mid-log.
+    append_raw(&events_log(&home, "default"), "{not valid json at all\n");
+
+    match load_routed(&home, "t-2760-evtbad") {
+        Err(TaskRouteError::Unreadable { .. }) => {}
+        other => panic!(
+            "a complete-malformed task-event record must fail closed as Unreadable \
+             (never silently skipped), got {other:?}"
+        ),
+    }
+}
+
+/// RED: a valid-JSON record with a `schema_version` newer than supported is a
+/// forward-incompat hazard → `Unreadable` (same as the fleet-wide fail-closed abort,
+/// but surfaced as a typed route error).
+#[test]
+fn route_task_future_schema_event_record_is_unreadable_2760() {
+    let home = tmp_home("evt-future");
+    seed_task_on_board(&home, "default", "t-2760-evtfut");
+    append_raw(
+        &events_log(&home, "default"),
+        "{\"schema_version\":9999,\"seq\":1,\"event\":{}}\n",
+    );
+
+    match load_routed(&home, "t-2760-evtfut") {
+        Err(TaskRouteError::Unreadable { .. }) => {}
+        other => panic!("a future-schema task-event record must be Unreadable, got {other:?}"),
+    }
+}
+
+/// GREEN behaviour: a final unterminated EOF fragment (torn tail from a crash
+/// mid-append) is the ONE tolerable case — repaired under the writer lock, then the
+/// route resolves. The log is left newline-terminated with the fragment gone.
+#[test]
+fn route_task_repairs_final_eof_fragment_then_resolves_2760() {
+    let home = tmp_home("evt-eof");
+    seed_task_on_board(&home, "default", "t-2760-eof");
+    let log = events_log(&home, "default");
+    // A torn tail: non-JSON AND no trailing newline (unterminated).
+    append_raw(&log, "{torn half-written tail no newline");
+    assert!(
+        !std::fs::read_to_string(&log).unwrap().ends_with('\n'),
+        "precondition: log ends in an unterminated fragment"
+    );
+
+    let routed = load_routed(&home, "t-2760-eof")
+        .expect("a torn EOF fragment must be repaired, then the route resolves");
+    assert_eq!(routed.task.id, "t-2760-eof");
+
+    let after = std::fs::read_to_string(&log).unwrap();
+    assert!(
+        after.ends_with('\n') && !after.contains("torn half-written tail"),
+        "the torn fragment must be truncated out of the live log under the lock"
+    );
+}
+
+/// RED: a COMPLETE (newline-terminated) malformed `task_index` record is
+/// `Unreadable` — it could hide a CONFLICTING project entry for the target id, so
+/// tolerating it would let an `Ambiguous` route slip through as unique. Pre-item-1
+/// the index read flagged it advisory and pressed on.
+#[test]
+fn route_task_complete_malformed_index_record_is_unreadable_2760() {
+    let home = tmp_home("idx-malformed");
+    seed_task_on_board(&home, "proj-i", "t-2760-idxbad");
+    super::board_router::record_task_project(&home, "t-2760-idxbad", "proj-i")
+        .expect("record index");
+    // A complete (trailing '\n') non-JSON index record.
+    append_raw(&home.join("task_index.jsonl"), "{not a valid index entry\n");
+
+    match load_routed(&home, "t-2760-idxbad") {
+        Err(TaskRouteError::Unreadable { .. }) => {}
+        other => panic!(
+            "a complete-malformed task_index record must fail closed as Unreadable, got {other:?}"
+        ),
+    }
+}
+
+/// GREEN behaviour: a final unterminated EOF fragment in `task_index.jsonl` is
+/// repaired under the `task_index` lock, then the route resolves.
+#[test]
+fn route_task_repairs_index_eof_fragment_then_resolves_2760() {
+    let home = tmp_home("idx-eof");
+    seed_task_on_board(&home, "proj-ie", "t-2760-idxeof");
+    super::board_router::record_task_project(&home, "t-2760-idxeof", "proj-ie")
+        .expect("record index");
+    let index = home.join("task_index.jsonl");
+    append_raw(&index, "{torn index tail no newline");
+    assert!(!std::fs::read_to_string(&index).unwrap().ends_with('\n'));
+
+    let routed = load_routed(&home, "t-2760-idxeof")
+        .expect("a torn task_index EOF fragment must be repaired, then the route resolves");
+    assert_eq!(routed.task.id, "t-2760-idxeof");
+
+    let after = std::fs::read_to_string(&index).unwrap();
+    assert!(
+        after.ends_with('\n') && !after.contains("torn index tail"),
+        "the torn task_index fragment must be truncated out under the lock"
+    );
+}
+
+/// RED (forcing proof): a lone index entry that names a DIFFERENT board than the id
+/// physically occupies is a hard inconsistency → `Unreadable`, never trusting either
+/// side.
+#[test]
+fn route_task_index_physical_board_mismatch_is_unreadable_2760() {
+    let home = tmp_home("idx-mismatch");
+    seed_task_on_board(&home, "proj-real", "t-2760-mm");
+    // Index points at a board the id does NOT physically occupy.
+    super::board_router::record_task_project(&home, "t-2760-mm", "proj-wrong")
+        .expect("record index");
+
+    match load_routed(&home, "t-2760-mm") {
+        Err(TaskRouteError::Unreadable { .. }) => {}
+        other => panic!(
+            "an index entry naming a different board than the physical location must be \
+             Unreadable, got {other:?}"
+        ),
+    }
+}

--- a/src/tasks/sweep.rs
+++ b/src/tasks/sweep.rs
@@ -476,7 +476,8 @@ pub(super) fn emit_cancelled_batch(
                 reason: format!("sweep:{category}: {audit_reason}"),
             })
             .collect();
-        let ids_on_board: Vec<TaskId> = survivors.iter().map(|(id, _)| TaskId(id.clone())).collect();
+        let ids_on_board: Vec<TaskId> =
+            survivors.iter().map(|(id, _)| TaskId(id.clone())).collect();
         // CR-2026-06-14 (row232): re-validate UNDER the append lock against FRESH
         // committed state. The dry-run that produced `confirm_ids` is out-of-lock,
         // so a task can race to a terminal state (Done/Cancelled) before apply. A

--- a/src/tasks/sweep.rs
+++ b/src/tasks/sweep.rs
@@ -413,16 +413,14 @@ pub(super) fn emit_cancelled_batch(
     // Board-key order is deterministic (`BTreeMap`) so the per-board passes are
     // stable. Single-project → every id routes to the DEFAULT board → one group →
     // byte-identical to the pre-#2760 single-batch behaviour.
-    let mut by_board: std::collections::BTreeMap<
-        std::path::PathBuf,
-        Vec<(String, &'static str, crate::tasks::RoutedTask)>,
-    > = std::collections::BTreeMap::new();
+    let mut by_board: std::collections::BTreeMap<std::path::PathBuf, Vec<(String, &'static str)>> =
+        std::collections::BTreeMap::new();
     for id in confirm_ids {
         match crate::tasks::load_routed(home, id) {
             Ok(routed) => by_board
                 .entry(routed.board().path().to_path_buf())
                 .or_default()
-                .push((id.clone(), lookup_category(id), routed)),
+                .push((id.clone(), lookup_category(id))),
             Err(e) => {
                 tracing::warn!(
                     task = %id, route_err = %e,
@@ -440,35 +438,13 @@ pub(super) fn emit_cancelled_batch(
         let mut sorted = items.clone();
         sorted.sort_by(|a, b| a.0.cmp(&b.0));
         let mut id_locks = Vec::with_capacity(sorted.len());
-        for (id, _, _) in &sorted {
+        for (id, _) in &sorted {
             match super::board_router::acquire_task_id_lock(home, id) {
                 Ok(g) => id_locks.push(g),
                 Err(e) => return Err(format!("acquire per-id lock for sweep of '{id}': {e}")),
             }
         }
-        // #2760 R2 (root REJECT of a542517b): the grouping route above is OUT of the
-        // per-id locks. RE-ROUTE each id UNDER its lock and DROP any whose route
-        // changed (duplicate-created / re-routed since the grouping route) — never
-        // cancel on a stale/changed route. Fail-closed skip, logged.
-        let survivors: Vec<(String, &'static str)> = sorted
-            .iter()
-            .filter(|(id, _, routed)| {
-                let ok = routed.route_unchanged(home);
-                if !ok {
-                    tracing::warn!(
-                        task = %id,
-                        "#2760 R2 sweep: skip cancel — route changed under the per-id lock"
-                    );
-                }
-                ok
-            })
-            .map(|(id, category, _)| (id.clone(), *category))
-            .collect();
-        if survivors.is_empty() {
-            drop(id_locks);
-            continue;
-        }
-        let events: Vec<TaskEvent> = survivors
+        let events: Vec<TaskEvent> = sorted
             .iter()
             .map(|(id, category)| TaskEvent::Cancelled {
                 task_id: TaskId(id.clone()),
@@ -476,8 +452,7 @@ pub(super) fn emit_cancelled_batch(
                 reason: format!("sweep:{category}: {audit_reason}"),
             })
             .collect();
-        let ids_on_board: Vec<TaskId> =
-            survivors.iter().map(|(id, _)| TaskId(id.clone())).collect();
+        let ids_on_board: Vec<TaskId> = sorted.iter().map(|(id, _)| TaskId(id.clone())).collect();
         // CR-2026-06-14 (row232): re-validate UNDER the append lock against FRESH
         // committed state. The dry-run that produced `confirm_ids` is out-of-lock,
         // so a task can race to a terminal state (Done/Cancelled) before apply. A
@@ -516,7 +491,7 @@ pub(super) fn emit_cancelled_batch(
                 // #78445-2 (d): each batch-cancelled task is terminal — clear BOTH
                 // obligation stores (this path previously cleared NEITHER).
                 // task_id-scoped → a co-dispatcher's other task rows survive.
-                for (id, category) in &survivors {
+                for (id, category) in &sorted {
                     super::task_terminal_cleanup(home, id);
                     crate::event_log::log(
                         home,
@@ -525,7 +500,7 @@ pub(super) fn emit_cancelled_batch(
                         &format!("task={id} category={category} reason={audit_reason}"),
                     );
                 }
-                total += survivors.len();
+                total += sorted.len();
             }
             Ok(Err(reason)) => return Err(reason),
             Err(e) => return Err(e.to_string()),

--- a/src/tasks/sweep.rs
+++ b/src/tasks/sweep.rs
@@ -389,7 +389,6 @@ pub(super) fn emit_cancelled_batch(
 ) -> Result<usize, String> {
     use crate::task_events::{InstanceName, TaskEvent, TaskId};
     let emitter = InstanceName::from("system:task_sweep");
-    let mut events: Vec<TaskEvent> = Vec::new();
     let lookup_category = |id: &str| -> &'static str {
         if categories.shipped.iter().any(|c| c.id == id) {
             return "shipped";
@@ -405,68 +404,107 @@ pub(super) fn emit_cancelled_batch(
         }
         "validation_leftovers"
     };
-    // Collect (id, category) so the `task_sweep_apply` audit lines are written
-    // only AFTER the cancel actually commits — the in-lock guard below can
-    // reject the batch, and an audit line for a cancel that never happened
-    // would mislead.
-    let mut audit: Vec<(String, &'static str)> = Vec::new();
+    // #2760: route each confirmed id to its AUTHORITATIVE board and group by board.
+    // The pre-#2760 body wrote every `Cancelled` to the DEFAULT board via
+    // `append_batch_checked(home, …)`, so a project-board task's cancel landed on a
+    // board whose own replay never saw it — the task stayed live (the same class of
+    // bug as the reclaim default-board write). An id that cannot be uniquely routed
+    // is SKIPPED (fail-closed; never cancelled on a guessed board) and logged.
+    // Board-key order is deterministic (`BTreeMap`) so the per-board passes are
+    // stable. Single-project → every id routes to the DEFAULT board → one group →
+    // byte-identical to the pre-#2760 single-batch behaviour.
+    let mut by_board: std::collections::BTreeMap<std::path::PathBuf, Vec<(String, &'static str)>> =
+        std::collections::BTreeMap::new();
     for id in confirm_ids {
-        let category = lookup_category(id);
-        events.push(TaskEvent::Cancelled {
-            task_id: TaskId(id.clone()),
-            by: emitter.clone(),
-            reason: format!("sweep:{category}: {audit_reason}"),
-        });
-        audit.push((id.clone(), category));
-    }
-    let count = events.len();
-    if count == 0 {
-        return Ok(0);
-    }
-    // CR-2026-06-14 (row232): re-validate UNDER the append lock against FRESH
-    // committed state. The dry-run that produced `confirm_ids` is out-of-lock, so
-    // a task can race to a terminal state (Done/Cancelled) before apply. A bare
-    // `append_batch` would clobber that terminal status (replay does not re-guard
-    // transitions). Fail closed: if ANY confirmed task is no longer cancellable,
-    // reject the whole batch — the operator re-runs the sweep, whose dry-run
-    // re-scans and drops the now-terminal task. The closure only inspects the
-    // replayed state — no `api::call` under the lock (#1629).
-    let checked = crate::task_events::append_batch_checked(home, &emitter, events, |state| {
-        for id in confirm_ids {
-            if let Some(rec) = state.tasks.get(&TaskId(id.clone())) {
-                if !rec
-                    .status
-                    .can_transition_to(crate::task_events::TaskStatus::Cancelled)
-                {
-                    return Err(format!(
-                        "task '{id}' is no longer cancellable (now {}); sweep aborted to avoid \
-                         clobbering a terminal task — re-run the sweep",
-                        super::status_to_legacy_str(rec.status)
-                    ));
-                }
-            }
-        }
-        Ok(())
-    });
-    match checked {
-        Ok(Ok(_)) => {
-            // #78445-2 (d): each batch-cancelled task is terminal — clear BOTH
-            // obligation stores (this path previously cleared NEITHER). task_id-scoped
-            // → a co-dispatcher's other task rows survive.
-            for id in confirm_ids {
-                super::task_terminal_cleanup(home, id);
-            }
-            for (id, category) in &audit {
-                crate::event_log::log(
-                    home,
-                    "task_sweep_apply",
-                    "system:task_sweep",
-                    &format!("task={id} category={category} reason={audit_reason}"),
+        match crate::tasks::load_routed(home, id) {
+            Ok(routed) => by_board
+                .entry(routed.board().path().to_path_buf())
+                .or_default()
+                .push((id.clone(), lookup_category(id))),
+            Err(e) => {
+                tracing::warn!(
+                    task = %id, route_err = %e,
+                    "#2760 sweep: skip cancel — task route unresolved (never a default-board write)"
                 );
             }
-            Ok(count)
         }
-        Ok(Err(reason)) => Err(reason),
-        Err(e) => Err(e.to_string()),
     }
+
+    let mut total = 0usize;
+    for (board, items) in &by_board {
+        // #2760 item 2: acquire this board's per-id router locks in SORTED id order
+        // (deadlock-free — ids on distinct boards never overlap, so no cross-board
+        // lock cycle) and hold them across the checked batch append.
+        let mut sorted = items.clone();
+        sorted.sort_by(|a, b| a.0.cmp(&b.0));
+        let mut id_locks = Vec::with_capacity(sorted.len());
+        for (id, _) in &sorted {
+            match super::board_router::acquire_task_id_lock(home, id) {
+                Ok(g) => id_locks.push(g),
+                Err(e) => return Err(format!("acquire per-id lock for sweep of '{id}': {e}")),
+            }
+        }
+        let events: Vec<TaskEvent> = sorted
+            .iter()
+            .map(|(id, category)| TaskEvent::Cancelled {
+                task_id: TaskId(id.clone()),
+                by: emitter.clone(),
+                reason: format!("sweep:{category}: {audit_reason}"),
+            })
+            .collect();
+        let ids_on_board: Vec<TaskId> = sorted.iter().map(|(id, _)| TaskId(id.clone())).collect();
+        // CR-2026-06-14 (row232): re-validate UNDER the append lock against FRESH
+        // committed state. The dry-run that produced `confirm_ids` is out-of-lock,
+        // so a task can race to a terminal state (Done/Cancelled) before apply. A
+        // bare `append_batch` would clobber that terminal status (replay does not
+        // re-guard transitions). Fail closed: if ANY confirmed task on THIS board is
+        // no longer cancellable, reject this board's batch — the operator re-runs
+        // the sweep, whose dry-run re-scans and drops the now-terminal task.
+        // Per-board (not global) atomicity: independent boards never block each
+        // other; single-project → one board → identical to the prior all-or-nothing.
+        // The closure only inspects the replayed state — no `api::call` under the
+        // lock (#1629).
+        let checked =
+            crate::task_events::append_batch_checked_at(board, &emitter, events, |state| {
+                for tid in &ids_on_board {
+                    if let Some(rec) = state.tasks.get(tid) {
+                        if !rec
+                            .status
+                            .can_transition_to(crate::task_events::TaskStatus::Cancelled)
+                        {
+                            return Err(format!(
+                                "task '{}' is no longer cancellable (now {}); sweep aborted to \
+                                 avoid clobbering a terminal task — re-run the sweep",
+                                tid.0,
+                                super::status_to_legacy_str(rec.status)
+                            ));
+                        }
+                    }
+                }
+                Ok(())
+            });
+        match checked {
+            Ok(Ok(_)) => {
+                // Release the per-id flocks BEFORE the cleanup/audit below (those may
+                // self-IPC / take other locks — never under a held flock, #1629).
+                drop(id_locks);
+                // #78445-2 (d): each batch-cancelled task is terminal — clear BOTH
+                // obligation stores (this path previously cleared NEITHER).
+                // task_id-scoped → a co-dispatcher's other task rows survive.
+                for (id, category) in &sorted {
+                    super::task_terminal_cleanup(home, id);
+                    crate::event_log::log(
+                        home,
+                        "task_sweep_apply",
+                        "system:task_sweep",
+                        &format!("task={id} category={category} reason={audit_reason}"),
+                    );
+                }
+                total += sorted.len();
+            }
+            Ok(Err(reason)) => return Err(reason),
+            Err(e) => return Err(e.to_string()),
+        }
+    }
+    Ok(total)
 }

--- a/src/tasks/sweep.rs
+++ b/src/tasks/sweep.rs
@@ -413,14 +413,16 @@ pub(super) fn emit_cancelled_batch(
     // Board-key order is deterministic (`BTreeMap`) so the per-board passes are
     // stable. Single-project → every id routes to the DEFAULT board → one group →
     // byte-identical to the pre-#2760 single-batch behaviour.
-    let mut by_board: std::collections::BTreeMap<std::path::PathBuf, Vec<(String, &'static str)>> =
-        std::collections::BTreeMap::new();
+    let mut by_board: std::collections::BTreeMap<
+        std::path::PathBuf,
+        Vec<(String, &'static str, crate::tasks::RoutedTask)>,
+    > = std::collections::BTreeMap::new();
     for id in confirm_ids {
         match crate::tasks::load_routed(home, id) {
             Ok(routed) => by_board
                 .entry(routed.board().path().to_path_buf())
                 .or_default()
-                .push((id.clone(), lookup_category(id))),
+                .push((id.clone(), lookup_category(id), routed)),
             Err(e) => {
                 tracing::warn!(
                     task = %id, route_err = %e,
@@ -438,13 +440,35 @@ pub(super) fn emit_cancelled_batch(
         let mut sorted = items.clone();
         sorted.sort_by(|a, b| a.0.cmp(&b.0));
         let mut id_locks = Vec::with_capacity(sorted.len());
-        for (id, _) in &sorted {
+        for (id, _, _) in &sorted {
             match super::board_router::acquire_task_id_lock(home, id) {
                 Ok(g) => id_locks.push(g),
                 Err(e) => return Err(format!("acquire per-id lock for sweep of '{id}': {e}")),
             }
         }
-        let events: Vec<TaskEvent> = sorted
+        // #2760 R2 (root REJECT of a542517b): the grouping route above is OUT of the
+        // per-id locks. RE-ROUTE each id UNDER its lock and DROP any whose route
+        // changed (duplicate-created / re-routed since the grouping route) — never
+        // cancel on a stale/changed route. Fail-closed skip, logged.
+        let survivors: Vec<(String, &'static str)> = sorted
+            .iter()
+            .filter(|(id, _, routed)| {
+                let ok = routed.route_unchanged(home);
+                if !ok {
+                    tracing::warn!(
+                        task = %id,
+                        "#2760 R2 sweep: skip cancel — route changed under the per-id lock"
+                    );
+                }
+                ok
+            })
+            .map(|(id, category, _)| (id.clone(), *category))
+            .collect();
+        if survivors.is_empty() {
+            drop(id_locks);
+            continue;
+        }
+        let events: Vec<TaskEvent> = survivors
             .iter()
             .map(|(id, category)| TaskEvent::Cancelled {
                 task_id: TaskId(id.clone()),
@@ -452,7 +476,7 @@ pub(super) fn emit_cancelled_batch(
                 reason: format!("sweep:{category}: {audit_reason}"),
             })
             .collect();
-        let ids_on_board: Vec<TaskId> = sorted.iter().map(|(id, _)| TaskId(id.clone())).collect();
+        let ids_on_board: Vec<TaskId> = survivors.iter().map(|(id, _)| TaskId(id.clone())).collect();
         // CR-2026-06-14 (row232): re-validate UNDER the append lock against FRESH
         // committed state. The dry-run that produced `confirm_ids` is out-of-lock,
         // so a task can race to a terminal state (Done/Cancelled) before apply. A
@@ -491,7 +515,7 @@ pub(super) fn emit_cancelled_batch(
                 // #78445-2 (d): each batch-cancelled task is terminal — clear BOTH
                 // obligation stores (this path previously cleared NEITHER).
                 // task_id-scoped → a co-dispatcher's other task rows survive.
-                for (id, category) in &sorted {
+                for (id, category) in &survivors {
                     super::task_terminal_cleanup(home, id);
                     crate::event_log::log(
                         home,
@@ -500,7 +524,7 @@ pub(super) fn emit_cancelled_batch(
                         &format!("task={id} category={category} reason={audit_reason}"),
                     );
                 }
-                total += sorted.len();
+                total += survivors.len();
             }
             Ok(Err(reason)) => return Err(reason),
             Err(e) => return Err(e.to_string()),

--- a/src/tasks/tests.rs
+++ b/src/tasks/tests.rs
@@ -2124,7 +2124,9 @@ fn cross_board_dep_detective_flags_but_does_not_release_in_progress_audit2_014()
     // already shows "blocked" for ANY InProgress task with an unsatisfied dep,
     // pre-existing behavior unrelated to this detective) must be untouched:
     // no event was emitted for A.
-    let board_a = super::board_router::board_for_task(&home, &a);
+    let board_a = super::board_router::route_task(&home, &a)
+        .expect("route A's board")
+        .1;
     let persisted = crate::task_events::replay_at(&board_a)
         .expect("replay A's board")
         .tasks
@@ -2193,7 +2195,9 @@ fn cross_board_dep_detective_release_toctou_skips_when_task_advances_audit2_014(
         "must not release a task that advanced to InProgress mid-scan: {report:?}"
     );
 
-    let board_a = super::board_router::board_for_task(&home, &a);
+    let board_a = super::board_router::route_task(&home, &a)
+        .expect("route A's board")
+        .1;
     let persisted = crate::task_events::replay_at(&board_a)
         .expect("replay A's board")
         .tasks
@@ -2298,7 +2302,9 @@ fn cross_board_dep_derived_block_is_in_memory_not_persisted_2117_q2() {
 
     // But the canonical event log persisted NO Blocked transition for A: a raw
     // replay of A's own board still yields Open.
-    let board_a = super::board_router::board_for_task(&home, &a);
+    let board_a = super::board_router::route_task(&home, &a)
+        .expect("route A's board")
+        .1;
     let persisted = crate::task_events::replay_at(&board_a)
         .expect("replay A's board")
         .tasks

--- a/src/tasks/tests.rs
+++ b/src/tasks/tests.rs
@@ -4344,13 +4344,12 @@ fn sweep_apply_routes_each_cancel_to_its_own_board_2760() {
     assert_eq!(count, 2, "both ids cancelled");
 
     // The project task's Cancelled landed on the PROJECT board, not the default.
-    let proj_rec =
-        crate::task_events::replay_at(&crate::task_events::board_root(&home, "proj-sw"))
-            .expect("replay proj board")
-            .tasks
-            .get(&crate::task_events::TaskId(proj_id.clone()))
-            .cloned()
-            .expect("project task must exist on its own board");
+    let proj_rec = crate::task_events::replay_at(&crate::task_events::board_root(&home, "proj-sw"))
+        .expect("replay proj board")
+        .tasks
+        .get(&crate::task_events::TaskId(proj_id.clone()))
+        .cloned()
+        .expect("project task must exist on its own board");
     assert_eq!(
         proj_rec.status,
         crate::task_events::TaskStatus::Cancelled,

--- a/src/tasks/tests.rs
+++ b/src/tasks/tests.rs
@@ -4307,6 +4307,75 @@ fn test_sweep_apply_emits_cancelled_and_logs_audit() {
     std::fs::remove_dir_all(&home).ok();
 }
 
+/// #2760 (default-board BUG fix): a sweep `apply` over ids on DIFFERENT boards must
+/// land each `Cancelled` on ITS OWN board. Pre-#2760 `emit_cancelled_batch` wrote
+/// every Cancelled to the DEFAULT board (`append_batch_checked(home, …)`), so a
+/// project-board task's cancel landed where its own board's replay never saw it —
+/// it stayed live. GREEN routes each id to its authoritative board.
+#[test]
+fn sweep_apply_routes_each_cancel_to_its_own_board_2760() {
+    let home = tmp_home("sweep_multiboard_2760");
+    write_fleet_yaml(&home, &["alive"]);
+    // One task on the DEFAULT board, one on a PROJECT board (explicit `project`).
+    let def_id = handle(
+        &home,
+        "alive",
+        &serde_json::json!({"action":"create","title":"def task","assignee":"alive"}),
+    )["id"]
+        .as_str()
+        .expect("def id")
+        .to_string();
+    let proj_id = handle(
+        &home,
+        "alive",
+        &serde_json::json!({"action":"create","title":"proj task","assignee":"alive","project":"proj-sw"}),
+    )["id"]
+        .as_str()
+        .expect("proj id")
+        .to_string();
+
+    let confirm: std::collections::HashSet<String> =
+        [def_id.clone(), proj_id.clone()].into_iter().collect();
+    // Empty categories → both ids classify as validation_leftovers; the emit still
+    // cancels each id on its own routed board.
+    let cats = sweep::Categories::default();
+    let count = sweep::emit_cancelled_batch(&home, &cats, &confirm, "multi-board sweep 2760")
+        .expect("emit_cancelled_batch");
+    assert_eq!(count, 2, "both ids cancelled");
+
+    // The project task's Cancelled landed on the PROJECT board, not the default.
+    let proj_rec =
+        crate::task_events::replay_at(&crate::task_events::board_root(&home, "proj-sw"))
+            .expect("replay proj board")
+            .tasks
+            .get(&crate::task_events::TaskId(proj_id.clone()))
+            .cloned()
+            .expect("project task must exist on its own board");
+    assert_eq!(
+        proj_rec.status,
+        crate::task_events::TaskStatus::Cancelled,
+        "project-board task cancelled on ITS board (not the default)"
+    );
+    let default_state =
+        crate::task_events::replay_at(&crate::task_events::board_root(&home, "default")).unwrap();
+    assert!(
+        !default_state
+            .tasks
+            .contains_key(&crate::task_events::TaskId(proj_id.clone())),
+        "the project task's cancel must NOT be written to the default board (#2760 BUG fix)"
+    );
+    // The default task's Cancelled landed on the default board.
+    assert_eq!(
+        default_state
+            .tasks
+            .get(&crate::task_events::TaskId(def_id.clone()))
+            .map(|r| r.status),
+        Some(crate::task_events::TaskStatus::Cancelled),
+        "default-board task cancelled on the default board"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
 // ── CR-2026-06-14 row232 — sweep apply must not clobber a concurrently-Done
 //    task (the dry-run → apply window is a TOCTOU; the in-lock guard fails
 //    closed). ──

--- a/src/tasks/tests.rs
+++ b/src/tasks/tests.rs
@@ -1328,8 +1328,8 @@ fn test_task_auto_unblock_when_all_deps_done() {
 
 /// Raw (unprojected) persisted status via an event-log replay of the task's board.
 fn raw_status_d63(home: &std::path::Path, id: &str) -> crate::task_events::TaskStatus {
-    let board = super::board_router::board_for_task(home, id);
-    crate::task_events::replay_at(&board)
+    let routed = super::load_routed(home, id).expect("route task to its board");
+    crate::task_events::replay_at(routed.board().path())
         .expect("replay board")
         .tasks
         .get(&crate::task_events::TaskId(id.to_string()))


### PR DESCRIPTION
## #2760 **Slice A** — strict routed task authority + per-id lock/revalidation + narrow ops

> **Scope: Slice A only — issue #2760 stays OPEN after this PR merges (no auto-close linkage).** Slice B (the durable `DispatchSaga` — branch-bearing dispatch atomicity, preflight-before-`bind:false`, `Prepared→Delivered→BranchLinked→Complete` recovery) is task `t-20260713134023819174-70517-62` and is the completion slice. An O(1) transactional route-ledger is a later follow-up (task `t-…-63`). Do **not** merge without fresh **dual VERIFIED** exact-head review.

Every per-ID task route resolves through a **strict** `tasks::load_routed(home,id) -> Result<RoutedTask, TaskRouteError>` that names the ONE authoritative board or fails closed — it **never** silently falls back to the default board on a miss.

### The bug it fixes
A project-board task with `review_class=single`/`dual` was dispatched as `review_class_unspecified` because the merge-authority preflight read a **default-only** seam (`load_by_id`). Live repros: t-…-35/-51/-55/-82/-93/-103/-106 — formal exact-head review dispatches refused, forcing correlated-query fallbacks.

### Foundation (`tasks/board_router.rs`, `tasks/mod.rs`)
- `route_task`: **physical-scan-authoritative** (index is an advisory cache). Indexed conflict → `Ambiguous`; index I/O / complete-malformed record → `Unreadable`; indexed-but-absent → `Unreadable` (never NotFound/default). Checked scan of default + every project board: any board replay-error → `Unreadable` even after a hit; exactly-one → `Ok` (+ absent-guarded index repair); zero → `NotFound`; >1 → `Ambiguous`. Router-only STRICT complete-record reader for `task_events` + `task_index` — a newline-terminated malformed record → `Unreadable`; ONLY a final unterminated EOF fragment is repaired once under the writer lock. Project ids canonicalised to slug so `owner/repo` boards route (index-vs-physical compared on the slug).
- Removed `load_by_id`, `board_for_task`, `resolve_task_project` + re-exports. **Compilation is the forcing proof** no stale consumer remains.

### Items 2+3+4 — per-id lock + write-time revalidation + narrow ops
- **`acquire_task_id_lock`** — a per-task-ID file flock (`home/task_locks/<slug>.lock`), the OUTER lock; the board/event writer lock is INNER (no self-IPC in that scope, `#1629`-safe).
- **`BoardKey` + `RouteFingerprint`** (opaque) = board + `created_at` incarnation. **`RoutedTask::with_revalidated_board`** re-resolves the strict route UNDER the per-id lock and REFUSES the mutation (no side effect) on a board/incarnation mismatch, then appends. Every authority MUTATION routes through it (removed the un-locked `append_batch_checked`).
- **11 mutation sites** migrated: handler `claim`/`done`/`update`/`metadata_set`/`ack_plan`/`create` (create adds a NotFound-under-lock cross-board dup guard); `auto_close`; `link_branch_to_task`; usage-limit block/recover; reclaim; sweep. **Default-board BUGS fixed**: reclaim `Released` and sweep `Cancelled` now route to each task's OWN board (were unconditionally written to the default board → invisible to project boards).
- **Narrow external ops** (item 4): `UsageLimitGuard`/`ApplyOutcome` + `apply_usage_limit_block` / `recover_usage_limit_block` / `release_reclaimed_task`. External modules carry no board `Path` — they pass a task-bound guard, get an outcome.

### Consumer policy (fail-closed)
DENY on route error (no side effects): review-class preflight, reviewer-assignment read, schedule validation, usage-limit, branch-link, reclaim ACL, auto-close, every handler mutation. KEEP-on-error: inbox obligations. dispatch-idle: Found-terminal + **canonical**-NotFound → dead; Unreadable/Ambiguous → live; non-task/query correlation → fail-open (fire).

### dispatch-idle liveness — typed `TaskId::parse_canonical`
`task_still_live`'s `NotFound → orphan-dead` policy is now gated on a typed **`TaskId::parse_canonical`** (single anchored canonical-grammar authority, reused as validation by `task_sweep`) — a non-task/query correlation fails-open (keeps nudging), so the frozen NotFound=orphan-dead policy applies ONLY to real task ids. (`auto_close`'s `starts_with("t-")` stays a cheap pre-filter — `load_routed` is its authority.)

### Verification (exact head `a542517b`)
- `rustfmt --edition 2021 --check` clean branch-wide; `clippy --lib --bin agend-terminal --bin agend-git --bin agend-mcp-bridge --tests --examples --features tray -- -D warnings` CLEAN.
- Full all-target `cargo test -p agend-terminal --features tray` (AGENTIC_GIT_REAL_GIT): green — the sole failure is the pre-existing `self_respawn_…_during_teardown` timing flake (passes in isolation, unrelated to #2760).
- REDs: strict-route matrix (19), per-id revalidation refusal, usage-limit narrow-op outcomes (Applied/AlreadyApplied/Stale on project board), reclaim/sweep default-board bug fixes, non-task fail-open + canonical-orphan suppress, `TaskId::parse_canonical` grammar unit, review_class single+dual on non-default board (the t-…93/103/106 repro).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
