### PR TITLE
feat(#2453 Slice A): shared reload_runtime_controls before app/daemon bootstrap

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -683,7 +683,7 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
     // (the TUI mouse copy-on-select mode) would reset to the compile-time default
     // on every restart. In-session changes update the in-process global directly
     // via `runtime_config::set` (the `Ctrl+B e` toggle and `:set`/`:config set`).
-    crate::runtime_config::reload(&home);
+    crate::runtime_controls::reload_runtime_controls(&home);
 
     // PR-D6/F1: fail LOUD if the retired `AGEND_WORKTREE_PRUNE_LIVE` is still set.
     // The LIVE fleet daemon runs THIS app-mode path — never `run_core` (see

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -758,6 +758,7 @@ fn run_core(home: &Path, source: FleetSource) -> anyhow::Result<()> {
         FleetSource::HandoffDeferred { .. } => None,
     };
 
+    crate::runtime_controls::reload_runtime_controls(home);
     let ctx = init_daemon_services(home, telegram_pre)?;
 
     // #event-bus Step 2 (legacy-zero): register the per-pattern delivery
@@ -899,10 +900,7 @@ fn run_core(home: &Path, source: FleetSource) -> anyhow::Result<()> {
             if let Some(p) = &tick_progress {
                 p.enter_preflight();
             }
-            crate::runtime_config::reload(home);
-            // #1339: operator-mode.json reloaded each tick — a mode change (via the
-            // `mode` MCP tool) propagates fleet-wide without a restart (reload-coherent).
-            crate::operator_mode::reload(home);
+            crate::runtime_controls::reload_runtime_controls(home);
             // PR4: the tracked runner publishes Handler(i) per handler and closes
             // with PostHandlers, which also covers the crash-dispatch below. When
             // diagnostics are OFF, `tick_progress` is None → untracked (byte-identical).

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,6 +77,7 @@ mod review_receipt;
 mod review_repro_test_util;
 mod runtime;
 pub mod runtime_config;
+pub(crate) mod runtime_controls;
 mod schedules;
 mod scm;
 mod sent_ledger;

--- a/src/runtime_controls.rs
+++ b/src/runtime_controls.rs
@@ -133,7 +133,7 @@ mod tests {
         );
 
         // Write garbage to the operator_mode file.
-        let mode_path = home.join("operator_mode.json");
+        let mode_path = home.join("operator-mode.json");
         std::fs::write(&mode_path, b"TAMPERED GARBAGE").unwrap();
 
         // Reload through the shared seam — must not crash.

--- a/src/runtime_controls.rs
+++ b/src/runtime_controls.rs
@@ -48,36 +48,76 @@ mod tests {
     }
 
     /// Helper semantics: reload_runtime_controls loads a valid signed
-    /// operator_mode. Use the production set_mode API to create a real
-    /// HMAC-signed Sleep fixture, then verify reload picks it up.
+    /// operator_mode. Use two distinct homes to prove the shared seam
+    /// reloads from the TARGET home, not from stale global state.
     #[test]
+    #[serial_test::serial]
     fn reload_runtime_controls_loads_signed_operator_mode() {
-        let home = tmp_home("loads-signed-mode");
-        // Use production API to write a valid signed Sleep mode.
+        let target_home = tmp_home("loads-signed-target");
+        let control_home = tmp_home("loads-signed-control");
+
+        // Write signed Sleep+delegate to the TARGET home.
         crate::operator_mode::set_mode(
-            &home,
+            &target_home,
             crate::operator_mode::OperatorMode::Sleep,
             Some("delegate-agent".into()),
             vec!["restart".into()],
         )
-        .expect("set_mode must succeed");
+        .expect("set_mode Sleep on target must succeed");
 
-        // Reload through the shared seam.
-        reload_runtime_controls(&home);
+        // Set global to Active via a DIFFERENT home so global is NOT Sleep.
+        crate::operator_mode::set_mode(
+            &control_home,
+            crate::operator_mode::OperatorMode::Active,
+            None,
+            Vec::new(),
+        )
+        .expect("set_mode Active on control must succeed");
+        // Reload control so global is Active.
+        crate::operator_mode::reload(&control_home);
+        let pre = crate::operator_mode::get();
+        assert_ne!(
+            pre.mode,
+            crate::operator_mode::OperatorMode::Sleep,
+            "precondition: global must NOT be Sleep before reload"
+        );
+
+        // Reload through the shared seam targeting the Sleep home.
+        reload_runtime_controls(&target_home);
 
         let state = crate::operator_mode::get();
         assert_eq!(
             state.mode,
             crate::operator_mode::OperatorMode::Sleep,
-            "reload_runtime_controls must load the signed Sleep mode from disk"
+            "reload_runtime_controls must load the signed Sleep mode from target_home"
         );
         assert_eq!(
             state.delegate_to.as_deref(),
             Some("delegate-agent"),
-            "delegate_to must survive reload"
+            "delegate_to must survive reload from target_home"
         );
 
         // Reset to Active for other tests.
+        crate::operator_mode::set_mode(
+            &control_home,
+            crate::operator_mode::OperatorMode::Active,
+            None,
+            Vec::new(),
+        )
+        .ok();
+        crate::operator_mode::reload(&control_home);
+        std::fs::remove_dir_all(&target_home).ok();
+        std::fs::remove_dir_all(&control_home).ok();
+    }
+
+    /// Shared-seam fail-closed: tampered/missing operator_mode file
+    /// must not crash and must preserve the current mode (fail-closed).
+    #[test]
+    #[serial_test::serial]
+    fn reload_runtime_controls_tampered_mode_fails_closed() {
+        let home = tmp_home("tampered-mode");
+
+        // Set global to Active first.
         crate::operator_mode::set_mode(
             &home,
             crate::operator_mode::OperatorMode::Active,
@@ -85,6 +125,28 @@ mod tests {
             Vec::new(),
         )
         .ok();
+        crate::operator_mode::reload(&home);
+        assert_eq!(
+            crate::operator_mode::get().mode,
+            crate::operator_mode::OperatorMode::Active,
+            "precondition: global is Active"
+        );
+
+        // Write garbage to the operator_mode file.
+        let mode_path = home.join("operator_mode.json");
+        std::fs::write(&mode_path, b"TAMPERED GARBAGE").unwrap();
+
+        // Reload through the shared seam — must not crash.
+        reload_runtime_controls(&home);
+
+        // Mode must remain Active (fail-closed).
+        let state = crate::operator_mode::get();
+        assert_eq!(
+            state.mode,
+            crate::operator_mode::OperatorMode::Active,
+            "tampered operator_mode must fail-closed and preserve current mode"
+        );
+
         std::fs::remove_dir_all(&home).ok();
     }
 
@@ -102,50 +164,60 @@ mod tests {
     }
 
     /// Startup ordering: reload_runtime_controls must be called BEFORE
-    /// setup_app_bootstrap within the run_app function body.
+    /// setup_app_bootstrap within the run_app function body (bounded slice).
     #[test]
     fn app_calls_reload_before_bootstrap() {
         let src = include_str!("app/mod.rs");
-        // Anchor within run_app function body — find its definition first.
         let fn_start = src
-            .find("fn run_app(")
+            .find("\nfn run_app(")
+            .or_else(|| src.find("fn run_app("))
             .expect("fn run_app must exist in app/mod.rs");
-        let body = &src[fn_start..];
+        // End the body slice at the next top-level function definition.
+        let after_start = &src[fn_start + 1..];
+        let fn_end = after_start
+            .find("\nfn setup_app_bootstrap")
+            .or_else(|| after_start.find("\npub fn setup_app_bootstrap"))
+            .unwrap_or(after_start.len());
+        let body = &after_start[..fn_end];
         let reload_pos = body
             .find("reload_runtime_controls")
-            .expect("reload_runtime_controls must be called inside run_app");
+            .expect("reload_runtime_controls call must exist inside run_app body");
         let bootstrap_pos = body
             .find("setup_app_bootstrap")
-            .expect("setup_app_bootstrap must be called inside run_app");
+            .expect("setup_app_bootstrap call must exist inside run_app body");
         assert!(
             reload_pos < bootstrap_pos,
             "reload_runtime_controls must appear before setup_app_bootstrap \
-             within the run_app function body"
+             within the bounded run_app function body"
         );
     }
 
     /// Startup ordering: reload_runtime_controls must be called BEFORE
-    /// init_daemon_services within the run_core function body.
+    /// init_daemon_services within the run_core function body (bounded slice).
     #[test]
     fn daemon_calls_reload_before_init_services() {
         let src = include_str!("daemon/mod.rs");
-        // Anchor within run_core function body.
         let fn_start = src
-            .find("fn run_core(")
+            .find("\nfn run_core(")
+            .or_else(|| src.find("fn run_core("))
             .expect("fn run_core must exist in daemon/mod.rs");
-        let body = &src[fn_start..];
+        let after_start = &src[fn_start + 1..];
+        // End the body slice at the next top-level function definition.
+        let fn_end = after_start
+            .find("\nfn init_daemon_services")
+            .or_else(|| after_start.find("\npub fn init_daemon_services"))
+            .unwrap_or(after_start.len());
+        let body = &after_start[..fn_end];
         let reload_pos = body
             .find("reload_runtime_controls(home)")
-            .expect("reload_runtime_controls(home) call must exist inside run_core");
-        // Match the actual function call, not comment mentions.
+            .expect("reload_runtime_controls(home) call must exist inside run_core body");
         let init_pos = body
-            .find("let ctx = init_daemon_services(")
-            .or_else(|| body.find("init_daemon_services(home"))
-            .expect("init_daemon_services call must exist inside run_core");
+            .find("init_daemon_services(")
+            .expect("init_daemon_services call must exist inside run_core body");
         assert!(
             reload_pos < init_pos,
             "reload_runtime_controls must be called before init_daemon_services \
-             within the run_core function body"
+             within the bounded run_core function body"
         );
     }
 }

--- a/src/runtime_controls.rs
+++ b/src/runtime_controls.rs
@@ -47,27 +47,44 @@ mod tests {
         std::fs::remove_dir_all(&home).ok();
     }
 
-    /// Helper semantics: reload_runtime_controls loads operator_mode.
-    /// Missing/untrusted file on startup → lockdown (Away).
-    /// Once initialized, missing file preserves last-known-good.
+    /// Helper semantics: reload_runtime_controls loads a valid signed
+    /// operator_mode. Use the production set_mode API to create a real
+    /// HMAC-signed Sleep fixture, then verify reload picks it up.
     #[test]
-    fn reload_runtime_controls_loads_operator_mode() {
-        let home = tmp_home("loads-mode");
-        // Exercise the reload path — should not panic even with no
-        // operator-mode.json. The exact resulting mode depends on
-        // whether INITIALIZED is already set (global test ordering),
-        // so we verify reload completes without error rather than
-        // asserting a specific mode.
+    fn reload_runtime_controls_loads_signed_operator_mode() {
+        let home = tmp_home("loads-signed-mode");
+        // Use production API to write a valid signed Sleep mode.
+        crate::operator_mode::set_mode(
+            &home,
+            crate::operator_mode::OperatorMode::Sleep,
+            Some("delegate-agent".into()),
+            vec!["restart".into()],
+        )
+        .expect("set_mode must succeed");
+
+        // Reload through the shared seam.
         reload_runtime_controls(&home);
-        let mode = crate::operator_mode::get().mode;
-        assert!(
-            matches!(
-                mode,
-                crate::operator_mode::OperatorMode::Active
-                    | crate::operator_mode::OperatorMode::Away
-            ),
-            "reload must produce Active or Away (lockdown), not Sleep"
+
+        let state = crate::operator_mode::get();
+        assert_eq!(
+            state.mode,
+            crate::operator_mode::OperatorMode::Sleep,
+            "reload_runtime_controls must load the signed Sleep mode from disk"
         );
+        assert_eq!(
+            state.delegate_to.as_deref(),
+            Some("delegate-agent"),
+            "delegate_to must survive reload"
+        );
+
+        // Reset to Active for other tests.
+        crate::operator_mode::set_mode(
+            &home,
+            crate::operator_mode::OperatorMode::Active,
+            None,
+            Vec::new(),
+        )
+        .ok();
         std::fs::remove_dir_all(&home).ok();
     }
 
@@ -85,37 +102,50 @@ mod tests {
     }
 
     /// Startup ordering: reload_runtime_controls must be called BEFORE
-    /// setup_app_bootstrap. Verify by source inspection.
+    /// setup_app_bootstrap within the run_app function body.
     #[test]
     fn app_calls_reload_before_bootstrap() {
         let src = include_str!("app/mod.rs");
-        let reload_pos = src.find("reload_runtime_controls");
-        let bootstrap_pos = src.find("setup_app_bootstrap");
+        // Anchor within run_app function body — find its definition first.
+        let fn_start = src
+            .find("fn run_app(")
+            .expect("fn run_app must exist in app/mod.rs");
+        let body = &src[fn_start..];
+        let reload_pos = body
+            .find("reload_runtime_controls")
+            .expect("reload_runtime_controls must be called inside run_app");
+        let bootstrap_pos = body
+            .find("setup_app_bootstrap")
+            .expect("setup_app_bootstrap must be called inside run_app");
         assert!(
-            reload_pos.is_some() && bootstrap_pos.is_some(),
-            "both reload_runtime_controls and setup_app_bootstrap must exist in app/mod.rs"
-        );
-        assert!(
-            reload_pos.unwrap() < bootstrap_pos.unwrap(),
-            "reload_runtime_controls must appear before setup_app_bootstrap in app/mod.rs"
+            reload_pos < bootstrap_pos,
+            "reload_runtime_controls must appear before setup_app_bootstrap \
+             within the run_app function body"
         );
     }
 
     /// Startup ordering: reload_runtime_controls must be called BEFORE
-    /// init_daemon_services. Verify by source inspection.
+    /// init_daemon_services within the run_core function body.
     #[test]
     fn daemon_calls_reload_before_init_services() {
         let src = include_str!("daemon/mod.rs");
-        let reload_pos = src.find("reload_runtime_controls(home)");
-        let init_pos = src.find("init_daemon_services(home");
+        // Anchor within run_core function body.
+        let fn_start = src
+            .find("fn run_core(")
+            .expect("fn run_core must exist in daemon/mod.rs");
+        let body = &src[fn_start..];
+        let reload_pos = body
+            .find("reload_runtime_controls(home)")
+            .expect("reload_runtime_controls(home) call must exist inside run_core");
+        // Match the actual function call, not comment mentions.
+        let init_pos = body
+            .find("let ctx = init_daemon_services(")
+            .or_else(|| body.find("init_daemon_services(home"))
+            .expect("init_daemon_services call must exist inside run_core");
         assert!(
-            reload_pos.is_some() && init_pos.is_some(),
-            "both reload_runtime_controls(home) and init_daemon_services(home) calls \
-             must exist in daemon/mod.rs"
-        );
-        assert!(
-            reload_pos.unwrap() < init_pos.unwrap(),
-            "reload_runtime_controls must be called before init_daemon_services in daemon/mod.rs"
+            reload_pos < init_pos,
+            "reload_runtime_controls must be called before init_daemon_services \
+             within the run_core function body"
         );
     }
 }

--- a/src/runtime_controls.rs
+++ b/src/runtime_controls.rs
@@ -8,6 +8,7 @@ pub fn reload_runtime_controls(home: &Path) {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
 
@@ -46,17 +47,26 @@ mod tests {
         std::fs::remove_dir_all(&home).ok();
     }
 
-    /// Helper semantics: reload_runtime_controls loads operator_mode from
-    /// a valid signed file, and falls back to Active on missing/tampered.
+    /// Helper semantics: reload_runtime_controls loads operator_mode.
+    /// Missing/untrusted file on startup → lockdown (Away).
+    /// Once initialized, missing file preserves last-known-good.
     #[test]
     fn reload_runtime_controls_loads_operator_mode() {
         let home = tmp_home("loads-mode");
-        // No operator-mode.json → default Active.
+        // Exercise the reload path — should not panic even with no
+        // operator-mode.json. The exact resulting mode depends on
+        // whether INITIALIZED is already set (global test ordering),
+        // so we verify reload completes without error rather than
+        // asserting a specific mode.
         reload_runtime_controls(&home);
-        assert_eq!(
-            crate::operator_mode::get().mode,
-            crate::operator_mode::OperatorMode::Active,
-            "missing mode file must default to Active"
+        let mode = crate::operator_mode::get().mode;
+        assert!(
+            matches!(
+                mode,
+                crate::operator_mode::OperatorMode::Active
+                    | crate::operator_mode::OperatorMode::Away
+            ),
+            "reload must produce Active or Away (lockdown), not Sleep"
         );
         std::fs::remove_dir_all(&home).ok();
     }
@@ -96,15 +106,16 @@ mod tests {
     #[test]
     fn daemon_calls_reload_before_init_services() {
         let src = include_str!("daemon/mod.rs");
-        let reload_pos = src.find("reload_runtime_controls");
-        let init_pos = src.find("init_daemon_services");
+        let reload_pos = src.find("reload_runtime_controls(home)");
+        let init_pos = src.find("init_daemon_services(home");
         assert!(
             reload_pos.is_some() && init_pos.is_some(),
-            "both reload_runtime_controls and init_daemon_services must exist in daemon/mod.rs"
+            "both reload_runtime_controls(home) and init_daemon_services(home) calls \
+             must exist in daemon/mod.rs"
         );
         assert!(
             reload_pos.unwrap() < init_pos.unwrap(),
-            "reload_runtime_controls must appear before init_daemon_services in daemon/mod.rs"
+            "reload_runtime_controls must be called before init_daemon_services in daemon/mod.rs"
         );
     }
 }

--- a/src/runtime_controls.rs
+++ b/src/runtime_controls.rs
@@ -1,0 +1,110 @@
+use std::path::Path;
+
+/// Shared reload seam: runtime_config THEN operator_mode, in strict order.
+/// Called before app bootstrap, before daemon init, and per tick.
+pub fn reload_runtime_controls(home: &Path) {
+    crate::runtime_config::reload(home);
+    crate::operator_mode::reload(home);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmp_home(tag: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "agend-rtctrl-{tag}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    /// Helper semantics: reload_runtime_controls applies runtime_config
+    /// values from disk.
+    #[test]
+    fn reload_runtime_controls_loads_persisted_config() {
+        let home = tmp_home("loads-config");
+        std::fs::write(
+            home.join("runtime-config.json"),
+            r#"{"schema_version": 1, "copy_on_select": true}"#,
+        )
+        .unwrap();
+        reload_runtime_controls(&home);
+        assert!(
+            crate::runtime_config::get().copy_on_select,
+            "reload_runtime_controls must load persisted runtime_config"
+        );
+        // Reset.
+        std::fs::write(home.join("runtime-config.json"), r#"{"schema_version": 1}"#).unwrap();
+        crate::runtime_config::reload(&home);
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Helper semantics: reload_runtime_controls loads operator_mode from
+    /// a valid signed file, and falls back to Active on missing/tampered.
+    #[test]
+    fn reload_runtime_controls_loads_operator_mode() {
+        let home = tmp_home("loads-mode");
+        // No operator-mode.json → default Active.
+        reload_runtime_controls(&home);
+        assert_eq!(
+            crate::operator_mode::get().mode,
+            crate::operator_mode::OperatorMode::Active,
+            "missing mode file must default to Active"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Host call ordering: operator_mode must be reloaded AFTER
+    /// runtime_config, so both are current before API ingress.
+    /// This test asserts the function calls both reloads.
+    #[test]
+    fn reload_runtime_controls_calls_both_reloads() {
+        let home = tmp_home("both-reloads");
+        std::fs::write(home.join("runtime-config.json"), r#"{"schema_version": 1}"#).unwrap();
+        // Should not panic; exercises both code paths.
+        reload_runtime_controls(&home);
+        reload_runtime_controls(&home); // idempotent
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Startup ordering: reload_runtime_controls must be called BEFORE
+    /// setup_app_bootstrap. Verify by source inspection.
+    #[test]
+    fn app_calls_reload_before_bootstrap() {
+        let src = include_str!("app/mod.rs");
+        let reload_pos = src.find("reload_runtime_controls");
+        let bootstrap_pos = src.find("setup_app_bootstrap");
+        assert!(
+            reload_pos.is_some() && bootstrap_pos.is_some(),
+            "both reload_runtime_controls and setup_app_bootstrap must exist in app/mod.rs"
+        );
+        assert!(
+            reload_pos.unwrap() < bootstrap_pos.unwrap(),
+            "reload_runtime_controls must appear before setup_app_bootstrap in app/mod.rs"
+        );
+    }
+
+    /// Startup ordering: reload_runtime_controls must be called BEFORE
+    /// init_daemon_services. Verify by source inspection.
+    #[test]
+    fn daemon_calls_reload_before_init_services() {
+        let src = include_str!("daemon/mod.rs");
+        let reload_pos = src.find("reload_runtime_controls");
+        let init_pos = src.find("init_daemon_services");
+        assert!(
+            reload_pos.is_some() && init_pos.is_some(),
+            "both reload_runtime_controls and init_daemon_services must exist in daemon/mod.rs"
+        );
+        assert!(
+            reload_pos.unwrap() < init_pos.unwrap(),
+            "reload_runtime_controls must appear before init_daemon_services in daemon/mod.rs"
+        );
+    }
+}

--- a/tests/common/harness.rs
+++ b/tests/common/harness.rs
@@ -8,52 +8,6 @@ use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
 
-/// Establish a signed Active operator-mode in the test home directory.
-/// Writes the key, mode JSON, and HMAC sidecar using the same crypto
-/// primitives as the production `config_integrity::sign` path.
-fn establish_signed_active_mode(home: &Path) -> Result<(), String> {
-    use hmac::{Hmac, KeyInit, Mac};
-    use sha2::Sha256;
-    use std::io::Write as _;
-
-    let content = b"{\"mode\":\"Active\",\"delegate_to\":null,\"delegate_scope\":[]}";
-
-    let key_path = home.join(".config-integrity-key");
-    let key: [u8; 32] = if let Ok(bytes) = std::fs::read(&key_path) {
-        bytes
-            .try_into()
-            .map_err(|_| "existing key wrong length".to_string())?
-    } else {
-        let mut k = [0u8; 32];
-        getrandom::fill(&mut k).map_err(|e| format!("getrandom: {e}"))?;
-        #[cfg(unix)]
-        {
-            let mut f = std::fs::OpenOptions::new()
-                .create(true)
-                .truncate(true)
-                .write(true)
-                .mode(0o600)
-                .open(&key_path)
-                .map_err(|e| format!("write key: {e}"))?;
-            f.write_all(&k).map_err(|e| format!("write key: {e}"))?;
-            f.sync_all().map_err(|e| format!("sync key: {e}"))?;
-        }
-        #[cfg(not(unix))]
-        std::fs::write(&key_path, &k).map_err(|e| format!("write key: {e}"))?;
-        k
-    };
-
-    let mut mac = Hmac::<Sha256>::new_from_slice(&key).map_err(|e| format!("hmac init: {e}"))?;
-    mac.update(content);
-    let tag = hex::encode(mac.finalize().into_bytes());
-
-    std::fs::write(home.join("operator-mode.json"), content)
-        .map_err(|e| format!("write mode: {e}"))?;
-    std::fs::write(home.join("operator-mode.json.hmac"), &tag)
-        .map_err(|e| format!("write hmac: {e}"))?;
-    Ok(())
-}
-
 /// A running daemon instance for integration testing.
 pub struct AgendHarness {
     pub home: PathBuf,
@@ -119,6 +73,7 @@ impl AgendHarness {
         std::fs::create_dir_all(&home).map_err(|e| format!("create home: {e}"))?;
         std::fs::write(home.join("fleet.yaml"), fleet_yaml)
             .map_err(|e| format!("write fleet.yaml: {e}"))?;
+
         let binary = binary_path();
         let mut cmd = Command::new(&binary);
         cmd.args(args)
@@ -249,10 +204,39 @@ impl AgendHarness {
                         std::thread::sleep(Duration::from_millis(50));
                     }
 
-                    // Daemon is running + ready. Establish Active
-                    // mode via the real CLI so fail-closed Away from
-                    // missing operator-mode.json is overridden.
-                    establish_signed_active_mode(&home)?;
+                    // Daemon is running + ready. Establish Active mode via the
+                    // real operator CLI; this is the only supported path that
+                    // writes the signed mode state and updates the daemon's
+                    // in-memory global.
+                    let mode_output = Command::new(binary_path())
+                        .args(["mode", "active"])
+                        .env("AGEND_HOME", &home)
+                        .output()
+                        .map_err(|e| format!("mode active CLI spawn failed: {e}"))?;
+                    if !mode_output.status.success() {
+                        return Err(format!(
+                            "mode active CLI exited with {}: {}",
+                            mode_output.status,
+                            String::from_utf8_lossy(&mode_output.stderr).trim()
+                        ));
+                    }
+                    let mode_stdout = String::from_utf8(mode_output.stdout)
+                        .map_err(|e| format!("mode active CLI stdout was not UTF-8: {e}"))?;
+                    if mode_stdout.trim_end_matches(['\r', '\n']) != "Operator mode → active" {
+                        return Err(format!(
+                            "mode active CLI confirmation mismatch: {:?}",
+                            mode_stdout
+                        ));
+                    }
+                    let mode_path = home.join("operator-mode.json");
+                    let hmac_path = home.join("operator-mode.json.hmac");
+                    if !mode_path.is_file() || !hmac_path.is_file() {
+                        return Err(format!(
+                            "mode active CLI did not persist operator mode and sidecar: mode={}, hmac={}",
+                            mode_path.display(),
+                            hmac_path.display()
+                        ));
+                    }
 
                     return Ok(Self {
                         home,

--- a/tests/common/harness.rs
+++ b/tests/common/harness.rs
@@ -8,6 +8,52 @@ use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
 
+/// Establish a signed Active operator-mode in the test home directory.
+/// Writes the key, mode JSON, and HMAC sidecar using the same crypto
+/// primitives as the production `config_integrity::sign` path.
+fn establish_signed_active_mode(home: &Path) -> Result<(), String> {
+    use hmac::{Hmac, KeyInit, Mac};
+    use sha2::Sha256;
+    use std::io::Write as _;
+
+    let content = b"{\"mode\":\"Active\",\"delegate_to\":null,\"delegate_scope\":[]}";
+
+    let key_path = home.join(".config-integrity-key");
+    let key: [u8; 32] = if let Ok(bytes) = std::fs::read(&key_path) {
+        bytes
+            .try_into()
+            .map_err(|_| "existing key wrong length".to_string())?
+    } else {
+        let mut k = [0u8; 32];
+        getrandom::fill(&mut k).map_err(|e| format!("getrandom: {e}"))?;
+        #[cfg(unix)]
+        {
+            let mut f = std::fs::OpenOptions::new()
+                .create(true)
+                .truncate(true)
+                .write(true)
+                .mode(0o600)
+                .open(&key_path)
+                .map_err(|e| format!("write key: {e}"))?;
+            f.write_all(&k).map_err(|e| format!("write key: {e}"))?;
+            f.sync_all().map_err(|e| format!("sync key: {e}"))?;
+        }
+        #[cfg(not(unix))]
+        std::fs::write(&key_path, &k).map_err(|e| format!("write key: {e}"))?;
+        k
+    };
+
+    let mut mac = Hmac::<Sha256>::new_from_slice(&key).map_err(|e| format!("hmac init: {e}"))?;
+    mac.update(content);
+    let tag = hex::encode(mac.finalize().into_bytes());
+
+    std::fs::write(home.join("operator-mode.json"), content)
+        .map_err(|e| format!("write mode: {e}"))?;
+    std::fs::write(home.join("operator-mode.json.hmac"), &tag)
+        .map_err(|e| format!("write hmac: {e}"))?;
+    Ok(())
+}
+
 /// A running daemon instance for integration testing.
 pub struct AgendHarness {
     pub home: PathBuf,
@@ -73,7 +119,6 @@ impl AgendHarness {
         std::fs::create_dir_all(&home).map_err(|e| format!("create home: {e}"))?;
         std::fs::write(home.join("fleet.yaml"), fleet_yaml)
             .map_err(|e| format!("write fleet.yaml: {e}"))?;
-
         let binary = binary_path();
         let mut cmd = Command::new(&binary);
         cmd.args(args)
@@ -203,6 +248,11 @@ impl AgendHarness {
                         }
                         std::thread::sleep(Duration::from_millis(50));
                     }
+
+                    // Daemon is running + ready. Establish Active
+                    // mode via the real CLI so fail-closed Away from
+                    // missing operator-mode.json is overridden.
+                    establish_signed_active_mode(&home)?;
 
                     return Ok(Self {
                         home,


### PR DESCRIPTION
## Summary
- Add shared `reload_runtime_controls(home)` seam: runtime_config THEN operator_mode
- Called before `setup_app_bootstrap` (app) and `init_daemon_services` (daemon)
- Reused per-tick (replaces inline pair)
- Bounded Slice A of #2453

## Test plan
- [x] `reload_runtime_controls_loads_persisted_config` — runtime config from disk
- [x] `reload_runtime_controls_loads_signed_operator_mode` — signed Sleep+delegate via two distinct homes, proves global reload from target (serial)
- [x] `reload_runtime_controls_tampered_mode_fails_closed` — garbage file stays Active (serial)
- [x] `reload_runtime_controls_calls_both_reloads` — exercises both paths, idempotent
- [x] `app_calls_reload_before_bootstrap` — anchored body-bounded slice proves ordering
- [x] `daemon_calls_reload_before_init_services` — anchored body-bounded slice proves ordering
- [x] clippy --all-targets -D warnings clean
- [x] cargo fmt clean
- [x] file-size invariant passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)