### PR TITLE
refactor: extract owned maintenance cycle (#2453)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1092,15 +1092,20 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
     // moved off the supervisor thread.
     let app_handlers = app_tick_handlers(Arc::clone(&daemon_binary_stale));
 
-    // PR4: opt-in out-of-band tick-stall diagnostics for the OWNED-app maintenance
-    // tick host. An attached app never ticks (tick_rx is `None` → never_rx), so it
-    // starts NO monitor. `_app_stall_monitor` lives across the render loop and
-    // stops+joins its thread on teardown; both are `None` when the env gate is off.
-    let (app_tick_progress, _app_stall_monitor) = if attached_mode {
-        (None, None)
-    } else {
-        crate::daemon::tick_stall::start_for_host("app-owned-tick", &app_handlers, &home)
-    };
+    // The attached app constructs no owned maintenance cycle. Owned mode keeps
+    // its profile handlers, owner-service witness, and optional stall monitor in
+    // one typed value; the tick producer and select arm remain host-local.
+    let app_cycle = crate::daemon::owned_maintenance::OwnedMaintenanceCycle::new_for_role(
+        if attached_mode {
+            crate::daemon::owner_services::OwnerRole::Attached
+        } else {
+            crate::daemon::owner_services::OwnerRole::Owned
+        },
+        app_handlers,
+        owner_services,
+        "app-owned-tick",
+        &home,
+    );
 
     // #2057 milestone 3: just BEFORE the render loop. If this is < the baseline,
     // a startup phase shrank the controlling TTY; milestone 2 brackets whether
@@ -1585,25 +1590,16 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
                 //   core.state.tick()               → supervisor::spawn (runs in
                 //     owned mode too — supervisor.rs:tick; the old manual call here
                 //     was a benign idempotent double, now removed).
-                app_maintenance_tick(
-                    &home,
-                    &registry,
-                    &app_externals,
-                    &app_configs,
-                    &app_handlers,
-                    app_tick_progress.as_deref(),
-                    // #2737: owned tick only fires when `tick_rx` is Some (owned
-                    // mode), where `owner_services` is always `Some` (the seam ran
-                    // in the owned bootstrap block above).
-                    owner_services
-                        .as_ref()
-                        .expect("owned maintenance tick requires the owner-service witness"),
-                );
+                app_cycle
+                    .as_ref()
+                    .expect("owned maintenance tick requires the owned cycle")
+                    .run_once(&home, &registry, &app_externals, &app_configs);
                 // PR4: back to Waiting between maintenance ticks so the monitor
                 // never attributes render/idle time to the maintenance host.
-                if let Some(p) = app_tick_progress.as_deref() {
-                    p.enter_waiting();
-                }
+                app_cycle
+                    .as_ref()
+                    .expect("owned maintenance tick requires the owned cycle")
+                    .enter_waiting();
             }
             default(select_timeout) => {
                 // #t-84833-10: periodic idle refresh — mark dirty so the cap above
@@ -1797,33 +1793,6 @@ fn setup_app_bootstrap(
             }
         };
     (api_guard, telegram_state, telegram_status, attached_run_dir)
-}
-
-/// Periodic owned-mode maintenance: run the full daemon per-tick handler
-/// pipeline once. Extracted verbatim from `run_app`'s tick arm (#14 god-fn
-/// split) — byte-identical, no behaviour change.
-fn app_maintenance_tick(
-    home: &Path,
-    registry: &AgentRegistry,
-    externals: &crate::agent::ExternalRegistry,
-    configs: &crate::api::ConfigRegistry,
-    handlers: &[Box<dyn crate::daemon::per_tick::PerTickHandler>],
-    progress: Option<&crate::daemon::tick_stall::TickProgress>,
-    // #2737: proof the owner-service seam ran. This owned-only tick is the
-    // witness consumer that makes app's dual-host reach a COMPILE property
-    // (structural I2) — run_app cannot reach here without an OwnerServicesStarted,
-    // which only the seam can mint. Unused at runtime (it is a capability witness).
-    _owner_services: &crate::daemon::owner_services::OwnerServicesStarted,
-) {
-    let tick_ctx = crate::daemon::per_tick::TickContext {
-        home,
-        registry,
-        externals,
-        configs,
-    };
-    // PR4: `progress` is `Some` only for an owned app with diagnostics enabled;
-    // `None` (attached or gate-off) runs the untracked path, byte-identical.
-    crate::daemon::per_tick::run_handlers_with_progress(handlers, &tick_ctx, progress);
 }
 
 /// App exit teardown: persist the on-screen layout, then (Owned mode only) sync

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -35,6 +35,7 @@ pub(crate) mod lifecycle;
 pub(crate) mod mcp_registry_watcher;
 pub(crate) mod notification_dedup;
 pub(crate) mod orphan_sweep;
