### PR TITLE
fix(#2765): exact-generation disposition ledger

### DIFF
--- a/src/agent/crash_disposition.rs
+++ b/src/agent/crash_disposition.rs
@@ -474,4 +474,98 @@ mod tests {
         assert!(ledger.mark_failed(failed_token));
         assert_eq!(ledger.disposition(failed.key()), Some(Disposition::Failed));
     }
+
+    #[test]
+    fn executing_cannot_be_mutated_by_late_claim_or_begin_or_discard() {
+        let ledger = CrashDispositionLedger::new();
+
+        let id_claim = InstanceId::new();
+        let deleted_claim = Arc::new(AtomicBool::new(false));
+        let claim_obs = observation(id_claim, SpawnGeneration::new(8), &deleted_claim, None);
+        ledger.register_generation(id_claim, claim_obs.generation);
+        assert!(ledger.publish(claim_obs.clone()));
+        let claim_token = ledger
+            .claim(claim_obs.key(), Claimant::Crash)
+            .expect("claim");
+        assert!(ledger.mark_ready(claim_token));
+        assert!(ledger.begin_execute(claim_token));
+        ledger.register_generation(id_claim, SpawnGeneration::new(9));
+        assert!(ledger
+            .claim(claim_obs.key(), Claimant::RespawnWatchdog)
+            .is_none());
+        assert_eq!(
+            ledger.disposition(claim_obs.key()),
+            Some(Disposition::Executing)
+        );
+
+        let id_begin = InstanceId::new();
+        let deleted_begin = Arc::new(AtomicBool::new(false));
+        let begin_obs = observation(id_begin, SpawnGeneration::new(10), &deleted_begin, None);
+        ledger.register_generation(id_begin, begin_obs.generation);
+        assert!(ledger.publish(begin_obs.clone()));
+        let begin_token = ledger
+            .claim(begin_obs.key(), Claimant::Crash)
+            .expect("claim");
+        assert!(ledger.mark_ready(begin_token));
+        assert!(ledger.begin_execute(begin_token));
+        deleted_begin.store(true, Ordering::SeqCst);
+        assert!(!ledger.begin_execute(begin_token));
+        assert!(!ledger.begin_execute(begin_token));
+        assert_eq!(
+            ledger.disposition(begin_obs.key()),
+            Some(Disposition::Executing)
+        );
+
+        let id_discard = InstanceId::new();
+        let deleted_discard = Arc::new(AtomicBool::new(false));
+        let discard_obs = observation(id_discard, SpawnGeneration::new(11), &deleted_discard, None);
+        ledger.register_generation(id_discard, discard_obs.generation);
+        assert!(ledger.publish(discard_obs.clone()));
+        let discard_token = ledger
+            .claim(discard_obs.key(), Claimant::Crash)
+            .expect("claim");
+        assert!(ledger.mark_ready(discard_token));
+        assert!(ledger.begin_execute(discard_token));
+        assert!(!ledger.discard(discard_obs.key()));
+        assert_eq!(
+            ledger.disposition(discard_obs.key()),
+            Some(Disposition::Executing)
+        );
+        assert!(ledger.mark_live(discard_token));
+        assert_eq!(
+            ledger.disposition(discard_obs.key()),
+            Some(Disposition::Live)
+        );
+    }
+
+    #[test]
+    fn superseded_terminal_entries_release_core_and_fence_late_publish() {
+        let ledger = CrashDispositionLedger::new();
+        let id = InstanceId::new();
+        let deleted = Arc::new(AtomicBool::new(false));
+        let old = observation(id, SpawnGeneration::new(12), &deleted, None);
+        let weak_core = Arc::downgrade(&old.core);
+        ledger.register_generation(id, old.generation);
+        assert!(ledger.publish(old.clone()));
+        let token = ledger.claim(old.key(), Claimant::Crash).expect("claim");
+        assert!(ledger.mark_ready(token));
+        assert!(ledger.begin_execute(token));
+        assert!(ledger.mark_failed(token));
+
+        ledger.register_generation(id, SpawnGeneration::new(13));
+        drop(old);
+        assert!(
+            weak_core.upgrade().is_none(),
+            "superseded terminal entries must not retain the old core Arc"
+        );
+        let late = observation(id, SpawnGeneration::new(12), &deleted, None);
+        assert!(!ledger.publish(late));
+        assert_eq!(
+            ledger.disposition(DispositionKey {
+                instance_id: id,
+                generation: SpawnGeneration::new(12)
+            }),
+            Some(Disposition::Failed)
+        );
+    }
 }

