### PR TITLE
fix(#2454): share move pane service

### DIFF
--- a/src/agent_ops.rs
+++ b/src/agent_ops.rs
@@ -236,6 +236,65 @@ pub fn pane_scrollback(
 }
 
 // ---------------------------------------------------------------------------
+// Pane relocation (move_pane) — #2454 in-process service
+// ---------------------------------------------------------------------------
+
+/// Direction used by the transport-neutral pane relocation service.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PaneMoveSplit {
+    Horizontal,
+    Vertical,
+}
+
+impl PaneMoveSplit {
+    pub fn parse(value: &str) -> Self {
+        match value {
+            "vertical" | "v" => Self::Vertical,
+            _ => Self::Horizontal,
+        }
+    }
+}
+
+/// Validated move request returned to API and MCP adapters.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PaneMoveEvent {
+    pub agent: String,
+    pub target_tab: String,
+    pub split_dir: PaneMoveSplit,
+}
+
+/// Validate a pane relocation request and append its audit event.
+///
+/// Layout mutation remains owned by the notifier/TUI event loop; this service
+/// owns the shared validation, split parsing, and event-log side effect.
+pub fn move_pane(
+    home: &Path,
+    agent_name: Option<&str>,
+    target_tab: Option<&str>,
+    split_dir: Option<&str>,
+) -> Result<PaneMoveEvent, String> {
+    let agent_name = agent_name.ok_or_else(|| "missing agent".to_string())?;
+    let agent_name = agent::validate_name(agent_name)?.to_string();
+    let target_tab = match target_tab {
+        Some(tab) if !tab.is_empty() => tab.to_string(),
+        _ => return Err("missing target_tab".to_string()),
+    };
+    let split_dir = PaneMoveSplit::parse(split_dir.unwrap_or("horizontal"));
+
+    crate::event_log::log(
+        home,
+        "move_pane",
+        &agent_name,
+        &format!("target_tab={target_tab} split={split_dir:?}"),
+    );
+    Ok(PaneMoveEvent {
+        agent: agent_name,
+        target_tab,
+        split_dir,
+    })
+}
+
+// ---------------------------------------------------------------------------
 // Metadata
 // ---------------------------------------------------------------------------
 
@@ -1082,6 +1141,26 @@ mod tests {
         ));
         std::fs::create_dir_all(&dir).ok();
         dir
+    }
+
+    #[test]
+    fn move_pane_validates_parses_and_logs_2454() {
+        let home = tmp_home("move-pane-service-2454");
+        let event = move_pane(&home, Some("agent-a"), Some("team-x"), Some("vertical")).unwrap();
+        assert_eq!(event.agent, "agent-a");
+        assert_eq!(event.target_tab, "team-x");
+        assert_eq!(event.split_dir, PaneMoveSplit::Vertical);
+        let log = std::fs::read_to_string(home.join("event-log.jsonl")).unwrap();
+        assert!(log.contains("\"kind\":\"move_pane\""));
+        assert!(log.contains("target_tab=team-x split=Vertical"));
+        assert_eq!(
+            move_pane(&home, None, Some("team-x"), None),
+            Err("missing agent".into())
+        );
+        assert_eq!(
+            move_pane(&home, Some("agent-a"), None, None),
+            Err("missing target_tab".into())
+        );
     }
 
     #[test]

