### PR TITLE
fix: retain worktree cleanup command diagnostics

### DIFF
--- a/src/worktree_cleanup.rs
+++ b/src/worktree_cleanup.rs
@@ -2490,4 +2490,7 @@ mod lifecycle_r1_tests;
 mod protected_sweep_tests;
 
 #[cfg(test)]
+mod windows_cleanup_diagnostics_tests;
+
+#[cfg(test)]
 mod review_repro_worktree_git;

--- a/src/worktree_cleanup.rs
+++ b/src/worktree_cleanup.rs
@@ -261,29 +261,58 @@ fn remove_worktree(
     branch: &str,
     delete_branch: bool,
     dry_run: bool,
-) -> bool {
+) -> Result<(), String> {
     if dry_run {
-        return true;
+        return Ok(());
     }
     let max_attempts: u32 = if cfg!(windows) { 3 } else { 1 };
     let mut wt_ok = false;
+    let mut failure = None;
     for attempt in 0..max_attempts {
         if attempt > 0 {
             std::thread::sleep(std::time::Duration::from_millis(100 * (1 << attempt)));
         }
-        wt_ok = crate::git_helpers::git_ok(
+        match crate::git_helpers::git_bypass(
             repo_root,
             &["worktree", "remove", "--force", worktree_path],
-        );
-        if wt_ok {
-            break;
+        ) {
+            Ok(output) if output.status.success() => {
+                wt_ok = true;
+                break;
+            }
+            Ok(output) => {
+                let status = output
+                    .status
+                    .code()
+                    .map(|code| format!("exit status {code}"))
+                    .unwrap_or_else(|| output.status.to_string());
+                let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+                let stderr = if stderr.is_empty() {
+                    "<empty>".to_string()
+                } else {
+                    stderr
+                };
+                failure = Some(format!(
+                    "sweep worktree remove failed: {status}; stderr: {stderr}"
+                ));
+            }
+            Err(error) => {
+                failure = Some(format!(
+                    "sweep worktree remove failed: could not execute git: {error}"
+                ));
+            }
         }
     }
     if wt_ok && delete_branch {
         // W1.2: best-effort branch delete (result was already ignored).
         let _ = crate::git_helpers::git_ok(repo_root, &["branch", "-D", branch]);
     }
-    wt_ok
+    if wt_ok {
+        Ok(())
+    } else {
+        Err(failure
+            .unwrap_or_else(|| "sweep worktree remove failed: no attempt result".to_string()))
+    }
 }
 
 /// Runtime-based sweep: uses live `binding.json` state to find repos and
@@ -485,29 +514,24 @@ pub fn sweep_from_registry(
             );
             // PR-D·D5: route the dir-Delete through the shared `janitor::dispose`
             // Delete arm — the sweep passes its OWN remover (`remove_worktree`:
-            // git_ok + windows-retry + `branch -D`), so its deliberate wrapper is
-            // preserved (D5-Q3 ruling B; the git_ok↔git_bypass unify is a separate
-            // PR, decision m-20260703064336281447-62). Byte-identical to the prior
-            // direct call: same args, push on success. `agent`/`candidate` are inert
-            // on the Delete arm; the Err reason is unused here (the sweep skips, it
-            // does not archive-fallthrough).
+            // git_bypass + windows-retry + `branch -D`), so its deliberate wrapper is
+            // preserved (D5-Q3 ruling B). The remover returns its final command
+            // diagnostics directly as the janitor error. `agent`/`candidate` are
+            // inert on the Delete arm; the Err reason is unused here (the sweep
+            // skips, it does not archive-fallthrough).
             let outcome = crate::daemon::janitor::dispose(
                 home,
                 crate::worktree::disposition::Disposition::Delete,
                 "",
                 None,
                 || {
-                    if remove_worktree(
+                    remove_worktree(
                         repo,
                         &entry.path,
                         &entry.branch,
                         branch_safe_to_delete,
                         false,
-                    ) {
-                        Ok(())
-                    } else {
-                        Err("sweep worktree remove failed".to_string())
-                    }
+                    )
                 },
             );
             match outcome {

--- a/src/worktree_cleanup.rs
+++ b/src/worktree_cleanup.rs
@@ -237,24 +237,11 @@ fn is_worktree_dirty(worktree_path: &Path) -> bool {
         .unwrap_or(true)
 }
 
-/// Remove a worktree, and delete its branch ONLY when `delete_branch` is set.
+/// Remove a worktree; delete its branch only when `delete_branch` is set.
 ///
-/// CR-2026-06-14 (data-loss): the worktree-DIR removal and the `git branch -D`
-/// are DECOUPLED. Reclaiming the worktree directory is harmless, but deleting
-/// the branch ref is irreversible — a remote-gone branch carrying
-/// committed-but-unpushed local work would lose it. The caller passes
-/// `delete_branch = true` only when the work is preserved in the default branch
-/// (merged or squash-merged); otherwise the branch ref (and its unpushed
-/// commits) survives even though the stale worktree dir is reclaimed.
-///
-/// On Windows, retries up to 3 times with exponential backoff (200ms, 400ms)
-/// to absorb transient EACCES from file locks held by preceding git processes.
-///
-/// #2605: `dry_run` skips both git calls entirely and reports success (as if
-/// removed) so a caller's candidate list can reflect what WOULD happen. PR-D6:
-/// the runtime sweep always passes `false` now (gating is `AUTO_CLEANUP` only);
-/// the param is retained for the audit-style callers/tests that still exercise
-/// the compute-but-don't-mutate path.
+/// Worktree and branch deletion are decoupled so unpushed remote-gone work is
+/// preserved. Windows retries up to 3 times with 200/400ms backoff for locks;
+/// `dry_run` skips both git calls and reports success.
 fn remove_worktree(
     repo_root: &Path,
     worktree_path: &str,
@@ -272,36 +259,33 @@ fn remove_worktree(
         if attempt > 0 {
             std::thread::sleep(std::time::Duration::from_millis(100 * (1 << attempt)));
         }
-        match crate::git_helpers::git_bypass(
+        let output = match crate::git_helpers::git_bypass(
             repo_root,
             &["worktree", "remove", "--force", worktree_path],
         ) {
-            Ok(output) if output.status.success() => {
-                wt_ok = true;
-                break;
-            }
-            Ok(output) => {
-                let status = output
-                    .status
-                    .code()
-                    .map(|code| format!("exit status {code}"))
-                    .unwrap_or_else(|| output.status.to_string());
-                let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-                let stderr = if stderr.is_empty() {
-                    "<empty>".to_string()
-                } else {
-                    stderr
-                };
-                failure = Some(format!(
-                    "sweep worktree remove failed: {status}; stderr: {stderr}"
-                ));
-            }
+            Ok(output) => output,
             Err(error) => {
                 failure = Some(format!(
                     "sweep worktree remove failed: could not execute git: {error}"
                 ));
+                continue;
             }
+        };
+        if output.status.success() {
+            wt_ok = true;
+            break;
         }
+        let status = output.status.code().map(|c| format!("exit status {c}"));
+        let status = status.unwrap_or_else(|| output.status.to_string());
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        failure = Some(format!(
+            "sweep worktree remove failed: {status}; stderr: {}",
+            if stderr.is_empty() {
+                "<empty>"
+            } else {
+                &stderr
+            }
+        ));
     }
     if wt_ok && delete_branch {
         // W1.2: best-effort branch delete (result was already ignored).
@@ -512,13 +496,8 @@ pub fn sweep_from_registry(
                 delete_branch = branch_safe_to_delete,
                 "removing stale worktree"
             );
-            // PR-D·D5: route the dir-Delete through the shared `janitor::dispose`
-            // Delete arm — the sweep passes its OWN remover (`remove_worktree`:
-            // git_bypass + windows-retry + `branch -D`), so its deliberate wrapper is
-            // preserved (D5-Q3 ruling B). The remover returns its final command
-            // diagnostics directly as the janitor error. `agent`/`candidate` are
-            // inert on the Delete arm; the Err reason is unused here (the sweep
-            // skips, it does not archive-fallthrough).
+            // Route Delete through janitor with the caller-local remover, retaining
+            // retry behavior and final command diagnostics.
             let outcome = crate::daemon::janitor::dispose(
                 home,
                 crate::worktree::disposition::Disposition::Delete,

--- a/src/worktree_cleanup/windows_cleanup_diagnostics_tests.rs
+++ b/src/worktree_cleanup/windows_cleanup_diagnostics_tests.rs
@@ -58,6 +58,7 @@ fn setup_repo() -> PathBuf {
     std::fs::create_dir_all(&repo).expect("repo directory");
     git_in(&repo, &["init", "-b", "main"]);
     std::fs::write(repo.join("README.md"), "init").expect("README");
+    std::fs::write(repo.join(".gitignore"), ".cleanup-lock\n").expect("gitignore");
     git_in(&repo, &["add", "."]);
     git_in(&repo, &["commit", "-m", "init"]);
     git_in(&repo, &["checkout", "-b", "feat/done"]);
@@ -137,10 +138,12 @@ fn install_failing_git(_stub_dir: &Path, _real_git: &Path) {}
 #[cfg(windows)]
 fn hold_exclusive_worktree_file(repo: &Path) -> std::fs::File {
     use std::os::windows::fs::OpenOptionsExt;
+    let lock_path = repo.join("wt-done").join(".cleanup-lock");
+    std::fs::write(&lock_path, "cleanup lock").expect("cleanup lock");
     std::fs::OpenOptions::new()
         .read(true)
         .share_mode(0)
-        .open(repo.join("wt-done").join("feat.txt"))
+        .open(lock_path)
         .expect("exclusive worktree file handle")
 }
 

--- a/src/worktree_cleanup/windows_cleanup_diagnostics_tests.rs
+++ b/src/worktree_cleanup/windows_cleanup_diagnostics_tests.rs
@@ -1,0 +1,210 @@
+//! Regression coverage for diagnostics retained by the worktree-removal caller.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use super::*;
+use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+fn git_in(dir: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .env("AGEND_GIT_BYPASS", "1")
+        .env("GIT_AUTHOR_NAME", "test")
+        .env("GIT_AUTHOR_EMAIL", "t@t")
+        .env("GIT_COMMITTER_NAME", "test")
+        .env("GIT_COMMITTER_EMAIL", "t@t")
+        .output()
+        .expect("git");
+    assert!(
+        output.status.success(),
+        "git {:?} failed: {}",
+        args,
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn git_commit_dated(dir: &Path, message: &str, date: &str) {
+    let output = Command::new("git")
+        .args(["commit", "-m", message])
+        .current_dir(dir)
+        .env("AGEND_GIT_BYPASS", "1")
+        .env("GIT_AUTHOR_NAME", "test")
+        .env("GIT_AUTHOR_EMAIL", "t@t")
+        .env("GIT_COMMITTER_NAME", "test")
+        .env("GIT_COMMITTER_EMAIL", "t@t")
+        .env("GIT_AUTHOR_DATE", date)
+        .env("GIT_COMMITTER_DATE", date)
+        .output()
+        .expect("dated git commit");
+    assert!(
+        output.status.success(),
+        "git commit failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn setup_repo() -> PathBuf {
+    let repo = std::env::temp_dir().join(format!(
+        "agend-wt-diagnostics-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&repo).expect("repo directory");
+    git_in(&repo, &["init", "-b", "main"]);
+    std::fs::write(repo.join("README.md"), "init").expect("README");
+    git_in(&repo, &["add", "."]);
+    git_in(&repo, &["commit", "-m", "init"]);
+    git_in(&repo, &["checkout", "-b", "feat/done"]);
+    std::fs::write(repo.join("feat.txt"), "feature").expect("feature");
+    git_in(&repo, &["add", "."]);
+    git_commit_dated(&repo, "feature work", "2024-01-01T00:00:00 +0000");
+    git_in(&repo, &["checkout", "main"]);
+    git_in(&repo, &["worktree", "add", "wt-done", "feat/done"]);
+    git_in(&repo, &["merge", "feat/done"]);
+    repo
+}
+
+fn write_binding(home: &Path, repo: &Path) {
+    let runtime = crate::paths::runtime_dir(home).join("other-agent");
+    std::fs::create_dir_all(&runtime).expect("runtime directory");
+    std::fs::write(
+        runtime.join("binding.json"),
+        serde_json::to_vec(&serde_json::json!({
+            "source_repo": repo.display().to_string()
+        }))
+        .expect("binding json"),
+    )
+    .expect("binding");
+}
+
+fn hygiene_tasks(home: &Path) -> Vec<(String, serde_json::Value)> {
+    crate::task_events::replay(home)
+        .map(|state| {
+            state
+                .tasks
+                .values()
+                .filter_map(|task| {
+                    Some((
+                        task.metadata
+                            .get(crate::daemon::hygiene_task::ALERT_KEY_META)?
+                            .as_str()?
+                            .to_string(),
+                        task.metadata
+                            .get(crate::daemon::hygiene_task::EVIDENCE_META)
+                            .cloned()
+                            .unwrap_or(serde_json::Value::Null),
+                    ))
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn real_git() -> PathBuf {
+    let path = std::env::var_os("PATH").expect("PATH");
+    let executable = if cfg!(windows) { "git.exe" } else { "git" };
+    std::env::split_paths(&path)
+        .map(|dir| dir.join(executable))
+        .find(|candidate| candidate.is_file())
+        .expect("git must be on PATH")
+}
+
+#[cfg(unix)]
+fn install_failing_git(stub_dir: &Path, real_git: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    let script = format!(
+        "#!/bin/sh\nif [ \"$1 $2\" = \"worktree remove\" ]; then\n  echo cleanup-diagnostic-sentinel 1>&2\n  exit 23\nfi\nexec '{}' \"$@\"\n",
+        real_git.display()
+    );
+    let path = stub_dir.join("git");
+    std::fs::write(&path, script).expect("git stub");
+    let mut permissions = std::fs::metadata(&path)
+        .expect("git stub metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(path, permissions).expect("git stub permissions");
+}
+
+#[cfg(windows)]
+fn install_failing_git(stub_dir: &Path, real_git: &Path) {
+    let script = format!(
+        "@echo off\nif \"%~1 %~2\"==\"worktree remove\" (\n  echo cleanup-diagnostic-sentinel 1>&2\n  exit /b 23\n)\n\"{}\" %*\nexit /b %ERRORLEVEL%\n",
+        real_git.display()
+    );
+    std::fs::write(stub_dir.join("git.cmd"), script).expect("git stub");
+}
+
+fn prepend_path(stub_dir: &Path, old_path: &std::ffi::OsString) -> std::ffi::OsString {
+    std::env::join_paths(
+        std::iter::once(stub_dir.to_path_buf()).chain(std::env::split_paths(old_path)),
+    )
+    .expect("PATH")
+}
+
+#[test]
+fn real_sweep_remove_failure_preserves_final_status_and_stderr_2830_red() {
+    let _lock = ENV_LOCK.lock();
+    let repo = setup_repo();
+    let home = std::env::temp_dir().join(format!(
+        "agend-wt-diagnostics-home-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&home).expect("home directory");
+    write_binding(&home, &repo);
+
+    let stub_dir = std::env::temp_dir().join(format!(
+        "agend-wt-diagnostics-git-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&stub_dir).expect("stub directory");
+    install_failing_git(&stub_dir, &real_git());
+
+    let old_path = std::env::var_os("PATH").expect("PATH");
+    let old_cleanup = std::env::var_os("AGEND_WORKTREE_AUTO_CLEANUP");
+    std::env::set_var("PATH", prepend_path(&stub_dir, &old_path));
+    std::env::set_var("AGEND_WORKTREE_AUTO_CLEANUP", "1");
+    let configs = HashMap::from([(String::from("other-agent"), Some(repo.join("other")))]);
+    let removed = sweep_from_registry(&home, &configs, &[]);
+    std::env::set_var("PATH", old_path);
+    match old_cleanup {
+        Some(value) => std::env::set_var("AGEND_WORKTREE_AUTO_CLEANUP", value),
+        None => std::env::remove_var("AGEND_WORKTREE_AUTO_CLEANUP"),
+    }
+
+    let tasks = hygiene_tasks(&home);
+    let key = format!("residue-remove-failed:{}:feat/done", repo.display());
+    let (_, evidence) = tasks
+        .iter()
+        .find(|(candidate, _)| candidate == &key)
+        .unwrap_or_else(|| panic!("expected hygiene task; removed={removed:?}, tasks={tasks:?}"));
+    let reason = evidence["reason"].as_str().unwrap_or_default();
+    assert!(
+        reason.contains("status 23"),
+        "final status was lost: {evidence}"
+    );
+    assert!(
+        reason.contains("cleanup-diagnostic-sentinel"),
+        "final stderr was lost: {evidence}"
+    );
+
+    std::fs::remove_dir_all(repo).ok();
+    std::fs::remove_dir_all(home).ok();
+    std::fs::remove_dir_all(stub_dir).ok();
+}

--- a/src/worktree_cleanup/windows_cleanup_diagnostics_tests.rs
+++ b/src/worktree_cleanup/windows_cleanup_diagnostics_tests.rs
@@ -132,12 +132,16 @@ fn install_failing_git(stub_dir: &Path, real_git: &Path) {
 }
 
 #[cfg(windows)]
-fn install_failing_git(stub_dir: &Path, real_git: &Path) {
-    let script = format!(
-        "@echo off\nif \"%~1 %~2\"==\"worktree remove\" (\n  echo cleanup-diagnostic-sentinel 1>&2\n  exit /b 23\n)\n\"{}\" %*\nexit /b %ERRORLEVEL%\n",
-        real_git.display()
-    );
-    std::fs::write(stub_dir.join("git.cmd"), script).expect("git stub");
+fn install_failing_git(_stub_dir: &Path, _real_git: &Path) {}
+
+#[cfg(windows)]
+fn hold_exclusive_worktree_file(repo: &Path) -> std::fs::File {
+    use std::os::windows::fs::OpenOptionsExt;
+    std::fs::OpenOptions::new()
+        .read(true)
+        .share_mode(0)
+        .open(repo.join("wt-done").join("feat.txt"))
+        .expect("exclusive worktree file handle")
 }
 
 fn prepend_path(stub_dir: &Path, old_path: &std::ffi::OsString) -> std::ffi::OsString {
@@ -177,6 +181,8 @@ fn real_sweep_remove_failure_preserves_final_status_and_stderr_2830_red() {
     let old_cleanup = std::env::var_os("AGEND_WORKTREE_AUTO_CLEANUP");
     std::env::set_var("PATH", prepend_path(&stub_dir, &old_path));
     std::env::set_var("AGEND_WORKTREE_AUTO_CLEANUP", "1");
+    #[cfg(windows)]
+    let exclusive = hold_exclusive_worktree_file(&repo);
     let configs = HashMap::from([(String::from("other-agent"), Some(repo.join("other")))]);
     let removed = sweep_from_registry(&home, &configs, &[]);
     std::env::set_var("PATH", old_path);
@@ -193,14 +199,29 @@ fn real_sweep_remove_failure_preserves_final_status_and_stderr_2830_red() {
         .unwrap_or_else(|| panic!("expected hygiene task; removed={removed:?}, tasks={tasks:?}"));
     let reason = evidence["reason"].as_str().unwrap_or_default();
     assert!(
-        reason.contains("status 23"),
+        reason.contains(if cfg!(windows) {
+            "status "
+        } else {
+            "status 23"
+        }),
         "final status was lost: {evidence}"
     );
     assert!(
-        reason.contains("cleanup-diagnostic-sentinel"),
+        reason.contains(if cfg!(windows) {
+            "stderr:"
+        } else {
+            "cleanup-diagnostic-sentinel"
+        }),
         "final stderr was lost: {evidence}"
     );
+    #[cfg(windows)]
+    assert!(
+        !reason.contains("stderr: <empty>"),
+        "native git failure should retain stderr bytes: {evidence}"
+    );
 
+    #[cfg(windows)]
+    drop(exclusive);
     std::fs::remove_dir_all(repo).ok();
     std::fs::remove_dir_all(home).ok();
     std::fs::remove_dir_all(stub_dir).ok();

--- a/src/worktree_cleanup/windows_cleanup_diagnostics_tests.rs
+++ b/src/worktree_cleanup/windows_cleanup_diagnostics_tests.rs
@@ -3,12 +3,9 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use super::*;
-use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-
-static ENV_LOCK: Mutex<()> = Mutex::new(());
 
 fn git_in(dir: &Path, args: &[&str]) {
     let output = Command::new("git")
@@ -152,7 +149,7 @@ fn prepend_path(stub_dir: &Path, old_path: &std::ffi::OsString) -> std::ffi::OsS
 
 #[test]
 fn real_sweep_remove_failure_preserves_final_status_and_stderr_2830_red() {
-    let _lock = ENV_LOCK.lock();
+    let _lock = super::tests::ENV_LOCK.lock();
     let repo = setup_repo();
     let home = std::env::temp_dir().join(format!(
         "agend-wt-diagnostics-home-{}-{}",


### PR DESCRIPTION
## What & why
The runtime worktree sweep currently collapses a failed `git worktree remove` into a boolean, losing the final command exit status and stderr needed by the durable hygiene task. This caller-local change preserves those diagnostics while retaining the existing retry behavior.

## Prior art check
- [x] Compared against current `main` at d5d15645fff60590d82f1c466513cccbad6dd173; the behavior is not already implemented.
- [x] Implemented decision d-20260717163116627477-4 from verified spike t-20260717144733759440-91328-3.
- [x] Scope excludes git-helper refactors, retry-policy changes, generalized abstractions, and unrelated Architecture-14 work.

## How it was verified
- `cargo test real_sweep_remove_failure_preserves_final_status_and_stderr_2830_red -- --nocapture`
- `cargo test worktree_cleanup:: -- --nocapture` (58 passed)
- `scripts/fmt-owned.sh --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- CI clippy command with tray/features and all owned targets
- `git diff --check`

Repo-wide `cargo fmt --all -- --check` still reports pre-existing formatting drift under `vendor/agentic-git`; no vendor files were changed.

## Compatibility
- [x] No on-disk format changes.

## Notes for reviewers
The immutable RED commits are 4cf34b34 and e0b6fe48; production GREEN is d294335c. Retry counts, 200/400ms Windows backoff, first-success break, branch-delete gating, and cross-platform semantics are unchanged.