### PR TITLE
feat(#2800): decouple typed review_assignment from terminal CI

### DIFF
--- a/src/daemon/pr_state/cold_pr_tests.rs
+++ b/src/daemon/pr_state/cold_pr_tests.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 struct ColdPrMock {
     pr_number: u64,
     head_sha: String,
+    head_ref: String,
     author: String,
 }
 
@@ -17,6 +18,7 @@ impl ScmProvider for ColdPrMock {
         Ok(PrSummary {
             number: self.pr_number,
             head_ref_oid: Some(self.head_sha.clone()),
+            head_ref: Some(self.head_ref.clone()),
             author_login: Some(self.author.clone()),
             ..Default::default()
         })
@@ -102,6 +104,7 @@ fn cold_pr_creates_pending_pr_state() {
     let _guard = scm::set_test_scm_provider(Arc::new(ColdPrMock {
         pr_number: 42,
         head_sha: head.clone(),
+        head_ref: "feat/x".into(),
         author: "dev".into(),
     }));
 
@@ -132,6 +135,7 @@ fn cold_pr_wrong_head_fails_closed() {
     let _guard = scm::set_test_scm_provider(Arc::new(ColdPrMock {
         pr_number: 42,
         head_sha: "b".repeat(40),
+        head_ref: "feat/x".into(),
         author: "dev".into(),
     }));
 
@@ -214,6 +218,7 @@ fn cold_pr_ensure_idempotent() {
     let _guard = scm::set_test_scm_provider(Arc::new(ColdPrMock {
         pr_number: 7,
         head_sha: head.clone(),
+        head_ref: "feat/x".into(),
         author: "dev".into(),
     }));
 
@@ -222,5 +227,71 @@ fn cold_pr_ensure_idempotent() {
 
     assert_eq!(s1.head_sha, s2.head_sha);
     assert_eq!(s1.pr_number, s2.pr_number);
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// #2800 T6: correct PR/SHA but wrong branch → SCM branch mismatch → fails closed.
+/// Regression: a real PR with matching head_sha but different head_ref must not
+/// create a mis-keyed pr-state file.
+#[test]
+fn cold_pr_wrong_branch_fails_closed() {
+    let home = tmp_home("t6-wrong-branch");
+    let head = "e".repeat(40);
+
+    struct WrongBranchMock(String);
+    impl ScmProvider for WrongBranchMock {
+        fn pr_view(&self, _r: &str, _p: u64, _f: &[&str]) -> anyhow::Result<PrSummary> {
+            Ok(PrSummary {
+                number: 50,
+                head_ref_oid: Some(self.0.clone()),
+                head_ref: Some("other/branch".into()),
+                author_login: Some("dev".into()),
+                ..Default::default()
+            })
+        }
+        fn pr_checks(&self, _r: &str, _p: u64) -> anyhow::Result<Vec<scm::CheckState>> {
+            unimplemented!()
+        }
+        fn pr_list(
+            &self,
+            _r: &str,
+            _f: &scm::ListFilter,
+            _fl: &[&str],
+            _c: Option<&Path>,
+        ) -> anyhow::Result<Vec<PrSummary>> {
+            unimplemented!()
+        }
+        fn pr_merge(
+            &self,
+            _r: &str,
+            _p: u64,
+            _o: &scm::MergeOpts,
+        ) -> anyhow::Result<scm::MergeOutcome> {
+            unimplemented!()
+        }
+        fn issue_view(&self, _r: &str, _n: u64, _f: &[&str]) -> anyhow::Result<scm::IssueSummary> {
+            unimplemented!()
+        }
+        fn compare(&self, _r: &str, _b: &str, _h: &str) -> anyhow::Result<scm::CompareResult> {
+            unimplemented!()
+        }
+    }
+
+    let _guard = scm::set_test_scm_provider(Arc::new(WrongBranchMock(head.clone())));
+
+    let result = ensure_from_scm(&home, "o/r", "feat/x", 50, &head, ReviewClass::Dual);
+
+    assert!(result.is_err(), "branch mismatch must fail closed");
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("SCM branch mismatch"),
+        "error must mention branch mismatch"
+    );
+    assert!(
+        load(&home, "o/r", "feat/x").is_none(),
+        "no pr-state file created on branch mismatch"
+    );
     std::fs::remove_dir_all(&home).ok();
 }

--- a/src/daemon/pr_state/cold_pr_tests.rs
+++ b/src/daemon/pr_state/cold_pr_tests.rs
@@ -1,0 +1,226 @@
+use super::*;
+use crate::scm::{self, PrSummary, ScmProvider};
+use std::path::Path;
+use std::sync::Arc;
+
+struct ColdPrMock {
+    pr_number: u64,
+    head_sha: String,
+    author: String,
+}
+
+impl ScmProvider for ColdPrMock {
+    fn pr_view(&self, _r: &str, pr: u64, _f: &[&str]) -> anyhow::Result<PrSummary> {
+        if pr != self.pr_number {
+            anyhow::bail!("PR #{pr} not found");
+        }
+        Ok(PrSummary {
+            number: self.pr_number,
+            head_ref_oid: Some(self.head_sha.clone()),
+            author_login: Some(self.author.clone()),
+            ..Default::default()
+        })
+    }
+    fn pr_checks(&self, _r: &str, _p: u64) -> anyhow::Result<Vec<scm::CheckState>> {
+        unimplemented!()
+    }
+    fn pr_list(
+        &self,
+        _r: &str,
+        _f: &scm::ListFilter,
+        _fl: &[&str],
+        _c: Option<&Path>,
+    ) -> anyhow::Result<Vec<PrSummary>> {
+        unimplemented!()
+    }
+    fn pr_merge(
+        &self,
+        _r: &str,
+        _p: u64,
+        _o: &scm::MergeOpts,
+    ) -> anyhow::Result<scm::MergeOutcome> {
+        unimplemented!()
+    }
+    fn issue_view(&self, _r: &str, _n: u64, _f: &[&str]) -> anyhow::Result<scm::IssueSummary> {
+        unimplemented!()
+    }
+    fn compare(&self, _r: &str, _b: &str, _h: &str) -> anyhow::Result<scm::CompareResult> {
+        unimplemented!()
+    }
+}
+
+struct NotFoundMock;
+
+impl ScmProvider for NotFoundMock {
+    fn pr_view(&self, _r: &str, pr: u64, _f: &[&str]) -> anyhow::Result<PrSummary> {
+        anyhow::bail!("PR #{pr} not found (404)")
+    }
+    fn pr_checks(&self, _r: &str, _p: u64) -> anyhow::Result<Vec<scm::CheckState>> {
+        unimplemented!()
+    }
+    fn pr_list(
+        &self,
+        _r: &str,
+        _f: &scm::ListFilter,
+        _fl: &[&str],
+        _c: Option<&Path>,
+    ) -> anyhow::Result<Vec<PrSummary>> {
+        unimplemented!()
+    }
+    fn pr_merge(
+        &self,
+        _r: &str,
+        _p: u64,
+        _o: &scm::MergeOpts,
+    ) -> anyhow::Result<scm::MergeOutcome> {
+        unimplemented!()
+    }
+    fn issue_view(&self, _r: &str, _n: u64, _f: &[&str]) -> anyhow::Result<scm::IssueSummary> {
+        unimplemented!()
+    }
+    fn compare(&self, _r: &str, _b: &str, _h: &str) -> anyhow::Result<scm::CompareResult> {
+        unimplemented!()
+    }
+}
+
+fn tmp_home(name: &str) -> std::path::PathBuf {
+    let p = std::env::temp_dir().join(format!(
+        "agend-cold-pr-{name}-{}-{}",
+        std::process::id(),
+        line!()
+    ));
+    let _ = std::fs::remove_dir_all(&p);
+    std::fs::create_dir_all(&p).unwrap();
+    p
+}
+
+/// #2800 T1: cold PR (no pr-state) → ensure_from_scm creates Pending pr-state.
+#[test]
+fn cold_pr_creates_pending_pr_state() {
+    let home = tmp_home("t1-cold-create");
+    let head = "a".repeat(40);
+    let _guard = scm::set_test_scm_provider(Arc::new(ColdPrMock {
+        pr_number: 42,
+        head_sha: head.clone(),
+        author: "dev".into(),
+    }));
+
+    let state = ensure_from_scm(&home, "o/r", "feat/x", 42, &head, ReviewClass::Dual)
+        .expect("cold PR ensure must succeed");
+
+    assert_eq!(state.repo, "o/r");
+    assert_eq!(state.branch, "feat/x");
+    assert_eq!(state.pr_number, 42);
+    assert_eq!(state.head_sha, head);
+    assert!(
+        matches!(state.ci_state, CiState::Pending),
+        "cold PR must start with CiState::Pending"
+    );
+    assert!(
+        matches!(state.merge_state, MergeState::NotReady),
+        "cold PR must not be merge-ready"
+    );
+    assert_eq!(state.review_class, ReviewClass::Dual);
+    assert_eq!(state.pr_author, "dev");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// #2800 T2: cold PR with wrong head_sha → SCM mismatch → fails closed.
+#[test]
+fn cold_pr_wrong_head_fails_closed() {
+    let home = tmp_home("t2-wrong-head");
+    let _guard = scm::set_test_scm_provider(Arc::new(ColdPrMock {
+        pr_number: 42,
+        head_sha: "b".repeat(40),
+        author: "dev".into(),
+    }));
+
+    let result = ensure_from_scm(
+        &home,
+        "o/r",
+        "feat/x",
+        42,
+        &"a".repeat(40),
+        ReviewClass::Dual,
+    );
+
+    assert!(result.is_err(), "head mismatch must fail closed");
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("SCM head mismatch"),
+        "error must mention head mismatch"
+    );
+    assert!(
+        load(&home, "o/r", "feat/x").is_none(),
+        "no pr-state file created on mismatch"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// #2800 T3: cold PR with non-existent PR number → SCM not found → fails closed.
+#[test]
+fn cold_pr_not_found_fails_closed() {
+    let home = tmp_home("t3-not-found");
+    let _guard = scm::set_test_scm_provider(Arc::new(NotFoundMock));
+
+    let result = ensure_from_scm(
+        &home,
+        "o/r",
+        "feat/x",
+        999,
+        &"a".repeat(40),
+        ReviewClass::Dual,
+    );
+
+    assert!(result.is_err(), "non-existent PR must fail closed");
+    assert!(
+        load(&home, "o/r", "feat/x").is_none(),
+        "no pr-state file created for non-existent PR"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// #2800 T4: existing pr-state with matching identity → ensure is no-op.
+#[test]
+fn existing_pr_state_is_noop() {
+    let home = tmp_home("t4-existing");
+    let head = "c".repeat(40);
+    let mut s = new_for_branch("o/r", "feat/x", &head, ReviewClass::Single);
+    s.pr_number = 10;
+    s.ci_state = CiState::Green {
+        sha: head.clone(),
+        observed_at: "2026-07-15T00:00:00Z".into(),
+    };
+    save(&home, &s).unwrap();
+
+    // No mock needed — should hit fast path without SCM call.
+    let state = ensure_from_scm(&home, "o/r", "feat/x", 10, &head, ReviewClass::Single)
+        .expect("existing pr-state must succeed");
+
+    assert!(
+        matches!(state.ci_state, CiState::Green { .. }),
+        "existing CiState must be preserved (not overwritten to Pending)"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// #2800 T5: idempotent — two ensure calls for the same cold PR converge.
+#[test]
+fn cold_pr_ensure_idempotent() {
+    let home = tmp_home("t5-idempotent");
+    let head = "d".repeat(40);
+    let _guard = scm::set_test_scm_provider(Arc::new(ColdPrMock {
+        pr_number: 7,
+        head_sha: head.clone(),
+        author: "dev".into(),
+    }));
+
+    let s1 = ensure_from_scm(&home, "o/r", "feat/x", 7, &head, ReviewClass::Dual).unwrap();
+    let s2 = ensure_from_scm(&home, "o/r", "feat/x", 7, &head, ReviewClass::Dual).unwrap();
+
+    assert_eq!(s1.head_sha, s2.head_sha);
+    assert_eq!(s1.pr_number, s2.pr_number);
+    std::fs::remove_dir_all(&home).ok();
+}

--- a/src/daemon/pr_state/mod.rs
+++ b/src/daemon/pr_state/mod.rs
@@ -1906,3 +1906,8 @@ pub fn format_ready_body(state: &PrState) -> String {
 #[allow(clippy::unwrap_used)]
 #[path = "tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+#[path = "cold_pr_tests.rs"]
+mod cold_pr_tests;

--- a/src/daemon/pr_state/mod.rs
+++ b/src/daemon/pr_state/mod.rs
@@ -911,6 +911,67 @@ where
     crate::store::with_json_state_or_create(&data_path, default_fn, mutate)
 }
 
+/// #2800: ensure a PrState exists for a cold PR whose CI has not yet
+/// reached terminal. Two-phase: (1) check local file; (2) if missing,
+/// confirm PR identity against the SCM provider, then CAS-create with
+/// `CiState::Pending`. The pr-state/file lock is NOT held across the
+/// network call — the provider query runs unlocked, and
+/// `with_pr_state_or_create` does the CAS afterwards. On a concurrent
+/// creator the CAS converges: if the file already exists with matching
+/// identity, the caller gets the existing state; a mismatch fails closed.
+pub fn ensure_from_scm(
+    home: &std::path::Path,
+    repo: &str,
+    branch: &str,
+    pr_number: u64,
+    expected_head: &str,
+    review_class: ReviewClass,
+) -> anyhow::Result<PrState> {
+    // Phase 1: fast path — file already exists. Return it as-is and let
+    // the caller do the identity check (preserves existing error codes).
+    if let Some(existing) = load(home, repo, branch) {
+        return Ok(existing);
+    }
+
+    // Phase 2: no local file — confirm identity against SCM provider.
+    let provider = crate::scm::make_scm_provider(repo, None);
+    let pr = provider
+        .pr_view(repo, pr_number, &["number", "headRefOid", "headRefName"])
+        .map_err(|e| anyhow::anyhow!("SCM pr_view failed for PR #{pr_number}: {e}"))?;
+    let scm_head = pr
+        .head_ref_oid
+        .as_deref()
+        .ok_or_else(|| anyhow::anyhow!("SCM returned no headRefOid for PR #{pr_number}"))?;
+    if !scm_head.eq_ignore_ascii_case(expected_head) {
+        anyhow::bail!(
+            "SCM head mismatch for PR #{pr_number}: expected {expected_head}, SCM reports {scm_head}"
+        );
+    }
+
+    // Phase 3: CAS-create with Pending CI.
+    let state = with_pr_state_or_create(
+        home,
+        repo,
+        branch,
+        || {
+            let mut s = new_for_branch(repo, branch, expected_head, review_class);
+            s.pr_number = pr_number;
+            s.pr_author = pr.author_login.unwrap_or_default();
+            s
+        },
+        |s| s.clone(),
+    )?;
+    if state.head_sha != expected_head || state.pr_number != pr_number {
+        anyhow::bail!(
+            "concurrent pr-state creator wrote mismatching identity \
+             (head={}, pr={}); expected head={expected_head}, pr={pr_number}",
+            state.head_sha,
+            state.pr_number
+        );
+    }
+    Ok(state)
+}
+
 /// Remove the per-PR file. Used by the per-tick scanner after a
 /// terminal state (Merged / ClosedUnmerged) is observed and the
 /// `[pr-merged]` / `[pr-closed-unmerged]` events have been emitted.

--- a/src/daemon/pr_state/mod.rs
+++ b/src/daemon/pr_state/mod.rs
@@ -947,6 +947,15 @@ pub fn ensure_from_scm(
             "SCM head mismatch for PR #{pr_number}: expected {expected_head}, SCM reports {scm_head}"
         );
     }
+    let scm_branch = pr
+        .head_ref
+        .as_deref()
+        .ok_or_else(|| anyhow::anyhow!("SCM returned no headRefName for PR #{pr_number}"))?;
+    if scm_branch != branch {
+        anyhow::bail!(
+            "SCM branch mismatch for PR #{pr_number}: expected {branch}, SCM reports {scm_branch}"
+        );
+    }
 
     // Phase 3: CAS-create with Pending CI.
     let state = with_pr_state_or_create(

--- a/src/mcp/handlers/comms_delegate/review_assignment.rs
+++ b/src/mcp/handlers/comms_delegate/review_assignment.rs
@@ -156,13 +156,6 @@ pub(crate) fn validate_review_assignment_marker(
     // head, wrong PR, or unresolved/mismatched review class all fail closed.
     let branch = args["branch"].as_str().unwrap_or_default();
     let pr_number = checks.pr_number.unwrap_or_default();
-    let state =
-        crate::review_receipt::load_pr_state_strict(home, &repo_slug, branch).map_err(|error| {
-            json!({
-                "error": format!("review_assignment exact subject rejected: {error}"),
-                "code": "review_assignment_subject_unavailable",
-            })
-        })?;
     let task_id = args["task_id"].as_str().unwrap_or_default();
     let task_review_class = crate::tasks::load_routed(home, task_id)
         .ok()
@@ -175,11 +168,33 @@ pub(crate) fn validate_review_assignment_marker(
                 .map(|value| ReviewClass::parse_fail_closed(Some(value)))
         })
         .unwrap_or(ReviewClass::Unresolved);
+    if matches!(task_review_class, ReviewClass::Unresolved) {
+        return Err(json!({
+            "error": "review_assignment requires a resolved review_class on the task",
+            "code": "review_assignment_subject_mismatch",
+        }));
+    }
+    // #2800: ensure a PrState exists even for a cold PR (CI still pending).
+    // Two-phase: local miss → SCM-confirm identity → CAS-create Pending.
+    // The pr-state/file lock is NOT held across the SCM network call.
+    let state = crate::daemon::pr_state::ensure_from_scm(
+        home,
+        &repo_slug,
+        branch,
+        pr_number,
+        reviewed_head,
+        task_review_class,
+    )
+    .map_err(|error| {
+        json!({
+            "error": format!("review_assignment exact subject rejected: {error}"),
+            "code": "review_assignment_subject_unavailable",
+        })
+    })?;
     if state.repo != repo_slug
         || state.branch != branch
         || state.pr_number != pr_number
         || state.head_sha != reviewed_head
-        || matches!(task_review_class, ReviewClass::Unresolved)
         || state.review_class != task_review_class
     {
         return Err(json!({


### PR DESCRIPTION
## Summary
- Adds ensure_from_scm to pr_state: two-phase cold-PR pr-state creation
- Wires into review_assignment validation for cold PRs
- Merge readiness unchanged (ready_gate.rs untouched)
- Closes #2800

## Test plan
- 5 deterministic cold PR tests with SCM provider fakes
- 18 existing review_assignment tests pass (no regression)
- cargo clippy clean