### PR TITLE
[#2765] Debit crash attempts after exact admission

### DIFF
--- a/src/agent/crash_disposition.rs
+++ b/src/agent/crash_disposition.rs
@@ -146,6 +146,19 @@ pub(crate) struct RecoveryExecutionPermit {
     key: DispositionKey,
     core: Arc<CoreMutex<AgentCore>>,
     restarting_admitted: bool,
+    attempt_debited: bool,
+}
+
+/// The health/accounting result committed by one exact-generation permit.
+/// This value is produced only after [`RecoveryExecutionPermit::admit_restarting`]
+/// succeeds and therefore never represents a raw crash observation.
+pub(crate) struct RecoveryAttempt {
+    pub(crate) should_respawn: bool,
+    pub(crate) delay: std::time::Duration,
+    pub(crate) should_notify: bool,
+    pub(crate) fire_self_orch_p0: bool,
+    pub(crate) fire_terminal_p0: bool,
+    pub(crate) escalation_snapshot: crate::health::PersistedEscalation,
 }
 
 impl RecoveryExecutionPermit {
@@ -163,6 +176,42 @@ impl RecoveryExecutionPermit {
 
     fn key(&self) -> DispositionKey {
         self.key
+    }
+
+    pub(crate) fn exact_core(&self) -> Arc<CoreMutex<AgentCore>> {
+        Arc::clone(&self.core)
+    }
+
+    /// Debit the retry budget exactly once on the exact old core captured by
+    /// this permit.  A reused permit cannot issue another attempt or mutate
+    /// persistence/accounting a second time.
+    pub(crate) fn debit_attempt(
+        &mut self,
+        self_orch: crate::teams::SelfOrchStatus,
+    ) -> Option<RecoveryAttempt> {
+        if !self.restarting_admitted || self.attempt_debited {
+            return None;
+        }
+        self.attempt_debited = true;
+        let mut core = self.core.lock();
+        let fire_self_orch_p0 = self_orch == crate::teams::SelfOrchStatus::Yes
+            && core.health.self_orch_crash_should_notify();
+        let (should_respawn, delay, should_notify) = core.health.record_crash();
+        let fire_terminal_p0 = !should_respawn
+            && self_orch != crate::teams::SelfOrchStatus::No
+            && !core.health.failed_escalated;
+        if fire_terminal_p0 {
+            core.health.failed_escalated = true;
+        }
+        let escalation_snapshot = core.health.escalation_snapshot();
+        Some(RecoveryAttempt {
+            should_respawn,
+            delay,
+            should_notify,
+            fire_self_orch_p0,
+            fire_terminal_p0,
+            escalation_snapshot,
+        })
     }
 }
 
@@ -296,6 +345,7 @@ impl CrashDispositionLedger {
             key: token.key,
             core,
             restarting_admitted: false,
+            attempt_debited: false,
         })
     }
 
@@ -688,6 +738,30 @@ mod tests {
             crate::state::AgentState::Crashed
         );
         assert_eq!(ledger.disposition(obs.key()), Some(Disposition::Failed));
+    }
+
+    #[test]
+    fn admitted_permit_debits_exact_core_once() {
+        let ledger = CrashDispositionLedger::new();
+        let id = InstanceId::new();
+        let deleted = Arc::new(AtomicBool::new(false));
+        let obs = observation(id, SpawnGeneration::new(92), &deleted, None);
+        ledger.register_generation(id, obs.generation);
+        assert!(ledger.publish(obs.clone()));
+        let token = ledger.claim(obs.key(), Claimant::Crash).expect("claim");
+        assert!(ledger.mark_ready(token));
+
+        let mut permit = ledger.begin_execute(token).expect("permit");
+        assert!(permit.admit_restarting());
+        let attempt = permit
+            .debit_attempt(crate::teams::SelfOrchStatus::No)
+            .expect("first debit");
+        assert!(attempt.should_respawn);
+        assert!(permit
+            .debit_attempt(crate::teams::SelfOrchStatus::No)
+            .is_none());
+        assert_eq!(obs.core.lock().health.total_crashes, 1);
+        assert!(ledger.mark_live(permit));
     }
 
     #[test]

