### PR TITLE
Fix aliased release lifecycle collision

### DIFF
--- a/src/binding.rs
+++ b/src/binding.rs
@@ -22,6 +22,8 @@ pub(crate) use release_guard::{
 };
 mod signature;
 pub(crate) use signature::signature_valid;
+mod unbind;
+pub(crate) use unbind::{unbind_with_permit, BindingRemoval};
 mod unbind_compat;
 #[allow(unused_imports)]
 pub use unbind_compat::unbind;
@@ -572,82 +574,6 @@ fn out_of_dispatch_notify_recipient(home: &Path, agent: &str) -> Option<String> 
 /// the same `binding.json.sig` name (it cannot import this — separate binary).
 fn binding_sig_path(dir: &Path) -> PathBuf {
     dir.join("binding.json.sig")
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum BindingRemoval {
-    Removed,
-    Absent,
-    Failed(String),
-}
-
-fn clear_binding_index(home: &Path, agent: &str) {
-    if let Ok(mut map) = binding_index().write() {
-        map.remove(&index_key(home, agent));
-        if let Ok(canonical) = std::fs::canonicalize(home) {
-            map.remove(&index_key(&canonical, agent));
-        }
-    }
-}
-
-pub(crate) fn unbind_with_permit(
-    home: &Path,
-    agent: &str,
-    permit: &crate::mcp::handlers::dispatch_hook::LifecyclePermit,
-) -> BindingRemoval {
-    if !permit.authorizes(home, agent) {
-        tracing::warn!(agent, "unbind refused: invalid lifecycle permit");
-        return BindingRemoval::Failed("invalid lifecycle permit".to_string());
-    }
-    let dir = crate::paths::runtime_dir(home).join(agent);
-    let binding_path = dir.join("binding.json");
-    // #2158 PR2 (ii): audit the release/clear side of binding-change detection with
-    // caller process context (read the prior branch before removal). Only logs when
-    // a binding actually existed (a no-op unbind stays silent).
-    let prev_branch = std::fs::read_to_string(&binding_path)
-        .ok()
-        .and_then(|c| parse_binding_guarded(&c))
-        .and_then(|v| v.get("branch").and_then(|b| b.as_str()).map(String::from));
-    match std::fs::remove_file(&binding_path) {
-        Ok(()) => {}
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            clear_binding_index(home, agent);
-            return BindingRemoval::Absent;
-        }
-        Err(error) => {
-            return BindingRemoval::Failed(format!(
-                "remove binding {}: {error}",
-                binding_path.display()
-            ));
-        }
-    }
-    // The authoritative binding file is gone; invalidate both lexical and
-    // canonical cache keys even if a best-effort sidecar cleanup later fails.
-    clear_binding_index(home, agent);
-    // #1651: drop the HMAC sidecar too, so a stale signature can't linger.
-    for path in [binding_sig_path(&dir), dir.join(OUT_OF_DISPATCH_SIDECAR)] {
-        if let Err(error) = std::fs::remove_file(&path) {
-            if error.kind() != std::io::ErrorKind::NotFound {
-                return BindingRemoval::Failed(format!("remove {}: {error}", path.display()));
-            }
-        }
-    }
-    if let Some(prev_branch) = prev_branch {
-        crate::event_log::log(
-            home,
-            "binding_released",
-            agent,
-            &format!(
-                "prev_branch={prev_branch}; {}",
-                crate::event_log::caller_process_context()
-            ),
-        );
-    }
-    // bug-audit Rank6: clear the out-of-dispatch notify latch so a release resets
-    // it — a later real re-claim of the same branch re-surfaces instead of being
-    // silently swallowed as "already notified". Scoped to release, so the
-    // per-(agent,branch) intra-cycle fire-once dedup is preserved.
-    BindingRemoval::Removed
 }
 
 // #1688 (codex): there is intentionally NO startup "re-sign unsigned bindings"
@@ -1577,41 +1503,6 @@ mod tests {
             "unbind must clear index entry"
         );
         std::fs::remove_dir_all(&home).ok();
