### PR TITLE
feat(fleet): template deployments carry  allowlist into fleet.yaml

### DIFF
--- a/src/deployments.rs
+++ b/src/deployments.rs
@@ -192,18 +192,53 @@ fn create_instance_entries(
             })
             .filter(|m| !m.is_empty());
         // Sprint 61 follow-up: per-instance skills allowlist from a template stanza.
-        // Mirrors `args` extraction, but does NOT `.filter(|v| !v.is_empty())` —
+        // Unlike `args` extraction this does NOT `.filter(|v| !v.is_empty())` —
         // `skills: []` (explicit opt-out of all skills) is a meaningful value per
         // `InstanceConfig::skills` docstring, and filtering it would silently flip
         // opt-out → install-all. `None` (field absent) means install every skill.
-        let template_skills = inst_val
-            .get("skills")
-            .and_then(|v| v.as_sequence())
-            .map(|seq| {
-                seq.iter()
-                    .filter_map(|x| x.as_str().map(|s| s.to_string()))
-                    .collect::<Vec<String>>()
-            });
+        //
+        // Presence-with-invalid-type must fail closed: a non-sequence value
+        // (e.g. scalar `skills: code-review`) or a sequence with non-string
+        // members (e.g. `skills: [42]`) is rejected at deployment time rather
+        // than silently resolving to `None` or a partial list. Only absent
+        // (None), empty `[]`, and valid string sequences pass through.
+        let template_skills = match inst_val.get("skills") {
+            None => None,
+            Some(skills_val) => {
+                let seq = match skills_val.as_sequence() {
+                    Some(s) => s,
+                    None => {
+                        tracing::warn!(
+                            deploy_name = %params.deploy_name,
+                            inst = %inst_name,
+                            "skipping template instance: `skills` must be a YAML sequence (list)"
+                        );
+                        continue;
+                    }
+                };
+                let mut skills = Vec::with_capacity(seq.len());
+                let mut invalid = false;
+                for x in seq {
+                    match x.as_str() {
+                        Some(s) => skills.push(s.to_string()),
+                        None => {
+                            tracing::warn!(
+                                deploy_name = %params.deploy_name,
+                                inst = %inst_name,
+                                value = ?x,
+                                "skipping template instance: every `skills` entry must be a string"
+                            );
+                            invalid = true;
+                            break;
+                        }
+                    }
+                }
+                if invalid {
+                    continue;
+                }
+                Some(skills)
+            }
+        };
         let source_repo = inst_val
             .get("source_repo")
             .and_then(|v| v.as_str())

--- a/src/deployments.rs
+++ b/src/deployments.rs
@@ -191,6 +191,19 @@ fn create_instance_entries(
                 out
             })
             .filter(|m| !m.is_empty());
+        // Sprint 61 follow-up: per-instance skills allowlist from a template stanza.
+        // Mirrors `args` extraction, but does NOT `.filter(|v| !v.is_empty())` —
+        // `skills: []` (explicit opt-out of all skills) is a meaningful value per
+        // `InstanceConfig::skills` docstring, and filtering it would silently flip
+        // opt-out → install-all. `None` (field absent) means install every skill.
+        let template_skills = inst_val
+            .get("skills")
+            .and_then(|v| v.as_sequence())
+            .map(|seq| {
+                seq.iter()
+                    .filter_map(|x| x.as_str().map(|s| s.to_string()))
+                    .collect::<Vec<String>>()
+            });
         let source_repo = inst_val
             .get("source_repo")
             .and_then(|v| v.as_str())
@@ -216,6 +229,7 @@ fn create_instance_entries(
                 instructions: yaml_str(inst_val, "instructions"),
                 source_repo,
                 skills_path: yaml_str(inst_val, "skills_path"),
+                skills: template_skills,
                 // #2104 (cheerc): both operator-controlled override fields were
                 // hardcoded None here → templates that set them were silently
                 // dropped. `repo` = explicit owner/name override (else daemon

--- a/src/deployments/tests.rs
+++ b/src/deployments/tests.rs
@@ -188,6 +188,78 @@ templates:
     std::fs::remove_dir_all(&home).ok();
 }
 
