### PR TITLE
chore(task83): owned-source formatter boundary + preflight/CI command convergence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,13 +73,21 @@ jobs:
       - name: Format check
         timeout-minutes: 5
         shell: bash
-        # #2524 P3: the `agentic-git` [[bin]] (Cargo.toml) compiles vendored
-        # submodule source, which `cargo fmt` walks and would flag against our
-        # rustfmt style — but that is upstream code we don't own (it round-trips to
-        # the agentic-git repo), and rustfmt's `ignore` is NOT reliably honored via
-        # `cargo fmt`'s per-target invocation. Format-check our OWN tracked sources
-        # only (git pathspec excludes vendor/); rustfmt reads no config → defaults.
-        run: git ls-files '*.rs' ':!:vendor/**' | xargs rustfmt --edition 2021 --check
+        # task83 (d-46): the owned-source rustfmt boundary now lives in ONE place —
+        # scripts/fmt-owned.sh — so CI, GitLab CI and preflight can't drift apart. It
+        # enumerates `git ls-files -z -- '*.rs' ':!:vendor/**'` (NUL-safe; excludes
+        # the vendored agentic-git submodule that `cargo fmt` would otherwise walk and
+        # reformat) and runs `rustfmt --edition 2021 --check`.
+        run: scripts/fmt-owned.sh --check
+
+      # task83: exercise the owned-fmt boundary contract itself (hermetic recursive-
+      # submodule fixture). Linux-only — one run of the shell contract is enough; the
+      # local file:// submodule fixture is unix-shell-shaped.
+      - name: Owned-fmt boundary test
+        if: runner.os == 'Linux'
+        timeout-minutes: 5
+        shell: bash
+        run: scripts/test_fmt_owned.sh
 
       # #2524 P3: the agentic-git `[[bin]]` compiles vendored submodule source.
       # `cargo clippy --all-targets` would lint it under agend-terminal's strict

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,12 +29,16 @@ before_script:
 fmt:
   stage: lint
   script:
-    - cargo fmt --check
+    # task83 (d-46): shared owned-source formatter surface — same script GitHub CI
+    # and scripts/preflight.sh call (owned *.rs, vendor/ excluded, NUL-safe).
+    - scripts/fmt-owned.sh --check
 
 clippy:
   stage: lint
   script:
-    - cargo clippy --all-targets --features tray -- -D warnings
+    # task83: GitHub's explicit OWNED-target clippy (not `--all-targets`, which
+    # drags in the vendored agentic-git bin under our strict `-D warnings`).
+    - cargo clippy --lib --bin agend-terminal --bin agend-git --bin agend-mcp-bridge --tests --examples --features tray -- -D warnings
 
 test:
   stage: test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,8 +12,8 @@ cargo build --release                # release (strip + LTO, matches CI)
 cargo test                           # unit + integration + MCP round-trip
 cargo test --bin agend-terminal      # unit tests only
 cargo test --test integration        # integration tests (Unix-only for now)
-cargo fmt --check
-cargo clippy -- -D warnings          # must be warning-free
+scripts/fmt-owned.sh --check         # THE owned-source fmt surface (excludes vendor/); no arg = format
+cargo clippy -- -D warnings          # quick check; scripts/preflight.sh runs CI's exact owned-target set
 ```
 
 `cargo clippy` enforces `unwrap_used = "deny"` (see `Cargo.toml`). Handle errors with `?` / `anyhow::Result`.
@@ -39,7 +39,7 @@ Run the one-shot CI-parity preflight to catch failures locally instead of after 
 scripts/preflight.sh          # full matrix; --quick skips the Windows cross-check
 ```
 