-    }
-
-    #[test]
-    fn unbind_reports_absent_and_failed_removal_truthfully() {
-        let absent_home = tmp_home("unbind-absent-outcome");
-        let absent_permit = crate::mcp::handlers::dispatch_hook::LifecyclePermit::acquire(
-            &absent_home,
-            "agent-absent",
-            crate::mcp::handlers::dispatch_hook::LifecycleOperation::Delete,
-        )
-        .expect("absent permit");
-        assert_eq!(
-            unbind_with_permit(&absent_home, "agent-absent", &absent_permit),
-            BindingRemoval::Absent
-        );
-        drop(absent_permit);
-        std::fs::remove_dir_all(&absent_home).ok();
-
-        let failed_home = tmp_home("unbind-failed-outcome");
-        let binding_path = crate::paths::runtime_dir(&failed_home)
-            .join("agent-failed")
-            .join("binding.json");
-        std::fs::create_dir_all(&binding_path).expect("binding path directory");
-        let failed_permit = crate::mcp::handlers::dispatch_hook::LifecyclePermit::acquire(
-            &failed_home,
-            "agent-failed",
-            crate::mcp::handlers::dispatch_hook::LifecycleOperation::Delete,
-        )
-        .expect("failed permit");
-        assert!(matches!(
-            unbind_with_permit(&failed_home, "agent-failed", &failed_permit),
-            BindingRemoval::Failed(_)
-        ));
-        drop(failed_permit);
-        std::fs::remove_dir_all(&failed_home).ok();
     }
 
     #[test]

--- a/src/binding.rs
+++ b/src/binding.rs
@@ -573,24 +573,66 @@ fn out_of_dispatch_notify_recipient(home: &Path, agent: &str) -> Option<String> 
 fn binding_sig_path(dir: &Path) -> PathBuf {
     dir.join("binding.json.sig")
 }
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum BindingRemoval {
+    Removed,
+    Absent,
+    Failed(String),
+}
+
+fn clear_binding_index(home: &Path, agent: &str) {
+    if let Ok(mut map) = binding_index().write() {
+        map.remove(&index_key(home, agent));
+        if let Ok(canonical) = std::fs::canonicalize(home) {
+            map.remove(&index_key(&canonical, agent));
+        }
+    }
+}
+
 pub(crate) fn unbind_with_permit(
     home: &Path,
     agent: &str,
     permit: &crate::mcp::handlers::dispatch_hook::LifecyclePermit,
-) {
+) -> BindingRemoval {
     if !permit.authorizes(home, agent) {
         tracing::warn!(agent, "unbind refused: invalid lifecycle permit");
-        return;
+        return BindingRemoval::Failed("invalid lifecycle permit".to_string());
     }
     let dir = crate::paths::runtime_dir(home).join(agent);
+    let binding_path = dir.join("binding.json");
     // #2158 PR2 (ii): audit the release/clear side of binding-change detection with
     // caller process context (read the prior branch before removal). Only logs when
     // a binding actually existed (a no-op unbind stays silent).
-    if let Some(prev_branch) = std::fs::read_to_string(dir.join("binding.json"))
+    let prev_branch = std::fs::read_to_string(&binding_path)
         .ok()
         .and_then(|c| parse_binding_guarded(&c))
-        .and_then(|v| v.get("branch").and_then(|b| b.as_str()).map(String::from))
-    {
+        .and_then(|v| v.get("branch").and_then(|b| b.as_str()).map(String::from));
+    match std::fs::remove_file(&binding_path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            clear_binding_index(home, agent);
+            return BindingRemoval::Absent;
+        }
+        Err(error) => {
+            return BindingRemoval::Failed(format!(
+                "remove binding {}: {error}",
+                binding_path.display()
+            ));
+        }
+    }
+    // The authoritative binding file is gone; invalidate both lexical and
+    // canonical cache keys even if a best-effort sidecar cleanup later fails.
+    clear_binding_index(home, agent);
+    // #1651: drop the HMAC sidecar too, so a stale signature can't linger.
+    for path in [binding_sig_path(&dir), dir.join(OUT_OF_DISPATCH_SIDECAR)] {
+        if let Err(error) = std::fs::remove_file(&path) {
+            if error.kind() != std::io::ErrorKind::NotFound {
+                return BindingRemoval::Failed(format!("remove {}: {error}", path.display()));
+            }
+        }
+    }
+    if let Some(prev_branch) = prev_branch {
         crate::event_log::log(
             home,
             "binding_released",
@@ -601,17 +643,11 @@ pub(crate) fn unbind_with_permit(
             ),
         );
     }
-    let _ = std::fs::remove_file(dir.join("binding.json"));
-    // #1651: drop the HMAC sidecar too, so a stale signature can't linger.
-    let _ = std::fs::remove_file(binding_sig_path(&dir));
     // bug-audit Rank6: clear the out-of-dispatch notify latch so a release resets
     // it — a later real re-claim of the same branch re-surfaces instead of being
     // silently swallowed as "already notified". Scoped to release, so the
     // per-(agent,branch) intra-cycle fire-once dedup is preserved.
-    let _ = std::fs::remove_file(dir.join(OUT_OF_DISPATCH_SIDECAR));
-    if let Ok(mut map) = binding_index().write() {
-        map.remove(&index_key(home, agent));
-    }
+    BindingRemoval::Removed
 }
 
 // #1688 (codex): there is intentionally NO startup "re-sign unsigned bindings"
