### PR TITLE
Protect default worktree and release-floor sweep

### DIFF
--- a/src/worktree_cleanup.rs
+++ b/src/worktree_cleanup.rs
@@ -112,12 +112,20 @@ fn list_worktrees(repo_root: &Path) -> Result<Vec<WorktreeEntry>, ()> {
         );
         return Err(());
     }
+    let canonical_repo = repo_root.canonicalize().ok();
     Ok(
         crate::git_worktree::parse_porcelain(&String::from_utf8_lossy(&out.stdout))
             .into_iter()
             .filter_map(|(path, branch)| {
                 let branch = branch?;
                 if branch == "main" || branch == "master" {
+                    return None;
+                }
+                let is_canonical_repo = canonical_repo
+                    .as_ref()
+                    .and_then(|repo| path.canonicalize().ok().map(|worktree| worktree == *repo))
+                    .unwrap_or(false);
+                if is_canonical_repo {
                     return None;
                 }
                 Some(WorktreeEntry {
@@ -132,6 +140,9 @@ fn list_worktrees(repo_root: &Path) -> Result<Vec<WorktreeEntry>, ()> {
 /// Check if a branch is merged into the default branch (local check, no API needed).
 fn is_branch_merged(repo_root: &Path, branch: &str) -> bool {
     let default = crate::git_helpers::default_branch(repo_root);
+    if branch == default {
+        return false;
+    }
     // W1.2: git_ok = always-bypass + bounded, true iff exit-0 (the
     // `output().map(success).unwrap_or(false)` idiom, byte-for-byte).
     if !crate::git_helpers::git_ok(
@@ -814,7 +825,7 @@ fn prune_orphaned_branches_with_home(
         match crate::git_helpers::git_cmd(repo_root, &["branch", "--format=%(refname:short)"]) {
             Ok(stdout) => stdout
                 .lines()
-                .filter(|b| *b != default.as_str())
+                .filter(|b| *b != default.as_str() && !crate::protected_refs::is_protected_ref(b))
                 .map(String::from)
                 .collect(),
             _ => return Vec::new(),

--- a/src/worktree_cleanup.rs
+++ b/src/worktree_cleanup.rs
@@ -980,6 +980,10 @@ mod tests {
     pub(super) static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     fn setup_test_repo(tag: &str) -> PathBuf {
+        setup_test_repo_with_default(tag, "main")
+    }
+
+    fn setup_test_repo_with_default(tag: &str, default_branch: &str) -> PathBuf {
         use std::sync::atomic::{AtomicU32, Ordering};
         static C: AtomicU32 = AtomicU32::new(0);
         let dir = std::env::temp_dir().join(format!(
@@ -989,7 +993,7 @@ mod tests {
             C.fetch_add(1, Ordering::Relaxed)
         ));
         std::fs::create_dir_all(&dir).ok();
-        git_in(&dir, &["init", "-b", "main"]);
+        git_in(&dir, &["init", "-b", default_branch]);
         std::fs::write(dir.join("README.md"), "init").ok();
         git_in(&dir, &["add", "."]);
         git_in(&dir, &["commit", "-m", "init"]);
@@ -1020,6 +1024,14 @@ mod tests {
         git_in(repo, &["add", "."]);
         git_commit_dated(repo, "feature work", tip_date);
         git_in(repo, &["checkout", "main"]);
+    }
+
+    fn make_old_dated_branch_from(repo: &Path, base: &str, branch: &str, tip_date: &str) {
+        git_in(repo, &["checkout", "-b", branch]);
+        std::fs::write(repo.join("feat.txt"), branch).ok();
+        git_in(repo, &["add", "."]);
+        git_commit_dated(repo, "feature work", tip_date);
+        git_in(repo, &["checkout", base]);
     }
 
     /// #2605: fake daemon `home` for `bound_source_repos` — repo discovery now
@@ -1159,6 +1171,81 @@ mod tests {
         assert!(
             list_worktrees(&repo).is_ok(),
             "a valid repo must enumerate worktrees as Ok"
+        );
+        std::fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn default_dev_canonical_worktree_is_not_a_phase1_candidate_2830_red() {
+        let _lock = ENV_LOCK.lock();
+        let repo = setup_test_repo_with_default("2830-default-dev-worktree", "dev");
+        let canonical_repo = repo.canonicalize().unwrap();
+        let entries = list_worktrees(&repo).expect("worktree enumeration");
+        assert!(
+            !entries.iter().any(|entry| {
+                entry.branch == "dev"
+                    && Path::new(&entry.path)
+                        .canonicalize()
+                        .ok()
+                        .is_some_and(|path| path == canonical_repo)
+            }),
+            "the canonical default worktree must never enter phase-1 cleanup candidates: {entries:?}"
+        );
+        std::fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn default_dev_is_never_reported_as_merged_2830_red() {
+        let _lock = ENV_LOCK.lock();
+        let repo = setup_test_repo_with_default("2830-default-dev-merged", "dev");
+        std::fs::write(repo.join("default-tip.txt"), "dev").unwrap();
+        git_in(&repo, &["add", "."]);
+        git_commit_dated(&repo, "old default tip", "2024-01-01T00:00:00 +0000");
+        assert!(
+            !is_branch_merged(&repo, "dev"),
+            "the actual default branch must never be considered merged into itself"
+        );
+        std::fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn unoccupied_local_release_main_survives_phase2_with_default_dev_2830_red() {
+        let _lock = ENV_LOCK.lock();
+        let repo = setup_test_repo_with_default("2830-release-main", "dev");
+        std::fs::write(repo.join("default-tip.txt"), "dev").unwrap();
+        git_in(&repo, &["add", "."]);
+        git_commit_dated(&repo, "old default tip", "2024-01-01T00:00:00 +0000");
+        git_in(&repo, &["branch", "main"]);
+
+        let pruned = prune_orphaned_branches(&repo, false);
+        assert!(
+            !pruned.iter().any(|(branch, _)| branch == "main"),
+            "the legacy release branch must survive phase 2 even when default=dev: {pruned:?}"
+        );
+        assert!(
+            crate::git_helpers::git_ok(&repo, &["rev-parse", "--verify", "main"]),
+            "phase 2 must not delete the unoccupied local release main branch"
+        );
+        std::fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn ordinary_merged_disposable_branch_remains_reapable_2830_red() {
+        let _lock = ENV_LOCK.lock();
+        let repo = setup_test_repo_with_default("2830-disposable-merged", "dev");
+        make_old_dated_branch_from(&repo, "dev", "feat/disposable", "2024-01-01T00:00:00 +0000");
+        git_in(&repo, &["merge", "--ff-only", "feat/disposable"]);
+
+        let pruned = prune_orphaned_branches(&repo, false);
+        assert!(
+            pruned
+                .iter()
+                .any(|(branch, reason)| branch == "feat/disposable" && *reason == "merged"),
+            "an ordinary merged disposable branch must remain reapable: {pruned:?}"
+        );
+        assert!(
+            !crate::git_helpers::git_ok(&repo, &["rev-parse", "--verify", "feat/disposable"]),
+            "the ordinary merged disposable branch should be removed"
         );
         std::fs::remove_dir_all(&repo).ok();
     }

--- a/src/worktree_cleanup.rs
+++ b/src/worktree_cleanup.rs
@@ -994,7 +994,7 @@ mod tests {
         setup_test_repo_with_default(tag, "main")
     }
 
-    fn setup_test_repo_with_default(tag: &str, default_branch: &str) -> PathBuf {
+    pub(super) fn setup_test_repo_with_default(tag: &str, default_branch: &str) -> PathBuf {
         use std::sync::atomic::{AtomicU32, Ordering};
         static C: AtomicU32 = AtomicU32::new(0);
         let dir = std::env::temp_dir().join(format!(
@@ -1011,7 +1011,7 @@ mod tests {
         dir
     }
 
-    fn git_in(dir: &Path, args: &[&str]) {
+    pub(super) fn git_in(dir: &Path, args: &[&str]) {
         Command::new("git")
             .args(args)
             .current_dir(dir)
@@ -1035,14 +1035,6 @@ mod tests {
         git_in(repo, &["add", "."]);
         git_commit_dated(repo, "feature work", tip_date);
         git_in(repo, &["checkout", "main"]);
-    }
-
-    fn make_old_dated_branch_from(repo: &Path, base: &str, branch: &str, tip_date: &str) {
-        git_in(repo, &["checkout", "-b", branch]);
-        std::fs::write(repo.join("feat.txt"), branch).ok();
-        git_in(repo, &["add", "."]);
-        git_commit_dated(repo, "feature work", tip_date);
-        git_in(repo, &["checkout", base]);
     }
 
     /// #2605: fake daemon `home` for `bound_source_repos` — repo discovery now
@@ -1182,81 +1174,6 @@ mod tests {
         assert!(
             list_worktrees(&repo).is_ok(),
             "a valid repo must enumerate worktrees as Ok"
-        );
-        std::fs::remove_dir_all(&repo).ok();
-    }
-
-    #[test]
-    fn default_dev_canonical_worktree_is_not_a_phase1_candidate_2830_red() {
-        let _lock = ENV_LOCK.lock();
-        let repo = setup_test_repo_with_default("2830-default-dev-worktree", "dev");
-        let canonical_repo = repo.canonicalize().unwrap();
-        let entries = list_worktrees(&repo).expect("worktree enumeration");
-        assert!(
-            !entries.iter().any(|entry| {
-                entry.branch == "dev"
-                    && Path::new(&entry.path)
-                        .canonicalize()
-                        .ok()
-                        .is_some_and(|path| path == canonical_repo)
-            }),
-            "the canonical default worktree must never enter phase-1 cleanup candidates: {entries:?}"
-        );
-        std::fs::remove_dir_all(&repo).ok();
-    }
-
-    #[test]
-    fn default_dev_is_never_reported_as_merged_2830_red() {
-        let _lock = ENV_LOCK.lock();
-        let repo = setup_test_repo_with_default("2830-default-dev-merged", "dev");
-        std::fs::write(repo.join("default-tip.txt"), "dev").unwrap();
-        git_in(&repo, &["add", "."]);
-        git_commit_dated(&repo, "old default tip", "2024-01-01T00:00:00 +0000");
-        assert!(
-            !is_branch_merged(&repo, "dev"),
-            "the actual default branch must never be considered merged into itself"
-        );
-        std::fs::remove_dir_all(&repo).ok();
-    }
-
-    #[test]
-    fn unoccupied_local_release_main_survives_phase2_with_default_dev_2830_red() {
-        let _lock = ENV_LOCK.lock();
-        let repo = setup_test_repo_with_default("2830-release-main", "dev");
-        std::fs::write(repo.join("default-tip.txt"), "dev").unwrap();
-        git_in(&repo, &["add", "."]);
-        git_commit_dated(&repo, "old default tip", "2024-01-01T00:00:00 +0000");
-        git_in(&repo, &["branch", "main"]);
-
-        let pruned = prune_orphaned_branches(&repo, false);
-        assert!(
-            !pruned.iter().any(|(branch, _)| branch == "main"),
-            "the legacy release branch must survive phase 2 even when default=dev: {pruned:?}"
-        );
-        assert!(
-            crate::git_helpers::git_ok(&repo, &["rev-parse", "--verify", "main"]),
-            "phase 2 must not delete the unoccupied local release main branch"
-        );
-        std::fs::remove_dir_all(&repo).ok();
-    }
-
-    #[test]
-    fn ordinary_merged_disposable_branch_remains_reapable_2830_red() {
-        let _lock = ENV_LOCK.lock();
-        let repo = setup_test_repo_with_default("2830-disposable-merged", "dev");
-        make_old_dated_branch_from(&repo, "dev", "feat/disposable", "2024-01-01T00:00:00 +0000");
-        git_in(&repo, &["merge", "--ff-only", "feat/disposable"]);
-
-        let pruned = prune_orphaned_branches(&repo, false);
-        assert!(
-            pruned
-                .iter()
-                .any(|(branch, reason)| branch == "feat/disposable" && *reason == "merged"),
-            "an ordinary merged disposable branch must remain reapable: {pruned:?}"
-        );
-        assert!(
-            !crate::git_helpers::git_ok(&repo, &["rev-parse", "--verify", "feat/disposable"]),
-            "the ordinary merged disposable branch should be removed"
         );
         std::fs::remove_dir_all(&repo).ok();
     }
@@ -1920,7 +1837,7 @@ mod tests {
 
     /// Commit like `git_in`'s commit but with a fixed author+committer DATE, so
     /// `branch_tip_age` is deterministic regardless of wall-clock.
-    fn git_commit_dated(dir: &Path, msg: &str, date: &str) {
+    pub(super) fn git_commit_dated(dir: &Path, msg: &str, date: &str) {
         Command::new("git")
             .args(["commit", "-m", msg])
             .current_dir(dir)
@@ -2568,6 +2485,9 @@ mod reconcile_ordering_tests;
 
 #[cfg(test)]
 mod lifecycle_r1_tests;
+
+#[cfg(test)]
+mod protected_sweep_tests;
 
 #[cfg(test)]
 mod review_repro_worktree_git;

--- a/src/worktree_cleanup/protected_sweep_tests.rs
+++ b/src/worktree_cleanup/protected_sweep_tests.rs
@@ -1,0 +1,88 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use super::tests::{git_commit_dated, git_in, setup_test_repo_with_default, ENV_LOCK};
+use super::*;
+use std::path::Path;
+
+fn make_old_dated_branch_from(repo: &Path, base: &str, branch: &str, tip_date: &str) {
+    git_in(repo, &["checkout", "-b", branch]);
+    std::fs::write(repo.join("feat.txt"), branch).ok();
+    git_in(repo, &["add", "."]);
+    git_commit_dated(repo, "feature work", tip_date);
+    git_in(repo, &["checkout", base]);
+}
+
+#[test]
+fn default_dev_canonical_worktree_is_not_a_phase1_candidate_2830_red() {
+    let _lock = ENV_LOCK.lock();
+    let repo = setup_test_repo_with_default("2830-default-dev-worktree", "dev");
+    let canonical_repo = repo.canonicalize().unwrap();
+    let entries = list_worktrees(&repo).expect("worktree enumeration");
+    assert!(
+        !entries.iter().any(|entry| {
+            entry.branch == "dev"
+                && Path::new(&entry.path)
+                    .canonicalize()
+                    .ok()
+                    .is_some_and(|path| path == canonical_repo)
+        }),
+        "the canonical default worktree must never enter phase-1 cleanup candidates: {entries:?}"
+    );
+    std::fs::remove_dir_all(&repo).ok();
+}
+
+#[test]
+fn default_dev_is_never_reported_as_merged_2830_red() {
+    let _lock = ENV_LOCK.lock();
+    let repo = setup_test_repo_with_default("2830-default-dev-merged", "dev");
+    std::fs::write(repo.join("default-tip.txt"), "dev").unwrap();
+    git_in(&repo, &["add", "."]);
+    git_commit_dated(&repo, "old default tip", "2024-01-01T00:00:00 +0000");
+    assert!(
+        !is_branch_merged(&repo, "dev"),
+        "the actual default branch must never be considered merged into itself"
+    );
+    std::fs::remove_dir_all(&repo).ok();
+}
+
+#[test]
+fn unoccupied_local_release_main_survives_phase2_with_default_dev_2830_red() {
+    let _lock = ENV_LOCK.lock();
+    let repo = setup_test_repo_with_default("2830-release-main", "dev");
+    std::fs::write(repo.join("default-tip.txt"), "dev").unwrap();
+    git_in(&repo, &["add", "."]);
+    git_commit_dated(&repo, "old default tip", "2024-01-01T00:00:00 +0000");
+    git_in(&repo, &["branch", "main"]);
+
+    let pruned = prune_orphaned_branches(&repo, false);
+    assert!(
+        !pruned.iter().any(|(branch, _)| branch == "main"),
+        "the legacy release branch must survive phase 2 even when default=dev: {pruned:?}"
+    );
+    assert!(
+        crate::git_helpers::git_ok(&repo, &["rev-parse", "--verify", "main"]),
+        "phase 2 must not delete the unoccupied local release main branch"
+    );
+    std::fs::remove_dir_all(&repo).ok();
+}
+
+#[test]
+fn ordinary_merged_disposable_branch_remains_reapable_2830_red() {
+    let _lock = ENV_LOCK.lock();
+    let repo = setup_test_repo_with_default("2830-disposable-merged", "dev");
+    make_old_dated_branch_from(&repo, "dev", "feat/disposable", "2024-01-01T00:00:00 +0000");
+    git_in(&repo, &["merge", "--ff-only", "feat/disposable"]);
+
+    let pruned = prune_orphaned_branches(&repo, false);
+    assert!(
+        pruned
+            .iter()
+            .any(|(branch, reason)| branch == "feat/disposable" && *reason == "merged"),
+        "an ordinary merged disposable branch must remain reapable: {pruned:?}"
+    );
+    assert!(
+        !crate::git_helpers::git_ok(&repo, &["rev-parse", "--verify", "feat/disposable"]),
+        "the ordinary merged disposable branch should be removed"
+    );
+    std::fs::remove_dir_all(&repo).ok();
+}


### PR DESCRIPTION
## Summary
- exclude the canonical default worktree from phase-1 cleanup candidates
- never classify the actual default branch as merged into itself
- preserve the case-insensitive `main`/`master` phase-2 floor when the default branch is different

Issue: #2830

## Verification
- `cargo test --bin agend-terminal worktree_cleanup::tests -- --nocapture` (45 passed)
- `cargo clippy --bin agend-terminal --all-targets -- -D warnings` (passed)
- `cargo fmt --package agend-terminal -- --check` (passed)

The immutable test-only RED commit is `594660ef62e0892089c20f5278397f8ce7e363f7`; production GREEN commit is `3e66aef869e4c9bdafb9f61bc492e6f505dce1ff`.
