### PR TITLE
fix: fail-closed shared-directory cleanup admission (#2764)

### DIFF
--- a/src/agent_ops.rs
+++ b/src/agent_ops.rs
@@ -681,6 +681,16 @@ pub(crate) fn cleanup_working_dir_admitted(
             );
             None
         }
+        cleanup_admission::CleanupAdmission::NoOp { reason } => {
+            tracing::debug!(
+                name,
+                dir = %working_dir.display(),
+                %reason,
+                "pre-delete cleanup admission found no working directory to mutate"
+            );
+            None
+        }
+        cleanup_admission::CleanupAdmission::Refuse { reason } => Some(reason.clone()),
         cleanup_admission::CleanupAdmission::RemoveOwned { canonical }
         | cleanup_admission::CleanupAdmission::ScrubExclusive { canonical } => {
             match dunce::canonicalize(working_dir) {

--- a/src/agent_ops.rs
+++ b/src/agent_ops.rs
@@ -16,6 +16,8 @@ use serde_json::{json, Value};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+pub(crate) mod cleanup_admission;
+
 // ---------------------------------------------------------------------------
 // Messaging
 // ---------------------------------------------------------------------------
@@ -658,6 +660,44 @@ pub fn cleanup_working_dir(home: &Path, name: &str, working_dir: &Path) -> Optio
     crate::agy_workspace::remove_link(home, name);
 
     conflict
+}
+
+/// Apply a pre-delete admission derived from the FleetConfig snapshot.
+/// `Preserve` is intentionally a complete path-local no-op: the shared
+/// directory must not even enter the backend scrub path.
+pub(crate) fn cleanup_working_dir_admitted(
+    home: &Path,
+    name: &str,
+    working_dir: &Path,
+    admission: &cleanup_admission::CleanupAdmission,
+) -> Option<String> {
+    match admission {
+        cleanup_admission::CleanupAdmission::Preserve { reason } => {
+            tracing::warn!(
+                name,
+                dir = %working_dir.display(),
+                %reason,
+                "pre-delete cleanup admission preserved working directory"
+            );
+            None
+        }
+        cleanup_admission::CleanupAdmission::RemoveOwned { canonical }
+        | cleanup_admission::CleanupAdmission::ScrubExclusive { canonical } => {
+            match dunce::canonicalize(working_dir) {
+                Ok(actual) if actual == *canonical => cleanup_working_dir(home, name, working_dir),
+                Ok(actual) => Some(format!(
+                    "working directory changed after admission: {} now resolves to {}, expected {}",
+                    working_dir.display(),
+                    actual.display(),
+                    canonical.display()
+                )),
+                Err(error) => Some(format!(
+                    "working directory no longer canonicalizes after admission: {} ({error})",
+                    working_dir.display()
+                )),
+            }
+        }
+    }
 }
 
 /// Whether `working_dir`'s on-disk identity artifacts name an instance OTHER

--- a/src/agent_ops/cleanup_admission.rs
+++ b/src/agent_ops/cleanup_admission.rs
@@ -14,6 +14,8 @@ pub(crate) enum CleanupAdmission {
     RemoveOwned { canonical: PathBuf },
     ScrubExclusive { canonical: PathBuf },
     Preserve { reason: String },
+    NoOp { reason: String },
+    Refuse { reason: String },
 }
 
 fn has_dotdot(path: &Path) -> bool {
@@ -23,6 +25,14 @@ fn has_dotdot(path: &Path) -> bool {
 
 fn paths_overlap(a: &Path, b: &Path) -> bool {
     a == b || a.starts_with(b) || b.starts_with(a)
+}
+
+fn path_entry_present(candidate: &Path) -> Result<bool, std::io::Error> {
+    match std::fs::symlink_metadata(candidate) {
+        Ok(_) => Ok(true),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error),
+    }
 }
 
 fn raw_working_directory(snapshot: &FleetConfig, home: &Path, name: &str) -> Option<PathBuf> {
@@ -42,18 +52,39 @@ pub(crate) fn derive(
     victim: &str,
     candidate: &Path,
 ) -> CleanupAdmission {
+    let candidate_present = match path_entry_present(candidate) {
+        Ok(present) => present,
+        Err(error) => {
+            return CleanupAdmission::Refuse {
+                reason: format!(
+                    "candidate {} cannot inspect metadata: {error}",
+                    candidate.display()
+                ),
+            };
+        }
+    };
     let Some(snapshot) = snapshot else {
-        return CleanupAdmission::Preserve {
+        if !candidate_present {
+            return CleanupAdmission::NoOp {
+                reason: "fleet snapshot unavailable but candidate is already absent".to_string(),
+            };
+        }
+        return CleanupAdmission::Refuse {
             reason: "fleet snapshot unavailable — cleanup ownership is unproven".to_string(),
         };
     };
     if !snapshot.instances.contains_key(victim) {
-        return CleanupAdmission::Preserve {
+        if !candidate_present {
+            return CleanupAdmission::NoOp {
+                reason: format!("victim '{victim}' is absent and candidate is already absent"),
+            };
+        }
+        return CleanupAdmission::Refuse {
             reason: format!("victim '{victim}' is absent from the fleet snapshot"),
         };
     }
     if candidate.as_os_str().is_empty() || has_dotdot(candidate) {
-        return CleanupAdmission::Preserve {
+        return CleanupAdmission::Refuse {
             reason: format!(
                 "candidate {} is empty or contains '..'",
                 candidate.display()
@@ -63,7 +94,12 @@ pub(crate) fn derive(
     let candidate_canonical = match dunce::canonicalize(candidate) {
         Ok(path) => path,
         Err(error) => {
-            return CleanupAdmission::Preserve {
+            if error.kind() == std::io::ErrorKind::NotFound && !candidate_present {
+                return CleanupAdmission::NoOp {
+                    reason: format!("candidate {} is already absent", candidate.display()),
+                };
+            }
+            return CleanupAdmission::Refuse {
                 reason: format!(
                     "candidate {} cannot canonicalize: {error}",
                     candidate.display()
@@ -77,12 +113,12 @@ pub(crate) fn derive(
             continue;
         }
         let Some(survivor_path) = raw_working_directory(snapshot, home, name) else {
-            return CleanupAdmission::Preserve {
+            return CleanupAdmission::Refuse {
                 reason: format!("survivor '{name}' has no resolvable working directory"),
             };
         };
         if has_dotdot(&survivor_path) {
-            return CleanupAdmission::Preserve {
+            return CleanupAdmission::Refuse {
                 reason: format!("survivor '{name}' working directory contains '..'"),
             };
         }
@@ -97,7 +133,7 @@ pub(crate) fn derive(
             }
             Ok(_) => {}
             Err(error) => {
-                return CleanupAdmission::Preserve {
+                return CleanupAdmission::Refuse {
                     reason: format!(
                         "survivor '{name}' working directory {} is ambiguous: {error}",
                         survivor_path.display()
@@ -116,7 +152,7 @@ pub(crate) fn derive(
             };
         }
         Err(error) => {
-            return CleanupAdmission::Preserve {
+            return CleanupAdmission::Refuse {
                 reason: format!("workspace root cannot canonicalize: {error}"),
             };
         }
@@ -128,7 +164,7 @@ pub(crate) fn derive(
         };
     }
     if candidate_canonical.starts_with(&workspace_canonical) {
-        return CleanupAdmission::Preserve {
+        return CleanupAdmission::Refuse {
             reason: format!(
                 "candidate {} is under workspace root but is not victim default {}",
                 candidate_canonical.display(),

--- a/src/agent_ops/cleanup_admission.rs
+++ b/src/agent_ops/cleanup_admission.rs
@@ -1,0 +1,142 @@
+//! Typed pre-delete admission for instance working-directory cleanup.
+//!
+//! The decision is made from the immutable FleetConfig snapshot captured before
+//! `full_delete_instance` removes the victim entry.  A survivor that resolves to
+//! an overlapping canonical path preserves the directory completely; only an
+//! unshared exact default may be removed recursively, while an unshared external
+//! directory keeps the existing agend-file scrub semantics.
+
+use crate::fleet::FleetConfig;
+use std::path::{Component, Path, PathBuf};
+
+#[derive(Debug, Clone)]
+pub(crate) enum CleanupAdmission {
+    RemoveOwned { canonical: PathBuf },
+    ScrubExclusive { canonical: PathBuf },
+    Preserve { reason: String },
+}
+
+fn has_dotdot(path: &Path) -> bool {
+    path.components()
+        .any(|component| matches!(component, Component::ParentDir))
+}
+
+fn paths_overlap(a: &Path, b: &Path) -> bool {
+    a == b || a.starts_with(b) || b.starts_with(a)
+}
+
+fn raw_working_directory(snapshot: &FleetConfig, home: &Path, name: &str) -> Option<PathBuf> {
+    let instance = snapshot.instances.get(name)?;
+    let path = instance
+        .working_directory
+        .as_deref()
+        .map(crate::fleet::resolve::expand_tilde_path)
+        .unwrap_or_else(|| crate::paths::workspace_dir(home).join(name));
+    (!path.as_os_str().is_empty()).then_some(path)
+}
+
+/// Derive the only path mutation a full delete may perform.
+pub(crate) fn derive(
+    snapshot: Option<&FleetConfig>,
+    home: &Path,
+    victim: &str,
+    candidate: &Path,
+) -> CleanupAdmission {
+    let Some(snapshot) = snapshot else {
+        return CleanupAdmission::Preserve {
+            reason: "fleet snapshot unavailable — cleanup ownership is unproven".to_string(),
+        };
+    };
+    if !snapshot.instances.contains_key(victim) {
+        return CleanupAdmission::Preserve {
+            reason: format!("victim '{victim}' is absent from the fleet snapshot"),
+        };
+    }
+    if candidate.as_os_str().is_empty() || has_dotdot(candidate) {
+        return CleanupAdmission::Preserve {
+            reason: format!(
+                "candidate {} is empty or contains '..'",
+                candidate.display()
+            ),
+        };
+    }
+    let candidate_canonical = match dunce::canonicalize(candidate) {
+        Ok(path) => path,
+        Err(error) => {
+            return CleanupAdmission::Preserve {
+                reason: format!(
+                    "candidate {} cannot canonicalize: {error}",
+                    candidate.display()
+                ),
+            };
+        }
+    };
+
+    for name in snapshot.instances.keys() {
+        if name == victim {
+            continue;
+        }
+        let Some(survivor_path) = raw_working_directory(snapshot, home, name) else {
+            return CleanupAdmission::Preserve {
+                reason: format!("survivor '{name}' has no resolvable working directory"),
+            };
+        };
+        if has_dotdot(&survivor_path) {
+            return CleanupAdmission::Preserve {
+                reason: format!("survivor '{name}' working directory contains '..'"),
+            };
+        }
+        match dunce::canonicalize(&survivor_path) {
+            Ok(survivor_canonical) if paths_overlap(&candidate_canonical, &survivor_canonical) => {
+                return CleanupAdmission::Preserve {
+                    reason: format!(
+                        "survivor '{name}' overlaps candidate {}",
+                        survivor_canonical.display()
+                    ),
+                };
+            }
+            Ok(_) => {}
+            Err(error) => {
+                return CleanupAdmission::Preserve {
+                    reason: format!(
+                        "survivor '{name}' working directory {} is ambiguous: {error}",
+                        survivor_path.display()
+                    ),
+                };
+            }
+        }
+    }
+
+    let workspace_root = crate::paths::workspace_dir(home);
+    let workspace_canonical = match dunce::canonicalize(&workspace_root) {
+        Ok(path) => path,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return CleanupAdmission::ScrubExclusive {
+                canonical: candidate_canonical,
+            };
+        }
+        Err(error) => {
+            return CleanupAdmission::Preserve {
+                reason: format!("workspace root cannot canonicalize: {error}"),
+            };
+        }
+    };
+    let owned_default = workspace_canonical.join(victim);
+    if candidate_canonical == owned_default {
+        return CleanupAdmission::RemoveOwned {
+            canonical: candidate_canonical,
+        };
+    }
+    if candidate_canonical.starts_with(&workspace_canonical) {
+        return CleanupAdmission::Preserve {
+            reason: format!(
+                "candidate {} is under workspace root but is not victim default {}",
+                candidate_canonical.display(),
+                owned_default.display()
+            ),
+        };
+    }
+    CleanupAdmission::ScrubExclusive {
+        canonical: candidate_canonical,
+    }
+}

--- a/src/mcp/handlers/instance_state/lifecycle.rs
+++ b/src/mcp/handlers/instance_state/lifecycle.rs
@@ -14,7 +14,7 @@
 //!   future callers (e.g. `handle_spawn` rejection-message enrichment)
 //!   that want to surface the divergent-store list to the operator.
 
-use crate::agent_ops::cleanup_working_dir;
+use crate::agent_ops::{cleanup_admission, cleanup_working_dir_admitted};
 use crate::channel::telegram;
 use serde_json::json;
 use std::path::Path;
@@ -82,13 +82,23 @@ pub(crate) fn full_delete_instance(home: &Path, name: &str) -> Result<(), String
     // leaked mark would make it un-spawnable for the daemon's lifetime.
     let _delete_guard = crate::agent::deleting::mark_deleting(home, name);
     let fleet = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home)).ok();
-    let (topic_id, working_dir) = fleet
+    let topic_id = fleet
         .as_ref()
-        .and_then(|c| {
-            c.resolve_instance(name)
-                .map(|r| (r.topic_id, r.working_directory))
+        .and_then(|c| c.resolve_instance(name).and_then(|r| r.topic_id));
+    // Derive the candidate from the raw pre-delete entry, not
+    // `resolve_instance`: an unrelated resolution error (for example a raw
+    // `..` path) must not fall back to a different default workspace.
+    let working_dir = fleet
+        .as_ref()
+        .and_then(|config| config.instances.get(name))
+        .and_then(|instance| {
+            instance
+                .working_directory
+                .as_deref()
+                .map(crate::fleet::resolve::expand_tilde_path)
         })
-        .unwrap_or((None, None));
+        .unwrap_or_else(|| crate::paths::workspace_dir(home).join(name));
+    let cleanup_admission = cleanup_admission::derive(fleet.as_ref(), home, name, &working_dir);
     // #1157: extract InstanceId before fleet.yaml removal for id-based metadata cleanup.
     let instance_id = fleet
         .as_ref()
@@ -146,16 +156,14 @@ pub(crate) fn full_delete_instance(home: &Path, name: &str) -> Result<(), String
     // `working_directory:` explicitly. `cleanup_working_dir` only `remove_dir_all`s
     // paths UNDER `$AGEND_HOME/workspace/`, so a user-provided dir is never nuked —
     // the default fed here is always under workspace/, the path it's safe to remove.
-    let wd = working_dir
-        .clone()
-        .unwrap_or_else(|| crate::paths::workspace_dir(home).join(name));
     // #46776: cleanup_working_dir holds the workspace-identity lock, decides
     // ownership ONCE under it, and returns the single verdict — NO separate,
     // unlocked probe (which could observe a different state). A refusal (foreign/
     // corrupt/unreadable identity, or a lock-acquire failure) preserves the
     // foreign tree; surface it as a step error so the delete reports failure
     // instead of a false success while B's directory is (correctly) left intact.
-    if let Some(reason) = cleanup_working_dir(home, name, &wd) {
+    if let Some(reason) = cleanup_working_dir_admitted(home, name, &working_dir, &cleanup_admission)
+    {
         step_errors.push(format!("working_dir cleanup refused: {reason}"));
     }
     // #1157: clean id-based metadata. Fleet.yaml is already removed above,

--- a/src/mcp/handlers/instance_state/lifecycle/tests.rs
+++ b/src/mcp/handlers/instance_state/lifecycle/tests.rs
@@ -667,7 +667,12 @@ fn full_delete_shared_sibling_default_preserves_all_bytes_2764_slice10a() {
     )
     .unwrap();
 
-    let _ = super::full_delete_instance(&home, "victim");
+    let result = super::full_delete_instance(&home, "victim");
+
+    assert!(
+        result.is_ok(),
+        "shared sibling teardown must succeed without mutating the survivor: {result:?}"
+    );
 
     assert!(
         cleanup_admission_canaries_intact(&sibling),
@@ -690,7 +695,12 @@ fn full_delete_shared_external_preserves_all_bytes_2764_slice10a() {
     )
     .unwrap();
 
-    let _ = super::full_delete_instance(&home, "victim");
+    let result = super::full_delete_instance(&home, "victim");
+
+    assert!(
+        result.is_ok(),
+        "shared external teardown must succeed without scrubbing the survivor: {result:?}"
+    );
 
     assert!(
         cleanup_admission_canaries_intact(&shared),
@@ -717,7 +727,12 @@ fn full_delete_symlink_alias_preserves_target_and_alias_2764_slice10a() {
     )
     .unwrap();
 
-    let _ = super::full_delete_instance(&home, "victim");
+    let result = super::full_delete_instance(&home, "victim");
+
+    assert!(
+        result.is_ok(),
+        "shared symlink teardown must succeed without mutating the target: {result:?}"
+    );
 
     assert!(
         cleanup_admission_canaries_intact(&sibling),
@@ -736,14 +751,23 @@ fn full_delete_symlink_alias_preserves_target_and_alias_2764_slice10a() {
 fn full_delete_unshared_default_still_removes_tree_2764_slice10a() {
     let home = tmp_home("slice10a_unshared_default");
     let victim_dir = crate::paths::workspace_dir(&home).join("victim");
-    cleanup_admission_seed_canaries(&victim_dir);
+    std::fs::create_dir_all(&victim_dir).unwrap();
+    std::fs::write(victim_dir.join("arbitrary.txt"), b"USER DATA").unwrap();
     std::fs::write(
         crate::fleet::fleet_yaml_path(&home),
-        "instances:\n  victim:\n    backend: claude\n",
+        format!(
+            "instances:\n  victim:\n    backend: claude\n    working_directory: {}\n",
+            victim_dir.display()
+        ),
     )
     .unwrap();
 
-    let _ = super::full_delete_instance(&home, "victim");
+    let result = super::full_delete_instance(&home, "victim");
+
+    assert!(
+        result.is_ok(),
+        "an unshared exact default teardown must succeed: {result:?}"
+    );
 
     assert!(
         !victim_dir.exists(),
@@ -759,7 +783,13 @@ fn full_delete_fleet_load_ambiguity_preserves_workspace_2764_slice10a() {
     cleanup_admission_seed_canaries(&victim_dir);
     std::fs::write(crate::fleet::fleet_yaml_path(&home), "instances: [\n").unwrap();
 
-    let _ = super::full_delete_instance(&home, "victim");
+    let result = super::full_delete_instance(&home, "victim");
+
+    let error = result.expect_err("malformed fleet state must fail closed loudly");
+    assert!(
+        error.contains("fleet.yaml removal"),
+        "malformed fleet failure should identify the fleet-store refusal: {error}"
+    );
 
     assert!(
         cleanup_admission_canaries_intact(&victim_dir),

--- a/src/mcp/handlers/instance_state/lifecycle/tests.rs
+++ b/src/mcp/handlers/instance_state/lifecycle/tests.rs
@@ -632,3 +632,138 @@ fn full_delete_clears_binding_and_succeeds_1879() {
 
     std::fs::remove_dir_all(&home).ok();
 }
+
+// ---------------------------------------------------------------------------
+// Architecture-14 Slice 10A: pre-delete CleanupAdmission (issue #2764)
+// ---------------------------------------------------------------------------
+
+fn cleanup_admission_seed_canaries(dir: &std::path::Path) {
+    std::fs::create_dir_all(dir.join(".codex")).unwrap();
+    std::fs::write(dir.join("arbitrary.txt"), b"USER DATA").unwrap();
+    std::fs::write(dir.join("AGENTS.md"), b"# agents\nuser-owned").unwrap();
+    std::fs::write(dir.join(".codex/config.toml"), b"key = 1\nuser-owned").unwrap();
+}
+
+fn cleanup_admission_canaries_intact(dir: &std::path::Path) -> bool {
+    std::fs::read(dir.join("arbitrary.txt")).ok().as_deref() == Some(b"USER DATA")
+        && std::fs::read(dir.join("AGENTS.md")).ok().as_deref() == Some(b"# agents\nuser-owned")
+        && std::fs::read(dir.join(".codex/config.toml"))
+            .ok()
+            .as_deref()
+            == Some(b"key = 1\nuser-owned")
+}
+
+#[test]
+fn full_delete_shared_sibling_default_preserves_all_bytes_2764_slice10a() {
+    let home = tmp_home("slice10a_sibling_default");
+    let sibling = crate::paths::workspace_dir(&home).join("sibling");
+    cleanup_admission_seed_canaries(&sibling);
+    std::fs::write(
+        crate::fleet::fleet_yaml_path(&home),
+        format!(
+            "instances:\n  victim:\n    backend: claude\n    working_directory: {}\n  sibling:\n    backend: claude\n",
+            sibling.display()
+        ),
+    )
+    .unwrap();
+
+    let _ = super::full_delete_instance(&home, "victim");
+
+    assert!(
+        cleanup_admission_canaries_intact(&sibling),
+        "shared sibling default must remain byte-identical"
+    );
+    std::fs::remove_dir_all(home).ok();
+}
+
+#[test]
+fn full_delete_shared_external_preserves_all_bytes_2764_slice10a() {
+    let home = tmp_home("slice10a_external_home");
+    let shared = tmp_home("slice10a_external_shared");
+    cleanup_admission_seed_canaries(&shared);
+    std::fs::write(
+        crate::fleet::fleet_yaml_path(&home),
+        format!(
+            "instances:\n  victim:\n    backend: claude\n    working_directory: {shared}\n  survivor:\n    backend: claude\n    working_directory: {shared}\n",
+            shared = shared.display()
+        ),
+    )
+    .unwrap();
+
+    let _ = super::full_delete_instance(&home, "victim");
+
+    assert!(
+        cleanup_admission_canaries_intact(&shared),
+        "shared external directory must not be backend-scrubbed"
+    );
+    std::fs::remove_dir_all(home).ok();
+    std::fs::remove_dir_all(shared).ok();
+}
+
+#[cfg(unix)]
+#[test]
+fn full_delete_symlink_alias_preserves_target_and_alias_2764_slice10a() {
+    let home = tmp_home("slice10a_symlink_alias");
+    let sibling = crate::paths::workspace_dir(&home).join("sibling");
+    let alias = crate::paths::workspace_dir(&home).join("victim-link");
+    cleanup_admission_seed_canaries(&sibling);
+    std::os::unix::fs::symlink(&sibling, &alias).unwrap();
+    std::fs::write(
+        crate::fleet::fleet_yaml_path(&home),
+        format!(
+            "instances:\n  victim:\n    backend: claude\n    working_directory: {}\n  sibling:\n    backend: claude\n",
+            alias.display()
+        ),
+    )
+    .unwrap();
+
+    let _ = super::full_delete_instance(&home, "victim");
+
+    assert!(
+        cleanup_admission_canaries_intact(&sibling),
+        "symlink alias must not remove or scrub its sibling target"
+    );
+    assert!(
+        std::fs::symlink_metadata(&alias)
+            .map(|meta| meta.file_type().is_symlink())
+            .unwrap_or(false),
+        "shared symlink alias must remain untouched"
+    );
+    std::fs::remove_dir_all(home).ok();
+}
+
+#[test]
+fn full_delete_unshared_default_still_removes_tree_2764_slice10a() {
+    let home = tmp_home("slice10a_unshared_default");
+    let victim_dir = crate::paths::workspace_dir(&home).join("victim");
+    cleanup_admission_seed_canaries(&victim_dir);
+    std::fs::write(
+        crate::fleet::fleet_yaml_path(&home),
+        "instances:\n  victim:\n    backend: claude\n",
+    )
+    .unwrap();
+
+    let _ = super::full_delete_instance(&home, "victim");
+
+    assert!(
+        !victim_dir.exists(),
+        "an unshared exact default workspace must still be removed"
+    );
+    std::fs::remove_dir_all(home).ok();
+}
+
+#[test]
+fn full_delete_fleet_load_ambiguity_preserves_workspace_2764_slice10a() {
+    let home = tmp_home("slice10a_fleet_ambiguous");
+    let victim_dir = crate::paths::workspace_dir(&home).join("victim");
+    cleanup_admission_seed_canaries(&victim_dir);
+    std::fs::write(crate::fleet::fleet_yaml_path(&home), "instances: [\n").unwrap();
+
+    let _ = super::full_delete_instance(&home, "victim");
+
+    assert!(
+        cleanup_admission_canaries_intact(&victim_dir),
+        "unreadable fleet state must fail closed before workspace deletion"
+    );
+    std::fs::remove_dir_all(home).ok();
+}

--- a/src/mcp/handlers/instance_state/lifecycle/tests.rs
+++ b/src/mcp/handlers/instance_state/lifecycle/tests.rs
@@ -797,3 +797,63 @@ fn full_delete_fleet_load_ambiguity_preserves_workspace_2764_slice10a() {
     );
     std::fs::remove_dir_all(home).ok();
 }
+
+#[cfg(unix)]
+#[test]
+fn full_delete_candidate_canonicalization_ambiguity_preserves_and_errors_2764_slice10a() {
+    let home = tmp_home("slice10a_candidate_ambiguous");
+    let victim_dir = crate::paths::workspace_dir(&home).join("victim");
+    cleanup_admission_seed_canaries(&victim_dir);
+    let ambiguous_candidate = victim_dir.join("ambiguous");
+    std::os::unix::fs::symlink(victim_dir.join("missing-target"), &ambiguous_candidate).unwrap();
+    std::fs::write(
+        crate::fleet::fleet_yaml_path(&home),
+        format!(
+            "instances:\n  victim:\n    backend: claude\n    working_directory: {}\n",
+            ambiguous_candidate.display()
+        ),
+    )
+    .unwrap();
+
+    let error = super::full_delete_instance(&home, "victim")
+        .expect_err("an unresolved candidate path must fail closed loudly");
+
+    assert!(
+        error.contains("candidate") && error.contains("cannot canonicalize"),
+        "candidate ambiguity should identify the admission refusal: {error}"
+    );
+    assert!(
+        cleanup_admission_canaries_intact(&victim_dir),
+        "candidate canonicalization ambiguity must preserve all victim bytes"
+    );
+    std::fs::remove_dir_all(home).ok();
+}
+
+#[test]
+fn full_delete_survivor_canonicalization_ambiguity_preserves_and_errors_2764_slice10a() {
+    let home = tmp_home("slice10a_survivor_ambiguous");
+    let victim_dir = crate::paths::workspace_dir(&home).join("victim");
+    cleanup_admission_seed_canaries(&victim_dir);
+    let missing_survivor = home.join("missing-survivor");
+    std::fs::write(
+        crate::fleet::fleet_yaml_path(&home),
+        format!(
+            "instances:\n  victim:\n    backend: claude\n  survivor:\n    backend: claude\n    working_directory: {}\n",
+            missing_survivor.display()
+        ),
+    )
+    .unwrap();
+
+    let error = super::full_delete_instance(&home, "victim")
+        .expect_err("an unresolved survivor path must fail closed loudly");
+
+    assert!(
+        error.contains("survivor 'survivor'") && error.contains("ambiguous"),
+        "survivor ambiguity should identify the admission refusal: {error}"
+    );
+    assert!(
+        cleanup_admission_canaries_intact(&victim_dir),
+        "survivor canonicalization ambiguity must preserve all victim bytes"
+    );
+    std::fs::remove_dir_all(home).ok();
+}


### PR DESCRIPTION
## Summary
- derive a typed pre-delete `CleanupAdmission` from the pre-delete FleetConfig snapshot
- preserve shared canonical directories completely, including external and symlink aliases
- allow recursive removal only for an unshared canonical `workspace/<instance>` path; retain narrow backend-file scrub for exclusive external paths
- fail closed on malformed FleetConfig, unresolved paths, path traversal, and post-admission canonical drift

## Verification
- RED then GREEN production-entry tests through `full_delete_instance`
- `cargo test --bin agend-terminal slice10a -- --nocapture`
- `cargo test --bin agend-terminal lifecycle::tests -- --nocapture`
- file-size invariants, rustfmt check, diff check, and exact clippy command pass

Decision: d-20260716155706755339-6
Issue: #2764
Review: dual (destructive P0)