-It runs exactly CI's `check` job — `cargo fmt --check`, `cargo clippy --all-targets --features tray -- -D warnings`, `cargo test --tests --features tray`, and a **Windows cross-check** (`x86_64-pc-windows-msvc`) that catches windows-only compile errors a unix dev box would otherwise miss. The Windows step prefers [`cargo-xwin`](https://github.com/rust-cross/cargo-xwin) (`cargo install cargo-xwin && rustup target add x86_64-pc-windows-msvc`) since a transitive C dependency (`ring`) won't cross-compile on macOS/Linux without the MSVC toolchain; if it's not installed the step SKIPs with a hint rather than false-failing.
+It runs the same fmt/clippy surface CI's `check` job runs — `scripts/fmt-owned.sh --check` (owned `*.rs`, `vendor/` excluded) and the owned-target `cargo clippy` — plus `cargo test --tests --features tray` and a **Windows cross-check** (`x86_64-pc-windows-msvc`) that catches windows-only compile errors a unix dev box would otherwise miss. (CI runs the tests via `nextest`, not `cargo test`, and a floating stable toolchain is not byte-exact over time — so preflight is a strong pre-check, not a byte-exact CI guarantee.) The Windows step prefers [`cargo-xwin`](https://github.com/rust-cross/cargo-xwin) (`cargo install cargo-xwin && rustup target add x86_64-pc-windows-msvc`) since a transitive C dependency (`ring`) won't cross-compile on macOS/Linux without the MSVC toolchain; if it's not installed the step SKIPs with a hint rather than false-failing.
 
 ### Coverage (optional, local)
 

--- a/CONTRIBUTING.zh-TW.md
+++ b/CONTRIBUTING.zh-TW.md
@@ -12,8 +12,8 @@ cargo build --release                # release (strip + LTO, matches CI)
 cargo test                           # unit + integration + MCP round-trip
 cargo test --bin agend-terminal      # unit tests only
 cargo test --test integration        # integration tests (Unix-only for now)
-cargo fmt --check
-cargo clippy -- -D warnings          # must be warning-free
+scripts/fmt-owned.sh --check         # 唯一的 owned-source fmt surface（排除 vendor/）；不帶參數即直接格式化
+cargo clippy -- -D warnings          # 快速檢查；scripts/preflight.sh 會跑 CI 完整的 owned-target 集合
 ```
 
 `cargo clippy` 會強制 `unwrap_used = "deny"`（參見 `Cargo.toml`）。請用 `?` / `anyhow::Result` 來處理錯誤。
@@ -38,7 +38,7 @@ CI 會在 Ubuntu + macOS + Windows 上複製這些步驟（`.github/workflows/ci
 scripts/preflight.sh          # full matrix; --quick skips the Windows cross-check
 ```
 
-它執行的正是 CI 的 `check` job——`cargo fmt --check`、`cargo clippy --all-targets --features tray -- -D warnings`、`cargo test --tests --features tray`，以及一個 **Windows cross-check**（`x86_64-pc-windows-msvc`），用來抓出 unix 開發機原本會漏掉的 Windows-only 編譯錯誤。Windows 這一步優先採用 [`cargo-xwin`](https://github.com/rust-cross/cargo-xwin)（`cargo install cargo-xwin && rustup target add x86_64-pc-windows-msvc`），因為有一個傳遞性 C 依賴（`ring`）在沒有 MSVC toolchain 的情況下無法在 macOS/Linux 上交叉編譯；若未安裝，這一步會 SKIP 並附上提示，而不是誤判為失敗。
+它執行與 CI `check` job 相同的 fmt/clippy 介面——`scripts/fmt-owned.sh --check`（owned `*.rs`，排除 `vendor/`）與 owned-target 的 `cargo clippy`——外加 `cargo test --tests --features tray`，以及一個 **Windows cross-check**（`x86_64-pc-windows-msvc`），用來抓出 unix 開發機原本會漏掉的 Windows-only 編譯錯誤。（注意：CI 是用 `nextest` 而非 `cargo test` 跑測試，且浮動的 stable toolchain 並非長期逐位元組一致——preflight 是強力的預先檢查，而非與 CI 逐位元組一致的保證。）Windows 這一步優先採用 [`cargo-xwin`](https://github.com/rust-cross/cargo-xwin)（`cargo install cargo-xwin && rustup target add x86_64-pc-windows-msvc`），因為有一個傳遞性 C 依賴（`ring`）在沒有 MSVC toolchain 的情況下無法在 macOS/Linux 上交叉編譯；若未安裝，這一步會 SKIP 並附上提示，而不是誤判為失敗。
 
 ### 覆蓋率（選填，本地）
 

--- a/scripts/fmt-owned.sh
+++ b/scripts/fmt-owned.sh
@@ -44,12 +44,17 @@ fi
 # rather than asserted as byte-exact — and without pinning a toolchain here.
 echo "fmt-owned: $(rustfmt --version 2>/dev/null) [edition 2021, owned *.rs, vendor/** excluded]" >&2
 
-# Resolve the SUPERPROJECT root so enumeration + rustfmt run against the owned
-# tree regardless of CWD — including when invoked from within a submodule (then
-# --show-superproject-working-tree names the parent superproject; otherwise we
-# are already at the top level).
-root="$(git rev-parse --show-superproject-working-tree 2>/dev/null || true)"
-[ -n "$root" ] || root="$(git rev-parse --show-toplevel)"
+# Resolve the OUTERMOST superproject working tree so enumeration + rustfmt always
+# run against the top-level owned tree, regardless of CWD. `--show-superproject-
+# working-tree` climbs only ONE level, so from a deeply nested submodule a single
+# call names the IMMEDIATE superproject (and would then format vendored sources
+# under it); loop until it reports no superproject to reach the top.
+root="$(git rev-parse --show-toplevel)"
+while true; do
+    super="$(git -C "$root" rev-parse --show-superproject-working-tree 2>/dev/null || true)"
+    [ -n "$super" ] || break
+    root="$super"
+done
 cd "$root"
 
 # NUL-safe: enumerate tracked owned *.rs (vendor/** excluded). A -z stream keeps

