### PR TITLE
fix(ci): add exact handoff pickup acknowledgement

### DIFF
--- a/src/daemon/ci_handoff_track.rs
+++ b/src/daemon/ci_handoff_track.rs
@@ -746,6 +746,27 @@ pub(crate) fn resolve_protected_episode(
     episode: &str,
     reason: &str,
 ) -> usize {
+    resolve_exact_episode(
+        home,
+        target,
+        correlation,
+        episode,
+        crate::inbox::CiHandoffClass::Protected,
+        reason,
+    )
+}
+
+/// Resolve one current-schema handoff only when target, correlation, episode,
+/// and class all match. This is the neutral pickup-settlement primitive used by
+/// `ci action=ack_handoff`; it never mutates the watch subscription.
+pub(crate) fn resolve_exact_episode(
+    home: &Path,
+    target: &str,
+    correlation: &str,
+    episode: &str,
+    class: crate::inbox::CiHandoffClass,
+    reason: &str,
+) -> usize {
     if episode.is_empty() {
         return 0;
     }
@@ -754,7 +775,7 @@ pub(crate) fn resolve_protected_episode(
         if track.target == target
             && track.correlation == correlation
             && track.ci_handoff_episode.as_deref() == Some(episode)
-            && track.ci_handoff_class == Some(crate::inbox::CiHandoffClass::Protected)
+            && track.ci_handoff_class == Some(class)
             && remove_if_episode_unchanged(
                 home,
                 &path,
@@ -766,12 +787,12 @@ pub(crate) fn resolve_protected_episode(
         {
             resolved += 1;
             tracing::info!(
-                tag = "#35896-11-track-resolved",
+                tag = "#2817-track-resolved",
                 agent = %target,
                 %correlation,
                 %episode,
                 reason,
-                "protected ci-handoff episode resolved"
+                "exact ci-handoff episode resolved"
             );
         }
     }
@@ -784,10 +805,10 @@ pub(crate) fn resolve_protected_episode(
 pub(crate) fn reconcile_processed(home: &Path, now: &chrono::DateTime<chrono::Utc>) -> usize {
     let mut resolved = 0;
     for (path, track) in list(home) {
-        if track.ci_handoff_class != Some(crate::inbox::CiHandoffClass::Protected) {
-            continue;
-        }
         let Some(episode) = track.ci_handoff_episode.as_deref() else {
+            continue;
+        };
+        let Some(class) = track.ci_handoff_class else {
             continue;
         };
         let Ok(sent_at) = chrono::DateTime::parse_from_rfc3339(&track.sent_at) else {
@@ -797,11 +818,12 @@ pub(crate) fn reconcile_processed(home: &Path, now: &chrono::DateTime<chrono::Ut
             continue;
         }
         if !matches!(
-            crate::inbox::storage::protected_handoff_row_state(
+            crate::inbox::storage::handoff_row_state(
                 home,
                 &track.target,
                 &track.correlation,
                 episode,
+                class,
             ),
             crate::inbox::storage::ProtectedHandoffRowState::Processed
         ) {
@@ -817,12 +839,12 @@ pub(crate) fn reconcile_processed(home: &Path, now: &chrono::DateTime<chrono::Ut
         ) {
             resolved += 1;
             tracing::info!(
-                tag = "#35896-11-track-reconciled",
+                tag = "#2817-track-reconciled",
                 agent = %track.target,
                 correlation = %track.correlation,
                 %episode,
                 reason = "ack_reconciled",
-                "processed protected ci-handoff episode reconciled"
+                "processed exact ci-handoff episode reconciled"
             );
         }
     }
@@ -2050,6 +2072,47 @@ mod tests {
             None,
             Some("ep-1"),
             Some(crate::inbox::CiHandoffClass::Protected)
+        ));
+        let now = chrono::DateTime::parse_from_rfc3339("2026-06-10T00:01:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        assert_eq!(reconcile_processed(&home, &now), 1);
+        assert!(list(&home).is_empty());
+        std::fs::remove_dir_all(&home).ok();
+    }
+    #[test]
+    fn ack_handoff_reconciler_also_resolves_processed_feature_episode_2817() {
+        let home = tmp_home("2817-feature-reconcile");
+        let correlation = "o/r@feat/ack";
+        let episode = "ep-feature";
+        let mut msg = crate::inbox::InboxMessage::new_system(
+            "system:ci",
+            "ci-ready-for-action",
+            "feature handoff".to_string(),
+        )
+        .with_correlation_id(correlation.to_string());
+        msg.ci_handoff_episode = Some(episode.to_string());
+        msg.ci_handoff_class = Some(crate::inbox::CiHandoffClass::Feature);
+        crate::inbox::enqueue(&home, "lead", msg).unwrap();
+        assert_eq!(
+            crate::inbox::storage::settle_ci_handoff_row_exact(
+                &home,
+                "lead",
+                correlation,
+                episode,
+                crate::inbox::CiHandoffClass::Feature,
+            ),
+            crate::inbox::storage::HandoffRowSettleOutcome::Settled
+        );
+        assert!(record_with_identity(
+            &home,
+            "lead",
+            correlation,
+            "2026-06-10T00:00:00Z",
+            None,
+            None,
+            Some(episode),
+            Some(crate::inbox::CiHandoffClass::Feature)
         ));
         let now = chrono::DateTime::parse_from_rfc3339("2026-06-10T00:01:00Z")
             .unwrap()

--- a/src/inbox/storage.rs
+++ b/src/inbox/storage.rs
@@ -5,7 +5,8 @@ use super::message::{InboxMessage, MessageStatus};
 
 mod ci_handoff;
 pub(crate) use ci_handoff::{
-    protected_handoff_row_state, protected_settlement_identity, ProtectedHandoffRowState,
+    handoff_row_state, protected_settlement_identity, settle_ci_handoff_row_exact,
+    HandoffRowSettleOutcome, ProtectedHandoffRowState,
 };
 
 mod message_query;

--- a/src/inbox/storage/ci_handoff.rs
+++ b/src/inbox/storage/ci_handoff.rs
@@ -34,7 +34,6 @@ pub(crate) fn handoff_row_state(
             return ProtectedHandoffRowState::Missing;
         };
         let matches: Vec<InboxMessage> = parse_inbox_messages(&content)
-            .into_iter()
             .filter(|msg| {
                 msg.kind.as_deref() == Some("ci-ready-for-action")
                     && msg.correlation_id.as_deref() == Some(correlation)

--- a/src/inbox/storage/ci_handoff.rs
+++ b/src/inbox/storage/ci_handoff.rs
@@ -1,5 +1,6 @@
 use super::{parse_inbox_messages, with_inbox_lock};
 use crate::inbox::message::{CiHandoffClass, InboxMessage};
+use std::io::Write;
 use std::path::Path;
 
 /// Exact row state used by the CI-handoff crash reconciler.
@@ -11,41 +12,123 @@ pub(crate) enum ProtectedHandoffRowState {
     Ambiguous,
 }
 
-/// Probe one target inbox under its flock for exactly one protected ci-ready
-/// row carrying the requested correlation + episode.
-pub(crate) fn protected_handoff_row_state(
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum HandoffRowSettleOutcome {
+    Settled,
+    AlreadySettled,
+    Missing,
+    Ambiguous,
+    WriteFailed,
+    LockFailed,
+}
+
+pub(crate) fn handoff_row_state(
     home: &Path,
     target: &str,
     correlation: &str,
     episode: &str,
+    class: CiHandoffClass,
 ) -> ProtectedHandoffRowState {
     let Ok(state) = with_inbox_lock(home, target, |path| {
         let Ok(content) = std::fs::read_to_string(path) else {
             return ProtectedHandoffRowState::Missing;
         };
-        let mut matches = 0usize;
-        let mut processed = false;
-        for msg in parse_inbox_messages(&content) {
-            if msg.kind.as_deref() != Some("ci-ready-for-action")
-                || msg.correlation_id.as_deref() != Some(correlation)
-                || msg.ci_handoff_episode.as_deref() != Some(episode)
-                || msg.ci_handoff_class != Some(CiHandoffClass::Protected)
-            {
-                continue;
+        let matches: Vec<InboxMessage> = parse_inbox_messages(&content)
+            .into_iter()
+            .filter(|msg| {
+                msg.kind.as_deref() == Some("ci-ready-for-action")
+                    && msg.correlation_id.as_deref() == Some(correlation)
+                    && msg.ci_handoff_episode.as_deref() == Some(episode)
+                    && msg.ci_handoff_class == Some(class)
+            })
+            .collect();
+        match matches.as_slice() {
+            [] => ProtectedHandoffRowState::Missing,
+            [msg] if msg.read_at.is_some() && msg.delivering_at.is_none() => {
+                ProtectedHandoffRowState::Processed
             }
-            matches += 1;
-            processed = msg.read_at.is_some() && msg.delivering_at.is_none();
-        }
-        match (matches, processed) {
-            (0, _) => ProtectedHandoffRowState::Missing,
-            (1, true) => ProtectedHandoffRowState::Processed,
-            (1, false) => ProtectedHandoffRowState::Pending,
-            (_, _) => ProtectedHandoffRowState::Ambiguous,
+            [_] => ProtectedHandoffRowState::Pending,
+            _ => ProtectedHandoffRowState::Ambiguous,
         }
     }) else {
         return ProtectedHandoffRowState::Missing;
     };
     state
+}
+
+/// Settle exactly one CI handoff row without touching the sidecar track.
+/// The caller performs the episode-CAS track delete only after this durable
+/// write completes, so the two file locks are never nested.
+pub(crate) fn settle_ci_handoff_row_exact(
+    home: &Path,
+    target: &str,
+    correlation: &str,
+    episode: &str,
+    class: CiHandoffClass,
+) -> HandoffRowSettleOutcome {
+    with_inbox_lock(home, target, |path| {
+        let Ok(content) = std::fs::read_to_string(path) else {
+            return HandoffRowSettleOutcome::Missing;
+        };
+        let mut messages = Vec::new();
+        let mut raw_lines = Vec::new();
+        let mut match_indexes = Vec::new();
+        for line in content.lines() {
+            if line.trim().is_empty() {
+                continue;
+            }
+            match serde_json::from_str::<InboxMessage>(line) {
+                Ok(msg) => {
+                    if msg.kind.as_deref() == Some("ci-ready-for-action")
+                        && msg.correlation_id.as_deref() == Some(correlation)
+                        && msg.ci_handoff_episode.as_deref() == Some(episode)
+                        && msg.ci_handoff_class == Some(class)
+                    {
+                        match_indexes.push(messages.len());
+                    }
+                    messages.push(msg);
+                }
+                Err(_) => raw_lines.push(line.to_string()),
+            }
+        }
+        let [index] = match_indexes.as_slice() else {
+            return if match_indexes.is_empty() {
+                HandoffRowSettleOutcome::Missing
+            } else {
+                HandoffRowSettleOutcome::Ambiguous
+            };
+        };
+        let msg = &mut messages[*index];
+        if msg.read_at.is_some() && msg.delivering_at.is_none() {
+            return HandoffRowSettleOutcome::AlreadySettled;
+        }
+        msg.read_at = Some(chrono::Utc::now().to_rfc3339());
+        msg.delivering_at = None;
+        let tmp = path.with_extension("jsonl.tmp");
+        let write = (|| -> anyhow::Result<()> {
+            let mut file = std::fs::OpenOptions::new()
+                .create(true)
+                .write(true)
+                .truncate(true)
+                .open(&tmp)?;
+            for message in messages {
+                writeln!(file, "{}", serde_json::to_string(&message)?)?;
+            }
+            for raw in raw_lines {
+                writeln!(file, "{raw}")?;
+            }
+            file.sync_all()?;
+            std::fs::rename(&tmp, path)?;
+            crate::store::fsync_parent_dir(path);
+            Ok(())
+        })();
+        if write.is_ok() {
+            HandoffRowSettleOutcome::Settled
+        } else {
+            HandoffRowSettleOutcome::WriteFailed
+        }
+    })
+    .unwrap_or(HandoffRowSettleOutcome::LockFailed)
 }
 
 /// Return the exact protected CI-handoff identity carried by a row.

--- a/src/mcp/handlers/ci/handoff_ack.rs
+++ b/src/mcp/handlers/ci/handoff_ack.rs
@@ -1,0 +1,131 @@
+use serde_json::{json, Value};
+use std::path::Path;
+
+use crate::inbox::storage::{
+    handoff_row_state, settle_ci_handoff_row_exact, HandoffRowSettleOutcome,
+    ProtectedHandoffRowState,
+};
+
+/// Neutral pickup settlement for a system-origin `ci-ready-for-action` row.
+/// It is deliberately narrower than `unwatch` and channel `discharge`: the
+/// caller may settle only its own exact episode, and the watch stays armed.
+pub(crate) fn handle_ack_handoff_ci(home: &Path, args: &Value, instance_name: &str) -> Value {
+    if instance_name.is_empty() {
+        return json!({
+            "error": "ack_handoff requires an authenticated instance caller",
+            "code": "caller_identity_required"
+        });
+    }
+    let raw_repo = match args["repository"].as_str().filter(|s| !s.is_empty()) {
+        Some(repo) => repo,
+        None => {
+            return json!({"error": "missing required 'repository'", "code": "missing_repository"})
+        }
+    };
+    let repository = match crate::mcp::handlers::dispatch_hook::canonicalize_repo_slug(raw_repo) {
+        Some(repo) => repo,
+        None => return json!({"error": "invalid repository", "code": "invalid_repo_format"}),
+    };
+    let branch = match args["branch"].as_str().filter(|s| !s.is_empty()) {
+        Some(branch) => branch,
+        None => return json!({"error": "missing required 'branch'", "code": "missing_branch"}),
+    };
+    let episode = match args["episode"].as_str().filter(|s| !s.is_empty()) {
+        Some(episode) => episode,
+        None => return json!({"error": "missing required 'episode'", "code": "missing_episode"}),
+    };
+    let correlation = format!("{repository}@{branch}");
+    let tracks = crate::daemon::ci_handoff_track::list(home);
+    let same_key: Vec<_> = tracks
+        .iter()
+        .filter(|(_, track)| track.target == instance_name && track.correlation == correlation)
+        .collect();
+    let exact: Vec<_> = same_key
+        .iter()
+        .filter(|(_, track)| track.ci_handoff_episode.as_deref() == Some(episode))
+        .collect();
+
+    if exact.is_empty() {
+        if !same_key.is_empty() {
+            return json!({"error": "episode mismatch (CAS)", "code": "episode_mismatch"});
+        }
+        for class in [
+            crate::inbox::CiHandoffClass::Feature,
+            crate::inbox::CiHandoffClass::Protected,
+        ] {
+            if handoff_row_state(home, instance_name, &correlation, episode, class)
+                == ProtectedHandoffRowState::Processed
+            {
+                return json!({
+                    "ok": true,
+                    "acked": true,
+                    "already_acked": true,
+                    "correlation": correlation,
+                    "episode": episode,
+                    "watch_preserved": true
+                });
+            }
+        }
+        return json!({"error": "no matching handoff track", "code": "track_not_found"});
+    }
+    if exact.len() != 1 {
+        return json!({"error": "ambiguous handoff track", "code": "track_ambiguous"});
+    }
+    let track = &exact[0].1;
+    let Some(class) = track.ci_handoff_class else {
+        return json!({"error": "handoff class missing", "code": "legacy_identity_unsupported"});
+    };
+
+    let row_outcome =
+        settle_ci_handoff_row_exact(home, instance_name, &correlation, episode, class);
+    let already_acked = match row_outcome {
+        HandoffRowSettleOutcome::Settled => false,
+        HandoffRowSettleOutcome::AlreadySettled => true,
+        HandoffRowSettleOutcome::Missing => {
+            return json!({"error": "matching inbox row not found", "code": "row_not_found"})
+        }
+        HandoffRowSettleOutcome::Ambiguous => {
+            return json!({"error": "matching inbox row is ambiguous", "code": "row_ambiguous"})
+        }
+        HandoffRowSettleOutcome::WriteFailed => {
+            return json!({"error": "failed to settle inbox row", "code": "row_write_failed"})
+        }
+        HandoffRowSettleOutcome::LockFailed => {
+            return json!({"error": "failed to lock inbox row", "code": "row_lock_failed"})
+        }
+    };
+
+    let resolved = crate::daemon::ci_handoff_track::resolve_exact_episode(
+        home,
+        instance_name,
+        &correlation,
+        episode,
+        class,
+        "ack_handoff",
+    );
+    if resolved != 1 {
+        return json!({
+            "error": "inbox row settled but handoff track CAS did not resolve; reconciler will retry",
+            "code": "track_settlement_incomplete",
+            "settled_row": true
+        });
+    }
+    crate::event_log::log(
+        home,
+        "ci_handoff_acknowledged",
+        instance_name,
+        &format!(
+            "correlation={correlation} episode={episode} class={class:?} watch_preserved=true"
+        ),
+    );
+    json!({
+        "ok": true,
+        "acked": true,
+        "already_acked": already_acked,
+        "settled_row": true,
+        "resolved_track": true,
+        "correlation": correlation,
+        "episode": episode,
+        "watch_preserved": true
+    })
+}

--- a/src/mcp/handlers/ci/mod.rs
+++ b/src/mcp/handlers/ci/mod.rs
@@ -37,6 +37,7 @@ pub(crate) mod checkout_txn;
 // ceiling (re-exported from checkout_txn so caller paths are unchanged).
 pub(crate) mod checkout_recovery;
 mod cleanup;
+mod handoff_ack;
 mod merge;
 mod release;
 mod watch;
@@ -44,6 +45,7 @@ mod watch;
 pub(super) use checkout::handle_checkout_repo;
 pub(super) use cleanup::handle_cleanup_init_commits;
 pub(crate) use cleanup::handle_cleanup_merged_branches;
+pub(crate) use handoff_ack::handle_ack_handoff_ci;
 pub(super) use merge::handle_merge_repo;
 pub(super) use release::handle_release_repo;
 pub(crate) use watch::{handle_defer_ci, handle_status_ci, handle_unwatch_ci, handle_watch_ci};

--- a/src/mcp/handlers/ci/watch_tests.rs
+++ b/src/mcp/handlers/ci/watch_tests.rs
@@ -1,5 +1,146 @@
 use super::*;
 
+fn seed_ack_handoff(
+    home: &Path,
+    target: &str,
+    correlation: &str,
+    episode: &str,
+    class: crate::inbox::CiHandoffClass,
+) {
+    let mut msg = crate::inbox::InboxMessage::new_system(
+        "system:ci",
+        "ci-ready-for-action",
+        format!("[ci-ready-for-action] {correlation}"),
+    )
+    .with_correlation_id(correlation.to_string());
+    msg.id = Some(format!("m-{target}-{episode}"));
+    msg.ci_handoff_episode = Some(episode.to_string());
+    msg.ci_handoff_class = Some(class);
+    crate::inbox::enqueue(home, target, msg).unwrap();
+    assert!(crate::daemon::ci_handoff_track::record_with_identity(
+        home,
+        target,
+        correlation,
+        "2026-07-18T00:00:00Z",
+        Some("0123456789abcdef0123456789abcdef01234567"),
+        Some("t-2817"),
+        Some(episode),
+        Some(class),
+    ));
+}
+
+fn ack_row(home: &Path, target: &str, episode: &str) -> crate::inbox::InboxMessage {
+    let content = std::fs::read_to_string(crate::inbox::inbox_path_resolved(home, target)).unwrap();
+    content
+        .lines()
+        .filter_map(|line| serde_json::from_str::<crate::inbox::InboxMessage>(line).ok())
+        .find(|msg| msg.ci_handoff_episode.as_deref() == Some(episode))
+        .expect("seeded ci-ready row")
+}
+
+#[test]
+fn ack_handoff_is_caller_scoped_non_noisy_and_preserves_watch_2817() {
+    let home = std::env::temp_dir().join(format!(
+        "agend-2817-ack-scoped-{}-{}",
+        std::process::id(),
+        line!()
+    ));
+    let _ = std::fs::remove_dir_all(&home);
+    std::fs::create_dir_all(home.join("ci-watches")).unwrap();
+    let watch = home.join("ci-watches").join("sentinel.json");
+    std::fs::write(&watch, b"watch-must-survive").unwrap();
+    let corr = "o/r@feat/ack";
+    seed_ack_handoff(
+        &home,
+        "lead",
+        corr,
+        "ep-lead",
+        crate::inbox::CiHandoffClass::Feature,
+    );
+    seed_ack_handoff(
+        &home,
+        "reviewer",
+        corr,
+        "ep-reviewer",
+        crate::inbox::CiHandoffClass::Feature,
+    );
+
+    let response = handle_ack_handoff_ci(
+        &home,
+        &json!({"repository": "o/r", "branch": "feat/ack", "episode": "ep-lead"}),
+        "lead",
+    );
+    assert_eq!(response["ok"], true, "ack must succeed: {response}");
+    assert_eq!(response["acked"], true, "ack must report settlement: {response}");
+    let tracks = crate::daemon::ci_handoff_track::list(&home);
+    assert_eq!(tracks.len(), 1, "only the caller's exact track is removed");
+    assert_eq!(tracks[0].1.target, "reviewer");
+    assert!(ack_row(&home, "lead", "ep-lead").read_at.is_some());
+    assert!(ack_row(&home, "reviewer", "ep-reviewer").read_at.is_none());
+    assert_eq!(std::fs::read(&watch).unwrap(), b"watch-must-survive");
+    let audit = std::fs::read_to_string(home.join("event-log.jsonl")).unwrap();
+    assert!(audit.contains("ci_handoff_acknowledged"));
+    assert!(!audit.contains("channel_reply_discharged"));
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn ack_handoff_wrong_episode_is_cas_rejected_2817() {
+    let home = std::env::temp_dir().join(format!(
+        "agend-2817-ack-cas-{}-{}",
+        std::process::id(),
+        line!()
+    ));
+    let _ = std::fs::remove_dir_all(&home);
+    std::fs::create_dir_all(&home).unwrap();
+    seed_ack_handoff(
+        &home,
+        "lead",
+        "o/r@feat/ack",
+        "ep-current",
+        crate::inbox::CiHandoffClass::Feature,
+    );
+
+    let response = handle_ack_handoff_ci(
+        &home,
+        &json!({"repository": "o/r", "branch": "feat/ack", "episode": "ep-stale"}),
+        "lead",
+    );
+    assert_eq!(response["code"], "episode_mismatch", "{response}");
+    assert_eq!(crate::daemon::ci_handoff_track::list(&home).len(), 1);
+    assert!(ack_row(&home, "lead", "ep-current").read_at.is_none());
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn ack_handoff_is_idempotent_and_handles_protected_episode_2817() {
+    let home = std::env::temp_dir().join(format!(
+        "agend-2817-ack-protected-{}-{}",
+        std::process::id(),
+        line!()
+    ));
+    let _ = std::fs::remove_dir_all(&home);
+    std::fs::create_dir_all(&home).unwrap();
+    seed_ack_handoff(
+        &home,
+        "lead",
+        "o/r@main",
+        "ep-main",
+        crate::inbox::CiHandoffClass::Protected,
+    );
+    let args = json!({"repository": "o/r", "branch": "main", "episode": "ep-main"});
+
+    let first = handle_ack_handoff_ci(&home, &args, "lead");
+    assert_eq!(first["ok"], true, "first ack must succeed: {first}");
+    assert!(crate::daemon::ci_handoff_track::list(&home).is_empty());
+    assert!(ack_row(&home, "lead", "ep-main").read_at.is_some());
+
+    let repeated = handle_ack_handoff_ci(&home, &args, "lead");
+    assert_eq!(repeated["ok"], true, "repeated ack must succeed: {repeated}");
+    assert_eq!(repeated["already_acked"], true, "{repeated}");
+    std::fs::remove_dir_all(&home).ok();
+}
+
 /// #t-92758 P2: `ci unwatch` is the lead's dismiss path for a stuck ci-ready —
 /// it must clear the caller's own ci-handoff track so the re-nudge watchdog
 /// stops. Runs even when no watch file exists (the dismiss intent stands).

--- a/src/mcp/handlers/ci/watch_tests.rs
+++ b/src/mcp/handlers/ci/watch_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::mcp::handlers::ci::handle_ack_handoff_ci;
 
 fn seed_ack_handoff(
     home: &Path,
@@ -71,7 +72,10 @@ fn ack_handoff_is_caller_scoped_non_noisy_and_preserves_watch_2817() {
         "lead",
     );
     assert_eq!(response["ok"], true, "ack must succeed: {response}");
-    assert_eq!(response["acked"], true, "ack must report settlement: {response}");
+    assert_eq!(
+        response["acked"], true,
+        "ack must report settlement: {response}"
+    );
     let tracks = crate::daemon::ci_handoff_track::list(&home);
     assert_eq!(tracks.len(), 1, "only the caller's exact track is removed");
     assert_eq!(tracks[0].1.target, "reviewer");
@@ -136,7 +140,10 @@ fn ack_handoff_is_idempotent_and_handles_protected_episode_2817() {
     assert!(ack_row(&home, "lead", "ep-main").read_at.is_some());
 
     let repeated = handle_ack_handoff_ci(&home, &args, "lead");
-    assert_eq!(repeated["ok"], true, "repeated ack must succeed: {repeated}");
+    assert_eq!(
+        repeated["ok"], true,
+        "repeated ack must succeed: {repeated}"
+    );
     assert_eq!(repeated["already_acked"], true, "{repeated}");
     std::fs::remove_dir_all(&home).ok();
 }

--- a/src/mcp/handlers/dispatch.rs
+++ b/src/mcp/handlers/dispatch.rs
@@ -313,10 +313,11 @@ pub(crate) fn dispatch_usage_limit_takeover(ctx: &HandlerCtx<'_>) -> Value {
 }
 
 action_adapter!(dispatch_ci, "ci", [
-    "watch"   => ci::handle_watch_ci,   hai;
-    "unwatch" => ci::handle_unwatch_ci, hai;
-    "status"  => ci::handle_status_ci,  hai;
-    "defer"   => ci::handle_defer_ci,   hai;
+    "watch"       => ci::handle_watch_ci,       hai;
+    "unwatch"     => ci::handle_unwatch_ci,     hai;
+    "status"      => ci::handle_status_ci,      hai;
+    "defer"       => ci::handle_defer_ci,       hai;
+    "ack_handoff" => ci::handle_ack_handoff_ci, hai;
 ]);
 
 action_adapter!(dispatch_decision, "decision", [

--- a/src/mcp/handlers/tests.rs
+++ b/src/mcp/handlers/tests.rs
@@ -2538,6 +2538,53 @@ fn watch_ci_valid_repo_returns_watching() {
 }
 
 #[test]
+fn ack_handoff_routes_through_public_ci_dispatch_2817() {
+    let _g = fleet_test_guard();
+    let home = tmp_home("ack-handoff-route");
+    std::env::set_var("AGEND_HOME", &home);
+    let correlation = "owner/repo@feat/ack";
+    let episode = "ep-dispatch";
+    let mut msg = crate::inbox::InboxMessage::new_system(
+        "system:ci",
+        "ci-ready-for-action",
+        "feature handoff".to_string(),
+    )
+    .with_correlation_id(correlation.to_string());
+    msg.ci_handoff_episode = Some(episode.to_string());
+    msg.ci_handoff_class = Some(crate::inbox::CiHandoffClass::Feature);
+    crate::inbox::enqueue(&home, "sender", msg).unwrap();
+    assert!(crate::daemon::ci_handoff_track::record_with_identity(
+        &home,
+        "sender",
+        correlation,
+        "2026-07-18T00:00:00Z",
+        None,
+        Some("t-2817"),
+        Some(episode),
+        Some(crate::inbox::CiHandoffClass::Feature),
+    ));
+
+    let result = handle_tool(
+        "ci",
+        &json!({
+            "action": "ack_handoff",
+            "repository": "owner/repo",
+            "branch": "feat/ack",
+            "episode": episode,
+        }),
+        "sender",
+    );
+    assert_eq!(
+        result["ok"], true,
+        "public dispatch must route ack: {result}"
+    );
+    assert!(crate::daemon::ci_handoff_track::list(&home).is_empty());
+
+    std::env::remove_var("AGEND_HOME");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
 fn checkout_repo_absolute_path_used_directly() {
     let _g = fleet_test_guard();
     let home = tmp_home("checkout-abs");

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -329,11 +329,11 @@ pub(crate) fn def_deployment() -> Value {
 }
 
 pub(crate) fn def_ci() -> Value {
-    json!({"name": "ci", "description": "Manage CI watching. Actions: watch, unwatch, status, defer.",
+    json!({"name": "ci", "description": "Manage CI watching and handoff pickup. Actions: watch, unwatch, status, defer, ack_handoff.",
         "inputSchema": {"type": "object", "properties": {
-            "action": {"type": "string", "enum": ["watch", "unwatch", "status", "defer"]},
-            "repository": {"type": "string", "description": "GitHub `owner/repo` slug. Required for watch/unwatch; optional filter for status."},
-            "branch": {"type": "string", "description": "Branch to watch (default: main); optional filter for status."},
+            "action": {"type": "string", "enum": ["watch", "unwatch", "status", "defer", "ack_handoff"]},
+            "repository": {"type": "string", "description": "GitHub `owner/repo` slug. Required for watch/unwatch/ack_handoff; optional filter for status."},
+            "branch": {"type": "string", "description": "Branch to watch (default: main); required for ack_handoff; optional filter for status."},
             "interval_secs": {"type": "number", "description": "Poll interval in seconds (default: 60)"},
             "next_after_ci": {"oneOf": [{"type": "string"}, {"type": "array", "items": {"type": "string"}}], "description": "Instance or instances to auto-notify when CI passes. Daemon sends [ci-ready-for-action] to each target."},
             "review_class": {"type": "string", "enum": ["single", "dual"], "description": "#972: review threshold for the daemon's PR-state aggregator. `single` (default) — §3.6 one VERIFIED unlocks the merge gate. `dual` — §3.5 two distinct VERIFIED required before `[pr-ready-for-merge]` fires."},
@@ -341,7 +341,7 @@ pub(crate) fn def_ci() -> Value {
             "ci_provider_url": {"type": "string", "description": "watch: base URL for a self-hosted CI provider, persisted on the watch sidecar alongside `ci_provider`."},
             "task_id": {"type": "string", "description": "watch: optional task id to bind this watch to. Persisted on the watch sidecar as a back-link so the `[ci-ready-for-action]` the daemon emits on CI pass carries a structured reference to the originating task. Normally injected by the dispatch auto-watch (dispatch_auto_bind_lease); a manual `ci action=watch` caller may also pass it to bind the watch to a specific task (#1031)."},
             "head_sha": {"type": "string", "description": "watch: full immutable commit SHA (40- or 64-hex) for an EXACT-HEAD post-merge watch on a protected ref (`main`/`master`). Generic protected-branch watches stay E4.5-rejected; a protected watch is accepted ONLY with `head_sha` PLUS `task_id` and explicit `next_after_ci`, and only from the target team orchestrator or operator. The poller resolves runs for THIS SHA only (GitHub `?head_sha=` fetch), ignoring newer main runs, so a later push can't falsely complete the post-merge check. Ignored on non-protected branches. GitHub-only this wave."},
-            "episode": {"type": "string", "description": "defer: exact episode identity for CAS."},
+            "episode": {"type": "string", "description": "defer/ack_handoff: exact episode identity for CAS. For ack_handoff, use the episode surfaced by `ci action=status`; the action settles only the caller's matching pickup without removing the watch."},
             "wake_task_id": {"type": "string", "description": "defer: task_id whose terminal state (Done|Cancelled) will reactivate the track."},
             "reason": {"type": "string", "description": "defer: human-readable reason for deferral."},
             "defer_secs": {"type": "integer", "description": "defer: bounded expiry in seconds (60..3600); required, no default."}

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -447,6 +447,31 @@ pub(crate) fn def_usage_limit_takeover() -> Value {
 mod tests {
     use super::*;
 
+    #[test]
+    fn ci_schema_exposes_exact_handoff_ack_2817() {
+        let d = def_ci();
+        let actions = d["inputSchema"]["properties"]["action"]["enum"]
+            .as_array()
+            .expect("ci action enum");
+        assert!(
+            actions.iter().any(|v| v == "ack_handoff"),
+            "#2817: the neutral CI pickup settlement must be discoverable"
+        );
+        let props = &d["inputSchema"]["properties"];
+        for field in ["repository", "branch", "episode"] {
+            assert!(
+                props[field].is_object(),
+                "#2817: ack_handoff identity field '{field}' must be declared"
+            );
+        }
+        assert!(
+            d["description"]
+                .as_str()
+                .is_some_and(|s| s.contains("ack_handoff")),
+            "#2817: top-level CI description must name the settlement action"
+        );
+    }
+
     /// #2453 R2 P1: the restart_daemon schema must describe app-mode IN-PLACE re-exec
     /// (Unix) and its `prepared` reply — the pre-R2 text ("app mode has no in-process
     /// restart consumer; quit and relaunch") is now STALE and misleads operators/agents


### PR DESCRIPTION
## Summary
- add discoverable `ci action=ack_handoff` for caller-scoped pickup settlement
- require repository, branch, and exact episode CAS; preserve the CI watch and co-subscribers
- durably settle the exact inbox row, then resolve its exact handoff track without nested locks
- reconcile a crash between the row write and track deletion

## RED/GREEN
- RED commit: `363e8fc9` — `cargo test 2817 --no-fail-fast` failed because `handle_ack_handoff_ci` did not exist
- GREEN head: `8608140e`
- `cargo test 2817 --no-fail-fast` — 6 passed
- `cargo test --test file_size_invariant --test src_file_size_invariant` — 3 passed
- `cargo clippy --all-targets --all-features -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed

Closes #2817