### PR TITLE
feat: enforce disposable review provenance lifecycle

### DIFF
--- a/src/binding.rs
+++ b/src/binding.rs
@@ -20,6 +20,8 @@ pub(crate) use release_guard::{
     acquire_agent_mutation_lock, acquire_binding_file_lock, guarded_binding_disk_fresh,
     preflight_guarded_binding, snapshot_guarded_binding, BindingFingerprint, GuardedBinding,
 };
+mod rebind_guard;
+use rebind_guard::same_agent_metadata_catchup_allowed;
 mod signature;
 pub(crate) use signature::signature_valid;
 mod unbind;
@@ -143,52 +145,6 @@ pub fn bind(home: &Path, agent: &str, task_id: &str, branch: &str) {
     }
 }
 
-/// #2496: strict, same-agent-only exception to guard-b (see call site). ALL
-/// conditions below must hold for a metadata-only catch-up to be allowed —
-/// any failure keeps guard-b's existing reject.
-fn same_agent_metadata_catchup_allowed(
-    home: &Path,
-    agent: &str,
-    worktree: &Path,
-    source_repo: &Path,
-    branch: &str,
-    ex_branch: &str,
-) -> bool {
-    if !crate::worktree::is_git_repo(worktree) {
-        return false;
-    }
-    if !crate::worktree_pool::is_daemon_managed(worktree) {
-        return false;
-    }
-    // Marker present (checked above) but its recorded `agent=` doesn't match
-    // the caller: this worktree is daemon-managed for a DIFFERENT agent —
-    // reject rather than treat as this agent's own stale metadata.
-    if let Some(marker_agent) = managed_marker_agent(worktree) {
-        if marker_agent != agent {
-            return false;
-        }
-    }
-    if crate::worktree::has_uncommitted_changes(worktree) {
-        return false;
-    }
-    let actual_branch =
-        crate::git_helpers::git_cmd(worktree, &["branch", "--show-current"]).unwrap_or_default();
-    if actual_branch != branch {
-        return false;
-    }
-    let source_repo_str = source_repo.display().to_string();
-    if scan_existing_branch_binding(home, &source_repo_str, branch, agent).is_some() {
-        return false;
-    }
-    if agent_has_active_ci_watch_on_branch(home, agent, ex_branch) {
-        return false;
-    }
-    if branch_has_active_task(home, ex_branch) {
-        return false;
-    }
-    true
-}
-
 /// Parse a daemon-managed worktree's `.agend-managed` marker for its recorded
 /// `agent=` line. `None` when the marker is missing or the line isn't present
 /// — callers that require ownership certainty must already have checked
@@ -259,6 +215,11 @@ pub(crate) fn branch_has_active_task(home: &Path, branch: &str) -> bool {
     })
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum BindingProvenance<'a> {
+    DaemonProvisionedReview { provisioned_head: &'a str },
+}
+
 /// Write a full binding including worktree + source-repo paths.
 ///
 /// `source_repo` is the parent repo that owns the worktree, persisted as a
