### PR TITLE
fix(#2760): canonicalize task dispatch correlation

### DIFF
--- a/src/api/handlers/messaging.rs
+++ b/src/api/handlers/messaging.rs
@@ -232,6 +232,15 @@ fn build_message(
             }
         }
     }
+    let task_id = params["task_id"]
+        .as_str()
+        .map(String::from)
+        .or_else(|| auto_task_id.clone());
+    let correlation_id = if params["kind"].as_str() == Some("task") {
+        task_id.clone()
+    } else {
+        params["correlation_id"].as_str().map(String::from)
+    };
     crate::inbox::InboxMessage {
         schema_version: 0,
         id: None,
@@ -239,14 +248,11 @@ fn build_message(
         delivering_at: None,
         thread_id,
         parent_id,
-        task_id: params["task_id"]
-            .as_str()
-            .map(String::from)
-            .or_else(|| auto_task_id.clone()),
+        task_id,
         force_meta: params
             .get("force_meta")
             .and_then(|v| serde_json::from_value::<crate::inbox::ForceMeta>(v.clone()).ok()),
-        correlation_id: params["correlation_id"].as_str().map(String::from),
+        correlation_id,
         // Display only. A validated review uses the server-derived exact head;
         // non-review reports may retain the caller's display value, but no
         // authorization logic reads it.
@@ -486,7 +492,13 @@ pub(crate) fn track_dispatch(
 ) {
     let kind_str = msg.kind.as_deref().unwrap_or("");
     if matches!(kind_str, "task" | "query") {
-        let outbound_corr = msg.correlation_id.as_deref().or(msg.task_id.as_deref());
+        // For tasks, task_id is the canonical lifecycle identity. Queries
+        // retain the historical correlation_id/task_id fallback semantics.
+        let outbound_corr = if kind_str == "task" {
+            msg.task_id.as_deref()
+        } else {
+            msg.correlation_id.as_deref().or(msg.task_id.as_deref())
+        };
         let explicit_threshold = params["expect_reply_within_secs"].as_i64();
         // #2099: a fire-and-forget dispatch (`no_report_expected`) records NO
         // dispatch-idle sidecar, so the ~threshold watchdog never nags the
@@ -567,13 +579,13 @@ pub(crate) fn track_dispatch(
         }
     } else if kind_str == "report" {
         // #1525: clear the dispatch-idle sidecar with the SAME key the record
-        // path uses — `correlation_id.or(task_id)` (see the kind=task branch
-        // above). `record_dispatch` keys the sidecar via that fallback, so a
-        // report that carries the id only in `task_id` (correlation_id empty)
-        // must match by task_id too; otherwise `mark_resolved`'s exact lookup
-        // silently no-ops and the completed dispatch's sidecar lingers until it
-        // fires a spurious `dispatch_idle_threshold_exceeded` nudge once the
-        // target goes Idle (#1516's working-state gate does not cover that).
+        // path uses — task_id for task dispatches, correlation_id/task_id
+        // fallback for query dispatches. A report that carries the id only in
+        // task_id (correlation_id empty) must match by task_id too; otherwise
+        // mark_resolved's exact lookup silently no-ops and the completed
+        // dispatch's sidecar lingers until it fires a spurious
+        // dispatch_idle_threshold_exceeded nudge once the target goes Idle
+        // (#1516's working-state gate does not cover that).
         if let Some(corr) = msg.correlation_id.as_deref().or(msg.task_id.as_deref()) {
             // #2004: `None` here is NORMAL (a report whose correlation has no
             // pending sidecar — most reports). The real swallowed failure —
@@ -710,6 +722,9 @@ pub(crate) fn handle_send(params: &Value, ctx: &HandlerCtx) -> Value {
         };
     if let Some(ref tid) = auto_task_id {
         msg.task_id = Some(tid.clone());
+        if params["kind"].as_str() == Some("task") {
+            msg.correlation_id = Some(tid.clone());
+        }
     }
     // #bughunt2: a failed enqueue (disk read-only / I/O) must surface as a real
     // failure — never report ok:true for a silently-dropped message. Return

--- a/src/api/handlers/messaging/tests.rs
+++ b/src/api/handlers/messaging/tests.rs
@@ -1306,6 +1306,119 @@ fn hook_fixup_team_dispatch_records_pending_via_default_threshold() {
     std::fs::remove_dir_all(&home).ok();
 }
 
+/// RED: a task dispatch must key delivery tracking by its leaf `task_id`, not
+/// by a stale umbrella `correlation_id`; a terminal report then closes the leaf
+/// while leaving the legitimate umbrella task open.
+#[test]
+fn task_dispatch_mismatch_tracks_and_closes_leaf_only() {
+    let home = tmp_home("task-correlation-leaf");
+    write_fixup_fleet(&home, &["fixup-lead", "fixup-reviewer"]);
+    let leaf = crate::tasks::handle(
+        &home,
+        "fixup-lead",
+        &json!({
+            "action": "create",
+            "title": "leaf task",
+            "assignee": "fixup-reviewer",
+        }),
+    )["id"]
+        .as_str()
+        .expect("leaf task id")
+        .to_string();
+    let umbrella = crate::tasks::handle(
+        &home,
+        "fixup-lead",
+        &json!({
+            "action": "create",
+            "title": "umbrella task",
+            "assignee": "fixup-reviewer",
+        }),
+    )["id"]
+        .as_str()
+        .expect("umbrella task id")
+        .to_string();
+    let ctx = test_ctx(&home);
+
+    let dispatched = handle_send(
+        &json!({
+            "from": "fixup-lead",
+            "target": "fixup-reviewer",
+            "text": "[delegate_task] leaf",
+            "kind": "task",
+            "task_id": leaf,
+            "correlation_id": umbrella,
+            "expect_reply_within_secs": 600,
+        }),
+        &ctx,
+    );
+    assert_eq!(
+        dispatched["ok"], true,
+        "task dispatch must succeed: {dispatched}"
+    );
+    let delivered = crate::inbox::drain(&home, "fixup-reviewer")
+        .into_iter()
+        .find(|m| m.text == "[delegate_task] leaf")
+        .expect("task message must be delivered to the target inbox");
+    assert_eq!(delivered.task_id.as_deref(), Some(leaf.as_str()));
+    assert_eq!(
+        delivered.correlation_id.as_deref(),
+        Some(leaf.as_str()),
+        "delivered task message must use task_id as canonical correlation"
+    );
+    let pending = crate::daemon::dispatch_idle::list_pending(&home);
+    assert!(
+        pending
+            .iter()
+            .any(|p| p.correlation_id.as_deref() == Some(leaf.as_str())),
+        "dispatch tracking must use the leaf task_id: {pending:?}"
+    );
+    assert!(
+        pending
+            .iter()
+            .all(|p| p.correlation_id.as_deref() != Some(umbrella.as_str())),
+        "stale umbrella correlation must not receive the leaf sidecar: {pending:?}"
+    );
+
+    let reported = handle_send(
+        &json!({
+            "from": "fixup-reviewer",
+            "target": "fixup-lead",
+            "text": "leaf complete",
+            "kind": "report",
+            "correlation_id": leaf,
+            "terminal": true,
+        }),
+        &ctx,
+    );
+    assert_eq!(
+        reported["ok"], true,
+        "terminal report must deliver: {reported}"
+    );
+    let listed = crate::tasks::handle(
+        &home,
+        "fixup-lead",
+        &json!({"action": "list", "include_history": true}),
+    );
+    let tasks = listed["tasks"].as_array().expect("task list");
+    let status = |id: &str| {
+        tasks
+            .iter()
+            .find(|task| task["id"].as_str() == Some(id))
+            .and_then(|task| task["status"].as_str())
+    };
+    assert_eq!(
+        status(&leaf),
+        Some("done"),
+        "leaf must auto-close: {tasks:?}"
+    );
+    assert_eq!(
+        status(&umbrella),
+        Some("open"),
+        "umbrella must remain open: {tasks:?}"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
 /// #2099 rework (PR #2108, reviewer-2 catch): close the SECOND ~30min nag
 /// channel. A fixup-team dispatch auto-arms dispatch_idle at the 1800s team
 /// default; a fire-and-forget dispatch (`no_report_expected=true`) must
@@ -2301,6 +2414,11 @@ fn auto_create_task_on_send_kind_task_without_task_id() {
         msg.task_id.as_deref(),
         Some(task_id),
         "outbound message must carry auto-generated task_id"
+    );
+    assert_eq!(
+        msg.correlation_id.as_deref(),
+        Some(task_id),
+        "auto-created task message must use task_id as canonical correlation"
     );
     std::fs::remove_dir_all(&home).ok();
 }

--- a/src/daemon/ci_handoff_track.rs
+++ b/src/daemon/ci_handoff_track.rs
@@ -1027,6 +1027,11 @@ mod tests {
             text: format!("[dispatch] {kind}"),
             kind: Some(kind.into()),
             correlation_id: Some("o/r@feat".into()),
+            task_id: if kind == "task" {
+                Some("t-x".into())
+            } else {
+                None
+            },
             timestamp: "2026-07-06T00:00:00Z".into(),
             ..Default::default()
         };
@@ -1054,7 +1059,8 @@ mod tests {
             "a kind=query is not a delegation — the dispatcher's ci-ready track must survive"
         );
 
-        // kind=task with the same correlation IS the delegation → resolves it.
+        // kind=task with its canonical task_id IS the delegation → resolves it;
+        // the repo/branch correlation is display-only for task lifecycle.
         crate::api::handlers::messaging::track_dispatch(
             &home,
             &params,

--- a/src/mcp/handlers/send_envelope.rs
+++ b/src/mcp/handlers/send_envelope.rs
@@ -359,6 +359,34 @@ mod tests {
         assert!(!obj.contains_key("branch"));
     }
 
+    /// RED: a task's lifecycle identity is its task_id, even when a stale
+    /// umbrella correlation_id is supplied. Both projections must carry the
+    /// same canonical correlation before either delivery path runs.
+    #[test]
+    fn task_projections_canonicalize_correlation_to_task_id() {
+        let env = SendEnvelope {
+            from: "lead".to_string(),
+            target: "reviewer".to_string(),
+            text: "[delegate_task] leaf".to_string(),
+            kind: Some("task".to_string()),
+            correlation_id: Some("t-umbrella".to_string()),
+            task_id: Some("t-leaf".to_string()),
+            ..SendEnvelope::default()
+        };
+
+        let params = env.to_send_params();
+        let fallback = env.to_inbox_message();
+        assert_eq!(params["task_id"], "t-leaf");
+        assert_eq!(params["correlation_id"], "t-leaf");
+        assert_eq!(fallback.task_id.as_deref(), Some("t-leaf"));
+        assert_eq!(fallback.correlation_id.as_deref(), Some("t-leaf"));
+        assert_eq!(
+            params["correlation_id"].as_str(),
+            fallback.correlation_id.as_deref(),
+            "normal API and API-down fallback must project the same canonical correlation"
+        );
+    }
+
     /// `directives_from_args` reads the whole directive set from args (the read
     /// that used to be hand-copied into every SEND site).
     #[test]

--- a/src/mcp/handlers/send_envelope.rs
+++ b/src/mcp/handlers/send_envelope.rs
@@ -90,6 +90,14 @@ impl SendEnvelope {
             provenance,
             branch,
         } = self;
+        // A task's lifecycle identity is its task_id. Ignore a stale or
+        // umbrella correlation before projecting the envelope so the daemon
+        // route and API-down fallback remain side-effect equivalent.
+        let correlation_id = if kind.as_deref() == Some("task") {
+            task_id
+        } else {
+            correlation_id
+        };
         let mut params = json!({
             "from": from,
             "target": target,
@@ -156,6 +164,14 @@ impl SendEnvelope {
             provenance: _,
             branch: _,
         } = self;
+        // Keep fallback delivery on the same canonical task correlation as the
+        // normal daemon SEND projection; non-task correlation semantics stay
+        // unchanged.
+        let correlation_id = if kind.as_deref() == Some("task") {
+            task_id
+        } else {
+            correlation_id
+        };
         let report_purpose = report_purpose
             .as_deref()
             .and_then(|p| {

--- a/src/mcp/handlers/tests.rs
+++ b/src/mcp/handlers/tests.rs
@@ -1596,7 +1596,11 @@ fn delegate_task_forwards_dispatch_directives_high1() {
         Some(true),
         "worktree_binding_required must reach the InboxMessage (delivery gate)"
     );
-    assert_eq!(m.correlation_id.as_deref(), Some("c-high1"));
+    assert_eq!(
+        m.correlation_id.as_deref(),
+        Some("t-high1-1"),
+        "kind=task must use task_id as canonical correlation"
+    );
     assert_eq!(m.reviewed_head.as_deref(), Some("abc1234"));
     assert_eq!(m.eta_minutes, Some(30));
     assert_eq!(m.reporting_cadence.as_deref(), Some("wave-end"));

--- a/src/tasks/auto_close.rs
+++ b/src/tasks/auto_close.rs
@@ -271,6 +271,78 @@ mod tests {
         );
     }
 
+    /// A completed child is not a reason to block a legitimate terminal report
+    /// for its still-open parent. Auto-close must not grow a has-children guard.
+    #[test]
+    fn parent_with_completed_child_still_auto_closes() {
+        let home = tmp_home("parent_completed_child");
+        let emitter = InstanceName::from("test:seed");
+        let parent = TaskId("t-parent-correlation".into());
+        let child = TaskId("t-child-correlation".into());
+        crate::task_events::append_batch_at(
+            &home,
+            &emitter,
+            vec![
+                TaskEvent::Created {
+                    task_id: parent.clone(),
+                    title: "parent".into(),
+                    description: String::new(),
+                    priority: "normal".into(),
+                    owner: Some(InstanceName::from("dev-agent")),
+                    due_at: None,
+                    depends_on: Vec::new(),
+                    routed_to: None,
+                    branch: None,
+                    bind: None,
+                    eta_secs: None,
+                    tags: vec![],
+                    parent_id: None,
+                },
+                TaskEvent::Created {
+                    task_id: child.clone(),
+                    title: "child".into(),
+                    description: String::new(),
+                    priority: "normal".into(),
+                    owner: Some(InstanceName::from("dev-agent")),
+                    due_at: None,
+                    depends_on: Vec::new(),
+                    routed_to: None,
+                    branch: None,
+                    bind: None,
+                    eta_secs: None,
+                    tags: vec![],
+                    parent_id: Some(parent.clone()),
+                },
+                TaskEvent::Done {
+                    task_id: child,
+                    by: InstanceName::from("dev-agent"),
+                    source: crate::task_events::DoneSource::OperatorManual {
+                        authored_at: "2026-01-01T00:00:00Z".into(),
+                        result: Some("child complete".into()),
+                    },
+                },
+            ],
+        )
+        .expect("seed parent and completed child");
+
+        let closed = auto_close_on_report(
+            &home,
+            "report",
+            &parent.0,
+            "dev-agent",
+            "parent complete",
+            true,
+        )
+        .unwrap();
+        assert!(closed, "parent terminal report should auto-close");
+        assert_eq!(
+            task_status(&home, &parent.0),
+            Some(crate::task_events::TaskStatus::Done),
+            "completed child must not block its parent from closing"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
     /// #78445-2 PR-C (defect d) RED-first: closing a task must SETTLE its
     /// `dispatch_tracking` rows (matched by task_id) so the stuck-dispatch sweep
     /// stops nagging about a dispatch whose task the board already closed (the


### PR DESCRIPTION
## Summary

- Treat `task_id` as the canonical lifecycle identity for `kind=task`.
- Normalize normal API and API-down `SendEnvelope` fallback projections, InboxMessage delivery, and dispatch side effects to that identity.
- Preserve non-task correlation semantics and do not add a has-children auto-close guard.

## Decision and scope

Implements frozen decision `d-20260717124432790461-0` on exact base `3c3af38280352c424e7e1526e5e807433a5a53ec`.

## RED → GREEN evidence

- RED `3b3b1cff`: projection, mismatch leaf/umbrella, and auto-created-task correlation tests fail as expected; completed-child parent auto-close passes.
- GREEN `1b08512d`: all targeted tests pass.
- `cargo test --bin agend-terminal mcp::handlers::send_envelope::tests` — 7 passed.
- `cargo test --bin agend-terminal api::handlers::messaging::tests` — 74 passed, 1 ignored.
- `cargo test --bin agend-terminal tasks::auto_close::tests` — 14 passed.
- `cargo fmt -- --check`, `git diff --check`, and `cargo clippy --bin agend-terminal --all-targets -- -D warnings` — passed.

No self-merge performed.