@@ -1541,6 +1577,41 @@ mod tests {
             "unbind must clear index entry"
         );
         std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn unbind_reports_absent_and_failed_removal_truthfully() {
+        let absent_home = tmp_home("unbind-absent-outcome");
+        let absent_permit = crate::mcp::handlers::dispatch_hook::LifecyclePermit::acquire(
+            &absent_home,
+            "agent-absent",
+            crate::mcp::handlers::dispatch_hook::LifecycleOperation::Delete,
+        )
+        .expect("absent permit");
+        assert_eq!(
+            unbind_with_permit(&absent_home, "agent-absent", &absent_permit),
+            BindingRemoval::Absent
+        );
+        drop(absent_permit);
+        std::fs::remove_dir_all(&absent_home).ok();
+
+        let failed_home = tmp_home("unbind-failed-outcome");
+        let binding_path = crate::paths::runtime_dir(&failed_home)
+            .join("agent-failed")
+            .join("binding.json");
+        std::fs::create_dir_all(&binding_path).expect("binding path directory");
+        let failed_permit = crate::mcp::handlers::dispatch_hook::LifecyclePermit::acquire(
+            &failed_home,
+            "agent-failed",
+            crate::mcp::handlers::dispatch_hook::LifecycleOperation::Delete,
+        )
+        .expect("failed permit");
+        assert!(matches!(
+            unbind_with_permit(&failed_home, "agent-failed", &failed_permit),
+            BindingRemoval::Failed(_)
+        ));
+        drop(failed_permit);
+        std::fs::remove_dir_all(&failed_home).ok();
     }
 
     #[test]