+/// Sprint 61 follow-up: a template instance's `skills:` allowlist must flow
+/// through deployment into the live `instances:` block, so it reaches the
+/// per-instance skills install at spawn time. Before this PR, `build_command`'s
+/// sister extraction site in `create_instance_entries` read `skills_path` but
+/// not `skills` — a template `skills: [a, b]` was silently dropped to `None`
+/// (install-all), the inverse of the operator's intent.
+#[test]
+fn deploy_persists_skills_allowlist_into_fleet_yaml() {
+    let home = tmp_home("skills_allowlist_persist");
+    let yaml = r#"
+templates:
+  dev:
+    instances:
+      reviewer:
+        backend: claude
+        skills:
+          - code-review
+          - receiving-code-review
+"#;
+    std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).unwrap();
+
+    let args = serde_json::json!({"template": "dev", "directory": home.display().to_string()});
+    let _ = deploy(&home, "caller", &args);
+
+    let reloaded = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&home)).unwrap();
+    assert_eq!(
+        reloaded
+            .instances
+            .get("dev-reviewer")
+            .and_then(|i| i.skills.clone()),
+        Some(vec![
+            "code-review".to_string(),
+            "receiving-code-review".to_string()
+        ]),
+        "template skills allowlist must persist into the deployed instance"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// `skills: []` (explicit opt-out — install NO skills) in a template stanza
+/// must survive deployment as `Some(vec![])`, NOT collapse to `None` (which
+/// means install ALL skills). This is the divergence from `args` extraction
+/// (which `.filter(|v| !v.is_empty())` would drop to `None`); for `skills` the
+/// empty vec is semantically meaningful.
+#[test]
+fn deploy_preserves_empty_skills_allowlist_opt_out() {
+    let home = tmp_home("skills_optout_persist");
+    let yaml = r#"
+templates:
+  dev:
+    instances:
+      lead:
+        backend: claude
+        skills: []
+"#;
+    std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).unwrap();
+
+    let args = serde_json::json!({"template": "dev", "directory": home.display().to_string()});
+    let _ = deploy(&home, "caller", &args);
+
+    let reloaded = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&home)).unwrap();
+    assert_eq!(
+        reloaded
+            .instances
+            .get("dev-lead")
+            .and_then(|i| i.skills.clone()),
+        Some(vec![]),
+        "`skills: []` must persist as Some(vec![]); a drop to None would silently flip opt-out → install-all"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
 /// #2104 (cheerc): template deployment must carry the template instance's
 /// operator-controlled override fields — `github_login` AND `repo` — into the
 /// deployed instance. Both were hardcoded `None` at the same site

--- a/src/deployments/tests.rs
+++ b/src/deployments/tests.rs
@@ -260,6 +260,63 @@ templates:
     std::fs::remove_dir_all(&home).ok();
 }
 
