### PR TITLE
feat(dispatch-settlement): reporter-scoped dispatch settlement (Architecture-14 item 3 slice 1)

### DIFF
--- a/src/api/handlers/messaging.rs
+++ b/src/api/handlers/messaging.rs
@@ -580,7 +580,7 @@ pub(crate) fn track_dispatch(
             // a matching sidecar whose DELETE fails, leaving it to fire a
             // spurious idle nudge later — warns inside `mark_resolved` at the
             // actual failure point, where the dispatch_id is known.
-            let _ = crate::daemon::dispatch_idle::mark_resolved(home, corr);
+            let _ = crate::daemon::dispatch_idle::mark_resolved(home, corr, from);
             // #1888 phase-2: a report carrying the handoff's `repo@branch`
             // correlation (reviewer verdicts do) RESOLVES the ci-handoff track —
             // the re-nudge stops on this signal, not on inbox read. A task-id
@@ -618,7 +618,7 @@ pub(crate) fn track_dispatch(
         // FALSE idle nudge despite the reply arriving. Aligning the key is a
         // superset — behaviour is unchanged when `correlation_id` is set.
         if let Some(corr) = msg.correlation_id.as_deref().or(msg.task_id.as_deref()) {
-            let _ = crate::daemon::dispatch_idle::refresh_issued_at(home, corr);
+            let _ = crate::daemon::dispatch_idle::refresh_issued_at(home, corr, from);
         }
     }
 }
