### PR TITLE
fix(P0): retire obsolete review assignments before nudge repair

### DIFF
--- a/src/daemon/assignment_authority.rs
+++ b/src/daemon/assignment_authority.rs
@@ -953,8 +953,13 @@ pub(crate) fn revoke(
 /// `expected_id`. Used by the reconciler to retire obsolete assignments whose
 /// PrState subject has advanced past the assignment's snapshot. The CAS guard
 /// prevents a stale retire from removing a replacement assignment that arrived
-/// between the lock-free `list_active` scan and this locked mutation. Supersedes
-/// the delivery nonce and enqueues a revocation notice when the row had been read.
+/// between the lock-free `list_active` scan and this locked mutation.
+///
+/// Ordering invariant: the stale inbox row (and any revocation notice) must be
+/// durably superseded BEFORE the authority record is deleted. A persistence
+/// failure at any point preserves the authority — fail closed. Retry after
+/// interruption converges: supersede is idempotent on an already-superseded
+/// row, so re-running after a crash between supersede and delete is safe.
 pub(crate) fn retire_if_id_matches(
     home: &Path,
     repo: &str,
@@ -969,19 +974,27 @@ pub(crate) fn retire_if_id_matches(
         Ok(Some(r)) if r.assignment_id == expected_id => r,
         _ => return Ok(false), // absent, corrupt, or replaced — no-op
     };
-    let removed = remove_if_assignment_matches(&path, expected_id);
-    if removed {
-        let successor = format!("retired-{}", expected_id);
-        let outcome = crate::inbox::storage::supersede_by_nonce(
-            home,
-            target,
-            &record.delivery_nonce,
-            &successor,
-        );
-        if outcome.was_read {
-            crate::inbox::storage::enqueue(home, target, build_revocation_notice(&record, now))?;
-        }
+
+    // Step 1: durably supersede the stale inbox row. If this fails the
+    // authority stays intact — the reviewer may still pick it up, which is
+    // strictly better than a dangling actionable row with no authority.
+    let successor = format!("retired-{}", expected_id);
+    let outcome = crate::inbox::storage::supersede_by_nonce_strict(
+        home,
+        target,
+        &record.delivery_nonce,
+        &successor,
+    )?;
+
+    // Step 2: if the reviewer had already read the assignment, enqueue a
+    // deterministic revocation notice so they learn it was retracted.
+    if outcome.was_read {
+        crate::inbox::storage::enqueue(home, target, build_revocation_notice(&record, now))?;
     }
+
+    // Step 3: NOW safe to delete the authority — the stale inbox state has
+    // been durably superseded (or was already non-actionable).
+    let removed = remove_if_assignment_matches_strict(&path, expected_id)?;
     Ok(removed)
 }
 

--- a/src/daemon/assignment_authority.rs
+++ b/src/daemon/assignment_authority.rs
@@ -497,7 +497,15 @@ fn build_delivery_message(record: &ActiveAssignment, now: &str) -> crate::inbox:
 
 /// A durable revocation notice — enqueued only when the retracted row had already
 /// been READ (I21), so the reviewer learns a seen assignment was pulled.
-fn build_revocation_notice(record: &ActiveAssignment, now: &str) -> crate::inbox::InboxMessage {
+fn revocation_nonce(assignment_id: uuid::Uuid) -> String {
+    format!("revoked-{assignment_id}")
+}
+
+fn build_revocation_notice(
+    record: &ActiveAssignment,
+    now: &str,
+    nonce: &str,
+) -> crate::inbox::InboxMessage {
     crate::inbox::InboxMessage {
         from: record.sender.clone(),
         text: format!(
@@ -509,6 +517,7 @@ fn build_revocation_notice(record: &ActiveAssignment, now: &str) -> crate::inbox
         task_id: Some(record.task_id.clone()),
         correlation_id: Some(record.task_id.clone()),
         pr_number: Some(record.pr_number),
+        delivery_nonce: Some(nonce.to_string()),
         ..Default::default()
     }
 }
@@ -811,7 +820,11 @@ pub(crate) fn persist(home: &Path, record: &ActiveAssignment) -> anyhow::Result<
                 crate::inbox::storage::enqueue(
                     home,
                     &record.target,
-                    build_revocation_notice(&old, &record.created_at),
+                    build_revocation_notice(
+                        &old,
+                        &record.created_at,
+                        &revocation_nonce(old.assignment_id),
+                    ),
                 )?;
             }
         }
@@ -988,8 +1001,18 @@ pub(crate) fn retire_if_id_matches(
 
     // Step 2: if the reviewer had already read the assignment, enqueue a
     // deterministic revocation notice so they learn it was retracted.
+    // Stable nonce + any-state dedup: if a prior attempt already enqueued
+    // the notice (but delete failed), the nonce is already present and we
+    // skip the duplicate append.
     if outcome.was_read {
-        crate::inbox::storage::enqueue(home, target, build_revocation_notice(&record, now))?;
+        let nonce = revocation_nonce(expected_id);
+        if !crate::inbox::storage::nonce_present_any_state(home, target, &nonce) {
+            crate::inbox::storage::enqueue(
+                home,
+                target,
+                build_revocation_notice(&record, now, &nonce),
+            )?;
+        }
     }
 
     // Step 3: NOW safe to delete the authority — the stale inbox state has
@@ -1028,7 +1051,11 @@ fn revoke_under_lock(
     // A row the reviewer had already READ is not retracted by the supersede alone
     // (it is already non-actionable) — surface an explicit revocation notice (I21).
     if outcome.was_read {
-        crate::inbox::storage::enqueue(home, target, build_revocation_notice(&record, now))?;
+        crate::inbox::storage::enqueue(
+            home,
+            target,
+            build_revocation_notice(&record, now, &revocation_nonce(record.assignment_id)),
+        )?;
     }
     Ok(removed)
 }

--- a/src/daemon/assignment_authority.rs
+++ b/src/daemon/assignment_authority.rs
@@ -405,6 +405,19 @@ fn remove_if_assignment_matches(path: &Path, expect: uuid::Uuid) -> bool {
     }
 }
 
+/// Strict variant of [`remove_if_assignment_matches`]: propagates `remove_file`
+/// errors so the caller can fail closed when durable delete confirmation matters.
+fn remove_if_assignment_matches_strict(path: &Path, expect: uuid::Uuid) -> anyhow::Result<bool> {
+    match read_record(path) {
+        Ok(Some(r)) if r.assignment_id == expect => {
+            std::fs::remove_file(path)
+                .map_err(|e| anyhow::anyhow!("remove assignment {}: {e}", path.display()))?;
+            Ok(true)
+        }
+        _ => Ok(false),
+    }
+}
+
 // ─────────────────────────── time helpers (clock-injected) ───────────────────────────
 
 fn parse_ts(s: &str) -> Option<chrono::DateTime<chrono::Utc>> {
@@ -934,6 +947,42 @@ pub(crate) fn revoke(
 ) -> anyhow::Result<bool> {
     let _lock = lock_branch(home, repo, branch)?;
     revoke_under_lock(home, repo, branch, target, now)
+}
+
+/// P0: CAS-retire an assignment ONLY if its on-disk `assignment_id` still equals
+/// `expected_id`. Used by the reconciler to retire obsolete assignments whose
+/// PrState subject has advanced past the assignment's snapshot. The CAS guard
+/// prevents a stale retire from removing a replacement assignment that arrived
+/// between the lock-free `list_active` scan and this locked mutation. Supersedes
+/// the delivery nonce and enqueues a revocation notice when the row had been read.
+pub(crate) fn retire_if_id_matches(
+    home: &Path,
+    repo: &str,
+    branch: &str,
+    target: &str,
+    expected_id: uuid::Uuid,
+    now: &str,
+) -> anyhow::Result<bool> {
+    let _lock = lock_branch(home, repo, branch)?;
+    let path = record_file(home, repo, branch, target);
+    let record = match read_record(&path) {
+        Ok(Some(r)) if r.assignment_id == expected_id => r,
+        _ => return Ok(false), // absent, corrupt, or replaced — no-op
+    };
+    let removed = remove_if_assignment_matches(&path, expected_id);
+    if removed {
+        let successor = format!("retired-{}", expected_id);
+        let outcome = crate::inbox::storage::supersede_by_nonce(
+            home,
+            target,
+            &record.delivery_nonce,
+            &successor,
+        );
+        if outcome.was_read {
+            crate::inbox::storage::enqueue(home, target, build_revocation_notice(&record, now))?;
+        }
+    }
+    Ok(removed)
 }
 
 /// The revoke body WITHOUT acquiring the branch lock — the caller MUST already

--- a/src/daemon/assignment_authority.rs
+++ b/src/daemon/assignment_authority.rs
@@ -497,6 +497,22 @@ fn build_delivery_message(record: &ActiveAssignment, now: &str) -> crate::inbox:
 
 /// A durable revocation notice — enqueued only when the retracted row had already
 /// been READ (I21), so the reviewer learns a seen assignment was pulled.
+fn revocation_nonce_present(home: &Path, target: &str, nonce: &str) -> bool {
+    let path = crate::inbox::storage::inbox_path_resolved(home, target);
+    let Ok(content) = std::fs::read_to_string(&path) else {
+        return false;
+    };
+    content
+        .lines()
+        .filter(|l| !l.trim().is_empty() && l.contains(nonce))
+        .any(|l| {
+            serde_json::from_str::<crate::inbox::InboxMessage>(l)
+                .ok()
+                .filter(|m| m.delivery_nonce.as_deref() == Some(nonce))
+                .is_some()
+        })
+}
+
 fn revocation_nonce(assignment_id: uuid::Uuid) -> String {
     format!("revoked-{assignment_id}")
 }
@@ -1006,7 +1022,7 @@ pub(crate) fn retire_if_id_matches(
     // skip the duplicate append.
     if outcome.was_read {
         let nonce = revocation_nonce(expected_id);
-        if !crate::inbox::storage::nonce_present_any_state(home, target, &nonce) {
+        if !revocation_nonce_present(home, target, &nonce) {
             crate::inbox::storage::enqueue(
                 home,
                 target,

--- a/src/daemon/assignment_authority.rs
+++ b/src/daemon/assignment_authority.rs
@@ -833,15 +833,14 @@ pub(crate) fn persist(home: &Path, record: &ActiveAssignment) -> anyhow::Result<
             // for the retired assignment (I21). Clock-injected via the new record's
             // `created_at` (persist takes no separate `now`).
             if outcome.was_read {
-                crate::inbox::storage::enqueue(
-                    home,
-                    &record.target,
-                    build_revocation_notice(
-                        &old,
-                        &record.created_at,
-                        &revocation_nonce(old.assignment_id),
-                    ),
-                )?;
+                let nonce = revocation_nonce(old.assignment_id);
+                if !revocation_nonce_present(home, &record.target, &nonce) {
+                    crate::inbox::storage::enqueue(
+                        home,
+                        &record.target,
+                        build_revocation_notice(&old, &record.created_at, &nonce),
+                    )?;
+                }
             }
         }
     }

--- a/src/daemon/per_tick/assignment_reconcile.rs
+++ b/src/daemon/per_tick/assignment_reconcile.rs
@@ -147,22 +147,58 @@ fn reconcile_branch(home: &Path, repo: &str, branch: &str, now: &str) -> Vec<Str
     store::tombstone_terminal_matches(home, repo, branch);
 
     let mut wakes = Vec::new();
+    // Load PrState ONCE per branch (shared across all records on this branch).
+    let raw_prstate = crate::daemon::pr_state::load(home, repo, branch);
     for record in store::list_active(home, repo, branch) {
         // A2: recover a Pending row (idempotent; nonce-dedup handles a crash-window
         // duplicate). Unconditional — even an acked record's row must be durable.
         if record.row == store::RowState::Pending {
             let _ = store::durable_enqueue(home, repo, branch, &record.target, now);
         }
+        // P0: retire assignments whose PrState subject has advanced past the
+        // assignment's snapshot. A head or PR-number contradiction means the
+        // assignment's review target no longer exists on this branch — nudging it
+        // is pointless. Absent/corrupt PrState (load returns None) is not proof
+        // of obsolescence, so the assignment is preserved (fail-closed).
+        // Head comparison is exact == on String (C3: no prefix, no normalization).
+        if let Some(ref state) = raw_prstate {
+            let head_contradicts = record
+                .reviewed_head
+                .as_deref()
+                .is_some_and(|rh| rh != state.head_sha);
+            let pr_contradicts = state.pr_number != record.pr_number;
+            if head_contradicts || pr_contradicts {
+                if store::retire_if_id_matches(
+                    home,
+                    repo,
+                    branch,
+                    &record.target,
+                    record.assignment_id,
+                    now,
+                )
+                .unwrap_or(false)
+                {
+                    tracing::info!(
+                        assignment_id = %record.assignment_id,
+                        target = %record.target,
+                        repo = %repo,
+                        branch = %branch,
+                        "assignment retired: PrState contradicts subject"
+                    );
+                }
+                continue;
+            }
+        }
         // Classify against the LIVE pr_state for THIS record's generation (its
         // pr_number). A pr_state for a different generation, or none, ⇒ Unengaged.
-        let prstate = crate::daemon::pr_state::load(home, repo, branch)
+        let prstate = raw_prstate
+            .as_ref()
             .filter(|p| p.pr_number == record.pr_number);
         // A3/A4: ONLY Unengaged is nudge/repair-eligible. `repair_row` self-gates on
         // the FIXED-interval lease (returns false when not due) and advances it, so
         // two ticks in one interval fire at most once (I12) — the wake follows only
         // an actual repair.
-        if store::classify_assignment(&record, prstate.as_ref())
-            == store::AssignmentEvidence::Unengaged
+        if store::classify_assignment(&record, prstate) == store::AssignmentEvidence::Unengaged
             && store::repair_row(home, repo, branch, &record.target, now).unwrap_or(false)
         {
             wakes.push(record.target.clone());
@@ -758,6 +794,582 @@ mod tests {
             n0,
             "the registered handler's run() repaired the lease-due Unengaged record"
         );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    // ─── P0: obsolete review assignment retirement tests ───────────────
+
+    /// Create an assignment with an explicit `reviewed_head`. The standard `mk`
+    /// creates a legacy row (reviewed_head = None); these tests exercise the
+    /// head-advance retirement path which requires a non-None reviewed_head.
+    fn mk_with_head(
+        repo: &str,
+        branch: &str,
+        target: &str,
+        pr: u64,
+        head: &str,
+        created: &str,
+    ) -> ActiveAssignment {
+        let mut rec = mk(repo, branch, target, pr, created);
+        rec.reviewed_head = Some(head.to_string());
+        rec
+    }
+
+    /// P0-1: PrState head has advanced past the assignment's reviewed_head and no
+    /// receipt exists. The assignment is obsolete and must be retired (removed from
+    /// the authority store), with no subsequent nudge.
+    #[test]
+    fn head_advance_no_receipt_retires() {
+        let home = tmp_home("p0-1");
+        let rec = mk_with_head(
+            "o/r",
+            "feat/x",
+            "reviewer",
+            7,
+            "sha-old",
+            "2026-07-13T00:00:00Z",
+        );
+        store::persist(&home, &rec).unwrap();
+        store::durable_enqueue(&home, "o/r", "feat/x", "reviewer", "2026-07-13T00:00:00Z").unwrap();
+        // PrState head has advanced to "sha-new" (assignment was for "sha-old").
+        open_prstate(&home, "o/r", "feat/x", 7, "sha-new");
+
+        let wakes = reconcile_all_collect(&home, "2026-07-13T00:01:00Z");
+        assert!(wakes.is_empty(), "no nudge after retirement");
+        assert!(
+            store::get(&home, "o/r", "feat/x", "reviewer").is_none(),
+            "assignment must be retired when PrState head contradicts reviewed_head"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// P0-2: PrState head has advanced and an old REJECTED receipt exists on the
+    /// PrState. The head contradiction still retires the assignment — a stale
+    /// receipt does not preserve a stale assignment.
+    #[test]
+    fn head_advance_with_rejected_receipt_retires() {
+        let home = tmp_home("p0-2");
+        let instance_id = crate::types::InstanceId::new();
+        let reviewed_head = "a".repeat(40); // full 40-hex SHA
+        let rec = store::ActiveAssignment::new_pending_typed(
+            "o/r",
+            "feat/x",
+            "reviewer",
+            instance_id,
+            7,
+            &reviewed_head,
+            crate::review_receipt::ReviewSlot::Primary,
+            "lead",
+            "t-rev-1",
+            ReviewClass::Dual,
+            ReviewAuthor::External("octocat".into()),
+            "Please review PR",
+            None,
+            None,
+            "2026-07-13T00:00:00Z",
+        );
+        let assignment_id = rec.assignment_id;
+        store::persist(&home, &rec).unwrap();
+
+        // PrState at a NEW head, with a REJECTED receipt for the OLD head.
+        let new_head = "b".repeat(40);
+        let mut s = pr_state::new_for_branch("o/r", "feat/x", &new_head, ReviewClass::Dual);
+        s.pr_number = 7;
+        s.merge_state = MergeState::NotReady;
+        s.validated_review_receipts = vec![crate::review_receipt::ReviewReceiptSummary {
+            receipt_id: "r-1".into(),
+            source_id: "s-1".into(),
+            evidence_digest: "c".repeat(64),
+            assignment_id,
+            reviewer_instance_id: instance_id,
+            reviewer_name: "reviewer".into(),
+            repo: "o/r".into(),
+            pr_number: 7,
+            branch: "feat/x".into(),
+            task_id: "t-rev-1".into(),
+            reviewed_head: reviewed_head.clone(),
+            review_class: ReviewClass::Dual,
+            slot: crate::review_receipt::ReviewSlot::Primary,
+            verdict: crate::review_receipt::ReviewVerdict::Rejected,
+        }];
+        pr_state::save(&home, &s).unwrap();
+
+        let wakes = reconcile_all_collect(&home, "2026-07-13T00:01:00Z");
+        assert!(wakes.is_empty(), "no nudge after retirement");
+        assert!(
+            store::get(&home, "o/r", "feat/x", "reviewer").is_none(),
+            "head-advanced assignment retires even with an old REJECTED receipt"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// P0-3: PrState pr_number differs from the assignment's pr_number (a new PR
+    /// was opened on the same branch). The assignment is for a dead generation and
+    /// must be retired.
+    #[test]
+    fn pr_number_mismatch_retires() {
+        let home = tmp_home("p0-3");
+        let rec = mk_with_head(
+            "o/r",
+            "feat/x",
+            "reviewer",
+            5,
+            "sha-a",
+            "2026-07-13T00:00:00Z",
+        );
+        store::persist(&home, &rec).unwrap();
+        store::durable_enqueue(&home, "o/r", "feat/x", "reviewer", "2026-07-13T00:00:00Z").unwrap();
+        // PrState is for a DIFFERENT PR number (new generation on same branch).
+        open_prstate(&home, "o/r", "feat/x", 6, "sha-a");
+
+        let wakes = reconcile_all_collect(&home, "2026-07-13T00:01:00Z");
+        assert!(
+            wakes.is_empty(),
+            "no nudge for a dead-generation assignment"
+        );
+        assert!(
+            store::get(&home, "o/r", "feat/x", "reviewer").is_none(),
+            "assignment must be retired when PrState pr_number contradicts"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// P0-4: PrState head matches the assignment's reviewed_head and the assignment
+    /// is Unengaged. Normal nudge behavior must be preserved — no retirement.
+    #[test]
+    fn same_head_unengaged_still_nudges() {
+        let home = tmp_home("p0-4");
+        let rec = mk_with_head(
+            "o/r",
+            "feat/x",
+            "reviewer",
+            7,
+            "sha-same",
+            "2026-07-13T00:00:00Z",
+        );
+        store::persist(&home, &rec).unwrap();
+        store::durable_enqueue(&home, "o/r", "feat/x", "reviewer", "2026-07-13T00:00:00Z").unwrap();
+        let n0 = rec.delivery_nonce.clone();
+        // Mark the row read so repair_row will actually fire.
+        mark_row_read(&home, "reviewer", &n0, "2026-07-13T00:00:00Z");
+        // PrState head matches the assignment's reviewed_head — no contradiction.
+        open_prstate(&home, "o/r", "feat/x", 7, "sha-same");
+
+        let wakes = reconcile_all_collect(&home, "2026-07-13T00:00:01Z");
+        assert!(
+            store::get(&home, "o/r", "feat/x", "reviewer").is_some(),
+            "assignment preserved when head matches"
+        );
+        assert_eq!(
+            wakes,
+            vec!["reviewer".to_string()],
+            "Unengaged nudge still fires when head matches"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// P0-5: ABA guard — an assignment replaced by a new assignment_id between the
+    /// lock-free list_active scan and the CAS retire must be preserved. The retire
+    /// is a CAS no-op on the new id.
+    #[test]
+    fn replacement_assignment_preserved_aba() {
+        let home = tmp_home("p0-5");
+        // Create assignment B (the replacement) with reviewed_head matching PrState.
+        let rec_b = mk_with_head(
+            "o/r",
+            "feat/x",
+            "reviewer",
+            7,
+            "sha-new",
+            "2026-07-13T00:01:00Z",
+        );
+        store::persist(&home, &rec_b).unwrap();
+        open_prstate(&home, "o/r", "feat/x", 7, "sha-new");
+
+        // A stale CAS retire with a different (old) assignment_id must be a no-op.
+        let stale_id = uuid::Uuid::new_v4();
+        let retired = store::retire_if_id_matches(
+            &home,
+            "o/r",
+            "feat/x",
+            "reviewer",
+            stale_id,
+            "2026-07-13T00:02:00Z",
+        )
+        .unwrap();
+        assert!(!retired, "CAS no-op: stale id does not remove replacement");
+        let got = store::get(&home, "o/r", "feat/x", "reviewer").unwrap();
+        assert_eq!(
+            got.assignment_id, rec_b.assignment_id,
+            "replacement assignment preserved with its own id"
+        );
+
+        // Reconcile also leaves B alone (head matches).
+        reconcile_all_collect(&home, "2026-07-13T00:03:00Z");
+        assert!(
+            store::get(&home, "o/r", "feat/x", "reviewer").is_some(),
+            "reconcile preserves replacement assignment whose head matches PrState"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// P0-6: no PrState file exists (never observed by the scanner). The assignment
+    /// must be preserved — absent PrState is not proof of obsolescence.
+    #[test]
+    fn absent_prstate_no_retire() {
+        let home = tmp_home("p0-6");
+        let rec = mk_with_head(
+            "o/r",
+            "feat/x",
+            "reviewer",
+            7,
+            "sha-old",
+            "2026-07-13T00:00:00Z",
+        );
+        store::persist(&home, &rec).unwrap();
+        store::durable_enqueue(&home, "o/r", "feat/x", "reviewer", "2026-07-13T00:00:00Z").unwrap();
+        // NO PrState file — the branch was never observed.
+
+        reconcile_all_collect(&home, "2026-07-13T00:01:00Z");
+        assert!(
+            store::get(&home, "o/r", "feat/x", "reviewer").is_some(),
+            "assignment preserved when no PrState exists"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// C1: a corrupt (unparseable) PrState file is treated as absent by
+    /// `pr_state::load` (returns None). The assignment must be preserved — a
+    /// corrupt PrState is not proof of obsolescence (fail-closed).
+    #[test]
+    fn c1_corrupt_prstate_preserves_assignment() {
+        let home = tmp_home("p0-c1");
+        let rec = mk_with_head(
+            "o/r",
+            "feat/x",
+            "reviewer",
+            7,
+            "sha-old",
+            "2026-07-13T00:00:00Z",
+        );
+        store::persist(&home, &rec).unwrap();
+        store::durable_enqueue(&home, "o/r", "feat/x", "reviewer", "2026-07-13T00:00:00Z").unwrap();
+        // Write a CORRUPT PrState file.
+        let ps_dir = pr_state::pr_state_dir(&home);
+        std::fs::create_dir_all(&ps_dir).unwrap();
+        std::fs::write(
+            ps_dir.join(pr_state::pr_state_filename("o/r", "feat/x")),
+            b"{ not valid prstate json",
+        )
+        .unwrap();
+
+        reconcile_all_collect(&home, "2026-07-13T00:01:00Z");
+        assert!(
+            store::get(&home, "o/r", "feat/x", "reviewer").is_some(),
+            "corrupt PrState must not cause retirement (fail-closed)"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// C2: PrState head matches the assignment's reviewed_head and the assignment
+    /// is EngagedUnsatisfied (a REJECTED receipt exists at the current head). The
+    /// assignment is neither retired (head matches) nor nudged (EngagedUnsatisfied
+    /// is a TRUE stop). This is a GREEN test — EngagedUnsatisfied non-nudge behavior
+    /// is already implemented; this test pins it in the retirement context.
+    #[test]
+    fn c2_current_head_engaged_unsatisfied_not_retired() {
+        let home = tmp_home("p0-c2");
+        let instance_id = crate::types::InstanceId::new();
+        let head = "a".repeat(40);
+        let rec = store::ActiveAssignment::new_pending_typed(
+            "o/r",
+            "feat/x",
+            "reviewer",
+            instance_id,
+            7,
+            &head,
+            crate::review_receipt::ReviewSlot::Primary,
+            "lead",
+            "t-rev-1",
+            ReviewClass::Dual,
+            ReviewAuthor::External("octocat".into()),
+            "Please review PR",
+            None,
+            None,
+            "2026-07-13T00:00:00Z",
+        );
+        let assignment_id = rec.assignment_id;
+        store::persist(&home, &rec).unwrap();
+        store::durable_enqueue(&home, "o/r", "feat/x", "reviewer", "2026-07-13T00:00:00Z").unwrap();
+
+        // PrState at the SAME head with a REJECTED receipt — EngagedUnsatisfied.
+        let mut s = pr_state::new_for_branch("o/r", "feat/x", &head, ReviewClass::Dual);
+        s.pr_number = 7;
+        s.merge_state = MergeState::NotReady;
+        s.validated_review_receipts = vec![crate::review_receipt::ReviewReceiptSummary {
+            receipt_id: "r-1".into(),
+            source_id: "s-1".into(),
+            evidence_digest: "c".repeat(64),
+            assignment_id,
+            reviewer_instance_id: instance_id,
+            reviewer_name: "reviewer".into(),
+            repo: "o/r".into(),
+            pr_number: 7,
+            branch: "feat/x".into(),
+            task_id: "t-rev-1".into(),
+            reviewed_head: head.clone(),
+            review_class: ReviewClass::Dual,
+            slot: crate::review_receipt::ReviewSlot::Primary,
+            verdict: crate::review_receipt::ReviewVerdict::Rejected,
+        }];
+        pr_state::save(&home, &s).unwrap();
+
+        let wakes = reconcile_all_collect(&home, "2026-07-13T00:01:00Z");
+        assert!(
+            store::get(&home, "o/r", "feat/x", "reviewer").is_some(),
+            "EngagedUnsatisfied at current head must NOT be retired"
+        );
+        assert!(
+            wakes.is_empty(),
+            "EngagedUnsatisfied is a TRUE stop — no nudge"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// C3: head comparison must be exact full-SHA byte-for-byte — no prefix matching,
+    /// no normalization, no case folding. Two SHAs that share a prefix but differ in
+    /// the last byte must trigger retirement.
+    #[test]
+    fn c3_head_sha_exact_byte_comparison() {
+        let home = tmp_home("p0-c3");
+        // Assignment reviewed_head differs from PrState head only in the last byte.
+        let assignment_head = format!("{}0", "a".repeat(39));
+        let prstate_head = format!("{}1", "a".repeat(39));
+        let rec = mk_with_head(
+            "o/r",
+            "feat/x",
+            "reviewer",
+            7,
+            &assignment_head,
+            "2026-07-13T00:00:00Z",
+        );
+        store::persist(&home, &rec).unwrap();
+        open_prstate(&home, "o/r", "feat/x", 7, &prstate_head);
+
+        reconcile_all_collect(&home, "2026-07-13T00:01:00Z");
+        assert!(
+            store::get(&home, "o/r", "feat/x", "reviewer").is_none(),
+            "a single-byte difference in full SHA must trigger retirement (exact comparison)"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    // ─── Durability failpoint tests ───────────────────────────────────
+
+    /// D1: inbox persistence failure preserves authority. If the strict
+    /// supersede cannot durably retract the stale inbox row, the authority
+    /// record must survive so the reconciler retries on the next tick.
+    #[cfg(unix)]
+    #[test]
+    fn d1_supersede_persistence_failure_preserves_authority() {
+        use std::os::unix::fs::PermissionsExt;
+        let home = tmp_home("d1-persist-fail");
+        let rec = mk_with_head(
+            "o/r",
+            "feat/x",
+            "reviewer",
+            7,
+            "sha-old",
+            "2026-07-13T00:00:00Z",
+        );
+        store::persist(&home, &rec).unwrap();
+        store::durable_enqueue(&home, "o/r", "feat/x", "reviewer", "2026-07-13T00:00:00Z").unwrap();
+        open_prstate(&home, "o/r", "feat/x", 7, "sha-new");
+
+        // Make the inbox directory read-only so the strict supersede write fails.
+        let inbox_dir = home.join("inbox");
+        let original_perms = std::fs::metadata(&inbox_dir).unwrap().permissions();
+        std::fs::set_permissions(&inbox_dir, std::fs::Permissions::from_mode(0o555)).unwrap();
+
+        let wakes = reconcile_all_collect(&home, "2026-07-13T00:01:00Z");
+
+        // Restore permissions before assertions (cleanup on panic).
+        std::fs::set_permissions(&inbox_dir, original_perms).unwrap();
+
+        assert!(
+            store::get(&home, "o/r", "feat/x", "reviewer").is_some(),
+            "authority MUST survive when inbox supersede fails (fail-closed)"
+        );
+        assert!(
+            wakes.is_empty(),
+            "no nudge — the head contradiction still prevents nudging"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// D2: interruption after durable supersede converges on retry. If the
+    /// inbox row is already superseded (from a prior interrupted retire) but
+    /// the authority was not deleted, a second retire call must converge:
+    /// the idempotent supersede is a no-op, and the authority is removed.
+    #[test]
+    fn d2_interruption_after_supersede_converges_on_retry() {
+        let home = tmp_home("d2-converge");
+        let rec = mk_with_head(
+            "o/r",
+            "feat/x",
+            "reviewer",
+            7,
+            "sha-old",
+            "2026-07-13T00:00:00Z",
+        );
+        let expected_id = rec.assignment_id;
+        store::persist(&home, &rec).unwrap();
+        store::durable_enqueue(&home, "o/r", "feat/x", "reviewer", "2026-07-13T00:00:00Z").unwrap();
+
+        // Simulate a prior interrupted retire: supersede the inbox row manually
+        // but leave the authority intact.
+        let successor = format!("retired-{}", expected_id);
+        crate::inbox::storage::supersede_by_nonce_strict(
+            &home,
+            "reviewer",
+            &rec.delivery_nonce,
+            &successor,
+        )
+        .expect("manual supersede must succeed");
+        assert!(
+            store::get(&home, "o/r", "feat/x", "reviewer").is_some(),
+            "authority is still present (simulated crash before delete)"
+        );
+
+        // Now PrState head advances — reconcile should converge and delete.
+        open_prstate(&home, "o/r", "feat/x", 7, "sha-new");
+        let wakes = reconcile_all_collect(&home, "2026-07-13T00:02:00Z");
+
+        assert!(
+            store::get(&home, "o/r", "feat/x", "reviewer").is_none(),
+            "retry after interrupted supersede must converge and delete authority"
+        );
+        assert!(wakes.is_empty(), "no nudge after retirement");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// D3: after retire, the old delivery nonce inbox row is non-actionable
+    /// (superseded_by is set or row was already read). Verifies the
+    /// supersede-before-delete ordering actually retracts the stale row.
+    #[test]
+    fn d3_old_nonce_non_actionable_after_retire() {
+        let home = tmp_home("d3-nonce");
+        let rec = mk_with_head(
+            "o/r",
+            "feat/x",
+            "reviewer",
+            7,
+            "sha-old",
+            "2026-07-13T00:00:00Z",
+        );
+        let old_nonce = rec.delivery_nonce.clone();
+        store::persist(&home, &rec).unwrap();
+        store::durable_enqueue(&home, "o/r", "feat/x", "reviewer", "2026-07-13T00:00:00Z").unwrap();
+        assert!(
+            crate::inbox::storage::nonce_present_actionable(&home, "reviewer", &old_nonce),
+            "old nonce must be actionable before retire"
+        );
+
+        open_prstate(&home, "o/r", "feat/x", 7, "sha-new");
+        reconcile_all_collect(&home, "2026-07-13T00:01:00Z");
+
+        assert!(
+            !crate::inbox::storage::nonce_present_actionable(&home, "reviewer", &old_nonce),
+            "old nonce must be non-actionable after retire (superseded)"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// D4: revocation notice is deterministic and idempotent. When the
+    /// reviewer has already read the assignment inbox row, a revocation
+    /// notice is enqueued exactly once per retire cycle. A second reconcile
+    /// tick (after convergence deletes the authority) enqueues no duplicate.
+    #[test]
+    fn d4_revocation_notice_idempotent() {
+        let home = tmp_home("d4-notice");
+        let rec = mk_with_head(
+            "o/r",
+            "feat/x",
+            "reviewer",
+            7,
+            "sha-old",
+            "2026-07-13T00:00:00Z",
+        );
+        store::persist(&home, &rec).unwrap();
+        store::durable_enqueue(&home, "o/r", "feat/x", "reviewer", "2026-07-13T00:00:00Z").unwrap();
+        // Mark the inbox row as READ so the retire path enqueues a revocation notice.
+        mark_row_read(
+            &home,
+            "reviewer",
+            &rec.delivery_nonce,
+            "2026-07-13T00:00:30Z",
+        );
+
+        open_prstate(&home, "o/r", "feat/x", 7, "sha-new");
+
+        // First reconcile: retires the assignment and enqueues revocation notice.
+        reconcile_all_collect(&home, "2026-07-13T00:01:00Z");
+        assert!(
+            store::get(&home, "o/r", "feat/x", "reviewer").is_none(),
+            "authority retired on first tick"
+        );
+
+        let inbox_content =
+            std::fs::read_to_string(home.join("inbox").join("reviewer.jsonl")).unwrap_or_default();
+        let notice_count = inbox_content
+            .lines()
+            .filter(|l| l.contains("review-assignment-revoked"))
+            .count();
+        assert_eq!(
+            notice_count, 1,
+            "exactly one revocation notice after first retire"
+        );
+
+        // Second reconcile: authority is gone, no duplicate notice.
+        reconcile_all_collect(&home, "2026-07-13T00:02:00Z");
+        let inbox_content2 =
+            std::fs::read_to_string(home.join("inbox").join("reviewer.jsonl")).unwrap_or_default();
+        let notice_count2 = inbox_content2
+            .lines()
+            .filter(|l| l.contains("review-assignment-revoked"))
+            .count();
+        assert_eq!(
+            notice_count2, 1,
+            "no duplicate revocation notice after second tick"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// D5: after retire, a stale delivery nonce cannot wake the reviewer.
+    /// Even if the nonce somehow survived in a pending state, the reconciler
+    /// must not produce a wake for a retired assignment.
+    #[test]
+    fn d5_retired_assignment_no_stale_wake() {
+        let home = tmp_home("d5-no-wake");
+        let rec = mk_with_head(
+            "o/r",
+            "feat/x",
+            "reviewer",
+            7,
+            "sha-old",
+            "2026-07-13T00:00:00Z",
+        );
+        store::persist(&home, &rec).unwrap();
+        store::durable_enqueue(&home, "o/r", "feat/x", "reviewer", "2026-07-13T00:00:00Z").unwrap();
+        open_prstate(&home, "o/r", "feat/x", 7, "sha-new");
+
+        // First tick retires.
+        let wakes1 = reconcile_all_collect(&home, "2026-07-13T00:01:00Z");
+        assert!(wakes1.is_empty(), "no wake on retirement tick");
+
+        // Second tick: authority gone, no residual wake.
+        let wakes2 = reconcile_all_collect(&home, "2026-07-13T00:02:00Z");
+        assert!(wakes2.is_empty(), "no stale wake after authority removed");
         std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/daemon/per_tick/assignment_reconcile.rs
+++ b/src/daemon/per_tick/assignment_reconcile.rs
@@ -1447,4 +1447,87 @@ mod tests {
         );
         std::fs::remove_dir_all(&home).ok();
     }
+
+    /// D7: persist replacement with pre-existing stable revocation notice
+    /// must not duplicate the notice. Seeds: old authority + already-enqueued
+    /// revocation notice (simulating a prior persist that enqueued but whose
+    /// atomic_write_json failed). A new persist replacement must see the
+    /// existing nonce and skip the duplicate enqueue.
+    #[test]
+    fn d7_persist_replacement_dedup_revocation_notice() {
+        let home = tmp_home("d7-persist-dedup");
+        let instance_id = crate::types::InstanceId::new();
+        let head = "a".repeat(40);
+        let old = store::ActiveAssignment::new_pending_typed(
+            "o/r",
+            "feat/x",
+            "reviewer",
+            instance_id,
+            7,
+            &head,
+            crate::review_receipt::ReviewSlot::Primary,
+            "lead",
+            "t-rev-1",
+            ReviewClass::Dual,
+            ReviewAuthor::External("octocat".into()),
+            "Please review PR",
+            None,
+            None,
+            "2026-07-13T00:00:00Z",
+        );
+        let old_id = old.assignment_id;
+        store::persist(&home, &old).unwrap();
+        store::durable_enqueue(&home, "o/r", "feat/x", "reviewer", "2026-07-13T00:00:00Z").unwrap();
+        mark_row_read(
+            &home,
+            "reviewer",
+            &old.delivery_nonce,
+            "2026-07-13T00:00:30Z",
+        );
+
+        // Seed: a revocation notice with stable nonce already present
+        // (simulating a prior persist that enqueued but failed to write).
+        let nonce = format!("revoked-{old_id}");
+        let notice = crate::inbox::InboxMessage {
+            text: "Reviewer assignment revoked.".to_string(),
+            kind: Some("review-assignment-revoked".to_string()),
+            timestamp: "2026-07-13T00:01:00Z".to_string(),
+            delivery_nonce: Some(nonce.clone()),
+            ..Default::default()
+        };
+        crate::inbox::storage::enqueue(&home, "reviewer", notice).unwrap();
+
+        // Now persist a replacement — should NOT duplicate the notice.
+        let new_head = "b".repeat(40);
+        let replacement = store::ActiveAssignment::new_pending_typed(
+            "o/r",
+            "feat/x",
+            "reviewer",
+            instance_id,
+            7,
+            &new_head,
+            crate::review_receipt::ReviewSlot::Primary,
+            "lead",
+            "t-rev-2",
+            ReviewClass::Dual,
+            ReviewAuthor::External("octocat".into()),
+            "Please review PR v2",
+            None,
+            None,
+            "2026-07-13T00:02:00Z",
+        );
+        store::persist(&home, &replacement).unwrap();
+
+        let inbox =
+            std::fs::read_to_string(home.join("inbox").join("reviewer.jsonl")).unwrap_or_default();
+        let notice_count = inbox
+            .lines()
+            .filter(|l| l.contains("review-assignment-revoked"))
+            .count();
+        assert_eq!(
+            notice_count, 1,
+            "persist replacement must not duplicate revocation notice (stable nonce dedup)"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
 }

--- a/src/daemon/per_tick/assignment_reconcile.rs
+++ b/src/daemon/per_tick/assignment_reconcile.rs
@@ -1372,4 +1372,79 @@ mod tests {
         assert!(wakes2.is_empty(), "no stale wake after authority removed");
         std::fs::remove_dir_all(&home).ok();
     }
+
+    /// D6: delete failure after revocation notice enqueue must not duplicate
+    /// the notice on retry. The stable nonce + any-state dedup ensures
+    /// exactly one notice even across a failed delete + successful retry.
+    #[cfg(unix)]
+    #[test]
+    fn d6_delete_failure_retry_no_duplicate_notice() {
+        use std::os::unix::fs::PermissionsExt;
+        let home = tmp_home("d6-delete-fail");
+        let rec = mk_with_head(
+            "o/r",
+            "feat/x",
+            "reviewer",
+            7,
+            "sha-old",
+            "2026-07-13T00:00:00Z",
+        );
+        store::persist(&home, &rec).unwrap();
+        store::durable_enqueue(&home, "o/r", "feat/x", "reviewer", "2026-07-13T00:00:00Z").unwrap();
+        mark_row_read(
+            &home,
+            "reviewer",
+            &rec.delivery_nonce,
+            "2026-07-13T00:00:30Z",
+        );
+        open_prstate(&home, "o/r", "feat/x", 7, "sha-new");
+
+        // Make the authority record's parent dir read-only so the delete
+        // fails AFTER the notice is enqueued (supersede succeeds because
+        // it writes to the inbox dir, not the authority dir).
+        // Find the branch dir by scanning reviewer-assignments/.
+        let ra_base = home.join("reviewer-assignments");
+        let record_dir = std::fs::read_dir(&ra_base)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .find(|p| p.is_dir())
+            .expect("branch dir must exist after persist");
+        let original_perms = std::fs::metadata(&record_dir).unwrap().permissions();
+        std::fs::set_permissions(&record_dir, std::fs::Permissions::from_mode(0o555)).unwrap();
+
+        // First attempt: notice enqueued, delete fails, authority preserved.
+        reconcile_all_collect(&home, "2026-07-13T00:01:00Z");
+        std::fs::set_permissions(&record_dir, original_perms.clone()).unwrap();
+
+        assert!(
+            store::get(&home, "o/r", "feat/x", "reviewer").is_some(),
+            "authority must survive delete failure"
+        );
+        let inbox_content =
+            std::fs::read_to_string(home.join("inbox").join("reviewer.jsonl")).unwrap_or_default();
+        let notice_count = inbox_content
+            .lines()
+            .filter(|l| l.contains("review-assignment-revoked"))
+            .count();
+        assert_eq!(notice_count, 1, "exactly one notice after first attempt");
+
+        // Second attempt (retry): notice dedup, delete now succeeds.
+        reconcile_all_collect(&home, "2026-07-13T00:02:00Z");
+        assert!(
+            store::get(&home, "o/r", "feat/x", "reviewer").is_none(),
+            "authority deleted on retry"
+        );
+        let inbox_content2 =
+            std::fs::read_to_string(home.join("inbox").join("reviewer.jsonl")).unwrap_or_default();
+        let notice_count2 = inbox_content2
+            .lines()
+            .filter(|l| l.contains("review-assignment-revoked"))
+            .count();
+        assert_eq!(
+            notice_count2, 1,
+            "still exactly one notice after retry (dedup by stable nonce)"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
 }

--- a/src/inbox/storage.rs
+++ b/src/inbox/storage.rs
@@ -725,6 +725,80 @@ pub fn supersede_by_nonce(
     .unwrap_or_default()
 }
 
+/// Strict variant of [`supersede_by_nonce`]: every persistence error (read,
+/// write, fsync, rename) propagates as `Err` so the caller can fail closed
+/// when durable supersede is a precondition for further mutations.
+pub fn supersede_by_nonce_strict(
+    home: &Path,
+    target: &str,
+    nonce: &str,
+    successor: &str,
+) -> anyhow::Result<NonceSupersedeOutcome> {
+    let path = inbox_path_resolved(home, target);
+    if !path.exists() {
+        return Ok(NonceSupersedeOutcome::default());
+    }
+    let inner = with_inbox_lock(
+        home,
+        target,
+        |path| -> anyhow::Result<NonceSupersedeOutcome> {
+            let mut outcome = NonceSupersedeOutcome::default();
+            let content = std::fs::read_to_string(path)
+                .map_err(|e| anyhow::anyhow!("read inbox {}: {e}", path.display()))?;
+            let mut changed = false;
+            let mut lines: Vec<String> = Vec::new();
+            for line in content.lines() {
+                if line.trim().is_empty() {
+                    lines.push(line.to_string());
+                    continue;
+                }
+                if !line.contains(nonce) {
+                    lines.push(line.to_string());
+                    continue;
+                }
+                if let Ok(mut msg) = serde_json::from_str::<InboxMessage>(line) {
+                    if msg.delivery_nonce.as_deref() == Some(nonce) {
+                        outcome.found = true;
+                        if msg.read_at.is_some() {
+                            outcome.was_read = true;
+                        }
+                        if msg.read_at.is_none() && msg.superseded_by.is_none() {
+                            msg.superseded_by = Some(successor.to_string());
+                            changed = true;
+                        }
+                    }
+                    lines.push(serde_json::to_string(&msg).unwrap_or_else(|_| line.to_string()));
+                } else {
+                    lines.push(line.to_string());
+                }
+            }
+            if changed {
+                let tmp = path.with_extension("jsonl.tmp");
+                let mut f = std::fs::OpenOptions::new()
+                    .create(true)
+                    .write(true)
+                    .truncate(true)
+                    .open(&tmp)
+                    .map_err(|e| anyhow::anyhow!("open tmp {}: {e}", tmp.display()))?;
+                use std::io::Write;
+                for l in &lines {
+                    writeln!(f, "{l}")
+                        .map_err(|e| anyhow::anyhow!("write tmp {}: {e}", tmp.display()))?;
+                }
+                f.sync_all()
+                    .map_err(|e| anyhow::anyhow!("fsync tmp {}: {e}", tmp.display()))?;
+                std::fs::rename(&tmp, path).map_err(|e| {
+                    anyhow::anyhow!("rename {} -> {}: {e}", tmp.display(), path.display())
+                })?;
+                crate::store::fsync_parent_dir_checked(path)
+                    .map_err(|e| anyhow::anyhow!("fsync parent {}: {e}", path.display()))?;
+            }
+            Ok(outcome)
+        },
+    )?;
+    inner
+}
+
 /// Drain unread messages: mark them with `read_at` and write back.
 /// Returns only the messages that were previously unread.
 ///

--- a/src/inbox/storage.rs
+++ b/src/inbox/storage.rs
@@ -661,74 +661,22 @@ pub fn supersede_by_nonce(
     nonce: &str,
     successor: &str,
 ) -> NonceSupersedeOutcome {
-    let path = inbox_path_resolved(home, target);
-    if !path.exists() {
-        return NonceSupersedeOutcome::default();
-    }
-    with_inbox_lock(home, target, |path| -> NonceSupersedeOutcome {
-        let mut outcome = NonceSupersedeOutcome::default();
-        let content = std::fs::read_to_string(path).unwrap_or_default();
-        let mut changed = false;
-        let mut lines: Vec<String> = Vec::new();
-        for line in content.lines() {
-            if line.trim().is_empty() {
-                lines.push(line.to_string());
-                continue;
-            }
-            // Cheap screen: a row that can't contain the nonce is preserved verbatim.
-            if !line.contains(nonce) {
-                lines.push(line.to_string());
-                continue;
-            }
-            if let Ok(mut msg) = serde_json::from_str::<InboxMessage>(line) {
-                if msg.delivery_nonce.as_deref() == Some(nonce) {
-                    outcome.found = true;
-                    if msg.read_at.is_some() {
-                        outcome.was_read = true;
-                    }
-                    // Only retract a still-live row; an already-read/superseded
-                    // row is already non-actionable and is left byte-identical.
-                    if msg.read_at.is_none() && msg.superseded_by.is_none() {
-                        msg.superseded_by = Some(successor.to_string());
-                        changed = true;
-                    }
-                }
-                lines.push(serde_json::to_string(&msg).unwrap_or_else(|_| line.to_string()));
-            } else {
-                // Forward-schema / torn line: preserve verbatim (never drop).
-                lines.push(line.to_string());
-            }
-        }
-        if changed {
-            let tmp = path.with_extension("jsonl.tmp");
-            if let Ok(mut f) = std::fs::OpenOptions::new()
-                .create(true)
-                .write(true)
-                .truncate(true)
-                .open(&tmp)
-            {
-                use std::io::Write;
-                let write_ok = (|| -> std::io::Result<()> {
-                    for l in &lines {
-                        writeln!(f, "{l}")?;
-                    }
-                    f.sync_all()
-                })()
-                .is_ok();
-                if write_ok && std::fs::rename(&tmp, path).is_ok() {
-                    crate::store::fsync_parent_dir(path); // durable rename
-                }
-            }
-        }
-        outcome
-    })
-    .unwrap_or_default()
+    supersede_by_nonce_inner(home, target, nonce, successor).unwrap_or_default()
 }
 
 /// Strict variant of [`supersede_by_nonce`]: every persistence error (read,
 /// write, fsync, rename) propagates as `Err` so the caller can fail closed
 /// when durable supersede is a precondition for further mutations.
 pub fn supersede_by_nonce_strict(
+    home: &Path,
+    target: &str,
+    nonce: &str,
+    successor: &str,
+) -> anyhow::Result<NonceSupersedeOutcome> {
+    supersede_by_nonce_inner(home, target, nonce, successor)
+}
+
+fn supersede_by_nonce_inner(
     home: &Path,
     target: &str,
     nonce: &str,

--- a/src/inbox/storage.rs
+++ b/src/inbox/storage.rs
@@ -600,28 +600,6 @@ pub fn mark_ci_watch_superseded(
 }
 
 /// t-…-17 reviewer-assignment outbox: is there an ACTIONABLE inbox row for
-/// Does `target`'s inbox contain a row carrying `delivery_nonce == nonce` in
-/// ANY state (unread, read, delivering, superseded)? Used for idempotent
-/// notice dedup where the presence of the nonce — regardless of lifecycle
-/// state — means the notice was already enqueued and must not be appended
-/// again. Lock-free read: the caller holds a serializing lock.
-pub fn nonce_present_any_state(home: &Path, target: &str, nonce: &str) -> bool {
-    let path = inbox_path_resolved(home, target);
-    let Ok(content) = std::fs::read_to_string(&path) else {
-        return false;
-    };
-    content
-        .lines()
-        .filter(|l| !l.trim().is_empty())
-        .filter(|l| l.contains(nonce))
-        .any(|l| {
-            serde_json::from_str::<InboxMessage>(l)
-                .ok()
-                .filter(|m| m.delivery_nonce.as_deref() == Some(nonce))
-                .is_some()
-        })
-}
-
 /// `target` carrying `delivery_nonce == nonce`? "Actionable" = the same
 /// post-#2299 predicate `is_actionable` uses (`read_at.is_none() &&
 /// delivering_at.is_none() && superseded_by.is_none()`). Used by the durable

--- a/src/inbox/storage.rs
+++ b/src/inbox/storage.rs
@@ -600,6 +600,28 @@ pub fn mark_ci_watch_superseded(
 }
 
 /// t-…-17 reviewer-assignment outbox: is there an ACTIONABLE inbox row for
+/// Does `target`'s inbox contain a row carrying `delivery_nonce == nonce` in
+/// ANY state (unread, read, delivering, superseded)? Used for idempotent
+/// notice dedup where the presence of the nonce — regardless of lifecycle
+/// state — means the notice was already enqueued and must not be appended
+/// again. Lock-free read: the caller holds a serializing lock.
+pub fn nonce_present_any_state(home: &Path, target: &str, nonce: &str) -> bool {
+    let path = inbox_path_resolved(home, target);
+    let Ok(content) = std::fs::read_to_string(&path) else {
+        return false;
+    };
+    content
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .filter(|l| l.contains(nonce))
+        .any(|l| {
+            serde_json::from_str::<InboxMessage>(l)
+                .ok()
+                .filter(|m| m.delivery_nonce.as_deref() == Some(nonce))
+                .is_some()
+        })
+}
+
 /// `target` carrying `delivery_nonce == nonce`? "Actionable" = the same
 /// post-#2299 predicate `is_actionable` uses (`read_at.is_none() &&
 /// delivering_at.is_none() && superseded_by.is_none()`). Used by the durable


### PR DESCRIPTION
## Summary
- Before classify/repair_row in the per-tick reconciler, load raw PrState and compare head_sha/pr_number against the assignment subject
- If PrState contradicts (head advanced or PR number mismatch), CAS-retire the assignment via `retire_if_id_matches` (ABA-safe)
- Absent/corrupt PrState → preserve (fail-closed, no retirement)
- Exact byte-for-byte head_sha comparison (no normalization)

Fixes the live 60s redelivery loop for assignment 607cef95 (PR #2777 r11).

## Test plan
- [x] 9 new deterministic tests (6 plan matrix + 3 review constraints C1/C2/C3)
- [x] 12 existing reconciler tests pass (no regression)
- [x] clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)