### PR TITLE
fix(#2781): decimal percent in Kiro idle regex + context alert formatting

### DIFF
--- a/src/backend_profile.rs
+++ b/src/backend_profile.rs
@@ -899,12 +899,12 @@ mod kiro_decimal_pct_2781 {
     }
 
     #[test]
-    fn kiro_decimal_only_pct_idle() {
+    fn kiro_decimal_status_token_idle() {
         let patterns = crate::state::StatePatterns::for_backend(&Backend::KiroCli);
         assert_eq!(
-            patterns.detect("  61.5%"),
+            patterns.detect("  ◔ 61.5%"),
             Some(AgentState::Idle),
-            "#2781: bare '61.5%' line must be Idle"
+            "#2781: Kiro status token '◔ 61.5%' must match Idle"
         );
     }
 
@@ -916,6 +916,29 @@ mod kiro_decimal_pct_2781 {
             patterns.detect(pane),
             Some(AgentState::Idle),
             "#2781: active Kiro with trailing percent must NOT be Idle"
+        );
+    }
+
+    #[test]
+    fn kiro_arbitrary_output_ending_in_pct_not_idle() {
+        let patterns = crate::state::StatePatterns::for_backend(&Backend::KiroCli);
+        assert_ne!(
+            patterns.detect("  Processing files 4.0%"),
+            Some(AgentState::Idle),
+            "#2781: arbitrary output ending in percent must NOT match Idle"
+        );
+    }
+
+    #[test]
+    fn context_alert_renders_one_decimal() {
+        let msg = format!(
+            "[context_alert] pct={pct:.1}% threshold={threshold:.1}%",
+            pct = 61.0_f32,
+            threshold = 80.0_f32,
+        );
+        assert!(
+            msg.contains("61.0%") && msg.contains("80.0%"),
+            "#2781: context_alert must render one-decimal: {msg}"
         );
     }
 }

--- a/src/backend_profile.rs
+++ b/src/backend_profile.rs
@@ -928,17 +928,4 @@ mod kiro_decimal_pct_2781 {
             "#2781: arbitrary output ending in percent must NOT match Idle"
         );
     }
-
-    #[test]
-    fn context_alert_renders_one_decimal() {
-        let msg = format!(
-            "[context_alert] pct={pct:.1}% threshold={threshold:.1}%",
-            pct = 61.0_f32,
-            threshold = 80.0_f32,
-        );
-        assert!(
-            msg.contains("61.0%") && msg.contains("80.0%"),
-            "#2781: context_alert must render one-decimal: {msg}"
-        );
-    }
 }

--- a/src/backend_profile.rs
+++ b/src/backend_profile.rs
@@ -882,3 +882,40 @@ mod opencode_autherror_2524 {
         );
     }
 }
+
+#[cfg(test)]
+mod kiro_decimal_pct_2781 {
+    use super::*;
+
+    #[test]
+    fn kiro_decimal_pct_matches_idle() {
+        let patterns = crate::state::StatePatterns::for_backend(&Backend::KiroCli);
+        let pane = "  ◔ 4.0%  ask a question or describe a task\n  4.0%";
+        assert_eq!(
+            patterns.detect(pane),
+            Some(AgentState::Idle),
+            "#2781: Kiro '4.0%' must match idle (decimal percent)"
+        );
+    }
+
+    #[test]
+    fn kiro_decimal_only_pct_idle() {
+        let patterns = crate::state::StatePatterns::for_backend(&Backend::KiroCli);
+        assert_eq!(
+            patterns.detect("  61.5%"),
+            Some(AgentState::Idle),
+            "#2781: bare '61.5%' line must be Idle"
+        );
+    }
+
+    #[test]
+    fn kiro_active_with_trailing_pct_not_idle() {
+        let patterns = crate::state::StatePatterns::for_backend(&Backend::KiroCli);
+        let pane = "  Kiro is working  ◔ 4.0%\n  Processing files...";
+        assert_ne!(
+            patterns.detect(pane),
+            Some(AgentState::Idle),
+            "#2781: active Kiro with trailing percent must NOT be Idle"
+        );
+    }
+}

--- a/src/backend_profile.rs
+++ b/src/backend_profile.rs
@@ -311,7 +311,7 @@ fn kirocli_profile() -> BackendProfile {
             (AgentState::Active, r"Kiro is working|esc to cancel"),
             (
                 AgentState::Idle,
-                r"\d+%\s*$|ask a question or describe a task",
+                r"\d+(?:\.\d+)?%\s*$|ask a question or describe a task",
             ),
             (AgentState::Idle, r"Trust All Tools active|/quit to exit"),
         ],