@@ -650,7 +650,7 @@ fn bridge_verdict_to_review_task(home: &Path, reporter: &str, msg: &crate::inbox
     let task_id = &summary.task_id;
     // Any verdict → the reviewer responded → clear the dispatch sidecar (kills the
     // post-response stuck-nudge), regardless of VERIFIED vs REJECTED.
-    let _ = crate::daemon::dispatch_idle::mark_resolved(home, task_id);
+    let _ = crate::daemon::dispatch_idle::mark_resolved(home, task_id, reporter);
     // Only VERIFIED closes the review task. terminal=true synthesized internally.
     if matches!(
         summary.verdict,

--- a/src/api/handlers/messaging/tests.rs
+++ b/src/api/handlers/messaging/tests.rs
@@ -3083,3 +3083,309 @@ fn report_fields_on_kind_task_rejected_without_leaked_task() {
     );
     std::fs::remove_dir_all(&home).ok();
 }
+
+// ── Architecture-14 item 3 slice 1: reporter-scoped dispatch settlement ──
+//
+// RED tests proving the current code does NOT scope settlement/refresh by
+// reporter identity. Each test sets up a cross-assignee replacement (dispatch
+// to agent-A, then to agent-B with the same task correlation) and shows that
+// a stale report/update from agent-A incorrectly affects agent-B's state.
+
+/// RED 1: stale prior-assignee report must NOT remove current assignee's
+/// dispatch_tracking entry. mark_completed removes ALL entries matching
+/// the correlation_id regardless of reporter vs entry.to — the function
+/// itself is unscoped. (The MCP handle_report_result path calls it
+/// directly at comms.rs:274 with the sender as _to, which is ignored.)
+#[test]
+fn red_stale_report_cannot_remove_current_dispatch_tracking() {
+    let home = tmp_home("red-dt-stale-report");
+
+    // Dispatch same task to both agent-A and agent-B.
+    crate::dispatch_tracking::track_dispatch(
+        &home,
+        crate::dispatch_tracking::DispatchEntry {
+            task_id: Some("t-shared".into()),
+            from: "lead".into(),
+            to: "agent-a".into(),
+            delegated_at: "2026-07-16T00:00:00Z".into(),
+            status: "pending".into(),
+            ..Default::default()
+        },
+    );
+    crate::dispatch_tracking::track_dispatch(
+        &home,
+        crate::dispatch_tracking::DispatchEntry {
+            task_id: Some("t-shared".into()),
+            from: "lead".into(),
+            to: "agent-b".into(),
+            delegated_at: "2026-07-16T01:00:00Z".into(),
+            status: "pending".into(),
+            ..Default::default()
+        },
+    );
+
+    // Stale agent-A reports — mark_completed called with reporter="agent-a".
+    // This simulates the MCP handle_report_result path (comms.rs:274).
+    crate::dispatch_tracking::mark_completed(&home, Some("t-shared"), "agent-a");
+
+    // Agent-B's dispatch_tracking entry must survive.
+    let store = crate::dispatch_tracking::take_pending_dispatchers_to(&home, "agent-b");
+    assert!(
+        !store.is_empty(),
+        "RED: stale agent-a report must NOT remove agent-b's dispatch_tracking entry"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// RED 2: stale prior-assignee report must NOT delete current assignee's
+/// dispatch_idle sidecar. Currently FAILS: mark_resolved matches by
+/// correlation_id without checking reporter == sidecar.target.
+#[test]
+fn red_stale_report_cannot_delete_current_dispatch_idle_sidecar() {
+    let home = tmp_home("red-idle-stale-report");
+    setup_team_env(
+        &home,
+        &["lead", "agent-a", "agent-b"],
+        &[("team", &["lead", "agent-a", "agent-b"])],
+    );
+
+    // Seed sidecar for agent-A dispatch.
+    let _id_a = crate::daemon::dispatch_idle::record_dispatch(
+        &home,
+        "lead",
+        "agent-a",
+        Some("t-shared"),
+        "task",
+        600,
+    );
+    // Seed sidecar for agent-B dispatch (same correlation).
+    let id_b = crate::daemon::dispatch_idle::record_dispatch(
+        &home,
+        "lead",
+        "agent-b",
+        Some("t-shared"),
+        "task",
+        600,
+    )
+    .expect("seed agent-b sidecar");
+
+    // Stale agent-A sends report.
+    let ctx = test_ctx(&home);
+    let _ = handle_send(
+        &json!({
+            "from": "agent-a",
+            "target": "lead",
+            "text": "done (stale)",
+            "kind": "report",
+            "correlation_id": "t-shared",
+        }),
+        &ctx,
+    );
+
+    // Agent-B's sidecar must survive.
+    let pending = crate::daemon::dispatch_idle::list_pending(&home);
+    assert!(
+        pending.iter().any(|p| p.dispatch_id == id_b),
+        "RED: stale agent-a report must NOT delete agent-b's dispatch_idle sidecar"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// RED 3: after restart (re-read from disk), current assignee's watchdog
+/// sidecar must still be present when only the stale assignee reported.
+#[test]
+fn red_restart_preserves_current_watchdog_after_stale_report() {
+    let home = tmp_home("red-restart-watchdog");
+    setup_team_env(
+        &home,
+        &["lead", "agent-a", "agent-b"],
+        &[("team", &["lead", "agent-a", "agent-b"])],
+    );
+
+    let id_b = crate::daemon::dispatch_idle::record_dispatch(
+        &home,
+        "lead",
+        "agent-b",
+        Some("t-shared"),
+        "task",
+        600,
+    )
+    .expect("seed agent-b sidecar");
+
+    // Stale agent-A report.
+    let ctx = test_ctx(&home);
+    let _ = handle_send(
+        &json!({
+            "from": "agent-a",
+            "target": "lead",
+            "text": "done (stale)",
+            "kind": "report",
+            "correlation_id": "t-shared",
+        }),
+        &ctx,
+    );
+
+    // Simulate restart: re-read from disk.
+    let pending = crate::daemon::dispatch_idle::list_pending(&home);
+    assert!(
+        pending.iter().any(|p| p.dispatch_id == id_b),
+        "RED: after stale report + restart, agent-b's watchdog sidecar must survive on disk"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// RED 4: watchdog must still fire (detect exceeded threshold) for current
+/// assignee after a stale prior-assignee report.
+#[test]
+fn red_watchdog_fires_for_current_assignee_after_stale_report() {
+    let home = tmp_home("red-watchdog-fires");
+    setup_team_env(
+        &home,
+        &["lead", "agent-a", "agent-b"],
+        &[("team", &["lead", "agent-a", "agent-b"])],
+    );
+
+    // Agent-B sidecar with a 1-second threshold (expires immediately).
+    let id_b = crate::daemon::dispatch_idle::record_dispatch(
+        &home,
+        "lead",
+        "agent-b",
+        Some("t-shared"),
+        "task",
+        1,
+    )
+    .expect("seed agent-b sidecar");
+
+    // Stale agent-A report.
+    let ctx = test_ctx(&home);
+    let _ = handle_send(
+        &json!({
+            "from": "agent-a",
+            "target": "lead",
+            "text": "done (stale)",
+            "kind": "report",
+            "correlation_id": "t-shared",
+        }),
+        &ctx,
+    );
+
+    // Wait for threshold to expire.
+    std::thread::sleep(std::time::Duration::from_secs(2));
+
+    // The sidecar must still exist AND be detectable as exceeded.
+    let pending = crate::daemon::dispatch_idle::list_pending(&home);
+    let entry = pending.iter().find(|p| p.dispatch_id == id_b);
+    assert!(
+        entry.is_some(),
+        "RED: agent-b's sidecar must survive stale report so watchdog can fire"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// RED 5: stale prior-assignee update/query must NOT refresh current
+/// assignee's issued_at. Currently FAILS: refresh_issued_at matches by
+/// correlation_id without checking reporter == sidecar.target.
+#[test]
+fn red_stale_update_cannot_refresh_current_issued_at() {
+    let home = tmp_home("red-refresh-stale");
+    setup_team_env(
+        &home,
+        &["lead", "agent-a", "agent-b"],
+        &[("team", &["lead", "agent-a", "agent-b"])],
+    );
+
+    let id_b = crate::daemon::dispatch_idle::record_dispatch(
+        &home,
+        "lead",
+        "agent-b",
+        Some("t-shared"),
+        "task",
+        600,
+    )
+    .expect("seed agent-b sidecar");
+
+    // Record original issued_at.
+    let before = crate::daemon::dispatch_idle::list_pending(&home);
+    let original_issued = before
+        .iter()
+        .find(|p| p.dispatch_id == id_b)
+        .expect("sidecar exists")
+        .issued_at
+        .clone();
+
+    std::thread::sleep(std::time::Duration::from_millis(50));
+
+    // Stale agent-A sends update with matching correlation.
+    let ctx = test_ctx(&home);
+    let _ = handle_send(
+        &json!({
+            "from": "agent-a",
+            "target": "lead",
+            "text": "BUSY still working",
+            "kind": "update",
+            "correlation_id": "t-shared",
+        }),
+        &ctx,
+    );
+
+    // Agent-B's issued_at must NOT have been refreshed.
+    let after = crate::daemon::dispatch_idle::list_pending(&home);
+    let current_issued = after
+        .iter()
+        .find(|p| p.dispatch_id == id_b)
+        .expect("sidecar must still exist")
+        .issued_at
+        .clone();
+    assert_eq!(
+        original_issued, current_issued,
+        "RED: stale agent-a update must NOT refresh agent-b's issued_at"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// RED 6: validated-review bridge settlement must be reporter-scoped.
+/// A verdict from a stale reviewer must NOT resolve the current reviewer's
+/// dispatch_idle sidecar.
+#[test]
+fn red_validated_review_bridge_settlement_is_reporter_scoped() {
+    let home = tmp_home("red-review-bridge");
+    setup_team_env(
+        &home,
+        &["lead", "reviewer-a", "reviewer-b"],
+        &[("team", &["lead", "reviewer-a", "reviewer-b"])],
+    );
+
+    // Sidecar for reviewer-B's review dispatch (task-keyed).
+    let id_b = crate::daemon::dispatch_idle::record_dispatch(
+        &home,
+        "lead",
+        "reviewer-b",
+        Some("t-review"),
+        "task",
+        600,
+    )
+    .expect("seed reviewer-b sidecar");
+
+    // Stale reviewer-A sends report. The bridge_verdict_to_review_task
+    // path calls mark_resolved(home, task_id) without checking reporter.
+    // We simulate a report with correlation matching the review task.
+    let ctx = test_ctx(&home);
+    let _ = handle_send(
+        &json!({
+            "from": "reviewer-a",
+            "target": "lead",
+            "text": "VERIFIED — looks good",
+            "kind": "report",
+            "correlation_id": "t-review",
+        }),
+        &ctx,
+    );
+
+    // Reviewer-B's sidecar must survive.
+    let pending = crate::daemon::dispatch_idle::list_pending(&home);
+    assert!(
+        pending.iter().any(|p| p.dispatch_id == id_b),
+        "RED: stale reviewer-a verdict must NOT resolve reviewer-b's dispatch_idle sidecar"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}

--- a/src/api/handlers/messaging/tests.rs
+++ b/src/api/handlers/messaging/tests.rs
@@ -3312,6 +3312,16 @@ fn red_watchdog_fires_for_current_assignee_after_stale_report() {
         crate::daemon::dispatch_idle::DispatchStatus::Exceeded,
         "RED: scan_and_emit must flip agent-b's sidecar to Exceeded"
     );
+    // dispatch_idle_threshold_exceeded must be durably enqueued to the dispatcher.
+    let msgs = crate::inbox::drain(&home, "lead");
+    assert!(
+        msgs.iter().any(|m| m
+            .kind
+            .as_deref()
+            .is_some_and(|k| k == "dispatch_idle_threshold_exceeded")
+            && m.correlation_id.as_deref() == Some("t-shared")),
+        "RED: scan_and_emit must enqueue dispatch_idle_threshold_exceeded to lead for t-shared"
+    );
     std::fs::remove_dir_all(&home).ok();
 }
 

--- a/src/api/handlers/messaging/tests.rs
+++ b/src/api/handlers/messaging/tests.rs
@@ -3466,3 +3466,86 @@ fn red_validated_review_bridge_settlement_is_reporter_scoped() {
     );
     std::fs::remove_dir_all(&home).ok();
 }
+
+// ── Empty-reporter fail-closed regression tests ──
+
+#[test]
+fn empty_reporter_mark_completed_leaves_rows_intact() {
+    let home = tmp_home("empty-reporter-dt");
+    crate::dispatch_tracking::track_dispatch(
+        &home,
+        crate::dispatch_tracking::DispatchEntry {
+            task_id: Some("t-empty".into()),
+            from: "lead".into(),
+            to: "dev".into(),
+            delegated_at: "2026-07-16T00:00:00Z".into(),
+            status: "pending".into(),
+            ..Default::default()
+        },
+    );
+    crate::dispatch_tracking::mark_completed(&home, Some("t-empty"), "");
+    let store = crate::dispatch_tracking::take_pending_dispatchers_to(&home, "dev");
+    assert!(
+        !store.is_empty(),
+        "empty reporter must NOT remove any dispatch_tracking row"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn empty_reporter_mark_resolved_leaves_sidecar_intact() {
+    let home = tmp_home("empty-reporter-idle");
+    let id = crate::daemon::dispatch_idle::record_dispatch(
+        &home,
+        "lead",
+        "dev",
+        Some("t-empty"),
+        "task",
+        600,
+    )
+    .expect("seed");
+    let resolved = crate::daemon::dispatch_idle::mark_resolved(&home, "t-empty", "");
+    assert!(resolved.is_none(), "empty reporter must return None");
+    let pending = crate::daemon::dispatch_idle::list_pending(&home);
+    assert!(
+        pending.iter().any(|p| p.dispatch_id == id),
+        "empty reporter must NOT delete the sidecar"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn empty_reporter_refresh_issued_at_leaves_sidecar_unchanged() {
+    let home = tmp_home("empty-reporter-refresh");
+    let id = crate::daemon::dispatch_idle::record_dispatch(
+        &home,
+        "lead",
+        "dev",
+        Some("t-empty"),
+        "task",
+        600,
+    )
+    .expect("seed");
+    let before = crate::daemon::dispatch_idle::list_pending(&home);
+    let original = before
+        .iter()
+        .find(|p| p.dispatch_id == id)
+        .unwrap()
+        .issued_at
+        .clone();
+    std::thread::sleep(std::time::Duration::from_millis(50));
+    let refreshed = crate::daemon::dispatch_idle::refresh_issued_at(&home, "t-empty", "");
+    assert!(refreshed.is_none(), "empty reporter must return None");
+    let after = crate::daemon::dispatch_idle::list_pending(&home);
+    let current = after
+        .iter()
+        .find(|p| p.dispatch_id == id)
+        .unwrap()
+        .issued_at
+        .clone();
+    assert_eq!(
+        original, current,
+        "empty reporter must NOT refresh issued_at"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}

--- a/src/api/handlers/messaging/tests.rs
+++ b/src/api/handlers/messaging/tests.rs
@@ -3092,13 +3092,18 @@ fn report_fields_on_kind_task_rejected_without_leaked_task() {
 // a stale report/update from agent-A incorrectly affects agent-B's state.
 
 /// RED 1: stale prior-assignee report must NOT remove current assignee's
-/// dispatch_tracking entry. mark_completed removes ALL entries matching
-/// the correlation_id regardless of reporter vs entry.to — the function
-/// itself is unscoped. (The MCP handle_report_result path calls it
-/// directly at comms.rs:274 with the sender as _to, which is ignored.)
+/// dispatch_tracking entry. Exercises the real MCP handle_report_result →
+/// mark_completed path (comms.rs:274). mark_completed removes ALL entries
+/// matching the correlation_id regardless of reporter vs entry.to.
 #[test]
 fn red_stale_report_cannot_remove_current_dispatch_tracking() {
     let home = tmp_home("red-dt-stale-report");
+    // Fleet needed for handle_report_result's fallback delivery.
+    std::fs::write(
+        crate::fleet::fleet_yaml_path(&home),
+        "instances:\n  lead:\n    backend: claude\n  agent-a:\n    backend: claude\n  agent-b:\n    backend: claude\n",
+    )
+    .unwrap();
 
     // Dispatch same task to both agent-A and agent-B.
     crate::dispatch_tracking::track_dispatch(
@@ -3124,9 +3129,22 @@ fn red_stale_report_cannot_remove_current_dispatch_tracking() {
         },
     );
 
-    // Stale agent-A reports — mark_completed called with reporter="agent-a".
-    // This simulates the MCP handle_report_result path (comms.rs:274).
-    crate::dispatch_tracking::mark_completed(&home, Some("t-shared"), "agent-a");
+    // Stale agent-A sends report through real MCP handle_report_result.
+    let sender = crate::identity::Sender::new("agent-a");
+    let args = json!({
+        "instance": "lead",
+        "summary": "done (stale)",
+        "correlation_id": "t-shared",
+        "request_kind": "report",
+    });
+    let ctx = crate::mcp::handlers::dispatch::HandlerCtx {
+        home: &home,
+        args: &args,
+        instance_name: sender.as_ref().map_or("", |s| s.as_str()),
+        sender: &sender,
+        runtime: None,
+    };
+    crate::mcp::handlers::dispatch::dispatch_send(&ctx);
 
     // Agent-B's dispatch_tracking entry must survive.
     let store = crate::dispatch_tracking::take_pending_dispatchers_to(&home, "agent-b");
@@ -3234,8 +3252,9 @@ fn red_restart_preserves_current_watchdog_after_stale_report() {
     std::fs::remove_dir_all(&home).ok();
 }
 
-/// RED 4: watchdog must still fire (detect exceeded threshold) for current
-/// assignee after a stale prior-assignee report.
+/// RED 4: watchdog must still fire (dispatch_idle_threshold_exceeded) for
+/// current assignee after a stale prior-assignee report. Uses an already-
+/// expired issued_at fixture and invokes the real scan_and_emit. No sleep.
 #[test]
 fn red_watchdog_fires_for_current_assignee_after_stale_report() {
     let home = tmp_home("red-watchdog-fires");
@@ -3245,18 +3264,27 @@ fn red_watchdog_fires_for_current_assignee_after_stale_report() {
         &[("team", &["lead", "agent-a", "agent-b"])],
     );
 
-    // Agent-B sidecar with a 1-second threshold (expires immediately).
-    let id_b = crate::daemon::dispatch_idle::record_dispatch(
-        &home,
-        "lead",
-        "agent-b",
-        Some("t-shared"),
-        "task",
-        1,
-    )
-    .expect("seed agent-b sidecar");
+    // Seed agent-B sidecar with already-expired issued_at (30s threshold, 2min ago).
+    let expired_time = chrono::Utc::now() - chrono::TimeDelta::try_seconds(120).unwrap();
+    let dispatch_id = format!("disp-red4-{}", std::process::id());
+    let sidecar = crate::daemon::dispatch_idle::PendingDispatch {
+        schema_version: 1,
+        dispatch_id: dispatch_id.clone(),
+        dispatcher: "lead".into(),
+        target: "agent-b".into(),
+        correlation_id: Some("t-shared".into()),
+        expected_kind: "task".into(),
+        threshold_secs: 30,
+        issued_at: expired_time.to_rfc3339(),
+        status: crate::daemon::dispatch_idle::DispatchStatus::Pending,
+        ..Default::default()
+    };
+    let dir = home.join("pending-dispatches");
+    std::fs::create_dir_all(&dir).ok();
+    let path = crate::daemon::dispatch_idle::pending_path(&home, &dispatch_id);
+    std::fs::write(&path, serde_json::to_string_pretty(&sidecar).unwrap()).unwrap();
 
-    // Stale agent-A report.
+    // Stale agent-A report (deletes the sidecar via mark_resolved).
     let ctx = test_ctx(&home);
     let _ = handle_send(
         &json!({
@@ -3269,15 +3297,20 @@ fn red_watchdog_fires_for_current_assignee_after_stale_report() {
         &ctx,
     );
 
-    // Wait for threshold to expire.
-    std::thread::sleep(std::time::Duration::from_secs(2));
+    // Run the real watchdog scan — must detect exceeded for agent-b.
+    crate::daemon::dispatch_idle::scan_and_emit(&home);
 
-    // The sidecar must still exist AND be detectable as exceeded.
+    // The sidecar must still exist with Exceeded status.
     let pending = crate::daemon::dispatch_idle::list_pending(&home);
-    let entry = pending.iter().find(|p| p.dispatch_id == id_b);
+    let entry = pending.iter().find(|p| p.dispatch_id == dispatch_id);
     assert!(
         entry.is_some(),
         "RED: agent-b's sidecar must survive stale report so watchdog can fire"
+    );
+    assert_eq!(
+        entry.unwrap().status,
+        crate::daemon::dispatch_idle::DispatchStatus::Exceeded,
+        "RED: scan_and_emit must flip agent-b's sidecar to Exceeded"
     );
     std::fs::remove_dir_all(&home).ok();
 }
@@ -3345,7 +3378,10 @@ fn red_stale_update_cannot_refresh_current_issued_at() {
 
 /// RED 6: validated-review bridge settlement must be reporter-scoped.
 /// A verdict from a stale reviewer must NOT resolve the current reviewer's
-/// dispatch_idle sidecar.
+/// dispatch_idle sidecar. Uses a genuine ValidatedCodeReviewReceipt
+/// through the bridge path. The sidecar is keyed by task_id (not
+/// repo@branch) so generic report settlement (correlation_id-based)
+/// cannot reach it — only the bridge can.
 #[test]
 fn red_validated_review_bridge_settlement_is_reporter_scoped() {
     let home = tmp_home("red-review-bridge");
@@ -3360,26 +3396,57 @@ fn red_validated_review_bridge_settlement_is_reporter_scoped() {
         &home,
         "lead",
         "reviewer-b",
-        Some("t-review"),
+        Some("t-review-task"),
         "task",
         600,
     )
     .expect("seed reviewer-b sidecar");
 
-    // Stale reviewer-A sends report. The bridge_verdict_to_review_task
-    // path calls mark_resolved(home, task_id) without checking reporter.
-    // We simulate a report with correlation matching the review task.
-    let ctx = test_ctx(&home);
-    let _ = handle_send(
-        &json!({
-            "from": "reviewer-a",
-            "target": "lead",
-            "text": "VERIFIED — looks good",
-            "kind": "report",
-            "correlation_id": "t-review",
-        }),
-        &ctx,
+    // Construct genuine validated-review receipt from stale reviewer-A.
+    // Receipt's task_id matches the sidecar correlation; the bridge
+    // resolves mark_resolved via this task_id.
+    let receipt = crate::review_receipt::ValidatedCodeReviewReceipt::for_test(
+        crate::review_receipt::ReviewReceiptSummary {
+            receipt_id: "review-receipt:red6".into(),
+            source_id: "m-red6".into(),
+            evidence_digest: "a".repeat(64),
+            assignment_id: uuid::Uuid::new_v4(),
+            reviewer_instance_id: crate::types::InstanceId(uuid::Uuid::new_v4()),
+            reviewer_name: "reviewer-a".into(),
+            repo: "org/repo".into(),
+            pr_number: 42,
+            branch: "feat/x".into(),
+            task_id: "t-review-task".into(),
+            reviewed_head: "b".repeat(40),
+            review_class: crate::daemon::pr_state::ReviewClass::Single,
+            slot: crate::review_receipt::ReviewSlot::Primary,
+            verdict: crate::review_receipt::ReviewVerdict::Verified,
+        },
     );
+
+    // Drive through track_dispatch with repo@branch as correlation_id
+    // (different from the task_id-keyed sidecar) so the generic
+    // mark_resolved at messaging.rs:583 does NOT match the sidecar.
+    // Only bridge_verdict_to_review_task (called inside track_dispatch
+    // at messaging.rs:611) can reach the task-keyed sidecar.
+    let msg = crate::inbox::InboxMessage {
+        schema_version: 1,
+        id: Some("m-red6-stale".into()),
+        from: "reviewer-a".into(),
+        text: "VERIFIED — looks good".into(),
+        kind: Some("report".into()),
+        correlation_id: Some("org/repo@feat/x".into()),
+        validated_code_review: Some(receipt),
+        timestamp: chrono::Utc::now().to_rfc3339(),
+        ..Default::default()
+    };
+    let params = json!({
+        "from": "reviewer-a",
+        "target": "lead",
+        "kind": "report",
+        "correlation_id": "org/repo@feat/x",
+    });
+    crate::api::handlers::messaging::track_dispatch(&home, &params, "reviewer-a", "lead", &msg);
 
     // Reviewer-B's sidecar must survive.
     let pending = crate::daemon::dispatch_idle::list_pending(&home);

--- a/src/daemon/dispatch_idle/mod.rs
+++ b/src/daemon/dispatch_idle/mod.rs
@@ -677,14 +677,14 @@ pub(crate) fn has_pending_for_instance(home: &Path, instance_name: &str) -> bool
 /// each with a distinct correlation_id). Returns the resolved
 /// dispatch_id, or `None` if no matching pending entry exists.
 pub(crate) fn mark_resolved(home: &Path, correlation_id: &str, reporter: &str) -> Option<String> {
-    if correlation_id.is_empty() {
+    if correlation_id.is_empty() || reporter.is_empty() {
         return None;
     }
     let mut first_deleted: Option<String> = None;
     for d in list_pending(home).into_iter().filter(|d| {
         matches!(d.status, DispatchStatus::Pending | DispatchStatus::Exceeded)
             && d.correlation_id.as_deref() == Some(correlation_id)
-            && (reporter.is_empty() || d.target == reporter)
+            && d.target == reporter
     }) {
         // [M2] DELETE the sidecar (rather than flip to `Resolved` and leave the
         // file to accumulate — the pre-fix primary `pending-dispatches/` leak)
@@ -718,13 +718,13 @@ pub(crate) fn refresh_issued_at(
     correlation_id: &str,
     reporter: &str,
 ) -> Option<String> {
-    if correlation_id.is_empty() {
+    if correlation_id.is_empty() || reporter.is_empty() {
         return None;
     }
     let matched = list_pending(home).into_iter().find(|d| {
         d.status == DispatchStatus::Pending
             && d.correlation_id.as_deref() == Some(correlation_id)
-            && (reporter.is_empty() || d.target == reporter)
+            && d.target == reporter
     });
     let d = matched?;
     let id = d.dispatch_id.clone();

--- a/src/daemon/dispatch_idle/mod.rs
+++ b/src/daemon/dispatch_idle/mod.rs
@@ -676,26 +676,15 @@ pub(crate) fn has_pending_for_instance(home: &Path, instance_name: &str) -> bool
 /// single dispatcher can have multiple pending dispatches outstanding,
 /// each with a distinct correlation_id). Returns the resolved
 /// dispatch_id, or `None` if no matching pending entry exists.
-pub(crate) fn mark_resolved(home: &Path, correlation_id: &str) -> Option<String> {
+pub(crate) fn mark_resolved(home: &Path, correlation_id: &str, reporter: &str) -> Option<String> {
     if correlation_id.is_empty() {
         return None;
     }
-    // A report arriving = the dispatch is done, whether it was still `Pending` or
-    // had already timed out to `Exceeded` (idle nudge fired). Match BOTH so a LATE
-    // report on an Exceeded dispatch still deletes the sidecar.
-    //
-    // t-dispatchidle-clear-on-report: delete ALL sidecars with this
-    // `correlation_id`, not just the first. A re-dispatched task (the SAME task_id
-    // sent twice — e.g. an initial dispatch + a design re-confirm, both
-    // `task_id=t-…`) creates DUPLICATE sidecars via `record_dispatch`'s fresh
-    // `next_dispatch_id()`. The pre-fix `.find()` deleted only one duplicate; the
-    // survivor went `Exceeded` and nudged the delegate AFTER it had already
-    // reported (the clear-on-report noise). (`record_dispatch`'s new dedup stops
-    // NEW duplicates; this delete-all keeps the resolve correct regardless.)
     let mut first_deleted: Option<String> = None;
     for d in list_pending(home).into_iter().filter(|d| {
         matches!(d.status, DispatchStatus::Pending | DispatchStatus::Exceeded)
             && d.correlation_id.as_deref() == Some(correlation_id)
+            && (reporter.is_empty() || d.target == reporter)
     }) {
         // [M2] DELETE the sidecar (rather than flip to `Resolved` and leave the
         // file to accumulate — the pre-fix primary `pending-dispatches/` leak)
@@ -724,12 +713,18 @@ pub(crate) fn mark_resolved(home: &Path, correlation_id: &str) -> Option<String>
 /// The sidecar stays live (future silence still fires), but the threshold
 /// clock restarts from now. Returns the refreshed dispatch_id, or `None`
 /// if no matching pending sidecar exists.
-pub(crate) fn refresh_issued_at(home: &Path, correlation_id: &str) -> Option<String> {
+pub(crate) fn refresh_issued_at(
+    home: &Path,
+    correlation_id: &str,
+    reporter: &str,
+) -> Option<String> {
     if correlation_id.is_empty() {
         return None;
     }
     let matched = list_pending(home).into_iter().find(|d| {
-        d.status == DispatchStatus::Pending && d.correlation_id.as_deref() == Some(correlation_id)
+        d.status == DispatchStatus::Pending
+            && d.correlation_id.as_deref() == Some(correlation_id)
+            && (reporter.is_empty() || d.target == reporter)
     });
     let d = matched?;
     let id = d.dispatch_id.clone();
@@ -1097,7 +1092,7 @@ pub(crate) fn scan_and_emit(home: &Path) {
             // path below.
             if d.refresh_count < REFRESH_CAP {
                 if let Some(corr) = d.correlation_id.as_deref() {
-                    let _ = refresh_issued_at(home, corr);
+                    let _ = refresh_issued_at(home, corr, &d.target);
                 }
                 bump_refresh_count(home, &d.dispatch_id);
             } else if !d.long_running_escalated {
@@ -1641,7 +1636,7 @@ mod tests {
         // An unrelated sidecar that must survive.
         let other = write_pending_at(&home, "lead", "dev", Some("t-other"), "task", 600, now);
 
-        let resolved = mark_resolved(&home, "t-dup");
+        let resolved = mark_resolved(&home, "t-dup", "dev");
         assert!(resolved.is_some(), "must report a deletion");
 
         let pending = list_pending(&home);
@@ -2331,7 +2326,7 @@ mod tests {
         let now = chrono::Utc::now();
         let id_a = write_pending_at(&home, "lead", "dev-1", Some("t-aaa"), "task", 600, now);
         let id_b = write_pending_at(&home, "lead", "dev-2", Some("t-bbb"), "task", 600, now);
-        let resolved = mark_resolved(&home, "t-aaa");
+        let resolved = mark_resolved(&home, "t-aaa", "dev-1");
         assert_eq!(
             resolved.as_deref(),
             Some(id_a.as_str()),
@@ -2390,7 +2385,7 @@ mod tests {
         pd.status = DispatchStatus::Exceeded;
         std::fs::write(&path, serde_json::to_string_pretty(&pd).unwrap()).unwrap();
 
-        let resolved = mark_resolved(&home, "t-late");
+        let resolved = mark_resolved(&home, "t-late", "dev");
         assert_eq!(
             resolved.as_deref(),
             Some(id.as_str()),
@@ -2418,7 +2413,7 @@ mod tests {
             600,
             issued,
         );
-        let resolved = mark_resolved(&home, "t-suppress");
+        let resolved = mark_resolved(&home, "t-suppress", "beta");
         assert!(resolved.is_some(), "mark_resolved must locate sidecar");
         scan_and_emit(&home);
         let inbox = crate::inbox::drain(&home, "alpha");
@@ -3242,7 +3237,7 @@ mod tests {
         let issued = chrono::Utc::now() - chrono::Duration::seconds(550);
         write_pending_at(&home, "lead", "dev", Some("t-1047-a"), "task", 600, issued);
         // Dispatchee sends update → timer resets.
-        let refreshed = refresh_issued_at(&home, "t-1047-a");
+        let refreshed = refresh_issued_at(&home, "t-1047-a", "dev");
         assert!(refreshed.is_some(), "refresh must locate sidecar");
         // Now 600s hasn't elapsed from the refreshed issued_at.
         scan_and_emit(&home);
@@ -3285,7 +3280,7 @@ mod tests {
         let home = tmp_home("1047-report");
         let issued = chrono::Utc::now() - chrono::Duration::seconds(550);
         write_pending_at(&home, "lead", "dev", Some("t-1047-c"), "task", 600, issued);
-        let resolved = mark_resolved(&home, "t-1047-c");
+        let resolved = mark_resolved(&home, "t-1047-c", "dev");
         assert!(resolved.is_some(), "report must resolve sidecar");
         let pending = list_pending(&home);
         assert!(

--- a/src/daemon/dispatch_idle/team_nudge.rs
+++ b/src/daemon/dispatch_idle/team_nudge.rs
@@ -520,7 +520,7 @@ mod tests {
         let home = tmp_home("m2-e2e");
         let id = write_exceeded_sidecar(&home, "fixup-lead", "fixup-reviewer", "t-m2c", 700);
         let path = pending_path(&home, &id);
-        crate::daemon::dispatch_idle::mark_resolved(&home, "t-m2c");
+        crate::daemon::dispatch_idle::mark_resolved(&home, "t-m2c", "fixup-reviewer");
         assert!(!path.exists(), "mark_resolved deleted the sidecar");
         assert!(
             !stamp_nudge_sent(&home, &id),

--- a/src/dispatch_tracking.rs
+++ b/src/dispatch_tracking.rs
@@ -52,20 +52,23 @@ pub fn track_dispatch(home: &Path, entry: DispatchEntry) {
     );
 }
 
-/// Mark a dispatch as completed (matched by task_id or to-instance).
-pub fn mark_completed(home: &Path, correlation_id: Option<&str>, _to: &str) {
+/// Mark a dispatch as completed. When `reporter` is non-empty, only the
+/// entry whose `to` matches the reporter is removed (reporter-scoped
+/// settlement). When `reporter` is empty, all entries for the correlation
+/// are removed (task-terminal cleanup — intentionally task-wide).
+pub fn mark_completed(home: &Path, correlation_id: Option<&str>, reporter: &str) {
     let cid = match correlation_id {
         Some(c) if !c.is_empty() => c,
-        _ => return, // No correlation_id → can't match, let sweep continue tracking
+        _ => return,
     };
     persist_or_log!(
         crate::store::mutate_versioned(&store_path(home), |store: &mut DispatchStore| {
-            // Remove the resolved dispatch entry outright (was: flip to "completed"
-            // and linger until the 30-day `gc_old_entries`). A completed dispatch
-            // needs no further warn/ask tracking, so dropping it caps accumulation
-            // at the source (the 651KB / 1649-completed bloat). Complementary to
-            // #1727: that stops `orphaned` nag; this removes the rows.
-            store.entries.retain(|e| e.task_id.as_deref() != Some(cid));
+            store.entries.retain(|e| {
+                if e.task_id.as_deref() != Some(cid) {
+                    return true;
+                }
+                !reporter.is_empty() && e.to != reporter
+            });
             Ok(())
         }),
         "dispatch_mark_completed"

--- a/src/dispatch_tracking.rs
+++ b/src/dispatch_tracking.rs
@@ -52,26 +52,42 @@ pub fn track_dispatch(home: &Path, entry: DispatchEntry) {
     );
 }
 
-/// Mark a dispatch as completed. When `reporter` is non-empty, only the
-/// entry whose `to` matches the reporter is removed (reporter-scoped
-/// settlement). When `reporter` is empty, all entries for the correlation
-/// are removed (task-terminal cleanup — intentionally task-wide).
+/// Reporter-scoped settlement: remove only the entry whose `to` matches
+/// `reporter`. Empty reporter matches nothing (fail-closed).
 pub fn mark_completed(home: &Path, correlation_id: Option<&str>, reporter: &str) {
     let cid = match correlation_id {
         Some(c) if !c.is_empty() => c,
         _ => return,
     };
+    if reporter.is_empty() {
+        return;
+    }
     persist_or_log!(
         crate::store::mutate_versioned(&store_path(home), |store: &mut DispatchStore| {
-            store.entries.retain(|e| {
-                if e.task_id.as_deref() != Some(cid) {
-                    return true;
-                }
-                !reporter.is_empty() && e.to != reporter
-            });
+            store
+                .entries
+                .retain(|e| e.task_id.as_deref() != Some(cid) || e.to != reporter);
             Ok(())
         }),
         "dispatch_mark_completed"
+    );
+}
+
+/// Task-wide cleanup: remove ALL entries for a task_id regardless of
+/// assignee. Used by `task_terminal_cleanup` when a task reaches a
+/// terminal state (done/cancelled).
+pub fn remove_all_for_task(home: &Path, task_id: &str) {
+    if task_id.is_empty() {
+        return;
+    }
+    persist_or_log!(
+        crate::store::mutate_versioned(&store_path(home), |store: &mut DispatchStore| {
+            store
+                .entries
+                .retain(|e| e.task_id.as_deref() != Some(task_id));
+            Ok(())
+        }),
+        "dispatch_remove_all_for_task"
     );
 }
 

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -41,7 +41,7 @@ use std::path::Path;
 /// silently leak either store.
 pub(crate) fn task_terminal_cleanup(home: &Path, task_id: &str) {
     let _ = crate::daemon::dispatch_idle::cleanup_pending_for_task_id(home, task_id);
-    crate::dispatch_tracking::mark_completed(home, Some(task_id), "");
+    crate::dispatch_tracking::remove_all_for_task(home, task_id);
 }
 
 pub use handler::handle;


### PR DESCRIPTION
## Summary
- Scope `dispatch_tracking::mark_completed`, `dispatch_idle::mark_resolved`, and `refresh_issued_at` by reporter identity
- A stale prior-assignee report/update can no longer remove/refresh the current assignee's dispatch tracking entry or watchdog sidecar
- Preserves task-wide cleanup for `task_terminal_cleanup` (empty reporter = task-wide)
- Implements decision d-20260716033511187355-10

## Test plan
- [ ] 6 RED→GREEN tests pass
- [ ] 15 dispatch_tracking, 88 dispatch_idle, 70 messaging module tests pass
- [ ] clippy --all-targets -D warnings clean, cargo fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)