### PR TITLE
fix: preserve declared backend through wrapper commands

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -759,7 +759,10 @@ fn build_command(config: &SpawnConfig) -> anyhow::Result<(CommandBuilder, Option
         ..
     } = config;
 
-    let detected_backend = Backend::from_command(backend_command);
+    let detected_backend = config
+        .backend
+        .cloned()
+        .or_else(|| Backend::from_command(backend_command));
 
     // argv = preset (per spawn_mode) + caller args + backend spawn_flags.
     // Centralized here so callers don't double-apply preset args.

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -613,6 +613,10 @@ pub type CrashChannel = crossbeam_channel::Sender<AgentExitEvent>;
 /// otherwise those flags get double-applied.
 pub struct SpawnConfig<'a> {
     pub name: &'a str,
+    /// Declared backend identity from fleet configuration. When present this
+    /// is authoritative even if `backend_command` is an arbitrary wrapper;
+    /// `None` preserves legacy command-basename inference.
+    pub backend: Option<&'a Backend>,
     pub backend_command: &'a str,
     pub args: &'a [String],
     pub spawn_mode: crate::backend::SpawnMode,
@@ -745,6 +749,7 @@ fn provision_opencode_data_dir(
 fn build_command(config: &SpawnConfig) -> anyhow::Result<(CommandBuilder, Option<Backend>)> {
     let SpawnConfig {
         name,
+        backend: _,
         backend_command,
         args,
         spawn_mode,
@@ -1170,6 +1175,7 @@ pub fn spawn_agent(
 ) -> anyhow::Result<crate::types::InstanceId> {
     let SpawnConfig {
         name,
+        backend: _,
         backend_command,
         args: _,
         spawn_mode: _,
@@ -2127,6 +2133,7 @@ fn on_clean_exit_shell_fallback(
     let spawn_result = spawn_agent(
         &SpawnConfig {
             name,
+            backend: None,
             backend_command: shell,
             args: &[],
             spawn_mode: crate::backend::SpawnMode::Fresh,

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -1108,11 +1108,7 @@ fn build_command_sets_git_editor_defaults() {
 fn build_command_wrapper_uses_declared_backend_for_presets_and_flags_2801() {
     let workspace = resolve_test_home("wrapper-2801");
     std::fs::create_dir_all(workspace.join(".claude")).expect(".claude dir");
-    std::fs::write(
-        workspace.join(".claude/agend.md"),
-        "fleet instructions",
-    )
-    .expect("agend.md");
+    std::fs::write(workspace.join(".claude/agend.md"), "fleet instructions").expect("agend.md");
     std::fs::write(workspace.join("mcp-config.json"), "{}").expect("mcp-config.json");
 
     let config = SpawnConfig {
@@ -1154,6 +1150,38 @@ fn build_command_wrapper_uses_declared_backend_for_presets_and_flags_2801() {
         );
     }
     std::fs::remove_dir_all(workspace).ok();
+}
+
+#[test]
+fn build_command_without_declared_backend_keeps_legacy_inference_2801() {
+    let config = SpawnConfig {
+        name: "legacy-inference-2801",
+        backend: None,
+        backend_command: "claude",
+        args: &[],
+        spawn_mode: crate::backend::SpawnMode::Fresh,
+        cols: 80,
+        rows: 24,
+        env: None,
+        working_dir: None,
+        submit_key: "\r",
+        home: None,
+        crash_tx: None,
+        shutdown: None,
+    };
+
+    let (cmd, detected) = build_command(&config).expect("build_command");
+    assert_eq!(detected, Some(Backend::ClaudeCode));
+    let argv: Vec<String> = cmd
+        .get_argv()
+        .iter()
+        .map(|arg| arg.to_string_lossy().into_owned())
+        .collect();
+    assert!(
+        argv.iter()
+            .any(|arg| arg == "--dangerously-skip-permissions"),
+        "legacy callers without a declaration must retain command inference; argv={argv:?}"
+    );
 }
 
 /// #2106: an operator's per-instance `ANTHROPIC_AUTH_TOKEN` in fleet.yaml

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -738,6 +738,7 @@ fn spawn_agent_refuses_mid_delete_1915() {
     let _guard = crate::agent::deleting::mark_deleting(&home, "victim");
     let cfg = SpawnConfig {
         name: "victim",
+        backend: None,
         backend_command: "true",
         args: &[],
         spawn_mode: crate::backend::SpawnMode::Fresh,
@@ -812,6 +813,7 @@ fn unmanaged_local_shell_spawns_without_fleet_entry() {
     let registry: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
     let cfg = SpawnConfig {
         name: "shell",
+        backend: None,
         backend_command: "true", // exits immediately; we only assert it registered
         args: &[],
         spawn_mode: crate::backend::SpawnMode::Fresh,
@@ -843,6 +845,7 @@ fn deleted_agent_reaper_no_shell_fallback() {
     let registry: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
     let spawn_cfg = SpawnConfig {
         name: "del-test",
+        backend: None,
         backend_command: "true", // exits immediately with code 0
         args: &[],
         spawn_mode: crate::backend::SpawnMode::Fresh,
@@ -1024,6 +1027,7 @@ fn build_command_strips_agend_git_bypass() {
     std::env::set_var("AGEND_GIT_BYPASS", "1");
     let config = SpawnConfig {
         name: "strip-test",
+        backend: None,
         backend_command: "echo",
         args: &[],
         spawn_mode: crate::backend::SpawnMode::Fresh,
@@ -1070,6 +1074,7 @@ fn build_command_strips_agend_git_bypass() {
 fn build_command_sets_git_editor_defaults() {
     let config = SpawnConfig {
         name: "git-editor-test",
+        backend: None,
         backend_command: "echo",
         args: &[],
         spawn_mode: crate::backend::SpawnMode::Fresh,
@@ -1095,6 +1100,62 @@ fn build_command_sets_git_editor_defaults() {
     }
 }
 
+/// #2801 RED: the declared backend is authoritative even when `command:` is
+/// an arbitrarily named wrapper. Basename inference cannot recover this from
+/// `backend_command`, so the spawn config must carry the resolved fleet
+/// backend into `build_command`.
+#[test]
+fn build_command_wrapper_uses_declared_backend_for_presets_and_flags_2801() {
+    let workspace = resolve_test_home("wrapper-2801");
+    std::fs::create_dir_all(workspace.join(".claude")).expect(".claude dir");
+    std::fs::write(
+        workspace.join(".claude/agend.md"),
+        "fleet instructions",
+    )
+    .expect("agend.md");
+    std::fs::write(workspace.join("mcp-config.json"), "{}").expect("mcp-config.json");
+
+    let config = SpawnConfig {
+        name: "wrapper-2801",
+        backend: Some(&Backend::ClaudeCode),
+        backend_command: "/opt/company/bin/model-proxy.sh",
+        args: &[],
+        spawn_mode: crate::backend::SpawnMode::Resume,
+        cols: 80,
+        rows: 24,
+        env: None,
+        working_dir: Some(&workspace),
+        submit_key: "\r",
+        home: None,
+        crash_tx: None,
+        shutdown: None,
+    };
+
+    let (cmd, detected) = build_command(&config).expect("build_command");
+    assert_eq!(
+        detected,
+        Some(Backend::ClaudeCode),
+        "the declared backend must win when the wrapper basename is unknown"
+    );
+    let argv: Vec<String> = cmd
+        .get_argv()
+        .iter()
+        .map(|arg| arg.to_string_lossy().into_owned())
+        .collect();
+    for expected in [
+        "--dangerously-skip-permissions",
+        "--continue",
+        "--append-system-prompt-file",
+        "--mcp-config",
+    ] {
+        assert!(
+            argv.iter().any(|arg| arg == expected),
+            "declared Claude backend must inject {expected}; argv={argv:?}"
+        );
+    }
+    std::fs::remove_dir_all(workspace).ok();
+}
+
 /// #2106: an operator's per-instance `ANTHROPIC_AUTH_TOKEN` in fleet.yaml
 /// `env:` must reach a claude-backed instance — it is a credential the backend
 /// declares (`credential_env_keys`) — so the operator can point that instance at
@@ -1113,6 +1174,7 @@ fn build_command_allows_operator_backend_credential_2106() {
     env.insert("MY_BENIGN_2106".to_string(), "ok".to_string());
     let config = SpawnConfig {
         name: "cred-2106",
+        backend: None,
         backend_command: "claude",
         args: &[],
         spawn_mode: crate::backend::SpawnMode::Fresh,
@@ -1160,6 +1222,7 @@ fn build_command_credential_override_is_per_backend_2106() {
     );
     let config = SpawnConfig {
         name: "cred-2106-codex",
+        backend: None,
         backend_command: "codex",
         args: &[],
         spawn_mode: crate::backend::SpawnMode::Fresh,
@@ -1198,6 +1261,7 @@ fn build_command_credential_override_is_per_backend_2106() {
 fn build_command_disables_opencode_autoupdate_only_for_opencode() {
     let cfg = |backend_command: &'static str, mode: crate::backend::SpawnMode| SpawnConfig {
         name: "autoupdate-test",
+        backend: None,
         backend_command,
         args: &[],
         spawn_mode: mode,
@@ -1273,6 +1337,7 @@ fn build_command_reinjects_agend_home_under_env_isolation_med5() {
     std::env::set_var("AGEND_ENV_ISOLATION", "1");
     let config = SpawnConfig {
         name: "med5-home",
+        backend: None,
         backend_command: "echo",
         args: &[],
         spawn_mode: crate::backend::SpawnMode::Fresh,
@@ -1323,6 +1388,7 @@ fn build_agy_cmd(
     .expect("write fleet.yaml");
     let config = SpawnConfig {
         name: "agy-int",
+        backend: None,
         backend_command: "agy",
         args: &[],
         spawn_mode: crate::backend::SpawnMode::Fresh,
@@ -2409,6 +2475,7 @@ fn matrix1_invariant_key_eq_id_eq_resolve() {
     spawn_agent(
         &SpawnConfig {
             name: "alpha",
+            backend: None,
             backend_command: "sleep",
             args: &sleep_args,
             spawn_mode: crate::backend::SpawnMode::Fresh,
@@ -2511,6 +2578,7 @@ fn matrix4_spawn_fails_fast_when_absent_from_fleet() {
     let result = spawn_agent(
         &SpawnConfig {
             name: "ghost",
+            backend: None,
             backend_command: "sleep",
             args: &sleep_args,
             spawn_mode: crate::backend::SpawnMode::Fresh,

--- a/src/agent_ops.rs
+++ b/src/agent_ops.rs
@@ -853,6 +853,7 @@ pub fn spawn_one(
     agent::spawn_agent(
         &agent::SpawnConfig {
             name,
+            backend: None,
             backend_command: backend,
             args,
             spawn_mode,

--- a/src/agent_ops.rs
+++ b/src/agent_ops.rs
@@ -798,6 +798,7 @@ pub fn spawn_one(
     work_dir: &Path,
     size: (u16, u16),
     env: Option<&std::collections::HashMap<String, String>>,
+    declared_backend: Option<&crate::backend::Backend>,
 ) -> anyhow::Result<crate::backend::SpawnMode> {
     std::fs::create_dir_all(work_dir).ok();
     // #1080: skills auto-install for dynamically spawned instances.
@@ -815,8 +816,10 @@ pub fn spawn_one(
             .ok()
             .and_then(|c| c.instances.get(name).and_then(|i| i.skills_path.clone()))
             .map(|p| crate::fleet::resolve::expand_tilde_path(&p));
-    let backend_skill =
-        crate::backend::Backend::from_command(backend).and_then(|b| b.skill_dir_name());
+    let effective_backend = declared_backend
+        .cloned()
+        .or_else(|| crate::backend::Backend::from_command(backend));
+    let backend_skill = effective_backend.clone().and_then(|b| b.skill_dir_name());
     match crate::skills::install_for_agent_backend_with_source(
         home,
         work_dir,
@@ -841,7 +844,7 @@ pub fn spawn_one(
     // #1682: clear BOTH the legacy name file and the id-resolved file — post-#1680
     // readers use `<uuid>.json`, which the old name-only remove left stale.
     remove_metadata(home, name);
-    let preset_submit_key = crate::backend::Backend::from_command(backend)
+    let preset_submit_key = effective_backend
         .map(|b| b.preset().submit_key)
         .unwrap_or("\r");
     // No-op when caller already passed Fresh; downgrades Resume → Fresh when
@@ -853,7 +856,7 @@ pub fn spawn_one(
     agent::spawn_agent(
         &agent::SpawnConfig {
             name,
-            backend: None,
+            backend: declared_backend,
             backend_command: backend,
             args,
             spawn_mode,

--- a/src/api/handlers/instance.rs
+++ b/src/api/handlers/instance.rs
@@ -582,6 +582,7 @@ mod tests {
         // Spawn a real shell agent so the registry has an entry with a HealthTracker.
         let spawn_cfg = agent::SpawnConfig {
             name,
+            backend: None,
             backend_command: crate::default_shell(),
             args: &[],
             spawn_mode: crate::backend::SpawnMode::Fresh,
@@ -713,6 +714,7 @@ mod tests {
         let wedge_args = vec!["-c".to_string(), "stty raw -echo; sleep 30".to_string()];
         let spawn_cfg = agent::SpawnConfig {
             name,
+            backend: None,
             backend_command: "sh",
             args: &wedge_args,
             spawn_mode: crate::backend::SpawnMode::Fresh,

--- a/src/api/handlers/instance.rs
+++ b/src/api/handlers/instance.rs
@@ -241,6 +241,25 @@ pub(crate) fn handle_spawn(params: &Value, ctx: &HandlerCtx) -> Value {
     // usually resolve it through the fleet entry. push_model_arg enforces
     // the first tier by never duplicating an existing flag.
     let fleet_config_for_model = std::cell::OnceCell::new();
+    // #2801: keep declared backend identity independent from the executable
+    // command. A fleet entry may declare Claude while `command` is a wrapper.
+    let params_backend = params["backend"]
+        .as_str()
+        .map(crate::backend::Backend::parse_str);
+    let declared_backend = params_backend
+        .clone()
+        .filter(|b| !matches!(b, crate::backend::Backend::Raw(_)))
+        .or_else(|| fleet_resolved.as_ref().map(|r| r.backend.clone()))
+        .or_else(|| {
+            fleet_config_for_model
+                .get_or_init(|| {
+                    crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(ctx.home)).ok()
+                })
+                .as_ref()
+                .and_then(|f| f.defaults.backend.clone())
+        })
+        .or(params_backend)
+        .unwrap_or(crate::backend::Backend::ClaudeCode);
     let tier_model = params["model_tier"]
         .as_str()
         .filter(|m| !m.is_empty())
@@ -266,24 +285,6 @@ pub(crate) fn handle_spawn(params: &Value, ctx: &HandlerCtx) -> Value {
         // Raw-parsed value is a command guess and must yield to the fleet
         // entry's declared backend. Params-Raw stands only when nothing else
         // declares — a genuinely raw backend.
-        let params_backend = params["backend"]
-            .as_str()
-            .map(crate::backend::Backend::parse_str);
-        let declared_backend = params_backend
-            .clone()
-            .filter(|b| !matches!(b, crate::backend::Backend::Raw(_)))
-            .or_else(|| fleet_resolved.as_ref().map(|r| r.backend.clone()))
-            .or_else(|| {
-                fleet_config_for_model
-                    .get_or_init(|| {
-                        crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(ctx.home))
-                            .ok()
-                    })
-                    .as_ref()
-                    .and_then(|f| f.defaults.backend.clone())
-            })
-            .or(params_backend)
-            .unwrap_or(crate::backend::Backend::ClaudeCode);
         crate::backend::Backend::push_model_arg(&mut args, &declared_backend, model);
     }
     let requested_work_dir = params["working_directory"]
@@ -318,7 +319,13 @@ pub(crate) fn handle_spawn(params: &Value, ctx: &HandlerCtx) -> Value {
     // #46776 fail-closed: a workspace-identity refusal (or provisioning I/O
     // failure) must ABORT the spawn — never fork an agent against foreign or
     // half-written provisioned state.
-    if let Err(e) = super::prepare_instructions(ctx.home, name, command, &work_dir, explicit_role) {
+    let behavior_command = match &declared_backend {
+        crate::backend::Backend::Shell | crate::backend::Backend::Raw(_) => command.to_string(),
+        _ => declared_backend.command_string(),
+    };
+    if let Err(e) =
+        super::prepare_instructions(ctx.home, name, &behavior_command, &work_dir, explicit_role)
+    {
         tracing::error!(agent = %name, error = %e, "SPAWN aborted: provisioning refused");
         return json!({"ok": false, "error": format!("provisioning refused: {e}")});
     }
@@ -348,6 +355,7 @@ pub(crate) fn handle_spawn(params: &Value, ctx: &HandlerCtx) -> Value {
         &work_dir,
         size,
         env_for_spawn,
+        Some(&declared_backend),
     ) {
         Ok(_spawn_mode) => {
             // fresh-restart self-kick: fire the first-turn recovery inject ONLY when
@@ -360,9 +368,9 @@ pub(crate) fn handle_spawn(params: &Value, ctx: &HandlerCtx) -> Value {
             // is harmless.
             if params["self_kick_on_ready"].as_bool().unwrap_or(false) {
                 if let Some(id) = crate::fleet::resolve_uuid(ctx.home, name) {
-                    let ready_timeout = crate::backend::Backend::from_command(command)
-                        .map(|b| b.preset().ready_timeout_secs)
-                        .unwrap_or(30)
+                    let ready_timeout = declared_backend
+                        .preset()
+                        .ready_timeout_secs
                         .saturating_add(15);
                     agent::spawn_self_kick_bootstrap(
                         std::sync::Arc::clone(ctx.registry),
@@ -1134,6 +1142,7 @@ mod tests {
             &work_dir,
             size,
             None,
+            None,
         );
         assert!(result.is_ok(), "spawn_one must succeed: {result:?}");
 
@@ -1474,7 +1483,10 @@ mod tests {
     /// Write a tiny shell script that captures its own argv (`$*`) to
     /// `sentinel_path` then sleeps so the agent stays alive long enough for
     /// cleanup_agent to reap it. The daemon-appended `--model <val>` lands in
-    /// the script's argv, so the sentinel content IS the spawned argv tail.
+    /// the script's argv, so the sentinel content IS the spawned argv tail. The
+    /// file is executable so it can stand in for a realistically named wrapper:
+    /// declared backend presets may precede caller args without `/bin/sh`
+    /// interpreting them as shell options (#2801).
     #[cfg(unix)]
     fn write_argv_capture_script(
         home: &std::path::Path,
@@ -1486,6 +1498,12 @@ mod tests {
             sentinel_path.display()
         );
         std::fs::write(&script, body).expect("write script");
+        use std::os::unix::fs::PermissionsExt;
+        let mut permissions = std::fs::metadata(&script)
+            .expect("script metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&script, permissions).expect("make script executable");
         script
     }
 
@@ -1509,8 +1527,7 @@ mod tests {
         let result = handle_spawn(
             &json!({
                 "name": "model-fleet-test",
-                "backend": "/bin/sh",
-                "args": script.display().to_string(),
+                "backend": script.display().to_string(),
                 // No --model in args, none in params — must come from fleet.yaml.
             }),
             &ctx,
@@ -1521,11 +1538,12 @@ mod tests {
         cleanup_agent(&ctx, "model-fleet-test");
         let _ = std::fs::remove_dir_all(&home);
 
-        assert_eq!(
-            actual.as_deref(),
-            Some("--model model-2038-fleet"),
+        assert!(
+            actual
+                .as_deref()
+                .is_some_and(|argv| argv.contains("--model model-2038-fleet")),
             "fleet.yaml model MUST reach the spawned argv on a runtime SPAWN \
-             (restart_instance shape); pre-#2038 it was boot-only"
+             (restart_instance shape); pre-#2038 it was boot-only; got {actual:?}"
         );
     }
 
@@ -1549,8 +1567,7 @@ mod tests {
         let result = handle_spawn(
             &json!({
                 "name": "shell-no-model-test",
-                "backend": "/bin/sh",
-                "args": script.display().to_string(),
+                "backend": script.display().to_string(),
             }),
             &ctx,
         );
@@ -1604,8 +1621,7 @@ mod tests {
             let result = handle_spawn(
                 &json!({
                     "name": "seat",
-                    "backend": "/bin/sh",
-                    "args": script.display().to_string(),
+                    "backend": script.display().to_string(),
                 }),
                 &ctx,
             );
@@ -1616,10 +1632,9 @@ mod tests {
             let actual = await_sentinel_nonempty(&sentinel);
             cleanup_agent(&ctx, "seat");
             let _ = std::fs::remove_dir_all(&home);
-            assert_eq!(
-                actual.as_deref(),
-                Some(want),
-                "{backend}: persisted model must reach the spawned argv"
+            assert!(
+                actual.as_deref().is_some_and(|argv| argv.contains(want)),
+                "{backend}: persisted model must reach the spawned argv; got {actual:?}"
             );
         }
     }
@@ -1656,8 +1671,7 @@ mod tests {
         let result = handle_spawn(
             &json!({
                 "name": "seat",
-                "backend": "/bin/sh",
-                "args": script.display().to_string(),
+                "backend": script.display().to_string(),
             }),
             &ctx,
         );
@@ -1665,10 +1679,11 @@ mod tests {
         let actual = await_sentinel_nonempty(&sentinel);
         cleanup_agent(&ctx, "seat");
         let _ = std::fs::remove_dir_all(&home);
-        assert_eq!(
-            actual.as_deref(),
-            Some("--model model-hand-edited"),
-            "the external edit must win on the next spawn (disk re-read)"
+        assert!(
+            actual
+                .as_deref()
+                .is_some_and(|argv| argv.contains("--model model-hand-edited")),
+            "the external edit must win on the next spawn (disk re-read); got {actual:?}"
         );
     }
 
@@ -1686,17 +1701,14 @@ mod tests {
 
         std::fs::write(
             crate::fleet::fleet_yaml_path(&home),
-            format!(
-                "instances:\n  args-fleet-test:\n    backend: claude\n    args:\n      - {}\n    model: model-2038-replace\n",
-                script.display()
-            ),
+            "instances:\n  args-fleet-test:\n    backend: claude\n    args:\n      - from-fleet\n    model: model-2038-replace\n",
         )
         .expect("write fleet.yaml");
 
         let result = handle_spawn(
             &json!({
                 "name": "args-fleet-test",
-                "backend": "/bin/sh",
+                "backend": script.display().to_string(),
                 // No "args" field at all — the deploy Phase 3 (args-less SPAWN) wire shape.
             }),
             &ctx,
@@ -1709,11 +1721,12 @@ mod tests {
 
         // The script itself ran (proving fleet args fallback) and saw the
         // appended model flag (proving model fallback).
-        assert_eq!(
-            actual.as_deref(),
-            Some("--model model-2038-replace"),
+        assert!(
+            actual.as_deref().is_some_and(|argv| {
+                argv.contains("from-fleet") && argv.contains("--model model-2038-replace")
+            }),
             "an args-less SPAWN (deploy Phase 3 shape) MUST respawn with the \
-             fleet entry's args + model"
+             fleet entry's args + model; got {actual:?}"
         );
     }
 
@@ -1736,8 +1749,8 @@ mod tests {
         let result = handle_spawn(
             &json!({
                 "name": "model-prec-test",
-                "backend": "/bin/sh",
-                "args": format!("{} --model model-2038-explicit", script.display()),
+                "backend": script.display().to_string(),
+                "args": "--model model-2038-explicit",
             }),
             &ctx,
         );
@@ -1749,8 +1762,13 @@ mod tests {
 
         let argv = actual.expect("sentinel must have content");
         assert_eq!(
-            argv, "--model model-2038-explicit",
-            "caller-passed --model MUST win over fleet.yaml model with no duplicate flag"
+            argv.matches("--model").count(),
+            1,
+            "caller-passed --model MUST win over fleet.yaml model with no duplicate flag; got {argv}"
+        );
+        assert!(
+            argv.contains("--model model-2038-explicit"),
+            "caller model value must be preserved; got {argv}"
         );
     }
 
@@ -1775,8 +1793,7 @@ mod tests {
         let result = handle_spawn(
             &json!({
                 "name": "params-model-test",
-                "backend": "/bin/sh",
-                "args": script.display().to_string(),
+                "backend": script.display().to_string(),
                 "model": "model-2038-params",
             }),
             &ctx,
@@ -1787,10 +1804,11 @@ mod tests {
         cleanup_agent(&ctx, "params-model-test");
         let _ = std::fs::remove_dir_all(&home);
 
-        assert_eq!(
-            actual.as_deref(),
-            Some("--model model-2038-params"),
-            "params.model MUST be honoured and win over the fleet entry's model"
+        assert!(
+            actual
+                .as_deref()
+                .is_some_and(|argv| argv.contains("--model model-2038-params")),
+            "params.model MUST be honoured and win over the fleet entry's model; got {actual:?}"
         );
     }
 
@@ -1814,8 +1832,7 @@ mod tests {
         let result = handle_spawn(
             &json!({
                 "name": "inst-model-test",
-                "backend": "/bin/sh",
-                "args": script.display().to_string(),
+                "backend": script.display().to_string(),
             }),
             &ctx,
         );
@@ -1825,10 +1842,11 @@ mod tests {
         cleanup_agent(&ctx, "inst-model-test");
         let _ = std::fs::remove_dir_all(&home);
 
-        assert_eq!(
-            actual.as_deref(),
-            Some("--model model-2038-inst-wins"),
-            "per-instance model MUST override defaults.model at the SPAWN entry"
+        assert!(
+            actual
+                .as_deref()
+                .is_some_and(|argv| argv.contains("--model model-2038-inst-wins")),
+            "per-instance model MUST override defaults.model at the SPAWN entry; got {actual:?}"
         );
     }
 

--- a/src/api/handlers/messaging/tests.rs
+++ b/src/api/handlers/messaging/tests.rs
@@ -187,6 +187,7 @@ fn test_send_to_active_registry_target_returns_pty() {
         Box::leak(Box::new(Arc::new(Mutex::new(HashMap::new()))));
     let spawn_cfg = crate::agent::SpawnConfig {
         name: "active-agent",
+        backend: None,
         backend_command: crate::default_shell(),
         args: &[],
         spawn_mode: crate::backend::SpawnMode::Fresh,
@@ -781,6 +782,7 @@ fn same_team_codex_update_absorbed() {
         Box::leak(Box::new(Arc::new(Mutex::new(HashMap::new()))));
     let spawn_cfg = crate::agent::SpawnConfig {
         name: "codex-agent",
+        backend: None,
         backend_command: crate::default_shell(),
         args: &[],
         spawn_mode: crate::backend::SpawnMode::Fresh,
@@ -860,6 +862,7 @@ fn cross_team_message_not_absorbed() {
         Box::leak(Box::new(Arc::new(Mutex::new(HashMap::new()))));
     let spawn_cfg = crate::agent::SpawnConfig {
         name: "codex-agent",
+        backend: None,
         backend_command: crate::default_shell(),
         args: &[],
         spawn_mode: crate::backend::SpawnMode::Fresh,
@@ -932,6 +935,7 @@ fn same_team_codex_update_orchestrator_not_skipped() {
         Box::leak(Box::new(Arc::new(Mutex::new(HashMap::new()))));
     let spawn_cfg = crate::agent::SpawnConfig {
         name: "codex-agent",
+        backend: None,
         backend_command: crate::default_shell(),
         args: &[],
         spawn_mode: crate::backend::SpawnMode::Fresh,
@@ -999,6 +1003,7 @@ fn same_team_codex_update_non_orchestrator_skipped() {
         Box::leak(Box::new(Arc::new(Mutex::new(HashMap::new()))));
     let spawn_cfg = crate::agent::SpawnConfig {
         name: "codex-agent",
+        backend: None,
         backend_command: crate::default_shell(),
         args: &[],
         spawn_mode: crate::backend::SpawnMode::Fresh,
@@ -1067,6 +1072,7 @@ fn cross_team_codex_update_orchestrator_not_skipped() {
         Box::leak(Box::new(Arc::new(Mutex::new(HashMap::new()))));
     let spawn_cfg = crate::agent::SpawnConfig {
         name: "codex-agent",
+        backend: None,
         backend_command: crate::default_shell(),
         args: &[],
         spawn_mode: crate::backend::SpawnMode::Fresh,
@@ -1670,6 +1676,7 @@ fn make_codex_ctx(
         Box::leak(Box::new(Arc::new(Mutex::new(HashMap::new()))));
     let spawn_cfg = crate::agent::SpawnConfig {
         name: codex_agent,
+        backend: None,
         backend_command: crate::default_shell(),
         args: &[],
         spawn_mode: crate::backend::SpawnMode::Fresh,
@@ -1940,6 +1947,7 @@ fn b6_non_codex_backend_pty_path_unchanged_by_override() {
         Box::leak(Box::new(Arc::new(Mutex::new(HashMap::new()))));
     let spawn_cfg = crate::agent::SpawnConfig {
         name: "claude-agent",
+        backend: None,
         backend_command: crate::default_shell(),
         args: &[],
         spawn_mode: crate::backend::SpawnMode::Fresh,
@@ -2139,6 +2147,7 @@ fn kind_report_cross_team_codex_via_general_still_injects() {
         Box::leak(Box::new(Arc::new(Mutex::new(HashMap::new()))));
     let spawn_cfg = crate::agent::SpawnConfig {
         name: "codex-rev",
+        backend: None,
         backend_command: crate::default_shell(),
         args: &[],
         spawn_mode: crate::backend::SpawnMode::Fresh,

--- a/src/api/handlers/team.rs
+++ b/src/api/handlers/team.rs
@@ -216,14 +216,14 @@ pub(crate) fn handle_create_team(params: &Value, ctx: &HandlerCtx) -> Value {
             .as_ref()
             .map(|r| r.args.clone())
             .unwrap_or_default();
+        let declared_backend = resolved
+            .as_ref()
+            .map(|r| r.backend.clone())
+            .unwrap_or_else(|| crate::backend::Backend::parse_str(backend));
         if let Some(model) = resolved.as_ref().and_then(|r| r.model.as_deref()) {
             // #2744: DECLARED identity — the resolved fleet entry's backend
             // (Phase 1 wrote it); fallback parses the declared member NAME,
             // never a command string.
-            let declared_backend = resolved
-                .as_ref()
-                .map(|r| r.backend.clone())
-                .unwrap_or_else(|| crate::backend::Backend::parse_str(backend));
             crate::backend::Backend::push_model_arg(&mut member_args, &declared_backend, model);
         }
         match crate::agent_ops::spawn_one(
@@ -236,6 +236,7 @@ pub(crate) fn handle_create_team(params: &Value, ctx: &HandlerCtx) -> Value {
             work_dir,
             size,
             resolved_env.as_ref(),
+            Some(&declared_backend),
         ) {
             Ok(_) => {
                 tracing::info!(team = team_name, member = %inst_name, backend = %backend, "CREATE_TEAM spawn ok");

--- a/src/app/pane_factory.rs
+++ b/src/app/pane_factory.rs
@@ -340,6 +340,7 @@ fn spawn_and_subscribe(
     let instance_id = agent::spawn_agent(
         &agent::SpawnConfig {
             name,
+            backend: None,
             backend_command: command,
             args,
             spawn_mode,

--- a/src/app/pane_factory.rs
+++ b/src/app/pane_factory.rs
@@ -124,19 +124,71 @@ pub(super) fn create_pane(
     name_counter: &mut HashMap<String, usize>,
     identity: SpawnIdentity,
 ) -> Result<Pane> {
+    create_pane_with_backend(
+        layout,
+        registry,
+        home,
+        base_name,
+        command,
+        args,
+        spawn_mode,
+        working_dir,
+        env,
+        submit_key,
+        cols,
+        rows,
+        wakeup_tx,
+        name_counter,
+        identity,
+        None,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn create_pane_with_backend(
+    layout: &mut Layout,
+    registry: &AgentRegistry,
+    home: &Path,
+    base_name: &str,
+    command: &str,
+    args: &[String],
+    spawn_mode: crate::backend::SpawnMode,
+    working_dir: Option<&Path>,
+    env: &HashMap<String, String>,
+    submit_key: &str,
+    cols: u16,
+    rows: u16,
+    wakeup_tx: &crossbeam_channel::Sender<usize>,
+    name_counter: &mut HashMap<String, usize>,
+    identity: SpawnIdentity,
+    declared_backend: Option<&Backend>,
+) -> Result<Pane> {
     let (mut pane, fwd_tx) = build_pane_placeholder(
         layout,
         home,
         base_name,
         command,
+        declared_backend,
         working_dir,
         cols,
         rows,
         name_counter,
     );
     attach_agent_to_pane(
-        &mut pane, fwd_tx, registry, home, command, args, spawn_mode, env, submit_key, cols, rows,
-        wakeup_tx, identity,
+        &mut pane,
+        fwd_tx,
+        registry,
+        home,
+        command,
+        args,
+        spawn_mode,
+        env,
+        submit_key,
+        cols,
+        rows,
+        wakeup_tx,
+        identity,
+        declared_backend,
     )?;
     Ok(pane)
 }
@@ -158,6 +210,7 @@ fn build_pane_placeholder(
     home: &Path,
     base_name: &str,
     command: &str,
+    declared_backend: Option<&Backend>,
     working_dir: Option<&Path>,
     cols: u16,
     rows: u16,
@@ -179,7 +232,9 @@ fn build_pane_placeholder(
 
     let pane_id = layout.next_pane_id();
     let (fwd_tx, fwd_rx) = crossbeam_channel::unbounded::<Vec<u8>>();
-    let backend = Backend::from_command(command);
+    let backend = declared_backend
+        .cloned()
+        .or_else(|| Backend::from_command(command));
 
     let pane = Pane {
         agent_name: name.into(),
@@ -227,6 +282,7 @@ fn attach_agent_to_pane(
     rows: u16,
     wakeup_tx: &crossbeam_channel::Sender<usize>,
     identity: SpawnIdentity,
+    declared_backend: Option<&Backend>,
 ) -> Result<()> {
     let name = pane.agent_name.to_string();
     let work_dir = pane
@@ -240,8 +296,19 @@ fn attach_agent_to_pane(
     // `spawn_and_subscribe` on a background worker (touches only the shareable
     // registry) while the render thread runs `apply_attachment` (pane mutation).
     let (instance_id, rx, dump) = spawn_and_subscribe(
-        registry, home, &name, command, args, spawn_mode, env, submit_key, &work_dir, cols, rows,
+        registry,
+        home,
+        &name,
+        command,
+        args,
+        spawn_mode,
+        env,
+        submit_key,
+        &work_dir,
+        cols,
+        rows,
         identity,
+        declared_backend,
     )?;
     apply_attachment(pane, instance_id, rx, dump, fwd_tx, wakeup_tx);
     Ok(())
@@ -268,18 +335,32 @@ fn spawn_and_subscribe(
     cols: u16,
     rows: u16,
     identity: SpawnIdentity,
+    declared_backend: Option<&Backend>,
 ) -> Result<(
     crate::types::InstanceId,
     crossbeam_channel::Receiver<Vec<u8>>,
     Vec<u8>,
 )> {
+    let effective_backend = declared_backend
+        .cloned()
+        .or_else(|| Backend::from_command(command));
+    let behavior_command = declared_backend
+        .filter(|backend| !matches!(backend, Backend::Shell | Backend::Raw(_)))
+        .map(Backend::command_string)
+        .unwrap_or_else(|| command.to_string());
+
     // Generate MCP config for agent backends
-    if Backend::from_command(command).is_some() {
+    if effective_backend
+        .as_ref()
+        .is_some_and(|backend| !matches!(backend, Backend::Shell | Backend::Raw(_)))
+    {
         match identity {
             SpawnIdentity::Managed => {
-                crate::instructions::generate_for_owner(work_dir, command, name)
+                crate::instructions::generate_for_owner(work_dir, &behavior_command, name)
             }
-            SpawnIdentity::UnmanagedLocalShell => crate::instructions::generate(work_dir, command),
+            SpawnIdentity::UnmanagedLocalShell => {
+                crate::instructions::generate(work_dir, &behavior_command)
+            }
         }
         .map_err(|e| anyhow::anyhow!("provisioning refused: {e}"))?;
     }
@@ -299,7 +380,7 @@ fn spawn_and_subscribe(
                 .ok()
                 .and_then(|c| c.instances.get(name).and_then(|i| i.skills_path.clone()))
                 .map(|p| crate::fleet::resolve::expand_tilde_path(&p));
-        let backend_skill = Backend::from_command(command).and_then(|b| b.skill_dir_name());
+        let backend_skill = effective_backend.and_then(|b| b.skill_dir_name());
         match crate::skills::install_for_agent_backend_with_source(
             home,
             work_dir,
@@ -340,7 +421,7 @@ fn spawn_and_subscribe(
     let instance_id = agent::spawn_agent(
         &agent::SpawnConfig {
             name,
-            backend: None,
+            backend: declared_backend,
             backend_command: command,
             args,
             spawn_mode,
@@ -589,6 +670,7 @@ pub(super) fn build_deferred_agent_pane(
         home,
         fleet_name,
         &resolved.backend_command,
+        Some(&resolved.backend),
         resolved.working_directory.as_deref(),
         cols,
         rows,
@@ -634,6 +716,7 @@ pub(super) fn build_deferred_direct_pane(
         home,
         base_name,
         command,
+        None,
         working_dir,
         cols,
         rows,
@@ -801,6 +884,7 @@ pub(super) fn run_attach(
                 cols,
                 rows,
                 SpawnIdentity::Managed,
+                Some(&resolved.backend),
             ) {
                 Ok((instance_id, rx, dump)) => {
                     // Overwrite basic instructions with the fleet-aware version
@@ -819,9 +903,12 @@ pub(super) fn run_attach(
                         team: team_ctx.as_ref(),
                         extra_instructions: extra_instructions.as_deref(),
                     };
-                    if let Err(e) =
-                        crate::instructions::generate_with_context(&work_dir, &command, Some(&ctx))
-                    {
+                    let behavior_command = resolved.backend.command_string();
+                    if let Err(e) = crate::instructions::generate_with_context(
+                        &work_dir,
+                        &behavior_command,
+                        Some(&ctx),
+                    ) {
                         tracing::error!(agent = %deduped_name, error = %e, "provisioning refused; not attaching");
                         return AttachOutcome::Failed {
                             pane_id,
@@ -871,6 +958,7 @@ pub(super) fn run_attach(
             // AttachSpec::Direct is the deferred SHELL / direct-command path
             // (see `build_deferred_direct_pane`) — unmanaged, no fleet.yaml entry.
             SpawnIdentity::UnmanagedLocalShell,
+            None,
         ) {
             Ok((instance_id, rx, dump)) => {
                 finish_attach(registry, pane_id, instance_id, rx, dump, work_dir, name)
@@ -1087,7 +1175,7 @@ pub(super) fn create_pane_from_resolved(
         Backend::push_model_arg(&mut args, &resolved.backend, model);
     }
 
-    let mut pane = create_pane(
+    let mut pane = create_pane_with_backend(
         layout,
         registry,
         home,
@@ -1103,11 +1191,13 @@ pub(super) fn create_pane_from_resolved(
         wakeup_tx,
         name_counter,
         SpawnIdentity::Managed,
+        Some(&resolved.backend),
     )?;
 
     // Overwrite basic instructions with fleet-aware version
     if let Some(ref wd) = pane.working_dir {
-        crate::instructions::generate_with_context(wd, &resolved.backend_command, Some(&ctx))
+        let behavior_command = resolved.backend.command_string();
+        crate::instructions::generate_with_context(wd, &behavior_command, Some(&ctx))
             .map_err(|e| anyhow::anyhow!("provisioning refused: {e}"))?;
     }
     pane.fleet_instance_name = Some(fleet_name.to_string());
@@ -1310,6 +1400,12 @@ mod tests {
             ),
         )
         .expect("write script");
+        use std::os::unix::fs::PermissionsExt;
+        let mut permissions = std::fs::metadata(&script)
+            .expect("script metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&script, permissions).expect("make script executable");
         script.display().to_string()
     }
 
@@ -1426,11 +1522,18 @@ mod tests {
             let actual = await_sentinel(&sentinel);
             crate::agent::lock_registry(registry).clear();
             std::fs::remove_dir_all(&home).ok();
-            assert_eq!(
-                actual.as_deref(),
-                Some(want),
-                "{tag}: deferred app path must apply the capability gate"
-            );
+            let actual = actual.expect("capture output");
+            if tag == "wrap" {
+                assert!(
+                    actual.contains(want),
+                    "{tag}: declared backend must preserve the model flag among preset args; got {actual}"
+                );
+            } else {
+                assert_eq!(
+                    actual, want,
+                    "{tag}: deferred app path must apply the capability gate"
+                );
+            }
         }
     }
 
@@ -1445,13 +1548,16 @@ mod tests {
         let sentinel = home.join("sentinel.txt");
         let script = argv_capture_script(&home, &sentinel);
         register_seat(&home, "seat-sync");
-        let resolved = resolved_seat(
+        let mut resolved = resolved_seat(
             "seat-sync",
             crate::backend::Backend::ClaudeCode,
-            vec![script, "--model".into(), "pinned".into()],
+            vec!["--model".into(), "pinned".into()],
             Some("fleet-loser"),
             &home,
         );
+        // Use the capture script itself as the wrapper executable. The declared
+        // Claude identity must enrich its argv without relying on its basename.
+        resolved.backend_command = script;
         let mut layout = Layout::new();
         let mut name_counter = HashMap::new();
         let (wakeup_tx, _wakeup_rx) = crossbeam_channel::unbounded();
@@ -1472,10 +1578,18 @@ mod tests {
         drop(pane);
         crate::agent::lock_registry(registry).clear();
         std::fs::remove_dir_all(&home).ok();
+        let actual = actual.expect("capture output");
         assert_eq!(
-            actual.as_deref(),
-            Some("--model pinned"),
-            "sync app path must dedupe against the explicit args flag"
+            actual.matches("--model").count(),
+            1,
+            "sync app path must dedupe against the explicit args flag; got {actual}"
+        );
+        assert!(
+            actual.contains("--model pinned")
+                && actual.contains("--dangerously-skip-permissions")
+                && actual.contains("--append-system-prompt-file")
+                && actual.contains("--mcp-config"),
+            "declared Claude identity must provision and inject its preset flags through a wrapper; got {actual}"
         );
     }
 

--- a/src/bootstrap/agent_resolve.rs
+++ b/src/bootstrap/agent_resolve.rs
@@ -18,6 +18,7 @@ pub type AgentDef = (
     Option<HashMap<String, String>>,
     Option<PathBuf>,
     String,
+    Option<backend::Backend>,
 );
 
 struct ResolveContext<'a> {
@@ -116,8 +117,9 @@ fn resolve_one(config: &FleetConfig, ctx: &ResolveContext<'_>, name: &str) -> Op
             team: None,
             extra_instructions: extra_instructions.as_deref(),
         };
+        let behavior_command = resolved.backend.command_string();
         if let Err(e) =
-            crate::instructions::generate_with_context(dir, &resolved.backend_command, Some(&ctx))
+            crate::instructions::generate_with_context(dir, &behavior_command, Some(&ctx))
         {
             tracing::error!(instance = name, error = %e, "provisioning refused; skipping instance boot");
             return None;
@@ -139,6 +141,7 @@ fn resolve_one(config: &FleetConfig, ctx: &ResolveContext<'_>, name: &str) -> Op
         Some(resolved.env),
         resolved.working_directory,
         resolved.submit_key,
+        Some(resolved.backend),
     ))
 }
 
@@ -280,7 +283,7 @@ mod tests {
             result.is_some(),
             "resolve_one must succeed with worktree:false"
         );
-        let (_, _, _, _, work_dir, _) = result.unwrap();
+        let (_, _, _, _, work_dir, _, _) = result.unwrap();
         // working_directory must be the original dir (not a .worktrees/ subdir)
         let wd = work_dir.unwrap();
         assert!(
@@ -322,7 +325,7 @@ mod tests {
         };
         let result = resolve_one(&config, &ctx, "test-agent");
         assert!(result.is_some());
-        let (_, _, _, _, work_dir, _) = result.unwrap();
+        let (_, _, _, _, work_dir, _, _) = result.unwrap();
         let wd = work_dir.unwrap();
         // working_directory should be redirected to the new external
         // layout `$AGEND_HOME/worktrees/test-agent/<branch>/` per
@@ -401,7 +404,7 @@ mod tests {
             result.is_some(),
             "resolve_one must succeed for orchestrator"
         );
-        let (_, _, _, _, returned_work_dir, _) = result.unwrap();
+        let (_, _, _, _, returned_work_dir, _, _) = result.unwrap();
         let wd = returned_work_dir.unwrap();
 
         // #888 LOAD-BEARING: working_directory must NOT be redirected
@@ -608,7 +611,7 @@ mod tests {
         assert!(result.is_some(), "resolve_one must succeed after prune");
         // Verify prune was attempted — worktree dir should be removed
         // (or at minimum, resolve_one returned the base dir, not the worktree)
-        let (_, _, _, _, work_dir, _) = result.unwrap();
+        let (_, _, _, _, work_dir, _, _) = result.unwrap();
         let wd = work_dir.unwrap();
         let wd_str = wd.to_string_lossy();
         assert!(
@@ -651,7 +654,7 @@ mod tests {
         };
         let result = resolve_one(&config, &ctx, "test-agent");
         assert!(result.is_some(), "resolve_one should succeed");
-        let (_, _, _, _, wd, _) = result.unwrap();
+        let (_, _, _, _, wd, _, _) = result.unwrap();
         let generated = std::fs::read_to_string(wd.unwrap().join(".claude/agend.md"))
             .expect("generated instructions file");
         assert!(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -50,6 +50,7 @@ pub fn capture_backend(b: &backend::Backend, seconds: u64) -> anyhow::Result<()>
     agent::spawn_agent(
         &agent::SpawnConfig {
             name: &name,
+            backend: None,
             backend_command: preset.command,
             args: &[],
             spawn_mode: backend::SpawnMode::Fresh,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -50,7 +50,7 @@ pub fn capture_backend(b: &backend::Backend, seconds: u64) -> anyhow::Result<()>
     agent::spawn_agent(
         &agent::SpawnConfig {
             name: &name,
-            backend: None,
+            backend: Some(b),
             backend_command: preset.command,
             args: &[],
             spawn_mode: backend::SpawnMode::Fresh,

--- a/src/daemon/crash_respawn.rs
+++ b/src/daemon/crash_respawn.rs
@@ -387,7 +387,10 @@ fn respawn_agent_worker(
                         .and_then(|i| i.skills_path.clone())
                 })
                 .map(|p| crate::fleet::resolve::expand_tilde_path(&p));
-        let backend_skill = crate::backend::Backend::from_command(&config.backend_command)
+        let backend_skill = config
+            .backend
+            .clone()
+            .or_else(|| crate::backend::Backend::from_command(&config.backend_command))
             .and_then(|b| b.skill_dir_name());
         if let Err(e) = crate::skills::install_for_agent_backend_with_source(
             home,
@@ -486,7 +489,7 @@ fn respawn_agent_worker(
     match agent::spawn_agent(
         &agent::SpawnConfig {
             name: &config.name,
-            backend: None,
+            backend: config.backend.as_ref(),
             backend_command: &config.backend_command,
             args: &config.args,
             spawn_mode: crate::backend::SpawnMode::Fresh,
@@ -719,6 +722,7 @@ mod deleted_gate_tests_1913 {
             VICTIM.to_string(),
             AgentConfig {
                 name: VICTIM.to_string(),
+                backend: None,
                 backend_command: "true".to_string(),
                 args: vec![],
                 env: None,
@@ -990,6 +994,7 @@ mod deleted_gate_tests_1913 {
 
         let config = AgentConfig {
             name: VICTIM.to_string(),
+            backend: None,
             backend_command: "nonexistent-command-12345".to_string(),
             args: vec![],
             env: None,

--- a/src/daemon/crash_respawn.rs
+++ b/src/daemon/crash_respawn.rs
@@ -486,6 +486,7 @@ fn respawn_agent_worker(
     match agent::spawn_agent(
         &agent::SpawnConfig {
             name: &config.name,
+            backend: None,
             backend_command: &config.backend_command,
             args: &config.args,
             spawn_mode: crate::backend::SpawnMode::Fresh,

--- a/src/daemon/lifecycle.rs
+++ b/src/daemon/lifecycle.rs
@@ -337,6 +337,7 @@ mod tests {
         let reg = empty_registry();
         let cfg = crate::agent::SpawnConfig {
             name: "never-written",
+            backend: None,
             backend_command: "cat",
             args: &[],
             spawn_mode: crate::backend::SpawnMode::Fresh,

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -264,6 +264,7 @@ pub(crate) fn record_shutdown_reason(reason: ShutdownReason) {
 #[derive(Clone)]
 pub struct AgentConfig {
     pub name: String,
+    pub backend: Option<crate::backend::Backend>,
     pub backend_command: String,
     pub args: Vec<String>,
     pub env: Option<HashMap<String, String>>,
@@ -495,6 +496,7 @@ pub type AgentDef = (
     Option<HashMap<String, String>>,
     Option<PathBuf>,
     String,
+    Option<crate::backend::Backend>,
 );
 
 /// Start daemon: do preflight (lock, run dir, cookie) then run the core loop.
@@ -1699,7 +1701,7 @@ fn spawn_and_register_agent(
     crash_tx: &crossbeam_channel::Sender<crate::agent::AgentExitEvent>,
     shutdown: &Arc<std::sync::atomic::AtomicBool>,
 ) -> anyhow::Result<()> {
-    let (name, command, args, env, working_dir, submit_key) = def;
+    let (name, command, args, env, working_dir, submit_key, backend) = def;
     // #1915 chokepoint (boot path): skip an instance deleted mid-boot BEFORE the
     // skills-install below re-creates `workspace/<name>`. The boot loop iterates a
     // fleet snapshot with a ~500ms inter-spawn stagger; a delete in that window
@@ -1736,6 +1738,7 @@ fn spawn_and_register_agent(
         name.clone(),
         AgentConfig {
             name: name.clone(),
+            backend: backend.clone(),
             backend_command: command.clone(),
             args: args.clone(),
             env: env.clone(),
@@ -1772,8 +1775,10 @@ fn spawn_and_register_agent(
                 .ok()
                 .and_then(|c| c.instances.get(name).and_then(|i| i.skills_path.clone()))
                 .map(|p| crate::fleet::resolve::expand_tilde_path(&p));
-        let backend_skill =
-            crate::backend::Backend::from_command(command).and_then(|b| b.skill_dir_name());
+        let backend_skill = backend
+            .clone()
+            .or_else(|| crate::backend::Backend::from_command(command))
+            .and_then(|b| b.skill_dir_name());
         match crate::skills::install_for_agent_backend_with_source(
             home,
             wd,
@@ -1802,7 +1807,7 @@ fn spawn_and_register_agent(
     if let Err(e) = agent::spawn_agent(
         &agent::SpawnConfig {
             name,
-            backend: None,
+            backend: backend.as_ref(),
             backend_command: command,
             args,
             spawn_mode,
@@ -2280,6 +2285,7 @@ mod tests {
             "agent-3".into(),
             AgentConfig {
                 name: "agent-3".into(),
+                backend: None,
                 backend_command: "claude".into(),
                 args: vec![],
                 env: None,
@@ -2578,6 +2584,7 @@ mod tests {
             None,
             None,
             "\r".into(),
+            None,
         )
     }
 

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -1802,6 +1802,7 @@ fn spawn_and_register_agent(
     if let Err(e) = agent::spawn_agent(
         &agent::SpawnConfig {
             name,
+            backend: None,
             backend_command: command,
             args,
             spawn_mode,

--- a/src/daemon/per_tick/recovery_dispatcher.rs
+++ b/src/daemon/per_tick/recovery_dispatcher.rs
@@ -934,6 +934,7 @@ mod tests {
         let args = vec!["-c".to_string(), "stty raw -echo; sleep 30".to_string()];
         let cfg = agent::SpawnConfig {
             name: "wedged-esc-target",
+            backend: None,
             backend_command: "sh",
             args: &args,
             spawn_mode: crate::backend::SpawnMode::Fresh,

--- a/src/daemon/supervisor/tests.rs
+++ b/src/daemon/supervisor/tests.rs
@@ -3014,6 +3014,7 @@ fn srl_inject_failed_reachable_via_real_wedged_actor_writer_2620() {
     let wedge_args = vec!["-c".to_string(), "stty raw -echo; sleep 30".to_string()];
     let spawn_cfg = crate::agent::SpawnConfig {
         name,
+        backend: None,
         backend_command: "sh",
         args: &wedge_args,
         spawn_mode: crate::backend::SpawnMode::Fresh,

--- a/src/main.rs
+++ b/src/main.rs
@@ -837,10 +837,20 @@ fn main() -> anyhow::Result<()> {
                         // `preset_spawn_args(spawn_mode)` — callers must NOT also
                         // stuff preset flags here or backends that reject
                         // duplicate flags (e.g. Grok `--always-approve`) exit 2.
-                        let submit_key = backend::Backend::from_command(&cmd)
+                        let declared_backend = backend::Backend::from_command(&cmd);
+                        let submit_key = declared_backend
+                            .as_ref()
                             .map(|b| b.preset().submit_key.to_string())
                             .unwrap_or_else(|| "\r".to_string());
-                        (name, cmd, Vec::new(), None, None, submit_key)
+                        (
+                            name,
+                            cmd,
+                            Vec::new(),
+                            None,
+                            None,
+                            submit_key,
+                            declared_backend,
+                        )
                     })
                     .collect();
                 // #1441: managed spawns fail-fast unless the instance is in
@@ -929,6 +939,7 @@ fn main() -> anyhow::Result<()> {
                         None,
                         None,
                         "\r".to_string(),
+                        Some(crate::backend::Backend::Shell),
                     )],
                 )?;
             }

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -520,7 +520,7 @@ fn test_backend(backend: &backend::Backend, home: &Path) -> Vec<TestResult> {
     let spawn_result = agent::spawn_agent(
         &agent::SpawnConfig {
             name: &agent_name,
-            backend: None,
+            backend: Some(backend),
             backend_command: preset.command,
             args: &[],
             spawn_mode: crate::backend::SpawnMode::Fresh,

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -48,6 +48,7 @@ impl TestResult {
 fn test_spawn_config<'a>(name: &'a str, home: Option<&'a Path>) -> agent::SpawnConfig<'a> {
     agent::SpawnConfig {
         name,
+        backend: None,
         backend_command: crate::default_shell(),
         args: &[],
         spawn_mode: crate::backend::SpawnMode::Fresh,
@@ -519,6 +520,7 @@ fn test_backend(backend: &backend::Backend, home: &Path) -> Vec<TestResult> {
     let spawn_result = agent::spawn_agent(
         &agent::SpawnConfig {
             name: &agent_name,
+            backend: None,
             backend_command: preset.command,
             args: &[],
             spawn_mode: crate::backend::SpawnMode::Fresh,


### PR DESCRIPTION
## Summary
- carry the resolved backend identity separately from the executable command
- use declared backend presets, flags, instruction provisioning, skills, model intent, and submit keys through wrapper commands
- retain legacy command inference when no backend declaration exists

## Verification
- RED: 9d1c38ce reproduces wrapper loss
- GREEN: cargo test --bin agend-terminal 2801 -- --nocapture
- cargo test --bin agend-terminal agent::tests -- --nocapture
- cargo test --bin agend-terminal daemon::crash_respawn -- --nocapture
- cargo test --bin agend-terminal app::pane_factory::tests -- --nocapture
- cargo test --bin agend-terminal api::handlers::instance::tests -- --nocapture
- cargo clippy --bin agend-terminal -- -D warnings
- cargo fmt -- --check

Closes #2801

---
*codex-125550* · Codex