--- a/scripts/fmt-owned.sh
+++ b/scripts/fmt-owned.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# scripts/fmt-owned.sh — THE single repository-owned rustfmt surface (task83, decision
+# d-20260713150435301072-46).
+#
+# "Owned" = tracked *.rs EXCLUDING vendor/** — the vendored agentic-git submodule
+# round-trips to its OWN repo/CI and must never be reformatted to our style. Plain
+# `cargo fmt` walks that submodule's sources (the [[bin]] compiles them) and would
+# flag/rewrite upstream code; this git pathspec never does. Every fmt caller —
+# GitHub CI, GitLab CI, scripts/preflight.sh (and pre-push via preflight) — invokes
+# THIS one script, so the owned-source boundary is defined in exactly one place.
+#
+# Usage:
+#   scripts/fmt-owned.sh            # format owned *.rs in place
+#   scripts/fmt-owned.sh --check    # verify formatting; non-zero exit on drift
+#   scripts/fmt-owned.sh -h|--help
+#
+# Exit: 0 clean; 1 rustfmt drift or failure; 2 bad invocation / no rustfmt.
+#
+# Portable to macOS system bash 3.2 and Git Bash on the Windows CI runner:
+# NUL-safe enumeration via a read loop (no `mapfile -d`, absent on bash 3.2).
+set -euo pipefail
+
+check=""
+case "${1:-}" in
+    --check)      check="--check" ;;
+    ""|--write)   : ;;
+    -h|--help)
+        sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+        exit 0
+        ;;
+    *)
+        echo "fmt-owned: unknown arg '$1' (use --check, --write, or no arg)" >&2
+        exit 2
+        ;;
+esac
+
+if ! command -v rustfmt >/dev/null 2>&1; then
+    echo "fmt-owned: rustfmt not found in PATH (install via rustup)" >&2
+    exit 2
+fi
+
+# Resolve the SUPERPROJECT root so enumeration + rustfmt run against the owned
+# tree regardless of CWD — including when invoked from within a submodule (then
+# --show-superproject-working-tree names the parent superproject; otherwise we
+# are already at the top level).
+root="$(git rev-parse --show-superproject-working-tree 2>/dev/null || true)"
+[ -n "$root" ] || root="$(git rev-parse --show-toplevel)"
+cd "$root"
+
+# NUL-safe: enumerate tracked owned *.rs (vendor/** excluded). A -z stream keeps
+# paths with spaces or newlines intact; the read loop preserves them exactly.
+files=()
+while IFS= read -r -d '' f; do
+    files+=("$f")
+done < <(git ls-files -z -- '*.rs' ':!:vendor/**')
+
+if [ "${#files[@]}" -eq 0 ]; then
+    echo "fmt-owned: no owned *.rs tracked under $root — nothing to do" >&2
+    exit 0
+fi
+
+# One rustfmt pass over the owned set (reads no rustfmt.toml → edition-2021
+# defaults, matching CI). rustfmt's exit status propagates: non-zero on a parse
+# error (write mode) or on any drift (--check mode).
+fmt_args=(--edition 2021)
+[ -n "$check" ] && fmt_args+=("$check")
+rustfmt "${fmt_args[@]}" "${files[@]}"

--- a/scripts/fmt-owned.sh
+++ b/scripts/fmt-owned.sh
@@ -39,6 +39,11 @@ if ! command -v rustfmt >/dev/null 2>&1; then
     exit 2
 fi
 
