### PR TITLE
fix(#2454): route task liveness through runtime snapshot

### DIFF
--- a/src/mcp/handlers/dispatch.rs
+++ b/src/mcp/handlers/dispatch.rs
@@ -928,4 +928,157 @@ mod tests {
             );
         }
     }
+
+    // #2454 Slice 5 RED: task health/sweep must consume the live registry
+    // forwarded through the real MCP task dispatcher.  The current handler
+    // still self-IPC's through the API (or reads runtime state from disk), so
+    // these tests deterministically fail with no daemon/socket listener.
+    fn runtime_with_external(name: &str) -> RuntimeContext {
+        RuntimeContext {
+            registry: std::sync::Arc::new(
+                parking_lot::Mutex::new(std::collections::HashMap::new()),
+            ),
+            externals: std::sync::Arc::new(parking_lot::Mutex::new(
+                std::collections::HashMap::from([(
+                    name.to_string(),
+                    crate::agent::ExternalAgentHandle {
+                        backend_command: "codex".to_string(),
+                        pid: 4242,
+                    },
+                )]),
+            )),
+            capability: crate::api::RestartCapability::Unsupported,
+            app_restart: None,
+            post_flush: None,
+        }
+    }
+
+    fn task_runtime_ctx<'a>(
+        home: &'a Path,
+        args: &'a Value,
+        runtime: &'a RuntimeContext,
+    ) -> HandlerCtx<'a> {
+        static EMPTY_SENDER: Option<Sender> = None;
+        HandlerCtx {
+            home,
+            args,
+            instance_name: "operator",
+            sender: &EMPTY_SENDER,
+            runtime: Some(runtime),
+        }
+    }
+
+    fn backdate_task(home: &Path, task_id: &str) {
+        let path = home.join("task_events.jsonl");
+        let old = (chrono::Utc::now() - chrono::Duration::days(31)).to_rfc3339();
+        let content = std::fs::read_to_string(&path).expect("task event log");
+        let rewritten = content
+            .lines()
+            .map(|line| {
+                let mut value: Value = serde_json::from_str(line).expect("task event JSON");
+                if value["event"]["task_id"] == task_id {
+                    value["timestamp"] = json!(old);
+                }
+                serde_json::to_string(&value).expect("serialized task event")
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        std::fs::write(path, format!("{rewritten}\n")).expect("rewrite task event log");
+    }
+
+    #[test]
+    fn task_health_uses_supplied_runtime_without_api_listener_2454() {
+        let home = std::env::temp_dir().join(format!(
+            "agend-task-health-runtime-red-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&home).expect("create temp home");
+        let created = crate::tasks::handle(
+            &home,
+            "operator",
+            &json!({
+                "action": "create",
+                "title": "runtime-owned task",
+                "assignee": "live-agent"
+            }),
+        );
+        let task_id = created["id"].as_str().expect("created task id");
+        backdate_task(&home, task_id);
+
+        let args = json!({"action": "health"});
+        let runtime = runtime_with_external("live-agent");
+        let ctx = task_runtime_ctx(&home, &args, &runtime);
+        let result = try_dispatch("task", &ctx).expect("task dispatch result");
+        assert_eq!(
+            result["live_agents_available"], true,
+            "health must use the supplied live RuntimeContext without API fallback: {result}"
+        );
+        let strict_owners = result["ghost_owners"]["strict_owners"]
+            .as_array()
+            .expect("strict owner list");
+        assert!(
+            !strict_owners.iter().any(|owner| owner == "live-agent"),
+            "a supplied live owner must not be classified as strict/ghost: {result}"
+        );
+        std::fs::remove_dir_all(home).ok();
+    }
+
+    #[test]
+    fn task_sweep_uses_supplied_runtime_without_api_listener_2454() {
+        let home = std::env::temp_dir().join(format!(
+            "agend-task-sweep-runtime-red-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&home).expect("create temp home");
+        let created = crate::tasks::handle(
+            &home,
+            "operator",
+            &json!({
+                "action": "create",
+                "title": "runtime-owned stale task",
+                "assignee": "live-agent"
+            }),
+        );
+        let task_id = created["id"].as_str().expect("created task id");
+        backdate_task(&home, task_id);
+
+        let args = json!({"action": "sweep"});
+        let runtime = runtime_with_external("live-agent");
+        let ctx = task_runtime_ctx(&home, &args, &runtime);
+        let result = try_dispatch("task", &ctx).expect("task dispatch result");
+        assert_eq!(
+            result["dry_run"], true,
+            "sweep must return a dry-run plan: {result}"
+        );
+        let disbanded = result["categories"]["team_disbanded"]
+            .as_array()
+            .expect("team_disbanded category");
+        assert!(
+            !disbanded.iter().any(|candidate| candidate["id"] == task_id),
+            "a supplied live owner must not be classified as team-disbanded: {result}"
+        );
+        std::fs::remove_dir_all(home).ok();
+    }
+
+    #[test]
+    fn task_health_and_sweep_runtime_none_are_explicit_errors_2454() {
+        let home = std::env::temp_dir().join(format!(
+            "agend-task-runtime-none-red-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&home).expect("create temp home");
+        for action in ["health", "sweep"] {
+            let args = json!({"action": action});
+            let ctx = ctx_for(&home, &args, "operator");
+            let result = try_dispatch("task", &ctx).expect("task dispatch result");
+            assert!(
+                result["error"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .contains("runtime unavailable"),
+                "task action={action} with runtime=None must fail explicitly, never socket-fallback: {result}"
+            );
+        }
+        std::fs::remove_dir_all(home).ok();
+    }
 }

--- a/src/mcp/handlers/dispatch.rs
+++ b/src/mcp/handlers/dispatch.rs
@@ -307,7 +307,30 @@ pub(crate) fn dispatch_restart_daemon(ctx: &HandlerCtx<'_>) -> Value {
 // handler. Unknown actions produce tool-specific error JSON.
 // ---------------------------------------------------------------------
 
-adapter!(dispatch_task, hai, task::handle_task);
+/// #2454 Slice 5: task health/sweep are runtime-backed reads.  They must use
+/// the live registry forwarded through the in-process MCP ingress and must
+/// fail closed when that runtime is absent; all other task actions preserve
+/// the existing public `tasks::handle` path.
+pub(crate) fn dispatch_task(ctx: &HandlerCtx<'_>) -> Value {
+    let action = ctx.args["action"].as_str().unwrap_or("");
+    if !matches!(action, "health" | "sweep") {
+        return task::handle_task(ctx.home, ctx.args, ctx.instance_name);
+    }
+    let Some(runtime) = ctx.runtime else {
+        return json!({
+            "error": "runtime unavailable: task health/sweep requires the in-process daemon runtime"
+        });
+    };
+    let live_instances =
+        crate::agent_ops::list_snapshot(ctx.home, &runtime.registry, &runtime.externals)["result"]
+            ["agents"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .filter_map(|agent| agent["name"].as_str().map(String::from))
+            .collect::<std::collections::HashSet<_>>();
+    crate::tasks::handle_with_live_instances(ctx.home, ctx.instance_name, ctx.args, &live_instances)
+}
 pub(crate) fn dispatch_usage_limit_takeover(ctx: &HandlerCtx<'_>) -> Value {
     usage_limit_takeover::handle_usage_limit_takeover(ctx)
 }

--- a/src/tasks/handler.rs
+++ b/src/tasks/handler.rs
@@ -56,6 +56,23 @@ pub fn handle(home: &Path, instance_name: &str, args: &Value) -> Value {
     }
 }
 
+/// #2454 Slice 5: MCP task health/sweep adapter with an already-captured live
+/// registry set.  The public [`handle`] signature remains the compatibility
+/// boundary for every non-MCP caller; only the two runtime-backed read arms
+/// are overridden here.
+pub(crate) fn handle_with_live_instances(
+    home: &Path,
+    instance_name: &str,
+    args: &Value,
+    live_instances: &std::collections::HashSet<String>,
+) -> Value {
+    match args["action"].as_str() {
+        Some("sweep") => handle_sweep_with_live_instances(home, args, live_instances),
+        Some("health") => handle_health_with_live_instances(home, Some(live_instances)),
+        _ => handle(home, instance_name, args),
+    }
+}
+
 /// #2037 (3): `id` is canonical, `task_id` accepted as alias — `send` calls it
 /// `task_id`, so the most common cross-tool slip is forgiving. Error messages
 /// name both.
@@ -1677,6 +1694,29 @@ fn handle_sweep(home: &Path, args: &Value) -> Value {
     // `Closes t-XXX-N` PR markers). This action is operator-
     // triggered, scans for 4 stale categories, returns a
     // dry-run plan, then applies on a confirm round-trip.
+    let live_instances: std::collections::HashSet<String> = crate::api::call(
+        home,
+        &serde_json::json!({"method": crate::api::method::LIST}),
+    )
+    .ok()
+    .and_then(|r| {
+        r["result"]["agents"].as_array().map(|arr| {
+            arr.iter()
+                .filter_map(|a| a["name"].as_str().map(String::from))
+                .collect()
+        })
+    })
+    .unwrap_or_default();
+    handle_sweep_with_live_instances(home, args, &live_instances)
+}
+
+fn handle_sweep_with_live_instances(
+    home: &Path,
+    args: &Value,
+    live_instances: &std::collections::HashSet<String>,
+) -> Value {
+    // #2454: the MCP adapter supplies this set from the in-process runtime;
+    // the public `handle` wrapper above retains its API-derived behavior.
     let apply = args["apply"].as_bool().unwrap_or(false);
     let confirm_ids: std::collections::HashSet<String> = args["confirm_ids"]
         .as_array()
@@ -1693,25 +1733,12 @@ fn handle_sweep(home: &Path, args: &Value) -> Value {
         .as_str()
         .map(String::from)
         .or_else(|| crate::daemon::task_sweep::load_sweep_config_for_doctor(home).repo);
-    let live_instances: std::collections::HashSet<String> = crate::api::call(
-        home,
-        &serde_json::json!({"method": crate::api::method::LIST}),
-    )
-    .ok()
-    .and_then(|r| {
-        r["result"]["agents"].as_array().map(|arr| {
-            arr.iter()
-                .filter_map(|a| a["name"].as_str().map(String::from))
-                .collect()
-        })
-    })
-    .unwrap_or_default();
     let now = chrono::Utc::now();
     let pr_lookup: super::sweep::PrLookup = &super::sweep::gh_pr_lookup;
     let issue_lookup: super::sweep::IssueLookup = &super::sweep::gh_issue_lookup;
     let categories = super::sweep::scan_categories(
         home,
-        &live_instances,
+        live_instances,
         pr_lookup,
         issue_lookup,
         repo_owned.as_deref(),
@@ -1762,6 +1789,15 @@ fn handle_health(home: &Path) -> Value {
     // diagnosis: "is the board clean?" + recommended next
     // actions surfaced as a structured `recommendations` array.
     let live = crate::runtime::list_live_agents(home);
+    handle_health_with_live_instances(home, live.as_ref())
+}
+
+fn handle_health_with_live_instances(
+    home: &Path,
+    live: Option<&std::collections::HashSet<String>>,
+) -> Value {
+    // #2454: the MCP adapter supplies `Some(live)` from the in-process
+    // RuntimeContext; the public `handle` wrapper above retains its API path.
     let fleet_instances: std::collections::HashSet<String> =
         crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))
             .ok()
@@ -1779,7 +1815,7 @@ fn handle_health(home: &Path) -> Value {
             });
         }
     };
-    build_health_response(&state, live.as_ref(), &fleet_instances)
+    build_health_response(&state, live, &fleet_instances)
 }
 
 fn handle_activity(home: &Path, args: &Value) -> Value {

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -45,6 +45,7 @@ pub(crate) fn task_terminal_cleanup(home: &Path, task_id: &str) {
 }
 
 pub use handler::handle;
+pub(crate) use handler::handle_with_live_instances;
 pub use handler::register_subscriber as register_cascade_subscriber;
 // #2117 P2: resolution helpers for the out-of-`tasks` callers — comms dispatch
 // auto-create (target board) and the per-board task sweep (project id from a


### PR DESCRIPTION
## Scope
Slice 5 only: route MCP task `health` and `sweep` through the in-process `RuntimeContext` live-agent snapshot. Preserve the public `tasks::handle` signature and API-derived behavior for non-MCP callers; all other task actions retain the existing dispatch path. Runtime absence is an explicit error for these two MCP actions.

## Test-first evidence
- RED parent: `99af9145b1a96a728e58dab0be977cbecab17370` (exact base `d2e5d7f808024cfedf062a2acf1d846e694d77a1`)
- GREEN: `2f52ec8e`
- `cargo test --bin agend-terminal '2454' -- --nocapture` -> 16 passed
- `cargo test --bin agend-terminal 'mcp::handlers::dispatch::tests::' -- --nocapture` -> 23 passed
- `cargo test --bin agend-terminal 'tasks::' -- --nocapture` -> 254 passed
- `cargo clippy --bin agend-terminal -- -D warnings` -> passed
- `rustfmt --edition 2021 --check ...` and `git diff --check` -> passed

No changes to excluded lifecycle/team/restart/SEND/deployment paths.