### PR TITLE
fix: fail-closed selector prevalidation for MCP send

### DIFF
--- a/src/mcp/handlers/comms.rs
+++ b/src/mcp/handlers/comms.rs
@@ -1,4 +1,4 @@
-use crate::agent_ops::{list_agents, send_to};
+use crate::agent_ops::send_to;
 use crate::channel::sink_registry::registry as ux_sink_registry;
 use crate::channel::ux_event::{FleetEvent, UxEvent};
 use crate::identity::Sender;
@@ -8,7 +8,8 @@ use std::path::Path;
 use super::send_envelope::SendEnvelope;
 use super::{
     comms_gates::{
-        enforce_send_invariants, record_triaged_if_present, validate_request_kind, validate_triaged,
+        enforce_send_invariants, record_triaged_if_present, validate_request_kind,
+        validate_selector_exclusivity, validate_triaged,
     },
     err_needs_identity, is_ok_result,
 };
@@ -37,8 +38,11 @@ pub(super) fn handle_unified_send(home: &Path, args: &Value, sender: &Option<Sen
     if let Some(err) = validate_request_kind(&args) {
         return err;
     }
-    // Broadcast mode: targets/team/tags present
-    if args.get("instances").is_some() || args.get("team").is_some() || args.get("tags").is_some() {
+    if let Some(err) = validate_selector_exclusivity(&args) {
+        return err;
+    }
+    // Broadcast mode: instances/team present (tags-only rejected above)
+    if args.get("instances").is_some() || args.get("team").is_some() {
         return handle_broadcast(home, &args, sender);
     }
 
@@ -351,6 +355,9 @@ pub(super) fn handle_broadcast(home: &Path, args: &Value, sender: &Option<Sender
         Some(m) => m,
         None => return json!({"error": "missing 'message'"}),
     };
+    if let Some(err) = validate_selector_exclusivity(args) {
+        return err;
+    }
     let team_name = args["team"].as_str().map(String::from);
     let targets: Vec<String> = if let Some(team) = team_name.as_deref() {
         crate::teams::get_members(home, team)
@@ -359,7 +366,7 @@ pub(super) fn handle_broadcast(home: &Path, args: &Value, sender: &Option<Sender
             .filter_map(|v| v.as_str().map(String::from))
             .collect()
     } else {
-        list_agents()
+        return json!({"error": "no valid recipient selector — specify instances or team", "code": "missing_selector"});
     };
     let targets: Vec<String> = targets
         .into_iter()

--- a/src/mcp/handlers/comms.rs
+++ b/src/mcp/handlers/comms.rs
@@ -32,13 +32,13 @@ pub(super) use comms_delegate::dispatch_should_skip_auto_bind;
 /// → delegate, summary → report, question → query, default → send_to).
 pub(super) fn handle_unified_send(home: &Path, args: &Value, sender: &Option<Sender>) -> Value {
     let mut args = args.clone();
+    if let Some(err) = validate_selector_exclusivity(&args) {
+        return err;
+    }
     if let Some(err) = enforce_send_invariants(home, &args, sender) {
         return err;
     }
     if let Some(err) = validate_request_kind(&args) {
-        return err;
-    }
-    if let Some(err) = validate_selector_exclusivity(&args) {
         return err;
     }
     // Broadcast mode: instances/team present (tags-only rejected above)

--- a/src/mcp/handlers/comms_gates/mod.rs
+++ b/src/mcp/handlers/comms_gates/mod.rs
@@ -10,6 +10,7 @@ mod anti_stall;
 mod dispatch;
 mod evidence_gate;
 mod request_kind_gate;
+mod selector_gate;
 mod sha_gate;
 mod triaged_gate;
 
@@ -24,6 +25,9 @@ pub(super) use anti_stall::enforce_send_invariants;
 // t-20260705005551919287-14440-22: request_kind enum validation
 // (handle_unified_send / handle_broadcast).
 pub(super) use request_kind_gate::validate_request_kind;
+
+// Architecture-14 item 4A: selector exclusivity + tags fail-closed.
+pub(super) use selector_gate::validate_selector_exclusivity;
 
 // Delegate-task pre-send gates (handle_delegate_task / comms_delegate).
 // #6: DispatchPreChecks promoted to pub(crate) so ci/review_workspace_tests can

--- a/src/mcp/handlers/comms_gates/selector_gate.rs
+++ b/src/mcp/handlers/comms_gates/selector_gate.rs
@@ -1,0 +1,30 @@
+use serde_json::{json, Value};
+
+const SELECTOR_FIELDS: &[&str] = &["instance", "instances", "team", "tags"];
+
+pub(crate) fn validate_selector_exclusivity(args: &Value) -> Option<Value> {
+    let present: Vec<&str> = SELECTOR_FIELDS
+        .iter()
+        .filter(|&&f| args.get(f).is_some())
+        .copied()
+        .collect();
+
+    if present.len() > 1 {
+        return Some(json!({
+            "error": format!(
+                "conflicting selector fields: [{}] — specify exactly one of instance/instances/team/tags",
+                present.join(", ")
+            ),
+            "code": "conflicting_selectors"
+        }));
+    }
+
+    if present == ["tags"] {
+        return Some(json!({
+            "error": "tag-based targeting is not supported — specify instance, instances, or team instead",
+            "code": "tags_not_supported"
+        }));
+    }
+
+    None
+}

--- a/src/mcp/handlers/comms_gates/selector_gate.rs
+++ b/src/mcp/handlers/comms_gates/selector_gate.rs
@@ -19,6 +19,13 @@ pub(crate) fn validate_selector_exclusivity(args: &Value) -> Option<Value> {
         }));
     }
 
+    if present.is_empty() {
+        return Some(json!({
+            "error": "missing recipient selector — specify exactly one of instance, instances, or team",
+            "code": "missing_selector"
+        }));
+    }
+
     if present == ["tags"] {
         return Some(json!({
             "error": "tag-based targeting is not supported — specify instance, instances, or team instead",

--- a/src/mcp/handlers/tests.rs
+++ b/src/mcp/handlers/tests.rs
@@ -3737,3 +3737,61 @@ fn send_valid_selector_team_only_no_selector_error() {
         "team-only is a valid selector, must not get selector error: {result}"
     );
 }
+
+#[test]
+fn send_mixed_selectors_no_sidecar_side_effects() {
+    let home = tmp_home("sel-mixed-se");
+    let sender = crate::identity::Sender::new("se-agent").expect("valid sender name");
+    let args = json!({
+        "instance": "a", "tags": ["dev"], "message": "hi",
+        "task_id": "t-selector-sidecar-test"
+    });
+    let result = super::comms::handle_unified_send(&home, &args, &Some(sender));
+    assert!(result.get("error").is_some(), "must reject mixed selectors: {result}");
+    let progress = home.join("task-progress").join("t-selector-sidecar-test.json");
+    assert!(
+        !progress.exists(),
+        "task-progress sidecar must not be created for a rejected mixed-selector send"
+    );
+    let activity = home.join("agent-activity").join("se-agent.json");
+    assert!(
+        !activity.exists(),
+        "agent-activity sidecar must not be created for a rejected mixed-selector send"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn send_tags_only_no_sidecar_side_effects() {
+    let home = tmp_home("sel-tags-se");
+    let sender = crate::identity::Sender::new("se-agent2").expect("valid sender name");
+    let args = json!({
+        "tags": ["dev"], "message": "hi",
+        "task_id": "t-tags-sidecar-test"
+    });
+    let result = super::comms::handle_unified_send(&home, &args, &Some(sender));
+    assert!(result.get("error").is_some(), "must reject tags-only: {result}");
+    let progress = home.join("task-progress").join("t-tags-sidecar-test.json");
+    assert!(
+        !progress.exists(),
+        "task-progress sidecar must not be created for a rejected tags-only send"
+    );
+    let activity = home.join("agent-activity").join("se-agent2.json");
+    assert!(
+        !activity.exists(),
+        "agent-activity sidecar must not be created for a rejected tags-only send"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn send_zero_selectors_returns_typed_missing_selector() {
+    let sender = crate::identity::Sender::new("test-agent").expect("valid sender name");
+    let args = json!({"message": "hi"});
+    let result = super::comms::handle_unified_send(&std::env::temp_dir(), &args, &Some(sender));
+    let code = result.get("code").and_then(|v| v.as_str()).unwrap_or("");
+    assert_eq!(
+        code, "missing_selector",
+        "zero selectors must return typed missing_selector error from the unified gate: {result}"
+    );
+}

--- a/src/mcp/handlers/tests.rs
+++ b/src/mcp/handlers/tests.rs
@@ -2649,25 +2649,15 @@ fn update_team_fallback_to_direct_when_daemon_unreachable() {
 // --- comms.rs broadcast ---
 
 #[test]
-fn broadcast_without_targets_sends_to_all() {
-    let _g = fleet_test_guard();
-    let home = tmp_home("bcast-all");
-    std::env::set_var("AGEND_HOME", &home);
-    std::fs::write(
-        crate::fleet::fleet_yaml_path(&home),
-        "instances:\n  sender:\n    backend: claude\n  target1:\n    backend: claude\n",
-    )
-    .ok();
+fn broadcast_without_targets_rejects_no_selector() {
     let sender = crate::identity::Sender::new("sender").expect("valid sender");
     let args = json!({"message": "hello all"});
-    let result = super::comms::handle_broadcast(&home, &args, &Some(sender));
-    // Should attempt to send (may fail without daemon, but count/sent_to shape must exist)
+    let result = super::comms::handle_broadcast(&std::env::temp_dir(), &args, &Some(sender));
+    let err = result.get("error").and_then(|v| v.as_str()).unwrap_or("");
     assert!(
-        result.get("sent_to").is_some() || result.get("count").is_some(),
-        "broadcast must return sent_to/count shape: {result}"
+        err.contains("selector") || err.contains("recipient"),
+        "broadcast with no selector must fail closed, not broadcast-all: {result}"
     );
-    std::env::remove_var("AGEND_HOME");
-    std::fs::remove_dir_all(&home).ok();
 }
 
 #[test]
@@ -3624,4 +3614,126 @@ fn is_read_only_tool_allowlist() {
             "{t} must NOT be classified read-only"
         );
     }
+}
+
+// --- Architecture-14 item 4A: selector prevalidation ---
+
+#[test]
+fn send_mixed_selectors_instance_and_instances_rejected() {
+    let sender = crate::identity::Sender::new("test-agent").expect("valid sender name");
+    let args = json!({"instance": "a", "instances": ["b", "c"], "message": "hi"});
+    let result = super::comms::handle_unified_send(&std::env::temp_dir(), &args, &Some(sender));
+    let err = result.get("error").and_then(|v| v.as_str()).unwrap_or("");
+    assert!(
+        err.contains("selector") || err.contains("conflict"),
+        "mixed instance+instances must be rejected before routing: {result}"
+    );
+}
+
+#[test]
+fn send_mixed_selectors_instance_and_team_rejected() {
+    let sender = crate::identity::Sender::new("test-agent").expect("valid sender name");
+    let args = json!({"instance": "a", "team": "myteam", "message": "hi"});
+    let result = super::comms::handle_unified_send(&std::env::temp_dir(), &args, &Some(sender));
+    let err = result.get("error").and_then(|v| v.as_str()).unwrap_or("");
+    assert!(
+        err.contains("selector") || err.contains("conflict"),
+        "mixed instance+team must be rejected before routing: {result}"
+    );
+}
+
+#[test]
+fn send_mixed_selectors_instance_and_tags_rejected() {
+    let sender = crate::identity::Sender::new("test-agent").expect("valid sender name");
+    let args = json!({"instance": "a", "tags": ["dev"], "message": "hi"});
+    let result = super::comms::handle_unified_send(&std::env::temp_dir(), &args, &Some(sender));
+    let err = result.get("error").and_then(|v| v.as_str()).unwrap_or("");
+    assert!(
+        err.contains("selector") || err.contains("conflict"),
+        "mixed instance+tags must be rejected before routing: {result}"
+    );
+}
+
+#[test]
+fn send_mixed_selectors_instances_and_team_rejected() {
+    let sender = crate::identity::Sender::new("test-agent").expect("valid sender name");
+    let args = json!({"instances": ["a"], "team": "myteam", "message": "hi"});
+    let result = super::comms::handle_unified_send(&std::env::temp_dir(), &args, &Some(sender));
+    let err = result.get("error").and_then(|v| v.as_str()).unwrap_or("");
+    assert!(
+        err.contains("selector") || err.contains("conflict"),
+        "mixed instances+team must be rejected before routing: {result}"
+    );
+}
+
+#[test]
+fn send_mixed_selectors_instances_and_tags_rejected() {
+    let sender = crate::identity::Sender::new("test-agent").expect("valid sender name");
+    let args = json!({"instances": ["a"], "tags": ["dev"], "message": "hi"});
+    let result = super::comms::handle_unified_send(&std::env::temp_dir(), &args, &Some(sender));
+    let err = result.get("error").and_then(|v| v.as_str()).unwrap_or("");
+    assert!(
+        err.contains("selector") || err.contains("conflict"),
+        "mixed instances+tags must be rejected before routing: {result}"
+    );
+}
+
+#[test]
+fn send_mixed_selectors_team_and_tags_rejected() {
+    let sender = crate::identity::Sender::new("test-agent").expect("valid sender name");
+    let args = json!({"team": "myteam", "tags": ["dev"], "message": "hi"});
+    let result = super::comms::handle_unified_send(&std::env::temp_dir(), &args, &Some(sender));
+    let err = result.get("error").and_then(|v| v.as_str()).unwrap_or("");
+    assert!(
+        err.contains("selector") || err.contains("conflict"),
+        "mixed team+tags must be rejected before routing: {result}"
+    );
+}
+
+#[test]
+fn send_tags_only_fail_closed() {
+    let sender = crate::identity::Sender::new("test-agent").expect("valid sender name");
+    let args = json!({"tags": ["dev"], "message": "hi"});
+    let result = super::comms::handle_unified_send(&std::env::temp_dir(), &args, &Some(sender));
+    let err = result.get("error").and_then(|v| v.as_str()).unwrap_or("");
+    assert!(
+        err.contains("tag") && (err.contains("not supported") || err.contains("not implemented")),
+        "tags-only must fail closed (not broadcast-all): {result}"
+    );
+}
+
+#[test]
+fn send_valid_selector_instance_only_no_selector_error() {
+    let sender = crate::identity::Sender::new("test-agent").expect("valid sender name");
+    let args = json!({"instance": "target", "message": "hi"});
+    let result = super::comms::handle_unified_send(&std::env::temp_dir(), &args, &Some(sender));
+    let err = result.get("error").and_then(|v| v.as_str()).unwrap_or("");
+    assert!(
+        !err.contains("selector") && !err.contains("conflict"),
+        "instance-only is a valid selector, must not get selector error: {result}"
+    );
+}
+
+#[test]
+fn send_valid_selector_instances_only_no_selector_error() {
+    let sender = crate::identity::Sender::new("test-agent").expect("valid sender name");
+    let args = json!({"instances": ["a", "b"], "message": "hi"});
+    let result = super::comms::handle_unified_send(&std::env::temp_dir(), &args, &Some(sender));
+    let err = result.get("error").and_then(|v| v.as_str()).unwrap_or("");
+    assert!(
+        !err.contains("selector") && !err.contains("conflict"),
+        "instances-only is a valid selector, must not get selector error: {result}"
+    );
+}
+
+#[test]
+fn send_valid_selector_team_only_no_selector_error() {
+    let sender = crate::identity::Sender::new("test-agent").expect("valid sender name");
+    let args = json!({"team": "myteam", "message": "hi"});
+    let result = super::comms::handle_unified_send(&std::env::temp_dir(), &args, &Some(sender));
+    let err = result.get("error").and_then(|v| v.as_str()).unwrap_or("");
+    assert!(
+        !err.contains("selector") && !err.contains("conflict"),
+        "team-only is a valid selector, must not get selector error: {result}"
+    );
 }

--- a/src/mcp/handlers/tests.rs
+++ b/src/mcp/handlers/tests.rs
@@ -3747,8 +3747,13 @@ fn send_mixed_selectors_no_sidecar_side_effects() {
         "task_id": "t-selector-sidecar-test"
     });
     let result = super::comms::handle_unified_send(&home, &args, &Some(sender));
-    assert!(result.get("error").is_some(), "must reject mixed selectors: {result}");
-    let progress = home.join("task-progress").join("t-selector-sidecar-test.json");
+    assert!(
+        result.get("error").is_some(),
+        "must reject mixed selectors: {result}"
+    );
+    let progress = home
+        .join("task-progress")
+        .join("t-selector-sidecar-test.json");
     assert!(
         !progress.exists(),
         "task-progress sidecar must not be created for a rejected mixed-selector send"
@@ -3770,7 +3775,10 @@ fn send_tags_only_no_sidecar_side_effects() {
         "task_id": "t-tags-sidecar-test"
     });
     let result = super::comms::handle_unified_send(&home, &args, &Some(sender));
-    assert!(result.get("error").is_some(), "must reject tags-only: {result}");
+    assert!(
+        result.get("error").is_some(),
+        "must reject tags-only: {result}"
+    );
     let progress = home.join("task-progress").join("t-tags-sidecar-test.json");
     assert!(
         !progress.exists(),


### PR DESCRIPTION
## Summary

- Enforce exactly one recipient selector (`instance`/`instances`/`team`/`tags`) in `handle_unified_send` before any routing or durable side effects (message delivery, task creation, binding, CI watch)
- Mixed selectors (e.g. `instance`+`tags`, `instances`+`team`) now return a clear `conflicting_selectors` error instead of silently picking one
- `tags`-only sends fail closed with `tags_not_supported` instead of falling through to `list_agents()` which would broadcast to all agents (the Architecture-14 tags gap)
- `handle_broadcast` also validates selector exclusivity for direct-call safety, and its final else-branch returns an error instead of `list_agents()`

## Architecture-14 item 4A

Closes the tags gap documented in `src/mcp/tools.rs:1000-1002`: `tags` field triggered broadcast MODE but value-based tag-targeting was NOT implemented — the `handle_broadcast` fallback silently broadcast to all agents.

## Test plan

- [x] 6 mixed-selector rejection tests (all 2-combinations of instance/instances/team/tags)
- [x] tags-only fail-closed test
- [x] 3 valid-selector pass-through tests (instance-only, instances-only, team-only)
- [x] Updated `broadcast_without_targets_sends_to_all` → `broadcast_without_targets_rejects_no_selector`
- [x] All 104 send/broadcast tests pass
- [x] `cargo fmt -- --check` clean
- [x] `cargo clippy -p agend-terminal -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)