+# Version-scope evidence (task83/d-46): record the EXACT rustfmt this run used, to
+# stderr, so a "matches CI" claim is scoped to a concrete version in the logs
+# rather than asserted as byte-exact — and without pinning a toolchain here.
+echo "fmt-owned: $(rustfmt --version 2>/dev/null) [edition 2021, owned *.rs, vendor/** excluded]" >&2
+
 # Resolve the SUPERPROJECT root so enumeration + rustfmt run against the owned
 # tree regardless of CWD — including when invoked from within a submodule (then
 # --show-superproject-working-tree names the parent superproject; otherwise we

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -59,11 +59,11 @@ done <<<"$refs"
 
 if [ "$ci_parity_needed" = "1" ]; then
     cd "$REPO_ROOT"
-    # DRY: delegate to the canonical preflight (fmt --check + clippy
-    # --all-targets --features tray + `cargo test --tests --features tray`),
-    # `--quick` to skip the slow Windows cross-check (CI's windows-latest is the
-    # backstop for that). Single source of the parity commands → the hook can
-    # never drift from CI / preflight.sh.
+    # DRY: delegate to the canonical preflight — the owned-source formatter
+    # surface (scripts/fmt-owned.sh --check) + the owned-target clippy +
+    # `cargo test --tests --features tray` — with `--quick` to skip the slow
+    # Windows cross-check (CI's windows-latest is the backstop). Single source of
+    # the parity commands → the hook can never drift from CI / preflight.sh.
     if [ -x scripts/preflight.sh ]; then
         echo "pre-push: CI-parity via 'scripts/preflight.sh --quick' (mirrors CI's check job, host-only)…" >&2
         if ! scripts/preflight.sh --quick; then

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -7,10 +7,14 @@
 # problems a local check would have caught — Windows-only compile errors,
 # fmt drift, tray-gated failures, and the 750-LOC file_size_invariant.
 #
-# Runs, in order (each is exactly what CI's `check` job runs):
-#   1. cargo fmt --check
-#   2. cargo clippy --all-targets --features tray -- -D warnings
+# Runs, in order — the fmt/clippy surface MATCHES CI's `check` job (task83/d-46):
+#   1. scripts/fmt-owned.sh --check   (owned *.rs, vendor/ excluded — CI's exact surface)
+#   2. cargo clippy <owned targets> --features tray -- -D warnings  (CI's exact targets)
 #   3. cargo test --tests --features tray   (unit + integration + invariants)
+#      NOTE: CI runs these via `nextest`, not `cargo test` — the test SELECTION
+#      matches but the runner differs, and a floating stable toolchain is not
+#      byte-exact over time. "Green here" is a strong pre-check, not a byte-exact
+#      guarantee of CI.
 #   4. Windows cross-check (x86_64-pc-windows-msvc)   <- the keystone
 #
 # Step 4 catches the class that hurts most: Windows-only code
@@ -94,10 +98,10 @@ step() {
     fi
 }
 
-step "fmt --check" \
-    cargo fmt --check
-step "clippy (--all-targets --features tray -D warnings)" \
-    cargo clippy --all-targets --features tray -- -D warnings
+step "fmt --check (owned surface)" \
+    scripts/fmt-owned.sh --check
+step "clippy (owned targets --features tray -D warnings)" \
+    cargo clippy --lib --bin agend-terminal --bin agend-git --bin agend-mcp-bridge --tests --examples --features tray -- -D warnings
 step "test (--tests --features tray: unit + integration + invariants)" \
     cargo test --tests --features tray
 

