### PR TITLE
fix: serialize exact binding release transactions

### DIFF
--- a/src/binding.rs
+++ b/src/binding.rs
@@ -15,6 +15,12 @@ use std::sync::{OnceLock, RwLock};
 /// bump; only a non-additive change to an existing field does.
 const BINDING_SCHEMA_VERSION: u64 = 1;
 
+pub(crate) mod release_guard;
+pub(crate) use release_guard::{
+    acquire_agent_mutation_lock, acquire_binding_file_lock, guarded_binding_disk_fresh,
+    snapshot_guarded_binding, BindingFingerprint, GuardedBinding,
+};
+
 static INDEX: OnceLock<RwLock<HashMap<String, serde_json::Value>>> = OnceLock::new();
 
 /// #1990: parse a `binding.json` body, rejecting one a NEWER daemon wrote
@@ -286,9 +292,9 @@ pub fn bind_full(
     let dir = crate::paths::runtime_dir(home).join(agent);
     std::fs::create_dir_all(&dir).map_err(|e| format!("create_dir_all {}: {e}", dir.display()))?;
     let path = dir.join("binding.json");
-    let lock_path = dir.join(".binding.json.lock");
-    let _lock = crate::store::acquire_file_lock(&lock_path)
-        .map_err(|e| format!("acquire_file_lock {}: {e}", lock_path.display()))?;
+    // S1: stable A lives outside runtime; legacy B stays for compatibility. A→B.
+    let _agent_lock = acquire_agent_mutation_lock(home, agent)?;
+    let _binding_lock = acquire_binding_file_lock(home, agent)?;
     // #2158 PR2: read the CURRENT on-disk binding UNDER the lock (the in-memory
     // index can be stale) — drives guard-b + the binding-CHANGE audit.
     let existing: Option<serde_json::Value> = std::fs::read_to_string(&path)

--- a/src/binding/release_guard.rs
+++ b/src/binding/release_guard.rs
@@ -1,0 +1,129 @@
+//! S1 release authority: permanent per-agent mutation lock plus disk-fresh
+//! tri-state binding reads.
+
+use std::path::{Path, PathBuf};
+
+/// Exact identity of one on-disk binding generation.
+///
+/// `digest` covers the complete binding bytes, so every field participates in
+/// CAS. `issued_at` and an optional future `generation` are also retained
+/// explicitly to make the identity contract auditable rather than implicit.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct BindingFingerprint {
+    pub(crate) digest: String,
+    pub(crate) issued_at: Option<String>,
+    pub(crate) generation: Option<u64>,
+}
+
+/// Destructive readers must distinguish a genuinely missing binding from bytes
+/// this daemon cannot safely understand.
+#[derive(Clone, Debug)]
+pub(crate) enum GuardedBinding {
+    Known {
+        value: serde_json::Value,
+        fingerprint: BindingFingerprint,
+    },
+    Absent,
+    Opaque(String),
+}
+
+/// RAII proof that the permanent per-agent mutation flock is held.
+pub(crate) struct AgentMutationGuard {
+    _flock: crate::store::FileFlockGuard,
+}
+
+/// Permanent lock path. It deliberately does not live under runtime/<agent>,
+/// because that directory is removed during lifecycle cleanup.
+pub(crate) fn agent_mutation_lock_path(home: &Path, agent: &str) -> PathBuf {
+    let key = crate::daemon::utils::sha256_hex(agent.as_bytes());
+    home.join(".agent-mutation-locks")
+        .join(format!("{key}.lock"))
+}
+
+pub(crate) fn acquire_agent_mutation_lock(
+    home: &Path,
+    agent: &str,
+) -> Result<AgentMutationGuard, String> {
+    crate::store::acquire_file_lock(&agent_mutation_lock_path(home, agent))
+        .map(|_flock| AgentMutationGuard { _flock })
+        .map_err(|e| format!("acquire permanent mutation lock for '{agent}': {e}"))
+}
+
+pub(crate) fn binding_file_lock_path(home: &Path, agent: &str) -> PathBuf {
+    crate::paths::runtime_dir(home)
+        .join(agent)
+        .join(".binding.json.lock")
+}
+
+pub(crate) fn acquire_binding_file_lock(
+    home: &Path,
+    agent: &str,
+) -> Result<crate::store::FileFlockGuard, String> {
+    let path = binding_file_lock_path(home, agent);
+    crate::store::acquire_file_lock(&path)
+        .map_err(|e| format!("acquire_file_lock {}: {e}", path.display()))
+}
+
+/// Read binding.json directly from disk. The caller must hold both the permanent
+/// agent mutation lock and the legacy binding-file lock.
+pub(crate) fn guarded_binding_disk_fresh(home: &Path, agent: &str) -> GuardedBinding {
+    let path = crate::paths::binding_path(home, agent);
+    let body = match std::fs::read(&path) {
+        Ok(body) => body,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return GuardedBinding::Absent,
+        Err(e) => return GuardedBinding::Opaque(format!("could not read {}: {e}", path.display())),
+    };
+    let value: serde_json::Value = match serde_json::from_slice::<serde_json::Value>(&body) {
+        Ok(value) if value.is_object() => value,
+        Ok(_) => return GuardedBinding::Opaque("binding JSON is not an object".to_string()),
+        Err(e) => return GuardedBinding::Opaque(format!("binding JSON is invalid: {e}")),
+    };
+    let version = value.get("version").and_then(|v| v.as_u64()).unwrap_or(0);
+    if version > super::BINDING_SCHEMA_VERSION {
+        return GuardedBinding::Opaque(format!(
+            "binding schema version {version} is newer than supported {}",
+            super::BINDING_SCHEMA_VERSION
+        ));
+    }
+    // `issued_at` predates the guarded reader but legacy raw bindings without it
+    // still exist. Their complete bytes remain exactly identifiable by `digest`;
+    // only a PRESENT-but-malformed value is ambiguous and therefore Opaque.
+    let issued_at = match value.get("issued_at") {
+        None => None,
+        Some(v) => match v.as_str() {
+            Some(s) if !s.is_empty() => Some(s.to_string()),
+            _ => {
+                return GuardedBinding::Opaque(
+                    "binding issued_at is present but invalid".to_string(),
+                )
+            }
+        },
+    };
+    let generation = match value.get("generation") {
+        None => None,
+        Some(v) => match v.as_u64() {
+            Some(generation) => Some(generation),
+            None => {
+                return GuardedBinding::Opaque(
+                    "binding generation is present but is not a u64".to_string(),
+                )
+            }
+        },
+    };
+    GuardedBinding::Known {
+        value,
+        fingerprint: BindingFingerprint {
+            digest: crate::daemon::utils::sha256_hex(&body),
+            issued_at,
+            generation,
+        },
+    }
+}
+
+/// Acquire both binding mutation locks and return a disk-fresh tri-state
+/// snapshot. The returned fingerprint remains usable after the guards drop.
+pub(crate) fn snapshot_guarded_binding(home: &Path, agent: &str) -> Result<GuardedBinding, String> {
+    let _agent = acquire_agent_mutation_lock(home, agent)?;
+    let _binding = acquire_binding_file_lock(home, agent)?;
+    Ok(guarded_binding_disk_fresh(home, agent))
+}

--- a/src/daemon/auto_release.rs
+++ b/src/daemon/auto_release.rs
@@ -647,10 +647,23 @@ fn process_intent(home: &Path, intent: &AutoReleaseIntent) -> IntentOutcome {
         tracing::info!(task_id = %intent.task_id, event, "auto_release: task has no assignee — dropping intent");
         return IntentOutcome::Done;
     };
