### PR TITLE
fix(#2454): inject supervised restart shutdown authority

### DIFF
--- a/src/api/handlers/external.rs
+++ b/src/api/handlers/external.rs
@@ -129,6 +129,7 @@ mod tests {
             capability: crate::api::RestartCapability::Unsupported,
             app_restart: None,
             post_flush: crate::api::app_restart::PostFlushSlot::new(),
+            shutdown: None,
         };
         (ctx, home)
     }

--- a/src/api/handlers/hook_event.rs
+++ b/src/api/handlers/hook_event.rs
@@ -94,6 +94,7 @@ mod tests {
             capability: crate::api::RestartCapability::Unsupported,
             app_restart: None,
             post_flush: crate::api::app_restart::PostFlushSlot::new(),
+            shutdown: None,
         }
     }
 

--- a/src/api/handlers/instance.rs
+++ b/src/api/handlers/instance.rs
@@ -563,6 +563,7 @@ mod tests {
             capability: crate::api::RestartCapability::Unsupported,
             app_restart: None,
             post_flush: crate::api::app_restart::PostFlushSlot::new(),
+            shutdown: None,
         };
         (ctx, home)
     }
@@ -698,6 +699,7 @@ mod tests {
             capability: crate::api::RestartCapability::Unsupported,
             app_restart: None,
             post_flush: crate::api::app_restart::PostFlushSlot::new(),
+            shutdown: None,
         };
         (ctx, home)
     }
@@ -784,6 +786,7 @@ mod tests {
             capability: crate::api::RestartCapability::Unsupported,
             app_restart: None,
             post_flush: crate::api::app_restart::PostFlushSlot::new(),
+            shutdown: None,
         };
 
         let resp = handle_spawn(&json!({"name": "twin", "backend": "claude"}), &ctx);
@@ -1178,6 +1181,7 @@ mod tests {
             capability: crate::api::RestartCapability::Unsupported,
             app_restart: None,
             post_flush: crate::api::app_restart::PostFlushSlot::new(),
+            shutdown: None,
         };
         (ctx, home)
     }