--- a/src/agent/crash_disposition.rs
+++ b/src/agent/crash_disposition.rs
@@ -1,0 +1,477 @@
+//! Exact-generation crash disposition authority.
+//!
+//! The PTY channel is only an advisory wake-up.  The owner-memory ledger below
+//! is the authority that fences an old process from a replacement generation
+//! and serialises crash/watchdog recovery claims.
+
+use super::AgentCore;
+use crate::sync_audit::CoreMutex;
+use crate::types::{AgentName, InstanceId};
+use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::fmt;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, OnceLock};
+
+/// Monotonic process-owner generation.  It is deliberately not persisted:
+/// restarting the owner starts a fresh namespace, while a replacement within
+/// one owner always receives a greater generation.
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub(crate) struct SpawnGeneration(u64);
+
+#[allow(dead_code)]
+impl SpawnGeneration {
+    pub(crate) const fn new(value: u64) -> Self {
+        Self(value)
+    }
+
+    pub(crate) const fn value(self) -> u64 {
+        self.0
+    }
+}
+
+/// Owner-scoped allocator.  Relaxed arithmetic is sufficient: ordering is
+/// carried by the ledger mutex and the only invariant is uniqueness/monotonicity.
+pub(crate) struct GenerationSource {
+    next: AtomicU64,
+}
+
+impl GenerationSource {
+    pub(crate) const fn new() -> Self {
+        Self {
+            next: AtomicU64::new(1),
+        }
+    }
+
+    pub(crate) fn next(&self) -> SpawnGeneration {
+        SpawnGeneration(self.next.fetch_add(1, Ordering::Relaxed))
+    }
+}
+
+static OWNER_GENERATIONS: OnceLock<GenerationSource> = OnceLock::new();
+
+pub(crate) fn owner_generation_source() -> &'static GenerationSource {
+    OWNER_GENERATIONS.get_or_init(GenerationSource::new)
+}
+
+/// Disposition state for one exact `(InstanceId, SpawnGeneration)` record.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum Disposition {
+    Pending,
+    Claimed,
+    Ready,
+    Executing,
+    Live,
+    Failed,
+    Discarded,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum Claimant {
+    Crash,
+    RespawnWatchdog,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct DispositionKey {
+    pub(crate) instance_id: InstanceId,
+    pub(crate) generation: SpawnGeneration,
+}
+
+/// Exact crash/startup-failure context captured before any name lookup can
+/// observe a replacement handle.  `core` and `deleted` are the old handle's
+/// own Arcs; the recovery sink must never substitute a by-name replacement.
+#[derive(Clone)]
+pub(crate) struct CrashObservation {
+    pub(crate) instance_id: InstanceId,
+    pub(crate) generation: SpawnGeneration,
+    pub(crate) core: Arc<CoreMutex<AgentCore>>,
+    pub(crate) deleted: Arc<AtomicBool>,
+    pub(crate) owner_shutdown: Option<Arc<AtomicBool>>,
+    pub(crate) name: AgentName,
+}
+
+impl fmt::Debug for CrashObservation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CrashObservation")
+            .field("instance_id", &self.instance_id)
+            .field("generation", &self.generation)
+            .field("deleted", &self.deleted.load(Ordering::SeqCst))
+            .field(
+                "owner_shutdown",
+                &self
+                    .owner_shutdown
+                    .as_ref()
+                    .map(|v| v.load(Ordering::SeqCst)),
+            )
+            .field("name", &self.name)
+            .finish()
+    }
+}
+
+impl CrashObservation {
+    pub(crate) fn key(&self) -> DispositionKey {
+        DispositionKey {
+            instance_id: self.instance_id,
+            generation: self.generation,
+        }
+    }
+
+    fn valid(&self, current: Option<SpawnGeneration>) -> bool {
+        current == Some(self.generation)
+            && !self.deleted.load(Ordering::SeqCst)
+            && !self
+                .owner_shutdown
+                .as_ref()
+                .map(|v| v.load(Ordering::SeqCst))
+                .unwrap_or(false)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct ClaimToken {
+    key: DispositionKey,
+}
+
+impl ClaimToken {
+    pub(crate) const fn key(self) -> DispositionKey {
+        self.key
+    }
+}
+
+struct Entry {
+    observation: CrashObservation,
+    disposition: Disposition,
+    claimant: Option<Claimant>,
+}
+
+struct LedgerInner {
+    current: HashMap<InstanceId, SpawnGeneration>,
+    entries: HashMap<DispositionKey, Entry>,
+}
+
+/// Owner-memory, single-lock disposition ledger.  All transitions and
+/// replacement invalidation happen under this mutex; callers snapshot the
+/// registry first and never hold a registry lock while entering here.
+pub(crate) struct CrashDispositionLedger {
+    inner: Mutex<LedgerInner>,
+}
+
+impl CrashDispositionLedger {
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: Mutex::new(LedgerInner {
+                current: HashMap::new(),
+                entries: HashMap::new(),
+            }),
+        }
+    }
+
+    /// Publish a source observation.  A deleted/shutdown source or stale
+    /// generation publishes nothing.  Duplicate publication of the same live
+    /// key is idempotent and leaves the existing disposition untouched.
+    pub(crate) fn publish(&self, observation: CrashObservation) -> bool {
+        let mut inner = self.inner.lock();
+        if observation.deleted.load(Ordering::SeqCst)
+            || observation
+                .owner_shutdown
+                .as_ref()
+                .map(|v| v.load(Ordering::SeqCst))
+                .unwrap_or(false)
+        {
+            return false;
+        }
+        let current = inner.current.get(&observation.instance_id).copied();
+        if current.is_some() && !observation.valid(current) {
+            return false;
+        }
+        if current.is_none() {
+            inner
+                .current
+                .insert(observation.instance_id, observation.generation);
+        }
+        let key = observation.key();
+        if let Some(entry) = inner.entries.get(&key) {
+            return entry.disposition != Disposition::Discarded;
+        }
+        inner.entries.insert(
+            key,
+            Entry {
+                observation,
+                disposition: Disposition::Pending,
+                claimant: None,
+            },
+        );
+        true
+    }
+
+    /// Register a newly installed handle generation and atomically discard all
+    /// older non-terminal records for that instance.
+    pub(crate) fn register_generation(&self, instance_id: InstanceId, generation: SpawnGeneration) {
+        let mut inner = self.inner.lock();
+        if inner
+            .current
+            .get(&instance_id)
+            .is_some_and(|old| *old >= generation)
+        {
+            return;
+        }
+        inner.current.insert(instance_id, generation);
+        for (key, entry) in &mut inner.entries {
+            if key.instance_id == instance_id
+                && key.generation != generation
+                && !matches!(
+                    entry.disposition,
+                    Disposition::Executing
+                        | Disposition::Live
+                        | Disposition::Failed
+                        | Disposition::Discarded
+                )
+            {
+                entry.disposition = Disposition::Discarded;
+            }
+        }
+    }
+
+    pub(crate) fn claim(&self, key: DispositionKey, claimant: Claimant) -> Option<ClaimToken> {
+        let mut inner = self.inner.lock();
+        let current = inner.current.get(&key.instance_id).copied();
+        let entry = inner.entries.get_mut(&key)?;
+        if !entry.observation.valid(current) {
+            entry.disposition = Disposition::Discarded;
+            return None;
+        }
+        if entry.disposition != Disposition::Pending {
+            return None;
+        }
+        entry.disposition = Disposition::Claimed;
+        entry.claimant = Some(claimant);
+        Some(ClaimToken { key })
+    }
+
+    pub(crate) fn mark_ready(&self, token: ClaimToken) -> bool {
+        self.transition(token, Disposition::Claimed, Disposition::Ready)
+    }
+
+    /// Revalidate the old handle's deleted/shutdown Arcs and current generation
+    /// while holding the same ledger lock that performs Discard invalidation.
+    pub(crate) fn begin_execute(&self, token: ClaimToken) -> bool {
+        let mut inner = self.inner.lock();
+        let current = inner.current.get(&token.key.instance_id).copied();
+        let Some(entry) = inner.entries.get_mut(&token.key) else {
+            return false;
+        };
+        if !entry.observation.valid(current) {
+            entry.disposition = Disposition::Discarded;
+            return false;
+        }
+        if entry.disposition != Disposition::Ready {
+            return false;
+        }
+        entry.disposition = Disposition::Executing;
+        true
+    }
+
+    pub(crate) fn mark_live(&self, token: ClaimToken) -> bool {
+        self.transition(token, Disposition::Executing, Disposition::Live)
+    }
+
+    pub(crate) fn mark_failed(&self, token: ClaimToken) -> bool {
+        self.transition(token, Disposition::Executing, Disposition::Failed)
+    }
+
+    pub(crate) fn discard(&self, key: DispositionKey) -> bool {
+        let mut inner = self.inner.lock();
+        let Some(entry) = inner.entries.get_mut(&key) else {
+            return false;
+        };
+        if matches!(
+            entry.disposition,
+            Disposition::Live | Disposition::Failed | Disposition::Discarded
+        ) {
+            return false;
+        }
+        entry.disposition = Disposition::Discarded;
+        true
+    }
+
+    pub(crate) fn disposition(&self, key: DispositionKey) -> Option<Disposition> {
+        self.inner
+            .lock()
+            .entries
+            .get(&key)
+            .map(|entry| entry.disposition)
+    }
+
+    /// Return pending observations for the per-tick recovery sweep.  Claimed or
+    /// executing work remains owned by its claimant; terminal Discarded records
+    /// are never returned.
+    pub(crate) fn pending(&self) -> Vec<CrashObservation> {
+        self.inner
+            .lock()
+            .entries
+            .values()
+            .filter(|entry| entry.disposition == Disposition::Pending)
+            .map(|entry| entry.observation.clone())
+            .collect()
+    }
+
+    fn transition(&self, token: ClaimToken, from: Disposition, to: Disposition) -> bool {
+        let mut inner = self.inner.lock();
+        let Some(entry) = inner.entries.get_mut(&token.key) else {
+            return false;
+        };
+        if entry.disposition != from {
+            return false;
+        }
+        entry.disposition = to;
+        true
+    }
+}
+
+static OWNER_LEDGER: OnceLock<CrashDispositionLedger> = OnceLock::new();
+static OWNER_CRASH_WAKE: OnceLock<crossbeam_channel::Sender<super::AgentExitEvent>> =
+    OnceLock::new();
+
+pub(crate) fn owner_ledger() -> &'static CrashDispositionLedger {
+    OWNER_LEDGER.get_or_init(CrashDispositionLedger::new)
+}
+
+pub(crate) fn install_owner_crash_wake(tx: crossbeam_channel::Sender<super::AgentExitEvent>) {
+    let _ = OWNER_CRASH_WAKE.set(tx);
+}
+
+pub(crate) fn owner_crash_wake() -> Option<crossbeam_channel::Sender<super::AgentExitEvent>> {
+    OWNER_CRASH_WAKE.get().cloned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::health::HealthTracker;
+    use crate::state::StateTracker;
+    use crate::vterm::VTerm;
+    use std::sync::atomic::AtomicBool;
+
+    fn observation(
+        id: InstanceId,
+        generation: SpawnGeneration,
+        deleted: &Arc<AtomicBool>,
+        shutdown: Option<&Arc<AtomicBool>>,
+    ) -> CrashObservation {
+        let core = Arc::new(CoreMutex::new(AgentCore {
+            vterm: VTerm::new(80, 24),
+            subscribers: Vec::new(),
+            state: StateTracker::new(None),
+            health: HealthTracker::new(),
+            api_activity: crate::agent::ApiActivity::default(),
+            observed_status: None,
+        }));
+        CrashObservation {
+            instance_id: id,
+            generation,
+            core,
+            deleted: Arc::clone(deleted),
+            owner_shutdown: shutdown.cloned(),
+            name: "ledger-test".into(),
+        }
+    }
+
+    #[test]
+    fn replacement_discards_old_pending_before_execution() {
+        let ledger = CrashDispositionLedger::new();
+        let id = InstanceId::new();
+        let deleted = Arc::new(AtomicBool::new(false));
+        let old = observation(id, SpawnGeneration::new(1), &deleted, None);
+        ledger.register_generation(id, old.generation);
+        assert!(ledger.publish(old.clone()));
+        let token = ledger.claim(old.key(), Claimant::Crash).expect("claim");
+        assert!(ledger.mark_ready(token));
+
+        ledger.register_generation(id, SpawnGeneration::new(2));
+        assert_eq!(ledger.disposition(old.key()), Some(Disposition::Discarded));
+        assert!(!ledger.begin_execute(token));
+        assert!(ledger.pending().is_empty());
+    }
+
+    #[test]
+    fn delete_and_shutdown_fence_publication_and_execution() {
+        let ledger = CrashDispositionLedger::new();
+        let id = InstanceId::new();
+        let deleted = Arc::new(AtomicBool::new(false));
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let obs = observation(id, SpawnGeneration::new(3), &deleted, Some(&shutdown));
+        ledger.register_generation(id, obs.generation);
+        assert!(ledger.publish(obs.clone()));
+        deleted.store(true, Ordering::SeqCst);
+        let token = ledger.claim(obs.key(), Claimant::Crash);
+        assert!(token.is_none());
+        assert_eq!(ledger.disposition(obs.key()), Some(Disposition::Discarded));
+
+        let id2 = InstanceId::new();
+        let deleted2 = Arc::new(AtomicBool::new(false));
+        let shutdown2 = Arc::new(AtomicBool::new(true));
+        let obs2 = observation(id2, SpawnGeneration::new(4), &deleted2, Some(&shutdown2));
+        assert!(!ledger.publish(obs2));
+    }
+
+    #[test]
+    fn one_atomic_claim_wins_between_crash_and_watchdog() {
+        let ledger = Arc::new(CrashDispositionLedger::new());
+        let id = InstanceId::new();
+        let deleted = Arc::new(AtomicBool::new(false));
+        let obs = observation(id, SpawnGeneration::new(5), &deleted, None);
+        ledger.register_generation(id, obs.generation);
+        assert!(ledger.publish(obs.clone()));
+        let barrier = Arc::new(std::sync::Barrier::new(3));
+        let a = {
+            let ledger = Arc::clone(&ledger);
+            let barrier = Arc::clone(&barrier);
+            let key = obs.key();
+            std::thread::spawn(move || {
+                barrier.wait();
+                ledger.claim(key, Claimant::Crash).is_some()
+            })
+        };
+        let b = {
+            let ledger = Arc::clone(&ledger);
+            let barrier = Arc::clone(&barrier);
+            let key = obs.key();
+            std::thread::spawn(move || {
+                barrier.wait();
+                ledger.claim(key, Claimant::RespawnWatchdog).is_some()
+            })
+        };
+        barrier.wait();
+        assert_ne!(
+            a.join().expect("crash claim thread"),
+            b.join().expect("watchdog claim thread")
+        );
+    }
+
+    #[test]
+    fn eligible_attempt_reaches_live_or_failed_only_after_execute() {
+        let ledger = CrashDispositionLedger::new();
+        let id = InstanceId::new();
+        let deleted = Arc::new(AtomicBool::new(false));
+        let live = observation(id, SpawnGeneration::new(6), &deleted, None);
+        ledger.register_generation(id, live.generation);
+        assert!(ledger.publish(live.clone()));
+        let live_token = ledger.claim(live.key(), Claimant::Crash).expect("claim");
+        assert!(ledger.mark_ready(live_token));
+        assert!(ledger.begin_execute(live_token));
+        assert!(ledger.mark_live(live_token));
+        assert_eq!(ledger.disposition(live.key()), Some(Disposition::Live));
+        assert!(!ledger.mark_failed(live_token));
+
+        let id2 = InstanceId::new();
+        let failed = observation(id2, SpawnGeneration::new(7), &deleted, None);
+        ledger.register_generation(id2, failed.generation);
+        assert!(ledger.publish(failed.clone()));
+        let failed_token = ledger.claim(failed.key(), Claimant::Crash).expect("claim");
+        assert!(ledger.mark_ready(failed_token));
+        assert!(ledger.begin_execute(failed_token));
+        assert!(ledger.mark_failed(failed_token));
+        assert_eq!(ledger.disposition(failed.key()), Some(Disposition::Failed));
+    }
+}

