### PR TITLE
fix: ignore checkout path locks in recovery sweep

### DIFF
--- a/src/mcp/handlers/ci/checkout_recovery.rs
+++ b/src/mcp/handlers/ci/checkout_recovery.rs
@@ -8,6 +8,11 @@ use super::checkout_txn::{
 };
 use std::path::Path;
 
+fn is_canonical_path_lock_name(name: &str) -> bool {
+    name.strip_prefix("wtpath-")
+        .is_some_and(|suffix| suffix.ends_with(".lock"))
+}
+
 /// Drive recovery of CRASHED (orphaned) checkout-transaction journals — the ONE shared
 /// callable for boot-repair AND a periodic tick (no dedicated worker; the caller sets
 /// cadence). Race-safe against a concurrent live checkout:
@@ -39,9 +44,15 @@ pub(crate) fn recover_pending_sweep<G>(
         let Some(mangled) = entry.file_name().to_str().map(str::to_string) else {
             continue;
         };
-        // (1) Unlocked read for path + nonce. Sibling `<key>.lock` files load as Absent
-        // (skipped); a corrupt record is QUARANTINED (retained as intervention authority —
-        // #2755 R3), NOT cleared; an unreadable record fails closed (#2755 R4).
+        // `lock_path` creates a sibling `wtpath-*.lock` file in `txn_root`.
+        // It is a live coordination primitive, not a journal directory; skip
+        // it before `load_typed` would misclassify the file as unreadable.
+        if is_canonical_path_lock_name(&mangled) {
+            continue;
+        }
+        // (1) Unlocked read for path + nonce. A corrupt record is QUARANTINED
+        // (retained as intervention authority — #2755 R3), NOT cleared; an
+        // unreadable record fails closed (#2755 R4).
         let seen = match load_typed(home, &mangled) {
             JournalLoad::Loaded(j) => j,
             JournalLoad::Unreadable => {

--- a/src/mcp/handlers/ci/checkout_recovery.rs
+++ b/src/mcp/handlers/ci/checkout_recovery.rs
@@ -4,14 +4,10 @@
 //! module is the boot + per-tick recovery DRIVER (`recover_pending_sweep[_prod]`).
 
 use super::checkout_txn::{
-    load_typed, quarantine_corrupt, try_acquire_path_lock, txn_root, Journal, JournalLoad, Phase,
+    is_canonical_path_lock_name, load_typed, quarantine_corrupt, try_acquire_path_lock, txn_root,
+    Journal, JournalLoad, Phase,
 };
 use std::path::Path;
-
-fn is_canonical_path_lock_name(name: &str) -> bool {
-    name.strip_prefix("wtpath-")
-        .is_some_and(|suffix| suffix.ends_with(".lock"))
-}
 
 /// Drive recovery of CRASHED (orphaned) checkout-transaction journals — the ONE shared
 /// callable for boot-repair AND a periodic tick (no dedicated worker; the caller sets

--- a/src/mcp/handlers/ci/checkout_submodule_tests.rs
+++ b/src/mcp/handlers/ci/checkout_submodule_tests.rs
@@ -910,6 +910,72 @@ fn txn_sweep_empty_area_is_zero() {
     std::fs::remove_dir_all(&home).ok();
 }
 
+/// The canonical per-target lock is a sibling file in `checkout_txn`, not a
+/// journal entry. The recovery entry point must ignore it without attempting
+/// to decode, audit, or remove it.
+#[test]
+#[tracing_test::traced_test]
+fn txn_sweep_ignores_canonical_path_lock_file() {
+    let home = tmp_home("sweep-path-lock");
+    let target = home.join("worktrees").join("agent-src");
+    let normalized = super::checkout_txn::normalize_target(&target);
+    let lock = super::checkout_txn::lock_path(&home, &normalized);
+    std::fs::create_dir_all(lock.parent().unwrap()).unwrap();
+    std::fs::write(&lock, b"").unwrap();
+    let callbacks = std::cell::Cell::new(0);
+
+    let n = recover_pending_sweep(
+        &home,
+        fixed_now(),
+        |_| {
+            callbacks.set(callbacks.get() + 1);
+            Some(())
+        },
+        |_| {
+            callbacks.set(callbacks.get() + 1);
+            true
+        },
+        |_| callbacks.set(callbacks.get() + 1),
+    );
+    assert_eq!(n, 0);
+    assert_eq!(callbacks.get(), 0, "path lock is not a journal candidate");
+    assert!(
+        !logs_contain("journal unreadable"),
+        "canonical path locks must not be classified as unreadable journals"
+    );
+    assert!(lock.is_file(), "canonical lock must remain untouched");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// A real journal directory whose `journal.json` cannot be read remains an
+/// unresolved recovery authority. The entry point must preserve it and avoid
+/// all destructive callbacks (fail closed).
+#[test]
+fn txn_sweep_unreadable_journal_directory_remains_fail_closed() {
+    let home = tmp_home("sweep-unreadable-journal");
+    let journal = super::checkout_txn::journal_path(&home, "m");
+    std::fs::create_dir_all(&journal).unwrap();
+    let callbacks = std::cell::Cell::new(0);
+
+    let n = recover_pending_sweep(
+        &home,
+        fixed_now(),
+        |_| {
+            callbacks.set(callbacks.get() + 1);
+            Some(())
+        },
+        |_| {
+            callbacks.set(callbacks.get() + 1);
+            true
+        },
+        |_| callbacks.set(callbacks.get() + 1),
+    );
+    assert_eq!(n, 0);
+    assert_eq!(callbacks.get(), 0, "unreadable journal cannot be recovered");
+    assert!(journal.is_dir(), "unreadable journal evidence remains");
+    std::fs::remove_dir_all(&home).ok();
+}
+
 /// Due + real worktree + lock free ⇒ removed + cleared.
 #[test]
 fn txn_sweep_due_remove_ok_clears() {

--- a/src/mcp/handlers/ci/checkout_submodule_tests.rs
+++ b/src/mcp/handlers/ci/checkout_submodule_tests.rs
@@ -947,6 +947,42 @@ fn txn_sweep_ignores_canonical_path_lock_file() {
     std::fs::remove_dir_all(&home).ok();
 }
 
+/// A lookalike lock name is not in the producer namespace. It must still pass
+/// through typed recovery handling and remain fail-closed as an unreadable
+/// journal artifact rather than being silently skipped.
+#[test]
+#[tracing_test::traced_test]
+fn txn_sweep_near_miss_path_lock_name_remains_fail_closed() {
+    let home = tmp_home("sweep-path-lock-near-miss");
+    let near_miss = "wtpath-not-a-canonical-lock.lock";
+    let artifact = super::checkout_txn::txn_root(&home).join(near_miss);
+    std::fs::create_dir_all(artifact.parent().unwrap()).unwrap();
+    std::fs::write(&artifact, b"").unwrap();
+    let callbacks = std::cell::Cell::new(0);
+
+    let n = recover_pending_sweep(
+        &home,
+        fixed_now(),
+        |_| {
+            callbacks.set(callbacks.get() + 1);
+            Some(())
+        },
+        |_| {
+            callbacks.set(callbacks.get() + 1);
+            true
+        },
+        |_| callbacks.set(callbacks.get() + 1),
+    );
+    assert_eq!(n, 0);
+    assert_eq!(callbacks.get(), 0, "near-miss remains fail-closed");
+    assert!(
+        logs_contain("journal unreadable") && logs_contain(near_miss),
+        "near-miss must be observed as an unreadable journal artifact"
+    );
+    assert!(artifact.is_file(), "near-miss evidence remains untouched");
+    std::fs::remove_dir_all(&home).ok();
+}
+
 /// A real journal directory whose `journal.json` cannot be read remains an
 /// unresolved recovery authority. The entry point must preserve it and avoid
 /// all destructive callbacks (fail closed).

--- a/src/mcp/handlers/ci/checkout_submodule_tests.rs
+++ b/src/mcp/handlers/ci/checkout_submodule_tests.rs
@@ -947,39 +947,26 @@ fn txn_sweep_ignores_canonical_path_lock_file() {
     std::fs::remove_dir_all(&home).ok();
 }
 
-/// A lookalike lock name is not in the producer namespace. It must still pass
-/// through typed recovery handling and remain fail-closed as an unreadable
-/// journal artifact rather than being silently skipped.
+/// A lookalike lock name is not in the producer namespace. A valid due journal
+/// using that key must still be processed rather than silently skipped.
 #[test]
-#[tracing_test::traced_test]
-fn txn_sweep_near_miss_path_lock_name_remains_fail_closed() {
+fn txn_sweep_near_miss_path_lock_name_is_processed() {
     let home = tmp_home("sweep-path-lock-near-miss");
     let near_miss = "wtpath-not-a-canonical-lock.lock";
-    let artifact = super::checkout_txn::txn_root(&home).join(near_miss);
-    std::fs::create_dir_all(artifact.parent().unwrap()).unwrap();
-    std::fs::write(&artifact, b"").unwrap();
-    let callbacks = std::cell::Cell::new(0);
-
-    let n = recover_pending_sweep(
+    let wt = home.join("wt");
+    save_pending(
         &home,
-        fixed_now(),
-        |_| {
-            callbacks.set(callbacks.get() + 1);
-            Some(())
-        },
-        |_| {
-            callbacks.set(callbacks.get() + 1);
-            true
-        },
-        |_| callbacks.set(callbacks.get() + 1),
+        near_miss,
+        &wt,
+        1,
+        fixed_now() - chrono::Duration::seconds(1),
     );
-    assert_eq!(n, 0);
-    assert_eq!(callbacks.get(), 0, "near-miss remains fail-closed");
+    let n = recover_pending_sweep(&home, fixed_now(), |_| Some(()), |_| true, |_| {});
+    assert_eq!(n, 1, "near-miss journal must be recovered");
     assert!(
-        logs_contain("journal unreadable") && logs_contain(near_miss),
-        "near-miss must be observed as an unreadable journal artifact"
+        Journal::load(&home, near_miss).is_none(),
+        "processed near-miss journal is cleared"
     );
-    assert!(artifact.is_file(), "near-miss evidence remains untouched");
     std::fs::remove_dir_all(&home).ok();
 }
 

--- a/src/mcp/handlers/ci/checkout_txn.rs
+++ b/src/mcp/handlers/ci/checkout_txn.rs
@@ -320,6 +320,22 @@ fn path_lock_key(normalized: &str) -> String {
     format!("wtpath-{:016x}", std::hash::Hasher::finish(&h))
 }
 
+/// Recognize only the exact lock-file namespace emitted by [`lock_path`].
+/// Other journal-key artifacts must continue through typed fail-closed
+/// handling rather than being silently classified as coordination locks.
+pub(crate) fn is_canonical_path_lock_name(name: &str) -> bool {
+    let Some(hex) = name
+        .strip_prefix("wtpath-")
+        .and_then(|suffix| suffix.strip_suffix(".lock"))
+    else {
+        return false;
+    };
+    hex.len() == 16
+        && hex
+            .bytes()
+            .all(|byte| matches!(byte, b'0'..=b'9' | b'a'..=b'f'))
+}
+
 /// The CANONICAL per-worktree-path lock file, keyed by the NORMALIZED target
 /// PATH (not the naming scheme). Kept outside the journal subdir so it is not
 /// swept with the journal. The single shared lock file for any op that mutates


### PR DESCRIPTION
## Summary
- exclude canonical `wtpath-*.lock` coordination files before journal decoding
- preserve fail-closed handling for unreadable journal directories
- add real `recover_pending_sweep` entry-point regressions, including trace assertion

## Verification
- cargo fmt --package agend-terminal -- --check
- cargo check --bin agend-terminal
- cargo clippy --bin agend-terminal --all-targets -- -D warnings
- focused recovery sweep tests passed

Source of truth: decision d-20260716122508090508-0; task t-20260716122516967633-94870-1.