--- a/src/daemon/crash_respawn.rs
+++ b/src/daemon/crash_respawn.rs
@@ -44,9 +44,7 @@ fn await_test_worker_gate() -> Option<Sender<()>> {
         .lock()
         .expect("test worker gate lock")
         .take();
-    let Some((entered, release, done)) = gate else {
-        return None;
-    };
+    let (entered, release, done) = gate?;
     let _ = entered.send(());
     let _ = release.recv();
     Some(done)

--- a/src/daemon/crash_respawn.rs
+++ b/src/daemon/crash_respawn.rs
@@ -86,19 +86,11 @@ pub(super) fn handle_crash_observation(
     // leaderless page off an indeterminate read. (The no-peer hung/AuthError
     // paths fail the other way — they escalate on `Unknown`.)
     let self_orch = crate::teams::self_orch_status(home, crashed_name);
-    let is_self_orch = self_orch == crate::teams::SelfOrchStatus::Yes;
 
     enum RegistryOutcome {
         Deleted,
         Missing,
-        Healthy {
-            should_respawn: bool,
-            delay: std::time::Duration,
-            should_notify: bool,
-            fire_self_orch_p0: bool,
-            fire_terminal_p0: bool,
-            escalation_snapshot: crate::health::PersistedEscalation,
-        },
+        Healthy { delay: std::time::Duration },
     }
 
     // Snapshot health and the deleted/missing outcome while holding the
@@ -128,41 +120,11 @@ pub(super) fn handle_crash_observation(
                     );
                     RegistryOutcome::Deleted
                 } else {
-                    let mut core = handle.core.lock();
-                    // #1701: decide the self-orch P0 BEFORE record_crash (which may
-                    // itself stamp the crash cooldown on its recent>=2 path) — the
-                    // accessor reads+stamps the crash-class cooldown (#1744-H3:
-                    // distinct from the hung cooldown), and for a self-orchestrator we
-                    // use ONLY this gate, never the generic recent>=2 one. The `&&`
-                    // short-circuits for non-orchestrators, so their cooldown is
-                    // untouched.
-                    let fire_p0 = is_self_orch && core.health.self_orch_crash_should_notify();
-                    let (respawn, delay, notify) = core.health.record_crash();
-                    // #1744-H4: a terminal Failed (max-retries) self-orchestrator crash
-                    // is a PERMANENT leaderless death. record_crash returns notify=true
-                    // ("don't respawn, do notify"), but fire_p0 is cooldown-gated and
-                    // the generic notify branch below is `!is_self_orch` — so without
-                    // this it pages NEITHER. Fire a once-off, cooldown-EXEMPT terminal
-                    // P0, fail-closed (Yes|Unknown fire, No skip), latched via the
-                    // PERSISTED `failed_escalated` so a restart (which rehydrates the
-                    // crash budget but not `state`) doesn't re-page the same death.
-                    let fire_terminal =
-                        should_fire_terminal_p0(respawn, self_orch, core.health.failed_escalated);
-                    if fire_terminal {
-                        core.health.failed_escalated = true;
-                    }
-                    // #1744-H2: snapshot the (just-mutated) escalation state under the
-                    // lock; persisted lock-free below so the crash budget + cooldown
-                    // (+ #1744-H4 failed_escalated) survive a daemon restart.
-                    let snap = core.health.escalation_snapshot();
-                    RegistryOutcome::Healthy {
-                        should_respawn: respawn,
-                        delay,
-                        should_notify: notify,
-                        fire_self_orch_p0: fire_p0,
-                        fire_terminal_p0: fire_terminal,
-                        escalation_snapshot: snap,
-                    }
+                    // Project the backoff without mutating health.  Retry
+                    // accounting is committed only after the worker admits its
+                    // exact-generation execution permit.
+                    let delay = handle.core.lock().health.next_crash_delay();
+                    RegistryOutcome::Healthy { delay }
                 }
             }
             None => {
@@ -172,63 +134,15 @@ pub(super) fn handle_crash_observation(
         }
     };
 