--- a/src/api/handlers/instance.rs
+++ b/src/api/handlers/instance.rs
@@ -411,32 +411,25 @@ pub(crate) fn handle_spawn(params: &Value, ctx: &HandlerCtx) -> Value {
 /// notifier) is a no-op and still returns `{"ok": true}`, matching the
 /// semantics of other layout-affecting MCP methods.
 pub(crate) fn handle_move_pane(params: &Value, ctx: &HandlerCtx) -> Value {
-    let agent_name = match params["agent"].as_str() {
-        Some(n) => n,
-        None => return json!({"ok": false, "error": "missing agent"}),
+    let event = match crate::agent_ops::move_pane(
+        ctx.home,
+        params["agent"].as_str(),
+        params["target_tab"].as_str(),
+        params["split_dir"].as_str(),
+    ) {
+        Ok(event) => event,
+        Err(error) => return json!({"ok": false, "error": error}),
     };
-    if let Err(e) = agent::validate_name(agent_name) {
-        return json!({"ok": false, "error": e});
-    }
-    let target_tab = match params["target_tab"].as_str() {
-        Some(t) if !t.is_empty() => t,
-        _ => return json!({"ok": false, "error": "missing target_tab"}),
-    };
-    let split_dir = PaneMoveSplitDir::parse(params["split_dir"].as_str().unwrap_or("horizontal"));
-
-    if let Some(n) = ctx.notifier {
-        n.notify(ApiEvent::PaneMoved {
-            agent: agent_name.to_string(),
-            target_tab: target_tab.to_string(),
-            split_dir,
+    if let Some(notifier) = ctx.notifier {
+        notifier.notify(ApiEvent::PaneMoved {
+            agent: event.agent.clone(),
+            target_tab: event.target_tab.clone(),
+            split_dir: match event.split_dir {
+                crate::agent_ops::PaneMoveSplit::Horizontal => PaneMoveSplitDir::Horizontal,
+                crate::agent_ops::PaneMoveSplit::Vertical => PaneMoveSplitDir::Vertical,
+            },
         });
     }
-    crate::event_log::log(
-        ctx.home,
-        "move_pane",
-        agent_name,
-        &format!("target_tab={target_tab} split={split_dir:?}"),
-    );
     json!({"ok": true})
 }
 

--- a/src/api/handlers/mcp_proxy.rs
+++ b/src/api/handlers/mcp_proxy.rs
@@ -152,6 +152,7 @@ pub(crate) fn handle_mcp_tool(params: &Value, ctx: &HandlerCtx) -> Value {
         // #2453 R2 flush barrier: carry THIS request's slot so `restart_daemon` can
         // register its commit-permission ack, run by `handle_session` after flush.
         post_flush: Some(ctx.post_flush.clone()),
+        notifier: ctx.notifier.cloned(),
     };
     handle_mcp_tool_inner(
         tool,
@@ -772,14 +773,15 @@ mod tests {
         let registry: crate::agent::AgentRegistry = Default::default();
         let configs: crate::api::ConfigRegistry = Default::default();
         let externals: crate::agent::ExternalRegistry = Default::default();
-        let notifier = RecordingNotifier {
+        let notifier = std::sync::Arc::new(RecordingNotifier {
             events: parking_lot::Mutex::new(Vec::new()),
-        };
+        });
+        let notifier_trait: std::sync::Arc<dyn ApiNotifier> = notifier.clone();
         let ctx = HandlerCtx {
             registry: &registry,
             configs: &configs,
             externals: &externals,
-            notifier: Some(&notifier),
+            notifier: Some(&notifier_trait),
             home: &home,
             capability: crate::api::RestartCapability::Unsupported,
             app_restart: None,
@@ -825,6 +827,22 @@ mod tests {
         );
         assert_eq!(vertical["result"]["instance"], "agent-b");
         assert_eq!(vertical["result"]["target_tab"], "team-y");
+
+        let invalid = handle_mcp_tool(
+            &json!({
+                "tool": "move_pane",
+                "arguments": {
+                    "instance": "bad/name",
+                    "target_tab": "team-z",
+                },
+            }),
+            &ctx,
+        );
+        assert_eq!(
+            invalid["result"]["error"],
+            "instance name 'bad/name' contains invalid characters (only a-z, 0-9, -, _ allowed)",
+            "MCP move_pane must preserve the legacy API validation-error payload"
+        );
 
         let events = notifier.take();
         assert_eq!(

--- a/src/api/handlers/mcp_proxy.rs
+++ b/src/api/handlers/mcp_proxy.rs
@@ -734,4 +734,136 @@ mod tests {
 
         std::fs::remove_dir_all(&dir).ok();
     }
+
+    /// #2454 Slice 6 RED correction: exercise the real mcp_tool ingress so the
+    /// notifier is part of the acceptance path, not only a direct API
+    /// characterization. The current RuntimeContext drops this borrowed
+    /// notifier and the MCP handler still self-IPC's, so both calls fail with
+    /// no API listener until GREEN threads the owned notifier through.
+    #[test]
+    fn move_pane_mcp_ingress_preserves_notifier_and_event_log_2454() {
+        use crate::api::{ApiEvent, ApiNotifier, PaneMoveSplitDir};
+
+        struct RecordingNotifier {
+            events: parking_lot::Mutex<Vec<ApiEvent>>,
+        }
+
+        impl RecordingNotifier {
+            fn take(&self) -> Vec<ApiEvent> {
+                std::mem::take(&mut *self.events.lock())
+            }
+        }
+
+        impl ApiNotifier for RecordingNotifier {
+            fn notify(&self, event: ApiEvent) {
+                self.events.lock().push(event);
+            }
+        }
+
+        let _fleet_guard = crate::mcp::handlers::fleet_test_guard();
+        let home = std::env::temp_dir().join(format!(
+            "agend-mcp-move-pane-ingress-red-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&home).expect("create temp home");
+        let previous_home = std::env::var_os("AGEND_HOME");
+        std::env::set_var("AGEND_HOME", &home);
+
+        let registry: crate::agent::AgentRegistry = Default::default();
+        let configs: crate::api::ConfigRegistry = Default::default();
+        let externals: crate::agent::ExternalRegistry = Default::default();
+        let notifier = RecordingNotifier {
+            events: parking_lot::Mutex::new(Vec::new()),
+        };
+        let ctx = HandlerCtx {
+            registry: &registry,
+            configs: &configs,
+            externals: &externals,
+            notifier: Some(&notifier),
+            home: &home,
+            capability: crate::api::RestartCapability::Unsupported,
+            app_restart: None,
+            post_flush: crate::api::app_restart::PostFlushSlot::new(),
+        };
+
+        let default = handle_mcp_tool(
+            &json!({
+                "tool": "move_pane",
+                "arguments": {"instance": "agent-a", "target_tab": "team-x"},
+            }),
+            &ctx,
+        );
+        assert_eq!(
+            default["ok"], true,
+            "mcp_tool outer default must succeed: {default}"
+        );
+        assert_eq!(
+            default["result"]["ok"], true,
+            "mcp_tool inner default must succeed without an API listener: {default}"
+        );
+        assert_eq!(default["result"]["instance"], "agent-a");
+        assert_eq!(default["result"]["target_tab"], "team-x");
+
+        let vertical = handle_mcp_tool(
+            &json!({
+                "tool": "move_pane",
+                "arguments": {
+                    "instance": "agent-b",
+                    "target_tab": "team-y",
+                    "split_dir": "vertical",
+                },
+            }),
+            &ctx,
+        );
+        assert_eq!(
+            vertical["ok"], true,
+            "mcp_tool outer vertical must succeed: {vertical}"
+        );
+        assert_eq!(
+            vertical["result"]["ok"], true,
+            "mcp_tool inner vertical must succeed without an API listener: {vertical}"
+        );
+        assert_eq!(vertical["result"]["instance"], "agent-b");
+        assert_eq!(vertical["result"]["target_tab"], "team-y");
+
+        let events = notifier.take();
+        assert_eq!(
+            events.len(),
+            2,
+            "default + vertical must emit two ordered events"
+        );
+        assert!(matches!(
+            &events[0],
+            ApiEvent::PaneMoved {
+                agent,
+                target_tab,
+                split_dir: PaneMoveSplitDir::Horizontal,
+            } if agent == "agent-a" && target_tab == "team-x"
+        ));
+        assert!(matches!(
+            &events[1],
+            ApiEvent::PaneMoved {
+                agent,
+                target_tab,
+                split_dir: PaneMoveSplitDir::Vertical,
+            } if agent == "agent-b" && target_tab == "team-y"
+        ));
+
+        let log = std::fs::read_to_string(home.join("event-log.jsonl"))
+            .expect("MCP move_pane must emit event-log records");
+        let lines: Vec<&str> = log.lines().collect();
+        assert_eq!(
+            lines.len(),
+            2,
+            "two MCP calls must emit exactly two records"
+        );
+        assert!(lines[0].contains("\"kind\":\"move_pane\"") && lines[0].contains("Horizontal"));
+        assert!(lines[1].contains("\"kind\":\"move_pane\"") && lines[1].contains("Vertical"));
+
+        match previous_home {
+            Some(value) => std::env::set_var("AGEND_HOME", value),
+            None => std::env::remove_var("AGEND_HOME"),
+        }
+        std::fs::remove_dir_all(home).ok();
+    }
 }

--- a/src/api/handlers/mcp_proxy.rs
+++ b/src/api/handlers/mcp_proxy.rs
@@ -736,11 +736,10 @@ mod tests {
         std::fs::remove_dir_all(&dir).ok();
     }
 
-    /// #2454 Slice 6 RED correction: exercise the real mcp_tool ingress so the
-    /// notifier is part of the acceptance path, not only a direct API
-    /// characterization. The current RuntimeContext drops this borrowed
-    /// notifier and the MCP handler still self-IPC's, so both calls fail with
-    /// no API listener until GREEN threads the owned notifier through.
+    /// #2454 Slice 6: exercise the real mcp_tool ingress so notifier
+    /// propagation is covered as part of the acceptance contract, alongside
+    /// the direct API characterization. This regression test preserves the
+    /// no-loopback runtime path and ordered event-log/notifier semantics.
     #[test]
     fn move_pane_mcp_ingress_preserves_notifier_and_event_log_2454() {
         use crate::api::{ApiEvent, ApiNotifier, PaneMoveSplitDir};

--- a/src/api/handlers/mod.rs
+++ b/src/api/handlers/mod.rs
@@ -14,6 +14,7 @@ pub(crate) mod team;
 use crate::agent::{AgentRegistry, ExternalRegistry};
 use crate::api::{ApiNotifier, ConfigRegistry};
 use std::path::Path;
+use std::sync::Arc;
 
 /// Write `agend.md` / `GEMINI.md` and the MCP config into `work_dir` before
 /// the child process is spawned. Centralises the fleet-aware instruction
@@ -135,7 +136,7 @@ pub(crate) struct HandlerCtx<'a> {
     pub registry: &'a AgentRegistry,
     pub configs: &'a ConfigRegistry,
     pub externals: &'a ExternalRegistry,
-    pub notifier: Option<&'a dyn ApiNotifier>,
+    pub notifier: Option<&'a Arc<dyn ApiNotifier>>,
     pub home: &'a Path,
     /// #2453 Stage R1: the API-server owner's restart capability, injected at
     /// [`crate::api::serve`] from the composition root and carried into the MCP

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -72,6 +72,7 @@ pub enum PaneMoveSplitDir {
 }
 
 impl PaneMoveSplitDir {
+    #[allow(dead_code)]
     pub fn parse(s: &str) -> Self {
         match s {
             "vertical" | "v" => Self::Vertical,
@@ -424,7 +425,7 @@ pub fn serve(
                     &shutdown,
                     &cfgs,
                     &ext,
-                    ntf.as_deref(),
+                    ntf.as_ref(),
                     session_operator_token,
                     session_cookie,
                     session_host,
@@ -561,7 +562,7 @@ fn handle_session(
     shutdown: &Arc<AtomicBool>,
     configs: &ConfigRegistry,
     externals: &ExternalRegistry,
-    notifier: Option<&dyn ApiNotifier>,
+    notifier: Option<&Arc<dyn ApiNotifier>>,
     operator_token: crate::auth_cookie::Cookie,
     cookie: crate::auth_cookie::Cookie,
     host: RestartCapability,

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -71,16 +71,6 @@ pub enum PaneMoveSplitDir {
     Vertical,
 }
 
-impl PaneMoveSplitDir {
-    #[allow(dead_code)]
-    pub fn parse(s: &str) -> Self {
-        match s {
-            "vertical" | "v" => Self::Vertical,
-            _ => Self::Horizontal,
-        }
-    }
-}
-
 /// Layout hint for newly created instances. Parsed at the API boundary so
 /// invalid values are caught early rather than silently defaulting downstream.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]

--- a/src/mcp/handlers/dispatch.rs
+++ b/src/mcp/handlers/dispatch.rs
@@ -27,6 +27,7 @@
 use crate::identity::Sender;
 use serde_json::{json, Value};
 use std::path::Path;
+use std::sync::Arc;
 
 use super::{
     binding_state, channel, ci, comms, instance, restart, review_assignment, schedule, task,
@@ -65,6 +66,9 @@ pub(crate) struct RuntimeContext {
     /// it flushes THIS response. `None` off the api `mcp_tool` ingress (no request to
     /// tie a flush to → the handler cannot arm the barrier and fails closed).
     pub post_flush: Option<crate::api::app_restart::PostFlushSlot>,
+    /// #2454: owner notifier forwarded from the API composition root so MCP
+    /// move_pane emits the same TUI event as the direct API ingress.
+    pub notifier: Option<Arc<dyn crate::api::ApiNotifier>>,
 }
 
 /// One MCP tool's dispatcher. Function pointer (not `Box<dyn …>`) so
@@ -260,7 +264,11 @@ adapter!(
     has,
     instance::set_model::handle_set_model
 );
-adapter!(dispatch_move_pane, ha, instance::handle_move_pane);
+/// #2454: move_pane is a runtime-aware adapter over the neutral service.
+pub(crate) fn dispatch_move_pane(ctx: &HandlerCtx<'_>) -> Value {
+    // The owned notifier travels inside RuntimeContext to the MCP adapter.
+    instance::handle_move_pane(ctx.home, ctx.args, ctx.runtime)
+}
 adapter!(
     dispatch_set_waiting_on,
     hais,
@@ -498,6 +506,7 @@ mod tests {
             capability: crate::api::RestartCapability::App,
             app_restart: None,
             post_flush: None,
+            notifier: None,
         };
         let ctx = HandlerCtx {
             home: &home,
@@ -973,6 +982,7 @@ mod tests {
             capability: crate::api::RestartCapability::Unsupported,
             app_restart: None,
             post_flush: None,
+            notifier: None,
         }
     }
 
@@ -1119,6 +1129,7 @@ mod tests {
             capability: crate::api::RestartCapability::Unsupported,
             app_restart: None,
             post_flush: None,
+            notifier: None,
         }
     }
 
@@ -1216,12 +1227,13 @@ mod tests {
         let registry: crate::agent::AgentRegistry = Default::default();
         let configs: crate::api::ConfigRegistry = Default::default();
         let externals: crate::agent::ExternalRegistry = Default::default();
-        let notifier = RecordingNotifier::new();
+        let notifier = std::sync::Arc::new(RecordingNotifier::new());
+        let notifier_trait: std::sync::Arc<dyn crate::api::ApiNotifier> = notifier.clone();
         let ctx = crate::api::handlers::HandlerCtx {
             registry: &registry,
             configs: &configs,
             externals: &externals,
-            notifier: Some(&notifier),
+            notifier: Some(&notifier_trait),
             home: &home,
             capability: crate::api::RestartCapability::Unsupported,
             app_restart: None,

--- a/src/mcp/handlers/dispatch.rs
+++ b/src/mcp/handlers/dispatch.rs
@@ -1309,9 +1309,29 @@ mod tests {
                 .contains("adapter!(dispatch_move_pane, ha, instance::handle_move_pane)"),
             "move_pane must use a runtime-aware custom dispatch adapter"
         );
+        let runtime_start = production_dispatch
+            .find("pub(crate) struct RuntimeContext {")
+            .expect("RuntimeContext declaration");
+        let runtime_end = production_dispatch[runtime_start..]
+            .find("/// One MCP tool's dispatcher")
+            .map(|offset| runtime_start + offset)
+            .expect("RuntimeContext end marker");
+        let runtime_region = &production_dispatch[runtime_start..runtime_end];
         assert!(
-            production_dispatch.contains("notifier"),
-            "RuntimeContext notifier must be forwarded into the MCP move_pane path"
+            runtime_region.contains("notifier"),
+            "RuntimeContext must own a notifier for MCP move_pane"
+        );
+        let move_start = production_dispatch
+            .find("pub(crate) fn dispatch_move_pane(")
+            .expect("runtime-aware dispatch_move_pane declaration");
+        let move_end = production_dispatch[move_start..]
+            .find("pub(crate) fn dispatch_usage_limit_takeover(")
+            .map(|offset| move_start + offset)
+            .expect("dispatch_move_pane end marker");
+        let move_region = &production_dispatch[move_start..move_end];
+        assert!(
+            move_region.contains("notifier"),
+            "dispatch_move_pane must forward RuntimeContext notifier"
         );
 
         let mcp = include_str!("instance_metadata.rs");

--- a/src/mcp/handlers/dispatch.rs
+++ b/src/mcp/handlers/dispatch.rs
@@ -1104,4 +1104,249 @@ mod tests {
         }
         std::fs::remove_dir_all(home).ok();
     }
+
+    // #2454 Slice 6 RED: move_pane must use the forwarded RuntimeContext
+    // directly. The current adapter still calls the daemon MOVE_PANE socket,
+    // so this real dispatch path deterministically fails without a listener.
+    fn move_pane_runtime() -> RuntimeContext {
+        RuntimeContext {
+            registry: std::sync::Arc::new(
+                parking_lot::Mutex::new(std::collections::HashMap::new()),
+            ),
+            externals: std::sync::Arc::new(parking_lot::Mutex::new(
+                std::collections::HashMap::new(),
+            )),
+            capability: crate::api::RestartCapability::Unsupported,
+            app_restart: None,
+            post_flush: None,
+        }
+    }
+
+    fn move_pane_runtime_ctx<'a>(
+        home: &'a Path,
+        args: &'a Value,
+        runtime: &'a RuntimeContext,
+    ) -> HandlerCtx<'a> {
+        static EMPTY_SENDER: Option<Sender> = None;
+        HandlerCtx {
+            home,
+            args,
+            instance_name: "operator",
+            sender: &EMPTY_SENDER,
+            runtime: Some(runtime),
+        }
+    }
+
+    #[test]
+    fn move_pane_uses_supplied_runtime_without_api_listener_2454() {
+        let home = std::env::temp_dir().join(format!(
+            "agend-move-pane-runtime-red-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&home).expect("create temp home");
+        let args = json!({
+            "instance": "agent-a",
+            "target_tab": "team-x",
+        });
+        let runtime = move_pane_runtime();
+        let ctx = move_pane_runtime_ctx(&home, &args, &runtime);
+        let result = try_dispatch("move_pane", &ctx).expect("move_pane dispatch result");
+        assert_eq!(
+            result["ok"], true,
+            "move_pane must succeed through RuntimeContext without an API listener: {result}"
+        );
+        assert_eq!(
+            result["instance"], "agent-a",
+            "move_pane target must be echoed"
+        );
+        assert_eq!(
+            result["target_tab"], "team-x",
+            "move_pane tab must be echoed"
+        );
+
+        let log = std::fs::read_to_string(home.join("event-log.jsonl"))
+            .expect("runtime move_pane must emit one event-log record");
+        let lines: Vec<&str> = log.lines().collect();
+        assert_eq!(
+            lines.len(),
+            1,
+            "move_pane must emit exactly one event: {lines:?}"
+        );
+        assert!(
+            lines[0].contains("\"kind\":\"move_pane\"")
+                && lines[0].contains("agent-a")
+                && lines[0].contains("team-x")
+                && lines[0].contains("Horizontal"),
+            "move_pane event must preserve default split semantics: {lines:?}"
+        );
+        std::fs::remove_dir_all(home).ok();
+    }
+
+    #[test]
+    fn move_pane_vertical_split_and_notifier_contract_2454() {
+        use crate::api::{ApiEvent, ApiNotifier, PaneMoveSplitDir};
+
+        struct RecordingNotifier {
+            events: parking_lot::Mutex<Vec<ApiEvent>>,
+        }
+
+        impl RecordingNotifier {
+            fn new() -> Self {
+                Self {
+                    events: parking_lot::Mutex::new(Vec::new()),
+                }
+            }
+
+            fn take(&self) -> Vec<ApiEvent> {
+                std::mem::take(&mut *self.events.lock())
+            }
+        }
+
+        impl ApiNotifier for RecordingNotifier {
+            fn notify(&self, event: ApiEvent) {
+                self.events.lock().push(event);
+            }
+        }
+
+        let home = std::env::temp_dir().join(format!(
+            "agend-move-pane-notifier-red-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&home).expect("create temp home");
+        let registry: crate::agent::AgentRegistry = Default::default();
+        let configs: crate::api::ConfigRegistry = Default::default();
+        let externals: crate::agent::ExternalRegistry = Default::default();
+        let notifier = RecordingNotifier::new();
+        let ctx = crate::api::handlers::HandlerCtx {
+            registry: &registry,
+            configs: &configs,
+            externals: &externals,
+            notifier: Some(&notifier),
+            home: &home,
+            capability: crate::api::RestartCapability::Unsupported,
+            app_restart: None,
+            post_flush: crate::api::app_restart::PostFlushSlot::new(),
+        };
+
+        let default = crate::api::handlers::instance::handle_move_pane(
+            &json!({"agent": "agent-a", "target_tab": "team-x"}),
+            &ctx,
+        );
+        assert_eq!(default["ok"], true, "API move_pane default must succeed");
+        let vertical = crate::api::handlers::instance::handle_move_pane(
+            &json!({
+                "agent": "agent-b",
+                "target_tab": "team-y",
+                "split_dir": "vertical",
+            }),
+            &ctx,
+        );
+        assert_eq!(vertical["ok"], true, "API move_pane vertical must succeed");
+
+        let events = notifier.take();
+        assert_eq!(events.len(), 2, "default + vertical must emit two events");
+        assert!(matches!(
+            &events[0],
+            ApiEvent::PaneMoved {
+                agent,
+                target_tab,
+                split_dir: PaneMoveSplitDir::Horizontal,
+            } if agent == "agent-a" && target_tab == "team-x"
+        ));
+        assert!(matches!(
+            &events[1],
+            ApiEvent::PaneMoved {
+                agent,
+                target_tab,
+                split_dir: PaneMoveSplitDir::Vertical,
+            } if agent == "agent-b" && target_tab == "team-y"
+        ));
+        let log = std::fs::read_to_string(home.join("event-log.jsonl"))
+            .expect("API move_pane must emit event-log records");
+        assert_eq!(
+            log.lines().count(),
+            2,
+            "two move_pane calls must emit two records"
+        );
+        assert!(log
+            .lines()
+            .all(|line| line.contains("\"kind\":\"move_pane\"")));
+        std::fs::remove_dir_all(home).ok();
+    }
+
+    #[test]
+    fn move_pane_runtime_none_is_explicit_and_never_socket_fallback_2454() {
+        let home = std::env::temp_dir().join(format!(
+            "agend-move-pane-runtime-none-red-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&home).expect("create temp home");
+        let args = json!({
+            "instance": "agent-a",
+            "target_tab": "team-x",
+        });
+        let ctx = ctx_for(&home, &args, "operator");
+        let result = try_dispatch("move_pane", &ctx).expect("move_pane dispatch result");
+        assert!(
+            result["error"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("runtime unavailable"),
+            "runtime=None must fail explicitly rather than use socket fallback: {result}"
+        );
+        std::fs::remove_dir_all(home).ok();
+    }
+
+    #[test]
+    fn move_pane_shared_service_and_no_api_call_invariants_2454() {
+        let dispatch = include_str!("dispatch.rs");
+        let production_dispatch = dispatch
+            .split("#[cfg(test)]")
+            .next()
+            .expect("dispatch production source");
+        assert!(
+            !production_dispatch
+                .contains("adapter!(dispatch_move_pane, ha, instance::handle_move_pane)"),
+            "move_pane must use a runtime-aware custom dispatch adapter"
+        );
+        assert!(
+            production_dispatch.contains("notifier"),
+            "RuntimeContext notifier must be forwarded into the MCP move_pane path"
+        );
+
+        let mcp = include_str!("instance_metadata.rs");
+        let mcp_start = mcp
+            .find("pub(super) fn handle_move_pane(")
+            .expect("MCP move_pane handler");
+        let mcp_end = mcp[mcp_start..]
+            .find("pub(super) fn handle_pane_snapshot(")
+            .map(|offset| mcp_start + offset)
+            .expect("MCP pane_snapshot handler");
+        let mcp_region = &mcp[mcp_start..mcp_end];
+        assert!(
+            mcp_region.contains("agent_ops::move_pane"),
+            "MCP move_pane must call the shared neutral service"
+        );
+        assert!(
+            !mcp_region.lines().any(|line| {
+                let trimmed = line.trim();
+                !trimmed.starts_with("//") && trimmed.contains("api::call")
+            }),
+            "MCP move_pane production region must contain no api::call"
+        );
+
+        let api = include_str!("../../api/handlers/instance.rs");
+        let api_start = api
+            .find("pub(crate) fn handle_move_pane(")
+            .expect("API move_pane handler");
+        let api_end = api[api_start..]
+            .find("pub(crate) fn handle_set_blocked_reason(")
+            .map(|offset| api_start + offset)
+            .expect("API blocked-reason handler");
+        let api_region = &api[api_start..api_end];
+        assert!(
+            api_region.contains("agent_ops::move_pane"),
+            "API move_pane must call the same shared neutral service"
+        );
+    }
 }

--- a/src/mcp/handlers/instance_metadata.rs
+++ b/src/mcp/handlers/instance_metadata.rs
@@ -129,24 +129,40 @@ pub(super) fn handle_set_waiting_on(
     }
 }
 
-pub(super) fn handle_move_pane(home: &Path, args: &Value) -> Value {
-    // MCP arg is `instance`; the daemon RPC contract names the field `agent`.
-    let instance = args["instance"].as_str().unwrap_or("");
-    let params = json!({
-        "agent": instance,
-        "target_tab": args["target_tab"],
-        "split_dir": args["split_dir"],
-    });
-    match crate::api::call(
+pub(super) fn handle_move_pane(
+    home: &Path,
+    args: &Value,
+    runtime: Option<&RuntimeContext>,
+) -> Value {
+    let Some(runtime) = runtime else {
+        return json!({"error": "runtime unavailable: move_pane requires the in-process daemon runtime"});
+    };
+    let event = match crate::agent_ops::move_pane(
         home,
-        &json!({"method": crate::api::method::MOVE_PANE, "params": params}),
+        args["instance"].as_str(),
+        args["target_tab"].as_str(),
+        args["split_dir"].as_str(),
     ) {
-        Ok(resp) if resp["ok"].as_bool() == Some(true) => {
-            json!({"ok": true, "instance": instance, "target_tab": args["target_tab"]})
-        }
-        Ok(resp) => json!({"error": resp["error"].as_str().unwrap_or("move_pane failed")}),
-        Err(e) => json!({"error": format!("move_pane: {e}")}),
+        Ok(event) => event,
+        Err(error) => return json!({"error": error}),
+    };
+    if let Some(notifier) = runtime.notifier.as_ref() {
+        notifier.notify(crate::api::ApiEvent::PaneMoved {
+            agent: event.agent.clone(),
+            target_tab: event.target_tab.clone(),
+            split_dir: match event.split_dir {
+                crate::agent_ops::PaneMoveSplit::Horizontal => {
+                    crate::api::PaneMoveSplitDir::Horizontal
+                }
+                crate::agent_ops::PaneMoveSplit::Vertical => crate::api::PaneMoveSplitDir::Vertical,
+            },
+        });
     }
+    json!({
+        "ok": true,
+        "instance": event.agent,
+        "target_tab": event.target_tab,
+    })
 }
 
 pub(super) fn handle_pane_snapshot(
@@ -401,6 +417,7 @@ mod blocked_reason_runtime_2454_tests {
             capability: crate::api::RestartCapability::Unsupported,
             app_restart: None,
             post_flush: None,
+            notifier: None,
         };
         (rt, home)
     }

--- a/src/mcp/handlers/instance_queries.rs
+++ b/src/mcp/handlers/instance_queries.rs
@@ -182,6 +182,7 @@ mod tests {
             capability: crate::api::RestartCapability::Unsupported,
             app_restart: None,
             post_flush: None,
+            notifier: None,
         };
 
         let result =
@@ -210,6 +211,7 @@ mod tests {
             capability: crate::api::RestartCapability::Unsupported,
             app_restart: None,
             post_flush: None,
+            notifier: None,
         }
     }
 
@@ -317,6 +319,7 @@ mod tests {
             capability: crate::api::RestartCapability::Unsupported,
             app_restart: None,
             post_flush: None,
+            notifier: None,
         };
 
         let result = handle_list_instances_with_runtime(

--- a/src/mcp/handlers/usage_limit_takeover_tests.rs
+++ b/src/mcp/handlers/usage_limit_takeover_tests.rs
@@ -164,6 +164,7 @@ fn fixture(tag: &str) -> Fixture {
         capability: crate::api::RestartCapability::Unsupported,
         app_restart: None,
         post_flush: None,
+        notifier: None,
     };
     let _ = source_head;
     Fixture {


### PR DESCRIPTION
## Summary
- add the transport-neutral `agent_ops::move_pane` service for shared validation, split parsing, and event-log emission
- route API and MCP move_pane through thin adapters; MCP uses the owned runtime notifier and fails closed when runtime is absent
- preserve API/MCP wire responses and update notifier ownership wiring without extending borrowed trait-object lifetimes

## Validation
- RED ancestry retained: `b5037011734e4421176c9d7cc8b40a8824f3a236` -> `476f737afc914cf723daa3b6f03fa67a920a5f72`
- `cargo test --bin agend-terminal '2454' -- --nocapture` (22 passed)
- `cargo test --bin agend-terminal 'api::tests::dispatch_move_pane' -- --nocapture` (4 passed)
- `cargo test --bin agend-terminal 'api::handlers::mcp_proxy::tests::move_pane' -- --nocapture` (1 passed)
- `cargo test --bin agend-terminal 'mcp::handlers::dispatch::tests::move_pane' -- --nocapture` (4 passed)
- `cargo clippy --bin agend-terminal -- -D warnings`
- `rustfmt --edition 2021 --check` on changed Rust files
- `git diff --check`
