### PR TITLE
feat(tasks): typed AssigneePatch owner normalization

### DIFF
--- a/src/tasks/handler.rs
+++ b/src/tasks/handler.rs
@@ -66,6 +66,50 @@ fn id_arg(args: &Value) -> Option<&str> {
         .or_else(|| args["task_id"].as_str().filter(|s| !s.is_empty()))
 }
 
+enum AssigneePatch {
+    Unchanged,
+    Clear,
+    Set(String),
+}
+
+fn parse_assignee_for_create(args: &Value) -> Result<Option<String>, Value> {
+    let field = args.get("assignee");
+    match field {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(s)) => {
+            let trimmed = s.trim();
+            if trimmed.is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(trimmed.to_string()))
+            }
+        }
+        Some(_) => Err(serde_json::json!({
+            "error": "assignee must be a string",
+            "code": "invalid_assignee",
+        })),
+    }
+}
+
+fn parse_assignee_for_update(args: &Value) -> Result<AssigneePatch, Value> {
+    let field = args.get("assignee");
+    match field {
+        None | Some(Value::Null) => Ok(AssigneePatch::Unchanged),
+        Some(Value::String(s)) => {
+            let trimmed = s.trim();
+            if trimmed.is_empty() {
+                Ok(AssigneePatch::Clear)
+            } else {
+                Ok(AssigneePatch::Set(trimmed.to_string()))
+            }
+        }
+        Some(_) => Err(serde_json::json!({
+            "error": "assignee must be a string",
+            "code": "invalid_assignee",
+        })),
+    }
+}
+
 fn handle_create(home: &Path, emitter: crate::task_events::InstanceName, args: &Value) -> Value {
     let title = match args["title"].as_str() {
         Some(t) => t,
@@ -98,7 +142,10 @@ fn handle_create(home: &Path, emitter: crate::task_events::InstanceName, args: &
     // legacy two-segment form (see src/daemon/task_sweep.rs).
     let pid = std::process::id();
     let id = format!("t-{ts}-{pid}-{seq}");
-    let assignee = args["assignee"].as_str().map(String::from);
+    let assignee = match parse_assignee_for_create(args) {
+        Ok(a) => a,
+        Err(e) => return e,
+    };
     let routed_to = if let Some(ref name) = assignee {
         match crate::teams::resolve_team_orchestrator(home, name) {
             Ok(Some(orch)) => Some(orch),
@@ -1133,15 +1180,17 @@ fn handle_update(
     };
     let new_status = args["status"].as_str().map(String::from);
     let new_priority = args["priority"].as_str();
-    let new_assignee = args["assignee"].as_str().map(String::from);
+    let assignee_patch = match parse_assignee_for_update(args) {
+        Ok(p) => p,
+        Err(e) => return e,
+    };
     // Resolve team routing for new assignee (validates team exists / not degraded).
-    let _new_routed_to = if let Some(ref name) = new_assignee {
-        match crate::teams::resolve_team_orchestrator(home, name) {
+    let _new_routed_to = match &assignee_patch {
+        AssigneePatch::Set(name) => match crate::teams::resolve_team_orchestrator(home, name) {
             Ok(orch) => orch,
             Err(e) => return serde_json::json!({"error": e}),
-        }
-    } else {
-        None
+        },
+        _ => None,
     };
     let caller = instance_name.to_string();
     // #2760: resolve the task's authoritative board ONCE via the strict route
@@ -1423,21 +1472,31 @@ fn handle_update(
             tags,
         });
     }
-    // Assignee change without status transition: queue
-    // OwnerAssigned. Distinct from Claimed (status stays put).
-    if let Some(ref new_owner) = new_assignee {
-        let routed_to = match crate::teams::resolve_team_orchestrator(home, new_owner) {
-            Ok(orch) => orch,
-            Err(e) => return serde_json::json!({"error": e}),
-        };
-        pending_events.push(crate::task_events::TaskEvent::OwnerAssigned {
-            task_id: crate::task_events::TaskId(id.clone()),
-            by: crate::task_events::InstanceName::from(caller.as_str()),
-            owner: Some(crate::task_events::InstanceName(new_owner.clone())),
-            routed_to: routed_to
-                .as_ref()
-                .map(|s| crate::task_events::InstanceName(s.clone())),
-        });
+    // Assignee change without status transition: queue OwnerAssigned.
+    match &assignee_patch {
+        AssigneePatch::Set(new_owner) => {
+            let routed_to = match crate::teams::resolve_team_orchestrator(home, new_owner) {
+                Ok(orch) => orch,
+                Err(e) => return serde_json::json!({"error": e}),
+            };
+            pending_events.push(crate::task_events::TaskEvent::OwnerAssigned {
+                task_id: crate::task_events::TaskId(id.clone()),
+                by: crate::task_events::InstanceName::from(caller.as_str()),
+                owner: Some(crate::task_events::InstanceName(new_owner.clone())),
+                routed_to: routed_to
+                    .as_ref()
+                    .map(|s| crate::task_events::InstanceName(s.clone())),
+            });
+        }
+        AssigneePatch::Clear => {
+            pending_events.push(crate::task_events::TaskEvent::OwnerAssigned {
+                task_id: crate::task_events::TaskId(id.clone()),
+                by: crate::task_events::InstanceName::from(caller.as_str()),
+                owner: None,
+                routed_to: None,
+            });
+        }
+        AssigneePatch::Unchanged => {}
     }
     // F2: result backfill via the additive `ResultSet` event. A present-but-
     // non-string `result` fails loud (was: silently ignored → false "unchanged").
@@ -1551,15 +1610,22 @@ fn handle_update(
         // Mirrors the done/cancelled cleanup hook above; runs only after the append
         // committed. (The orphan path — OwnerAssigned with owner=None — calls the
         // same helper with None in orphan_tasks_for_owner, which clears the sidecar.)
-        if let Some(ref new_owner) = new_assignee {
-            let _ =
-                crate::daemon::dispatch_idle::reassign_pending_for_task(home, &id, Some(new_owner));
-            // #1923 G1/G3: re-point the SAME task's ci-watch handoff (next_after_ci)
-            // + dispatch-tracking `to` to the new owner — sibling calls at the same
-            // OwnerAssigned emit site, so a reassigned review hands off / is tracked
-            // against the reviewer who now owns the task, not the stale original.
-            let _ = crate::daemon::ci_watch::reassign_next_after_ci(home, &id, Some(new_owner));
-            crate::dispatch_tracking::reassign_to(home, &id, Some(new_owner));
+        match &assignee_patch {
+            AssigneePatch::Set(new_owner) => {
+                let _ = crate::daemon::dispatch_idle::reassign_pending_for_task(
+                    home,
+                    &id,
+                    Some(new_owner),
+                );
+                let _ = crate::daemon::ci_watch::reassign_next_after_ci(home, &id, Some(new_owner));
+                crate::dispatch_tracking::reassign_to(home, &id, Some(new_owner));
+            }
+            AssigneePatch::Clear => {
+                let _ = crate::daemon::dispatch_idle::reassign_pending_for_task(home, &id, None);
+                let _ = crate::daemon::ci_watch::reassign_next_after_ci(home, &id, None);
+                crate::dispatch_tracking::reassign_to(home, &id, None);
+            }
+            AssigneePatch::Unchanged => {}
         }
     }
     // #807 Item 1: see create arm note.

--- a/src/tasks/handler/tests.rs
+++ b/src/tasks/handler/tests.rs
@@ -2780,3 +2780,196 @@ fn p0_ack_plan_corrupt_vector_containing_caller_rejects() {
     );
     std::fs::remove_dir_all(&home).ok();
 }
+
+// ---------------------------------------------------------------------------
+// Architecture-14 item 4: typed AssigneePatch RED tests (real-entry via handle)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn create_missing_assignee_is_unassigned() {
+    let home = tmp_home("ap-t1");
+    let r = handle(
+        &home,
+        "op",
+        &serde_json::json!({"action": "create", "title": "t1"}),
+    );
+    assert!(r.get("error").is_none(), "create must succeed: {r}");
+    let id = r["id"].as_str().expect("id");
+    let tasks = crate::tasks::list_all(&home);
+    let task = tasks.iter().find(|t| t.id == id).expect("task");
+    assert!(task.assignee.is_none(), "missing assignee → None");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn create_blank_assignee_is_unassigned() {
+    let home = tmp_home("ap-t2");
+    let r = handle(
+        &home,
+        "op",
+        &serde_json::json!({"action": "create", "title": "t2", "assignee": ""}),
+    );
+    assert!(r.get("error").is_none(), "create must succeed: {r}");
+    let id = r["id"].as_str().expect("id");
+    let tasks = crate::tasks::list_all(&home);
+    let task = tasks.iter().find(|t| t.id == id).expect("task");
+    assert!(
+        task.assignee.is_none(),
+        "blank assignee must be None, not Some('')"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn create_set_assignee_trims_whitespace() {
+    let home = tmp_home("ap-t3");
+    let r = handle(
+        &home,
+        "op",
+        &serde_json::json!({"action": "create", "title": "t3", "assignee": " agent "}),
+    );
+    assert!(r.get("error").is_none(), "create must succeed: {r}");
+    let id = r["id"].as_str().expect("id");
+    let tasks = crate::tasks::list_all(&home);
+    let task = tasks.iter().find(|t| t.id == id).expect("task");
+    assert_eq!(
+        task.assignee.as_deref(),
+        Some("agent"),
+        "must trim whitespace"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn create_non_string_assignee_errors() {
+    let home = tmp_home("ap-t4");
+    let r = handle(
+        &home,
+        "op",
+        &serde_json::json!({"action": "create", "title": "t4", "assignee": 42}),
+    );
+    assert!(
+        r.get("error").is_some(),
+        "non-string assignee must error: {r}"
+    );
+    assert!(
+        r["code"].as_str() == Some("invalid_assignee")
+            || r["error"]
+                .as_str()
+                .is_some_and(|s| s.contains("invalid_assignee")),
+        "error must identify invalid_assignee: {r}"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn update_missing_assignee_unchanged() {
+    let home = tmp_home("ap-t5");
+    let r = handle(
+        &home,
+        "op",
+        &serde_json::json!({"action": "create", "title": "t5", "assignee": "dev-agent"}),
+    );
+    let id = r["id"].as_str().expect("id");
+    let r = handle(
+        &home,
+        "op",
+        &serde_json::json!({"action": "update", "id": id, "title": "updated"}),
+    );
+    assert!(r.get("error").is_none(), "update must succeed: {r}");
+    let tasks = crate::tasks::list_all(&home);
+    let task = tasks.iter().find(|t| t.id == id).expect("task");
+    assert_eq!(
+        task.assignee.as_deref(),
+        Some("dev-agent"),
+        "assignee must be unchanged"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn update_blank_assignee_clears() {
+    let home = tmp_home("ap-t6");
+    let r = handle(
+        &home,
+        "op",
+        &serde_json::json!({"action": "create", "title": "t6", "assignee": "dev-agent"}),
+    );
+    let id = r["id"].as_str().expect("id");
+    let _ = handle(
+        &home,
+        "dev-agent",
+        &serde_json::json!({"action": "claim", "id": id}),
+    );
+    let r = handle(
+        &home,
+        "op",
+        &serde_json::json!({"action": "update", "id": id, "assignee": ""}),
+    );
+    assert!(r.get("error").is_none(), "update clear must succeed: {r}");
+    let tasks = crate::tasks::list_all(&home);
+    let task = tasks.iter().find(|t| t.id == id).expect("task");
+    assert!(
+        task.assignee.is_none(),
+        "blank assignee update must clear to None"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn update_set_assignee_trims() {
+    let home = tmp_home("ap-t7");
+    let r = handle(
+        &home,
+        "op",
+        &serde_json::json!({"action": "create", "title": "t7", "assignee": "old"}),
+    );
+    let id = r["id"].as_str().expect("id");
+    let _ = handle(
+        &home,
+        "old",
+        &serde_json::json!({"action": "claim", "id": id}),
+    );
+    let r = handle(
+        &home,
+        "op",
+        &serde_json::json!({"action": "update", "id": id, "assignee": " new "}),
+    );
+    assert!(r.get("error").is_none(), "update must succeed: {r}");
+    let tasks = crate::tasks::list_all(&home);
+    let task = tasks.iter().find(|t| t.id == id).expect("task");
+    assert_eq!(
+        task.assignee.as_deref(),
+        Some("new"),
+        "must trim whitespace"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn update_non_string_assignee_errors() {
+    let home = tmp_home("ap-t8");
+    let r = handle(
+        &home,
+        "op",
+        &serde_json::json!({"action": "create", "title": "t8", "assignee": "dev-agent"}),
+    );
+    let id = r["id"].as_str().expect("id");
+    let r = handle(
+        &home,
+        "op",
+        &serde_json::json!({"action": "update", "id": id, "assignee": true}),
+    );
+    assert!(
+        r.get("error").is_some(),
+        "non-string assignee must error: {r}"
+    );
+    let tasks = crate::tasks::list_all(&home);
+    let task = tasks.iter().find(|t| t.id == id).expect("task");
+    assert_eq!(
+        task.assignee.as_deref(),
+        Some("dev-agent"),
+        "assignee must be unchanged on error"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}

--- a/src/tasks/handler/tests.rs
+++ b/src/tasks/handler/tests.rs
@@ -2990,7 +2990,8 @@ fn update_clear_settles_three_sidecars() {
         "dev-agent",
         &serde_json::json!({"action": "claim", "id": id}),
     );
-    // Seed a dispatch-idle pending entry via record_dispatch.
+    // Seed all three sidecars.
+    // 1. dispatch-idle
     crate::daemon::dispatch_idle::record_dispatch(
         &home,
         "lead",
@@ -3003,6 +3004,37 @@ fn update_clear_settles_three_sidecars() {
         crate::daemon::dispatch_idle::has_pending_for_instance(&home, "dev-agent"),
         "precondition: dispatch-idle sidecar exists"
     );
+    // 2. ci-watch with task_id + next_after_ci
+    let ci_dir = crate::daemon::ci_watch::ci_watches_dir(&home);
+    std::fs::create_dir_all(&ci_dir).ok();
+    let watch_fname = crate::daemon::ci_watch::watch_filename("owner/repo", "feat/t9");
+    std::fs::write(
+        ci_dir.join(&watch_fname),
+        serde_json::to_string_pretty(&serde_json::json!({
+            "repo": "owner/repo", "branch": "feat/t9", "interval_secs": 60,
+            "task_id": id, "next_after_ci": ["dev-agent"],
+            "subscribers": [{"instance": "lead"}],
+        }))
+        .expect("json"),
+    )
+    .expect("write watch");
+    // 3. dispatch-tracking
+    crate::dispatch_tracking::track_dispatch(
+        &home,
+        crate::dispatch_tracking::DispatchEntry {
+            task_id: Some(id.to_string()),
+            from: "lead".to_string(),
+            to: "dev-agent".to_string(),
+            from_id: None,
+            to_id: None,
+            delegated_at: chrono::Utc::now().to_rfc3339(),
+            status: "pending".to_string(),
+        },
+    );
+    assert!(
+        crate::dispatch_tracking::active_target_names(&home).contains(&"dev-agent".to_string()),
+        "precondition: dispatch-tracking sidecar exists"
+    );
     // Clear assignee.
     let r = handle(
         &home,
@@ -3010,10 +3042,25 @@ fn update_clear_settles_three_sidecars() {
         &serde_json::json!({"action": "update", "id": id, "assignee": ""}),
     );
     assert!(r.get("error").is_none(), "clear must succeed: {r}");
-    // After commit, sidecars cleared.
+    // After commit, all three sidecars cleared.
     assert!(
         !crate::daemon::dispatch_idle::has_pending_for_instance(&home, "dev-agent"),
-        "dispatch-idle sidecar must be cleared after assignee clear"
+        "dispatch-idle sidecar must be cleared"
+    );
+    // ci-watch: next_after_ci must be reassigned to None
+    let watch_content = std::fs::read_to_string(ci_dir.join(&watch_fname)).unwrap_or_default();
+    let watch: serde_json::Value = serde_json::from_str(&watch_content).unwrap_or_default();
+    assert!(
+        watch.get("next_after_ci").is_none()
+            || watch["next_after_ci"]
+                .as_array()
+                .is_some_and(|a| a.is_empty()),
+        "ci-watch next_after_ci must be cleared: {watch}"
+    );
+    // dispatch-tracking: dev-agent no longer active target
+    assert!(
+        !crate::dispatch_tracking::active_target_names(&home).contains(&"dev-agent".to_string()),
+        "dispatch-tracking must clear dev-agent"
     );
     std::fs::remove_dir_all(&home).ok();
 }
@@ -3052,6 +3099,22 @@ fn combined_status_done_and_clear_attributes_to_old_owner() {
         "status must be done"
     );
     assert!(task.assignee.is_none(), "assignee must be cleared");
+    // Inspect persisted envelopes: Done event must be attributed to the
+    // pre-commit owner (dev-agent), not the post-clear None.
+    let envelopes = crate::task_events::envelopes_for_task_at(&home, id).expect("envelopes");
+    let done_event = envelopes
+        .iter()
+        .find(|e| matches!(&e.event, crate::task_events::TaskEvent::Done { .. }))
+        .expect("Done event must exist");
+    match &done_event.event {
+        crate::task_events::TaskEvent::Done { by, .. } => {
+            assert_eq!(
+                by.0, "dev-agent",
+                "Done.by must be the pre-commit owner, not cleared"
+            );
+        }
+        _ => panic!("expected Done"),
+    }
     std::fs::remove_dir_all(&home).ok();
 }
 

--- a/src/tasks/handler/tests.rs
+++ b/src/tasks/handler/tests.rs
@@ -2973,3 +2973,137 @@ fn update_non_string_assignee_errors() {
     );
     std::fs::remove_dir_all(&home).ok();
 }
+
+/// T9: Clear settles all three sidecars (dispatch-idle, next_after_ci,
+/// dispatch-tracking) with None after commit.
+#[test]
+fn update_clear_settles_three_sidecars() {
+    let home = tmp_home("ap-t9");
+    let r = handle(
+        &home,
+        "dev-agent",
+        &serde_json::json!({"action": "create", "title": "t9", "assignee": "dev-agent"}),
+    );
+    let id = r["id"].as_str().expect("id");
+    let _ = handle(
+        &home,
+        "dev-agent",
+        &serde_json::json!({"action": "claim", "id": id}),
+    );
+    // Seed a dispatch-idle pending entry via record_dispatch.
+    crate::daemon::dispatch_idle::record_dispatch(
+        &home,
+        "lead",
+        "dev-agent",
+        Some(id),
+        "task",
+        600,
+    );
+    assert!(
+        crate::daemon::dispatch_idle::has_pending_for_instance(&home, "dev-agent"),
+        "precondition: dispatch-idle sidecar exists"
+    );
+    // Clear assignee.
+    let r = handle(
+        &home,
+        "dev-agent",
+        &serde_json::json!({"action": "update", "id": id, "assignee": ""}),
+    );
+    assert!(r.get("error").is_none(), "clear must succeed: {r}");
+    // After commit, sidecars cleared.
+    assert!(
+        !crate::daemon::dispatch_idle::has_pending_for_instance(&home, "dev-agent"),
+        "dispatch-idle sidecar must be cleared after assignee clear"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// T10: Combined status=done + assignee="" attributes done event to the
+/// pre-commit owner and clears sidecars post-commit.
+#[test]
+fn combined_status_done_and_clear_attributes_to_old_owner() {
+    let home = tmp_home("ap-t10");
+    let r = handle(
+        &home,
+        "dev-agent",
+        &serde_json::json!({"action": "create", "title": "t10", "assignee": "dev-agent"}),
+    );
+    let id = r["id"].as_str().expect("id");
+    let _ = handle(
+        &home,
+        "dev-agent",
+        &serde_json::json!({"action": "claim", "id": id}),
+    );
+    // Combined: status=done + clear assignee in one update.
+    let r = handle(
+        &home,
+        "dev-agent",
+        &serde_json::json!({"action": "update", "id": id, "status": "done", "assignee": "", "result": "completed"}),
+    );
+    assert!(
+        r.get("error").is_none(),
+        "combined update must succeed: {r}"
+    );
+    let tasks = crate::tasks::list_all(&home);
+    let task = tasks.iter().find(|t| t.id == id).expect("task");
+    assert_eq!(
+        task.status,
+        crate::task_events::TaskStatus::Done,
+        "status must be done"
+    );
+    assert!(task.assignee.is_none(), "assignee must be cleared");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// T11: ACL failure produces no sidecar mutation.
+#[test]
+fn update_acl_failure_no_sidecar_mutation() {
+    let home = tmp_home("ap-t11");
+    let r = handle(
+        &home,
+        "dev-agent",
+        &serde_json::json!({"action": "create", "title": "t11", "assignee": "dev-agent"}),
+    );
+    let id = r["id"].as_str().expect("id");
+    let _ = handle(
+        &home,
+        "dev-agent",
+        &serde_json::json!({"action": "claim", "id": id}),
+    );
+    // Seed sidecar for dev-agent via record_dispatch.
+    crate::daemon::dispatch_idle::record_dispatch(
+        &home,
+        "lead",
+        "dev-agent",
+        Some(id),
+        "task",
+        600,
+    );
+    assert!(
+        crate::daemon::dispatch_idle::has_pending_for_instance(&home, "dev-agent"),
+        "precondition"
+    );
+    // Unauthorized caller tries to clear assignee.
+    let r = handle(
+        &home,
+        "intruder",
+        &serde_json::json!({"action": "update", "id": id, "assignee": ""}),
+    );
+    assert!(
+        r.get("error").is_some(),
+        "unauthorized update must fail: {r}"
+    );
+    // Sidecar must be unchanged.
+    assert!(
+        crate::daemon::dispatch_idle::has_pending_for_instance(&home, "dev-agent"),
+        "dispatch-idle sidecar must survive ACL failure"
+    );
+    let tasks = crate::tasks::list_all(&home);
+    let task = tasks.iter().find(|t| t.id == id).expect("task");
+    assert_eq!(
+        task.assignee.as_deref(),
+        Some("dev-agent"),
+        "assignee unchanged after ACL failure"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}

--- a/src/tasks/handler/tests.rs
+++ b/src/tasks/handler/tests.rs
@@ -2867,14 +2867,14 @@ fn update_missing_assignee_unchanged() {
     let home = tmp_home("ap-t5");
     let r = handle(
         &home,
-        "op",
+        "dev-agent",
         &serde_json::json!({"action": "create", "title": "t5", "assignee": "dev-agent"}),
     );
     let id = r["id"].as_str().expect("id");
     let r = handle(
         &home,
-        "op",
-        &serde_json::json!({"action": "update", "id": id, "title": "updated"}),
+        "dev-agent",
+        &serde_json::json!({"action": "update", "id": id, "description": "updated"}),
     );
     assert!(r.get("error").is_none(), "update must succeed: {r}");
     let tasks = crate::tasks::list_all(&home);
@@ -2892,7 +2892,7 @@ fn update_blank_assignee_clears() {
     let home = tmp_home("ap-t6");
     let r = handle(
         &home,
-        "op",
+        "dev-agent",
         &serde_json::json!({"action": "create", "title": "t6", "assignee": "dev-agent"}),
     );
     let id = r["id"].as_str().expect("id");
@@ -2903,7 +2903,7 @@ fn update_blank_assignee_clears() {
     );
     let r = handle(
         &home,
-        "op",
+        "dev-agent",
         &serde_json::json!({"action": "update", "id": id, "assignee": ""}),
     );
     assert!(r.get("error").is_none(), "update clear must succeed: {r}");
@@ -2921,7 +2921,7 @@ fn update_set_assignee_trims() {
     let home = tmp_home("ap-t7");
     let r = handle(
         &home,
-        "op",
+        "old",
         &serde_json::json!({"action": "create", "title": "t7", "assignee": "old"}),
     );
     let id = r["id"].as_str().expect("id");
@@ -2932,7 +2932,7 @@ fn update_set_assignee_trims() {
     );
     let r = handle(
         &home,
-        "op",
+        "old",
         &serde_json::json!({"action": "update", "id": id, "assignee": " new "}),
     );
     assert!(r.get("error").is_none(), "update must succeed: {r}");


### PR DESCRIPTION
## Summary

Architecture-14 item 4: parse assignee once into typed `AssigneePatch` {Unchanged, Clear, Set(trimmed)} before team routing or event construction.

- **Create**: missing/null/blank → unassigned; non-string → `invalid_assignee` error; Set → trimmed
- **Update**: missing/null → Unchanged; blank/whitespace → Clear (`OwnerAssigned{None}`); non-string → error; Set → trimmed
- **Clear** commits `OwnerAssigned{owner:None, routed_to:None}` in same batch, settles 3 sidecars post-commit only
- **Combined status+clear**: both events built from pre-commit snapshot (correct attribution by construction)

## Tests (8 real-entry through `tasks::handle`)
- T1-T4: create matrix (missing/blank/trim/non-string)
- T5-T8: update matrix (unchanged/clear/trim/non-string-error)

71 handler tests pass. `-D warnings` + clippy + fmt clean.

## Test plan
- [ ] CI green
- [ ] Verify blank assignee on existing fleet tasks clears correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)