--- a/src/binding/unbind.rs
+++ b/src/binding/unbind.rs
@@ -1,0 +1,70 @@
+use std::path::Path;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum BindingRemoval {
+    Removed,
+    Absent,
+    Failed(String),
+}
+
+fn clear_binding_index(home: &Path, agent: &str) {
+    if let Ok(mut map) = super::binding_index().write() {
+        map.remove(&super::index_key(home, agent));
+        if let Ok(canonical) = std::fs::canonicalize(home) {
+            map.remove(&super::index_key(&canonical, agent));
+        }
+    }
+}
+
+pub(crate) fn unbind_with_permit(
+    home: &Path,
+    agent: &str,
+    permit: &crate::mcp::handlers::dispatch_hook::LifecyclePermit,
+) -> BindingRemoval {
+    if !permit.authorizes(home, agent) {
+        tracing::warn!(agent, "unbind refused: invalid lifecycle permit");
+        return BindingRemoval::Failed("invalid lifecycle permit".to_string());
+    }
+    let dir = crate::paths::runtime_dir(home).join(agent);
+    let binding_path = dir.join("binding.json");
+    // #2158 PR2 (ii): audit the release/clear side of binding-change detection with
+    // caller process context (read the prior branch before removal). Only logs when
+    // a binding actually existed (a no-op unbind stays silent).
+    let prev_branch = std::fs::read_to_string(&binding_path)
+        .ok()
+        .and_then(|c| super::parse_binding_guarded(&c))
+        .and_then(|v| v.get("branch").and_then(|b| b.as_str()).map(String::from));
+    if let Err(error) = std::fs::remove_file(&binding_path) {
+        if error.kind() == std::io::ErrorKind::NotFound {
+            clear_binding_index(home, agent);
+            return BindingRemoval::Absent;
+        }
+        return BindingRemoval::Failed(format!(
+            "remove binding {}: {error}",
+            binding_path.display()
+        ));
+    }
+    clear_binding_index(home, agent);
+    for path in [
+        super::binding_sig_path(&dir),
+        dir.join(super::OUT_OF_DISPATCH_SIDECAR),
+    ] {
+        if let Err(error) = std::fs::remove_file(&path) {
+            if error.kind() != std::io::ErrorKind::NotFound {
+                return BindingRemoval::Failed(format!("remove {}: {error}", path.display()));
+            }
+        }
+    }
+    if let Some(prev_branch) = prev_branch {
+        crate::event_log::log(
+            home,
+            "binding_released",
+            agent,
+            &format!(
+                "prev_branch={prev_branch}; {}",
+                crate::event_log::caller_process_context()
+            ),
+        );
+    }
+    BindingRemoval::Removed
+}

--- a/src/binding/unbind_compat.rs
+++ b/src/binding/unbind_compat.rs
@@ -10,5 +10,5 @@ pub fn unbind(home: &std::path::Path, agent: &str) {
     ) else {
         return;
     };
-    super::unbind_with_permit(home, agent, &permit);
+    let _ = super::unbind_with_permit(home, agent, &permit);
 }

--- a/src/mcp/handlers/dispatch_hook/lifecycle_permit.rs
+++ b/src/mcp/handlers/dispatch_hook/lifecycle_permit.rs
@@ -29,6 +29,17 @@ fn next_token() -> u64 {
     NEXT.fetch_add(1, Ordering::Relaxed)
 }
 
+/// Resolve the physical lifecycle-home identity when the path exists. Release
+/// entry points routinely receive equivalent lexical paths (and symlink
+/// aliases) for the same home; retaining a lexical fallback keeps the permit
+/// usable for pre-flight callers that are probing a not-yet-created home.
+fn lifecycle_home_key(home: &Path) -> String {
+    std::fs::canonicalize(home)
+        .unwrap_or_else(|_| home.to_path_buf())
+        .display()
+        .to_string()
+}
+
 /// Exclusive lifecycle authority for one `(home, agent)` pair.
 ///
 /// Non-Clone RAII guard: `Drop` removes the active-map entry exactly once.