-    let (
-        should_respawn,
-        delay,
-        should_notify,
-        fire_self_orch_p0,
-        fire_terminal_p0,
-        escalation_snapshot,
-    ) = match registry_outcome {
+    let delay = match registry_outcome {
         RegistryOutcome::Deleted | RegistryOutcome::Missing => {
             ledger.discard(key);
             return;
         }
-        RegistryOutcome::Healthy {
-            should_respawn,
-            delay,
-            should_notify,
-            fire_self_orch_p0,
-            fire_terminal_p0,
-            escalation_snapshot,
-        } => (
-            should_respawn,
-            delay,
-            should_notify,
-            fire_self_orch_p0,
-            fire_terminal_p0,
-            escalation_snapshot,
-        ),
+        RegistryOutcome::Healthy { delay } => delay,
     };
-
-    // #1744-H2: persist the crash budget + crash cooldown (lock released above).
-    crate::daemon::escalation_persist::persist(home, crashed_name, &escalation_snapshot);
-
-    // #1701: a self-orchestrator crash escalates to the operator on EVERY crash
-    // (cooldown-gated) — the team is leaderless until respawn and no peer can
-    // relay. A non-orchestrator agent keeps the generic recent>=2 crash notify.
-    if fire_terminal_p0 {
-        // #1744-H4: terminal-Failed self-orch — takes precedence over the
-        // per-crash page (its wording is "permanent, won't respawn", not "until
-        // respawn"). Once-off via the persisted `failed_escalated` latch.
-        notify_self_orch_terminal(crashed_name);
-    } else if fire_self_orch_p0 {
-        notify_self_orch_crash(crashed_name, &instance_id, &ctx.registry);
-    } else if !is_self_orch && should_notify {
-        notify_crash(crashed_name, &instance_id, &ctx.registry);
-    }
-
-    if !should_respawn {
-        tracing::warn!(agent = %crashed_name, "max retries exceeded, not respawning");
-        ledger.discard(key);
-        return;
-    }
 
     tracing::info!(agent = %crashed_name, ?delay, "respawning");
-    let saved_health = {
-        let r = agent::lock_registry(&ctx.registry);
-        r.get(&instance_id).map(|h| h.core.lock().health.clone())
-    };
 
     let reg = Arc::clone(&ctx.registry);
     let home = home.to_path_buf();
@@ -245,11 +159,13 @@ pub(super) fn handle_crash_observation(
                 &home,
                 config,
                 delay,
-                saved_health,
+                None,
                 &reg,
                 tx,
                 &shutdown_for_respawn,
                 Some(claim),
+                self_orch,
+                instance_id,
             );
         })
     {
@@ -324,6 +240,7 @@ fn notify_self_orch_crash(
 /// (fail-closed: `Yes`|`Unknown` fire, `No` skip — a leaderless death is too
 /// costly to miss on an indeterminate teams read), and it has not already been
 /// terminally paged (`failed_escalated`, persisted for cross-restart once-off).
+#[cfg(test)]
 fn should_fire_terminal_p0(
     should_respawn: bool,
     self_orch: crate::teams::SelfOrchStatus,
@@ -390,6 +307,8 @@ fn respawn_agent_worker(
     tx: crossbeam_channel::Sender<crate::agent::AgentExitEvent>,
     shutdown: &Arc<AtomicBool>,
     claim: Option<ClaimToken>,
+    self_orch: crate::teams::SelfOrchStatus,
+    instance_id: crate::types::InstanceId,
 ) {
     std::thread::sleep(delay);
     if shutdown.load(Ordering::Relaxed) {
@@ -452,6 +371,54 @@ fn respawn_agent_worker(
         }
         None => None,
     };
+    let mut saved_health = saved_health;
+    if permit.is_some() {
+        let attempt = permit
+            .as_mut()
+            .and_then(|permit| permit.debit_attempt(self_orch));
+        let Some(attempt) = attempt else {
+            tracing::warn!(agent = %config.name, "exact-generation recovery permit was already debited");
+            if let Some(permit) = permit.take() {
+                let _ = agent::crash_disposition::owner_ledger().mark_failed(permit);
+            }
+            return;
+        };
+        let exact_core = permit
+            .as_ref()
+            .expect("permit remains after debit")
+            .exact_core();
+        saved_health = Some(exact_core.lock().health.clone());
+        tracing::debug!(
+            agent = %config.name,
+            ?attempt.delay,
+            "exact-generation crash attempt admitted"
+        );
+        crate::event_log::log(
+            home,
+            "crash_respawn_attempt",
+            &config.name,
+            "exact-generation recovery permit admitted one retry attempt",
+        );
+        crate::daemon::escalation_persist::persist(
+            home,
+            &config.name,
+            &attempt.escalation_snapshot,
+        );
+        if attempt.fire_terminal_p0 {
+            notify_self_orch_terminal(&config.name);
+        } else if attempt.fire_self_orch_p0 {
+            notify_self_orch_crash(&config.name, &instance_id, reg);
+        } else if self_orch != crate::teams::SelfOrchStatus::Yes && attempt.should_notify {
+            notify_crash(&config.name, &instance_id, reg);
+        }
+        if !attempt.should_respawn {
+            tracing::warn!(agent = %config.name, "max retries exceeded, not respawning");
+            if let Some(permit) = permit.take() {
+                let _ = agent::crash_disposition::owner_ledger().mark_failed(permit);
+            }
+            return;
+        }
+    }
     match agent::spawn_agent(
         &agent::SpawnConfig {
             name: &config.name,
@@ -699,10 +666,6 @@ mod deleted_gate_tests_1913 {
             configs: Arc::new(Mutex::new(configs)),
             crash_tx,
             crash_rx,
-            // shutdown=true: for the deleted=false case the respawn worker thread
-            // aborts after its backoff WITHOUT a real `spawn_agent` — the test
-            // asserts the respawn PATH was entered (record_crash bumped
-            // total_crashes), not that a process actually launched.
             shutdown: Arc::new(AtomicBool::new(true)),
         }
     }
@@ -768,17 +731,15 @@ mod deleted_gate_tests_1913 {
             .register_generation(handle.id, handle.generation);
         reg.lock()
             .insert(InstanceId::parse(VICTIM_UUID).expect("valid uuid"), handle);
-        let ctx = make_ctx(Arc::clone(&reg));
+        let ctx = DaemonContext {
+            shutdown: Arc::new(AtomicBool::new(false)),
+            ..make_ctx(Arc::clone(&reg))
+        };
 
         handle_crash_respawn(&home, VICTIM, &ctx);
 
-        assert_eq!(
-            total_crashes(&reg),
-            1,
-            "#1913 regression guard: a real crash (deleted=false) must STILL enter \
-             the respawn path (record_crash runs) — the deleted-gate must not \
-             suppress normal crash recovery"
-        );
+        wait_for_total_crashes(&reg, 1);
+        assert_eq!(total_crashes(&reg), 1);
         std::fs::remove_dir_all(&home).ok();
     }
 
@@ -880,7 +841,11 @@ mod deleted_gate_tests_1913 {
         let generation = handle.generation;
         reg.lock().insert(id, handle);
         let ctx = make_ctx(Arc::clone(&reg));
-        ctx.configs.lock().get_mut(VICTIM).unwrap().backend_command =
+        ctx.configs
+            .lock()
+            .get_mut(VICTIM)
+            .expect("victim config")
+            .backend_command =
             "missing-exact-attempt-command".to_string();
         crate::agent::crash_disposition::owner_ledger().register_generation(id, generation);
         let observation = {
@@ -911,8 +876,17 @@ mod deleted_gate_tests_1913 {
             "debit is not raw-observation side effect"
         );
         wait_for_total_crashes(&reg, 1);
-        let persisted = crate::daemon::escalation_persist::load_for(&home, VICTIM)
-            .expect("accepted attempt must persist escalation count");
+        let persist_deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        let persisted = loop {
+            if let Some(persisted) = crate::daemon::escalation_persist::load_for(&home, VICTIM) {
+                break persisted;
+            }
+            assert!(
+                std::time::Instant::now() < persist_deadline,
+                "accepted attempt must persist escalation count"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        };
         assert_eq!(persisted.total_crashes, 1);
         let log = std::fs::read_to_string(home.join("event-log.jsonl")).unwrap_or_default();
         assert_eq!(
@@ -954,6 +928,8 @@ mod deleted_gate_tests_1913 {
             crash_tx,
             &shutdown,
             None,
+            crate::teams::SelfOrchStatus::No,
+            InstanceId::parse(VICTIM_UUID).expect("valid uuid"),
         );
 
         // Verify 1: event-log.jsonl should have a crash_respawn_failed record

--- a/src/daemon/crash_respawn.rs
+++ b/src/daemon/crash_respawn.rs
@@ -16,7 +16,48 @@ use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
+#[cfg(test)]
+use std::sync::mpsc::{Receiver, Sender};
+#[cfg(test)]
+use std::sync::{Mutex, OnceLock};
+
 use super::{run_dir, serve_agent_tui, AgentConfig, DaemonContext};
+
+#[cfg(test)]
+type TestWorkerGate = (Sender<()>, Receiver<()>, Sender<()>);
+
+#[cfg(test)]
+static TEST_WORKER_GATE: OnceLock<Mutex<Option<TestWorkerGate>>> = OnceLock::new();
+
+#[cfg(test)]
+fn install_test_worker_gate(gate: TestWorkerGate) {
+    *TEST_WORKER_GATE
+        .get_or_init(|| Mutex::new(None))
+        .lock()
+        .expect("test worker gate lock") = Some(gate);
+}
+
+#[cfg(test)]
+fn await_test_worker_gate() -> Option<Sender<()>> {
+    let gate = TEST_WORKER_GATE
+        .get_or_init(|| Mutex::new(None))
+        .lock()
+        .expect("test worker gate lock")
+        .take();
+    let Some((entered, release, done)) = gate else {
+        return None;
+    };
+    let _ = entered.send(());
+    let _ = release.recv();
+    Some(done)
+}
+
+#[cfg(test)]
+fn signal_test_worker_done(done: &Option<Sender<()>>) {
+    if let Some(done) = done {
+        let _ = done.clone().send(());
+    }
+}
 
 /// Compatibility entry used by legacy tests and name-triggered internal call
 /// sites. Production PTY events use [`handle_crash_observation`] directly.
@@ -310,12 +351,22 @@ fn respawn_agent_worker(
     self_orch: crate::teams::SelfOrchStatus,
     instance_id: crate::types::InstanceId,
 ) {
+    #[cfg(test)]
+    let test_done = if claim.is_some() {
+        await_test_worker_gate()
+    } else {
+        None
+    };
+    #[cfg(not(test))]
+    let _test_done: Option<()> = None;
     std::thread::sleep(delay);
     if shutdown.load(Ordering::Relaxed) {
         if let Some(token) = claim {
             agent::crash_disposition::owner_ledger().discard(token.key());
         }
         tracing::info!(agent = %config.name, "shutdown during respawn backoff, aborting");
+        #[cfg(test)]
+        signal_test_worker_done(&test_done);
         return;
     }
     let (cols, rows) = crossterm::terminal::size().unwrap_or((120, 40));
@@ -354,6 +405,8 @@ fn respawn_agent_worker(
             agent::crash_disposition::owner_ledger().discard(token.key());
         }
         tracing::info!(agent = %config.name, "shutdown before respawn execution admission, aborting");
+        #[cfg(test)]
+        signal_test_worker_done(&test_done);
         return;
     }
     let mut permit = match claim {
@@ -361,10 +414,14 @@ fn respawn_agent_worker(
             let Some(mut permit) = agent::crash_disposition::owner_ledger().begin_execute(token)
             else {
                 tracing::info!(agent = %config.name, "exact-generation recovery was discarded before execution");
+                #[cfg(test)]
+                signal_test_worker_done(&test_done);
                 return;
             };
             if !permit.admit_restarting() {
                 tracing::info!(agent = %config.name, "execution permit could not admit Restarting");
+                #[cfg(test)]
+                signal_test_worker_done(&test_done);
                 return;
             }
             Some(permit)
@@ -381,6 +438,8 @@ fn respawn_agent_worker(
             if let Some(permit) = permit.take() {
                 let _ = agent::crash_disposition::owner_ledger().mark_failed(permit);
             }
+            #[cfg(test)]
+            signal_test_worker_done(&test_done);
             return;
         };
         let exact_core = permit
@@ -416,6 +475,8 @@ fn respawn_agent_worker(
             if let Some(permit) = permit.take() {
                 let _ = agent::crash_disposition::owner_ledger().mark_failed(permit);
             }
+            #[cfg(test)]
+            signal_test_worker_done(&test_done);
             return;
         }
     }
@@ -670,19 +731,16 @@ mod deleted_gate_tests_1913 {
         }
     }
 
-    fn wait_for_total_crashes(reg: &AgentRegistry, expected: u32) {
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(8);
-        loop {
-            if total_crashes(reg) == expected {
-                return;
-            }
-            assert!(
-                std::time::Instant::now() < deadline,
-                "timed out waiting for total_crashes={expected}, got {}",
-                total_crashes(reg)
-            );
-            std::thread::sleep(std::time::Duration::from_millis(20));
-        }
+    fn worker_gate() -> (
+        std::sync::mpsc::Receiver<()>,
+        std::sync::mpsc::Sender<()>,
+        std::sync::mpsc::Receiver<()>,
+    ) {
+        let (entered_tx, entered_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let (done_tx, done_rx) = std::sync::mpsc::channel();
+        super::install_test_worker_gate((entered_tx, release_rx, done_tx));
+        (entered_rx, release_tx, done_rx)
     }
 
     fn total_crashes(reg: &AgentRegistry) -> u32 {
@@ -727,6 +785,7 @@ mod deleted_gate_tests_1913 {
         let home = tmp_home("crash");
         let reg: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
         let handle = make_handle(false);
+        handle.core.lock().health.total_crashes = 4;
         crate::agent::crash_disposition::owner_ledger()
             .register_generation(handle.id, handle.generation);
         reg.lock()
@@ -735,11 +794,15 @@ mod deleted_gate_tests_1913 {
             shutdown: Arc::new(AtomicBool::new(false)),
             ..make_ctx(Arc::clone(&reg))
         };
+        let (entered_rx, release_tx, done_rx) = worker_gate();
 
         handle_crash_respawn(&home, VICTIM, &ctx);
 
-        wait_for_total_crashes(&reg, 1);
-        assert_eq!(total_crashes(&reg), 1);
+        entered_rx.recv().expect("respawn worker entered gate");
+        assert_eq!(total_crashes(&reg), 4);
+        release_tx.send(()).expect("release respawn worker");
+        done_rx.recv().expect("respawn worker completed");
+        assert_eq!(total_crashes(&reg), 5);
         std::fs::remove_dir_all(&home).ok();
     }
 
@@ -751,6 +814,7 @@ mod deleted_gate_tests_1913 {
         let home = tmp_home("superseded-before-execute");
         let reg: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
         let handle = make_handle(false);
+        handle.core.lock().health.total_crashes = 4;
         let id = handle.id;
         let generation = handle.generation;
         reg.lock().insert(id, handle);
@@ -771,19 +835,22 @@ mod deleted_gate_tests_1913 {
                 name: h.name.clone(),
             }
         };
+        let (entered_rx, release_tx, done_rx) = worker_gate();
 
         handle_crash_observation(&home, &observation, &ctx);
         assert_eq!(
             total_crashes(&reg),
-            0,
+            4,
             "RED: debit must wait for execution admission"
         );
 
+        entered_rx.recv().expect("respawn worker entered gate");
         let replacement = crate::agent::crash_disposition::owner_generation_source().next();
         crate::agent::crash_disposition::owner_ledger().register_generation(id, replacement);
-        std::thread::sleep(std::time::Duration::from_secs(6));
+        release_tx.send(()).expect("release respawn worker");
+        done_rx.recv().expect("respawn worker completed");
 
-        assert_eq!(total_crashes(&reg), 0);
+        assert_eq!(total_crashes(&reg), 4);
         assert!(
             crate::daemon::escalation_persist::load_for(&home, VICTIM).is_none(),
             "superseded recovery must not persist an attempt"
@@ -799,6 +866,7 @@ mod deleted_gate_tests_1913 {
         let home = tmp_home("shutdown-before-execute");
         let reg: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
         let handle = make_handle(false);
+        handle.core.lock().health.total_crashes = 4;
         let id = handle.id;
         let generation = handle.generation;
         reg.lock().insert(id, handle);
@@ -816,15 +884,18 @@ mod deleted_gate_tests_1913 {
                 name: h.name.clone(),
             }
         };
+        let (entered_rx, release_tx, done_rx) = worker_gate();
 
         handle_crash_observation(&home, &observation, &ctx);
         assert_eq!(
             total_crashes(&reg),
-            0,
+            4,
             "RED: shutdown must reject before debit"
         );
-        std::thread::sleep(std::time::Duration::from_secs(6));
-        assert_eq!(total_crashes(&reg), 0);
+        entered_rx.recv().expect("respawn worker entered gate");
+        release_tx.send(()).expect("release respawn worker");
+        done_rx.recv().expect("respawn worker completed");
+        assert_eq!(total_crashes(&reg), 4);
         assert!(crate::daemon::escalation_persist::load_for(&home, VICTIM).is_none());
         std::fs::remove_dir_all(&home).ok();
     }
@@ -837,6 +908,7 @@ mod deleted_gate_tests_1913 {
         let home = tmp_home("exact-admission");
         let reg: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
         let handle = make_handle(false);
+        handle.core.lock().health.total_crashes = 4;
         let id = handle.id;
         let generation = handle.generation;
         reg.lock().insert(id, handle);
@@ -845,8 +917,7 @@ mod deleted_gate_tests_1913 {
             .lock()
             .get_mut(VICTIM)
             .expect("victim config")
-            .backend_command =
-            "missing-exact-attempt-command".to_string();
+            .backend_command = "missing-exact-attempt-command".to_string();
         crate::agent::crash_disposition::owner_ledger().register_generation(id, generation);
         let observation = {
             let r = reg.lock();
@@ -868,26 +939,22 @@ mod deleted_gate_tests_1913 {
             owner_shutdown: Some(Arc::clone(&ctx.shutdown)),
             ..observation
         };
+        let (entered_rx, release_tx, done_rx) = worker_gate();
 
         handle_crash_observation(&home, &observation, &ctx);
         assert_eq!(
             total_crashes(&reg),
-            0,
+            4,
             "debit is not raw-observation side effect"
         );
-        wait_for_total_crashes(&reg, 1);
-        let persist_deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
-        let persisted = loop {
-            if let Some(persisted) = crate::daemon::escalation_persist::load_for(&home, VICTIM) {
-                break persisted;
-            }
-            assert!(
-                std::time::Instant::now() < persist_deadline,
-                "accepted attempt must persist escalation count"
-            );
-            std::thread::sleep(std::time::Duration::from_millis(20));
-        };
-        assert_eq!(persisted.total_crashes, 1);
+        entered_rx.recv().expect("respawn worker entered gate");
+        assert_eq!(total_crashes(&reg), 4);
+        release_tx.send(()).expect("release respawn worker");
+        done_rx.recv().expect("respawn worker completed");
+        assert_eq!(total_crashes(&reg), 5);
+        let persisted = crate::daemon::escalation_persist::load_for(&home, VICTIM)
+            .expect("accepted attempt must persist escalation count");
+        assert_eq!(persisted.total_crashes, 5);
         let log = std::fs::read_to_string(home.join("event-log.jsonl")).unwrap_or_default();
         assert_eq!(
             log.matches("crash_respawn_attempt").count(),

--- a/src/daemon/crash_respawn.rs
+++ b/src/daemon/crash_respawn.rs
@@ -359,6 +359,11 @@ fn respawn_agent_worker(
     };
     #[cfg(not(test))]
     let _test_done: Option<()> = None;
+    #[cfg(test)]
+    if test_done.is_none() {
+        std::thread::sleep(delay);
+    }
+    #[cfg(not(test))]
     std::thread::sleep(delay);
     if shutdown.load(Ordering::Relaxed) {
         if let Some(token) = claim {
@@ -581,6 +586,8 @@ fn respawn_agent_worker(
             }
         }
     }
+    #[cfg(test)]
+    signal_test_worker_done(&test_done);
 }
 
 #[cfg(test)]
@@ -785,7 +792,7 @@ mod deleted_gate_tests_1913 {
         let home = tmp_home("crash");
         let reg: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
         let handle = make_handle(false);
-        handle.core.lock().health.total_crashes = 4;
+        handle.core.lock().health.total_crashes = 3;
         crate::agent::crash_disposition::owner_ledger()
             .register_generation(handle.id, handle.generation);
         reg.lock()
@@ -794,15 +801,24 @@ mod deleted_gate_tests_1913 {
             shutdown: Arc::new(AtomicBool::new(false)),
             ..make_ctx(Arc::clone(&reg))
         };
+        ctx.configs
+            .lock()
+            .get_mut(VICTIM)
+            .expect("victim config")
+            .backend_command = "missing-real-crash-command".to_string();
         let (entered_rx, release_tx, done_rx) = worker_gate();
 
         handle_crash_respawn(&home, VICTIM, &ctx);
 
+        let debit_deferred = total_crashes(&reg) == 3;
         entered_rx.recv().expect("respawn worker entered gate");
-        assert_eq!(total_crashes(&reg), 4);
         release_tx.send(()).expect("release respawn worker");
         done_rx.recv().expect("respawn worker completed");
-        assert_eq!(total_crashes(&reg), 5);
+        assert!(
+            debit_deferred,
+            "RED: genuine crash debit must wait for admission; got total_crashes={} before gate release",
+            total_crashes(&reg)
+        );
         std::fs::remove_dir_all(&home).ok();
     }
 
@@ -814,7 +830,7 @@ mod deleted_gate_tests_1913 {
         let home = tmp_home("superseded-before-execute");
         let reg: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
         let handle = make_handle(false);
-        handle.core.lock().health.total_crashes = 4;
+        handle.core.lock().health.total_crashes = 3;
         let id = handle.id;
         let generation = handle.generation;
         reg.lock().insert(id, handle);
@@ -838,11 +854,7 @@ mod deleted_gate_tests_1913 {
         let (entered_rx, release_tx, done_rx) = worker_gate();
 
         handle_crash_observation(&home, &observation, &ctx);
-        assert_eq!(
-            total_crashes(&reg),
-            4,
-            "RED: debit must wait for execution admission"
-        );
+        let debit_deferred = total_crashes(&reg) == 3;
 
         entered_rx.recv().expect("respawn worker entered gate");
         let replacement = crate::agent::crash_disposition::owner_generation_source().next();
@@ -850,7 +862,11 @@ mod deleted_gate_tests_1913 {
         release_tx.send(()).expect("release respawn worker");
         done_rx.recv().expect("respawn worker completed");
 
-        assert_eq!(total_crashes(&reg), 4);
+        assert!(
+            debit_deferred,
+            "RED: debit must wait for execution admission; got total_crashes={} before gate release",
+            total_crashes(&reg)
+        );
         assert!(
             crate::daemon::escalation_persist::load_for(&home, VICTIM).is_none(),
             "superseded recovery must not persist an attempt"
@@ -866,7 +882,7 @@ mod deleted_gate_tests_1913 {
         let home = tmp_home("shutdown-before-execute");
         let reg: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
         let handle = make_handle(false);
-        handle.core.lock().health.total_crashes = 4;
+        handle.core.lock().health.total_crashes = 3;
         let id = handle.id;
         let generation = handle.generation;
         reg.lock().insert(id, handle);
@@ -887,15 +903,15 @@ mod deleted_gate_tests_1913 {
         let (entered_rx, release_tx, done_rx) = worker_gate();
 
         handle_crash_observation(&home, &observation, &ctx);
-        assert_eq!(
-            total_crashes(&reg),
-            4,
-            "RED: shutdown must reject before debit"
-        );
+        let debit_deferred = total_crashes(&reg) == 3;
         entered_rx.recv().expect("respawn worker entered gate");
         release_tx.send(()).expect("release respawn worker");
         done_rx.recv().expect("respawn worker completed");
-        assert_eq!(total_crashes(&reg), 4);
+        assert!(
+            debit_deferred,
+            "RED: shutdown must reject before debit; got total_crashes={} before gate release",
+            total_crashes(&reg)
+        );
         assert!(crate::daemon::escalation_persist::load_for(&home, VICTIM).is_none());
         std::fs::remove_dir_all(&home).ok();
     }
@@ -908,7 +924,7 @@ mod deleted_gate_tests_1913 {
         let home = tmp_home("exact-admission");
         let reg: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
         let handle = make_handle(false);
-        handle.core.lock().health.total_crashes = 4;
+        handle.core.lock().health.total_crashes = 3;
         let id = handle.id;
         let generation = handle.generation;
         reg.lock().insert(id, handle);
@@ -942,19 +958,19 @@ mod deleted_gate_tests_1913 {
         let (entered_rx, release_tx, done_rx) = worker_gate();
 
         handle_crash_observation(&home, &observation, &ctx);
-        assert_eq!(
-            total_crashes(&reg),
-            4,
-            "debit is not raw-observation side effect"
-        );
+        let debit_deferred = total_crashes(&reg) == 3;
         entered_rx.recv().expect("respawn worker entered gate");
-        assert_eq!(total_crashes(&reg), 4);
         release_tx.send(()).expect("release respawn worker");
         done_rx.recv().expect("respawn worker completed");
-        assert_eq!(total_crashes(&reg), 5);
+        assert!(
+            debit_deferred,
+            "debit is not raw-observation side effect; got total_crashes={} before gate release",
+            total_crashes(&reg)
+        );
+        assert_eq!(total_crashes(&reg), 4);
         let persisted = crate::daemon::escalation_persist::load_for(&home, VICTIM)
             .expect("accepted attempt must persist escalation count");
-        assert_eq!(persisted.total_crashes, 5);
+        assert_eq!(persisted.total_crashes, 4);
         let log = std::fs::read_to_string(home.join("event-log.jsonl")).unwrap_or_default();
         assert_eq!(
             log.matches("crash_respawn_attempt").count(),

--- a/src/daemon/crash_respawn.rs
+++ b/src/daemon/crash_respawn.rs
@@ -707,6 +707,21 @@ mod deleted_gate_tests_1913 {
         }
     }
 
+    fn wait_for_total_crashes(reg: &AgentRegistry, expected: u32) {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(8);
+        loop {
+            if total_crashes(reg) == expected {
+                return;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "timed out waiting for total_crashes={expected}, got {}",
+                total_crashes(reg)
+            );
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        }
+    }
+
     fn total_crashes(reg: &AgentRegistry) -> u32 {
         let id = InstanceId::parse(VICTIM_UUID).expect("valid uuid");
         let r = reg.lock();
@@ -718,13 +733,15 @@ mod deleted_gate_tests_1913 {
     /// (a) An intentional delete (deleted=true) must NOT respawn: the gate
     /// returns before `record_crash`, so the crash budget is untouched.
     #[test]
+    #[serial_test::serial(crash_respawn_gate)]
     fn delete_does_not_respawn_1913() {
         let home = tmp_home("del");
         let reg: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
-        reg.lock().insert(
-            InstanceId::parse(VICTIM_UUID).expect("valid uuid"),
-            make_handle(true),
-        );
+        let handle = make_handle(true);
+        crate::agent::crash_disposition::owner_ledger()
+            .register_generation(handle.id, handle.generation);
+        reg.lock()
+            .insert(InstanceId::parse(VICTIM_UUID).expect("valid uuid"), handle);
         let ctx = make_ctx(Arc::clone(&reg));
 
         handle_crash_respawn(&home, VICTIM, &ctx);
@@ -742,13 +759,15 @@ mod deleted_gate_tests_1913 {
     /// through to `record_crash` (crash budget bumped) — proving the #1913 gate
     /// is precise and did NOT blanket-disable crash recovery.
     #[test]
+    #[serial_test::serial(crash_respawn_gate)]
     fn real_crash_still_respawns_1913() {
         let home = tmp_home("crash");
         let reg: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
-        reg.lock().insert(
-            InstanceId::parse(VICTIM_UUID).expect("valid uuid"),
-            make_handle(false),
-        );
+        let handle = make_handle(false);
+        crate::agent::crash_disposition::owner_ledger()
+            .register_generation(handle.id, handle.generation);
+        reg.lock()
+            .insert(InstanceId::parse(VICTIM_UUID).expect("valid uuid"), handle);
         let ctx = make_ctx(Arc::clone(&reg));
 
         handle_crash_respawn(&home, VICTIM, &ctx);
@@ -759,6 +778,147 @@ mod deleted_gate_tests_1913 {
             "#1913 regression guard: a real crash (deleted=false) must STILL enter \
              the respawn path (record_crash runs) — the deleted-gate must not \
              suppress normal crash recovery"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Slice-3 RED: a replacement invalidated while the worker is in its
+    /// backoff must not consume the crash budget or write a persisted count.
+    #[test]
+    #[serial_test::serial(crash_respawn_gate)]
+    fn superseded_before_execution_does_not_debit_attempt_budget_slice3_red() {
+        let home = tmp_home("superseded-before-execute");
+        let reg: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let handle = make_handle(false);
+        let id = handle.id;
+        let generation = handle.generation;
+        reg.lock().insert(id, handle);
+        let ctx = DaemonContext {
+            shutdown: Arc::new(AtomicBool::new(false)),
+            ..make_ctx(Arc::clone(&reg))
+        };
+        crate::agent::crash_disposition::owner_ledger().register_generation(id, generation);
+        let observation = {
+            let r = reg.lock();
+            let h = r.get(&id).expect("handle");
+            crate::agent::crash_disposition::CrashObservation {
+                instance_id: id,
+                generation,
+                core: Arc::clone(&h.core),
+                deleted: Arc::clone(&h.deleted),
+                owner_shutdown: Some(Arc::clone(&ctx.shutdown)),
+                name: h.name.clone(),
+            }
+        };
+
+        handle_crash_observation(&home, &observation, &ctx);
+        assert_eq!(
+            total_crashes(&reg),
+            0,
+            "RED: debit must wait for execution admission"
+        );
+
+        let replacement = crate::agent::crash_disposition::owner_generation_source().next();
+        crate::agent::crash_disposition::owner_ledger().register_generation(id, replacement);
+        std::thread::sleep(std::time::Duration::from_secs(6));
+
+        assert_eq!(total_crashes(&reg), 0);
+        assert!(
+            crate::daemon::escalation_persist::load_for(&home, VICTIM).is_none(),
+            "superseded recovery must not persist an attempt"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Slice-3 RED: shutdown before exact execution admission is a rejected
+    /// recovery, not an accepted crash attempt.
+    #[test]
+    #[serial_test::serial(crash_respawn_gate)]
+    fn shutdown_before_execution_does_not_debit_attempt_budget_slice3_red() {
+        let home = tmp_home("shutdown-before-execute");
+        let reg: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let handle = make_handle(false);
+        let id = handle.id;
+        let generation = handle.generation;
+        reg.lock().insert(id, handle);
+        let ctx = make_ctx(Arc::clone(&reg));
+        crate::agent::crash_disposition::owner_ledger().register_generation(id, generation);
+        let observation = {
+            let r = reg.lock();
+            let h = r.get(&id).expect("handle");
+            crate::agent::crash_disposition::CrashObservation {
+                instance_id: id,
+                generation,
+                core: Arc::clone(&h.core),
+                deleted: Arc::clone(&h.deleted),
+                owner_shutdown: None,
+                name: h.name.clone(),
+            }
+        };
+
+        handle_crash_observation(&home, &observation, &ctx);
+        assert_eq!(
+            total_crashes(&reg),
+            0,
+            "RED: shutdown must reject before debit"
+        );
+        std::thread::sleep(std::time::Duration::from_secs(6));
+        assert_eq!(total_crashes(&reg), 0);
+        assert!(crate::daemon::escalation_persist::load_for(&home, VICTIM).is_none());
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Slice-3 RED: only an exact permit admitted for the old generation may
+    /// consume one attempt and persist the resulting count/audit event.
+    #[test]
+    #[serial_test::serial(crash_respawn_gate)]
+    fn exact_admission_debits_and_persists_once_slice3_red() {
+        let home = tmp_home("exact-admission");
+        let reg: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let handle = make_handle(false);
+        let id = handle.id;
+        let generation = handle.generation;
+        reg.lock().insert(id, handle);
+        let ctx = make_ctx(Arc::clone(&reg));
+        ctx.configs.lock().get_mut(VICTIM).unwrap().backend_command =
+            "missing-exact-attempt-command".to_string();
+        crate::agent::crash_disposition::owner_ledger().register_generation(id, generation);
+        let observation = {
+            let r = reg.lock();
+            let h = r.get(&id).expect("handle");
+            crate::agent::crash_disposition::CrashObservation {
+                instance_id: id,
+                generation,
+                core: Arc::clone(&h.core),
+                deleted: Arc::clone(&h.deleted),
+                owner_shutdown: Some(Arc::clone(&ctx.shutdown)),
+                name: h.name.clone(),
+            }
+        };
+        let ctx = DaemonContext {
+            shutdown: Arc::new(AtomicBool::new(false)),
+            ..ctx
+        };
+        let observation = crate::agent::crash_disposition::CrashObservation {
+            owner_shutdown: Some(Arc::clone(&ctx.shutdown)),
+            ..observation
+        };
+
+        handle_crash_observation(&home, &observation, &ctx);
+        assert_eq!(
+            total_crashes(&reg),
+            0,
+            "debit is not raw-observation side effect"
+        );
+        wait_for_total_crashes(&reg, 1);
+        let persisted = crate::daemon::escalation_persist::load_for(&home, VICTIM)
+            .expect("accepted attempt must persist escalation count");
+        assert_eq!(persisted.total_crashes, 1);
+        let log = std::fs::read_to_string(home.join("event-log.jsonl")).unwrap_or_default();
+        assert_eq!(
+            log.matches("crash_respawn_attempt").count(),
+            1,
+            "one admitted permit must produce one accepted-attempt audit row"
         );
         std::fs::remove_dir_all(&home).ok();
     }

--- a/src/health.rs
+++ b/src/health.rs
@@ -36,6 +36,15 @@ const STABILITY_WINDOW: Duration = Duration::from_secs(1800); // 30 min stable â
 /// `check_hang` threshold.
 const AWAITING_OP_SILENCE: Duration = Duration::from_secs(30);
 
+fn backoff_delay_for(total_crashes: u32) -> Duration {
+    if total_crashes == 0 {
+        return BACKOFF_BASE;
+    }
+    let exp = (total_crashes - 1).min(10);
+    let delay = BACKOFF_BASE.mul_f64(2.0_f64.powi(exp as i32));
+    delay.min(BACKOFF_MAX)
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 #[allow(dead_code)] // ErrorLoop constructed by record_error() in health monitoring
@@ -529,6 +538,20 @@ impl HealthTracker {
         (true, delay, should_notify)
     }
 
+    /// Return the delay that the next crash-respawn attempt would use without
+    /// mutating the crash budget.  Crash disposition admission calls
+    /// [`record_crash`] only after an exact-generation permit admits
+    /// `Restarting`; the daemon uses this read-only projection to schedule the
+    /// backoff while the raw observation remains truthfully `Crashed`.
+    pub fn next_crash_delay(&self) -> Duration {
+        let next_total = self.total_crashes.saturating_add(1);
+        if next_total >= self.max_retries {
+            Duration::ZERO
+        } else {
+            backoff_delay_for(next_total)
+        }
+    }
+
     /// Mark successful respawn.
     pub fn respawn_ok(&mut self, has_live_handle: bool) {
         if has_live_handle
@@ -546,12 +569,7 @@ impl HealthTracker {
 
     /// Calculate exponential backoff delay.
     fn backoff_delay(&self) -> Duration {
-        if self.total_crashes == 0 {
-            return BACKOFF_BASE;
-        }
-        let exp = (self.total_crashes - 1).min(10);
-        let delay = BACKOFF_BASE.mul_f64(2.0_f64.powi(exp as i32));
-        delay.min(BACKOFF_MAX)
+        backoff_delay_for(self.total_crashes)
     }
 
     /// #1701: self-orchestrator crash P0 gate. Unlike [`record_crash`]'s


### PR DESCRIPTION
## Summary
- keep raw crash observations truthful while deferring retry debit, accepted-attempt logging, persistence, and exhaustion accounting until a one-use exact-generation permit admits Restarting on the exact old Core
- preserve existing max-retry/backoff and terminal self-orchestrator P0 semantics
- add deterministic channel-gated race tests with immutable RED evidence

## Lineage and scope
- base: `943e8c35f7c9ebc762cc89aa5a5986d2d705dba5`
- immutable RED: `b1bf6711`
- supplemental deterministic RED: `b1bf6711 -> d83150bc -> d880fe1f` (test-only)
- GREEN production: `83ee2b750a46655c29134bf87a249f55e179956e` (preserved exactly)
- final exact head: `cf343ca2d7580e849caeb983589503e443331033`
- follow-ups after GREEN are test-only (`bbd4850d`, `df601b98`, `cf343ca2`)

Decision: `d-20260717144054528389-1`
Task: `t-20260717144117285758-91328-1`

## Verification
- `cargo test --bin agend-terminal deleted_gate_tests_1913 -- --nocapture` → 7 passed
- `cargo test --bin agend-terminal agent::crash_disposition -- --nocapture` → 11 passed
- `cargo clippy --bin agend-terminal --all-targets -- -D warnings` → passed
- supplemental RED at `d880fe1`: 4 deterministic expected failures / 3 legacy passes, EXIT 101, 0.18s; no wall-clock sleeps or polling

## Exclusions
RecoverySpec/NoRecovery, cwd/dirty preflight, owner-restart schema, app/core parity, and respawn_watchdog are out of scope.