-    let Some(binding) = crate::binding::read(home, &assignee) else {
-        // Already released / never bound → nothing to do (idempotent).
-        tracing::debug!(agent = %assignee, task_id = %intent.task_id, event, "auto_release: agent unbound — dropping intent");
-        return IntentOutcome::Done;
+    let (binding, binding_fingerprint) = match crate::binding::snapshot_guarded_binding(
+        home, &assignee,
+    ) {
+        Ok(crate::binding::GuardedBinding::Absent) => {
+            // Already released / never bound → nothing to do (idempotent).
+            tracing::debug!(agent = %assignee, task_id = %intent.task_id, event, "auto_release: agent unbound — dropping intent");
+            return IntentOutcome::Done;
+        }
+        Ok(crate::binding::GuardedBinding::Opaque(reason)) => {
+            tracing::warn!(agent = %assignee, %reason, "auto_release: opaque binding state — retaining for retry");
+            return IntentOutcome::Retry;
+        }
+        Ok(crate::binding::GuardedBinding::Known { value, fingerprint }) => (value, fingerprint),
+        Err(e) => {
+            tracing::warn!(agent = %assignee, error = %e, "auto_release: binding snapshot failed — retaining for retry");
+            return IntentOutcome::Retry;
+        }
     };
 
     // ── must-fix #5: eligibility — only dispatch leases get invariant-release.
@@ -774,53 +787,20 @@ fn process_intent(home: &Path, intent: &AutoReleaseIntent) -> IntentOutcome {
     // construction). Byte-identical — `should_release_now` + its equivalence pin.
     let release_now = should_release_now(&decision, releasable, reviewer_bypassed);
     if release_now {
-        // codex gap ②: CAS+release must be ONE atomic critical section under
-        // `.binding.json.lock` — the same lock `bind_full` holds (binding.rs:67)
-        // and the GC path uses (worktree_pool.rs:717). The pre-lock CAS above is
-        // only a cheap early-out; a concurrent bind_full from ANOTHER thread
-        // (MCP handler) could interleave between it and the release. So re-read
-        // + re-validate the FULL lease identity under the lock, then release in
-        // the same section. (`release_full` → `unbind` does NOT take this lock —
-        // binding.rs:119 just removes the file — so no deadlock, mirroring the
-        // pre-PR-1 merge path.)
-        let lock_path = crate::paths::runtime_dir(home)
-            .join(&assignee)
-            .join(".binding.json.lock");
-        let _lock = match crate::store::acquire_file_lock(&lock_path) {
-            Ok(l) => l,
-            Err(e) => {
-                tracing::warn!(agent = %assignee, error = %e, "auto_release: binding lock failed — retaining for retry");
-                return IntentOutcome::Retry;
-            }
-        };
-        let Some(live) = crate::binding::read(home, &assignee) else {
-            // Unbound under the lock → already released. Nothing to do.
-            return IntentOutcome::Done;
-        };
-        if let Some(snap) = intent.lease.as_ref() {
-            if &LeaseIdentity::from_binding(&assignee, &live) != snap {
-                tracing::info!(agent = %assignee, task_id = %intent.task_id, "auto_release: lease identity changed under lock (re-leased) — skip (TOCTOU CAS)");
-                return IntentOutcome::Done;
-            }
-        }
         let dirty = worktree_dirty.unwrap_or(false);
-        // PR-D·D5: route through the shared `janitor::dispose` Release arm
-        // (== `release_full(home, agent, false)`). The lock/CAS/re-validation above
-        // and the fail-closed retain-on-failure below stay in THIS caller (D5-Q1);
-        // dispose owns only the Release→release_full mechanism binding.
+        // S1: auto-release no longer carries a caller-held binding flock into the
+        // mechanism. It supplies the exact disk generation evaluated above; the
+        // shared release transaction owns A→L→A and the final raw fingerprint CAS.
         let crate::daemon::janitor::DispositionOutcome::Released(outcome) =
-            crate::daemon::janitor::dispose(
-                home,
-                crate::worktree::disposition::Disposition::Release,
-                &assignee,
-                None,
-                || Ok(()),
-            )
+            crate::daemon::janitor::dispose_release_exact(home, &assignee, &binding_fingerprint)
         else {
-            unreachable!("Release disposition yields Released");
+            unreachable!("exact Release disposition yields Released");
         };
         if outcome.released {
             tracing::info!(agent = %assignee, task_id = %intent.task_id, event, ?confidence, dirty, outcome = ?outcome, "auto_release: released worktree (release invariant satisfied)");
+            IntentOutcome::Done
+        } else if outcome.stale_fingerprint {
+            tracing::info!(agent = %assignee, task_id = %intent.task_id, "auto_release: exact binding fingerprint moved — dropping stale intent");
             IntentOutcome::Done
         } else {
             // #P1b: release_full is FAIL-CLOSED — dirty WIP that could not be

--- a/src/daemon/janitor.rs
+++ b/src/daemon/janitor.rs
@@ -87,6 +87,19 @@ pub(crate) fn dispose(
     }
 }
 
+/// Auto-release variant of the shared Release mechanism. The caller supplies the
+/// exact disk-fresh binding fingerprint it evaluated; the release transaction
+/// refuses if that generation moved before L→A reacquisition.
+pub(crate) fn dispose_release_exact(
+    home: &Path,
+    agent: &str,
+    expected: &crate::binding::BindingFingerprint,
+) -> DispositionOutcome {
+    DispositionOutcome::Released(crate::worktree_pool::release_full_exact(
+        home, agent, expected,
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/mcp/handlers/ci/checkout.rs
+++ b/src/mcp/handlers/ci/checkout.rs
@@ -528,6 +528,7 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
                     branch,
                 );
             }
+            let mut bound_fingerprint = None;
             if bind {
                 // #2533: optional caller-supplied task_id — attributes this self-claim
                 // to a task (§3.19.1 reviewer checkout is the common case) so `bind_full`
@@ -570,6 +571,36 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
                         branch,
                     );
                 }
+                bound_fingerprint =
+                    match crate::binding::snapshot_guarded_binding(home, instance_name) {
+                        Ok(crate::binding::GuardedBinding::Known { fingerprint, .. }) => {
+                            Some(fingerprint)
+                        }
+                        other => {
+                            // Binding bytes exist but their exact destructive identity
+                            // cannot be proven. Arm retained rollback intent and leave
+                            // both binding + worktree in place for recovery.
+                            let outcome = super::checkout_txn::rollback_failed(
+                                home,
+                                &mangled,
+                                &mut journal,
+                                txn_now,
+                                || false,
+                                || {},
+                            );
+                            return rollback_response(
+                                outcome,
+                                &format!("could not snapshot committed binding: {other:?}"),
+                                "binding_snapshot",
+                                "bind_full",
+                                branch,
+                            );
+                        }
+                    };
+                #[cfg(test)]
+                crate::worktree_pool::release_test_seam::hit(
+                    crate::worktree_pool::ReleaseTestPhase::CheckoutBoundBeforeCommit,
+                );
                 // #2158 GR1 (operator-approved): a self-claimed `repo action=checkout
                 // bind=true` no longer SILENTLY arms a ci_watch — neither here (this
                 // inline arm is removed) NOR via the shared dispatch_hook path
@@ -591,17 +622,28 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
             // provision.
             journal.advance(super::checkout_txn::Phase::Committed);
             if journal.save(home, &mangled).is_err() {
+                let fingerprint = bound_fingerprint.as_ref();
                 let outcome = super::checkout_txn::rollback_failed(
                     home,
                     &mangled,
                     &mut journal,
                     txn_now,
-                    remove_worktree,
                     || {
-                        if bind {
-                            crate::binding::unbind(home, instance_name);
+                        if let Some(fingerprint) = fingerprint {
+                            let released =
+                                crate::worktree_pool::release_bound_target_exact_under_branch_lock(
+                                    home,
+                                    instance_name,
+                                    fingerprint,
+                                    &worktree_dir,
+                                    &source_canonical,
+                                );
+                            released.released
+                        } else {
+                            remove_worktree()
                         }
                     },
+                    || {},
                 );
                 return rollback_response(
                     outcome,

--- a/src/mcp/handlers/ci/checkout_submodule_tests.rs
+++ b/src/mcp/handlers/ci/checkout_submodule_tests.rs
@@ -1289,6 +1289,87 @@ fn checkout_commit_write_failure_rolls_back_2755() {
     std::fs::remove_dir_all(&repo).ok();
 }
 
+/// S1: checkout's exact rollback and a concurrent manual release may both
+/// snapshot the same binding, but the checkout actor owns L(repo,branch) until
+/// its failed commit is rolled back. The later manual actor must observe Absent
+/// and perform no second transition. Phase channels make the order sleep-free.
+#[cfg(unix)]
+#[test]
+fn checkout_rollback_vs_manual_release_applies_one_transition_s1() {
+    let home = tmp_home("s1-checkout-rollback");
+    let repo = tmp_repo_with_file("s1-checkout-rollback", "readme.txt", "x\n");
+    git_run_ok(&repo, &["branch", "feat/rollback"], false);
+    let instance = "agent-s1-rollback";
+    let args = json!({
+        "repository_path": repo.display().to_string(),
+        "branch": "feat/rollback",
+        "bind": true,
+        "task_id": "T-s1-rollback",
+    });
+
+    let (bound_tx, bound_rx) = std::sync::mpsc::channel();
+    let (commit_tx, commit_rx) = std::sync::mpsc::channel();
+    let checkout_home = home.clone();
+    let checkout = std::thread::spawn(move || {
+        let _hook = crate::worktree_pool::release_test_seam::install(move |phase| {
+            if phase == crate::worktree_pool::ReleaseTestPhase::CheckoutBoundBeforeCommit {
+                bound_tx.send(()).expect("publish bound checkout phase");
+                commit_rx.recv().expect("resume failed checkout commit");
+            }
+        });
+        super::checkout_txn::set_fail_committed_save(true);
+        let response = super::checkout::handle_checkout_repo(&checkout_home, &args, instance);
+        super::checkout_txn::set_fail_committed_save(false);
+        response
+    });
+
+    bound_rx.recv().expect("checkout bound before commit");
+    let (snap_tx, snap_rx) = std::sync::mpsc::channel();
+    let (release_tx, release_rx) = std::sync::mpsc::channel();
+    let release_home = home.clone();
+    let release = std::thread::spawn(move || {
+        let _hook = crate::worktree_pool::release_test_seam::install(move |phase| {
+            if phase == crate::worktree_pool::ReleaseTestPhase::AfterBindingSnapshot {
+                snap_tx.send(()).expect("publish manual release snapshot");
+                release_rx.recv().expect("resume manual release");
+            }
+        });
+        crate::worktree_pool::release_full(&release_home, instance, false)
+    });
+    snap_rx
+        .recv()
+        .expect("manual release snapped checkout binding");
+
+    commit_tx
+        .send(())
+        .expect("let checkout exact rollback win under branch lease");
+    let response = checkout.join().expect("checkout thread");
+    assert_eq!(
+        response["code"].as_str(),
+        Some("commit_failed"),
+        "checkout must expose the injected commit failure: {response}"
+    );
+
+    release_tx.send(()).expect("resume losing manual release");
+    let manual = release.join().expect("manual release thread");
+    assert!(
+        manual.already_released && !manual.binding_removed && !manual.worktree_removed,
+        "manual actor must converge on Absent after checkout rollback: {manual:?}"
+    );
+    assert!(
+        crate::binding::read(&home, instance).is_none(),
+        "checkout rollback removes its exact binding once"
+    );
+    let mangled = mangled_for(instance, &repo);
+    assert!(
+        !home.join("worktrees").join(mangled).exists(),
+        "checkout rollback removes its exact worktree once"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&repo).ok();
+}
+
 /// #2755 R3 (marker durability, real entry): a marker CONTENTS fsync failure during
 /// provisioning ABORTS the transaction — the worktree is rolled back and a structured
 /// `marker_fsync_failed` error returned, never a success with a non-durable marker.

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -697,6 +697,52 @@ pub(crate) enum WipPreservation {
     UnpreservableNestedDirty(String),
 }
 
+/// Operator-visible effects produced while classifying/preserving WIP. Release
+/// transactions collect these under their flocks and emit them only after the
+/// branch + agent + binding guards have dropped.
+pub(crate) enum ReleaseNotice {
+    WipPreserved {
+        recipient: String,
+        text: String,
+    },
+    UnpreservableNestedDirty {
+        agent: String,
+        branch: String,
+        wt_path: PathBuf,
+        nested_status: String,
+        sender: Option<String>,
+    },
+}
+
+impl ReleaseNotice {
+    pub(crate) fn emit(self, home: &Path) {
+        #[cfg(test)]
+        crate::worktree_pool::release_test_seam::hit(
+            crate::worktree_pool::ReleaseTestPhase::BeforeNoticeEmit,
+        );
+        match self {
+            ReleaseNotice::WipPreserved { recipient, text } => {
+                let source = crate::inbox::NotifySource::System("release_dirty_wip_preserved");
+                crate::inbox::notify_agent(home, &recipient, &source, &text);
+            }
+            ReleaseNotice::UnpreservableNestedDirty {
+                agent,
+                branch,
+                wt_path,
+                nested_status,
+                sender,
+            } => notify_unpreservable_nested_dirty(
+                home,
+                &agent,
+                &branch,
+                &wt_path,
+                &nested_status,
+                sender.as_deref(),
+            ),
+        }
+    }
+}
+
 impl WipPreservation {
     /// The reason the caller MUST refuse to remove the worktree (fail-closed):
     /// preservation FAILED (`Blocked`) OR the dirt is nested-submodule-internal and
@@ -756,9 +802,26 @@ pub(crate) fn preserve_dirty_worktree(
     branch: &str,
     sender: Option<&str>,
 ) -> WipPreservation {
+    let (outcome, notices) = preserve_dirty_worktree_collect(home, agent, wt_path, branch, sender);
+    for notice in notices {
+        notice.emit(home);
+    }
+    outcome
+}
+
+/// Transaction-facing variant of [`preserve_dirty_worktree`]. It performs the
+/// same snapshot/classification work but returns notice payloads instead of
+/// emitting while the caller's release flocks are held.
+pub(crate) fn preserve_dirty_worktree_collect(
+    home: &Path,
+    agent: &str,
+    wt_path: &Path,
+    branch: &str,
+    sender: Option<&str>,
+) -> (WipPreservation, Vec<ReleaseNotice>) {
     use crate::git_helpers::git_cmd;
     if branch.is_empty() {
-        return WipPreservation::Clean; // unknown branch → nothing to key a recovery ref on
+        return (WipPreservation::Clean, Vec::new()); // unknown branch → nothing to key a recovery ref on
     }
     // Not a LIVE git worktree (a pruned/dangling stale dir — its `.git` gitlink
     // points at a removed gitdir, or there is none) → there is no git WIP to
@@ -769,10 +832,10 @@ pub(crate) fn preserve_dirty_worktree(
     // call sites pass `home/worktrees/...` (outside any repo), so rev-parse can't
     // resolve a spurious ancestor `.git`.
     if git_cmd(wt_path, &["rev-parse", "--git-dir"]).is_err() {
-        return WipPreservation::Clean;
+        return (WipPreservation::Clean, Vec::new());
     }
     if !worktree_has_preservable_wip(wt_path) {
-        return WipPreservation::Clean; // clean / marker-only → zero behaviour change
+        return (WipPreservation::Clean, Vec::new()); // clean / marker-only → zero behaviour change
     }
     // Branch tip tree. Err → Blocked (fail-closed): a repo we can't read HEAD^{tree}
     // from is one we can't safely snapshot, so refuse removal.
@@ -781,9 +844,12 @@ pub(crate) fn preserve_dirty_worktree(
         other => {
             tracing::warn!(agent, branch, ?other,
                 "preserve dirty WIP: HEAD^{{tree}} resolve failed — refusing to remove (fail-closed)");
-            return WipPreservation::Blocked(format!(
-                "`git rev-parse HEAD^{{tree}}` failed: {other:?}"
-            ));
+            return (
+                WipPreservation::Blocked(format!(
+                    "`git rev-parse HEAD^{{tree}}` failed: {other:?}"
+                )),
+                Vec::new(),
+            );
         }
     };
     // LIVE index tree — READ-ONLY. `write-tree` reads the current index and writes
@@ -797,9 +863,12 @@ pub(crate) fn preserve_dirty_worktree(
         other => {
             tracing::warn!(agent, branch, ?other,
                 "preserve dirty WIP: `write-tree` (live index) failed — refusing to remove (fail-closed)");
-            return WipPreservation::Blocked(format!(
-                "`git write-tree` (live index) failed: {other:?}"
-            ));
+            return (
+                WipPreservation::Blocked(format!(
+                    "`git write-tree` (live index) failed: {other:?}"
+                )),
+                Vec::new(),
+            );
         }
     };
     // Working-tree tree via a TEMP index so the LIVE index is byte-untouched.
@@ -808,7 +877,7 @@ pub(crate) fn preserve_dirty_worktree(
         Err(e) => {
             tracing::warn!(agent, branch, error = %e,
                 "preserve dirty WIP: working-tree snapshot failed — refusing to remove (fail-closed)");
-            return WipPreservation::Blocked(e);
+            return (WipPreservation::Blocked(e), Vec::new());
         }
     };
     // Classification (R5 data-safety, 2nd-seat blocker @ fc8481d3): ANY nested-
@@ -828,14 +897,22 @@ pub(crate) fn preserve_dirty_worktree(
     // unmerged live index / snapshot failure keeps its `Blocked` precedence.)
     let nested = enumerate_nested_dirty(wt_path);
     if !nested.is_empty() {
-        notify_unpreservable_nested_dirty(home, agent, branch, wt_path, &nested, sender);
         tracing::warn!(agent, branch,
             "preserve dirty WIP: nested submodule-internal dirt present (unpreservable by a parent ref — sole or mixed with parent dirt) — refusing removal (fail-closed)");
-        return WipPreservation::UnpreservableNestedDirty(
-            "worktree has uncommitted changes inside a nested submodule's working tree \
-             (gitlink unchanged); a parent recovery ref cannot capture them, so removal was \
-             refused to preserve the nested WIP in place"
-                .into(),
+        return (
+            WipPreservation::UnpreservableNestedDirty(
+                "worktree has uncommitted changes inside a nested submodule's working tree \
+                 (gitlink unchanged); a parent recovery ref cannot capture them, so removal was \
+                 refused to preserve the nested WIP in place"
+                    .into(),
+            ),
+            vec![ReleaseNotice::UnpreservableNestedDirty {
+                agent: agent.to_string(),
+                branch: branch.to_string(),
+                wt_path: wt_path.to_path_buf(),
+                nested_status: nested,
+                sender: sender.map(str::to_string),
+            }],
         );
     }
     // PRESERVE. commit-tree needs a committer identity supplied via `-c` so the
@@ -862,9 +939,12 @@ pub(crate) fn preserve_dirty_worktree(
             other => {
                 tracing::warn!(agent, branch, ?other,
                     "preserve dirty WIP: staged-snapshot `commit-tree` failed — refusing to remove (fail-closed)");
-                return WipPreservation::Blocked(format!(
-                    "`git commit-tree` (staged snapshot) failed: {other:?}"
-                ));
+                return (
+                    WipPreservation::Blocked(format!(
+                        "`git commit-tree` (staged snapshot) failed: {other:?}"
+                    )),
+                    Vec::new(),
+                );
             }
         }
     } else {
@@ -896,7 +976,10 @@ pub(crate) fn preserve_dirty_worktree(
                 ?other,
                 "preserve dirty WIP: `commit-tree` failed — refusing to remove (fail-closed)"
             );
-            return WipPreservation::Blocked(format!("`git commit-tree` failed: {other:?}"));
+            return (
+                WipPreservation::Blocked(format!("`git commit-tree` failed: {other:?}")),
+                Vec::new(),
+            );
         }
     };
     let ts = chrono::Utc::now().format("%Y%m%dT%H%M%SZ").to_string();
@@ -904,13 +987,20 @@ pub(crate) fn preserve_dirty_worktree(
     if let Err(e) = git_cmd(wt_path, &["update-ref", &ref_name, &commit]) {
         tracing::warn!(agent, branch, error = %e,
             "preserve dirty WIP: `update-ref` failed — refusing to remove (fail-closed)");
-        return WipPreservation::Blocked(format!("`git update-ref {ref_name}` failed: {e}"));
+        return (
+            WipPreservation::Blocked(format!("`git update-ref {ref_name}` failed: {e}")),
+            Vec::new(),
+        );
     }
     tracing::info!(agent, branch, %ref_name, dual_parent = parent2.is_some(),
         "preserve dirty WIP: uncommitted worktree changes snapshotted before manual release");
     prune_recovery_refs(wt_path, branch);
-    notify_wip_preserved(home, agent, branch, &ref_name, parent2.is_some(), sender);
-    WipPreservation::Preserved
+    let recipient = wip_notice_recipient(home, agent, sender);
+    let text = wip_preserved_notice(agent, branch, &ref_name, parent2.is_some());
+    (
+        WipPreservation::Preserved,
+        vec![ReleaseNotice::WipPreserved { recipient, text }],
+    )
 }
 
 /// Bound the recovery-ref set for `branch`: keep at most
@@ -1007,23 +1097,6 @@ fn wip_preserved_notice(agent: &str, branch: &str, ref_name: &str, dual_parent: 
          Auto-pruned after {RECOVERY_TTL_DAYS}d / max {RECOVERY_MAX_PER_BRANCH} per branch. \
          #2158-adjacent."
     )
-}
-
-/// Notify the release's CALLER that a dirty worktree's WIP was preserved, with a
-/// one-line recovery command. Recipient + body per the pure helpers above.
-/// Best-effort.
-fn notify_wip_preserved(
-    home: &Path,
-    agent: &str,
-    branch: &str,
-    ref_name: &str,
-    dual_parent: bool,
-    sender: Option<&str>,
-) {
-    let recipient = wip_notice_recipient(home, agent, sender);
-    let text = wip_preserved_notice(agent, branch, ref_name, dual_parent);
-    let source = crate::inbox::NotifySource::System("release_dirty_wip_preserved");
-    crate::inbox::notify_agent(home, &recipient, &source, &text);
 }
 
 /// Monotonic sequence for per-worktree TEMP artifacts (temp index files + atomic

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -10,6 +10,8 @@ use std::path::{Path, PathBuf};
 pub(crate) enum ReleaseTestPhase {
     AfterBindingSnapshot,
     BeforeWorktreeRemove,
+    BeforeNoticeEmit,
+    CheckoutBoundBeforeCommit,
 }
 
 #[cfg(test)]
@@ -17,8 +19,10 @@ pub(crate) mod release_test_seam {
     use super::ReleaseTestPhase;
     use std::cell::RefCell;
 
+    type ReleaseHook = Box<dyn Fn(ReleaseTestPhase)>;
+
     thread_local! {
-        static HOOK: RefCell<Option<Box<dyn Fn(ReleaseTestPhase)>>> = RefCell::new(None);
+        static HOOK: RefCell<Option<ReleaseHook>> = RefCell::new(None);
     }
 
     pub(crate) struct Guard;
@@ -34,7 +38,7 @@ pub(crate) mod release_test_seam {
         Guard
     }
 
-    pub(super) fn hit(phase: ReleaseTestPhase) {
+    pub(crate) fn hit(phase: ReleaseTestPhase) {
         HOOK.with(|slot| {
             if let Some(hook) = slot.borrow().as_ref() {
                 hook(phase);
@@ -216,6 +220,9 @@ pub struct ReleaseOutcome {
     pub dry_run_preview: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+    /// Internal exact-CAS signal for auto-release. Not part of the MCP response.
+    #[serde(skip)]
+    pub(crate) stale_fingerprint: bool,
 }
 
 /// Delete the local branch ref after worktree release, IFF:
@@ -544,30 +551,59 @@ fn resolve_branch_cleanup(
     }
 }
 
-pub fn release_full(home: &Path, agent: &str, dry_run: bool) -> ReleaseOutcome {
+struct LockedRelease {
+    out: ReleaseOutcome,
+    notices: Vec<crate::worktree::ReleaseNotice>,
+    clear_refusal_marker: Option<PathBuf>,
+    finish_full_release: bool,
+    managed_verified: bool,
+    worktree_absent: bool,
+}
+
+fn idempotent_absent() -> ReleaseOutcome {
+    ReleaseOutcome {
+        released: true,
+        already_released: true,
+        ..ReleaseOutcome::default()
+    }
+}
+
+fn opaque_release(reason: String) -> ReleaseOutcome {
+    ReleaseOutcome {
+        error: Some(format!(
+            "release refused: opaque binding state ({reason}); binding evidence preserved"
+        )),
+        ..ReleaseOutcome::default()
+    }
+}
+
+fn stale_release() -> ReleaseOutcome {
+    ReleaseOutcome {
+        stale_fingerprint: true,
+        error: Some(
+            "release refused: binding fingerprint changed before destructive authority was reacquired"
+                .to_string(),
+        ),
+        ..ReleaseOutcome::default()
+    }
+}
+
+fn release_known_locked(
+    home: &Path,
+    agent: &str,
+    binding: &serde_json::Value,
+    dry_run: bool,
+) -> LockedRelease {
     let mut out = ReleaseOutcome::default();
-
-    let Some(binding) = crate::binding::read(home, agent) else {
-        // #1465: release is idempotent. "No binding" means the release
-        // target state is already reached → report a success no-op rather
-        // than an error, so automated dispatch/release can treat release as
-        // a safe always-succeeds operation. (A genuine cleanup failure WITH
-        // a binding present still returns `released:false` + `error` below —
-        // idempotent success applies ONLY to this nothing-to-do path.)
-        out.released = true;
-        out.already_released = true;
-        return out;
-    };
-    #[cfg(test)]
-    release_test_seam::hit(ReleaseTestPhase::AfterBindingSnapshot);
-
+    let mut notices = Vec::new();
+    let mut clear_refusal_marker = None;
     let wt_path_str = binding["worktree"].as_str().unwrap_or("");
     let mut managed_verified = false;
     let mut worktree_absent = false;
 
     if !wt_path_str.is_empty() {
         let wt_path = Path::new(wt_path_str);
-        let source_repo = source_repo_from_binding(&binding, wt_path);
+        let source_repo = source_repo_from_binding(binding, wt_path);
 
         if dry_run {
             // #t-21: dry_run is observation-only. Classify the worktree with the
@@ -583,7 +619,14 @@ pub fn release_full(home: &Path, agent: &str, dry_run: bool) -> ReleaseOutcome {
                     "worktree at {} has no .agend-managed marker — refusing to remove (binding NOT cleared)",
                     wt_path.display()
                 ));
-                return out;
+                return LockedRelease {
+                    out,
+                    notices,
+                    clear_refusal_marker,
+                    finish_full_release: false,
+                    managed_verified,
+                    worktree_absent,
+                };
             } else {
                 managed_verified = true;
             }
@@ -600,8 +643,10 @@ pub fn release_full(home: &Path, agent: &str, dry_run: bool) -> ReleaseOutcome {
                 // No caller identity on the background pool-sweep path → None
                 // routes the WIP-preserved notice to the agent's team orchestrator
                 // (fallback: operator inbox) rather than a hardcoded recipient.
-                let preservation =
-                    crate::worktree::preserve_dirty_worktree(home, agent, wt_path, branch, None);
+                let (preservation, collected) = crate::worktree::preserve_dirty_worktree_collect(
+                    home, agent, wt_path, branch, None,
+                );
+                notices.extend(collected);
                 if let Some(reason) = preservation.blocked_reason() {
                     // reviewer4 #2672 fix — FAIL-CLOSED: there IS uncommitted WIP
                     // but it could not be snapshotted (e.g. a contended
@@ -614,7 +659,14 @@ pub fn release_full(home: &Path, agent: &str, dry_run: bool) -> ReleaseOutcome {
                          preserved ({reason}); not removing it so the WIP can be recovered. \
                          Commit or stash the changes, then release again."
                     ));
-                    return out;
+                    return LockedRelease {
+                        out,
+                        notices,
+                        clear_refusal_marker,
+                        finish_full_release: false,
+                        managed_verified,
+                        worktree_absent,
+                    };
                 }
             }
             #[cfg(test)]
@@ -627,7 +679,7 @@ pub fn release_full(home: &Path, agent: &str, dry_run: bool) -> ReleaseOutcome {
                     // per-worktree unpreservable-nested-dirt notice marker; clear
                     // it (+ its lock) so a future re-lease of this path re-notifies
                     // from a clean slate. Best-effort.
-                    crate::worktree::clear_nested_refusal_marker(home, wt_path);
+                    clear_refusal_marker = Some(wt_path.to_path_buf());
                 }
                 WorktreeRemoval::AlreadyAbsent => {
                     worktree_absent = true;
@@ -643,7 +695,14 @@ pub fn release_full(home: &Path, agent: &str, dry_run: bool) -> ReleaseOutcome {
                     // dry_run classifier above mutates nothing.)
                     clear_binding_state(home, agent);
                     out.binding_removed = true;
-                    return out;
+                    return LockedRelease {
+                        out,
+                        notices,
+                        clear_refusal_marker,
+                        finish_full_release: false,
+                        managed_verified,
+                        worktree_absent,
+                    };
                 }
                 WorktreeRemoval::Failed(err) => {
                     managed_verified = true;
@@ -680,27 +739,227 @@ pub fn release_full(home: &Path, agent: &str, dry_run: bool) -> ReleaseOutcome {
         }
     }
 
-    resolve_branch_cleanup(
-        &binding,
+    LockedRelease {
+        out,
+        notices,
+        clear_refusal_marker,
+        finish_full_release: true,
         managed_verified,
         worktree_absent,
-        dry_run,
-        &mut out,
-    );
+    }
+}
 
-    crate::event_log::log(
-        home,
-        "worktree_released_full",
-        agent,
-        &format!(
-            "wt_removed={} binding_removed={} error={}",
-            out.worktree_removed,
-            out.binding_removed,
-            out.error.as_deref().unwrap_or("")
-        ),
-    );
+fn release_full_guarded(
+    home: &Path,
+    agent: &str,
+    dry_run: bool,
+    expected: Option<&crate::binding::BindingFingerprint>,
+) -> ReleaseOutcome {
+    use crate::binding::GuardedBinding;
 
+    let (snapshot, fingerprint) = match crate::binding::snapshot_guarded_binding(home, agent) {
+        Err(e) => return opaque_release(e),
+        Ok(GuardedBinding::Absent) => return idempotent_absent(),
+        Ok(GuardedBinding::Opaque(reason)) => return opaque_release(reason),
+        Ok(GuardedBinding::Known { value, fingerprint }) => (value, fingerprint),
+    };
+    if expected.is_some_and(|expected| expected != &fingerprint) {
+        return stale_release();
+    }
+    #[cfg(test)]
+    release_test_seam::hit(ReleaseTestPhase::AfterBindingSnapshot);
+
+    let branch = snapshot["branch"].as_str().unwrap_or("");
+    if branch.is_empty() {
+        return opaque_release("known binding has no branch lease identity".to_string());
+    }
+    let wt = snapshot["worktree"].as_str().unwrap_or("");
+    let source_repo = source_repo_from_binding(&snapshot, Path::new(wt));
+    let source_repo_str = source_repo.display().to_string();
+    let _branch_lock =
+        match crate::binding::acquire_branch_lease_lock(home, &source_repo_str, branch) {
+            Ok(lock) => lock,
+            Err(e) => return opaque_release(format!("branch lease lock failed: {e}")),
+        };
+    let _agent_lock = match crate::binding::acquire_agent_mutation_lock(home, agent) {
+        Ok(lock) => lock,
+        Err(e) => return opaque_release(e),
+    };
+    let _binding_lock = match crate::binding::acquire_binding_file_lock(home, agent) {
+        Ok(lock) => lock,
+        Err(e) => return opaque_release(e),
+    };
+    let current = match crate::binding::guarded_binding_disk_fresh(home, agent) {
+        GuardedBinding::Absent => return idempotent_absent(),
+        GuardedBinding::Opaque(reason) => return opaque_release(reason),
+        GuardedBinding::Known {
+            value,
+            fingerprint: live,
+        } if live == fingerprint => value,
+        GuardedBinding::Known { .. } => return stale_release(),
+    };
+    let mut locked = release_known_locked(home, agent, &current, dry_run);
+    // Explicit drops document the lock boundary: no notice, marker cleanup,
+    // branch cleanup, or release event runs with a flock held.
+    drop(_binding_lock);
+    drop(_agent_lock);
+    drop(_branch_lock);
+
+    for notice in locked.notices.drain(..) {
+        notice.emit(home);
+    }
+    if let Some(path) = locked.clear_refusal_marker.take() {
+        crate::worktree::clear_nested_refusal_marker(home, &path);
+    }
+    if locked.finish_full_release {
+        resolve_branch_cleanup(
+            &current,
+            locked.managed_verified,
+            locked.worktree_absent,
+            dry_run,
+            &mut locked.out,
+        );
+        crate::event_log::log(
+            home,
+            "worktree_released_full",
+            agent,
+            &format!(
+                "wt_removed={} binding_removed={} error={}",
+                locked.out.worktree_removed,
+                locked.out.binding_removed,
+                locked.out.error.as_deref().unwrap_or("")
+            ),
+        );
+    }
+    locked.out
+}
+
+pub fn release_full(home: &Path, agent: &str, dry_run: bool) -> ReleaseOutcome {
+    release_full_guarded(home, agent, dry_run, None)
+}
+
+pub(crate) fn release_full_exact(
+    home: &Path,
+    agent: &str,
+    expected: &crate::binding::BindingFingerprint,
+) -> ReleaseOutcome {
+    release_full_guarded(home, agent, false, Some(expected))
+}
+
+fn release_bound_target_exact_impl(
+    home: &Path,
+    agent: &str,
+    expected: &crate::binding::BindingFingerprint,
+    target: &Path,
+    source_repo: &Path,
+    caller_holds_branch_lease: bool,
+    clear_binding_on_remove_failure: bool,
+) -> ReleaseOutcome {
+    use crate::binding::GuardedBinding;
+
+    let snapshot = match crate::binding::snapshot_guarded_binding(home, agent) {
+        Err(e) => return opaque_release(e),
+        Ok(GuardedBinding::Absent) => return idempotent_absent(),
+        Ok(GuardedBinding::Opaque(reason)) => return opaque_release(reason),
+        Ok(GuardedBinding::Known { value, fingerprint }) if &fingerprint == expected => value,
+        Ok(GuardedBinding::Known { .. }) => return stale_release(),
+    };
+    #[cfg(test)]
+    release_test_seam::hit(ReleaseTestPhase::AfterBindingSnapshot);
+    let branch = snapshot["branch"].as_str().unwrap_or("");
+    if branch.is_empty() {
+        return opaque_release("known binding has no branch lease identity".to_string());
+    }
+    let branch_lock = if caller_holds_branch_lease {
+        None
+    } else {
+        match crate::binding::acquire_branch_lease_lock(
+            home,
+            &source_repo.display().to_string(),
+            branch,
+        ) {
+            Ok(lock) => Some(lock),
+            Err(e) => return opaque_release(format!("branch lease lock failed: {e}")),
+        }
+    };
+    let _agent_lock = match crate::binding::acquire_agent_mutation_lock(home, agent) {
+        Ok(lock) => lock,
+        Err(e) => return opaque_release(e),
+    };
+    let _binding_lock = match crate::binding::acquire_binding_file_lock(home, agent) {
+        Ok(lock) => lock,
+        Err(e) => return opaque_release(e),
+    };
+    let current = match crate::binding::guarded_binding_disk_fresh(home, agent) {
+        GuardedBinding::Absent => return idempotent_absent(),
+        GuardedBinding::Opaque(reason) => return opaque_release(reason),
+        GuardedBinding::Known { value, fingerprint } if &fingerprint == expected => value,
+        GuardedBinding::Known { .. } => return stale_release(),
+    };
+    let target_str = target.display().to_string();
+    if current.get("worktree").and_then(|v| v.as_str()) != Some(target_str.as_str()) {
+        return stale_release();
+    }
+
+    #[cfg(test)]
+    release_test_seam::hit(ReleaseTestPhase::BeforeWorktreeRemove);
+    let mut out = ReleaseOutcome::default();
+    let mut clear_marker = false;
+    let remove = remove_worktree(agent, target, source_repo);
+    match remove {
+        WorktreeRemoval::Removed => {
+            out.worktree_removed = true;
+            clear_marker = true;
+            clear_binding_state(home, agent);
+            out.binding_removed = true;
+            out.released = true;
+        }
+        WorktreeRemoval::AlreadyAbsent => {
+            clear_binding_state(home, agent);
+            out.binding_removed = true;
+            out.released = true;
+        }
+        WorktreeRemoval::Unmanaged(error) => out.error = Some(error),
+        WorktreeRemoval::Failed(error) => {
+            out.error = Some(error);
+            if clear_binding_on_remove_failure {
+                clear_binding_state(home, agent);
+                out.binding_removed = true;
+            }
+        }
+    }
+    drop(_binding_lock);
+    drop(_agent_lock);
+    drop(branch_lock);
+    if clear_marker {
+        crate::worktree::clear_nested_refusal_marker(home, target);
+    }
     out
+}
+
+/// Exact Known-target release for reverse reconciliation. It acquires the
+/// branch lease itself and leaves the binding intact if removal fails.
+pub(crate) fn release_bound_target_exact(
+    home: &Path,
+    agent: &str,
+    expected: &crate::binding::BindingFingerprint,
+    target: &Path,
+    source_repo: &Path,
+) -> ReleaseOutcome {
+    release_bound_target_exact_impl(home, agent, expected, target, source_repo, false, false)
+}
+
+/// Exact Known-target release for checkout rollback, whose caller already holds
+/// L(repo,branch). Preserves the rollback path's historical partial-unbind
+/// behavior if the worktree removal itself fails.
+pub(crate) fn release_bound_target_exact_under_branch_lock(
+    home: &Path,
+    agent: &str,
+    expected: &crate::binding::BindingFingerprint,
+    target: &Path,
+    source_repo: &Path,
+) -> ReleaseOutcome {
+    release_bound_target_exact_impl(home, agent, expected, target, source_repo, true, true)
 }
 
 /// Pin a worktree (operator override — prevents GC in Phase 4).

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -5,6 +5,44 @@
 
 use std::path::{Path, PathBuf};
 
+#[cfg(test)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ReleaseTestPhase {
+    AfterBindingSnapshot,
+    BeforeWorktreeRemove,
+}
+
+#[cfg(test)]
+pub(crate) mod release_test_seam {
+    use super::ReleaseTestPhase;
+    use std::cell::RefCell;
+
+    thread_local! {
+        static HOOK: RefCell<Option<Box<dyn Fn(ReleaseTestPhase)>>> = RefCell::new(None);
+    }
+
+    pub(crate) struct Guard;
+
+    impl Drop for Guard {
+        fn drop(&mut self) {
+            HOOK.with(|slot| *slot.borrow_mut() = None);
+        }
+    }
+
+    pub(crate) fn install(hook: impl Fn(ReleaseTestPhase) + 'static) -> Guard {
+        HOOK.with(|slot| *slot.borrow_mut() = Some(Box::new(hook)));
+        Guard
+    }
+
+    pub(super) fn hit(phase: ReleaseTestPhase) {
+        HOOK.with(|slot| {
+            if let Some(hook) = slot.borrow().as_ref() {
+                hook(phase);
+            }
+        });
+    }
+}
+
 // #1639: the daemon-internal git wrapper lives in `git_helpers::git_bypass`
 // (the #781-centralized single source for the `AGEND_GIT_BYPASS=1` contract).
 // Call sites below go through it directly rather than a local copy.
@@ -520,6 +558,8 @@ pub fn release_full(home: &Path, agent: &str, dry_run: bool) -> ReleaseOutcome {
         out.already_released = true;
         return out;
     };
+    #[cfg(test)]
+    release_test_seam::hit(ReleaseTestPhase::AfterBindingSnapshot);
 
     let wt_path_str = binding["worktree"].as_str().unwrap_or("");
     let mut managed_verified = false;
@@ -577,6 +617,8 @@ pub fn release_full(home: &Path, agent: &str, dry_run: bool) -> ReleaseOutcome {
                     return out;
                 }
             }
+            #[cfg(test)]
+            release_test_seam::hit(ReleaseTestPhase::BeforeWorktreeRemove);
             match remove_worktree(agent, wt_path, &source_repo) {
                 WorktreeRemoval::Removed => {
                     managed_verified = true;

--- a/src/worktree_pool/tests.rs
+++ b/src/worktree_pool/tests.rs
@@ -916,6 +916,12 @@ fn release_full_refuses_binding_rewrite_between_snapshot_and_remove_s1() {
     });
 
     snap_rx.recv().expect("release reached snapshot phase");
+    // Same-branch checkout/reuse owns L(repo,branch) while it refreshes binding
+    // metadata. Manual release must wait for that owner, then reject its stale
+    // fingerprint rather than deleting the reused generation.
+    let reuse_lease =
+        crate::binding::acquire_branch_lease_lock(&home, &repo.display().to_string(), "feat/cas")
+            .expect("same-branch reuse lease");
     crate::binding::bind_full(
         &home,
         "agent-cas",
@@ -926,6 +932,7 @@ fn release_full_refuses_binding_rewrite_between_snapshot_and_remove_s1() {
         false,
     )
     .expect("install generation B");
+    drop(reuse_lease);
     resume_tx.send(()).expect("resume release after rebind");
 
     let outcome = release_thread.join().expect("release thread");
@@ -1067,6 +1074,113 @@ fn release_refuses_opaque_binding_instead_of_treating_it_absent_s1() {
     );
 
     std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn agent_mutation_lock_survives_runtime_directory_deletion_s1() {
+    let home = tmp_home("s1-stable-agent-lock");
+    let runtime = crate::paths::runtime_dir(&home).join("agent-stable");
+    std::fs::create_dir_all(&runtime).expect("runtime dir");
+    let path = crate::binding::release_guard::agent_mutation_lock_path(&home, "agent-stable");
+    assert!(
+        !path.starts_with(crate::paths::runtime_dir(&home)),
+        "permanent agent lock must live outside deletable runtime: {}",
+        path.display()
+    );
+
+    let held = crate::binding::acquire_agent_mutation_lock(&home, "agent-stable")
+        .expect("first agent mutation lock");
+    std::fs::remove_dir_all(&runtime).expect("delete runtime while lock held");
+    assert!(path.exists(), "stable lock inode survives runtime deletion");
+    assert!(
+        crate::store::try_acquire_file_lock(&path)
+            .expect("contended lock probe")
+            .is_none(),
+        "second actor still contends on the same inode"
+    );
+    drop(held);
+    assert!(
+        crate::store::try_acquire_file_lock(&path)
+            .expect("released lock probe")
+            .is_some(),
+        "stable lock becomes acquirable after guard drop"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn auto_release_exact_fingerprint_cannot_release_new_generation_s1() {
+    let home = tmp_home("s1-auto-exact");
+    let repo = tmp_repo("s1-auto-exact-repo");
+    let lease = lease_bound(&home, &repo, "agent-auto", "feat/auto-exact");
+    let old =
+        match crate::binding::snapshot_guarded_binding(&home, "agent-auto").expect("snapshot A") {
+            crate::binding::GuardedBinding::Known { fingerprint, .. } => fingerprint,
+            other => panic!("expected Known A, got {other:?}"),
+        };
+    let branch_lock = crate::binding::acquire_branch_lease_lock(
+        &home,
+        &repo.display().to_string(),
+        "feat/auto-exact",
+    )
+    .expect("branch lease for generation B");
+    crate::binding::bind_full(
+        &home,
+        "agent-auto",
+        "T-generation-b",
+        "feat/auto-exact",
+        &lease.path,
+        &repo,
+        false,
+    )
+    .expect("write generation B");
+    drop(branch_lock);
+
+    let outcome = release_full_exact(&home, "agent-auto", &old);
+    assert!(
+        outcome.stale_fingerprint && !outcome.released,
+        "auto-release A must reject B exactly: {outcome:?}"
+    );
+    assert!(lease.path.exists(), "generation B worktree survives");
+    assert_eq!(
+        crate::binding::read(&home, "agent-auto").expect("generation B binding")["task_id"],
+        "T-generation-b"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&repo).ok();
+}
+
+#[test]
+fn dirty_release_begins_notice_emit_after_all_transaction_flocks_drop_s1() {
+    let home = tmp_home("s1-notice-unlocked");
+    let repo = tmp_repo("s1-notice-unlocked-repo");
+    let lease = lease_bound(&home, &repo, "agent-notice", "feat/notice");
+    std::fs::write(lease.path.join("precious.txt"), b"dirty WIP").expect("dirty WIP");
+
+    let (depth_tx, depth_rx) = std::sync::mpsc::channel();
+    let _hook = release_test_seam::install(move |phase| {
+        if phase == ReleaseTestPhase::BeforeNoticeEmit {
+            depth_tx
+                .send(crate::sync_audit::flock_depth())
+                .expect("publish notice flock depth");
+        }
+    });
+    let outcome = release_full(&home, "agent-notice", false);
+    assert!(outcome.released, "dirty release succeeds: {outcome:?}");
+    assert_eq!(
+        depth_rx.recv().expect("notice emit observed"),
+        0,
+        "notice dispatch begins after branch + agent + binding flocks drop"
+    );
+    assert_eq!(
+        recovery_refs(&repo, "feat/notice").len(),
+        1,
+        "the observed notice corresponds to a created recovery ref"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&repo).ok();
 }
 
 /// §3.9 regression (#t-21 HIGH #1): `release_full(dry_run=true)` must be

--- a/src/worktree_pool/tests.rs
+++ b/src/worktree_pool/tests.rs
@@ -944,6 +944,131 @@ fn release_full_refuses_binding_rewrite_between_snapshot_and_remove_s1() {
     std::fs::remove_dir_all(&repo).ok();
 }
 
+/// S1 RED: two release actors may snapshot the same generation, but only one may
+/// perform the remove+unbind transition. Both threads rendezvous after snapshot,
+/// so the race is deterministic and sleep-free.
+#[test]
+fn concurrent_release_actors_apply_one_transition_s1() {
+    let home = tmp_home("s1-release-once");
+    let repo = tmp_repo("s1-release-once-repo");
+    lease_bound(&home, &repo, "agent-once", "feat/once");
+
+    let rendezvous = std::sync::Arc::new(std::sync::Barrier::new(2));
+    let run = |home: PathBuf, rendezvous: std::sync::Arc<std::sync::Barrier>| {
+        std::thread::spawn(move || {
+            let _hook = release_test_seam::install(move |phase| {
+                if phase == ReleaseTestPhase::AfterBindingSnapshot {
+                    rendezvous.wait();
+                }
+            });
+            release_full(&home, "agent-once", false)
+        })
+    };
+    let a = run(home.clone(), rendezvous.clone());
+    let b = run(home.clone(), rendezvous);
+    let outcomes = [a.join().expect("release A"), b.join().expect("release B")];
+
+    assert_eq!(
+        outcomes.iter().filter(|o| o.binding_removed).count(),
+        1,
+        "one generation permits exactly one binding transition: {outcomes:?}"
+    );
+    assert_eq!(
+        outcomes.iter().filter(|o| o.worktree_removed).count(),
+        1,
+        "one generation permits exactly one worktree removal: {outcomes:?}"
+    );
+    assert_eq!(
+        outcomes.iter().filter(|o| o.already_released).count(),
+        1,
+        "the losing actor converges as an idempotent no-op: {outcomes:?}"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&repo).ok();
+}
+
+/// S1 RED: reverse reconciliation is another live remove+unbind actor. If it
+/// wins after manual release's snapshot, the manual actor must converge on
+/// Absent instead of applying a second transition to the restored workspace.
+#[test]
+fn reverse_reconcile_vs_release_applies_one_transition_s1() {
+    let home = tmp_home("s1-reverse-release");
+    let repo = tmp_repo("s1-reverse-release-repo");
+    let ws = converted_workspace_with_commit(&home, &repo, "agent-reverse", "feat/reverse");
+    crate::binding::bind_full(
+        &home,
+        "agent-reverse",
+        "T-reverse",
+        "feat/reverse",
+        &ws,
+        &repo,
+        false,
+    )
+    .expect("bind converted workspace");
+
+    let (snap_tx, snap_rx) = std::sync::mpsc::channel();
+    let (resume_tx, resume_rx) = std::sync::mpsc::channel();
+    let home_for_release = home.clone();
+    let release_thread = std::thread::spawn(move || {
+        let _hook = release_test_seam::install(move |phase| {
+            if phase == ReleaseTestPhase::AfterBindingSnapshot {
+                snap_tx.send(()).expect("publish snapshot phase");
+                resume_rx.recv().expect("resume manual release");
+            }
+        });
+        release_full(&home_for_release, "agent-reverse", false)
+    });
+
+    snap_rx.recv().expect("manual release snapped binding");
+    reverse_reconcile(&home, "agent-reverse").expect("reverse reconcile wins");
+    resume_tx.send(()).expect("resume manual release");
+    let manual = release_thread.join().expect("manual release thread");
+
+    assert!(
+        manual.already_released && !manual.binding_removed && !manual.worktree_removed,
+        "losing manual actor must be an Absent no-op, not a second transition: {manual:?}"
+    );
+    assert!(
+        ws.join(".git").is_dir(),
+        "reverse reconcile's restored standalone workspace survives"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&repo).ok();
+}
+
+/// S1 RED: an unreadable/corrupt/future binding is Opaque, never Absent. A
+/// destructive caller must refuse rather than treating ambiguity as an
+/// idempotent success.
+#[test]
+fn release_refuses_opaque_binding_instead_of_treating_it_absent_s1() {
+    let home = tmp_home("s1-opaque-binding");
+    let runtime = crate::paths::runtime_dir(&home).join("agent-opaque");
+    std::fs::create_dir_all(&runtime).expect("runtime dir");
+    std::fs::write(runtime.join("binding.json"), b"{not valid json").expect("opaque binding");
+
+    let outcome = release_full(&home, "agent-opaque", false);
+    assert!(
+        !outcome.released && !outcome.already_released,
+        "Opaque must refuse, never collapse to Absent: {outcome:?}"
+    );
+    assert!(
+        outcome
+            .error
+            .as_deref()
+            .is_some_and(|e| e.contains("opaque")),
+        "refusal names opaque binding state: {:?}",
+        outcome.error
+    );
+    assert!(
+        runtime.join("binding.json").exists(),
+        "opaque evidence is preserved byte-for-byte"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+}
+
 /// §3.9 regression (#t-21 HIGH #1): `release_full(dry_run=true)` must be
 /// observation-only — the worktree directory AND binding.json must survive.
 /// Pre-fix, `remove_worktree` + `clear_binding_state` ran unconditionally,

--- a/src/worktree_pool/tests.rs
+++ b/src/worktree_pool/tests.rs
@@ -893,6 +893,57 @@ fn p0x_release_full_happy_path_removes_worktree_and_binding() {
     std::fs::remove_dir_all(&repo).ok();
 }
 
+/// S1 RED: a release that snapshots binding generation A must not tear down a
+/// same-agent generation B installed before destructive authority is reacquired.
+/// The phase seam makes the interleaving deterministic (no sleeps).
+#[test]
+fn release_full_refuses_binding_rewrite_between_snapshot_and_remove_s1() {
+    let home = tmp_home("s1-fingerprint-move");
+    let repo = tmp_repo("s1-fingerprint-move-repo");
+    let lease = lease_bound(&home, &repo, "agent-cas", "feat/cas");
+
+    let (snap_tx, snap_rx) = std::sync::mpsc::channel();
+    let (resume_tx, resume_rx) = std::sync::mpsc::channel();
+    let home_for_release = home.clone();
+    let release_thread = std::thread::spawn(move || {
+        let _hook = release_test_seam::install(move |phase| {
+            if phase == ReleaseTestPhase::AfterBindingSnapshot {
+                snap_tx.send(()).expect("publish snapshot phase");
+                resume_rx.recv().expect("resume release");
+            }
+        });
+        release_full(&home_for_release, "agent-cas", false)
+    });
+
+    snap_rx.recv().expect("release reached snapshot phase");
+    crate::binding::bind_full(
+        &home,
+        "agent-cas",
+        "T-generation-b",
+        "feat/cas",
+        &lease.path,
+        &repo,
+        false,
+    )
+    .expect("install generation B");
+    resume_tx.send(()).expect("resume release after rebind");
+
+    let outcome = release_thread.join().expect("release thread");
+    assert!(
+        !outcome.released,
+        "stale generation A release must refuse generation B: {outcome:?}"
+    );
+    assert!(
+        lease.path.exists(),
+        "generation B worktree must survive stale release"
+    );
+    let live = crate::binding::read(&home, "agent-cas").expect("generation B binding survives");
+    assert_eq!(live["task_id"], "T-generation-b");
+
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&repo).ok();
+}
+
 /// §3.9 regression (#t-21 HIGH #1): `release_full(dry_run=true)` must be
 /// observation-only — the worktree directory AND binding.json must survive.
 /// Pre-fix, `remove_worktree` + `clear_binding_state` ran unconditionally,

--- a/src/worktree_pool/workspace.rs
+++ b/src/worktree_pool/workspace.rs
@@ -523,6 +523,28 @@ pub fn reverse_reconcile(home: &Path, agent: &str) -> Result<(), String> {
     if !ws.join(".git").is_file() {
         return Ok(());
     }
+    // S1: a live binding makes reverse reconciliation a release actor. Capture
+    // its exact disk generation now; the guarded transaction below will re-read
+    // it after taking L(repo,branch) and refuse if authority moved meanwhile.
+    let live_fingerprint = match crate::binding::snapshot_guarded_binding(home, agent)? {
+        crate::binding::GuardedBinding::Absent => None,
+        crate::binding::GuardedBinding::Opaque(reason) => {
+            return Err(format!(
+                "reverse_reconcile refused: opaque binding state ({reason})"
+            ))
+        }
+        crate::binding::GuardedBinding::Known { value, fingerprint } => {
+            let bound = value.get("worktree").and_then(|v| v.as_str());
+            let ws_str = ws.display().to_string();
+            if bound != Some(ws_str.as_str()) {
+                return Err(
+                    "reverse_reconcile refused: live binding targets a different worktree"
+                        .to_string(),
+                );
+            }
+            Some(fingerprint)
+        }
+    };
     // Save uncommitted/untracked work BEFORE any destructive step (committed work
     // is already safe in canonical). Fail-closed: backup error → abort, untouched.
     if worktree_has_work_at_risk(&ws) {
@@ -537,17 +559,31 @@ pub fn reverse_reconcile(home: &Path, agent: &str) -> Result<(), String> {
     // teardown use (git worktree remove --force from the owning repo; branch ref +
     // commits remain in canonical).
     let source_repo = resolve_owning_repo(home, agent, &ws);
-    match remove_worktree(agent, &ws, &source_repo) {
-        WorktreeRemoval::Removed | WorktreeRemoval::AlreadyAbsent => {}
-        WorktreeRemoval::Unmanaged(m) => {
-            return Err(format!("reverse_reconcile: {m}"));
+    if let Some(fingerprint) = live_fingerprint {
+        let outcome =
+            super::release_bound_target_exact(home, agent, &fingerprint, &ws, &source_repo);
+        if !outcome.released {
+            return Err(format!(
+                "reverse_reconcile: guarded release failed: {}",
+                outcome
+                    .error
+                    .as_deref()
+                    .unwrap_or("unknown release failure")
+            ));
         }
-        WorktreeRemoval::Failed(e) => {
-            return Err(format!("reverse_reconcile: worktree remove failed: {e}"));
+    } else {
+        // No live binding means there is no release transition to serialize; keep
+        // the legacy remove-only path for already-unbound converted workspaces.
+        match remove_worktree(agent, &ws, &source_repo) {
+            WorktreeRemoval::Removed | WorktreeRemoval::AlreadyAbsent => {}
+            WorktreeRemoval::Unmanaged(m) => {
+                return Err(format!("reverse_reconcile: {m}"));
+            }
+            WorktreeRemoval::Failed(e) => {
+                return Err(format!("reverse_reconcile: worktree remove failed: {e}"));
+            }
         }
     }
-    // Clear the (B) binding so the next dispatch leases fresh (legacy path).
-    crate::binding::unbind(home, agent);
     // Restore `/workspace/<agent>` as a clean standalone (git-init), matching the
     // pre-(B) state. `git worktree remove` deleted the dir, so recreate it; the
     // next spawn's `ensure_project_root` would also do this, but doing it here


### PR DESCRIPTION
## What & why

Serializes destructive binding release as a generation-aware transaction so a releaser that snapshots generation A cannot tear down a same-agent generation B. This S1 slice adds a permanent per-agent mutation lock, disk-fresh tri-state binding reads, exact raw-byte fingerprints, the A snapshot → L(repo,branch) → A/CAS release ladder, and exact actor paths for auto-release, checkout rollback, and reverse reconciliation.

## Prior art check (required)

- [x] I checked `docs/KNOWN_ISSUES.md`; this is not listed as intentionally deferred.
- [x] I compared this change against current `main`; the guarded release transaction is not already implemented.
- [x] I searched closed issues and PRs for `release binding fingerprint`; no matching prior attempt was returned.
- [x] This implements the approved S1 decision `d-20260714015901054857-7`; the new evidence is deterministic pre-fix race reproduction in `1451b51c` and `b4b91b71`.

## How it was verified

- RED anchor: `1451b51c` failed because stale release A removed generation B.
- RED actor matrix: `b4b91b71` failed pre-fix for concurrent release, reverse-reconcile double transition, and corrupt binding collapsing to Absent.
- `cargo test --bin agend-terminal s1 -- --nocapture` → 9 passed.
- `scripts/fmt-owned.sh --check` → passed.
- `cargo clippy --lib --bin agend-terminal --bin agend-git --bin agend-mcp-bridge --tests --examples --features tray -- -D warnings` → passed.
- `AGEND_LOCK_AUDIT=1 cargo nextest run --features tray,discord --profile ci` → 5,931 passed, 37 profile-skipped.

## Compatibility (on-disk formats)

- [x] No tier (a)/(b) on-disk format is changed. The new `.agent-mutation-locks` files are tier (c) lock files; `binding.json` remains byte-compatible, including legacy bindings without `issued_at`.
- [x] No breaking format change or migration is required.

## Notes for reviewers

The decisive race answer is deterministic: if A releases after checkout/reuse has installed B, the exact fingerprint CAS refuses A and preserves B. `Absent` is an idempotent no-op; unreadable, corrupt, future, or malformed-present binding state is `Opaque` and refuses destruction. Notice payloads are collected while locked and emitted only after all release flocks drop.

Scope is intentionally S1 only. Force/rebase policy (S2), branch-cleanup CAS/fencing (S3), and epoch/full-delete redesign (S4) remain excluded.

---
*archfix-codex-dev* · Codex/GPT-5