### PR TITLE
fix(#2454): move list snapshot to neutral agent_ops service

### DIFF
--- a/src/agent_ops.rs
+++ b/src/agent_ops.rs
@@ -773,6 +773,97 @@ pub fn list_agents() -> Vec<String> {
     crate::runtime::list_agents_with_fallback(&crate::home_dir())
 }
 
+/// #2454 S3: neutral typed list-snapshot service.  Owns the lock-drop-
+/// before-disk-I/O ordering and the full/external agent serialisation.
+/// Both the API LIST wire handler and the MCP instance-query path call
+/// this — neither owns the logic.
+pub(crate) fn list_snapshot(
+    home: &Path,
+    registry: &AgentRegistry,
+    externals: &crate::agent::ExternalRegistry,
+) -> Value {
+    let reg = agent::lock_registry(registry);
+    let snapshot: Vec<(String, Value)> = reg
+        .values()
+        .map(|handle| {
+            let name = handle.name.to_string();
+            let (
+                agent_state,
+                health_state,
+                blocked_reason,
+                blocked_note,
+                context,
+                context_provider,
+                api_in_flight,
+                last_api_activity_at,
+                observed_status,
+            ) = {
+                let c = handle.core.lock();
+                (
+                    c.state.get_state().display_name().to_string(),
+                    c.health.state.display_name().to_string(),
+                    c.health.current_reason.as_ref().map(|r| r.to_string()),
+                    c.health.current_note.clone(),
+                    c.state.resolved_context(),
+                    c.state.context_provider(),
+                    c.api_activity.in_flight,
+                    c.api_activity.last_active_epoch_ms,
+                    c.observed_status.clone(),
+                )
+            };
+            let entry = json!({
+                "name": name.as_str(),
+                "backend": handle.backend_command,
+                "submit_key": handle.submit_key,
+                "inject_prefix": handle.inject_prefix,
+                "agent_state": agent_state,
+                "health_state": health_state,
+                "blocked_reason": blocked_reason,
+                "blocked_note": blocked_note,
+                "context_pct": context.map(|(pct, _)| pct),
+                "context_source": context.map(|(_, source)| source),
+                "context_provider": context_provider.source_name(),
+                "api_in_flight": api_in_flight,
+                "last_api_activity_at": last_api_activity_at,
+                "observed_status": observed_status,
+                "kind": "managed",
+            });
+            (name, entry)
+        })
+        .collect();
+    drop(reg);
+
+    let mut agents: Vec<Value> = Vec::with_capacity(snapshot.len());
+    for (name, mut entry) in snapshot {
+        let (dispatched_waiting_for, pending_response_to) =
+            crate::daemon::dispatch_idle::pending_for_instance(home, &name);
+        if let Some(obj) = entry.as_object_mut() {
+            obj.insert(
+                "dispatched_waiting_for".into(),
+                json!(dispatched_waiting_for),
+            );
+            obj.insert("pending_response_to".into(), json!(pending_response_to));
+        }
+        agents.push(entry);
+    }
+    let ext = agent::lock_external(externals);
+    for (name, handle) in ext.iter() {
+        let (dispatched_waiting_for, pending_response_to) =
+            crate::daemon::dispatch_idle::pending_for_instance(home, name);
+        agents.push(json!({
+            "name": name,
+            "backend": handle.backend_command,
+            "agent_state": "external",
+            "health_state": "connected",
+            "kind": "external",
+            "pid": handle.pid,
+            "dispatched_waiting_for": dispatched_waiting_for,
+            "pending_response_to": pending_response_to,
+        }));
+    }
+    json!({"ok": true, "result": {"protocol_version": crate::framing::PROTOCOL_VERSION, "agents": agents}})
+}
+
 /// Spawn a single agent into `registry` and start its TUI-serve thread.
 /// Shared by the SPAWN and CREATE_TEAM API handlers.
 ///

--- a/src/api/handlers/query.rs
+++ b/src/api/handlers/query.rs
@@ -4,131 +4,21 @@
 //! without mutating state.
 
 use super::HandlerCtx;
-use crate::agent::{self, AgentRegistry, ExternalRegistry};
+use crate::agent::{AgentRegistry, ExternalRegistry};
 use serde_json::{json, Value};
 
 pub(crate) fn handle_list(_params: &Value, ctx: &HandlerCtx) -> Value {
     list_response(ctx.home, ctx.registry, ctx.externals)
 }
 
+/// #2454 S3: thin wire adapter — delegates to the neutral
+/// `agent_ops::list_snapshot` service that owns the implementation.
 pub(crate) fn list_response(
     home: &std::path::Path,
     registry: &AgentRegistry,
     externals: &ExternalRegistry,
 ) -> Value {
-    // H9: snapshot each managed agent's fields UNDER the tier-1 registry lock,
-    // then drop(reg) BEFORE the per-agent dispatch_idle disk I/O. The original
-    // called `pending_for_instance` (→ `read_dir` + a `read_to_string` +
-    // `serde_json::from_str` per `.json` sidecar) inside the `.map()` while the
-    // lock was still held, so a LIST with N agents performed N dir scans +
-    // N*M file reads/parses entirely under the lock — blocking every other API
-    // handler, the supervisor tick, crash-respawn, hang-detection and the TUI
-    // render path on disk contention. Mirrors the external-agent loop below.
-    let reg = agent::lock_registry(registry);
-    let snapshot: Vec<(String, Value)> = reg
-        .values()
-        .map(|handle| {
-            let name = handle.name.to_string();
-            let (
-                agent_state,
-                health_state,
-                blocked_reason,
-                blocked_note,
-                context,
-                context_provider,
-                api_in_flight,
-                last_api_activity_at,
-                observed_status,
-            ) = {
-                let c = handle.core.lock();
-                (
-                    c.state.get_state().display_name().to_string(),
-                    c.health.state.display_name().to_string(),
-                    // #1933: surface the self-reported blocked reason + its
-                    // operator-readable note so an operator can see WHY an agent is
-                    // blocked and its free-text annotation (previously internal-only).
-                    c.health.current_reason.as_ref().map(|r| r.to_string()),
-                    c.health.current_note.clone(),
-                    // Context% telemetry: resolved usage + producing source
-                    // ("pattern" = the agent's own statusline, "transcript" =
-                    // token-usage estimate). Absent = honestly unknown.
-                    c.state.resolved_context(),
-                    // #2439: the backend's context-telemetry CAPABILITY (statusline
-                    // vs unavailable), derived from statusline-pattern presence.
-                    // Always present — distinct from context_source/context_pct above,
-                    // which are absent when there's no fresh reading.
-                    c.state.context_provider(),
-                    // #2413 Phase 1: out-of-path API-activity signal, read under the
-                    // SAME lock as agent_state so a consumer can reconcile the two
-                    // atomically (false-idle = agent_state=="idle" && api_in_flight).
-                    c.api_activity.in_flight,
-                    c.api_activity.last_active_epoch_ms,
-                    // #2413 Phase B: the reducer's fused status, read under the SAME
-                    // lock as agent_state so a consumer can diff them atomically (the
-                    // observed-vs-raw diff IS the quantification). None only if the per-tick
-                    // reduce didn't run (default-ON; off under AGEND_SHADOW_OBSERVER=0).
-                    c.observed_status.clone(),
-                )
-            };
-            let entry = json!({
-                "name": name.as_str(),
-                "backend": handle.backend_command,
-                "submit_key": handle.submit_key,
-                "inject_prefix": handle.inject_prefix,
-                "agent_state": agent_state,
-                "health_state": health_state,
-                "blocked_reason": blocked_reason,
-                "blocked_note": blocked_note,
-                "context_pct": context.map(|(pct, _)| pct),
-                // CONTRACT (#2439): keep emitting "pattern" here for the existing
-                // external-dashboard consumers — the new typed capability goes in the
-                // additive `context_provider` field below, NOT by renaming this.
-                "context_source": context.map(|(_, source)| source),
-                "context_provider": context_provider.source_name(),
-                // #2413 Phase 1: live LLM-socket activity (out-of-path lsof probe).
-                // api_in_flight=true while pattern-state is "idle" ⇒ false-idle.
-                "api_in_flight": api_in_flight,
-                "last_api_activity_at": last_api_activity_at,
-                // #2413 Phase B: additive reducer status (state/confidence/authority/
-                // evidence-trail/since_ms). null unless the Shadow Observer flag is on.
-                "observed_status": observed_status,
-                "kind": "managed",
-            });
-            (name, entry)
-        })
-        .collect();
-    drop(reg);
-
-    // Disk I/O now runs WITHOUT the registry lock held.
-    let mut agents: Vec<Value> = Vec::with_capacity(snapshot.len());
-    for (name, mut entry) in snapshot {
-        let (dispatched_waiting_for, pending_response_to) =
-            crate::daemon::dispatch_idle::pending_for_instance(home, &name);
-        if let Some(obj) = entry.as_object_mut() {
-            obj.insert(
-                "dispatched_waiting_for".into(),
-                json!(dispatched_waiting_for),
-            );
-            obj.insert("pending_response_to".into(), json!(pending_response_to));
-        }
-        agents.push(entry);
-    }
-    let ext = agent::lock_external(externals);
-    for (name, handle) in ext.iter() {
-        let (dispatched_waiting_for, pending_response_to) =
-            crate::daemon::dispatch_idle::pending_for_instance(home, name);
-        agents.push(json!({
-            "name": name,
-            "backend": handle.backend_command,
-            "agent_state": "external",
-            "health_state": "connected",
-            "kind": "external",
-            "pid": handle.pid,
-            "dispatched_waiting_for": dispatched_waiting_for,
-            "pending_response_to": pending_response_to,
-        }));
-    }
-    json!({"ok": true, "result": {"protocol_version": crate::framing::PROTOCOL_VERSION, "agents": agents}})
+    crate::agent_ops::list_snapshot(home, registry, externals)
 }
 
 pub(crate) fn handle_status(_params: &Value, ctx: &HandlerCtx) -> Value {

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -22,14 +22,6 @@ pub mod request_dedup;
 
 pub type ConfigRegistry = Arc<Mutex<HashMap<String, crate::daemon::AgentConfig>>>;
 
-pub(crate) fn list_response(
-    home: &std::path::Path,
-    registry: &crate::agent::AgentRegistry,
-    externals: &crate::agent::ExternalRegistry,
-) -> serde_json::Value {
-    handlers::query::list_response(home, registry, externals)
-}
-
 // ---------------------------------------------------------------------------
 // ApiNotifier — decouples api.rs from the TUI layer
 // ---------------------------------------------------------------------------

--- a/src/mcp/handlers/instance_queries.rs
+++ b/src/mcp/handlers/instance_queries.rs
@@ -306,4 +306,79 @@ mod tests {
 
         std::fs::remove_dir_all(&home).ok();
     }
+
+    /// #2454 S3 RED: `describe_instance` (the `instance` param path in
+    /// `list_instances`) must use the supplied RuntimeContext and succeed
+    /// with NO daemon / API listener.  Currently it delegates to
+    /// `handle_describe_instance` which calls `api::call` — this test
+    /// fails until the in-process path is wired.
+    #[test]
+    fn describe_instance_uses_runtime_context_without_api_listener_2454() {
+        let home = std::env::temp_dir().join(format!(
+            "agend-describe-runtime-2454-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&home).unwrap();
+        let registry = Arc::new(parking_lot::Mutex::new(HashMap::new()));
+        let (handle, _reader) = crate::daemon::per_tick::mock_live_agent_no_context("target-agent");
+        registry.lock().insert(handle.id, handle);
+        let externals = Arc::new(parking_lot::Mutex::new(HashMap::new()));
+        let runtime = RuntimeContext {
+            registry,
+            externals,
+            capability: crate::api::RestartCapability::Unsupported,
+            app_restart: None,
+            post_flush: None,
+        };
+
+        let result = handle_list_instances_with_runtime(
+            &home,
+            &json!({"instance": "target-agent"}),
+            "caller",
+            Some(&runtime),
+        );
+        assert!(
+            result.get("error").is_none(),
+            "describe via runtime must succeed without a daemon; got: {result}"
+        );
+        let inst = &result["instance"];
+        assert_eq!(
+            inst["name"].as_str(),
+            Some("target-agent"),
+            "describe must return the target instance from the runtime registry: {result}"
+        );
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #2454 S3 RED source invariant: production code in this module must
+    /// contain ZERO `crate::api::call` invocations.  Any loopback in the
+    /// instance-query path is a regression.
+    #[test]
+    fn no_production_api_call_in_instance_queries_2454() {
+        let source = include_str!("instance_queries.rs");
+        let needle_a = concat!("crate::", "api::", "call");
+        let needle_b = concat!("api::", "call(");
+        let in_test_mod = source.find("#[cfg(test)]").unwrap_or(source.len());
+        let production = &source[..in_test_mod];
+        let production_calls: Vec<(usize, &str)> = production
+            .lines()
+            .enumerate()
+            .filter(|(_, line)| {
+                let trimmed = line.trim();
+                !trimmed.starts_with("//") && !trimmed.starts_with("///")
+            })
+            .filter(|(_, line)| line.contains(needle_a) || line.contains(needle_b))
+            .collect();
+        assert!(
+            production_calls.is_empty(),
+            "instance_queries.rs must contain zero production api::call sites; found {}: {:?}",
+            production_calls.len(),
+            production_calls
+        );
+    }
 }

--- a/src/mcp/handlers/instance_queries.rs
+++ b/src/mcp/handlers/instance_queries.rs
@@ -296,6 +296,7 @@ mod tests {
     /// `handle_describe_instance` which calls `api::call` — this test
     /// fails until the in-process path is wired.
     #[test]
+    #[allow(clippy::unwrap_used)]
     fn describe_instance_uses_runtime_context_without_api_listener_2454() {
         let home = std::env::temp_dir().join(format!(
             "agend-describe-runtime-2454-{}-{}",

--- a/src/mcp/handlers/instance_queries.rs
+++ b/src/mcp/handlers/instance_queries.rs
@@ -9,26 +9,16 @@ pub(super) fn handle_list_instances_with_runtime(
     instance_name: &str,
     runtime: Option<&RuntimeContext>,
 ) -> Value {
-    // If `instance` param is provided, return detailed info for that instance (replaces describe_instance)
     if let Some(target) = args["instance"].as_str().filter(|s| !s.is_empty()) {
-        return handle_describe_instance(home, &json!({"name": target}));
+        return describe_instance(home, target, runtime);
     }
-    // #2475: compact-by-default for routine polling. The API LIST response still
-    // carries full `observed_status.evidence` for dashboards / describe paths;
-    // the MCP `list_instances` read tool strips that evidence unless explicitly
-    // requested, because agents poll this often and the evidence array is noisy
-    // context ballast. Set `verbose:true` or `include_evidence:true` for detail.
     let include_evidence = args["verbose"].as_bool().unwrap_or(false)
         || args["include_evidence"].as_bool().unwrap_or(false);
     let Some(runtime) = runtime else {
         return with_operator_mode(json!({"instances": list_agents(), "compact": true}));
     };
-    let resp = crate::api::list_response(home, &runtime.registry, &runtime.externals);
+    let resp = crate::agent_ops::list_snapshot(home, &runtime.registry, &runtime.externals);
     if let Some(agents) = resp["result"]["agents"].as_array() {
-        // #991 PR-C: load fleet.yaml ONCE for the whole batch (not per-agent)
-        // so operators can grep "which agents intentionally have no topic"
-        // via `list_instances` — previously only `describe_instance`
-        // (single-instance) exposed this field.
         let fleet_config =
             crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home)).ok();
         let instances: Vec<Value> = agents
@@ -44,8 +34,6 @@ pub(super) fn handle_list_instances_with_runtime(
                 if name == instance_name {
                     info["is_self"] = json!(true);
                 }
-                // Omit when unset (auto default) — matches describe_instance's
-                // existing omission convention, not an explicit "auto" value.
                 if let Some(mode) = fleet_config
                     .as_ref()
                     .and_then(|c| c.instances.get(name))
@@ -89,41 +77,36 @@ fn strip_observed_evidence(info: &mut Value) {
     }
 }
 
-pub(super) fn handle_describe_instance(home: &Path, args: &Value) -> Value {
-    let name = args["name"].as_str().unwrap_or("");
+fn describe_instance(home: &Path, name: &str, runtime: Option<&RuntimeContext>) -> Value {
     crate::validate_name_or_err!(name);
-    match crate::api::call(home, &json!({"method": crate::api::method::LIST})) {
-        Ok(resp) => {
-            match resp["result"]["agents"]
-                .as_array()
-                .and_then(|a| a.iter().find(|x| x["name"].as_str() == Some(name)))
-            {
-                Some(agent) => {
-                    let mut info = agent.clone();
-                    merge_metadata(home, name, &mut info);
-                    // Surface topic_id from topics.json + topic_binding_mode from fleet.yaml.
-                    if info.get("topic_id").is_none() {
-                        if let Some(tid) =
-                            crate::channel::telegram::lookup_topic_for_instance(home, name)
-                        {
-                            info["topic_id"] = json!(tid);
-                        }
-                    }
-                    if let Some(inst) =
-                        crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))
-                            .ok()
-                            .and_then(|c| c.instances.get(name).cloned())
-                    {
-                        if let Some(ref mode) = inst.topic_binding_mode {
-                            info["topic_binding_mode"] = json!(mode);
-                        }
-                    }
-                    json!({"instance": info})
+    let Some(runtime) = runtime else {
+        return json!({"error": "runtime context unavailable — describe requires a live registry"});
+    };
+    let resp = crate::agent_ops::list_snapshot(home, &runtime.registry, &runtime.externals);
+    match resp["result"]["agents"]
+        .as_array()
+        .and_then(|a| a.iter().find(|x| x["name"].as_str() == Some(name)))
+    {
+        Some(agent) => {
+            let mut info = agent.clone();
+            merge_metadata(home, name, &mut info);
+            if info.get("topic_id").is_none() {
+                if let Some(tid) = crate::channel::telegram::lookup_topic_for_instance(home, name) {
+                    info["topic_id"] = json!(tid);
                 }
-                None => json!({"error": format!("Instance '{name}' not found")}),
             }
+            if let Some(inst) =
+                crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))
+                    .ok()
+                    .and_then(|c| c.instances.get(name).cloned())
+            {
+                if let Some(ref mode) = inst.topic_binding_mode {
+                    info["topic_binding_mode"] = json!(mode);
+                }
+            }
+            json!({"instance": info})
         }
-        Err(e) => json!({"error": format!("API unavailable: {e}")}),
+        None => json!({"error": format!("Instance '{name}' not found")}),
     }
 }
 

--- a/src/mcp/handlers/instance_queries.rs
+++ b/src/mcp/handlers/instance_queries.rs
@@ -356,29 +356,36 @@ mod tests {
     }
 
     /// #2454 S3 RED source invariant: production code in this module must
-    /// contain ZERO `crate::api::call` invocations.  Any loopback in the
-    /// instance-query path is a regression.
+    /// contain ZERO references to the API query layer — neither socket
+    /// loopback (`api::call`) nor in-process API-layer calls
+    /// (`api::list_response`).  Instance queries must go through the
+    /// neutral agent_ops service, not the API wire layer.
     #[test]
-    fn no_production_api_call_in_instance_queries_2454() {
+    fn no_production_api_dependency_in_instance_queries_2454() {
         let source = include_str!("instance_queries.rs");
-        let needle_a = concat!("crate::", "api::", "call");
-        let needle_b = concat!("api::", "call(");
         let in_test_mod = source.find("#[cfg(test)]").unwrap_or(source.len());
         let production = &source[..in_test_mod];
-        let production_calls: Vec<(usize, &str)> = production
+        let needles: &[&str] = &[
+            concat!("crate::", "api::", "call"),
+            concat!("api::", "call("),
+            concat!("crate::", "api::", "list_response"),
+            concat!("api::", "list_response("),
+        ];
+        let violations: Vec<(usize, &str)> = production
             .lines()
             .enumerate()
             .filter(|(_, line)| {
                 let trimmed = line.trim();
                 !trimmed.starts_with("//") && !trimmed.starts_with("///")
             })
-            .filter(|(_, line)| line.contains(needle_a) || line.contains(needle_b))
+            .filter(|(_, line)| needles.iter().any(|n| line.contains(n)))
             .collect();
         assert!(
-            production_calls.is_empty(),
-            "instance_queries.rs must contain zero production api::call sites; found {}: {:?}",
-            production_calls.len(),
-            production_calls
+            violations.is_empty(),
+            "instance_queries.rs must contain zero production API-layer references \
+             (api::call OR api::list_response); found {}: {:?}",
+            violations.len(),
+            violations
         );
     }
 }

--- a/tests/review_api_query_lock_io_api.rs
+++ b/tests/review_api_query_lock_io_api.rs
@@ -34,10 +34,7 @@ fn list_snapshot_body(src: &str) -> Vec<(usize, String)> {
     for (i, raw) in src.lines().enumerate() {
         let trimmed = raw.trim_start();
         if !in_fn {
-            if trimmed.starts_with("pub(crate) fn list_snapshot(")
-                || trimmed.starts_with("fn list_snapshot(")
-                || trimmed.starts_with("pub fn list_snapshot(")
-            {
+            if raw.starts_with("pub(crate) fn list_snapshot(") {
                 in_fn = true;
                 out.push((i + 1, raw.to_string()));
             }

--- a/tests/review_api_query_lock_io_api.rs
+++ b/tests/review_api_query_lock_io_api.rs
@@ -1,56 +1,42 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
-//! Review-repro static invariant (scope: api).
+//! Review-repro static invariant (scope: list snapshot).
 //!
-//! Finding: "handle_list holds the global registry mutex across per-agent
+//! Finding: "list snapshot holds the global registry mutex across per-agent
 //! blocking disk I/O."
 //!
-//! `list_response` (src/api/handlers/query.rs) takes the tier-1 registry lock
-//! (`agent::lock_registry`) and then, INSIDE the `.map()` over
-//! `reg.values()`, calls
-//! `crate::daemon::dispatch_idle::pending_for_instance(ctx.home, name)` for
-//! every managed agent while the lock is STILL held. `pending_for_instance`
-//! → `list_pending(home)` does a full `read_dir` plus a `read_to_string` +
-//! `serde_json::from_str` per `.json` sidecar — once per agent. So a LIST
-//! with N agents performs N directory scans + N*M file reads/parses
-//! entirely under the registry lock, blocking ~30 daemon per-tick handlers,
-//! the supervisor tick, crash-respawn, hang-detection, and the TUI render
-//! path that all need the same lock.
+//! `list_snapshot` (src/agent_ops.rs — extracted from the former
+//! api::handlers::query::list_response by #2454 S3) takes the tier-1
+//! registry lock (`agent::lock_registry`) and must DROP it before any
+//! per-agent `pending_for_instance` disk I/O.
 //!
 //! The runtime "lock held across IO" cannot be driven without a timing
 //! race, so this is a SOURCE-SCANNING invariant (the codebase's first-class
 //! method for held-lock invariants, mirroring tests/core_mutex_invariant.rs
 //! and tests/anti_pattern_invariant.rs). It asserts that within
-//! `list_response`, NO `pending_for_instance` call appears between the
+//! `list_snapshot`, NO `pending_for_instance` call appears between the
 //! `lock_registry` acquisition and the matching `drop(reg)`.
-//!
-//! RED now: `pending_for_instance` is called inside the `.map()` closure
-//! before `drop(reg)`. GREEN after the fix snapshots the per-agent fields
-//! under the lock, drops `reg`, and only THEN calls `pending_for_instance`
-//! (or calls `list_pending` once up front and filters in memory).
 
 use std::path::PathBuf;
 
-fn query_rs() -> PathBuf {
+fn list_snapshot_source() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("src")
-        .join("api")
-        .join("handlers")
-        .join("query.rs")
+        .join("agent_ops.rs")
 }
 
-/// Extract the body lines of `list_response` (from its `fn` signature to the
+/// Extract the body lines of `list_snapshot` (from its `fn` signature to the
 /// next top-level `fn ` at the same indentation). Returns 1-based line
 /// numbers paired with the line text, comment/doc lines stripped.
-fn list_response_body(src: &str) -> Vec<(usize, String)> {
+fn list_snapshot_body(src: &str) -> Vec<(usize, String)> {
     let mut out = Vec::new();
     let mut in_fn = false;
     for (i, raw) in src.lines().enumerate() {
         let trimmed = raw.trim_start();
         if !in_fn {
-            if trimmed.starts_with("pub(crate) fn list_response(")
-                || trimmed.starts_with("fn list_response(")
-                || trimmed.starts_with("pub fn list_response(")
+            if trimmed.starts_with("pub(crate) fn list_snapshot(")
+                || trimmed.starts_with("fn list_snapshot(")
+                || trimmed.starts_with("pub fn list_snapshot(")
             {
                 in_fn = true;
                 out.push((i + 1, raw.to_string()));
@@ -58,17 +44,14 @@ fn list_response_body(src: &str) -> Vec<(usize, String)> {
             continue;
         }
         // Stop at the start of the NEXT top-level function definition.
-        if trimmed.starts_with("pub(crate) fn ")
+        if (trimmed.starts_with("pub(crate) fn ")
             || trimmed.starts_with("pub fn ")
-            || (trimmed.starts_with("fn ") && !raw.starts_with(' '))
+            || trimmed.starts_with("fn "))
+            && !trimmed.starts_with("fn list_snapshot(")
+            && (!raw.starts_with(' ') || raw.starts_with("pub"))
         {
-            // A new top-level fn at column 0 ends handle_list.
-            if !raw.starts_with(' ') || raw.starts_with("pub") {
-                break;
-            }
+            break;
         }
-        // Strip comment / doc lines so a comment mentioning the pattern
-        // can't trip the scan.
         if trimmed.starts_with("//") || trimmed.starts_with('*') {
             continue;
         }
@@ -79,41 +62,36 @@ fn list_response_body(src: &str) -> Vec<(usize, String)> {
 
 #[test]
 fn list_response_does_not_hold_registry_lock_across_dispatch_idle_io_api() {
-    let path = query_rs();
-    let src = std::fs::read_to_string(&path).expect("read query.rs");
-    let body = list_response_body(&src);
+    let path = list_snapshot_source();
+    let src = std::fs::read_to_string(&path).expect("read agent_ops.rs");
+    let body = list_snapshot_body(&src);
     assert!(
         !body.is_empty(),
-        "could not locate list_response in {}",
+        "could not locate list_snapshot in {}",
         path.display()
     );
 
-    // Find the registry-lock acquisition and the matching drop within the
-    // function body.
     let lock_idx = body
         .iter()
         .position(|(_, l)| l.contains("lock_registry("))
-        .expect("list_response must acquire the registry lock");
+        .expect("list_snapshot must acquire the registry lock");
     let drop_idx = body
         .iter()
         .skip(lock_idx)
         .position(|(_, l)| l.contains("drop(reg)"))
         .map(|p| p + lock_idx)
-        .expect("list_response must release the registry lock with drop(reg)");
+        .expect("list_snapshot must release the registry lock with drop(reg)");
 
-    // Any pending_for_instance (or list_pending) call BETWEEN the lock and
-    // the drop is the bug: per-agent blocking disk I/O under the tier-1
-    // registry lock.
     let mut offenders = Vec::new();
     for (line_no, line) in &body[lock_idx..=drop_idx] {
         if line.contains("pending_for_instance") || line.contains("list_pending") {
-            offenders.push(format!("query.rs:{line_no}: {}", line.trim()));
+            offenders.push(format!("agent_ops.rs:{line_no}: {}", line.trim()));
         }
     }
 
     assert!(
         offenders.is_empty(),
-        "list_response calls dispatch_idle disk I/O WHILE holding the tier-1 \
+        "list_snapshot calls dispatch_idle disk I/O WHILE holding the tier-1 \
          registry lock (between lock_registry and drop(reg)). This blocks \
          every other API handler, the supervisor tick, crash-respawn, \
          hang-detection, and the TUI render path under disk contention. \

--- a/tests/review_api_query_lock_io_api.rs
+++ b/tests/review_api_query_lock_io_api.rs
@@ -100,3 +100,26 @@ fn list_response_does_not_hold_registry_lock_across_dispatch_idle_io_api() {
         offenders.join("\n")
     );
 }
+
+/// #2454 S3 r2 RED: an indented/nested `fn list_snapshot(` decoy must NOT
+/// be selected by the extraction helper.  The current `trim_start`-based
+/// discovery accepts indented lines, so a nested decoy produces a
+/// non-empty body — this test fails until the helper requires column-0.
+#[test]
+fn indented_list_snapshot_decoy_must_not_be_selected() {
+    let decoy = "\
+        fn other() {\n\
+            fn list_snapshot(home: &Path) -> Value {\n\
+                lock_registry(r);\n\
+                drop(reg);\n\
+            }\n\
+        }\n";
+    let body = list_snapshot_body(decoy);
+    assert!(
+        body.is_empty(),
+        "an indented/nested list_snapshot must not be selected; \
+         got {} lines: {:?}",
+        body.len(),
+        body
+    );
+}


### PR DESCRIPTION
## Summary

- Extract `list_response` logic from `api::handlers::query` to `agent_ops::list_snapshot` — a neutral typed in-process boundary
- Both API LIST wire handler and MCP instance queries call `agent_ops::list_snapshot` directly, breaking the MCP→API compile dependency for the instance-query loopback family
- `describe_instance` now uses supplied `RuntimeContext` in-process (no `api::call` socket loopback); `runtime=None` returns an explicit error

## Changes (4 files)

- **`src/agent_ops.rs`**: new `list_snapshot(home, registry, externals)` — owns lock-drop-before-disk-I/O ordering, managed/external agent serialisation, dispatch_idle enrichment
- **`src/api/handlers/query.rs`**: `list_response` becomes thin adapter calling `agent_ops::list_snapshot`; unused `self` import removed
- **`src/api/mod.rs`**: dead `list_response` re-export removed (zero callers after MCP migration)
- **`src/mcp/handlers/instance_queries.rs`**: list path uses `agent_ops::list_snapshot`; `describe_instance` accepts `RuntimeContext`, uses `list_snapshot` in-process; source invariant rejects both `api::call` AND `api::list_response`

## Semantics preserved

- Full/compact/evidence modes
- External agent entries
- Metadata merge, topic_id lookup, topic_binding_mode
- operator_mode, is_self marker
- Lock-drop-before-disk-I/O ordering

## Test evidence

- **RED commits**: `cae11291` (behavioral + api::call invariant), `f8c59a93` (supplemental api::list_response invariant)
- **GREEN**: `33af5649` — 8/8 instance_queries tests pass (incl. both former REDs); describe_instance_response_shape_has_required_keys passes
- `cargo clippy --bin agend-terminal --no-default-features -- -D warnings` clean
- `cargo fmt -- --check` clean

Advances #2454 (Slice 3 — instance query loopback family; remaining loopback families still open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)