+/// A template `skills:` that is NOT a YAML sequence (e.g. a bare scalar
+/// `skills: code-review`) must reject the instance at deployment time
+/// rather than fall through to `None` (install every skill).
+#[test]
+fn deploy_rejects_non_sequence_skills() {
+    let home = tmp_home("skills_non_seq_reject");
+    let yaml = r#"
+templates:
+  dev:
+    instances:
+      lead:
+        backend: claude
+        skills: code-review
+"#;
+    std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).unwrap();
+
+    let args = serde_json::json!({"template": "dev", "directory": home.display().to_string()});
+    // Deployment itself succeeds — only the invalid instance is skipped.
+    let _ = deploy(&home, "caller", &args);
+
+    let reloaded = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&home)).unwrap();
+    assert!(
+        !reloaded.instances.contains_key("dev-lead"),
+        "instance with non-sequence `skills` must be skipped, not deployed"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// A template `skills:` sequence containing a non-string member
+/// (e.g. `skills: [42]` or `skills: [valid, 42]`) must reject the
+/// instance rather than silently dropping invalid entries.
+#[test]
+fn deploy_rejects_non_string_skills_member() {
+    let home = tmp_home("skills_non_str_reject");
+    let yaml = r#"
+templates:
+  dev:
+    instances:
+      lead:
+        backend: claude
+        skills:
+          - a
+          - 42
+"#;
+    std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).unwrap();
+
+    let args = serde_json::json!({"template": "dev", "directory": home.display().to_string()});
+    let _ = deploy(&home, "caller", &args);
+
+    let reloaded = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&home)).unwrap();
+    assert!(
+        !reloaded.instances.contains_key("dev-lead"),
+        "instance with non-string `skills` member must be skipped, not deployed"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
 /// #2104 (cheerc): template deployment must carry the template instance's
 /// operator-controlled override fields — `github_login` AND `repo` — into the
 /// deployed instance. Both were hardcoded `None` at the same site

--- a/src/fleet/merge.rs
+++ b/src/fleet/merge.rs
@@ -69,6 +69,20 @@ pub fn merge_instance_into_existing(
             .map(|args| Value::Sequence(args.iter().map(|s| Value::String(s.clone())).collect())),
     )?;
 
+    // Sprint 61 follow-up: `skills` is the same Sequence shape as `args` but
+    // with different empty-vec semantics — `Some(vec![])` is a meaningful opt-out
+    // that MUST round-trip (NOT filtered to `None` like `args` would be safe to
+    // do). `merge_typed_field` already preserves Some-ness, so no special-casing
+    // here; the filter happens at the extraction site in deployments.rs.
+    merge_typed_field(
+        name,
+        existing,
+        "skills",
+        config.skills.as_ref().map(|skills| {
+            Value::Sequence(skills.iter().map(|s| Value::String(s.clone())).collect())
+        }),
+    )?;
+
     merge_typed_field(
         name,
         existing,
@@ -176,6 +190,15 @@ pub(super) fn build_instance_mapping(config: &InstanceYamlEntry) -> serde_yaml_n
             .map(|s| serde_yaml_ng::Value::String(s.clone()))
             .collect();
         inst.insert("args".into(), serde_yaml_ng::Value::Sequence(seq));
+    }
+    if let Some(ref skills) = config.skills {
+        // Same Sequence shape as `args`. Some(vec![]) round-trips as an empty
+        // YAML sequence (`skills: []`) — the explicit opt-out is preserved.
+        let seq: Vec<serde_yaml_ng::Value> = skills
+            .iter()
+            .map(|s| serde_yaml_ng::Value::String(s.clone()))
+            .collect();
+        inst.insert("skills".into(), serde_yaml_ng::Value::Sequence(seq));
     }
     if let Some(ref env_map) = config.env {
         let mut env_yaml = serde_yaml_ng::Mapping::new();

--- a/src/fleet/mod.rs
+++ b/src/fleet/mod.rs
@@ -993,6 +993,14 @@ pub struct InstanceYamlEntry {
     pub topic_binding_mode: Option<String>,
     /// Custom skills path override.
     pub skills_path: Option<String>,
+    /// Sprint 61 follow-up: mirror of [`InstanceConfig::skills`] — per-instance
+    /// skills allowlist. Template deployments populate this from the template
+    /// stanza's `skills:` field; `Some(vec![])` is meaningful (explicit opt-out
+    /// of all skills — preserved, NOT filtered to empty like `args`), and
+    /// `None` means "install every skill in the source" (preserves the legacy
+    /// default). Round-trips through `merge.rs`'s `build_instance_mapping` /
+    /// `merge_instance_into_existing` as a YAML Sequence.
+    pub skills: Option<Vec<String>>,
     /// Mirror of [`InstanceConfig::created_by`] — the identified caller that
     /// ran `create_instance`, written at spawn time.
     pub created_by: Option<String>,

--- a/src/fleet/tests.rs
+++ b/src/fleet/tests.rs
@@ -1627,6 +1627,60 @@ fn add_instance_to_yaml_round_trips_skills_path() {
 }
 
 #[test]
+fn add_instance_to_yaml_round_trips_skills_allowlist() {
+    let dir = std::env::temp_dir().join(format!("agend-fleet-sk-rt-{}", std::process::id()));
+    fs::create_dir_all(&dir).ok();
+    let entry = InstanceYamlEntry {
+        backend: Some("claude".to_string()),
+        skills: Some(vec!["code-review".to_string(), "refactor".to_string()]),
+        ..Default::default()
+    };
+    add_instance_to_yaml(&dir, "sk-agent", &entry).expect("add");
+    let content = std::fs::read_to_string(dir.join("fleet.yaml")).expect("read");
+    assert!(
+        content.contains("skills:\n    - code-review\n    - refactor\n"),
+        "skills allowlist must round-trip as a YAML sequence: {content}"
+    );
+    let config = FleetConfig::load(&dir.join("fleet.yaml")).expect("load");
+    let resolved = config.instances.get("sk-agent").expect("get");
+    assert_eq!(
+        resolved.skills,
+        Some(vec!["code-review".to_string(), "refactor".to_string()]),
+        "skills allowlist must round-trip via serde into InstanceConfig.skills"
+    );
+    fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn add_instance_to_yaml_preserves_empty_skills_allowlist_opt_out() {
+    // `skills: []` is an explicit opt-out (install NO skills). It MUST round-trip
+    // as `skills: []`, NOT be collapsed to `None` (which means install ALL).
+    // This is the divergence from `args` (where `.filter(|v| !v.is_empty())`
+    // safely drops empty vecs); for `skills` the empty vec is semantically meaningful.
+    let dir = std::env::temp_dir().join(format!("agend-fleet-sk-empty-{}", std::process::id()));
+    fs::create_dir_all(&dir).ok();
+    let entry = InstanceYamlEntry {
+        backend: Some("claude".to_string()),
+        skills: Some(vec![]),
+        ..Default::default()
+    };
+    add_instance_to_yaml(&dir, "sk-optout", &entry).expect("add");
+    let content = std::fs::read_to_string(dir.join("fleet.yaml")).expect("read");
+    assert!(
+        content.contains("skills: []"),
+        "empty skills opt-out must round-trip as `skills: []`, not be dropped to None: {content}"
+    );
+    let config = FleetConfig::load(&dir.join("fleet.yaml")).expect("load");
+    let resolved = config.instances.get("sk-optout").expect("get");
+    assert_eq!(
+        resolved.skills,
+        Some(vec![]),
+        "Some(vec![]) must survive round-trip — None would silently opt IN"
+    );
+    fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
 fn topic_binding_mode_round_trips_through_fleet_yaml() {
     let dir = std::env::temp_dir().join(format!("agend-fleet-tb-rt-{}", std::process::id()));
     write_fleet(&dir, "instances: {}\n");


### PR DESCRIPTION
Closes #2803.

## What

Template stanzas in `fleet.yaml` already support `skills_path:` (custom source dir override), but the sibling `skills:` per-instance allowlist (#585 PR-2) is silently dropped by the deployment flow — a template

\`\`\`yaml
templates:
  dev:
    instances:
      reviewer:
        backend: claude
        skills:
          - code-review
          - receiving-code-review
\`\`\`

survives \`deploy\` as \`None\` rather than \`Some([\"code-review\", ...])\`, so the deployed instance installs **every** skill in the source — the inverse of the operator's intent. The \`skills: []\` explicit opt-out has the same defect, silently flipping opt-out → install-all.

The read side (`InstanceConfig::skills` parsing + the per-spawn install hook in `pane_factory.rs`) already works — #585 PR-2 landed it. The gap is purely in the template write path: the declared value never reaches the persisted \`instances:\` block.

## How

Mirror the existing \`skills_path\` / \`args\` plumbing at the four template → \`instances:\` write sites:

| Site | Change |
|---|---|
| \`InstanceYamlEntry\` (fleet/mod.rs) | add \`pub skills: Option<Vec<String>>\` field, mirrors \`skills_path\` (`#585 PR-2`) and \`args\` type shape |
| \`create_instance_entries\` (deployments.rs) | extract \`skills\` sequence from \`inst_val\` — **deliberately NOT** \`.filter(!empty)\` like \`args\`, because \`Some(vec![])\` is a meaningful opt-out |
| \`build_instance_mapping\` (merge.rs) | write \`skills:\` as a YAML Sequence, mirrors \`args\` writer |
| \`merge_instance_into_existing\` (merge.rs) | route \`skills\` through \`merge_typed_field\`, so a re-deploy over an operator hand-edit surfaces a \`FieldConflict\` instead of silently clobbering (same \`OperatorHandEdit\` field-class as \`args\`/\`env\`) |

## Scope

- LOC: ~30 production + ~130 tests across 5 files
- Schema: no \`FLEET_SCHEMA_VERSION\` bump — additive \`Option\` field with serde default \`None\`, zero-migration
- Risk: low — \`None\` path is byte-identical to today's behavior (verified by the 135 existing fleet/deployment tests staying green)

## Tests (3 new)

- \`add_instance_to_yaml_round_trips_skills_allowlist\` — \`Some([a, b])\` round-trips as a YAML sequence through \`add_instance_to_yaml\` → \`InstanceConfig::skills\`
- \`add_instance_to_yaml_preserves_empty_skills_allowlist_opt_out\` — \`Some(vec![])\` survives as \`skills: []\`, NOT collapsed to \`None\` (which would silently opt IN)
- \`deploy_persists_skills_allowlist_into_fleet_yaml\` — template \`skills:\` list persists into the deployed \`instances:\` block as \`Some([...])\`
- \`deploy_preserves_empty_skills_allowlist_opt_out\` — template \`skills: []\` survives deployment as \`Some(vec![])\`

## Compatibility

- An instance config that omits \`skills:\` → serde \`None\` → install-all (unchanged)
- A template stanza that omits \`skills:\` → extraction returns \`None\` → nothing written → unchanged
- A re-deploy over an operator hand-edited \`skills:\` → existing \`OperatorHandEdit\` field class fires \`FieldConflict\` (same as \`args\`/\`env\` today)

## How to Verify

\`\`\`bash
cargo test --bin agend-terminal -- fleet::tests::add_instance_to_yaml_round_trips_skills_allowlist
cargo test --bin agend-terminal -- fleet::tests::add_instance_to_yaml_preserves_empty_skills_allowlist_opt_out
cargo test --bin agend-terminal -- deployments::tests::deploy_persists_skills_allowlist_into_fleet_yaml
cargo test --bin agend-terminal -- deployments::tests::deploy_preserves_empty_skills_allowlist_opt_out
cargo test --bin agend-terminal -- fleet::tests:: deployments::tests::   # 135 existing pass unchanged
cargo fmt --check && cargo clippy --bin agend-terminal --lib -- -D warnings
\`\`\`

All green locally.