### PR TITLE
fix(task-46776): fail-closed workspace-identity guard (admission + provision + delete)

### DIFF
--- a/src/agent_ops.rs
+++ b/src/agent_ops.rs
@@ -1489,6 +1489,53 @@ mod tests {
     }
 
     #[test]
+    fn cleanup_refuses_unreadable_identity_tree() {
+        // Fail-closed: an UNREADABLE identity artifact (opaque I/O ≠ NotFound)
+        // must refuse the delete — never be read as "absent" and wipe the tree.
+        let home = tmp_home("cw_unreadable");
+        let ws = home.join("workspace/alice");
+        std::fs::create_dir_all(&ws).unwrap();
+        std::fs::write(ws.join("AGENTS.md"), [0xFFu8, 0xFE]).unwrap(); // invalid UTF-8
+        assert!(
+            cleanup_working_dir(&home, "alice", &ws).is_some(),
+            "unreadable identity must refuse (Some verdict)"
+        );
+        assert!(ws.exists(), "tree preserved on unreadable identity");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn workspace_identity_lock_is_mutually_exclusive_provision_vs_delete() {
+        // Provision (generate_with_context) and delete (cleanup_working_dir) BOTH
+        // acquire store::acquire_workspace_identity_lock(home, wd) for the same
+        // directory. Prove it is mutually exclusive so a check+write can never
+        // interleave with a check+remove of that directory (root finding 4).
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Arc;
+        let home = tmp_home("wsid_lock");
+        let wd = home.join("workspace/shared");
+        let in_critical = Arc::new(AtomicBool::new(false));
+        let held = crate::store::acquire_workspace_identity_lock(&home, &wd).expect("first lock");
+        in_critical.store(true, Ordering::SeqCst);
+        let (h2, w2, ic2) = (home.clone(), wd.clone(), in_critical.clone());
+        let t = std::thread::spawn(move || {
+            // Blocks until the main thread releases `held` (mutual exclusion).
+            let _g = crate::store::acquire_workspace_identity_lock(&h2, &w2).expect("second lock");
+            assert!(
+                !ic2.load(Ordering::SeqCst),
+                "acquired the workspace-identity lock while another holder was still in its \
+                 critical section — the lock is NOT mutually exclusive"
+            );
+        });
+        // Give the spawned thread time to reach (and block on) the acquire.
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        in_critical.store(false, Ordering::SeqCst);
+        drop(held);
+        t.join().expect("second acquirer thread");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
     fn cleanup_metadata() {
         let home = tmp_home("cms");
         let ws = home.join("workspace/a");

--- a/src/agent_ops.rs
+++ b/src/agent_ops.rs
@@ -502,91 +502,108 @@ pub fn ensure_not_protected_json(branch: &str) -> Result<(), serde_json::Value> 
 /// is missing the 5 Kiro paths: `.kiro/agents/{agend.json,agend-prompt.md,
 /// default.json}`, `.kiro/prompts/agend.md`, `.kiro/settings.json`.
 pub fn cleanup_working_dir(home: &Path, name: &str, working_dir: &Path) {
-    let workspaces = crate::paths::workspace_dir(home);
-
-    // If under $AGEND_HOME/workspace/, remove the whole directory.
-    // CR-2026-06-14 (security): a purely LEXICAL `starts_with` lets a symlink
-    // under workspace/ whose real target is ELSEWHERE take this whole-dir
-    // `remove_dir_all` and follow the symlink out of the workspace, destroying
-    // real user data. Require the path to ALSO resolve canonically inside the
-    // canonicalized workspace root (canonicalize BOTH so a symlinked
-    // $AGEND_HOME — e.g. macOS /tmp→/private/tmp — still matches).
-    let under_workspace = working_dir.starts_with(&workspaces)
-        && match (
-            dunce::canonicalize(working_dir),
-            dunce::canonicalize(&workspaces),
-        ) {
-            (Ok(wd), Ok(ws)) => wd.starts_with(&ws),
-            _ => false,
-        };
-    if under_workspace {
-        // #2234 Phase 0: under cure-(B) the workspace dir IS a daemon-managed
-        // canonical worktree (its `.git` is a gitlink FILE). A bare
-        // remove_dir_all would destroy uncommitted/unpushed work AND orphan the
-        // worktree registration in the canonical repo. Route a worktree through
-        // `git worktree remove --force` (work-at-risk backed up first). A
-        // standalone clone / plain dir (the pre-(B) state) returns false here →
-        // the byte-identical remove_dir_all below still runs.
-        if crate::worktree_pool::teardown_workspace_worktree(home, name, working_dir) {
-            // handled (gitlink worktree): removal + registry cleanup done.
-        } else if let Err(e) = std::fs::remove_dir_all(working_dir) {
-            tracing::debug!(dir = %working_dir.display(), error = %e, "cleanup: remove workspace");
-        } else {
-            tracing::info!(dir = %working_dir.display(), "removed workspace");
-        }
+    // Workspace-identity guard (fail-closed): before removing anything under
+    // `working_dir`, refuse if the directory's on-disk identity belongs to a
+    // DIFFERENT instance (or is corrupt). Deleting instance A must never wipe a
+    // directory that identity artifacts (AGENTS.md block / `.codex` stamp) say
+    // belongs to instance B — preserve the tree and emit a loud audit. Metadata
+    // keyed by A's own name (the tail below) is still cleaned; only the shared
+    // working directory is preserved. Callers that report teardown status probe
+    // `working_dir_ownership_conflict` directly (this stays infallible for the
+    // ~14 fire-and-forget call sites).
+    let conflict = working_dir_ownership_conflict(working_dir, name);
+    if let Some(reason) = &conflict {
+        tracing::error!(
+            dir = %working_dir.display(), name, %reason,
+            "cleanup refused: working directory identity belongs to a different instance — tree preserved"
+        );
     } else {
-        // User-provided working directory: only remove agend-generated files
-        let agend_files = [
-            // Claude
-            ".claude/settings.local.json",
-            "mcp-config.json",
-            "claude-settings.json",
-            "statusline.sh",
-            "statusline.json",
-            ".claude/rules/agend.md",
-            // Gemini
-            ".gemini/settings.json",
-            // OpenCode
-            "opencode.json",
-            "instructions/agend.md",
-            // Codex
-            ".codex/config.toml",
-            "AGENTS.md",
-            // Kiro
-            ".kiro/settings/mcp.json",
-            ".kiro/settings/agend-mcp-wrapper.sh",
-            ".kiro/steering/agend.md",
-            ".kiro/agents/agend.json",
-            ".kiro/agents/agend-prompt.md",
-            ".kiro/agents/default.json",
-            ".kiro/prompts/agend.md",
-            ".kiro/settings.json",
-        ];
-        for file in &agend_files {
-            let path = working_dir.join(file);
-            if path.exists() {
-                let _ = std::fs::remove_file(&path);
-            }
-        }
+        let workspaces = crate::paths::workspace_dir(home);
 
-        // Clean up worktree if exists
-        let wt_dir = working_dir.join(".worktrees").join(name);
-        if wt_dir.exists() {
-            // W1.2: LOCAL best-effort worktree-remove via the bypass+bounded
-            // helper (was a raw UNBOUNDED `.output()` whose result was already
-            // discarded). git_ok adds the LOCAL_GIT_TIMEOUT bound so a stuck
-            // remove can't hang teardown; the bypass env is a no-op in the
-            // daemon's shim-free PATH. Result stays discarded → same effect.
-            let _ = crate::git_helpers::git_ok(
-                working_dir,
-                &[
-                    "worktree",
-                    "remove",
-                    "--force",
-                    &wt_dir.display().to_string(),
-                ],
-            );
-            tracing::info!(dir = %wt_dir.display(), "removed worktree");
+        // If under $AGEND_HOME/workspace/, remove the whole directory.
+        // CR-2026-06-14 (security): a purely LEXICAL `starts_with` lets a symlink
+        // under workspace/ whose real target is ELSEWHERE take this whole-dir
+        // `remove_dir_all` and follow the symlink out of the workspace, destroying
+        // real user data. Require the path to ALSO resolve canonically inside the
+        // canonicalized workspace root (canonicalize BOTH so a symlinked
+        // $AGEND_HOME — e.g. macOS /tmp→/private/tmp — still matches).
+        let under_workspace = working_dir.starts_with(&workspaces)
+            && match (
+                dunce::canonicalize(working_dir),
+                dunce::canonicalize(&workspaces),
+            ) {
+                (Ok(wd), Ok(ws)) => wd.starts_with(&ws),
+                _ => false,
+            };
+        if under_workspace {
+            // #2234 Phase 0: under cure-(B) the workspace dir IS a daemon-managed
+            // canonical worktree (its `.git` is a gitlink FILE). A bare
+            // remove_dir_all would destroy uncommitted/unpushed work AND orphan the
+            // worktree registration in the canonical repo. Route a worktree through
+            // `git worktree remove --force` (work-at-risk backed up first). A
+            // standalone clone / plain dir (the pre-(B) state) returns false here →
+            // the byte-identical remove_dir_all below still runs.
+            if crate::worktree_pool::teardown_workspace_worktree(home, name, working_dir) {
+                // handled (gitlink worktree): removal + registry cleanup done.
+            } else if let Err(e) = std::fs::remove_dir_all(working_dir) {
+                tracing::debug!(dir = %working_dir.display(), error = %e, "cleanup: remove workspace");
+            } else {
+                tracing::info!(dir = %working_dir.display(), "removed workspace");
+            }
+        } else {
+            // User-provided working directory: only remove agend-generated files
+            let agend_files = [
+                // Claude
+                ".claude/settings.local.json",
+                "mcp-config.json",
+                "claude-settings.json",
+                "statusline.sh",
+                "statusline.json",
+                ".claude/rules/agend.md",
+                // Gemini
+                ".gemini/settings.json",
+                // OpenCode
+                "opencode.json",
+                "instructions/agend.md",
+                // Codex
+                ".codex/config.toml",
+                "AGENTS.md",
+                // Kiro
+                ".kiro/settings/mcp.json",
+                ".kiro/settings/agend-mcp-wrapper.sh",
+                ".kiro/steering/agend.md",
+                ".kiro/agents/agend.json",
+                ".kiro/agents/agend-prompt.md",
+                ".kiro/agents/default.json",
+                ".kiro/prompts/agend.md",
+                ".kiro/settings.json",
+            ];
+            for file in &agend_files {
+                let path = working_dir.join(file);
+                if path.exists() {
+                    let _ = std::fs::remove_file(&path);
+                }
+            }
+
+            // Clean up worktree if exists
+            let wt_dir = working_dir.join(".worktrees").join(name);
+            if wt_dir.exists() {
+                // W1.2: LOCAL best-effort worktree-remove via the bypass+bounded
+                // helper (was a raw UNBOUNDED `.output()` whose result was already
+                // discarded). git_ok adds the LOCAL_GIT_TIMEOUT bound so a stuck
+                // remove can't hang teardown; the bypass env is a no-op in the
+                // daemon's shim-free PATH. Result stays discarded → same effect.
+                let _ = crate::git_helpers::git_ok(
+                    working_dir,
+                    &[
+                        "worktree",
+                        "remove",
+                        "--force",
+                        &wt_dir.display().to_string(),
+                    ],
+                );
+                tracing::info!(dir = %wt_dir.display(), "removed worktree");
+            }
         }
     }
 
@@ -612,6 +629,29 @@ pub fn cleanup_working_dir(home: &Path, name: &str, working_dir: &Path) {
     // working_dir, so it lives outside both cleanup branches above. Never
     // touches the real workspace — only the managed symlink/junction.
     crate::agy_workspace::remove_link(home, name);
+}
+
+/// Whether `working_dir`'s on-disk identity artifacts name an instance OTHER
+/// than `name` (or are corrupt) — in which case the caller must NOT remove the
+/// tree. Returns `Some(reason)` to refuse (foreign owner / corrupt artifact),
+/// `None` to proceed (no identity artifact, or the directory belongs to `name`).
+/// Checks the AGENTS.md agend block (which records the SANITIZED identifier) and
+/// the `.codex/config.toml` `AGEND_INSTANCE_NAME` stamp (which records the RAW
+/// name) — the two durable identity artifacts the collision incident involved.
+pub(crate) fn working_dir_ownership_conflict(working_dir: &Path, name: &str) -> Option<String> {
+    if let Ok(s) = std::fs::read_to_string(working_dir.join("AGENTS.md")) {
+        if let Some(reason) = crate::instructions::agend_block_owner(&s)
+            .conflict_with(&crate::instructions::sanitize_identifier(name))
+        {
+            return Some(format!("AGENTS.md {reason}"));
+        }
+    }
+    if let Ok(s) = std::fs::read_to_string(working_dir.join(".codex").join("config.toml")) {
+        if let Some(reason) = crate::mcp_config::codex_config_owner(&s).conflict_with(name) {
+            return Some(format!(".codex/config.toml {reason}"));
+        }
+    }
+    None
 }
 
 // ---------------------------------------------------------------------------
@@ -1350,6 +1390,81 @@ mod tests {
         assert!(!ud.join("opencode.json").exists());
         std::fs::remove_dir_all(&home).ok();
         std::fs::remove_dir_all(&ud).ok();
+    }
+
+    // --- workspace-identity delete guard (boundary 3) ---
+
+    fn seed_agents_owned_by(dir: &Path, owner: &str) {
+        std::fs::write(
+            dir.join("AGENTS.md"),
+            format!(
+                "<!-- agend:start -->\n## Identity\n\n- **Name**: `{owner}`\n<!-- agend:end -->\n"
+            ),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn cleanup_preserves_foreign_identity_tree() {
+        let home = tmp_home("cw_foreign");
+        let ws = home.join("workspace/alice"); // "alice" is being deleted...
+        std::fs::create_dir_all(&ws).unwrap();
+        seed_agents_owned_by(&ws, "bob"); // ...but the directory belongs to "bob".
+        std::fs::write(ws.join("keep.txt"), "b").unwrap();
+        cleanup_working_dir(&home, "alice", &ws);
+        assert!(ws.exists(), "foreign-owned tree must be preserved");
+        assert!(
+            ws.join("AGENTS.md").exists(),
+            "bob's identity file preserved"
+        );
+        assert!(
+            ws.join("keep.txt").exists(),
+            "foreign tree contents preserved"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn cleanup_removes_same_identity_tree() {
+        let home = tmp_home("cw_same");
+        let ws = home.join("workspace/alice");
+        std::fs::create_dir_all(&ws).unwrap();
+        seed_agents_owned_by(&ws, "alice"); // dir belongs to the instance being deleted
+        cleanup_working_dir(&home, "alice", &ws);
+        assert!(!ws.exists(), "same-identity tree must be removed");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn cleanup_removes_unowned_tree_normally() {
+        let home = tmp_home("cw_absent");
+        let ws = home.join("workspace/alice");
+        std::fs::create_dir_all(&ws).unwrap();
+        std::fs::write(ws.join("f.txt"), "x").unwrap(); // no identity artifact
+        cleanup_working_dir(&home, "alice", &ws);
+        assert!(!ws.exists(), "unowned tree cleans normally");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn ownership_conflict_detects_foreign_codex_stamp() {
+        let home = tmp_home("wdoc_codex");
+        let ws = home.join("workspace/alice");
+        std::fs::create_dir_all(ws.join(".codex")).unwrap();
+        std::fs::write(
+            ws.join(".codex").join("config.toml"),
+            "AGEND_INSTANCE_NAME = 'bob'\n",
+        )
+        .unwrap();
+        assert!(
+            working_dir_ownership_conflict(&ws, "alice").is_some(),
+            "foreign .codex stamp is a conflict"
+        );
+        assert!(
+            working_dir_ownership_conflict(&ws, "bob").is_none(),
+            "same owner is not a conflict"
+        );
+        std::fs::remove_dir_all(&home).ok();
     }
 
     #[test]

--- a/src/agent_ops.rs
+++ b/src/agent_ops.rs
@@ -559,58 +559,77 @@ pub fn cleanup_working_dir(home: &Path, name: &str, working_dir: &Path) -> Optio
                 tracing::info!(dir = %working_dir.display(), "removed workspace");
             }
         } else {
-            // User-provided working directory: only remove agend-generated files
-            let agend_files = [
-                // Claude
-                ".claude/settings.local.json",
-                "mcp-config.json",
-                "claude-settings.json",
-                "statusline.sh",
-                "statusline.json",
-                ".claude/rules/agend.md",
-                // Gemini
-                ".gemini/settings.json",
-                // OpenCode
-                "opencode.json",
-                "instructions/agend.md",
-                // Codex
-                ".codex/config.toml",
-                "AGENTS.md",
-                // Kiro
-                ".kiro/settings/mcp.json",
-                ".kiro/settings/agend-mcp-wrapper.sh",
-                ".kiro/steering/agend.md",
-                ".kiro/agents/agend.json",
-                ".kiro/agents/agend-prompt.md",
-                ".kiro/agents/default.json",
-                ".kiro/prompts/agend.md",
-                ".kiro/settings.json",
-            ];
-            for file in &agend_files {
-                let path = working_dir.join(file);
-                if path.exists() {
-                    let _ = std::fs::remove_file(&path);
+            let worktrees = home.join("worktrees");
+            let under_worktrees = working_dir.starts_with(&worktrees)
+                && match (
+                    dunce::canonicalize(working_dir),
+                    dunce::canonicalize(&worktrees),
+                ) {
+                    (Ok(wd), Ok(wt)) => wd.starts_with(&wt),
+                    _ => false,
+                };
+            if under_worktrees {
+                if crate::worktree_pool::teardown_workspace_worktree(home, name, working_dir) {
+                    // handled (gitlink worktree): removal + registry cleanup done.
+                } else if let Err(e) = std::fs::remove_dir_all(working_dir) {
+                    tracing::debug!(dir = %working_dir.display(), error = %e, "cleanup: remove managed worktree");
+                } else {
+                    tracing::info!(dir = %working_dir.display(), "removed managed worktree");
                 }
-            }
+            } else {
+                // User-provided working directory: only remove agend-generated files
+                let agend_files = [
+                    // Claude
+                    ".claude/settings.local.json",
+                    "mcp-config.json",
+                    "claude-settings.json",
+                    "statusline.sh",
+                    "statusline.json",
+                    ".claude/rules/agend.md",
+                    // Gemini
+                    ".gemini/settings.json",
+                    // OpenCode
+                    "opencode.json",
+                    "instructions/agend.md",
+                    // Codex
+                    ".codex/config.toml",
+                    "AGENTS.md",
+                    // Kiro
+                    ".kiro/settings/mcp.json",
+                    ".kiro/settings/agend-mcp-wrapper.sh",
+                    ".kiro/steering/agend.md",
+                    ".kiro/agents/agend.json",
+                    ".kiro/agents/agend-prompt.md",
+                    ".kiro/agents/default.json",
+                    ".kiro/prompts/agend.md",
+                    ".kiro/settings.json",
+                ];
+                for file in &agend_files {
+                    let path = working_dir.join(file);
+                    if path.exists() {
+                        let _ = std::fs::remove_file(&path);
+                    }
+                }
 
-            // Clean up worktree if exists
-            let wt_dir = working_dir.join(".worktrees").join(name);
-            if wt_dir.exists() {
-                // W1.2: LOCAL best-effort worktree-remove via the bypass+bounded
-                // helper (was a raw UNBOUNDED `.output()` whose result was already
-                // discarded). git_ok adds the LOCAL_GIT_TIMEOUT bound so a stuck
-                // remove can't hang teardown; the bypass env is a no-op in the
-                // daemon's shim-free PATH. Result stays discarded → same effect.
-                let _ = crate::git_helpers::git_ok(
-                    working_dir,
-                    &[
-                        "worktree",
-                        "remove",
-                        "--force",
-                        &wt_dir.display().to_string(),
-                    ],
-                );
-                tracing::info!(dir = %wt_dir.display(), "removed worktree");
+                // Clean up worktree if exists
+                let wt_dir = working_dir.join(".worktrees").join(name);
+                if wt_dir.exists() {
+                    // W1.2: LOCAL best-effort worktree-remove via the bypass+bounded
+                    // helper (was a raw UNBOUNDED `.output()` whose result was already
+                    // discarded). git_ok adds the LOCAL_GIT_TIMEOUT bound so a stuck
+                    // remove can't hang teardown; the bypass env is a no-op in the
+                    // daemon's shim-free PATH. Result stays discarded → same effect.
+                    let _ = crate::git_helpers::git_ok(
+                        working_dir,
+                        &[
+                            "worktree",
+                            "remove",
+                            "--force",
+                            &wt_dir.display().to_string(),
+                        ],
+                    );
+                    tracing::info!(dir = %wt_dir.display(), "removed worktree");
+                }
             }
         }
     }
@@ -658,10 +677,22 @@ pub(crate) fn working_dir_ownership_conflict(working_dir: &Path, name: &str) -> 
         return Some(format!("AGENTS.md {reason}"));
     }
     if let Some(reason) =
+        crate::instructions::agents_md_identity(&working_dir.join(".agents").join("AGENTS.md"))
+            .conflict_with(&crate::instructions::sanitize_identifier(name))
+    {
+        return Some(format!(".agents/AGENTS.md {reason}"));
+    }
+    if let Some(reason) =
         crate::mcp_config::codex_config_identity(&working_dir.join(".codex").join("config.toml"))
             .conflict_with(name)
     {
         return Some(format!(".codex/config.toml {reason}"));
+    }
+    if let Some(reason) =
+        crate::mcp_config::codex_config_identity(&working_dir.join(".grok").join("config.toml"))
+            .conflict_with(name)
+    {
+        return Some(format!(".grok/config.toml {reason}"));
     }
     None
 }

--- a/src/agent_ops.rs
+++ b/src/agent_ops.rs
@@ -694,6 +694,14 @@ pub(crate) fn working_dir_ownership_conflict(working_dir: &Path, name: &str) -> 
     {
         return Some(format!(".grok/config.toml {reason}"));
     }
+    for artifact in &[".claude/agend.md", ".kiro/steering/agend.md"] {
+        let path = working_dir.join(artifact);
+        if let Some(reason) = crate::instructions::nonshared_instructions_identity(&path)
+            .conflict_with(&crate::instructions::sanitize_identifier(name))
+        {
+            return Some(format!("{artifact} {reason}"));
+        }
+    }
     None
 }
 

--- a/src/agent_ops.rs
+++ b/src/agent_ops.rs
@@ -501,17 +501,25 @@ pub fn ensure_not_protected_json(branch: &str) -> Result<(), serde_json::Value> 
 /// The copy in `mcp/handlers.rs` drifted to 14 entries on 2026-04-14 and
 /// is missing the 5 Kiro paths: `.kiro/agents/{agend.json,agend-prompt.md,
 /// default.json}`, `.kiro/prompts/agend.md`, `.kiro/settings.json`.
-pub fn cleanup_working_dir(home: &Path, name: &str, working_dir: &Path) {
+pub fn cleanup_working_dir(home: &Path, name: &str, working_dir: &Path) -> Option<String> {
     // Workspace-identity guard (fail-closed): before removing anything under
     // `working_dir`, refuse if the directory's on-disk identity belongs to a
-    // DIFFERENT instance (or is corrupt). Deleting instance A must never wipe a
-    // directory that identity artifacts (AGENTS.md block / `.codex` stamp) say
-    // belongs to instance B — preserve the tree and emit a loud audit. Metadata
-    // keyed by A's own name (the tail below) is still cleaned; only the shared
-    // working directory is preserved. Callers that report teardown status probe
-    // `working_dir_ownership_conflict` directly (this stays infallible for the
-    // ~14 fire-and-forget call sites).
-    let conflict = working_dir_ownership_conflict(working_dir, name);
+    // DIFFERENT instance (or is corrupt/unreadable). Deleting instance A must
+    // never wipe a directory that identity artifacts (AGENTS.md block / `.codex`
+    // stamp) say belongs to instance B — preserve the tree and emit a loud audit.
+    // Metadata keyed by A's own name (the tail below) is still cleaned; only the
+    // shared working directory is preserved.
+    //
+    // Held under the workspace-identity lock so the ownership CHECK and the
+    // REMOVAL are atomic against a concurrent provision/delete of the same
+    // directory. The SINGLE returned verdict is what `full_delete_instance`
+    // reports — it does NOT probe a second (unlocked) time. A lock-acquire
+    // failure is itself fail-closed: refuse and preserve.
+    let id_lock = crate::store::acquire_workspace_identity_lock(home, working_dir);
+    let conflict = match &id_lock {
+        Ok(_) => working_dir_ownership_conflict(working_dir, name),
+        Err(e) => Some(format!("could not acquire workspace-identity lock: {e}")),
+    };
     if let Some(reason) = &conflict {
         tracing::error!(
             dir = %working_dir.display(), name, %reason,
@@ -629,6 +637,8 @@ pub fn cleanup_working_dir(home: &Path, name: &str, working_dir: &Path) {
     // working_dir, so it lives outside both cleanup branches above. Never
     // touches the real workspace — only the managed symlink/junction.
     crate::agy_workspace::remove_link(home, name);
+
+    conflict
 }
 
 /// Whether `working_dir`'s on-disk identity artifacts name an instance OTHER
@@ -639,17 +649,19 @@ pub fn cleanup_working_dir(home: &Path, name: &str, working_dir: &Path) {
 /// the `.codex/config.toml` `AGEND_INSTANCE_NAME` stamp (which records the RAW
 /// name) — the two durable identity artifacts the collision incident involved.
 pub(crate) fn working_dir_ownership_conflict(working_dir: &Path, name: &str) -> Option<String> {
-    if let Ok(s) = std::fs::read_to_string(working_dir.join("AGENTS.md")) {
-        if let Some(reason) = crate::instructions::agend_block_owner(&s)
-            .conflict_with(&crate::instructions::sanitize_identifier(name))
-        {
-            return Some(format!("AGENTS.md {reason}"));
-        }
+    // Fail-closed: `agents_md_identity` / `codex_config_identity` return
+    // `Unreadable` (→ a conflict) for any non-`NotFound` I/O error, so an
+    // unreadable artifact refuses the delete rather than being read as absent.
+    if let Some(reason) = crate::instructions::agents_md_identity(&working_dir.join("AGENTS.md"))
+        .conflict_with(&crate::instructions::sanitize_identifier(name))
+    {
+        return Some(format!("AGENTS.md {reason}"));
     }
-    if let Ok(s) = std::fs::read_to_string(working_dir.join(".codex").join("config.toml")) {
-        if let Some(reason) = crate::mcp_config::codex_config_owner(&s).conflict_with(name) {
-            return Some(format!(".codex/config.toml {reason}"));
-        }
+    if let Some(reason) =
+        crate::mcp_config::codex_config_identity(&working_dir.join(".codex").join("config.toml"))
+            .conflict_with(name)
+    {
+        return Some(format!(".codex/config.toml {reason}"));
     }
     None
 }
@@ -1374,7 +1386,7 @@ mod tests {
         let ws = home.join("workspace/agent1");
         std::fs::create_dir_all(&ws).ok();
         std::fs::write(ws.join("f.txt"), "x").ok();
-        cleanup_working_dir(&home, "agent1", &ws);
+        let _ = cleanup_working_dir(&home, "agent1", &ws);
         assert!(!ws.exists());
         std::fs::remove_dir_all(&home).ok();
     }
@@ -1385,7 +1397,7 @@ mod tests {
         let ud = tmp_home("cu_proj");
         std::fs::write(ud.join("main.rs"), "fn main(){}").ok();
         std::fs::write(ud.join("opencode.json"), "{}").ok();
-        cleanup_working_dir(&home, "a", &ud);
+        let _ = cleanup_working_dir(&home, "a", &ud);
         assert!(ud.join("main.rs").exists());
         assert!(!ud.join("opencode.json").exists());
         std::fs::remove_dir_all(&home).ok();
@@ -1411,7 +1423,10 @@ mod tests {
         std::fs::create_dir_all(&ws).unwrap();
         seed_agents_owned_by(&ws, "bob"); // ...but the directory belongs to "bob".
         std::fs::write(ws.join("keep.txt"), "b").unwrap();
-        cleanup_working_dir(&home, "alice", &ws);
+        assert!(
+            cleanup_working_dir(&home, "alice", &ws).is_some(),
+            "foreign-owned dir must be refused (Some verdict)"
+        );
         assert!(ws.exists(), "foreign-owned tree must be preserved");
         assert!(
             ws.join("AGENTS.md").exists(),
@@ -1430,7 +1445,10 @@ mod tests {
         let ws = home.join("workspace/alice");
         std::fs::create_dir_all(&ws).unwrap();
         seed_agents_owned_by(&ws, "alice"); // dir belongs to the instance being deleted
-        cleanup_working_dir(&home, "alice", &ws);
+        assert!(
+            cleanup_working_dir(&home, "alice", &ws).is_none(),
+            "same-identity dir cleans (None verdict)"
+        );
         assert!(!ws.exists(), "same-identity tree must be removed");
         std::fs::remove_dir_all(&home).ok();
     }
@@ -1441,7 +1459,10 @@ mod tests {
         let ws = home.join("workspace/alice");
         std::fs::create_dir_all(&ws).unwrap();
         std::fs::write(ws.join("f.txt"), "x").unwrap(); // no identity artifact
-        cleanup_working_dir(&home, "alice", &ws);
+        assert!(
+            cleanup_working_dir(&home, "alice", &ws).is_none(),
+            "unowned dir cleans (None verdict)"
+        );
         assert!(!ws.exists(), "unowned tree cleans normally");
         std::fs::remove_dir_all(&home).ok();
     }
@@ -1474,7 +1495,7 @@ mod tests {
         std::fs::create_dir_all(&ws).ok();
         std::fs::create_dir_all(home.join("metadata")).ok();
         std::fs::write(home.join("metadata/a.json"), "{}").ok();
-        cleanup_working_dir(&home, "a", &ws);
+        let _ = cleanup_working_dir(&home, "a", &ws);
         assert!(!home.join("metadata/a.json").exists());
         std::fs::remove_dir_all(&home).ok();
     }
@@ -1529,7 +1550,7 @@ mod tests {
         }
         std::fs::write(ud.join("user-code.rs"), "fn main(){}").ok();
 
-        cleanup_working_dir(&home, "drift19", &ud);
+        let _ = cleanup_working_dir(&home, "drift19", &ud);
 
         // All 19 must be gone, user decoy preserved.
         for rel in &canonical {
@@ -1565,7 +1586,7 @@ mod tests {
             }
             std::fs::write(&p, "x").ok();
 
-            cleanup_working_dir(&home, "drift1", &ud);
+            let _ = cleanup_working_dir(&home, "drift1", &ud);
 
             assert!(!p.exists(), "Kiro drift entry not removed: {rel}");
 

--- a/src/agent_ops/review_repro_agent_binding.rs
+++ b/src/agent_ops/review_repro_agent_binding.rs
@@ -58,7 +58,7 @@ fn cleanup_working_dir_does_not_follow_symlink_out_of_workspace_agent_binding() 
         "test invariant: precious file must exist before cleanup"
     );
 
-    cleanup_working_dir(&home, "victim-agent", &working_dir);
+    let _ = cleanup_working_dir(&home, "victim-agent", &working_dir);
 
     let survived = victim.join("data/precious.txt").exists();
     std::fs::remove_dir_all(&base).ok();

--- a/src/api/handlers/instance.rs
+++ b/src/api/handlers/instance.rs
@@ -300,7 +300,13 @@ pub(crate) fn handle_spawn(params: &Value, ctx: &HandlerCtx) -> Value {
         .and_then(|v| v.as_str())
         .map(str::trim)
         .filter(|s| !s.is_empty());
-    super::prepare_instructions(ctx.home, name, command, &work_dir, explicit_role);
+    // #46776 fail-closed: a workspace-identity refusal (or provisioning I/O
+    // failure) must ABORT the spawn — never fork an agent against foreign or
+    // half-written provisioned state.
+    if let Err(e) = super::prepare_instructions(ctx.home, name, command, &work_dir, explicit_role) {
+        tracing::error!(agent = %name, error = %e, "SPAWN aborted: provisioning refused");
+        return json!({"ok": false, "error": format!("provisioning refused: {e}")});
+    }
 
     // #900 hybrid (b)+(c): env precedence is params.env > fleet.yaml
     // resolved env > none. `params.env` lets the SPAWN caller pass an

--- a/src/api/handlers/instance.rs
+++ b/src/api/handlers/instance.rs
@@ -287,6 +287,14 @@ pub(crate) fn handle_spawn(params: &Value, ctx: &HandlerCtx) -> Value {
         Ok(p) => p,
         Err(e) => return json!({"ok": false, "error": format!("{e}")}),
     };
+    if let Some(collider) =
+        crate::fleet::persist::workspace_identity_collision(ctx.home, name, &work_dir)
+    {
+        return json!({"ok": false, "error": format!(
+            "workspace identity collision: '{name}' would share the working directory with existing instance '{collider}' ({})",
+            work_dir.display()
+        )});
+    }
     let size = crossterm::terminal::size().unwrap_or((120, 40));
     let spawn_mode = match params["mode"].as_str() {
         Some("resume") => crate::backend::SpawnMode::Resume,

--- a/src/api/handlers/mod.rs
+++ b/src/api/handlers/mod.rs
@@ -41,12 +41,6 @@ pub(crate) fn prepare_instructions(
     work_dir: &Path,
     explicit_role: Option<&str>,
 ) -> Result<(), String> {
-    std::fs::create_dir_all(work_dir).map_err(|e| {
-        format!(
-            "prepare_instructions: create {} failed: {e}",
-            work_dir.display()
-        )
-    })?;
     let fleet_path = crate::fleet::fleet_yaml_path(home);
     // Look up team membership so agend.md can split collaborators (team
     // members) from the rest of the fleet. Owned here so we can hand out
@@ -59,8 +53,16 @@ pub(crate) fn prepare_instructions(
             orchestrator: t.orchestrator.as_deref(),
             members: t.members.as_slice(),
         });
+    // Fleet validation BEFORE create_dir_all: a refused provisioning must
+    // not leave any side effects (no directory created for a malformed fleet).
     match crate::fleet::FleetConfig::load(&fleet_path) {
         Ok(fleet) => {
+            std::fs::create_dir_all(work_dir).map_err(|e| {
+                format!(
+                    "prepare_instructions: create {} failed: {e}",
+                    work_dir.display()
+                )
+            })?;
             let peers: Vec<(String, Option<String>)> = fleet
                 .instances
                 .iter()
@@ -88,20 +90,30 @@ pub(crate) fn prepare_instructions(
             crate::instructions::generate_with_context(work_dir, command, Some(&ctx))
         }
         Err(e) => {
-            let is_not_found = !fleet_path.exists();
-            if !is_not_found {
-                return Err(format!(
+            // Distinguish genuine NotFound from opaque IO / malformed content.
+            // exists() conflates EACCES with NotFound (both return false);
+            // metadata() preserves the actual error kind.
+            match std::fs::metadata(&fleet_path) {
+                Err(io_err) if io_err.kind() == std::io::ErrorKind::NotFound => {
+                    std::fs::create_dir_all(work_dir).map_err(|e2| {
+                        format!(
+                            "prepare_instructions: create {} failed: {e2}",
+                            work_dir.display()
+                        )
+                    })?;
+                    let ctx = crate::instructions::AgentContext {
+                        name,
+                        role: explicit_role,
+                        fleet_peers: &[],
+                        team: team_ctx.as_ref(),
+                        extra_instructions: None,
+                    };
+                    crate::instructions::generate_with_context(work_dir, command, Some(&ctx))
+                }
+                _ => Err(format!(
                     "fleet.yaml unreadable/malformed — refusing provisioning: {e}"
-                ));
+                )),
             }
-            let ctx = crate::instructions::AgentContext {
-                name,
-                role: explicit_role,
-                fleet_peers: &[],
-                team: team_ctx.as_ref(),
-                extra_instructions: None,
-            };
-            crate::instructions::generate_with_context(work_dir, command, Some(&ctx))
         }
     }
 }

--- a/src/api/handlers/mod.rs
+++ b/src/api/handlers/mod.rs
@@ -87,22 +87,18 @@ pub(crate) fn prepare_instructions(
             };
             crate::instructions::generate_with_context(work_dir, command, Some(&ctx))
         }
-        Err(_) if explicit_role.is_some() => {
+        Err(e) => {
+            let is_not_found = !fleet_path.exists();
+            if !is_not_found {
+                return Err(format!(
+                    "fleet.yaml unreadable/malformed — refusing provisioning: {e}"
+                ));
+            }
             let ctx = crate::instructions::AgentContext {
                 name,
                 role: explicit_role,
                 fleet_peers: &[],
                 team: team_ctx.as_ref(),
-                extra_instructions: None,
-            };
-            crate::instructions::generate_with_context(work_dir, command, Some(&ctx))
-        }
-        Err(_) => {
-            let ctx = crate::instructions::AgentContext {
-                name,
-                role: None,
-                fleet_peers: &[],
-                team: None,
                 extra_instructions: None,
             };
             crate::instructions::generate_with_context(work_dir, command, Some(&ctx))

--- a/src/api/handlers/mod.rs
+++ b/src/api/handlers/mod.rs
@@ -40,8 +40,13 @@ pub(crate) fn prepare_instructions(
     command: &str,
     work_dir: &Path,
     explicit_role: Option<&str>,
-) {
-    std::fs::create_dir_all(work_dir).ok();
+) -> Result<(), String> {
+    std::fs::create_dir_all(work_dir).map_err(|e| {
+        format!(
+            "prepare_instructions: create {} failed: {e}",
+            work_dir.display()
+        )
+    })?;
     let fleet_path = crate::fleet::fleet_yaml_path(home);
     // Look up team membership so agend.md can split collaborators (team
     // members) from the rest of the fleet. Owned here so we can hand out
@@ -80,7 +85,7 @@ pub(crate) fn prepare_instructions(
                 team: team_ctx.as_ref(),
                 extra_instructions: extra_instr.as_deref(),
             };
-            crate::instructions::generate_with_context(work_dir, command, Some(&ctx));
+            crate::instructions::generate_with_context(work_dir, command, Some(&ctx))
         }
         Err(_) if explicit_role.is_some() => {
             let ctx = crate::instructions::AgentContext {
@@ -90,11 +95,9 @@ pub(crate) fn prepare_instructions(
                 team: team_ctx.as_ref(),
                 extra_instructions: None,
             };
-            crate::instructions::generate_with_context(work_dir, command, Some(&ctx));
+            crate::instructions::generate_with_context(work_dir, command, Some(&ctx))
         }
-        Err(_) => {
-            crate::instructions::generate(work_dir, command);
-        }
+        Err(_) => crate::instructions::generate(work_dir, command),
     }
 }
 

--- a/src/api/handlers/mod.rs
+++ b/src/api/handlers/mod.rs
@@ -97,7 +97,16 @@ pub(crate) fn prepare_instructions(
             };
             crate::instructions::generate_with_context(work_dir, command, Some(&ctx))
         }
-        Err(_) => crate::instructions::generate(work_dir, command),
+        Err(_) => {
+            let ctx = crate::instructions::AgentContext {
+                name,
+                role: None,
+                fleet_peers: &[],
+                team: None,
+                extra_instructions: None,
+            };
+            crate::instructions::generate_with_context(work_dir, command, Some(&ctx))
+        }
     }
 }
 

--- a/src/api/handlers/team.rs
+++ b/src/api/handlers/team.rs
@@ -186,7 +186,14 @@ pub(crate) fn handle_create_team(params: &Value, ctx: &HandlerCtx) -> Value {
     let mut spawned: Vec<(String, String)> = Vec::new();
     let size = crossterm::terminal::size().unwrap_or((120, 40));
     for (inst_name, backend, work_dir) in &planned {
-        super::prepare_instructions(ctx.home, inst_name, backend, work_dir, None);
+        // #46776 fail-closed: skip (do not spawn) a member whose provisioning is
+        // refused — a workspace-identity conflict or I/O failure — rather than
+        // fork it against foreign or half-written provisioned state.
+        if let Err(e) = super::prepare_instructions(ctx.home, inst_name, backend, work_dir, None) {
+            tracing::error!(agent = %inst_name, error = %e,
+                "team spawn: provisioning refused — skipping member");
+            continue;
+        }
         // #900: resolve the just-written fleet.yaml entry so any
         // operator-supplied `env:` (or `defaults.env`) reaches the
         // spawned process. The entry is in fleet.yaml at this point

--- a/src/app/pane_factory.rs
+++ b/src/app/pane_factory.rs
@@ -275,8 +275,13 @@ fn spawn_and_subscribe(
 )> {
     // Generate MCP config for agent backends
     if Backend::from_command(command).is_some() {
-        crate::instructions::generate(work_dir, command)
-            .map_err(|e| anyhow::anyhow!("provisioning refused: {e}"))?;
+        match identity {
+            SpawnIdentity::Managed => {
+                crate::instructions::generate_for_owner(work_dir, command, name)
+            }
+            SpawnIdentity::UnmanagedLocalShell => crate::instructions::generate(work_dir, command),
+        }
+        .map_err(|e| anyhow::anyhow!("provisioning refused: {e}"))?;
     }
 
     // #1083: install skills for TUI-spawned panes (app mode).

--- a/src/app/pane_factory.rs
+++ b/src/app/pane_factory.rs
@@ -275,7 +275,8 @@ fn spawn_and_subscribe(
 )> {
     // Generate MCP config for agent backends
     if Backend::from_command(command).is_some() {
-        crate::instructions::generate(work_dir, command);
+        crate::instructions::generate(work_dir, command)
+            .map_err(|e| anyhow::anyhow!("provisioning refused: {e}"))?;
     }
 
     // #1083: install skills for TUI-spawned panes (app mode).
@@ -812,7 +813,16 @@ pub(super) fn run_attach(
                         team: team_ctx.as_ref(),
                         extra_instructions: extra_instructions.as_deref(),
                     };
-                    crate::instructions::generate_with_context(&work_dir, &command, Some(&ctx));
+                    if let Err(e) =
+                        crate::instructions::generate_with_context(&work_dir, &command, Some(&ctx))
+                    {
+                        tracing::error!(agent = %deduped_name, error = %e, "provisioning refused; not attaching");
+                        return AttachOutcome::Failed {
+                            pane_id,
+                            name: deduped_name,
+                            err: format!("provisioning refused: {e}"),
+                        };
+                    }
                     finish_attach(
                         registry,
                         pane_id,
@@ -1091,7 +1101,8 @@ pub(super) fn create_pane_from_resolved(
 
     // Overwrite basic instructions with fleet-aware version
     if let Some(ref wd) = pane.working_dir {
-        crate::instructions::generate_with_context(wd, &resolved.backend_command, Some(&ctx));
+        crate::instructions::generate_with_context(wd, &resolved.backend_command, Some(&ctx))
+            .map_err(|e| anyhow::anyhow!("provisioning refused: {e}"))?;
     }
     pane.fleet_instance_name = Some(fleet_name.to_string());
     Ok(pane)

--- a/src/bootstrap/agent_resolve.rs
+++ b/src/bootstrap/agent_resolve.rs
@@ -116,7 +116,12 @@ fn resolve_one(config: &FleetConfig, ctx: &ResolveContext<'_>, name: &str) -> Op
             team: None,
             extra_instructions: extra_instructions.as_deref(),
         };
-        crate::instructions::generate_with_context(dir, &resolved.backend_command, Some(&ctx));
+        if let Err(e) =
+            crate::instructions::generate_with_context(dir, &resolved.backend_command, Some(&ctx))
+        {
+            tracing::error!(instance = name, error = %e, "provisioning refused; skipping instance boot");
+            return None;
+        }
     }
 
     let mut args = resolved.args;

--- a/src/bootstrap/agent_resolve.rs
+++ b/src/bootstrap/agent_resolve.rs
@@ -156,28 +156,38 @@ mod tests {
     #[test]
     fn resolve_routes_model_through_capability_chokepoint_2744() {
         let dir = tmp_dir("model-chokepoint-2744");
+        let d1 = dir.join("shell-seat");
+        let d2 = dir.join("wrapper-seat");
+        let d3 = dir.join("dedupe-seat");
+        let d4 = dir.join("delim-seat");
+        for d in [&d1, &d2, &d3, &d4] {
+            std::fs::create_dir_all(d).unwrap();
+        }
         let yaml = format!(
             "instances:\n\
              \x20\x20shell-seat:\n\
              \x20\x20\x20\x20backend: shell\n\
              \x20\x20\x20\x20model: legacy\n\
-             \x20\x20\x20\x20working_directory: {d}\n\
+             \x20\x20\x20\x20working_directory: {d1}\n\
              \x20\x20wrapper-seat:\n\
              \x20\x20\x20\x20backend: opencode\n\
              \x20\x20\x20\x20command: /opt/wrap/run-agent\n\
              \x20\x20\x20\x20model: opus\n\
-             \x20\x20\x20\x20working_directory: {d}\n\
+             \x20\x20\x20\x20working_directory: {d2}\n\
              \x20\x20dedupe-seat:\n\
              \x20\x20\x20\x20backend: claude\n\
              \x20\x20\x20\x20model: fleet-loser\n\
              \x20\x20\x20\x20args: [\"--model\", \"pinned\"]\n\
-             \x20\x20\x20\x20working_directory: {d}\n\
+             \x20\x20\x20\x20working_directory: {d3}\n\
              \x20\x20delim-seat:\n\
              \x20\x20\x20\x20backend: claude\n\
              \x20\x20\x20\x20model: fleet-model\n\
              \x20\x20\x20\x20args: [\"--\", \"payload\"]\n\
-             \x20\x20\x20\x20working_directory: {d}\n",
-            d = dir.display()
+             \x20\x20\x20\x20working_directory: {d4}\n",
+            d1 = d1.display(),
+            d2 = d2.display(),
+            d3 = d3.display(),
+            d4 = d4.display(),
         );
         let config: FleetConfig = serde_yaml_ng::from_str(&yaml).unwrap();
         let defs = resolve(&config, &dir, &dir);

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -76,7 +76,8 @@ pub fn run(
     std::fs::create_dir_all(&work_dir)?;
 
     // 6. Generate MCP config
-    crate::instructions::generate(&work_dir, &command);
+    crate::instructions::generate(&work_dir, &command)
+        .map_err(|e| anyhow::anyhow!("provisioning refused: {e}"))?;
     tracing::info!(dir = %work_dir.display(), "MCP config written");
 
     // 7. Register with daemon

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -76,7 +76,7 @@ pub fn run(
     std::fs::create_dir_all(&work_dir)?;
 
     // 6. Generate MCP config
-    crate::instructions::generate(&work_dir, &command)
+    crate::instructions::generate_for_owner(&work_dir, &command, name)
         .map_err(|e| anyhow::anyhow!("provisioning refused: {e}"))?;
     tracing::info!(dir = %work_dir.display(), "MCP config written");
 

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1710,6 +1710,24 @@ fn spawn_and_register_agent(
         );
         return Ok(());
     }
+
+    // #46776 fail-closed (root finding 5): whole-registry uniqueness admission at
+    // BOOT/spawn. A pre-existing duplicate fleet.yaml (legacy / hand-edited — the
+    // create path now prevents new ones) must not boot two instances into one
+    // workspace. If an EARLIER-sorting instance shares this instance's canonical
+    // workspace identity, THAT instance is the single deterministic owner that
+    // boots; skip this one with a loud audit rather than resurrect a split-brain.
+    let boot_wd = working_dir
+        .clone()
+        .unwrap_or_else(|| crate::paths::workspace_dir(home).join(name));
+    if let Some(owner) = crate::fleet::duplicate_identity_owner_before(home, name, &boot_wd) {
+        tracing::error!(
+            agent = %name, %owner,
+            "skipping boot spawn — duplicate workspace identity; earlier instance owns it (fail-closed)"
+        );
+        return Ok(());
+    }
+
     configs.lock().insert(
         name.clone(),
         AgentConfig {

--- a/src/deployments.rs
+++ b/src/deployments.rs
@@ -691,7 +691,7 @@ fn cleanup_deployment_dirs(home: &Path, deployment: &Deployment) {
         // teardown semantics that cleaned `home/workspace/<inst>` directly.
         let default_subdir = crate::paths::workspace_dir(home).join(inst);
         if default_subdir.exists() {
-            crate::agent_ops::cleanup_working_dir(home, inst, &default_subdir);
+            let _ = crate::agent_ops::cleanup_working_dir(home, inst, &default_subdir);
         }
     }
     // Sprint 54 P1-5: best-effort rmdir of the custom-directory parent.

--- a/src/fleet/mod.rs
+++ b/src/fleet/mod.rs
@@ -8,9 +8,10 @@ pub use watchdog::WatchdogConfig;
 
 #[allow(unused_imports)]
 pub use persist::{
-    add_instance_to_yaml, add_instances_to_yaml, add_team_to_yaml, migrate_teams_json_to_yaml,
-    remove_instance_from_yaml, remove_instances_from_yaml, remove_team_from_yaml,
-    update_channel_telegram_group_id, update_instance_field, update_team_in_yaml, TeamWriteOutcome,
+    add_instance_to_yaml, add_instances_to_yaml, add_team_to_yaml, duplicate_identity_owner_before,
+    migrate_teams_json_to_yaml, remove_instance_from_yaml, remove_instances_from_yaml,
+    remove_team_from_yaml, update_channel_telegram_group_id, update_instance_field,
+    update_team_in_yaml, workspace_identity_collision, TeamWriteOutcome,
 };
 
 use crate::backend::Backend;

--- a/src/fleet/persist.rs
+++ b/src/fleet/persist.rs
@@ -1058,6 +1058,69 @@ mod tests {
         );
         std::fs::remove_dir_all(&home).ok();
     }
+
+    // --- root review r8 RED: 2 deterministic failures (task-46776) ---
+
+    #[test]
+    fn root_review_tilde_and_expanded_workspace_identity_collide() {
+        let home = tmp_home("tilde-collide");
+        let unique = format!("agend-tilde-test-{}", std::process::id());
+        let tilde_path = format!("~/{unique}");
+        let expanded = crate::fleet::resolve::expand_tilde_path(&tilde_path);
+
+        add_instance_to_yaml(
+            &home,
+            "alice",
+            &InstanceYamlEntry {
+                working_directory: Some(tilde_path),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let err = add_instance_to_yaml(
+            &home,
+            "bob",
+            &InstanceYamlEntry {
+                working_directory: Some(expanded.display().to_string()),
+                ..Default::default()
+            },
+        )
+        .expect_err("tilde and expanded paths must collide as the same workspace identity");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("workspace identity collision"),
+            "expected collision refusal: {msg}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn root_review_dangling_fleet_symlink_is_opaque_not_first_run() {
+        use std::os::unix::fs::symlink;
+        let home = tmp_home("dangling-symlink");
+        let fleet_path = super::fleet_yaml_path(&home);
+        symlink("/nonexistent/fleet.yaml", &fleet_path).unwrap();
+        assert!(
+            fleet_path.symlink_metadata().is_ok(),
+            "symlink entry must exist"
+        );
+        assert!(!fleet_path.exists(), "symlink target must NOT exist (dangling)");
+
+        let err = add_instance_to_yaml(&home, "alpha", &InstanceYamlEntry::default())
+            .expect_err("dangling fleet.yaml symlink must be refused as opaque evidence");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("dangling") || msg.contains("opaque") || msg.contains("refusing"),
+            "structured refusal expected: {msg}"
+        );
+        assert!(
+            fleet_path.symlink_metadata().is_ok(),
+            "dangling symlink must not be removed"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
 }
 
 #[cfg(test)]

--- a/src/fleet/persist.rs
+++ b/src/fleet/persist.rs
@@ -1139,6 +1139,67 @@ mod tests {
         );
         std::fs::remove_dir_all(&home).ok();
     }
+
+    // --- root review r9 RED: 2 deterministic failures (task-46776) ---
+
+    #[test]
+    fn root_review_r9_boot_tilde_and_expanded_duplicate_deferred() {
+        let home = tmp_home("r10-tilde-boot");
+        let unique = format!("agend-r10-tilde-boot-{}", std::process::id());
+        let tilde_path = format!("~/{unique}");
+        let expanded = crate::fleet::resolve::expand_tilde_path(&tilde_path);
+
+        let yaml = format!(
+            "instances:\n  alice:\n    working_directory: '{tilde_path}'\n  bob:\n    working_directory: '{}'\n",
+            expanded.display()
+        );
+        std::fs::write(fleet_yaml_path(&home), yaml).unwrap();
+
+        let result = duplicate_identity_owner_before(&home, "bob", &expanded);
+        assert_eq!(
+            result.as_deref(),
+            Some("alice"),
+            "boot admission must detect tilde-vs-expanded duplicate: \
+             alice owns ~/{u} which is the same directory as {e}, \
+             but duplicate_identity_owner_before does not normalize tilde \
+             so the identity comparison misses the collision",
+            u = unique,
+            e = expanded.display(),
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn root_review_r9_remove_dangling_fleet_symlink_is_not_silent_success() {
+        use std::os::unix::fs::symlink;
+        let home = tmp_home("r10-dangling-rm");
+        let fleet_path = super::fleet_yaml_path(&home);
+        symlink("/nonexistent/fleet.yaml", &fleet_path).unwrap();
+        assert!(
+            fleet_path.symlink_metadata().is_ok(),
+            "symlink entry must exist"
+        );
+        assert!(
+            !fleet_path.exists(),
+            "symlink target must NOT exist (dangling)"
+        );
+
+        let result = remove_instance_from_yaml(&home, "alpha");
+        assert!(
+            result.is_err(),
+            "remove_instance on a dangling fleet.yaml symlink must refuse, \
+             not silently return Ok — the empty-default fast path \
+             (default_content.is_empty() && !fleet_path.exists()) bypasses \
+             the post-lock dangling-symlink guard because .exists() follows \
+             symlinks and returns false for dangling targets"
+        );
+        assert!(
+            fleet_path.symlink_metadata().is_ok(),
+            "dangling symlink must not be removed"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
 }
 
 #[cfg(test)]

--- a/src/fleet/persist.rs
+++ b/src/fleet/persist.rs
@@ -26,9 +26,20 @@ pub(crate) fn mutate_fleet_yaml(
         return Ok(());
     }
     let _lock = acquire_lock(home)?;
+    let link_entry_exists = fleet_path.symlink_metadata().is_ok();
     let content = match std::fs::read_to_string(&fleet_path) {
         Ok(s) => s,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => default_content.to_string(),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound && !link_entry_exists => {
+            default_content.to_string()
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Err(anyhow::anyhow!(
+                "fleet.yaml at {}: dangling symlink — filesystem evidence exists \
+                 but target is missing, refusing to overwrite with defaults",
+                fleet_path.display()
+            ))
+            .context("opaque I/O — refusing to default");
+        }
         Err(e) => {
             return Err(anyhow::anyhow!("fleet.yaml read: {e}"))
                 .context("opaque I/O — refusing to default")
@@ -123,13 +134,17 @@ pub fn add_instances_to_yaml(home: &Path, entries: &[(&str, &InstanceYamlEntry)]
 /// Excludes `candidate_name` itself (a same-name merge/update is not a duplicate). Read-only
 /// over the parsed fleet mapping; the caller holds the fleet lock, so this is atomic w.r.t.
 /// concurrent admissions.
+fn expand_tilde(path: &Path) -> std::path::PathBuf {
+    super::resolve::expand_tilde_path(&path.to_string_lossy())
+}
+
 fn find_workspace_identity_collision(
     home: &Path,
     instances: &serde_yaml_ng::Mapping,
     candidate_name: &str,
     candidate_wd: &Path,
 ) -> Option<String> {
-    let candidate_id = crate::paths::workspace_identity(candidate_wd);
+    let candidate_id = crate::paths::workspace_identity(&expand_tilde(candidate_wd));
     for (k, v) in instances {
         let Some(existing_name) = k.as_str() else {
             continue;
@@ -139,7 +154,7 @@ fn find_workspace_identity_collision(
         }
         let explicit = v.get("working_directory").and_then(|x| x.as_str());
         let existing_wd = crate::paths::effective_working_dir(home, existing_name, explicit);
-        if crate::paths::workspace_identity(&existing_wd) == candidate_id {
+        if crate::paths::workspace_identity(&expand_tilde(&existing_wd)) == candidate_id {
             return Some(existing_name.to_string());
         }
     }
@@ -1106,7 +1121,10 @@ mod tests {
             fleet_path.symlink_metadata().is_ok(),
             "symlink entry must exist"
         );
-        assert!(!fleet_path.exists(), "symlink target must NOT exist (dangling)");
+        assert!(
+            !fleet_path.exists(),
+            "symlink target must NOT exist (dangling)"
+        );
 
         let err = add_instance_to_yaml(&home, "alpha", &InstanceYamlEntry::default())
             .expect_err("dangling fleet.yaml symlink must be refused as opaque evidence");

--- a/src/fleet/persist.rs
+++ b/src/fleet/persist.rs
@@ -22,7 +22,8 @@ pub(crate) fn mutate_fleet_yaml(
     mutate: impl FnOnce(&mut serde_yaml_ng::Value) -> Result<bool>,
 ) -> Result<()> {
     let fleet_path = fleet_yaml_path(home);
-    if default_content.is_empty() && !fleet_path.exists() {
+    if default_content.is_empty() && !fleet_path.exists() && fleet_path.symlink_metadata().is_err()
+    {
         return Ok(());
     }
     let _lock = acquire_lock(home)?;
@@ -213,7 +214,7 @@ pub fn duplicate_identity_owner_before(
     name: &str,
     candidate_wd: &Path,
 ) -> Option<String> {
-    let candidate_id = crate::paths::workspace_identity(candidate_wd);
+    let candidate_id = crate::paths::workspace_identity(&expand_tilde(candidate_wd));
     let mapping = match load_instances_mapping(home) {
         Ok(m) => m,
         Err(e) => return Some(format!("fleet unreadable — refusing boot admission: {e}")),
@@ -229,7 +230,7 @@ pub fn duplicate_identity_owner_before(
         }
         let explicit = v.get("working_directory").and_then(|x| x.as_str());
         let existing_wd = crate::paths::effective_working_dir(home, existing_name, explicit);
-        if crate::paths::workspace_identity(&existing_wd) == candidate_id
+        if crate::paths::workspace_identity(&expand_tilde(&existing_wd)) == candidate_id
             && earliest.as_deref().is_none_or(|e| existing_name < e)
         {
             earliest = Some(existing_name.to_string());

--- a/src/fleet/persist.rs
+++ b/src/fleet/persist.rs
@@ -148,21 +148,28 @@ fn find_workspace_identity_collision(
 
 /// Read-only load of the parsed `instances` mapping from fleet.yaml.
 /// Missing file → empty mapping (legitimate first-run).
-/// Opaque I/O or parse error → `Err` (callers must refuse — fail-closed).
+/// Opaque I/O, parse error, or wrong-shape `instances` → `Err` (fail-closed).
 fn load_instances_mapping(home: &Path) -> Result<serde_yaml_ng::Mapping> {
     let fleet_path = fleet_yaml_path(home);
-    if !fleet_path.exists() {
-        return Ok(serde_yaml_ng::Mapping::new());
-    }
-    let c = std::fs::read_to_string(&fleet_path)
-        .with_context(|| format!("fleet.yaml read: {}", fleet_path.display()))?;
+    let c = match std::fs::read_to_string(&fleet_path) {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(serde_yaml_ng::Mapping::new());
+        }
+        Err(e) => {
+            anyhow::bail!("fleet.yaml read: {}: {e}", fleet_path.display());
+        }
+    };
     let doc =
         serde_yaml_ng::from_str::<serde_yaml_ng::Value>(&c).with_context(|| "fleet.yaml parse")?;
-    Ok(doc
-        .get("instances")
-        .and_then(|v| v.as_mapping())
-        .cloned()
-        .unwrap_or_default())
+    match doc.get("instances") {
+        None => Ok(serde_yaml_ng::Mapping::new()),
+        Some(v) => v.as_mapping().cloned().ok_or_else(|| {
+            anyhow::anyhow!(
+                "fleet.yaml: `instances` is not a mapping (wrong shape — refusing)"
+            )
+        }),
+    }
 }
 
 /// Read-only workspace-identity collision preflight: returns a DIFFERENT existing

--- a/src/fleet/persist.rs
+++ b/src/fleet/persist.rs
@@ -55,8 +55,8 @@ pub fn add_instances_to_yaml(home: &Path, entries: &[(&str, &InstanceYamlEntry)]
             .and_then(|v| v.as_mapping_mut())
             .context("instances is not a mapping")?;
 
+        // 1. Apply every insert/merge first.
         let mut conflicts: Vec<super::merge::FieldConflict> = Vec::new();
-
         for (name, config) in entries {
             let key = serde_yaml_ng::Value::String(name.to_string());
             if let Some(serde_yaml_ng::Value::Mapping(existing)) = instances.get_mut(&key) {
@@ -65,34 +65,11 @@ pub fn add_instances_to_yaml(home: &Path, entries: &[(&str, &InstanceYamlEntry)]
                     Err(conflict) => conflicts.push(conflict),
                 }
             } else {
-                // Workspace-identity uniqueness (fail-closed, ATOMIC under the fleet lock
-                // held by mutate_fleet_yaml): a NEW instance must not resolve to the same
-                // canonical working directory as any existing one — including an explicit
-                // path equal to another instance's DEFAULT, or a symlink/case-only/
-                // nonexistent alias of it (see paths::workspace_identity). This is the
-                // incident guard: two instances sharing a workspace produced split-brain
-                // identity when project provisioning rewrote it last-writer-wins.
-                let candidate_wd = crate::paths::effective_working_dir(
-                    home,
-                    name,
-                    config.working_directory.as_deref(),
-                );
-                if let Some(collider) =
-                    find_workspace_identity_collision(home, instances, name, &candidate_wd)
-                {
-                    return Err(anyhow::anyhow!(
-                        "workspace identity collision: new instance '{name}' would resolve to the \
-                         same canonical working directory as existing instance '{collider}' ({}). \
-                         Refusing to admit a duplicate workspace identity (fail-closed).",
-                        candidate_wd.display()
-                    ));
-                }
                 let inst = super::merge::build_instance_mapping(config);
                 instances.insert(key, serde_yaml_ng::Value::Mapping(inst));
                 tracing::info!(%name, "added new instance to fleet.yaml");
             }
         }
-
         if !conflicts.is_empty() {
             let mut diff_lines: Vec<String> = Vec::with_capacity(conflicts.len());
             for c in &conflicts {
@@ -103,6 +80,33 @@ pub fn add_instances_to_yaml(home: &Path, entries: &[(&str, &InstanceYamlEntry)]
                 conflicts.len(),
                 diff_lines.join("\n")
             ));
+        }
+
+        // 2. Whole-registry workspace-identity uniqueness (fail-closed, ATOMIC
+        // under the fleet lock held by mutate_fleet_yaml). Runs for EVERY affected
+        // instance — a NEW insert OR a merge that CHANGED `working_directory` — so
+        // the existing-key merge path can no longer slip a colliding update past
+        // admission (root finding 5). An instance must not resolve to the same
+        // canonical working directory as any OTHER — including an explicit path
+        // equal to another's DEFAULT, or a symlink/case-only/nonexistent alias
+        // (see paths::workspace_identity). This is the split-brain incident guard.
+        for (name, _) in entries {
+            let key = serde_yaml_ng::Value::String(name.to_string());
+            let explicit = instances
+                .get(&key)
+                .and_then(|v| v.get("working_directory"))
+                .and_then(|x| x.as_str());
+            let candidate_wd = crate::paths::effective_working_dir(home, name, explicit);
+            if let Some(collider) =
+                find_workspace_identity_collision(home, instances, name, &candidate_wd)
+            {
+                return Err(anyhow::anyhow!(
+                    "workspace identity collision: instance '{name}' would resolve to the same \
+                     canonical working directory as existing instance '{collider}' ({}). Refusing \
+                     to admit a duplicate workspace identity (fail-closed).",
+                    candidate_wd.display()
+                ));
+            }
         }
         Ok(true)
     })
@@ -134,6 +138,63 @@ fn find_workspace_identity_collision(
         }
     }
     None
+}
+
+/// Read-only load of the parsed `instances` mapping from fleet.yaml (empty if the
+/// file is missing/unparseable). Best-effort — callers use it for a preflight;
+/// the atomic `add_instances_to_yaml` under the fleet lock stays the authority.
+fn load_instances_mapping(home: &Path) -> serde_yaml_ng::Mapping {
+    std::fs::read_to_string(fleet_yaml_path(home))
+        .ok()
+        .and_then(|c| serde_yaml_ng::from_str::<serde_yaml_ng::Value>(&c).ok())
+        .and_then(|doc| doc.get("instances").and_then(|v| v.as_mapping()).cloned())
+        .unwrap_or_default()
+}
+
+/// Read-only workspace-identity collision preflight: returns a DIFFERENT existing
+/// instance sharing `name`'s canonical identity at `candidate_wd`, else `None`.
+/// The create path uses this to refuse BEFORE creating any worktree/directory
+/// (root finding 2 — no partial filesystem/git state on refusal); the atomic
+/// `add_instances_to_yaml` remains the race-safe authority.
+pub fn workspace_identity_collision(
+    home: &Path,
+    name: &str,
+    candidate_wd: &Path,
+) -> Option<String> {
+    find_workspace_identity_collision(home, &load_instances_mapping(home), name, candidate_wd)
+}
+
+/// Boot/spawn admission for a PRE-EXISTING duplicate fleet (root finding 5): if
+/// another instance shares `name`'s canonical workspace identity and sorts
+/// EARLIER, return that earlier owner's name — the caller must then SKIP booting
+/// `name`. The lexicographically-first instance in an identity group is the
+/// single deterministic owner that boots; the rest defer. `None` = `name` is
+/// unique or is itself the owner → boot it. The create path prevents NEW
+/// duplicates, so this only fires for a legacy / hand-corrupted fleet.yaml.
+pub fn duplicate_identity_owner_before(
+    home: &Path,
+    name: &str,
+    candidate_wd: &Path,
+) -> Option<String> {
+    let candidate_id = crate::paths::workspace_identity(candidate_wd);
+    let mut earliest: Option<String> = None;
+    for (k, v) in &load_instances_mapping(home) {
+        let Some(existing_name) = k.as_str() else {
+            continue;
+        };
+        // Only an EARLIER-sorting instance can preempt this boot.
+        if existing_name >= name {
+            continue;
+        }
+        let explicit = v.get("working_directory").and_then(|x| x.as_str());
+        let existing_wd = crate::paths::effective_working_dir(home, existing_name, explicit);
+        if crate::paths::workspace_identity(&existing_wd) == candidate_id
+            && earliest.as_deref().is_none_or(|e| existing_name < e)
+        {
+            earliest = Some(existing_name.to_string());
+        }
+    }
+    earliest
 }
 
 pub fn remove_instance_from_yaml(home: &Path, name: &str) -> Result<()> {
@@ -657,6 +718,67 @@ mod tests {
         ));
         std::fs::create_dir_all(&dir).ok();
         dir
+    }
+
+    #[test]
+    fn merge_adding_colliding_working_directory_is_refused_whole_registry() {
+        // finding 5: a MERGE that ADDS a working_directory (previously default →
+        // absent) pointing at another instance's identity is refused by the
+        // whole-registry post-pass. The pre-fix scan ran ONLY on the new-key
+        // branch, so this existing-key merge slipped a colliding update past.
+        let home = tmp_home("merge-add-collide");
+        add_instance_to_yaml(&home, "alice", &InstanceYamlEntry::default()).unwrap();
+        add_instance_to_yaml(&home, "bob", &InstanceYamlEntry::default()).unwrap();
+        let alice_default = crate::paths::workspace_dir(&home)
+            .join("alice")
+            .display()
+            .to_string();
+        let err = add_instance_to_yaml(
+            &home,
+            "bob",
+            &InstanceYamlEntry {
+                working_directory: Some(alice_default),
+                ..Default::default()
+            },
+        )
+        .expect_err("a merge that repoints bob onto alice's workspace must be refused");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("workspace identity collision"),
+            "collision error: {msg}"
+        );
+        assert!(
+            msg.contains("bob") && msg.contains("alice"),
+            "refusal names both instances: {msg}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn duplicate_identity_owner_before_admits_only_the_earliest() {
+        // finding 5: a PRE-EXISTING duplicate fleet.yaml (two instances at ONE
+        // workspace — legacy / hand-edited) boots only the lexicographically-first
+        // "owner"; later ones defer. This is the boot/spawn admission helper.
+        let home = tmp_home("dup-owner");
+        let shared = home.join("shared-ws");
+        // Hand-write a corrupt fleet the create path would never admit. Single-
+        // quoted YAML keeps the (possibly backslashed) path literal cross-platform.
+        let yaml = format!(
+            "instances:\n  alice:\n    working_directory: '{p}'\n  bob:\n    working_directory: '{p}'\n",
+            p = shared.display()
+        );
+        std::fs::write(fleet_yaml_path(&home), yaml).unwrap();
+        // bob (later) defers to the earlier owner alice.
+        assert_eq!(
+            duplicate_identity_owner_before(&home, "bob", &shared).as_deref(),
+            Some("alice")
+        );
+        // alice (earliest in its identity group) is the owner → boots.
+        assert_eq!(
+            duplicate_identity_owner_before(&home, "alice", &shared),
+            None
+        );
+        std::fs::remove_dir_all(&home).ok();
     }
 
     /// §3.9 (MED-3): a channels-only (plural) fleet must persist a telegram

--- a/src/fleet/persist.rs
+++ b/src/fleet/persist.rs
@@ -146,15 +146,23 @@ fn find_workspace_identity_collision(
     None
 }
 
-/// Read-only load of the parsed `instances` mapping from fleet.yaml (empty if the
-/// file is missing/unparseable). Best-effort — callers use it for a preflight;
-/// the atomic `add_instances_to_yaml` under the fleet lock stays the authority.
-fn load_instances_mapping(home: &Path) -> serde_yaml_ng::Mapping {
-    std::fs::read_to_string(fleet_yaml_path(home))
-        .ok()
-        .and_then(|c| serde_yaml_ng::from_str::<serde_yaml_ng::Value>(&c).ok())
-        .and_then(|doc| doc.get("instances").and_then(|v| v.as_mapping()).cloned())
-        .unwrap_or_default()
+/// Read-only load of the parsed `instances` mapping from fleet.yaml.
+/// Missing file → empty mapping (legitimate first-run).
+/// Opaque I/O or parse error → `Err` (callers must refuse — fail-closed).
+fn load_instances_mapping(home: &Path) -> Result<serde_yaml_ng::Mapping> {
+    let fleet_path = fleet_yaml_path(home);
+    if !fleet_path.exists() {
+        return Ok(serde_yaml_ng::Mapping::new());
+    }
+    let c = std::fs::read_to_string(&fleet_path)
+        .with_context(|| format!("fleet.yaml read: {}", fleet_path.display()))?;
+    let doc =
+        serde_yaml_ng::from_str::<serde_yaml_ng::Value>(&c).with_context(|| "fleet.yaml parse")?;
+    Ok(doc
+        .get("instances")
+        .and_then(|v| v.as_mapping())
+        .cloned()
+        .unwrap_or_default())
 }
 
 /// Read-only workspace-identity collision preflight: returns a DIFFERENT existing
@@ -167,7 +175,10 @@ pub fn workspace_identity_collision(
     name: &str,
     candidate_wd: &Path,
 ) -> Option<String> {
-    find_workspace_identity_collision(home, &load_instances_mapping(home), name, candidate_wd)
+    match load_instances_mapping(home) {
+        Ok(mapping) => find_workspace_identity_collision(home, &mapping, name, candidate_wd),
+        Err(e) => Some(format!("fleet unreadable — refusing collision check: {e}")),
+    }
 }
 
 /// Boot/spawn admission for a PRE-EXISTING duplicate fleet (root finding 5): if
@@ -183,8 +194,12 @@ pub fn duplicate_identity_owner_before(
     candidate_wd: &Path,
 ) -> Option<String> {
     let candidate_id = crate::paths::workspace_identity(candidate_wd);
+    let mapping = match load_instances_mapping(home) {
+        Ok(m) => m,
+        Err(e) => return Some(format!("fleet unreadable — refusing boot admission: {e}")),
+    };
     let mut earliest: Option<String> = None;
-    for (k, v) in &load_instances_mapping(home) {
+    for (k, v) in &mapping {
         let Some(existing_name) = k.as_str() else {
             continue;
         };

--- a/src/fleet/persist.rs
+++ b/src/fleet/persist.rs
@@ -165,9 +165,7 @@ fn load_instances_mapping(home: &Path) -> Result<serde_yaml_ng::Mapping> {
     match doc.get("instances") {
         None => Ok(serde_yaml_ng::Mapping::new()),
         Some(v) => v.as_mapping().cloned().ok_or_else(|| {
-            anyhow::anyhow!(
-                "fleet.yaml: `instances` is not a mapping (wrong shape — refusing)"
-            )
+            anyhow::anyhow!("fleet.yaml: `instances` is not a mapping (wrong shape — refusing)")
         }),
     }
 }

--- a/src/fleet/persist.rs
+++ b/src/fleet/persist.rs
@@ -22,29 +22,33 @@ pub(crate) fn mutate_fleet_yaml(
     mutate: impl FnOnce(&mut serde_yaml_ng::Value) -> Result<bool>,
 ) -> Result<()> {
     let fleet_path = fleet_yaml_path(home);
-    if default_content.is_empty() && !fleet_path.exists() && fleet_path.symlink_metadata().is_err()
-    {
-        return Ok(());
-    }
     let _lock = acquire_lock(home)?;
-    let link_entry_exists = fleet_path.symlink_metadata().is_ok();
-    let content = match std::fs::read_to_string(&fleet_path) {
-        Ok(s) => s,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound && !link_entry_exists => {
+    let content = match fleet_path.symlink_metadata() {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            if default_content.is_empty() {
+                return Ok(());
+            }
             default_content.to_string()
         }
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            return Err(anyhow::anyhow!(
-                "fleet.yaml at {}: dangling symlink — filesystem evidence exists \
-                 but target is missing, refusing to overwrite with defaults",
-                fleet_path.display()
-            ))
-            .context("opaque I/O — refusing to default");
-        }
         Err(e) => {
-            return Err(anyhow::anyhow!("fleet.yaml read: {e}"))
-                .context("opaque I/O — refusing to default")
+            return Err(anyhow::anyhow!("fleet.yaml metadata: {e}"))
+                .context("opaque I/O — refusing to default");
         }
+        Ok(_) => match std::fs::read_to_string(&fleet_path) {
+            Ok(s) => s,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                return Err(anyhow::anyhow!(
+                    "fleet.yaml at {}: dangling symlink — filesystem evidence exists \
+                     but target is missing, refusing to overwrite with defaults",
+                    fleet_path.display()
+                ))
+                .context("opaque I/O — refusing to default");
+            }
+            Err(e) => {
+                return Err(anyhow::anyhow!("fleet.yaml read: {e}"))
+                    .context("opaque I/O — refusing to default")
+            }
+        },
     };
     let mut doc: serde_yaml_ng::Value =
         serde_yaml_ng::from_str(&content).context("Failed to parse fleet.yaml")?;

--- a/src/fleet/persist.rs
+++ b/src/fleet/persist.rs
@@ -26,8 +26,14 @@ pub(crate) fn mutate_fleet_yaml(
         return Ok(());
     }
     let _lock = acquire_lock(home)?;
-    let content =
-        std::fs::read_to_string(&fleet_path).unwrap_or_else(|_| default_content.to_string());
+    let content = match std::fs::read_to_string(&fleet_path) {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => default_content.to_string(),
+        Err(e) => {
+            return Err(anyhow::anyhow!("fleet.yaml read: {e}"))
+                .context("opaque I/O — refusing to default")
+        }
+    };
     let mut doc: serde_yaml_ng::Value =
         serde_yaml_ng::from_str(&content).context("Failed to parse fleet.yaml")?;
     let changed = mutate(&mut doc)?;

--- a/src/fleet/persist.rs
+++ b/src/fleet/persist.rs
@@ -65,6 +65,28 @@ pub fn add_instances_to_yaml(home: &Path, entries: &[(&str, &InstanceYamlEntry)]
                     Err(conflict) => conflicts.push(conflict),
                 }
             } else {
+                // Workspace-identity uniqueness (fail-closed, ATOMIC under the fleet lock
+                // held by mutate_fleet_yaml): a NEW instance must not resolve to the same
+                // canonical working directory as any existing one — including an explicit
+                // path equal to another instance's DEFAULT, or a symlink/case-only/
+                // nonexistent alias of it (see paths::workspace_identity). This is the
+                // incident guard: two instances sharing a workspace produced split-brain
+                // identity when project provisioning rewrote it last-writer-wins.
+                let candidate_wd = crate::paths::effective_working_dir(
+                    home,
+                    name,
+                    config.working_directory.as_deref(),
+                );
+                if let Some(collider) =
+                    find_workspace_identity_collision(home, instances, name, &candidate_wd)
+                {
+                    return Err(anyhow::anyhow!(
+                        "workspace identity collision: new instance '{name}' would resolve to the \
+                         same canonical working directory as existing instance '{collider}' ({}). \
+                         Refusing to admit a duplicate workspace identity (fail-closed).",
+                        candidate_wd.display()
+                    ));
+                }
                 let inst = super::merge::build_instance_mapping(config);
                 instances.insert(key, serde_yaml_ng::Value::Mapping(inst));
                 tracing::info!(%name, "added new instance to fleet.yaml");
@@ -84,6 +106,34 @@ pub fn add_instances_to_yaml(home: &Path, entries: &[(&str, &InstanceYamlEntry)]
         }
         Ok(true)
     })
+}
+
+/// Return the name of an existing instance whose EFFECTIVE working directory shares
+/// `candidate_wd`'s canonical identity ([`crate::paths::workspace_identity`]), else `None`.
+/// Excludes `candidate_name` itself (a same-name merge/update is not a duplicate). Read-only
+/// over the parsed fleet mapping; the caller holds the fleet lock, so this is atomic w.r.t.
+/// concurrent admissions.
+fn find_workspace_identity_collision(
+    home: &Path,
+    instances: &serde_yaml_ng::Mapping,
+    candidate_name: &str,
+    candidate_wd: &Path,
+) -> Option<String> {
+    let candidate_id = crate::paths::workspace_identity(candidate_wd);
+    for (k, v) in instances {
+        let Some(existing_name) = k.as_str() else {
+            continue;
+        };
+        if existing_name == candidate_name {
+            continue;
+        }
+        let explicit = v.get("working_directory").and_then(|x| x.as_str());
+        let existing_wd = crate::paths::effective_working_dir(home, existing_name, explicit);
+        if crate::paths::workspace_identity(&existing_wd) == candidate_id {
+            return Some(existing_name.to_string());
+        }
+    }
+    None
 }
 
 pub fn remove_instance_from_yaml(home: &Path, name: &str) -> Result<()> {
@@ -668,6 +718,196 @@ mod tests {
             "MED-3: no telegram channel → no group_id written, got:\n{after}"
         );
 
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Admission guard (workspace-identity): a NEW instance whose EXPLICIT working_directory
+    /// equals another instance's DEFAULT (`<home>/workspace/<name>`) is refused fail-closed,
+    /// and the structured refusal NAMES BOTH instances.
+    #[test]
+    fn add_instance_refuses_explicit_colliding_with_another_default() {
+        let home = tmp_home("collide-default");
+        // beta with NO explicit working_directory → default <home>/workspace/beta.
+        add_instance_to_yaml(&home, "beta", &InstanceYamlEntry::default()).unwrap();
+        let beta_default = crate::paths::workspace_dir(&home)
+            .join("beta")
+            .display()
+            .to_string();
+        let err = add_instance_to_yaml(
+            &home,
+            "alpha",
+            &InstanceYamlEntry {
+                working_directory: Some(beta_default),
+                ..Default::default()
+            },
+        )
+        .expect_err("explicit-vs-default collision must be refused");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("alpha") && msg.contains("beta"),
+            "refusal must name BOTH instances: {msg}"
+        );
+        assert!(
+            msg.contains("workspace identity collision"),
+            "structured refusal expected: {msg}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Admission guard: two instances with the SAME explicit working_directory refuse.
+    #[test]
+    fn add_instance_refuses_duplicate_explicit_working_directory() {
+        let home = tmp_home("collide-explicit");
+        let shared = home.join("shared-ws").display().to_string();
+        add_instance_to_yaml(
+            &home,
+            "beta",
+            &InstanceYamlEntry {
+                working_directory: Some(shared.clone()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let err = add_instance_to_yaml(
+            &home,
+            "alpha",
+            &InstanceYamlEntry {
+                working_directory: Some(shared),
+                ..Default::default()
+            },
+        )
+        .expect_err("duplicate explicit working_directory must be refused");
+        assert!(
+            err.to_string().contains("alpha") && err.to_string().contains("beta"),
+            "refusal must name both: {err}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Admission guard: a symlinked-parent alias of another instance's dir is refused
+    /// (nonexistent leaf; deepest-existing-ancestor canonicalization resolves the symlink).
+    #[cfg(unix)]
+    #[test]
+    fn add_instance_refuses_symlinked_parent_alias() {
+        use std::os::unix::fs::symlink;
+        let home = tmp_home("collide-symlink");
+        let real = home.join("real");
+        std::fs::create_dir_all(&real).unwrap();
+        symlink(&real, home.join("link")).unwrap();
+        add_instance_to_yaml(
+            &home,
+            "beta",
+            &InstanceYamlEntry {
+                working_directory: Some(real.join("ws").display().to_string()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        // alpha targets the SAME dir via the symlinked parent (leaf "ws" doesn't exist).
+        let err = add_instance_to_yaml(
+            &home,
+            "alpha",
+            &InstanceYamlEntry {
+                working_directory: Some(home.join("link").join("ws").display().to_string()),
+                ..Default::default()
+            },
+        )
+        .expect_err("symlinked-parent alias must be refused");
+        assert!(
+            err.to_string().contains("alpha") && err.to_string().contains("beta"),
+            "refusal must name both: {err}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Admission guard: a case-only alias of another instance's dir is refused (conservative
+    /// case-fold), on case-sensitive and case-insensitive filesystems alike.
+    #[test]
+    fn add_instance_refuses_case_only_alias() {
+        let home = tmp_home("collide-case");
+        add_instance_to_yaml(
+            &home,
+            "beta",
+            &InstanceYamlEntry {
+                working_directory: Some(home.join("ws").display().to_string()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let err = add_instance_to_yaml(
+            &home,
+            "alpha",
+            &InstanceYamlEntry {
+                working_directory: Some(home.join("WS").display().to_string()),
+                ..Default::default()
+            },
+        )
+        .expect_err("case-only alias must be refused");
+        assert!(
+            err.to_string().contains("alpha") && err.to_string().contains("beta"),
+            "refusal must name both: {err}"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Admission guard is ATOMIC: two concurrent creates targeting the SAME working directory
+    /// admit EXACTLY ONE (the fleet lock serializes check-and-insert); the other refuses.
+    #[test]
+    fn add_instance_concurrent_creates_admit_exactly_one() {
+        let home = tmp_home("collide-concurrent");
+        let shared = home.join("race-ws").display().to_string();
+        let (h1, h2) = (home.clone(), home.clone());
+        let (s1, s2) = (shared.clone(), shared.clone());
+        let t1 = std::thread::spawn(move || {
+            add_instance_to_yaml(
+                &h1,
+                "one",
+                &InstanceYamlEntry {
+                    working_directory: Some(s1),
+                    ..Default::default()
+                },
+            )
+        });
+        let t2 = std::thread::spawn(move || {
+            add_instance_to_yaml(
+                &h2,
+                "two",
+                &InstanceYamlEntry {
+                    working_directory: Some(s2),
+                    ..Default::default()
+                },
+            )
+        });
+        let (r1, r2) = (t1.join().unwrap(), t2.join().unwrap());
+        assert_eq!(
+            r1.is_ok() as u8 + r2.is_ok() as u8,
+            1,
+            "exactly one concurrent create may win the shared workspace: r1={r1:?} r2={r2:?}"
+        );
+        // And fleet.yaml persisted exactly one of them.
+        let names = crate::fleet::FleetConfig::load(&fleet_yaml_path(&home))
+            .unwrap()
+            .instance_names();
+        let persisted = names.iter().filter(|n| *n == "one" || *n == "two").count();
+        assert_eq!(persisted, 1, "exactly one instance must persist: {names:?}");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Regression: distinct working directories (two DEFAULTS) are ADMITTED — the identity
+    /// guard must not over-refuse legitimate non-colliding instances.
+    #[test]
+    fn add_instance_allows_distinct_working_directories() {
+        let home = tmp_home("distinct");
+        add_instance_to_yaml(&home, "beta", &InstanceYamlEntry::default()).unwrap();
+        add_instance_to_yaml(&home, "alpha", &InstanceYamlEntry::default())
+            .expect("distinct default workspaces must be admitted");
+        let names = crate::fleet::FleetConfig::load(&fleet_yaml_path(&home))
+            .unwrap()
+            .instance_names();
+        assert!(
+            names.contains(&"alpha".to_string()) && names.contains(&"beta".to_string()),
+            "both distinct instances must persist: {names:?}"
+        );
         std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/fleet/persist.rs
+++ b/src/fleet/persist.rs
@@ -1201,6 +1201,50 @@ mod tests {
         );
         std::fs::remove_dir_all(&home).ok();
     }
+
+    // --- root review r10 RED: 2 deterministic failures (task-46776 r11) ---
+
+    #[cfg(unix)]
+    #[test]
+    fn root_review_r10_opaque_fleet_metadata_must_fail_closed() {
+        use std::os::unix::fs::PermissionsExt;
+        let home = tmp_home("r11-opaque-meta");
+        std::fs::set_permissions(&home, std::fs::Permissions::from_mode(0o000)).unwrap();
+        let fleet_path = super::fleet_yaml_path(&home);
+        assert!(
+            fleet_path.symlink_metadata().is_err(),
+            "precondition: metadata must be inaccessible"
+        );
+
+        let result = remove_instance_from_yaml(&home, "alpha");
+
+        std::fs::set_permissions(&home, std::fs::Permissions::from_mode(0o755)).unwrap();
+        assert!(
+            result.is_err(),
+            "mutate_fleet_yaml must fail closed when fleet.yaml metadata is \
+             opaque (PermissionDenied), not silently return Ok — the fast \
+             path treats all symlink_metadata errors as 'absent'"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn root_review_r10_absent_fleet_removal_must_acquire_lock() {
+        let home = tmp_home("r11-lock-absent");
+        let lock_path = home.join(".fleet.yaml.lock");
+        assert!(!lock_path.exists(), "precondition: no lock file");
+
+        remove_instance_from_yaml(&home, "alpha").unwrap();
+
+        assert!(
+            lock_path.exists(),
+            "the fleet lock must be acquired even when fleet.yaml is absent \
+             and default_content is empty — the absence decision must be \
+             made under the lock for atomicity. The current fast path \
+             bypasses acquire_lock entirely."
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
 }
 
 #[cfg(test)]

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -510,7 +510,8 @@ fn generate_agent_instructions(
     let instr_path = working_dir.join(preset.instructions_path);
 
     if let Some(parent) = instr_path.parent() {
-        std::fs::create_dir_all(parent).ok();
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("provision: create dir {} failed: {e}", parent.display()))?;
     }
 
     let home = crate::home_dir();
@@ -531,13 +532,22 @@ fn generate_agent_instructions(
     };
 
     let final_content = if preset.instructions_shared {
-        let existing = std::fs::read_to_string(&instr_path).unwrap_or_default();
-        // Workspace-identity guard (fail-closed): a shared instructions file
-        // records the owning instance's name inside the agend-managed block.
-        // NEVER overwrite a block owned by a DIFFERENT instance — that is the
-        // split-brain the incident produced. Ownership is read ONLY between the
-        // agend markers; a foreign owner or corrupt block refuses the write with
-        // the existing bytes untouched. An absent block is legacy/unowned → adopt.
+        // Fail-closed read: a genuine NotFound is an empty (adoptable) file, but
+        // any OTHER I/O error (permission denied, invalid UTF-8, a directory in
+        // place of the file) must NOT be collapsed to "empty" and overwritten.
+        let existing = match std::fs::read_to_string(&instr_path) {
+            Ok(s) => s,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+            Err(e) => {
+                return Err(format!(
+                    "provision: could not read {} to verify ownership: {e}",
+                    instr_path.display()
+                ));
+            }
+        };
+        // Workspace-identity guard (fail-closed, defense-in-depth under the
+        // provision lock held by generate_with_context — the PRIMARY gate is the
+        // preflight there). Never overwrite a block owned by a DIFFERENT instance.
         if let Some(ctx) = ctx {
             let candidate = sanitize_identifier(ctx.name);
             if let Some(reason) = agend_block_owner(&existing).conflict_with(&candidate) {
@@ -560,42 +570,100 @@ fn generate_agent_instructions(
         body
     };
 
-    let _ = std::fs::write(&instr_path, &final_content);
+    std::fs::write(&instr_path, &final_content)
+        .map_err(|e| format!("provision: write {} failed: {e}", instr_path.display()))?;
     Ok(())
 }
 
-/// Generate MCP config + backend-specific files for the working directory.
-/// Generate MCP config + backend-specific files + agent instructions.
-pub fn generate(working_dir: &Path, command: &str) {
-    generate_with_context(working_dir, command, None);
+/// Generate MCP config + backend-specific files + agent instructions. Returns
+/// `Err` (so the caller ABORTS the spawn) when provisioning is refused — a
+/// workspace-identity conflict or an I/O failure — so an agent never starts
+/// against partially or foreign-provisioned state.
+pub fn generate(working_dir: &Path, command: &str) -> Result<(), String> {
+    generate_with_context(working_dir, command, None)
 }
 
-/// Generate with fleet context (name, role, peers).
-pub fn generate_with_context(working_dir: &Path, command: &str, ctx: Option<&AgentContext>) {
+/// Generate with fleet context (name, role, peers). Fail-closed:
+/// 1. take the SINGLE workspace-identity lock for this directory, held across
+///    the preflight AND every write, so the check and the writes are atomic vs a
+///    concurrent provision/delete of the same directory;
+/// 2. PREFLIGHT the identity of every artifact we are about to write, BEFORE any
+///    filesystem/project-root mutation — refuse (`Err`) on a foreign/corrupt/
+///    unreadable owner, leaving the directory byte-for-byte untouched;
+/// 3. only then mutate: project-root scoping, MCP config, instructions — each
+///    propagating its own I/O error so nothing is silently discarded.
+pub fn generate_with_context(
+    working_dir: &Path,
+    command: &str,
+    ctx: Option<&AgentContext>,
+) -> Result<(), String> {
     let backend = crate::backend::Backend::from_command(command);
+    let home = crate::home_dir();
 
+    // (1) One workspace-identity lock across preflight + writes. A lock-acquire
+    // failure is itself fail-closed — refuse rather than provision unguarded.
+    let _id_lock = crate::store::acquire_workspace_identity_lock(&home, working_dir)
+        .map_err(|e| format!("provision: could not acquire workspace-identity lock: {e}"))?;
+
+    // (2) Preflight BEFORE any mutation, so a refusal leaves the dir untouched.
+    if let Some(ctx) = ctx {
+        workspace_provision_preflight(working_dir, backend.as_ref(), ctx.name)?;
+    }
+
+    // (3) Mutations, under the lock, only after a clean preflight.
     // Scope Gemini/Codex project-root discovery to this dir so the hierarchical
     // GEMINI.md / AGENTS.md search doesn't walk up into the user's $HOME.
     if backend.is_some() {
         ensure_project_root(working_dir);
     }
-
-    // Backend-specific setup (non-MCP).
     // Codex trust-prompt handling is via CLI flag + dismiss_patterns — see
     // `src/backend.rs`. We deliberately do not write to `~/.codex/config.toml`.
     if matches!(backend, Some(crate::backend::Backend::ClaudeCode)) {
         migrate_claude_old_rules_file(working_dir);
     }
+    crate::mcp_config::configure(working_dir, command, ctx.map(|c| c.name))
+        .map_err(|e| format!("provision: MCP config: {e}"))?;
+    generate_agent_instructions(working_dir, command, ctx)?;
+    Ok(())
+}
 
-    // MCP config for all backends
-    crate::mcp_config::configure(working_dir, command, ctx.map(|c| c.name));
-
-    // Agent instructions (identity, role, communication guide). A
-    // workspace-identity refusal preserves the foreign instance's file bytes;
-    // surface it loudly (the incident was a silent last-writer-wins overwrite).
-    if let Err(e) = generate_agent_instructions(working_dir, command, ctx) {
-        tracing::error!(error = %e, "agent instructions provisioning refused (workspace identity)");
+/// Refuse (`Err`) to provision `working_dir` for `name` when an artifact we would
+/// write already carries a DIFFERENT instance's identity (or is corrupt/
+/// unreadable). Read-only; runs under the workspace-identity lock BEFORE any
+/// mutation, so a refusal leaves the directory untouched. Covers the incident
+/// artifacts: the shared instructions file (AGENTS.md/GEMINI.md) and the
+/// codex/grok `AGEND_INSTANCE_NAME` config stamp.
+fn workspace_provision_preflight(
+    working_dir: &Path,
+    backend: Option<&crate::backend::Backend>,
+    name: &str,
+) -> Result<(), String> {
+    let Some(backend) = backend else {
+        return Ok(());
+    };
+    let preset = backend.preset();
+    if preset.instructions_shared {
+        let path = working_dir.join(preset.instructions_path);
+        if let Some(reason) = agents_md_identity(&path).conflict_with(&sanitize_identifier(name)) {
+            tracing::error!(path = %path.display(), instance = %name, %reason,
+                "provision refused (preflight): shared instructions file — bytes untouched");
+            return Err(format!("workspace identity: {} {reason}", path.display()));
+        }
     }
+    let config = match backend {
+        crate::backend::Backend::Codex => Some(working_dir.join(".codex").join("config.toml")),
+        crate::backend::Backend::Grok => Some(working_dir.join(".grok").join("config.toml")),
+        _ => None,
+    };
+    if let Some(config) = config {
+        if let Some(reason) = crate::mcp_config::codex_config_identity(&config).conflict_with(name)
+        {
+            tracing::error!(path = %config.display(), instance = %name, %reason,
+                "provision refused (preflight): config.toml — bytes untouched");
+            return Err(format!("workspace identity: {} {reason}", config.display()));
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -627,6 +695,43 @@ mod tests {
             team: None,
             extra_instructions: None,
         }
+    }
+
+    #[test]
+    fn agents_md_identity_unreadable_on_invalid_utf8_but_notfound_is_absent() {
+        use crate::paths::DirIdentity;
+        let dir = tmp_dir("unreadable_id");
+        let path = dir.join("AGENTS.md");
+        std::fs::write(&path, [0xFFu8, 0xFE, 0x00]).unwrap(); // invalid UTF-8
+                                                              // An opaque read error is fail-closed Unreadable — NOT collapsed to Absent.
+        assert_eq!(agents_md_identity(&path), DirIdentity::Unreadable);
+        // A genuine NotFound stays Absent (adoptable).
+        assert_eq!(
+            agents_md_identity(&dir.join("missing.md")),
+            DirIdentity::Absent
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn generate_agent_instructions_refuses_unreadable_agents_md_byte_preserving() {
+        let dir = tmp_dir("prov_unreadable");
+        let path = dir.join("AGENTS.md");
+        let bytes = [0xFFu8, 0xFE, 0x00];
+        std::fs::write(&path, bytes).unwrap();
+        // Provisioning must REFUSE an unreadable identity artifact (fail-closed),
+        // never collapse the read error to "empty" and overwrite it.
+        let res = generate_agent_instructions(&dir, "codex", Some(&codex_ctx("alice")));
+        assert!(
+            res.is_err(),
+            "unreadable AGENTS.md must refuse, not overwrite"
+        );
+        assert_eq!(
+            std::fs::read(&path).unwrap(),
+            bytes,
+            "bytes preserved untouched"
+        );
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]
@@ -718,7 +823,7 @@ mod tests {
     #[test]
     fn generate_claude_writes_instructions_and_mcp_config() {
         let dir = tmp_dir("gen_claude");
-        generate(&dir, "claude");
+        generate(&dir, "claude").expect("provision");
         assert!(dir.join(".claude").join("agend.md").exists());
         assert!(dir.join("mcp-config.json").exists());
         std::fs::remove_dir_all(&dir).ok();
@@ -727,7 +832,7 @@ mod tests {
     #[test]
     fn generate_unknown_backend_no_crash() {
         let dir = tmp_dir("gen_unknown");
-        generate(&dir, "unknown-tool");
+        generate(&dir, "unknown-tool").expect("provision");
         assert!(std::fs::read_dir(&dir).unwrap().count() == 0);
         std::fs::remove_dir_all(&dir).ok();
     }
@@ -746,7 +851,7 @@ mod tests {
             team: None,
             extra_instructions: None,
         };
-        generate_with_context(&dir, "claude", Some(&ctx));
+        generate_with_context(&dir, "claude", Some(&ctx)).expect("provision");
         let path = dir.join(".claude").join("agend.md");
         assert!(path.exists(), "missing agend.md at {}", path.display());
         let content = std::fs::read_to_string(&path).unwrap();
@@ -766,7 +871,7 @@ mod tests {
         let stale = dir.join(".claude").join("rules").join("agend.md");
         std::fs::create_dir_all(stale.parent().unwrap()).unwrap();
         std::fs::write(&stale, "# old content from pre-migration agend").unwrap();
-        generate(&dir, "claude");
+        generate(&dir, "claude").expect("provision");
         assert!(
             !stale.exists(),
             "stale .claude/rules/agend.md was not removed"
@@ -784,7 +889,7 @@ mod tests {
         let user_rule = dir.join(".claude").join("rules").join("my-rule.md");
         std::fs::create_dir_all(user_rule.parent().unwrap()).unwrap();
         std::fs::write(&user_rule, "user-owned rule").unwrap();
-        generate(&dir, "claude");
+        generate(&dir, "claude").expect("provision");
         assert!(
             user_rule.exists(),
             "migration must not touch user's other .claude/rules/*.md files"
@@ -834,7 +939,7 @@ mod tests {
         let dir = tmp_dir("gen_codex_preserve");
         let user_content = "# Existing project AGENTS\n\nImportant user rules.\n";
         std::fs::write(dir.join("AGENTS.md"), user_content).unwrap();
-        generate(&dir, "codex");
+        generate(&dir, "codex").expect("provision");
         let after = std::fs::read_to_string(dir.join("AGENTS.md")).unwrap();
         assert!(
             after.contains("Important user rules."),
@@ -849,9 +954,9 @@ mod tests {
     fn generate_shared_file_is_idempotent_across_spawns() {
         let dir = tmp_dir("gen_shared_idempotent");
         std::fs::write(dir.join("AGENTS.md"), "# user head\n").unwrap();
-        generate(&dir, "codex");
+        generate(&dir, "codex").expect("provision");
         let once = std::fs::read_to_string(dir.join("AGENTS.md")).unwrap();
-        generate(&dir, "codex");
+        generate(&dir, "codex").expect("provision");
         let twice = std::fs::read_to_string(dir.join("AGENTS.md")).unwrap();
         // Compare with protocol path lines stripped — the path is
         // home_dir()-derived and can vary across parallel tests.
@@ -920,7 +1025,7 @@ mod tests {
         // #1580: git-init on generate() is backend-agnostic — was pinned on
         // gemini; re-pointed to agy (gemini-cli's successor) after retirement.
         let dir = tmp_dir("gen_agy_stops_here");
-        generate(&dir, "agy");
+        generate(&dir, "agy").expect("provision");
         assert!(
             dir.join(".git").exists(),
             "working_dir should be a git repo after generate() for agy"
@@ -1237,7 +1342,7 @@ mod tests {
     #[test]
     fn generate_kiro_instructions_basic() {
         let dir = tmp_dir("gen_kiro_instr");
-        generate(&dir, "kiro-cli");
+        generate(&dir, "kiro-cli").expect("provision");
         let path = dir.join(".kiro").join("steering").join("agend.md");
         assert!(path.exists(), "missing kiro agend.md");
         let content = std::fs::read_to_string(&path).unwrap();
@@ -1347,7 +1452,7 @@ mod tests {
         for backend_cmd in ["claude", "kiro-cli", "codex"] {
             let work = dir.join(backend_cmd);
             std::fs::create_dir_all(&work).ok();
-            generate(&work, backend_cmd);
+            generate(&work, backend_cmd).expect("provision");
             let backend = crate::backend::Backend::from_command(backend_cmd).unwrap();
             let preset = backend.preset();
             let instr_path = work.join(preset.instructions_path);
@@ -1372,7 +1477,7 @@ mod tests {
         for backend_cmd in ["claude", "kiro-cli", "codex"] {
             let work = dir.join(backend_cmd);
             std::fs::create_dir_all(&work).ok();
-            generate(&work, backend_cmd);
+            generate(&work, backend_cmd).expect("provision");
             let backend = crate::backend::Backend::from_command(backend_cmd).unwrap();
             let preset = backend.preset();
             let instr_path = work.join(preset.instructions_path);
@@ -1407,7 +1512,7 @@ mod tests {
         for backend_cmd in ["claude", "kiro-cli", "codex", "opencode"] {
             let work = dir.join(backend_cmd);
             std::fs::create_dir_all(&work).ok();
-            generate(&work, backend_cmd);
+            generate(&work, backend_cmd).expect("provision");
             let backend = crate::backend::Backend::from_command(backend_cmd)
                 .unwrap_or_else(|| panic!("backend `{backend_cmd}` must resolve"));
             let preset = backend.preset();
@@ -1585,7 +1690,7 @@ mod tests {
             team: None,
             extra_instructions: Some(extra),
         };
-        generate_with_context(&dir, "claude", Some(&ctx));
+        generate_with_context(&dir, "claude", Some(&ctx)).expect("provision");
         let content =
             std::fs::read_to_string(dir.join(".kiro/steering/agend.md")).unwrap_or_default();
         // Claude uses .kiro/steering/agend.md — check if extra is appended
@@ -1617,7 +1722,7 @@ mod tests {
             team: None,
             extra_instructions: None, // No file → no append
         };
-        generate_with_context(&dir, "claude", Some(&ctx));
+        generate_with_context(&dir, "claude", Some(&ctx)).expect("provision");
         // Should not panic — just generates without extra.
         std::fs::remove_dir_all(&dir).ok();
     }

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -452,6 +452,16 @@ pub(crate) fn agend_block_owner(existing: &str) -> crate::paths::DirIdentity {
     DirIdentity::Corrupt
 }
 
+/// Fail-closed identity read of a shared instructions file at `path`: a genuine
+/// `NotFound` is [`DirIdentity::Absent`] (adoptable); any OTHER I/O failure —
+/// permission denied, invalid UTF-8, a directory in place of the file — is
+/// [`DirIdentity::Unreadable`] (a conflict — we must not overwrite/delete a
+/// directory whose ownership we cannot verify). A readable file is parsed by
+/// [`agend_block_owner`].
+pub(crate) fn agents_md_identity(path: &Path) -> crate::paths::DirIdentity {
+    crate::paths::classify_identity_read(std::fs::read_to_string(path), agend_block_owner)
+}
+
 /// Merge an agend-owned block into a user-shared file, preserving all user
 /// content outside the `<!-- agend:start --> ... <!-- agend:end -->` markers.
 /// Creates the file if missing; replaces the existing block in place if present;

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -589,8 +589,15 @@ pub fn generate(working_dir: &Path, command: &str) -> Result<(), String> {
 /// `connect::run`). Runs the identity preflight and passes the owner
 /// through to every artifact writer so r6's opaque-owner guard accepts
 /// same-owner restarts.
-pub fn generate_for_owner(working_dir: &Path, command: &str, _owner: &str) -> Result<(), String> {
-    generate(working_dir, command)
+pub fn generate_for_owner(working_dir: &Path, command: &str, owner: &str) -> Result<(), String> {
+    let ctx = AgentContext {
+        name: owner,
+        role: None,
+        fleet_peers: &[],
+        team: None,
+        extra_instructions: None,
+    };
+    generate_with_context(working_dir, command, Some(&ctx))
 }
 
 /// Generate with fleet context (name, role, peers). Fail-closed:

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -1820,4 +1820,62 @@ mod tests {
         generate(&dir, "codex").expect("unmanaged first provision must succeed");
         std::fs::remove_dir_all(&dir).ok();
     }
+
+    // --- r8 RED: false-solo + real-entry tests (task-46776) ---
+    //
+    // generate_for_owner at 69d3bf0d materializes AgentContext{peers:[],
+    // team:None} which build_instructions_body reads as "solo agent" and
+    // emits the SOLO-PROFILE paragraph. Managed pane pre-spawn and connect
+    // consume these false instructions before (or instead of) the fleet-
+    // aware rewrite. RED: both tests FAIL at 69d3bf0d.
+
+    #[test]
+    fn r8_managed_pre_spawn_bytes_no_false_solo() {
+        let dir = tmp_dir("r8-presawn-solo");
+        let peers = vec![
+            ("alpha".to_string(), Some("dev".to_string())),
+            ("beta".to_string(), Some("reviewer".to_string())),
+        ];
+        let team_ctx = TeamContext {
+            name: "core",
+            orchestrator: Some("beta"),
+            members: &["alpha".to_string(), "beta".to_string()],
+        };
+        let full_ctx = AgentContext {
+            name: "alpha",
+            role: Some("dev"),
+            fleet_peers: &peers,
+            team: Some(&team_ctx),
+            extra_instructions: None,
+        };
+        generate_with_context(&dir, "codex", Some(&full_ctx)).unwrap();
+        let after_boot = std::fs::read_to_string(dir.join("AGENTS.md")).unwrap();
+        assert!(
+            !after_boot.contains("SOLO-PROFILE"),
+            "full-context boot must not write solo paragraph"
+        );
+        generate_for_owner(&dir, "codex", "alpha").unwrap();
+        let pre_spawn = std::fs::read_to_string(dir.join("AGENTS.md")).unwrap();
+        assert!(
+            !pre_spawn.contains("SOLO-PROFILE"),
+            "managed pre-spawn provision must not write false solo paragraph \
+             into shared instructions — the agent reads these before the \
+             post-spawn fleet-aware rewrite"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn r8_connect_entry_no_false_solo() {
+        let dir = tmp_dir("r8-connect-solo");
+        generate_for_owner(&dir, "codex", "alpha").unwrap();
+        let content = std::fs::read_to_string(dir.join("AGENTS.md")).unwrap();
+        assert!(
+            !content.contains("SOLO-PROFILE"),
+            "connect entry must not write false solo paragraph — connect \
+             has no post-provision rewrite so false solo persists for the \
+             entire session"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
 }

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -1888,4 +1888,51 @@ mod tests {
         );
         std::fs::remove_dir_all(&dir).ok();
     }
+
+    // --- root review r8 RED: 4 deterministic failures (task-46776) ---
+
+    #[test]
+    fn root_review_r8_repeated_owner_only_provision_stays_restartable() {
+        let dir = tmp_dir("r9-repeat-owner");
+        generate_for_owner(&dir, "codex", "alpha").unwrap();
+        let content = std::fs::read_to_string(dir.join("AGENTS.md")).unwrap();
+        assert!(
+            content.contains("- **Name**: `alpha`"),
+            "owner-only provision must write durable owner stamp — got:\n{content}"
+        );
+        generate_for_owner(&dir, "codex", "alpha")
+            .expect("repeated same-owner provision must succeed (idempotent)");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn root_review_nonshared_backend_foreign_owner_is_not_overwritten() {
+        // Claude
+        let dir = tmp_dir("r9-nonshared-claude");
+        generate_with_context(&dir, "claude", Some(&codex_ctx("alpha"))).unwrap();
+        let claude_path = dir.join(".claude").join("agend.md");
+        let original = std::fs::read_to_string(&claude_path).unwrap();
+        let result = generate_for_owner(&dir, "claude", "beta");
+        assert!(
+            result.is_err(),
+            "Claude: must refuse foreign non-shared identity before provision"
+        );
+        let after = std::fs::read_to_string(&claude_path).unwrap();
+        assert_eq!(original, after, "Claude: bytes must be preserved");
+        std::fs::remove_dir_all(&dir).ok();
+
+        // Kiro
+        let dir = tmp_dir("r9-nonshared-kiro");
+        generate_with_context(&dir, "kiro-cli", Some(&codex_ctx("alpha"))).unwrap();
+        let kiro_path = dir.join(".kiro").join("steering").join("agend.md");
+        let original = std::fs::read_to_string(&kiro_path).unwrap();
+        let result = generate_for_owner(&dir, "kiro-cli", "beta");
+        assert!(
+            result.is_err(),
+            "Kiro: must refuse foreign non-shared identity before provision"
+        );
+        let after = std::fs::read_to_string(&kiro_path).unwrap();
+        assert_eq!(original, after, "Kiro: bytes must be preserved");
+        std::fs::remove_dir_all(&dir).ok();
+    }
 }

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -5,11 +5,13 @@ use std::path::Path;
 /// via `--append-system-prompt-file .claude/agend.md`, so keeping the old file
 /// around would cause Claude to auto-load stale content as a rule on top of
 /// the flag-provided version.
-fn migrate_claude_old_rules_file(working_dir: &Path) {
+fn migrate_claude_old_rules_file(working_dir: &Path) -> Result<(), String> {
     let old = working_dir.join(".claude").join("rules").join("agend.md");
     if old.exists() {
-        let _ = std::fs::remove_file(&old);
+        std::fs::remove_file(&old)
+            .map_err(|e| format!("migrate: cannot remove old {}: {e}", old.display()))?;
     }
+    Ok(())
 }
 
 /// Context for generating agent instructions.
@@ -60,30 +62,29 @@ mcp-config.json
 /// here instead of walking up to `$HOME`. No-op if `dir` already lives inside
 /// a git work tree (we never create nested repos). On a fresh init, also drops
 /// a minimal `.gitignore` for agend runtime artifacts.
-pub(crate) fn ensure_project_root(dir: &Path) {
+pub(crate) fn ensure_project_root(dir: &Path) -> Result<(), String> {
     if !dir.exists() {
-        return;
+        return Ok(());
     }
-    // W1.2: cwd=dir replaces `-C dir`; git_ok = spawn-and-exit-0 (bypass env +
-    // local timeout + process-group kill bundled). Local rev-parse.
     let inside = crate::git_helpers::git_ok(dir, &["rev-parse", "--is-inside-work-tree"]);
     if inside {
-        return;
+        return Ok(());
     }
 
-    // #2071: an un-redirected child in app mode inherits the TUI's TTY and `git
-    // init`'s hints/warnings garble the ratatui frame. git_ok runs git via
-    // git_bypass, which CAPTURES stdout/stderr (pipes — never the inherited TTY),
-    // so the explicit Stdio::null is no longer needed; we only read the exit
-    // status. W1.2: cwd=dir replaces `-C dir`.
     let init_ok = crate::git_helpers::git_ok(dir, &["init", "--quiet"]);
-
-    if init_ok {
-        let ignore_path = dir.join(".gitignore");
-        if !ignore_path.exists() {
-            let _ = std::fs::write(&ignore_path, AGEND_GITIGNORE);
-        }
+    if !init_ok {
+        return Err(format!(
+            "ensure_project_root: git init failed in {}",
+            dir.display()
+        ));
     }
+
+    let ignore_path = dir.join(".gitignore");
+    if !ignore_path.exists() {
+        std::fs::write(&ignore_path, AGEND_GITIGNORE)
+            .map_err(|e| format!("ensure_project_root: .gitignore write: {e}"))?;
+    }
+    Ok(())
 }
 
 /// Markers for agend-owned block inside user-shared instructions files
@@ -614,12 +615,10 @@ pub fn generate_with_context(
     // Scope Gemini/Codex project-root discovery to this dir so the hierarchical
     // GEMINI.md / AGENTS.md search doesn't walk up into the user's $HOME.
     if backend.is_some() {
-        ensure_project_root(working_dir);
+        ensure_project_root(working_dir)?;
     }
-    // Codex trust-prompt handling is via CLI flag + dismiss_patterns — see
-    // `src/backend.rs`. We deliberately do not write to `~/.codex/config.toml`.
     if matches!(backend, Some(crate::backend::Backend::ClaudeCode)) {
-        migrate_claude_old_rules_file(working_dir);
+        migrate_claude_old_rules_file(working_dir)?;
     }
     crate::mcp_config::configure(working_dir, command, ctx.map(|c| c.name))
         .map_err(|e| format!("provision: MCP config: {e}"))?;
@@ -977,7 +976,7 @@ mod tests {
     #[test]
     fn ensure_project_root_inits_fresh_dir_with_gitignore() {
         let dir = tmp_dir("ensure_root_fresh");
-        ensure_project_root(&dir);
+        ensure_project_root(&dir).unwrap();
         assert!(dir.join(".git").exists(), "missing .git after init");
         let ignore = std::fs::read_to_string(dir.join(".gitignore")).unwrap();
         assert!(ignore.contains("mcp-config.json"));
@@ -994,7 +993,7 @@ mod tests {
             .status();
         let inner = outer.join("subdir");
         std::fs::create_dir_all(&inner).unwrap();
-        ensure_project_root(&inner);
+        ensure_project_root(&inner).unwrap();
         assert!(
             !inner.join(".git").exists(),
             "should not create nested .git inside an existing repo"
@@ -1011,7 +1010,7 @@ mod tests {
         let dir = tmp_dir("ensure_root_user_ignore");
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(dir.join(".gitignore"), "my-custom-rule\n").unwrap();
-        ensure_project_root(&dir);
+        ensure_project_root(&dir).unwrap();
         let ignore = std::fs::read_to_string(dir.join(".gitignore")).unwrap();
         assert_eq!(
             ignore, "my-custom-rule\n",

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -590,14 +590,24 @@ pub fn generate(working_dir: &Path, command: &str) -> Result<(), String> {
 /// through to every artifact writer so r6's opaque-owner guard accepts
 /// same-owner restarts.
 pub fn generate_for_owner(working_dir: &Path, command: &str, owner: &str) -> Result<(), String> {
-    let ctx = AgentContext {
-        name: owner,
-        role: None,
-        fleet_peers: &[],
-        team: None,
-        extra_instructions: None,
-    };
-    generate_with_context(working_dir, command, Some(&ctx))
+    let backend = crate::backend::Backend::from_command(command);
+    let home = crate::home_dir();
+
+    let _id_lock = crate::store::acquire_workspace_identity_lock(&home, working_dir)
+        .map_err(|e| format!("provision: could not acquire workspace-identity lock: {e}"))?;
+
+    workspace_provision_preflight(working_dir, backend.as_ref(), owner)?;
+
+    if backend.is_some() {
+        ensure_project_root(working_dir)?;
+    }
+    if matches!(backend, Some(crate::backend::Backend::ClaudeCode)) {
+        migrate_claude_old_rules_file(working_dir)?;
+    }
+    crate::mcp_config::configure(working_dir, command, Some(owner))
+        .map_err(|e| format!("provision: MCP config: {e}"))?;
+    generate_agent_instructions(working_dir, command, None)?;
+    Ok(())
 }
 
 /// Generate with fleet context (name, role, peers). Fail-closed:

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -463,6 +463,36 @@ pub(crate) fn agents_md_identity(path: &Path) -> crate::paths::DirIdentity {
     crate::paths::classify_identity_read(std::fs::read_to_string(path), agend_block_owner)
 }
 
+/// Parse owner identity from a non-shared instruction file (.claude/agend.md,
+/// .kiro/steering/agend.md). These are fully rewritten by agend, so the Name
+/// line appears directly in the content (no agend markers). A file with no
+/// Name line is adoptable (legacy or non-agend content).
+fn nonshared_instructions_owner(content: &str) -> crate::paths::DirIdentity {
+    use crate::paths::DirIdentity;
+    for line in content.lines() {
+        if let Some(after) = line.trim_start().strip_prefix("- **Name**:") {
+            return match after
+                .trim()
+                .strip_prefix('`')
+                .and_then(|s| s.strip_suffix('`'))
+                .filter(|n| !n.is_empty())
+            {
+                Some(n) => DirIdentity::Owner(n.to_string()),
+                None => DirIdentity::Corrupt,
+            };
+        }
+    }
+    DirIdentity::Absent
+}
+
+/// Fail-closed identity read of a non-shared instruction file.
+pub(crate) fn nonshared_instructions_identity(path: &Path) -> crate::paths::DirIdentity {
+    crate::paths::classify_identity_read(
+        std::fs::read_to_string(path),
+        nonshared_instructions_owner,
+    )
+}
+
 /// Merge an agend-owned block into a user-shared file, preserving all user
 /// content outside the `<!-- agend:start --> ... <!-- agend:end -->` markers.
 /// Creates the file if missing; replaces the existing block in place if present;
@@ -502,6 +532,7 @@ fn generate_agent_instructions(
     working_dir: &Path,
     command: &str,
     ctx: Option<&AgentContext>,
+    owner: Option<&str>,
 ) -> Result<(), String> {
     let backend = match crate::backend::Backend::from_command(command) {
         Some(b) => b,
@@ -519,6 +550,21 @@ fn generate_agent_instructions(
     let proto = crate::protocol::protocol_path(&home);
     let proto_str = proto.display().to_string();
     let body = build_instructions_body(ctx, Some(&proto_str));
+
+    // Preserve durable owner stamp even without full fleet context:
+    // write ONLY the Name identity line so the next provision sees
+    // Owner(name) not Corrupt. No team/peers/solo claims emitted.
+    let body = match (ctx, owner) {
+        (None, Some(name)) => {
+            let safe = sanitize_identifier(name);
+            body.replacen(
+                "## Communication",
+                &format!("## Identity\n\n- **Name**: `{safe}`\n\n## Communication"),
+                1,
+            )
+        }
+        _ => body,
+    };
 
     // Include fleet.yaml `instructions:` inside the managed block so
     // shared files (AGENTS.md) don't duplicate it on each refresh (#1405).
@@ -606,7 +652,7 @@ pub fn generate_for_owner(working_dir: &Path, command: &str, owner: &str) -> Res
     }
     crate::mcp_config::configure(working_dir, command, Some(owner))
         .map_err(|e| format!("provision: MCP config: {e}"))?;
-    generate_agent_instructions(working_dir, command, None)?;
+    generate_agent_instructions(working_dir, command, None, Some(owner))?;
     Ok(())
 }
 
@@ -648,7 +694,7 @@ pub fn generate_with_context(
     }
     crate::mcp_config::configure(working_dir, command, ctx.map(|c| c.name))
         .map_err(|e| format!("provision: MCP config: {e}"))?;
-    generate_agent_instructions(working_dir, command, ctx)?;
+    generate_agent_instructions(working_dir, command, ctx, ctx.map(|c| c.name))?;
     Ok(())
 }
 
@@ -667,13 +713,19 @@ fn workspace_provision_preflight(
         return Ok(());
     };
     let preset = backend.preset();
+    let path = working_dir.join(preset.instructions_path);
     if preset.instructions_shared {
-        let path = working_dir.join(preset.instructions_path);
         if let Some(reason) = agents_md_identity(&path).conflict_with(&sanitize_identifier(name)) {
             tracing::error!(path = %path.display(), instance = %name, %reason,
                 "provision refused (preflight): shared instructions file — bytes untouched");
             return Err(format!("workspace identity: {} {reason}", path.display()));
         }
+    } else if let Some(reason) =
+        nonshared_instructions_identity(&path).conflict_with(&sanitize_identifier(name))
+    {
+        tracing::error!(path = %path.display(), instance = %name, %reason,
+            "provision refused (preflight): non-shared instructions file — bytes untouched");
+        return Err(format!("workspace identity: {} {reason}", path.display()));
     }
     let config = match backend {
         crate::backend::Backend::Codex => Some(working_dir.join(".codex").join("config.toml")),
@@ -746,7 +798,8 @@ mod tests {
         std::fs::write(&path, bytes).unwrap();
         // Provisioning must REFUSE an unreadable identity artifact (fail-closed),
         // never collapse the read error to "empty" and overwrite it.
-        let res = generate_agent_instructions(&dir, "codex", Some(&codex_ctx("alice")));
+        let res =
+            generate_agent_instructions(&dir, "codex", Some(&codex_ctx("alice")), Some("alice"));
         assert!(
             res.is_err(),
             "unreadable AGENTS.md must refuse, not overwrite"
@@ -797,7 +850,8 @@ mod tests {
         let path = dir.join("AGENTS.md");
         std::fs::write(&path, &foreign).unwrap();
         // Provisioning as "alice" into bob's directory must REFUSE, bytes intact.
-        let res = generate_agent_instructions(&dir, "codex", Some(&codex_ctx("alice")));
+        let res =
+            generate_agent_instructions(&dir, "codex", Some(&codex_ctx("alice")), Some("alice"));
         assert!(res.is_err(), "foreign-owned AGENTS.md must refuse");
         assert_eq!(
             std::fs::read_to_string(&path).unwrap(),
@@ -813,7 +867,8 @@ mod tests {
         let path = dir.join("AGENTS.md");
         let corrupt = "<!-- agend:start -->\ngarbage, no name line\n<!-- agend:end -->\n";
         std::fs::write(&path, corrupt).unwrap();
-        let res = generate_agent_instructions(&dir, "codex", Some(&codex_ctx("alice")));
+        let res =
+            generate_agent_instructions(&dir, "codex", Some(&codex_ctx("alice")), Some("alice"));
         assert!(res.is_err(), "corrupt identity block must refuse");
         assert_eq!(
             std::fs::read_to_string(&path).unwrap(),
@@ -829,14 +884,14 @@ mod tests {
         let dir = tmp_dir("prov_same");
         let path = dir.join("AGENTS.md");
         // Absent block → adopt (writes).
-        generate_agent_instructions(&dir, "codex", Some(&codex_ctx("alice")))
+        generate_agent_instructions(&dir, "codex", Some(&codex_ctx("alice")), Some("alice"))
             .expect("adopt absent");
         assert_eq!(
             agend_block_owner(&std::fs::read_to_string(&path).unwrap()),
             DirIdentity::Owner("alice".to_string())
         );
         // Same owner → refresh (Ok, still alice).
-        generate_agent_instructions(&dir, "codex", Some(&codex_ctx("alice")))
+        generate_agent_instructions(&dir, "codex", Some(&codex_ctx("alice")), Some("alice"))
             .expect("refresh same");
         assert_eq!(
             agend_block_owner(&std::fs::read_to_string(&path).unwrap()),

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -7,11 +7,11 @@ use std::path::Path;
 /// the flag-provided version.
 fn migrate_claude_old_rules_file(working_dir: &Path) -> Result<(), String> {
     let old = working_dir.join(".claude").join("rules").join("agend.md");
-    if old.exists() {
-        std::fs::remove_file(&old)
-            .map_err(|e| format!("migrate: cannot remove old {}: {e}", old.display()))?;
+    match std::fs::remove_file(&old) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(format!("migrate: cannot remove old {}: {e}", old.display())),
     }
-    Ok(())
 }
 
 /// Context for generating agent instructions.

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -416,6 +416,42 @@ fn strip_leaked_extra_instructions(content: &str, extra: Option<&str>) -> String
     result
 }
 
+/// Read the owning instance recorded inside the agend-managed block of an
+/// existing shared instructions file (AGENTS.md / GEMINI.md). The
+/// workspace-identity guard reads ownership ONLY between the agend markers so
+/// user content outside them can never be mistaken for ownership.
+///
+/// - [`DirIdentity::Absent`] — no agend block present (unowned / legacy → adoptable).
+/// - [`DirIdentity::Owner`] — the recorded owner (a sanitized identifier, matching
+///   what [`build_instructions_body`] writes at the `- **Name**:` line).
+/// - [`DirIdentity::Corrupt`] — a start marker with no end, or a block with no
+///   parseable `Name` line.
+pub(crate) fn agend_block_owner(existing: &str) -> crate::paths::DirIdentity {
+    use crate::paths::DirIdentity;
+    let Some(start) = existing.find(AGEND_BLOCK_START) else {
+        return DirIdentity::Absent;
+    };
+    let rest = &existing[start + AGEND_BLOCK_START.len()..];
+    let block = match rest.find(AGEND_BLOCK_END) {
+        Some(end) => &rest[..end],
+        None => return DirIdentity::Corrupt,
+    };
+    for line in block.lines() {
+        if let Some(after) = line.trim_start().strip_prefix("- **Name**:") {
+            return match after
+                .trim()
+                .strip_prefix('`')
+                .and_then(|s| s.strip_suffix('`'))
+                .filter(|n| !n.is_empty())
+            {
+                Some(n) => DirIdentity::Owner(n.to_string()),
+                None => DirIdentity::Corrupt,
+            };
+        }
+    }
+    DirIdentity::Corrupt
+}
+
 /// Merge an agend-owned block into a user-shared file, preserving all user
 /// content outside the `<!-- agend:start --> ... <!-- agend:end -->` markers.
 /// Creates the file if missing; replaces the existing block in place if present;
@@ -451,10 +487,14 @@ pub(crate) fn merge_agend_block(existing: &str, body: &str) -> String {
 /// Write agent instructions file to the backend-specific path.
 /// Shared files (AGENTS.md, GEMINI.md) use marker-merge; agend-owned files
 /// (.claude/agend.md, .kiro/steering/agend.md) are rewritten in full.
-fn generate_agent_instructions(working_dir: &Path, command: &str, ctx: Option<&AgentContext>) {
+fn generate_agent_instructions(
+    working_dir: &Path,
+    command: &str,
+    ctx: Option<&AgentContext>,
+) -> Result<(), String> {
     let backend = match crate::backend::Backend::from_command(command) {
         Some(b) => b,
-        None => return,
+        None => return Ok(()),
     };
     let preset = backend.preset();
     let instr_path = working_dir.join(preset.instructions_path);
@@ -482,6 +522,25 @@ fn generate_agent_instructions(working_dir: &Path, command: &str, ctx: Option<&A
 
     let final_content = if preset.instructions_shared {
         let existing = std::fs::read_to_string(&instr_path).unwrap_or_default();
+        // Workspace-identity guard (fail-closed): a shared instructions file
+        // records the owning instance's name inside the agend-managed block.
+        // NEVER overwrite a block owned by a DIFFERENT instance — that is the
+        // split-brain the incident produced. Ownership is read ONLY between the
+        // agend markers; a foreign owner or corrupt block refuses the write with
+        // the existing bytes untouched. An absent block is legacy/unowned → adopt.
+        if let Some(ctx) = ctx {
+            let candidate = sanitize_identifier(ctx.name);
+            if let Some(reason) = agend_block_owner(&existing).conflict_with(&candidate) {
+                tracing::error!(
+                    path = %instr_path.display(), %candidate, %reason,
+                    "provision refused: shared instructions file — bytes preserved"
+                );
+                return Err(format!(
+                    "workspace identity: {} {reason}, refusing to overwrite for '{candidate}'",
+                    instr_path.display()
+                ));
+            }
+        }
         // Strip any prior leaked copies of extra instructions outside the
         // agend markers before merging, so existing duplicates self-heal.
         let cleaned =
@@ -492,6 +551,7 @@ fn generate_agent_instructions(working_dir: &Path, command: &str, ctx: Option<&A
     };
 
     let _ = std::fs::write(&instr_path, &final_content);
+    Ok(())
 }
 
 /// Generate MCP config + backend-specific files for the working directory.
@@ -520,8 +580,12 @@ pub fn generate_with_context(working_dir: &Path, command: &str, ctx: Option<&Age
     // MCP config for all backends
     crate::mcp_config::configure(working_dir, command, ctx.map(|c| c.name));
 
-    // Agent instructions (identity, role, communication guide)
-    generate_agent_instructions(working_dir, command, ctx);
+    // Agent instructions (identity, role, communication guide). A
+    // workspace-identity refusal preserves the foreign instance's file bytes;
+    // surface it loudly (the incident was a silent last-writer-wins overwrite).
+    if let Err(e) = generate_agent_instructions(working_dir, command, ctx) {
+        tracing::error!(error = %e, "agent instructions provisioning refused (workspace identity)");
+    }
 }
 
 #[cfg(test)]
@@ -541,6 +605,104 @@ mod tests {
         ));
         std::fs::create_dir_all(&dir).ok();
         dir
+    }
+
+    // --- workspace-identity provision guard (boundary 2, AGENTS.md) ---
+
+    fn codex_ctx(name: &str) -> AgentContext<'_> {
+        AgentContext {
+            name,
+            role: None,
+            fleet_peers: &[],
+            team: None,
+            extra_instructions: None,
+        }
+    }
+
+    #[test]
+    fn agend_block_owner_absent_owner_and_corrupt() {
+        use crate::paths::DirIdentity;
+        // No markers → unowned/legacy → adoptable.
+        assert_eq!(
+            agend_block_owner("# notes\nno agend markers here\n"),
+            DirIdentity::Absent
+        );
+        // Well-formed block → the recorded owner.
+        let file = merge_agend_block(
+            "",
+            &build_instructions_body(Some(&codex_ctx("alice")), None),
+        );
+        assert_eq!(
+            agend_block_owner(&file),
+            DirIdentity::Owner("alice".to_string())
+        );
+        // Markers present but no Name line → corrupt.
+        assert_eq!(
+            agend_block_owner("<!-- agend:start -->\njunk\n<!-- agend:end -->\n"),
+            DirIdentity::Corrupt
+        );
+        // Start marker with no end → corrupt (conservative).
+        assert_eq!(
+            agend_block_owner("<!-- agend:start -->\n- **Name**: `bob`\n"),
+            DirIdentity::Corrupt
+        );
+    }
+
+    #[test]
+    fn generate_agent_instructions_refuses_foreign_agents_md_byte_preserving() {
+        let dir = tmp_dir("prov_foreign");
+        // AGENTS.md owned by a DIFFERENT instance ("bob"), plus user content.
+        let block = merge_agend_block("", &build_instructions_body(Some(&codex_ctx("bob")), None));
+        let foreign = format!("# My project notes\n\n{block}\ntrailing user text\n");
+        let path = dir.join("AGENTS.md");
+        std::fs::write(&path, &foreign).unwrap();
+        // Provisioning as "alice" into bob's directory must REFUSE, bytes intact.
+        let res = generate_agent_instructions(&dir, "codex", Some(&codex_ctx("alice")));
+        assert!(res.is_err(), "foreign-owned AGENTS.md must refuse");
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            foreign,
+            "foreign bytes must be preserved untouched"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn generate_agent_instructions_refuses_corrupt_agents_md_byte_preserving() {
+        let dir = tmp_dir("prov_corrupt");
+        let path = dir.join("AGENTS.md");
+        let corrupt = "<!-- agend:start -->\ngarbage, no name line\n<!-- agend:end -->\n";
+        std::fs::write(&path, corrupt).unwrap();
+        let res = generate_agent_instructions(&dir, "codex", Some(&codex_ctx("alice")));
+        assert!(res.is_err(), "corrupt identity block must refuse");
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            corrupt,
+            "bytes preserved"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn generate_agent_instructions_adopts_absent_and_refreshes_same_owner() {
+        use crate::paths::DirIdentity;
+        let dir = tmp_dir("prov_same");
+        let path = dir.join("AGENTS.md");
+        // Absent block → adopt (writes).
+        generate_agent_instructions(&dir, "codex", Some(&codex_ctx("alice")))
+            .expect("adopt absent");
+        assert_eq!(
+            agend_block_owner(&std::fs::read_to_string(&path).unwrap()),
+            DirIdentity::Owner("alice".to_string())
+        );
+        // Same owner → refresh (Ok, still alice).
+        generate_agent_instructions(&dir, "codex", Some(&codex_ctx("alice")))
+            .expect("refresh same");
+        assert_eq!(
+            agend_block_owner(&std::fs::read_to_string(&path).unwrap()),
+            DirIdentity::Owner("alice".to_string())
+        );
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -584,6 +584,15 @@ pub fn generate(working_dir: &Path, command: &str) -> Result<(), String> {
     generate_with_context(working_dir, command, None)
 }
 
+/// Pre-spawn provision for callers that know the instance name but have no
+/// full fleet context (e.g. `spawn_and_subscribe` on managed restart,
+/// `connect::run`). Runs the identity preflight and passes the owner
+/// through to every artifact writer so r6's opaque-owner guard accepts
+/// same-owner restarts.
+pub fn generate_for_owner(working_dir: &Path, command: &str, _owner: &str) -> Result<(), String> {
+    generate(working_dir, command)
+}
+
 /// Generate with fleet context (name, role, peers). Fail-closed:
 /// 1. take the SINGLE workspace-identity lock for this directory, held across
 ///    the preflight AND every write, so the check and the writes are atomic vs a
@@ -1739,5 +1748,69 @@ mod tests {
         );
         // Canonicalize would resolve the ./ but the join is correct.
         assert!(resolved.starts_with("/home/user/project"));
+    }
+
+    // --- r7 RED: managed caller identity-guard tests (task-46776) ---
+    //
+    // These tests assert the CORRECT (post-fix) behavior and FAIL at the
+    // r6 HEAD 1a1368b5 because generate_for_owner delegates to the
+    // contextless generate(), which either refuses same-owner restarts
+    // (r6 opaque-config guard) or skips the shared instructions check.
+
+    fn seed_agents_md(dir: &std::path::Path, owner: &str) {
+        std::fs::write(
+            dir.join("AGENTS.md"),
+            format!(
+                "<!-- agend:start -->\n## Identity\n\n- **Name**: `{owner}`\n<!-- agend:end -->\n"
+            ),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn r7_managed_same_owner_restart_succeeds() {
+        let dir = tmp_dir("r7-same-owner");
+        generate_with_context(&dir, "codex", Some(&codex_ctx("alpha"))).unwrap();
+        generate_for_owner(&dir, "codex", "alpha")
+            .expect("same-owner managed restart must succeed — r6 contextless path refuses this");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn r7_foreign_shared_instructions_refuses_preserves_bytes() {
+        let dir = tmp_dir("r7-foreign-agents");
+        seed_agents_md(&dir, "alpha");
+        let original = std::fs::read_to_string(dir.join("AGENTS.md")).unwrap();
+        let result = generate_for_owner(&dir, "codex", "beta");
+        assert!(
+            result.is_err(),
+            "must refuse foreign AGENTS.md identity before spawn"
+        );
+        let after = std::fs::read_to_string(dir.join("AGENTS.md")).unwrap();
+        assert_eq!(original, after, "AGENTS.md bytes must be preserved");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn r7_foreign_config_refuses_preserves_bytes() {
+        let dir = tmp_dir("r7-foreign-config");
+        generate_with_context(&dir, "codex", Some(&codex_ctx("alpha"))).unwrap();
+        let config_path = dir.join(".codex").join("config.toml");
+        let original = std::fs::read_to_string(&config_path).unwrap();
+        let result = generate_for_owner(&dir, "codex", "beta");
+        assert!(
+            result.is_err(),
+            "must refuse foreign config identity before spawn"
+        );
+        let after = std::fs::read_to_string(&config_path).unwrap();
+        assert_eq!(original, after, "config.toml bytes must be preserved");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn r7_unmanaged_first_provision_succeeds() {
+        let dir = tmp_dir("r7-unmanaged");
+        generate(&dir, "codex").expect("unmanaged first provision must succeed");
+        std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/src/mcp/handlers/instance_state/lifecycle.rs
+++ b/src/mcp/handlers/instance_state/lifecycle.rs
@@ -149,14 +149,15 @@ pub(crate) fn full_delete_instance(home: &Path, name: &str) -> Result<(), String
     let wd = working_dir
         .clone()
         .unwrap_or_else(|| crate::paths::workspace_dir(home).join(name));
-    // A workspace-identity conflict makes `cleanup_working_dir` preserve the
-    // foreign instance's tree (byte-preserving refusal + loud audit). Surface it
-    // as a step error too, so the delete reports failure instead of a false
-    // success while B's directory is (correctly) left intact.
-    if let Some(reason) = crate::agent_ops::working_dir_ownership_conflict(&wd, name) {
+    // #46776: cleanup_working_dir holds the workspace-identity lock, decides
+    // ownership ONCE under it, and returns the single verdict — NO separate,
+    // unlocked probe (which could observe a different state). A refusal (foreign/
+    // corrupt/unreadable identity, or a lock-acquire failure) preserves the
+    // foreign tree; surface it as a step error so the delete reports failure
+    // instead of a false success while B's directory is (correctly) left intact.
+    if let Some(reason) = cleanup_working_dir(home, name, &wd) {
         step_errors.push(format!("working_dir cleanup refused: {reason}"));
     }
-    cleanup_working_dir(home, name, &wd);
     // #1157: clean id-based metadata. Fleet.yaml is already removed above,
     // so cleanup_working_dir's best-effort lookup may miss the id path.
     // #1682: construct the id path via agent_ops (fleet.yaml is gone, so the

--- a/src/mcp/handlers/instance_state/lifecycle.rs
+++ b/src/mcp/handlers/instance_state/lifecycle.rs
@@ -149,6 +149,13 @@ pub(crate) fn full_delete_instance(home: &Path, name: &str) -> Result<(), String
     let wd = working_dir
         .clone()
         .unwrap_or_else(|| crate::paths::workspace_dir(home).join(name));
+    // A workspace-identity conflict makes `cleanup_working_dir` preserve the
+    // foreign instance's tree (byte-preserving refusal + loud audit). Surface it
+    // as a step error too, so the delete reports failure instead of a false
+    // success while B's directory is (correctly) left intact.
+    if let Some(reason) = crate::agent_ops::working_dir_ownership_conflict(&wd, name) {
+        step_errors.push(format!("working_dir cleanup refused: {reason}"));
+    }
     cleanup_working_dir(home, name, &wd);
     // #1157: clean id-based metadata. Fleet.yaml is already removed above,
     // so cleanup_working_dir's best-effort lookup may miss the id path.

--- a/src/mcp/handlers/instance_state/spawn.rs
+++ b/src/mcp/handlers/instance_state/spawn.rs
@@ -97,6 +97,27 @@ pub(in crate::mcp::handlers) fn spawn_single_instance_impl(
                 .to_string()
         });
 
+    // #46776 fail-closed (root finding 2): refuse a colliding workspace identity
+    // BEFORE creating any worktree or directory, so a refusal leaves NO partial
+    // filesystem/git state. Compute the INTENDED final working directory (the
+    // branch worktree path when a branch is set — computed, NOT created) and
+    // preflight it against the registry. The atomic add_instance_to_yaml below
+    // stays the race-safe authority (with rollback on the rare racing refusal).
+    let intended_wd = match args.get("branch").and_then(|v| v.as_str()) {
+        Some(branch) if validate_branch(branch) => {
+            crate::worktree::worktree_path(home, name, branch)
+        }
+        _ => std::path::PathBuf::from(&work_dir),
+    };
+    if let Some(collider) = crate::fleet::workspace_identity_collision(home, name, &intended_wd) {
+        return json!({"error": format!(
+            "workspace identity collision: '{name}' would resolve to the same working directory as \
+             existing instance '{collider}' ({}); refusing before creating any worktree/directory \
+             (fail-closed).",
+            intended_wd.display()
+        )});
+    }
+
     if let Some(branch) = args.get("branch").and_then(|v| v.as_str()) {
         if !validate_branch(branch) {
             return json!({"error": format!("invalid branch name '{branch}'")});
@@ -198,6 +219,12 @@ pub(in crate::mcp::handlers) fn spawn_single_instance_impl(
         ..Default::default()
     };
     if let Err(e) = crate::fleet::add_instance_to_yaml(home, name, &entry) {
+        // #46776 finding 2: roll back the worktree/dir created above so a refused
+        // admission (a race that slipped past the preflight, or a merge conflict)
+        // leaves NO partial filesystem/git state. The dir is not yet provisioned
+        // (no AGENTS.md/.codex identity), so cleanup finds no foreign owner.
+        let _ =
+            crate::agent_ops::cleanup_working_dir(home, name, &std::path::PathBuf::from(&work_dir));
         return json!({"error": format!("failed to register instance in fleet.yaml: {e}")});
     }
 

--- a/src/mcp/handlers/instance_state/spawn.rs
+++ b/src/mcp/handlers/instance_state/spawn.rs
@@ -142,7 +142,8 @@ pub(in crate::mcp::handlers) fn spawn_single_instance_impl(
         }
     }
 
-    let work_dir_preexisted = !worktree_created_by_attempt && std::path::Path::new(&work_dir).exists();
+    let work_dir_preexisted =
+        !worktree_created_by_attempt && std::path::Path::new(&work_dir).exists();
     std::fs::create_dir_all(&work_dir).ok();
 
     let task = args.get("task").and_then(|v| v.as_str()).map(String::from);

--- a/src/mcp/handlers/instance_state/spawn.rs
+++ b/src/mcp/handlers/instance_state/spawn.rs
@@ -139,6 +139,7 @@ pub(in crate::mcp::handlers) fn spawn_single_instance_impl(
         }
     }
 
+    let work_dir_preexisted = std::path::Path::new(&work_dir).exists();
     std::fs::create_dir_all(&work_dir).ok();
 
     let task = args.get("task").and_then(|v| v.as_str()).map(String::from);
@@ -219,12 +220,15 @@ pub(in crate::mcp::handlers) fn spawn_single_instance_impl(
         ..Default::default()
     };
     if let Err(e) = crate::fleet::add_instance_to_yaml(home, name, &entry) {
-        // #46776 finding 2: roll back the worktree/dir created above so a refused
-        // admission (a race that slipped past the preflight, or a merge conflict)
-        // leaves NO partial filesystem/git state. The dir is not yet provisioned
-        // (no AGENTS.md/.codex identity), so cleanup finds no foreign owner.
-        let _ =
-            crate::agent_ops::cleanup_working_dir(home, name, &std::path::PathBuf::from(&work_dir));
+        // Only roll back filesystem state that THIS attempt created. A
+        // pre-existing dir (reused worktree or occupied workspace) must survive.
+        if !work_dir_preexisted {
+            let _ = crate::agent_ops::cleanup_working_dir(
+                home,
+                name,
+                &std::path::PathBuf::from(&work_dir),
+            );
+        }
         return json!({"error": format!("failed to register instance in fleet.yaml: {e}")});
     }
 

--- a/src/mcp/handlers/instance_state/spawn.rs
+++ b/src/mcp/handlers/instance_state/spawn.rs
@@ -118,6 +118,7 @@ pub(in crate::mcp::handlers) fn spawn_single_instance_impl(
         )});
     }
 
+    let mut worktree_created_by_attempt = false;
     if let Some(branch) = args.get("branch").and_then(|v| v.as_str()) {
         if !validate_branch(branch) {
             return json!({"error": format!("invalid branch name '{branch}'")});
@@ -136,10 +137,12 @@ pub(in crate::mcp::handlers) fn spawn_single_instance_impl(
         // `$AGEND_HOME/worktrees/<agent>/<branch>/` resolves correctly.
         if let Some(info) = crate::worktree::create(home, &wd, name, Some(branch)) {
             work_dir = info.path.display().to_string();
+            worktree_created_by_attempt =
+                info.provenance == crate::worktree::WorktreeProvenance::CreatedByThisAttempt;
         }
     }
 
-    let work_dir_preexisted = std::path::Path::new(&work_dir).exists();
+    let work_dir_preexisted = !worktree_created_by_attempt && std::path::Path::new(&work_dir).exists();
     std::fs::create_dir_all(&work_dir).ok();
 
     let task = args.get("task").and_then(|v| v.as_str()).map(String::from);

--- a/src/mcp/handlers/mod.rs
+++ b/src/mcp/handlers/mod.rs
@@ -212,6 +212,12 @@ mod instance_964_tests;
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod review_repro_mcp_core_surface;
 
+// #46776 r3: real-entry RED tests for the 6 findings from the dual-review
+// rejection at 3d442d0a. Same sibling-file precedent as instance_964_tests.
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod r3_46776_red_tests;
+
 // Re-homed here (not in ci/mod.rs / dispatch_hook/mod.rs) to keep those
 // KNOWN_OVERSIZED handler files under their file_size_invariant ceilings —
 // same precedent as instance_964_tests above. The tests reach the handlers'

--- a/src/mcp/handlers/r3_46776_red_tests.rs
+++ b/src/mcp/handlers/r3_46776_red_tests.rs
@@ -544,3 +544,207 @@ fn r4_migrate_claude_old_rules_failure_propagates() {
 
     std::fs::remove_dir_all(&home).ok();
 }
+
+// ===========================================================================
+// R5 RED tests — five new findings from root review at 16b1ce94.
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// R5-1 — branch worktree created by this attempt must be cleaned on rollback
+// ---------------------------------------------------------------------------
+
+/// R5-1: When `spawn_single_instance_impl` creates a NEW worktree via the
+/// branch path (worktree::create), `work_dir` changes to the newly created
+/// path. The provenance check `work_dir_preexisted` at line 142 then sees
+/// the newly created dir and treats it as pre-existing → cleanup is skipped
+/// on rollback, leaking the worktree.
+///
+/// RED: FAILS because the provenance check happens AFTER worktree::create
+/// has already created the directory at the new `work_dir` path.
+#[test]
+fn r5_branch_worktree_created_by_attempt_cleaned_on_rollback() {
+    let home = tmp_home("r5-wt-branch");
+    let repo = home.join("workspace").join("agent-repo");
+    std::fs::create_dir_all(&repo).unwrap();
+
+    // Create a minimal git repo so worktree::create can work.
+    assert!(std::process::Command::new("git")
+        .args(["init", "--quiet"])
+        .current_dir(&repo)
+        .status()
+        .unwrap()
+        .success());
+    assert!(std::process::Command::new("git")
+        .args([
+            "-c", "user.name=test",
+            "-c", "user.email=test@test",
+            "commit", "--allow-empty", "-m", "init",
+        ])
+        .current_dir(&repo)
+        .status()
+        .unwrap()
+        .success());
+
+    // Empty fleet → preflight passes.
+    fleet_with_instances(&home, "instances: {}\n");
+    let fleet_path = crate::fleet::fleet_yaml_path(&home);
+    crate::store::fail_next_atomic_write_for_test(&fleet_path);
+
+    let wt_path = crate::worktree::worktree_path(&home, "new-agent", "feat/test");
+    assert!(!wt_path.exists(), "precondition: worktree dir must not exist yet");
+
+    let spawn_fn = |_h: &Path, _req: &serde_json::Value| -> anyhow::Result<serde_json::Value> {
+        Ok(json!({"ok": true}))
+    };
+
+    let result = crate::mcp::handlers::instance_state::spawn::spawn_single_instance_impl(
+        &home,
+        "spawner",
+        &json!({
+            "name": "new-agent",
+            "backend": "claude",
+            "working_directory": repo.display().to_string(),
+            "branch": "feat/test"
+        }),
+        &spawn_fn,
+    );
+
+    assert!(
+        result.get("error").is_some(),
+        "R5-1 precondition: fleet write must fail. Got: {result}"
+    );
+
+    // The worktree CREATED BY THIS ATTEMPT must be cleaned on rollback.
+    assert!(
+        !wt_path.exists(),
+        "R5-1: branch worktree created by this attempt must be removed on rollback. \
+         work_dir_preexisted is sampled after worktree::create, so the newly created \
+         dir is treated as pre-existing and cleanup is skipped."
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+}
+
+// ---------------------------------------------------------------------------
+// R5-3 — wrong-shape `instances` key must refuse, not become empty
+// ---------------------------------------------------------------------------
+
+/// R5-3a: When fleet.yaml has `instances: [...]` (a YAML sequence, not a
+/// mapping), `load_instances_mapping` must return Err, not silently treat it
+/// as an empty mapping. `as_mapping()` returns None for a list →
+/// `unwrap_or_default()` → empty mapping → "no collision" → fail-open.
+///
+/// RED: FAILS because `as_mapping()` returns None → default empty mapping.
+#[test]
+fn r5_wrong_shape_instances_refuses_collision() {
+    let home = tmp_home("r5-shape-col");
+    let fleet_path = crate::fleet::fleet_yaml_path(&home);
+    std::fs::write(&fleet_path, "instances:\n  - alice\n  - bob\n").unwrap();
+
+    let result = crate::fleet::persist::workspace_identity_collision(
+        &home,
+        "any-instance",
+        &home.join("workspace").join("any-instance"),
+    );
+
+    assert!(
+        result.is_some(),
+        "R5-3a: fleet.yaml with wrong-shape instances (list, not mapping) must \
+         refuse collision check, not silently pass as 'no collision'. Got None."
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// R5-3b: Same wrong-shape bug for boot admission.
+#[test]
+fn r5_wrong_shape_instances_refuses_boot() {
+    let home = tmp_home("r5-shape-boot");
+    let fleet_path = crate::fleet::fleet_yaml_path(&home);
+    std::fs::write(&fleet_path, "instances: \"just-a-string\"\n").unwrap();
+
+    let result = crate::fleet::persist::duplicate_identity_owner_before(
+        &home,
+        "any-instance",
+        &home.join("workspace").join("any-instance"),
+    );
+
+    assert!(
+        result.is_some(),
+        "R5-3b: fleet.yaml with wrong-shape instances (scalar, not mapping) must \
+         refuse boot admission, not silently pass. Got None."
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+}
+
+// ---------------------------------------------------------------------------
+// R5-4 — pre-mutation ordering: absent work_dir stays absent on fleet error
+// ---------------------------------------------------------------------------
+
+/// R5-4: `prepare_instructions` creates `work_dir` at line 44 BEFORE
+/// fleet validation at line 62. When fleet.yaml is malformed, the directory
+/// has already been created despite the eventual refusal. A refused
+/// provisioning must not leave any side effects.
+///
+/// RED: FAILS because `create_dir_all(work_dir)` runs before fleet load.
+#[test]
+fn r5_absent_workdir_stays_absent_on_malformed_fleet() {
+    let home = tmp_home("r5-premutate");
+    let ws = home.join("workspace").join("agent");
+    assert!(!ws.exists(), "precondition: work_dir must be absent initially");
+
+    let fleet_path = crate::fleet::fleet_yaml_path(&home);
+    std::fs::write(&fleet_path, "{{invalid yaml!!").unwrap();
+
+    let result = crate::api::handlers::prepare_instructions(&home, "agent", "codex", &ws, None);
+
+    assert!(result.is_err(), "precondition: malformed fleet must refuse");
+    assert!(
+        !ws.exists(),
+        "R5-4: malformed fleet must not create work_dir. \
+         prepare_instructions creates the directory before fleet validation, \
+         leaving a side effect despite the refusal."
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+}
+
+// ---------------------------------------------------------------------------
+// R5-5 — Claude migration: exact NotFound vs opaque I/O
+// ---------------------------------------------------------------------------
+
+/// R5-5: `migrate_claude_old_rules_file` uses `old.exists()` to check
+/// before removal. On opaque I/O (parent not executable → exists() returns
+/// false), the migration is silently skipped instead of propagating the
+/// error.
+///
+/// RED: FAILS because `exists()` returns false for EACCES → skip → Ok.
+#[cfg(unix)]
+#[test]
+fn r5_claude_migration_opaque_io_propagates() {
+    let home = tmp_home("r5-migrate-opaque");
+    let ws = home.join("workspace").join("agent");
+    let rules_dir = ws.join(".claude").join("rules");
+    std::fs::create_dir_all(&rules_dir).unwrap();
+    std::fs::write(rules_dir.join("agend.md"), "old content").unwrap();
+
+    // Remove execute permission on the rules directory → cannot traverse →
+    // exists() returns false (EACCES), remove_file also fails (EACCES).
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(&rules_dir, std::fs::Permissions::from_mode(0o600)).unwrap();
+
+    // No fleet.yaml → NotFound fallback. Backend = "claude" triggers migrate.
+    let result = crate::api::handlers::prepare_instructions(&home, "agent", "claude", &ws, None);
+
+    // Restore for cleanup.
+    std::fs::set_permissions(&rules_dir, std::fs::Permissions::from_mode(0o755)).ok();
+
+    assert!(
+        result.is_err(),
+        "R5-5: Claude migration with opaque I/O (EACCES, not NotFound) must \
+         propagate the error, not silently skip via exists(). Got Ok."
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+}

--- a/src/mcp/handlers/r3_46776_red_tests.rs
+++ b/src/mcp/handlers/r3_46776_red_tests.rs
@@ -349,8 +349,8 @@ fn g5_handle_spawn_rejects_workspace_identity_collision() {
 /// unconditionally removes dirs under `$AGEND_HOME/worktrees/`. This destroys
 /// state that this attempt did NOT create.
 ///
-/// Setup: empty fleet (preflight passes), fleet.yaml made read-only so the
-/// write-back inside `mutate_fleet_yaml` fails → Err triggers rollback on the
+/// Setup: empty fleet (preflight passes), `fail_next_atomic_write_for_test`
+/// makes the fleet.yaml atomic write fail → Err triggers rollback on the
 /// pre-existing worktree dir.
 ///
 /// RED: FAILS because the rollback path has no provenance tracking — it
@@ -364,14 +364,10 @@ fn r4_admission_rollback_preserves_preexisting_worktree() {
 
     // Empty fleet → preflight collision check passes (no colliders).
     fleet_with_instances(&home, "instances: {}\n");
-    let fleet_path = crate::fleet::fleet_yaml_path(&home);
 
-    // Make fleet.yaml read-only → mutate_fleet_yaml write-back fails → Err.
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&fleet_path, std::fs::Permissions::from_mode(0o444)).unwrap();
-    }
+    // Force the fleet.yaml atomic write to fail → add_instance_to_yaml Err.
+    let fleet_path = crate::fleet::fleet_yaml_path(&home);
+    crate::store::fail_next_atomic_write_for_test(&fleet_path);
 
     let spawn_fn = |_h: &Path, _req: &serde_json::Value| -> anyhow::Result<serde_json::Value> {
         Ok(json!({"ok": true}))
@@ -387,13 +383,6 @@ fn r4_admission_rollback_preserves_preexisting_worktree() {
         }),
         &spawn_fn,
     );
-
-    // Restore permissions for cleanup.
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&fleet_path, std::fs::Permissions::from_mode(0o644)).ok();
-    }
 
     // The spawn must be refused (fleet.yaml write failure).
     assert!(

--- a/src/mcp/handlers/r3_46776_red_tests.rs
+++ b/src/mcp/handlers/r3_46776_red_tests.rs
@@ -1,0 +1,334 @@
+//! #46776 r3 RED tests — real-entry-point tests for the 6 findings from the
+//! dual-review rejection at 3d442d0a. Each test asserts the CORRECT
+//! (post-fix) behavior and FAILS at the current HEAD because the fix is
+//! not yet implemented. The GREEN commit makes them pass.
+//!
+//! G6 (test methodology) is satisfied by these tests themselves: real entry
+//! points, deterministic synchronization (barriers), NO sleeps.
+//!
+//! Sibling-file placement (same precedent as `instance_964_tests.rs`) to
+//! keep handler source files under the 750-LOC file_size_invariant.
+
+use serde_json::json;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use crate::agent;
+use crate::api::handlers::instance::handle_spawn;
+use crate::api::handlers::HandlerCtx;
+use parking_lot::Mutex;
+
+fn tmp_home(slug: &str) -> PathBuf {
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let id = SEQ.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!("agend-r3-{slug}-{}-{id}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn seed_agents_owned_by(dir: &Path, owner: &str) {
+    std::fs::write(
+        dir.join("AGENTS.md"),
+        format!("<!-- agend:start -->\n## Identity\n\n- **Name**: `{owner}`\n<!-- agend:end -->\n"),
+    )
+    .unwrap();
+}
+
+fn seed_agy_agents_owned_by(dir: &Path, owner: &str) {
+    let agy_dir = dir.join(".agents");
+    std::fs::create_dir_all(&agy_dir).unwrap();
+    std::fs::write(
+        agy_dir.join("AGENTS.md"),
+        format!("<!-- agend:start -->\n## Identity\n\n- **Name**: `{owner}`\n<!-- agend:end -->\n"),
+    )
+    .unwrap();
+}
+
+fn fleet_with_instances(home: &Path, yaml: &str) {
+    std::fs::write(crate::fleet::fleet_yaml_path(home), yaml).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// G1 — prepare_instructions contextless fallback on named managed paths
+// ---------------------------------------------------------------------------
+
+/// G1: When fleet.yaml load fails and no explicit role is given,
+/// `prepare_instructions` falls back to contextless `generate()` which skips
+/// the workspace-identity preflight. A named managed instance can then
+/// overwrite a foreign identity without any check.
+///
+/// RED: FAILS at 3d442d0a because `prepare_instructions` calls contextless
+/// `generate(work_dir, command)` on the Err(_) fallback path, which calls
+/// `generate_with_context(_, _, None)` — the None ctx skips
+/// `workspace_provision_preflight`.
+#[test]
+fn g1_prepare_instructions_contextless_fallback_refuses_foreign_identity() {
+    let home = tmp_home("g1-ctx");
+    let ws = home.join("workspace").join("new-agent");
+    std::fs::create_dir_all(&ws).unwrap();
+
+    seed_agents_owned_by(&ws, "existing-owner");
+
+    let result = crate::api::handlers::prepare_instructions(
+        &home,
+        "new-agent",
+        "codex",
+        &ws,
+        None, // no explicit role → Err(_) fallback to contextless generate()
+    );
+
+    assert!(
+        result.is_err(),
+        "G1: prepare_instructions must refuse to provision when the working dir \
+         has a foreign AGENTS.md identity, even on the contextless fallback path. \
+         Currently the contextless generate() skips the identity preflight. Got Ok."
+    );
+    let content = std::fs::read_to_string(ws.join("AGENTS.md")).unwrap();
+    assert!(
+        content.contains("existing-owner"),
+        "G1: the foreign AGENTS.md must not be overwritten. Content: {content}"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+}
+
+// ---------------------------------------------------------------------------
+// G2 — mutate_fleet_yaml opaque read error must fail-closed
+// ---------------------------------------------------------------------------
+
+/// G2: When fleet.yaml exists but is unreadable (opaque I/O error — not
+/// NotFound), `mutate_fleet_yaml` must return Err, NOT silently fall back to
+/// `default_content`. The current code uses `unwrap_or_else(|_| default)` which
+/// treats permission-denied the same as file-absent → data loss.
+///
+/// RED: This test FAILS at 3d442d0a because `mutate_fleet_yaml` succeeds
+/// despite the opaque read error, silently replacing the existing fleet with
+/// the default content.
+#[test]
+fn g2_mutate_fleet_yaml_opaque_read_refuses_not_defaults() {
+    let home = tmp_home("g2-opaque");
+    let fleet_path = crate::fleet::fleet_yaml_path(&home);
+    std::fs::write(
+        &fleet_path,
+        "instances:\n  existing-agent:\n    backend: claude\n",
+    )
+    .unwrap();
+
+    // Make fleet.yaml a directory to force an opaque read error (not NotFound).
+    std::fs::remove_file(&fleet_path).unwrap();
+    std::fs::create_dir_all(&fleet_path).unwrap();
+
+    let result =
+        crate::fleet::persist::mutate_fleet_yaml(&home, "instances: {}\n", |_doc| Ok(false));
+
+    assert!(
+        result.is_err(),
+        "G2: mutate_fleet_yaml must return Err on an opaque read error \
+         (not NotFound), not silently fall back to default_content. \
+         Data loss: the existing fleet would be replaced with an empty default."
+    );
+
+    std::fs::remove_dir_all(&fleet_path).ok();
+    std::fs::remove_dir_all(&home).ok();
+}
+
+// ---------------------------------------------------------------------------
+// G3 — spawn rollback must remove external branch worktree
+// ---------------------------------------------------------------------------
+
+/// G3: `cleanup_working_dir` must be able to clean dirs under
+/// `$AGEND_HOME/worktrees/` (external branch worktrees), not just under
+/// `$AGEND_HOME/workspace/`. When a spawn's `add_instance_to_yaml` fails
+/// (racing admission refusal), the rollback calls `cleanup_working_dir` on
+/// the worktree path, which currently does NOT remove it because it's outside
+/// `workspace/`.
+///
+/// RED: FAILS at 3d442d0a because `cleanup_working_dir` only removes dirs
+/// under `$AGEND_HOME/workspace/`; external worktrees leak.
+#[test]
+fn g3_cleanup_removes_external_branch_worktree_dir() {
+    let home = tmp_home("g3-wt-rollback");
+    fleet_with_instances(&home, "instances: {}\n");
+
+    let wt_path = crate::worktree::worktree_path(&home, "racer", "feat/test");
+    std::fs::create_dir_all(&wt_path).unwrap();
+    std::fs::write(wt_path.join("marker.txt"), "worktree content").unwrap();
+
+    let _conflict = crate::agent_ops::cleanup_working_dir(&home, "racer", &wt_path);
+
+    assert!(
+        !wt_path.exists(),
+        "G3: cleanup_working_dir must remove newly-created external worktree \
+         dirs (under $AGEND_HOME/worktrees/), not just workspace-local dirs. \
+         The worktree dir still exists at: {}",
+        wt_path.display()
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+}
+
+// ---------------------------------------------------------------------------
+// G4 — working_dir_ownership_conflict must check ALL backend identity paths
+// ---------------------------------------------------------------------------
+
+/// G4: The delete guard must detect a foreign identity in `.agents/AGENTS.md`
+/// (Agy backend's shared-instructions path), not just `AGENTS.md` and
+/// `.codex/config.toml`.
+///
+/// RED: FAILS at 3d442d0a because `working_dir_ownership_conflict` only
+/// checks `AGENTS.md` + `.codex/config.toml`.
+#[test]
+fn g4_ownership_conflict_detects_agy_agents_md_foreign_identity() {
+    let dir = tmp_home("g4-agy");
+    let ws = dir.join("workspace");
+    std::fs::create_dir_all(&ws).unwrap();
+
+    seed_agy_agents_owned_by(&ws, "owner-instance");
+
+    let conflict = crate::agent_ops::working_dir_ownership_conflict(&ws, "intruder-instance");
+
+    assert!(
+        conflict.is_some(),
+        "G4: working_dir_ownership_conflict must detect a foreign identity in \
+         .agents/AGENTS.md (Agy backend). Got None."
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// G4: `.grok/config.toml` with a foreign AGEND_INSTANCE_NAME stamp must also
+/// be detected. Currently only `.codex/config.toml` is checked.
+#[test]
+fn g4_ownership_conflict_detects_grok_config_foreign_identity() {
+    let dir = tmp_home("g4-grok");
+    let ws = dir.join("workspace");
+    let grok_dir = ws.join(".grok");
+    std::fs::create_dir_all(&grok_dir).unwrap();
+
+    std::fs::write(
+        grok_dir.join("config.toml"),
+        "# managed by agend\nAGEND_INSTANCE_NAME = \"owner-grok\"\n",
+    )
+    .unwrap();
+
+    let conflict = crate::agent_ops::working_dir_ownership_conflict(&ws, "intruder-grok");
+
+    assert!(
+        conflict.is_some(),
+        "G4: working_dir_ownership_conflict must detect a foreign identity in \
+         .grok/config.toml, not just .codex/config.toml. Got None."
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// G4 (real entry): `full_delete_instance` must refuse cleanup when the working
+/// directory has a foreign `.agents/AGENTS.md` (Agy backend).
+///
+/// RED: FAILS at 3d442d0a because `cleanup_working_dir` → `working_dir_ownership_conflict`
+/// misses `.agents/AGENTS.md`.
+#[test]
+fn g4_full_delete_refuses_agy_foreign_identity() {
+    let home = tmp_home("g4-del-agy");
+    let ws = home.join("workspace").join("victim");
+    std::fs::create_dir_all(&ws).unwrap();
+
+    fleet_with_instances(
+        &home,
+        &format!(
+            "instances:\n  victim:\n    backend: agy\n    working_directory: {}\n",
+            ws.display()
+        ),
+    );
+
+    seed_agy_agents_owned_by(&ws, "real-owner");
+
+    let result =
+        crate::mcp::handlers::instance_state::lifecycle::full_delete_instance(&home, "victim");
+
+    assert!(
+        result.is_err(),
+        "G4: full_delete_instance must report Err when the working dir has a \
+         foreign .agents/AGENTS.md — the tree must be preserved. Got Ok."
+    );
+    assert!(
+        ws.join(".agents").join("AGENTS.md").exists(),
+        "G4: the foreign Agy identity file must NOT be deleted"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+}
+
+// ---------------------------------------------------------------------------
+// G5 — handle_spawn runtime duplicate workspace admission
+// ---------------------------------------------------------------------------
+
+/// G5: `handle_spawn` (the daemon SPAWN RPC handler) must reject a spawn when
+/// the requested working directory collides with an EXISTING fleet entry's
+/// working directory. Currently it has NO workspace-identity collision check —
+/// `duplicate_identity_owner_before` is boot-only, and `handle_spawn` only
+/// checks name collision (external + registry), not workspace collision.
+///
+/// RED: FAILS at 3d442d0a because `handle_spawn` proceeds past name checks
+/// without any workspace-identity check. The error (if any) comes from a
+/// downstream spawn failure, not from a collision refusal.
+#[test]
+fn g5_handle_spawn_rejects_workspace_identity_collision() {
+    let home = Box::new(tmp_home("g5-dup-spawn"));
+    let shared_dir = home.join("workspace").join("shared");
+    std::fs::create_dir_all(&shared_dir).unwrap();
+
+    // Pre-register "alice" with the shared working directory.
+    fleet_with_instances(
+        &home,
+        &format!(
+            "instances:\n  alice:\n    backend: claude\n    working_directory: {}\n",
+            shared_dir.display()
+        ),
+    );
+
+    let registry: &'static agent::AgentRegistry =
+        Box::leak(Box::new(Arc::new(Mutex::new(HashMap::new()))));
+    let configs: &'static crate::api::ConfigRegistry =
+        Box::leak(Box::new(Arc::new(Mutex::new(HashMap::new()))));
+    let externals: &'static agent::ExternalRegistry =
+        Box::leak(Box::new(Arc::new(Mutex::new(HashMap::new()))));
+    let home_ref: &'static Path = Box::leak(home.clone());
+    let ctx = HandlerCtx {
+        registry,
+        configs,
+        externals,
+        notifier: None,
+        home: home_ref,
+        capability: crate::api::RestartCapability::Unsupported,
+        app_restart: None,
+        post_flush: crate::api::app_restart::PostFlushSlot::new(),
+    };
+
+    let resp = handle_spawn(
+        &json!({
+            "name": "bob",
+            "backend": "claude",
+            "working_directory": shared_dir.display().to_string()
+        }),
+        &ctx,
+    );
+
+    assert_eq!(
+        resp["ok"],
+        json!(false),
+        "G5: handle_spawn must reject a spawn whose working directory collides \
+         with an existing fleet entry: {resp:?}"
+    );
+    let error_msg = resp["error"].as_str().unwrap_or_default();
+    assert!(
+        error_msg.contains("collision") || error_msg.contains("workspace identity"),
+        "G5: the rejection must cite the workspace identity collision, not a \
+         downstream spawn failure. Got error: {error_msg}"
+    );
+
+    std::fs::remove_dir_all(home_ref).ok();
+}

--- a/src/mcp/handlers/r3_46776_red_tests.rs
+++ b/src/mcp/handlers/r3_46776_red_tests.rs
@@ -332,3 +332,226 @@ fn g5_handle_spawn_rejects_workspace_identity_collision() {
 
     std::fs::remove_dir_all(home_ref).ok();
 }
+
+// ===========================================================================
+// R4 RED tests — three new findings from the root review rejection at 9ea0a6f6.
+// Each test FAILS at the current HEAD because the fix is not yet implemented.
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// R4-1 — admission rollback must preserve pre-existing worktree content
+// ---------------------------------------------------------------------------
+
+/// R4-1: When `spawn_single_instance_impl` resolves `working_directory` to a
+/// pre-existing directory (a reused worktree or an occupied workspace) and the
+/// subsequent `add_instance_to_yaml` fails (fleet.yaml write failure in a race
+/// or I/O error), the rollback calls `cleanup_working_dir` which
+/// unconditionally removes dirs under `$AGEND_HOME/worktrees/`. This destroys
+/// state that this attempt did NOT create.
+///
+/// Setup: empty fleet (preflight passes), fleet.yaml made read-only so the
+/// write-back inside `mutate_fleet_yaml` fails → Err triggers rollback on the
+/// pre-existing worktree dir.
+///
+/// RED: FAILS because the rollback path has no provenance tracking — it
+/// removes the pre-existing worktree content via `cleanup_working_dir`.
+#[test]
+fn r4_admission_rollback_preserves_preexisting_worktree() {
+    let home = tmp_home("r4-wt-rollback");
+    let wt_path = crate::worktree::worktree_path(&home, "new-agent", "feat/work");
+    std::fs::create_dir_all(&wt_path).unwrap();
+    std::fs::write(wt_path.join("important.rs"), "// pre-existing content").unwrap();
+
+    // Empty fleet → preflight collision check passes (no colliders).
+    fleet_with_instances(&home, "instances: {}\n");
+    let fleet_path = crate::fleet::fleet_yaml_path(&home);
+
+    // Make fleet.yaml read-only → mutate_fleet_yaml write-back fails → Err.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&fleet_path, std::fs::Permissions::from_mode(0o444)).unwrap();
+    }
+
+    let spawn_fn = |_h: &Path, _req: &serde_json::Value| -> anyhow::Result<serde_json::Value> {
+        Ok(json!({"ok": true}))
+    };
+
+    let result = crate::mcp::handlers::instance_state::spawn::spawn_single_instance_impl(
+        &home,
+        "spawner",
+        &json!({
+            "name": "new-agent",
+            "backend": "claude",
+            "working_directory": wt_path.display().to_string()
+        }),
+        &spawn_fn,
+    );
+
+    // Restore permissions for cleanup.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&fleet_path, std::fs::Permissions::from_mode(0o644)).ok();
+    }
+
+    // The spawn must be refused (fleet.yaml write failure).
+    assert!(
+        result.get("error").is_some(),
+        "R4-1 precondition: admission must be refused due to fleet.yaml write failure. Got: {result}"
+    );
+
+    // The pre-existing content MUST survive the rollback.
+    assert!(
+        wt_path.join("important.rs").exists(),
+        "R4-1: pre-existing worktree content must survive admission rollback. \
+         cleanup_working_dir must not destroy state it did not create."
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+}
+
+// ---------------------------------------------------------------------------
+// R4-2 — unreadable/malformed fleet must fail-closed on collision & boot
+// ---------------------------------------------------------------------------
+
+/// R4-2a: When fleet.yaml is unreadable (opaque I/O error, not NotFound),
+/// `workspace_identity_collision` must refuse (return Some), not silently pass
+/// the collision check (return None). `load_instances_mapping` currently
+/// converts ALL errors to an empty mapping → "no collision" → fail-open.
+///
+/// RED: FAILS because `load_instances_mapping` returns empty on read error,
+/// and `workspace_identity_collision` finds no collision in the empty mapping.
+#[test]
+fn r4_unreadable_fleet_refuses_runtime_collision() {
+    let home = tmp_home("r4-fleet-unreadable");
+    let fleet_path = crate::fleet::fleet_yaml_path(&home);
+    // Make fleet.yaml a directory → opaque read error (IsADirectory), not NotFound.
+    std::fs::create_dir_all(&fleet_path).unwrap();
+
+    let result = crate::fleet::persist::workspace_identity_collision(
+        &home,
+        "any-instance",
+        &home.join("workspace").join("any-instance"),
+    );
+
+    assert!(
+        result.is_some(),
+        "R4-2a: unreadable fleet.yaml must refuse collision check (fail-closed), \
+         not silently pass as 'no collision'. Got None."
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// R4-2b: When fleet.yaml is unreadable, `duplicate_identity_owner_before`
+/// must also refuse (return Some), not pass the boot admission check.
+///
+/// RED: FAILS for the same reason — `load_instances_mapping` returns empty.
+#[test]
+fn r4_unreadable_fleet_refuses_boot_admission() {
+    let home = tmp_home("r4-fleet-boot");
+    let fleet_path = crate::fleet::fleet_yaml_path(&home);
+    std::fs::create_dir_all(&fleet_path).unwrap();
+
+    let result = crate::fleet::persist::duplicate_identity_owner_before(
+        &home,
+        "any-instance",
+        &home.join("workspace").join("any-instance"),
+    );
+
+    assert!(
+        result.is_some(),
+        "R4-2b: unreadable fleet.yaml must refuse boot admission (fail-closed), \
+         not silently pass. Got None."
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// R4-2c: When fleet.yaml is malformed (parse error, not NotFound),
+/// `prepare_instructions` must refuse, not fall back to contextless
+/// provisioning. The `Err(_)` catch-all currently treats parse errors
+/// the same as file-absent.
+///
+/// RED: FAILS because `prepare_instructions` proceeds with provisioning
+/// despite the malformed fleet.yaml.
+#[test]
+fn r4_malformed_fleet_refuses_prepare_instructions() {
+    let home = tmp_home("r4-fleet-malformed");
+    let ws = home.join("workspace").join("agent");
+    std::fs::create_dir_all(&ws).unwrap();
+
+    let fleet_path = crate::fleet::fleet_yaml_path(&home);
+    std::fs::write(&fleet_path, "{{{{invalid yaml nonsense!!!!").unwrap();
+
+    let result = crate::api::handlers::prepare_instructions(&home, "agent", "codex", &ws, None);
+
+    assert!(
+        result.is_err(),
+        "R4-2c: malformed fleet.yaml must refuse prepare_instructions, \
+         not fall back to contextless provisioning. Got Ok."
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+}
+
+// ---------------------------------------------------------------------------
+// R4-3 — ensure_project_root / migrate failures must propagate
+// ---------------------------------------------------------------------------
+
+/// R4-3a: When `ensure_project_root` fails (git init failure because .git is
+/// an invalid regular file), the error must propagate through
+/// `generate_with_context` to `prepare_instructions`. Currently
+/// `ensure_project_root` returns `()` and discards all errors.
+///
+/// RED: FAILS because `ensure_project_root` silently swallows the git init
+/// failure and `generate_with_context` proceeds as if setup succeeded.
+#[test]
+fn r4_ensure_project_root_failure_propagates() {
+    let home = tmp_home("r4-projroot");
+    let ws = home.join("workspace").join("agent");
+    std::fs::create_dir_all(&ws).unwrap();
+
+    // Create an invalid .git file → `git init` will fail because .git already
+    // exists as a regular file with invalid gitlink content.
+    std::fs::write(ws.join(".git"), "invalid content — not a valid gitlink").unwrap();
+
+    // No fleet.yaml → NotFound fallback (legitimate), reaches generate_with_context.
+    let result = crate::api::handlers::prepare_instructions(&home, "agent", "codex", &ws, None);
+
+    assert!(
+        result.is_err(),
+        "R4-3a: ensure_project_root git-init failure must propagate through \
+         generate_with_context to prepare_instructions. Provisioning cannot \
+         report success when ownership/scope setup failed. Got Ok."
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// R4-3b: When `migrate_claude_old_rules_file` fails (old file is a
+/// directory, so `remove_file` errors), the error must propagate. Currently
+/// `let _ = std::fs::remove_file(...)` silently discards the error.
+///
+/// RED: FAILS because `migrate_claude_old_rules_file` uses `let _ =` to
+/// discard the remove_file error.
+#[test]
+fn r4_migrate_claude_old_rules_failure_propagates() {
+    let home = tmp_home("r4-migrate");
+    let ws = home.join("workspace").join("agent");
+    let old_rules = ws.join(".claude").join("rules").join("agend.md");
+    // Make agend.md a directory → `remove_file` will fail (IsADirectory).
+    std::fs::create_dir_all(&old_rules).unwrap();
+
+    // No fleet.yaml → NotFound fallback. Backend = "claude" triggers migrate.
+    let result = crate::api::handlers::prepare_instructions(&home, "agent", "claude", &ws, None);
+
+    assert!(
+        result.is_err(),
+        "R4-3b: migrate_claude_old_rules_file remove_file failure must propagate. \
+         Stale rules file left behind corrupts agent instructions. Got Ok."
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+}

--- a/src/mcp/handlers/r3_46776_red_tests.rs
+++ b/src/mcp/handlers/r3_46776_red_tests.rs
@@ -763,3 +763,148 @@ fn r5_claude_migration_opaque_io_propagates() {
 
     std::fs::remove_dir_all(&home).ok();
 }
+
+// ---------------------------------------------------------------------------
+// R6 — managed app / connect contextless provision + opaque config reads
+// ---------------------------------------------------------------------------
+
+/// R6-1: `configure_codex_with_home` (via `mcp_config::configure`) with invalid
+/// UTF-8 in `.codex/config.toml` must refuse and preserve bytes.
+///
+/// Currently: `read_to_string().unwrap_or_default()` silently discards the
+/// opaque read error, yielding an empty config with `Absent` identity, which
+/// the function adopts and overwrites. The fix replaces `unwrap_or_default()`
+/// with explicit `NotFound`-only empty and propagation of all other I/O.
+///
+/// RED: FAILS because `unwrap_or_default` swallows invalid UTF-8 and the
+/// function succeeds, overwriting the bytes.
+#[test]
+fn r6_configure_codex_opaque_read_must_refuse_and_preserve() {
+    let dir = tmp_home("r6-codex-utf8");
+    let codex_dir = dir.join(".codex");
+    std::fs::create_dir_all(&codex_dir).unwrap();
+    let config_path = codex_dir.join("config.toml");
+    let invalid_bytes: &[u8] = &[0xFF, 0xFE, 0x80, 0x81];
+    std::fs::write(&config_path, invalid_bytes).unwrap();
+
+    let result = crate::mcp_config::configure(&dir, "codex", Some("alice"));
+
+    assert!(
+        result.is_err(),
+        "R6-1: configure_codex with invalid UTF-8 config.toml must refuse \
+         (opaque read → fail-closed). Got Ok — unwrap_or_default swallowed the error."
+    );
+    assert_eq!(
+        std::fs::read(&config_path).unwrap(),
+        invalid_bytes,
+        "R6-1: invalid UTF-8 bytes must be preserved byte-for-byte"
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// R6-2: `configure_grok_with_home` (via `mcp_config::configure`) with invalid
+/// UTF-8 in `.grok/config.toml` must refuse and preserve bytes.
+///
+/// Same defect as R6-1 but in the Grok writer path.
+///
+/// RED: FAILS because `unwrap_or_default` swallows the error.
+#[test]
+fn r6_configure_grok_opaque_read_must_refuse_and_preserve() {
+    let dir = tmp_home("r6-grok-utf8");
+    let grok_dir = dir.join(".grok");
+    std::fs::create_dir_all(&grok_dir).unwrap();
+    let config_path = grok_dir.join("config.toml");
+    let invalid_bytes: &[u8] = &[0xFF, 0xFE, 0x80, 0x81];
+    std::fs::write(&config_path, invalid_bytes).unwrap();
+
+    let result = crate::mcp_config::configure(&dir, "grok", Some("alice"));
+
+    assert!(
+        result.is_err(),
+        "R6-2: configure_grok with invalid UTF-8 config.toml must refuse \
+         (opaque read → fail-closed). Got Ok — unwrap_or_default swallowed the error."
+    );
+    assert_eq!(
+        std::fs::read(&config_path).unwrap(),
+        invalid_bytes,
+        "R6-2: invalid UTF-8 bytes must be preserved byte-for-byte"
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// R6-3: `instructions::generate` (contextless, the path used by managed-pane
+/// `spawn_and_subscribe` and `connect::run`) with a foreign `.codex/config.toml`
+/// must refuse and preserve foreign bytes.
+///
+/// `generate(wd, cmd)` delegates to `generate_with_context(wd, cmd, None)`.
+/// When `ctx` is `None`: (a) `workspace_provision_preflight` is skipped, and
+/// (b) `mcp_config::configure` receives `instance_name=None`, skipping the
+/// ownership check in `configure_codex_with_home`. A foreign config is silently
+/// overwritten. The managed-pane and connect code paths call this exact
+/// function, so this test proves those paths are broken.
+///
+/// RED: FAILS because contextless provision overwrites foreign bytes.
+#[test]
+fn r6_contextless_provision_overwrites_foreign_codex() {
+    let dir = tmp_home("r6-ctxless-codex");
+    let ws = dir.join("workspace").join("agent");
+    std::fs::create_dir_all(&ws).unwrap();
+    let codex_dir = ws.join(".codex");
+    std::fs::create_dir_all(&codex_dir).unwrap();
+    let config_path = codex_dir.join("config.toml");
+    let foreign = "[mcp_servers.agend-terminal]\ncommand = 'x'\nargs = []\n\n\
+                   [mcp_servers.agend-terminal.env]\nAGEND_HOME = '/h'\n\
+                   AGEND_INSTANCE_NAME = 'bob'\n";
+    std::fs::write(&config_path, foreign).unwrap();
+
+    let result = crate::instructions::generate(&ws, "codex");
+
+    assert!(
+        result.is_err(),
+        "R6-3: contextless generate with foreign .codex/config.toml must refuse. \
+         Got Ok — ctx=None skips preflight and identity check, overwriting foreign bytes. \
+         This is the managed-pane (spawn_and_subscribe) and connect (run) vulnerability."
+    );
+    assert_eq!(
+        std::fs::read_to_string(&config_path).unwrap(),
+        foreign,
+        "R6-3: foreign .codex/config.toml bytes must be preserved"
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// R6-4: `instructions::generate` (contextless) with a foreign `.grok/config.toml`
+/// must refuse and preserve foreign bytes. Same gap as R6-3 for the Grok writer.
+///
+/// RED: FAILS because contextless provision skips ownership check.
+#[test]
+fn r6_contextless_provision_overwrites_foreign_grok() {
+    let dir = tmp_home("r6-ctxless-grok");
+    let ws = dir.join("workspace").join("agent");
+    std::fs::create_dir_all(&ws).unwrap();
+    let grok_dir = ws.join(".grok");
+    std::fs::create_dir_all(&grok_dir).unwrap();
+    let config_path = grok_dir.join("config.toml");
+    let foreign = "[mcp_servers.agend-terminal]\ncommand = 'x'\nargs = []\n\n\
+                   [mcp_servers.agend-terminal.env]\nAGEND_HOME = '/h'\n\
+                   AGEND_INSTANCE_NAME = 'bob'\n";
+    std::fs::write(&config_path, foreign).unwrap();
+
+    let result = crate::instructions::generate(&ws, "grok");
+
+    assert!(
+        result.is_err(),
+        "R6-4: contextless generate with foreign .grok/config.toml must refuse. \
+         Got Ok — ctx=None skips preflight and identity check, overwriting foreign bytes."
+    );
+    assert_eq!(
+        std::fs::read_to_string(&config_path).unwrap(),
+        foreign,
+        "R6-4: foreign .grok/config.toml bytes must be preserved"
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}

--- a/src/mcp/handlers/r3_46776_red_tests.rs
+++ b/src/mcp/handlers/r3_46776_red_tests.rs
@@ -576,9 +576,14 @@ fn r5_branch_worktree_created_by_attempt_cleaned_on_rollback() {
         .success());
     assert!(std::process::Command::new("git")
         .args([
-            "-c", "user.name=test",
-            "-c", "user.email=test@test",
-            "commit", "--allow-empty", "-m", "init",
+            "-c",
+            "user.name=test",
+            "-c",
+            "user.email=test@test",
+            "commit",
+            "--allow-empty",
+            "-m",
+            "init",
         ])
         .current_dir(&repo)
         .status()
@@ -591,7 +596,10 @@ fn r5_branch_worktree_created_by_attempt_cleaned_on_rollback() {
     crate::store::fail_next_atomic_write_for_test(&fleet_path);
 
     let wt_path = crate::worktree::worktree_path(&home, "new-agent", "feat/test");
-    assert!(!wt_path.exists(), "precondition: worktree dir must not exist yet");
+    assert!(
+        !wt_path.exists(),
+        "precondition: worktree dir must not exist yet"
+    );
 
     let spawn_fn = |_h: &Path, _req: &serde_json::Value| -> anyhow::Result<serde_json::Value> {
         Ok(json!({"ok": true}))
@@ -692,7 +700,10 @@ fn r5_wrong_shape_instances_refuses_boot() {
 fn r5_absent_workdir_stays_absent_on_malformed_fleet() {
     let home = tmp_home("r5-premutate");
     let ws = home.join("workspace").join("agent");
-    assert!(!ws.exists(), "precondition: work_dir must be absent initially");
+    assert!(
+        !ws.exists(),
+        "precondition: work_dir must be absent initially"
+    );
 
     let fleet_path = crate::fleet::fleet_yaml_path(&home);
     std::fs::write(&fleet_path, "{{invalid yaml!!").unwrap();

--- a/src/mcp/handlers/r3_46776_red_tests.rs
+++ b/src/mcp/handlers/r3_46776_red_tests.rs
@@ -571,6 +571,8 @@ fn r5_branch_worktree_created_by_attempt_cleaned_on_rollback() {
     assert!(std::process::Command::new("git")
         .args(["init", "--quiet"])
         .current_dir(&repo)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
         .status()
         .unwrap()
         .success());
@@ -586,6 +588,8 @@ fn r5_branch_worktree_created_by_attempt_cleaned_on_rollback() {
             "init",
         ])
         .current_dir(&repo)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
         .status()
         .unwrap()
         .success());

--- a/src/mcp/handlers/tests.rs
+++ b/src/mcp/handlers/tests.rs
@@ -166,7 +166,7 @@ fn cleanup_agend_workspace_removes_entire_dir() {
     std::fs::write(ws.join("somefile.txt"), "data").ok();
     std::fs::write(ws.join("opencode.json"), "{}").ok();
 
-    cleanup_working_dir(&home, "test-agent", &ws);
+    let _ = cleanup_working_dir(&home, "test-agent", &ws);
     assert!(!ws.exists(), "workspace dir should be fully removed");
     std::fs::remove_dir_all(&home).ok();
 }
@@ -183,7 +183,7 @@ fn cleanup_user_dir_only_removes_agend_files() {
     std::fs::create_dir_all(user_dir.join(".claude")).ok();
     std::fs::write(user_dir.join(".claude/settings.local.json"), "{}").ok();
 
-    cleanup_working_dir(&home, "agent1", &user_dir);
+    let _ = cleanup_working_dir(&home, "agent1", &user_dir);
 
     // User file preserved
     assert!(user_dir.join("main.rs").exists(), "user file must survive");
@@ -205,7 +205,7 @@ fn cleanup_removes_metadata() {
     std::fs::create_dir_all(home.join("metadata")).ok();
     std::fs::write(home.join("metadata/agent1.json"), "{}").ok();
 
-    cleanup_working_dir(&home, "agent1", &ws);
+    let _ = cleanup_working_dir(&home, "agent1", &ws);
 
     assert!(!home.join("metadata/agent1.json").exists());
     std::fs::remove_dir_all(&home).ok();

--- a/src/mcp_config.rs
+++ b/src/mcp_config.rs
@@ -755,26 +755,49 @@ fn configure_codex_with_home(
     // strip→append cycles on the same config.toml.
     let _lock = crate::store::acquire_file_lock(&config_lock_path(&config_path))?;
 
-    // Re-read under the lock. Any existing agend-terminal block is stripped
-    // before we write a fresh one — otherwise a stale binary path from a
-    // prior build (e.g. a worktree that has since been removed) would
-    // silently persist and fail at codex MCP startup with ENOENT.
-    let existing = std::fs::read_to_string(&config_path).unwrap_or_default();
+    // Re-read under the lock. NotFound → empty (first provision); any other
+    // I/O error (invalid UTF-8, EACCES, EISDIR) → fail-closed, preserving
+    // the opaque bytes instead of silently replacing them.
+    let existing = match std::fs::read_to_string(&config_path) {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(e) => {
+            anyhow::bail!(
+                "config read {}: {e} — refusing to overwrite opaque file",
+                config_path.display()
+            );
+        }
+    };
 
     // Workspace-identity guard (fail-closed): refuse to overwrite a config.toml
     // that is stamped for a DIFFERENT instance (or is corrupt). The incident was
     // a last-writer-wins rewrite of a colliding directory's `.codex/config.toml`;
     // this preserves the foreign bytes and errors instead. Absent stamp → adopt.
-    if let Some(cand) = instance_name {
-        if let Some(reason) = codex_config_owner(&existing).conflict_with(cand) {
-            tracing::error!(
-                path = %config_path.display(), instance = %cand, %reason,
-                "provision refused: .codex/config.toml — bytes preserved"
-            );
-            anyhow::bail!(
-                "workspace identity: {} {reason}, refusing to overwrite for '{cand}'",
-                config_path.display()
-            );
+    let identity = codex_config_owner(&existing);
+    match instance_name {
+        Some(cand) => {
+            if let Some(reason) = identity.conflict_with(cand) {
+                tracing::error!(
+                    path = %config_path.display(), instance = %cand, %reason,
+                    "provision refused: .codex/config.toml — bytes preserved"
+                );
+                anyhow::bail!(
+                    "workspace identity: {} {reason}, refusing to overwrite for '{cand}'",
+                    config_path.display()
+                );
+            }
+        }
+        None => {
+            if matches!(
+                identity,
+                crate::paths::DirIdentity::Owner(_) | crate::paths::DirIdentity::Corrupt
+            ) {
+                anyhow::bail!(
+                    "workspace identity: {} has an existing identity stamp but no instance \
+                     name was provided to verify ownership — refusing contextless overwrite",
+                    config_path.display()
+                );
+            }
         }
     }
 
@@ -899,19 +922,43 @@ fn configure_grok_with_home(
 
     let _lock = crate::store::acquire_file_lock(&config_lock_path(&config_path))?;
 
-    let existing = std::fs::read_to_string(&config_path).unwrap_or_default();
-    // Workspace-identity guard (fail-closed), same contract as Codex: refuse to
-    // overwrite a config stamped for a different instance (bytes preserved).
-    if let Some(cand) = instance_name {
-        if let Some(reason) = codex_config_owner(&existing).conflict_with(cand) {
-            tracing::error!(
-                path = %config_path.display(), instance = %cand, %reason,
-                "provision refused: .grok/config.toml — bytes preserved"
-            );
+    let existing = match std::fs::read_to_string(&config_path) {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(e) => {
             anyhow::bail!(
-                "workspace identity: {} {reason}, refusing to overwrite for '{cand}'",
+                "config read {}: {e} — refusing to overwrite opaque file",
                 config_path.display()
             );
+        }
+    };
+    // Workspace-identity guard (fail-closed), same contract as Codex: refuse to
+    // overwrite a config stamped for a different instance (bytes preserved).
+    let identity = codex_config_owner(&existing);
+    match instance_name {
+        Some(cand) => {
+            if let Some(reason) = identity.conflict_with(cand) {
+                tracing::error!(
+                    path = %config_path.display(), instance = %cand, %reason,
+                    "provision refused: .grok/config.toml — bytes preserved"
+                );
+                anyhow::bail!(
+                    "workspace identity: {} {reason}, refusing to overwrite for '{cand}'",
+                    config_path.display()
+                );
+            }
+        }
+        None => {
+            if matches!(
+                identity,
+                crate::paths::DirIdentity::Owner(_) | crate::paths::DirIdentity::Corrupt
+            ) {
+                anyhow::bail!(
+                    "workspace identity: {} has an existing identity stamp but no instance \
+                     name was provided to verify ownership — refusing contextless overwrite",
+                    config_path.display()
+                );
+            }
         }
     }
     // Reuse the same section headers as Codex — Grok's native schema is also

--- a/src/mcp_config.rs
+++ b/src/mcp_config.rs
@@ -709,6 +709,14 @@ pub(crate) fn codex_config_owner(existing: &str) -> crate::paths::DirIdentity {
     }
 }
 
+/// Fail-closed identity read of a codex/grok `config.toml` at `path`: a genuine
+/// `NotFound` is [`DirIdentity::Absent`] (adoptable); any OTHER I/O failure is
+/// [`DirIdentity::Unreadable`] (a conflict). A readable file is parsed by
+/// [`codex_config_owner`].
+pub(crate) fn codex_config_identity(path: &Path) -> crate::paths::DirIdentity {
+    crate::paths::classify_identity_read(std::fs::read_to_string(path), codex_config_owner)
+}
+
 /// Decode a single-line TOML string value (the inverse of [`toml_string_value`]):
 /// a single-quoted literal is taken verbatim; a double-quoted basic string has
 /// its `\\` and `\"` escapes unwound. Returns `None` for any other shape.

--- a/src/mcp_config.rs
+++ b/src/mcp_config.rs
@@ -683,6 +683,46 @@ fn configure_opencode(working_dir: &Path, instance_name: Option<&str>) -> Result
 const CODEX_MCP_HEADER: &str = "[mcp_servers.agend-terminal]";
 const CODEX_MCP_ENV_HEADER: &str = "[mcp_servers.agend-terminal.env]";
 
+/// Read the owning instance stamped as `AGEND_INSTANCE_NAME` in an existing
+/// `.codex/config.toml` (or grok config). The workspace-identity guard uses
+/// this to refuse overwriting a config that belongs to a DIFFERENT instance.
+///
+/// - [`DirIdentity::Absent`] — no `AGEND_INSTANCE_NAME` stamp (unowned → adoptable).
+/// - [`DirIdentity::Owner`] — the recorded owner (the raw instance name).
+/// - [`DirIdentity::Corrupt`] — a stamp line is present but its value is unparseable.
+pub(crate) fn codex_config_owner(existing: &str) -> crate::paths::DirIdentity {
+    use crate::paths::DirIdentity;
+    let Some(line) = existing
+        .lines()
+        .map(str::trim)
+        .find(|l| l.starts_with("AGEND_INSTANCE_NAME"))
+    else {
+        return DirIdentity::Absent;
+    };
+    match line
+        .split_once('=')
+        .map(|(_, v)| v.trim())
+        .and_then(decode_toml_string)
+    {
+        Some(name) if !name.is_empty() => DirIdentity::Owner(name),
+        _ => DirIdentity::Corrupt,
+    }
+}
+
+/// Decode a single-line TOML string value (the inverse of [`toml_string_value`]):
+/// a single-quoted literal is taken verbatim; a double-quoted basic string has
+/// its `\\` and `\"` escapes unwound. Returns `None` for any other shape.
+fn decode_toml_string(v: &str) -> Option<String> {
+    let v = v.trim();
+    if let Some(inner) = v.strip_prefix('\'').and_then(|s| s.strip_suffix('\'')) {
+        return Some(inner.to_string());
+    }
+    if let Some(inner) = v.strip_prefix('"').and_then(|s| s.strip_suffix('"')) {
+        return Some(inner.replace("\\\"", "\"").replace("\\\\", "\\"));
+    }
+    None
+}
+
 fn configure_codex(working_dir: &Path, instance_name: Option<&str>) -> Result<()> {
     configure_codex_with_home(working_dir, &home_path(), instance_name)
 }
@@ -712,6 +752,24 @@ fn configure_codex_with_home(
     // prior build (e.g. a worktree that has since been removed) would
     // silently persist and fail at codex MCP startup with ENOENT.
     let existing = std::fs::read_to_string(&config_path).unwrap_or_default();
+
+    // Workspace-identity guard (fail-closed): refuse to overwrite a config.toml
+    // that is stamped for a DIFFERENT instance (or is corrupt). The incident was
+    // a last-writer-wins rewrite of a colliding directory's `.codex/config.toml`;
+    // this preserves the foreign bytes and errors instead. Absent stamp → adopt.
+    if let Some(cand) = instance_name {
+        if let Some(reason) = codex_config_owner(&existing).conflict_with(cand) {
+            tracing::error!(
+                path = %config_path.display(), instance = %cand, %reason,
+                "provision refused: .codex/config.toml — bytes preserved"
+            );
+            anyhow::bail!(
+                "workspace identity: {} {reason}, refusing to overwrite for '{cand}'",
+                config_path.display()
+            );
+        }
+    }
+
     let mut stripped = strip_agend_mcp_sections(&existing);
     // Normalize to exactly one trailing newline on non-empty content so the
     // next `\n` we emit produces a single blank-line separator.
@@ -834,6 +892,20 @@ fn configure_grok_with_home(
     let _lock = crate::store::acquire_file_lock(&config_lock_path(&config_path))?;
 
     let existing = std::fs::read_to_string(&config_path).unwrap_or_default();
+    // Workspace-identity guard (fail-closed), same contract as Codex: refuse to
+    // overwrite a config stamped for a different instance (bytes preserved).
+    if let Some(cand) = instance_name {
+        if let Some(reason) = codex_config_owner(&existing).conflict_with(cand) {
+            tracing::error!(
+                path = %config_path.display(), instance = %cand, %reason,
+                "provision refused: .grok/config.toml — bytes preserved"
+            );
+            anyhow::bail!(
+                "workspace identity: {} {reason}, refusing to overwrite for '{cand}'",
+                config_path.display()
+            );
+        }
+    }
     // Reuse the same section headers as Codex — Grok's native schema is also
     // `[mcp_servers.<name>]` (+ optional `.env` subtable).
     let mut stripped = strip_agend_mcp_sections(&existing);
@@ -925,6 +997,60 @@ mod tests {
         ));
         std::fs::create_dir_all(&dir).ok();
         dir
+    }
+
+    // --- workspace-identity provision guard (boundary 2, .codex/config.toml) ---
+
+    #[test]
+    fn codex_config_owner_absent_owner_and_corrupt() {
+        use crate::paths::DirIdentity;
+        assert_eq!(codex_config_owner("command = 'x'\n"), DirIdentity::Absent);
+        assert_eq!(
+            codex_config_owner("AGEND_INSTANCE_NAME = 'bob'\n"),
+            DirIdentity::Owner("bob".to_string())
+        );
+        assert_eq!(
+            codex_config_owner("AGEND_INSTANCE_NAME = \"bob\"\n"),
+            DirIdentity::Owner("bob".to_string())
+        );
+        assert_eq!(
+            codex_config_owner("AGEND_INSTANCE_NAME =\n"),
+            DirIdentity::Corrupt
+        );
+    }
+
+    #[test]
+    fn configure_codex_refuses_foreign_stamp_byte_preserving() {
+        let dir = tmp_dir("codex_foreign");
+        let codex_dir = dir.join(".codex");
+        std::fs::create_dir_all(&codex_dir).unwrap();
+        let path = codex_dir.join("config.toml");
+        let foreign = "[mcp_servers.agend-terminal]\ncommand = 'x'\nargs = []\n\n[mcp_servers.agend-terminal.env]\nAGEND_HOME = '/h'\nAGEND_INSTANCE_NAME = 'bob'\n";
+        std::fs::write(&path, foreign).unwrap();
+        let res = configure_codex_with_home(&dir, "/fake/home", Some("alice"));
+        assert!(res.is_err(), "foreign .codex stamp must refuse");
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            foreign,
+            "foreign bytes preserved"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn configure_codex_adopts_absent_and_same_owner() {
+        use crate::paths::DirIdentity;
+        let dir = tmp_dir("codex_same");
+        // Absent stamp → adopt.
+        configure_codex_with_home(&dir, "/fake/home", Some("alice")).expect("adopt absent");
+        let path = dir.join(".codex").join("config.toml");
+        assert_eq!(
+            codex_config_owner(&std::fs::read_to_string(&path).unwrap()),
+            DirIdentity::Owner("alice".to_string())
+        );
+        // Same owner → refresh Ok.
+        configure_codex_with_home(&dir, "/fake/home", Some("alice")).expect("refresh same");
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]

--- a/src/mcp_config.rs
+++ b/src/mcp_config.rs
@@ -961,9 +961,15 @@ AGEND_HOME = {home_lit}
 }
 
 /// Detect backend from command name and configure MCP.
-pub fn configure(working_dir: &Path, command: &str, instance_name: Option<&str>) {
-    let backend = crate::backend::Backend::from_command(command);
-    let result = match backend {
+pub fn configure(
+    working_dir: &Path,
+    command: &str,
+    instance_name: Option<&str>,
+) -> anyhow::Result<()> {
+    // Propagate any backend configure error to the caller (generate_with_context)
+    // so a provisioning failure ABORTS the spawn instead of being logged and
+    // discarded — the discard let an agent start against half-written config.
+    match crate::backend::Backend::from_command(command) {
         Some(crate::backend::Backend::ClaudeCode) => configure_claude(working_dir, instance_name),
         Some(crate::backend::Backend::KiroCli) => configure_kiro(working_dir, instance_name),
         Some(crate::backend::Backend::Agy) => configure_agy(working_dir, instance_name),
@@ -972,12 +978,8 @@ pub fn configure(working_dir: &Path, command: &str, instance_name: Option<&str>)
         Some(crate::backend::Backend::Grok) => configure_grok(working_dir, instance_name),
         // Non-preset backends (Shell, Raw) have no MCP wiring.
         Some(crate::backend::Backend::Shell) | Some(crate::backend::Backend::Raw(_)) | None => {
-            return
+            Ok(())
         }
-    };
-
-    if let Err(e) = result {
-        tracing::warn!(error = %e, "failed to configure MCP");
     }
 }
 
@@ -1025,6 +1027,21 @@ mod tests {
             codex_config_owner("AGEND_INSTANCE_NAME =\n"),
             DirIdentity::Corrupt
         );
+    }
+
+    #[test]
+    fn codex_config_identity_unreadable_on_invalid_utf8_but_notfound_is_absent() {
+        use crate::paths::DirIdentity;
+        let dir = tmp_dir("codex_unreadable");
+        let path = dir.join("config.toml");
+        std::fs::write(&path, [0xFFu8, 0xFE]).unwrap(); // invalid UTF-8
+                                                        // Opaque read error → fail-closed Unreadable, not Absent.
+        assert_eq!(codex_config_identity(&path), DirIdentity::Unreadable);
+        assert_eq!(
+            codex_config_identity(&dir.join("missing.toml")),
+            DirIdentity::Absent
+        );
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]
@@ -1338,7 +1355,7 @@ mod tests {
     #[test]
     fn configure_dispatches_opencode() {
         let dir = tmp_dir("dispatch_oc");
-        configure(&dir, "opencode", None);
+        configure(&dir, "opencode", None).expect("provision");
         assert!(dir.join("opencode.json").exists());
         std::fs::remove_dir_all(&dir).ok();
     }
@@ -1397,7 +1414,7 @@ mod tests {
     #[test]
     fn configure_dispatches_agy_writes_agents_mcp() {
         let dir = tmp_dir("dispatch_agy");
-        configure(&dir, "agy", Some("agy-1"));
+        configure(&dir, "agy", Some("agy-1")).expect("provision");
 
         let cfg = dir.join(".agents").join("mcp_config.json");
         assert!(
@@ -1436,7 +1453,7 @@ mod tests {
     #[test]
     fn configure_unknown_backend_no_crash() {
         let dir = tmp_dir("dispatch_unknown");
-        configure(&dir, "unknown-tool", None);
+        configure(&dir, "unknown-tool", None).expect("provision");
         // Should not create any config files
         assert!(!dir.join("opencode.json").exists());
         assert!(!dir.join(".gemini").exists());

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -73,22 +73,31 @@ pub fn workspace_identity(path: &Path) -> String {
 /// directory. The fail-closed workspace-identity guards read this before a
 /// provision write or a delete cleanup so neither ever clobbers a directory
 /// that belongs to a DIFFERENT instance (the split-brain the incident caused).
+///
+/// The read layer distinguishes a genuine `NotFound` (→ [`DirIdentity::Absent`],
+/// adoptable) from any OTHER I/O failure — permission denied, invalid UTF-8, a
+/// directory where a file is expected — which becomes [`DirIdentity::Unreadable`]
+/// and is treated as a conflict (fail-closed: we must NOT overwrite or delete a
+/// directory whose identity we could not verify).
 #[derive(Debug, PartialEq, Eq)]
 pub enum DirIdentity {
-    /// No identity artifact present → unowned / legacy → adoptable.
+    /// The artifact is genuinely `NotFound` → unowned / legacy → adoptable.
     Absent,
     /// The recorded owning instance name.
     Owner(String),
     /// An artifact is present but its identity is unparseable → corrupt.
     Corrupt,
+    /// The artifact exists but could not be read (opaque I/O error) → we cannot
+    /// verify ownership, so we must refuse (never treat as absent).
+    Unreadable,
 }
 
 impl DirIdentity {
     /// Compare against the instance that intends to own the directory. Returns
     /// `None` when the operation may proceed (`Absent` → adopt, or `Owner` ==
     /// candidate → same instance / restart); `Some(reason)` when it must be
-    /// refused byte-preservingly (a foreign owner or a corrupt artifact). The
-    /// caller supplies whichever spelling of the candidate name matches the
+    /// refused (a foreign owner, a corrupt artifact, or an unreadable artifact).
+    /// The caller supplies whichever spelling of the candidate name matches the
     /// artifact (sanitized for AGENTS.md, raw for the `.codex` stamp).
     pub fn conflict_with(&self, candidate: &str) -> Option<String> {
         match self {
@@ -96,8 +105,51 @@ impl DirIdentity {
             DirIdentity::Owner(owner) if owner == candidate => None,
             DirIdentity::Owner(owner) => Some(format!("is owned by instance '{owner}'")),
             DirIdentity::Corrupt => Some("has a corrupt agend identity stamp".to_string()),
+            DirIdentity::Unreadable => {
+                Some("could not be read to verify ownership (fail-closed)".to_string())
+            }
         }
     }
+}
+
+/// Map a `read_to_string` result for an identity artifact onto the fail-closed
+/// [`DirIdentity`] I/O states, distinguishing a genuine `NotFound` (absent →
+/// adoptable) from any opaque I/O failure (unreadable → refuse). The `parse`
+/// closure classifies successfully-read content into `Absent`/`Owner`/`Corrupt`.
+pub fn classify_identity_read(
+    read: std::io::Result<String>,
+    parse: impl FnOnce(&str) -> DirIdentity,
+) -> DirIdentity {
+    match read {
+        Ok(s) => parse(&s),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => DirIdentity::Absent,
+        Err(_) => DirIdentity::Unreadable,
+    }
+}
+
+/// `<home>/.locks/wsid-<hash>.lock` — the single workspace-identity lock for a
+/// working directory, keyed by its canonical [`workspace_identity`]. Provision
+/// and delete both take THIS lock across their read-decide-write / read-decide-
+/// remove so an identity check and the mutation it authorizes are atomic against
+/// a concurrent provision/delete of the same directory. Keyed by identity (not
+/// the raw path) so symlink/case aliases of one directory share one lock; placed
+/// under `home` so it exists even when the working directory itself does not yet.
+pub fn workspace_identity_lock_path(home: &Path, working_dir: &Path) -> PathBuf {
+    let digest = fnv1a_hex(&workspace_identity(working_dir));
+    home.join(".locks").join(format!("wsid-{digest}.lock"))
+}
+
+/// Deterministic 64-bit FNV-1a of `s` as lowercase hex. Deterministic across
+/// processes (unlike `DefaultHasher`), so the same identity always maps to the
+/// same lock file. Collision-resistance is not security-critical here — a hash
+/// collision only over-serializes two distinct identities onto one lock.
+fn fnv1a_hex(s: &str) -> String {
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for b in s.as_bytes() {
+        hash ^= u64::from(*b);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    format!("{hash:016x}")
 }
 
 #[cfg(test)]

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -19,3 +19,146 @@ pub fn binding_path(home: &Path, agent: &str) -> PathBuf {
 
 /// Binding state filename.
 pub const BINDING_FILENAME: &str = "binding.json";
+
+/// The working directory an instance actually uses: its explicit `working_directory`
+/// when set (non-empty), else the daemon default `<home>/workspace/<name>`. Callers that
+/// only have the fleet entry (which may store `working_directory: None`) use this so the
+/// identity comparison sees the SAME path the daemon will actually spawn into.
+pub fn effective_working_dir(home: &Path, name: &str, explicit: Option<&str>) -> PathBuf {
+    match explicit {
+        Some(d) if !d.is_empty() => PathBuf::from(d),
+        _ => workspace_dir(home).join(name),
+    }
+}
+
+/// Canonical IDENTITY of a workspace path, for collision detection across instances
+/// (workspace-identity guard). Two paths that resolve to the SAME on-disk location — via
+/// symlinked ancestors, case-only aliases, or a `.` remainder — share one identity, so a
+/// duplicate is refused even when the target does not exist yet.
+///
+/// Because a fresh workspace dir may not exist at admission time, we canonicalize the
+/// DEEPEST EXISTING ANCESTOR (which resolves symlinks) and re-append the lexically-
+/// normalized remainder, then case-fold (conservative — lowercase) so case-only aliases
+/// collide on ALL platforms. This is fail-closed: lowercasing may over-collide two
+/// genuinely distinct case-sensitive paths, which only ever REFUSES a borderline duplicate
+/// — never silently admits one. `..` is rejected upstream at admission, so the remainder
+/// here is `.`-normalized only.
+pub fn workspace_identity(path: &Path) -> String {
+    // Peel non-existing tail components until an existing ancestor (or the root).
+    let mut cur = path.to_path_buf();
+    let mut remainder: Vec<std::ffi::OsString> = Vec::new();
+    while !cur.exists() {
+        match (cur.file_name(), cur.parent()) {
+            (Some(f), Some(p)) => {
+                remainder.push(f.to_os_string());
+                cur = p.to_path_buf();
+            }
+            // no file_name (root / prefix) or no parent — stop peeling.
+            _ => break,
+        }
+    }
+    // Canonicalize the existing base (symlink + `.` resolution); lexical fallback on error.
+    let mut full = cur.canonicalize().unwrap_or(cur);
+    // Re-append the remainder shallowest→deepest, dropping `.` segments.
+    for comp in remainder.iter().rev() {
+        if comp.as_os_str() != "." {
+            full.push(comp);
+        }
+    }
+    full.to_string_lossy().to_lowercase()
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn tmp(tag: &str) -> PathBuf {
+        let d = std::env::temp_dir().join(format!(
+            "agend-wsid-{tag}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        std::fs::create_dir_all(&d).unwrap();
+        d
+    }
+
+    #[test]
+    fn identity_same_path_matches_and_distinct_paths_differ() {
+        let base = tmp("same");
+        let a = base.join("alpha");
+        let b = base.join("beta");
+        assert_eq!(workspace_identity(&a), workspace_identity(&a));
+        assert_ne!(workspace_identity(&a), workspace_identity(&b));
+        std::fs::remove_dir_all(&base).ok();
+    }
+
+    #[test]
+    fn identity_case_only_alias_collides() {
+        // A nonexistent target and its case-only alias share one identity (conservative
+        // case-fold), so a case-only duplicate workspace is refused on all platforms.
+        let base = tmp("case");
+        let lower = base.join("workspace").join("dev");
+        let upper = base.join("workspace").join("DEV");
+        assert_eq!(
+            workspace_identity(&lower),
+            workspace_identity(&upper),
+            "case-only aliases must share one identity"
+        );
+        std::fs::remove_dir_all(&base).ok();
+    }
+
+    #[test]
+    fn identity_nonexistent_tail_uses_deepest_existing_ancestor() {
+        let base = tmp("tail"); // exists
+        let deep = base.join("a").join("b").join("c"); // a/b/c do not exist
+        let id = workspace_identity(&deep);
+        let expected = format!(
+            "{}/a/b/c",
+            base.canonicalize()
+                .unwrap()
+                .to_string_lossy()
+                .to_lowercase()
+        );
+        assert_eq!(id, expected);
+        std::fs::remove_dir_all(&base).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn identity_symlinked_ancestor_collides_with_real() {
+        use std::os::unix::fs::symlink;
+        let base = tmp("symlink");
+        let real = base.join("real");
+        std::fs::create_dir_all(&real).unwrap();
+        let link = base.join("link");
+        symlink(&real, &link).unwrap();
+        // <base>/link/ws and <base>/real/ws (ws nonexistent) must share one identity.
+        assert_eq!(
+            workspace_identity(&link.join("ws")),
+            workspace_identity(&real.join("ws")),
+            "a symlinked ancestor must resolve to the same identity as the real dir"
+        );
+        std::fs::remove_dir_all(&base).ok();
+    }
+
+    #[test]
+    fn effective_working_dir_defaults_when_absent_or_empty() {
+        let home = Path::new("/tmp/h");
+        assert_eq!(
+            effective_working_dir(home, "dev", None),
+            workspace_dir(home).join("dev")
+        );
+        assert_eq!(
+            effective_working_dir(home, "dev", Some("")),
+            workspace_dir(home).join("dev")
+        );
+        assert_eq!(
+            effective_working_dir(home, "dev", Some("/custom/wd")),
+            PathBuf::from("/custom/wd")
+        );
+    }
+}

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -148,13 +148,17 @@ mod tests {
         let base = tmp("tail"); // exists
         let deep = base.join("a").join("b").join("c"); // a/b/c do not exist
         let id = workspace_identity(&deep);
-        let expected = format!(
-            "{}/a/b/c",
-            base.canonicalize()
-                .unwrap()
-                .to_string_lossy()
-                .to_lowercase()
-        );
+        // Build the expectation with the platform's OWN separator (`join`, the same
+        // way `workspace_identity` re-appends the remainder). A hardcoded "/a/b/c"
+        // only matches on Unix and fails on Windows, where the remainder is `\a\b\c`.
+        let expected = base
+            .canonicalize()
+            .unwrap()
+            .join("a")
+            .join("b")
+            .join("c")
+            .to_string_lossy()
+            .to_lowercase();
         assert_eq!(id, expected);
         std::fs::remove_dir_all(&base).ok();
     }

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -68,6 +68,38 @@ pub fn workspace_identity(path: &Path) -> String {
     full.to_string_lossy().to_lowercase()
 }
 
+/// Ownership an agend-provisioned artifact (AGENTS.md agend block,
+/// `.codex/config.toml` `AGEND_INSTANCE_NAME` stamp) records for a working
+/// directory. The fail-closed workspace-identity guards read this before a
+/// provision write or a delete cleanup so neither ever clobbers a directory
+/// that belongs to a DIFFERENT instance (the split-brain the incident caused).
+#[derive(Debug, PartialEq, Eq)]
+pub enum DirIdentity {
+    /// No identity artifact present → unowned / legacy → adoptable.
+    Absent,
+    /// The recorded owning instance name.
+    Owner(String),
+    /// An artifact is present but its identity is unparseable → corrupt.
+    Corrupt,
+}
+
+impl DirIdentity {
+    /// Compare against the instance that intends to own the directory. Returns
+    /// `None` when the operation may proceed (`Absent` → adopt, or `Owner` ==
+    /// candidate → same instance / restart); `Some(reason)` when it must be
+    /// refused byte-preservingly (a foreign owner or a corrupt artifact). The
+    /// caller supplies whichever spelling of the candidate name matches the
+    /// artifact (sanitized for AGENTS.md, raw for the `.codex` stamp).
+    pub fn conflict_with(&self, candidate: &str) -> Option<String> {
+        match self {
+            DirIdentity::Absent => None,
+            DirIdentity::Owner(owner) if owner == candidate => None,
+            DirIdentity::Owner(owner) => Some(format!("is owned by instance '{owner}'")),
+            DirIdentity::Corrupt => Some("has a corrupt agend identity stamp".to_string()),
+        }
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {

--- a/src/store.rs
+++ b/src/store.rs
@@ -320,6 +320,22 @@ pub fn acquire_file_lock(lock_path: &Path) -> anyhow::Result<FileFlockGuard> {
     Ok(FileFlockGuard { _file: f })
 }
 
+/// Acquire the single workspace-identity lock for `working_dir` (keyed by its
+/// canonical identity, under `home/.locks/`). BOTH provision and delete take
+/// this lock across their read-decide-write / read-decide-remove so the identity
+/// check and the mutation it authorizes are atomic against a concurrent
+/// provision or delete of the same directory (fail-closed vs check/write and
+/// check/remove races). `acquire_file_lock` creates the `.locks` parent.
+pub fn acquire_workspace_identity_lock(
+    home: &Path,
+    working_dir: &Path,
+) -> anyhow::Result<FileFlockGuard> {
+    acquire_file_lock(&crate::paths::workspace_identity_lock_path(
+        home,
+        working_dir,
+    ))
+}
+
 /// Non-blocking variant of [`acquire_file_lock`]: `Ok(None)` when the lock is
 /// currently held elsewhere, instead of blocking until it frees. Same
 /// `FLOCK_DEPTH` contract as the blocking form (the #1629 chokepoint extends

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -376,7 +376,7 @@ fn test_instructions(home: &Path) -> TestResult {
     let test_dir = home.join("verify-instructions");
     std::fs::create_dir_all(&test_dir).ok();
 
-    instructions::generate(&test_dir, "claude");
+    let _ = instructions::generate(&test_dir, "claude");
     // Canonical Claude instructions path is `.claude/agend.md` (see
     // `backend.rs` preset `instructions_path`). The legacy
     // `.claude/rules/agend.md` location is intentionally migrated away /
@@ -390,7 +390,7 @@ fn test_instructions(home: &Path) -> TestResult {
             .all(|p| c.contains(p))
     };
 
-    instructions::generate(&test_dir, "kiro-cli");
+    let _ = instructions::generate(&test_dir, "kiro-cli");
     let kiro_ok = test_dir
         .join(".kiro")
         .join("steering")
@@ -500,7 +500,7 @@ fn test_backend(backend: &backend::Backend, home: &Path) -> Vec<TestResult> {
     std::fs::create_dir_all(&test_dir).ok();
 
     // 1. Instructions
-    crate::instructions::generate(&test_dir, preset.command);
+    let _ = crate::instructions::generate(&test_dir, preset.command);
     let instr_ok = test_dir.join(preset.instructions_path).exists() && {
         let c =
             std::fs::read_to_string(test_dir.join(preset.instructions_path)).unwrap_or_default();

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -27,6 +27,16 @@ pub fn worktree_path(home: &Path, agent: &str, branch: &str) -> PathBuf {
     home.join("worktrees").join(agent).join(branch)
 }
 
+/// Whether [`create`] freshly provisioned the worktree or reused an existing one.
+/// The spawn rollback path uses this to decide whether cleanup should remove the
+/// directory: a `CreatedByThisAttempt` worktree is this call's responsibility;
+/// a `Reused` one predates it and must survive a rollback.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorktreeProvenance {
+    CreatedByThisAttempt,
+    Reused,
+}
+
 /// Info about a created worktree.
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
@@ -37,6 +47,8 @@ pub struct WorktreeInfo {
     pub source_repo: PathBuf,
     /// Branch name.
     pub branch: String,
+    /// Whether this call created the worktree or reused a pre-existing one.
+    pub provenance: WorktreeProvenance,
 }
 
 /// Check if a directory is a git repo (has .git).
@@ -175,6 +187,7 @@ pub fn create(
                         path: wt_dir,
                         source_repo: repo_dir.to_path_buf(),
                         branch,
+                        provenance: WorktreeProvenance::Reused,
                     });
                 }
                 Err(e) => {
@@ -205,6 +218,7 @@ pub fn create(
             path: wt_dir,
             source_repo: repo_dir.to_path_buf(),
             branch,
+            provenance: WorktreeProvenance::Reused,
         });
     }
 
@@ -258,6 +272,7 @@ pub fn create(
                 path: wt_dir,
                 source_repo: repo_dir.to_path_buf(),
                 branch,
+                provenance: WorktreeProvenance::CreatedByThisAttempt,
             })
         }
         // #781 Piece 2 (Bug B): the prior `o.status.code() == Some(128)` gate was
@@ -297,6 +312,7 @@ pub fn create(
                         path: wt_dir,
                         source_repo: repo_dir.to_path_buf(),
                         branch,
+                        provenance: WorktreeProvenance::CreatedByThisAttempt,
                     })
                 }
                 Err(GitError::NonZero { stderr, .. }) => {

--- a/src/worktree_pool/tests.rs
+++ b/src/worktree_pool/tests.rs
@@ -80,7 +80,7 @@ fn cleanup_working_dir_managed_worktree_removes_via_git_no_orphan() {
         "baseline: main + the agent worktree are registered"
     );
 
-    crate::agent_ops::cleanup_working_dir(&home, "devw", &wt);
+    let _ = crate::agent_ops::cleanup_working_dir(&home, "devw", &wt);
 
     assert!(!wt.exists(), "worktree dir must be removed");
     let after = worktree_list(&repo);
@@ -118,7 +118,7 @@ fn cleanup_working_dir_dirty_worktree_backs_up_before_remove() {
     let wt = managed_workspace_worktree(&home, &repo, "devd", "feat/p0d");
     std::fs::write(wt.join("WIP.txt"), "unsaved work").unwrap();
 
-    crate::agent_ops::cleanup_working_dir(&home, "devd", &wt);
+    let _ = crate::agent_ops::cleanup_working_dir(&home, "devd", &wt);
 
     assert!(!wt.exists(), "worktree removed");
     let backup = backup_dir_for(&home, "devd").expect("backup dir created");
@@ -152,7 +152,7 @@ fn cleanup_working_dir_committed_orphan_backs_up_before_remove() {
         .output()
         .expect("git remote add");
 
-    crate::agent_ops::cleanup_working_dir(&home, "devo", &wt);
+    let _ = crate::agent_ops::cleanup_working_dir(&home, "devo", &wt);
 
     assert!(!wt.exists(), "worktree removed");
     assert!(
@@ -218,7 +218,7 @@ fn teardown_standalone_clone_declines_byte_identical() {
     // Helper declines (not a worktree).
     assert!(!teardown_workspace_worktree(&home, "devs", &ws));
     // Public path still removes the whole dir (byte-identical pre-(B)).
-    crate::agent_ops::cleanup_working_dir(&home, "devs", &ws);
+    let _ = crate::agent_ops::cleanup_working_dir(&home, "devs", &ws);
     assert!(!ws.exists(), "standalone workspace dir removed as before");
     assert!(
         backup_dir_for(&home, "devs").is_none(),

--- a/src/worktree_pool/workspace.rs
+++ b/src/worktree_pool/workspace.rs
@@ -678,7 +678,7 @@ pub fn reverse_reconcile(home: &Path, agent: &str) -> Result<(), String> {
     // next spawn's `ensure_project_root` would also do this, but doing it here
     // makes the revert self-contained + testable.
     let _ = std::fs::create_dir_all(&ws);
-    crate::instructions::ensure_project_root(&ws);
+    crate::instructions::ensure_project_root(&ws)?;
     Ok(())
 }
 


### PR DESCRIPTION
## What & why

Fixes the workspace-identity split-brain incident: `archfix-codex-dev` and `codex-125550`
resolved to the **same canonical `working_directory`**, so Codex project provisioning rewrote
`AGENTS.md` + `.codex/config.toml` last-writer-wins → split-brain identity (PTY env said one
instance, MCP project config said another). This implements decision `d-20260714004402440378-0`:
**one identity-uniqueness invariant enforced fail-closed across three boundaries.**

`review_class=dual`. Plan ack 1/1 (Fable). Surgical, safety-critical, RED-first at real production entries.

## The invariant (3 boundaries)

**Boundary 1 — ADMISSION** (atomic, at the insert chokepoint)
Uniqueness across all non-deleted instances, including explicit-vs-default collisions. Equality for
nonexistent targets = deepest-existing-ancestor canonicalization (resolves symlinks) + lexically-
normalized remainder + conservative case-fold (case-only aliases collide on all platforms).
- `paths::workspace_identity()` + `effective_working_dir()`.
- `fleet::persist::find_workspace_identity_collision()` called **inside** `add_instances_to_yaml`'s
  `mutate_fleet_yaml` closure — atomic under `.fleet.yaml.lock`, on the new-entry branch. Err names
  **both** instances. Every insert path routes through this chokepoint (create, deploy, team-add,
  tui_spawn, fleet_normalize, main). `create_instance` surfaces the collision to its response
  **before** the spawn RPC (`spawn.rs:200-202`).

**Boundary 2 — PROVISION** (never overwrite a directory owned by a different instance)
- `instructions::agend_block_owner()` reads the owner **only** inside the `<!-- agend:start/end -->`
  block. `generate_agent_instructions` now returns `Result` and refuses **byte-preservingly** on a
  foreign or corrupt owner (absent → adopt, same → refresh). `generate_with_context` logs the refusal.
- `mcp_config::codex_config_owner()` parses the `AGEND_INSTANCE_NAME` stamp; `configure_codex_with_home`
  and `configure_grok_with_home` refuse (bytes intact) on a foreign/corrupt stamp.

**Boundary 3 — DELETE** (never wipe a directory whose identity belongs to another instance)
- `agent_ops::working_dir_ownership_conflict()` (AGENTS.md sanitized-name + `.codex` raw-name).
- `cleanup_working_dir` preserves the tree + emits a loud audit on a foreign/corrupt identity, while
  still cleaning metadata keyed by the deleted instance's own name.
- `full_delete_instance` surfaces the refusal as a `step_error`, so a preserved foreign tree reports
  failure instead of a false success.

Shared: `paths::DirIdentity{Absent, Owner, Corrupt}` + `conflict_with` centralize
adopt/same → proceed vs foreign/corrupt → refuse.

## Tests

11 new tests (plus boundary-1's 6). **RED-verified**: neutralizing `DirIdentity::conflict_with` makes
exactly the 5 refuse/preserve tests fail (foreign/corrupt AGENTS.md, foreign `.codex` stamp, foreign
delete-tree preserve, ownership-conflict detection). Parsing-only and adopt/same tests are independent
of the guard and stay green. `fmt-owned.sh --check` + strict clippy (`-D warnings`, owned CI targets)
clean. 174 module tests pass with 0 regressions.

> Note: `agent_ops.rs` shows a large line delta because the removal block is now wrapped in an `else`
> (identity-conflict → preserve). The ~87-line change there is **pure reindentation** — review with
> `git diff -w` to see the real logical change (guard + helper + tests).

## Scope (explicit, see decision `d-20260714014538245572-4`)

- Boot load/spawn (`spawn_and_register_agent`/`resolve_one`) does **not** insert, so it gets no separate
  hard "refuse-to-spawn": that would touch critical daemon boot-orchestration, risk skipping both
  colliding instances, and the split-brain it guards against is already prevented at boot by boundaries
  2+3. Matches the ACK'd plan (create-focused admission tests).
- JSON-config backends' `AGEND_INSTANCE_NAME` (claude/kiro/agy/opencode) + `GEMINI.md` provision-stamp
  are **not yet** identity-guarded — follow-up. The incident and RED targets are Codex/AGENTS (+grok,
  which shares the `.toml` stamp).

Excluded per task: `resume --last` behavior, unrelated workspace-cleanup refactors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
