### PR TITLE
fix(#2454 S4): shared inject_input service, migrate MCP interrupt

### DIFF
--- a/src/agent_ops.rs
+++ b/src/agent_ops.rs
@@ -864,6 +864,87 @@ pub(crate) fn list_snapshot(
     json!({"ok": true, "result": {"protocol_version": crate::framing::PROTOCOL_VERSION, "agents": agents}})
 }
 
+/// #2454 S4: neutral typed input-injection service.  Shared by the API
+/// INJECT wire handler and the MCP interrupt path — neither owns the
+/// registry lookup, operated-state gate, or PTY write logic.
+pub(crate) fn inject_input(
+    registry: &AgentRegistry,
+    externals: &crate::agent::ExternalRegistry,
+    home: &std::path::Path,
+    target: &str,
+    data: &[u8],
+    raw: bool,
+) -> Result<usize, InjectError> {
+    if let Err(e) = agent::validate_name(target) {
+        return Err(InjectError::Validation(e));
+    }
+    let snap = {
+        let reg = agent::lock_registry(registry);
+        crate::fleet::resolve_uuid(home, target)
+            .and_then(|id| reg.get(&id))
+            .map(|handle| {
+                let operated_state = {
+                    let core = handle.core.lock();
+                    crate::daemon::shadow::operated_state(
+                        core.state.current,
+                        core.observed_status.as_ref(),
+                    )
+                };
+                (agent::InjectTarget::from_handle(handle), operated_state)
+            })
+    };
+    match snap {
+        Some((tgt, operated_state)) => {
+            if operated_state.is_unavailable() {
+                let state_name = operated_state.display_name();
+                return Err(InjectError::Unavailable(format!(
+                    "agent '{target}' is {state_name}, retry later"
+                )));
+            }
+            let result = if raw {
+                agent::write_to_pty(&tgt.pty_writer, data)
+            } else {
+                agent::inject_with_target_gated(&tgt, target, data, true, None)
+            };
+            match result {
+                Ok(()) => Ok(data.len()),
+                Err(e) => Err(InjectError::Write(format!("{e}"))),
+            }
+        }
+        None => {
+            let ext = agent::lock_external(externals);
+            if ext.contains_key(target) {
+                Err(InjectError::External(format!(
+                    "agent '{target}' is external — use send instead of inject"
+                )))
+            } else {
+                Err(InjectError::NotFound(format!("agent '{target}' not found")))
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum InjectError {
+    Validation(String),
+    Unavailable(String),
+    External(String),
+    NotFound(String),
+    Write(String),
+}
+
+impl std::fmt::Display for InjectError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Validation(e)
+            | Self::Unavailable(e)
+            | Self::External(e)
+            | Self::NotFound(e)
+            | Self::Write(e) => f.write_str(e),
+        }
+    }
+}
+
 /// Spawn a single agent into `registry` and start its TUI-serve thread.
 /// Shared by the SPAWN and CREATE_TEAM API handlers.
 ///

--- a/src/api/handlers/instance.rs
+++ b/src/api/handlers/instance.rs
@@ -5,67 +5,22 @@ use crate::agent;
 use crate::api::{ApiEvent, LayoutHint, PaneMoveSplitDir};
 use serde_json::{json, Value};
 
+/// #2454 S4: thin wire adapter — delegates to the neutral
+/// `agent_ops::inject_input` service that owns the implementation.
 pub(crate) fn handle_inject(params: &Value, ctx: &HandlerCtx) -> Value {
     let name = params["name"].as_str().unwrap_or("");
-    if let Err(e) = agent::validate_name(name) {
-        return json!({"ok": false, "error": e});
-    }
     let data = params["data"].as_str().unwrap_or("");
     let raw = params["raw"].as_bool().unwrap_or(false);
-    // #1530/F1: snapshot the inject target (+ the restarting check) under the
-    // registry lock, then RELEASE it before the (up to 5s + payload-scaled)
-    // blocking PTY write — never hold the registry across write/inject.
-    // #1441: registry is UUID-keyed; resolve name via fleet.yaml.
-    let snap = {
-        let reg = agent::lock_registry(ctx.registry);
-        crate::fleet::resolve_uuid(ctx.home, name)
-            .and_then(|id| reg.get(&id))
-            .map(|handle| {
-                // #2465: routed through operated_state for single-source consistency with the
-                // other decision consumers (#1493) — NOT a behavioral change here today.
-                // `is_unavailable` = Crashed|Restarting; the gate keeps Crashed raw (non-decisive
-                // screen) and only overrides on a COARSE disagreement (rule d), so a fresh Active
-                // hook AGREES with Restarting's Working baseline and does NOT flip is_unavailable.
-                // This diverges from raw only for a cross-coarse Hook/Stream correction (e.g.
-                // raw=Restarting + Hook=WaitingForUser/RateLimited — more relevant after #2466).
-                // Lock scoped + dropped before `from_handle` to preserve the single-acquisition order.
-                let operated_state = {
-                    let core = handle.core.lock();
-                    crate::daemon::shadow::operated_state(
-                        core.state.current,
-                        core.observed_status.as_ref(),
-                    )
-                };
-                (agent::InjectTarget::from_handle(handle), operated_state)
-            })
-    };
-    match snap {
-        Some((tgt, operated_state)) => {
-            if operated_state.is_unavailable() {
-                let state_name = operated_state.display_name();
-                json!({"ok": false, "error": format!("agent '{name}' is {state_name}, retry later")})
-            } else {
-                let result = if raw {
-                    agent::write_to_pty(&tgt.pty_writer, data.as_bytes())
-                } else {
-                    // #1769: the api INJECT path carries operator/relay data (and
-                    // its own headers) — not a daemon auto-nudge → no marker.
-                    agent::inject_with_target_gated(&tgt, name, data.as_bytes(), true, None)
-                };
-                match result {
-                    Ok(()) => json!({"ok": true, "result": {"bytes": data.len()}}),
-                    Err(e) => json!({"ok": false, "error": format!("{e}")}),
-                }
-            }
-        }
-        None => {
-            let ext = agent::lock_external(ctx.externals);
-            if ext.contains_key(name) {
-                json!({"ok": false, "error": format!("agent '{name}' is external — use send instead of inject")})
-            } else {
-                json!({"ok": false, "error": format!("agent '{name}' not found")})
-            }
-        }
+    match crate::agent_ops::inject_input(
+        ctx.registry,
+        ctx.externals,
+        ctx.home,
+        name,
+        data.as_bytes(),
+        raw,
+    ) {
+        Ok(bytes) => json!({"ok": true, "result": {"bytes": bytes}}),
+        Err(e) => json!({"ok": false, "error": format!("{e}")}),
     }
 }
 

--- a/src/mcp/handlers/instance_metadata.rs
+++ b/src/mcp/handlers/instance_metadata.rs
@@ -45,55 +45,45 @@ pub(super) fn handle_set_description(home: &Path, args: &Value, instance_name: &
     set_string_attr(home, instance_name, desc, "description", 1024)
 }
 
+/// #2454 S4: MCP interrupt uses the neutral `agent_ops::inject_input`
+/// service in-process via RuntimeContext — no api::call loopback.
 pub(super) fn handle_interrupt(
     home: &Path,
     args: &Value,
     runtime: Option<&RuntimeContext>,
-) -> Value {
-    handle_interrupt_impl(home, args, runtime, &crate::api::call)
-}
-
-/// Inner impl parameterized on the INJECT RPC — the deterministic test seam
-/// (patterned on `spawn_single_instance_impl`). Production passes
-/// [`crate::api::call`]; a test injects a stub so the interrupt(snapshot=true)
-/// path can be exercised with no live daemon. #2454: the INJECT self-IPC stays a
-/// loopback (untouched, separate op), but the optional post-interrupt snapshot
-/// now runs IN-PROCESS via `agent_ops::pane_scrollback`.
-fn handle_interrupt_impl(
-    home: &Path,
-    args: &Value,
-    runtime: Option<&RuntimeContext>,
-    inject_fn: &dyn Fn(&Path, &Value) -> anyhow::Result<Value>,
 ) -> Value {
     let target = match super::require_instance(args) {
         Ok(t) => t,
         Err(e) => return e,
     };
     crate::validate_name_or_err!(target);
-    match inject_fn(home, &super::interrupt_esc_params(target)) {
-        Ok(resp) if resp["ok"].as_bool() == Some(true) => {
+    let Some(runtime) = runtime else {
+        return json!({"error": "runtime unavailable: interrupt requires the in-process daemon runtime"});
+    };
+    match crate::agent_ops::inject_input(
+        &runtime.registry,
+        &runtime.externals,
+        home,
+        target,
+        b"\x1b",
+        true,
+    ) {
+        Ok(_) => {
             if let Some(reason) = args["reason"].as_str() {
                 let header = crate::inbox::format_event_header("interrupt", &[("reason", reason)]);
                 crate::inbox::compose_aware_inject(home, target, &header);
             }
             let mut result = json!({"ok": true, "target": target});
             if args["snapshot"].as_bool() == Some(true) {
-                // #2454: best-effort in-process snapshot (no api::call). A missing
-                // runtime or a lookup miss simply OMITS the snapshot — it never
-                // turns a successful interrupt into a failure (same intent as the
-                // former `if let Ok(snap) = api::call { if snap.ok {…} }`).
-                if let Some(text) = runtime.and_then(|rt| {
-                    crate::agent_ops::pane_scrollback(&rt.registry, home, target, 40)
-                }) {
+                if let Some(text) =
+                    crate::agent_ops::pane_scrollback(&runtime.registry, home, target, 40)
+                {
                     result["snapshot"] = json!(text);
                 }
             }
             result
         }
-        Ok(resp) => json!({"error": resp["error"].as_str().unwrap_or("inject failed")}),
-        Err(e) => {
-            json!({"error": format!("interrupt failed — agent '{target}' not reachable (API unavailable: {e})")})
-        }
+        Err(e) => json!({"error": e.to_string()}),
     }
 }
 
@@ -403,7 +393,8 @@ mod blocked_reason_runtime_2454_tests {
             format!("instances:\n  {name}:\n    id: {}\n", id.full()),
         )
         .expect("seed fleet.yaml");
-        let handle = mk_test_handle(name, id);
+        let mut handle = mk_test_handle(name, id);
+        handle.pty_writer = Arc::new(Mutex::new(Box::new(std::io::sink())));
         let rt = RuntimeContext {
             registry: Arc::new(Mutex::new(HashMap::from([(id, handle)]))),
             externals: Arc::new(Mutex::new(HashMap::new())),
@@ -520,47 +511,29 @@ mod blocked_reason_runtime_2454_tests {
     }
 
     #[test]
-    fn interrupt_snapshot_runs_in_process_and_is_best_effort() {
+    fn interrupt_snapshot_runs_in_process_and_runtime_none_errors() {
         let (rt, home) = runtime_with_agent("agent-x");
-        let inject_ok = |_: &Path, _: &Value| -> anyhow::Result<Value> { Ok(json!({"ok": true})) };
-        // snapshot=true + runtime present → snapshot populated IN-PROCESS (no daemon).
-        let with_snap = handle_interrupt_impl(
+        let with_snap = handle_interrupt(
             &home,
             &json!({"instance": "agent-x", "snapshot": true}),
             Some(&rt),
-            &inject_ok,
         );
         assert_eq!(with_snap["ok"].as_bool(), Some(true), "{with_snap}");
         assert!(
             with_snap["snapshot"].is_string(),
             "snapshot must be populated in-process: {with_snap}"
         );
-        // runtime=None → snapshot OMITTED, interrupt still succeeds (best-effort).
-        let no_rt = handle_interrupt_impl(
+        let no_rt = handle_interrupt(
             &home,
             &json!({"instance": "agent-x", "snapshot": true}),
             None,
-            &inject_ok,
-        );
-        assert_eq!(no_rt["ok"].as_bool(), Some(true), "{no_rt}");
-        assert!(
-            no_rt.get("snapshot").is_none(),
-            "no runtime → snapshot omitted, interrupt still ok: {no_rt}"
-        );
-        // INJECT failure still fails the interrupt (unchanged).
-        let inject_err = |_: &Path, _: &Value| -> anyhow::Result<Value> { anyhow::bail!("boom") };
-        let failed = handle_interrupt_impl(
-            &home,
-            &json!({"instance": "agent-x", "snapshot": true}),
-            Some(&rt),
-            &inject_err,
         );
         assert!(
-            failed["error"]
+            no_rt["error"]
                 .as_str()
                 .unwrap_or_default()
-                .contains("not reachable"),
-            "INJECT failure must fail the interrupt: {failed}"
+                .contains("runtime"),
+            "runtime=None must be an explicit error: {no_rt}"
         );
     }
 

--- a/src/mcp/handlers/instance_metadata.rs
+++ b/src/mcp/handlers/instance_metadata.rs
@@ -535,6 +535,12 @@ mod blocked_reason_runtime_2454_tests {
                 .contains("runtime"),
             "runtime=None must be an explicit error: {no_rt}"
         );
+        let missing = handle_interrupt(&home, &json!({"instance": "missing"}), Some(&rt));
+        assert_eq!(
+            missing["error"].as_str(),
+            Some("agent 'missing' not found"),
+            "unknown target must surface exact domain error: {missing}"
+        );
     }
 
     /// #2454 S4 immutable RED: `handle_interrupt` with a live

--- a/src/mcp/handlers/instance_metadata.rs
+++ b/src/mcp/handlers/instance_metadata.rs
@@ -563,4 +563,76 @@ mod blocked_reason_runtime_2454_tests {
             "INJECT failure must fail the interrupt: {failed}"
         );
     }
+
+    /// #2454 S4 RED: `handle_interrupt` with a RuntimeContext and a live
+    /// mock agent must succeed without a daemon / API listener. Currently
+    /// fails because the inject path calls `api::call` (socket loopback).
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn interrupt_uses_runtime_context_without_api_listener_2454() {
+        let home = std::env::temp_dir().join(format!(
+            "agend-interrupt-runtime-2454-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&home).unwrap();
+        let registry = Arc::new(parking_lot::Mutex::new(HashMap::new()));
+        let (handle, _reader) = crate::daemon::per_tick::mock_live_agent_no_context("target-agent");
+        registry.lock().insert(handle.id, handle);
+        let externals = Arc::new(parking_lot::Mutex::new(HashMap::new()));
+        let runtime = RuntimeContext {
+            registry,
+            externals,
+            capability: crate::api::RestartCapability::Unsupported,
+            app_restart: None,
+            post_flush: None,
+        };
+
+        let result = handle_interrupt(&home, &json!({"name": "target-agent"}), Some(&runtime));
+        assert!(
+            result.get("error").is_none(),
+            "interrupt via runtime must succeed without a daemon; got: {result}"
+        );
+        assert_eq!(
+            result["ok"].as_bool(),
+            Some(true),
+            "interrupt must return ok:true on success: {result}"
+        );
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #2454 S4 RED source invariant: production code in handle_interrupt
+    /// and handle_interrupt_impl must contain ZERO `api::call` references.
+    /// The inject path must use a neutral in-process service.
+    #[test]
+    fn no_production_api_call_in_interrupt_handler_2454() {
+        let source = include_str!("instance_metadata.rs");
+        let in_test_mod = source.find("#[cfg(test)]").unwrap_or(source.len());
+        let production = &source[..in_test_mod];
+        let needle_a = concat!("crate::", "api::", "call");
+        let needle_b = concat!("api::", "call(");
+        let needle_c = concat!("api::", "call)");
+        let violations: Vec<(usize, &str)> = production
+            .lines()
+            .enumerate()
+            .filter(|(_, line)| {
+                let trimmed = line.trim();
+                !trimmed.starts_with("//") && !trimmed.starts_with("///")
+            })
+            .filter(|(_, line)| {
+                line.contains(needle_a) || line.contains(needle_b) || line.contains(needle_c)
+            })
+            .collect();
+        assert!(
+            violations.is_empty(),
+            "instance_metadata.rs interrupt handlers must contain zero production \
+             api::call references; found {}: {:?}",
+            violations.len(),
+            violations
+        );
+    }
 }

--- a/src/mcp/handlers/instance_metadata.rs
+++ b/src/mcp/handlers/instance_metadata.rs
@@ -564,75 +564,93 @@ mod blocked_reason_runtime_2454_tests {
         );
     }
 
-    /// #2454 S4 RED: `handle_interrupt` with a RuntimeContext and a live
-    /// mock agent must succeed without a daemon / API listener. Currently
-    /// fails because the inject path calls `api::call` (socket loopback).
+    /// #2454 S4 RED (supplemental): `handle_interrupt` with a live
+    /// RuntimeContext (seeded fleet.yaml/UUID) must succeed without a
+    /// daemon. Currently fails because the inject path uses `api::call`
+    /// (socket loopback) — the error must mention API/unavailable.
     #[test]
-    #[allow(clippy::unwrap_used)]
     fn interrupt_uses_runtime_context_without_api_listener_2454() {
-        let home = std::env::temp_dir().join(format!(
-            "agend-interrupt-runtime-2454-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_nanos()
-        ));
-        std::fs::create_dir_all(&home).unwrap();
-        let registry = Arc::new(parking_lot::Mutex::new(HashMap::new()));
-        let (handle, _reader) = crate::daemon::per_tick::mock_live_agent_no_context("target-agent");
-        registry.lock().insert(handle.id, handle);
-        let externals = Arc::new(parking_lot::Mutex::new(HashMap::new()));
-        let runtime = RuntimeContext {
-            registry,
-            externals,
-            capability: crate::api::RestartCapability::Unsupported,
-            app_restart: None,
-            post_flush: None,
-        };
-
-        let result = handle_interrupt(&home, &json!({"name": "target-agent"}), Some(&runtime));
+        let (rt, home) = runtime_with_agent("agent-x");
+        let result = handle_interrupt(&home, &json!({"instance": "agent-x"}), Some(&rt));
+        let err = result["error"].as_str().unwrap_or("");
         assert!(
-            result.get("error").is_none(),
-            "interrupt via runtime must succeed without a daemon; got: {result}"
+            err.contains("API unavailable") || err.contains("not reachable"),
+            "RED: current interrupt must fail via api::call loopback; got: {result}"
         );
-        assert_eq!(
-            result["ok"].as_bool(),
-            Some(true),
-            "interrupt must return ok:true on success: {result}"
-        );
-
+        // GREEN expectation (uncomment after migration):
+        // assert!(result.get("error").is_none(), "interrupt via runtime must succeed: {result}");
+        // assert_eq!(result["ok"].as_bool(), Some(true), "ok:true expected: {result}");
         std::fs::remove_dir_all(&home).ok();
     }
 
-    /// #2454 S4 RED source invariant: production code in handle_interrupt
-    /// and handle_interrupt_impl must contain ZERO `api::call` references.
-    /// The inject path must use a neutral in-process service.
+    /// #2454 S4 RED source invariant: the MCP interrupt region
+    /// (handle_interrupt through handle_set_waiting_on) must contain
+    /// ZERO `api::call` references.  Scoped to exclude MOVE_PANE.
     #[test]
-    fn no_production_api_call_in_interrupt_handler_2454() {
+    fn no_api_call_in_interrupt_region_2454() {
         let source = include_str!("instance_metadata.rs");
-        let in_test_mod = source.find("#[cfg(test)]").unwrap_or(source.len());
-        let production = &source[..in_test_mod];
+        let start_marker = concat!("pub(super) fn handle_", "interrupt(");
+        let end_marker = concat!("pub(super) fn handle_set_", "waiting_on(");
+        let start = source.find(start_marker).expect("interrupt region start");
+        let end = source[start..]
+            .find(end_marker)
+            .map(|p| p + start)
+            .expect("interrupt region end");
+        let region = &source[start..end];
         let needle_a = concat!("crate::", "api::", "call");
         let needle_b = concat!("api::", "call(");
         let needle_c = concat!("api::", "call)");
-        let violations: Vec<(usize, &str)> = production
+        let violations: Vec<&str> = region
             .lines()
-            .enumerate()
-            .filter(|(_, line)| {
+            .filter(|line| {
                 let trimmed = line.trim();
                 !trimmed.starts_with("//") && !trimmed.starts_with("///")
             })
-            .filter(|(_, line)| {
+            .filter(|line| {
                 line.contains(needle_a) || line.contains(needle_b) || line.contains(needle_c)
             })
             .collect();
         assert!(
             violations.is_empty(),
-            "instance_metadata.rs interrupt handlers must contain zero production \
-             api::call references; found {}: {:?}",
+            "MCP interrupt region must contain zero api::call; found {}: {:?}",
             violations.len(),
             violations
+        );
+    }
+
+    /// #2454 S4 RED shared-service invariant: after GREEN, both the MCP
+    /// interrupt region AND the API handle_inject adapter must reference
+    /// `agent_ops::inject_input` — the frozen neutral service name.
+    /// Currently neither does.
+    #[test]
+    fn shared_inject_input_service_referenced_by_both_callers_2454() {
+        let service = concat!("agent_ops::", "inject_input");
+        let mcp_src = include_str!("instance_metadata.rs");
+        let mcp_start = mcp_src
+            .find(concat!("pub(super) fn handle_", "interrupt("))
+            .expect("MCP interrupt start");
+        let mcp_end = mcp_src[mcp_start..]
+            .find(concat!("pub(super) fn handle_set_", "waiting_on("))
+            .map(|p| p + mcp_start)
+            .expect("MCP interrupt end");
+        let mcp_region = &mcp_src[mcp_start..mcp_end];
+        let mcp_has = mcp_region.contains(service);
+
+        let api_src = include_str!("../../api/handlers/instance.rs");
+        let api_start = api_src
+            .find(concat!("pub(crate) fn handle_", "inject("))
+            .expect("API handle_inject start");
+        let api_end_marker = api_src[api_start..]
+            .find("\npub")
+            .map(|p| p + api_start)
+            .unwrap_or(api_src.len());
+        let api_region = &api_src[api_start..api_end_marker];
+        let api_has = api_region.contains(service);
+
+        assert!(
+            mcp_has && api_has,
+            "both MCP interrupt and API handle_inject must reference the neutral \
+             agent_ops::inject_input service; MCP={mcp_has}, API={api_has}"
         );
     }
 }

--- a/src/mcp/handlers/instance_metadata.rs
+++ b/src/mcp/handlers/instance_metadata.rs
@@ -564,22 +564,23 @@ mod blocked_reason_runtime_2454_tests {
         );
     }
 
-    /// #2454 S4 RED (supplemental): `handle_interrupt` with a live
+    /// #2454 S4 immutable RED: `handle_interrupt` with a live
     /// RuntimeContext (seeded fleet.yaml/UUID) must succeed without a
-    /// daemon. Currently fails because the inject path uses `api::call`
-    /// (socket loopback) — the error must mention API/unavailable.
+    /// daemon. This test is IMMUTABLE — GREEN makes it pass without
+    /// editing this assertion.
     #[test]
     fn interrupt_uses_runtime_context_without_api_listener_2454() {
         let (rt, home) = runtime_with_agent("agent-x");
         let result = handle_interrupt(&home, &json!({"instance": "agent-x"}), Some(&rt));
-        let err = result["error"].as_str().unwrap_or("");
         assert!(
-            err.contains("API unavailable") || err.contains("not reachable"),
-            "RED: current interrupt must fail via api::call loopback; got: {result}"
+            result.get("error").is_none(),
+            "interrupt via runtime must succeed without a daemon; got: {result}"
         );
-        // GREEN expectation (uncomment after migration):
-        // assert!(result.get("error").is_none(), "interrupt via runtime must succeed: {result}");
-        // assert_eq!(result["ok"].as_bool(), Some(true), "ok:true expected: {result}");
+        assert_eq!(
+            result["ok"].as_bool(),
+            Some(true),
+            "interrupt must return ok:true on success: {result}"
+        );
         std::fs::remove_dir_all(&home).ok();
     }
 

--- a/src/mcp/handlers/mod.rs
+++ b/src/mcp/handlers/mod.rs
@@ -92,16 +92,6 @@ pub(super) fn require_instance(args: &Value) -> Result<&str, Value> {
     }
 }
 
-/// Build the INJECT API params for an interrupt ESC byte injection.
-/// Extracted for testability — unit tests verify the exact params
-/// without needing a running daemon.
-pub fn interrupt_esc_params(target: &str) -> Value {
-    json!({
-        "method": crate::api::method::INJECT,
-        "params": {"name": target, "data": "\x1b", "raw": true}
-    })
-}
-
 // Re-export for tests that use `use super::*`.
 #[cfg(test)]
 use instance::resolve_team_layout;

--- a/src/mcp/handlers/tests.rs
+++ b/src/mcp/handlers/tests.rs
@@ -1923,20 +1923,6 @@ fn test_delegate_task_no_second_reviewer_flag_default_behavior() {
 // ── interrupt tool tests ──
 
 #[test]
-fn test_interrupt_esc_params_contains_exact_esc_byte() {
-    let params = super::interrupt_esc_params("my-agent");
-    assert_eq!(params["method"], "inject");
-    assert_eq!(params["params"]["name"], "my-agent");
-    // Verify the data field is exactly the ESC byte (0x1b)
-    let data = params["params"]["data"]
-        .as_str()
-        .expect("data must be string");
-    assert_eq!(data.len(), 1, "ESC byte must be exactly 1 byte");
-    assert_eq!(data.as_bytes()[0], 0x1b, "data must be ESC byte (0x1b)");
-    assert_eq!(params["params"]["raw"], true, "must be raw inject");
-}
-
-#[test]
 fn test_interrupt_reason_header_format() {
     let header = crate::inbox::format_event_header("interrupt", &[("reason", "priority task")]);
     assert!(header.contains("[AGEND-MSG]"), "must have header prefix");
@@ -1965,12 +1951,12 @@ fn test_interrupt_handler_validates_target() {
     let r = handle_tool("interrupt", &json!({"instance": "../escape"}), "caller");
     assert!(r.get("error").is_some());
 
-    // Valid target but no daemon → reaches inject path
+    // Valid target but no runtime → explicit error (no api::call fallback)
     let r = handle_tool("interrupt", &json!({"instance": "valid-agent"}), "caller");
     let err = r["error"].as_str().unwrap_or("");
     assert!(
-        err.contains("not reachable") || err.contains("API unavailable"),
-        "valid target must reach inject path: {err}"
+        err.contains("runtime"),
+        "valid target without runtime must return explicit runtime error: {err}"
     );
     std::env::remove_var("AGEND_HOME");
     std::fs::remove_dir_all(&home).ok();


### PR DESCRIPTION
## Summary

- Extract `agent_ops::inject_input` — neutral typed input-injection service shared by API INJECT and MCP interrupt
- API `handle_inject` becomes thin adapter; MCP `handle_interrupt` uses RuntimeContext in-process
- Deleted: `interrupt_esc_params` helper + test (obsolete loopback seam)
- runtime=None → explicit error (no api::call fallback)

## Changes (5 files)

- **`src/agent_ops.rs`**: new `inject_input(registry, externals, home, target, data, raw)` + `InjectError` enum
- **`src/api/handlers/instance.rs`**: `handle_inject` → thin adapter calling `agent_ops::inject_input`
- **`src/mcp/handlers/instance_metadata.rs`**: `handle_interrupt` uses `inject_input` via RuntimeContext; removed `handle_interrupt_impl` seam; fixture uses `io::sink()` PTY writer
- **`src/mcp/handlers/mod.rs`**: deleted `interrupt_esc_params`
- **`src/mcp/handlers/tests.rs`**: deleted obsolete `test_interrupt_esc_params`; updated characterization test for runtime=None

## Semantics preserved

- Name validation, UUID resolution, operated-state gate
- Lock-drop before PTY I/O
- Raw ESC write for interrupt, gated inject for non-raw
- Unavailable/external/not-found/validation/write error strings (verbatim)
- Reason header inject + best-effort snapshot
- Byte count in API response

## Test evidence

- RED commits: `71195e5f`, `b6eff978`, `681ef496` (behavioral + scoped invariant + shared-service)
- GREEN: `62822a71` + `f9c0df6d` (domain failure assertion)
- 9/9 instance_metadata tests pass (3x stable)
- `handle_inject_returns_ok_false_on_genuine_actor_write_failure_2620` passes
- `test_interrupt_handler_validates_target` passes (updated for runtime=None)
- Clippy `--all-targets --no-default-features` clean; fmt clean

Advances #2454 (Slice 4 — interrupt loopback family)

🤖 Generated with [Claude Code](https://claude.com/claude-code)