--- a/src/api/handlers/mcp_proxy.rs
+++ b/src/api/handlers/mcp_proxy.rs
@@ -153,6 +153,7 @@ pub(crate) fn handle_mcp_tool(params: &Value, ctx: &HandlerCtx) -> Value {
         // register its commit-permission ack, run by `handle_session` after flush.
         post_flush: Some(ctx.post_flush.clone()),
         notifier: ctx.notifier.cloned(),
+        shutdown: ctx.shutdown.clone(),
     };
     handle_mcp_tool_inner(
         tool,
@@ -515,6 +516,7 @@ mod tests {
             capability: crate::api::RestartCapability::Unsupported,
             app_restart: None,
             post_flush: crate::api::app_restart::PostFlushSlot::new(),
+            shutdown: None,
         };
 
         let full = crate::mcp::tools::tool_definitions()["tools"]
@@ -574,6 +576,7 @@ mod tests {
             capability: crate::api::RestartCapability::Unsupported,
             app_restart: None,
             post_flush: crate::api::app_restart::PostFlushSlot::new(),
+            shutdown: None,
         };
 
         let resp = handle_mcp_tool(
@@ -621,6 +624,7 @@ mod tests {
             capability: crate::api::RestartCapability::Unsupported,
             app_restart: None,
             post_flush: crate::api::app_restart::PostFlushSlot::new(),
+            shutdown: None,
         };
 
         let resp = handle_mcp_tool(
@@ -671,6 +675,7 @@ mod tests {
             capability: crate::api::RestartCapability::Unsupported,
             app_restart: None,
             post_flush: crate::api::app_restart::PostFlushSlot::new(),
+            shutdown: None,
         };
 
         let resp = handle_mcp_tools_list(&json!({"instance": "bad"}), &ctx);
@@ -713,6 +718,7 @@ mod tests {
             capability: crate::api::RestartCapability::Unsupported,
             app_restart: None,
             post_flush: crate::api::app_restart::PostFlushSlot::new(),
+            shutdown: None,
         };
 
         let full = crate::mcp::tools::tool_definitions()["tools"]
@@ -785,6 +791,7 @@ mod tests {
             capability: crate::api::RestartCapability::Unsupported,
             app_restart: None,
             post_flush: crate::api::app_restart::PostFlushSlot::new(),
+            shutdown: None,
         };
 
         let default = handle_mcp_tool(
@@ -932,6 +939,7 @@ mod tests {
             capability: crate::api::RestartCapability::Unsupported,
             app_restart: None,
             post_flush: crate::api::app_restart::PostFlushSlot::new(),
+            shutdown: None,
         };
 
         for arguments in [
@@ -1039,6 +1047,7 @@ mod tests {
             app_restart: None,
             post_flush,
             notifier: None,
+            shutdown: None,
         };
         let result = handle_mcp_tool(
             &serde_json::json!({
@@ -1075,5 +1084,92 @@ mod tests {
             "event-log must contain inject_input detail ('not found'): {event_log}"
         );
         std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// #2454 Slice 9 RED: drive the real MCP restart_daemon ingress with a
+    /// Daemon capability and an injected shutdown flag. The legacy handler
+    /// still self-IPC's SHUTDOWN, so the response is ok while the flag stays
+    /// false until GREEN wires the shared authority through.
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn restart_daemon_real_entry_shutdown_flag_2454() {
+        use std::ffi::OsString;
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Arc;
+
+        let _guard = crate::mcp::handlers::fleet_test_guard();
+        let home = std::env::temp_dir().join(format!(
+            "agend-s9-mcp-restart-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&home).unwrap();
+        std::fs::write(
+            crate::fleet::fleet_yaml_path(&home),
+            "instances:\n  operator:\n    role_kind: orchestrator\n",
+        )
+        .unwrap();
+
+        let previous_home = std::env::var_os("AGEND_HOME");
+        let previous_handoff = std::env::var_os("AGEND_RESTART_HANDOFF");
+        let previous_supervised = std::env::var_os("AGEND_SUPERVISED");
+        std::env::set_var("AGEND_HOME", &home);
+        std::env::set_var("AGEND_RESTART_HANDOFF", OsString::from("0"));
+        std::env::set_var("AGEND_SUPERVISED", OsString::from("1"));
+
+        let previous_restart_pending = crate::daemon::RESTART_PENDING.load(Ordering::Acquire);
+        crate::daemon::RESTART_PENDING.store(false, Ordering::Release);
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let registry: crate::agent::AgentRegistry = Default::default();
+        let configs: crate::api::ConfigRegistry = Default::default();
+        let externals: crate::agent::ExternalRegistry = Default::default();
+        let ctx = HandlerCtx {
+            registry: &registry,
+            configs: &configs,
+            externals: &externals,
+            notifier: None,
+            home: &home,
+            capability: crate::api::RestartCapability::Daemon,
+            app_restart: None,
+            post_flush: crate::api::app_restart::PostFlushSlot::new(),
+            shutdown: Some(shutdown.clone()),
+        };
+        let response = handle_mcp_tool(
+            &json!({
+                "tool": "restart_daemon",
+                "instance": "operator",
+                "arguments": {}
+            }),
+            &ctx,
+        );
+        let response_ok = response["ok"] == true && response["result"]["ok"] == true;
+        let shutdown_set = shutdown.load(Ordering::Acquire);
+
+        crate::daemon::RESTART_PENDING.store(previous_restart_pending, Ordering::Release);
+        match previous_home {
+            Some(value) => std::env::set_var("AGEND_HOME", value),
+            None => std::env::remove_var("AGEND_HOME"),
+        }
+        match previous_handoff {
+            Some(value) => std::env::set_var("AGEND_RESTART_HANDOFF", value),
+            None => std::env::remove_var("AGEND_RESTART_HANDOFF"),
+        }
+        match previous_supervised {
+            Some(value) => std::env::set_var("AGEND_SUPERVISED", value),
+            None => std::env::remove_var("AGEND_SUPERVISED"),
+        }
+        std::fs::remove_dir_all(&home).ok();
+
+        assert!(
+            response_ok,
+            "legacy restart_daemon response must remain ok: {response}"
+        );
+        assert!(
+            shutdown_set,
+            "RED: production restart_daemon must set the injected shutdown flag: {response}"
+        );
     }
 }

--- a/src/api/handlers/mcp_proxy.rs
+++ b/src/api/handlers/mcp_proxy.rs
@@ -1086,10 +1086,8 @@ mod tests {
         std::fs::remove_dir_all(&home).ok();
     }
 
-    /// #2454 Slice 9 RED: drive the real MCP restart_daemon ingress with a
-    /// Daemon capability and an injected shutdown flag. The legacy handler
-    /// still self-IPC's SHUTDOWN, so the response is ok while the flag stays
-    /// false until GREEN wires the shared authority through.
+    /// #2454 Slice 9: drive the real MCP restart_daemon ingress with a Daemon
+    /// capability and an injected shutdown flag.
     #[test]
     #[allow(clippy::unwrap_used)]
     fn restart_daemon_real_entry_shutdown_flag_2454() {
@@ -1169,7 +1167,98 @@ mod tests {
         );
         assert!(
             shutdown_set,
-            "RED: production restart_daemon must set the injected shutdown flag: {response}"
+            "production restart_daemon must set the injected shutdown flag: {response}"
+        );
+    }
+
+    /// #2454 Slice 9: a supervised Daemon request without an injected shutdown
+    /// authority must fail closed before touching restart state.
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn restart_daemon_real_entry_without_shutdown_fails_closed_2454() {
+        use std::ffi::OsString;
+        use std::sync::atomic::Ordering;
+
+        let _guard = crate::mcp::handlers::fleet_test_guard();
+        let home = std::env::temp_dir().join(format!(
+            "agend-s9-mcp-restart-no-shutdown-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&home).unwrap();
+        std::fs::write(
+            crate::fleet::fleet_yaml_path(&home),
+            "instances:\n  operator:\n    role_kind: orchestrator\n",
+        )
+        .unwrap();
+
+        let previous_home = std::env::var_os("AGEND_HOME");
+        let previous_handoff = std::env::var_os("AGEND_RESTART_HANDOFF");
+        let previous_supervised = std::env::var_os("AGEND_SUPERVISED");
+        std::env::set_var("AGEND_HOME", &home);
+        std::env::set_var("AGEND_RESTART_HANDOFF", OsString::from("0"));
+        std::env::set_var("AGEND_SUPERVISED", OsString::from("1"));
+
+        let previous_restart_pending = crate::daemon::RESTART_PENDING.load(Ordering::Acquire);
+        crate::daemon::RESTART_PENDING.store(false, Ordering::Release);
+        let registry: crate::agent::AgentRegistry = Default::default();
+        let configs: crate::api::ConfigRegistry = Default::default();
+        let externals: crate::agent::ExternalRegistry = Default::default();
+        let ctx = HandlerCtx {
+            registry: &registry,
+            configs: &configs,
+            externals: &externals,
+            notifier: None,
+            home: &home,
+            capability: crate::api::RestartCapability::Daemon,
+            app_restart: None,
+            post_flush: crate::api::app_restart::PostFlushSlot::new(),
+            shutdown: None,
+        };
+        let response = handle_mcp_tool(
+            &json!({
+                "tool": "restart_daemon",
+                "instance": "operator",
+                "arguments": {}
+            }),
+            &ctx,
+        );
+        let pending = crate::daemon::RESTART_PENDING.load(Ordering::Acquire);
+        let marker_exists = home.join("restart-requested").exists();
+
+        crate::daemon::RESTART_PENDING.store(previous_restart_pending, Ordering::Release);
+        match previous_home {
+            Some(value) => std::env::set_var("AGEND_HOME", value),
+            None => std::env::remove_var("AGEND_HOME"),
+        }
+        match previous_handoff {
+            Some(value) => std::env::set_var("AGEND_RESTART_HANDOFF", value),
+            None => std::env::remove_var("AGEND_RESTART_HANDOFF"),
+        }
+        match previous_supervised {
+            Some(value) => std::env::set_var("AGEND_SUPERVISED", value),
+            None => std::env::remove_var("AGEND_SUPERVISED"),
+        }
+        std::fs::remove_dir_all(&home).ok();
+
+        assert_eq!(
+            response["ok"], true,
+            "MCP ingress must return a response: {response}"
+        );
+        assert_eq!(
+            response["result"]["ok"], false,
+            "missing authority must fail closed: {response}"
+        );
+        assert!(
+            !pending,
+            "missing authority must not set RESTART_PENDING: {response}"
+        );
+        assert!(
+            !marker_exists,
+            "missing authority must not write restart-requested"
         );
     }
 }

--- a/src/api/handlers/messaging/tests.rs
+++ b/src/api/handlers/messaging/tests.rs
@@ -20,6 +20,7 @@ fn test_ctx(home: &std::path::Path) -> HandlerCtx<'_> {
         capability: crate::api::RestartCapability::Unsupported,
         app_restart: None,
         post_flush: crate::api::app_restart::PostFlushSlot::new(),
+        shutdown: None,
     }
 }
 
@@ -224,6 +225,7 @@ fn test_send_to_active_registry_target_returns_pty() {
         capability: crate::api::RestartCapability::Unsupported,
         app_restart: None,
         post_flush: crate::api::app_restart::PostFlushSlot::new(),
+        shutdown: None,
     };
     let result = handle_send(
         &json!({"from": "sender", "target": "active-agent", "text": "hi"}),
@@ -819,6 +821,7 @@ fn same_team_codex_update_absorbed() {
         capability: crate::api::RestartCapability::Unsupported,
         app_restart: None,
         post_flush: crate::api::app_restart::PostFlushSlot::new(),
+        shutdown: None,
     };
     let result = handle_send(
         &json!({"from": "sender", "target": "codex-agent", "text": "status update", "kind": "update"}),
@@ -899,6 +902,7 @@ fn cross_team_message_not_absorbed() {
         capability: crate::api::RestartCapability::Unsupported,
         app_restart: None,
         post_flush: crate::api::app_restart::PostFlushSlot::new(),
+        shutdown: None,
     };
     // general can send cross-team; codex update should still inject (not absorbed)
     let result = handle_send(
@@ -971,6 +975,7 @@ fn same_team_codex_update_orchestrator_not_skipped() {
         capability: crate::api::RestartCapability::Unsupported,
         app_restart: None,
         post_flush: crate::api::app_restart::PostFlushSlot::new(),
+        shutdown: None,
     };
     let result = handle_send(
         &json!({"from": "sender", "target": "codex-agent", "text": "status update", "kind": "update"}),
@@ -1039,6 +1044,7 @@ fn same_team_codex_update_non_orchestrator_skipped() {
         capability: crate::api::RestartCapability::Unsupported,
         app_restart: None,
         post_flush: crate::api::app_restart::PostFlushSlot::new(),
+        shutdown: None,
     };
     let result = handle_send(
         &json!({"from": "sender", "target": "codex-agent", "text": "status update", "kind": "update"}),
@@ -1108,6 +1114,7 @@ fn cross_team_codex_update_orchestrator_not_skipped() {
         capability: crate::api::RestartCapability::Unsupported,
         app_restart: None,
         post_flush: crate::api::app_restart::PostFlushSlot::new(),
+        shutdown: None,
     };
     let result = handle_send(
         &json!({"from": "general", "target": "codex-agent", "text": "cross-team update", "kind": "update"}),
@@ -1712,6 +1719,7 @@ fn make_codex_ctx(
         capability: crate::api::RestartCapability::Unsupported,
         app_restart: None,
         post_flush: crate::api::app_restart::PostFlushSlot::new(),
+        shutdown: None,
     };
     (registry, ctx, home.to_path_buf())
 }
@@ -1977,6 +1985,7 @@ fn b6_non_codex_backend_pty_path_unchanged_by_override() {
         capability: crate::api::RestartCapability::Unsupported,
         app_restart: None,
         post_flush: crate::api::app_restart::PostFlushSlot::new(),
+        shutdown: None,
     };
     seed_drained_blocker(&home, "claude-agent", "query", "corr-b6");
 
@@ -2183,6 +2192,7 @@ fn kind_report_cross_team_codex_via_general_still_injects() {
         capability: crate::api::RestartCapability::Unsupported,
         app_restart: None,
         post_flush: crate::api::app_restart::PostFlushSlot::new(),
+        shutdown: None,
     };
     let result = handle_send(
         &json!({

--- a/src/api/handlers/mod.rs
+++ b/src/api/handlers/mod.rs
@@ -151,4 +151,7 @@ pub(crate) struct HandlerCtx<'a> {
     /// ack), and — after writing the response — calls `run_after_flush`. Cheap
     /// `Arc` clone; unused by non-restart tools.
     pub post_flush: crate::api::app_restart::PostFlushSlot,
+    /// #2454 Slice 9 RED: optional shared daemon shutdown authority. Production
+    /// API sessions inject it; ordinary helper/test contexts stay standalone.
+    pub shutdown: Option<Arc<std::sync::atomic::AtomicBool>>,
 }

--- a/src/api/handlers/mod.rs
+++ b/src/api/handlers/mod.rs
@@ -151,7 +151,7 @@ pub(crate) struct HandlerCtx<'a> {
     /// ack), and — after writing the response — calls `run_after_flush`. Cheap
     /// `Arc` clone; unused by non-restart tools.
     pub post_flush: crate::api::app_restart::PostFlushSlot,
-    /// #2454 Slice 9 RED: optional shared daemon shutdown authority. Production
-    /// API sessions inject it; ordinary helper/test contexts stay standalone.
+    /// #2454 Slice 9: optional shared daemon shutdown authority. Production API
+    /// sessions inject it; ordinary helper/test contexts stay standalone.
     pub shutdown: Option<Arc<std::sync::atomic::AtomicBool>>,
 }

--- a/src/api/handlers/mod.rs
+++ b/src/api/handlers/mod.rs
@@ -151,7 +151,8 @@ pub(crate) struct HandlerCtx<'a> {
     /// ack), and — after writing the response — calls `run_after_flush`. Cheap
     /// `Arc` clone; unused by non-restart tools.
     pub post_flush: crate::api::app_restart::PostFlushSlot,
-    /// #2454 Slice 9: optional shared daemon shutdown authority. Production API
-    /// sessions inject it; ordinary helper/test contexts stay standalone.
+    /// #2454 Slice 9: shared daemon shutdown authority. Production API sessions
+    /// inject it; the inline SHUTDOWN path and MCP `restart_daemon` carry the
+    /// same authority. Ordinary helper/test contexts stay standalone.
     pub shutdown: Option<Arc<std::sync::atomic::AtomicBool>>,
 }

--- a/src/api/handlers/team.rs
+++ b/src/api/handlers/team.rs
@@ -435,6 +435,7 @@ mod tests {
             capability: crate::api::RestartCapability::Unsupported,
             app_restart: None,
             post_flush: crate::api::app_restart::PostFlushSlot::new(),
+            shutdown: None,
         }
     }
 
@@ -565,6 +566,7 @@ mod tests_1964 {
             capability: crate::api::RestartCapability::Unsupported,
             app_restart: None,
             post_flush: crate::api::app_restart::PostFlushSlot::new(),
+            shutdown: None,
         }
     }
 
@@ -741,6 +743,7 @@ mod tests_2525 {
             capability: crate::api::RestartCapability::Unsupported,
             app_restart: None,
             post_flush: crate::api::app_restart::PostFlushSlot::new(),
+            shutdown: None,
         }
     }
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -667,6 +667,7 @@ fn handle_session(
             capability: host,
             app_restart: app_restart.as_ref(),
             post_flush: post_flush.clone(),
+            shutdown: Some(Arc::clone(shutdown)),
         };
 
         // P0a (#2342 B4): per-method CAPABILITY gate FIRST — authority is proven

--- a/src/daemon/poll_reminder.rs
+++ b/src/daemon/poll_reminder.rs
@@ -420,6 +420,7 @@ mod tests {
             capability: crate::api::RestartCapability::Unsupported,
             app_restart: None,
             post_flush: crate::api::app_restart::PostFlushSlot::new(),
+            shutdown: None,
         }
     }
 

--- a/src/mcp/handlers/dispatch.rs
+++ b/src/mcp/handlers/dispatch.rs
@@ -1449,10 +1449,9 @@ mod tests {
     }
 
     /// Baseline count: exactly 11 same-daemon api::call production sites
-    /// remain in src/mcp/handlers/ at this commit (was 12 pre-S9; the
-    /// team_task_inject thread's direct call consolidated into the shared
-    /// inject_with_routing helper). Any addition without a corresponding
-    /// removal is a regression.
+    /// remain in src/mcp/handlers/ at this commit (was 12 before Slice 9
+    /// removed the supervised restart SHUTDOWN loopback). Any addition without
+    /// a corresponding removal is a regression.
     #[test]
     fn production_api_call_baseline_is_11_2454() {
         let needle_call = concat!("crate::", "api::", "call");

--- a/src/mcp/handlers/dispatch.rs
+++ b/src/mcp/handlers/dispatch.rs
@@ -69,6 +69,9 @@ pub(crate) struct RuntimeContext {
     /// #2454: owner notifier forwarded from the API composition root so MCP
     /// move_pane emits the same TUI event as the direct API ingress.
     pub notifier: Option<Arc<dyn crate::api::ApiNotifier>>,
+    /// #2454 Slice 9 RED: optional shared daemon shutdown authority forwarded
+    /// from the API MCP ingress. Standalone bridge calls leave it absent.
+    pub shutdown: Option<Arc<std::sync::atomic::AtomicBool>>,
 }
 
 /// One MCP tool's dispatcher. Function pointer (not `Box<dyn …>`) so
@@ -302,11 +305,12 @@ pub(crate) fn dispatch_pane_snapshot(ctx: &HandlerCtx<'_>) -> Value {
 /// standalone bridge call that never traversed the api `mcp_tool` ingress) maps
 /// to `None` → default-deny in the handler.
 pub(crate) fn dispatch_restart_daemon(ctx: &HandlerCtx<'_>) -> Value {
-    restart::handle_restart_daemon(
+    restart::handle_restart_daemon_with_shutdown(
         ctx.home,
         ctx.runtime.map(|r| r.capability),
         ctx.runtime.and_then(|r| r.app_restart.clone()),
         ctx.runtime.and_then(|r| r.post_flush.clone()),
+        ctx.runtime.and_then(|r| r.shutdown.clone()),
     )
 }
 
@@ -513,6 +517,7 @@ mod tests {
             app_restart: None,
             post_flush: None,
             notifier: None,
+            shutdown: None,
         };
         let ctx = HandlerCtx {
             home: &home,
@@ -989,6 +994,7 @@ mod tests {
             app_restart: None,
             post_flush: None,
             notifier: None,
+            shutdown: None,
         }
     }
 
@@ -1136,6 +1142,7 @@ mod tests {
             app_restart: None,
             post_flush: None,
             notifier: None,
+            shutdown: None,
         }
     }
 
@@ -1244,6 +1251,7 @@ mod tests {
             capability: crate::api::RestartCapability::Unsupported,
             app_restart: None,
             post_flush: crate::api::app_restart::PostFlushSlot::new(),
+            shutdown: None,
         };
 
         let default = crate::api::handlers::instance::handle_move_pane(

--- a/src/mcp/handlers/dispatch.rs
+++ b/src/mcp/handlers/dispatch.rs
@@ -69,8 +69,8 @@ pub(crate) struct RuntimeContext {
     /// #2454: owner notifier forwarded from the API composition root so MCP
     /// move_pane emits the same TUI event as the direct API ingress.
     pub notifier: Option<Arc<dyn crate::api::ApiNotifier>>,
-    /// #2454 Slice 9 RED: optional shared daemon shutdown authority forwarded
-    /// from the API MCP ingress. Standalone bridge calls leave it absent.
+    /// #2454 Slice 9: optional shared daemon shutdown authority forwarded from
+    /// the API MCP ingress. Standalone bridge calls leave it absent.
     pub shutdown: Option<Arc<std::sync::atomic::AtomicBool>>,
 }
 
@@ -1448,13 +1448,13 @@ mod tests {
         std::fs::remove_dir_all(&home).ok();
     }
 
-    /// Baseline count: exactly 12 same-daemon api::call production sites
-    /// remain in src/mcp/handlers/ at this commit (was 13 pre-S8; the
+    /// Baseline count: exactly 11 same-daemon api::call production sites
+    /// remain in src/mcp/handlers/ at this commit (was 12 pre-S9; the
     /// team_task_inject thread's direct call consolidated into the shared
     /// inject_with_routing helper). Any addition without a corresponding
     /// removal is a regression.
     #[test]
-    fn production_api_call_baseline_is_12_2454() {
+    fn production_api_call_baseline_is_11_2454() {
         let needle_call = concat!("crate::", "api::", "call");
         let needle_at = concat!("api::", "call_at");
         let test_mod_marker = "#[cfg(test)]\nmod ";
@@ -1483,8 +1483,8 @@ mod tests {
             }
         }
         assert_eq!(
-            count, 12,
-            "production same-daemon api::call baseline must be exactly 12; got {count}"
+            count, 11,
+            "production same-daemon api::call baseline must be exactly 11; got {count}"
         );
     }
 

--- a/src/mcp/handlers/instance_metadata.rs
+++ b/src/mcp/handlers/instance_metadata.rs
@@ -418,6 +418,7 @@ mod blocked_reason_runtime_2454_tests {
             app_restart: None,
             post_flush: None,
             notifier: None,
+            shutdown: None,
         };
         (rt, home)
     }

--- a/src/mcp/handlers/instance_queries.rs
+++ b/src/mcp/handlers/instance_queries.rs
@@ -183,6 +183,7 @@ mod tests {
             app_restart: None,
             post_flush: None,
             notifier: None,
+            shutdown: None,
         };
 
         let result =
@@ -212,6 +213,7 @@ mod tests {
             app_restart: None,
             post_flush: None,
             notifier: None,
+            shutdown: None,
         }
     }
 
@@ -320,6 +322,7 @@ mod tests {
             app_restart: None,
             post_flush: None,
             notifier: None,
+            shutdown: None,
         };
 
         let result = handle_list_instances_with_runtime(

--- a/src/mcp/handlers/r3_46776_red_tests.rs
+++ b/src/mcp/handlers/r3_46776_red_tests.rs
@@ -306,6 +306,7 @@ fn g5_handle_spawn_rejects_workspace_identity_collision() {
         capability: crate::api::RestartCapability::Unsupported,
         app_restart: None,
         post_flush: crate::api::app_restart::PostFlushSlot::new(),
+        shutdown: None,
     };
 
     let resp = handle_spawn(

--- a/src/mcp/handlers/restart.rs
+++ b/src/mcp/handlers/restart.rs
@@ -12,15 +12,29 @@ use std::path::Path;
 /// both to a fail-closed response; a future staged app strategy becomes the
 /// `App` arm (decision d-20260712012329422433-1) with the compiler forcing every
 /// dispatch site to handle it — no god-object switch.
+#[cfg(test)]
 pub(super) fn handle_restart_daemon(
     home: &Path,
     capability: Option<crate::api::RestartCapability>,
     app_restart: Option<crate::api::app_restart::AppRestart>,
     post_flush: Option<crate::api::app_restart::PostFlushSlot>,
 ) -> Value {
+    handle_restart_daemon_with_shutdown(home, capability, app_restart, post_flush, None)
+}
+
+/// #2454 Slice 9 RED: carries the API-owned shutdown authority through the
+/// daemon strategy. Phase 1 intentionally leaves the authority unused so the
+/// real-entry test records the pre-GREEN failure deterministically.
+pub(super) fn handle_restart_daemon_with_shutdown(
+    home: &Path,
+    capability: Option<crate::api::RestartCapability>,
+    app_restart: Option<crate::api::app_restart::AppRestart>,
+    post_flush: Option<crate::api::app_restart::PostFlushSlot>,
+    shutdown: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
+) -> Value {
     use crate::api::RestartCapability;
     match capability {
-        Some(RestartCapability::Daemon) => daemon_restart_strategy(home),
+        Some(RestartCapability::Daemon) => daemon_restart_strategy(home, shutdown),
         Some(RestartCapability::App) => app_restart_strategy(app_restart, post_flush),
         Some(RestartCapability::Unsupported) | None => unsupported_fail_closed(),
     }
@@ -216,7 +230,10 @@ fn unsupported_fail_closed() -> Value {
 /// body below is the pre-Stage-R1 handler VERBATIM (self-respawn default /
 /// legacy exit(42) opt-out) — byte-semantically unchanged; only the app-mode
 /// gate that used to precede it moved out to the capability dispatch above.
-fn daemon_restart_strategy(home: &Path) -> Value {
+fn daemon_restart_strategy(
+    home: &Path,
+    _shutdown: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
+) -> Value {
     // #1814: self-respawn is the DEFAULT (Stage 4). By default the daemon owns
     // its own respawn (spawn successor → Phase-1 health gate → abort-stay-alive
     // on failure), so restart never hinges on an external supervisor being

--- a/src/mcp/handlers/restart.rs
+++ b/src/mcp/handlers/restart.rs
@@ -22,9 +22,9 @@ pub(super) fn handle_restart_daemon(
     handle_restart_daemon_with_shutdown(home, capability, app_restart, post_flush, None)
 }
 
-/// #2454 Slice 9 RED: carries the API-owned shutdown authority through the
-/// daemon strategy. Phase 1 intentionally leaves the authority unused so the
-/// real-entry test records the pre-GREEN failure deterministically.
+/// #2454 Slice 9: carries the API-owned shutdown authority through the daemon
+/// strategy so the supervised legacy path can shut down the current daemon
+/// without a loopback API call.
 pub(super) fn handle_restart_daemon_with_shutdown(
     home: &Path,
     capability: Option<crate::api::RestartCapability>,
@@ -232,7 +232,7 @@ fn unsupported_fail_closed() -> Value {
 /// gate that used to precede it moved out to the capability dispatch above.
 fn daemon_restart_strategy(
     home: &Path,
-    _shutdown: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
+    shutdown: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
 ) -> Value {
     // #1814: self-respawn is the DEFAULT (Stage 4). By default the daemon owns
     // its own respawn (spawn successor → Phase-1 health gate → abort-stay-alive
@@ -287,9 +287,16 @@ fn daemon_restart_strategy(
                       yet and stays fail-closed.)"
         });
     }
+    let Some(shutdown) = shutdown else {
+        return json!({
+            "ok": false,
+            "error": "restart_daemon requires an injected shutdown authority; refusing to mutate restart state"
+        });
+    };
     crate::daemon::RESTART_PENDING.store(true, std::sync::atomic::Ordering::Release);
     std::fs::write(home.join("restart-requested"), "").ok();
-    let _ = crate::api::call(home, &json!({"method": crate::api::method::SHUTDOWN}));
+    crate::daemon::record_shutdown_reason(crate::daemon::ShutdownReason::ApiShutdown);
+    shutdown.store(true, std::sync::atomic::Ordering::Relaxed);
     json!({"ok": true, "restart": "pending", "note": "daemon will exit(42) after graceful shutdown; supervisor restarts"})
 }
 

--- a/src/mcp/handlers/usage_limit_takeover_tests.rs
+++ b/src/mcp/handlers/usage_limit_takeover_tests.rs
@@ -165,6 +165,7 @@ fn fixture(tag: &str) -> Fixture {
         app_restart: None,
         post_flush: None,
         notifier: None,
+        shutdown: None,
     };
     let _ = source_head;
     Fixture {


### PR DESCRIPTION
## Summary
- route supervised legacy Daemon restart shutdown through the injected API authority
- fail closed before restart-state mutation when authority is absent
- preserve pending/marker behavior and update the frozen self-IPC source-count guard

## Validation
- exact RED real-entry test now passes
- missing-authority real-entry negative test passes
- restart handler tests pass
- MCP proxy tests pass
- dispatch/source-count guard tests pass
- cargo check --bin agend-terminal --no-default-features
- cargo test --bin agend-terminal --no-default-features --no-run
- cargo fmt -- --check

GREEN commit is directly based on RED 5e9bb3dc18f6f0d595a5fa93d4206481051784fa.