### PR TITLE
fix: enforce branch lifecycle retirement gates

### DIFF
--- a/src/branch_sweep.rs
+++ b/src/branch_sweep.rs
@@ -3,23 +3,24 @@
 //! Operator-triggered hygiene sweep that categorizes local branches
 //! into 4 buckets (`clean_merged`, `squash_merged`, `stale_idle`,
 //! `active_unknown`) and offers a dry-run + confirm-subset workflow
-//! to delete the safe ones. Mirrors the `tasks::sweep_impl` pattern
+//! to delete only the proven-safe ones. Mirrors the `tasks::sweep_impl` pattern
 //! from #806 — same `dry-run + confirm_ids + system identity +
 //! audit_reason` shape — but operates on local git refs instead of
 //! the task board.
 //!
-//! No GitHub API dependency. Everything is local `git for-each-ref` /
-//! `git cherry` / `git branch -D` subprocess. Cache layer (in-memory
-//! `HashMap` per sweep) dedups repeated cherry calls when branches
+//! Local Git provides the primary evidence; a configured GitHub remote is
+//! queried only for the apply-time open-PR preservation gate. Cache layer
+//! (in-memory `HashMap` per sweep) dedups repeated cherry calls when branches
 //! share ancestry.
 //!
 //! Safety stack (mirrors #806 + force-delete-specific layers):
 //! - `system:branch_sweep` identity (allow-list at tasks.rs:485)
 //! - dry-run default; apply requires explicit `apply=true`
-//! - `confirm_ids` MUST be subset of `candidate_ids` from prior dry-run
+//! - `confirm_ids` MUST be a subset of the current dry-run inventory; only
+//!   proven terminal IDs can pass the apply classifier
 //! - `audit_reason` required, non-empty
-//! - `active_unknown` bucket skipped unless operator explicitly picks
-//!   those IDs (the bucket itself surfaces in dry-run for visibility)
+//! - `active_unknown` bucket is always preserved, even when an operator
+//!   includes its ID in `confirm_ids`; it remains visible for follow-up
 //! - `event_log.jsonl` records `branch=<name> source=<sha>` so an
 //!   operator can `git branch <name> <sha>` to restore
 
@@ -119,10 +120,9 @@ impl Categories {
         v
     }
 
-    /// Total IDs including the explicit-opt-in `active_unknown`
-    /// bucket. Used to validate confirm_ids subset — operator CAN
-    /// pick active_unknown IDs, they just don't show up in the
-    /// default `deletable_ids`.
+    /// Total IDs including the non-deletable `active_unknown` bucket. The
+    /// handler uses this inventory to reject stale IDs while keeping unknown
+    /// branches visible; the lifecycle classifier still preserves them.
     pub fn all_ids(&self) -> Vec<String> {
         let mut v: Vec<String> = self
             .clean_merged
@@ -452,7 +452,15 @@ fn is_clean_merged(repo: &Path, base: &str, branch: &str) -> bool {
     };
     stdout
         .lines()
-        .map(|l| l.trim_start_matches('*').trim())
+        .map(|line| {
+            line.trim_start_matches(|ch| {
+                // `git branch` prefixes the current checkout with `*`; the
+                // fleet-managed git shim additionally uses `+` for a branch held by
+                // another worktree. Both prefixes still identify the branch name.
+                ch == '*' || ch == '+'
+            })
+            .trim()
+        })
         .any(|line| line == branch)
 }
 
@@ -512,6 +520,56 @@ pub(crate) enum PrMergeStatus {
     Merged,
     NotMerged,
     Unknown,
+}
+
+/// Tri-state open-PR probe used by branch lifecycle retirement. A repository
+/// without a GitHub remote has no open-PR surface to query (`NotOpen`), while
+/// a GitHub/SCM lookup failure is `Unknown` and must fail closed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum OpenPrStatus {
+    Open,
+    NotOpen,
+    Unknown,
+}
+
+/// Resolve whether `branch` still has an open PR. The lifecycle classifier
+/// owns the fail direction; this helper only gathers the SCM evidence.
+pub(crate) fn open_pr_status(repo: &Path, base: &str, branch: &str) -> OpenPrStatus {
+    let remote_url = match crate::git_helpers::git_cmd(repo, &["remote", "get-url", "origin"]) {
+        Ok(url) => url,
+        Err(crate::git_helpers::GitError::NonZero { stderr, .. })
+            if stderr.contains("No such remote") =>
+        {
+            // No remote is a deterministic local-fixture/no-PR state, not a
+            // transient SCM outage.
+            return OpenPrStatus::NotOpen;
+        }
+        Err(_) => return OpenPrStatus::Unknown,
+    };
+    let Some(gh_repo) = extract_github_repo(&remote_url) else {
+        // A configured non-GitHub remote is an unresolved SCM surface, not
+        // evidence that the branch has no open review. Keep the lifecycle
+        // decision fail-closed until a provider can answer it.
+        return OpenPrStatus::Unknown;
+    };
+    let Ok(prs) = crate::scm::make_scm_provider(&gh_repo, None).pr_list(
+        &gh_repo,
+        &crate::scm::ListFilter {
+            state: Some("open"),
+            head: Some(branch.to_string()),
+            base: Some(base.to_string()),
+            ..Default::default()
+        },
+        &["number"],
+        None,
+    ) else {
+        return OpenPrStatus::Unknown;
+    };
+    if prs.is_empty() {
+        OpenPrStatus::NotOpen
+    } else {
+        OpenPrStatus::Open
+    }
 }
 
 /// GitHub API based detection: query whether a merged PR exists for this
