### PR TITLE
fix: dispatch prevalidation atomicity — reject before side effects

### DIFF
--- a/src/api/handlers/messaging.rs
+++ b/src/api/handlers/messaging.rs
@@ -673,15 +673,10 @@ pub(crate) fn handle_send(params: &Value, ctx: &HandlerCtx) -> Value {
     if let Err(e) = check_quota_gate(ctx.registry, ctx.home, params, vs.target) {
         return e;
     }
-    let auto_task_id =
-        match auto_create_task_if_needed(params, ctx.home, vs.from, vs.target, vs.text) {
-            Ok(id) => id,
-            Err(e) => return e,
-        };
-    let mut msg = build_message(params, ctx.home, &vs, &auto_task_id);
-    // A2: pre-stamp the SAME server-owned id that storage will persist. The
-    // authoritative validator derives receipt/source identities from it; the
-    // caller never supplies an exact-once key.
+    // Build message with auto_task_id=None so all rejection-capable preflights
+    // run before any side effects. The task is created only after authorize_report
+    // and check_worktree_enforcement pass.
+    let mut msg = build_message(params, ctx.home, &vs, &None);
     let server_message_id = crate::inbox::stamp_message_id(&mut msg);
     let report_auth = match crate::review_receipt::authorize_report(
         ctx.home,
@@ -700,12 +695,19 @@ pub(crate) fn handle_send(params: &Value, ctx: &HandlerCtx) -> Value {
     msg.report_purpose = report_auth.purpose;
     msg.validated_code_review = report_auth.receipt;
     if let Some(receipt) = msg.validated_code_review.as_ref() {
-        // Exact server-derived assignment head; top-level reviewed_head remains
-        // a display field and is never read for authorization.
         msg.reviewed_head = Some(receipt.summary().reviewed_head.clone());
     }
     if let Err(e) = check_worktree_enforcement(params, ctx.home, vs.target) {
         return e;
+    }
+    // All preflights passed — now create the auto-task (side effect).
+    let auto_task_id =
+        match auto_create_task_if_needed(params, ctx.home, vs.from, vs.target, vs.text) {
+            Ok(id) => id,
+            Err(e) => return e,
+        };
+    if let Some(ref tid) = auto_task_id {
+        msg.task_id = Some(tid.clone());
     }
     // #bughunt2: a failed enqueue (disk read-only / I/O) must surface as a real
     // failure — never report ok:true for a silently-dropped message. Return

--- a/src/api/handlers/messaging/tests.rs
+++ b/src/api/handlers/messaging/tests.rs
@@ -3039,3 +3039,43 @@ fn purpose_and_verdict_shape_mismatches_reject_before_delivery_2760() {
     assert_eq!(crate::inbox::unread_count(&home, "fixup-lead").0, 0);
     std::fs::remove_dir_all(&home).ok();
 }
+
+/// Late-validation atomicity: `kind=task` carrying report-only fields
+/// (`report_purpose`) must be rejected BEFORE `auto_create_task_if_needed`
+/// runs — zero task/inbox side effects.
+#[test]
+fn report_fields_on_kind_task_rejected_without_leaked_task() {
+    let home = tmp_home("prevalidation-atomicity");
+    write_fixup_fleet(&home, &["fixup-lead", "fixup-dev"]);
+    let ctx = test_ctx(&home);
+    let result = handle_send(
+        &json!({
+            "from": "fixup-lead",
+            "target": "fixup-dev",
+            "text": "test task with illegal report fields",
+            "kind": "task",
+            "report_purpose": "code_review",
+        }),
+        &ctx,
+    );
+    assert_eq!(result["ok"], false, "must reject: {result}");
+    assert_eq!(
+        result["code"].as_str(),
+        Some("report_authority_rejected"),
+        "error code: {result}"
+    );
+    // The critical invariant: no task must have been created as a side effect.
+    let board = crate::task_events::replay(&home).unwrap_or_default();
+    assert!(
+        board.tasks.is_empty(),
+        "rejected send must not leak a task — found {} task(s) on board",
+        board.tasks.len()
+    );
+    // No inbox message delivered either.
+    assert_eq!(
+        crate::inbox::unread_count(&home, "fixup-dev").0,
+        0,
+        "rejected send must not deliver an inbox message"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}


### PR DESCRIPTION
## Summary

- Reorders `handle_send` in the API messaging path so all rejection-capable preflights (`authorize_report`, `check_worktree_enforcement`) run **before** the side-effecting `auto_create_task_if_needed`
- Previously, a `kind=task` send with invalid report-only fields (e.g. `report_purpose=code_review`) would create a `TaskEvent::Created` before the validation rejected the send, leaking an orphaned task on the board
- The fix builds the `InboxMessage` with `auto_task_id=None`, stamps the server message ID, runs full authorization, and only creates the auto-task after all preflights pass — then assigns the task ID into the message before delivery

## Evidence

- **RED test** (`report_fields_on_kind_task_rejected_without_leaked_task`): sends `kind=task` + `report_purpose=code_review`, asserts error returned AND zero tasks on board AND zero inbox messages
- Before fix: "found 1 task(s) on board" (leaked task)
- After fix: all assertions pass — zero side effects on rejection
- **64/64 messaging module tests pass** (0 failures, 1 ignored)
- **Clippy clean** (`-D warnings`)
- Existing `auto_create_task_on_send_kind_task_without_task_id` test still passes (valid task sends unaffected)

## Test plan

- [x] RED test goes GREEN after fix
- [x] Valid `kind=task` sends still auto-create tasks correctly
- [x] `nonreport_transport_nulls_are_inert_but_values_are_rejected_2760` passes
- [x] Full messaging test suite (64 tests) passes
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)