--- a/scripts/test_fmt_owned.sh
+++ b/scripts/test_fmt_owned.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# scripts/test_fmt_owned.sh — hermetic tests for scripts/fmt-owned.sh (task83,
+# decision d-20260713150435301072-46).
+#
+# Builds a throwaway git superproject with a RECURSIVE (2-level) submodule and
+# asserts the owned-source formatter boundary:
+#   - a malformed OWNED *.rs is formatted (write mode);
+#   - a filename with a SPACE is handled (NUL-safe enumeration);
+#   - the vendored submodule's content, gitlink and status stay BYTE-IDENTICAL
+#     (recursively), and a super-tracked vendor/** file is never touched;
+#   - --check DETECTS owned drift (non-zero) and passes once clean;
+#   - a rustfmt PARSE FAILURE propagates (non-zero);
+#   - the recursive parent/submodule tree ends CLEAN.
+#
+# Usage: scripts/test_fmt_owned.sh    # exits 0 all-pass, 1 on any failure, 2 setup.
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+fmt_owned="$script_dir/fmt-owned.sh"
+
+pass=0
+fail=0
+ok()  { echo "PASS  $1"; pass=$((pass + 1)); }
+bad() { echo "FAIL  $1"; fail=$((fail + 1)); }
+
+command -v rustfmt >/dev/null 2>&1 || { echo "test_fmt_owned: rustfmt not found" >&2; exit 2; }
+
+# git that permits local file:// submodules (git >=2.38 blocks them by default)
+# and a deterministic default branch, hermetic identity.
+git_h() {
+    git -c protocol.file.allow=always -c init.defaultBranch=main \
+        -c user.email=t@example.invalid -c user.name=t \
+        -c commit.gpgsign=false "$@"
+}
+
+sha() { git hash-object "$1"; }   # content hash independent of the working repo
+
+work="$(mktemp -d -t fmt-owned-test.XXXXXX)"
+trap 'rm -rf "$work"' EXIT
+
+mk_repo() { mkdir -p "$1"; git_h -C "$1" init -q; }
+commit_all() { git_h -C "$1" add -A; git_h -C "$1" commit -q -m "$2"; }
+
+# ── Build super → vendor/dep → nested/inner (2-level recursive submodule) ──────
+inner="$work/inner"; mk_repo "$inner"
+printf 'fn inner() {}\n' > "$inner/inner.rs"
+commit_all "$inner" inner
+
+dep="$work/dep"; mk_repo "$dep"
+git_h -C "$dep" submodule add -q "$inner" nested >/dev/null 2>&1
+printf 'fn dep() {}\n' > "$dep/dep.rs"
+commit_all "$dep" dep
+
+super="$work/super"; mk_repo "$super"
+git_h -C "$super" submodule add -q "$dep" vendor/dep >/dev/null 2>&1
+git_h -C "$super" submodule update -q --init --recursive
+
+# Owned sources (deliberately MISformatted) + a super-tracked vendor/** file that
+# the pathspec must exclude even though it is not itself a submodule.
+mkdir -p "$super/src"
+printf 'fn   main( ){  }\n'      > "$super/src/main.rs"     # owned, malformed
+printf 'fn   spaced( ){  }\n'    > "$super/src/a b.rs"      # owned, malformed, SPACE in name
+printf 'fn   vendored( ){  }\n'  > "$super/vendor/excluded.rs"  # super-tracked under vendor/**
+commit_all "$super" super
+
+# Snapshot everything the formatter must NOT change.
+excluded_before="$(sha "$super/vendor/excluded.rs")"
+dep_rs_before="$(sha "$dep/dep.rs")"
+inner_rs_before="$(sha "$inner/inner.rs")"
+submod_status_before="$(git_h -C "$super" submodule status --recursive)"
+
+run_owned() { ( cd "$super" && "$fmt_owned" "$@" ); }
+rc() { local c=0; "$@" >/dev/null 2>&1 || c=$?; echo "$c"; }
+
+# ── 1. --check DETECTS owned drift (malformed files present) ──────────────────
+[ "$(rc run_owned --check)" -ne 0 ] \
+    && ok "--check detects owned drift (non-zero)" \
+    || bad "--check should be non-zero on malformed owned files"
+
+# ── 2/3. write mode FORMATS owned files, incl. the SPACE-named one ────────────
+run_owned >/dev/null 2>&1 || true
+if rustfmt --edition 2021 --check "$super/src/main.rs" >/dev/null 2>&1; then
+    ok "owned malformed file is formatted (src/main.rs)"
+else
+    bad "src/main.rs not formatted by write mode"
+fi
+if rustfmt --edition 2021 --check "$super/src/a b.rs" >/dev/null 2>&1; then
+    ok "space-named owned file is formatted (NUL/space path works)"
+else
+    bad "src/a b.rs (space) not formatted — NUL-safe enumeration broken"
+fi
+
+# ── 4. vendor content + gitlink + status BYTE-IDENTICAL (recursive) ───────────
+excluded_after="$(sha "$super/vendor/excluded.rs")"
+dep_rs_after="$(sha "$dep/dep.rs")"
+inner_rs_after="$(sha "$inner/inner.rs")"
+submod_status_after="$(git_h -C "$super" submodule status --recursive)"
+if [ "$excluded_before" = "$excluded_after" ] \
+    && [ "$dep_rs_before" = "$dep_rs_after" ] \
+    && [ "$inner_rs_before" = "$inner_rs_after" ] \
+    && [ "$submod_status_before" = "$submod_status_after" ]; then
+    ok "vendor/** + recursive submodule content/gitlink/status byte-identical"
+else
+    bad "formatter mutated vendored/excluded content or submodule state"
+fi
+
+# super working tree shows ONLY owned src/ changes, never a vendor/ entry.
+if git_h -C "$super" status --porcelain | grep -q '^.* vendor/'; then
+    bad "super status reports a vendor/ modification after formatting"
+else
+    ok "super status has no vendor/ modification"
+fi
+
+# ── 5. --check PASSES once the owned tree is clean ────────────────────────────
+[ "$(rc run_owned --check)" -eq 0 ] \
+    && ok "--check passes after formatting (clean)" \
+    || bad "--check should be zero once owned files are formatted"
+
+# ── 6. recursive cleanliness: commit owned changes → whole tree clean ─────────
+commit_all "$super" formatted
+super_dirty="$(git_h -C "$super" status --porcelain)"
+recurse_dirty="$(git_h -C "$super" submodule foreach --recursive 'git status --porcelain' 2>/dev/null | grep -v '^Entering' || true)"
+if [ -z "$super_dirty" ] && [ -z "$recurse_dirty" ]; then
+    ok "recursive parent/submodule cleanliness after commit"
+else
+    bad "tree not clean recursively (super='$super_dirty' sub='$recurse_dirty')"
+fi
+
+# ── 7. rustfmt PARSE FAILURE propagates (non-zero) ────────────────────────────
+printf 'fn broken( {\n' > "$super/src/broken.rs"   # unparseable Rust
+git_h -C "$super" add -A >/dev/null 2>&1
+[ "$(rc run_owned)" -ne 0 ] \
+    && ok "rustfmt parse failure propagates (non-zero)" \
+    || bad "unparseable owned file should make write mode non-zero"
+
+echo
+echo "summary: $pass passed, $fail failed"
+[ "$fail" -eq 0 ] || exit 1
+exit 0