+pub(crate) mod owned_maintenance;
 pub(crate) mod owner_services;
 pub(crate) mod per_tick;
 pub(crate) mod poll_reminder;

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -856,13 +856,7 @@ fn run_core(home: &Path, source: FleetSource) -> anyhow::Result<()> {
     );
     tracing::info!("running, Ctrl+C or `agend-terminal stop` to stop");
 
-    let (_keepalive, handlers, tick_rx) = build_tick_infrastructure(home, &ctx);
-
-    // PR4: opt-in out-of-band tick-stall diagnostics for the daemon tick host.
-    // `_stall_monitor` is `None` unless `AGEND_TICK_STALL_SECS` enables it; it
-    // lives for the whole `'serve` loop and stops+joins its thread on teardown.
-    let (tick_progress, _stall_monitor) =
-        crate::daemon::tick_stall::start_for_host("daemon-tick", &handlers, home);
+    let (keepalive, tick_rx) = build_tick_infrastructure(home, &ctx);
 
     // #1814 round-2: `'serve` wraps the tick loop + teardown so the final
     // recover-as-primary gate (below) can `continue 'serve` to resume serving if
@@ -881,9 +875,7 @@ fn run_core(home: &Path, source: FleetSource) -> anyhow::Result<()> {
             }
 
             // PR4: idle, blocked awaiting the next tick/crash/shutdown signal.