--- a/src/agent/crash_disposition.rs
+++ b/src/agent/crash_disposition.rs
@@ -140,10 +140,7 @@ impl ClaimToken {
 }
 
 struct Entry {
-    /// `None` is a compact tombstone.  The disposition remains queryable and
-    /// the owner `current` map still rejects late publication, while the old
-    /// generation's Core/deleted Arcs are released once it is superseded.
-    observation: Option<CrashObservation>,
+    observation: CrashObservation,
     disposition: Disposition,
     claimant: Option<Claimant>,
 }
@@ -195,12 +192,12 @@ impl CrashDispositionLedger {
         }
         let key = observation.key();
         if let Some(entry) = inner.entries.get(&key) {
-            return entry.observation.is_some() && entry.disposition != Disposition::Discarded;
+            return entry.disposition != Disposition::Discarded;
         }
         inner.entries.insert(
             key,
             Entry {
-                observation: Some(observation),
+                observation,
                 disposition: Disposition::Pending,
                 claimant: None,
             },
@@ -208,8 +205,9 @@ impl CrashDispositionLedger {
         true
     }
 
-    /// Register a newly installed handle generation and atomically discard all
-    /// older non-terminal records for that instance.
+    /// Register a newly installed handle generation and remove all superseded
+    /// records that are not currently executing.  The current-generation map
+    /// remains the late-publication fence after the old entry is removed.
     pub(crate) fn register_generation(&self, instance_id: InstanceId, generation: SpawnGeneration) {
         let mut inner = self.inner.lock();
         if inner
@@ -220,20 +218,11 @@ impl CrashDispositionLedger {
             return;
         }
         inner.current.insert(instance_id, generation);
-        for (key, entry) in &mut inner.entries {
-            if key.instance_id == instance_id
+        inner.entries.retain(|key, entry| {
+            !(key.instance_id == instance_id
                 && key.generation != generation
-                && entry.disposition != Disposition::Executing
-            {
-                if !matches!(
-                    entry.disposition,
-                    Disposition::Live | Disposition::Failed | Disposition::Discarded
-                ) {
-                    entry.disposition = Disposition::Discarded;
-                }
-                entry.observation = None;
-            }
-        }
+                && entry.disposition != Disposition::Executing)
+        });
     }
 
     pub(crate) fn claim(&self, key: DispositionKey, claimant: Claimant) -> Option<ClaimToken> {
@@ -246,10 +235,8 @@ impl CrashDispositionLedger {
         if entry.disposition != Disposition::Pending {
             return None;
         }
-        let observation = entry.observation.as_ref()?;
-        if !observation.valid(current) {
+        if !entry.observation.valid(current) {
             entry.disposition = Disposition::Discarded;
-            entry.observation = None;
             return None;
         }
         entry.disposition = Disposition::Claimed;
@@ -274,12 +261,8 @@ impl CrashDispositionLedger {
         if entry.disposition != Disposition::Ready {
             return false;
         }
-        let Some(observation) = entry.observation.as_ref() else {
-            return false;
-        };
-        if !observation.valid(current) {
+        if !entry.observation.valid(current) {
             entry.disposition = Disposition::Discarded;
-            entry.observation = None;
             return false;
         }
         entry.disposition = Disposition::Executing;
@@ -306,7 +289,6 @@ impl CrashDispositionLedger {
             return false;
         }
         entry.disposition = Disposition::Discarded;
-        entry.observation = None;
         true
     }
 
@@ -326,11 +308,8 @@ impl CrashDispositionLedger {
             .lock()
             .entries
             .values()
-            .filter_map(|entry| {
-                (entry.disposition == Disposition::Pending)
-                    .then(|| entry.observation.clone())
-                    .flatten()
-            })
+            .filter(|entry| entry.disposition == Disposition::Pending)
+            .map(|entry| entry.observation.clone())
             .collect()
     }
 
@@ -347,12 +326,14 @@ impl CrashDispositionLedger {
         if matches!(to, Disposition::Live | Disposition::Failed)
             && current != Some(token.key.generation)
         {
-            // An older worker may finish after a replacement generation was
-            // installed.  Keep its terminal tombstone, but release the heavy
-            // old observation now that no further execution is possible.
-            entry.observation = None;
+            inner.entries.remove(&token.key);
         }
         true
+    }
+
+    #[cfg(test)]
+    pub(crate) fn entry_count(&self) -> usize {
+        self.inner.lock().entries.len()
     }
 }
 
@@ -405,7 +386,7 @@ mod tests {
     }
 
     #[test]
-    fn replacement_discards_old_pending_before_execution() {
+    fn replacement_removes_old_pending_before_execution() {
         let ledger = CrashDispositionLedger::new();
         let id = InstanceId::new();
         let deleted = Arc::new(AtomicBool::new(false));
@@ -416,7 +397,7 @@ mod tests {
         assert!(ledger.mark_ready(token));
 
         ledger.register_generation(id, SpawnGeneration::new(2));
-        assert_eq!(ledger.disposition(old.key()), Some(Disposition::Discarded));
+        assert_eq!(ledger.disposition(old.key()), None);
         assert!(!ledger.begin_execute(token));
         assert!(ledger.pending().is_empty());
     }
@@ -594,7 +575,55 @@ mod tests {
                 instance_id: id,
                 generation: SpawnGeneration::new(12)
             }),
-            Some(Disposition::Failed)
+            None
         );
+        assert_eq!(ledger.entry_count(), 0);
+    }
+
+    #[test]
+    fn superseded_generations_are_removed_and_count_stays_bounded() {
+        let ledger = CrashDispositionLedger::new();
+        let id = InstanceId::new();
+        let deleted = Arc::new(AtomicBool::new(false));
+
+        for value in 20..=83 {
+            let generation = SpawnGeneration::new(value);
+            let obs = observation(id, generation, &deleted, None);
+            ledger.register_generation(id, generation);
+            assert!(ledger.publish(obs.clone()));
+            let token = ledger.claim(obs.key(), Claimant::Crash).expect("claim");
+            assert!(ledger.mark_ready(token));
+            assert!(ledger.discard(obs.key()));
+            assert!(
+                ledger.entry_count() <= 1,
+                "superseded entries must be removed, count={}",
+                ledger.entry_count()
+            );
+        }
+
+        let late = observation(id, SpawnGeneration::new(20), &deleted, None);
+        assert!(!ledger.publish(late));
+        assert!(ledger.entry_count() <= 1);
+    }
+
+    #[test]
+    fn superseded_executing_entry_is_removed_after_terminal_settlement() {
+        let ledger = CrashDispositionLedger::new();
+        let id = InstanceId::new();
+        let deleted = Arc::new(AtomicBool::new(false));
+        let old = observation(id, SpawnGeneration::new(84), &deleted, None);
+        let weak_core = Arc::downgrade(&old.core);
+        ledger.register_generation(id, old.generation);
+        assert!(ledger.publish(old.clone()));
+        let token = ledger.claim(old.key(), Claimant::Crash).expect("claim");
+        assert!(ledger.mark_ready(token));
+        assert!(ledger.begin_execute(token));
+        ledger.register_generation(id, SpawnGeneration::new(85));
+        assert_eq!(ledger.entry_count(), 1, "Executing remains owned");
+        assert!(ledger.mark_live(token));
+        drop(old);
+        assert_eq!(ledger.entry_count(), 0);
+        assert!(weak_core.upgrade().is_none());
+        assert_eq!(ledger.disposition(token.key()), None);
     }
 }

--- a/src/agent/crash_disposition.rs
+++ b/src/agent/crash_disposition.rs
@@ -140,7 +140,10 @@ impl ClaimToken {
 }
 
 struct Entry {
-    observation: CrashObservation,
+    /// `None` is a compact tombstone.  The disposition remains queryable and
+    /// the owner `current` map still rejects late publication, while the old
+    /// generation's Core/deleted Arcs are released once it is superseded.
+    observation: Option<CrashObservation>,
     disposition: Disposition,
     claimant: Option<Claimant>,
 }
@@ -192,12 +195,12 @@ impl CrashDispositionLedger {
         }
         let key = observation.key();
         if let Some(entry) = inner.entries.get(&key) {
-            return entry.disposition != Disposition::Discarded;
+            return entry.observation.is_some() && entry.disposition != Disposition::Discarded;
         }
         inner.entries.insert(
             key,
             Entry {
-                observation,
+                observation: Some(observation),
                 disposition: Disposition::Pending,
                 claimant: None,
             },
@@ -220,15 +223,15 @@ impl CrashDispositionLedger {
         for (key, entry) in &mut inner.entries {
             if key.instance_id == instance_id
                 && key.generation != generation
-                && !matches!(
-                    entry.disposition,
-                    Disposition::Executing
-                        | Disposition::Live
-                        | Disposition::Failed
-                        | Disposition::Discarded
-                )
+                && entry.disposition != Disposition::Executing
             {
-                entry.disposition = Disposition::Discarded;
+                if !matches!(
+                    entry.disposition,
+                    Disposition::Live | Disposition::Failed | Disposition::Discarded
+                ) {
+                    entry.disposition = Disposition::Discarded;
+                }
+                entry.observation = None;
             }
         }
     }
@@ -237,11 +240,16 @@ impl CrashDispositionLedger {
         let mut inner = self.inner.lock();
         let current = inner.current.get(&key.instance_id).copied();
         let entry = inner.entries.get_mut(&key)?;
-        if !entry.observation.valid(current) {
-            entry.disposition = Disposition::Discarded;
+        // State eligibility is checked before source validity.  An already
+        // Executing record remains owned and must never be rewritten to
+        // Discarded by a late delete/replacement observation.
+        if entry.disposition != Disposition::Pending {
             return None;
         }
-        if entry.disposition != Disposition::Pending {
+        let observation = entry.observation.as_ref()?;
+        if !observation.valid(current) {
+            entry.disposition = Disposition::Discarded;
+            entry.observation = None;
             return None;
         }
         entry.disposition = Disposition::Claimed;
@@ -261,11 +269,17 @@ impl CrashDispositionLedger {
         let Some(entry) = inner.entries.get_mut(&token.key) else {
             return false;
         };
-        if !entry.observation.valid(current) {
-            entry.disposition = Disposition::Discarded;
+        // Only Ready can enter execution.  In particular, a copied token or a
+        // late invalidation must not rewrite an already Executing record.
+        if entry.disposition != Disposition::Ready {
             return false;
         }
-        if entry.disposition != Disposition::Ready {
+        let Some(observation) = entry.observation.as_ref() else {
+            return false;
+        };
+        if !observation.valid(current) {
+            entry.disposition = Disposition::Discarded;
+            entry.observation = None;
             return false;
         }
         entry.disposition = Disposition::Executing;
@@ -285,13 +299,14 @@ impl CrashDispositionLedger {
         let Some(entry) = inner.entries.get_mut(&key) else {
             return false;
         };
-        if matches!(
+        if !matches!(
             entry.disposition,
-            Disposition::Live | Disposition::Failed | Disposition::Discarded
+            Disposition::Pending | Disposition::Claimed | Disposition::Ready
         ) {
             return false;
         }
         entry.disposition = Disposition::Discarded;
+        entry.observation = None;
         true
     }
 
@@ -311,13 +326,17 @@ impl CrashDispositionLedger {
             .lock()
             .entries
             .values()
-            .filter(|entry| entry.disposition == Disposition::Pending)
-            .map(|entry| entry.observation.clone())
+            .filter_map(|entry| {
+                (entry.disposition == Disposition::Pending)
+                    .then(|| entry.observation.clone())
+                    .flatten()
+            })
             .collect()
     }
 
     fn transition(&self, token: ClaimToken, from: Disposition, to: Disposition) -> bool {
         let mut inner = self.inner.lock();
+        let current = inner.current.get(&token.key.instance_id).copied();
         let Some(entry) = inner.entries.get_mut(&token.key) else {
             return false;
         };
@@ -325,6 +344,14 @@ impl CrashDispositionLedger {
             return false;
         }
         entry.disposition = to;
+        if matches!(to, Disposition::Live | Disposition::Failed)
+            && current != Some(token.key.generation)
+        {
+            // An older worker may finish after a replacement generation was
+            // installed.  Keep its terminal tombstone, but release the heavy
+            // old observation now that no further execution is possible.
+            entry.observation = None;
+        }
         true
     }
 }
@@ -403,9 +430,10 @@ mod tests {
         let obs = observation(id, SpawnGeneration::new(3), &deleted, Some(&shutdown));
         ledger.register_generation(id, obs.generation);
         assert!(ledger.publish(obs.clone()));
+        let token = ledger.claim(obs.key(), Claimant::Crash).expect("claim");
+        assert!(ledger.mark_ready(token));
         deleted.store(true, Ordering::SeqCst);
-        let token = ledger.claim(obs.key(), Claimant::Crash);
-        assert!(token.is_none());
+        assert!(!ledger.begin_execute(token));
         assert_eq!(ledger.disposition(obs.key()), Some(Disposition::Discarded));
 
         let id2 = InstanceId::new();
@@ -509,7 +537,8 @@ mod tests {
         assert!(ledger.mark_ready(begin_token));
         assert!(ledger.begin_execute(begin_token));
         deleted_begin.store(true, Ordering::SeqCst);
-        assert!(!ledger.begin_execute(begin_token));
+        let copied_begin_token = begin_token;
+        assert!(!ledger.begin_execute(copied_begin_token));
         assert!(!ledger.begin_execute(begin_token));
         assert_eq!(
             ledger.disposition(begin_obs.key()),

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 mod dismiss;
 #[allow(unused_imports)]
 pub use dismiss::try_dismiss_dialog;
+pub(crate) mod crash_disposition;
 use dismiss::{
     dismiss_scan_armed, is_dismissible_prompt_state, prepare_dismiss_patterns,
     try_prepared_dismiss_dialog, PreparedDismissPattern,
@@ -101,6 +102,9 @@ pub struct AgentHandle {
     /// slow `Fresh` (the load-bearing false-kill guard). Immutable for the life of
     /// the handle; a respawn replaces the whole handle with a freshly-stamped one.
     pub(crate) spawn_mode: crate::backend::SpawnMode,
+    /// Owner-scoped monotonic identity for the process represented by this
+    /// handle. Recovery must carry this exact generation, never just `name`.
+    pub(crate) generation: crash_disposition::SpawnGeneration,
     /// Set by DELETE handler to prevent reaper from spawning shell fallback.
     pub(crate) deleted: Arc<std::sync::atomic::AtomicBool>,
 }
@@ -592,7 +596,7 @@ fn strip_ansi(s: &str) -> String {
 #[derive(Debug, Clone)]
 pub enum AgentExitEvent {
     /// Agent crashed or exited unexpectedly — daemon should respawn.
-    Crash(String),
+    Crash(crash_disposition::CrashObservation),
     /// Agent exited cleanly (exit code 0, e.g. `/exit` or `/quit`) — no respawn.
     CleanExit(String),
 }
@@ -1302,6 +1306,7 @@ pub fn spawn_agent(
     // lookup. Extracted to `resolve_spawn_instance_id` so the managed/unmanaged
     // identity policy is unit-testable without a live PTY spawn.
     let instance_id = resolve_spawn_instance_id(config.home, name)?;
+    let generation = crash_disposition::owner_generation_source().next();
 
     // Register in registry
     {
@@ -1335,11 +1340,13 @@ pub fn spawn_agent(
                 // #t-777-3: stamp the spawn mode so the respawn-stuck watchdog
                 // distinguishes a hung Resume from a slow Fresh boot.
                 spawn_mode: config.spawn_mode,
+                generation,
                 deleted: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             },
         );
     }
     rollback.mark_registered(instance_id);
+    crash_disposition::owner_ledger().register_generation(instance_id, generation);
 
     // PTY read thread — feeds VTerm + broadcasts + auto-dismiss trust dialog + session reaper
     let core2 = Arc::clone(&core);
@@ -1377,6 +1384,7 @@ pub fn spawn_agent(
         dismiss_patterns: dismiss,
         shutdown: shutdown_for_reaper,
         deleted: deleted_for_reaper,
+        generation,
     };
     let capture = {
         let backend_str = detected_backend
@@ -1688,6 +1696,7 @@ struct PtyReadContext {
     dismiss_patterns: Vec<PreparedDismissPattern>,
     shutdown: Option<Arc<std::sync::atomic::AtomicBool>>,
     deleted: Arc<std::sync::atomic::AtomicBool>,
+    generation: crash_disposition::SpawnGeneration,
 }
 
 /// PTY read loop: feeds VTerm, broadcasts output, auto-dismisses dialogs, handles exit.
@@ -1750,6 +1759,7 @@ fn pty_read_loop(
         dismiss_patterns,
         shutdown,
         deleted,
+        generation,
     } = ctx;
     let mut buf = [0u8; 8192];
     let mut dismiss_cooldown_until: Option<std::time::Instant> = None;
@@ -1888,6 +1898,8 @@ fn pty_read_loop(
         crash_tx,
         shutdown,
         deleted,
+        core,
+        *generation,
     );
 }
 
@@ -2037,12 +2049,13 @@ fn is_startup_failure(name: &str, id: &crate::types::InstanceId, registry: &Agen
 }
 
 fn on_startup_failure(
-    name: &str,
+    observation: &crash_disposition::CrashObservation,
     home: &Option<std::path::PathBuf>,
     crash_tx: &Option<CrashChannel>,
 ) {
+    let name = observation.name.as_ref();
     tracing::warn!(
-        agent = name,
+        agent = %name,
         "startup failure (exited too quickly, no user input)"
     );
     if let Some(ref home) = home {
@@ -2053,8 +2066,13 @@ fn on_startup_failure(
             "exited too quickly, no user input",
         );
     }
+    if !crash_disposition::owner_ledger().publish(observation.clone()) {
+        return;
+    }
     if let Some(ref tx) = crash_tx {
-        let _ = tx.send(AgentExitEvent::Crash(name.to_string()));
+        if let Err(e) = tx.try_send(AgentExitEvent::Crash(observation.clone())) {
+            tracing::warn!(agent = %name, error = %e, "startup-failure channel wake dropped; ledger sweep remains authoritative");
+        }
     }
 }
 
@@ -2152,30 +2170,23 @@ fn on_clean_exit_shell_fallback(
 }
 
 fn on_crash_exit(
-    name: &str,
-    id: &crate::types::InstanceId,
-    registry: &AgentRegistry,
+    observation: &crash_disposition::CrashObservation,
     crash_tx: &Option<CrashChannel>,
 ) {
-    tracing::info!(agent = name, "setting restarting state");
-    {
-        let reg = lock_registry(registry);
-        if let Some(handle) = reg.get(id) {
-            // registry → core order; `core` is a short non-self-IPC temporary
-            // (set_restarting only) dropped on this statement. Safe per the
-            // unidirectional registry→core invariant — no reverse path in-tree
-            // (#1593 killed it; runtime guard #1492/#1535) — so no snapshot-Arc.
-            // See the spawn-site note + docs/DAEMON-LOCK-ORDERING.md.
-            handle.core.lock().state.set_restarting();
-        }
+    let name = observation.name.as_ref();
+    if !crash_disposition::owner_ledger().publish(observation.clone()) {
+        return;
     }
+    tracing::info!(agent = name, "setting restarting state");
+    observation.core.lock().state.set_restarting();
     if let Some(ref tx) = crash_tx {
-        if let Err(e) = tx.try_send(AgentExitEvent::Crash(name.to_string())) {
+        if let Err(e) = tx.try_send(AgentExitEvent::Crash(observation.clone())) {
             tracing::warn!(agent = %name, error = %e, "crash channel full — respawn event dropped");
         }
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn handle_pty_close(
     name: &str,
     id: &crate::types::InstanceId,
@@ -2184,6 +2195,8 @@ fn handle_pty_close(
     crash_tx: &Option<CrashChannel>,
     shutdown: &Option<Arc<std::sync::atomic::AtomicBool>>,
     deleted: &Arc<std::sync::atomic::AtomicBool>,
+    core: &Arc<CoreMutex<AgentCore>>,
+    generation: crash_disposition::SpawnGeneration,
 ) {
     let is_shutdown = shutdown
         .as_ref()
@@ -2215,7 +2228,18 @@ fn handle_pty_close(
     match classify_exit(exit_code) {
         ExitKind::UserExit => {
             if is_startup_failure(name, id, registry) {
-                on_startup_failure(name, home, crash_tx);
+                on_startup_failure(
+                    &crash_disposition::CrashObservation {
+                        instance_id: *id,
+                        generation,
+                        core: Arc::clone(core),
+                        deleted: Arc::clone(deleted),
+                        owner_shutdown: shutdown.clone(),
+                        name: name.to_string().into(),
+                    },
+                    home,
+                    crash_tx,
+                );
             } else {
                 on_clean_exit_shell_fallback(
                     name, id, exit_code, registry, home, crash_tx, shutdown,
@@ -2254,7 +2278,17 @@ fn handle_pty_close(
             cleanup_agent(name, id, registry, home);
         }
         ExitKind::Crash => {
-            on_crash_exit(name, id, registry, crash_tx);
+            on_crash_exit(
+                &crash_disposition::CrashObservation {
+                    instance_id: *id,
+                    generation,
+                    core: Arc::clone(core),
+                    deleted: Arc::clone(deleted),
+                    owner_shutdown: shutdown.clone(),
+                    name: name.to_string().into(),
+                },
+                crash_tx,
+            );
         }
     }
 }
@@ -2850,6 +2884,7 @@ pub(crate) fn mk_test_handle(name: &str, id: crate::types::InstanceId) -> AgentH
         spawned_at: std::time::Instant::now(),
         spawned_at_epoch_ms: 0,
         spawn_mode: crate::backend::SpawnMode::Fresh,
+        generation: crash_disposition::SpawnGeneration::default(),
         deleted: Arc::new(std::sync::atomic::AtomicBool::new(false)),
     }
 }

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -385,6 +385,7 @@ fn sweep_child_tree_body(pid_file: &std::path::Path) {
         spawned_at: std::time::Instant::now(),
         spawned_at_epoch_ms: 0,
         spawn_mode: crate::backend::SpawnMode::Fresh,
+        generation: crate::agent::crash_disposition::SpawnGeneration::default(),
         deleted: Arc::new(std::sync::atomic::AtomicBool::new(false)),
     };
     let registry: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
@@ -1001,6 +1002,7 @@ fn write_to_agent_typed_uses_timeout() {
         spawned_at: std::time::Instant::now(),
         spawned_at_epoch_ms: 0,
         spawn_mode: crate::backend::SpawnMode::Fresh,
+        generation: crate::agent::crash_disposition::SpawnGeneration::default(),
         deleted: Arc::new(std::sync::atomic::AtomicBool::new(false)),
     };
     let result = write_to_agent_typed(&handle, b"x");
@@ -1841,6 +1843,7 @@ fn pty_read_error_triggers_cleanup() {
             spawned_at: std::time::Instant::now(),
             spawned_at_epoch_ms: 0,
             spawn_mode: crate::backend::SpawnMode::Fresh,
+            generation: crate::agent::crash_disposition::SpawnGeneration::default(),
             deleted: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         },
     );
@@ -1861,6 +1864,7 @@ fn pty_read_error_triggers_cleanup() {
         dismiss_patterns: Vec::new(),
         shutdown: Some(shutdown),
         deleted: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        generation: crate::agent::crash_disposition::SpawnGeneration::default(),
     };
 
     let mut reader = FailingReader {
@@ -1887,11 +1891,9 @@ fn pty_read_error_triggers_cleanup() {
 //   `restart_instance` issues DELETE(no_wait) → SPAWN. The
 //   new instance is re-created under the SAME name (with a fresh
 //   `deleted=false` handle) BEFORE the OS reaps the old process and its death is
-//   classified. `AgentExitEvent::Crash` carries only the NAME (no PID /
-//   generation), so the #1913 crash-respawn SINK gates (config-by-name,
-//   deleted-by-name, registry-by-name in `daemon::crash_respawn`) all resolve to
-//   the NEW healthy handle — they would let the OLD process's death drive a
-//   respawn → a second, duplicate instance (double-spawn / zombie PTY).
+//   classified. The exact-generation ledger now fences that old observation;
+//   these source-side tests remain the first guard because a deleted handle must
+//   never publish a recovery wake in the first place.
 //
 //   The ONLY reliable protection is the SOURCE guard inside `handle_pty_close`:
 //   it checks the OLD handle's OWN `deleted` Arc — captured by Arc identity at
@@ -1902,8 +1904,8 @@ fn pty_read_error_triggers_cleanup() {
 //   SeqCst load reliably sees `true`.
 //
 //   If anyone ever moves the `deleted` check after `classify_exit`, or lets a
-//   path emit an exit event before it, these two tests MUST go RED — the
-//   name-keyed sink gates will silently fail to catch that regression.
+//   path emit an exit event before it, these two tests MUST go RED — source
+//   suppression remains the earliest and most precise teardown fence.
 
 /// Build an agent handle whose backend child exits with a CRASH-classified code
 /// (3 → `ExitKind::Crash`, distinct from 0/130 user-exit and 137/143
@@ -1912,7 +1914,8 @@ fn pty_read_error_triggers_cleanup() {
 /// real exit code.
 #[allow(clippy::unwrap_used)]
 fn make_crash_exit_handle(deleted: bool) -> (AgentHandle, crate::types::InstanceId) {
-    let id = crate::types::InstanceId::default();
+    let id = crate::types::InstanceId::new();
+    let generation = crate::agent::crash_disposition::owner_generation_source().next();
     let pty_writer: PtyWriter = Arc::new(Mutex::new(Box::new(Vec::<u8>::new())));
     let core = Arc::new(crate::sync_audit::CoreMutex::new(AgentCore {
         vterm: VTerm::new(80, 24),
@@ -1962,6 +1965,7 @@ fn make_crash_exit_handle(deleted: bool) -> (AgentHandle, crate::types::Instance
         spawned_at: std::time::Instant::now(),
         spawned_at_epoch_ms: 0,
         spawn_mode: crate::backend::SpawnMode::Fresh,
+        generation,
         deleted: Arc::new(std::sync::atomic::AtomicBool::new(deleted)),
     };
     (handle, id)
@@ -1982,6 +1986,7 @@ fn run_pty_close_capturing_crash(
     let core = Arc::clone(&handle.core);
     let pty_writer = Arc::clone(&handle.pty_writer);
     let deleted = Arc::clone(&handle.deleted);
+    let generation = handle.generation;
     registry.lock().insert(id, handle);
     let (tx, rx) = crossbeam_channel::unbounded();
     let ctx = PtyReadContext {
@@ -1995,6 +2000,7 @@ fn run_pty_close_capturing_crash(
         dismiss_patterns: Vec::new(),
         shutdown: Some(Arc::new(std::sync::atomic::AtomicBool::new(false))),
         deleted,
+        generation,
     };
     struct EofReader;
     impl std::io::Read for EofReader {
@@ -2060,7 +2066,32 @@ fn crash_publication_carries_exact_generation_context_slice1_red() {
     assert_eq!(observation.instance_id, id);
     assert!(observation.generation.value() > 0);
     assert!(std::sync::Arc::strong_count(&observation.core) >= 1);
-    assert!(!observation.deleted.load(std::sync::atomic::Ordering::SeqCst));
+    assert!(!observation
+        .deleted
+        .load(std::sync::atomic::Ordering::SeqCst));
+}
+
+#[test]
+#[allow(clippy::unwrap_used)]
+fn startup_failure_publication_carries_exact_generation_context_slice1() {
+    let (handle, id) = make_crash_exit_handle(false);
+    let observation = crate::agent::crash_disposition::CrashObservation {
+        instance_id: id,
+        generation: handle.generation,
+        core: Arc::clone(&handle.core),
+        deleted: Arc::clone(&handle.deleted),
+        owner_shutdown: None,
+        name: handle.name.clone(),
+    };
+    let (tx, rx) = crossbeam_channel::bounded(1);
+    on_startup_failure(&observation, &None, &Some(tx));
+    let got = rx.try_recv().unwrap();
+    let crate::agent::AgentExitEvent::Crash(observation) = got else {
+        panic!("startup failure must publish a Crash observation");
+    };
+    assert_eq!(observation.instance_id, id);
+    assert_eq!(observation.generation, handle.generation);
+    assert!(Arc::ptr_eq(&observation.core, &handle.core));
 }
 
 struct ChunkReader {
@@ -2124,6 +2155,7 @@ fn run_pty_read_loop_for_r8(
         dismiss_patterns: dismiss::prepare_dismiss_patterns(&dismiss_patterns),
         shutdown: Some(Arc::new(std::sync::atomic::AtomicBool::new(true))),
         deleted: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        generation: crate::agent::crash_disposition::SpawnGeneration::default(),
     };
     let mut reader = ChunkReader { chunks, next: 0 };
     let capture = crate::capture::make_capture_writer(None, "r8-dismiss-test", backend.name());
@@ -2323,6 +2355,7 @@ fn mk_handle_1441(name: &str, id: crate::types::InstanceId) -> AgentHandle {
         spawned_at: std::time::Instant::now(),
         spawned_at_epoch_ms: 0,
         spawn_mode: crate::backend::SpawnMode::Fresh,
+        generation: crate::agent::crash_disposition::SpawnGeneration::default(),
         deleted: Arc::new(std::sync::atomic::AtomicBool::new(false)),
     }
 }

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -2045,6 +2045,24 @@ fn deleted_guard_is_precise_real_crash_still_emits_rank4() {
     );
 }
 
+/// Slice-1 RED: a production PTY crash publication must carry the exact
+/// generation/core/deleted context that belongs to the reaped handle.  The
+/// legacy name-only event cannot prove ABA safety at the recovery sink.
+#[test]
+#[allow(clippy::unwrap_used)]
+fn crash_publication_carries_exact_generation_context_slice1_red() {
+    let (handle, id) = make_crash_exit_handle(false);
+    let rx = run_pty_close_capturing_crash(handle, id);
+    let got = rx.try_recv().unwrap();
+    let crate::agent::AgentExitEvent::Crash(observation) = got else {
+        panic!("real crash must publish a Crash observation");
+    };
+    assert_eq!(observation.instance_id, id);
+    assert!(observation.generation.value() > 0);
+    assert!(std::sync::Arc::strong_count(&observation.core) >= 1);
+    assert!(!observation.deleted.load(std::sync::atomic::Ordering::SeqCst));
+}
+
 struct ChunkReader {
     chunks: Vec<&'static [u8]>,
     next: usize,

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -2058,13 +2058,14 @@ fn deleted_guard_is_precise_real_crash_still_emits_rank4() {
 #[allow(clippy::unwrap_used)]
 fn crash_publication_carries_exact_generation_context_slice1_red() {
     let (handle, id) = make_crash_exit_handle(false);
+    let expected_generation = handle.generation;
     let rx = run_pty_close_capturing_crash(handle, id);
     let got = rx.try_recv().unwrap();
     let crate::agent::AgentExitEvent::Crash(observation) = got else {
         panic!("real crash must publish a Crash observation");
     };
     assert_eq!(observation.instance_id, id);
-    assert!(observation.generation.value() > 0);
+    assert_eq!(observation.generation, expected_generation);
     assert!(std::sync::Arc::strong_count(&observation.core) >= 1);
     assert!(!observation
         .deleted

--- a/src/daemon/crash_respawn.rs
+++ b/src/daemon/crash_respawn.rs
@@ -88,14 +88,22 @@ pub(super) fn handle_crash_observation(
     let self_orch = crate::teams::self_orch_status(home, crashed_name);
     let is_self_orch = self_orch == crate::teams::SelfOrchStatus::Yes;
 
-    let (
-        should_respawn,
-        delay,
-        should_notify,
-        fire_self_orch_p0,
-        fire_terminal_p0,
-        escalation_snapshot,
-    ) = {
+    enum RegistryOutcome {
+        Deleted,
+        Missing,
+        Healthy {
+            should_respawn: bool,
+            delay: std::time::Duration,
+            should_notify: bool,
+            fire_self_orch_p0: bool,
+            fire_terminal_p0: bool,
+            escalation_snapshot: crate::health::PersistedEscalation,
+        },
+    }
+
+    // Snapshot health and the deleted/missing outcome while holding the
+    // registry guard. Ledger settlement happens after this guard drops.
+    let registry_outcome = {
         let reg = agent::lock_registry(&ctx.registry);
         match reg.get(&instance_id) {
             Some(handle) => {
@@ -118,44 +126,79 @@ pub(super) fn handle_crash_observation(
                         agent = %crashed_name,
                         "exit is an intentional delete (deleted flag set) — skipping crash-respawn"
                     );
-                    ledger.discard(key);
-                    return;
+                    RegistryOutcome::Deleted
+                } else {
+                    let mut core = handle.core.lock();
+                    // #1701: decide the self-orch P0 BEFORE record_crash (which may
+                    // itself stamp the crash cooldown on its recent>=2 path) — the
+                    // accessor reads+stamps the crash-class cooldown (#1744-H3:
+                    // distinct from the hung cooldown), and for a self-orchestrator we
+                    // use ONLY this gate, never the generic recent>=2 one. The `&&`
+                    // short-circuits for non-orchestrators, so their cooldown is
+                    // untouched.
+                    let fire_p0 = is_self_orch && core.health.self_orch_crash_should_notify();
+                    let (respawn, delay, notify) = core.health.record_crash();
+                    // #1744-H4: a terminal Failed (max-retries) self-orchestrator crash
+                    // is a PERMANENT leaderless death. record_crash returns notify=true
+                    // ("don't respawn, do notify"), but fire_p0 is cooldown-gated and
+                    // the generic notify branch below is `!is_self_orch` — so without
+                    // this it pages NEITHER. Fire a once-off, cooldown-EXEMPT terminal
+                    // P0, fail-closed (Yes|Unknown fire, No skip), latched via the
+                    // PERSISTED `failed_escalated` so a restart (which rehydrates the
+                    // crash budget but not `state`) doesn't re-page the same death.
+                    let fire_terminal =
+                        should_fire_terminal_p0(respawn, self_orch, core.health.failed_escalated);
+                    if fire_terminal {
+                        core.health.failed_escalated = true;
+                    }
+                    // #1744-H2: snapshot the (just-mutated) escalation state under the
+                    // lock; persisted lock-free below so the crash budget + cooldown
+                    // (+ #1744-H4 failed_escalated) survive a daemon restart.
+                    let snap = core.health.escalation_snapshot();
+                    RegistryOutcome::Healthy {
+                        should_respawn: respawn,
+                        delay,
+                        should_notify: notify,
+                        fire_self_orch_p0: fire_p0,
+                        fire_terminal_p0: fire_terminal,
+                        escalation_snapshot: snap,
+                    }
                 }
-                let mut core = handle.core.lock();
-                // #1701: decide the self-orch P0 BEFORE record_crash (which may
-                // itself stamp the crash cooldown on its recent>=2 path) — the
-                // accessor reads+stamps the crash-class cooldown (#1744-H3:
-                // distinct from the hung cooldown), and for a self-orchestrator we
-                // use ONLY this gate, never the generic recent>=2 one. The `&&`
-                // short-circuits for non-orchestrators, so their cooldown is
-                // untouched.
-                let fire_p0 = is_self_orch && core.health.self_orch_crash_should_notify();
-                let (respawn, delay, notify) = core.health.record_crash();
-                // #1744-H4: a terminal Failed (max-retries) self-orchestrator crash
-                // is a PERMANENT leaderless death. record_crash returns notify=true
-                // ("don't respawn, do notify"), but fire_p0 is cooldown-gated and
-                // the generic notify branch below is `!is_self_orch` — so without
-                // this it pages NEITHER. Fire a once-off, cooldown-EXEMPT terminal
-                // P0, fail-closed (Yes|Unknown fire, No skip), latched via the
-                // PERSISTED `failed_escalated` so a restart (which rehydrates the
-                // crash budget but not `state`) doesn't re-page the same death.
-                let fire_terminal =
-                    should_fire_terminal_p0(respawn, self_orch, core.health.failed_escalated);
-                if fire_terminal {
-                    core.health.failed_escalated = true;
-                }
-                // #1744-H2: snapshot the (just-mutated) escalation state under the
-                // lock; persisted lock-free below so the crash budget + cooldown
-                // (+ #1744-H4 failed_escalated) survive a daemon restart.
-                let snap = core.health.escalation_snapshot();
-                (respawn, delay, notify, fire_p0, fire_terminal, snap)
             }
             None => {
                 tracing::warn!(agent = %crashed_name, "not in registry, skipping");
-                ledger.discard(key);
-                return;
+                RegistryOutcome::Missing
             }
         }
+    };
+
+    let (
+        should_respawn,
+        delay,
+        should_notify,
+        fire_self_orch_p0,
+        fire_terminal_p0,
+        escalation_snapshot,
+    ) = match registry_outcome {
+        RegistryOutcome::Deleted | RegistryOutcome::Missing => {
+            ledger.discard(key);
+            return;
+        }
+        RegistryOutcome::Healthy {
+            should_respawn,
+            delay,
+            should_notify,
+            fire_self_orch_p0,
+            fire_terminal_p0,
+            escalation_snapshot,
+        } => (
+            should_respawn,
+            delay,
+            should_notify,
+            fire_self_orch_p0,
+            fire_terminal_p0,
+            escalation_snapshot,
+        ),
     };
 
     // #1744-H2: persist the crash budget + crash cooldown (lock released above).

--- a/src/daemon/crash_respawn.rs
+++ b/src/daemon/crash_respawn.rs
@@ -533,7 +533,7 @@ mod tests {
 /// gate, so `0` proves the gate fired and `1` proves it let a real crash through.
 #[cfg(test)]
 mod deleted_gate_tests_1913 {
-    use super::handle_crash_respawn;
+    use super::{handle_crash_observation, handle_crash_respawn};
     use super::{AgentConfig, DaemonContext};
     use crate::agent::{AgentHandle, AgentRegistry};
     use crate::types::InstanceId;
@@ -746,6 +746,40 @@ mod deleted_gate_tests_1913 {
             assert_eq!(core.health.state, crate::health::HealthState::Failed);
         }
 
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn missing_registry_after_ready_is_discarded() {
+        let home = tmp_home("missing-registry");
+        let handle = make_handle(false);
+        let observation = crate::agent::crash_disposition::CrashObservation {
+            // Keep this key unique so parallel tests cannot reuse the fixed
+            // fleet UUID used by the legacy delete-gate fixtures.
+            instance_id: InstanceId::new(),
+            generation: handle.generation,
+            core: Arc::clone(&handle.core),
+            deleted: Arc::clone(&handle.deleted),
+            owner_shutdown: None,
+            name: handle.name.clone(),
+        };
+        let key = observation.key();
+        let registry: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let ctx = make_ctx(registry);
+
+        handle_crash_observation(&home, &observation, &ctx);
+
+        assert_eq!(
+            crate::agent::crash_disposition::owner_ledger().disposition(key),
+            Some(crate::agent::crash_disposition::Disposition::Discarded)
+        );
+        assert!(
+            !crate::agent::crash_disposition::owner_ledger()
+                .pending()
+                .iter()
+                .any(|pending| pending.key() == key),
+            "a missing registry must not strand a Ready recovery as Pending"
+        );
         std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/daemon/crash_respawn.rs
+++ b/src/daemon/crash_respawn.rs
@@ -9,6 +9,7 @@
 //! does NOT apply here: the fleet keeps self-healing even in away/sleep. An
 //! agent cannot invoke this (it can at most crash ITSELF → its own respawn).
 
+use crate::agent::crash_disposition::{ClaimToken, Claimant, CrashObservation};
 use crate::agent::{self, AgentRegistry};
 use crate::channel::NotifySeverity;
 use std::path::Path;
@@ -17,7 +18,50 @@ use std::sync::Arc;
 
 use super::{run_dir, serve_agent_tui, AgentConfig, DaemonContext};
 
+/// Compatibility entry used by legacy tests and name-triggered internal call
+/// sites. Production PTY events use [`handle_crash_observation`] directly.
+#[allow(dead_code)]
 pub(super) fn handle_crash_respawn(home: &Path, crashed_name: &str, ctx: &DaemonContext) {
+    let Some(instance_id) = crate::fleet::resolve_uuid(home, crashed_name) else {
+        tracing::warn!(agent = %crashed_name, "no fleet UUID, skipping respawn");
+        return;
+    };
+    let observation = {
+        let reg = agent::lock_registry(&ctx.registry);
+        reg.get(&instance_id).map(|handle| CrashObservation {
+            instance_id,
+            generation: handle.generation,
+            core: Arc::clone(&handle.core),
+            deleted: Arc::clone(&handle.deleted),
+            // Name-triggered compatibility entry is not a source publication;
+            // the source event already carries its own shutdown Arc.
+            owner_shutdown: None,
+            name: handle.name.clone(),
+        })
+    };
+    let Some(observation) = observation else {
+        return;
+    };
+    handle_crash_observation(home, &observation, ctx);
+}
+
+pub(super) fn handle_crash_observation(
+    home: &Path,
+    observation: &CrashObservation,
+    ctx: &DaemonContext,
+) {
+    let crashed_name = observation.name.as_str();
+    let key = observation.key();
+    let ledger = agent::crash_disposition::owner_ledger();
+    if ledger.disposition(key).is_none() && !ledger.publish(observation.clone()) {
+        return;
+    }
+    let Some(claim) = ledger.claim(key, Claimant::Crash) else {
+        return;
+    };
+    if !ledger.mark_ready(claim) {
+        return;
+    }
     tracing::warn!(agent = %crashed_name, "crashed");
     crate::event_log::log(home, "crash", crashed_name, "agent crashed");
 
@@ -25,15 +69,12 @@ pub(super) fn handle_crash_respawn(home: &Path, crashed_name: &str, ctx: &Daemon
         Some(c) => c,
         None => {
             tracing::debug!(agent = %crashed_name, "no config for respawn (likely deleted)");
+            ledger.discard(key);
             return;
         }
     };
 
-    // #1441: registry is UUID-keyed; resolve the crashed name via fleet.yaml.
-    let Some(instance_id) = crate::fleet::resolve_uuid(home, crashed_name) else {
-        tracing::warn!(agent = %crashed_name, "no fleet UUID, skipping respawn");
-        return;
-    };
+    let instance_id = observation.instance_id;
 
     // #1701: is the crashed agent its OWN team orchestrator? Resolved here (a
     // teams-file read) BEFORE taking the registry lock, so no file IO runs under
@@ -134,6 +175,7 @@ pub(super) fn handle_crash_respawn(home: &Path, crashed_name: &str, ctx: &Daemon
 
     if !should_respawn {
         tracing::warn!(agent = %crashed_name, "max retries exceeded, not respawning");
+        ledger.discard(key);
         return;
     }
 
@@ -162,10 +204,40 @@ pub(super) fn handle_crash_respawn(home: &Path, crashed_name: &str, ctx: &Daemon
                 &reg,
                 tx,
                 &shutdown_for_respawn,
+                Some(claim),
             );
         })
     {
+        ledger.discard(key);
         tracing::warn!(agent = %name_for_err, error = %e, "failed to spawn respawn thread");
+    }
+}
+
+/// Advisory-channel backstop. A full or disconnected crash channel leaves the
+/// exact observation Pending in the owner ledger; the per-tick watchdog calls
+/// this sweep so recovery does not depend on delivery of that wake-up.
+pub(crate) fn sweep_pending_dispositions(
+    home: &Path,
+    registry: &AgentRegistry,
+    externals: &crate::agent::ExternalRegistry,
+    configs: &crate::api::ConfigRegistry,
+) {
+    let pending = agent::crash_disposition::owner_ledger().pending();
+    if pending.is_empty() {
+        return;
+    }
+    let tx = agent::crash_disposition::owner_crash_wake()
+        .unwrap_or_else(|| crossbeam_channel::unbounded().0);
+    let ctx = DaemonContext {
+        registry: Arc::clone(registry),
+        externals: Arc::clone(externals),
+        configs: Arc::clone(configs),
+        crash_tx: tx,
+        crash_rx: crossbeam_channel::never(),
+        shutdown: Arc::new(AtomicBool::new(false)),
+    };
+    for observation in pending {
+        handle_crash_observation(home, &observation, &ctx);
     }
 }
 
@@ -263,6 +335,7 @@ fn notify_crash(
     );
 }
 
+#[allow(clippy::too_many_arguments)]
 fn respawn_agent_worker(
     home: &Path,
     config: AgentConfig,
@@ -271,11 +344,21 @@ fn respawn_agent_worker(
     reg: &AgentRegistry,
     tx: crossbeam_channel::Sender<crate::agent::AgentExitEvent>,
     shutdown: &Arc<AtomicBool>,
+    claim: Option<ClaimToken>,
 ) {
     std::thread::sleep(delay);
     if shutdown.load(Ordering::Relaxed) {
+        if let Some(token) = claim {
+            agent::crash_disposition::owner_ledger().discard(token.key());
+        }
         tracing::info!(agent = %config.name, "shutdown during respawn backoff, aborting");
         return;
+    }
+    if let Some(token) = claim {
+        if !agent::crash_disposition::owner_ledger().begin_execute(token) {
+            tracing::info!(agent = %config.name, "exact-generation recovery was discarded before execution");
+            return;
+        }
     }
     let (cols, rows) = crossterm::terminal::size().unwrap_or((120, 40));
     if let Some(ref wd) = config.working_dir {
@@ -322,6 +405,9 @@ fn respawn_agent_worker(
         reg,
     ) {
         Ok(_) => {
+            if let Some(token) = claim {
+                let _ = agent::crash_disposition::owner_ledger().mark_live(token);
+            }
             tracing::info!(agent = %config.name, "respawned");
             crate::event_log::log(home, "respawn", &config.name, "agent respawned");
             // #1441: registry is UUID-keyed; resolve the respawned name once.
@@ -375,6 +461,9 @@ fn respawn_agent_worker(
             }
         }
         Err(e) => {
+            if let Some(token) = claim {
+                let _ = agent::crash_disposition::owner_ledger().mark_failed(token);
+            }
             tracing::warn!(agent = %config.name, error = %e, "respawn failed");
             crate::event_log::log(
                 home,
@@ -480,6 +569,7 @@ mod deleted_gate_tests_1913 {
     /// `reg.get` align), backed by a real already-exited `true` child PTY.
     fn make_handle(deleted: bool) -> AgentHandle {
         use portable_pty::{native_pty_system, PtySize};
+        let generation = crate::agent::crash_disposition::owner_generation_source().next();
         let pair = native_pty_system()
             .openpty(PtySize {
                 rows: 24,
@@ -519,6 +609,7 @@ mod deleted_gate_tests_1913 {
             spawned_at: std::time::Instant::now(),
             spawned_at_epoch_ms: 0,
             spawn_mode: crate::backend::SpawnMode::Fresh,
+            generation,
             deleted: Arc::new(AtomicBool::new(deleted)),
         }
     }
@@ -637,6 +728,7 @@ mod deleted_gate_tests_1913 {
             &reg,
             crash_tx,
             &shutdown,
+            None,
         );
 
         // Verify 1: event-log.jsonl should have a crash_respawn_failed record

--- a/src/daemon/crash_respawn.rs
+++ b/src/daemon/crash_respawn.rs
@@ -118,6 +118,7 @@ pub(super) fn handle_crash_observation(
                         agent = %crashed_name,
                         "exit is an intentional delete (deleted flag set) — skipping crash-respawn"
                     );
+                    ledger.discard(key);
                     return;
                 }
                 let mut core = handle.core.lock();
@@ -151,6 +152,7 @@ pub(super) fn handle_crash_observation(
             }
             None => {
                 tracing::warn!(agent = %crashed_name, "not in registry, skipping");
+                ledger.discard(key);
                 return;
             }
         }

--- a/src/daemon/lifecycle.rs
+++ b/src/daemon/lifecycle.rs
@@ -427,6 +427,7 @@ mod tests {
             spawned_at: std::time::Instant::now(),
             spawned_at_epoch_ms: 0,
             spawn_mode: crate::backend::SpawnMode::Fresh,
+            generation: crate::agent::crash_disposition::SpawnGeneration::default(),
             deleted: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         }
     }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1096,6 +1096,7 @@ fn init_daemon_services(
 
     let externals: crate::agent::ExternalRegistry = Arc::new(Mutex::new(HashMap::new()));
     let (crash_tx, crash_rx) = crossbeam_channel::bounded::<crate::agent::AgentExitEvent>(64);
+    crate::agent::crash_disposition::install_owner_crash_wake(crash_tx.clone());
     let configs: Arc<Mutex<HashMap<String, AgentConfig>>> = Arc::new(Mutex::new(HashMap::new()));
     let shutdown = Arc::new(AtomicBool::new(false));
 

--- a/src/daemon/per_tick/mod.rs
+++ b/src/daemon/per_tick/mod.rs
@@ -334,8 +334,8 @@ pub(crate) fn dispatch_exit_event_guarded(
         AgentExitEvent::CleanExit(ref name) => {
             super::handle_clean_exit(home, name.as_str(), &ctx.registry, &ctx.configs);
         }
-        AgentExitEvent::Crash(name) => {
-            super::crash_respawn::handle_crash_respawn(home, &name, ctx);
+        AgentExitEvent::Crash(observation) => {
+            super::crash_respawn::handle_crash_observation(home, &observation, ctx);
         }
     }));
     if let Err(payload) = guarded {
@@ -617,6 +617,7 @@ pub(crate) fn mock_live_agent_no_context(
         spawned_at: std::time::Instant::now(),
         spawned_at_epoch_ms: 0,
         spawn_mode: crate::backend::SpawnMode::Fresh,
+        generation: crate::agent::crash_disposition::SpawnGeneration::default(),
         deleted: Arc::new(std::sync::atomic::AtomicBool::new(false)),
     };
     (handle, reader)
@@ -688,6 +689,7 @@ pub(crate) fn mock_live_agent_with_context(
         spawned_at: std::time::Instant::now(),
         spawned_at_epoch_ms: 0,
         spawn_mode: crate::backend::SpawnMode::Fresh,
+        generation: crate::agent::crash_disposition::SpawnGeneration::default(),
         deleted: Arc::new(std::sync::atomic::AtomicBool::new(false)),
     };
     (handle, reader)

--- a/src/daemon/per_tick/respawn_watchdog.rs
+++ b/src/daemon/per_tick/respawn_watchdog.rs
@@ -269,6 +269,14 @@ impl PerTickHandler for RespawnWatchdogHandler {
     }
 
     fn run(&self, ctx: &TickContext<'_>) {
+        // The bounded crash channel is advisory only. Recover Pending exact
+        // generations first so a full/disconnected wake cannot strand a crash.
+        crate::daemon::crash_respawn::sweep_pending_dispositions(
+            ctx.home,
+            ctx.registry,
+            ctx.externals,
+            ctx.configs,
+        );
         // ON by default; operator kill-switch read each tick.
         if std::env::var(DISABLE_ENV_VAR)
             .map(|v| v == "0")
@@ -417,6 +425,37 @@ impl RespawnWatchdogHandler {
             name,
             &format!("auto-Fresh restart attempt {attempt}/{RESPAWN_MAX_RETRIES}"),
         );
+        // Snapshot the exact Resume handle before dropping the registry lock;
+        // crash and watchdog recovery then share one ledger claim for this
+        // `(InstanceId, generation)` and cannot both issue DELETE+SPAWN.
+        let observation = {
+            let reg = agent::lock_registry_tracked(ctx.registry, "respawn_watchdog_claim");
+            reg.values()
+                .find(|handle| handle.name.as_str() == name)
+                .map(|handle| agent::crash_disposition::CrashObservation {
+                    instance_id: handle.id,
+                    generation: handle.generation,
+                    core: std::sync::Arc::clone(&handle.core),
+                    deleted: std::sync::Arc::clone(&handle.deleted),
+                    owner_shutdown: None,
+                    name: handle.name.clone(),
+                })
+        };
+        let Some(observation) = observation else {
+            return;
+        };
+        let ledger = agent::crash_disposition::owner_ledger();
+        let key = observation.key();
+        if ledger.disposition(key).is_none() && !ledger.publish(observation.clone()) {
+            return;
+        }
+        let Some(claim) = ledger.claim(key, agent::crash_disposition::Claimant::RespawnWatchdog)
+        else {
+            return;
+        };
+        if !ledger.mark_ready(claim) {
+            return;
+        }
         let home = ctx.home.to_path_buf();
         let name_owned = name.to_string();
         // fire-and-forget: the restart round-trips DELETE+SPAWN over the api
@@ -424,7 +463,13 @@ impl RespawnWatchdogHandler {
         // is kept — the restart is self-contained, its outcome is reported via
         // tracing + the operator notify on failure, and progress is re-observed
         // by next-tick re-detection (the cap handles a persistent failure).
-        std::thread::spawn(move || {
+        let spawn_result = std::thread::Builder::new()
+            .name(format!("{name}_watchdog_restart"))
+            .spawn(move || {
+            if !agent::crash_disposition::owner_ledger().begin_execute(claim) {
+                tracing::info!(target: TARGET, agent = %name_owned, "watchdog recovery discarded before execution");
+                return;
+            }
             let reason =
                 format!("respawn-stuck watchdog auto-Fresh (#t-777-3, attempt {attempt}/{RESPAWN_MAX_RETRIES})");
             let spawned = crate::mcp::handlers::instance_state::restart_instance_autonomic(
@@ -433,6 +478,7 @@ impl RespawnWatchdogHandler {
                 &reason,
             );
             if spawned {
+                let _ = agent::crash_disposition::owner_ledger().mark_live(claim);
                 tracing::info!(
                     target: TARGET,
                     agent = %name_owned,
@@ -440,6 +486,7 @@ impl RespawnWatchdogHandler {
                     "respawn-stuck watchdog: auto-Fresh restart issued"
                 );
             } else {
+                let _ = agent::crash_disposition::owner_ledger().mark_failed(claim);
                 tracing::error!(
                     target: TARGET,
                     agent = %name_owned,
@@ -449,6 +496,10 @@ impl RespawnWatchdogHandler {
                 notify_restart_failed(&name_owned);
             }
         });
+        if let Err(error) = spawn_result {
+            ledger.discard(key);
+            tracing::error!(target: TARGET, agent = %name, error = %error, "respawn watchdog worker failed to start");
+        }
     }
 
     /// (A) Terminal escalation after the retry cap: pause the agent

--- a/src/daemon/poll_reminder.rs
+++ b/src/daemon/poll_reminder.rs
@@ -326,6 +326,7 @@ mod tests {
             spawned_at: std::time::Instant::now(),
             spawned_at_epoch_ms: 0,
             spawn_mode: crate::backend::SpawnMode::Fresh,
+            generation: crate::agent::crash_disposition::SpawnGeneration::default(),
             deleted: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         };
         let reg: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));

--- a/src/daemon/supervisor/tests.rs
+++ b/src/daemon/supervisor/tests.rs
@@ -1406,6 +1406,7 @@ fn mock_agent_handle_with_size(
         spawned_at: std::time::Instant::now(),
         spawned_at_epoch_ms: 0,
         spawn_mode: crate::backend::SpawnMode::Fresh,
+        generation: crate::agent::crash_disposition::SpawnGeneration::default(),
         deleted: Arc::new(std::sync::atomic::AtomicBool::new(false)),
     };
     (handle, reader)


### PR DESCRIPTION
## Summary

- Publishes #2765 / Architecture-14 item 1 at the root-VERIFIED exact head.
- Bounds the generation disposition ledger and settles crash observations outside the registry lock while preserving late-publication fencing.
- Scope is limited to the ledger, crash observation path, and focused regressions; no persistence or executor changes.

## Verification

- Immutable RED: `eef3493ba63edef0ca8e1743c1b798905873431d`
- Root VERIFIED head: `e420b2b4c69e583e8318838bc2d1053621aab409`
- Focused tests: `cargo test --bin agend-terminal crash_disposition --no-default-features -- --nocapture` (8 passed); `cargo test --bin agend-terminal exact_generation_context_slice1 --no-default-features -- --nocapture` (2 passed); `cargo test --bin agend-terminal deleted_gate_tests_1913 --no-default-features -- --nocapture` (4 passed); `cargo test --bin agend-terminal respawn_watchdog --no-default-features -- --nocapture` (22 passed).
- `cargo clippy --tests --no-default-features -- -D warnings` passed; `git diff --check` passed.

Published without rebase, amend, or code changes after the root verification.