### PR TITLE
feat(repo-release): delegate managed worktree to canonical guarded release

### DIFF
--- a/src/daemon/janitor.rs
+++ b/src/daemon/janitor.rs
@@ -96,7 +96,7 @@ pub(crate) fn dispose_release_exact(
     expected: &crate::binding::BindingFingerprint,
 ) -> DispositionOutcome {
     DispositionOutcome::Released(crate::worktree_pool::release_full_exact(
-        home, agent, expected,
+        home, agent, expected, None,
     ))
 }
 

--- a/src/daemon/janitor.rs
+++ b/src/daemon/janitor.rs
@@ -96,7 +96,7 @@ pub(crate) fn dispose_release_exact(
     expected: &crate::binding::BindingFingerprint,
 ) -> DispositionOutcome {
     DispositionOutcome::Released(crate::worktree_pool::release_full_exact(
-        home, agent, expected,
+        home, agent, expected, false,
     ))
 }
 

--- a/src/daemon/janitor.rs
+++ b/src/daemon/janitor.rs
@@ -96,7 +96,7 @@ pub(crate) fn dispose_release_exact(
     expected: &crate::binding::BindingFingerprint,
 ) -> DispositionOutcome {
     DispositionOutcome::Released(crate::worktree_pool::release_full_exact(
-        home, agent, expected, None,
+        home, agent, expected,
     ))
 }
 

--- a/src/mcp/handlers/ci/release.rs
+++ b/src/mcp/handlers/ci/release.rs
@@ -27,8 +27,6 @@ fn delegate_managed_release(home: &Path, canonical: &Path, caller: &str) -> Valu
     let fingerprint = match crate::binding::snapshot_guarded_binding(home, &marker_agent) {
         Ok(crate::binding::GuardedBinding::Known { value, fingerprint }) => {
             let bound_wt = value["worktree"].as_str().unwrap_or("");
-            let bound_branch = value["branch"].as_str().unwrap_or("");
-            let bound_source = value["source_repo"].as_str().unwrap_or("");
             if bound_wt != canonical.to_str().unwrap_or("") {
                 return json!({
                     "error": format!(
@@ -37,24 +35,6 @@ fn delegate_managed_release(home: &Path, canonical: &Path, caller: &str) -> Valu
                         marker_agent, bound_wt, canonical.display()
                     ),
                     "code": "managed_release_path_mismatch",
-                });
-            }
-            if !marker_branch.is_empty() && bound_branch != marker_branch {
-                return json!({
-                    "error": format!(
-                        "marker branch '{}' does not match binding branch '{}' — refusing",
-                        marker_branch, bound_branch
-                    ),
-                    "code": "managed_release_branch_mismatch",
-                });
-            }
-            if !marker_repo.is_empty() && !bound_source.is_empty() && bound_source != marker_repo {
-                return json!({
-                    "error": format!(
-                        "marker source_repo '{}' does not match binding source_repo '{}' — refusing",
-                        marker_repo, bound_source
-                    ),
-                    "code": "managed_release_source_mismatch",
                 });
             }
             fingerprint
@@ -87,7 +67,16 @@ fn delegate_managed_release(home: &Path, canonical: &Path, caller: &str) -> Valu
             "code": "managed_release_unauthorized",
         });
     }
-    let outcome = crate::worktree_pool::release_full_exact(home, &marker_agent, &fingerprint);
+    let marker_id = crate::worktree_pool::MarkerIdentity {
+        branch: marker_branch,
+        source_repo: marker_repo,
+    };
+    let outcome = crate::worktree_pool::release_full_exact(
+        home,
+        &marker_agent,
+        &fingerprint,
+        Some(&marker_id),
+    );
     json!({
         "path": canonical.display().to_string(),
         "delegated_to_canonical": true,

--- a/src/mcp/handlers/ci/release.rs
+++ b/src/mcp/handlers/ci/release.rs
@@ -67,7 +67,7 @@ fn delegate_managed_release(home: &Path, canonical: &Path, caller: &str) -> Valu
             "code": "managed_release_unauthorized",
         });
     }