-            if let Some(p) = &tick_progress {
-                p.enter_waiting();
-            }
+            keepalive.maintenance.enter_waiting();
             let exit_event: Option<crate::agent::AgentExitEvent>;
             crossbeam_channel::select! {
                 recv(ctx.crash_rx) -> msg => { exit_event = msg.ok(); }
@@ -891,21 +883,11 @@ fn run_core(home: &Path, source: FleetSource) -> anyhow::Result<()> {
                 recv(shutdown_rx) -> _ => { continue; }
             }
 
-            let tick_ctx = per_tick::TickContext {
-                home,
-                registry: &ctx.registry,
-                externals: &ctx.externals,
-                configs: &ctx.configs,
-            };
-            // PR4: Preflight — the per-tick config reloads run before the sweep.
-            if let Some(p) = &tick_progress {
-                p.enter_preflight();
-            }
-            crate::runtime_controls::reload_runtime_controls(home);
-            // PR4: the tracked runner publishes Handler(i) per handler and closes
-            // with PostHandlers, which also covers the crash-dispatch below. When
-            // diagnostics are OFF, `tick_progress` is None → untracked (byte-identical).
-            per_tick::run_handlers_with_progress(&handlers, &tick_ctx, tick_progress.as_deref());
+            // The cycle owns preflight, profile handlers, and optional progress;
+            // crash dispatch remains host-local while progress stays PostHandlers.
+            keepalive
+                .maintenance
+                .run_once(home, &ctx.registry, &ctx.externals, &ctx.configs);
 
             let exit_event = match exit_event {
                 Some(e) => e,
@@ -1236,21 +1218,13 @@ fn spawn_fleet_agents(home: &Path, agents: &[AgentDef], ctx: &DaemonContext) {
 /// until the main loop exits.
 struct TickKeepalive {
     _task_sweep: crate::daemon::task_sweep::TaskSweep,
-    // #2737: owner-service witness held for daemon lifetime. build_tick_infrastructure
-    // cannot construct TickKeepalive without calling the two-phase seam, so run_core's
-    // dual-host reach is a COMPILE property (structural I2, replacing the old
-    // `owner_services_called_by_both_hosts` string-scan).
-    _owner_services: crate::daemon::owner_services::OwnerServicesStarted,
+    maintenance: crate::daemon::owned_maintenance::OwnedMaintenanceCycle,
 }
 
 fn build_tick_infrastructure(
     home: &Path,
     ctx: &DaemonContext,
-) -> (
-    TickKeepalive,
-    Vec<Box<dyn per_tick::PerTickHandler>>,
-    crossbeam_channel::Receiver<()>,
-) {
+) -> (TickKeepalive, crossbeam_channel::Receiver<()>) {
     let _task_sweep =
         crate::daemon::task_sweep::TaskSweep::spawn(home.to_path_buf(), Arc::clone(&ctx.shutdown));
 
@@ -1299,6 +1273,12 @@ fn build_tick_infrastructure(
     let daemon_binary_stale: crate::daemon::mcp_registry_watcher::DaemonBinaryStale =
         Arc::new(AtomicBool::new(false));
     let handlers = build_default_handlers(daemon_binary_stale);
+    let maintenance = crate::daemon::owned_maintenance::OwnedMaintenanceCycle::new(
+        handlers,
+        owner_services,
+        "daemon-tick",
+        home,
+    );
 
     let tick_rx = {
         let (tx, rx) = crossbeam_channel::bounded(1);
@@ -1319,9 +1299,8 @@ fn build_tick_infrastructure(
     (
         TickKeepalive {
             _task_sweep,
-            _owner_services: owner_services,
+            maintenance,
         },
-        handlers,
         tick_rx,
     )
 }

--- a/src/daemon/owned_maintenance.rs
+++ b/src/daemon/owned_maintenance.rs
@@ -1,0 +1,100 @@
+//! Typed ownership for one host's owned maintenance cycle.
+
+#[cfg(test)]
+mod tests {
+    use super::OwnedMaintenanceCycle;
+    use crate::agent::{AgentRegistry, ExternalRegistry};
+    use crate::daemon::owner_services::{
+        start_owner_monitoring, start_owner_stream_observers, OwnerMonitoringStarters, OwnerRole,
+        OwnerStreamStarters,
+    };
+    use crate::daemon::per_tick::{PerTickHandler, TickContext};
+    use parking_lot::Mutex;
+    use std::collections::HashMap;
+    use std::path::Path;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    struct RecordingHandler {
+        runs: Arc<AtomicUsize>,
+    }
+
+    impl PerTickHandler for RecordingHandler {
+        fn name(&self) -> &'static str {
+            "recording"
+        }
+
+        fn run(&self, _ctx: &TickContext<'_>) {
+            self.runs.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    fn owner_services_started() -> crate::daemon::owner_services::OwnerServicesStarted {
+        let registry: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let monitoring = OwnerMonitoringStarters {
+            monitor_tick: &|_, _, _| {},
+            api_activity_probe: &|_, _| {},
+        };
+        let streams = OwnerStreamStarters {
+            rollout: &|_, _, _| {},
+            opencode: &|_, _, _| {},
+            kiro: &|_, _, _| {},
+        };
+        let phase_one = start_owner_monitoring(
+            OwnerRole::Owned,
+            Path::new("/tmp/owned-maintenance-cycle-red"),
+            &registry,
+            &monitoring,
+        );
+        start_owner_stream_observers(
+            OwnerRole::Owned,
+            &phase_one,
+            Path::new("/tmp/owned-maintenance-cycle-red"),
+            &registry,
+            &streams,
+        )
+    }
+
+    #[test]
+    fn run_once_owns_profile_and_finishes_in_post_handlers() {
+        let runs = Arc::new(AtomicUsize::new(0));
+        let progress = crate::daemon::tick_stall::TickProgress::new(
+            "owned-maintenance-red",
+            Arc::from(vec!["recording"]),
+        );
+        let cycle = OwnedMaintenanceCycle::from_parts(
+            vec![Box::new(RecordingHandler {
+                runs: Arc::clone(&runs),
+            })],
+            owner_services_started(),
+            Some(Arc::clone(&progress)),
+            None,
+        );
+        let home = std::env::temp_dir().join(format!(
+            "agend-owned-maintenance-red-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&home).unwrap();
+        let registry: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let externals: ExternalRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let configs = Arc::new(Mutex::new(HashMap::new()));
+
+        cycle.run_once(&home, &registry, &externals, &configs);
+
+        assert_eq!(runs.load(Ordering::SeqCst), 1);
+        assert_eq!(cycle.handler_names(), ["recording"]);
+        assert_eq!(cycle.phase_for_test(), Some(crate::daemon::tick_stall::Phase::PostHandlers));
+    }
+
+    #[test]
+    fn attached_role_constructs_no_cycle() {
+        assert!(OwnedMaintenanceCycle::new_for_role(
+            OwnerRole::Attached,
+            Vec::new(),
+            None,
+            "attached-maintenance-red",
+            Path::new("/tmp/owned-maintenance-cycle-red"),
+        )
+        .is_none());
+    }
+}

--- a/src/daemon/owned_maintenance.rs
+++ b/src/daemon/owned_maintenance.rs
@@ -1,5 +1,117 @@
 //! Typed ownership for one host's owned maintenance cycle.
 
+use crate::agent::{AgentRegistry, ExternalRegistry};
+use crate::api::ConfigRegistry;
+use crate::daemon::owner_services::{OwnerRole, OwnerServicesStarted};
+use crate::daemon::per_tick::{run_handlers_with_progress, PerTickHandler, TickContext};
+use crate::daemon::tick_stall::{TickProgress, TickStallMonitorGuard};
+use std::path::Path;
+use std::sync::Arc;
+
+/// Owned-mode maintenance state shared by the daemon and TUI hosts.
+///
+/// This type owns only the per-host handler profile, the owner-service witness,
+/// and optional progress/stall-monitor state. The cadence producer, receiver,
+/// select topology, bootstrap, shutdown, and shadow planes remain in each host.
+pub(crate) struct OwnedMaintenanceCycle {
+    handlers: Vec<Box<dyn PerTickHandler>>,
+    _owner_services: OwnerServicesStarted,
+    progress: Option<Arc<TickProgress>>,
+    _stall_monitor: Option<TickStallMonitorGuard>,
+}
+
+impl OwnedMaintenanceCycle {
+    /// Construct an owned cycle and centralize progress/stall-monitor setup.
+    pub(crate) fn new(
+        handlers: Vec<Box<dyn PerTickHandler>>,
+        owner_services: OwnerServicesStarted,
+        host: &'static str,
+        home: &Path,
+    ) -> Self {
+        let (progress, stall_monitor) =
+            crate::daemon::tick_stall::start_for_host(host, &handlers, home);
+        Self::from_parts(handlers, owner_services, progress, stall_monitor)
+    }
+
+    /// Test/host seam for supplying already-created progress and monitor state.
+    pub(crate) fn from_parts(
+        handlers: Vec<Box<dyn PerTickHandler>>,
+        owner_services: OwnerServicesStarted,
+        progress: Option<Arc<TickProgress>>,
+        stall_monitor: Option<TickStallMonitorGuard>,
+    ) -> Self {
+        Self {
+            handlers,
+            _owner_services: owner_services,
+            progress,
+            _stall_monitor: stall_monitor,
+        }
+    }
+
+    /// Construct only for an owned host. Attached hosts return `None` without
+    /// consuming a witness or creating any cycle state.
+    pub(crate) fn new_for_role(
+        role: OwnerRole,
+        handlers: Vec<Box<dyn PerTickHandler>>,
+        owner_services: Option<OwnerServicesStarted>,
+        host: &'static str,
+        home: &Path,
+    ) -> Option<Self> {
+        if role == OwnerRole::Attached {
+            return None;
+        }
+        Some(Self::new(
+            handlers,
+            owner_services.expect("owned maintenance requires owner-service witness"),
+            host,
+            home,
+        ))
+    }
+
+    /// Publish the between-tick boundary. Hosts call this immediately before
+    /// waiting in their own select loop.
+    pub(crate) fn enter_waiting(&self) {
+        if let Some(progress) = &self.progress {
+            progress.enter_waiting();
+        }
+    }
+
+    /// Run one maintenance cycle. The cycle closes in `PostHandlers`; callers
+    /// retain host-specific control of any crash dispatch before entering
+    /// `Waiting` for the next select.
+    pub(crate) fn run_once(
+        &self,
+        home: &Path,
+        registry: &AgentRegistry,
+        externals: &ExternalRegistry,
+        configs: &ConfigRegistry,
+    ) {
+        if let Some(progress) = &self.progress {
+            progress.enter_preflight();
+        }
+        crate::runtime_controls::reload_runtime_controls(home);
+        let tick_ctx = TickContext {
+            home,
+            registry,
+            externals,
+            configs,
+        };
+        run_handlers_with_progress(&self.handlers, &tick_ctx, self.progress.as_deref());
+    }
+
+    #[cfg(test)]
+    fn handler_names(&self) -> Vec<&'static str> {
+        self.handlers.iter().map(|handler| handler.name()).collect()
+    }
+
+    #[cfg(test)]
+    fn phase_for_test(&self) -> Option<crate::daemon::tick_stall::Phase> {
+        self.progress
+            .as_deref()
+            .and_then(crate::daemon::tick_stall::TickProgress::phase_for_test)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::OwnedMaintenanceCycle;
@@ -74,7 +186,7 @@ mod tests {
             "agend-owned-maintenance-red-{}",
             std::process::id()
         ));
-        std::fs::create_dir_all(&home).unwrap();
+        std::fs::create_dir_all(&home).expect("create owned-maintenance test home");
         let registry: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
         let externals: ExternalRegistry = Arc::new(Mutex::new(HashMap::new()));
         let configs = Arc::new(Mutex::new(HashMap::new()));

--- a/src/daemon/owned_maintenance.rs
+++ b/src/daemon/owned_maintenance.rs
@@ -83,7 +83,10 @@ mod tests {
 
         assert_eq!(runs.load(Ordering::SeqCst), 1);
         assert_eq!(cycle.handler_names(), ["recording"]);
-        assert_eq!(cycle.phase_for_test(), Some(crate::daemon::tick_stall::Phase::PostHandlers));
+        assert_eq!(
+            cycle.phase_for_test(),
+            Some(crate::daemon::tick_stall::Phase::PostHandlers)
+        );
     }
 
     #[test]

--- a/src/daemon/owner_services.rs
+++ b/src/daemon/owner_services.rs
@@ -20,8 +20,8 @@
 //!   observers" a COMPILE dependency (you cannot call phase 2 without phase 1's token).
 //! - the five low-level spawns require a private `OwnerServicePermit`, so a host-body
 //!   direct spawn cannot compile (structural I4 — no host-local copy).
-//! - `OwnerServicesStarted` is retained by each owner host (app: required by the
-//!   owned-only `app_maintenance_tick`; daemon: held in `TickKeepalive`), so a host
+//! - `OwnerServicesStarted` is retained by each owner host (app: held by the
+//!   owned-only `OwnedMaintenanceCycle`; daemon: held in `TickKeepalive`), so a host
 //!   that skips the seam fails to compile (structural I2 — dual-host reach).
 
 use crate::agent::AgentRegistry;
@@ -57,7 +57,7 @@ pub(crate) struct OwnerServicePermit(());
 pub(crate) struct OwnerMonitoringStarted(());
 
 /// Final witness — proof that BOTH owner-service phases ran. Retained by each
-/// owner host (app: required by owned-only `app_maintenance_tick`; daemon: held
+/// owner host (app: held by the owned-only `OwnedMaintenanceCycle`; daemon: held
 /// in `TickKeepalive`), so a host that skips the seam fails to compile
 /// (structural I2 — the former `owner_services_called_by_both_hosts` guard).
 /// Ctor is private to this module.

--- a/src/daemon/tick_stall.rs
+++ b/src/daemon/tick_stall.rs
@@ -167,6 +167,11 @@ impl TickProgress {
         })
     }
 
+    #[cfg(test)]
+    pub(crate) fn phase_for_test(&self) -> Option<Phase> {
+        self.snapshot().map(|snapshot| snapshot.phase)
+    }
+
     /// The alert `handler` label for a phase: the stalled handler's name for
     /// `Handler`, else a phase descriptor.
     fn handler_label(&self, phase: Phase) -> &str {
@@ -1144,12 +1149,12 @@ mod tests {
         );
     }
 
-    // ── #6: attached app starts no monitor (structural source-pin) ─────────
+    // ── #6: attached app constructs no cycle (structural source-pin) ───────
 
-    /// An attached app never ticks, so it must never start a stall monitor. This
-    /// is a structural invariant of the app wiring (same idiom as
+    /// An attached app never ticks, so it must never construct an owned cycle.
+    /// This is a structural invariant of the app wiring (same idiom as
     /// `per_tick::tests::notification_handlers_wire_boot_grace`): a future edit
-    /// that drops the `attached_mode` gate would silently start a monitor on a
+    /// that drops the `attached_mode` gate would silently create owned state on a
     /// host that never ticks. Also pins the daemon `run_core` host wiring.
     #[test]
     fn hosts_wired_daemon_yes_attached_app_no() {
@@ -1157,28 +1162,28 @@ mod tests {
             .or_else(|_| std::fs::read_to_string("agend-terminal/src/app/mod.rs"))
             .expect("src/app/mod.rs must be readable");
         let anchor = app
-            .find("let (app_tick_progress, _app_stall_monitor)")
-            .expect("app must bind the owned-app stall monitor");
-        let region = &app[anchor..(anchor + 600).min(app.len())];
+            .find("let app_cycle = crate::daemon::owned_maintenance::OwnedMaintenanceCycle::new_for_role(")
+            .expect("app must bind the owned maintenance cycle");
+        let region = &app[anchor..(anchor + 800).min(app.len())];
         assert!(
             region.contains("if attached_mode"),
-            "the app monitor must be gated on attached_mode"
+            "the app cycle must be gated on attached_mode"
         );
         assert!(
-            region.contains("(None, None)"),
-            "an attached app must resolve to (None, None) — no monitor"
+            region.contains("OwnerRole::Attached"),
+            "an attached app must select the attached role"
         );
         assert!(
-            region.contains("start_for_host(\"app-owned-tick\""),
-            "an owned app starts the app-owned-tick monitor"
+            region.contains("OwnerRole::Owned"),
+            "an owned app must select the owned role"
         );
 
         let daemon = std::fs::read_to_string("src/daemon/mod.rs")
             .or_else(|_| std::fs::read_to_string("agend-terminal/src/daemon/mod.rs"))
             .expect("src/daemon/mod.rs must be readable");
         assert!(
-            daemon.contains("start_for_host(\"daemon-tick\""),
-            "the daemon run_core host starts the daemon-tick monitor"
+            daemon.contains("OwnedMaintenanceCycle::new("),
+            "the daemon run_core host constructs the owned maintenance cycle"
         );
     }
 }


### PR DESCRIPTION
## Summary
- extract owned-mode maintenance profile, owner-service witness, tick progress, stall guard, and `run_once` into `OwnedMaintenanceCycle`
- keep cadence producers, receivers/select topology, startup/shutdown, API ingress, and shadow ordering host-local
- keep attached app construction-free and preserve PostHandlers → crash dispatch → Waiting semantics

## Validation
- RED contract: `684574bb2a86cf3ed969cba4c3d64fa506c26284`
- format-only RED follow-up: `33b1f4a8`
- GREEN: `c06b3ae2cfdec4bb8ffec0f3dfe40242287adf4`
- `cargo clippy --all-targets --all-features -- -D warnings`
- focused owned-maintenance, tick-stall, app, daemon, and owner-services tests
- changed-file rustfmt and `git diff --check`

The full binary suite was also exercised; changed focused suites pass. The aggregate run encountered unrelated environment-sensitive resource/fixture failures (including open-file exhaustion and unavailable fixture remotes).