@@ -752,9 +810,32 @@ pub(crate) fn scan(
 /// success is observable in the event log.
 ///
 /// Dead-code allow lifts at C3 when the MCP handler wires the call.
+#[allow(dead_code)]
 pub(crate) fn emit_delete_batch(
     home: &Path,
     repo: &Path,
+    categories: &Categories,
+    confirm_ids: &std::collections::HashSet<String>,
+    audit_reason: &str,
+) -> Result<usize, String> {
+    emit_delete_batch_with_context(
+        Some(home),
+        repo,
+        "main",
+        categories,
+        confirm_ids,
+        audit_reason,
+    )
+}
+
+/// Apply a branch-sweep confirmation with lifecycle evidence. The legacy
+/// wrapper above keeps the existing unit-test seam; production MCP callers
+/// pass the explicit base and home so active holders, tasks, and PR state are
+/// checked before any branch mutation.
+pub(crate) fn emit_delete_batch_with_context(
+    home: Option<&Path>,
+    repo: &Path,
+    base: &str,
     categories: &Categories,
     confirm_ids: &std::collections::HashSet<String>,
     audit_reason: &str,
@@ -802,6 +883,81 @@ pub(crate) fn emit_delete_batch(
         let Some(cand) = name_to_candidate.get(name.as_str()) else {
             continue;
         };
+        let is_reviewer = categories.reviewer_checkout.iter().any(|c| c.name == *name);
+        let provenance = if is_reviewer {
+            crate::worktree::disposition::BranchProvenance::ReviewerResidue
+        } else if categories.clean_merged.iter().any(|c| c.name == *name) {
+            crate::worktree::disposition::BranchProvenance::Merged
+        } else if categories.squash_merged.iter().any(|c| c.name == *name) {
+            crate::worktree::disposition::BranchProvenance::SquashMerged
+        } else {
+            // `active_unknown` has no terminal provenance and therefore
+            // remains fail-closed in the shared classifier.
+            crate::worktree::disposition::BranchProvenance::Unknown
+        };
+        let binding_active =
+            home.and_then(|h| crate::worktree_cleanup::branch_has_active_binding(h, repo, name));
+        let active_holder = match (branch_is_checked_out(repo, name), binding_active) {
+            (Some(true), _) | (_, Some(true)) => Some(true),
+            (Some(false), Some(false)) => Some(false),
+            _ => None,
+        };
+        let task_active = home.and_then(|h| branch_has_active_task(h, name));
+        let terminal = !matches!(
+            provenance,
+            crate::worktree::disposition::BranchProvenance::Unknown
+        );
+        let open_pr = if terminal {
+            match open_pr_status(repo, base, name) {
+                OpenPrStatus::Open => Some(true),
+                OpenPrStatus::NotOpen => Some(false),
+                OpenPrStatus::Unknown => None,
+            }
+        } else {
+            // Unknown provenance is already a KEEP decision; do not probe an
+            // external SCM surface for a branch that cannot be deleted.
+            Some(false)
+        };
+        // Reviewer residue is only deleted after a recovery ref is prepared
+        // below; all other proven terminal categories are already preserved
+        // by their merge/squash provenance.
+        let unique_unpreserved_work = Some(false);
+        let lifecycle = crate::worktree::disposition::branch_lifecycle_disposition(
+            &crate::worktree::disposition::BranchLifecycleInput {
+                provenance,
+                terminal,
+                active_holder,
+                task_active,
+                open_pr,
+                unique_unpreserved_work,
+            },
+        );
+        if !matches!(
+            lifecycle,
+            crate::worktree::disposition::BranchLifecycleDisposition::Delete
+        ) {
+            crate::event_log::log(
+                home.unwrap_or(repo),
+                "branch_sweep_apply_skipped",
+                "system:branch_sweep",
+                &format!(
+                    "branch={name} reason=branch lifecycle evidence not terminal or provenance unknown; preserved"
+                ),
+            );
+            continue;
+        }
+        let recovery_ref = if is_reviewer {
+            Some(prepare_branch_recovery(
+                home,
+                repo,
+                name,
+                &cand.tip_sha,
+                audit_reason,
+            )?)
+        } else {
+            None
+        };
+        let _ = recovery_ref;
         // W1.2: git_cmd's GitError preserves the two distinct failure logs this
         // site emits — NonZero carries the trimmed stderr, Spawn carries the io error.
         match crate::git_helpers::git_cmd(repo, &["branch", "-D", name]) {
@@ -809,7 +965,7 @@ pub(crate) fn emit_delete_batch(
                 deleted += 1;
                 let category = category_of(name);
                 crate::event_log::log(
-                    home,
+                    home.unwrap_or(repo),
                     "branch_sweep_apply",
                     "system:branch_sweep",
                     &format!(
@@ -821,7 +977,7 @@ pub(crate) fn emit_delete_batch(
             }
             Err(crate::git_helpers::GitError::NonZero { stderr, .. }) => {
                 crate::event_log::log(
-                    home,
+                    home.unwrap_or(repo),
                     "branch_sweep_apply_failed",
                     "system:branch_sweep",
                     &format!("branch={name} stderr={stderr}"),
@@ -829,7 +985,7 @@ pub(crate) fn emit_delete_batch(
             }
             Err(crate::git_helpers::GitError::Spawn(e)) => {
                 crate::event_log::log(
-                    home,
+                    home.unwrap_or(repo),
                     "branch_sweep_apply_failed",
                     "system:branch_sweep",
                     &format!("branch={name} spawn_error={e}"),
@@ -838,6 +994,90 @@ pub(crate) fn emit_delete_batch(
         }
     }
     Ok(deleted)
+}
+
+fn branch_is_checked_out(repo: &Path, branch: &str) -> Option<bool> {
+    let out = crate::git_helpers::git_cmd(repo, &["worktree", "list", "--porcelain"]).ok()?;
+    let mut live_worktree = false;
+    let mut prunable = false;
+    for line in out.lines() {
+        if let Some(path) = line.strip_prefix("worktree ") {
+            live_worktree = Path::new(path.trim()).exists();
+            prunable = false;
+            continue;
+        }
+        if line.starts_with("prunable ") {
+            prunable = true;
+            live_worktree = false;
+            continue;
+        }
+        if line
+            .strip_prefix("branch refs/heads/")
+            .is_some_and(|name| name.trim() == branch)
+            && live_worktree
+            && !prunable
+        {
+            return Some(true);
+        }
+    }
+    Some(false)
+}
+
+pub(crate) fn branch_has_active_task(home: &Path, branch: &str) -> Option<bool> {
+    let tasks = crate::tasks::list_all_strict(home).ok()?;
+    Some(tasks.iter().any(|task| {
+        task.branch.as_deref() == Some(branch)
+            && !matches!(
+                task.status,
+                crate::task_events::TaskStatus::Done
+                    | crate::task_events::TaskStatus::Cancelled
+                    | crate::task_events::TaskStatus::Verified
+            )
+    }))
+}
+
+/// Create a durable recovery ref for a reviewer residue before deleting its
+/// branch. The source SHA is the CAS identity; the returned ref is the
+/// operator-visible recovery/audit identity.
+pub(crate) fn prepare_branch_recovery(
+    home: Option<&Path>,
+    repo: &Path,
+    branch: &str,
+    tip_sha: &str,
+    reason: &str,
+) -> Result<String, String> {
+    if tip_sha.is_empty() {
+        return Err(format!("branch '{branch}' has no source SHA; preserved"));
+    }
+    let safe_branch: String = branch
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect();
+    let identity = format!(
+        "refs/agend/recovery/branch/{safe_branch}/{}-{}",
+        &tip_sha[..tip_sha.len().min(12)],
+        chrono::Utc::now().format("%Y%m%dT%H%M%SZ")
+    );
+    let out = crate::git_helpers::git_bypass(repo, &["update-ref", &identity, tip_sha])
+        .map_err(|e| format!("prepare recovery ref for '{branch}' failed: {e}"))?;
+    if !out.status.success() {
+        return Err(format!(
+            "prepare recovery ref for '{branch}' failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        ));
+    }
+    if let Some(home) = home {
+        crate::event_log::log(
+            home,
+            "branch_cleanup_prepared",
+            "system:branch_lifecycle",
+            &format!(
+                "repo={} branch={branch} source_sha={tip_sha} recovery_ref={identity} reason={reason}",
+                repo.display()
+            ),
+        );
+    }
+    Ok(identity)
 }
 
 #[cfg(test)]
@@ -1529,7 +1769,7 @@ mod tests {
         let repo = setup_repo("orphan_wt_reg");
         let home = repo.parent().unwrap().to_path_buf();
         create_branch_with_commit(&repo, "feat-orphan", "feat: orphan");
-        git_run(
+        let _merge = git_run(
             &repo,
             &["merge", "--no-ff", "-m", "merge feat-orphan", "feat-orphan"],
         );
@@ -1623,6 +1863,53 @@ mod tests {
         assert!(
             log.contains("post-#817 test apply"),
             "event-log must carry the audit_reason"
+        );
+
+        std::fs::remove_dir_all(repo.parent().unwrap()).ok();
+    }
+
+    #[test]
+    fn branch_recovery_ref_records_source_sha_and_audit_identity() {
+        let repo = setup_repo("branch_recovery_metadata");
+        let home = repo.parent().unwrap().to_path_buf();
+        git_run(&repo, &["checkout", "-b", "review/123"]);
+        std::fs::write(repo.join("residue.txt"), "review residue\n").expect("write");
+        git_run(&repo, &["add", "residue.txt"]);
+        git_run(&repo, &["commit", "-m", "review residue"]);
+        let tip = String::from_utf8_lossy(&git_run(&repo, &["rev-parse", "HEAD"]).stdout)
+            .trim()
+            .to_string();
+        git_run(&repo, &["checkout", "main"]);
+
+        let recovery_ref = prepare_branch_recovery(
+            Some(&home),
+            &repo,
+            "review/123",
+            &tip,
+            "recovery metadata test",
+        )
+        .expect("recovery ref must be created");
+        let resolved =
+            String::from_utf8_lossy(&git_run(&repo, &["rev-parse", &recovery_ref]).stdout)
+                .trim()
+                .to_string();
+        assert_eq!(resolved, tip, "recovery ref must preserve the source SHA");
+        assert!(
+            recovery_ref.starts_with("refs/agend/recovery/branch/review_123/"),
+            "recovery identity must include the sanitized branch: {recovery_ref}"
+        );
+        let log = std::fs::read_to_string(home.join("event-log.jsonl")).unwrap_or_default();
+        assert!(
+            log.contains("branch_cleanup_prepared"),
+            "audit event missing: {log}"
+        );
+        assert!(
+            log.contains(&format!("source_sha={tip}")),
+            "source SHA missing: {log}"
+        );
+        assert!(
+            log.contains(&format!("recovery_ref={recovery_ref}")),
+            "recovery identity missing: {log}"
         );
 
         std::fs::remove_dir_all(repo.parent().unwrap()).ok();
@@ -1770,14 +2057,11 @@ mod tests {
     }
 
     #[test]
-    fn test_branch_sweep_handler_active_unknown_requires_explicit_opt_in() {
-        // GREEN: a branch in `active_unknown` (recent, unmerged, not
-        // squash-applied) is NOT in `candidate_ids` (deletable_ids
-        // excludes active_unknown). Handler's dry-run surfaces it
-        // separately so the operator can SEE it. Operator can still
-        // delete it by passing its name in confirm_ids — handler's
-        // subset check uses all_ids (which DOES include
-        // active_unknown). Locks the explicit-opt-in contract.
+    fn test_branch_sweep_handler_active_unknown_remains_fail_closed() {
+        // A branch in `active_unknown` (recent, unmerged, not
+        // squash-applied) is NOT in `candidate_ids` and remains visible in
+        // the dry-run response. Even an explicit confirm cannot delete it:
+        // unknown provenance is a lifecycle KEEP decision.
         let repo = setup_repo("active_unknown_opt_in");
         let home = repo.parent().unwrap().to_path_buf();
         let agent = "test-agent";
@@ -1813,7 +2097,7 @@ mod tests {
             .collect();
         assert!(
             !candidate_ids.contains(&"wip-active"),
-            "wip-active must NOT be in candidate_ids (active_unknown opt-in), got: {candidate_ids:?}"
+            "wip-active must NOT be in candidate_ids (active_unknown is non-deletable), got: {candidate_ids:?}"
         );
         let active_unknown: Vec<&str> = r["categories"]["active_unknown"]
             .as_array()
@@ -1826,21 +2110,25 @@ mod tests {
             "wip-active must appear in active_unknown bucket for visibility, got: {active_unknown:?}"
         );
 
-        // Apply with wip-active in confirm_ids → handler accepts
-        // (subset check uses all_ids, NOT deletable_ids).
+        // Apply with wip-active in confirm_ids → handler reports no deletion
+        // and preserves the branch, despite the name being in all_ids.
         let r = crate::mcp::handlers::ci::handle_cleanup_merged_branches(
             &home,
             &serde_json::json!({
                 "instance": agent,
                 "apply": true,
                 "confirm_ids": ["wip-active"],
-                "audit_reason": "explicit opt-in for active_unknown",
+                "audit_reason": "verify active_unknown remains preserved",
             }),
             agent,
         );
-        assert_eq!(
-            r["applied"], 1,
-            "explicit confirm_ids opt-in must delete active_unknown branch: {r}"
+        assert_eq!(r["applied"], 0, "active_unknown must remain preserved: {r}");
+        assert!(
+            enumerate_branches(&repo)
+                .expect("branches")
+                .iter()
+                .any(|candidate| candidate.name == "wip-active"),
+            "active_unknown branch must remain after explicit confirmation"
         );
 
         std::fs::remove_dir_all(repo.parent().unwrap()).ok();

--- a/src/branch_sweep.rs
+++ b/src/branch_sweep.rs
@@ -532,6 +532,70 @@ pub(crate) enum OpenPrStatus {
     Unknown,
 }
 
+/// One bounded open-PR inventory for a repository/sweep.  The daemon cleanup
+/// path must not issue one SCM lookup per branch; a failed inventory remains
+/// `Unknown` for every affected branch so the lifecycle classifier preserves
+/// them all.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct OpenPrSnapshot {
+    open_branches: Option<std::collections::HashSet<String>>,
+}
+
+impl OpenPrSnapshot {
+    pub(crate) fn status_for(&self, branch: &str) -> OpenPrStatus {
+        match &self.open_branches {
+            Some(open) if open.contains(branch) => OpenPrStatus::Open,
+            Some(_) => OpenPrStatus::NotOpen,
+            None => OpenPrStatus::Unknown,
+        }
+    }
+}
+
+/// Gather the repository's open-PR inventory once.  `headRefName` is the only
+/// field needed by the lifecycle gate; the explicit limit keeps this external
+/// call bounded even for a repository with a large review backlog.
+pub(crate) fn open_pr_snapshot(repo: &Path, base: &str) -> OpenPrSnapshot {
+    let remote_url = match crate::git_helpers::git_cmd(repo, &["remote", "get-url", "origin"]) {
+        Ok(url) => url,
+        Err(crate::git_helpers::GitError::NonZero { stderr, .. })
+            if stderr.contains("No such remote") =>
+        {
+            return OpenPrSnapshot {
+                open_branches: Some(std::collections::HashSet::new()),
+            };
+        }
+        Err(_) => return OpenPrSnapshot::default(),
+    };
+    let Some(gh_repo) = extract_github_repo(&remote_url) else {
+        return OpenPrSnapshot::default();
+    };
+    let Ok(prs) = crate::scm::make_scm_provider(&gh_repo, None).pr_list(
+        &gh_repo,
+        &crate::scm::ListFilter {
+            state: Some("open"),
+            base: Some(base.to_string()),
+            limit: Some(1000),
+            ..Default::default()
+        },
+        &["headRefName"],
+        None,
+    ) else {
+        return OpenPrSnapshot::default();
+    };
+    let mut open_branches = std::collections::HashSet::new();
+    for pr in prs {
+        let Some(branch) = pr.head_ref else {
+            // A malformed/partial provider response is not proof that the
+            // branch has no open PR; preserve all candidates on this snapshot.
+            return OpenPrSnapshot::default();
+        };
+        open_branches.insert(branch);
+    }
+    OpenPrSnapshot {
+        open_branches: Some(open_branches),
+    }
+}
+
 /// Resolve whether `branch` still has an open PR. The lifecycle classifier
 /// owns the fail direction; this helper only gathers the SCM evidence.
 pub(crate) fn open_pr_status(repo: &Path, base: &str, branch: &str) -> OpenPrStatus {

--- a/src/branch_sweep.rs
+++ b/src/branch_sweep.rs
@@ -541,6 +541,8 @@ pub(crate) struct OpenPrSnapshot {
     open_branches: Option<std::collections::HashSet<String>>,
 }
 
+const OPEN_PR_SNAPSHOT_CAP: usize = 1000;
+
 impl OpenPrSnapshot {
     pub(crate) fn status_for(&self, branch: &str) -> OpenPrStatus {
         match &self.open_branches {
@@ -554,7 +556,7 @@ impl OpenPrSnapshot {
 /// Gather the repository's open-PR inventory once.  `headRefName` is the only
 /// field needed by the lifecycle gate; the explicit limit keeps this external
 /// call bounded even for a repository with a large review backlog.
-pub(crate) fn open_pr_snapshot(repo: &Path, base: &str) -> OpenPrSnapshot {
+pub(crate) fn open_pr_snapshot(repo: &Path, _base: &str) -> OpenPrSnapshot {
     let remote_url = match crate::git_helpers::git_cmd(repo, &["remote", "get-url", "origin"]) {
         Ok(url) => url,
         Err(crate::git_helpers::GitError::NonZero { stderr, .. })
@@ -573,8 +575,11 @@ pub(crate) fn open_pr_snapshot(repo: &Path, base: &str) -> OpenPrSnapshot {
         &gh_repo,
         &crate::scm::ListFilter {
             state: Some("open"),
-            base: Some(base.to_string()),
-            limit: Some(1000),
+            // Open PRs targeting any base protect the branch. Request one
+            // beyond the bounded inventory so truncation is distinguishable
+            // from a complete result and remains fail-closed.
+            base: None,
+            limit: Some((OPEN_PR_SNAPSHOT_CAP + 1) as u32),
             ..Default::default()
         },
         &["headRefName"],
@@ -582,6 +587,9 @@ pub(crate) fn open_pr_snapshot(repo: &Path, base: &str) -> OpenPrSnapshot {
     ) else {
         return OpenPrSnapshot::default();
     };
+    if prs.len() > OPEN_PR_SNAPSHOT_CAP {
+        return OpenPrSnapshot::default();
+    }
     let mut open_branches = std::collections::HashSet::new();
     for pr in prs {
         let Some(branch) = pr.head_ref else {
@@ -598,7 +606,7 @@ pub(crate) fn open_pr_snapshot(repo: &Path, base: &str) -> OpenPrSnapshot {
 
 /// Resolve whether `branch` still has an open PR. The lifecycle classifier
 /// owns the fail direction; this helper only gathers the SCM evidence.
-pub(crate) fn open_pr_status(repo: &Path, base: &str, branch: &str) -> OpenPrStatus {
+pub(crate) fn open_pr_status(repo: &Path, _base: &str, branch: &str) -> OpenPrStatus {
     let remote_url = match crate::git_helpers::git_cmd(repo, &["remote", "get-url", "origin"]) {
         Ok(url) => url,
         Err(crate::git_helpers::GitError::NonZero { stderr, .. })
@@ -621,7 +629,10 @@ pub(crate) fn open_pr_status(repo: &Path, base: &str, branch: &str) -> OpenPrSta
         &crate::scm::ListFilter {
             state: Some("open"),
             head: Some(branch.to_string()),
-            base: Some(base.to_string()),
+            // A branch remains protected by an open PR regardless of target
+            // base; do not narrow this apply-time probe to the repository's
+            // default branch.
+            base: None,
             ..Default::default()
         },
         &["number"],

--- a/src/mcp/handlers/ci/cleanup.rs
+++ b/src/mcp/handlers/ci/cleanup.rs
@@ -53,7 +53,8 @@ pub(crate) fn handle_cleanup_init_commits(home: &Path, args: &Value, instance_na
 /// (default "main"; compare target for clean/squash-merged detection),
 /// `min_age_days` (default 90; stale_idle threshold), `apply` (default false),
 /// `confirm_ids` + `audit_reason` (required when apply=true; the latter logged to
-/// event-log.jsonl per deleted branch).
+/// event-log.jsonl per deleted branch). An explicit `repository_path` is accepted
+/// for its configured orchestrator and never falls back to an unrelated binding.
 pub(crate) fn handle_cleanup_merged_branches(
     home: &Path,
     args: &Value,
@@ -63,16 +64,9 @@ pub(crate) fn handle_cleanup_merged_branches(
         .as_str()
         .filter(|s| !s.is_empty())
         .unwrap_or(instance_name);
-    let source_repo = match crate::binding::read(home, agent)
-        .and_then(|v| v["source_repo"].as_str().map(std::path::PathBuf::from))
-    {
-        Some(p) => p,
-        None => {
-            return json!({
-                "error": format!("no binding source_repo for agent '{agent}'"),
-                "code": "no_binding_source_repo",
-            });
-        }
+    let source_repo = match resolve_cleanup_source_repo(home, args, agent, instance_name) {
+        Ok(path) => path,
+        Err(error) => return error,
     };
     let base = args["base"].as_str().unwrap_or("main");
     let min_age_days = args["min_age_days"]
@@ -109,7 +103,7 @@ pub(crate) fn handle_cleanup_merged_branches(
             "candidate_ids": categories.deletable_ids(),
             "total_candidates": categories.total(),
             "to_apply_hint": "repo action=cleanup_merged_branches apply=true confirm_ids=<subset> audit_reason=<...>",
-            "active_unknown_note": "active_unknown bucket is NOT in candidate_ids by default — include those names explicitly in confirm_ids if you really want to delete them",
+            "active_unknown_note": "active_unknown bucket is not deletable until terminal provenance and preservation evidence are proven; it remains visible for operator follow-up",
         });
     }
     let confirm_ids: std::collections::HashSet<String> = args["confirm_ids"]
@@ -134,8 +128,8 @@ pub(crate) fn handle_cleanup_merged_branches(
         });
     }
     // Validate confirm_ids ⊆ all_ids (including active_unknown for
-    // explicit opt-in). Mismatch ⇒ reject loudly — operator must
-    // re-run dry-run to refresh the candidate list.
+    // visibility). Mismatch ⇒ reject loudly — operator must re-run dry-run
+    // to refresh the candidate list; lifecycle apply remains fail-closed.
     let candidate_set: std::collections::HashSet<String> =
         categories.all_ids().into_iter().collect();
     let unknown: Vec<String> = confirm_ids.difference(&candidate_set).cloned().collect();
@@ -147,9 +141,10 @@ pub(crate) fn handle_cleanup_merged_branches(
             "code": "stale_confirm_ids",
         });
     }
-    match crate::branch_sweep::emit_delete_batch(
-        home,
+    match crate::branch_sweep::emit_delete_batch_with_context(
+        Some(home),
         &source_repo,
+        base,
         &categories,
         &confirm_ids,
         audit_reason,
@@ -163,5 +158,134 @@ pub(crate) fn handle_cleanup_merged_branches(
             "error": format!("branch sweep apply failed: {e}"),
             "code": "apply_failed",
         }),
+    }
+}
+
+/// Resolve the cleanup target without ever falling back from an explicit
+/// `repository_path` to a caller binding. An unbound caller is allowed only
+/// when it is the configured orchestrator for the canonical source path;
+/// operator-direct calls (`instance_name == ""`) retain the existing operator
+/// authority.
+fn resolve_cleanup_source_repo(
+    home: &Path,
+    args: &Value,
+    agent: &str,
+    caller: &str,
+) -> Result<std::path::PathBuf, Value> {
+    if let Some(raw) = args["repository_path"].as_str().filter(|s| !s.is_empty()) {
+        let path = match std::fs::canonicalize(raw) {
+            Ok(path) if path.is_dir() => path,
+            Ok(path) => {
+                return Err(json!({
+                    "error": format!("repository_path is not a directory: {}", path.display()),
+                    "code": "invalid_repository_path",
+                }));
+            }
+            Err(e) => {
+                return Err(json!({
+                    "error": format!("repository_path is not readable: {e}"),
+                    "code": "invalid_repository_path",
+                }));
+            }
+        };
+        let authority = if caller.is_empty() { agent } else { caller };
+        if !authority.is_empty() && !orchestrator_owns_repo(home, authority, &path) {
+            return Err(json!({
+                "error": format!("'{authority}' is not authorized to clean repository_path '{}'", path.display()),
+                "code": "repository_path_unauthorized",
+            }));
+        }
+        return Ok(path);
+    }
+
+    crate::binding::read(home, agent)
+        .and_then(|v| v["source_repo"].as_str().map(std::path::PathBuf::from))
+        .ok_or_else(|| {
+            json!({
+                "error": format!("no binding source_repo for agent '{agent}'"),
+                "code": "no_binding_source_repo",
+            })
+        })
+}
+
+fn orchestrator_owns_repo(home: &Path, caller: &str, repo: &Path) -> bool {
+    let Ok(repo) = std::fs::canonicalize(repo) else {
+        return false;
+    };
+    crate::teams::list_all(home).into_iter().any(|team| {
+        team.orchestrator.as_deref() == Some(caller)
+            && team
+                .source_repo
+                .as_deref()
+                .and_then(|source| std::fs::canonicalize(source).ok())
+                .is_some_and(|source| source == repo)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn explicit_repository_path_requires_its_orchestrator_and_never_falls_back() {
+        let root = std::env::temp_dir().join(format!(
+            "agend-cleanup-auth-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        let home = root.join("home");
+        let target = root.join("target-repo");
+        let unrelated = root.join("unrelated-repo");
+        std::fs::create_dir_all(&home).expect("home");
+        std::fs::create_dir_all(&target).expect("target");
+        std::fs::create_dir_all(&unrelated).expect("unrelated");
+
+        // An unbound non-orchestrator cannot redirect cleanup to an explicit
+        // repository, even when its stale binding points at another repo.
+        let binding_dir = home.join("runtime").join("worker");
+        std::fs::create_dir_all(&binding_dir).expect("binding dir");
+        std::fs::write(
+            binding_dir.join("binding.json"),
+            serde_json::json!({"source_repo": unrelated}).to_string(),
+        )
+        .expect("binding");
+        let args = serde_json::json!({"repository_path": target});
+        let denied =
+            resolve_cleanup_source_repo(&home, &args, "worker", "worker").expect_err("deny");
+        assert_eq!(denied["code"], "repository_path_unauthorized");
+
+        let created = crate::teams::create(
+            &home,
+            &serde_json::json!({
+                "name": "archfix",
+                "members": ["orchestrator"],
+                "orchestrator": "orchestrator",
+                "repository_path": target,
+            }),
+        );
+        assert_eq!(created["status"], "created", "team setup failed: {created}");
+        let spoofed = resolve_cleanup_source_repo(
+            &home,
+            &serde_json::json!({"repository_path": target}),
+            "orchestrator",
+            "worker",
+        )
+        .expect_err("target instance must not spoof caller authority");
+        assert_eq!(spoofed["code"], "repository_path_unauthorized");
+        let resolved = resolve_cleanup_source_repo(
+            &home,
+            &serde_json::json!({"repository_path": target}),
+            "orchestrator",
+            "orchestrator",
+        )
+        .expect("configured orchestrator may target its repo");
+        assert_eq!(
+            resolved,
+            std::fs::canonicalize(&target).expect("target canonicalization")
+        );
+        std::fs::remove_dir_all(root).ok();
     }
 }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -373,7 +373,7 @@ pub(crate) fn def_repo() -> Value {
             "action": {"type": "string", "enum": ["checkout", "release", "cleanup_init_commits", "cleanup_merged_branches", "merge"]},
             "pr": {"type": "integer", "description": "PR number for merge action."},
             "repository": {"type": "string", "description": "merge: GitHub `owner/repo` slug to merge the PR in (defaults to the canonical repo). Distinct from `repository_path` (a local checkout path)."},
-            "repository_path": {"type": "string", "description": "checkout: local filesystem path to the source repository. Standard cross-tool name (matches bind_self / team update)."},
+            "repository_path": {"type": "string", "description": "checkout: local filesystem path to the source repository; cleanup_merged_branches: explicit cleanup target (authorized only for its configured orchestrator). Standard cross-tool name (matches bind_self / team update)."},
             "branch": {"type": "string"},
             "path": {"type": "string"},
             "instance": {"type": "string", "description": "#789: name of the existing instance to target for cleanup_init_commits (defaults to caller's instance_name). Cleans empty `init` commits accumulated in the agent's bound worktree by backend session-checkpoint heartbeats. Returns {cleaned_count, [skipped_reason]}. Idempotent — call before push to scrub PR history."},

--- a/src/scm/mod.rs
+++ b/src/scm/mod.rs
@@ -681,6 +681,7 @@ type CompareHook = Box<dyn Fn() + Send + Sync>;
 #[derive(Default)]
 pub(crate) struct MockScmProvider {
     pr_list: Option<MockPrList>,
+    pr_list_calls: std::sync::atomic::AtomicUsize,
     compare: Option<Result<CompareResult, String>>,
     /// #2749 correction: counts `compare` invocations so a test can assert the
     /// off-tick populator's retry-lease BACKOFF (one compare per lease, not per cycle).
@@ -750,6 +751,11 @@ impl MockScmProvider {
         self.compare_calls
             .load(std::sync::atomic::Ordering::Relaxed)
     }
+
+    pub(crate) fn pr_list_calls(&self) -> usize {
+        self.pr_list_calls
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
 }
 
 #[cfg(test)]
@@ -761,6 +767,8 @@ impl ScmProvider for MockScmProvider {
         _fields: &[&str],
         _cwd: Option<&Path>,
     ) -> anyhow::Result<Vec<PrSummary>> {
+        self.pr_list_calls
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         match &self.pr_list {
             Some(MockPrList::Prs(n)) => Ok(vec![PrSummary::default(); *n]),
             Some(MockPrList::Fail(msg)) => Err(anyhow::anyhow!(msg.clone())),

--- a/src/scm/mod.rs
+++ b/src/scm/mod.rs
@@ -682,6 +682,9 @@ type CompareHook = Box<dyn Fn() + Send + Sync>;
 pub(crate) struct MockScmProvider {
     pr_list: Option<MockPrList>,
     pr_list_calls: std::sync::atomic::AtomicUsize,
+    pr_list_saw_base: std::sync::atomic::AtomicBool,
+    pr_list_saw_head: std::sync::atomic::AtomicBool,
+    pr_list_last_limit: std::sync::atomic::AtomicU32,
     compare: Option<Result<CompareResult, String>>,
     /// #2749 correction: counts `compare` invocations so a test can assert the
     /// off-tick populator's retry-lease BACKOFF (one compare per lease, not per cycle).
@@ -698,6 +701,8 @@ pub(crate) struct MockScmProvider {
 pub(crate) enum MockPrList {
     /// Return this many default PRs — non-empty ⇒ "the branch has/had a PR".
     Prs(usize),
+    /// Return open PR summaries with the supplied head branch names.
+    Branches(Vec<String>),
     /// Return an `Err` ⇒ a transient gh failure (a no-PR confirm must NOT release).
     Fail(String),
 }
@@ -756,6 +761,26 @@ impl MockScmProvider {
         self.pr_list_calls
             .load(std::sync::atomic::Ordering::Relaxed)
     }
+
+    pub(crate) fn pr_list_saw_base(&self) -> bool {
+        self.pr_list_saw_base
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    pub(crate) fn pr_list_saw_head(&self) -> bool {
+        self.pr_list_saw_head
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    pub(crate) fn pr_list_last_limit(&self) -> Option<u32> {
+        match self
+            .pr_list_last_limit
+            .load(std::sync::atomic::Ordering::Relaxed)
+        {
+            0 => None,
+            limit => Some(limit),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -763,14 +788,29 @@ impl ScmProvider for MockScmProvider {
     fn pr_list(
         &self,
         _repo: &str,
-        _filter: &ListFilter,
+        filter: &ListFilter,
         _fields: &[&str],
         _cwd: Option<&Path>,
     ) -> anyhow::Result<Vec<PrSummary>> {
         self.pr_list_calls
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        self.pr_list_saw_base
+            .store(filter.base.is_some(), std::sync::atomic::Ordering::Relaxed);
+        self.pr_list_saw_head
+            .store(filter.head.is_some(), std::sync::atomic::Ordering::Relaxed);
+        self.pr_list_last_limit.store(
+            filter.limit.unwrap_or_default(),
+            std::sync::atomic::Ordering::Relaxed,
+        );
         match &self.pr_list {
             Some(MockPrList::Prs(n)) => Ok(vec![PrSummary::default(); *n]),
+            Some(MockPrList::Branches(branches)) => Ok(branches
+                .iter()
+                .map(|branch| PrSummary {
+                    head_ref: Some(branch.clone()),
+                    ..Default::default()
+                })
+                .collect()),
             Some(MockPrList::Fail(msg)) => Err(anyhow::anyhow!(msg.clone())),
             None => Ok(vec![]),
         }

--- a/src/worktree/disposition.rs
+++ b/src/worktree/disposition.rs
@@ -101,6 +101,70 @@ pub(crate) enum BranchDisposition {
     DeleteBranch,
 }
 
+/// Provenance of a branch that a lifecycle path is considering for removal.
+/// Naming alone is never sufficient provenance: callers must resolve one of
+/// these variants from the binding/task/SCM evidence they own, otherwise the
+/// classifier fails closed with [`BranchLifecycleDisposition::Keep`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BranchProvenance {
+    /// A review checkout carrying an authority-proven lease identity.
+    ManagedReview,
+    /// A normal branch whose tip is reachable from the default branch.
+    Merged,
+    /// A normal branch whose changes are proven squash-merged.
+    SquashMerged,
+    /// A terminal reviewer-checkout residue (for example an aged, unbound
+    /// `review/*` checkout). This is distinct from a forged name: callers
+    /// still need all the terminal/occupancy/task/PR gates below.
+    ReviewerResidue,
+    /// Evidence was missing or contradictory.
+    Unknown,
+}
+
+/// Typed branch-ref lifecycle decision shared by release and cleanup paths.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BranchLifecycleDisposition {
+    Keep,
+    Delete,
+}
+
+/// Resolved evidence for the branch lifecycle decision. `None` on any
+/// safety-critical dimension means that the caller could not prove the safe
+/// answer; the classifier intentionally treats that as `Keep`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct BranchLifecycleInput {
+    pub provenance: BranchProvenance,
+    pub terminal: bool,
+    pub active_holder: Option<bool>,
+    pub task_active: Option<bool>,
+    pub open_pr: Option<bool>,
+    pub unique_unpreserved_work: Option<bool>,
+}
+
+/// Decide whether a branch ref may be deleted after its worktree/lease
+/// lifecycle has reached a terminal boundary. This is deliberately pure so
+/// release and cleanup cannot grow subtly different ad-hoc branch-name rules.
+/// Every unresolved or negative-preservation signal keeps the branch.
+pub(crate) fn branch_lifecycle_disposition(
+    input: &BranchLifecycleInput,
+) -> BranchLifecycleDisposition {
+    if !input.terminal
+        || input.active_holder != Some(false)
+        || input.task_active != Some(false)
+        || input.open_pr != Some(false)
+        || input.unique_unpreserved_work != Some(false)
+    {
+        return BranchLifecycleDisposition::Keep;
+    }
+    match input.provenance {
+        BranchProvenance::ManagedReview
+        | BranchProvenance::Merged
+        | BranchProvenance::SquashMerged
+        | BranchProvenance::ReviewerResidue => BranchLifecycleDisposition::Delete,
+        BranchProvenance::Unknown => BranchLifecycleDisposition::Keep,
+    }
+}
+
 /// Pre-computed, caller-gathered signals for [`terminal_disposition`]. Ambiguity
 /// is preserved as `Option::None` on the dimensions where the DECISION (not the
 /// I/O) owns the fail-direction, so the classifier can route it to `Keep`.
@@ -458,5 +522,56 @@ mod tests {
             branch_disposition(BranchSignal::ProvablyInDefault),
             BranchDisposition::DeleteBranch
         );
+    }
+
+    fn branch_input(provenance: BranchProvenance) -> BranchLifecycleInput {
+        BranchLifecycleInput {
+            provenance,
+            terminal: true,
+            active_holder: Some(false),
+            task_active: Some(false),
+            open_pr: Some(false),
+            unique_unpreserved_work: Some(false),
+        }
+    }
+
+    #[test]
+    fn branch_lifecycle_deletes_only_proven_terminal_dispositions() {
+        for provenance in [
+            BranchProvenance::ManagedReview,
+            BranchProvenance::Merged,
+            BranchProvenance::SquashMerged,
+            BranchProvenance::ReviewerResidue,
+        ] {
+            assert_eq!(
+                branch_lifecycle_disposition(&branch_input(provenance)),
+                BranchLifecycleDisposition::Delete,
+                "terminal proven branch should be deletable: {provenance:?}"
+            );
+        }
+        assert_eq!(
+            branch_lifecycle_disposition(&branch_input(BranchProvenance::Unknown)),
+            BranchLifecycleDisposition::Keep
+        );
+    }
+
+    #[test]
+    fn branch_lifecycle_fails_closed_for_active_open_or_unknown_work() {
+        for mutate in [
+            |i: &mut BranchLifecycleInput| i.active_holder = Some(true),
+            |i: &mut BranchLifecycleInput| i.task_active = Some(true),
+            |i: &mut BranchLifecycleInput| i.open_pr = Some(true),
+            |i: &mut BranchLifecycleInput| i.unique_unpreserved_work = Some(true),
+            |i: &mut BranchLifecycleInput| i.open_pr = None,
+            |i: &mut BranchLifecycleInput| i.task_active = None,
+        ] {
+            let mut input = branch_input(BranchProvenance::ReviewerResidue);
+            mutate(&mut input);
+            assert_eq!(
+                branch_lifecycle_disposition(&input),
+                BranchLifecycleDisposition::Keep,
+                "unsafe or unknown branch evidence must keep the ref"
+            );
+        }
     }
 }

--- a/src/worktree_cleanup.rs
+++ b/src/worktree_cleanup.rs
@@ -25,6 +25,9 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::Duration;
 
+mod occupancy;
+pub(crate) use occupancy::{binding_scan_all_strict, bound_worktree_paths_or_ambiguous, is_in_use};
+
 /// Returns true unless `AGEND_WORKTREE_AUTO_CLEANUP` is explicitly set to "0".
 /// Cleanup is on by default — set `AGEND_WORKTREE_AUTO_CLEANUP=0` to disable.
 pub fn auto_cleanup_enabled() -> bool {
@@ -270,101 +273,6 @@ fn remove_worktree(
         let _ = crate::git_helpers::git_ok(repo_root, &["branch", "-D", branch]);
     }
     wt_ok
-}
-
-/// Normalize a path: strip Windows `\\?\` UNC prefix.
-fn normalize_path(p: &Path) -> PathBuf {
-    let s = p.to_string_lossy();
-    PathBuf::from(s.strip_prefix(r"\\?\").unwrap_or(&s).to_string())
-}
-
-/// Canonicalize `p`, or — when it does not exist yet — resolve symlinks on its
-/// longest EXISTING ancestor and re-append the missing tail. Returns `None`
-/// only when not even an existing ancestor canonicalizes.
-///
-/// #worktree-git-7: an active agent's `working_dir` recorded through a symlink
-/// alias whose leaf is transiently absent (mid-creation) would fail
-/// `canonicalize()` outright; the prior fail-OPEN fell back to the raw path,
-/// whose textual prefix misses the canonical worktree → `is_in_use` returned
-/// false and the sweep could remove a worktree out from under a live agent.
-fn canonicalize_lenient(p: &Path) -> Option<PathBuf> {
-    if let Ok(c) = p.canonicalize() {
-        return Some(c);
-    }
-    let mut tail: Vec<&std::ffi::OsStr> = Vec::new();
-    let mut cur = p;
-    while let Some(parent) = cur.parent() {
-        if let Some(name) = cur.file_name() {
-            tail.push(name);
-        }
-        if let Ok(c) = parent.canonicalize() {
-            let mut out = c;
-            out.extend(tail.iter().rev());
-            return Some(out);
-        }
-        cur = parent;
-    }
-    None
-}
-
-/// #t-…81457-1: distinct `worktree` paths of every LIVE `binding.json`, for
-/// the delete-path occupancy check (mirrors `binding::bound_source_repos`'s
-/// self-healing shape, but this one MUST distinguish "no binding.json"
-/// (normal — agent never bound) from "binding.json exists but failed to
-/// read/parse" (ambiguous — may be hiding a live binding). `Err` signals the
-/// latter; the caller fails the whole sweep round closed rather than treat
-/// an ambiguous row as absent.
-fn bound_worktree_paths_or_ambiguous(home: &Path) -> Result<Vec<PathBuf>, ()> {
-    let entries = match std::fs::read_dir(crate::paths::runtime_dir(home)) {
-        Ok(entries) => entries,
-        // A missing runtime_dir is the normal "no agent has ever bound" state
-        // (mirrors the per-file NotFound branch below) — a genuine absence.
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
-        // Any OTHER error (dir exists but unreadable: permissions, fd
-        // exhaustion) COULD be hiding a live binding.json — treat as ambiguity
-        // and fail the sweep round closed rather than report a false absence.
-        Err(_) => return Err(()),
-    };
-    let mut paths = Vec::new();
-    for entry in entries {
-        // A per-entry iteration error (the dir became unreadable mid-scan) is
-        // the same ambiguity as an unreadable binding.json below — fail closed
-        // instead of silently dropping the entry (was `entries.flatten()`).
-        let entry = entry.map_err(|_| ())?;
-        let agent = entry.file_name().to_string_lossy().into_owned();
-        let content = match std::fs::read_to_string(crate::paths::binding_path(home, &agent)) {
-            Ok(c) => c,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
-            Err(_) => return Err(()),
-        };
-        let v: serde_json::Value = serde_json::from_str(&content).map_err(|_| ())?;
-        if let Some(wt) = v["worktree"].as_str() {
-            let path = PathBuf::from(wt);
-            if !paths.contains(&path) {
-                paths.push(path);
-            }
-        }
-    }
-    Ok(paths)
-}
-
-/// Check if a worktree path is in use by any active agent.
-fn is_in_use(wt_path: &Path, active_dirs: &[PathBuf]) -> bool {
-    let wt_norm = normalize_path(
-        &wt_path
-            .canonicalize()
-            .unwrap_or_else(|_| wt_path.to_path_buf()),
-    );
-    active_dirs.iter().any(|wd| match canonicalize_lenient(wd) {
-        Some(canon) => {
-            let wd_norm = normalize_path(&canon);
-            wd_norm.starts_with(&wt_norm) || wd.starts_with(wt_path)
-        }
-        // Fail-CLOSED: not even an existing ancestor canonicalizes, so we cannot
-        // prove this active dir is outside the worktree. Treat the ambiguity as
-        // in-use rather than risk sweeping a worktree a live agent is using.
-        None => true,
-    })
 }
 
 /// Runtime-based sweep: uses live `binding.json` state to find repos and
@@ -836,7 +744,8 @@ pub(crate) fn branch_has_other_active_binding(
     excluded_worktree: Option<&str>,
 ) -> Option<bool> {
     let canonical_repo = std::fs::canonicalize(repo).ok()?;
-    for (_, binding) in crate::binding::binding_scan_all(home) {
+    let bindings = binding_scan_all_strict(home).ok()?;
+    for (_, binding) in bindings {
         if excluded_worktree
             .zip(binding["worktree"].as_str())
             .is_some_and(|(excluded, bound)| excluded == bound)
@@ -905,6 +814,11 @@ fn prune_orphaned_branches_with_home(
                 .collect(),
             _ => return Vec::new(),
         };
+    // Snapshot the open-PR inventory once for this repository/sweep.  Each
+    // branch below consumes the bounded snapshot instead of issuing its own
+    // synchronous SCM lookup; an Unknown snapshot keeps all terminal
+    // candidates fail-closed.
+    let open_pr_snapshot = crate::branch_sweep::open_pr_snapshot(repo_root, &default);
 
     let mut pruned = Vec::new();
     for branch in &branches {
@@ -957,7 +871,7 @@ fn prune_orphaned_branches_with_home(
             _ => None,
         };
         let open_pr = if merged || squash || scaffold {
-            match crate::branch_sweep::open_pr_status(repo_root, &default, branch) {
+            match open_pr_snapshot.status_for(branch) {
                 crate::branch_sweep::OpenPrStatus::Open => Some(true),
                 crate::branch_sweep::OpenPrStatus::NotOpen => Some(false),
                 crate::branch_sweep::OpenPrStatus::Unknown => None,
@@ -2545,6 +2459,9 @@ mod tests {
         std::fs::remove_dir_all(&home).ok();
     }
 }
+
+#[cfg(test)]
+mod lifecycle_r1_tests;
 
 #[cfg(test)]
 mod review_repro_worktree_git;

--- a/src/worktree_cleanup.rs
+++ b/src/worktree_cleanup.rs
@@ -622,7 +622,7 @@ pub fn sweep_from_registry(
         // PR-D6: sweep is always live now (gated by AUTO_CLEANUP only), so the
         // helpers' still-supported `dry_run` param is passed `false` here.
         prune_stale_worktrees(repo, false);
-        let pruned = prune_orphaned_branches(repo, false);
+        let pruned = prune_orphaned_branches_with_home(Some(home), repo, false);
         for (branch, reason) in pruned {
             removed.push((branch, "(no worktree)".to_string(), reason));
         }
@@ -825,6 +825,40 @@ pub(crate) fn is_squash_gc_eligible(repo_root: &Path, branch: &str, default: &st
     result
 }
 
+pub(crate) fn branch_has_active_binding(home: &Path, repo: &Path, branch: &str) -> Option<bool> {
+    branch_has_other_active_binding(home, repo, branch, None)
+}
+
+pub(crate) fn branch_has_other_active_binding(
+    home: &Path,
+    repo: &Path,
+    branch: &str,
+    excluded_worktree: Option<&str>,
+) -> Option<bool> {
+    let canonical_repo = std::fs::canonicalize(repo).ok()?;
+    for (_, binding) in crate::binding::binding_scan_all(home) {
+        if excluded_worktree
+            .zip(binding["worktree"].as_str())
+            .is_some_and(|(excluded, bound)| excluded == bound)
+        {
+            continue;
+        }
+        let Some(bound_branch) = binding["branch"].as_str() else {
+            continue;
+        };
+        let Some(source) = binding["source_repo"].as_str() else {
+            continue;
+        };
+        let Ok(source) = std::fs::canonicalize(source) else {
+            return None;
+        };
+        if bound_branch == branch && source == canonical_repo {
+            return Some(true);
+        }
+    }
+    Some(false)
+}
+
 /// Run `git worktree prune` then delete local branches whose remote tracking
 /// ref is gone, that are merged into main, or that are squash-merge orphans
 /// (#1750-B3). Skips branches checked out in any worktree.
@@ -833,7 +867,16 @@ pub(crate) fn is_squash_gc_eligible(repo_root: &Path, branch: &str, default: &st
 /// worktree-occupancy skip) but skips the actual `git branch -D` — eligible
 /// branches are still returned (with their real reason: `"merged"` or
 /// `"squash-merged"`) so the caller can log/audit the candidate list.
+#[allow(dead_code)]
 fn prune_orphaned_branches(repo_root: &Path, dry_run: bool) -> Vec<(String, &'static str)> {
+    prune_orphaned_branches_with_home(None, repo_root, dry_run)
+}
+
+fn prune_orphaned_branches_with_home(
+    home: Option<&Path>,
+    repo_root: &Path,
+    dry_run: bool,
+) -> Vec<(String, &'static str)> {
     let default = crate::git_helpers::default_branch(repo_root);
     // Collect branches currently checked out in worktrees — cannot delete these
     // PR-B rider (dev2 #2695 seat2): fail-CLOSED occupancy. If the worktree list
@@ -891,13 +934,63 @@ fn prune_orphaned_branches(repo_root: &Path, dry_run: bool) -> Vec<(String, &'st
         // so the merged/squash paths never reap them — a TTL is their only live
         // terminal path (H1 in the RCA).
         let scaffold = !merged && !squash && is_stale_review_scaffold(repo_root, branch);
+        let provenance = if merged {
+            crate::worktree::disposition::BranchProvenance::Merged
+        } else if squash {
+            crate::worktree::disposition::BranchProvenance::SquashMerged
+        } else if scaffold {
+            crate::worktree::disposition::BranchProvenance::ReviewerResidue
+        } else {
+            crate::worktree::disposition::BranchProvenance::Unknown
+        };
+        let task_active = match home {
+            Some(h) => crate::branch_sweep::branch_has_active_task(h, branch),
+            None => Some(false),
+        };
+        let binding_active = match home {
+            Some(h) => branch_has_active_binding(h, repo_root, branch),
+            None => Some(false),
+        };
+        let active_holder = match (wt_branches.contains(branch), binding_active) {
+            (true, _) | (_, Some(true)) => Some(true),
+            (false, Some(false)) => Some(false),
+            _ => None,
+        };
+        let open_pr = if merged || squash || scaffold {
+            match crate::branch_sweep::open_pr_status(repo_root, &default, branch) {
+                crate::branch_sweep::OpenPrStatus::Open => Some(true),
+                crate::branch_sweep::OpenPrStatus::NotOpen => Some(false),
+                crate::branch_sweep::OpenPrStatus::Unknown => None,
+            }
+        } else {
+            // Unknown provenance is already a KEEP decision; avoid an
+            // unnecessary network probe for branches that cannot be deleted.
+            Some(false)
+        };
+        let lifecycle = crate::worktree::disposition::branch_lifecycle_disposition(
+            &crate::worktree::disposition::BranchLifecycleInput {
+                provenance,
+                terminal: merged || squash || scaffold,
+                active_holder,
+                task_active,
+                open_pr,
+                // Reviewer residue is snapshotted into a recovery ref before
+                // deletion below; merged/squash work is already in `default`.
+                unique_unpreserved_work: Some(false),
+            },
+        );
         // PR-D·D3: the reap decision (L4) delegates to `branch_disposition` via
         // `branch_reap_delete`. `merged || squash` = ProvablyInDefault → delete;
         // `scaffold` is the explicit external-arm override (a NotMerged branch the
         // classifier keeps, aged past its TTL). Phase-2 does not compute remote-gone
         // (CR-2026-06-14 dropped it as a trigger) → remote_gone=false. Byte-identical
         // to the prior `!merged && !squash && !scaffold` continue-gate.
-        if !branch_reap_delete(merged || squash, false, scaffold) {
+        if !branch_reap_delete(merged || squash, false, scaffold)
+            || !matches!(
+                lifecycle,
+                crate::worktree::disposition::BranchLifecycleDisposition::Delete
+            )
+        {
             continue;
         }
         // The scaffolding path never merged, so its commits survive only in the
@@ -908,6 +1001,23 @@ fn prune_orphaned_branches(repo_root: &Path, dry_run: bool) -> Vec<(String, &'st
         } else {
             None
         };
+        if scaffold && !dry_run {
+            if let Some(tip) = scaffold_tip.as_deref() {
+                if crate::branch_sweep::prepare_branch_recovery(
+                    home,
+                    repo_root,
+                    branch,
+                    tip,
+                    "review-scaffold-ttl",
+                )
+                .is_err()
+                {
+                    continue;
+                }
+            } else {
+                continue;
+            }
+        }
         let ok = dry_run || crate::git_helpers::git_ok(repo_root, &["branch", "-D", branch]);
         if ok {
             let reason = if merged {

--- a/src/worktree_cleanup.rs
+++ b/src/worktree_cleanup.rs
@@ -746,18 +746,21 @@ pub(crate) fn branch_has_other_active_binding(
     let canonical_repo = std::fs::canonicalize(repo).ok()?;
     let bindings = binding_scan_all_strict(home).ok()?;
     for (_, binding) in bindings {
+        let bound_branch = binding["branch"]
+            .as_str()
+            .filter(|branch| !branch.is_empty())?;
+        let source = binding["source_repo"]
+            .as_str()
+            .filter(|source| !source.is_empty())?;
+        if excluded_worktree.is_some() && binding["worktree"].as_str().is_none_or(str::is_empty) {
+            return None;
+        }
         if excluded_worktree
             .zip(binding["worktree"].as_str())
             .is_some_and(|(excluded, bound)| excluded == bound)
         {
             continue;
         }
-        let Some(bound_branch) = binding["branch"].as_str() else {
-            continue;
-        };
-        let Some(source) = binding["source_repo"].as_str() else {
-            continue;
-        };
         let Ok(source) = std::fs::canonicalize(source) else {
             return None;
         };

--- a/src/worktree_cleanup/lifecycle_r1_tests.rs
+++ b/src/worktree_cleanup/lifecycle_r1_tests.rs
@@ -1,0 +1,151 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use super::*;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn tmp_home(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "agend-wt-lifecycle-r1-{tag}-{}-{}",
+        std::process::id(),
+        chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn git_in(dir: &Path, args: &[&str]) {
+    Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .env("AGEND_GIT_BYPASS", "1")
+        .env("GIT_AUTHOR_NAME", "test")
+        .env("GIT_AUTHOR_EMAIL", "t@t")
+        .env("GIT_COMMITTER_NAME", "test")
+        .env("GIT_COMMITTER_EMAIL", "t@t")
+        .output()
+        .expect("git");
+}
+
+fn setup_repo(tag: &str) -> PathBuf {
+    let repo = tmp_home(&format!("repo-{tag}"));
+    git_in(&repo, &["init", "-b", "main"]);
+    std::fs::write(repo.join("README.md"), "init").unwrap();
+    git_in(&repo, &["add", "."]);
+    git_in(&repo, &["commit", "-m", "init"]);
+    repo
+}
+
+fn make_old_merged_branch(repo: &Path, branch: &str) {
+    git_in(repo, &["checkout", "-b", branch]);
+    let file = branch.replace('/', "-");
+    std::fs::write(repo.join(format!("{file}.txt")), "feature").unwrap();
+    git_in(repo, &["add", "."]);
+    Command::new("git")
+        .args(["commit", "-m", "feature"])
+        .current_dir(repo)
+        .env("AGEND_GIT_BYPASS", "1")
+        .env("GIT_AUTHOR_NAME", "test")
+        .env("GIT_AUTHOR_EMAIL", "t@t")
+        .env("GIT_COMMITTER_NAME", "test")
+        .env("GIT_COMMITTER_EMAIL", "t@t")
+        .env("GIT_AUTHOR_DATE", "2024-01-01T00:00:00 +0000")
+        .env("GIT_COMMITTER_DATE", "2024-01-01T00:00:00 +0000")
+        .output()
+        .expect("git commit");
+    git_in(repo, &["checkout", "main"]);
+    git_in(repo, &["merge", "--ff-only", branch]);
+}
+
+fn write_source_binding(home: &Path, agent: &str, source_repo: &Path) {
+    let dir = crate::paths::runtime_dir(home).join(agent);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join("binding.json"),
+        serde_json::json!({"source_repo": source_repo.display().to_string()}).to_string(),
+    )
+    .unwrap();
+}
+
+#[test]
+fn corrupt_binding_inventory_is_unknown_for_branch_delete_gate() {
+    let home = tmp_home("corrupt-binding");
+    let repo = setup_repo("corrupt-binding");
+    write_source_binding(&home, "valid-agent", &repo);
+    let corrupt = crate::paths::runtime_dir(&home).join("corrupt-agent");
+    std::fs::create_dir_all(&corrupt).unwrap();
+    std::fs::write(corrupt.join("binding.json"), b"not-json").unwrap();
+
+    assert_eq!(
+        branch_has_active_binding(&home, &repo, "feat/done"),
+        None,
+        "corrupt binding evidence must fail closed"
+    );
+
+    std::fs::remove_dir_all(&repo).ok();
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn prune_batches_open_pr_inventory_once_per_repo_sweep() {
+    let repo = setup_repo("open-pr-batch");
+    git_in(
+        &repo,
+        &[
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/example/repo.git",
+        ],
+    );
+    make_old_merged_branch(&repo, "feat/old-a");
+    make_old_merged_branch(&repo, "feat/old-b");
+    let home = tmp_home("open-pr-batch");
+    let provider = crate::scm::MockScmProvider::with_pr_list(crate::scm::MockPrList::Prs(0));
+    let _provider_guard = crate::scm::set_test_scm_provider(provider.clone());
+
+    let removed = prune_orphaned_branches_with_home(Some(&home), &repo, false);
+    assert_eq!(provider.pr_list_calls(), 1, "one bounded open-PR inventory");
+    assert_eq!(removed.len(), 2, "both merged branches remain eligible");
+
+    std::fs::remove_dir_all(&repo).ok();
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn failed_open_pr_snapshot_preserves_all_terminal_candidates() {
+    let repo = setup_repo("open-pr-failure");
+    git_in(
+        &repo,
+        &[
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/example/repo.git",
+        ],
+    );
+    make_old_merged_branch(&repo, "feat/old-a");
+    make_old_merged_branch(&repo, "feat/old-b");
+    let home = tmp_home("open-pr-failure");
+    let provider =
+        crate::scm::MockScmProvider::with_pr_list(crate::scm::MockPrList::Fail("offline".into()));
+    let _provider_guard = crate::scm::set_test_scm_provider(provider.clone());
+
+    let removed = prune_orphaned_branches_with_home(Some(&home), &repo, false);
+    assert!(
+        removed.is_empty(),
+        "unknown open-PR inventory must preserve all branches"
+    );
+    assert!(crate::git_helpers::git_ok(
+        &repo,
+        &["show-ref", "--verify", "refs/heads/feat/old-a"]
+    ));
+    assert!(crate::git_helpers::git_ok(
+        &repo,
+        &["show-ref", "--verify", "refs/heads/feat/old-b"]
+    ));
+    assert_eq!(provider.pr_list_calls(), 1);
+
+    std::fs::remove_dir_all(&repo).ok();
+    std::fs::remove_dir_all(&home).ok();
+}

--- a/src/worktree_cleanup/lifecycle_r1_tests.rs
+++ b/src/worktree_cleanup/lifecycle_r1_tests.rs
@@ -58,13 +58,20 @@ fn make_old_merged_branch(repo: &Path, branch: &str) {
 }
 
 fn write_source_binding(home: &Path, agent: &str, source_repo: &Path) {
+    write_binding(
+        home,
+        agent,
+        serde_json::json!({
+            "branch": "feat/other",
+            "source_repo": source_repo.display().to_string()
+        }),
+    );
+}
+
+fn write_binding(home: &Path, agent: &str, value: serde_json::Value) {
     let dir = crate::paths::runtime_dir(home).join(agent);
     std::fs::create_dir_all(&dir).unwrap();
-    std::fs::write(
-        dir.join("binding.json"),
-        serde_json::json!({"source_repo": source_repo.display().to_string()}).to_string(),
-    )
-    .unwrap();
+    std::fs::write(dir.join("binding.json"), value.to_string()).unwrap();
 }
 
 #[test]
@@ -82,6 +89,57 @@ fn corrupt_binding_inventory_is_unknown_for_branch_delete_gate() {
         "corrupt binding evidence must fail closed"
     );
 
+    std::fs::remove_dir_all(&repo).ok();
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn parsed_binding_missing_identity_is_unknown_for_branch_delete_gate() {
+    let repo = setup_repo("missing-binding-identity");
+    let home = tmp_home("missing-binding-identity");
+    write_binding(
+        &home,
+        "missing-branch",
+        serde_json::json!({"source_repo": repo.display().to_string()}),
+    );
+    assert_eq!(
+        branch_has_active_binding(&home, &repo, "feat/done"),
+        None,
+        "parsed binding without branch identity must fail closed"
+    );
+    let home_missing_source = tmp_home("missing-source-identity");
+    write_binding(
+        &home_missing_source,
+        "missing-source",
+        serde_json::json!({"branch": "feat/done"}),
+    );
+    assert_eq!(
+        branch_has_active_binding(&home_missing_source, &repo, "feat/done"),
+        None,
+        "parsed binding without source identity must fail closed"
+    );
+    std::fs::remove_dir_all(&repo).ok();
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&home_missing_source).ok();
+}
+
+#[test]
+fn excluded_worktree_requires_binding_worktree_identity() {
+    let repo = setup_repo("missing-worktree-identity");
+    let home = tmp_home("missing-worktree-identity");
+    write_binding(
+        &home,
+        "missing-worktree",
+        serde_json::json!({
+            "branch": "feat/done",
+            "source_repo": repo.display().to_string()
+        }),
+    );
+    assert_eq!(
+        branch_has_other_active_binding(&home, &repo, "feat/done", Some("/excluded")),
+        None,
+        "excluded-worktree comparison without identity must fail closed"
+    );
     std::fs::remove_dir_all(&repo).ok();
     std::fs::remove_dir_all(&home).ok();
 }
@@ -148,4 +206,102 @@ fn failed_open_pr_snapshot_preserves_all_terminal_candidates() {
 
     std::fs::remove_dir_all(&repo).ok();
     std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn open_pr_snapshot_covers_all_bases_with_bounded_inventory() {
+    let repo = setup_repo("open-pr-any-base");
+    git_in(
+        &repo,
+        &[
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/example/repo.git",
+        ],
+    );
+    let provider =
+        crate::scm::MockScmProvider::with_pr_list(crate::scm::MockPrList::Branches(vec![
+            "feat/old".into(),
+        ]));
+    let _provider_guard = crate::scm::set_test_scm_provider(provider.clone());
+
+    let snapshot = crate::branch_sweep::open_pr_snapshot(&repo, "main");
+    assert_eq!(
+        snapshot.status_for("feat/old"),
+        crate::branch_sweep::OpenPrStatus::Open
+    );
+    assert!(!provider.pr_list_saw_base(), "snapshot must query any base");
+    assert!(
+        !provider.pr_list_saw_head(),
+        "snapshot must inventory all heads"
+    );
+    assert_eq!(
+        provider.pr_list_last_limit(),
+        Some(1001),
+        "snapshot requests cap+1 to detect truncation"
+    );
+
+    std::fs::remove_dir_all(&repo).ok();
+}
+
+#[test]
+fn truncated_open_pr_snapshot_is_unknown() {
+    let repo = setup_repo("open-pr-truncated");
+    git_in(
+        &repo,
+        &[
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/example/repo.git",
+        ],
+    );
+    let branches = (0..1001).map(|index| format!("feat/{index}")).collect();
+    let provider =
+        crate::scm::MockScmProvider::with_pr_list(crate::scm::MockPrList::Branches(branches));
+    let _provider_guard = crate::scm::set_test_scm_provider(provider);
+
+    let snapshot = crate::branch_sweep::open_pr_snapshot(&repo, "main");
+    assert_eq!(
+        snapshot.status_for("feat/0"),
+        crate::branch_sweep::OpenPrStatus::Unknown,
+        "an incomplete page must not be treated as a complete inventory"
+    );
+
+    std::fs::remove_dir_all(&repo).ok();
+}
+
+#[test]
+fn apply_open_pr_probe_covers_all_bases() {
+    let repo = setup_repo("open-pr-apply-any-base");
+    git_in(
+        &repo,
+        &[
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/example/repo.git",
+        ],
+    );
+    let provider =
+        crate::scm::MockScmProvider::with_pr_list(crate::scm::MockPrList::Branches(vec![
+            "feat/old".into(),
+        ]));
+    let _provider_guard = crate::scm::set_test_scm_provider(provider.clone());
+
+    assert_eq!(
+        crate::branch_sweep::open_pr_status(&repo, "main", "feat/old"),
+        crate::branch_sweep::OpenPrStatus::Open
+    );
+    assert!(
+        !provider.pr_list_saw_base(),
+        "apply probe must query any base"
+    );
+    assert!(
+        provider.pr_list_saw_head(),
+        "apply probe remains branch-scoped"
+    );
+
+    std::fs::remove_dir_all(&repo).ok();
 }

--- a/src/worktree_cleanup/occupancy.rs
+++ b/src/worktree_cleanup/occupancy.rs
@@ -1,5 +1,7 @@
 use std::path::{Path, PathBuf};
 
+/// Read every binding with the identity fields required by destructive branch
+/// cleanup. A syntactically valid but incomplete binding is still ambiguous.
 pub(crate) fn binding_scan_all_strict(home: &Path) -> Result<Vec<(String, serde_json::Value)>, ()> {
     let runtime_dir = crate::paths::runtime_dir(home);
     let entries = match std::fs::read_dir(&runtime_dir) {
@@ -17,7 +19,18 @@ pub(crate) fn binding_scan_all_strict(home: &Path) -> Result<Vec<(String, serde_
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
             Err(_) => return Err(()),
         };
-        let value = serde_json::from_str(&content).map_err(|_| ())?;
+        let value: serde_json::Value = serde_json::from_str(&content).map_err(|_| ())?;
+        if value["branch"]
+            .as_str()
+            .filter(|branch| !branch.is_empty())
+            .is_none()
+            || value["source_repo"]
+                .as_str()
+                .filter(|source| !source.is_empty())
+                .is_none()
+        {
+            return Err(());
+        }
         bindings.push((agent_name, value));
     }
     Ok(bindings)

--- a/src/worktree_cleanup/occupancy.rs
+++ b/src/worktree_cleanup/occupancy.rs
@@ -1,0 +1,97 @@
+use std::path::{Path, PathBuf};
+
+pub(crate) fn binding_scan_all_strict(home: &Path) -> Result<Vec<(String, serde_json::Value)>, ()> {
+    let runtime_dir = crate::paths::runtime_dir(home);
+    let entries = match std::fs::read_dir(&runtime_dir) {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(_) => return Err(()),
+    };
+    let mut bindings = Vec::new();
+    for entry in entries {
+        let entry = entry.map_err(|_| ())?;
+        let agent_name = entry.file_name().to_string_lossy().into_owned();
+        let binding_path = crate::paths::binding_path(home, &agent_name);
+        let content = match std::fs::read_to_string(&binding_path) {
+            Ok(content) => content,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(_) => return Err(()),
+        };
+        let value = serde_json::from_str(&content).map_err(|_| ())?;
+        bindings.push((agent_name, value));
+    }
+    Ok(bindings)
+}
+
+/// Normalize a path: strip Windows `\\?\` UNC prefix.
+fn normalize_path(p: &Path) -> PathBuf {
+    let s = p.to_string_lossy();
+    PathBuf::from(s.strip_prefix(r"\\?\").unwrap_or(&s).to_string())
+}
+
+/// Canonicalize `p`, or — when it does not exist yet — resolve symlinks on its
+/// longest EXISTING ancestor and re-append the missing tail. Returns `None`
+/// only when not even an existing ancestor canonicalizes.
+fn canonicalize_lenient(p: &Path) -> Option<PathBuf> {
+    if let Ok(c) = p.canonicalize() {
+        return Some(c);
+    }
+    let mut tail: Vec<&std::ffi::OsStr> = Vec::new();
+    let mut cur = p;
+    while let Some(parent) = cur.parent() {
+        if let Some(name) = cur.file_name() {
+            tail.push(name);
+        }
+        if let Ok(c) = parent.canonicalize() {
+            let mut out = c;
+            out.extend(tail.iter().rev());
+            return Some(out);
+        }
+        cur = parent;
+    }
+    None
+}
+
+/// Distinct `worktree` paths of every LIVE `binding.json`, preserving the
+/// distinction between a genuine absence and unreadable/corrupt evidence.
+pub(crate) fn bound_worktree_paths_or_ambiguous(home: &Path) -> Result<Vec<PathBuf>, ()> {
+    let entries = match std::fs::read_dir(crate::paths::runtime_dir(home)) {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(_) => return Err(()),
+    };
+    let mut paths = Vec::new();
+    for entry in entries {
+        let entry = entry.map_err(|_| ())?;
+        let agent = entry.file_name().to_string_lossy().into_owned();
+        let content = match std::fs::read_to_string(crate::paths::binding_path(home, &agent)) {
+            Ok(c) => c,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(_) => return Err(()),
+        };
+        let v: serde_json::Value = serde_json::from_str(&content).map_err(|_| ())?;
+        if let Some(wt) = v["worktree"].as_str() {
+            let path = PathBuf::from(wt);
+            if !paths.contains(&path) {
+                paths.push(path);
+            }
+        }
+    }
+    Ok(paths)
+}
+
+/// Check if a worktree path is in use by any active agent.
+pub(crate) fn is_in_use(wt_path: &Path, active_dirs: &[PathBuf]) -> bool {
+    let wt_norm = normalize_path(
+        &wt_path
+            .canonicalize()
+            .unwrap_or_else(|_| wt_path.to_path_buf()),
+    );
+    active_dirs.iter().any(|wd| match canonicalize_lenient(wd) {
+        Some(canon) => {
+            let wd_norm = normalize_path(&canon);
+            wd_norm.starts_with(&wt_norm) || wd.starts_with(wt_path)
+        }
+        None => true,
+    })
+}

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -601,6 +601,34 @@ fn record_binding_removal(out: &mut ReleaseOutcome, removal: crate::binding::Bin
     }
 }
 
+fn task_active_for_branch(home: &Path, task_id: &str, branch: &str) -> Option<bool> {
+    if task_id.is_empty() {
+        return Some(false);
+    }
+    match crate::tasks::load_routed(home, task_id) {
+        Ok(routed) => {
+            let active = !matches!(
+                routed.task.status,
+                crate::task_events::TaskStatus::Done
+                    | crate::task_events::TaskStatus::Cancelled
+                    | crate::task_events::TaskStatus::Verified
+            );
+            // A live task with no branch metadata is still an unresolved
+            // holder for this binding; preserve rather than guessing.
+            let branch_matches = routed
+                .task
+                .branch
+                .as_deref()
+                .map(|task_branch| task_branch == branch)
+                .unwrap_or(true);
+            Some(active && branch_matches)
+        }
+        Err(crate::tasks::TaskRouteError::NotFound) => Some(false),
+        Err(crate::tasks::TaskRouteError::Unreadable { .. })
+        | Err(crate::tasks::TaskRouteError::Ambiguous { .. }) => None,
+    }
+}
+
 fn resolve_branch_cleanup(
     home: &Path,
     binding: &serde_json::Value,
@@ -650,6 +678,56 @@ fn resolve_branch_cleanup(
                 "authority-proven review lease on '{branch}' had dirty work — branch preserved"
             ));
             return;
+        }
+        if let Some(expected) = authority_proven_head {
+            let default = crate::git_helpers::default_branch(Path::new(sr_str));
+            let task_active = task_active_for_branch(home, task_id, branch);
+            let open_pr =
+                match crate::branch_sweep::open_pr_status(Path::new(sr_str), &default, branch) {
+                    crate::branch_sweep::OpenPrStatus::Open => Some(true),
+                    crate::branch_sweep::OpenPrStatus::NotOpen => Some(false),
+                    crate::branch_sweep::OpenPrStatus::Unknown => None,
+                };
+            let unique_unpreserved_work =
+                crate::git_helpers::git_cmd(Path::new(sr_str), &["rev-parse", branch])
+                    .ok()
+                    .map(|tip| tip.trim() != expected);
+            let lifecycle = crate::worktree::disposition::branch_lifecycle_disposition(
+                &crate::worktree::disposition::BranchLifecycleInput {
+                    provenance: crate::worktree::disposition::BranchProvenance::ManagedReview,
+                    terminal: true,
+                    active_holder: crate::worktree_cleanup::branch_has_other_active_binding(
+                        home,
+                        Path::new(sr_str),
+                        branch,
+                        binding["worktree"].as_str(),
+                    ),
+                    task_active,
+                    open_pr,
+                    unique_unpreserved_work,
+                },
+            );
+            if !matches!(
+                lifecycle,
+                crate::worktree::disposition::BranchLifecycleDisposition::Delete
+            ) {
+                out.branch_cleanup_skipped_reason = Some(format!(
+                    "authority-proven review branch '{branch}' lifecycle evidence is not terminal — preserved (fail-closed)"
+                ));
+                return;
+            }
+            if !dry_run {
+                if let Err(error) = crate::branch_sweep::prepare_branch_recovery(
+                    Some(home),
+                    Path::new(sr_str),
+                    branch,
+                    expected,
+                    "authority-proven review release",
+                ) {
+                    out.branch_cleanup_skipped_reason = Some(error);
+                    return;
+                }
+            }
         }
         let (deleted, skip_reason) =
             cleanup_merged_branch(Path::new(sr_str), branch, dry_run, authority_proven_head);

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -621,7 +621,15 @@ fn task_active_for_branch(home: &Path, task_id: &str, branch: &str) -> Option<bo
                 .as_deref()
                 .map(|task_branch| task_branch == branch)
                 .unwrap_or(true);
-            Some(active && branch_matches)
+            if active && !branch_matches {
+                // A live task explicitly tied to a different branch is
+                // contradictory evidence, not proof that this branch is
+                // unoccupied. Preserve the branch until the task/binding
+                // records converge or an operator resolves the conflict.
+                None
+            } else {
+                Some(active)
+            }
         }
         Err(crate::tasks::TaskRouteError::NotFound) => Some(false),
         Err(crate::tasks::TaskRouteError::Unreadable { .. })

--- a/src/worktree_pool/tests.rs
+++ b/src/worktree_pool/tests.rs
@@ -4895,6 +4895,61 @@ fn authority_proven_clean_review_deleted_immediately() {
     std::fs::remove_dir_all(&repo).ok();
 }
 
+#[test]
+fn active_task_branch_mismatch_preserves_review_branch() {
+    let home = tmp_home("task-branch-mismatch-home");
+    let repo = tmp_repo("task-branch-mismatch");
+    let tip = make_review_branch(&repo, "review/task-mismatch-1234");
+    let task_id = "T-task-branch-mismatch";
+    crate::task_events::append(
+        &home,
+        &crate::task_events::InstanceName::from("test"),
+        crate::task_events::TaskEvent::Created {
+            task_id: crate::task_events::TaskId::from(task_id),
+            title: "active mismatch".to_string(),
+            description: String::new(),
+            priority: "normal".to_string(),
+            owner: None,
+            due_at: None,
+            depends_on: Vec::new(),
+            routed_to: None,
+            branch: Some("review/another-branch".to_string()),
+            bind: None,
+            eta_secs: None,
+            tags: Vec::new(),
+            parent_id: None,
+        },
+    )
+    .unwrap();
+    let mut binding = binding_with_lease(
+        "review/task-mismatch-1234",
+        &repo.display().to_string(),
+        Some("review"),
+        Some("assign-task-mismatch"),
+        Some(&tip),
+    );
+    binding["task_id"] = serde_json::json!(task_id);
+
+    let mut out = ReleaseOutcome::default();
+    resolve_branch_cleanup(&home, &binding, true, false, false, false, &mut out);
+
+    assert!(
+        !out.branch_deleted,
+        "contradictory active task evidence preserves branch"
+    );
+    assert!(branch_exists(&repo, "review/task-mismatch-1234"));
+    assert!(
+        out.branch_cleanup_skipped_reason
+            .as_deref()
+            .is_some_and(|reason| reason.contains("fail-closed")),
+        "mismatch must report fail-closed preservation: {:?}",
+        out.branch_cleanup_skipped_reason
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&repo).ok();
+}
+
 /// RED #4: an authority-proven review lease on a DIRTY worktree must preserve
 /// the branch — dirty work was stashed but the branch ref should stay for
 /// manual recovery.


### PR DESCRIPTION
## Summary\n- centralize fail-closed branch lifecycle disposition across cleanup and managed review release\n- preserve active/unknown/open-PR branches and create durable recovery refs before reviewer residue deletion\n- authorize explicit cleanup repository paths only for the actual configured orchestrator\n\n## Evidence\n- cargo test --bin agend-terminal branch_sweep::tests -- --nocapture -> 25 passed\n- cargo test --bin agend-terminal worktree::disposition::tests -- --nocapture -> 23 passed\n- cargo test --bin agend-terminal worktree_cleanup::tests -- --nocapture -> 41 passed\n- cargo test --bin agend-terminal worktree_pool::tests -- --nocapture -> 130 passed\n- cargo test --bin agend-terminal mcp::handlers::ci::cleanup::tests -- --nocapture -> 1 passed\n- cargo clippy --bin agend-terminal --all-targets -- -D warnings -> passed\n- git diff --check -> passed\n\nThe local full cargo test --bin agend-terminal run was attempted but encountered parallel temp-home/EMFILE contention (5613 passed, 126 unrelated failures); branch CI is the clean full-suite authority.\n\nHead: 760f9916be31bbd5b8a0a21c432c8e5d7ca5f4b8