### PR TITLE
fix: enforce usage-limit takeover operator capability at API ingress

### DIFF
--- a/docs/MCP-TOOLS.md
+++ b/docs/MCP-TOOLS.md
@@ -168,7 +168,7 @@ Revoke a specific reviewer assignment by exact `assignment_id`. Authorization: t
 
 ### `usage_limit_takeover`
 Architecture-14 item 5 Slice 2A operator-only PREPARE seam. Validates the persisted `CandidateReady` episode and writes one durable `Prepared` journal; it does not execute takeover or mutate the source binding/task/process.
-- **source**: source instance whose persisted usage-limit episode is being prepared
+- **instance**: source instance whose persisted usage-limit episode is being prepared
 - **episode_id**: exact persisted episode id; the candidate is derived from `CandidateReady` and cannot be supplied by the caller
 
 ## Daemon Operations

--- a/docs/MCP-TOOLS.md
+++ b/docs/MCP-TOOLS.md
@@ -1,6 +1,6 @@
 [繁體中文](MCP-TOOLS.zh-TW.md)
 
-# AgEnD MCP Tools Reference (31 tools)
+# AgEnD MCP Tools Reference (32 tools)
 
 ## Action-based Tools
 
@@ -165,6 +165,11 @@ Report structured daemon-side bind state for an agent. Non-destructive introspec
 ### `revoke_review_assignment`
 Revoke a specific reviewer assignment by exact `assignment_id`. Authorization: team orchestrator or operator. Idempotent — repeated calls with a stale/missing assignment_id return success. After successful revoke, merge readiness is recomputed.
 - **assignment_id**: UUID of the assignment to revoke (exact CAS identity)
+
+### `usage_limit_takeover`
+Architecture-14 item 5 Slice 2A operator-only PREPARE seam. Validates the persisted `CandidateReady` episode and writes one durable `Prepared` journal; it does not execute takeover or mutate the source binding/task/process.
+- **source**: source instance whose persisted usage-limit episode is being prepared
+- **episode_id**: exact persisted episode id; the candidate is derived from `CandidateReady` and cannot be supplied by the caller
 
 ## Daemon Operations
 

--- a/docs/MCP-TOOLS.zh-TW.md
+++ b/docs/MCP-TOOLS.zh-TW.md
@@ -168,7 +168,7 @@
 
 ### `usage_limit_takeover`
 Architecture-14 item 5 Slice 2A 的 operator-only PREPARE 介面。驗證持久化的 `CandidateReady` episode 並寫入單一 durable `Prepared` journal；不執行 takeover，也不修改 source binding、task 或 process。
-- **source**: 要準備其 usage-limit episode 的 source instance
+- **instance**: 要準備其 usage-limit episode 的 source instance
 - **episode_id**: 持久化 episode 的精確 id；candidate 從 `CandidateReady` 推導，呼叫端不可自行提供
 
 ## Daemon 操作（Daemon Operations）

--- a/docs/MCP-TOOLS.zh-TW.md
+++ b/docs/MCP-TOOLS.zh-TW.md
@@ -1,6 +1,6 @@
 [English](MCP-TOOLS.md)
 
-# AgEnD MCP Tools Reference — 工具參考（31 個工具）
+# AgEnD MCP Tools Reference — 工具參考（32 個工具）
 
 ## 動作型工具（Action-based Tools）
 
@@ -165,6 +165,11 @@
 ### `revoke_review_assignment`
 依精確的 `assignment_id` 撤銷特定的 reviewer 指派。授權對象：team orchestrator 或 operator。具冪等性——用過期或不存在的 assignment_id 重複呼叫仍會回傳成功。撤銷成功後會重新計算 merge readiness。
 - **assignment_id**: 要撤銷的指派 UUID（精確的 CAS 身分）
