### PR TITLE
fix(#2454): share update team service

### DIFF
--- a/src/api/handlers/mcp_proxy.rs
+++ b/src/api/handlers/mcp_proxy.rs
@@ -883,4 +883,107 @@ mod tests {
         }
         std::fs::remove_dir_all(home).ok();
     }
+
+    /// #2454 Slice 7 RED: exercise the real MCP `team action=update` ingress
+    /// with a supplied notifier and no API listener. The current MCP adapter
+    /// falls back to the direct teams store but drops the owned runtime
+    /// notifier, so effective add/remove events are absent until GREEN.
+    #[test]
+    fn update_team_mcp_ingress_preserves_effective_diff_events_2454() {
+        use crate::api::{ApiEvent, ApiNotifier};
+
+        struct RecordingNotifier {
+            events: parking_lot::Mutex<Vec<ApiEvent>>,
+        }
+
+        impl ApiNotifier for RecordingNotifier {
+            fn notify(&self, event: ApiEvent) {
+                self.events.lock().push(event);
+            }
+        }
+
+        let _fleet_guard = crate::mcp::handlers::fleet_test_guard();
+        let home = std::env::temp_dir().join(format!(
+            "agend-mcp-update-team-ingress-red-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&home).expect("create temp home");
+        std::fs::write(
+            crate::fleet::fleet_yaml_path(&home),
+            "teams:\n  t1:\n    members: [m1, m2]\n    created_at: \"2026-01-01T00:00:00Z\"\n",
+        )
+        .expect("seed team");
+        let previous_home = std::env::var_os("AGEND_HOME");
+        std::env::set_var("AGEND_HOME", &home);
+
+        let registry: crate::agent::AgentRegistry = Default::default();
+        let configs: crate::api::ConfigRegistry = Default::default();
+        let externals: crate::agent::ExternalRegistry = Default::default();
+        let notifier = std::sync::Arc::new(RecordingNotifier {
+            events: parking_lot::Mutex::new(Vec::new()),
+        });
+        let notifier_trait: std::sync::Arc<dyn ApiNotifier> = notifier.clone();
+        let ctx = HandlerCtx {
+            registry: &registry,
+            configs: &configs,
+            externals: &externals,
+            notifier: Some(&notifier_trait),
+            home: &home,
+            capability: crate::api::RestartCapability::Unsupported,
+            app_restart: None,
+            post_flush: crate::api::app_restart::PostFlushSlot::new(),
+        };
+
+        for arguments in [
+            json!({"action": "update", "name": "t1", "add": ["m3"]}),
+            json!({"action": "update", "name": "t1", "remove": ["m2"]}),
+            json!({"action": "update", "name": "t1", "add": ["m1"]}),
+        ] {
+            let response = handle_mcp_tool(&json!({"tool": "team", "arguments": arguments}), &ctx);
+            assert_eq!(
+                response["ok"], true,
+                "MCP team update outer response: {response}"
+            );
+            assert_eq!(
+                response["result"]["status"], "updated",
+                "MCP team update direct fallback response: {response}"
+            );
+        }
+
+        let events = std::mem::take(&mut *notifier.events.lock());
+        assert_eq!(
+            events.len(),
+            2,
+            "add/remove must emit events while noop emits none: {events:?}"
+        );
+        assert!(matches!(
+            &events[0],
+            ApiEvent::TeamMembersChanged { name, added, removed }
+                if name == "t1" && added == &["m3"] && removed.is_empty()
+        ));
+        assert!(matches!(
+            &events[1],
+            ApiEvent::TeamMembersChanged { name, added, removed }
+                if name == "t1" && added.is_empty() && removed == &["m2"]
+        ));
+
+        match previous_home {
+            Some(value) => std::env::set_var("AGEND_HOME", value),
+            None => std::env::remove_var("AGEND_HOME"),
+        }
+        std::fs::remove_dir_all(home).ok();
+    }
+
+    #[test]
+    fn update_team_shared_service_and_no_api_call_invariants_2454() {
+        let source = include_str!("../../mcp/handlers/task.rs");
+        let update_start = source
+            .find("pub(super) fn handle_update_team(")
+            .expect("MCP update_team handler");
+        let update_region = &source[update_start..];
+        assert!(
+            !update_region.contains("api::call"),
+            "MCP handle_update_team production region must not self-IPC"
+        );
+    }
 }

--- a/src/api/handlers/team.rs
+++ b/src/api/handlers/team.rs
@@ -494,6 +494,16 @@ mod tests {
 
     #[test]
     fn update_team_error_preserves_outer_success_envelope_2454() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        struct CountNotifier(AtomicUsize);
+
+        impl crate::api::ApiNotifier for CountNotifier {
+            fn notify(&self, _event: crate::api::ApiEvent) {
+                self.0.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+
         let home = tmp_home("update-error-envelope");
         crate::teams::create(
             &home,
@@ -503,10 +513,11 @@ mod tests {
                 "orchestrator": "lead",
             }),
         );
-        let response = handle_update_team(
-            &json!({"name": "devs", "remove": ["lead"]}),
-            &test_ctx(&home),
-        );
+        let notifier = Arc::new(CountNotifier(AtomicUsize::new(0)));
+        let notifier_trait: Arc<dyn crate::api::ApiNotifier> = notifier.clone();
+        let mut ctx = test_ctx(&home);
+        ctx.notifier = Some(&notifier_trait);
+        let response = handle_update_team(&json!({"name": "devs", "remove": ["lead"]}), &ctx);
         assert_eq!(
             response["ok"], true,
             "API wire envelope changed: {response}"
@@ -515,6 +526,7 @@ mod tests {
         assert!(response["result"]["error"]
             .as_str()
             .is_some_and(|error| error.contains("cannot remove orchestrator")));
+        assert_eq!(notifier.0.load(Ordering::Relaxed), 0);
         std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/api/handlers/team.rs
+++ b/src/api/handlers/team.rs
@@ -9,39 +9,22 @@ pub(crate) fn handle_update_team(params: &Value, ctx: &HandlerCtx) -> Value {
         Some(n) => n.to_string(),
         None => return json!({"ok": false, "error": "missing name"}),
     };
-    let before = crate::teams::get_members(ctx.home, &team_name);
-    // Snapshot the pre-mutation roster so the TUI event carries the
-    // *effective* diff (noop adds like re-adding an existing member
-    // must not trigger a pane move).
-    let result = crate::teams::update(ctx.home, params);
-    let after = crate::teams::get_members(ctx.home, &team_name);
-    let before_set: std::collections::HashSet<&String> = before.iter().collect();
-    let after_set: std::collections::HashSet<&String> = after.iter().collect();
-    let added: Vec<String> = after
-        .iter()
-        .filter(|m| !before_set.contains(m))
-        .cloned()
-        .collect();
-    let removed: Vec<String> = before
-        .iter()
-        .filter(|m| !after_set.contains(m))
-        .cloned()
-        .collect();
-    let diff_nonempty = !added.is_empty() || !removed.is_empty();
+    let outcome = crate::teams::update_with_diff(ctx.home, params);
+    if let Some(error) = outcome.result["error"].as_str() {
+        return json!({"ok": false, "error": error});
+    }
     if let Some(n) = ctx.notifier {
+        let diff_nonempty = !outcome.added.is_empty() || !outcome.removed.is_empty();
         if diff_nonempty {
-            tracing::info!(team = %team_name, added = ?added, removed = ?removed, "UPDATE_TEAM emitting TeamMembersChanged");
+            tracing::info!(team = %team_name, added = ?outcome.added, removed = ?outcome.removed, "UPDATE_TEAM emitting TeamMembersChanged");
             n.notify(ApiEvent::TeamMembersChanged {
                 name: team_name.clone(),
-                added: added.clone(),
-                removed: removed.clone(),
+                added: outcome.added.clone(),
+                removed: outcome.removed.clone(),
             });
         }
     }
-    // Same condition as the TUI notification: an empty diff means a
-    // noop update (e.g. `update_team add` with members already on the
-    // roster), no reason to broadcast anything either.
-    json!({"ok": true, "result": result})
+    json!({"ok": true, "result": outcome.result})
 }
 
 /// #1964 Bug 1: plan `count` member names for `team` as `<team>-N`. Names

--- a/src/api/handlers/team.rs
+++ b/src/api/handlers/team.rs
@@ -10,18 +10,17 @@ pub(crate) fn handle_update_team(params: &Value, ctx: &HandlerCtx) -> Value {
         None => return json!({"ok": false, "error": "missing name"}),
     };
     let outcome = crate::teams::update_with_diff(ctx.home, params);
-    if let Some(error) = outcome.result["error"].as_str() {
-        return json!({"ok": false, "error": error});
-    }
-    if let Some(n) = ctx.notifier {
-        let diff_nonempty = !outcome.added.is_empty() || !outcome.removed.is_empty();
-        if diff_nonempty {
-            tracing::info!(team = %team_name, added = ?outcome.added, removed = ?outcome.removed, "UPDATE_TEAM emitting TeamMembersChanged");
-            n.notify(ApiEvent::TeamMembersChanged {
-                name: team_name.clone(),
-                added: outcome.added.clone(),
-                removed: outcome.removed.clone(),
-            });
+    if outcome.result.get("error").is_none() {
+        if let Some(n) = ctx.notifier {
+            let diff_nonempty = !outcome.added.is_empty() || !outcome.removed.is_empty();
+            if diff_nonempty {
+                tracing::info!(team = %team_name, added = ?outcome.added, removed = ?outcome.removed, "UPDATE_TEAM emitting TeamMembersChanged");
+                n.notify(ApiEvent::TeamMembersChanged {
+                    name: team_name.clone(),
+                    added: outcome.added.clone(),
+                    removed: outcome.removed.clone(),
+                });
+            }
         }
     }
     json!({"ok": true, "result": outcome.result})
@@ -490,6 +489,32 @@ mod tests {
             team.accept_from
         );
 
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn update_team_error_preserves_outer_success_envelope_2454() {
+        let home = tmp_home("update-error-envelope");
+        crate::teams::create(
+            &home,
+            &json!({
+                "name": "devs",
+                "members": ["lead"],
+                "orchestrator": "lead",
+            }),
+        );
+        let response = handle_update_team(
+            &json!({"name": "devs", "remove": ["lead"]}),
+            &test_ctx(&home),
+        );
+        assert_eq!(
+            response["ok"], true,
+            "API wire envelope changed: {response}"
+        );
+        assert!(response.get("error").is_none());
+        assert!(response["result"]["error"]
+            .as_str()
+            .is_some_and(|error| error.contains("cannot remove orchestrator")));
         std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/src/mcp/handlers/dispatch.rs
+++ b/src/mcp/handlers/dispatch.rs
@@ -404,12 +404,18 @@ action_adapter!(dispatch_set_metadata, "set_metadata", [
     "description"  => instance::handle_set_description,  hai;
 ]);
 
-action_adapter!(dispatch_team, "team", [
-    "create" => task::handle_create_team,  ha;
-    "delete" => task::handle_delete_team,  ha;
-    "list"   => task::handle_list_teams,   h;
-    "update" => task::handle_update_team,  ha;
-]);
+/// #2454 Slice 7: team update carries the owned runtime notifier into the
+/// transport-neutral roster service; other team actions retain their legacy
+/// adapter shapes.
+pub(crate) fn dispatch_team(ctx: &HandlerCtx<'_>) -> Value {
+    match ctx.args["action"].as_str().unwrap_or("") {
+        "create" => task::handle_create_team(ctx.home, ctx.args),
+        "delete" => task::handle_delete_team(ctx.home, ctx.args),
+        "list" => task::handle_list_teams(ctx.home),
+        "update" => task::handle_update_team(ctx.home, ctx.args, ctx.runtime),
+        other => json!({"error": format!("unknown team action: {other}")}),
+    }
+}
 
 // `inbox` — branch on `args["action"]` then arg presence:
 //   - `action=ack`  → confirm processed (#2299; delivering → processed)

--- a/src/mcp/handlers/task.rs
+++ b/src/mcp/handlers/task.rs
@@ -1,6 +1,7 @@
 use crate::channel::sink_registry::registry as ux_sink_registry;
 use crate::channel::ux_event::{FleetEvent, UxEvent};
 use crate::identity::Sender;
+use crate::mcp::handlers::dispatch::RuntimeContext;
 use serde_json::{json, Value};
 use std::path::Path;
 
@@ -102,15 +103,23 @@ pub(super) fn handle_list_teams(home: &Path) -> Value {
     crate::teams::list(home)
 }
 
-pub(super) fn handle_update_team(home: &Path, args: &Value) -> Value {
-    match crate::api::call(
-        home,
-        &json!({"method": crate::api::method::UPDATE_TEAM, "params": args}),
-    ) {
-        Ok(resp) if resp["ok"].as_bool() == Some(true) => resp["result"].clone(),
-        Ok(resp) => {
-            json!({"error": resp["error"].as_str().unwrap_or("update_team failed")})
+pub(super) fn handle_update_team(
+    home: &Path,
+    args: &Value,
+    runtime: Option<&RuntimeContext>,
+) -> Value {
+    let team_name = args["name"].as_str().unwrap_or("");
+    let outcome = crate::teams::update_with_diff(home, args);
+    if outcome.result.get("error").is_none() {
+        if let Some(notifier) = runtime.and_then(|runtime| runtime.notifier.as_ref()) {
+            if !outcome.added.is_empty() || !outcome.removed.is_empty() {
+                notifier.notify(crate::api::ApiEvent::TeamMembersChanged {
+                    name: team_name.to_string(),
+                    added: outcome.added.clone(),
+                    removed: outcome.removed.clone(),
+                });
+            }
         }
-        Err(_) => crate::teams::update(home, args),
     }
+    outcome.result
 }

--- a/src/teams.rs
+++ b/src/teams.rs
@@ -674,6 +674,41 @@ pub fn get_members(home: &Path, team_name: &str) -> Vec<String> {
         .unwrap_or_default()
 }
 
+/// Result of a team update together with its effective roster diff.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TeamUpdateOutcome {
+    pub result: Value,
+    pub added: Vec<String>,
+    pub removed: Vec<String>,
+}
+
+/// Apply a team update and return the original wire result plus the effective
+/// added/removed member diff. Callers own transport-specific response mapping
+/// and notification; this service owns the single roster mutation path.
+pub fn update_with_diff(home: &Path, args: &Value) -> TeamUpdateOutcome {
+    let team_name = args["name"].as_str().unwrap_or("");
+    let before = get_members(home, team_name);
+    let result = update(home, args);
+    let after = get_members(home, team_name);
+    let before_set: std::collections::HashSet<&String> = before.iter().collect();
+    let after_set: std::collections::HashSet<&String> = after.iter().collect();
+    let added = after
+        .iter()
+        .filter(|member| !before_set.contains(member))
+        .cloned()
+        .collect();
+    let removed = before
+        .iter()
+        .filter(|member| !after_set.contains(member))
+        .cloned()
+        .collect();
+    TeamUpdateOutcome {
+        result,
+        added,
+        removed,
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
@@ -1130,6 +1165,37 @@ mod tests {
         assert_eq!(r["status"], "updated");
         let listed = list(&home);
         assert_eq!(listed["teams"][0]["orchestrator"], "b");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn update_with_diff_reports_effective_changes_and_noop() {
+        let home = tmp_home("update_with_diff");
+        create(
+            &home,
+            &serde_json::json!({"name": "devs", "members": ["a"]}),
+        );
+        let added = update_with_diff(
+            &home,
+            &serde_json::json!({
+                "name": "devs",
+                "add": ["b"],
+            }),
+        );
+        assert_eq!(added.result["status"], "updated");
+        assert_eq!(added.added, vec!["b"]);
+        assert!(added.removed.is_empty());
+
+        let noop = update_with_diff(
+            &home,
+            &serde_json::json!({
+                "name": "devs",
+                "add": ["a"],
+            }),
+        );
+        assert_eq!(noop.result["status"], "updated");
+        assert!(noop.added.is_empty());
+        assert!(noop.removed.is_empty());
         std::fs::remove_dir_all(&home).ok();
     }
 


### PR DESCRIPTION
## Summary
- add typed `teams::update_with_diff` service returning the existing update result plus effective added/removed roster changes
- route API and MCP `team action=update` through the shared service
- preserve MCP direct-update compatibility when runtime/notifier is absent while emitting `TeamMembersChanged` only for non-empty diffs

## Validation
- exact RED base: `f8b0143c7827f200c4a11b13d46ee4d927918639`
- RED commit: `118ba7339f415fe732808628803dc21881dcbffb` (test-only, 2 expected failures)
- GREEN head: `d3bec94f622812a59b4bda264fb5094dcf55a64e`
- `cargo test --bin agend-terminal '2454' -- --nocapture` (24 passed)
- API update_team dispatch tests (4 passed)
- MCP direct-update fallback test (1 passed)
- typed service test (1 passed)
- full `cargo test --bin agend-terminal` (5915 tests)
- `cargo clippy --bin agend-terminal -- -D warnings`
- rustfmt and `git diff --check`
