### PR TITLE
[#2779] Support per-instance context thresholds

### DIFF
--- a/src/daemon/per_tick/context_alert.rs
+++ b/src/daemon/per_tick/context_alert.rs
@@ -21,15 +21,66 @@
 
 use super::{PerTickHandler, TickContext};
 use parking_lot::Mutex;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 /// Re-alert cadence while usage stays continuously above the threshold.
 const REALERT_AFTER: Duration = Duration::from_secs(30 * 60);
 
+#[cfg(test)]
 fn alert_threshold() -> f32 {
     let (alert, _, _) = crate::runtime_config::resolve_effective_thresholds();
     alert
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct ThresholdTriplet {
+    pub(super) alert: f32,
+    pub(super) handoff: f32,
+    pub(super) escalate: f32,
+}
+
+pub(super) type InvalidOverrideWarnings = Arc<Mutex<HashSet<String>>>;
+
+pub(super) fn resolve_instance_thresholds(
+    name: &str,
+    global: ThresholdTriplet,
+    fleet: &crate::fleet::FleetConfig,
+    warnings: &InvalidOverrideWarnings,
+) -> ThresholdTriplet {
+    let Some(instance) = fleet.instances.get(name) else {
+        warnings.lock().remove(name);
+        return global;
+    };
+    let composed = ThresholdTriplet {
+        alert: instance.context_alert_pct.unwrap_or(global.alert),
+        handoff: instance.context_handoff_pct.unwrap_or(global.handoff),
+        escalate: instance
+            .context_handoff_escalate_pct
+            .unwrap_or(global.escalate),
+    };
+    if crate::runtime_config::validate_thresholds(
+        composed.alert,
+        composed.handoff,
+        composed.escalate,
+    )
+    .is_ok()
+    {
+        warnings.lock().remove(name);
+        return composed;
+    }
+
+    if warnings.lock().insert(name.to_string()) {
+        tracing::warn!(
+            agent = %name,
+            alert = composed.alert,
+            handoff = composed.handoff,
+            escalate = composed.escalate,
+            "context thresholds invalid for instance; using complete global triplet"
+        );
+    }
+    global
 }
 
 /// Per-agent alert latch.
@@ -73,13 +124,23 @@ fn decide(state: &mut AlertState, pct: f32, threshold: f32, now: Instant) -> boo
 pub(crate) struct ContextAlertHandler {
     gate: crate::daemon::cadence_gate::CadenceGate,
     states: Mutex<HashMap<String, AlertState>>,
+    invalid_override_warnings: InvalidOverrideWarnings,
 }
 
 impl ContextAlertHandler {
+    #[cfg(test)]
     pub(crate) fn new(every_n_ticks: u64) -> Self {
+        Self::new_with_warnings(every_n_ticks, Arc::new(Mutex::new(HashSet::new())))
+    }
+
+    pub(super) fn new_with_warnings(
+        every_n_ticks: u64,
+        invalid_override_warnings: InvalidOverrideWarnings,
+    ) -> Self {
         Self {
             gate: crate::daemon::cadence_gate::CadenceGate::new(every_n_ticks),
             states: Mutex::new(HashMap::new()),
+            invalid_override_warnings,
         }
     }
 
@@ -92,6 +153,11 @@ impl ContextAlertHandler {
     #[cfg(test)]
     pub(crate) fn is_armed(&self, name: &str) -> Option<bool> {
         self.states.lock().get(name).map(|s| s.armed)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn invalid_warning_count(&self) -> usize {
+        self.invalid_override_warnings.lock().len()
     }
 }
 
@@ -125,13 +191,22 @@ impl PerTickHandler for ContextAlertHandler {
             live
         };
 
-        // Phase 2: threshold/hysteresis evaluation + orchestrator notify.
-        let threshold = alert_threshold();
+        // Phase 2: resolve one global snapshot, then overlay each instance's
+        // optional fields while evaluating its own latch.
+        let (alert, handoff, escalate) = crate::runtime_config::resolve_effective_thresholds();
+        let global = ThresholdTriplet {
+            alert,
+            handoff,
+            escalate,
+        };
         let now = Instant::now();
-        let fleet = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(ctx.home))
-            .unwrap_or_default();
+        let fleet = crate::fleet::FleetConfig::load_arc(&crate::fleet::fleet_yaml_path(ctx.home))
+            .unwrap_or_else(|_| Arc::new(crate::fleet::FleetConfig::default()));
         let mut states = self.states.lock();
         for (name, pct, source) in resolved {
+            let threshold =
+                resolve_instance_thresholds(&name, global, &fleet, &self.invalid_override_warnings)
+                    .alert;
             let state = states.entry(name.clone()).or_default();
             if !decide(state, pct, threshold, now) {
                 continue;
@@ -170,6 +245,9 @@ impl PerTickHandler for ContextAlertHandler {
         // #latch-prune: drop latch entries for agents gone from the registry
         // (cleanup-on-delete) so a deleted agent leaves no stale state.
         states.retain(|name, _| live.contains(name));
+        self.invalid_override_warnings
+            .lock()
+            .retain(|name| live.contains(name));
     }
 }
 

--- a/src/daemon/per_tick/context_handoff.rs
+++ b/src/daemon/per_tick/context_handoff.rs
@@ -29,9 +29,13 @@
 //! still-high agent — same accepted trade-off as `context_alert`
 //! (current-state nudge, single, self-limiting).
 
+use super::context_alert::{
+    resolve_instance_thresholds, InvalidOverrideWarnings, ThresholdTriplet,
+};
 use super::{PerTickHandler, TickContext};
 use parking_lot::Mutex;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 /// The handoff file the injection asks for, relative to the agent's
 /// working directory. Matches the manual-rescue convention from the 6/10
@@ -42,6 +46,7 @@ pub(crate) const HANDOFF_FILENAME: &str = "SESSION-HANDOFF.md";
 /// effective-triplet snapshot, so a config reload / env change between two
 /// separate resolves can't hand `decide` a torn pair. Overrides:
 /// `AGEND_CONTEXT_HANDOFF_PCT` / `AGEND_CONTEXT_HANDOFF_ESCALATE_PCT`.
+#[cfg(test)]
 fn tick_thresholds() -> (f32, f32) {
     let (_, handoff, escalate) = crate::runtime_config::resolve_effective_thresholds();
     (handoff, escalate)
@@ -189,13 +194,26 @@ fn handoff_written_since(working_dir: Option<&std::path::Path>, since_ms: i64) -
 pub(crate) struct ContextHandoffHandler {
     gate: crate::daemon::cadence_gate::CadenceGate,
     states: Mutex<HashMap<String, EpisodeState>>,
+    invalid_override_warnings: InvalidOverrideWarnings,
 }
 
 impl ContextHandoffHandler {
+    #[cfg(test)]
     pub(crate) fn new(every_n_ticks: u64) -> Self {
+        Self::new_with_warnings(
+            every_n_ticks,
+            Arc::new(Mutex::new(std::collections::HashSet::new())),
+        )
+    }
+
+    pub(super) fn new_with_warnings(
+        every_n_ticks: u64,
+        invalid_override_warnings: InvalidOverrideWarnings,
+    ) -> Self {
         Self {
             gate: crate::daemon::cadence_gate::CadenceGate::new(every_n_ticks),
             states: Mutex::new(HashMap::new()),
+            invalid_override_warnings,
         }
     }
 
@@ -242,10 +260,19 @@ impl PerTickHandler for ContextHandoffHandler {
             live
         };
 
-        let (handoff_pct, escalate_pct) = tick_thresholds();
+        let (alert, handoff, escalate) = crate::runtime_config::resolve_effective_thresholds();
+        let global = ThresholdTriplet {
+            alert,
+            handoff,
+            escalate,
+        };
+        let fleet = crate::fleet::FleetConfig::load_arc(&crate::fleet::fleet_yaml_path(ctx.home))
+            .unwrap_or_else(|_| Arc::new(crate::fleet::FleetConfig::default()));
         let now_ms = chrono::Utc::now().timestamp_millis();
         let mut states = self.states.lock();
         for (name, pct, is_idle) in snapshot {
+            let thresholds =
+                resolve_instance_thresholds(&name, global, &fleet, &self.invalid_override_warnings);
             let state = states.entry(name.clone()).or_default();
             let working_dir = ctx
                 .configs
@@ -258,8 +285,8 @@ impl PerTickHandler for ContextHandoffHandler {
                 is_idle,
                 |since| handoff_written_since(working_dir.as_deref(), since),
                 now_ms,
-                handoff_pct,
-                escalate_pct,
+                thresholds.handoff,
+                thresholds.escalate,
             );
             match action {
                 Some(Action::Inject) => {
@@ -313,8 +340,9 @@ impl PerTickHandler for ContextHandoffHandler {
                 Some(Action::Escalate) => {
                     let msg = format!(
                         "[context-handoff] agent '{name}' context at {pct:.1}% and no \
-                         {HANDOFF_FILENAME} update since the {handoff_pct:.1}% nudge — \
-                         consider a manual handoff + restart_instance. (One-time notice.)"
+                         {HANDOFF_FILENAME} update since the {thresholds_handoff:.1}% nudge — \
+                         consider a manual handoff + restart_instance. (One-time notice.)",
+                        thresholds_handoff = thresholds.handoff
                     );
                     crate::channel::notify_all_escalation_channels(
                         &name,
@@ -331,6 +359,9 @@ impl PerTickHandler for ContextHandoffHandler {
         // #latch-prune: drop episode latches for agents gone from the registry
         // (cleanup-on-delete) so a deleted agent leaves no stale episode state.
         states.retain(|name, _| live.contains(name));
+        self.invalid_override_warnings
+            .lock()
+            .retain(|name| live.contains(name));
     }
 }
 

--- a/src/daemon/per_tick/context_thresholds.rs
+++ b/src/daemon/per_tick/context_thresholds.rs
@@ -44,6 +44,9 @@
 use super::context_alert::ContextAlertHandler;
 use super::context_handoff::ContextHandoffHandler;
 use super::{PerTickHandler, TickContext};
+use parking_lot::Mutex;
+use std::collections::HashSet;
+use std::sync::Arc;
 
 pub(crate) struct ContextThresholdsHandler {
     context_alert: ContextAlertHandler,
@@ -52,9 +55,16 @@ pub(crate) struct ContextThresholdsHandler {
 
 impl ContextThresholdsHandler {
     pub(crate) fn new(alert_ticks: u64, handoff_ticks: u64) -> Self {
+        let invalid_override_warnings = Arc::new(Mutex::new(HashSet::new()));
         Self {
-            context_alert: ContextAlertHandler::new(alert_ticks),
-            context_handoff: ContextHandoffHandler::new(handoff_ticks),
+            context_alert: ContextAlertHandler::new_with_warnings(
+                alert_ticks,
+                Arc::clone(&invalid_override_warnings),
+            ),
+            context_handoff: ContextHandoffHandler::new_with_warnings(
+                handoff_ticks,
+                invalid_override_warnings,
+            ),
         }
     }
 }
@@ -161,11 +171,7 @@ mod tests {
     }
 
     fn reset_runtime_defaults(home: &std::path::Path) {
-        std::fs::write(
-            home.join("runtime-config.json"),
-            r#"{"schema_version": 1}"#,
-        )
-        .unwrap();
+        std::fs::write(home.join("runtime-config.json"), r#"{"schema_version": 1}"#).unwrap();
         crate::runtime_config::reload(home);
         for key in [
             "AGEND_CONTEXT_ALERT_PCT",
@@ -374,7 +380,7 @@ mod tests {
         reset_runtime_defaults(&home);
         std::fs::write(
             crate::fleet::fleet_yaml_path(&home),
-            "instances:\n  low:\n    context_alert_pct: 70.0\n  high:\n    context_alert_pct: 90.0\n",
+            "instances:\n  low:\n    context_alert_pct: 70.0\n  high:\n    context_alert_pct: 84.0\n",
         )
         .unwrap();
         let (registry, externals, configs) = empty_ctx_parts();
@@ -426,7 +432,7 @@ mod tests {
         reset_runtime_defaults(&home);
         std::fs::write(
             crate::fleet::fleet_yaml_path(&home),
-            "instances:\n  invalid:\n    context_alert_pct: 95.0\n    context_handoff_pct: 90.0\n    context_handoff_escalate_pct: 92.0\n  valid:\n    context_alert_pct: 90.0\n",
+            "instances:\n  invalid:\n    context_alert_pct: 95.0\n    context_handoff_pct: 90.0\n    context_handoff_escalate_pct: 92.0\n  valid:\n    context_alert_pct: 84.0\n",
         )
         .unwrap();
         let (registry, externals, configs) = empty_ctx_parts();
@@ -455,7 +461,7 @@ mod tests {
         reset_runtime_defaults(&home);
         std::fs::write(
             crate::fleet::fleet_yaml_path(&home),
-            "instances:\n  watched:\n    context_alert_pct: 90.0\n",
+            "instances:\n  watched:\n    context_alert_pct: 84.0\n",
         )
         .unwrap();
         let (registry, externals, configs) = empty_ctx_parts();
@@ -466,7 +472,7 @@ mod tests {
         assert_eq!(
             handler.is_armed("watched"),
             Some(true),
-            "the instance override must keep 82% below its 90% threshold"
+            "the instance override must keep 82% below its 84% threshold"
         );
 
         std::fs::write(crate::fleet::fleet_yaml_path(&home), "instances: {}\n").unwrap();
@@ -479,7 +485,11 @@ mod tests {
 
         registry.lock().clear();
         handler.run(&ctx);
-        assert_eq!(handler.is_armed("watched"), None, "deleted agents must be pruned");
+        assert_eq!(
+            handler.is_armed("watched"),
+            None,
+            "deleted agents must be pruned"
+        );
         std::fs::remove_dir_all(&home).ok();
     }
 
@@ -491,7 +501,7 @@ mod tests {
         let fleet_path = crate::fleet::fleet_yaml_path(&home);
         std::fs::write(
             &fleet_path,
-            "instances:\n  watched:\n    context_alert_pct: 90.0\n",
+            "instances:\n  watched:\n    context_alert_pct: 84.0\n",
         )
         .unwrap();
         let (registry, externals, configs) = empty_ctx_parts();
@@ -511,6 +521,104 @@ mod tests {
             handler.is_armed("watched"),
             Some(false),
             "the next fired tick must observe a changed fleet override"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    #[serial(runtime_config)]
+    #[tracing_test::traced_test]
+    fn invalid_override_warning_is_shared_deduped_and_rearmed_after_valid() {
+        let home = tmp_home("invalid-warning-dedup");
+        reset_runtime_defaults(&home);
+        let fleet_path = crate::fleet::fleet_yaml_path(&home);
+        std::fs::write(
+            &fleet_path,
+            "instances:\n  watched:\n    context_alert_pct: 95.0\n    context_handoff_pct: 90.0\n    context_handoff_escalate_pct: 92.0\n",
+        )
+        .unwrap();
+        let (registry, externals, configs) = empty_ctx_parts();
+        add_context_agent(&registry, "watched", 82.0);
+        let handler = ContextThresholdsHandler::new(1, 1);
+        let ctx = context_ctx(&home, &registry, &externals, &configs);
+
+        handler.run(&ctx);
+        assert_eq!(
+            handler.context_alert.invalid_warning_count(),
+            1,
+            "alert and handoff must share one invalid-warning entry per agent"
+        );
+
+        std::fs::write(
+            &fleet_path,
+            "instances:\n  watched:\n    context_alert_pct: 84.0\n    context_handoff_pct: 86.0\n    context_handoff_escalate_pct: 92.0\n",
+        )
+        .unwrap();
+        handler.run(&ctx);
+        assert!(
+            handler.context_alert.invalid_warning_count() == 0,
+            "a valid composition must reset the invalid warning episode"
+        );
+
+        std::fs::write(
+            &fleet_path,
+            "instances:\n  watched:\n    context_alert_pct: 95.0\n    context_handoff_pct: 90.0\n    context_handoff_escalate_pct: 92.0\n",
+        )
+        .unwrap();
+        handler.run(&ctx);
+        logs_assert(|lines: &[&str]| {
+            let count = lines
+                .iter()
+                .filter(|line| line.contains("context thresholds invalid for instance"))
+                .count();
+            if count == 2 {
+                Ok(())
+            } else {
+                Err(format!(
+                    "invalid warning must emit once per invalid episode across both handlers; got {count}"
+                ))
+            }
+        });
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    #[serial(runtime_config)]
+    fn global_runtime_reload_updates_only_agents_without_overrides() {
+        let home = tmp_home("runtime-reload-with-instance-override");
+        reset_runtime_defaults(&home);
+        std::fs::write(
+            crate::fleet::fleet_yaml_path(&home),
+            "instances:\n  overridden:\n    context_alert_pct: 84.0\n",
+        )
+        .unwrap();
+        let (registry, externals, configs) = empty_ctx_parts();
+        add_context_agent(&registry, "plain", 82.0);
+        add_context_agent(&registry, "overridden", 82.0);
+        let ctx = context_ctx(&home, &registry, &externals, &configs);
+
+        let first = ContextAlertHandler::new(1);
+        first.run(&ctx);
+        assert_eq!(first.is_armed("plain"), Some(false));
+        assert_eq!(first.is_armed("overridden"), Some(true));
+
+        std::fs::write(
+            home.join("runtime-config.json"),
+            r#"{"schema_version": 1, "context_alert_pct": 83.0, "context_handoff_pct": 85.0, "context_handoff_escalate_pct": 92.0}"#,
+        )
+        .unwrap();
+        crate::runtime_config::reload(&home);
+        let second = ContextAlertHandler::new(1);
+        second.run(&ctx);
+        assert_eq!(
+            second.is_armed("plain"),
+            Some(true),
+            "a global runtime reload must affect an agent without an override"
+        );
+        assert_eq!(
+            second.is_armed("overridden"),
+            Some(true),
+            "an instance override remains authoritative across global reload"
         );
         std::fs::remove_dir_all(&home).ok();
     }

--- a/src/daemon/per_tick/context_thresholds.rs
+++ b/src/daemon/per_tick/context_thresholds.rs
@@ -127,8 +127,12 @@ mod test_hooks {
 mod tests {
     use super::*;
     use parking_lot::Mutex as PLMutex;
+    use serial_test::serial;
     use std::collections::HashMap;
     use std::sync::Arc;
+
+    use super::super::context_alert::ContextAlertHandler;
+    use super::super::context_handoff::{ContextHandoffHandler, Phase};
 
     fn tmp_home(tag: &str) -> std::path::PathBuf {
         use std::sync::atomic::{AtomicU32, Ordering};
@@ -154,6 +158,41 @@ mod tests {
             Arc::new(PLMutex::new(HashMap::new())),
             Arc::new(PLMutex::new(HashMap::new())),
         )
+    }
+
+    fn reset_runtime_defaults(home: &std::path::Path) {
+        std::fs::write(
+            home.join("runtime-config.json"),
+            r#"{"schema_version": 1}"#,
+        )
+        .unwrap();
+        crate::runtime_config::reload(home);
+        for key in [
+            "AGEND_CONTEXT_ALERT_PCT",
+            "AGEND_CONTEXT_HANDOFF_PCT",
+            "AGEND_CONTEXT_HANDOFF_ESCALATE_PCT",
+        ] {
+            std::env::remove_var(key);
+        }
+    }
+
+    fn add_context_agent(registry: &crate::agent::AgentRegistry, name: &str, pct: f32) {
+        let (handle, _reader) = crate::daemon::per_tick::mock_live_agent_with_context(name, pct);
+        registry.lock().insert(handle.id, handle);
+    }
+
+    fn context_ctx<'a>(
+        home: &'a std::path::Path,
+        registry: &'a crate::agent::AgentRegistry,
+        externals: &'a crate::agent::ExternalRegistry,
+        configs: &'a Arc<PLMutex<HashMap<String, crate::daemon::AgentConfig>>>,
+    ) -> TickContext<'a> {
+        TickContext {
+            home,
+            registry,
+            externals,
+            configs,
+        }
     }
 
     #[test]
@@ -324,6 +363,154 @@ mod tests {
             "90% crosses the handoff threshold on an Idle mock agent — handoff \
              must have independently transitioned Armed → IdleMarked, got {:?}",
             handler.context_handoff.phase_of("watched")
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    #[serial(runtime_config)]
+    fn per_instance_alert_thresholds_are_isolated() {
+        let home = tmp_home("per-instance-alert-isolation");
+        reset_runtime_defaults(&home);
+        std::fs::write(
+            crate::fleet::fleet_yaml_path(&home),
+            "instances:\n  low:\n    context_alert_pct: 70.0\n  high:\n    context_alert_pct: 90.0\n",
+        )
+        .unwrap();
+        let (registry, externals, configs) = empty_ctx_parts();
+        add_context_agent(&registry, "low", 82.0);
+        add_context_agent(&registry, "high", 82.0);
+        let handler = ContextAlertHandler::new(1);
+        handler.run(&context_ctx(&home, &registry, &externals, &configs));
+
+        assert_eq!(
+            handler.is_armed("low"),
+            Some(false),
+            "the low per-instance alert threshold must fire at 82%"
+        );
+        assert_eq!(
+            handler.is_armed("high"),
+            Some(true),
+            "the high per-instance alert threshold must remain armed at 82%"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    #[serial(runtime_config)]
+    fn partial_instance_overlay_preserves_global_handoff_and_escalate() {
+        let home = tmp_home("partial-handoff-overlay");
+        reset_runtime_defaults(&home);
+        std::fs::write(
+            crate::fleet::fleet_yaml_path(&home),
+            "instances:\n  partial:\n    context_handoff_pct: 88.0\n",
+        )
+        .unwrap();
+        let (registry, externals, configs) = empty_ctx_parts();
+        add_context_agent(&registry, "partial", 86.0);
+        let handler = ContextHandoffHandler::new(1);
+        handler.run(&context_ctx(&home, &registry, &externals, &configs));
+
+        assert_eq!(
+            handler.phase_of("partial"),
+            Some(Phase::Armed),
+            "partial overlay must use the per-instance handoff threshold while retaining the global escalate threshold"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    #[serial(runtime_config)]
+    fn invalid_instance_triplet_falls_back_atomically_without_poisoning_other_agents() {
+        let home = tmp_home("invalid-instance-triplet");
+        reset_runtime_defaults(&home);
+        std::fs::write(
+            crate::fleet::fleet_yaml_path(&home),
+            "instances:\n  invalid:\n    context_alert_pct: 95.0\n    context_handoff_pct: 90.0\n    context_handoff_escalate_pct: 92.0\n  valid:\n    context_alert_pct: 90.0\n",
+        )
+        .unwrap();
+        let (registry, externals, configs) = empty_ctx_parts();
+        add_context_agent(&registry, "invalid", 82.0);
+        add_context_agent(&registry, "valid", 82.0);
+        let handler = ContextAlertHandler::new(1);
+        handler.run(&context_ctx(&home, &registry, &externals, &configs));
+
+        assert_eq!(
+            handler.is_armed("invalid"),
+            Some(false),
+            "invalid per-instance composition must fall back to the complete global triplet"
+        );
+        assert_eq!(
+            handler.is_armed("valid"),
+            Some(true),
+            "one agent's invalid override must not poison another agent's valid override"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    #[serial(runtime_config)]
+    fn missing_instance_falls_back_to_global_and_deleted_latch_is_pruned() {
+        let home = tmp_home("missing-instance-fallback");
+        reset_runtime_defaults(&home);
+        std::fs::write(
+            crate::fleet::fleet_yaml_path(&home),
+            "instances:\n  watched:\n    context_alert_pct: 90.0\n",
+        )
+        .unwrap();
+        let (registry, externals, configs) = empty_ctx_parts();
+        add_context_agent(&registry, "watched", 82.0);
+        let handler = ContextAlertHandler::new(1);
+        let ctx = context_ctx(&home, &registry, &externals, &configs);
+        handler.run(&ctx);
+        assert_eq!(
+            handler.is_armed("watched"),
+            Some(true),
+            "the instance override must keep 82% below its 90% threshold"
+        );
+
+        std::fs::write(crate::fleet::fleet_yaml_path(&home), "instances: {}\n").unwrap();
+        handler.run(&ctx);
+        assert_eq!(
+            handler.is_armed("watched"),
+            Some(false),
+            "a missing instance entry must use the complete global threshold triplet"
+        );
+
+        registry.lock().clear();
+        handler.run(&ctx);
+        assert_eq!(handler.is_armed("watched"), None, "deleted agents must be pruned");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    #[serial(runtime_config)]
+    fn fleet_reload_changes_per_instance_threshold_on_next_fired_tick() {
+        let home = tmp_home("fleet-reload-threshold");
+        reset_runtime_defaults(&home);
+        let fleet_path = crate::fleet::fleet_yaml_path(&home);
+        std::fs::write(
+            &fleet_path,
+            "instances:\n  watched:\n    context_alert_pct: 90.0\n",
+        )
+        .unwrap();
+        let (registry, externals, configs) = empty_ctx_parts();
+        add_context_agent(&registry, "watched", 82.0);
+        let handler = ContextAlertHandler::new(1);
+        let ctx = context_ctx(&home, &registry, &externals, &configs);
+        handler.run(&ctx);
+        assert_eq!(handler.is_armed("watched"), Some(true));
+
+        std::fs::write(
+            &fleet_path,
+            "instances:\n  watched:\n    context_alert_pct: 70\n",
+        )
+        .unwrap();
+        handler.run(&ctx);
+        assert_eq!(
+            handler.is_armed("watched"),
+            Some(false),
+            "the next fired tick must observe a changed fleet override"
         );
         std::fs::remove_dir_all(&home).ok();
     }

--- a/src/fleet/mod.rs
+++ b/src/fleet/mod.rs
@@ -516,6 +516,18 @@ pub struct InstanceConfig {
     /// without hard-coding backend model IDs on every instance.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model_tier: Option<String>,
+    /// Optional per-instance context-alert threshold override. When absent,
+    /// the effective global runtime threshold applies.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_alert_pct: Option<f32>,
+    /// Optional per-instance context-handoff threshold override. When absent,
+    /// the effective global runtime threshold applies.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_handoff_pct: Option<f32>,
+    /// Optional per-instance context-handoff escalation threshold override.
+    /// When absent, the effective global runtime threshold applies.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_handoff_escalate_pct: Option<f32>,
     /// Display name for UI/Telegram.
     pub display_name: Option<String>,
     /// Path to extra instructions file (relative to fleet.yaml dir).


### PR DESCRIPTION
## Summary
- add optional per-instance alert, handoff, and escalation threshold overrides
- resolve one global threshold triplet and one cached fleet snapshot per fired handler tick
- validate overlays atomically with per-agent fallback and shared warning deduplication

## Verification
- RED checkpoint: a150bf77
- GREEN: 60cfa936c4ac6dbf693148142261b1318be9d2b4
- `cargo test daemon::per_tick::context_ -- --nocapture` (36 passed)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `scripts/fmt-owned.sh --check`

No vendor/submodule changes.