--- a/src/backend_profile.rs
+++ b/src/backend_profile.rs
@@ -311,7 +311,7 @@ fn kirocli_profile() -> BackendProfile {
             (AgentState::Active, r"Kiro is working|esc to cancel"),
             (
                 AgentState::Idle,
-                r"\d+(?:\.\d+)?%\s*$|ask a question or describe a task",
+                r"◔\s*\d+(?:\.\d+)?%\s*$|ask a question or describe a task",
             ),
             (AgentState::Idle, r"Trust All Tools active|/quit to exit"),
         ],

--- a/src/daemon/per_tick/context_alert.rs
+++ b/src/daemon/per_tick/context_alert.rs
@@ -364,4 +364,73 @@ mod tests {
         crate::runtime_config::reload(&temp_dir);
         std::fs::remove_dir_all(&temp_dir).ok();
     }
+
+    /// #2781: the PRODUCTION context_alert message must render usage and
+    /// threshold with one decimal place. Drives the real ContextAlertHandler
+    /// with a mock agent at 82.0% (above the 80.0% default threshold),
+    /// drains the orchestrator inbox, and asserts the rendered text contains
+    /// one-decimal values.
+    #[test]
+    #[serial(runtime_config)]
+    fn context_alert_production_renders_one_decimal() {
+        use parking_lot::Mutex as PLMutex;
+        use std::collections::HashMap;
+        use std::sync::Arc;
+
+        let home =
+            std::env::temp_dir().join(format!("agend-ctxalert-decimal-{}", std::process::id()));
+        std::fs::create_dir_all(&home).ok();
+
+        // Ensure default thresholds (alert=80.0).
+        std::fs::write(home.join("runtime-config.json"), r#"{"schema_version": 1}"#).unwrap();
+        crate::runtime_config::reload(&home);
+        std::env::remove_var("AGEND_CONTEXT_ALERT_PCT");
+
+        // Fleet with a team so alert routes to orchestrator.
+        std::fs::write(
+            crate::fleet::fleet_yaml_path(&home),
+            "instances:\n  lead:\n    backend: claude\n  watched:\n    backend: claude\n\
+             teams:\n  test:\n    members: [lead, watched]\n    orchestrator: lead\n",
+        )
+        .unwrap();
+
+        let registry: crate::agent::AgentRegistry = Arc::new(PLMutex::new(HashMap::new()));
+        let (handle, _reader) =
+            crate::daemon::per_tick::mock_live_agent_with_context("watched", 82.0);
+        registry.lock().insert(handle.id, handle);
+        let externals: crate::agent::ExternalRegistry = Arc::new(PLMutex::new(HashMap::new()));
+        let configs: Arc<PLMutex<HashMap<String, crate::daemon::AgentConfig>>> =
+            Arc::new(PLMutex::new(HashMap::new()));
+
+        let h = ContextAlertHandler::new(1);
+        let ctx = TickContext {
+            home: &home,
+            registry: &registry,
+            externals: &externals,
+            configs: &configs,
+        };
+        h.run(&ctx);
+
+        // Drain orchestrator inbox and check the rendered message.
+        let msgs = crate::inbox::drain(&home, "lead");
+        let alert_msg = msgs
+            .iter()
+            .find(|m| m.text.contains("[context_alert]"))
+            .expect("#2781: context_alert must deliver an inbox message to the orchestrator");
+        assert!(
+            alert_msg.text.contains("82.0%"),
+            "#2781: usage must render one decimal: {}",
+            alert_msg.text
+        );
+        assert!(
+            alert_msg.text.contains("80.0%"),
+            "#2781: threshold must render one decimal: {}",
+            alert_msg.text
+        );
+
+        // Clean up.
+        std::fs::write(home.join("runtime-config.json"), r#"{"schema_version": 1}"#).unwrap();
+        crate::runtime_config::reload(&home);
+        std::fs::remove_dir_all(&home).ok();
+    }
 }

--- a/src/daemon/per_tick/context_alert.rs
+++ b/src/daemon/per_tick/context_alert.rs
@@ -147,8 +147,8 @@ impl PerTickHandler for ContextAlertHandler {
                 continue;
             }
             let text = format!(
-                "[context_alert] agent '{name}' context usage at {pct:.0}% \
-                 (source: {source}, threshold {threshold:.0}%). Handling is NOT \
+                "[context_alert] agent '{name}' context usage at {pct:.1}% \
+                 (source: {source}, threshold {threshold:.1}%). Handling is NOT \
                  automated — at a natural boundary consider a handoff + \
                  restart_instance to free the context. Re-alerts every 30min \
                  while it stays high."

--- a/src/daemon/per_tick/context_alert.rs
+++ b/src/daemon/per_tick/context_alert.rs
@@ -379,9 +379,11 @@ mod tests {
 
         let home =
             std::env::temp_dir().join(format!("agend-ctxalert-decimal-{}", std::process::id()));
-        std::fs::create_dir_all(&home).ok();
+        let _ = std::fs::remove_dir_all(&home);
+        std::fs::create_dir_all(&home).unwrap();
 
-        // Ensure default thresholds (alert=80.0).
+        // Save + clear env so default thresholds (alert=80.0) apply.
+        let old_pct = std::env::var("AGEND_CONTEXT_ALERT_PCT").ok();
         std::fs::write(home.join("runtime-config.json"), r#"{"schema_version": 1}"#).unwrap();
         crate::runtime_config::reload(&home);
         std::env::remove_var("AGEND_CONTEXT_ALERT_PCT");
@@ -428,7 +430,12 @@ mod tests {
             alert_msg.text
         );
 
-        // Clean up.
+        // Restore env + clean up.
+        if let Some(val) = old_pct {
+            std::env::set_var("AGEND_CONTEXT_ALERT_PCT", val);
+        } else {
+            std::env::remove_var("AGEND_CONTEXT_ALERT_PCT");
+        }
         std::fs::write(home.join("runtime-config.json"), r#"{"schema_version": 1}"#).unwrap();
         crate::runtime_config::reload(&home);
         std::fs::remove_dir_all(&home).ok();

--- a/src/daemon/per_tick/context_handoff.rs
+++ b/src/daemon/per_tick/context_handoff.rs
@@ -156,7 +156,7 @@ fn decide(
 /// splitting into multiple submits.
 fn handoff_payload(pct: f32) -> String {
     format!(
-        "{marker} context usage at {pct:.0}% — before it runs out: (1) write {HANDOFF_FILENAME} \
+        "{marker} context usage at {pct:.1}% — before it runs out: (1) write {HANDOFF_FILENAME} \
          in your working directory (current task + state, key decisions, next steps, \
          open branches/PRs); (2) add a brief handoff note to your active task on the \
          board (task action=update); then continue working. One-shot reminder — the \
@@ -289,7 +289,7 @@ impl PerTickHandler for ContextHandoffHandler {
                             "context_handoff_injected",
                             &name,
                             &format!(
-                                "context at {pct:.0}% — handoff nudge injected (one per episode)"
+                                "context at {pct:.1}% — handoff nudge injected (one per episode)"
                             ),
                         );
                     } else {
@@ -305,15 +305,15 @@ impl PerTickHandler for ContextHandoffHandler {
                         "context_full_idle",
                         &name,
                         &format!(
-                            "context at {pct:.0}% while Idle — not injecting (idle context-full \
+                            "context at {pct:.1}% while Idle — not injecting (idle context-full \
                              is not urgent); injection fires if it wakes while still high"
                         ),
                     );
                 }
                 Some(Action::Escalate) => {
                     let msg = format!(
-                        "[context-handoff] agent '{name}' context at {pct:.0}% and no \
-                         {HANDOFF_FILENAME} update since the {handoff_pct:.0}% nudge — \
+                        "[context-handoff] agent '{name}' context at {pct:.1}% and no \
+                         {HANDOFF_FILENAME} update since the {handoff_pct:.1}% nudge — \
                          consider a manual handoff + restart_instance. (One-time notice.)"
                     );
                     crate::channel::notify_all_escalation_channels(

--- a/src/daemon/per_tick/context_handoff.rs
+++ b/src/daemon/per_tick/context_handoff.rs
@@ -631,4 +631,26 @@ mod tests {
         assert!(handoff < escalate);
         std::fs::remove_dir_all(&temp_dir).ok();
     }
+
+    #[test]
+    fn handoff_payload_renders_one_decimal_2781() {
+        let msg = super::handoff_payload(61.0);
+        assert!(
+            msg.contains("61.0%"),
+            "#2781: handoff payload must render one-decimal '61.0%', got: {msg}"
+        );
+        assert!(
+            !msg.contains("61%") || msg.contains("61.0%"),
+            "#2781: must not render integer-only '61%'"
+        );
+    }
+
+    #[test]
+    fn handoff_payload_renders_fractional_decimal_2781() {
+        let msg = super::handoff_payload(85.3);
+        assert!(
+            msg.contains("85.3%"),
+            "#2781: handoff payload must render '85.3%', got: {msg}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Kiro idle detection regex now matches decimal percentages (`4.0%`) as one token
- Context alert/handoff messages render one-decimal precision (`61.0%` not `61%`)

Closes #2781

## Test plan
- [ ] 5 RED→GREEN tests: Kiro decimal idle match, fractional match, active non-idle, handoff one-decimal, handoff fractional
- [ ] clippy --all-targets clean, fmt clean, file-size invariant pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)