@@ -290,6 +251,33 @@ pub fn bind_full(
     // task_id here — a single-target auto-create `send kind=task` legitimately
     // binds with task_id="" and must NOT false-notify.
     is_self_claim: bool,
+) -> Result<(), String> {
+    bind_full_with_provenance(
+        home,
+        agent,
+        task_id,
+        branch,
+        worktree,
+        source_repo,
+        is_self_claim,
+        None,
+    )
+}
+
+/// Write a full binding with optional typed provenance included in the initial
+/// signed document. Provenance is deliberately not a post-bind augmentation:
+/// callers that need destructive lifecycle authority must publish all identity
+/// fields before the binding is signed and visible to release/GC readers.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn bind_full_with_provenance(
+    home: &Path,
+    agent: &str,
+    task_id: &str,
+    branch: &str,
+    worktree: &std::path::Path,
+    source_repo: &std::path::Path,
+    is_self_claim: bool,
+    provenance: Option<BindingProvenance<'_>>,
 ) -> Result<(), String> {
     // #1888 phase-2: the agent claiming a branch is acting on any pending
     // ci-handoff for it — resolve the track (re-nudge stops). Scoped to this
@@ -383,6 +371,11 @@ pub fn bind_full(
     if !src_str.is_empty() {
         binding["source_repo"] = json!(src_str);
         register_managed_repo(home, &src_str);
+    }
+    if let Some(BindingProvenance::DaemonProvisionedReview { provisioned_head }) = provenance {
+        binding["checkout_purpose"] = json!("disposable_review");
+        binding["provenance"] = json!("DaemonProvisionedReview");
+        binding["provisioned_head"] = json!(provisioned_head);
     }
     let body = serde_json::to_string_pretty(&binding).unwrap_or_default();
     crate::store::atomic_write(&path, body.as_bytes())

--- a/src/binding/rebind_guard.rs
+++ b/src/binding/rebind_guard.rs
@@ -1,0 +1,40 @@
+use std::path::Path;
+
+/// #2496: strict, same-agent-only exception to guard-b. ALL conditions must
+/// hold for metadata-only catch-up; any failure keeps guard-b's existing reject.
+pub(super) fn same_agent_metadata_catchup_allowed(
+    home: &Path,
+    agent: &str,
+    worktree: &Path,
+    source_repo: &Path,
+    branch: &str,
+    ex_branch: &str,
+) -> bool {
+    if !crate::worktree::is_git_repo(worktree) || !crate::worktree_pool::is_daemon_managed(worktree)
+    {
+        return false;
+    }
+    // A marker for a different agent proves this is not stale metadata owned
+    // by the caller and must remain protected.
+    if let Some(marker_agent) = super::managed_marker_agent(worktree) {
+        if marker_agent != agent {
+            return false;
+        }
+    }
+    if crate::worktree::has_uncommitted_changes(worktree) {
+        return false;
+    }
+    let actual_branch =
+        crate::git_helpers::git_cmd(worktree, &["branch", "--show-current"]).unwrap_or_default();
+    if actual_branch != branch {
+        return false;
+    }
+    let source_repo_str = source_repo.display().to_string();
+    if super::scan_existing_branch_binding(home, &source_repo_str, branch, agent).is_some()
+        || super::agent_has_active_ci_watch_on_branch(home, agent, ex_branch)
+        || super::branch_has_active_task(home, ex_branch)
+    {
+        return false;
+    }
+    true
+}

--- a/src/mcp/handlers/ci/checkout.rs
+++ b/src/mcp/handlers/ci/checkout.rs
@@ -6,34 +6,9 @@ use std::path::Path;
 // keep this handler under the LOC ceiling (call sites below are unchanged).
 use super::checkout_helpers::{rollback_response, sync_marker_contents, validate_expected_head};
 
-/// #2755 structured redaction: replace absolute filesystem paths (and Windows
-/// drive paths) in an error string RETURNED over the wire with `<path>`. The
-/// structured `code`/`stage`/`branch` stay actionable for the caller, but raw
-/// paths / git stderr — which leak the local layout, usernames, or submodule
-/// URLs — are stripped. The FULL, un-redacted detail is still recorded in the
-/// daemon event-log (`log_checkout_outcome`), so operators keep debuggability.
-pub(super) fn redact_paths(s: &str) -> String {
-    use std::sync::OnceLock;
-    static RE: OnceLock<regex::Regex> = OnceLock::new();
-    let re = RE.get_or_init(|| {
-        // A Windows drive path (`C:\…`), OR a POSIX path of ≥2 segments starting
-        // at a non-word boundary — the `≥2` + boundary avoid mangling "and/or"
-        // and a URL's "//host". Rust's regex has no lookbehind, so the leading
-        // boundary char is captured (`b`) and restored in the replacement.
-        regex::Regex::new(r"(?P<b>^|[^\w])(?P<p>[A-Za-z]:\\[\w.\\@~%+-]+|(?:/[\w.@~%+-]+){2,})")
-            .expect("valid redaction regex")
-    });
-    re.replace_all(s, "${b}<path>").into_owned()
-}
-
-/// #1447: resolve the checkout source repo from `repository_path` — the
-/// cross-tool standard name used by bind_self / team update. Returns `None`
-/// when absent or empty.
-pub(crate) fn checkout_source(args: &Value) -> Option<&str> {
-    args.get("repository_path")
-        .and_then(Value::as_str)
-        .filter(|s| !s.is_empty())
-}
+use super::checkout_disposable::CheckoutPurpose;
+pub(crate) use super::checkout_helpers::checkout_source;
+pub(super) use super::checkout_helpers::redact_paths;
 
 pub(crate) fn handle_checkout_repo(home: &Path, args: &Value, instance_name: &str) -> Value {
     let result = handle_checkout_repo_inner(home, args, instance_name);
@@ -50,12 +25,7 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
     if !validate_branch(branch) {
         return json!({"error": format!("invalid branch name '{branch}'")});
     }
-    // #778 Option 1: optional atomic provision + bind. When `bind:true`,
-    // tail-ops mirror `bind_self → dispatch_auto_bind_lease` (marker +
-    // binding.json + ci_watches arm) directly on the just-provisioned
-    // worktree. Default `false` preserves existing back-compat callers
-    // (review pool, operator triage) that materialize a detached-HEAD
-    // inspection worktree without claiming it.
+    // #778: bind:true atomically claims the provisioned worktree; false keeps inspection-only behavior.
     let bind = args["bind"].as_bool().unwrap_or(false);
     if bind && instance_name.is_empty() {
         return json!({
@@ -63,6 +33,10 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
             "code": "needs_identity"
         });
     }
+    let checkout_purpose = match super::checkout_disposable::parse(args, bind) {
+        Ok(purpose) => purpose,
+        Err(error) => return error,
+    };
     // The bind transaction owns the per-agent lifecycle authority before any
     // provisioning preflight. Keep this permit through branch locking,
     // bind_full, commit, and exact rollback so checkout cannot race release or
@@ -89,20 +63,13 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
             return e;
         }
     }
-    // Windows-safe path mangling: also collapse `\` (path separator) and
-    // `:` (drive letter) so a source like `C:\Users\runner\...` doesn't
-    // produce a worktree path with mid-name colons (rejected by NTFS).
-    // Pre-existing tests didn't exercise Windows-built happy-path until
-    // #778's new bind:true coverage.
+    // Windows-safe path mangling collapses separators and drive-letter colons.
     let worktree_dir = home.join("worktrees").join(format!(
         "{}-{}",
         instance_name,
         source.replace(['/', '\\', ':'], "_").replace('~', "")
     ));
-    // #2158 PR1: resolve + validate the source repo path fail-closed (absolute or
-    // known agent name only; canonicalize; reject system dirs). Extracted to
-    // `source_resolve` — keeps this oversized handler under the file_size ceiling
-    // (t-61 split debt) and isolates the security-sensitive resolution for review.
+    // #2158: source resolution is fail-closed and isolated in `source_resolve`.
     let (source_path, source_canonical) =
         match super::source_resolve::resolve_checkout_source_path(home, source) {
             Ok(pair) => pair,
@@ -110,6 +77,13 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
         };
     if let Some(e) = validate_expected_head(args, &source_path, branch) {
         return e;
+    }
+    if checkout_purpose == Some(CheckoutPurpose::DisposableReview) {
+        if let Err(error) =
+            super::checkout_disposable::preflight_branch(Path::new(&source_path), branch)
+        {
+            return error;
+        }
     }
     let expected_ref = super::checkout_helpers::expected_creation_ref(args, &source_path, branch);
     std::fs::create_dir_all(worktree_dir.parent().unwrap_or(home)).ok();
@@ -142,6 +116,14 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
             Ok((created, fetched)) => {
                 auto_created_branch = created;
                 fetch_attempted = fetched;
+                if checkout_purpose == Some(CheckoutPurpose::DisposableReview) && !created {
+                    return json!({
+                        "error": format!("disposable review branch '{branch}' was not created by this checkout"),
+                        "code": "disposable_review_requires_new_branch",
+                        "auto_created_branch": false,
+                        "branch": branch,
+                    });
+                }
             }
             Err(err) => {
                 let mut e = json!({
@@ -573,7 +555,13 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
                     .as_str()
                     .filter(|s| !s.is_empty())
                     .unwrap_or("");
-                if let Err(e) = crate::binding::bind_full(
+                let provenance =
+                    checkout_purpose.map(|purpose| {
+                        purpose.provenance(args["expected_head"].as_str().expect(
+                            "disposable_review validates expected_head before provisioning",
+                        ))
+                    });
+                if let Err(e) = crate::binding::bind_full_with_provenance(
                     home,
                     instance_name,
                     task_id,
@@ -581,6 +569,7 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
                     &worktree_dir,
                     &source_canonical,
                     true, // #2158 GR1: agent self-claim (repo checkout bind:true) → notify operator
+                    provenance,
                 ) {
                     // #1310: rollback worktree on binding failure to prevent orphans
                     tracing::warn!(
@@ -598,6 +587,15 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
                         remove_worktree,
                         || {},
                     );
+                    if matches!(outcome, super::checkout_txn::RollbackOutcome::Removed)
+                        && auto_created_branch
+                    {
+                        super::checkout_disposable::rollback_auto_created_branch(
+                            Path::new(&source_path),
+                            branch,
+                            args["expected_head"].as_str().unwrap_or(""),
+                        );
+                    }
                     return rollback_response(
                         outcome,
                         &format!("bind_full failed: {}", redact_paths(&e.to_string())),
@@ -606,13 +604,15 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
                         branch,
                     );
                 }
-                crate::binding::try_augment_review_lease(
-                    home,
-                    instance_name,
-                    task_id,
-                    branch,
-                    &source_canonical,
-                );
+                if checkout_purpose.is_none() {
+                    crate::binding::try_augment_review_lease(
+                        home,
+                        instance_name,
+                        task_id,
+                        branch,
+                        &source_canonical,
+                    );
+                }
                 bound_fingerprint =
                     match crate::binding::snapshot_guarded_binding(home, instance_name) {
                         Ok(crate::binding::GuardedBinding::Known { fingerprint, .. }) => {
@@ -650,6 +650,9 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
                 resp["ci_watch_armed"] = json!(false);
                 resp["auto_created_branch"] = json!(auto_created_branch);
                 resp["fetch_attempted"] = json!(fetch_attempted);
+                if checkout_purpose == Some(CheckoutPurpose::DisposableReview) {
+                    resp["checkout_purpose"] = json!("disposable_review");
+                }
             }
             // #2755 Committed: the durable linearization point. Success is returned
             // ONLY after this journal write lands; a store::atomic_write failure

--- a/src/mcp/handlers/ci/checkout_disposable.rs
+++ b/src/mcp/handlers/ci/checkout_disposable.rs
@@ -1,0 +1,157 @@
+use serde_json::{json, Value};
+use std::path::Path;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum CheckoutPurpose {
+    DisposableReview,
+}
+
+impl CheckoutPurpose {
+    pub(super) fn provenance(
+        self,
+        provisioned_head: &str,
+    ) -> crate::binding::BindingProvenance<'_> {
+        match self {
+            Self::DisposableReview => {
+                crate::binding::BindingProvenance::DaemonProvisionedReview { provisioned_head }
+            }
+        }
+    }
+}
+
+pub(super) fn parse(args: &Value, bind: bool) -> Result<Option<CheckoutPurpose>, Value> {
+    let purpose = match args.get("checkout_purpose") {
+        None => None,
+        Some(Value::String(value)) if value == "disposable_review" => {
+            Some(CheckoutPurpose::DisposableReview)
+        }
+        Some(Value::String(value)) => {
+            return Err(json!({
+                "error": format!("unsupported checkout_purpose '{value}'"),
+                "code": "invalid_checkout_purpose",
+            }));
+        }
+        Some(_) => {
+            return Err(json!({
+                "error": "checkout_purpose must be a string",
+                "code": "invalid_checkout_purpose",
+            }));
+        }
+    };
+    if purpose == Some(CheckoutPurpose::DisposableReview) {
+        if !bind {
+            return Err(json!({
+                "error": "checkout_purpose=disposable_review requires bind=true",
+                "code": "disposable_review_requires_bind",
+            }));
+        }
+        if args["task_id"].as_str().is_none_or(str::is_empty) {
+            return Err(json!({
+                "error": "checkout_purpose=disposable_review requires a non-empty task_id",
+                "code": "disposable_review_requires_task_id",
+            }));
+        }
+        if args["expected_head"].as_str().is_none_or(str::is_empty) {
+            return Err(json!({
+                "error": "checkout_purpose=disposable_review requires expected_head",
+                "code": "disposable_review_requires_expected_head",
+            }));
+        }
+    }
+    Ok(purpose)
+}
+
+pub(super) fn preflight_branch(source_path: &Path, branch: &str) -> Result<(), Value> {
+    let branch_ref = format!("refs/heads/{branch}");
+    let already_exists =
+        crate::git_helpers::git_cmd(source_path, &["rev-parse", "--verify", &branch_ref]).is_ok();
+    // `ensure_branch_exists` also materializes a local branch from an
+    // existing `origin/<branch>` tracking ref and reports `created=false`.
+    // Reject that state before provisioning so a disposable checkout never
+    // leaves a daemon-created local ref behind after discovering remote
+    // provenance.
+    let remote_tracking_ref = format!("refs/remotes/origin/{branch}");
+    let remote_already_exists = crate::git_helpers::git_cmd(
+        source_path,
+        &["rev-parse", "--verify", &remote_tracking_ref],
+    )
+    .is_ok();
+    if already_exists || remote_already_exists {
+        return Err(json!({
+            "error": format!("disposable review branch '{branch}' already exists"),
+            "code": "disposable_review_requires_new_branch",
+            "auto_created_branch": false,
+            "branch": branch,
+        }));
+    }
+    // Query the exact remote ref instead of relying on remote.origin.fetch:
+    // narrow/negative refspecs may make a fetch succeed while omitting a live
+    // review branch. ls-remote does not mutate local refs and proves absence
+    // independently of the configured fetch refspec.
+    match crate::git_helpers::git_bypass(source_path, &["remote", "get-url", "origin"]) {
+        Ok(remote) if remote.status.success() => {
+            let remote_ref = format!("refs/heads/{branch}");
+            let queried = crate::git_helpers::git_bypass_timeout(
+                source_path,
+                &["ls-remote", "--heads", "origin", &remote_ref],
+                std::time::Duration::from_secs(12),
+            );
+            let output = match queried {
+                Ok(output) if output.status.success() => output,
+                _ => {
+                    return Err(json!({
+                        "error": format!("could not prove disposable review branch '{branch}' is absent from origin"),
+                        "code": "disposable_review_branch_absence_unproven",
+                        "auto_created_branch": false,
+                        "branch": branch,
+                    }));
+                }
+            };
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let mut lines = stdout.lines();
+            if let Some(line) = lines.next() {
+                let mut fields = line.split_whitespace();
+                let sha = fields.next().unwrap_or_default();
+                let ref_name = fields.next().unwrap_or_default();
+                let valid_sha = matches!(sha.len(), 40 | 64)
+                    && sha.as_bytes().iter().all(u8::is_ascii_hexdigit)
+                    && fields.next().is_none();
+                if !valid_sha || ref_name != remote_ref {
+                    return Err(json!({
+                        "error": format!("could not prove disposable review branch '{branch}' is absent from origin"),
+                        "code": "disposable_review_branch_absence_unproven",
+                        "auto_created_branch": false,
+                        "branch": branch,
+                    }));
+                }
+                return Err(json!({
+                    "error": format!("disposable review branch '{branch}' already exists"),
+                    "code": "disposable_review_requires_new_branch",
+                    "auto_created_branch": false,
+                    "branch": branch,
+                }));
+            }
+        }
+        Ok(remote)
+            if String::from_utf8_lossy(&remote.stderr)
+                .to_ascii_lowercase()
+                .contains("no such remote") => {}
+        Ok(_) | Err(_) => {
+            return Err(json!({
+                "error": format!("could not resolve origin while proving disposable review branch '{branch}' is new"),
+                "code": "disposable_review_branch_absence_unproven",
+                "auto_created_branch": false,
+                "branch": branch,
+            }));
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn rollback_auto_created_branch(source_path: &Path, branch: &str, expected_head: &str) {
+    let branch_ref = format!("refs/heads/{branch}");
+    let _ = crate::git_helpers::git_bypass(
+        source_path,
+        &["update-ref", "-d", &branch_ref, expected_head],
+    );
+}

--- a/src/mcp/handlers/ci/checkout_helpers.rs
+++ b/src/mcp/handlers/ci/checkout_helpers.rs
@@ -6,6 +6,27 @@ use super::checkout_txn::RollbackOutcome;
 use serde_json::{json, Value};
 use std::path::Path;
 
+/// #2755 structured redaction: replace absolute filesystem paths (and Windows
+/// drive paths) in an error string returned over the wire with `<path>`.
+pub(super) fn redact_paths(s: &str) -> String {
+    use std::sync::OnceLock;
+    static RE: OnceLock<regex::Regex> = OnceLock::new();
+    let re = RE.get_or_init(|| {
+        regex::Regex::new(r"(?P<b>^|[^\w])(?P<p>[A-Za-z]:\\[\w.\\@~%+-]+|(?:/[\w.@~%+-]+){2,})")
+            .expect("valid redaction regex")
+    });
+    re.replace_all(s, "${b}<path>").into_owned()
+}
+
+/// #1447: resolve the checkout source repo from `repository_path` — the
+/// cross-tool standard name used by bind_self / team update. Returns `None`
+/// when absent or empty.
+pub(crate) fn checkout_source(args: &Value) -> Option<&str> {
+    args.get("repository_path")
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+}
+
 #[cfg(all(test, unix))]
 use std::cell::RefCell;
 
@@ -20,7 +41,7 @@ use std::cell::RefCell;
 /// guarantees coverage of all current and future return paths.
 pub(super) fn log_checkout_outcome(home: &Path, args: &Value, instance_name: &str, result: &Value) {
     let branch = args["branch"].as_str().unwrap_or("HEAD");
-    let source = super::checkout::checkout_source(args).unwrap_or("");
+    let source = checkout_source(args).unwrap_or("");
     let ok = result.get("error").is_none();
     let mut msg = format!("branch={branch} source={source} ok={ok}");
     if let Some(err) = result.get("error").and_then(Value::as_str) {

--- a/src/mcp/handlers/ci/mod.rs
+++ b/src/mcp/handlers/ci/mod.rs
@@ -20,6 +20,9 @@ mod source_resolve;
 // the re-exports below preserve EVERY `ci::handle_*` path used by dispatch.rs and
 // every `super::*` path used by the child `tests` module (zero caller/test edits).
 mod checkout;
+// Architecture-14 disposable-review purpose validation and remote-absence
+// preflight live in a sibling module to keep checkout.rs below the LOC ceiling.
+mod checkout_disposable;
 // #2755 R3: response-mapping + marker-durability helpers extracted from checkout.rs
 // to keep that handler under the LOC ceiling (same relief pattern as source_resolve).
 mod checkout_helpers;

--- a/src/mcp/handlers/ci/review_workspace_tests.rs
+++ b/src/mcp/handlers/ci/review_workspace_tests.rs
@@ -892,7 +892,7 @@ fn checkout_disposable_review_persists_provenance_and_terminal_release_deletes()
     let parent = tmp_home("disposable-review-fresh-src");
     let source = setup_source_repo(&parent, "seed");
     let expected = get_sha(&source, "main");
-    seed_origin_view(&source, "review/disposable-fresh", &expected);
+    seed_origin_view(&source, "main", &expected);
     seed_terminal_task(
         &home,
         "task-disposable-fresh",

--- a/src/mcp/handlers/ci/review_workspace_tests.rs
+++ b/src/mcp/handlers/ci/review_workspace_tests.rs
@@ -139,6 +139,32 @@ fn seed_origin_view(repo: &Path, branch: &str, sha: &str) {
 }
 
 #[cfg(unix)]
+fn configure_local_github_origin(repo: &Path, parent: &Path) {
+    let bare = parent.join("origin.git");
+    let out = std::process::Command::new("git")
+        .args(["init", "--bare", bare.to_str().expect("bare path")])
+        .env("AGEND_GIT_BYPASS", "1")
+        .output()
+        .expect("git init bare");
+    assert!(out.status.success(), "bare origin init failed: {out:?}");
+    let bare_url = format!("file://{}", bare.display());
+    let out = std::process::Command::new("git")
+        .args(["remote", "set-url", "origin", &bare_url])
+        .current_dir(repo)
+        .env("AGEND_GIT_BYPASS", "1")
+        .output()
+        .expect("git remote set-url");
+    assert!(out.status.success(), "remote set-url failed: {out:?}");
+    let out = std::process::Command::new("git")
+        .args(["push", "origin", "main"])
+        .current_dir(repo)
+        .env("AGEND_GIT_BYPASS", "1")
+        .output()
+        .expect("git push main");
+    assert!(out.status.success(), "push main failed: {out:?}");
+}
+
+#[cfg(unix)]
 fn derived_worktree(home: &Path, instance: &str, source: &Path) -> std::path::PathBuf {
     home.join("worktrees").join(format!(
         "{instance}-{}",
@@ -844,7 +870,7 @@ fn checkout_expected_head_reuse_worktree_mismatch_refuses_without_sync() {
 
 #[cfg(unix)]
 fn seed_terminal_task(home: &Path, task_id: &str, branch: &str, terminal: bool) {
-    use crate::task_events::{DoneSource, InstanceName, TaskEvent, TaskId};
+    use crate::task_events::{InstanceName, TaskEvent, TaskId};
 
     let emitter = InstanceName::from("disposable-review-test");
     let id = TaskId::from(task_id);
@@ -869,20 +895,28 @@ fn seed_terminal_task(home: &Path, task_id: &str, branch: &str, terminal: bool) 
     )
     .expect("create task");
     if terminal {
-        crate::task_events::append(
-            home,
-            &emitter,
-            TaskEvent::Done {
-                task_id: id,
-                by: emitter.clone(),
-                source: DoneSource::OperatorManual {
-                    authored_at: "2026-07-16T00:00:00Z".to_string(),
-                    result: None,
-                },
-            },
-        )
-        .expect("finish task");
+        finish_task(home, task_id);
     }
+}
+
+#[cfg(unix)]
+fn finish_task(home: &Path, task_id: &str) {
+    use crate::task_events::{DoneSource, InstanceName, TaskEvent, TaskId};
+
+    let emitter = InstanceName::from("disposable-review-test");
+    crate::task_events::append(
+        home,
+        &emitter,
+        TaskEvent::Done {
+            task_id: TaskId::from(task_id),
+            by: emitter.clone(),
+            source: DoneSource::OperatorManual {
+                authored_at: "2026-07-16T00:00:00Z".to_string(),
+                result: None,
+            },
+        },
+    )
+    .expect("finish task");
 }
 
 #[test]
@@ -892,12 +926,13 @@ fn checkout_disposable_review_persists_provenance_and_terminal_release_deletes()
     let parent = tmp_home("disposable-review-fresh-src");
     let source = setup_source_repo(&parent, "seed");
     let expected = get_sha(&source, "main");
+    remove_origin(&source);
     seed_origin_view(&source, "main", &expected);
     seed_terminal_task(
         &home,
         "task-disposable-fresh",
         "review/disposable-fresh",
-        true,
+        false,
     );
 
     let resp = super::handle_checkout_repo(
@@ -930,16 +965,43 @@ fn checkout_disposable_review_persists_provenance_and_terminal_release_deletes()
         Some(expected.as_str())
     );
 
+    // This fixture intentionally has no SCM provider to answer PR state. A
+    // missing origin is the deterministic "no open PR" signal; the review
+    // branch's strict provisioned-head CAS still drives deletion after the
+    // terminal task gate passes.
+
+    let active_release = crate::mcp::handlers::worktree::handle_release_worktree(
+        &home,
+        &json!({"instance": "disposable-review-agent", "dry_run": true}),
+        &None,
+    );
+    assert_eq!(
+        active_release["released"].as_bool(),
+        Some(true),
+        "{active_release}"
+    );
+    assert!(
+        crate::git_helpers::git_ok(
+            &source,
+            &["rev-parse", "--verify", "review/disposable-fresh"],
+        ),
+        "active task must keep branch during dry-run: {active_release}"
+    );
+    finish_task(&home, "task-disposable-fresh");
+
     let released = crate::mcp::handlers::worktree::handle_release_worktree(
         &home,
         &json!({"instance": "disposable-review-agent"}),
         &None,
     );
     assert_eq!(released["released"].as_bool(), Some(true), "{released}");
-    assert!(!crate::git_helpers::git_ok(
-        &source,
-        &["rev-parse", "--verify", "review/disposable-fresh"],
-    ));
+    assert!(
+        !crate::git_helpers::git_ok(
+            &source,
+            &["rev-parse", "--verify", "review/disposable-fresh"],
+        ),
+        "branch must be deleted after terminal release: {released} binding={binding:?}"
+    );
     assert!(crate::binding::read(&home, "disposable-review-agent").is_none());
 
     std::fs::remove_dir_all(&home).ok();
@@ -989,6 +1051,390 @@ fn checkout_disposable_review_rejects_preexisting_branch_without_mutation() {
 
 #[test]
 #[cfg(unix)]
+fn checkout_disposable_review_rejects_remote_preexisting_branch_without_mutation() {
+    let home = tmp_home("disposable-review-remote-existing");
+    let parent = tmp_home("disposable-review-remote-existing-src");
+    let source = setup_source_repo(&parent, "review/disposable-remote-existing");
+    let expected = get_sha(&source, "review/disposable-remote-existing");
+    let deleted = std::process::Command::new("git")
+        .args(["branch", "-D", "review/disposable-remote-existing"])
+        .current_dir(&source)
+        .env("AGEND_GIT_BYPASS", "1")
+        .output()
+        .expect("delete local branch");
+    assert!(
+        deleted.status.success(),
+        "delete local branch failed: {deleted:?}"
+    );
+    seed_origin_view(&source, "review/disposable-remote-existing", &expected);
+    seed_terminal_task(
+        &home,
+        "task-disposable-remote-existing",
+        "review/disposable-remote-existing",
+        true,
+    );
+
+    let resp = super::handle_checkout_repo(
+        &home,
+        &json!({
+            "repository_path": source.display().to_string(),
+            "branch": "review/disposable-remote-existing",
+            "bind": true,
+            "task_id": "task-disposable-remote-existing",
+            "expected_head": &expected,
+            "from_ref": "main",
+            "checkout_purpose": "disposable_review",
+        }),
+        "disposable-review-remote-agent",
+    );
+    assert_eq!(
+        resp["code"].as_str(),
+        Some("disposable_review_requires_new_branch"),
+        "remote pre-existing branch must be rejected: {resp}"
+    );
+    assert!(!crate::git_helpers::git_ok(
+        &source,
+        &[
+            "rev-parse",
+            "--verify",
+            "refs/heads/review/disposable-remote-existing"
+        ],
+    ));
+    assert!(crate::binding::read(&home, "disposable-review-remote-agent").is_none());
+    assert!(!derived_worktree(&home, "disposable-review-remote-agent", &source).exists());
+
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&parent).ok();
+}
+
+#[test]
+#[cfg(unix)]
+fn checkout_disposable_review_rejects_remote_only_branch_without_local_residue() {
+    let home = tmp_home("disposable-review-remote-only");
+    let parent = tmp_home("disposable-review-remote-only-src");
+    let source = setup_source_repo(&parent, "seed");
+    configure_local_github_origin(&source, &parent);
+    let branch = "review/disposable-remote-only";
+    let expected = get_sha(&source, "main");
+    let run = |args: &[&str]| {
+        let out = std::process::Command::new("git")
+            .args(args)
+            .current_dir(&source)
+            .env("AGEND_GIT_BYPASS", "1")
+            .output()
+            .expect("git");
+        assert!(out.status.success(), "git {args:?} failed: {out:?}");
+    };
+    run(&["branch", branch, "main"]);
+    run(&["push", "origin", branch]);
+    run(&["branch", "-D", branch]);
+    run(&["update-ref", "-d", &format!("refs/remotes/origin/{branch}")]);
+    seed_terminal_task(&home, "task-disposable-remote-only", branch, true);
+
+    let resp = super::handle_checkout_repo(
+        &home,
+        &json!({
+            "repository_path": source.display().to_string(),
+            "branch": branch,
+            "bind": true,
+            "task_id": "task-disposable-remote-only",
+            "expected_head": &expected,
+            "from_ref": "main",
+            "checkout_purpose": "disposable_review",
+        }),
+        "disposable-review-remote-only-agent",
+    );
+    assert_eq!(
+        resp["code"].as_str(),
+        Some("disposable_review_requires_new_branch"),
+        "remote-only branch must be rejected after authoritative fetch: {resp}"
+    );
+    assert!(!crate::git_helpers::git_ok(
+        &source,
+        &["rev-parse", "--verify", &format!("refs/heads/{branch}")],
+    ));
+    assert!(crate::binding::read(&home, "disposable-review-remote-only-agent").is_none());
+    assert!(!derived_worktree(&home, "disposable-review-remote-only-agent", &source).exists());
+
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&parent).ok();
+}
+
+#[test]
+#[cfg(unix)]
+fn checkout_disposable_review_rejects_remote_only_branch_with_narrow_fetch_refspec() {
+    let home = tmp_home("disposable-review-narrow-refspec");
+    let parent = tmp_home("disposable-review-narrow-refspec-src");
+    let source = setup_source_repo(&parent, "seed");
+    configure_local_github_origin(&source, &parent);
+    let branch = "review/disposable-narrow-refspec";
+    let expected = get_sha(&source, "main");
+    let run = |args: &[&str]| {
+        let out = std::process::Command::new("git")
+            .args(args)
+            .current_dir(&source)
+            .env("AGEND_GIT_BYPASS", "1")
+            .output()
+            .expect("git");
+        assert!(out.status.success(), "git {args:?} failed: {out:?}");
+    };
+    run(&["branch", branch, "main"]);
+    run(&["push", "origin", branch]);
+    // A fetch using this narrow refspec succeeds but cannot observe the remote
+    // review branch. The exact ls-remote preflight must still reject it.
+    run(&[
+        "config",
+        "--replace-all",
+        "remote.origin.fetch",
+        "+refs/heads/main:refs/remotes/origin/main",
+    ]);
+    run(&["branch", "-D", branch]);
+    run(&["update-ref", "-d", &format!("refs/remotes/origin/{branch}")]);
+    seed_terminal_task(&home, "task-disposable-narrow-refspec", branch, true);
+
+    let resp = super::handle_checkout_repo(
+        &home,
+        &json!({
+            "repository_path": source.display().to_string(),
+            "branch": branch,
+            "bind": true,
+            "task_id": "task-disposable-narrow-refspec",
+            "expected_head": &expected,
+            "from_ref": "main",
+            "checkout_purpose": "disposable_review",
+        }),
+        "disposable-review-narrow-refspec-agent",
+    );
+    assert_eq!(
+        resp["code"].as_str(),
+        Some("disposable_review_requires_new_branch"),
+        "narrow fetch refspec must not hide a remote-only branch: {resp}"
+    );
+    assert!(!crate::git_helpers::git_ok(
+        &source,
+        &["rev-parse", "--verify", &format!("refs/heads/{branch}")],
+    ));
+    assert!(!crate::git_helpers::git_ok(
+        &source,
+        &[
+            "rev-parse",
+            "--verify",
+            &format!("refs/remotes/origin/{branch}")
+        ],
+    ));
+    assert!(crate::binding::read(&home, "disposable-review-narrow-refspec-agent").is_none());
+    assert!(!derived_worktree(&home, "disposable-review-narrow-refspec-agent", &source).exists());
+
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&parent).ok();
+}
+
+#[test]
+#[cfg(unix)]
+fn checkout_disposable_review_fails_closed_when_remote_absence_is_unproven() {
+    let home = tmp_home("disposable-review-unproven");
+    let parent = tmp_home("disposable-review-unproven-src");
+    let source = setup_source_repo(&parent, "seed");
+    let expected = get_sha(&source, "main");
+    seed_terminal_task(
+        &home,
+        "task-disposable-unproven",
+        "review/disposable-unproven",
+        true,
+    );
+
+    let resp = super::handle_checkout_repo(
+        &home,
+        &json!({
+            "repository_path": source.display().to_string(),
+            "branch": "review/disposable-unproven",
+            "bind": true,
+            "task_id": "task-disposable-unproven",
+            "expected_head": &expected,
+            "from_ref": "main",
+            "checkout_purpose": "disposable_review",
+        }),
+        "disposable-review-unproven-agent",
+    );
+    assert_eq!(
+        resp["code"].as_str(),
+        Some("disposable_review_branch_absence_unproven"),
+        "configured but unreachable origin must fail closed: {resp}"
+    );
+    assert!(!crate::git_helpers::git_ok(
+        &source,
+        &[
+            "rev-parse",
+            "--verify",
+            "refs/heads/review/disposable-unproven"
+        ],
+    ));
+    assert!(crate::binding::read(&home, "disposable-review-unproven-agent").is_none());
+
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&parent).ok();
+}
+
+#[test]
+#[cfg(unix)]
+fn disposable_review_release_ignores_subject_pr_but_protects_review_head_pr() {
+    let checkout_and_release = |suffix: &str, branch: &str, open_heads: Vec<String>| {
+        let home = tmp_home(&format!("disposable-review-pr-{suffix}"));
+        let parent = tmp_home(&format!("disposable-review-pr-{suffix}-src"));
+        let source = setup_source_repo(&parent, "seed");
+        configure_local_github_origin(&source, &parent);
+        let expected = get_sha(&source, "main");
+        seed_terminal_task(&home, &format!("task-disposable-pr-{suffix}"), branch, true);
+        let resp = super::handle_checkout_repo(
+            &home,
+            &json!({
+                "repository_path": source.display().to_string(),
+                "branch": branch,
+                "bind": true,
+                "task_id": format!("task-disposable-pr-{suffix}"),
+                "expected_head": &expected,
+                "from_ref": "main",
+                "checkout_purpose": "disposable_review",
+            }),
+            &format!("disposable-review-pr-agent-{suffix}"),
+        );
+        assert!(resp.get("error").is_none(), "checkout must succeed: {resp}");
+        let remote = std::process::Command::new("git")
+            .args([
+                "remote",
+                "set-url",
+                "origin",
+                "https://github.com/owner/repo.git",
+            ])
+            .current_dir(&source)
+            .env("AGEND_GIT_BYPASS", "1")
+            .output()
+            .expect("git remote set-url");
+        assert!(remote.status.success(), "remote set-url failed: {remote:?}");
+        assert_eq!(
+            crate::git_helpers::git_cmd(&source, &["remote", "get-url", "origin"])
+                .ok()
+                .as_deref(),
+            Some("https://github.com/owner/repo.git")
+        );
+        let agent = format!("disposable-review-pr-agent-{suffix}");
+        let provider =
+            crate::scm::MockScmProvider::with_pr_list(crate::scm::MockPrList::Branches(open_heads));
+        let _provider_guard = crate::scm::set_test_scm_provider(provider.clone());
+        let released = crate::mcp::handlers::worktree::handle_release_worktree(
+            &home,
+            &json!({"instance": agent}),
+            &None,
+        );
+        let branch_exists = crate::git_helpers::git_ok(
+            &source,
+            &["rev-parse", "--verify", &format!("refs/heads/{branch}")],
+        );
+        assert!(
+            provider.pr_list_calls() > 0,
+            "open PR probe was not invoked"
+        );
+        std::fs::remove_dir_all(&home).ok();
+        std::fs::remove_dir_all(&parent).ok();
+        (released, branch_exists)
+    };
+
+    let (subject_release, subject_branch_exists) = checkout_and_release(
+        "subject",
+        "review/disposable-subject",
+        vec!["feature/subject".to_string()],
+    );
+    assert_eq!(
+        subject_release["branch_deleted"].as_bool(),
+        Some(true),
+        "{subject_release}"
+    );
+    assert!(
+        !subject_branch_exists,
+        "subject-head PR must not protect review branch"
+    );
+
+    let (review_release, review_branch_exists) = checkout_and_release(
+        "review",
+        "review/disposable-review-head",
+        vec!["review/disposable-review-head".to_string()],
+    );
+    assert_eq!(
+        review_release["branch_deleted"].as_bool(),
+        Some(false),
+        "{review_release}"
+    );
+    assert!(
+        review_branch_exists,
+        "open PR headed at review branch must protect it"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn checkout_disposable_review_reuse_cannot_bypass_new_branch_gate() {
+    let home = tmp_home("disposable-review-reuse-gate");
+    let parent = tmp_home("disposable-review-reuse-gate-src");
+    let source = setup_source_repo(&parent, "seed");
+    remove_origin(&source);
+    let expected = get_sha(&source, "main");
+    seed_origin_view(&source, "main", &expected);
+    let branch = "review/disposable-reuse-gate";
+    let ordinary_agent = "ordinary-reuse-agent";
+    let first = super::handle_checkout_repo(
+        &home,
+        &json!({
+            "repository_path": source.display().to_string(),
+            "branch": branch,
+            "bind": true,
+            "from_ref": "main",
+            "expected_head": &expected,
+        }),
+        ordinary_agent,
+    );
+    assert!(
+        first.get("error").is_none(),
+        "ordinary checkout failed: {first}"
+    );
+    let agent = "disposable-reuse-agent";
+
+    let resp = super::handle_checkout_repo(
+        &home,
+        &json!({
+            "repository_path": source.display().to_string(),
+            "branch": branch,
+            "bind": true,
+            "task_id": "task-disposable-reuse-gate",
+            "expected_head": &expected,
+            "from_ref": "main",
+            "checkout_purpose": "disposable_review",
+        }),
+        agent,
+    );
+    assert_eq!(
+        resp["code"].as_str(),
+        Some("disposable_review_requires_new_branch"),
+        "idempotent reuse must not bypass disposable provenance gate: {resp}"
+    );
+    assert!(crate::binding::read(&home, agent).is_none());
+    assert!(crate::git_helpers::git_ok(
+        &source,
+        &["rev-parse", "--verify", &format!("refs/heads/{branch}")],
+    ));
+    let worktree = first["path"].as_str().expect("ordinary worktree path");
+    let _ = crate::mcp::handlers::worktree::handle_release_worktree(
+        &home,
+        &json!({"instance": ordinary_agent}),
+        &None,
+    );
+    let _ = crate::git_helpers::git_bypass(&source, &["worktree", "remove", "--force", worktree]);
+
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&parent).ok();
+}
+
+#[test]
+#[cfg(unix)]
 fn checkout_disposable_review_requires_bind_task_and_expected_head() {
     let home = tmp_home("disposable-review-args");
     let parent = tmp_home("disposable-review-args-src");
@@ -1029,6 +1475,16 @@ fn checkout_disposable_review_requires_bind_task_and_expected_head() {
             }),
             "disposable_review_requires_expected_head",
         ),
+        (
+            "wrong-type",
+            json!({
+                "repository_path": source.display().to_string(),
+                "branch": "review/disposable-args",
+                "bind": true,
+                "checkout_purpose": true,
+            }),
+            "invalid_checkout_purpose",
+        ),
     ] {
         let resp = super::handle_checkout_repo(&home, &args, &format!("disposable-{tag}"));
         if crate::binding::read(&home, &format!("disposable-{tag}")).is_some() {
@@ -1050,8 +1506,10 @@ fn checkout_disposable_review_requires_bind_task_and_expected_head() {
 fn checkout_disposable_review_binding_failure_rolls_back_worktree() {
     let home = tmp_home("disposable-review-atomic");
     let parent = tmp_home("disposable-review-atomic-src");
-    let source = setup_source_repo(&parent, "review/disposable-atomic");
-    let expected = get_sha(&source, "review/disposable-atomic");
+    let source = setup_source_repo(&parent, "seed");
+    let expected = get_sha(&source, "main");
+    remove_origin(&source);
+    seed_origin_view(&source, "main", &expected);
     let agent = "disposable-atomic-agent";
     let binding_path = crate::paths::binding_path(&home, agent);
     crate::store::fail_next_atomic_write_for_test(&binding_path);
@@ -1064,6 +1522,7 @@ fn checkout_disposable_review_binding_failure_rolls_back_worktree() {
             "bind": true,
             "task_id": "task-disposable-atomic",
             "expected_head": &expected,
+            "from_ref": "main",
             "checkout_purpose": "disposable_review",
         }),
         agent,
@@ -1072,8 +1531,18 @@ fn checkout_disposable_review_binding_failure_rolls_back_worktree() {
         resp.get("error").is_some(),
         "forced binding failure must fail: {resp}"
     );
+    assert_eq!(resp["code"].as_str(), Some("bind_rollback"), "{resp}");
+    assert_eq!(resp["stage"].as_str(), Some("bind_full"), "{resp}");
     assert!(crate::binding::read(&home, agent).is_none());
     assert!(!derived_worktree(&home, agent, &source).exists());
+    assert!(!crate::git_helpers::git_ok(
+        &source,
+        &[
+            "rev-parse",
+            "--verify",
+            "refs/heads/review/disposable-atomic"
+        ],
+    ));
 
     std::fs::remove_dir_all(&home).ok();
     std::fs::remove_dir_all(&parent).ok();

--- a/src/mcp/handlers/ci/review_workspace_tests.rs
+++ b/src/mcp/handlers/ci/review_workspace_tests.rs
@@ -837,3 +837,244 @@ fn checkout_expected_head_reuse_worktree_mismatch_refuses_without_sync() {
     std::fs::remove_dir_all(&home).ok();
     std::fs::remove_dir_all(&parent).ok();
 }
+
+// ══════════════════════════════════════════════════════════════════════
+// Architecture-14 item 10 — daemon-provisioned disposable review provenance
+// ══════════════════════════════════════════════════════════════════════
+
+#[cfg(unix)]
+fn seed_terminal_task(home: &Path, task_id: &str, branch: &str, terminal: bool) {
+    use crate::task_events::{DoneSource, InstanceName, TaskEvent, TaskId};
+
+    let emitter = InstanceName::from("disposable-review-test");
+    let id = TaskId::from(task_id);
+    crate::task_events::append(
+        home,
+        &emitter,
+        TaskEvent::Created {
+            task_id: id.clone(),
+            title: "disposable review".to_string(),
+            description: String::new(),
+            priority: "normal".to_string(),
+            owner: None,
+            due_at: None,
+            depends_on: Vec::new(),
+            routed_to: None,
+            branch: Some(branch.to_string()),
+            bind: Some(true),
+            eta_secs: None,
+            tags: Vec::new(),
+            parent_id: None,
+        },
+    )
+    .expect("create task");
+    if terminal {
+        crate::task_events::append(
+            home,
+            &emitter,
+            TaskEvent::Done {
+                task_id: id,
+                by: emitter.clone(),
+                source: DoneSource::OperatorManual {
+                    authored_at: "2026-07-16T00:00:00Z".to_string(),
+                    result: None,
+                },
+            },
+        )
+        .expect("finish task");
+    }
+}
+
+#[test]
+#[cfg(unix)]
+fn checkout_disposable_review_persists_provenance_and_terminal_release_deletes() {
+    let home = tmp_home("disposable-review-fresh");
+    let parent = tmp_home("disposable-review-fresh-src");
+    let source = setup_source_repo(&parent, "seed");
+    let expected = get_sha(&source, "main");
+    seed_origin_view(&source, "review/disposable-fresh", &expected);
+    seed_terminal_task(
+        &home,
+        "task-disposable-fresh",
+        "review/disposable-fresh",
+        true,
+    );
+
+    let resp = super::handle_checkout_repo(
+        &home,
+        &json!({
+            "repository_path": source.display().to_string(),
+            "branch": "review/disposable-fresh",
+            "bind": true,
+            "task_id": "task-disposable-fresh",
+            "expected_head": &expected,
+            "from_ref": "main",
+            "checkout_purpose": "disposable_review",
+        }),
+        "disposable-review-agent",
+    );
+    assert!(resp.get("error").is_none(), "checkout must succeed: {resp}");
+    assert_eq!(resp["auto_created_branch"].as_bool(), Some(true), "{resp}");
+    let binding =
+        crate::binding::read(&home, "disposable-review-agent").expect("disposable review binding");
+    assert_eq!(
+        binding["checkout_purpose"].as_str(),
+        Some("disposable_review")
+    );
+    assert_eq!(
+        binding["provenance"].as_str(),
+        Some("DaemonProvisionedReview")
+    );
+    assert_eq!(
+        binding["provisioned_head"].as_str(),
+        Some(expected.as_str())
+    );
+
+    let released = crate::mcp::handlers::worktree::handle_release_worktree(
+        &home,
+        &json!({"instance": "disposable-review-agent"}),
+        &None,
+    );
+    assert_eq!(released["released"].as_bool(), Some(true), "{released}");
+    assert!(!crate::git_helpers::git_ok(
+        &source,
+        &["rev-parse", "--verify", "review/disposable-fresh"],
+    ));
+    assert!(crate::binding::read(&home, "disposable-review-agent").is_none());
+
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&parent).ok();
+}
+
+#[test]
+#[cfg(unix)]
+fn checkout_disposable_review_rejects_preexisting_branch_without_mutation() {
+    let home = tmp_home("disposable-review-existing");
+    let parent = tmp_home("disposable-review-existing-src");
+    let source = setup_source_repo(&parent, "review/disposable-existing");
+    let expected = get_sha(&source, "review/disposable-existing");
+    seed_terminal_task(
+        &home,
+        "task-disposable-existing",
+        "review/disposable-existing",
+        true,
+    );
+
+    let resp = super::handle_checkout_repo(
+        &home,
+        &json!({
+            "repository_path": source.display().to_string(),
+            "branch": "review/disposable-existing",
+            "bind": true,
+            "task_id": "task-disposable-existing",
+            "expected_head": &expected,
+            "checkout_purpose": "disposable_review",
+        }),
+        "disposable-existing-agent",
+    );
+    assert_eq!(
+        resp["code"].as_str(),
+        Some("disposable_review_requires_new_branch"),
+        "{resp}"
+    );
+    assert!(crate::binding::read(&home, "disposable-existing-agent").is_none());
+    assert!(
+        !derived_worktree(&home, "disposable-existing-agent", &source).exists(),
+        "pre-existing disposable-review branch must not provision a worktree"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&parent).ok();
+}
+
+#[test]
+#[cfg(unix)]
+fn checkout_disposable_review_requires_bind_task_and_expected_head() {
+    let home = tmp_home("disposable-review-args");
+    let parent = tmp_home("disposable-review-args-src");
+    let source = setup_source_repo(&parent, "review/disposable-args");
+    let expected = get_sha(&source, "review/disposable-args");
+
+    for (tag, args, code) in [
+        (
+            "no-bind",
+            json!({
+                "repository_path": source.display().to_string(),
+                "branch": "review/disposable-args",
+                "task_id": "task-disposable-args",
+                "expected_head": &expected,
+                "checkout_purpose": "disposable_review",
+            }),
+            "disposable_review_requires_bind",
+        ),
+        (
+            "no-task",
+            json!({
+                "repository_path": source.display().to_string(),
+                "branch": "review/disposable-args",
+                "bind": true,
+                "expected_head": &expected,
+                "checkout_purpose": "disposable_review",
+            }),
+            "disposable_review_requires_task_id",
+        ),
+        (
+            "no-head",
+            json!({
+                "repository_path": source.display().to_string(),
+                "branch": "review/disposable-args",
+                "bind": true,
+                "task_id": "task-disposable-args",
+                "checkout_purpose": "disposable_review",
+            }),
+            "disposable_review_requires_expected_head",
+        ),
+    ] {
+        let resp = super::handle_checkout_repo(&home, &args, &format!("disposable-{tag}"));
+        if crate::binding::read(&home, &format!("disposable-{tag}")).is_some() {
+            let _ = crate::mcp::handlers::worktree::handle_release_worktree(
+                &home,
+                &json!({"instance": format!("disposable-{tag}")}),
+                &None,
+            );
+        }
+        assert_eq!(resp["code"].as_str(), Some(code), "{tag}: {resp}");
+    }
+
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&parent).ok();
+}
+
+#[test]
+#[cfg(unix)]
+fn checkout_disposable_review_binding_failure_rolls_back_worktree() {
+    let home = tmp_home("disposable-review-atomic");
+    let parent = tmp_home("disposable-review-atomic-src");
+    let source = setup_source_repo(&parent, "review/disposable-atomic");
+    let expected = get_sha(&source, "review/disposable-atomic");
+    let agent = "disposable-atomic-agent";
+    let binding_path = crate::paths::binding_path(&home, agent);
+    crate::store::fail_next_atomic_write_for_test(&binding_path);
+
+    let resp = super::handle_checkout_repo(
+        &home,
+        &json!({
+            "repository_path": source.display().to_string(),
+            "branch": "review/disposable-atomic",
+            "bind": true,
+            "task_id": "task-disposable-atomic",
+            "expected_head": &expected,
+            "checkout_purpose": "disposable_review",
+        }),
+        agent,
+    );
+    assert!(
+        resp.get("error").is_some(),
+        "forced binding failure must fail: {resp}"
+    );
+    assert!(crate::binding::read(&home, agent).is_none());
+    assert!(!derived_worktree(&home, agent, &source).exists());
+
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&parent).ok();
+}

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -385,6 +385,7 @@ pub(crate) fn def_repo() -> Value {
             "audit_reason": {"type": "string", "description": "#817 cleanup_merged_branches apply=true: required audit text recorded in event-log.jsonl per deleted branch with source SHA for restore."},
             "from_ref": {"type": "string", "description": "checkout bind:true: base ref to auto-create `branch` from when it doesn't exist locally (default `origin/main`)."},
             "expected_head": {"type": "string", "description": "#6: optional exact full-SHA precondition. When provided, the branch HEAD must equal this value; mismatch returns structured error with zero mutation. Omitted preserves current behavior."},
+            "checkout_purpose": {"type": "string", "enum": ["disposable_review"], "description": "Architecture-14 item 10: typed daemon-provisioned disposable review checkout. Requires bind=true, task_id, expected_head, and a newly-created branch."},
             "task_id": {"type": "string", "description": "#2533: checkout bind:true — optional task board id this self-claim is attributable to. Recorded in binding.json; a task_id-carrying self-claim is treated as in-dispatch (no `binding_out_of_dispatch` operator warning). Absent → unattributed bind, existing warning behavior unchanged."},
             "force": {"type": "boolean", "description": "#2539: merge — emergency bypass for the CI fail-closed gate and the base-staleness (BEHIND/DIRTY) refusal. Requires non-empty `force_reason`; the bypass is audit-logged to fleet_events.jsonl. The handler always read this field, but it was never declared here — an MCP client validating against this schema had no way to send it, so force=true silently never reached the daemon (#2539)."},
             "force_reason": {"type": "string", "description": "#2539: merge — required non-empty justification when `force=true`, recorded in the fleet_events.jsonl audit entry."}
@@ -1144,6 +1145,7 @@ mod tests {
             ("repo", "from_ref", "ci/mod.rs checkout auto-create base"),
             ("repo", "task_id", "ci/checkout.rs checkout bind:true → binding::bind_full task_id linkage (#2533)"),
             ("repo", "expected_head", "ci/checkout.rs checkout bind:true full-SHA precondition — mismatch returns structured error with zero mutation (#6 d-4)"),
+            ("repo", "checkout_purpose", "ci/checkout.rs typed disposable_review provenance gate (Architecture-14 item 10)"),
             ("repo", "force", "ci/merge.rs handle_merge_repo — CI/base-staleness fail-closed gate bypass (#2539)"),
             ("repo", "force_reason", "ci/merge.rs handle_merge_repo — required non-empty when force=true, audit-logged (#2539)"),
             // ── bind_self ──

--- a/src/scm/mod.rs
+++ b/src/scm/mod.rs
@@ -806,6 +806,12 @@ impl ScmProvider for MockScmProvider {
             Some(MockPrList::Prs(n)) => Ok(vec![PrSummary::default(); *n]),
             Some(MockPrList::Branches(branches)) => Ok(branches
                 .iter()
+                .filter(|branch| {
+                    filter
+                        .head
+                        .as_deref()
+                        .is_none_or(|head| head == branch.as_str())
+                })
                 .map(|branch| PrSummary {
                     head_ref: Some(branch.clone()),
                     ..Default::default()

--- a/src/worktree/disposition.rs
+++ b/src/worktree/disposition.rs
@@ -574,4 +574,22 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn disposable_review_subject_pr_open_is_irrelevant_but_review_pr_protects() {
+        let mut input = branch_input(BranchProvenance::ManagedReview);
+        // The subject PR may remain open; the lifecycle probe is scoped to the
+        // disposable review branch itself, so no PR headed at this branch is
+        // evidence of safety to delete.
+        input.open_pr = Some(false);
+        assert_eq!(
+            branch_lifecycle_disposition(&input),
+            BranchLifecycleDisposition::Delete
+        );
+        input.open_pr = Some(true);
+        assert_eq!(
+            branch_lifecycle_disposition(&input),
+            BranchLifecycleDisposition::Keep
+        );
+    }
 }

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -637,6 +637,55 @@ fn task_active_for_branch(home: &Path, task_id: &str, branch: &str) -> Option<bo
     }
 }
 
+fn disposable_review_provisioned_head(
+    binding: &serde_json::Value,
+) -> Result<Option<&str>, &'static str> {
+    let has_disposable_field = binding.get("checkout_purpose").is_some()
+        || binding.get("provenance").is_some()
+        || binding.get("provisioned_head").is_some();
+    if !has_disposable_field {
+        return Ok(None);
+    }
+    if binding.get("checkout_purpose").and_then(|v| v.as_str()) != Some("disposable_review")
+        || binding.get("provenance").and_then(|v| v.as_str()) != Some("DaemonProvisionedReview")
+    {
+        return Err("invalid disposable review provenance");
+    }
+    let head = binding
+        .get("provisioned_head")
+        .and_then(|v| v.as_str())
+        .filter(|head| {
+            (head.len() == 40 || head.len() == 64) && head.chars().all(|c| c.is_ascii_hexdigit())
+        })
+        .ok_or("missing or invalid disposable review provisioned_head")?;
+    Ok(Some(head))
+}
+
+fn disposable_review_task_terminal(home: &Path, task_id: &str, branch: &str) -> Option<bool> {
+    if task_id.is_empty() {
+        return None;
+    }
+    match crate::tasks::load_routed(home, task_id) {
+        Ok(routed) => {
+            // A terminal task is authoritative only for the branch it owns;
+            // a mismatched branch is contradictory evidence and must preserve
+            // the disposable review branch fail-closed.
+            if routed.task.branch.as_deref() != Some(branch) {
+                return None;
+            }
+            Some(matches!(
+                routed.task.status,
+                crate::task_events::TaskStatus::Done
+                    | crate::task_events::TaskStatus::Cancelled
+                    | crate::task_events::TaskStatus::Verified
+            ))
+        }
+        Err(crate::tasks::TaskRouteError::NotFound)
+        | Err(crate::tasks::TaskRouteError::Unreadable { .. })
+        | Err(crate::tasks::TaskRouteError::Ambiguous { .. }) => None,
+    }
+}
+
 fn resolve_branch_cleanup(
     home: &Path,
     binding: &serde_json::Value,
@@ -649,12 +698,23 @@ fn resolve_branch_cleanup(
     let branch = binding["branch"].as_str().unwrap_or("");
     let sr_str = binding["source_repo"].as_str().unwrap_or("");
     let task_id = binding["task_id"].as_str().unwrap_or("");
+    let disposable_head = match disposable_review_provisioned_head(binding) {
+        Ok(head) => head,
+        Err(reason) => {
+            out.branch_cleanup_skipped_reason = Some(format!(
+                "disposable review provenance {reason} — preserved (fail-closed)"
+            ));
+            return;
+        }
+    };
     if !managed_verified && !worktree_absent {
         out.branch_cleanup_skipped_reason =
             Some("cannot verify .agend-managed marker — skipping branch cleanup".to_string());
     } else if !branch.is_empty() && !sr_str.is_empty() {
         // Authority-proven review lease: lease_kind + review_assignment_id + expected_head
-        // all present → eligible for immediate delete with expected-head CAS.
+        // all present → eligible for immediate delete with expected-head CAS. A
+        // daemon-provisioned disposable review uses the same strict lifecycle
+        // classifier, but its provenance is independent of assignment_authority.
         // Dirty work → never auto-delete regardless of provenance.
         let authority_proven_head = if was_dirty {
             None
@@ -676,20 +736,26 @@ fn resolve_branch_cleanup(
                         .filter(|s| !s.is_empty()),
                 )
         };
+        let review_head = disposable_head.or(authority_proven_head);
         if was_dirty
-            && binding
-                .get("lease_kind")
-                .and_then(|v| v.as_str())
-                .is_some_and(|k| k == "review")
+            && (disposable_head.is_some()
+                || binding
+                    .get("lease_kind")
+                    .and_then(|v| v.as_str())
+                    .is_some_and(|k| k == "review"))
         {
             out.branch_cleanup_skipped_reason = Some(format!(
                 "authority-proven review lease on '{branch}' had dirty work — branch preserved"
             ));
             return;
         }
-        if let Some(expected) = authority_proven_head {
+        if let Some(expected) = review_head {
             let default = crate::git_helpers::default_branch(Path::new(sr_str));
-            let task_active = task_active_for_branch(home, task_id, branch);
+            let task_active = if disposable_head.is_some() {
+                disposable_review_task_terminal(home, task_id, branch).map(|terminal| !terminal)
+            } else {
+                task_active_for_branch(home, task_id, branch)
+            };
             let open_pr =
                 match crate::branch_sweep::open_pr_status(Path::new(sr_str), &default, branch) {
                     crate::branch_sweep::OpenPrStatus::Open => Some(true),
@@ -700,16 +766,17 @@ fn resolve_branch_cleanup(
                 crate::git_helpers::git_cmd(Path::new(sr_str), &["rev-parse", branch])
                     .ok()
                     .map(|tip| tip.trim() != expected);
+            let active_holder = crate::worktree_cleanup::branch_has_other_active_binding(
+                home,
+                Path::new(sr_str),
+                branch,
+                binding["worktree"].as_str(),
+            );
             let lifecycle = crate::worktree::disposition::branch_lifecycle_disposition(
                 &crate::worktree::disposition::BranchLifecycleInput {
                     provenance: crate::worktree::disposition::BranchProvenance::ManagedReview,
                     terminal: true,
-                    active_holder: crate::worktree_cleanup::branch_has_other_active_binding(
-                        home,
-                        Path::new(sr_str),
-                        branch,
-                        binding["worktree"].as_str(),
-                    ),
+                    active_holder,
                     task_active,
                     open_pr,
                     unique_unpreserved_work,
@@ -737,8 +804,17 @@ fn resolve_branch_cleanup(
                 }
             }
         }
-        let (deleted, skip_reason) =
-            cleanup_merged_branch(Path::new(sr_str), branch, dry_run, authority_proven_head);
+        let (deleted, skip_reason) = cleanup_merged_branch(
+            Path::new(sr_str),
+            branch,
+            dry_run,
+            // A daemon-provisioned disposable review has the same strict
+            // expected-head CAS as an assignment-authority review lease. Once
+            // its lifecycle gates pass, pass that provenance head through to
+            // the deletion primitive so the branch is reaped without a PR
+            // merge signal (review scaffolding is intentionally unmerged).
+            review_head,
+        );
         out.branch_deleted = deleted;
         out.branch_cleanup_skipped_reason = skip_reason.clone();
         // Cleanup intent: clean feature branch released pre-merge → persist

--- a/src/worktree_pool/tests.rs
+++ b/src/worktree_pool/tests.rs
@@ -4847,7 +4847,7 @@ fn binding_with_disposable_review(
 }
 
 fn seed_disposable_task(home: &Path, task_id: &str, branch: &str, terminal: bool) {
-    use crate::task_events::{DoneSource, InstanceName, TaskEvent, TaskId};
+    use crate::task_events::{InstanceName, TaskEvent, TaskId};
 
     let emitter = InstanceName::from("disposable-review-pool-test");
     let id = TaskId::from(task_id);
@@ -4872,20 +4872,27 @@ fn seed_disposable_task(home: &Path, task_id: &str, branch: &str, terminal: bool
     )
     .unwrap();
     if terminal {
-        crate::task_events::append(
-            home,
-            &emitter,
-            TaskEvent::Done {
-                task_id: id,
-                by: emitter.clone(),
-                source: DoneSource::OperatorManual {
-                    authored_at: "2026-07-16T00:00:00Z".to_string(),
-                    result: None,
-                },
-            },
-        )
-        .unwrap();
+        finish_disposable_task(home, task_id);
     }
+}
+
+fn finish_disposable_task(home: &Path, task_id: &str) {
+    use crate::task_events::{DoneSource, InstanceName, TaskEvent, TaskId};
+
+    let emitter = InstanceName::from("disposable-review-pool-test");
+    crate::task_events::append(
+        home,
+        &emitter,
+        TaskEvent::Done {
+            task_id: TaskId::from(task_id),
+            by: emitter.clone(),
+            source: DoneSource::OperatorManual {
+                authored_at: "2026-07-16T00:00:00Z".to_string(),
+                result: None,
+            },
+        },
+    )
+    .unwrap();
 }
 
 /// RED #2: a branch named `review/*` but WITHOUT authority-proven provenance
@@ -5164,19 +5171,11 @@ fn disposable_review_active_task_kept_then_terminal_task_deletes() {
     );
     assert!(branch_exists(&repo, branch));
 
-    seed_disposable_task(&home, "T-disposable-active-terminal-done", branch, true);
+    // Transition the SAME task from active to terminal; a different terminal
+    // task id must not authorize deletion of this branch.
+    finish_disposable_task(&home, task_id);
     let mut terminal = ReleaseOutcome::default();
-    let mut terminal_binding = binding.clone();
-    terminal_binding["task_id"] = serde_json::json!("T-disposable-active-terminal-done");
-    resolve_branch_cleanup(
-        &home,
-        &terminal_binding,
-        true,
-        false,
-        false,
-        false,
-        &mut terminal,
-    );
+    resolve_branch_cleanup(&home, &binding, true, false, false, false, &mut terminal);
     assert!(
         terminal.branch_deleted,
         "terminal disposable review must delete: {:?}",
@@ -5212,6 +5211,28 @@ fn disposable_review_missing_corrupt_or_drifted_state_is_kept() {
         &mut missing_out,
     );
     assert!(!missing_out.branch_deleted);
+    assert!(branch_exists(&repo, branch));
+
+    let mismatch_task = "T-disposable-branch-mismatch";
+    seed_disposable_task(
+        &home,
+        mismatch_task,
+        "review/another-disposable-branch",
+        true,
+    );
+    let mut mismatch = missing_task.clone();
+    mismatch["task_id"] = serde_json::json!(mismatch_task);
+    let mut mismatch_out = ReleaseOutcome::default();
+    resolve_branch_cleanup(
+        &home,
+        &mismatch,
+        true,
+        false,
+        false,
+        false,
+        &mut mismatch_out,
+    );
+    assert!(!mismatch_out.branch_deleted);
     assert!(branch_exists(&repo, branch));
 
     let mut corrupt = missing_task.clone();

--- a/src/worktree_pool/tests.rs
+++ b/src/worktree_pool/tests.rs
@@ -4827,6 +4827,67 @@ fn binding_with_lease(
     b
 }
 
+fn binding_with_disposable_review(
+    branch: &str,
+    source_repo: &str,
+    task_id: &str,
+    provisioned_head: &str,
+) -> serde_json::Value {
+    serde_json::json!({
+        "version": 1,
+        "agent": "test-agent",
+        "task_id": task_id,
+        "branch": branch,
+        "issued_at": "2026-07-16T00:00:00Z",
+        "source_repo": source_repo,
+        "checkout_purpose": "disposable_review",
+        "provenance": "DaemonProvisionedReview",
+        "provisioned_head": provisioned_head,
+    })
+}
+
+fn seed_disposable_task(home: &Path, task_id: &str, branch: &str, terminal: bool) {
+    use crate::task_events::{DoneSource, InstanceName, TaskEvent, TaskId};
+
+    let emitter = InstanceName::from("disposable-review-pool-test");
+    let id = TaskId::from(task_id);
+    crate::task_events::append(
+        home,
+        &emitter,
+        TaskEvent::Created {
+            task_id: id.clone(),
+            title: "disposable review".to_string(),
+            description: String::new(),
+            priority: "normal".to_string(),
+            owner: None,
+            due_at: None,
+            depends_on: Vec::new(),
+            routed_to: None,
+            branch: Some(branch.to_string()),
+            bind: Some(true),
+            eta_secs: None,
+            tags: Vec::new(),
+            parent_id: None,
+        },
+    )
+    .unwrap();
+    if terminal {
+        crate::task_events::append(
+            home,
+            &emitter,
+            TaskEvent::Done {
+                task_id: id,
+                by: emitter.clone(),
+                source: DoneSource::OperatorManual {
+                    authored_at: "2026-07-16T00:00:00Z".to_string(),
+                    result: None,
+                },
+            },
+        )
+        .unwrap();
+    }
+}
+
 /// RED #2: a branch named `review/*` but WITHOUT authority-proven provenance
 /// (no lease_kind in binding) must NOT be deleted by the authority-proven path.
 /// It falls through to the normal merged/squash check, which keeps it (review
@@ -5081,5 +5142,111 @@ fn expected_head_drift_fail_closed() {
         "skip reason must mention fail-closed: {reason}"
     );
 
+    std::fs::remove_dir_all(&repo).ok();
+}
+
+#[test]
+fn disposable_review_active_task_kept_then_terminal_task_deletes() {
+    let home = tmp_home("disposable-active-terminal-home");
+    let repo = tmp_repo("disposable-active-terminal");
+    let branch = "review/disposable-active-terminal";
+    let tip = make_review_branch(&repo, branch);
+    let task_id = "T-disposable-active-terminal";
+    let binding =
+        binding_with_disposable_review(branch, &repo.display().to_string(), task_id, &tip);
+
+    seed_disposable_task(&home, task_id, branch, false);
+    let mut active = ReleaseOutcome::default();
+    resolve_branch_cleanup(&home, &binding, true, false, false, false, &mut active);
+    assert!(
+        !active.branch_deleted,
+        "active task must preserve review branch"
+    );
+    assert!(branch_exists(&repo, branch));
+
+    seed_disposable_task(&home, "T-disposable-active-terminal-done", branch, true);
+    let mut terminal = ReleaseOutcome::default();
+    let mut terminal_binding = binding.clone();
+    terminal_binding["task_id"] = serde_json::json!("T-disposable-active-terminal-done");
+    resolve_branch_cleanup(
+        &home,
+        &terminal_binding,
+        true,
+        false,
+        false,
+        false,
+        &mut terminal,
+    );
+    assert!(
+        terminal.branch_deleted,
+        "terminal disposable review must delete: {:?}",
+        terminal.branch_cleanup_skipped_reason
+    );
+    assert!(!branch_exists(&repo, branch));
+
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&repo).ok();
+}
+
+#[test]
+fn disposable_review_missing_corrupt_or_drifted_state_is_kept() {
+    let home = tmp_home("disposable-fail-closed-home");
+    let repo = tmp_repo("disposable-fail-closed");
+    let branch = "review/disposable-fail-closed";
+    let tip = make_review_branch(&repo, branch);
+
+    let missing_task = binding_with_disposable_review(
+        branch,
+        &repo.display().to_string(),
+        "T-disposable-missing",
+        &tip,
+    );
+    let mut missing_out = ReleaseOutcome::default();
+    resolve_branch_cleanup(
+        &home,
+        &missing_task,
+        true,
+        false,
+        false,
+        false,
+        &mut missing_out,
+    );
+    assert!(!missing_out.branch_deleted);
+    assert!(branch_exists(&repo, branch));
+
+    let mut corrupt = missing_task.clone();
+    corrupt["provenance"] = serde_json::json!("Forged");
+    let mut corrupt_out = ReleaseOutcome::default();
+    resolve_branch_cleanup(&home, &corrupt, true, false, false, false, &mut corrupt_out);
+    assert!(!corrupt_out.branch_deleted);
+    assert!(branch_exists(&repo, branch));
+
+    let mut drift = missing_task;
+    drift["task_id"] = serde_json::json!("T-disposable-drift");
+    seed_disposable_task(&home, "T-disposable-drift", branch, true);
+    let _new_tip = make_review_branch(&repo, "review/disposable-drift-scaffold");
+    // Move the disposable branch itself after provenance was recorded.
+    git_in(&repo, &["checkout", branch]);
+    std::fs::write(repo.join("drift.txt"), "drift").unwrap();
+    git_in(&repo, &["add", "."]);
+    git_in(
+        &repo,
+        &[
+            "-c",
+            "user.name=t",
+            "-c",
+            "user.email=t@t",
+            "commit",
+            "-m",
+            "drift",
+        ],
+    );
+    git_in(&repo, &["checkout", "main"]);
+    let mut drift_out = ReleaseOutcome::default();
+    resolve_branch_cleanup(&home, &drift, true, false, false, false, &mut drift_out);
+    assert!(!drift_out.branch_deleted);
+    assert!(branch_exists(&repo, branch));
+
+    std::fs::remove_dir_all(&home).ok();
     std::fs::remove_dir_all(&repo).ok();
 }


### PR DESCRIPTION
Architecture-14 item 10 implementation.

## Scope
- add typed checkout_purpose=disposable_review validation with bind/task/full expected-head/new-branch gates
- persist DaemonProvisionedReview and provisioned_head atomically in the initial binding
- enforce fail-closed terminal release gates and strict provisioned-head CAS branch deletion
- preserve assignment-authority review lease behavior

## Verification
- cargo fmt --package agend-terminal -- --check
- cargo check --bin agend-terminal
- cargo test --bin agend-terminal disposable_review_ -- --nocapture (8 passed)
- cargo test --bin agend-terminal review_workspace_tests -- --nocapture (21 passed)
- git diff --check

Task: t-20260716141916646521-94870-7
Decision: d-20260716141736992354-1