--- a/scripts/test_fmt_owned.sh
+++ b/scripts/test_fmt_owned.sh
@@ -133,6 +133,20 @@ git_h -C "$super" add -A >/dev/null 2>&1
     && ok "rustfmt parse failure propagates (non-zero)" \
     || bad "unparseable owned file should make write mode non-zero"
 
+# ── 8. every production fmt caller invokes the shared surface ─────────────────
+# (pre-push converges transitively via preflight, so the direct callers suffice.)
+repo_root="$(cd "$script_dir/.." && pwd)"
+callers_ok=1
+for f in .github/workflows/ci.yml .gitlab-ci.yml scripts/preflight.sh; do
+    if ! grep -q 'fmt-owned\.sh' "$repo_root/$f"; then
+        echo "  (no fmt-owned.sh reference in $f)" >&2
+        callers_ok=0
+    fi
+done
+[ "$callers_ok" -eq 1 ] \
+    && ok "all production fmt callers invoke scripts/fmt-owned.sh" \
+    || bad "a production fmt caller does not invoke the shared surface"
+
 echo
 echo "summary: $pass passed, $fail failed"
 [ "$fail" -eq 0 ] || exit 1

--- a/scripts/test_fmt_owned.sh
+++ b/scripts/test_fmt_owned.sh
@@ -43,12 +43,12 @@ commit_all() { git_h -C "$1" add -A; git_h -C "$1" commit -q -m "$2"; }
 
 # ── Build super → vendor/dep → nested/inner (2-level recursive submodule) ──────
 inner="$work/inner"; mk_repo "$inner"
-printf 'fn inner() {}\n' > "$inner/inner.rs"
+printf 'fn   inner( ){  }\n' > "$inner/inner.rs"   # vendored + MALFORMED — must stay untouched
 commit_all "$inner" inner
 
 dep="$work/dep"; mk_repo "$dep"
 git_h -C "$dep" submodule add -q "$inner" nested >/dev/null 2>&1
-printf 'fn dep() {}\n' > "$dep/dep.rs"
+printf 'fn   dep( ){  }\n' > "$dep/dep.rs"         # vendored + MALFORMED — must stay untouched
 commit_all "$dep" dep
 
 super="$work/super"; mk_repo "$super"