-    let outcome = crate::worktree_pool::release_full_exact(home, &marker_agent, &fingerprint);
+    let outcome = crate::worktree_pool::release_full_exact(home, &marker_agent, &fingerprint, true);
     json!({
         "path": canonical.display().to_string(),
         "delegated_to_canonical": true,

--- a/src/mcp/handlers/ci/release.rs
+++ b/src/mcp/handlers/ci/release.rs
@@ -1,4 +1,83 @@
 use serde_json::{json, Value};
+use std::path::Path;
+
+fn parse_managed_marker(wt: &Path) -> Option<(String, String, String)> {
+    let content = std::fs::read_to_string(wt.join(crate::worktree_pool::MANAGED_MARKER)).ok()?;
+    let get = |prefix: &str| {
+        content
+            .lines()
+            .find_map(|l| l.strip_prefix(prefix))
+            .map(|s| s.trim().to_string())
+            .unwrap_or_default()
+    };
+    let agent = get("agent=");
+    if agent.is_empty() {
+        return None;
+    }
+    Some((agent, get("branch="), get("source_repo=")))
+}
+
+fn delegate_managed_release(home: &Path, canonical: &Path, caller: &str) -> Value {
+    let Some((marker_agent, _marker_branch, _marker_repo)) = parse_managed_marker(canonical) else {
+        return json!({
+            "error": "managed worktree marker unreadable or missing agent — refusing (fail-closed)",
+            "code": "managed_marker_invalid",
+        });
+    };
+    let fingerprint = match crate::binding::snapshot_guarded_binding(home, &marker_agent) {
+        Ok(crate::binding::GuardedBinding::Known { value, fingerprint }) => {
+            let bound_wt = value["worktree"].as_str().unwrap_or("");
+            if bound_wt != canonical.to_str().unwrap_or("") {
+                return json!({
+                    "error": format!(
+                        "managed marker claims agent '{}' but binding worktree '{}' \
+                         does not match requested path '{}' — refusing (stale marker)",
+                        marker_agent, bound_wt, canonical.display()
+                    ),
+                    "code": "managed_release_path_mismatch",
+                });
+            }
+            fingerprint
+        }
+        Ok(crate::binding::GuardedBinding::Absent) => {
+            return json!({
+                "error": format!(
+                    "managed marker claims agent '{}' but no binding exists — refusing",
+                    marker_agent
+                ),
+                "code": "managed_release_no_binding",
+            });
+        }
+        Ok(crate::binding::GuardedBinding::Opaque(reason)) | Err(reason) => {
+            return json!({
+                "error": format!("binding opaque for '{}': {reason} — refusing", marker_agent),
+                "code": "managed_release_opaque",
+            });
+        }
+    };
+    if !caller.is_empty()
+        && caller != marker_agent
+        && !crate::teams::is_orchestrator_of(home, caller, &marker_agent)
+    {
+        return json!({
+            "error": format!(
+                "caller '{}' not authorized to release agent '{}' worktree",
+                caller, marker_agent
+            ),
+            "code": "managed_release_unauthorized",
+        });
+    }
+    let outcome = crate::worktree_pool::release_full_exact(home, &marker_agent, &fingerprint);
+    json!({
+        "path": canonical.display().to_string(),
+        "delegated_to_canonical": true,
+        "released": outcome.released,
+        "worktree_removed": outcome.worktree_removed,
+        "binding_removed": outcome.binding_removed,
+        "branch_deleted": outcome.branch_deleted,
+        "error": outcome.error,
+    })
+}
 
 /// #t-…83936-6 P0 (data-loss incident): is `p` a TRUE linked git worktree — the
 /// ONLY shape `handle_release_repo`'s `remove_dir_all` fallback may delete?
@@ -106,17 +185,21 @@ pub(crate) fn validate_release_path(path_str: &str) -> Result<std::path::PathBuf
     Ok(canonical)
 }
 
-pub(crate) fn handle_release_repo(args: &Value) -> Value {
+pub(crate) fn handle_release_repo(home: &Path, args: &Value, instance_name: &str) -> Value {
     let path = match args["path"].as_str() {
         Some(p) => p,
         None => return json!({"error": "missing 'path'"}),
     };
 
-    // H3 fix: validate + canonicalize path before any filesystem ops.
     let canonical = match validate_release_path(path) {
         Ok(p) => p,
         Err(e) => return json!({"error": e}),
     };
+
+    if crate::worktree_pool::is_daemon_managed(&canonical) {
+        return delegate_managed_release(home, &canonical, instance_name);
+    }
+
     let path_str = canonical.to_string_lossy();
 
     // Derive source repo from worktree .git link before any removal —

--- a/src/mcp/handlers/ci/release.rs
+++ b/src/mcp/handlers/ci/release.rs
@@ -18,7 +18,7 @@ fn parse_managed_marker(wt: &Path) -> Option<(String, String, String)> {
 }
 
 fn delegate_managed_release(home: &Path, canonical: &Path, caller: &str) -> Value {
-    let Some((marker_agent, _marker_branch, _marker_repo)) = parse_managed_marker(canonical) else {
+    let Some((marker_agent, marker_branch, marker_repo)) = parse_managed_marker(canonical) else {
         return json!({
             "error": "managed worktree marker unreadable or missing agent — refusing (fail-closed)",
             "code": "managed_marker_invalid",
@@ -27,6 +27,8 @@ fn delegate_managed_release(home: &Path, canonical: &Path, caller: &str) -> Valu
     let fingerprint = match crate::binding::snapshot_guarded_binding(home, &marker_agent) {
         Ok(crate::binding::GuardedBinding::Known { value, fingerprint }) => {
             let bound_wt = value["worktree"].as_str().unwrap_or("");
+            let bound_branch = value["branch"].as_str().unwrap_or("");
+            let bound_source = value["source_repo"].as_str().unwrap_or("");
             if bound_wt != canonical.to_str().unwrap_or("") {
                 return json!({
                     "error": format!(
@@ -35,6 +37,24 @@ fn delegate_managed_release(home: &Path, canonical: &Path, caller: &str) -> Valu
                         marker_agent, bound_wt, canonical.display()
                     ),
                     "code": "managed_release_path_mismatch",
+                });
+            }
+            if !marker_branch.is_empty() && bound_branch != marker_branch {
+                return json!({
+                    "error": format!(
+                        "marker branch '{}' does not match binding branch '{}' — refusing",
+                        marker_branch, bound_branch
+                    ),
+                    "code": "managed_release_branch_mismatch",
+                });
+            }
+            if !marker_repo.is_empty() && !bound_source.is_empty() && bound_source != marker_repo {
+                return json!({
+                    "error": format!(
+                        "marker source_repo '{}' does not match binding source_repo '{}' — refusing",
+                        marker_repo, bound_source
+                    ),
+                    "code": "managed_release_source_mismatch",
                 });
             }
             fingerprint

--- a/src/mcp/handlers/ci/release.rs
+++ b/src/mcp/handlers/ci/release.rs
@@ -18,7 +18,7 @@ fn parse_managed_marker(wt: &Path) -> Option<(String, String, String)> {
 }
 
 fn delegate_managed_release(home: &Path, canonical: &Path, caller: &str) -> Value {
-    let Some((marker_agent, marker_branch, marker_repo)) = parse_managed_marker(canonical) else {
+    let Some((marker_agent, _, _)) = parse_managed_marker(canonical) else {
         return json!({
             "error": "managed worktree marker unreadable or missing agent — refusing (fail-closed)",
             "code": "managed_marker_invalid",
@@ -67,16 +67,7 @@ fn delegate_managed_release(home: &Path, canonical: &Path, caller: &str) -> Valu
             "code": "managed_release_unauthorized",
         });
     }
-    let marker_id = crate::worktree_pool::MarkerIdentity {
-        branch: marker_branch,
-        source_repo: marker_repo,
-    };
-    let outcome = crate::worktree_pool::release_full_exact(
-        home,
-        &marker_agent,
-        &fingerprint,
-        Some(&marker_id),
-    );
+    let outcome = crate::worktree_pool::release_full_exact(home, &marker_agent, &fingerprint);
     json!({
         "path": canonical.display().to_string(),
         "delegated_to_canonical": true,

--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -2,7 +2,11 @@ use super::*;
 
 #[test]
 fn release_repo_rejects_root_path() {
-    let result = handle_release_repo(&serde_json::json!({"path": "/"}));
+    let result = handle_release_repo(
+        std::path::Path::new("/tmp"),
+        &serde_json::json!({"path": "/"}),
+        "",
+    );
     assert!(result["error"].as_str().is_some(), "root must be rejected");
 }
 
@@ -14,7 +18,11 @@ fn release_repo_rejects_system_path() {
 
 #[test]
 fn release_repo_rejects_empty_path() {
-    let result = handle_release_repo(&serde_json::json!({"path": ""}));
+    let result = handle_release_repo(
+        std::path::Path::new("/tmp"),
+        &serde_json::json!({"path": ""}),
+        "",
+    );
     assert!(result["error"].as_str().is_some(), "empty must be rejected");
 }
 
@@ -146,7 +154,11 @@ fn handle_release_repo_never_deletes_bare_repo_83936() {
     assert!(bare.join("HEAD").exists(), "a bare repo must have HEAD");
     assert!(!bare.join(".git").exists(), "a bare repo has NO .git child");
 
-    let _ = handle_release_repo(&serde_json::json!({"path": bare.to_str().unwrap()}));
+    let _ = handle_release_repo(
+        std::path::Path::new("/tmp"),
+        &serde_json::json!({"path": bare.to_str().unwrap()}),
+        "",
+    );
 
     assert!(
         bare.exists() && bare.join("HEAD").exists(),
@@ -181,7 +193,11 @@ fn handle_release_repo_never_deletes_separate_git_dir_main_83936() {
     let keep = worktree.join("KEEP.txt");
     std::fs::write(&keep, "main content").unwrap();
 
-    let _ = handle_release_repo(&serde_json::json!({"path": worktree.to_str().unwrap()}));
+    let _ = handle_release_repo(
+        std::path::Path::new("/tmp"),
+        &serde_json::json!({"path": worktree.to_str().unwrap()}),
+        "",
+    );
 
     assert!(
         worktree.exists() && keep.exists(),
@@ -200,7 +216,11 @@ fn handle_release_repo_refuses_non_repo_dir_83936() {
     std::fs::create_dir_all(&dir).ok();
     std::fs::write(dir.join("file.txt"), "data").unwrap();
 
-    let _ = handle_release_repo(&serde_json::json!({"path": dir.to_str().unwrap()}));
+    let _ = handle_release_repo(
+        std::path::Path::new("/tmp"),
+        &serde_json::json!({"path": dir.to_str().unwrap()}),
+        "",
+    );
 
     assert!(
         dir.exists(),
@@ -220,7 +240,11 @@ fn handle_release_repo_never_deletes_main_repo_83936() {
     let keep = repo.join("KEEP.txt");
     std::fs::write(&keep, "canonical content").unwrap();
 
-    let _ = handle_release_repo(&serde_json::json!({"path": repo.to_str().unwrap()}));
+    let _ = handle_release_repo(
+        std::path::Path::new("/tmp"),
+        &serde_json::json!({"path": repo.to_str().unwrap()}),
+        "",
+    );
 
     assert!(
         repo.exists(),
@@ -260,7 +284,11 @@ fn handle_release_repo_still_removes_linked_worktree_83936() {
         super::validate_release_path(wt.to_str().unwrap()).is_ok(),
         "a linked worktree must validate OK"
     );
-    let _ = handle_release_repo(&serde_json::json!({"path": wt.to_str().unwrap()}));
+    let _ = handle_release_repo(
+        std::path::Path::new("/tmp"),
+        &serde_json::json!({"path": wt.to_str().unwrap()}),
+        "",
+    );
     assert!(
         !wt.exists(),
         "a linked worktree must still be releasable/removed"
@@ -3108,8 +3136,21 @@ fn seed_managed_marker(
     crate::binding::bind_full(home, agent, "", branch, wt, repo, false).expect("bind");
 }
 
-fn dispatch_repo_release(_home: &std::path::Path, _caller: &str, path: &str) -> serde_json::Value {
-    handle_release_repo(&serde_json::json!({"path": path}))
+fn dispatch_repo_release(home: &std::path::Path, caller: &str, path: &str) -> serde_json::Value {
+    let args = serde_json::json!({"action": "release", "path": path});
+    let sender: Option<crate::identity::Sender> = if caller.is_empty() {
+        None
+    } else {
+        crate::identity::Sender::new(caller)
+    };
+    let ctx = crate::mcp::handlers::dispatch::HandlerCtx {
+        home,
+        args: &args,
+        instance_name: sender.as_ref().map_or("", |s| s.as_str()),
+        sender: &sender,
+        runtime: None,
+    };
+    crate::mcp::handlers::dispatch::dispatch_repo(&ctx)
 }
 
 /// RED A1: managed worktree release must clear binding.

--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -3444,3 +3444,73 @@ fn repo_release_marker_rewritten_after_snapshot_refuses() {
     );
     std::fs::remove_dir_all(&base).ok();
 }
+
+/// Marker DELETED after pre-read — under-lock re-read must refuse.
+#[test]
+#[cfg(unix)]
+fn repo_release_marker_deleted_after_snapshot_refuses() {
+    use crate::worktree_pool::{release_test_seam, ReleaseTestPhase};
+
+    let (base, home, repo, wt) = managed_wt_fixture("del");
+    seed_managed_marker(&wt, &repo, &home, "agent-del", "feat/test");
+
+    let wt_clone = wt.clone();
+    let _guard = release_test_seam::install(move |phase| {
+        if phase == ReleaseTestPhase::AfterBindingSnapshot {
+            let _ = std::fs::remove_file(wt_clone.join(".agend-managed"));
+        }
+    });
+
+    let r = dispatch_repo_release(&home, "agent-del", wt.to_str().unwrap());
+
+    assert!(
+        r.get("error").is_some(),
+        "marker deleted after snapshot must be caught under lock: {r}"
+    );
+    assert!(
+        wt.exists(),
+        "worktree must be preserved when marker is deleted"
+    );
+    assert!(
+        crate::binding::read(&home, "agent-del").is_some(),
+        "binding must be preserved when marker is deleted"
+    );
+    std::fs::remove_dir_all(&base).ok();
+}
+
+/// Marker rewritten with BLANK branch/source after pre-read — must refuse.
+#[test]
+#[cfg(unix)]
+fn repo_release_marker_blanked_after_snapshot_refuses() {
+    use crate::worktree_pool::{release_test_seam, ReleaseTestPhase};
+
+    let (base, home, repo, wt) = managed_wt_fixture("blank");
+    seed_managed_marker(&wt, &repo, &home, "agent-blank", "feat/test");
+
+    let wt_clone = wt.clone();
+    let _guard = release_test_seam::install(move |phase| {
+        if phase == ReleaseTestPhase::AfterBindingSnapshot {
+            std::fs::write(
+                wt_clone.join(".agend-managed"),
+                "agent=agent-blank\nbranch=\nsource_repo=\n",
+            )
+            .expect("blank marker in seam");
+        }
+    });
+
+    let r = dispatch_repo_release(&home, "agent-blank", wt.to_str().unwrap());
+
+    assert!(
+        r.get("error").is_some(),
+        "blanked marker after snapshot must be caught under lock: {r}"
+    );
+    assert!(
+        wt.exists(),
+        "worktree must be preserved when marker is blanked"
+    );
+    assert!(
+        crate::binding::read(&home, "agent-blank").is_some(),
+        "binding must be preserved when marker is blanked"
+    );
+    std::fs::remove_dir_all(&base).ok();
+}

--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -3070,6 +3070,7 @@ fn rewatch_clears_tombstone_optout_1991() {
 // Arch-14 item 10: repo release canonical delegation (real dispatch entry)
 // ---------------------------------------------------------------------------
 
+#[cfg(unix)]
 fn managed_wt_fixture(
     tag: &str,
 ) -> (
@@ -3094,6 +3095,7 @@ fn managed_wt_fixture(
     (base, home, repo, wt)
 }
 
+#[cfg(unix)]
 fn git_init(repo: &std::path::Path) {
     std::process::Command::new("git")
         .args(["init", "-b", "main"])
@@ -3118,6 +3120,7 @@ fn git_init(repo: &std::path::Path) {
         .ok();
 }
 
+#[cfg(unix)]
 fn seed_managed_marker(
     wt: &std::path::Path,
     repo: &std::path::Path,
@@ -3136,6 +3139,7 @@ fn seed_managed_marker(
     crate::binding::bind_full(home, agent, "", branch, wt, repo, false).expect("bind");
 }
 
+#[cfg(unix)]
 fn dispatch_repo_release(home: &std::path::Path, caller: &str, path: &str) -> serde_json::Value {
     let args = serde_json::json!({"action": "release", "path": path});
     let sender: Option<crate::identity::Sender> = if caller.is_empty() {

--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -3037,3 +3037,267 @@ fn rewatch_clears_tombstone_optout_1991() {
     );
     std::fs::remove_dir_all(&home).ok();
 }
+
+// ---------------------------------------------------------------------------
+// Arch-14 item 10: repo release canonical delegation (real dispatch entry)
+// ---------------------------------------------------------------------------
+
+fn managed_wt_fixture(
+    tag: &str,
+) -> (
+    std::path::PathBuf,
+    std::path::PathBuf,
+    std::path::PathBuf,
+    std::path::PathBuf,
+) {
+    let base = release_guard_tmp(tag);
+    let repo = base.join("source");
+    std::fs::create_dir_all(&repo).expect("mkdir");
+    git_init(&repo);
+    let wt = base.join("managed-wt");
+    std::process::Command::new("git")
+        .args(["worktree", "add", wt.to_str().unwrap(), "-b", "feat/test"])
+        .current_dir(&repo)
+        .env("AGEND_GIT_BYPASS", "1")
+        .output()
+        .ok();
+    let home = base.join("home");
+    std::fs::create_dir_all(&home).ok();
+    (base, home, repo, wt)
+}
+
+fn git_init(repo: &std::path::Path) {
+    std::process::Command::new("git")
+        .args(["init", "-b", "main"])
+        .current_dir(repo)
+        .env("AGEND_GIT_BYPASS", "1")
+        .output()
+        .ok();
+    std::process::Command::new("git")
+        .args([
+            "-c",
+            "user.name=t",
+            "-c",
+            "user.email=t@t",
+            "commit",
+            "--allow-empty",
+            "-m",
+            "init",
+        ])
+        .current_dir(repo)
+        .env("AGEND_GIT_BYPASS", "1")
+        .output()
+        .ok();
+}
+
+fn seed_managed_marker(
+    wt: &std::path::Path,
+    repo: &std::path::Path,
+    home: &std::path::Path,
+    agent: &str,
+    branch: &str,
+) {
+    std::fs::write(
+        wt.join(".agend-managed"),
+        format!(
+            "agent={agent}\nbranch={branch}\nsource_repo={}\n",
+            repo.display()
+        ),
+    )
+    .expect("write marker");
+    crate::binding::bind_full(home, agent, "", branch, wt, repo, false).expect("bind");
+}
+
+fn dispatch_repo_release(_home: &std::path::Path, _caller: &str, path: &str) -> serde_json::Value {
+    handle_release_repo(&serde_json::json!({"path": path}))
+}
+
+/// RED A1: managed worktree release must clear binding.
+#[test]
+#[cfg(unix)]
+fn repo_release_managed_clears_binding_via_dispatch() {
+    let (base, home, repo, wt) = managed_wt_fixture("a1");
+    seed_managed_marker(&wt, &repo, &home, "agent-a1", "feat/test");
+    assert!(
+        crate::binding::read(&home, "agent-a1").is_some(),
+        "precondition"
+    );
+    let _ = dispatch_repo_release(&home, "agent-a1", wt.to_str().unwrap());
+    assert!(
+        crate::binding::read(&home, "agent-a1").is_none(),
+        "managed release must clear binding (RED: currently orphaned)"
+    );
+    std::fs::remove_dir_all(&base).ok();
+}
+
+/// RED A3: corrupt marker must fail-closed — worktree preserved.
+#[test]
+#[cfg(unix)]
+fn repo_release_corrupt_marker_refuses_via_dispatch() {
+    let (base, home, _repo, wt) = managed_wt_fixture("a3");
+    std::fs::write(wt.join(".agend-managed"), "corrupt\n").expect("corrupt");
+    let _ = dispatch_repo_release(&home, "anyone", wt.to_str().unwrap());
+    assert!(
+        wt.exists(),
+        "corrupt-marker managed worktree must be preserved (RED)"
+    );
+    std::fs::remove_dir_all(&base).ok();
+}
+
+/// RED A5: stale marker naming agent-a while agent-a's binding is at
+/// different live path → refuse, preserve live binding.
+#[test]
+#[cfg(unix)]
+fn repo_release_stale_marker_preserves_live_binding() {
+    let (base, home, repo, stale_wt) = managed_wt_fixture("a5");
+    // Agent-a bound to a DIFFERENT live worktree.
+    let live_wt = base.join("live-wt");
+    std::process::Command::new("git")
+        .args([
+            "worktree",
+            "add",
+            live_wt.to_str().unwrap(),
+            "-b",
+            "feat/live",
+        ])
+        .current_dir(&repo)
+        .env("AGEND_GIT_BYPASS", "1")
+        .output()
+        .ok();
+    seed_managed_marker(&live_wt, &repo, &home, "agent-a", "feat/live");
+    // Stale worktree claims agent-a with full marker but binding points elsewhere.
+    std::fs::write(
+        stale_wt.join(".agend-managed"),
+        format!(
+            "agent=agent-a\nbranch=feat/test\nsource_repo={}\n",
+            repo.display()
+        ),
+    )
+    .expect("stale marker");
+
+    let r = dispatch_repo_release(&home, "agent-a", stale_wt.to_str().unwrap());
+
+    // Stale path must also be preserved (not deleted).
+    assert!(
+        stale_wt.exists(),
+        "stale managed worktree must be preserved when binding mismatches (RED)"
+    );
+    assert!(
+        r.get("error").is_some() || r.get("code").is_some(),
+        "stale-path mismatch must return error/code (RED): {r}"
+    );
+    assert!(live_wt.exists(), "live worktree must survive stale release");
+    let binding = crate::binding::read(&home, "agent-a");
+    assert!(binding.is_some(), "binding must survive");
+    assert_eq!(
+        binding.unwrap()["worktree"].as_str().unwrap_or(""),
+        live_wt.to_str().unwrap(),
+        "binding must still point to live worktree"
+    );
+    std::fs::remove_dir_all(&base).ok();
+}
+
+/// RED A2: dirty managed worktree → WIP preserved in recovery ref,
+/// binding + worktree still released.
+#[test]
+#[cfg(unix)]
+fn repo_release_dirty_managed_preserves_wip() {
+    let (base, home, repo, wt) = managed_wt_fixture("a2");
+    seed_managed_marker(&wt, &repo, &home, "agent-a2", "feat/test");
+    // Seed tracked file + dirty it.
+    std::fs::write(wt.join("tracked.txt"), "v1\n").expect("tracked");
+    std::process::Command::new("git")
+        .args(["add", "tracked.txt"])
+        .current_dir(&wt)
+        .env("AGEND_GIT_BYPASS", "1")
+        .output()
+        .ok();
+    std::process::Command::new("git")
+        .args([
+            "-c",
+            "user.name=t",
+            "-c",
+            "user.email=t@t",
+            "commit",
+            "-m",
+            "seed",
+        ])
+        .current_dir(&wt)
+        .env("AGEND_GIT_BYPASS", "1")
+        .output()
+        .ok();
+    std::fs::write(wt.join("tracked.txt"), "v1\nDIRTY\n").expect("dirty");
+
+    let _r = dispatch_repo_release(&home, "agent-a2", wt.to_str().unwrap());
+
+    // Binding must be cleared even for dirty release (WIP preserved first).
+    assert!(
+        crate::binding::read(&home, "agent-a2").is_none(),
+        "dirty managed release must clear binding (RED)"
+    );
+    // Recovery ref must contain the DIRTY content.
+    let refs = {
+        let out = std::process::Command::new("git")
+            .args([
+                "for-each-ref",
+                "--format=%(refname)",
+                "refs/agend/recovery/feat/test/",
+            ])
+            .current_dir(&repo)
+            .env("AGEND_GIT_BYPASS", "1")
+            .output()
+            .expect("git for-each-ref");
+        String::from_utf8_lossy(&out.stdout)
+            .lines()
+            .filter(|l| !l.is_empty())
+            .map(str::to_string)
+            .collect::<Vec<_>>()
+    };
+    assert!(
+        !refs.is_empty(),
+        "dirty managed release must create a recovery ref (RED)"
+    );
+    let show = std::process::Command::new("git")
+        .args(["show", &format!("{}:tracked.txt", refs[0])])
+        .current_dir(&repo)
+        .env("AGEND_GIT_BYPASS", "1")
+        .output()
+        .expect("git show");
+    assert!(
+        String::from_utf8_lossy(&show.stdout).contains("DIRTY"),
+        "recovery ref must contain the DIRTY modification (RED)"
+    );
+    std::fs::remove_dir_all(&base).ok();
+}
+
+/// RED A4: non-owner peer caller is refused; owner succeeds.
+#[test]
+#[cfg(unix)]
+fn repo_release_non_owner_refused_owner_succeeds() {
+    let (base, home, repo, wt) = managed_wt_fixture("a4");
+    seed_managed_marker(&wt, &repo, &home, "owner-agent", "feat/test");
+
+    // Peer caller (not owner) → must be refused.
+    let r = dispatch_repo_release(&home, "peer-agent", wt.to_str().unwrap());
+    assert!(
+        crate::binding::read(&home, "owner-agent").is_some(),
+        "binding must survive peer attempt (RED)"
+    );
+    assert!(
+        r.get("error").is_some(),
+        "non-owner peer must be refused (RED): {r}"
+    );
+    assert!(
+        wt.exists(),
+        "worktree must survive non-owner release attempt (RED)"
+    );
+
+    // Owner caller → must succeed.
+    let r = dispatch_repo_release(&home, "owner-agent", wt.to_str().unwrap());
+    assert!(
+        crate::binding::read(&home, "owner-agent").is_none(),
+        "owner release must clear binding (RED)"
+    );
+    let _ = r; // response structure TBD
+    std::fs::remove_dir_all(&base).ok();
+}

--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -3514,3 +3514,45 @@ fn repo_release_marker_blanked_after_snapshot_refuses() {
     );
     std::fs::remove_dir_all(&base).ok();
 }
+
+/// Both binding and marker share the same non-existent source_repo path.
+/// Canonicalize must fail → refuse, not pass via raw string equality.
+#[test]
+#[cfg(unix)]
+fn repo_release_nonexistent_source_refuses() {
+    let (base, home, _repo, wt) = managed_wt_fixture("nosrc");
+    let bogus = "/nonexistent/source/repo/for/test";
+    // Write marker with non-existent source.
+    std::fs::write(
+        wt.join(".agend-managed"),
+        format!("agent=agent-nosrc\nbranch=feat/test\nsource_repo={bogus}\n"),
+    )
+    .expect("write marker");
+    // Bind with the same non-existent source.
+    crate::binding::bind_full(
+        &home,
+        "agent-nosrc",
+        "",
+        "feat/test",
+        &wt,
+        std::path::Path::new(bogus),
+        false,
+    )
+    .expect("bind");
+
+    let r = dispatch_repo_release(&home, "agent-nosrc", wt.to_str().unwrap());
+
+    assert!(
+        r.get("error").is_some(),
+        "non-existent source_repo must refuse even when both match: {r}"
+    );
+    assert!(
+        wt.exists(),
+        "worktree must be preserved on non-existent source"
+    );
+    assert!(
+        crate::binding::read(&home, "agent-nosrc").is_some(),
+        "binding must be preserved on non-existent source"
+    );
+    std::fs::remove_dir_all(&base).ok();
+}

--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -3389,7 +3389,7 @@ fn repo_release_marker_source_mismatch_refuses() {
     // Overwrite marker with a DIFFERENT source_repo.
     std::fs::write(
         wt.join(".agend-managed"),
-        format!("agent=agent-srmm\nbranch=feat/test\nsource_repo=/bogus/repo\n"),
+        "agent=agent-srmm\nbranch=feat/test\nsource_repo=/bogus/repo\n",
     )
     .expect("overwrite marker");
 
@@ -3403,6 +3403,44 @@ fn repo_release_marker_source_mismatch_refuses() {
     assert!(
         crate::binding::read(&home, "agent-srmm").is_some(),
         "binding must be preserved on source mismatch"
+    );
+    std::fs::remove_dir_all(&base).ok();
+}
+
+/// Marker rewritten AFTER pre-read but BEFORE canonical locks — proves
+/// the under-lock fresh re-read catches it.
+#[test]
+#[cfg(unix)]
+fn repo_release_marker_rewritten_after_snapshot_refuses() {
+    use crate::worktree_pool::{release_test_seam, ReleaseTestPhase};
+
+    let (base, home, repo, wt) = managed_wt_fixture("seam");
+    seed_managed_marker(&wt, &repo, &home, "agent-seam", "feat/test");
+
+    let wt_clone = wt.clone();
+    let _guard = release_test_seam::install(move |phase| {
+        if phase == ReleaseTestPhase::AfterBindingSnapshot {
+            std::fs::write(
+                wt_clone.join(".agend-managed"),
+                "agent=agent-seam\nbranch=feat/tampered\nsource_repo=/tampered\n",
+            )
+            .expect("rewrite marker in seam");
+        }
+    });
+
+    let r = dispatch_repo_release(&home, "agent-seam", wt.to_str().unwrap());
+
+    assert!(
+        r.get("error").is_some(),
+        "marker rewritten after snapshot must be caught under lock: {r}"
+    );
+    assert!(
+        wt.exists(),
+        "worktree must be preserved when marker is tampered"
+    );
+    assert!(
+        crate::binding::read(&home, "agent-seam").is_some(),
+        "binding must be preserved when marker is tampered"
     );
     std::fs::remove_dir_all(&base).ok();
 }

--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -3346,3 +3346,63 @@ fn repo_release_non_owner_refused_owner_succeeds() {
     let _ = r; // response structure TBD
     std::fs::remove_dir_all(&base).ok();
 }
+
+/// Marker says branch=feat/other but binding has branch=feat/test → refuse,
+/// preserve worktree + binding.
+#[test]
+#[cfg(unix)]
+fn repo_release_marker_branch_mismatch_refuses() {
+    let (base, home, repo, wt) = managed_wt_fixture("br-mm");
+    // Bind normally (branch=feat/test from the worktree add).
+    seed_managed_marker(&wt, &repo, &home, "agent-brmm", "feat/test");
+    // Overwrite marker with a DIFFERENT branch — simulates stale/tampered marker.
+    std::fs::write(
+        wt.join(".agend-managed"),
+        format!(
+            "agent=agent-brmm\nbranch=feat/other\nsource_repo={}\n",
+            repo.display()
+        ),
+    )
+    .expect("overwrite marker");
+
+    let r = dispatch_repo_release(&home, "agent-brmm", wt.to_str().unwrap());
+
+    assert!(
+        r.get("error").is_some(),
+        "branch mismatch must return error: {r}"
+    );
+    assert!(wt.exists(), "worktree must be preserved on branch mismatch");
+    assert!(
+        crate::binding::read(&home, "agent-brmm").is_some(),
+        "binding must be preserved on branch mismatch"
+    );
+    std::fs::remove_dir_all(&base).ok();
+}
+
+/// Marker says source_repo=/other but binding has the real repo → refuse,
+/// preserve worktree + binding.
+#[test]
+#[cfg(unix)]
+fn repo_release_marker_source_mismatch_refuses() {
+    let (base, home, repo, wt) = managed_wt_fixture("sr-mm");
+    seed_managed_marker(&wt, &repo, &home, "agent-srmm", "feat/test");
+    // Overwrite marker with a DIFFERENT source_repo.
+    std::fs::write(
+        wt.join(".agend-managed"),
+        format!("agent=agent-srmm\nbranch=feat/test\nsource_repo=/bogus/repo\n"),
+    )
+    .expect("overwrite marker");
+
+    let r = dispatch_repo_release(&home, "agent-srmm", wt.to_str().unwrap());
+
+    assert!(
+        r.get("error").is_some(),
+        "source mismatch must return error: {r}"
+    );
+    assert!(wt.exists(), "worktree must be preserved on source mismatch");
+    assert!(
+        crate::binding::read(&home, "agent-srmm").is_some(),
+        "binding must be preserved on source mismatch"
+    );
+    std::fs::remove_dir_all(&base).ok();
+}

--- a/src/mcp/handlers/dispatch.rs
+++ b/src/mcp/handlers/dispatch.rs
@@ -350,7 +350,7 @@ pub(crate) fn dispatch_health(ctx: &HandlerCtx<'_>) -> Value {
 
 action_adapter!(dispatch_repo, "repo", [
     "checkout"                => ci::handle_checkout_repo,              hai;
-    "release"                 => ci::handle_release_repo,               a;
+    "release"                 => ci::handle_release_repo,               hai;
     "cleanup_init_commits"    => ci::handle_cleanup_init_commits,       hai;
     "cleanup_merged_branches" => ci::handle_cleanup_merged_branches,    hai;
     "merge"                   => ci::handle_merge_repo,                 hai;

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -970,14 +970,16 @@ fn release_full_guarded(
         GuardedBinding::Known { .. } => return stale_release(),
     };
     let wt_path = current["worktree"].as_str().unwrap_or("");
-    let marker_path = Path::new(wt_path).join(MANAGED_MARKER);
-    if marker_path.exists() {
+    let wt_exists = !wt_path.is_empty() && Path::new(wt_path).exists();
+    if wt_exists {
+        let marker_path = Path::new(wt_path).join(MANAGED_MARKER);
         let marker_content = match std::fs::read_to_string(&marker_path) {
             Ok(c) => c,
             Err(_) => {
                 return ReleaseOutcome {
                     error: Some(
-                        "managed marker unreadable under lock — refusing (fail-closed)".into(),
+                        "managed marker absent or unreadable under lock — refusing (fail-closed)"
+                            .into(),
                     ),
                     ..ReleaseOutcome::default()
                 };
@@ -993,11 +995,12 @@ fn release_full_guarded(
         let mk_agent = mk_get("agent=");
         let mk_branch = mk_get("branch=");
         let mk_source = mk_get("source_repo=");
-        if mk_agent.is_empty() {
+        if mk_agent.is_empty() || mk_branch.is_empty() || mk_source.is_empty() {
             return ReleaseOutcome {
-                error: Some(
-                    "managed marker missing agent under lock — refusing (fail-closed)".into(),
-                ),
+                error: Some(format!(
+                    "managed marker has empty identity under lock (agent={mk_agent:?} \
+                     branch={mk_branch:?} source={mk_source:?}) — refusing (fail-closed)"
+                )),
                 ..ReleaseOutcome::default()
             };
         }
@@ -1010,7 +1013,7 @@ fn release_full_guarded(
             };
         }
         let bound_branch = current["branch"].as_str().unwrap_or("");
-        if !mk_branch.is_empty() && mk_branch != bound_branch {
+        if mk_branch != bound_branch {
             return ReleaseOutcome {
                 error: Some(format!(
                     "marker branch '{mk_branch}' does not match binding branch '{bound_branch}' — refusing"
@@ -1018,11 +1021,17 @@ fn release_full_guarded(
                 ..ReleaseOutcome::default()
             };
         }
-        let bound_source = current["source_repo"].as_str().unwrap_or("");
-        if !mk_source.is_empty() && !bound_source.is_empty() && mk_source != bound_source {
+        let bound_source = source_repo_from_binding(&current, Path::new(wt_path));
+        let mk_source_canonical =
+            std::fs::canonicalize(&mk_source).unwrap_or_else(|_| PathBuf::from(&mk_source));
+        let bound_source_canonical =
+            std::fs::canonicalize(&bound_source).unwrap_or_else(|_| bound_source.clone());
+        if mk_source_canonical != bound_source_canonical {
             return ReleaseOutcome {
                 error: Some(format!(
-                    "marker source_repo '{mk_source}' does not match binding source_repo '{bound_source}' — refusing"
+                    "marker source_repo '{}' does not match binding source_repo '{}' — refusing",
+                    mk_source,
+                    bound_source.display()
                 )),
                 ..ReleaseOutcome::default()
             };

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -149,11 +149,6 @@ pub fn is_daemon_managed(worktree_path: &Path) -> bool {
     worktree_path.join(MANAGED_MARKER).exists()
 }
 
-pub(crate) struct MarkerIdentity {
-    pub branch: String,
-    pub source_repo: String,
-}
-
 /// Outcome of a hard release — emitted by `release_full` and serialized
 /// directly into the `release_worktree` MCP tool response.
 #[derive(Clone, Copy, Debug)]
@@ -921,7 +916,6 @@ fn release_full_guarded(
     permit: &crate::mcp::handlers::dispatch_hook::LifecyclePermit,
     expected: Option<&crate::binding::BindingFingerprint>,
     provenance: ReleaseProvenance,
-    marker: Option<&MarkerIdentity>,
 ) -> ReleaseOutcome {
     use crate::binding::GuardedBinding;
 
@@ -975,24 +969,60 @@ fn release_full_guarded(
         } if live == fingerprint => value,
         GuardedBinding::Known { .. } => return stale_release(),
     };
-    if let Some(mk) = marker {
-        let bound_branch = current["branch"].as_str().unwrap_or("");
-        let bound_source = current["source_repo"].as_str().unwrap_or("");
-        if !mk.branch.is_empty() && bound_branch != mk.branch {
+    let wt_path = current["worktree"].as_str().unwrap_or("");
+    let marker_path = Path::new(wt_path).join(MANAGED_MARKER);
+    if marker_path.exists() {
+        let marker_content = match std::fs::read_to_string(&marker_path) {
+            Ok(c) => c,
+            Err(_) => {
+                return ReleaseOutcome {
+                    error: Some(
+                        "managed marker unreadable under lock — refusing (fail-closed)".into(),
+                    ),
+                    ..ReleaseOutcome::default()
+                };
+            }
+        };
+        let mk_get = |prefix: &str| {
+            marker_content
+                .lines()
+                .find_map(|l| l.strip_prefix(prefix))
+                .map(|s| s.trim().to_string())
+                .unwrap_or_default()
+        };
+        let mk_agent = mk_get("agent=");
+        let mk_branch = mk_get("branch=");
+        let mk_source = mk_get("source_repo=");
+        if mk_agent.is_empty() {
+            return ReleaseOutcome {
+                error: Some(
+                    "managed marker missing agent under lock — refusing (fail-closed)".into(),
+                ),
+                ..ReleaseOutcome::default()
+            };
+        }
+        if mk_agent != agent {
             return ReleaseOutcome {
                 error: Some(format!(
-                    "marker branch '{}' does not match binding branch '{bound_branch}' — refusing",
-                    mk.branch
+                    "marker agent '{mk_agent}' does not match release agent '{agent}' — refusing"
                 )),
                 ..ReleaseOutcome::default()
             };
         }
-        if !mk.source_repo.is_empty() && !bound_source.is_empty() && bound_source != mk.source_repo
-        {
+        let bound_branch = current["branch"].as_str().unwrap_or("");
+        if !mk_branch.is_empty() && mk_branch != bound_branch {
             return ReleaseOutcome {
                 error: Some(format!(
-                    "marker source_repo '{}' does not match binding source_repo '{bound_source}' — refusing",
-                    mk.source_repo
+                    "marker branch '{mk_branch}' does not match binding branch '{bound_branch}' — refusing"
+                )),
+                ..ReleaseOutcome::default()
+            };
+        }
+        let bound_source = current["source_repo"].as_str().unwrap_or("");
+        if !mk_source.is_empty() && !bound_source.is_empty() && mk_source != bound_source {
+            return ReleaseOutcome {
+                error: Some(format!(
+                    "marker source_repo '{mk_source}' does not match binding source_repo '{bound_source}' — refusing"
                 )),
                 ..ReleaseOutcome::default()
             };
@@ -1058,7 +1088,6 @@ pub fn release_full(home: &Path, agent: &str, dry_run: bool) -> ReleaseOutcome {
         &permit,
         None,
         ReleaseProvenance::Manual,
-        None,
     )
 }
 
@@ -1078,14 +1107,13 @@ pub(crate) fn release_full_with_permit_origin(
     permit: &crate::mcp::handlers::dispatch_hook::LifecyclePermit,
     provenance: ReleaseProvenance,
 ) -> ReleaseOutcome {
-    release_full_guarded(home, agent, dry_run, permit, None, provenance, None)
+    release_full_guarded(home, agent, dry_run, permit, None, provenance)
 }
 
 pub(crate) fn release_full_exact(
     home: &Path,
     agent: &str,
     expected: &crate::binding::BindingFingerprint,
-    marker: Option<&MarkerIdentity>,
 ) -> ReleaseOutcome {
     let permit = match crate::mcp::handlers::dispatch_hook::LifecyclePermit::acquire(
         home,
@@ -1107,7 +1135,6 @@ pub(crate) fn release_full_exact(
         &permit,
         Some(expected),
         ReleaseProvenance::Auto,
-        marker,
     )
 }
 

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -149,6 +149,11 @@ pub fn is_daemon_managed(worktree_path: &Path) -> bool {
     worktree_path.join(MANAGED_MARKER).exists()
 }
 
+pub(crate) struct MarkerIdentity {
+    pub branch: String,
+    pub source_repo: String,
+}
+
 /// Outcome of a hard release — emitted by `release_full` and serialized
 /// directly into the `release_worktree` MCP tool response.
 #[derive(Clone, Copy, Debug)]
@@ -916,6 +921,7 @@ fn release_full_guarded(
     permit: &crate::mcp::handlers::dispatch_hook::LifecyclePermit,
     expected: Option<&crate::binding::BindingFingerprint>,
     provenance: ReleaseProvenance,
+    marker: Option<&MarkerIdentity>,
 ) -> ReleaseOutcome {
     use crate::binding::GuardedBinding;
 
@@ -969,6 +975,29 @@ fn release_full_guarded(
         } if live == fingerprint => value,
         GuardedBinding::Known { .. } => return stale_release(),
     };
+    if let Some(mk) = marker {
+        let bound_branch = current["branch"].as_str().unwrap_or("");
+        let bound_source = current["source_repo"].as_str().unwrap_or("");
+        if !mk.branch.is_empty() && bound_branch != mk.branch {
+            return ReleaseOutcome {
+                error: Some(format!(
+                    "marker branch '{}' does not match binding branch '{bound_branch}' — refusing",
+                    mk.branch
+                )),
+                ..ReleaseOutcome::default()
+            };
+        }
+        if !mk.source_repo.is_empty() && !bound_source.is_empty() && bound_source != mk.source_repo
+        {
+            return ReleaseOutcome {
+                error: Some(format!(
+                    "marker source_repo '{}' does not match binding source_repo '{bound_source}' — refusing",
+                    mk.source_repo
+                )),
+                ..ReleaseOutcome::default()
+            };
+        }
+    }
     let mut locked = release_known_locked(home, agent, &current, dry_run, permit);
     // Explicit drops document the lock boundary: no notice, marker cleanup,
     // branch cleanup, or release event runs with a flock held.
@@ -1029,6 +1058,7 @@ pub fn release_full(home: &Path, agent: &str, dry_run: bool) -> ReleaseOutcome {
         &permit,
         None,
         ReleaseProvenance::Manual,
+        None,
     )
 }
 
@@ -1048,13 +1078,14 @@ pub(crate) fn release_full_with_permit_origin(
     permit: &crate::mcp::handlers::dispatch_hook::LifecyclePermit,
     provenance: ReleaseProvenance,
 ) -> ReleaseOutcome {
-    release_full_guarded(home, agent, dry_run, permit, None, provenance)
+    release_full_guarded(home, agent, dry_run, permit, None, provenance, None)
 }
 
 pub(crate) fn release_full_exact(
     home: &Path,
     agent: &str,
     expected: &crate::binding::BindingFingerprint,
+    marker: Option<&MarkerIdentity>,
 ) -> ReleaseOutcome {
     let permit = match crate::mcp::handlers::dispatch_hook::LifecyclePermit::acquire(
         home,
@@ -1076,6 +1107,7 @@ pub(crate) fn release_full_exact(
         &permit,
         Some(expected),
         ReleaseProvenance::Auto,
+        marker,
     )
 }
 

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -1021,17 +1021,43 @@ fn release_full_guarded(
                 ..ReleaseOutcome::default()
             };
         }
-        let bound_source = source_repo_from_binding(&current, Path::new(wt_path));
-        let mk_source_canonical =
-            std::fs::canonicalize(&mk_source).unwrap_or_else(|_| PathBuf::from(&mk_source));
-        let bound_source_canonical =
-            std::fs::canonicalize(&bound_source).unwrap_or_else(|_| bound_source.clone());
+        let bound_source_str = current["source_repo"].as_str().unwrap_or("");
+        if bound_source_str.is_empty() {
+            return ReleaseOutcome {
+                error: Some("binding source_repo is empty — refusing (fail-closed)".into()),
+                ..ReleaseOutcome::default()
+            };
+        }
+        let Ok(mk_source_canonical) = std::fs::canonicalize(&mk_source) else {
+            return ReleaseOutcome {
+                error: Some(format!(
+                    "marker source_repo '{mk_source}' cannot be canonicalized — refusing"
+                )),
+                ..ReleaseOutcome::default()
+            };
+        };
+        let Ok(bound_source_canonical) = std::fs::canonicalize(bound_source_str) else {
+            return ReleaseOutcome {
+                error: Some(format!(
+                    "binding source_repo '{bound_source_str}' cannot be canonicalized — refusing"
+                )),
+                ..ReleaseOutcome::default()
+            };
+        };
         if mk_source_canonical != bound_source_canonical {
             return ReleaseOutcome {
                 error: Some(format!(
                     "marker source_repo '{}' does not match binding source_repo '{}' — refusing",
-                    mk_source,
-                    bound_source.display()
+                    mk_source, bound_source_str
+                )),
+                ..ReleaseOutcome::default()
+            };
+        }
+        if !target_source_repo_matches(Path::new(wt_path), &bound_source_canonical) {
+            return ReleaseOutcome {
+                error: Some(format!(
+                    "worktree git pointer does not match source_repo '{}' — refusing",
+                    bound_source_canonical.display()
                 )),
                 ..ReleaseOutcome::default()
             };

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -916,6 +916,7 @@ fn release_full_guarded(
     permit: &crate::mcp::handlers::dispatch_hook::LifecyclePermit,
     expected: Option<&crate::binding::BindingFingerprint>,
     provenance: ReleaseProvenance,
+    validate_marker: bool,
 ) -> ReleaseOutcome {
     use crate::binding::GuardedBinding;
 
@@ -971,7 +972,7 @@ fn release_full_guarded(
     };
     let wt_path = current["worktree"].as_str().unwrap_or("");
     let wt_exists = !wt_path.is_empty() && Path::new(wt_path).exists();
-    if wt_exists {
+    if validate_marker && wt_exists {
         let marker_path = Path::new(wt_path).join(MANAGED_MARKER);
         let marker_content = match std::fs::read_to_string(&marker_path) {
             Ok(c) => c,
@@ -1123,6 +1124,7 @@ pub fn release_full(home: &Path, agent: &str, dry_run: bool) -> ReleaseOutcome {
         &permit,
         None,
         ReleaseProvenance::Manual,
+        false,
     )
 }
 
@@ -1142,13 +1144,14 @@ pub(crate) fn release_full_with_permit_origin(
     permit: &crate::mcp::handlers::dispatch_hook::LifecyclePermit,
     provenance: ReleaseProvenance,
 ) -> ReleaseOutcome {
-    release_full_guarded(home, agent, dry_run, permit, None, provenance)
+    release_full_guarded(home, agent, dry_run, permit, None, provenance, false)
 }
 
 pub(crate) fn release_full_exact(
     home: &Path,
     agent: &str,
     expected: &crate::binding::BindingFingerprint,
+    validate_marker: bool,
 ) -> ReleaseOutcome {
     let permit = match crate::mcp::handlers::dispatch_hook::LifecyclePermit::acquire(
         home,
@@ -1170,6 +1173,7 @@ pub(crate) fn release_full_exact(
         &permit,
         Some(expected),
         ReleaseProvenance::Auto,
+        validate_marker,
     )
 }
 

--- a/src/worktree_pool/tests.rs
+++ b/src/worktree_pool/tests.rs
@@ -1012,7 +1012,7 @@ fn aliased_manual_and_auto_release_share_one_lifecycle_transaction_s2() {
     });
 
     entered_rx.recv().expect("manual release reached snapshot");
-    let auto = release_full_exact(&alias, "agent-alias", &expected);
+    let auto = release_full_exact(&alias, "agent-alias", &expected, false);
     assert!(
         auto.error
             .as_deref()
@@ -1227,7 +1227,7 @@ fn auto_release_exact_fingerprint_cannot_release_new_generation_s1() {
     .expect("write generation B");
     drop(branch_lock);
 
-    let outcome = release_full_exact(&home, "agent-auto", &old);
+    let outcome = release_full_exact(&home, "agent-auto", &old, false);
     assert!(
         outcome.stale_fingerprint && !outcome.released,
         "auto-release A must reject B exactly: {outcome:?}"
@@ -4699,7 +4699,7 @@ fn r6_dirty_recovery_ref_integrity_under_concurrent_release() {
     // Actor B (auto-CAS release via release_full_exact): must be refused
     // by the permit — it must create no recovery ref, remove no binding,
     // remove no worktree content.
-    let outcome_b = release_full_exact(&home, "agent-di", &fingerprint);
+    let outcome_b = release_full_exact(&home, "agent-di", &fingerprint, false);
     assert!(
         outcome_b
             .error

--- a/src/worktree_pool/tests.rs
+++ b/src/worktree_pool/tests.rs
@@ -1012,7 +1012,7 @@ fn aliased_manual_and_auto_release_share_one_lifecycle_transaction_s2() {
     });
 
     entered_rx.recv().expect("manual release reached snapshot");
-    let auto = release_full_exact(&alias, "agent-alias", &expected);
+    let auto = release_full_exact(&alias, "agent-alias", &expected, None);
     assert!(
         auto.error
             .as_deref()
@@ -1227,7 +1227,7 @@ fn auto_release_exact_fingerprint_cannot_release_new_generation_s1() {
     .expect("write generation B");
     drop(branch_lock);
 
-    let outcome = release_full_exact(&home, "agent-auto", &old);
+    let outcome = release_full_exact(&home, "agent-auto", &old, None);
     assert!(
         outcome.stale_fingerprint && !outcome.released,
         "auto-release A must reject B exactly: {outcome:?}"
@@ -4699,7 +4699,7 @@ fn r6_dirty_recovery_ref_integrity_under_concurrent_release() {
     // Actor B (auto-CAS release via release_full_exact): must be refused
     // by the permit — it must create no recovery ref, remove no binding,
     // remove no worktree content.
-    let outcome_b = release_full_exact(&home, "agent-di", &fingerprint);
+    let outcome_b = release_full_exact(&home, "agent-di", &fingerprint, None);
     assert!(
         outcome_b
             .error

--- a/src/worktree_pool/tests.rs
+++ b/src/worktree_pool/tests.rs
@@ -1012,7 +1012,7 @@ fn aliased_manual_and_auto_release_share_one_lifecycle_transaction_s2() {
     });
 
     entered_rx.recv().expect("manual release reached snapshot");
-    let auto = release_full_exact(&alias, "agent-alias", &expected, None);
+    let auto = release_full_exact(&alias, "agent-alias", &expected);
     assert!(
         auto.error
             .as_deref()
@@ -1227,7 +1227,7 @@ fn auto_release_exact_fingerprint_cannot_release_new_generation_s1() {
     .expect("write generation B");
     drop(branch_lock);
 
-    let outcome = release_full_exact(&home, "agent-auto", &old, None);
+    let outcome = release_full_exact(&home, "agent-auto", &old);
     assert!(
         outcome.stale_fingerprint && !outcome.released,
         "auto-release A must reject B exactly: {outcome:?}"
@@ -4699,7 +4699,7 @@ fn r6_dirty_recovery_ref_integrity_under_concurrent_release() {
     // Actor B (auto-CAS release via release_full_exact): must be refused
     // by the permit — it must create no recovery ref, remove no binding,
     // remove no worktree content.
-    let outcome_b = release_full_exact(&home, "agent-di", &fingerprint, None);
+    let outcome_b = release_full_exact(&home, "agent-di", &fingerprint);
     assert!(
         outcome_b
             .error


### PR DESCRIPTION
## Summary

Architecture-14 item 10: `repo action=release(path)` on a daemon-managed worktree now delegates to the canonical guarded release transaction.

**Problem**: `repo release` directly removed worktree directories via `git worktree remove --force` without touching binding.json, leaving stale bindings.

**Fix**: When `.agend-managed` marker present:
- Parse agent/branch/source_repo from marker
- Snapshot `GuardedBinding Known` + fingerprint  
- Verify requested path matches binding worktree (stale/forged → `path_mismatch`)
- ACL: self / team-orchestrator / operator
- `release_full_exact` with fingerprint (WIP preservation, binding clear, branch cleanup)
- Corrupt/opaque/absent → fail-closed

Unmanaged worktrees: unchanged direct-removal behavior.

## Commits
1. RED: `8d0f9301` — 5 tests-only on pure baseline, all FAIL
2. GREEN: `077a9571` — delegation + adapter shape change

## Tests (5)
- A1: managed release clears binding
- A2: dirty managed preserves WIP in recovery ref (asserts DIRTY content)
- A3: corrupt marker fails closed
- A4: non-owner peer refused; owner succeeds
- A5: stale marker (binding path mismatch) preserves live binding

🤖 Generated with [Claude Code](https://claude.com/claude-code)