+
+### `usage_limit_takeover`
+Architecture-14 item 5 Slice 2A 的 operator-only PREPARE 介面。驗證持久化的 `CandidateReady` episode 並寫入單一 durable `Prepared` journal；不執行 takeover，也不修改 source binding、task 或 process。
+- **source**: 要準備其 usage-limit episode 的 source instance
+- **episode_id**: 持久化 episode 的精確 id；candidate 從 `CandidateReady` 推導，呼叫端不可自行提供
 
 ## Daemon 操作（Daemon Operations）
 

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -2798,10 +2798,10 @@ pub fn subscribe_with_dump(agent: &AgentHandle) -> (crossbeam_channel::Receiver<
 /// Minimal managed `AgentHandle` over a throwaway `true` PTY, for cross-module
 /// tests that need a registry entry whose CONTENTS are irrelevant — e.g. the
 /// t-65 register-external TOCTOU repro only needs `reg.contains_key(id)` to be
-/// true. Spawns a short-lived `true`; the caller owns cleanup of the registry.
-/// `unix`-gated: the `true` binary (and this PTY pattern) is unix-only, matching
-/// the sibling `true`-backed handle tests.
-#[cfg(all(test, unix))]
+/// true. Spawns a minimal test PTY child; the caller owns cleanup of the registry.
+/// Uses the platform's portable-pty command shape so cross-platform tests can
+/// construct the same minimal live handle.
+#[cfg(test)]
 pub(crate) fn mk_test_handle(name: &str, id: crate::types::InstanceId) -> AgentHandle {
     let pair = native_pty_system()
         .openpty(PtySize {
@@ -2811,9 +2811,16 @@ pub(crate) fn mk_test_handle(name: &str, id: crate::types::InstanceId) -> AgentH
             pixel_height: 0,
         })
         .expect("openpty");
+    #[cfg(not(target_os = "windows"))]
     let mut cmd = CommandBuilder::new("true");
+    #[cfg(target_os = "windows")]
+    let mut cmd = {
+        let mut c = CommandBuilder::new("cmd");
+        c.args(["/c", "findstr", ".*"]);
+        c
+    };
     cmd.cwd(std::env::temp_dir());
-    let child = pair.slave.spawn_command(cmd).expect("spawn true");
+    let child = pair.slave.spawn_command(cmd).expect("spawn test PTY child");
     drop(pair.slave);
     let pty_writer: PtyWriter = Arc::new(Mutex::new(pair.master.take_writer().expect("writer")));
     let pty_master: Arc<Mutex<Box<dyn MasterPty + Send>>> = Arc::new(Mutex::new(pair.master));

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -700,7 +700,7 @@ fn handle_session(
         // Agent principal can only be on `mcp_tool`/`mcp_tools_list`; Operator has
         // full authority (mode gate is a pass-through for direct methods). A deny
         // short-circuits before dispatch.
-        let response = if !operator_gate::capability_allows(principal, method) {
+        let response = if !operator_gate::capability_allows_request(principal, method, params) {
             json!({
                 "ok": false,
                 "error": format!(
@@ -1445,21 +1445,20 @@ mod tests {
         (port, home, rec, shutdown)
     }
 
-    /// Send an NDJSON request to the API server and read one response.
-    fn api_request(port: u16, home: &std::path::Path, request: &Value) -> Value {
+    /// Send an NDJSON request to the API server and read one response using a
+    /// caller-supplied authenticated principal token.
+    fn api_request_with_auth(
+        port: u16,
+        request: &Value,
+        auth: &crate::auth_cookie::Cookie,
+    ) -> Value {
         let addr = std::net::SocketAddr::from(([127, 0, 0, 1], port));
         let stream =
             std::net::TcpStream::connect_timeout(&addr, std::time::Duration::from_secs(2)).unwrap();
         let mut writer = stream.try_clone().unwrap();
         let mut reader = std::io::BufReader::new(stream);
 
-        // Auth handshake — this helper drives operator-surface DIRECT methods
-        // (delete/create_team/…), so it presents the operator full-capability
-        // token (P0a), exactly as the real `api::call`/`call_at` now do.
-        let run_dir = crate::daemon::run_dir(home);
-        let operator_token = crate::auth_cookie::read_operator_token(&run_dir).unwrap();
-        crate::auth_cookie::client_handshake_ndjson(&mut reader, &mut writer, &operator_token)
-            .unwrap();
+        crate::auth_cookie::client_handshake_ndjson(&mut reader, &mut writer, auth).unwrap();
 
         writeln!(writer, "{}", request).unwrap();
         writer.flush().unwrap();
@@ -1467,6 +1466,13 @@ mod tests {
         let mut line = String::new();
         reader.read_line(&mut line).unwrap();
         serde_json::from_str(line.trim()).unwrap_or(json!({"error": "parse failed"}))
+    }
+
+    /// Send an NDJSON request on the operator-capability surface.
+    fn api_request(port: u16, home: &std::path::Path, request: &Value) -> Value {
+        let run_dir = crate::daemon::run_dir(home);
+        let operator_token = crate::auth_cookie::read_operator_token(&run_dir).unwrap();
+        api_request_with_auth(port, request, &operator_token)
     }
 
     fn stop_server(shutdown: &Arc<AtomicBool>, home: &std::path::Path) {
@@ -1483,6 +1489,55 @@ mod tests {
         }
         std::thread::sleep(std::time::Duration::from_millis(100));
         std::fs::remove_dir_all(home).ok();
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn authenticated_agent_usage_limit_takeover_is_denied_at_api_ingress() {
+        let (port, home, _notifier, shutdown) = start_test_server("usage-limit-api-gate");
+        let run_dir = crate::daemon::run_dir(&home);
+        let agent_cookie = crate::auth_cookie::read_cookie(&run_dir).unwrap();
+
+        for mode in ["active", "away", "sleep"] {
+            let mode_resp = api_request(
+                port,
+                &home,
+                &json!({"method": "mode", "params": {"mode": mode}}),
+            );
+            assert_eq!(mode_resp["ok"], true, "mode setup failed: {mode_resp}");
+            for instance in ["", "forged-operator"] {
+                let response = api_request_with_auth(
+                    port,
+                    &json!({
+                        "method": "mcp_tool",
+                        "params": {
+                            "tool": "usage_limit_takeover",
+                            "instance": instance,
+                            "arguments": {
+                                "source": "worker-a",
+                                "episode_id": "forged"
+                            }
+                        }
+                    }),
+                    &agent_cookie,
+                );
+                assert_eq!(
+                    response["ok"], false,
+                    "agent request unexpectedly allowed: {response}"
+                );
+                assert_eq!(
+                    response["denied_by"], "capability",
+                    "denial must occur at authenticated API ingress: {response}"
+                );
+            }
+        }
+
+        let _ = api_request(
+            port,
+            &home,
+            &json!({"method": "mode", "params": {"mode": "active"}}),
+        );
+        stop_server(&shutdown, &home);
     }
 
     #[test]

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1514,7 +1514,7 @@ mod tests {
                             "tool": "usage_limit_takeover",
                             "instance": instance,
                             "arguments": {
-                                "source": "worker-a",
+                                "instance": "worker-a",
                                 "episode_id": "forged"
                             }
                         }
@@ -1547,7 +1547,7 @@ mod tests {
                     "tool": "usage_limit_takeover",
                     "instance": "",
                     "arguments": {
-                        "source": "worker-a",
+                        "instance": "worker-a",
                         "episode_id": "forged"
                     }
                 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1532,11 +1532,36 @@ mod tests {
             }
         }
 
-        let _ = api_request(
+        let active_resp = api_request(
             port,
             &home,
             &json!({"method": "mode", "params": {"mode": "active"}}),
         );
+        assert_eq!(active_resp["ok"], true, "mode reset failed: {active_resp}");
+        let operator_response = api_request(
+            port,
+            &home,
+            &json!({
+                "method": "mcp_tool",
+                "params": {
+                    "tool": "usage_limit_takeover",
+                    "instance": "",
+                    "arguments": {
+                        "source": "worker-a",
+                        "episode_id": "forged"
+                    }
+                }
+            }),
+        );
+        assert_eq!(
+            operator_response["ok"], true,
+            "operator path was gated: {operator_response}"
+        );
+        assert_eq!(
+            operator_response["result"]["error_code"], "binding_unreadable",
+            "operator request must reach the usage-limit handler: {operator_response}"
+        );
+
         stop_server(&shutdown, &home);
     }
 

--- a/src/api/operator_gate.rs
+++ b/src/api/operator_gate.rs
@@ -807,7 +807,7 @@ mod tests {
             let params = json!({
                 "tool": "usage_limit_takeover",
                 "instance": instance,
-                "arguments": {"source": "worker-a", "episode_id": "forged"}
+                "arguments": {"instance": "worker-a", "episode_id": "forged"}
             });
             assert!(
                 !capability_allows_request(P::Agent, method::MCP_TOOL, &params),

--- a/src/api/operator_gate.rs
+++ b/src/api/operator_gate.rs
@@ -172,9 +172,21 @@ pub(crate) fn capability_allows(principal: crate::auth_cookie::Principal, method
 pub(crate) fn capability_allows_request(
     principal: crate::auth_cookie::Principal,
     method: &str,
-    _params: &Value,
+    params: &Value,
 ) -> bool {
-    capability_allows(principal, method)
+    if !capability_allows(principal, method) {
+        return false;
+    }
+    // `usage_limit_takeover` is an operator-only seam. Enforce that authority
+    // from the authenticated principal before the mcp_tool worker resolves
+    // the spoofable payload instance or enters the mode gate.
+    if principal == crate::auth_cookie::Principal::Agent
+        && method == super::method::MCP_TOOL
+        && params.get("tool").and_then(Value::as_str) == Some("usage_limit_takeover")
+    {
+        return false;
+    }
+    true
 }
 
 /// Decide whether `method` (+ `params`) is allowed under the current

--- a/src/api/operator_gate.rs
+++ b/src/api/operator_gate.rs
@@ -167,6 +167,16 @@ pub(crate) fn capability_allows(principal: crate::auth_cookie::Principal, method
     }
 }
 
+/// Per-request capability gate, including the inner MCP tool carried by the
+/// authenticated `mcp_tool` transport.
+pub(crate) fn capability_allows_request(
+    principal: crate::auth_cookie::Principal,
+    method: &str,
+    _params: &Value,
+) -> bool {
+    capability_allows(principal, method)
+}
+
 /// Decide whether `method` (+ `params`) is allowed under the current
 /// `state`. `Ok(())` = allowed; `Err(reason)` = denied (caller returns the
 /// reason to the requester). Pure — no I/O, fully unit-testable.
@@ -777,5 +787,25 @@ mod tests {
                 "agent cookie must NOT be capable of direct method '{m}'"
             );
         }
+    }
+
+    #[test]
+    fn capability_agent_cannot_invoke_usage_limit_takeover_at_request_gate() {
+        for instance in ["", "forged-operator"] {
+            let params = json!({
+                "tool": "usage_limit_takeover",
+                "instance": instance,
+                "arguments": {"source": "worker-a", "episode_id": "forged"}
+            });
+            assert!(
+                !capability_allows_request(P::Agent, method::MCP_TOOL, &params),
+                "authenticated agent must be denied regardless of payload instance"
+            );
+        }
+        assert!(capability_allows_request(
+            P::Operator,
+            method::MCP_TOOL,
+            &json!({"tool": "usage_limit_takeover", "instance": ""})
+        ));
     }
 }

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -24,7 +24,7 @@ const TICK: Duration = Duration::from_secs(10);
 mod usage_limit;
 pub(crate) use usage_limit::*;
 mod reactions;
-mod usage_limit_control;
+pub(crate) mod usage_limit_control;
 pub(crate) use reactions::*;
 
 /// Vterm tail size pushed to Telegram when a stall is detected.

--- a/src/daemon/supervisor/usage_limit_control.rs
+++ b/src/daemon/supervisor/usage_limit_control.rs
@@ -152,21 +152,23 @@ trait ControlEffects {
     }
 }
 
+pub(crate) fn candidate_is_eligible(input: &TickInput, candidate: &CandidateFacts) -> bool {
+    candidate.team == input.source_team
+        && candidate.role == input.source_role
+        && candidate.backend != input.source_backend
+        && candidate.live
+        && candidate.healthy
+        && candidate.idle
+        && !candidate.bound
+        && !candidate.has_active_task
+        && !candidate.current_usage_limit
+        && candidate.routing_compatible
+}
+
 pub(crate) fn choose_candidate(input: &TickInput, candidates: &[CandidateFacts]) -> Option<String> {
     candidates
         .iter()
-        .find(|candidate| {
-            candidate.team == input.source_team
-                && candidate.role == input.source_role
-                && candidate.backend != input.source_backend
-                && candidate.live
-                && candidate.healthy
-                && candidate.idle
-                && !candidate.bound
-                && !candidate.has_active_task
-                && !candidate.current_usage_limit
-                && candidate.routing_compatible
-        })
+        .find(|candidate| candidate_is_eligible(input, candidate))
         .map(|candidate| candidate.name.clone())
 }
 
@@ -335,7 +337,10 @@ struct FsEffects<'a> {
     episode: Option<Episode>,
 }
 
-fn acquire_binding_lock(home: &Path, source: &str) -> anyhow::Result<crate::store::FileFlockGuard> {
+pub(crate) fn acquire_binding_lock(
+    home: &Path,
+    source: &str,
+) -> anyhow::Result<crate::store::FileFlockGuard> {
     crate::store::acquire_file_lock(
         &crate::paths::runtime_dir(home)
             .join(source)
@@ -343,7 +348,7 @@ fn acquire_binding_lock(home: &Path, source: &str) -> anyhow::Result<crate::stor
     )
 }
 
-fn read_current_binding(home: &Path, source: &str) -> Option<serde_json::Value> {
+pub(crate) fn read_current_binding(home: &Path, source: &str) -> Option<serde_json::Value> {
     let content = std::fs::read_to_string(
         crate::paths::runtime_dir(home)
             .join(source)
@@ -532,7 +537,7 @@ fn correlation_from_disk(home: &Path, source: &str) -> Option<(Correlation, crat
     Some((correlation, task))
 }
 
-fn fleet_facts(
+pub(crate) fn fleet_facts(
     home: &Path,
     registry: &crate::agent::AgentRegistry,
     source: &str,

--- a/src/mcp/handlers/dispatch.rs
+++ b/src/mcp/handlers/dispatch.rs
@@ -30,7 +30,7 @@ use std::path::Path;
 
 use super::{
     binding_state, channel, ci, comms, instance, restart, review_assignment, schedule, task,
-    worktree,
+    usage_limit_takeover, worktree,
 };
 
 /// Shared per-call context — every common parameter `handle_tool`
@@ -308,6 +308,9 @@ pub(crate) fn dispatch_restart_daemon(ctx: &HandlerCtx<'_>) -> Value {
 // ---------------------------------------------------------------------
 
 adapter!(dispatch_task, hai, task::handle_task);
+pub(crate) fn dispatch_usage_limit_takeover(ctx: &HandlerCtx<'_>) -> Value {
+    usage_limit_takeover::handle_usage_limit_takeover(ctx)
+}
 
 action_adapter!(dispatch_ci, "ci", [
     "watch"   => ci::handle_watch_ci,   hai;
@@ -560,9 +563,10 @@ mod tests {
                 "release_worktree",
                 "binding_state",
                 "revoke_review_assignment",
+                "usage_limit_takeover",
             ]
         );
-        assert_eq!(crate::mcp::registry::all().len(), 31);
+        assert_eq!(crate::mcp::registry::all().len(), 32);
     }
 
     #[test]

--- a/src/mcp/handlers/mod.rs
+++ b/src/mcp/handlers/mod.rs
@@ -27,6 +27,7 @@ mod send_envelope;
 mod task;
 mod usage_limit_takeover;
 #[cfg(test)]
+#[path = "usage_limit_takeover_tests.rs"]
 mod usage_limit_takeover_tests;
 mod worktree;
 

--- a/src/mcp/handlers/mod.rs
+++ b/src/mcp/handlers/mod.rs
@@ -25,6 +25,8 @@ mod restart;
 mod schedule;
 mod send_envelope;
 mod task;
+#[cfg(test)]
+mod usage_limit_takeover_tests;
 mod worktree;
 
 /// Test-only thin shim into `release_worktree`'s production handler. Used by

--- a/src/mcp/handlers/mod.rs
+++ b/src/mcp/handlers/mod.rs
@@ -25,6 +25,7 @@ mod restart;
 mod schedule;
 mod send_envelope;
 mod task;
+mod usage_limit_takeover;
 #[cfg(test)]
 mod usage_limit_takeover_tests;
 mod worktree;
@@ -35,6 +36,14 @@ mod worktree;
 #[cfg(test)]
 pub(crate) fn worktree_test_release(home: &std::path::Path, args: &Value) -> Value {
     worktree::handle_release_worktree(home, args, &None)
+}
+
+/// Shared test guard for handlers that exercise the real dispatch path. Those
+/// tests swap the process-wide `AGEND_HOME` used by `crate::home_dir()`.
+#[cfg(test)]
+pub(crate) fn fleet_test_guard() -> parking_lot::MutexGuard<'static, ()> {
+    static GUARD: parking_lot::Mutex<()> = parking_lot::Mutex::new(());
+    GUARD.lock()
 }
 
 use crate::agent_ops::save_metadata;

--- a/src/mcp/handlers/tests.rs
+++ b/src/mcp/handlers/tests.rs
@@ -233,8 +233,7 @@ use parking_lot::{Mutex, MutexGuard};
 use std::sync::Arc;
 
 fn fleet_test_guard() -> MutexGuard<'static, ()> {
-    static GUARD: Mutex<()> = Mutex::new(());
-    GUARD.lock()
+    super::fleet_test_guard()
 }
 
 struct Recorder {

--- a/src/mcp/handlers/usage_limit_takeover.rs
+++ b/src/mcp/handlers/usage_limit_takeover.rs
@@ -371,8 +371,8 @@ pub(crate) fn handle_usage_limit_takeover(ctx: &HandlerCtx<'_>) -> Value {
             "usage_limit_takeover requires daemon runtime",
         );
     };
-    let Some(source) = ctx.args.get("source").and_then(Value::as_str) else {
-        return refusal("missing_source", "source is required");
+    let Some(source) = ctx.args.get("instance").and_then(Value::as_str) else {
+        return refusal("missing_instance", "instance is required");
     };
     let Some(episode_id) = ctx.args.get("episode_id").and_then(Value::as_str) else {
         return refusal("missing_episode_id", "episode_id is required");
@@ -380,7 +380,7 @@ pub(crate) fn handle_usage_limit_takeover(ctx: &HandlerCtx<'_>) -> Value {
     if source.is_empty() || episode_id.is_empty() {
         return refusal(
             "invalid_argument",
-            "source and episode_id must be non-empty",
+            "instance and episode_id must be non-empty",
         );
     }
     let _lock = match acquire_binding_lock(ctx.home, source) {

--- a/src/mcp/handlers/usage_limit_takeover.rs
+++ b/src/mcp/handlers/usage_limit_takeover.rs
@@ -1,0 +1,396 @@
+//! Operator-only, durable PREPARE seam for usage-limit takeover.
+//!
+//! This slice deliberately stops at a journaled `Prepared` phase. It never
+//! changes a binding, task owner, process, model, or resume queue.
+
+use crate::daemon::supervisor::usage_limit_control::{
+    acquire_binding_lock, candidate_is_eligible, fleet_facts, Episode, EpisodeState, TickInput,
+};
+use crate::mcp::handlers::dispatch::HandlerCtx;
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::path::{Path, PathBuf};
+
+const JOURNAL_NAME: &str = "usage_limit_takeover.json";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PreparationJournal {
+    episode_id: String,
+    source: String,
+    candidate: String,
+    binding_issued_at: String,
+    source_head: String,
+    phase: String,
+    created_at: String,
+}
+
+fn refusal(code: &str, message: impl Into<String>) -> Value {
+    let message = message.into();
+    json!({
+        "error": format!("usage_limit_takeover refused: {message}"),
+        "error_code": code,
+        "code": code,
+        "message": message,
+    })
+}
+
+fn field<'a>(binding: &'a Value, name: &str) -> Option<&'a str> {
+    binding
+        .get(name)
+        .and_then(Value::as_str)
+        .filter(|v| !v.is_empty())
+}
+
+fn journal_path(home: &Path, source: &str) -> PathBuf {
+    crate::paths::runtime_dir(home)
+        .join(source)
+        .join(JOURNAL_NAME)
+}
+
+fn git_proof(worktree: &Path, branch: &str) -> Result<String, Value> {
+    if !worktree.is_dir() {
+        return Err(refusal(
+            "worktree_unreadable",
+            "binding worktree is not a directory",
+        ));
+    }
+    let current_branch = crate::git_helpers::git_cmd(worktree, &["branch", "--show-current"])
+        .map_err(|_| refusal("git_unreadable", "cannot read source worktree branch"))?;
+    if current_branch != branch {
+        return Err(refusal(
+            "branch_mismatch",
+            format!("source worktree branch is {current_branch:?}, expected {branch:?}"),
+        ));
+    }
+    let status = crate::git_helpers::git_cmd(worktree, &["status", "--porcelain"])
+        .map_err(|_| refusal("git_unreadable", "cannot read source worktree status"))?;
+    if !status.is_empty() {
+        return Err(refusal(
+            "source_dirty",
+            "source worktree has uncommitted changes",
+        ));
+    }
+    crate::git_helpers::git_cmd(worktree, &["rev-parse", "HEAD"])
+        .map_err(|_| refusal("git_unreadable", "cannot prove source HEAD"))
+}
+
+fn load_episode(home: &Path, source: &str) -> Result<Episode, Value> {
+    let path = crate::paths::runtime_dir(home)
+        .join(source)
+        .join("usage_limit_episode.json");
+    let bytes = std::fs::read(&path)
+        .map_err(|_| refusal("episode_unreadable", "usage-limit episode is unreadable"))?;
+    serde_json::from_slice(&bytes)
+        .map_err(|_| refusal("episode_unreadable", "usage-limit episode is malformed"))
+}
+
+fn validate_blocked_task(
+    home: &Path,
+    task_id: &str,
+    source: &str,
+    branch: &str,
+    issued_at: &str,
+    episode_id: &str,
+    candidate: &str,
+) -> Result<(), Value> {
+    let routed = crate::tasks::load_routed(home, task_id)
+        .map_err(|_| refusal("task_unreadable", "task route is not uniquely readable"))?;
+    if routed.task.status != crate::task_events::TaskStatus::Blocked
+        || routed.task.assignee.as_deref() != Some(source)
+        || routed.task.branch.as_deref() != Some(branch)
+        || routed.record().owner.as_ref().map(|owner| owner.as_str()) != Some(source)
+        || routed.record().branch.as_deref() != Some(branch)
+    {
+        return Err(refusal(
+            "task_generation_mismatch",
+            "task is not blocked for the exact source and branch",
+        ));
+    }
+    let reason = routed
+        .record()
+        .block_reason
+        .as_deref()
+        .and_then(|raw| serde_json::from_str::<Value>(raw).ok())
+        .ok_or_else(|| {
+            refusal(
+                "blocked_reason_mismatch",
+                "task blocked reason is unreadable",
+            )
+        })?;
+    let base_exact = reason.get("type").and_then(Value::as_str) == Some("usage_limit_episode")
+        && reason.get("episode_id").and_then(Value::as_str) == Some(episode_id)
+        && reason.get("source").and_then(Value::as_str) == Some(source)
+        && reason.get("binding_issued_at").and_then(Value::as_str) == Some(issued_at)
+        && reason.get("branch").and_then(Value::as_str) == Some(branch)
+        && reason.get("state").and_then(Value::as_str) == Some("CandidateReady")
+        && reason
+            .get("proposal")
+            .and_then(|proposal| proposal.get("executable"))
+            .and_then(Value::as_bool)
+            == Some(false)
+        && reason
+            .get("proposal")
+            .and_then(|proposal| proposal.get("requires"))
+            .and_then(Value::as_str)
+            == Some("operator_takeover_slice_2");
+    let recorded_candidate = reason
+        .get("proposal")
+        .and_then(|proposal| proposal.get("candidate"))
+        .and_then(Value::as_str);
+    if base_exact && recorded_candidate == Some(candidate) {
+        Ok(())
+    } else if base_exact && recorded_candidate.is_some() {
+        Err(refusal(
+            "candidate_mismatch",
+            "task block reason records a different candidate",
+        ))
+    } else {
+        Err(refusal(
+            "blocked_reason_mismatch",
+            "task block reason does not prove this episode and candidate",
+        ))
+    }
+}
+
+fn validate_candidate(
+    home: &Path,
+    registry: &crate::agent::AgentRegistry,
+    source: &str,
+    task: &crate::tasks::Task,
+    candidate: &str,
+) -> Result<(), Value> {
+    let fleet = crate::teams::try_load_fleet(home)
+        .map_err(|_| refusal("fleet_unreadable", "fleet configuration is unreadable"))?;
+    let source_backend = fleet
+        .resolve_instance(source)
+        .map(|resolved| resolved.backend.as_str().to_string())
+        .ok_or_else(|| refusal("source_unreadable", "source instance is not configured"))?;
+    let (source_team, source_role, candidates, _) = fleet_facts(home, registry, source, Some(task));
+    let input = TickInput {
+        now: Utc::now(),
+        raw_state: crate::state::AgentState::UsageLimit,
+        source_backend,
+        source_team,
+        source_role,
+        unlock_at: None,
+        correlation: None,
+        candidates: Vec::new(),
+        recipient: String::new(),
+    };
+    let Some(facts) = candidates.iter().find(|facts| facts.name == candidate) else {
+        return Err(refusal(
+            "candidate_ineligible",
+            "episode candidate is not live in the source team",
+        ));
+    };
+    if candidate_is_eligible(&input, facts) {
+        Ok(())
+    } else {
+        Err(refusal(
+            "candidate_ineligible",
+            "episode candidate no longer satisfies current eligibility",
+        ))
+    }
+}
+
+fn prepare(
+    home: &Path,
+    registry: &crate::agent::AgentRegistry,
+    source: &str,
+    episode_id: &str,
+) -> Value {
+    let Some(binding) =
+        crate::daemon::supervisor::usage_limit_control::read_current_binding(home, source)
+    else {
+        return refusal(
+            "binding_unreadable",
+            "source binding is missing or malformed",
+        );
+    };
+    if field(&binding, "agent") != Some(source) {
+        return refusal(
+            "binding_source_mismatch",
+            "binding agent does not match source",
+        );
+    }
+    let episode = match load_episode(home, source) {
+        Ok(episode) => episode,
+        Err(error) => return error,
+    };
+    let candidate = match episode.candidate.as_deref() {
+        Some(candidate) if !candidate.is_empty() => candidate,
+        _ => {
+            return refusal(
+                "candidate_ineligible",
+                "CandidateReady episode has no candidate",
+            )
+        }
+    };
+    if episode.state != EpisodeState::CandidateReady {
+        return refusal(
+            "episode_not_candidate_ready",
+            "episode is not CandidateReady",
+        );
+    }
+    if episode.key.source != source || episode.key.notification_id() != episode_id {
+        return refusal(
+            "episode_mismatch",
+            "requested episode is not the persisted source episode",
+        );
+    }
+    let issued_at = match field(&binding, "issued_at") {
+        Some(value) if value == episode.key.binding_issued_at => value,
+        _ => {
+            return refusal(
+                "binding_generation_mismatch",
+                "binding generation differs from episode",
+            )
+        }
+    };
+    if field(&binding, "task_id") != Some(episode.key.task_id.as_str())
+        || field(&binding, "branch") != Some(episode.key.branch.as_str())
+    {
+        return refusal(
+            "binding_generation_mismatch",
+            "binding task or branch differs from episode",
+        );
+    }
+    let worktree = match field(&binding, "worktree") {
+        Some(path) => PathBuf::from(path),
+        None => return refusal("worktree_unreadable", "binding has no worktree path"),
+    };
+    let source_repo = match field(&binding, "source_repo") {
+        Some(path) => PathBuf::from(path),
+        None => return refusal("source_unreadable", "binding has no source repository path"),
+    };
+    if !source_repo.is_dir()
+        || crate::git_helpers::git_cmd(&source_repo, &["rev-parse", "--show-toplevel"]).is_err()
+    {
+        return refusal("source_unreadable", "binding has no source repository path");
+    }
+    let source_head = match git_proof(&worktree, &episode.key.branch) {
+        Ok(head) => head,
+        Err(error) => return error,
+    };
+    let routed = match crate::tasks::load_routed(home, &episode.key.task_id) {
+        Ok(routed) => routed,
+        Err(_) => return refusal("task_unreadable", "task route is not uniquely readable"),
+    };
+    if let Err(error) = validate_blocked_task(
+        home,
+        &episode.key.task_id,
+        source,
+        &episode.key.branch,
+        issued_at,
+        episode_id,
+        candidate,
+    ) {
+        return error;
+    }
+    if let Err(error) = validate_candidate(home, registry, source, &routed.task, candidate) {
+        return error;
+    }
+
+    let path = journal_path(home, source);
+    match std::fs::read(&path) {
+        Ok(bytes) => {
+            let journal: PreparationJournal = match serde_json::from_slice(&bytes) {
+                Ok(journal) => journal,
+                Err(_) => return refusal("journal_unreadable", "takeover journal is malformed"),
+            };
+            if journal.episode_id == episode_id
+                && journal.source == source
+                && journal.candidate == candidate
+                && journal.binding_issued_at == issued_at
+                && journal.source_head == source_head
+                && journal.phase == "Prepared"
+            {
+                return json!({
+                    "status": "prepared",
+                    "phase": journal.phase,
+                    "episode_id": journal.episode_id,
+                    "source": journal.source,
+                    "candidate": journal.candidate,
+                    "binding_issued_at": journal.binding_issued_at,
+                    "source_head": journal.source_head,
+                    "created_at": journal.created_at,
+                    "idempotent": true,
+                });
+            }
+            return refusal(
+                "conflicting_preparation",
+                "source already has a different prepared takeover",
+            );
+        }
+        Err(error) if error.kind() != std::io::ErrorKind::NotFound && !path.is_dir() => {
+            return refusal("journal_unreadable", "takeover journal cannot be read")
+        }
+        Err(_) => {}
+    }
+
+    let journal = PreparationJournal {
+        episode_id: episode_id.to_string(),
+        source: source.to_string(),
+        candidate: candidate.to_string(),
+        binding_issued_at: issued_at.to_string(),
+        source_head: source_head.clone(),
+        phase: "Prepared".into(),
+        created_at: Utc::now().to_rfc3339(),
+    };
+    let bytes = match serde_json::to_vec_pretty(&journal) {
+        Ok(bytes) => bytes,
+        Err(_) => return refusal("journal_write_failed", "cannot serialize takeover journal"),
+    };
+    if crate::store::atomic_write(&path, &bytes).is_err() {
+        return refusal(
+            "journal_write_failed",
+            "cannot durably write takeover journal",
+        );
+    }
+    json!({
+        "status": "prepared",
+        "phase": "Prepared",
+        "episode_id": episode_id,
+        "source": source,
+        "candidate": candidate,
+        "binding_issued_at": issued_at,
+        "source_head": source_head,
+        "created_at": journal.created_at,
+        "idempotent": false,
+    })
+}
+
+pub(crate) fn handle_usage_limit_takeover(ctx: &HandlerCtx<'_>) -> Value {
+    if ctx.sender.is_some() {
+        return refusal("operator_only", "usage_limit_takeover is operator-only");
+    }
+    let Some(runtime) = ctx.runtime else {
+        return refusal(
+            "runtime_unavailable",
+            "usage_limit_takeover requires daemon runtime",
+        );
+    };
+    let Some(source) = ctx.args.get("source").and_then(Value::as_str) else {
+        return refusal("missing_source", "source is required");
+    };
+    let Some(episode_id) = ctx.args.get("episode_id").and_then(Value::as_str) else {
+        return refusal("missing_episode_id", "episode_id is required");
+    };
+    if source.is_empty() || episode_id.is_empty() {
+        return refusal(
+            "invalid_argument",
+            "source and episode_id must be non-empty",
+        );
+    }
+    let _lock = match acquire_binding_lock(ctx.home, source) {
+        Ok(lock) => lock,
+        Err(_) => {
+            return refusal(
+                "source_lock_failed",
+                "cannot acquire source-scoped takeover lock",
+            )
+        }
+    };
+    prepare(ctx.home, &runtime.registry, source, episode_id)
+}

--- a/src/mcp/handlers/usage_limit_takeover_tests.rs
+++ b/src/mcp/handlers/usage_limit_takeover_tests.rs
@@ -190,7 +190,7 @@ fn usage_limit_takeover_prepares_through_real_mcp_entry() {
     let f = fixture("success");
     let result = call(
         &f,
-        json!({"source": "worker-a", "episode_id": f.episode_id}),
+        json!({"instance": "worker-a", "episode_id": f.episode_id}),
     );
     assert_eq!(result["phase"], "Prepared", "unexpected result: {result}");
     assert_eq!(result["candidate"], "worker-b");
@@ -200,7 +200,7 @@ fn usage_limit_takeover_prepares_through_real_mcp_entry() {
 #[serial]
 fn usage_limit_takeover_repeat_is_idempotent() {
     let f = fixture("repeat");
-    let args = json!({"source": "worker-a", "episode_id": f.episode_id});
+    let args = json!({"instance": "worker-a", "episode_id": f.episode_id});
     let first = call(&f, args.clone());
     let second = call(&f, args);
     assert_eq!(first["phase"], "Prepared", "first: {first}");
@@ -212,7 +212,7 @@ fn usage_limit_takeover_repeat_is_idempotent() {
 #[serial]
 fn usage_limit_takeover_concurrent_barrier_requests_converge_one_prepared_identity() {
     let f = fixture("concurrency-barrier");
-    let args = json!({"source": "worker-a", "episode_id": f.episode_id});
+    let args = json!({"instance": "worker-a", "episode_id": f.episode_id});
     let barrier = Arc::new(Barrier::new(2));
     let mut threads = Vec::new();
     for _ in 0..2 {
@@ -253,7 +253,7 @@ fn usage_limit_takeover_concurrent_barrier_requests_converge_one_prepared_identi
 #[serial]
 fn usage_limit_takeover_conflicting_existing_journal_fails_closed() {
     let f = fixture("conflict");
-    let args = json!({"source": "worker-a", "episode_id": f.episode_id});
+    let args = json!({"instance": "worker-a", "episode_id": f.episode_id});
     let first = call(&f, args.clone());
     assert_eq!(first["phase"], "Prepared", "first: {first}");
     let journal = crate::paths::runtime_dir(&f.home).join("worker-a/usage_limit_takeover.json");
@@ -280,7 +280,7 @@ fn usage_limit_takeover_refuses_dirty_source_without_journal() {
     std::fs::write(f.worktree.join("tracked.txt"), "dirty\n").expect("dirty");
     let result = call(
         &f,
-        json!({"source": "worker-a", "episode_id": f.episode_id}),
+        json!({"instance": "worker-a", "episode_id": f.episode_id}),
     );
     assert_eq!(code(&result), "source_dirty", "unexpected result: {result}");
     assert!(!crate::paths::runtime_dir(&f.home)
@@ -304,7 +304,7 @@ fn usage_limit_takeover_refuses_generation_mismatch() {
     .expect("binding");
     let result = call(
         &f,
-        json!({"source": "worker-a", "episode_id": f.episode_id}),
+        json!({"instance": "worker-a", "episode_id": f.episode_id}),
     );
     assert_eq!(
         code(&result),
@@ -329,7 +329,7 @@ fn usage_limit_takeover_refuses_candidate_mismatch() {
     .expect("episode");
     let result = call(
         &f,
-        json!({"source": "worker-a", "episode_id": f.episode_id}),
+        json!({"instance": "worker-a", "episode_id": f.episode_id}),
     );
     assert_eq!(
         code(&result),
@@ -351,7 +351,7 @@ fn usage_limit_takeover_refuses_currently_ineligible_candidate() {
     drop(registry);
     let result = call(
         &f,
-        json!({"source": "worker-a", "episode_id": f.episode_id}),
+        json!({"instance": "worker-a", "episode_id": f.episode_id}),
     );
     assert_eq!(
         code(&result),
@@ -368,7 +368,7 @@ fn usage_limit_takeover_refuses_journal_write_failure_without_partial() {
     std::fs::create_dir_all(&journal).expect("journal collision");
     let result = call(
         &f,
-        json!({"source": "worker-a", "episode_id": f.episode_id}),
+        json!({"instance": "worker-a", "episode_id": f.episode_id}),
     );
     assert_eq!(
         code(&result),
@@ -384,7 +384,7 @@ fn usage_limit_takeover_is_operator_only() {
     let f = fixture("operator-only");
     let result = execute_tool_with_runtime(
         "usage_limit_takeover",
-        &json!({"source": "worker-a", "episode_id": f.episode_id}),
+        &json!({"instance": "worker-a", "episode_id": f.episode_id}),
         "worker-a",
         f.runtime.clone(),
     );

--- a/src/mcp/handlers/usage_limit_takeover_tests.rs
+++ b/src/mcp/handlers/usage_limit_takeover_tests.rs
@@ -5,7 +5,7 @@ use crate::types::InstanceId;
 use serde_json::{json, Value};
 use serial_test::serial;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, Barrier};
 
 struct Fixture {
     home: PathBuf,
@@ -200,6 +200,48 @@ fn usage_limit_takeover_repeat_is_idempotent() {
     assert_eq!(first["phase"], "Prepared", "first: {first}");
     assert_eq!(second["phase"], "Prepared", "second: {second}");
     assert_eq!(second["idempotent"], true, "repeat: {second}");
+}
+
+#[test]
+#[serial]
+fn usage_limit_takeover_concurrent_barrier_requests_converge_one_prepared_identity() {
+    let f = fixture("concurrency-barrier");
+    let args = json!({"source": "worker-a", "episode_id": f.episode_id});
+    let barrier = Arc::new(Barrier::new(2));
+    let mut threads = Vec::new();
+    for _ in 0..2 {
+        let runtime = f.runtime.clone();
+        let args = args.clone();
+        let barrier = Arc::clone(&barrier);
+        threads.push(std::thread::spawn(move || {
+            barrier.wait();
+            execute_tool_with_runtime("usage_limit_takeover", &args, "", runtime)
+        }));
+    }
+    let results: Vec<_> = threads
+        .into_iter()
+        .map(|thread| thread.join().expect("takeover thread"))
+        .collect();
+    assert_eq!(results.len(), 2);
+    assert!(
+        results.iter().all(|result| result["phase"] == "Prepared"),
+        "concurrent results: {results:?}"
+    );
+
+    let journal_path =
+        crate::paths::runtime_dir(&f.home).join("worker-a/usage_limit_takeover.json");
+    let journal_bytes = std::fs::read(&journal_path).expect("one prepared journal");
+    let journal: Value = serde_json::from_slice(&journal_bytes).expect("journal json");
+    assert_eq!(journal["phase"], "Prepared");
+    assert_eq!(journal["episode_id"], f.episode_id);
+    assert_eq!(journal["source"], "worker-a");
+    assert_eq!(journal["candidate"], "worker-b");
+    assert_eq!(journal["binding_issued_at"], "2026-07-16T05:00:00Z");
+    assert_eq!(journal["source_head"].as_str().map(str::len), Some(40));
+    assert!(
+        journal_path.is_file(),
+        "exactly one journal identity must remain"
+    );
 }
 
 #[test]

--- a/src/mcp/handlers/usage_limit_takeover_tests.rs
+++ b/src/mcp/handlers/usage_limit_takeover_tests.rs
@@ -12,6 +12,7 @@ struct Fixture {
     runtime: RuntimeContext,
     episode_id: String,
     worktree: PathBuf,
+    _env_guard: parking_lot::MutexGuard<'static, ()>,
     _source: String,
 }
 
@@ -41,6 +42,7 @@ fn git(path: &Path, args: &[&str]) -> String {
 }
 
 fn fixture(tag: &str) -> Fixture {
+    let env_guard = super::fleet_test_guard();
     let home = std::env::temp_dir().join(format!(
         "agend-usage-limit-takeover-{tag}-{}",
         uuid::Uuid::new_v4()
@@ -119,7 +121,11 @@ fn fixture(tag: &str) -> Fixture {
                     "binding_issued_at": "2026-07-16T05:00:00Z",
                     "branch": "feat/slice-1",
                     "state": "CandidateReady",
-                    "proposal": {"candidate": "worker-b"}
+                    "proposal": {
+                        "candidate": "worker-b",
+                        "executable": false,
+                        "requires": "operator_takeover_slice_2"
+                    }
                 })
                 .to_string(),
             },
@@ -149,10 +155,9 @@ fn fixture(tag: &str) -> Fixture {
     .expect("episode");
 
     let candidate = crate::agent::mk_test_handle("worker-b", InstanceId::new());
-    let registry = Arc::new(parking_lot::Mutex::new(std::collections::HashMap::from([(
-        candidate.id,
-        candidate,
-    )])));
+    let registry = Arc::new(parking_lot::Mutex::new(std::collections::HashMap::from([
+        (candidate.id, candidate),
+    ])));
     let runtime = RuntimeContext {
         registry,
         externals: Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new())),
@@ -166,6 +171,7 @@ fn fixture(tag: &str) -> Fixture {
         runtime,
         episode_id,
         worktree,
+        _env_guard: env_guard,
         _source: "worker-a".into(),
     }
 }
@@ -227,7 +233,6 @@ fn usage_limit_takeover_concurrent_barrier_requests_converge_one_prepared_identi
         results.iter().all(|result| result["phase"] == "Prepared"),
         "concurrent results: {results:?}"
     );
-
     let journal_path =
         crate::paths::runtime_dir(&f.home).join("worker-a/usage_limit_takeover.json");
     let journal_bytes = std::fs::read(&journal_path).expect("one prepared journal");
@@ -241,6 +246,30 @@ fn usage_limit_takeover_concurrent_barrier_requests_converge_one_prepared_identi
     assert!(
         journal_path.is_file(),
         "exactly one journal identity must remain"
+    );
+}
+
+#[test]
+#[serial]
+fn usage_limit_takeover_conflicting_existing_journal_fails_closed() {
+    let f = fixture("conflict");
+    let args = json!({"source": "worker-a", "episode_id": f.episode_id});
+    let first = call(&f, args.clone());
+    assert_eq!(first["phase"], "Prepared", "first: {first}");
+    let journal = crate::paths::runtime_dir(&f.home).join("worker-a/usage_limit_takeover.json");
+    let mut persisted: Value =
+        serde_json::from_slice(&std::fs::read(&journal).expect("journal")).expect("journal json");
+    persisted["candidate"] = json!("worker-c");
+    std::fs::write(
+        &journal,
+        serde_json::to_vec_pretty(&persisted).expect("journal write"),
+    )
+    .expect("journal");
+    let second = call(&f, args);
+    assert_eq!(
+        code(&second),
+        "conflicting_preparation",
+        "unexpected result: {second}"
     );
 }
 
@@ -264,11 +293,15 @@ fn usage_limit_takeover_refuses_dirty_source_without_journal() {
 fn usage_limit_takeover_refuses_generation_mismatch() {
     let f = fixture("generation");
     let binding_path = crate::paths::runtime_dir(&f.home).join("worker-a/binding.json");
-    let mut binding: Value = serde_json::from_slice(&std::fs::read(&binding_path).expect("binding"))
-        .expect("binding json");
+    let mut binding: Value =
+        serde_json::from_slice(&std::fs::read(&binding_path).expect("binding"))
+            .expect("binding json");
     binding["issued_at"] = json!("2026-07-16T06:00:00Z");
-    std::fs::write(&binding_path, serde_json::to_vec_pretty(&binding).expect("binding write"))
-        .expect("binding");
+    std::fs::write(
+        &binding_path,
+        serde_json::to_vec_pretty(&binding).expect("binding write"),
+    )
+    .expect("binding");
     let result = call(
         &f,
         json!({"source": "worker-a", "episode_id": f.episode_id}),
@@ -285,16 +318,46 @@ fn usage_limit_takeover_refuses_generation_mismatch() {
 fn usage_limit_takeover_refuses_candidate_mismatch() {
     let f = fixture("candidate");
     let episode_path = crate::paths::runtime_dir(&f.home).join("worker-a/usage_limit_episode.json");
-    let mut episode: Value = serde_json::from_slice(&std::fs::read(&episode_path).expect("episode"))
-        .expect("episode json");
+    let mut episode: Value =
+        serde_json::from_slice(&std::fs::read(&episode_path).expect("episode"))
+            .expect("episode json");
     episode["candidate"] = json!("worker-c");
-    std::fs::write(&episode_path, serde_json::to_vec_pretty(&episode).expect("episode write"))
-        .expect("episode");
+    std::fs::write(
+        &episode_path,
+        serde_json::to_vec_pretty(&episode).expect("episode write"),
+    )
+    .expect("episode");
     let result = call(
         &f,
         json!({"source": "worker-a", "episode_id": f.episode_id}),
     );
-    assert_eq!(code(&result), "candidate_ineligible", "unexpected result: {result}");
+    assert_eq!(
+        code(&result),
+        "candidate_mismatch",
+        "unexpected result: {result}"
+    );
+}
+
+#[test]
+#[serial]
+fn usage_limit_takeover_refuses_currently_ineligible_candidate() {
+    let f = fixture("ineligible");
+    let registry = f.runtime.registry.lock();
+    let handle = registry.values().next().expect("candidate");
+    handle.published_state.store(
+        crate::state::AgentState::UsageLimit as u8,
+        std::sync::atomic::Ordering::Relaxed,
+    );
+    drop(registry);
+    let result = call(
+        &f,
+        json!({"source": "worker-a", "episode_id": f.episode_id}),
+    );
+    assert_eq!(
+        code(&result),
+        "candidate_ineligible",
+        "unexpected result: {result}"
+    );
 }
 
 #[test]
@@ -307,7 +370,11 @@ fn usage_limit_takeover_refuses_journal_write_failure_without_partial() {
         &f,
         json!({"source": "worker-a", "episode_id": f.episode_id}),
     );
-    assert_eq!(code(&result), "journal_write_failed", "unexpected result: {result}");
+    assert_eq!(
+        code(&result),
+        "journal_write_failed",
+        "unexpected result: {result}"
+    );
     assert!(journal.is_dir(), "failed write must not replace collision");
 }
 
@@ -321,5 +388,9 @@ fn usage_limit_takeover_is_operator_only() {
         "worker-a",
         f.runtime.clone(),
     );
-    assert_eq!(code(&result), "operator_only", "unexpected result: {result}");
+    assert_eq!(
+        code(&result),
+        "operator_only",
+        "unexpected result: {result}"
+    );
 }

--- a/src/mcp/handlers/usage_limit_takeover_tests.rs
+++ b/src/mcp/handlers/usage_limit_takeover_tests.rs
@@ -1,0 +1,283 @@
+use super::dispatch::RuntimeContext;
+use crate::daemon::supervisor::usage_limit_control::{Episode, EpisodeKey, EpisodeState};
+use crate::mcp::execute_tool_with_runtime;
+use crate::types::InstanceId;
+use serde_json::{json, Value};
+use serial_test::serial;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+struct Fixture {
+    home: PathBuf,
+    runtime: RuntimeContext,
+    episode_id: String,
+    worktree: PathBuf,
+    _source: String,
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        std::env::remove_var("AGEND_HOME");
+        let _ = std::fs::remove_dir_all(&self.home);
+    }
+}
+
+fn git(path: &Path, args: &[&str]) -> String {
+    let output = std::process::Command::new("git")
+        .args(args)
+        .current_dir(path)
+        .output()
+        .expect("git command");
+    assert!(
+        output.status.success(),
+        "git {:?}: {}",
+        args,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout)
+        .expect("git utf8")
+        .trim()
+        .to_string()
+}
+
+fn fixture(tag: &str) -> Fixture {
+    let home = std::env::temp_dir().join(format!(
+        "agend-usage-limit-takeover-{tag}-{}",
+        uuid::Uuid::new_v4()
+    ));
+    std::fs::create_dir_all(&home).expect("home");
+    std::env::set_var("AGEND_HOME", &home);
+    std::fs::write(
+        home.join("fleet.yaml"),
+        "instances:\n  worker-a: { backend: codex, role: dev }\n  worker-b: { backend: claude, role: dev }\nteams:\n  archfix:\n    members: [worker-a, worker-b]\n    orchestrator: worker-a\n",
+    )
+    .expect("fleet");
+
+    let worktree = home.join("source-worktree");
+    std::fs::create_dir_all(&worktree).expect("worktree");
+    git(&worktree, &["init", "-q"]);
+    git(&worktree, &["config", "user.email", "test@example.invalid"]);
+    git(&worktree, &["config", "user.name", "test"]);
+    std::fs::write(worktree.join("tracked.txt"), "clean\n").expect("tracked");
+    git(&worktree, &["add", "tracked.txt"]);
+    git(&worktree, &["commit", "-qm", "fixture"]);
+    git(&worktree, &["branch", "-M", "feat/slice-1"]);
+    let source_head = git(&worktree, &["rev-parse", "HEAD"]);
+
+    let runtime_dir = crate::paths::runtime_dir(&home).join("worker-a");
+    std::fs::create_dir_all(&runtime_dir).expect("runtime");
+    let binding = json!({
+        "version": 1,
+        "agent": "worker-a",
+        "task_id": "t-takeover",
+        "branch": "feat/slice-1",
+        "issued_at": "2026-07-16T05:00:00Z",
+        "worktree": worktree,
+        "source_repo": worktree,
+    });
+    std::fs::write(
+        runtime_dir.join("binding.json"),
+        serde_json::to_vec_pretty(&binding).expect("binding json"),
+    )
+    .expect("binding");
+
+    let task_id = crate::task_events::TaskId("t-takeover".into());
+    let owner = crate::task_events::InstanceName("worker-a".into());
+    crate::task_events::append_batch(
+        &home,
+        &owner,
+        vec![
+            crate::task_events::TaskEvent::Created {
+                task_id: task_id.clone(),
+                title: "takeover".into(),
+                description: String::new(),
+                priority: "high".into(),
+                owner: Some(owner.clone()),
+                due_at: None,
+                depends_on: Vec::new(),
+                routed_to: None,
+                branch: Some("feat/slice-1".into()),
+                bind: Some(true),
+                eta_secs: None,
+                tags: Vec::new(),
+                parent_id: None,
+            },
+            crate::task_events::TaskEvent::Claimed {
+                task_id: task_id.clone(),
+                by: owner.clone(),
+            },
+            crate::task_events::TaskEvent::InProgress {
+                task_id: task_id.clone(),
+                by: owner.clone(),
+            },
+            crate::task_events::TaskEvent::Blocked {
+                task_id,
+                reason: json!({
+                    "type": "usage_limit_episode",
+                    "episode_id": "usage-limit:t-takeover:worker-a:2026-07-16T05:00:00Z:feat/slice-1",
+                    "source": "worker-a",
+                    "binding_issued_at": "2026-07-16T05:00:00Z",
+                    "branch": "feat/slice-1",
+                    "state": "CandidateReady",
+                    "proposal": {"candidate": "worker-b"}
+                })
+                .to_string(),
+            },
+        ],
+    )
+    .expect("task events");
+
+    let key = EpisodeKey {
+        task_id: "t-takeover".into(),
+        source: "worker-a".into(),
+        binding_issued_at: "2026-07-16T05:00:00Z".into(),
+        branch: "feat/slice-1".into(),
+    };
+    let episode_id = key.notification_id();
+    std::fs::write(
+        runtime_dir.join("usage_limit_episode.json"),
+        serde_json::to_vec_pretty(&Episode {
+            key,
+            state: EpisodeState::CandidateReady,
+            consecutive_ticks: 2,
+            candidate: Some("worker-b".into()),
+            unlock_at: Some("2026-07-16T06:00:00Z".into()),
+            recipient: "worker-a".into(),
+        })
+        .expect("episode json"),
+    )
+    .expect("episode");
+
+    let candidate = crate::agent::mk_test_handle("worker-b", InstanceId::new());
+    let registry = Arc::new(parking_lot::Mutex::new(std::collections::HashMap::from([(
+        candidate.id,
+        candidate,
+    )])));
+    let runtime = RuntimeContext {
+        registry,
+        externals: Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new())),
+        capability: crate::api::RestartCapability::Unsupported,
+        app_restart: None,
+        post_flush: None,
+    };
+    let _ = source_head;
+    Fixture {
+        home,
+        runtime,
+        episode_id,
+        worktree,
+        _source: "worker-a".into(),
+    }
+}
+
+fn call(f: &Fixture, args: Value) -> Value {
+    execute_tool_with_runtime("usage_limit_takeover", &args, "", f.runtime.clone())
+}
+
+fn code(value: &Value) -> &str {
+    value["error_code"].as_str().unwrap_or("")
+}
+
+#[test]
+#[serial]
+fn usage_limit_takeover_prepares_through_real_mcp_entry() {
+    let f = fixture("success");
+    let result = call(
+        &f,
+        json!({"source": "worker-a", "episode_id": f.episode_id}),
+    );
+    assert_eq!(result["phase"], "Prepared", "unexpected result: {result}");
+    assert_eq!(result["candidate"], "worker-b");
+}
+
+#[test]
+#[serial]
+fn usage_limit_takeover_repeat_is_idempotent() {
+    let f = fixture("repeat");
+    let args = json!({"source": "worker-a", "episode_id": f.episode_id});
+    let first = call(&f, args.clone());
+    let second = call(&f, args);
+    assert_eq!(first["phase"], "Prepared", "first: {first}");
+    assert_eq!(second["phase"], "Prepared", "second: {second}");
+    assert_eq!(second["idempotent"], true, "repeat: {second}");
+}
+
+#[test]
+#[serial]
+fn usage_limit_takeover_refuses_dirty_source_without_journal() {
+    let f = fixture("dirty");
+    std::fs::write(f.worktree.join("tracked.txt"), "dirty\n").expect("dirty");
+    let result = call(
+        &f,
+        json!({"source": "worker-a", "episode_id": f.episode_id}),
+    );
+    assert_eq!(code(&result), "source_dirty", "unexpected result: {result}");
+    assert!(!crate::paths::runtime_dir(&f.home)
+        .join("worker-a/usage_limit_takeover.json")
+        .exists());
+}
+
+#[test]
+#[serial]
+fn usage_limit_takeover_refuses_generation_mismatch() {
+    let f = fixture("generation");
+    let binding_path = crate::paths::runtime_dir(&f.home).join("worker-a/binding.json");
+    let mut binding: Value = serde_json::from_slice(&std::fs::read(&binding_path).expect("binding"))
+        .expect("binding json");
+    binding["issued_at"] = json!("2026-07-16T06:00:00Z");
+    std::fs::write(&binding_path, serde_json::to_vec_pretty(&binding).expect("binding write"))
+        .expect("binding");
+    let result = call(
+        &f,
+        json!({"source": "worker-a", "episode_id": f.episode_id}),
+    );
+    assert_eq!(
+        code(&result),
+        "binding_generation_mismatch",
+        "unexpected result: {result}"
+    );
+}
+
+#[test]
+#[serial]
+fn usage_limit_takeover_refuses_candidate_mismatch() {
+    let f = fixture("candidate");
+    let episode_path = crate::paths::runtime_dir(&f.home).join("worker-a/usage_limit_episode.json");
+    let mut episode: Value = serde_json::from_slice(&std::fs::read(&episode_path).expect("episode"))
+        .expect("episode json");
+    episode["candidate"] = json!("worker-c");
+    std::fs::write(&episode_path, serde_json::to_vec_pretty(&episode).expect("episode write"))
+        .expect("episode");
+    let result = call(
+        &f,
+        json!({"source": "worker-a", "episode_id": f.episode_id}),
+    );
+    assert_eq!(code(&result), "candidate_ineligible", "unexpected result: {result}");
+}
+
+#[test]
+#[serial]
+fn usage_limit_takeover_refuses_journal_write_failure_without_partial() {
+    let f = fixture("write-failure");
+    let journal = crate::paths::runtime_dir(&f.home).join("worker-a/usage_limit_takeover.json");
+    std::fs::create_dir_all(&journal).expect("journal collision");
+    let result = call(
+        &f,
+        json!({"source": "worker-a", "episode_id": f.episode_id}),
+    );
+    assert_eq!(code(&result), "journal_write_failed", "unexpected result: {result}");
+    assert!(journal.is_dir(), "failed write must not replace collision");
+}
+
+#[test]
+#[serial]
+fn usage_limit_takeover_is_operator_only() {
+    let f = fixture("operator-only");
+    let result = execute_tool_with_runtime(
+        "usage_limit_takeover",
+        &json!({"source": "worker-a", "episode_id": f.episode_id}),
+        "worker-a",
+        f.runtime.clone(),
+    );
+    assert_eq!(code(&result), "operator_only", "unexpected result: {result}");
+}

--- a/src/mcp/registry.rs
+++ b/src/mcp/registry.rs
@@ -347,7 +347,7 @@ pub(crate) fn tool_allowed_for_role_action(
     tool_allowed_for_role(role_kind, tool)
 }
 
-static ALL_TOOLS: [ToolEntry; 31] = [
+static ALL_TOOLS: [ToolEntry; 32] = [
     // ── Channel ──
     ToolEntry {
         name: "reply",
@@ -555,6 +555,12 @@ static ALL_TOOLS: [ToolEntry; 31] = [
         handler: super::handlers::dispatch::dispatch_revoke_review_assignment,
         class: ToolClass::SIDE_EFFECT,
     },
+    ToolEntry {
+        name: "usage_limit_takeover",
+        definition: super::tools::def_usage_limit_takeover,
+        handler: super::handlers::dispatch::dispatch_usage_limit_takeover,
+        class: ToolClass::SIDE_EFFECT,
+    },
 ];
 
 #[cfg(test)]
@@ -676,8 +682,8 @@ mod tests {
         let all_names: Vec<&str> = all().iter().map(|e| e.name).collect();
         assert_eq!(
             all_names.len(),
-            31,
-            "registry baseline is 31 tools (#2547 P0: 37->33; #2548 Wave1-PR1: tui_screenshot removed, gc_dry_run/tokens/watchdog moved to CLI, config set-side moved to CLI = 33->29; #2548 Wave1-PR2: mode folded into list_instances, force_release_worktree merged into release_worktree(force:true) = 29->27; #991 Phase 2: + bind_topic = 27->28; #2550 P1: + instance (folded read-only alias) = 28->29; #2744 PR-A: + set_model = 29->30; #2782 slice 1: + revoke_review_assignment = 30->31)"
+            32,
+            "registry baseline is 32 tools (+ usage_limit_takeover Architecture-14 item 5 Slice 2A)"
         );
         for role in [
             None,
@@ -689,7 +695,7 @@ mod tests {
             assert_eq!(
                 names(role),
                 all_names,
-                "role {role:?} must surface all 31 tools in registry order (default-all-open)"
+                "role {role:?} must surface all 32 tools in registry order (default-all-open)"
             );
         }
     }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -430,6 +430,14 @@ pub(crate) fn def_revoke_review_assignment() -> Value {
         }, "required": ["assignment_id"]}})
 }
 
+pub(crate) fn def_usage_limit_takeover() -> Value {
+    json!({"name": "usage_limit_takeover", "description": "Operator-only Architecture-14 item 5 Slice 2A seam. Validate a persisted CandidateReady usage-limit episode and durably PREPARE, without executing takeover or changing the source binding/task/process.",
+        "inputSchema": {"type": "object", "properties": {
+            "source": {"type": "string", "description": "Source instance whose persisted usage-limit episode is being prepared."},
+            "episode_id": {"type": "string", "description": "Exact persisted usage-limit episode id; candidate is derived from CandidateReady and cannot be supplied by the caller."}
+        }, "required": ["source", "episode_id"]}})
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -718,7 +726,7 @@ mod tests {
         let tools = defs["tools"].as_array().expect("tools array");
         assert_eq!(
             tools.len(),
-            31,
+            32,
             "#1400: 34 + tokens (#1077 Phase 1) = 35; + mode (#1339 Operator Mode) = 36; \
              + ephemeral (#1967 Phase-1) = 37; - replace_instance (#2547, folded into \
              restart_instance mode=fresh) = 36; - set_display_name/set_description \
@@ -729,7 +737,7 @@ mod tests {
              into release_worktree(force:true)) = 27; + bind_topic (#991 Phase 2) = 28; \
              + instance (#2550 P1, folded read-only alias for list_instances/pane_snapshot) = 29; \
              + set_model (#2744 PR-A, typed fleet model intent) = 30; \
-             + revoke_review_assignment (#2782 slice 1) = 31. \
+             + revoke_review_assignment (#2782 slice 1) = 31; + usage_limit_takeover (Architecture-14 item 5 Slice 2A) = 32. \
              Current tools: {:?}",
             tools
                 .iter()
@@ -1190,6 +1198,9 @@ mod tests {
             ("config", "key", "mcp/handlers/dispatch.rs runtime_config::get_key"),
             // ── revoke_review_assignment (#2782 slice 1) ──
             ("revoke_review_assignment", "assignment_id", "mcp/handlers/comms_delegate/review_assignment.rs handle_revoke_review_assignment — lookup_by_assignment_id_strict + retire_if_id_matches CAS target"),
+            // ── usage_limit_takeover (Architecture-14 item 5 Slice 2A) ──
+            ("usage_limit_takeover", "source", "mcp/handlers/usage_limit_takeover.rs source-scoped lock and persisted binding validation"),
+            ("usage_limit_takeover", "episode_id", "mcp/handlers/usage_limit_takeover.rs persisted CandidateReady episode identity validation"),
         ];
 
         // Intentionally-deferred passthrough: advertised by design, Phase-2
@@ -1226,6 +1237,7 @@ mod tests {
             "restart_instance",
             "config",
             "revoke_review_assignment",
+            "usage_limit_takeover",
         ];
 
         // Simple query/display/control tools — not directive-bearing, so their

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -433,9 +433,9 @@ pub(crate) fn def_revoke_review_assignment() -> Value {
 pub(crate) fn def_usage_limit_takeover() -> Value {
     json!({"name": "usage_limit_takeover", "description": "Operator-only Architecture-14 item 5 Slice 2A seam. Validate a persisted CandidateReady usage-limit episode and durably PREPARE, without executing takeover or changing the source binding/task/process.",
         "inputSchema": {"type": "object", "properties": {
-            "source": {"type": "string", "description": "Source instance whose persisted usage-limit episode is being prepared."},
+            "instance": {"type": "string", "description": "Source instance whose persisted usage-limit episode is being prepared."},
             "episode_id": {"type": "string", "description": "Exact persisted usage-limit episode id; candidate is derived from CandidateReady and cannot be supplied by the caller."}
-        }, "required": ["source", "episode_id"]}})
+        }, "required": ["instance", "episode_id"]}})
 }
 
 #[cfg(test)]
@@ -1199,7 +1199,7 @@ mod tests {
             // ── revoke_review_assignment (#2782 slice 1) ──
             ("revoke_review_assignment", "assignment_id", "mcp/handlers/comms_delegate/review_assignment.rs handle_revoke_review_assignment — lookup_by_assignment_id_strict + retire_if_id_matches CAS target"),
             // ── usage_limit_takeover (Architecture-14 item 5 Slice 2A) ──
-            ("usage_limit_takeover", "source", "mcp/handlers/usage_limit_takeover.rs source-scoped lock and persisted binding validation"),
+            ("usage_limit_takeover", "instance", "mcp/handlers/usage_limit_takeover.rs source-scoped lock and persisted binding validation"),
             ("usage_limit_takeover", "episode_id", "mcp/handlers/usage_limit_takeover.rs persisted CandidateReady episode identity validation"),
         ];
 


### PR DESCRIPTION
## Summary

- Enforce authenticated API-ingress capability for the operator-only `usage_limit_takeover` MCP tool.
- Deny Agent-principal calls before payload instance/role resolution or operator-mode dispatch; preserve the Operator path.
- Keep takeover behavior PREPARE-only with no lifecycle/task/binding mutation.

## A/B decision and exact-head reviews

- A/B decision: `d-20260716064726451424-5`
- RED: `baa1cc60d6ff2413a488e337f7164d27c0d712f2`
- GREEN exact head: `37625f5fe9e7a0baf7fd6432818b38239d0c16a3`
- Dual exact-head VERIFIED reviews: root review `t-20260716065622031801-47337-21`; independent review `t-20260716065621849908-47337-20`

## Verification

- `cargo test --bin agend-terminal usage_limit_takeover -- --nocapture` — 12 passed
- `cargo test --bin agend-terminal api::operator_gate::tests -- --nocapture` — 20 passed
- `cargo test --bin agend-terminal api:: --quiet` — 220 passed, 1 ignored
- `cargo clippy --bin agend-terminal --tests -- -D warnings` — passed
- rustfmt check and `git diff --check` — passed