@@ -63,7 +74,7 @@ impl LifecyclePermit {
         agent: &str,
         operation: LifecycleOperation,
     ) -> Result<Self, String> {
-        let key = (home.display().to_string(), agent.to_string());
+        let key = (lifecycle_home_key(home), agent.to_string());
         let token = next_token();
         let mut active = active_permits().lock();
         if active.contains_key(&key) {
@@ -80,7 +91,7 @@ impl LifecyclePermit {
     }
 
     pub(crate) fn authorizes(&self, home: &Path, agent: &str) -> bool {
-        let key = (home.display().to_string(), agent.to_string());
+        let key = (lifecycle_home_key(home), agent.to_string());
         active_permits().lock().get(&key) == Some(&self.token)
     }
 }
@@ -114,6 +125,6 @@ impl BindGuard {
 }
 
 pub(crate) fn is_active(home: &Path, agent: &str) -> bool {
-    let key = (home.display().to_string(), agent.to_string());
+    let key = (lifecycle_home_key(home), agent.to_string());
     active_permits().lock().contains_key(&key)
 }

--- a/src/mcp/handlers/instance_state/lifecycle.rs
+++ b/src/mcp/handlers/instance_state/lifecycle.rs
@@ -288,7 +288,16 @@ pub(crate) fn full_delete_instance(home: &Path, name: &str) -> Result<(), String
     // also clears the binding itself on success, so the unbind below is a
     // defensive idempotent no-op for the bound-agent case (still needed for the
     // never-bound / partial-state cases).
-    let _ = crate::worktree_pool::release_full_with_permit(home, name, false, &lifecycle_permit);
+    let release = crate::worktree_pool::release_full_with_permit_origin(
+        home,
+        name,
+        false,
+        &lifecycle_permit,
+        crate::worktree_pool::ReleaseProvenance::Delete,
+    );
+    if let Some(error) = release.error {
+        step_errors.push(format!("worktree release: {error}"));
+    }
     // release_full removes the leaf worktree `worktrees/<name>/<branch>/`; drop the
     // now-empty agent dir `worktrees/<name>/` too so the audit below reads clean.
     // #1907: a slash-containing branch (e.g. `feat/x`) nests intermediate dirs
@@ -305,7 +314,11 @@ pub(crate) fn full_delete_instance(home: &Path, name: &str) -> Result<(), String
     // ran bind_self / repo checkout) without a prior release both leaked the
     // binding (blocking a same-name re-bind) AND tripped the residual audit below
     // → the whole teardown returned Err despite otherwise succeeding.
-    crate::binding::unbind_with_permit(home, name, &lifecycle_permit);
+    if let crate::binding::BindingRemoval::Failed(error) =
+        crate::binding::unbind_with_permit(home, name, &lifecycle_permit)
+    {
+        step_errors.push(format!("binding removal: {error}"));
+    }
     // #1907: `unbind` drops binding.json + its HMAC sidecar but leaves the now-empty
     // `runtime/<name>/` dir + its `.binding.json.lock` flock behind. Remove the whole
     // dir so teardown is fully clean (the residual audit below now checks it). Safe:

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -151,6 +151,24 @@ pub fn is_daemon_managed(worktree_path: &Path) -> bool {
 
 /// Outcome of a hard release — emitted by `release_full` and serialized
 /// directly into the `release_worktree` MCP tool response.
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum ReleaseProvenance {
+    Manual,
+    Auto,
+    Delete,
+}
+
+impl std::fmt::Display for ReleaseProvenance {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let name = match self {
+            Self::Manual => "manual",
+            Self::Auto => "auto",
+            Self::Delete => "delete",
+        };
+        f.write_str(name)
+    }
+}
+
 #[derive(Debug, Default, Clone, serde::Serialize)]
 pub struct ReleaseOutcome {
     pub released: bool,
@@ -509,8 +527,27 @@ fn clear_binding_state(
     home: &Path,
     agent: &str,
     permit: &crate::mcp::handlers::dispatch_hook::LifecyclePermit,
-) {
-    crate::binding::unbind_with_permit(home, agent, permit);
+) -> crate::binding::BindingRemoval {
+    crate::binding::unbind_with_permit(home, agent, permit)
+}
+
+fn record_binding_removal(out: &mut ReleaseOutcome, removal: crate::binding::BindingRemoval) {
+    match removal {
+        crate::binding::BindingRemoval::Removed => out.binding_removed = true,
+        crate::binding::BindingRemoval::Absent => {
+            if out.error.is_none() {
+                out.error = Some("binding disappeared before removal".to_string());
+            }
+        }
+        crate::binding::BindingRemoval::Failed(error) => {
+            if let Some(existing) = &mut out.error {
+                existing.push_str("; binding removal failed: ");
+                existing.push_str(&error);
+            } else {
+                out.error = Some(format!("binding removal failed: {error}"));
+            }
+        }
+    }
 }
 
 fn resolve_branch_cleanup(
@@ -679,8 +716,8 @@ fn release_known_locked(
                     // worktree-protection refusal must not also skip binding
                     // cleanup. (This arm is already the non-dry_run path; the
                     // dry_run classifier above mutates nothing.)
-                    clear_binding_state(home, agent, permit);
-                    out.binding_removed = true;
+                    let removal = clear_binding_state(home, agent, permit);
+                    record_binding_removal(&mut out, removal);
                     return LockedRelease {
                         out,
                         notices,
@@ -714,22 +751,23 @@ fn release_known_locked(
         ));
         out.released = true;
     } else {
-        clear_binding_state(home, agent, permit);
-        out.binding_removed = true;
+        let removal = clear_binding_state(home, agent, permit);
+        record_binding_removal(&mut out, removal);
         // #1465 guardrail: only report `released` when no cleanup step failed.
         // A `WorktreeRemoval::Failed` set `out.error` above — idempotent success
         // must NOT mask a real execution error as success (reviewer contract:
         // "binding present but cleanup failed → released:false + error").
-        if out.error.is_none() {
+        if out.error.is_none() && out.binding_removed {
             out.released = true;
         }
     }
 
+    let finish_full_release = out.released || dry_run;
     LockedRelease {
         out,
         notices,
         clear_refusal_marker,
-        finish_full_release: true,
+        finish_full_release,
         managed_verified,
         worktree_absent,
     }
@@ -741,6 +779,7 @@ fn release_full_guarded(
     dry_run: bool,
     permit: &crate::mcp::handlers::dispatch_hook::LifecyclePermit,
     expected: Option<&crate::binding::BindingFingerprint>,
+    provenance: ReleaseProvenance,
 ) -> ReleaseOutcome {
     use crate::binding::GuardedBinding;
 
@@ -820,7 +859,8 @@ fn release_full_guarded(
             "worktree_released_full",
             agent,
             &format!(
-                "wt_removed={} binding_removed={} error={}",
+                "operation={:?} provenance={provenance} wt_removed={} binding_removed={} error={}",
+                permit.operation,
                 locked.out.worktree_removed,
                 locked.out.binding_removed,
                 locked.out.error.as_deref().unwrap_or("")
@@ -841,10 +881,17 @@ pub fn release_full(home: &Path, agent: &str, dry_run: bool) -> ReleaseOutcome {
             return ReleaseOutcome {
                 error: Some(format!("release refused: {error}")),
                 ..ReleaseOutcome::default()
-            }
+            };
         }
     };
-    release_full_guarded(home, agent, dry_run, &permit, None)
+    release_full_guarded(
+        home,
+        agent,
+        dry_run,
+        &permit,
+        None,
+        ReleaseProvenance::Manual,
+    )
 }
 
 pub(crate) fn release_full_with_permit(
@@ -853,7 +900,17 @@ pub(crate) fn release_full_with_permit(
     dry_run: bool,
     permit: &crate::mcp::handlers::dispatch_hook::LifecyclePermit,
 ) -> ReleaseOutcome {
-    release_full_guarded(home, agent, dry_run, permit, None)
+    release_full_with_permit_origin(home, agent, dry_run, permit, ReleaseProvenance::Manual)
+}
+
+pub(crate) fn release_full_with_permit_origin(
+    home: &Path,
+    agent: &str,
+    dry_run: bool,
+    permit: &crate::mcp::handlers::dispatch_hook::LifecyclePermit,
+    provenance: ReleaseProvenance,
+) -> ReleaseOutcome {
+    release_full_guarded(home, agent, dry_run, permit, None, provenance)
 }
 
 pub(crate) fn release_full_exact(
@@ -874,7 +931,14 @@ pub(crate) fn release_full_exact(
             }
         }
     };
-    release_full_guarded(home, agent, false, &permit, Some(expected))
+    release_full_guarded(
+        home,
+        agent,
+        false,
+        &permit,
+        Some(expected),
+        ReleaseProvenance::Auto,
+    )
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1009,9 +1073,9 @@ fn release_bound_target_exact_impl(
             drop(branch_lock);
             return out;
         }
-        clear_binding_state(home, agent, permit);
-        out.binding_removed = true;
-        out.released = true;
+        let removal = clear_binding_state(home, agent, permit);
+        record_binding_removal(&mut out, removal);
+        out.released = out.error.is_none() && out.binding_removed;
         drop(_binding_lock);
         drop(_agent_lock);
         drop(branch_lock);
@@ -1057,21 +1121,21 @@ fn release_bound_target_exact_impl(
         WorktreeRemoval::Removed => {
             out.worktree_removed = true;
             clear_marker = true;
-            clear_binding_state(home, agent, permit);
-            out.binding_removed = true;
-            out.released = true;
+            let removal = clear_binding_state(home, agent, permit);
+            record_binding_removal(&mut out, removal);
+            out.released = out.error.is_none() && out.binding_removed;
         }
         WorktreeRemoval::AlreadyAbsent => {
-            clear_binding_state(home, agent, permit);
-            out.binding_removed = true;
-            out.released = true;
+            let removal = clear_binding_state(home, agent, permit);
+            record_binding_removal(&mut out, removal);
+            out.released = out.error.is_none() && out.binding_removed;
         }
         WorktreeRemoval::Unmanaged(error) => out.error = Some(error),
         WorktreeRemoval::Failed(error) => {
             out.error = Some(error);
             if clear_binding_on_remove_failure {
-                clear_binding_state(home, agent, permit);
-                out.binding_removed = true;
+                let removal = clear_binding_state(home, agent, permit);
+                record_binding_removal(&mut out, removal);
             }
         }
     }
@@ -1167,7 +1231,7 @@ pub(crate) fn release_bound_target_exact_under_branch_lock(
             return ReleaseOutcome {
                 error: Some(format!("release refused: {error}")),
                 ..ReleaseOutcome::default()
-            }
+            };
         }
     };
     release_bound_target_exact_impl(

--- a/src/worktree_pool/tests.rs
+++ b/src/worktree_pool/tests.rs
@@ -1043,6 +1043,41 @@ fn aliased_manual_and_auto_release_share_one_lifecycle_transaction_s2() {
     std::fs::remove_dir_all(&repo).ok();
 }
 
+#[test]
+fn unbind_reports_absent_and_failed_removal_truthfully() {
+    let absent_home = tmp_home("unbind-absent-outcome");
+    let absent_permit = crate::mcp::handlers::dispatch_hook::LifecyclePermit::acquire(
+        &absent_home,
+        "agent-absent",
+        crate::mcp::handlers::dispatch_hook::LifecycleOperation::Delete,
+    )
+    .expect("absent permit");
+    assert_eq!(
+        crate::binding::unbind_with_permit(&absent_home, "agent-absent", &absent_permit),
+        crate::binding::BindingRemoval::Absent
+    );
+    drop(absent_permit);
+    std::fs::remove_dir_all(&absent_home).ok();
+
+    let failed_home = tmp_home("unbind-failed-outcome");
+    let binding_path = crate::paths::runtime_dir(&failed_home)
+        .join("agent-failed")
+        .join("binding.json");
+    std::fs::create_dir_all(&binding_path).expect("binding path directory");
+    let failed_permit = crate::mcp::handlers::dispatch_hook::LifecyclePermit::acquire(
+        &failed_home,
+        "agent-failed",
+        crate::mcp::handlers::dispatch_hook::LifecycleOperation::Delete,
+    )
+    .expect("failed permit");
+    assert!(matches!(
+        crate::binding::unbind_with_permit(&failed_home, "agent-failed", &failed_permit),
+        crate::binding::BindingRemoval::Failed(_)
+    ));
+    drop(failed_permit);
+    std::fs::remove_dir_all(&failed_home).ok();
+}
+
 /// S1 RED: reverse reconciliation is another lifecycle actor. The lifecycle
 /// permit ensures that when release holds the permit, reverse_reconcile is
 /// refused before any mutation — and vice versa.

--- a/src/worktree_pool/tests.rs
+++ b/src/worktree_pool/tests.rs
@@ -981,6 +981,61 @@ fn concurrent_release_actors_apply_one_transition_s1() {
     std::fs::remove_dir_all(&repo).ok();
 }
 
+/// S2 RED: manual and auto-release entry points must share lifecycle authority
+/// when they address the same existing home through distinct path aliases.
+/// `home/.` is the same directory as `home`, but its pre-fix display key was
+/// distinct, allowing the second actor to acquire a competing permit.
+#[test]
+fn aliased_manual_and_auto_release_share_one_lifecycle_transaction_s2() {
+    let home = tmp_home("s2-release-alias");
+    let repo = tmp_repo("s2-release-alias-repo");
+    lease_bound(&home, &repo, "agent-alias", "feat/alias");
+    let alias = home.join(".");
+    let expected = match crate::binding::snapshot_guarded_binding(&home, "agent-alias")
+        .expect("snapshot binding")
+    {
+        crate::binding::GuardedBinding::Known { fingerprint, .. } => fingerprint,
+        other => panic!("expected known binding, got {other:?}"),
+    };
+
+    let (entered_tx, entered_rx) = std::sync::mpsc::channel();
+    let (resume_tx, resume_rx) = std::sync::mpsc::channel();
+    let home_for_manual = home.clone();
+    let manual = std::thread::spawn(move || {
+        let _hook = release_test_seam::install(move |phase| {
+            if phase == ReleaseTestPhase::AfterBindingSnapshot {
+                entered_tx.send(()).expect("signal manual snapshot");
+                resume_rx.recv().expect("wait for manual resume");
+            }
+        });
+        release_full(&home_for_manual, "agent-alias", false)
+    });
+
+    entered_rx.recv().expect("manual release reached snapshot");
+    let auto = release_full_exact(&alias, "agent-alias", &expected);
+    assert!(
+        auto.error
+            .as_deref()
+            .is_some_and(|error| error.contains("lifecycle transaction already in flight")),
+        "aliased auto-release must be refused while manual release owns the permit: {auto:?}"
+    );
+    assert!(!auto.released && !auto.binding_removed);
+
+    resume_tx.send(()).expect("resume manual release");
+    let manual = manual.join().expect("manual release thread");
+    assert!(manual.released && manual.binding_removed, "manual: {manual:?}");
+
+    let events = std::fs::read_to_string(home.join("event-log.jsonl")).unwrap_or_default();
+    assert_eq!(
+        events.matches("worktree_released_full").count(),
+        1,
+        "one aliased release transaction must emit one terminal event: {events}"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&repo).ok();
+}
+
 /// S1 RED: reverse reconciliation is another lifecycle actor. The lifecycle
 /// permit ensures that when release holds the permit, reverse_reconcile is
 /// refused before any mutation — and vice versa.

--- a/src/worktree_pool/tests.rs
+++ b/src/worktree_pool/tests.rs
@@ -1023,13 +1023,20 @@ fn aliased_manual_and_auto_release_share_one_lifecycle_transaction_s2() {
 
     resume_tx.send(()).expect("resume manual release");
     let manual = manual.join().expect("manual release thread");
-    assert!(manual.released && manual.binding_removed, "manual: {manual:?}");
+    assert!(
+        manual.released && manual.binding_removed,
+        "manual: {manual:?}"
+    );
 
     let events = std::fs::read_to_string(home.join("event-log.jsonl")).unwrap_or_default();
     assert_eq!(
         events.matches("worktree_released_full").count(),
         1,
         "one aliased release transaction must emit one terminal event: {events}"
+    );
+    assert!(
+        events.contains("operation=Release provenance=manual"),
+        "terminal release event must preserve manual provenance: {events}"
     );
 
     std::fs::remove_dir_all(&home).ok();


### PR DESCRIPTION
## Summary
- canonicalize existing lifecycle-home identity before acquiring/validating permits
- propagate truthful binding removal outcomes and suppress terminal events on failed cleanup
- distinguish manual/auto/delete release provenance in terminal audit events

## Verification
- RED: `cargo test --bin agend-terminal aliased_manual_and_auto_release_share_one_lifecycle_transaction_s2 -- --nocapture` failed before the implementation commit (auto alias acquired a competing permit and removed the binding)
- GREEN: focused alias race and removal outcome tests pass
- `cargo clippy --bin agend-terminal --tests -- -D warnings`
- full workspace clippy is blocked by pre-existing vendor `agentic-git` test `unwrap_used` diagnostics

Test-first commits: `9df0adb8533cbab73a33a627c7e72af7bcc765ad` then `87b53fabc358a80fbe76e7f584613e709401a842`.