@@ -146,6 +146,24 @@ done
 [ "$callers_ok" -eq 1 ] \
     && ok "all production fmt callers invoke scripts/fmt-owned.sh" \
     || bad "a production fmt caller does not invoke the shared surface"
+
+# ── 9. invoked from a deeply NESTED submodule CWD → resolves to the OUTERMOST
+#       superproject. `--show-superproject-working-tree` climbs ONE level, so from
+#       vendor/dep/nested (the doubly-nested inner) a single call picks the IMMEDIATE
+#       superproject (vendor/dep) and would format vendored dep.rs, dirtying the
+#       top-level `vendor/dep` gitlink. The formatter must climb to the top.
+rm -f "$super/src/broken.rs"                        # drop section 7's unparseable file
+printf 'fn   from_nested( ){  }\n' > "$super/src/from_nested.rs"
+git_h -C "$super" add -A >/dev/null 2>&1
+dep_nested_before="$(sha "$dep/dep.rs")"
+( cd "$super/vendor/dep/nested" && "$fmt_owned" ) >/dev/null 2>&1 || true
+if rustfmt --edition 2021 --check "$super/src/from_nested.rs" >/dev/null 2>&1 \
+    && [ "$dep_nested_before" = "$(sha "$dep/dep.rs")" ] \
+    && ! git_h -C "$super" status --porcelain | grep -q 'vendor/'; then
+    ok "nested-submodule CWD resolves to outermost superproject (owned formatted, vendored dep.rs untouched)"
+else
+    bad "nested CWD picked the immediate superproject — formatted vendored dep.rs / dirtied top-level vendor/"
+fi
 
 echo
 echo "summary: $pass passed, $fail failed"


### PR DESCRIPTION
Implements decision **d-20260713150435301072-46** (task83): a single repository-owned rustfmt surface, with all production fmt callers converged on it and preflight/GitLab clippy converged on GitHub's explicit owned targets. RED-first; base main `35d5e664`.

## What
- **`scripts/fmt-owned.sh`** — THE owned-source rustfmt surface. No arg formats, `--check` checks. Enumerates `git ls-files -z -- '*.rs' ':!:vendor/**'` (NUL-safe), resolves the superproject root, runs `rustfmt --edition 2021`, propagates failures. Portable to macOS system bash 3.2 and Git Bash (no `mapfile -d`). Logs the exact rustfmt version to stderr (version-scope evidence, no toolchain pin).
- **Callers converged**: `.github/workflows/ci.yml` (Format check → the script; + a Linux-only boundary-test step), `.gitlab-ci.yml` (fmt → script), `scripts/preflight.sh` (fmt → script). pre-push converges transitively via preflight.
- **Clippy converged**: preflight + GitLab now use GitHub's explicit owned-target `cargo clippy` (was `--all-targets`, which lints the vendored agentic-git bin under our strict `-D warnings`). Command is byte-identical across all three.
- **Honest docs**: `CONTRIBUTING.md` / `CONTRIBUTING.zh-TW.md` + preflight/pre-push comments — the fmt/clippy surface matches CI, but local tests run via `cargo test` vs CI's `nextest` and a floating stable toolchain is not byte-exact, so preflight is a strong pre-check, not a byte-exact guarantee.

## RED-first
`scripts/test_fmt_owned.sh` (committed BEFORE the implementation) builds a hermetic 2-level recursive-submodule fixture (super → vendor/dep → nested/inner) and asserts: owned malformed `*.rs` formatted; SPACE-named owned file formatted (NUL-safe); vendored submodule content/gitlink/status byte-identical recursively + super-tracked `vendor/**` untouched; `--check` detects drift; rustfmt parse failure propagates; recursive tree ends clean; all direct callers invoke the surface. **9/9.** Meaningful RED verified: dropping the `:!:vendor/**` exclusion makes the vendor-preservation assertions fail.

## Out of scope (per plan)
agentic-git lib/bin split (tasks 22→23), Cargo target ownership, upstream fmt-only dep, broad toolchain pin, pre-commit staged-file semantics, preflight test runner.

## Verification
`test_fmt_owned.sh` 9/9; `fmt-owned.sh --check` clean on the repo; owned clippy target clean; ci.yml + .gitlab-ci.yml valid YAML; `bash -n` clean on all touched scripts. Dual exact-head review requested; I do not self-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)