### PR TITLE
feat(#2765): typed Restarting execution permit

### DIFF
--- a/src/agent/crash_disposition.rs
+++ b/src/agent/crash_disposition.rs
@@ -139,6 +139,33 @@ impl ClaimToken {
     }
 }
 
+/// Opaque authority for one exact-generation recovery execution.  The permit
+/// is intentionally non-`Copy`/non-`Clone`: once it is settled as Live or
+/// Failed it cannot be replayed for a second ledger transition.
+pub(crate) struct RecoveryExecutionPermit {
+    key: DispositionKey,
+    core: Arc<CoreMutex<AgentCore>>,
+    restarting_admitted: bool,
+}
+
+impl RecoveryExecutionPermit {
+    /// Publish Restarting on the exact old core immediately before spawning a
+    /// replacement.  This is idempotent only as a guarded one-shot operation;
+    /// callers cannot use the same permit to publish a second transition.
+    pub(crate) fn admit_restarting(&mut self) -> bool {
+        if self.restarting_admitted {
+            return false;
+        }
+        self.core.lock().state.set_restarting_with_permit(self);
+        self.restarting_admitted = true;
+        true
+    }
+
+    fn key(&self) -> DispositionKey {
+        self.key
+    }
+}
+
 struct Entry {
     observation: CrashObservation,
     disposition: Disposition,
@@ -245,36 +272,62 @@ impl CrashDispositionLedger {
     }
 
     pub(crate) fn mark_ready(&self, token: ClaimToken) -> bool {
-        self.transition(token, Disposition::Claimed, Disposition::Ready)
+        self.transition(token.key(), Disposition::Claimed, Disposition::Ready)
     }
 
     /// Revalidate the old handle's deleted/shutdown Arcs and current generation
     /// while holding the same ledger lock that performs Discard invalidation.
-    pub(crate) fn begin_execute(&self, token: ClaimToken) -> bool {
+    pub(crate) fn begin_execute(&self, token: ClaimToken) -> Option<RecoveryExecutionPermit> {
         let mut inner = self.inner.lock();
         let current = inner.current.get(&token.key.instance_id).copied();
-        let Some(entry) = inner.entries.get_mut(&token.key) else {
-            return false;
-        };
+        let entry = inner.entries.get_mut(&token.key)?;
         // Only Ready can enter execution.  In particular, a copied token or a
         // late invalidation must not rewrite an already Executing record.
         if entry.disposition != Disposition::Ready {
-            return false;
+            return None;
         }
         if !entry.observation.valid(current) {
             entry.disposition = Disposition::Discarded;
+            return None;
+        }
+        let core = Arc::clone(&entry.observation.core);
+        entry.disposition = Disposition::Executing;
+        Some(RecoveryExecutionPermit {
+            key: token.key,
+            core,
+            restarting_admitted: false,
+        })
+    }
+
+    pub(crate) fn mark_live(&self, permit: RecoveryExecutionPermit) -> bool {
+        if !permit.restarting_admitted {
             return false;
         }
-        entry.disposition = Disposition::Executing;
-        true
+        self.transition(permit.key(), Disposition::Executing, Disposition::Live)
     }
 
-    pub(crate) fn mark_live(&self, token: ClaimToken) -> bool {
-        self.transition(token, Disposition::Executing, Disposition::Live)
+    pub(crate) fn mark_failed(&self, permit: RecoveryExecutionPermit) -> bool {
+        if !permit.restarting_admitted {
+            return false;
+        }
+        let key = permit.key();
+        let core = Arc::clone(&permit.core);
+        let settled = self.transition(key, Disposition::Executing, Disposition::Failed);
+        if settled {
+            core.lock().state.set_crashed_from_recovery();
+        }
+        settled
     }
 
-    pub(crate) fn mark_failed(&self, token: ClaimToken) -> bool {
-        self.transition(token, Disposition::Executing, Disposition::Failed)
+    /// Publish a raw crash observation, then record Crashed outside the ledger
+    /// mutex.  This keeps producer state mutation separate from ledger locking
+    /// and makes the crash funnel explicit for PTY exits and API kills.
+    pub(crate) fn publish_crashed(&self, observation: CrashObservation) -> bool {
+        let published = self.publish(observation.clone());
+        if published {
+            observation.core.lock().state.set_crashed_from_observation();
+        }
+        published
     }
 
     pub(crate) fn discard(&self, key: DispositionKey) -> bool {
@@ -313,20 +366,19 @@ impl CrashDispositionLedger {
             .collect()
     }
 
-    fn transition(&self, token: ClaimToken, from: Disposition, to: Disposition) -> bool {
+    fn transition(&self, key: DispositionKey, from: Disposition, to: Disposition) -> bool {
         let mut inner = self.inner.lock();
-        let current = inner.current.get(&token.key.instance_id).copied();
-        let Some(entry) = inner.entries.get_mut(&token.key) else {
+        let current = inner.current.get(&key.instance_id).copied();
+        let Some(entry) = inner.entries.get_mut(&key) else {
             return false;
         };
         if entry.disposition != from {
             return false;
         }
         entry.disposition = to;
-        if matches!(to, Disposition::Live | Disposition::Failed)
-            && current != Some(token.key.generation)
+        if matches!(to, Disposition::Live | Disposition::Failed) && current != Some(key.generation)
         {
-            inner.entries.remove(&token.key);
+            inner.entries.remove(&key);
         }
         true
     }
@@ -385,6 +437,12 @@ mod tests {
         }
     }
 
+    fn admit(ledger: &CrashDispositionLedger, token: ClaimToken) -> RecoveryExecutionPermit {
+        let mut permit = ledger.begin_execute(token).expect("execution permit");
+        assert!(permit.admit_restarting());
+        permit
+    }
+
     #[test]
     fn replacement_removes_old_pending_before_execution() {
         let ledger = CrashDispositionLedger::new();
@@ -398,7 +456,7 @@ mod tests {
 
         ledger.register_generation(id, SpawnGeneration::new(2));
         assert_eq!(ledger.disposition(old.key()), None);
-        assert!(!ledger.begin_execute(token));
+        assert!(ledger.begin_execute(token).is_none());
         assert!(ledger.pending().is_empty());
     }
 
@@ -414,7 +472,7 @@ mod tests {
         let token = ledger.claim(obs.key(), Claimant::Crash).expect("claim");
         assert!(ledger.mark_ready(token));
         deleted.store(true, Ordering::SeqCst);
-        assert!(!ledger.begin_execute(token));
+        assert!(ledger.begin_execute(token).is_none());
         assert_eq!(ledger.disposition(obs.key()), Some(Disposition::Discarded));
 
         let id2 = InstanceId::new();
@@ -468,10 +526,9 @@ mod tests {
         assert!(ledger.publish(live.clone()));
         let live_token = ledger.claim(live.key(), Claimant::Crash).expect("claim");
         assert!(ledger.mark_ready(live_token));
-        assert!(ledger.begin_execute(live_token));
-        assert!(ledger.mark_live(live_token));
+        let live_permit = admit(&ledger, live_token);
+        assert!(ledger.mark_live(live_permit));
         assert_eq!(ledger.disposition(live.key()), Some(Disposition::Live));
-        assert!(!ledger.mark_failed(live_token));
 
         let id2 = InstanceId::new();
         let failed = observation(id2, SpawnGeneration::new(7), &deleted, None);
@@ -479,8 +536,8 @@ mod tests {
         assert!(ledger.publish(failed.clone()));
         let failed_token = ledger.claim(failed.key(), Claimant::Crash).expect("claim");
         assert!(ledger.mark_ready(failed_token));
-        assert!(ledger.begin_execute(failed_token));
-        assert!(ledger.mark_failed(failed_token));
+        let failed_permit = admit(&ledger, failed_token);
+        assert!(ledger.mark_failed(failed_permit));
         assert_eq!(ledger.disposition(failed.key()), Some(Disposition::Failed));
     }
 
@@ -497,7 +554,8 @@ mod tests {
             .claim(claim_obs.key(), Claimant::Crash)
             .expect("claim");
         assert!(ledger.mark_ready(claim_token));
-        assert!(ledger.begin_execute(claim_token));
+        let mut claim_permit = ledger.begin_execute(claim_token).expect("permit");
+        assert!(claim_permit.admit_restarting());
         ledger.register_generation(id_claim, SpawnGeneration::new(9));
         assert!(ledger
             .claim(claim_obs.key(), Claimant::RespawnWatchdog)
@@ -516,11 +574,12 @@ mod tests {
             .claim(begin_obs.key(), Claimant::Crash)
             .expect("claim");
         assert!(ledger.mark_ready(begin_token));
-        assert!(ledger.begin_execute(begin_token));
+        let mut begin_permit = ledger.begin_execute(begin_token).expect("permit");
+        assert!(begin_permit.admit_restarting());
         deleted_begin.store(true, Ordering::SeqCst);
         let copied_begin_token = begin_token;
-        assert!(!ledger.begin_execute(copied_begin_token));
-        assert!(!ledger.begin_execute(begin_token));
+        assert!(ledger.begin_execute(copied_begin_token).is_none());
+        assert!(ledger.begin_execute(begin_token).is_none());
         assert_eq!(
             ledger.disposition(begin_obs.key()),
             Some(Disposition::Executing)
@@ -535,13 +594,13 @@ mod tests {
             .claim(discard_obs.key(), Claimant::Crash)
             .expect("claim");
         assert!(ledger.mark_ready(discard_token));
-        assert!(ledger.begin_execute(discard_token));
+        let discard_permit = admit(&ledger, discard_token);
         assert!(!ledger.discard(discard_obs.key()));
         assert_eq!(
             ledger.disposition(discard_obs.key()),
             Some(Disposition::Executing)
         );
-        assert!(ledger.mark_live(discard_token));
+        assert!(ledger.mark_live(discard_permit));
         assert_eq!(
             ledger.disposition(discard_obs.key()),
             Some(Disposition::Live)
@@ -559,8 +618,8 @@ mod tests {
         assert!(ledger.publish(old.clone()));
         let token = ledger.claim(old.key(), Claimant::Crash).expect("claim");
         assert!(ledger.mark_ready(token));
-        assert!(ledger.begin_execute(token));
-        assert!(ledger.mark_failed(token));
+        let token_permit = admit(&ledger, token);
+        assert!(ledger.mark_failed(token_permit));
 
         ledger.register_generation(id, SpawnGeneration::new(13));
         drop(old);
@@ -594,10 +653,41 @@ mod tests {
         let token = ledger.claim(obs.key(), Claimant::Crash).expect("claim");
         assert!(ledger.mark_ready(token));
 
-        let permit = ledger
+        let mut permit = ledger
             .begin_execute(token)
             .expect("exact-generation admission must mint a permit");
+        assert!(permit.admit_restarting());
         assert!(ledger.mark_live(permit));
+    }
+
+    #[test]
+    fn execution_permit_admits_restarting_once_and_failed_returns_exact_core_to_crashed() {
+        let ledger = CrashDispositionLedger::new();
+        let id = InstanceId::new();
+        let deleted = Arc::new(AtomicBool::new(false));
+        let obs = observation(id, SpawnGeneration::new(91), &deleted, None);
+        ledger.register_generation(id, obs.generation);
+        assert!(ledger.publish_crashed(obs.clone()));
+        assert_eq!(
+            obs.core.lock().state.get_state(),
+            crate::state::AgentState::Crashed
+        );
+        let token = ledger.claim(obs.key(), Claimant::Crash).expect("claim");
+        assert!(ledger.mark_ready(token));
+
+        let mut permit = ledger.begin_execute(token).expect("permit");
+        assert!(permit.admit_restarting());
+        assert!(!permit.admit_restarting());
+        assert_eq!(
+            obs.core.lock().state.get_state(),
+            crate::state::AgentState::Restarting
+        );
+        assert!(ledger.mark_failed(permit));
+        assert_eq!(
+            obs.core.lock().state.get_state(),
+            crate::state::AgentState::Crashed
+        );
+        assert_eq!(ledger.disposition(obs.key()), Some(Disposition::Failed));
     }
 
     #[test]
@@ -637,10 +727,10 @@ mod tests {
         assert!(ledger.publish(old.clone()));
         let token = ledger.claim(old.key(), Claimant::Crash).expect("claim");
         assert!(ledger.mark_ready(token));
-        assert!(ledger.begin_execute(token));
+        let permit = admit(&ledger, token);
         ledger.register_generation(id, SpawnGeneration::new(85));
         assert_eq!(ledger.entry_count(), 1, "Executing remains owned");
-        assert!(ledger.mark_live(token));
+        assert!(ledger.mark_live(permit));
         drop(old);
         assert_eq!(ledger.entry_count(), 0);
         assert!(weak_core.upgrade().is_none());

--- a/src/agent/crash_disposition.rs
+++ b/src/agent/crash_disposition.rs
@@ -580,6 +580,26 @@ mod tests {
         assert_eq!(ledger.entry_count(), 0);
     }
 
+    /// Slice-2 RED: execution admission must return an opaque, one-use permit
+    /// rather than a copyable boolean.  The permit is the only authority that
+    /// may cross the ledger boundary into the Restarting transition.
+    #[test]
+    fn begin_execute_returns_typed_one_use_permit_slice2_red() {
+        let ledger = CrashDispositionLedger::new();
+        let id = InstanceId::new();
+        let deleted = Arc::new(AtomicBool::new(false));
+        let obs = observation(id, SpawnGeneration::new(90), &deleted, None);
+        ledger.register_generation(id, obs.generation);
+        assert!(ledger.publish(obs.clone()));
+        let token = ledger.claim(obs.key(), Claimant::Crash).expect("claim");
+        assert!(ledger.mark_ready(token));
+
+        let permit = ledger
+            .begin_execute(token)
+            .expect("exact-generation admission must mint a permit");
+        assert!(ledger.mark_live(permit));
+    }
+
     #[test]
     fn superseded_generations_are_removed_and_count_stays_bounded() {
         let ledger = CrashDispositionLedger::new();

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -2174,11 +2174,10 @@ fn on_crash_exit(
     crash_tx: &Option<CrashChannel>,
 ) {
     let name = observation.name.as_ref();
-    if !crash_disposition::owner_ledger().publish(observation.clone()) {
+    if !crash_disposition::owner_ledger().publish_crashed(observation.clone()) {
         return;
     }
-    tracing::info!(agent = name, "setting restarting state");
-    observation.core.lock().state.set_restarting();
+    tracing::info!(agent = name, "recorded crashed state");
     if let Some(ref tx) = crash_tx {
         if let Err(e) = tx.try_send(AgentExitEvent::Crash(observation.clone())) {
             tracing::warn!(agent = %name, error = %e, "crash channel full — respawn event dropped");

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -2095,6 +2095,39 @@ fn startup_failure_publication_carries_exact_generation_context_slice1() {
     assert!(Arc::ptr_eq(&observation.core, &handle.core));
 }
 
+/// Slice-2 RED: a crash observation is published as Crashed and must remain
+/// there until the daemon obtains an exact-generation execution permit.
+#[test]
+fn crash_observed_stays_crashed_until_execution_admission_slice2_red() {
+    let id = crate::types::InstanceId::new();
+    let generation = crate::agent::crash_disposition::owner_generation_source().next();
+    let core = Arc::new(crate::sync_audit::CoreMutex::new(AgentCore {
+        vterm: VTerm::new(80, 24),
+        subscribers: Vec::new(),
+        state: StateTracker::new(None),
+        health: HealthTracker::new(),
+        api_activity: crate::agent::ApiActivity::default(),
+        observed_status: None,
+    }));
+    let deleted = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let observation = crate::agent::crash_disposition::CrashObservation {
+        instance_id: id,
+        generation,
+        core: Arc::clone(&core),
+        deleted,
+        owner_shutdown: None,
+        name: "slice2-crash-producer".into(),
+    };
+    crate::agent::crash_disposition::owner_ledger().register_generation(id, generation);
+
+    on_crash_exit(&observation, &None);
+
+    assert_eq!(
+        core.lock().state.get_state(),
+        crate::state::AgentState::Crashed
+    );
+}
+
 struct ChunkReader {
     chunks: Vec<&'static [u8]>,
     next: usize,

--- a/src/api/handlers/instance.rs
+++ b/src/api/handlers/instance.rs
@@ -610,6 +610,68 @@ mod tests {
         }
     }
 
+    /// Slice-2 RED: the API kill producer must publish Crashed before the PTY
+    /// exit path and later exact-generation admission, never Restarting itself.
+    #[test]
+    fn handle_kill_keeps_agent_crashed_until_execution_admission_slice2_red() {
+        let name = "slice2-kill-producer";
+        let (ctx, home) = test_ctx_with_agent(name);
+        let response = handle_kill(&json!({"name": name}), &ctx);
+        assert_eq!(
+            response["ok"],
+            json!(true),
+            "kill must succeed: {response:?}"
+        );
+
+        let id = crate::fleet::resolve_uuid(ctx.home, name).expect("fleet id");
+        let state = {
+            let reg = agent::lock_registry(ctx.registry);
+            let core = Arc::clone(
+                &reg.get(&id)
+                    .expect("kill does not remove the registry entry")
+                    .core,
+            );
+            drop(reg);
+            core.lock().state.get_state()
+        };
+        assert_eq!(
+            state,
+            crate::state::AgentState::Crashed,
+            "API kill must not publish Restarting before permit admission"
+        );
+        cleanup_agent(&ctx, name);
+        std::fs::remove_dir_all(home.as_ref()).ok();
+    }
+
+    /// Slice-2 RED: Crashed has a distinct INJECT rejection message; calling
+    /// it "restarting" hides the fact that no execution permit was admitted.
+    #[test]
+    fn inject_rejection_names_crashed_state_slice2_red() {
+        let name = "slice2-inject-crashed";
+        let (ctx, home) = test_ctx_with_agent(name);
+        let id = crate::fleet::resolve_uuid(ctx.home, name).expect("fleet id");
+        {
+            let reg = agent::lock_registry(ctx.registry);
+            reg.get(&id)
+                .expect("spawned handle")
+                .core
+                .lock()
+                .state
+                .current = crate::state::AgentState::Crashed;
+        }
+
+        let response = handle_inject(&json!({"name": name, "data": "x", "raw": true}), &ctx);
+        assert_eq!(response["ok"], json!(false));
+        assert!(
+            response["error"]
+                .as_str()
+                .is_some_and(|error| error.contains("crashed")),
+            "Crashed INJECT rejection must say crashed: {response:?}"
+        );
+        cleanup_agent(&ctx, name);
+        std::fs::remove_dir_all(home.as_ref()).ok();
+    }
+
     /// Sibling of [`test_ctx_with_agent`]: spawns a REAL, permanently-wedged
     /// agent (`stty raw -echo; sleep 30` — never drains stdin) instead of a
     /// healthy shell, so a caller can force a genuine PTY write failure

--- a/src/api/handlers/instance.rs
+++ b/src/api/handlers/instance.rs
@@ -632,7 +632,8 @@ mod tests {
                     .core,
             );
             drop(reg);
-            core.lock().state.get_state()
+            let state = core.lock().state.get_state();
+            state
         };
         assert_eq!(
             state,

--- a/src/api/handlers/instance.rs
+++ b/src/api/handlers/instance.rs
@@ -29,21 +29,21 @@ pub(crate) fn handle_inject(params: &Value, ctx: &HandlerCtx) -> Value {
                 // This diverges from raw only for a cross-coarse Hook/Stream correction (e.g.
                 // raw=Restarting + Hook=WaitingForUser/RateLimited — more relevant after #2466).
                 // Lock scoped + dropped before `from_handle` to preserve the single-acquisition order.
-                let is_restarting = {
+                let operated_state = {
                     let core = handle.core.lock();
                     crate::daemon::shadow::operated_state(
                         core.state.current,
                         core.observed_status.as_ref(),
                     )
-                    .is_unavailable()
                 };
-                (agent::InjectTarget::from_handle(handle), is_restarting)
+                (agent::InjectTarget::from_handle(handle), operated_state)
             })
     };
     match snap {
-        Some((tgt, is_restarting)) => {
-            if is_restarting {
-                json!({"ok": false, "error": format!("agent '{name}' is restarting, retry later")})
+        Some((tgt, operated_state)) => {
+            if operated_state.is_unavailable() {
+                let state_name = operated_state.display_name();
+                json!({"ok": false, "error": format!("agent '{name}' is {state_name}, retry later")})
             } else {
                 let result = if raw {
                     agent::write_to_pty(&tgt.pty_writer, data.as_bytes())
@@ -78,19 +78,26 @@ pub(crate) fn handle_kill(params: &Value, ctx: &HandlerCtx) -> Value {
     // #1441: registry is UUID-keyed; resolve name via fleet.yaml.
     match crate::fleet::resolve_uuid(ctx.home, name).and_then(|id| reg.get(&id)) {
         Some(handle) => {
-            {
-                let mut core = handle.core.lock();
-                core.state.set_restarting();
-            }
-            let mut child = handle.child.lock();
+            let observation = crate::agent::crash_disposition::CrashObservation {
+                instance_id: handle.id,
+                generation: handle.generation,
+                core: std::sync::Arc::clone(&handle.core),
+                deleted: std::sync::Arc::clone(&handle.deleted),
+                owner_shutdown: None,
+                name: handle.name.clone(),
+            };
+            let child = std::sync::Arc::clone(&handle.child);
+            drop(reg);
+            crate::agent::crash_disposition::owner_ledger().publish_crashed(observation);
             // Kill the process group (not just the leader) to propagate to
             // child subprocesses (kiro-cli spawns bun/mcp/acp children).
-            if let Some(pid) = child.process_id() {
-                crate::process::kill_process_tree(pid);
+            {
+                let mut child = child.lock();
+                if let Some(pid) = child.process_id() {
+                    crate::process::kill_process_tree(pid);
+                }
+                let _ = child.kill(); // also kill via PTY handle as fallback
             }
-            let _ = child.kill(); // also kill via PTY handle as fallback
-            drop(child);
-            drop(reg);
             crate::event_log::log(ctx.home, "kill", name, "killed via API");
             json!({"ok": true})
         }

--- a/src/daemon/crash_respawn.rs
+++ b/src/daemon/crash_respawn.rs
@@ -399,12 +399,6 @@ fn respawn_agent_worker(
         tracing::info!(agent = %config.name, "shutdown during respawn backoff, aborting");
         return;
     }
-    if let Some(token) = claim {
-        if !agent::crash_disposition::owner_ledger().begin_execute(token) {
-            tracing::info!(agent = %config.name, "exact-generation recovery was discarded before execution");
-            return;
-        }
-    }
     let (cols, rows) = crossterm::terminal::size().unwrap_or((120, 40));
     if let Some(ref wd) = config.working_dir {
         let skills_filter: Option<Vec<String>> =
@@ -432,6 +426,32 @@ fn respawn_agent_worker(
             tracing::warn!(agent = %config.name, error = %e, "crash-respawn skills install failed");
         }
     }
+
+    // Re-check shutdown after backoff/setup, then admit the exact-generation
+    // permit immediately before the replacement spawn.  Until this point the
+    // old core remains visibly Crashed rather than prematurely Restarting.
+    if shutdown.load(Ordering::Relaxed) {
+        if let Some(token) = claim {
+            agent::crash_disposition::owner_ledger().discard(token.key());
+        }
+        tracing::info!(agent = %config.name, "shutdown before respawn execution admission, aborting");
+        return;
+    }
+    let mut permit = match claim {
+        Some(token) => {
+            let Some(mut permit) = agent::crash_disposition::owner_ledger().begin_execute(token)
+            else {
+                tracing::info!(agent = %config.name, "exact-generation recovery was discarded before execution");
+                return;
+            };
+            if !permit.admit_restarting() {
+                tracing::info!(agent = %config.name, "execution permit could not admit Restarting");
+                return;
+            }
+            Some(permit)
+        }
+        None => None,
+    };
     match agent::spawn_agent(
         &agent::SpawnConfig {
             name: &config.name,
@@ -450,8 +470,8 @@ fn respawn_agent_worker(
         reg,
     ) {
         Ok(_) => {
-            if let Some(token) = claim {
-                let _ = agent::crash_disposition::owner_ledger().mark_live(token);
+            if let Some(permit) = permit.take() {
+                let _ = agent::crash_disposition::owner_ledger().mark_live(permit);
             }
             tracing::info!(agent = %config.name, "respawned");
             crate::event_log::log(home, "respawn", &config.name, "agent respawned");
@@ -506,8 +526,8 @@ fn respawn_agent_worker(
             }
         }
         Err(e) => {
-            if let Some(token) = claim {
-                let _ = agent::crash_disposition::owner_ledger().mark_failed(token);
+            if let Some(permit) = permit.take() {
+                let _ = agent::crash_disposition::owner_ledger().mark_failed(permit);
             }
             tracing::warn!(agent = %config.name, error = %e, "respawn failed");
             crate::event_log::log(

--- a/src/daemon/per_tick/reclaim.rs
+++ b/src/daemon/per_tick/reclaim.rs
@@ -653,6 +653,20 @@ mod tests {
         }
     }
 
+    #[test]
+    fn crashed_state_is_not_reclaimed_slice2_red() {
+        assert!(
+            !should_reclaim(
+                AgentState::Crashed,
+                true,
+                false,
+                Duration::from_secs(30 * 60),
+                RECLAIM_GRACE,
+            ),
+            "a Crashed agent must remain available for exact-generation recovery"
+        );
+    }
+
     /// (b) A genuine usage_limit with > grace remaining IS reclaimed: task → Open,
     /// owner cleared, work-stuck latch entry removed.
     #[test]

--- a/src/daemon/per_tick/reclaim.rs
+++ b/src/daemon/per_tick/reclaim.rs
@@ -59,6 +59,7 @@ fn is_excluded_state(state: AgentState) -> bool {
             | AgentState::InteractivePrompt
             | AgentState::PermissionPrompt
             | AgentState::Starting
+            | AgentState::Crashed
             | AgentState::Restarting
     )
 }

--- a/src/daemon/per_tick/respawn_watchdog.rs
+++ b/src/daemon/per_tick/respawn_watchdog.rs
@@ -466,8 +466,13 @@ impl RespawnWatchdogHandler {
         let spawn_result = std::thread::Builder::new()
             .name(format!("{name}_watchdog_restart"))
             .spawn(move || {
-            if !agent::crash_disposition::owner_ledger().begin_execute(claim) {
+            let Some(mut permit) = agent::crash_disposition::owner_ledger().begin_execute(claim)
+            else {
                 tracing::info!(target: TARGET, agent = %name_owned, "watchdog recovery discarded before execution");
+                return;
+            };
+            if !permit.admit_restarting() {
+                tracing::info!(target: TARGET, agent = %name_owned, "watchdog execution permit could not admit Restarting");
                 return;
             }
             let reason =
@@ -478,7 +483,7 @@ impl RespawnWatchdogHandler {
                 &reason,
             );
             if spawned {
-                let _ = agent::crash_disposition::owner_ledger().mark_live(claim);
+                let _ = agent::crash_disposition::owner_ledger().mark_live(permit);
                 tracing::info!(
                     target: TARGET,
                     agent = %name_owned,
@@ -486,7 +491,7 @@ impl RespawnWatchdogHandler {
                     "respawn-stuck watchdog: auto-Fresh restart issued"
                 );
             } else {
-                let _ = agent::crash_disposition::owner_ledger().mark_failed(claim);
+                let _ = agent::crash_disposition::owner_ledger().mark_failed(permit);
                 tracing::error!(
                     target: TARGET,
                     agent = %name_owned,

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -2262,9 +2262,34 @@ impl StateTracker {
         self.maybe_expire_latched_state();
     }
 
-    /// Force state to Restarting (called by reaper on crash).
-    pub fn set_restarting(&mut self) {
+    /// Test-only/state-local escape hatch for asserting transition bookkeeping.
+    /// Production recovery must use the typed permit funnel below.
+    #[cfg(test)]
+    pub(crate) fn set_restarting(&mut self) {
         self.record_set(AgentState::Restarting); // #1527: also logs the transition
+    }
+
+    /// Record a raw crash observation.  This is deliberately distinct from
+    /// the recovery admission path: crash producers publish `Crashed` before
+    /// any exact-generation permit can authorize `Restarting`.
+    pub(crate) fn set_crashed_from_observation(&mut self) {
+        self.record_set(AgentState::Crashed);
+    }
+
+    /// The only production Restarting transition.  The caller must hold the
+    /// opaque exact-generation execution permit minted by the disposition
+    /// ledger after revalidation.
+    pub(crate) fn set_restarting_with_permit(
+        &mut self,
+        _permit: &crate::agent::crash_disposition::RecoveryExecutionPermit,
+    ) {
+        self.record_set(AgentState::Restarting); // #1527: also logs the transition
+    }
+
+    /// Return an admitted execution to the raw Crashed state after spawn
+    /// failure, using the same exact old core captured by the permit.
+    pub(crate) fn set_crashed_from_recovery(&mut self) {
+        self.record_set(AgentState::Crashed);
     }
 
     /// Force state to AwaitingOperator when the agent is stalled waiting on

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -364,7 +364,8 @@ fn test_crash_respawn_health() {
     let resp = daemon.api_call(&serde_json::json!({"method": "kill", "params": {"name": "shell"}}));
     assert_eq!(resp["ok"], true);
 
-    // Wait for agent to enter restarting/starting state
+    // During recovery backoff/setup the agent truthfully remains crashed;
+    // Restarting is published only immediately before the replacement spawn.
     let _ = wait_until(
         || {
             let r = daemon.api_call(&serde_json::json!({"method": "list"}));
@@ -372,7 +373,7 @@ fn test_crash_respawn_health() {
                 .as_array()
                 .and_then(|a| a.first())
                 .and_then(|a| a["agent_state"].as_str())
-                .map(|s| s == "restarting" || s == "starting")
+                .map(|s| s == "crashed" || s == "restarting" || s == "starting")
                 .unwrap_or(false)
         },
         Duration::from_secs(5),
@@ -382,8 +383,8 @@ fn test_crash_respawn_health() {
     if !agents.is_empty() {
         let state = agents[0]["agent_state"].as_str().unwrap_or("");
         assert!(
-            state == "restarting" || state == "starting",
-            "expected restarting or starting, got: {state}"
+            state == "crashed" || state == "restarting" || state == "starting",
+            "expected crashed, restarting, or starting, got: {state}"
         );
     }
 
@@ -484,11 +485,11 @@ fn test_inject_restarting() {
         "params": {"name": "shell", "data": "hello"}
     }));
 
-    // Should get "restarting" error, not "not found"
+    // Should get the truthful recovery-state error, not "not found".
     let error = resp["error"].as_str().unwrap_or("");
     assert!(
-        error.contains("restarting"),
-        "expected 'restarting' error, got: {error}"
+        error.contains("crashed") || error.contains("restarting"),
+        "expected 'crashed' or 'restarting' error, got: {error}"
     );
 
     daemon.stop();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -364,27 +364,15 @@ fn test_crash_respawn_health() {
     let resp = daemon.api_call(&serde_json::json!({"method": "kill", "params": {"name": "shell"}}));
     assert_eq!(resp["ok"], true);
 
-    // During recovery backoff/setup the agent truthfully remains crashed;
-    // Restarting is published only immediately before the replacement spawn.
-    let _ = wait_until(
-        || {
-            let r = daemon.api_call(&serde_json::json!({"method": "list"}));
-            r["result"]["agents"]
-                .as_array()
-                .and_then(|a| a.first())
-                .and_then(|a| a["agent_state"].as_str())
-                .map(|s| s == "crashed" || s == "restarting" || s == "starting")
-                .unwrap_or(false)
-        },
-        Duration::from_secs(5),
-    );
+    // KILL publishes the truthful crashed state synchronously. Restarting is
+    // published only immediately before the replacement spawn.
     let resp = daemon.api_call(&serde_json::json!({"method": "list"}));
     let agents = resp["result"]["agents"].as_array().expect("a");
     if !agents.is_empty() {
         let state = agents[0]["agent_state"].as_str().unwrap_or("");
-        assert!(
-            state == "crashed" || state == "restarting" || state == "starting",
-            "expected crashed, restarting, or starting, got: {state}"
+        assert_eq!(
+            state, "crashed",
+            "expected crashed immediately after kill, got: {state}"
         );
     }
 
@@ -473,24 +461,20 @@ fn test_crash_respawn_health() {
 }
 
 #[test]
-fn test_inject_restarting() {
+fn test_inject_after_kill_reports_crashed() {
     let mut daemon = TestDaemon::start("inject_restart");
 
     // Kill then immediately inject
     daemon.api_call(&serde_json::json!({"method": "kill", "params": {"name": "shell"}}));
-    std::thread::sleep(Duration::from_millis(300));
 
     let resp = daemon.api_call(&serde_json::json!({
         "method": "inject",
         "params": {"name": "shell", "data": "hello"}
     }));
 
-    // Should get the truthful recovery-state error, not "not found".
+    // Should get the exact truthful crashed-state error, not "not found".
     let error = resp["error"].as_str().unwrap_or("");
-    assert!(
-        error.contains("crashed") || error.contains("restarting"),
-        "expected 'crashed' or 'restarting' error, got: {error}"
-    );
+    assert_eq!(error, "agent 'shell' is crashed, retry later");
 
     daemon.stop();
 }


### PR DESCRIPTION
## Summary
- issue #2765 Slice 2: gate Restarting behind an opaque exact-generation one-use RecoveryExecutionPermit
- keep crash producers in Crashed until execution admission; settle spawn failure back to the exact old core
- make INJECT wording truthful and exclude Crashed from reclaim

## Scope
Implements frozen decision `d-20260717053806729037-7`; no new spawn sites, no registry→ledger lock nesting, and no attempt-budget/persistence/adapter work.

Agend-Agent: archfix-codex-dev
Agend-Task: t-20260717054014183570-55600-25
Agend-Branch: fix/2765-restarting-execution-permit
Agend-Decision: d-20260717053806729037-7

## Verification
- `cargo fmt -- --check`
- `git diff --check`
- `cargo test --bin agend-terminal slice2_red` (5 passed)
- `cargo test --bin agend-terminal agent::crash_disposition::tests` (10 passed)
- `cargo test --bin agend-terminal crash_respawn` (5 passed)
- `cargo test --bin agend-terminal respawn_watchdog` (22 passed)
- `cargo clippy --bin agend-terminal --all-targets -- -D warnings`

The full binary suite was also attempted; unrelated parallel fixture failures exhausted the process file-descriptor limit (`Too many open files`).,--draft=false