### PR TITLE
feat: use first-party agentic-git wrapper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,8 +76,7 @@ jobs:
         # task83 (d-46): the owned-source rustfmt boundary now lives in ONE place —
         # scripts/fmt-owned.sh — so CI, GitLab CI and preflight can't drift apart. It
         # enumerates `git ls-files -z -- '*.rs' ':!:vendor/**'` (NUL-safe; excludes
-        # the vendored agentic-git submodule that `cargo fmt` would otherwise walk and
-        # reformat) and runs `rustfmt --edition 2021 --check`.
+        # the vendored agentic-git submodule) and runs `rustfmt --edition 2021 --check`.
         run: scripts/fmt-owned.sh --check
 
       # task83: exercise the owned-fmt boundary contract itself (hermetic recursive-
@@ -89,27 +88,22 @@ jobs:
         shell: bash
         run: scripts/test_fmt_owned.sh
 
-      # #2524 P3: the agentic-git `[[bin]]` compiles vendored submodule source.
-      # `cargo clippy --all-targets` would lint it under agend-terminal's strict
-      # `-D warnings` + `unwrap_used=deny`, but that is UPSTREAM code gated by
-      # agentic-git's OWN CI — and `--all-targets` IGNORES the target's
-      # `test = false`, dragging in its unix-only inline tests (which also fail to
-      # compile on Windows). So run the strict gate on OUR OWN targets only:
-      # `--tests` DOES honor `test=false`, so it excludes the vendored bin's
-      # unittest; enumerate our bins (NOT agentic-git) so `--bins`/`--all-targets`
-      # never pull the vendored binary either. Add a new agend-terminal bin here.
-      # This keeps full default+tray coverage of everything we own.
+      # First-party agentic-git wrapper regression: real cargo fmt must leave the
+      # parent and every recursive submodule byte-clean on the ephemeral checkout.
+      - name: Real cargo fmt recursive-clean proof
+        timeout-minutes: 5
+        shell: bash
+        run: |
+          cargo fmt
+          test -z "$(git diff --name-only)"
+          dirty="$(git submodule foreach --recursive 'git status --porcelain' | grep -v '^Entering' || true)"
+          test -z "$dirty"
+
+      # The first-party wrapper delegates to upstream's library entrypoint; lint
+      # the binary strictly alongside the other agend-terminal targets.
       - name: Clippy (our targets, strict)
         timeout-minutes: 15
-        run: cargo clippy --lib --bin agend-terminal --bin agend-git --bin agend-mcp-bridge --tests --examples --features tray -- -D warnings
-      # The vendored agentic-git bin: lint as ADVISORY only (`--cap-lints=warn` →
-      # nothing gates), never imposing agend-terminal's `-D` bar on upstream code.
-      # We do NOT edit the submodule source to add `#[allow]` (that forks the
-      # vendored crate). Real Windows-compile coverage comes from the Build step.
-      - name: Clippy (vendored agentic-git bin, advisory)
-        timeout-minutes: 15
-        continue-on-error: true
-        run: cargo clippy --bin agentic-git --features tray -- --cap-lints=warn
+        run: cargo clippy --lib --bin agend-terminal --bin agend-git --bin agend-mcp-bridge --bin agentic-git --tests --examples --features tray -- -D warnings
 
       - name: Build
         timeout-minutes: 20

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,9 +36,9 @@ fmt:
 clippy:
   stage: lint
   script:
