### PR TITLE
feat(ci-watch): pr_state terminal CAS-checked feature-watch removal

### DIFF
--- a/src/daemon/ci_watch/mod.rs
+++ b/src/daemon/ci_watch/mod.rs
@@ -64,6 +64,7 @@ pub use provider::{
     BitbucketCiProvider, CiPollResult, CiProvider, CiRun, GitHubCiProvider, GitLabCiProvider,
     MergeableState, PrState,
 };
+pub(crate) use registry::remove_watch_json_only;
 #[allow(unused_imports)]
 pub use registry::{
     ci_watches_dir, cleanup_watches_for_instance, has_instance_anywhere, reassign_next_after_ci,

--- a/src/daemon/ci_watch/mod.rs
+++ b/src/daemon/ci_watch/mod.rs
@@ -78,6 +78,8 @@ pub use sweep::{gc_stale_watches, startup_sweep};
 pub(crate) use sweep::classify_subscribed_watch_expiry;
 pub use watcher::check_ci_watches;
 
+#[cfg(test)]
+pub(crate) use registry::flush_watch_state;
 pub(crate) use registry::parse_subscribers;
 #[allow(unused_imports)]
 pub(crate) use watch_state::WatchState;

--- a/src/daemon/ci_watch/poller.rs
+++ b/src/daemon/ci_watch/poller.rs
@@ -1493,6 +1493,12 @@ async fn ci_check_repo(
     registry: &AgentRegistry,
     provider: &dyn CiProvider,
 ) -> anyhow::Result<()> {
+    // Seed generation_id for legacy watches missing it. This is the
+    // durable-before-polling seeding: the generation is persisted on the
+    // first flush so subsequent polls carry it for CAS.
+    if state.generation_id.is_none() {
+        state.generation_id = Some(uuid::Uuid::new_v4().to_string());
+    }
     let snapshot = state.clone();
     let repo = state.repo.clone();
     let branch = state.branch.clone();

--- a/src/daemon/ci_watch/poller.rs
+++ b/src/daemon/ci_watch/poller.rs
@@ -1525,7 +1525,7 @@ async fn ci_check_repo(
         Ok(Some(pr)) => pr,
         Ok(None) => {
             if state != snapshot {
-                flush_watch_state(watch_path, &state);
+                flush_watch_state(watch_path, &state, snapshot.head_sha.as_deref());
             }
             // #1750 A2: do NOT refresh `expires_at` here. `Ok(None)` means the
             // poll found NO runs for the branch — a deleted/merged-away branch or
@@ -1538,7 +1538,7 @@ async fn ci_check_repo(
         }
         Err(e) => {
             if state != snapshot {
-                flush_watch_state(watch_path, &state);
+                flush_watch_state(watch_path, &state, snapshot.head_sha.as_deref());
             }
             return Err(e);
         }
@@ -1629,7 +1629,7 @@ async fn ci_check_repo(
             state.last_notified_by_workflow = cursors;
         }
         if state != snapshot {
-            flush_watch_state(watch_path, &state);
+            flush_watch_state(watch_path, &state, snapshot.head_sha.as_deref());
         }
         if activity {
             refresh_expires_at(watch_path);
@@ -1652,7 +1652,7 @@ async fn ci_check_repo(
         return Ok(());
     }
     if state != snapshot {
-        flush_watch_state(watch_path, &state);
+        flush_watch_state(watch_path, &state, snapshot.head_sha.as_deref());
     }
     refresh_expires_at(watch_path);
     Ok(())

--- a/src/daemon/ci_watch/poller.rs
+++ b/src/daemon/ci_watch/poller.rs
@@ -1525,7 +1525,7 @@ async fn ci_check_repo(
         Ok(Some(pr)) => pr,
         Ok(None) => {
             if state != snapshot {
-                flush_watch_state(watch_path, &state, snapshot.head_sha.as_deref());
+                flush_watch_state(watch_path, &state, snapshot.generation_id.as_deref());
             }
             // #1750 A2: do NOT refresh `expires_at` here. `Ok(None)` means the
             // poll found NO runs for the branch — a deleted/merged-away branch or
@@ -1538,7 +1538,7 @@ async fn ci_check_repo(
         }
         Err(e) => {
             if state != snapshot {
-                flush_watch_state(watch_path, &state, snapshot.head_sha.as_deref());
+                flush_watch_state(watch_path, &state, snapshot.generation_id.as_deref());
             }
             return Err(e);
         }
@@ -1629,7 +1629,7 @@ async fn ci_check_repo(
             state.last_notified_by_workflow = cursors;
         }
         if state != snapshot {
-            flush_watch_state(watch_path, &state, snapshot.head_sha.as_deref());
+            flush_watch_state(watch_path, &state, snapshot.generation_id.as_deref());
         }
         if activity {
             refresh_expires_at(watch_path);
@@ -1652,7 +1652,7 @@ async fn ci_check_repo(
         return Ok(());
     }
     if state != snapshot {
-        flush_watch_state(watch_path, &state, snapshot.head_sha.as_deref());
+        flush_watch_state(watch_path, &state, snapshot.generation_id.as_deref());
     }
     refresh_expires_at(watch_path);
     Ok(())

--- a/src/daemon/ci_watch/registry.rs
+++ b/src/daemon/ci_watch/registry.rs
@@ -402,11 +402,21 @@ pub(crate) fn flush_watch_state(
         Some(c) => c,
         None => return, // file deleted by concurrent unwatch — respect deletion
     };
-    // Generation CAS: if the disk generation_id differs from the pre-poll
-    // snapshot (a new watch was created after settlement), skip the merge
-    // to prevent cross-generation overwrite. Missing generation_id on disk
-    // (legacy watch not yet seeded) also skips — fail closed.
-    if let Some(expected) = expected_generation {
+    // Generation CAS: the expected_generation MUST match the disk
+    // generation_id. Missing expected (None) is fail-closed: a poller
+    // that doesn't carry a generation_id (legacy snapshot) must not
+    // mutate — it may be from a prior generation.
+    let expected = match expected_generation {
+        Some(e) if !e.is_empty() => e,
+        _ => {
+            tracing::info!(
+                path = %watch_path.display(),
+                "flush_watch_state: no expected_generation — fail-closed, skipping flush"
+            );
+            return;
+        }
+    };
+    {
         let disk_gen = merged.generation_id.as_deref().unwrap_or("");
         if disk_gen != expected {
             tracing::info!(
@@ -516,9 +526,11 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
         let watch_path = dir.join("test.json");
 
+        let gen = "test-gen-flush";
         let initial = super::super::watch_state::WatchState {
             repo: "o/r".into(),
             branch: "feat".into(),
+            generation_id: Some(gen.to_string()),
             subscribers: Some(vec![
                 super::super::watch_state::Subscriber {
                     instance: "A".into(),
@@ -544,7 +556,7 @@ mod tests {
         }]);
         std::fs::write(&watch_path, serde_json::to_string_pretty(&on_disk).unwrap()).unwrap();
 
-        flush_watch_state(&watch_path, &stale, None);
+        flush_watch_state(&watch_path, &stale, Some(gen));
 
         let result: super::super::watch_state::WatchState =
             serde_json::from_str(&std::fs::read_to_string(&watch_path).unwrap()).unwrap();
@@ -690,13 +702,14 @@ mod tests {
         let stale = super::super::watch_state::WatchState {
             repo: "o/r".into(),
             branch: "feat".into(),
+            generation_id: Some("gen-deleted".to_string()),
             last_run_id: Some(99),
             ..Default::default()
         };
 
         // File does not exist (concurrent unwatch deleted it).
         assert!(!watch_path.exists());
-        flush_watch_state(&watch_path, &stale, None);
+        flush_watch_state(&watch_path, &stale, Some("gen-deleted"));
         assert!(
             !watch_path.exists(),
             "flush must not resurrect a deleted watch file"
@@ -717,6 +730,7 @@ mod tests {
             expires_at: Some("2026-01-01T00:00:00Z".into()),
             task_id: Some("t-old".into()),
             required_checks: None,
+            generation_id: Some("gen-meta".to_string()),
             ..Default::default()
         };
         std::fs::write(&watch_path, serde_json::to_string_pretty(&initial).unwrap()).unwrap();
@@ -726,14 +740,14 @@ mod tests {
         stale.last_run_id = Some(42);
         stale.head_sha = Some("abc".into());
 
-        // Concurrent `ci watch` updates metadata on disk.
+        // Concurrent `ci watch` updates metadata on disk (same generation).
         let mut updated = initial;
         updated.expires_at = Some("2026-06-01T00:00:00Z".into());
         updated.task_id = Some("t-new".into());
         updated.required_checks = Some(vec!["build".into()]);
         std::fs::write(&watch_path, serde_json::to_string_pretty(&updated).unwrap()).unwrap();
 
-        flush_watch_state(&watch_path, &stale, None);
+        flush_watch_state(&watch_path, &stale, Some("gen-meta"));
 
         let result: super::super::watch_state::WatchState =
             serde_json::from_str(&std::fs::read_to_string(&watch_path).unwrap()).unwrap();

--- a/src/daemon/ci_watch/registry.rs
+++ b/src/daemon/ci_watch/registry.rs
@@ -78,6 +78,7 @@ pub fn remove_watch(
 /// obtain a different inode, and a stale flush from the old guard can
 /// corrupt the new generation). The `.lock` is cleaned up after guard drop
 /// by the orphan sweep in `gc_stale_watches`.
+/// Returns true if the file was removed (or already absent).
 pub(crate) fn remove_watch_json_only(
     home: &Path,
     watch_path: &Path,
@@ -85,14 +86,26 @@ pub(crate) fn remove_watch_json_only(
     repo: &str,
     branch: &str,
     reason: &str,
-) {
-    let _ = std::fs::remove_file(watch_path);
-    crate::event_log::log(
-        home,
-        "ci_watch_removed",
-        subscriber_label,
-        &format!("repo={repo} branch={branch} reason={reason} lock_preserved=true"),
-    );
+) -> bool {
+    match std::fs::remove_file(watch_path) {
+        Ok(()) => {
+            crate::event_log::log(
+                home,
+                "ci_watch_removed",
+                subscriber_label,
+                &format!("repo={repo} branch={branch} reason={reason} lock_preserved=true"),
+            );
+            true
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => true,
+        Err(e) => {
+            tracing::warn!(
+                path = %watch_path.display(), error = %e,
+                "remove_watch_json_only: deletion failed — retryable"
+            );
+            false
+        }
+    }
 }
 
 /// #1488: scrub a deleted instance out of every CI watch. For each watch file:
@@ -364,7 +377,15 @@ pub(super) fn update_watch_state_with_notify(
 /// Merge-safe: starts from the on-disk state (preserving all
 /// control-plane fields) and only applies poll-owned deltas from
 /// the in-memory snapshot.
-pub(super) fn flush_watch_state(watch_path: &Path, state: &super::watch_state::WatchState) {
+///
+/// `expected_head`: the head_sha the poller read at poll start. If the
+/// on-disk head differs (a new generation was created after the old watch
+/// was settled), the flush is skipped to prevent cross-generation overwrite.
+pub(super) fn flush_watch_state(
+    watch_path: &Path,
+    state: &super::watch_state::WatchState,
+    expected_head: Option<&str>,
+) {
     let lock_path = watch_path.with_extension("lock");
     let _lock = match crate::store::acquire_file_lock(&lock_path) {
         Ok(l) => l,
@@ -380,6 +401,21 @@ pub(super) fn flush_watch_state(watch_path: &Path, state: &super::watch_state::W
         Some(c) => c,
         None => return, // file deleted by concurrent unwatch — respect deletion
     };
+    // Generation CAS: if the disk head changed since the poll started (a new
+    // generation was created after this poll's watch was settled), skip the
+    // merge to prevent cross-generation overwrite.
+    if let Some(expected) = expected_head {
+        let disk_head = merged.head_sha.as_deref().unwrap_or("");
+        if disk_head != expected {
+            tracing::info!(
+                path = %watch_path.display(),
+                expected = %expected,
+                disk = %disk_head,
+                "flush_watch_state: generation CAS mismatch — skipping stale flush"
+            );
+            return;
+        }
+    }
     // Apply only poll-owned fields from in-memory state.
     merged.last_run_id = state.last_run_id;
     merged.head_sha = state.head_sha.clone();
@@ -506,7 +542,7 @@ mod tests {
         }]);
         std::fs::write(&watch_path, serde_json::to_string_pretty(&on_disk).unwrap()).unwrap();
 
-        flush_watch_state(&watch_path, &stale);
+        flush_watch_state(&watch_path, &stale, None);
 
         let result: super::super::watch_state::WatchState =
             serde_json::from_str(&std::fs::read_to_string(&watch_path).unwrap()).unwrap();
@@ -658,7 +694,7 @@ mod tests {
 
         // File does not exist (concurrent unwatch deleted it).
         assert!(!watch_path.exists());
-        flush_watch_state(&watch_path, &stale);
+        flush_watch_state(&watch_path, &stale, None);
         assert!(
             !watch_path.exists(),
             "flush must not resurrect a deleted watch file"
@@ -695,7 +731,7 @@ mod tests {
         updated.required_checks = Some(vec!["build".into()]);
         std::fs::write(&watch_path, serde_json::to_string_pretty(&updated).unwrap()).unwrap();
 
-        flush_watch_state(&watch_path, &stale);
+        flush_watch_state(&watch_path, &stale, None);
 
         let result: super::super::watch_state::WatchState =
             serde_json::from_str(&std::fs::read_to_string(&watch_path).unwrap()).unwrap();

--- a/src/daemon/ci_watch/registry.rs
+++ b/src/daemon/ci_watch/registry.rs
@@ -378,13 +378,14 @@ pub(super) fn update_watch_state_with_notify(
 /// control-plane fields) and only applies poll-owned deltas from
 /// the in-memory snapshot.
 ///
-/// `expected_head`: the head_sha the poller read at poll start. If the
-/// on-disk head differs (a new generation was created after the old watch
-/// was settled), the flush is skipped to prevent cross-generation overwrite.
-pub(super) fn flush_watch_state(
+/// `expected_generation`: the generation_id the poller read at poll start.
+/// If the on-disk generation_id differs (a new watch was created after this
+/// poll's watch was settled), the flush is skipped to prevent cross-generation
+/// overwrite. `None` skips the CAS (test seams only).
+pub(crate) fn flush_watch_state(
     watch_path: &Path,
     state: &super::watch_state::WatchState,
-    expected_head: Option<&str>,
+    expected_generation: Option<&str>,
 ) {
     let lock_path = watch_path.with_extension("lock");
     let _lock = match crate::store::acquire_file_lock(&lock_path) {
@@ -401,16 +402,17 @@ pub(super) fn flush_watch_state(
         Some(c) => c,
         None => return, // file deleted by concurrent unwatch — respect deletion
     };
-    // Generation CAS: if the disk head changed since the poll started (a new
-    // generation was created after this poll's watch was settled), skip the
-    // merge to prevent cross-generation overwrite.
-    if let Some(expected) = expected_head {
-        let disk_head = merged.head_sha.as_deref().unwrap_or("");
-        if disk_head != expected {
+    // Generation CAS: if the disk generation_id differs from the pre-poll
+    // snapshot (a new watch was created after settlement), skip the merge
+    // to prevent cross-generation overwrite. Missing generation_id on disk
+    // (legacy watch not yet seeded) also skips — fail closed.
+    if let Some(expected) = expected_generation {
+        let disk_gen = merged.generation_id.as_deref().unwrap_or("");
+        if disk_gen != expected {
             tracing::info!(
                 path = %watch_path.display(),
                 expected = %expected,
-                disk = %disk_head,
+                disk = %disk_gen,
                 "flush_watch_state: generation CAS mismatch — skipping stale flush"
             );
             return;

--- a/src/daemon/ci_watch/registry.rs
+++ b/src/daemon/ci_watch/registry.rs
@@ -418,7 +418,11 @@ pub(crate) fn flush_watch_state(
     };
     {
         let disk_gen = merged.generation_id.as_deref().unwrap_or("");
-        if disk_gen != expected {
+        if disk_gen.is_empty() {
+            // Legacy watch on disk without generation_id: seed it from the
+            // poller's in-memory value (which was seeded at poll start).
+            merged.generation_id = Some(expected.to_string());
+        } else if disk_gen != expected {
             tracing::info!(
                 path = %watch_path.display(),
                 expected = %expected,

--- a/src/daemon/ci_watch/registry.rs
+++ b/src/daemon/ci_watch/registry.rs
@@ -71,6 +71,30 @@ pub fn remove_watch(
     );
 }
 
+/// Remove only the `.json` watch file, leaving the `.lock` sidecar intact.
+///
+/// Called under a held per-watch flock so the `.lock` inode must NOT be
+/// unlinked while the guard holds it (doing so lets a concurrent re-create
+/// obtain a different inode, and a stale flush from the old guard can
+/// corrupt the new generation). The `.lock` is cleaned up after guard drop
+/// by the orphan sweep in `gc_stale_watches`.
+pub(crate) fn remove_watch_json_only(
+    home: &Path,
+    watch_path: &Path,
+    subscriber_label: &str,
+    repo: &str,
+    branch: &str,
+    reason: &str,
+) {
+    let _ = std::fs::remove_file(watch_path);
+    crate::event_log::log(
+        home,
+        "ci_watch_removed",
+        subscriber_label,
+        &format!("repo={repo} branch={branch} reason={reason} lock_preserved=true"),
+    );
+}
+
 /// #1488: scrub a deleted instance out of every CI watch. For each watch file:
 /// drop `instance` from the `subscribers` list (and the legacy single
 /// `instance` field), and clear `next_after_ci` if it pointed at the deleted

--- a/src/daemon/ci_watch/watch_state.rs
+++ b/src/daemon/ci_watch/watch_state.rs
@@ -40,6 +40,15 @@ pub struct WatchState {
     #[serde(default = "default_interval")]
     pub interval_secs: u64,
 
+    /// Immutable generation identity. Set once at watch creation; never
+    /// mutated by poll flushes. Used by `flush_watch_state` to CAS against
+    /// the pre-poll snapshot — a stale flush that acquired the lock after
+    /// settlement + new-generation creation sees a different generation_id
+    /// and skips the write. Legacy watches without this field are seeded on
+    /// first flush (fail-closed: a missing generation_id skips the flush).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub generation_id: Option<String>,
+
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ci_provider: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/daemon/pr_state/mod.rs
+++ b/src/daemon/pr_state/mod.rs
@@ -1920,3 +1920,8 @@ mod tests;
 #[allow(clippy::unwrap_used)]
 #[path = "cold_pr_tests.rs"]
 mod cold_pr_tests;
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+#[path = "watch_settlement_tests.rs"]
+mod watch_settlement_tests;

--- a/src/daemon/pr_state/scanner.rs
+++ b/src/daemon/pr_state/scanner.rs
@@ -62,6 +62,58 @@ fn record_terminal_emitted(home: &Path, key: &str) {
     );
 }
 
+/// Settle a feature-branch CI watch on terminal PR state.
+/// Returns `true` if settlement is terminal (removed, absent, mismatch,
+/// protected) — pr_state may be removed. Returns `false` if retryable
+/// (lock/read/parse/remove failure) — pr_state should be retained.
+fn settle_feature_watch(home: &Path, repo: &str, branch: &str, terminal_head: &str) -> bool {
+    if crate::agent_ops::is_protected_ref(branch) {
+        return true;
+    }
+    let ci_dir = crate::daemon::ci_watch::ci_watches_dir(home);
+    let fname = crate::daemon::ci_watch::watch_filename(repo, branch);
+    let watch_path = ci_dir.join(&fname);
+    if !watch_path.exists() {
+        return true;
+    }
+    let lock_path = watch_path.with_extension("lock");
+    let Ok(_guard) = crate::store::acquire_file_lock(&lock_path) else {
+        return false;
+    };
+    let content = match std::fs::read_to_string(&watch_path) {
+        Ok(c) => c,
+        Err(_) => return false,
+    };
+    let watch: crate::daemon::ci_watch::WatchState = match serde_json::from_str(&content) {
+        Ok(w) => w,
+        Err(_) => return false,
+    };
+    let watch_head = watch.head_sha.as_deref().unwrap_or("");
+    if watch.repo != repo
+        || watch.branch != branch
+        || watch_head.is_empty()
+        || watch_head != terminal_head
+        || watch.target_head_sha.is_some()
+    {
+        return true;
+    }
+    let subs: Vec<String> = watch
+        .subscribers
+        .as_deref()
+        .unwrap_or(&[])
+        .iter()
+        .map(|s| s.instance.clone())
+        .collect();
+    crate::daemon::ci_watch::remove_watch_json_only(
+        home,
+        &watch_path,
+        &subs.join(","),
+        repo,
+        branch,
+        "pr_terminal_cas_settlement",
+    )
+}
+
 /// Per-tick scanner: walks `<home>/pr-state/*.json`, emits any newly-
 /// eligible `[pr-ready-for-merge]` events (debounced via
 /// `ready_emitted_for_sha`), and sweeps terminal-state files.
@@ -636,17 +688,28 @@ pub fn scan_and_emit_with(
                 }
             },
         };
+        // Run watch settlement BEFORE pr_state removal so a retryable
+        // settlement failure retains pr_state as the retry source.
+        let watch_settle_ok =
+            if let Some((ref t_repo, ref t_branch, ref terminal_head)) = deferred_watch_settle {
+                settle_feature_watch(home, t_repo, t_branch, terminal_head)
+            } else {
+                true
+            };
         match result {
-            Ok(Some(ScanAction::Remove)) if terminal_recorded => {
-                // The durable terminal marker is already recorded above (or there was
-                // none to record), so removing the pr_state file here can never lose
-                // it (crash-safe ordering).
+            Ok(Some(ScanAction::Remove)) if terminal_recorded && watch_settle_ok => {
                 let _ = remove(home, &repo, &branch);
             }
+            Ok(Some(ScanAction::Remove)) if terminal_recorded => {
+                // Watch settlement had a retryable failure — retain pr_state
+                // so the next scan re-observes the terminal and retries.
+                tracing::info!(
+                    repo = %repo, branch = %branch,
+                    "pr_state retained: watch settlement retryable failure"
+                );
+            }
             Ok(Some(ScanAction::Remove)) => {
-                // record_terminal FAILED — SKIP the remove (B3 fail closed). The
-                // pr_state file is retained as the retry source; the next scan
-                // re-observes the terminal and record_terminal (idempotent) retries.
+                // record_terminal FAILED — SKIP the remove (B3 fail closed).
             }
             Err(e) => {
                 tracing::warn!(
@@ -693,52 +756,6 @@ pub fn scan_and_emit_with(
                 &format!("{repo}@{branch}"),
                 "pr_merge_blocked",
             );
-        }
-        // Post-flock CI-watch CAS settlement: remove the feature-branch watch
-        // only when repo+branch+head_sha all match the terminal state.
-        // This is the deterministic settlement path for watches that the
-        // poller's check_pr_terminal cannot reach (branch deleted after merge).
-        if let Some((t_repo, t_branch, terminal_head)) = deferred_watch_settle {
-            if !crate::agent_ops::is_protected_ref(&t_branch) {
-                let ci_dir = crate::daemon::ci_watch::ci_watches_dir(home);
-                let fname = crate::daemon::ci_watch::watch_filename(&t_repo, &t_branch);
-                let watch_path = ci_dir.join(&fname);
-                if watch_path.exists() {
-                    let lock_path = watch_path.with_extension("lock");
-                    if let Ok(_guard) = crate::store::acquire_file_lock(&lock_path) {
-                        if let Ok(content) = std::fs::read_to_string(&watch_path) {
-                            if let Ok(watch) = serde_json::from_str::<
-                                crate::daemon::ci_watch::WatchState,
-                            >(&content)
-                            {
-                                let watch_head = watch.head_sha.as_deref().unwrap_or("");
-                                if watch.repo == t_repo
-                                    && watch.branch == t_branch
-                                    && !watch_head.is_empty()
-                                    && watch_head == terminal_head
-                                    && watch.target_head_sha.is_none()
-                                {
-                                    let subs: Vec<String> = watch
-                                        .subscribers
-                                        .as_deref()
-                                        .unwrap_or(&[])
-                                        .iter()
-                                        .map(|s| s.instance.clone())
-                                        .collect();
-                                    crate::daemon::ci_watch::remove_watch_json_only(
-                                        home,
-                                        &watch_path,
-                                        &subs.join(","),
-                                        &t_repo,
-                                        &t_branch,
-                                        "pr_terminal_cas_settlement",
-                                    );
-                                }
-                            }
-                        }
-                    }
-                }
-            }
         }
         let _ = registry; // reserved for future gh-poll author lookup hook
     }

--- a/src/daemon/pr_state/scanner.rs
+++ b/src/daemon/pr_state/scanner.rs
@@ -175,6 +175,10 @@ pub fn scan_and_emit_with(
             .as_deref()
             .is_some_and(|k| terminal_already_emitted(home, k));
         let mut emitted_terminal = false;
+        // Deferred CI-watch CAS settlement: (repo, branch, terminal_head).
+        // Captured inside the locked MergeState match on ANY terminal path
+        // (first emit AND replay-suppressed) so restart re-scan can settle.
+        let mut deferred_watch_settle: Option<(String, String, String)> = None;
         let result = with_pr_state(home, &repo, &branch, |state| {
             let mut dirty = false;
 
@@ -387,7 +391,17 @@ pub fn scan_and_emit_with(
                         state.ready_emitted_for_sha = Some(state.head_sha.clone());
                         emitted_terminal = true; // [C1] record in ledger post-flock
                         dirty = true;
+                        deferred_watch_settle = Some((
+                            state.repo.clone(),
+                            state.branch.clone(),
+                            state.head_sha.clone(),
+                        ));
                     } else {
+                        deferred_watch_settle = Some((
+                            state.repo.clone(),
+                            state.branch.clone(),
+                            state.head_sha.clone(),
+                        ));
                         tracing::debug!(
                             repo = %state.repo,
                             branch = %state.branch,
@@ -669,6 +683,52 @@ pub fn scan_and_emit_with(
                 &format!("{repo}@{branch}"),
                 "pr_merge_blocked",
             );
+        }
+        // Post-flock CI-watch CAS settlement: remove the feature-branch watch
+        // only when repo+branch+head_sha all match the terminal state.
+        // This is the deterministic settlement path for watches that the
+        // poller's check_pr_terminal cannot reach (branch deleted after merge).
+        if let Some((t_repo, t_branch, terminal_head)) = deferred_watch_settle {
+            if !crate::agent_ops::is_protected_ref(&t_branch) {
+                let ci_dir = crate::daemon::ci_watch::ci_watches_dir(home);
+                let fname = crate::daemon::ci_watch::watch_filename(&t_repo, &t_branch);
+                let watch_path = ci_dir.join(&fname);
+                if watch_path.exists() {
+                    let lock_path = watch_path.with_extension("lock");
+                    if let Ok(_guard) = crate::store::acquire_file_lock(&lock_path) {
+                        if let Ok(content) = std::fs::read_to_string(&watch_path) {
+                            if let Ok(watch) = serde_json::from_str::<
+                                crate::daemon::ci_watch::WatchState,
+                            >(&content)
+                            {
+                                let watch_head = watch.head_sha.as_deref().unwrap_or("");
+                                if watch.repo == t_repo
+                                    && watch.branch == t_branch
+                                    && !watch_head.is_empty()
+                                    && watch_head == terminal_head
+                                    && watch.target_head_sha.is_none()
+                                {
+                                    let subs: Vec<String> = watch
+                                        .subscribers
+                                        .as_deref()
+                                        .unwrap_or(&[])
+                                        .iter()
+                                        .map(|s| s.instance.clone())
+                                        .collect();
+                                    crate::daemon::ci_watch::remove_watch_json_only(
+                                        home,
+                                        &watch_path,
+                                        &subs.join(","),
+                                        &t_repo,
+                                        &t_branch,
+                                        "pr_terminal_cas_settlement",
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
         let _ = registry; // reserved for future gh-poll author lookup hook
     }

--- a/src/daemon/pr_state/scanner.rs
+++ b/src/daemon/pr_state/scanner.rs
@@ -434,7 +434,17 @@ pub fn scan_and_emit_with(
                                                  // (the sweeper applies the conservative close-grace).
                         release_after_unlock = Some((state.branch.clone(), "close_unmerged"));
                         dirty = true;
+                        deferred_watch_settle = Some((
+                            state.repo.clone(),
+                            state.branch.clone(),
+                            state.head_sha.clone(),
+                        ));
                     } else {
+                        deferred_watch_settle = Some((
+                            state.repo.clone(),
+                            state.branch.clone(),
+                            state.head_sha.clone(),
+                        ));
                         tracing::debug!(
                             repo = %state.repo,
                             branch = %state.branch,

--- a/src/daemon/pr_state/tests.rs
+++ b/src/daemon/pr_state/tests.rs
@@ -44,7 +44,7 @@ fn stamp_fresh_ancestry(s: &mut PrState) {
     s.freshness_error = false;
 }
 
-fn new_state(head: &str, class: ReviewClass) -> PrState {
+pub(super) fn new_state(head: &str, class: ReviewClass) -> PrState {
     PrState {
         repo: "owner/repo".to_string(),
         pr_number: 100,
@@ -2975,7 +2975,7 @@ fn t20_1017_replay_age_threshold_is_fixed_1h() {
 }
 
 /// #2059-#3: write a fleet.yaml team so `find_team_for` resolves.
-fn write_team_fleet(home: &std::path::Path, orch: &str, members: &[&str]) {
+pub(super) fn write_team_fleet(home: &std::path::Path, orch: &str, members: &[&str]) {
     let mut y = String::from("instances:\n");
     for m in members {
         y.push_str(&format!("  {m}:\n    backend: claude\n"));

--- a/src/daemon/pr_state/watch_settlement_tests.rs
+++ b/src/daemon/pr_state/watch_settlement_tests.rs
@@ -27,6 +27,22 @@ fn write_merged_pr_state(home: &std::path::Path, repo: &str, branch: &str, head:
 }
 
 fn write_watch(home: &std::path::Path, repo: &str, branch: &str, head_sha: &str) {
+    write_watch_with_gen(
+        home,
+        repo,
+        branch,
+        head_sha,
+        &uuid::Uuid::new_v4().to_string(),
+    );
+}
+
+fn write_watch_with_gen(
+    home: &std::path::Path,
+    repo: &str,
+    branch: &str,
+    head_sha: &str,
+    generation_id: &str,
+) {
     let ci_dir = crate::daemon::ci_watch::ci_watches_dir(home);
     std::fs::create_dir_all(&ci_dir).ok();
     let fname = crate::daemon::ci_watch::watch_filename(repo, branch);
@@ -34,6 +50,7 @@ fn write_watch(home: &std::path::Path, repo: &str, branch: &str, head_sha: &str)
         "repo": repo,
         "branch": branch,
         "head_sha": head_sha,
+        "generation_id": generation_id,
         "interval_secs": 60,
         "subscribers": [{"instance": "dev-agent", "subscribed_at": "2026-01-01T00:00:00Z"}],
     });
@@ -326,6 +343,56 @@ fn closed_unmerged_terminal_removes_matching_watch() {
         !watch_exists(&home, repo, branch),
         "closed-unmerged terminal must also remove matching feature watch"
     );
+
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// R8: Deterministic concurrency proof — a stale flush_watch_state with gen1's
+/// generation_id cannot overwrite a gen2 watch created after settlement.
+#[test]
+fn stale_flush_across_settlement_and_new_generation_thread() {
+    use crate::daemon::ci_watch::{ci_watches_dir, flush_watch_state, watch_filename, WatchState};
+    use std::sync::{Arc, Barrier};
+
+    let home = tmp_home("r8-concurrent");
+    let repo = "owner/repo";
+    let branch = "feat/r8";
+    let gen1_id = "gen1-uuid-aaa";
+    let gen2_id = "gen2-uuid-bbb";
+    let gen1_head = "gen1-head";
+    let gen2_head = "gen2-head";
+
+    write_watch_with_gen(&home, repo, branch, gen1_head, gen1_id);
+    let ci_dir = ci_watches_dir(&home);
+    let fname = watch_filename(repo, branch);
+    let watch_path = ci_dir.join(&fname);
+    let snapshot: WatchState =
+        serde_json::from_str(&std::fs::read_to_string(&watch_path).expect("read gen1"))
+            .expect("parse gen1");
+
+    // Settle gen1.
+    std::fs::remove_file(&watch_path).expect("remove gen1");
+
+    // Create gen2 with different generation.
+    write_watch_with_gen(&home, repo, branch, gen2_head, gen2_id);
+
+    // Stale worker thread flushes gen1 snapshot.
+    let barrier = Arc::new(Barrier::new(2));
+    let b2 = barrier.clone();
+    let wp = watch_path.clone();
+    let snap = snapshot.clone();
+    let t = std::thread::spawn(move || {
+        b2.wait();
+        flush_watch_state(&wp, &snap, snap.generation_id.as_deref());
+    });
+    barrier.wait();
+    t.join().expect("worker thread");
+
+    // Gen2 must be uncorrupted.
+    let content = std::fs::read_to_string(&watch_path).expect("read after flush");
+    let after: WatchState = serde_json::from_str(&content).expect("parse after flush");
+    assert_eq!(after.generation_id.as_deref(), Some(gen2_id));
+    assert_eq!(after.head_sha.as_deref(), Some(gen2_head));
 
     std::fs::remove_dir_all(&home).ok();
 }

--- a/src/daemon/pr_state/watch_settlement_tests.rs
+++ b/src/daemon/pr_state/watch_settlement_tests.rs
@@ -144,21 +144,43 @@ fn head_advanced_watch_preserved_by_cas_mismatch() {
     std::fs::remove_dir_all(&home).ok();
 }
 
-/// R3: Protected-ref branch watch (main/master) is never removed by
-/// the scanner terminal path — only exact-head watches on protected
-/// refs are valid, and they use a different filename key.
+/// R3a: A regular-keyed watch on a protected ref (main) is preserved by
+/// the is_protected_ref guard, even when repo+branch+head all match.
 #[test]
-fn protected_main_watch_preserved_on_feature_terminal() {
-    let home = tmp_home("r3-protected");
+fn protected_ref_guard_preserves_main_watch() {
+    let home = tmp_home("r3a-protected");
     let repo = "owner/repo";
     let head = "main-head-abc";
 
-    // A feature PR merged into main; an exact-head main watch also exists.
-    write_merged_pr_state(&home, repo, "feat/r3", head);
+    // Synthesize a terminal state for "main" AND a regular-keyed main watch.
+    write_merged_pr_state(&home, repo, "main", head);
+    write_watch(&home, repo, "main", head);
+    assert!(watch_exists(&home, repo, "main"), "precondition");
+
+    tests::write_team_fleet(&home, "lead", &["dev"]);
+    run_scan(&home);
+
+    assert!(
+        watch_exists(&home, repo, "main"),
+        "regular main watch must be preserved by is_protected_ref guard"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// R3b: Exact-head main watch (different filename key) is untouched by
+/// feature terminal settlement.
+#[test]
+fn exact_head_main_watch_isolated_from_feature_terminal() {
+    let home = tmp_home("r3b-exact");
+    let repo = "owner/repo";
+    let head = "main-head-abc";
+
+    write_merged_pr_state(&home, repo, "feat/r3b", head);
     write_exact_head_watch(&home, repo, "main", head, head);
     assert!(
         exact_head_watch_exists(&home, repo, "main", head),
-        "precondition: exact-head main watch exists"
+        "precondition"
     );
 
     tests::write_team_fleet(&home, "lead", &["dev"]);
@@ -166,7 +188,7 @@ fn protected_main_watch_preserved_on_feature_terminal() {
 
     assert!(
         exact_head_watch_exists(&home, repo, "main", head),
-        "exact-head main watch must NOT be removed by feature terminal settlement"
+        "exact-head main watch must NOT be removed by feature terminal"
     );
 
     std::fs::remove_dir_all(&home).ok();
@@ -269,6 +291,40 @@ fn stale_flush_new_generation_no_cross_corruption() {
         watch["head_sha"].as_str(),
         Some(new_head),
         "gen2 watch content must be uncorrupted"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+}
+
+fn write_closed_unmerged_pr_state(home: &std::path::Path, repo: &str, branch: &str, head: &str) {
+    let mut s = tests::new_state(head, ReviewClass::Single);
+    s.repo = repo.to_string();
+    s.branch = branch.to_string();
+    s.merge_state = MergeState::ClosedUnmerged {
+        closed_at: chrono::Utc::now().to_rfc3339(),
+    };
+    s.pr_author = "dev".to_string();
+    save(home, &s).expect("save pr_state");
+}
+
+/// R7: ClosedUnmerged terminal also removes matching feature watch.
+#[test]
+fn closed_unmerged_terminal_removes_matching_watch() {
+    let home = tmp_home("r7-closed");
+    let repo = "owner/repo";
+    let branch = "feat/r7";
+    let head = "head-r7-closed";
+
+    write_closed_unmerged_pr_state(&home, repo, branch, head);
+    write_watch(&home, repo, branch, head);
+    assert!(watch_exists(&home, repo, branch), "precondition");
+
+    tests::write_team_fleet(&home, "lead", &["dev"]);
+    run_scan(&home);
+
+    assert!(
+        !watch_exists(&home, repo, branch),
+        "closed-unmerged terminal must also remove matching feature watch"
     );
 
     std::fs::remove_dir_all(&home).ok();

--- a/src/daemon/pr_state/watch_settlement_tests.rs
+++ b/src/daemon/pr_state/watch_settlement_tests.rs
@@ -396,3 +396,46 @@ fn stale_flush_across_settlement_and_new_generation_thread() {
 
     std::fs::remove_dir_all(&home).ok();
 }
+
+/// R9: Corrupt/unreadable watch file retains pr_state for retry.
+/// After repair, next scan settles both.
+#[test]
+fn corrupt_watch_retains_pr_state_then_repair_settles() {
+    let home = tmp_home("r9-corrupt");
+    let repo = "owner/repo";
+    let branch = "feat/r9";
+    let head = "head-r9";
+
+    write_merged_pr_state(&home, repo, branch, head);
+    // Write a CORRUPT watch file (invalid JSON).
+    let ci_dir = crate::daemon::ci_watch::ci_watches_dir(&home);
+    std::fs::create_dir_all(&ci_dir).ok();
+    let fname = crate::daemon::ci_watch::watch_filename(repo, branch);
+    std::fs::write(ci_dir.join(&fname), "{{corrupt json").expect("write corrupt");
+
+    tests::write_team_fleet(&home, "lead", &["dev"]);
+
+    // First scan: settlement fails (parse error) → pr_state retained.
+    run_scan(&home);
+    let _pr_state_dir = super::pr_state_dir(&home);
+    // Watch should still exist (corrupt, couldn't settle).
+    assert!(
+        ci_dir.join(&fname).exists(),
+        "corrupt watch file must survive"
+    );
+
+    // Repair: write a valid watch with matching head.
+    write_watch(&home, repo, branch, head);
+    // Re-create pr_state (first scan may or may not have removed it
+    // depending on whether settlement retained it).
+    write_merged_pr_state(&home, repo, branch, head);
+
+    // Second scan: settlement succeeds.
+    run_scan(&home);
+    assert!(
+        !watch_exists(&home, repo, branch),
+        "repaired watch must be settled on next scan"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+}

--- a/src/daemon/pr_state/watch_settlement_tests.rs
+++ b/src/daemon/pr_state/watch_settlement_tests.rs
@@ -415,26 +415,27 @@ fn corrupt_watch_retains_pr_state_then_repair_settles() {
 
     tests::write_team_fleet(&home, "lead", &["dev"]);
 
-    // First scan: settlement fails (parse error) → pr_state retained.
+    // First scan: settlement fails (parse error) → pr_state RETAINED.
     run_scan(&home);
-    let _pr_state_dir = super::pr_state_dir(&home);
-    // Watch should still exist (corrupt, couldn't settle).
     assert!(
         ci_dir.join(&fname).exists(),
-        "corrupt watch file must survive"
+        "corrupt watch file must survive scan 1"
+    );
+    // Assert pr_state was retained (retryable failure → not removed).
+    assert!(
+        super::load(&home, repo, branch).is_some(),
+        "pr_state must be retained when watch settlement fails (retryable)"
     );
 
-    // Repair: write a valid watch with matching head.
+    // Repair: write a valid watch with matching head. Do NOT re-create
+    // pr_state — it was retained from scan 1.
     write_watch(&home, repo, branch, head);
-    // Re-create pr_state (first scan may or may not have removed it
-    // depending on whether settlement retained it).
-    write_merged_pr_state(&home, repo, branch, head);
 
-    // Second scan: settlement succeeds.
+    // Second scan: settlement succeeds → both watch and pr_state removed.
     run_scan(&home);
     assert!(
         !watch_exists(&home, repo, branch),
-        "repaired watch must be settled on next scan"
+        "repaired watch must be settled on scan 2"
     );
 
     std::fs::remove_dir_all(&home).ok();

--- a/src/daemon/pr_state/watch_settlement_tests.rs
+++ b/src/daemon/pr_state/watch_settlement_tests.rs
@@ -1,0 +1,275 @@
+use super::*;
+use crate::daemon::pr_state::gh_poll::tests::MockGhPoller;
+use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+fn tmp_home(tag: &str) -> std::path::PathBuf {
+    let home =
+        std::env::temp_dir().join(format!("agend-watch-settle-{}-{}", tag, std::process::id()));
+    let _ = std::fs::remove_dir_all(&home);
+    std::fs::create_dir_all(&home).expect("create tmp home");
+    std::fs::create_dir_all(home.join("inbox")).ok();
+    std::fs::write(crate::fleet::fleet_yaml_path(&home), "instances: {}\n").ok();
+    home
+}
+
+fn write_merged_pr_state(home: &std::path::Path, repo: &str, branch: &str, head: &str) {
+    let mut s = tests::new_state(head, ReviewClass::Single);
+    s.repo = repo.to_string();
+    s.branch = branch.to_string();
+    s.merge_state = MergeState::Merged {
+        merge_commit: format!("merge-{head}"),
+        merged_at: chrono::Utc::now().to_rfc3339(),
+    };
+    s.pr_author = "dev".to_string();
+    save(home, &s).expect("save pr_state");
+}
+
+fn write_watch(home: &std::path::Path, repo: &str, branch: &str, head_sha: &str) {
+    let ci_dir = crate::daemon::ci_watch::ci_watches_dir(home);
+    std::fs::create_dir_all(&ci_dir).ok();
+    let fname = crate::daemon::ci_watch::watch_filename(repo, branch);
+    let watch = serde_json::json!({
+        "repo": repo,
+        "branch": branch,
+        "head_sha": head_sha,
+        "interval_secs": 60,
+        "subscribers": [{"instance": "dev-agent", "subscribed_at": "2026-01-01T00:00:00Z"}],
+    });
+    std::fs::write(
+        ci_dir.join(&fname),
+        serde_json::to_string_pretty(&watch).expect("json"),
+    )
+    .expect("write watch");
+}
+
+fn watch_exists(home: &std::path::Path, repo: &str, branch: &str) -> bool {
+    let ci_dir = crate::daemon::ci_watch::ci_watches_dir(home);
+    let fname = crate::daemon::ci_watch::watch_filename(repo, branch);
+    ci_dir.join(&fname).exists()
+}
+
+fn write_exact_head_watch(
+    home: &std::path::Path,
+    repo: &str,
+    branch: &str,
+    head_sha: &str,
+    target_head_sha: &str,
+) {
+    let ci_dir = crate::daemon::ci_watch::ci_watches_dir(home);
+    std::fs::create_dir_all(&ci_dir).ok();
+    let fname = crate::daemon::ci_watch::watch_filename_exact_head(repo, branch, target_head_sha);
+    let watch = serde_json::json!({
+        "repo": repo,
+        "branch": branch,
+        "head_sha": head_sha,
+        "target_head_sha": target_head_sha,
+        "interval_secs": 60,
+        "subscribers": [{"instance": "dev-agent"}],
+    });
+    std::fs::write(
+        ci_dir.join(&fname),
+        serde_json::to_string_pretty(&watch).expect("json"),
+    )
+    .expect("write exact-head watch");
+}
+
+fn exact_head_watch_exists(
+    home: &std::path::Path,
+    repo: &str,
+    branch: &str,
+    target_head_sha: &str,
+) -> bool {
+    let ci_dir = crate::daemon::ci_watch::ci_watches_dir(home);
+    let fname = crate::daemon::ci_watch::watch_filename_exact_head(repo, branch, target_head_sha);
+    ci_dir.join(&fname).exists()
+}
+
+fn null_registry() -> crate::agent::AgentRegistry {
+    Arc::new(Mutex::new(HashMap::new()))
+}
+
+fn run_scan(home: &std::path::Path) {
+    let registry = null_registry();
+    let poller = MockGhPoller::new(vec![Ok(vec![])]);
+    scanner::scan_and_emit_with(home, &registry, &poller);
+}
+
+/// R1: A merged PR with matching head_sha removes the feature watch.
+#[test]
+fn terminal_pr_merged_feature_watch_removed_by_cas() {
+    let home = tmp_home("r1-merged");
+    let repo = "owner/repo";
+    let branch = "feat/r1";
+    let head = "abc1234def5678";
+
+    write_merged_pr_state(&home, repo, branch, head);
+    write_watch(&home, repo, branch, head);
+    assert!(
+        watch_exists(&home, repo, branch),
+        "precondition: watch exists"
+    );
+
+    tests::write_team_fleet(&home, "lead", &["dev"]);
+    run_scan(&home);
+
+    assert!(
+        !watch_exists(&home, repo, branch),
+        "feature watch must be removed after merged terminal with matching head"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// R2: Head advanced (watch.head_sha != terminal head) preserves watch.
+#[test]
+fn head_advanced_watch_preserved_by_cas_mismatch() {
+    let home = tmp_home("r2-mismatch");
+    let repo = "owner/repo";
+    let branch = "feat/r2";
+
+    write_merged_pr_state(&home, repo, branch, "terminal-head-aaa");
+    write_watch(&home, repo, branch, "different-head-bbb");
+    assert!(watch_exists(&home, repo, branch), "precondition");
+
+    tests::write_team_fleet(&home, "lead", &["dev"]);
+    run_scan(&home);
+
+    assert!(
+        watch_exists(&home, repo, branch),
+        "watch must be preserved when head_sha doesn't match terminal head"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// R3: Protected-ref branch watch (main/master) is never removed by
+/// the scanner terminal path — only exact-head watches on protected
+/// refs are valid, and they use a different filename key.
+#[test]
+fn protected_main_watch_preserved_on_feature_terminal() {
+    let home = tmp_home("r3-protected");
+    let repo = "owner/repo";
+    let head = "main-head-abc";
+
+    // A feature PR merged into main; an exact-head main watch also exists.
+    write_merged_pr_state(&home, repo, "feat/r3", head);
+    write_exact_head_watch(&home, repo, "main", head, head);
+    assert!(
+        exact_head_watch_exists(&home, repo, "main", head),
+        "precondition: exact-head main watch exists"
+    );
+
+    tests::write_team_fleet(&home, "lead", &["dev"]);
+    run_scan(&home);
+
+    assert!(
+        exact_head_watch_exists(&home, repo, "main", head),
+        "exact-head main watch must NOT be removed by feature terminal settlement"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// R4: Watch already gone → idempotent no-op, no error.
+#[test]
+fn scanner_watch_removal_idempotent_when_already_gone() {
+    let home = tmp_home("r4-idempotent");
+    let repo = "owner/repo";
+    let branch = "feat/r4";
+
+    write_merged_pr_state(&home, repo, branch, "head-r4");
+    // No watch file — scanner should not error.
+    assert!(!watch_exists(&home, repo, branch), "precondition: no watch");
+
+    tests::write_team_fleet(&home, "lead", &["dev"]);
+    run_scan(&home);
+    // No panic, no error — test passes if we get here.
+
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// R5: Restart/re-scan settles even when terminal emit ledger already exists
+/// (replay-suppressed path). The deferred_watch_settle captures on BOTH
+/// first-emit and replay-suppressed arms.
+#[test]
+fn restart_rescan_settles_when_ledger_already_emitted() {
+    let home = tmp_home("r5-restart");
+    let repo = "owner/repo";
+    let branch = "feat/r5";
+    let head = "head-r5-restart";
+
+    write_merged_pr_state(&home, repo, branch, head);
+    write_watch(&home, repo, branch, head);
+    tests::write_team_fleet(&home, "lead", &["dev"]);
+
+    // First scan: emits terminal event + removes watch.
+    run_scan(&home);
+    assert!(
+        !watch_exists(&home, repo, branch),
+        "first scan must remove watch"
+    );
+
+    // Simulate restart: re-create watch (as if poller re-armed it somehow)
+    // and re-create the pr_state file (as if lingering CI re-created it).
+    write_merged_pr_state(&home, repo, branch, head);
+    write_watch(&home, repo, branch, head);
+
+    // Second scan: terminal emit ledger says "already emitted" → replay
+    // suppressed. But deferred_watch_settle should still capture and settle.
+    run_scan(&home);
+    assert!(
+        !watch_exists(&home, repo, branch),
+        "re-scan (replay-suppressed) must still remove watch via deferred settlement"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// R6: New generation watch on same branch after removal — the JSON-only
+/// removal under lock must not corrupt a newly written watch file for a
+/// different head (stale flush regression).
+#[test]
+fn stale_flush_new_generation_no_cross_corruption() {
+    let home = tmp_home("r6-generation");
+    let repo = "owner/repo";
+    let branch = "feat/r6";
+    let old_head = "old-head-gen1";
+    let new_head = "new-head-gen2";
+
+    // Generation 1: merged PR, matching watch → removed.
+    write_merged_pr_state(&home, repo, branch, old_head);
+    write_watch(&home, repo, branch, old_head);
+    tests::write_team_fleet(&home, "lead", &["dev"]);
+    run_scan(&home);
+    assert!(!watch_exists(&home, repo, branch), "gen1 watch removed");
+
+    // Generation 2: new PR on same branch, new watch with different head.
+    write_watch(&home, repo, branch, new_head);
+    assert!(watch_exists(&home, repo, branch), "gen2 watch written");
+
+    // Re-scan with old terminal state — CAS should NOT match new head.
+    // The pr_state was removed by first scan; re-create with old head to
+    // simulate a stale re-observation.
+    write_merged_pr_state(&home, repo, branch, old_head);
+    run_scan(&home);
+
+    // Gen2 watch must survive — old terminal head doesn't match new watch head.
+    assert!(
+        watch_exists(&home, repo, branch),
+        "gen2 watch with different head must survive old-generation terminal"
+    );
+    // Verify the watch content is uncorrupted.
+    let ci_dir = crate::daemon::ci_watch::ci_watches_dir(&home);
+    let fname = crate::daemon::ci_watch::watch_filename(repo, branch);
+    let content = std::fs::read_to_string(ci_dir.join(&fname)).expect("read gen2 watch");
+    let watch: serde_json::Value = serde_json::from_str(&content).expect("parse gen2 watch");
+    assert_eq!(
+        watch["head_sha"].as_str(),
+        Some(new_head),
+        "gen2 watch content must be uncorrupted"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+}

--- a/src/mcp/handlers/ci/watch.rs
+++ b/src/mcp/handlers/ci/watch.rs
@@ -126,8 +126,17 @@ pub(crate) fn handle_watch_ci(home: &Path, args: &Value, instance_name: &str) ->
                 "last_notified_head_sha": null,
                 "expires_at": (chrono::Utc::now() + chrono::Duration::hours(crate::daemon::ci_watch::WATCH_TTL_HOURS)).to_rfc3339(),
                 "last_terminal_seen_at": null,
+                "generation_id": uuid::Uuid::new_v4().to_string(),
             })
         });
+    // Seed legacy watches missing generation_id.
+    if watch
+        .get("generation_id")
+        .and_then(|v| v.as_str())
+        .is_none()
+    {
+        watch["generation_id"] = json!(uuid::Uuid::new_v4().to_string());
+    }
 
     // Migrate legacy schema (single `instance` field, no `subscribers`
     // array) into the canonical multi-subscriber form. Subsequent reads


### PR DESCRIPTION
## Summary

Fixes retained CI watches after PR merge + `--delete-branch` (Architecture-14 item 2).

**Root cause**: `check_pr_terminal` uses `pulls?head=owner:branch` which returns `[]` after branch deletion → `PrState::Unknown` → two-consecutive-terminal guard never fires → watch retained until 72h TTL.

**Fix**: The `pr_state` scanner independently detects `MergeState::Merged` from the durable pr_state store. On terminal transition, defers a post-flock CI-watch CAS settlement:
- Acquire per-watch file lock
- Re-read watch JSON; verify `repo + branch + head_sha` identity
- CAS match → `remove_watch_json_only` (JSON only, lock sidecar preserved)
- Mismatch → preserve (head advanced / different generation)
- Protected ref / `target_head_sha` present → skip (exact-head main watch isolated)

Captures on BOTH first-emit AND replay-suppressed arms → restart re-scan converges.

## Tests (6)
- `terminal_pr_merged_feature_watch_removed_by_cas` — matching head removed
- `head_advanced_watch_preserved_by_cas_mismatch` — different head preserved
- `protected_main_watch_preserved_on_feature_terminal` — exact-head main untouched
- `scanner_watch_removal_idempotent_when_already_gone` — missing watch no-op
- `restart_rescan_settles_when_ledger_already_emitted` — replay-suppressed still settles
- `stale_flush_new_generation_no_cross_corruption` — new generation watch survives old terminal

## Test plan
- [ ] CI green
- [ ] Verify retained `feat/template-skills-allowlist` watch is removed after rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)