### PR TITLE
fix(task116): explicit Blocked projection split-brain — only raw Open is view-derived (d-63)

### DIFF
--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -269,21 +269,26 @@ impl<'a> DepResolver<'a> {
     }
 }
 
-/// Evaluate dependency status for a single task against a [`DepResolver`].
-/// - open + any dep not done → "blocked"
-/// - blocked + all deps done → "open" (auto-unblock)
-/// - claimed/done/cancelled → unchanged
+/// Evaluate the VIEW status of a single task against a [`DepResolver`] (decision
+/// d-20260713172801677583-63). Dependency-derived blocking is view-only and applies
+/// to RAW `Open` ONLY:
+/// - raw Open + any dep not Done → "blocked" (view; the raw replay stays Open)
+/// - raw Open + all deps Done (or no deps) → "open"
+/// - EVERY other raw status (Blocked / InProgress / InReview / Verified / Backlog /
+///   Claimed / Done / Cancelled) → UNCHANGED
+///
+/// So an EXPLICIT/persisted Blocked (operator, usage-limit, legacy migration) never
+/// auto-unblocks when its deps finish, and non-Open statuses are never projected to
+/// Blocked — get/list agree with the update response and the raw replay (no
+/// split-brain). Dep-derived Blocked is never persisted (see
+/// [`apply_dependency_eval_in_memory`]).
 fn evaluate_with_resolver(
     resolver: &mut DepResolver,
     task: &Task,
 ) -> crate::task_events::TaskStatus {
     use crate::task_events::TaskStatus;
-    if task.depends_on.is_empty()
-        || matches!(
-            task.status,
-            TaskStatus::Claimed | TaskStatus::Done | TaskStatus::Cancelled
-        )
-    {
+    // Only RAW Open is view-derived; everything else passes through unchanged.
+    if task.status != TaskStatus::Open || task.depends_on.is_empty() {
         return task.status;
     }
     let all_deps_done = task
@@ -291,11 +296,7 @@ fn evaluate_with_resolver(
         .iter()
         .all(|dep_id| resolver.status_of(dep_id) == Some(TaskStatus::Done));
     if all_deps_done {
-        if task.status == TaskStatus::Blocked {
-            TaskStatus::Open
-        } else {
-            task.status
-        }
+        TaskStatus::Open
     } else {
         TaskStatus::Blocked
     }

--- a/src/tasks/tests.rs
+++ b/src/tasks/tests.rs
@@ -1320,6 +1320,435 @@ fn test_task_auto_unblock_when_all_deps_done() {
     std::fs::remove_dir_all(&home).ok();
 }
 
+// ── d-63: explicit/raw Blocked passes through; ONLY raw Open is view-derived ──
+// Split-brain bug: `evaluate_with_resolver` auto-unblocked a raw Blocked task once
+// its deps were Done, so get/list projected Open while the update response + raw
+// replay stayed Blocked. Surgical rule: raw status != Open passes through unchanged;
+// only raw Open derives dependency Blocked. These exercise the REAL task handlers.
+
+/// Raw (unprojected) persisted status via an event-log replay of the task's board.
+fn raw_status_d63(home: &std::path::Path, id: &str) -> crate::task_events::TaskStatus {
+    let board = super::board_router::board_for_task(home, id);
+    crate::task_events::replay_at(&board)
+        .expect("replay board")
+        .tasks
+        .get(&crate::task_events::TaskId(id.to_string()))
+        .expect("task present on its board")
+        .status
+}
+
+/// Projected status via the `get` handler.
+fn status_via_get_d63(home: &std::path::Path, caller: &str, id: &str) -> String {
+    handle(
+        home,
+        caller,
+        &serde_json::json!({"action": "get", "id": id}),
+    )["task"]["status"]
+        .as_str()
+        .unwrap()
+        .to_string()
+}
+
+/// (1) explicit operator Blocked with all deps Done AGREES Blocked across the update
+/// response, get, list, AND the raw replay — no split-brain.
+#[test]
+fn d63_explicit_blocked_with_done_deps_agrees_all_surfaces() {
+    let home = tmp_home("d63-explicit");
+    let dep = handle(
+        &home,
+        "u",
+        &serde_json::json!({"action": "create", "title": "dep", "assignee": "u"}),
+    )["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    handle(
+        &home,
+        "u",
+        &serde_json::json!({"action": "done", "id": dep, "result": "ok"}),
+    );
+    let child = handle(&home, "u", &serde_json::json!({"action": "create", "title": "child", "assignee": "u", "depends_on": [dep]}))["id"].as_str().unwrap().to_string();
+    let upd = handle(
+        &home,
+        "u",
+        &serde_json::json!({"action": "update", "id": child, "status": "blocked"}),
+    );
+    assert_eq!(
+        upd["task"]["status"], "blocked",
+        "update response reports raw Blocked"
+    );
+    assert_eq!(
+        status_via_get_d63(&home, "u", &child),
+        "blocked",
+        "get must agree Blocked (not projected Open)"
+    );
+    assert_eq!(
+        status_via_list(&home, "u", "child"),
+        "blocked",
+        "list must agree Blocked (not projected Open)"
+    );
+    assert_eq!(
+        raw_status_d63(&home, &child),
+        crate::task_events::TaskStatus::Blocked,
+        "raw replay is Blocked"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// (2) raw Open with an UNMET dep is a VIEW Blocked while the raw replay stays Open.
+#[test]
+fn d63_raw_open_unmet_dep_view_blocked_raw_open() {
+    let home = tmp_home("d63-open-unmet");
+    let dep = handle(
+        &home,
+        "u",
+        &serde_json::json!({"action": "create", "title": "dep", "assignee": "u"}),
+    )["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let child = handle(&home, "u", &serde_json::json!({"action": "create", "title": "child", "assignee": "u", "depends_on": [dep]}))["id"].as_str().unwrap().to_string();
+    assert_eq!(
+        status_via_list(&home, "u", "child"),
+        "blocked",
+        "unmet dep → view Blocked"
+    );
+    assert_eq!(
+        status_via_get_d63(&home, "u", &child),
+        "blocked",
+        "get view Blocked"
+    );
+    assert_eq!(
+        raw_status_d63(&home, &child),
+        crate::task_events::TaskStatus::Open,
+        "raw replay stays Open (view-only block)"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// (3) completing the dep returns a raw-Open task's VIEW to Open.
+#[test]
+fn d63_completing_dep_returns_raw_open_view_to_open() {
+    let home = tmp_home("d63-complete");
+    let dep = handle(
+        &home,
+        "u",
+        &serde_json::json!({"action": "create", "title": "dep", "assignee": "u"}),
+    )["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let child = handle(&home, "u", &serde_json::json!({"action": "create", "title": "child", "assignee": "u", "depends_on": [dep]}))["id"].as_str().unwrap().to_string();
+    assert_eq!(status_via_list(&home, "u", "child"), "blocked");
+    handle(
+        &home,
+        "u",
+        &serde_json::json!({"action": "done", "id": dep, "result": "ok"}),
+    );
+    assert_eq!(
+        status_via_list(&home, "u", "child"),
+        "open",
+        "dep Done → raw-Open child view returns to Open"
+    );
+    assert_eq!(
+        raw_status_d63(&home, &child),
+        crate::task_events::TaskStatus::Open
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// (4) a usage-limit Blocked (system-seeded, not an operator update) SURVIVES dep
+/// satisfaction — the exact auto-unblock bug (dep Done must not reopen it).
+#[test]
+fn d63_usage_limit_blocked_survives_satisfied_deps() {
+    let home = tmp_home("d63-usage-limit");
+    let inst = crate::task_events::InstanceName::from("u");
+    let dep = handle(
+        &home,
+        "u",
+        &serde_json::json!({"action": "create", "title": "dep", "assignee": "u"}),
+    )["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let child = handle(&home, "u", &serde_json::json!({"action": "create", "title": "child", "assignee": "u", "depends_on": [dep]}))["id"].as_str().unwrap().to_string();
+    crate::task_events::append(
+        &home,
+        &inst,
+        crate::task_events::TaskEvent::Blocked {
+            task_id: crate::task_events::TaskId(child.clone()),
+            reason: "usage limit reached".into(),
+        },
+    )
+    .unwrap();
+    handle(
+        &home,
+        "u",
+        &serde_json::json!({"action": "done", "id": dep, "result": "ok"}),
+    );
+    assert_eq!(
+        status_via_list(&home, "u", "child"),
+        "blocked",
+        "usage-limit Blocked must survive Done deps"
+    );
+    assert_eq!(status_via_get_d63(&home, "u", &child), "blocked");
+    assert_eq!(
+        raw_status_d63(&home, &child),
+        crate::task_events::TaskStatus::Blocked
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// (5) explicit Blocked → explicit `status=open` STILL succeeds — the fix removes the
+/// AUTO unblock, not the operator's ability to unblock.
+#[test]
+fn d63_explicit_blocked_to_open_transition_succeeds() {
+    let home = tmp_home("d63-unblock");
+    let dep = handle(
+        &home,
+        "u",
+        &serde_json::json!({"action": "create", "title": "dep", "assignee": "u"}),
+    )["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    handle(
+        &home,
+        "u",
+        &serde_json::json!({"action": "done", "id": dep, "result": "ok"}),
+    );
+    let child = handle(&home, "u", &serde_json::json!({"action": "create", "title": "child", "assignee": "u", "depends_on": [dep]}))["id"].as_str().unwrap().to_string();
+    handle(
+        &home,
+        "u",
+        &serde_json::json!({"action": "update", "id": child, "status": "blocked"}),
+    );
+    let r = handle(
+        &home,
+        "u",
+        &serde_json::json!({"action": "update", "id": child, "status": "open"}),
+    );
+    assert_eq!(r["event"], "updated", "Blocked → open must succeed: {r:?}");
+    assert_eq!(
+        raw_status_d63(&home, &child),
+        crate::task_events::TaskStatus::Open,
+        "explicit unblock persists Open"
+    );
+    assert_eq!(status_via_list(&home, "u", "child"), "open");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// (6) a legacy-migration Blocked (seeded via events, as a tasks.json migration
+/// produces) SURVIVES Done deps.
+#[test]
+fn d63_legacy_migration_blocked_survives_satisfied_deps() {
+    let home = tmp_home("d63-legacy");
+    let inst = crate::task_events::InstanceName::from("u");
+    let dep = handle(
+        &home,
+        "u",
+        &serde_json::json!({"action": "create", "title": "dep", "assignee": "u"}),
+    )["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    handle(
+        &home,
+        "u",
+        &serde_json::json!({"action": "done", "id": dep, "result": "ok"}),
+    );
+    let child = crate::task_events::TaskId("t-d63-legacy-child".into());
+    crate::task_events::append(
+        &home,
+        &inst,
+        crate::task_events::TaskEvent::Created {
+            task_id: child.clone(),
+            title: "legacy-child".into(),
+            description: String::new(),
+            priority: "normal".into(),
+            owner: None,
+            due_at: None,
+            branch: None,
+            depends_on: vec![crate::task_events::TaskId(dep.clone())],
+            routed_to: None,
+            bind: None,
+            eta_secs: None,
+            tags: vec![],
+            parent_id: None,
+        },
+    )
+    .unwrap();
+    crate::task_events::append(
+        &home,
+        &inst,
+        crate::task_events::TaskEvent::Blocked {
+            task_id: child.clone(),
+            reason: "legacy migration".into(),
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        status_via_list(&home, "u", "legacy-child"),
+        "blocked",
+        "legacy-migration Blocked must survive Done deps"
+    );
+    assert_eq!(
+        raw_status_d63(&home, &child.0),
+        crate::task_events::TaskStatus::Blocked
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// List including non-actionable statuses (default `list` trims to
+/// open/claimed/in_progress/blocked, so Backlog/InReview/Verified need this).
+fn status_via_list_full_d63(home: &std::path::Path, caller: &str, title: &str) -> String {
+    handle(
+        home,
+        caller,
+        &serde_json::json!({"action": "list", "include_history": true}),
+    )["tasks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|t| t["title"] == title)
+        .unwrap_or_else(|| panic!("task '{title}' not in list"))["status"]
+        .as_str()
+        .unwrap()
+        .to_string()
+}
+
+/// (7) NON-Open raw statuses with an UNMET dep pass through AS-IS in get/list — only
+/// raw Open is view-derived, so InProgress / Backlog / InReview / Verified are NEVER
+/// projected to Blocked. Seeded via events because the claim gate blocks the normal
+/// claim→in_progress path while a dep is unmet (Fable task123 required addition).
+#[test]
+fn d63_non_open_statuses_with_unmet_dep_pass_through() {
+    let home = tmp_home("d63-nonopen");
+    let inst = crate::task_events::InstanceName::from("u");
+    // A shared UNMET (Open) dependency.
+    let dep = handle(
+        &home,
+        "u",
+        &serde_json::json!({"action": "create", "title": "dep", "assignee": "u"}),
+    )["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let dep_id = crate::task_events::TaskId(dep.clone());
+    let tid = |s: &str| crate::task_events::TaskId(s.into());
+    let seed = |id: &str, title: &str, extra: Vec<crate::task_events::TaskEvent>| {
+        crate::task_events::append(
+            &home,
+            &inst,
+            crate::task_events::TaskEvent::Created {
+                task_id: tid(id),
+                title: title.into(),
+                description: String::new(),
+                priority: "normal".into(),
+                owner: None,
+                due_at: None,
+                branch: None,
+                depends_on: vec![dep_id.clone()],
+                routed_to: None,
+                bind: None,
+                eta_secs: None,
+                tags: vec![],
+                parent_id: None,
+            },
+        )
+        .unwrap();
+        for ev in extra {
+            crate::task_events::append(&home, &inst, ev).unwrap();
+        }
+    };
+    seed(
+        "t-d63-inprog",
+        "inprog",
+        vec![
+            crate::task_events::TaskEvent::Claimed {
+                task_id: tid("t-d63-inprog"),
+                by: inst.clone(),
+            },
+            crate::task_events::TaskEvent::InProgress {
+                task_id: tid("t-d63-inprog"),
+                by: inst.clone(),
+            },
+        ],
+    );
+    seed(
+        "t-d63-backlog",
+        "backlog",
+        vec![crate::task_events::TaskEvent::MovedToBacklog {
+            task_id: tid("t-d63-backlog"),
+        }],
+    );
+    seed(
+        "t-d63-inreview",
+        "inreview",
+        vec![crate::task_events::TaskEvent::MovedToReview {
+            task_id: tid("t-d63-inreview"),
+        }],
+    );
+    seed(
+        "t-d63-verified",
+        "verified",
+        vec![crate::task_events::TaskEvent::Verified {
+            task_id: tid("t-d63-verified"),
+            by_reviewer: inst.clone(),
+            verdict: "VERIFIED".into(),
+        }],
+    );
+    for (title, id, want, want_status) in [
+        (
+            "inprog",
+            "t-d63-inprog",
+            "in_progress",
+            crate::task_events::TaskStatus::InProgress,
+        ),
+        (
+            "backlog",
+            "t-d63-backlog",
+            "backlog",
+            crate::task_events::TaskStatus::Backlog,
+        ),
+        (
+            "inreview",
+            "t-d63-inreview",
+            "in_review",
+            crate::task_events::TaskStatus::InReview,
+        ),
+        (
+            "verified",
+            "t-d63-verified",
+            "verified",
+            crate::task_events::TaskStatus::Verified,
+        ),
+    ] {
+        assert_eq!(
+            raw_status_d63(&home, id),
+            want_status,
+            "{title}: raw status seeded"
+        );
+        assert_eq!(
+            status_via_get_d63(&home, "u", id),
+            want,
+            "{title}: get must pass through (never Blocked)"
+        );
+        assert_eq!(
+            status_via_list_full_d63(&home, "u", title),
+            want,
+            "{title}: list must pass through (never Blocked)"
+        );
+    }
+    std::fs::remove_dir_all(&home).ok();
+}
+
+// (8) cross-board raw-Open dependency projection is preserved by the d-63 rule (raw
+// Open still derives Blocked/Open across boards). Covered by the existing tests
+// `cross_board_dep_done_unblocks_dependent_2117_q2` and
+// `cross_board_dep_derived_block_is_in_memory_not_persisted_2117_q2` below, which
+// continue to pass unchanged (the fix only stops projecting NON-Open statuses).
+
 // ── #2117 Q2: cross-board depends_on resolution (multi-project) ──
 
 /// Multi-project fleet: teamA(devA)@orgA/projA, teamB(devB)@orgB/projB. A task


### PR DESCRIPTION
Implements decision **d-20260713172801677583-63** (task116). Base main `35d5e664`; single file of production change, disjoint from PR #2770.

## Bug
`evaluate_with_resolver` (src/tasks/mod.rs) converted a raw **Blocked** task to Open whenever its dependencies were Done, and projected any non-Claimed/Done/Cancelled status to Blocked on an unmet dep. `get`/`list` showed that projection while the **update response** and **raw event-log replay** read the persisted status — so an explicit / usage-limit / legacy-migration Blocked appeared **Open in list but Blocked everywhere else** (split-brain).

## Surgical rule
Return the raw status **unchanged unless it is Open**; for raw Open only, all-deps-Done → Open else view Blocked. So an explicit Blocked never auto-unblocks, and InProgress/InReview/Verified/Backlog pass through. Dependency-derived blocking stays view-only and unpersisted (`apply_dependency_eval_in_memory` unchanged); **projection call sites and persistence emitters untouched**; doc comment corrected.

## RED-first (real task handlers: create/update/get/list/done + raw replay)
1. explicit Blocked + Done deps agrees Blocked across update response/get/list/raw;
2. raw Open + unmet dep → view Blocked, raw Open [preserved];
3. completing dep → raw-Open view returns to Open [preserved];
4. usage-limit Blocked survives satisfied deps;
5. explicit Blocked → status=open transition still succeeds [preserved];
6. legacy-migration Blocked survives Done deps;
7. InProgress/Backlog/InReview/Verified + unmet dep pass through AS-IS (never Blocked);
8. cross-board raw-Open projection preserved — cited to existing `cross_board_*_2117_q2`.

RED-proven against `35d5e664`: groups (1)(4)(6)(7) fail pre-fix; the fix commit turns them GREEN.

## Out of scope (per plan)
No block-source schema, claim-gate/atomicity redesign, #2760 router changes, or other status-projection refactor.

## Verification
7 d63 groups GREEN; **full task suite 269/269**; clippy strict `-D warnings` clean; rustfmt clean. Independent (single) review before merge; I do not self-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)