-    # task83: GitHub's explicit OWNED-target clippy (not `--all-targets`, which
-    # drags in the vendored agentic-git bin under our strict `-D warnings`).
-    - cargo clippy --lib --bin agend-terminal --bin agend-git --bin agend-mcp-bridge --tests --examples --features tray -- -D warnings
+    # Keep GitLab aligned with GitHub: the first-party agentic-git wrapper is
+    # part of the strict target set.
+    - cargo clippy --lib --bin agend-terminal --bin agend-git --bin agend-mcp-bridge --bin agentic-git --tests --examples --features tray -- -D warnings
 
 test:
   stage: test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 name = "agend-terminal"
 version = "0.10.0"
 dependencies = [
+ "agentic-git",
  "agentic-git-core",
  "alacritty_terminal",
  "anyhow",
@@ -76,6 +77,18 @@ dependencies = [
  "uuid",
  "which",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "agentic-git"
+version = "0.2.3"
+dependencies = [
+ "agentic-git-core",
+ "chrono",
+ "getrandom 0.4.3",
+ "libc",
+ "serde_json",
+ "which",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,11 +73,8 @@ codegen-units = 16
 # #2524 P3 (agentic-git migration): build the vendored agentic-git shim as
 # agend-terminal's OWN bin target, so `cargo build` produces the sibling binary
 # with ZERO build script + it rides `cargo install`/release archives automatically.
-# `path=` compiles main.rs directly — it does NOT resolve the standalone
-# agentic-git package, so Cargo.lock keeps exactly ONE agentic-git-core (the same
-# path dep the daemon links; single-source invariant, §3.A cond #1). Distinct from
-# a `[workspace]` member (blocked by the submodule's own `[workspace]`) — this is
-# just source compiled under agend-terminal's manifest (edition/MSRV identical).
+# The first-party wrapper delegates to the vendored package's public entrypoint;
+# the path dependency keeps the package's library/bin split and one core crate.
 #
 # `test = false` is LOAD-BEARING for cross-platform CI: the binary itself builds
 # on all targets (it has cfg(windows) paths; unix code is `#[cfg(unix)]`-gated),
@@ -88,7 +85,7 @@ codegen-units = 16
 # into its test surface — else `cargo nextest` on Windows fails to compile them.
 [[bin]]
 name = "agentic-git"
-path = "vendor/agentic-git/crates/agentic-git/src/main.rs"
+path = "src/bin/agentic-git.rs"
 test = false
 
 [dependencies]
@@ -149,7 +146,7 @@ hmac = "0.13"
 digest = "0.11"
 hex = "0.4"
 # embedder P1b (§3.A): link agentic-git-core from the pinned submodule
-# (vendor/agentic-git @ 5306c85 = the P1a merge). The daemon signs bindings via
+# (vendor/agentic-git @ 5c02b142 = the published 0.2.3 release). The daemon signs bindings via
 # `agentic_git_core::integrity_core::sign_binding` (provision+sign, BARE hex —
 # byte-identical to the pre-swap `config_integrity::sign`), so one HMAC source
 # feeds signer(daemon) + verifier(shim) with zero drift. The submodule PATH is
@@ -159,6 +156,7 @@ hex = "0.4"
 # LOAD-BEARING (reviewer4 cond #1): exactly ONE agentic-git-core in Cargo.lock —
 # enforced by tests/agentic_core_single_source.rs (RED-first).
 agentic-git-core = { path = "vendor/agentic-git/crates/agentic-git-core", version = "0.2.0" }
+agentic-git = { path = "vendor/agentic-git/crates/agentic-git", version = "0.2.3" }
 chrono = { version = "0.4", features = ["serde"] }
 chrono-tz = "0.10"
 cron = "0.17"

--- a/scripts/fmt-owned.sh
+++ b/scripts/fmt-owned.sh
@@ -3,9 +3,8 @@
 # d-20260713150435301072-46).
 #
 # "Owned" = tracked *.rs EXCLUDING vendor/** — the vendored agentic-git submodule
-# round-trips to its OWN repo/CI and must never be reformatted to our style. Plain
-# `cargo fmt` walks that submodule's sources (the [[bin]] compiles them) and would
-# flag/rewrite upstream code; this git pathspec never does. Every fmt caller —
+# round-trips to its OWN repo/CI. The parent wrapper keeps plain `cargo fmt` scoped
+# to parent-owned sources; this pathspec remains the explicit boundary. Every fmt caller —
 # GitHub CI, GitLab CI, scripts/preflight.sh (and pre-push via preflight) — invokes
 # THIS one script, so the owned-source boundary is defined in exactly one place.
 #

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -9,7 +9,7 @@
 #
 # Runs, in order — the fmt/clippy surface MATCHES CI's `check` job (task83/d-46):
 #   1. scripts/fmt-owned.sh --check   (owned *.rs, vendor/ excluded — CI's exact surface)
-#   2. cargo clippy <owned targets> --features tray -- -D warnings  (CI's exact targets)
+#   2. cargo clippy <owned targets + agentic-git wrapper> --features tray -- -D warnings  (CI's exact targets)
 #   3. cargo test --tests --features tray   (unit + integration + invariants)
 #      NOTE: CI runs these via `nextest`, not `cargo test` — the test SELECTION
 #      matches but the runner differs, and a floating stable toolchain is not
@@ -101,7 +101,7 @@ step() {
 step "fmt --check (owned surface)" \
     scripts/fmt-owned.sh --check
 step "clippy (owned targets --features tray -D warnings)" \
-    cargo clippy --lib --bin agend-terminal --bin agend-git --bin agend-mcp-bridge --tests --examples --features tray -- -D warnings
+    cargo clippy --lib --bin agend-terminal --bin agend-git --bin agend-mcp-bridge --bin agentic-git --tests --examples --features tray -- -D warnings
 step "test (--tests --features tray: unit + integration + invariants)" \
     cargo test --tests --features tray
 

--- a/src/bin/agentic-git.rs
+++ b/src/bin/agentic-git.rs
@@ -1,0 +1,3 @@
+fn main() {
+    agentic_git::shim_entry();
+}

--- a/tests/agentic_git_bin_target_invariant.rs
+++ b/tests/agentic_git_bin_target_invariant.rs
@@ -25,7 +25,7 @@
 use std::path::Path;
 
 const BIN_NAME: &str = "agentic-git";
-const BIN_PATH: &str = "vendor/agentic-git/crates/agentic-git/src/main.rs";
+const BIN_PATH: &str = "src/bin/agentic-git.rs";
 
 /// The body of the `[[bin]]` table whose `name = "<BIN_NAME>"`, or `None` if no
 /// such target is declared. A `[[bin]]` table runs until the next top-level `[`.
@@ -83,6 +83,10 @@ fn agentic_git_bin_target_is_declared_with_windows_safe_test_false() {
          without this `cargo nextest` on Windows breaks. Those tests run in \
          agentic-git's own CI. Found block:\n{block}"
     );
+    assert!(
+        !BIN_PATH.starts_with("vendor/"),
+        "the parent Cargo target must never point beneath vendor"
+    );
 }
 
 /// Regression-proof (RED-first): the parser + guard MUST fire when the `[[bin]]`
@@ -106,8 +110,12 @@ fn checker_fires_on_missing_target_or_test_flag() {
     let block = agentic_git_bin_block(NO_TEST_FALSE)
         .expect("the [[bin]] block must be found even without test=false");
     assert!(
-        has_kv(&block, "path", &format!("\"{BIN_PATH}\"")),
-        "path guard must still recognize the vendored path"
+        has_kv(
+            &block,
+            "path",
+            "\"vendor/agentic-git/crates/agentic-git/src/main.rs\""
+        ),
+        "path guard must still recognize the legacy path in this negative fixture"
     );
     assert!(
         !has_kv(&block, "test", "false"),

--- a/tests/agentic_git_shim_swap.rs
+++ b/tests/agentic_git_shim_swap.rs
@@ -24,7 +24,7 @@
 //! `agentic-git-core` from this same submodule, P1b), so `include_str!` on it
 //! adds no new fragility.
 
-const VENDORED_SHIM: &str = include_str!("../vendor/agentic-git/crates/agentic-git/src/main.rs");
+const VENDORED_SHIM: &str = include_str!("../vendor/agentic-git/crates/agentic-git/src/lib.rs");
 
 /// Every git guard agend-terminal relies on must be present in the vendored
 /// successor shim (design §5 DUAL parity core). A missing one = a silent guard


### PR DESCRIPTION
## Summary

- replace the parent Cargo target that pointed directly into vendor with a first-party src/bin/agentic-git.rs wrapper
- advance the agentic-git submodule to the published library/bin split and add the minimal agentic-git path dependency while preserving the agentic-git binary name and test=false
- keep one agentic-git-core source, prohibit vendored Cargo target paths, and include the wrapper in strict clippy, preflight, and release coverage
- prove that a real cargo fmt leaves both the parent repository and recursive submodules byte-clean across the GitHub matrix

## Verification

- exact rebased head: 6f5c1edf7700bd3fddaa0da031e4737bd53499b6
- rebased onto main e13a3f303a32ef9c24ac50307d640a5a9b7752da with stable patch-id preserved from 43eea09d588f5bf59fabe3a804c5e8074eae9b1a
- clean parent worktree and clean pinned submodule at 5c02b1421beda6590e8ebdfd137df9b49ee0bd02 (agentic-git v0.2.3)
- checkpoint verification covers the wrapper build and CLI entry, real shim deny/allow/tamper paths, single-core lockfile invariant, strict wrapper lint coverage, and recursive format cleanliness
- exact-head event-driven CI is the remaining merge gate

---
*archfix-codex-dev* · Codex/GPT-5
