### PR TITLE
fix(#2454): share runtime delete service

### DIFF
--- a/src/agent_ops.rs
+++ b/src/agent_ops.rs
@@ -295,6 +295,82 @@ pub fn move_pane(
 }
 
 // ---------------------------------------------------------------------------
+// Instance deletion — shared API/MCP runtime service (#2454 Slice 10)
+// ---------------------------------------------------------------------------
+
+/// Runtime-owned state required by the managed DELETE operation.  The wire
+/// adapters (API and MCP) build this value from their respective contexts;
+/// the service itself does not know which transport invoked it.
+pub struct DeleteContext<'a> {
+    pub registry: &'a AgentRegistry,
+    pub configs: &'a crate::api::ConfigRegistry,
+    pub externals: &'a agent::ExternalRegistry,
+    pub notifier: Option<&'a Arc<dyn crate::api::ApiNotifier>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeleteOutcome {
+    Managed,
+    External,
+    /// The caller had no in-process runtime and the legacy API loopback was
+    /// used.  The result is intentionally not decoded here: legacy callers
+    /// historically treated the DELETE response as best-effort.
+    Legacy,
+}
+
+/// Perform the daemon-side portion of DELETE once, preserving the exact API
+/// semantics for managed and external agents.  Runtime callers use the
+/// registries directly; a `None` context keeps the one legacy loopback needed
+/// by TUI/team/test callers that have no in-process API owner.
+pub fn delete_instance(
+    home: &Path,
+    name: &str,
+    context: Option<&DeleteContext<'_>>,
+    skip_exit_wait: bool,
+) -> DeleteOutcome {
+    let Some(context) = context else {
+        let mut params = json!({"name": name});
+        if skip_exit_wait {
+            params["no_wait"] = json!(true);
+        }
+        let _ = crate::api::call(
+            home,
+            &json!({
+                "method": crate::api::method::DELETE,
+                "params": params,
+            }),
+        );
+        return DeleteOutcome::Legacy;
+    };
+
+    // Match the API adapter's external-first behavior.  External agents have
+    // no managed registry/config entry and therefore need no notifier event.
+    if agent::lock_external(context.externals)
+        .remove(name)
+        .is_some()
+    {
+        crate::event_log::log(home, "delete", name, "external agent deleted");
+        return DeleteOutcome::External;
+    }
+
+    crate::daemon::lifecycle::delete_transaction(
+        home,
+        name,
+        context.registry,
+        Some(context.configs),
+        skip_exit_wait,
+    );
+    crate::daemon::poll_reminder::remove_agent(name);
+    if let Some(notifier) = context.notifier {
+        tracing::info!(agent = name, "DELETE emitting InstanceDeleted");
+        notifier.notify(crate::api::ApiEvent::InstanceDeleted {
+            name: name.to_string(),
+        });
+    }
+    DeleteOutcome::Managed
+}
+
+// ---------------------------------------------------------------------------
 // Metadata
 // ---------------------------------------------------------------------------
 

--- a/src/agent_ops.rs
+++ b/src/agent_ops.rs
@@ -312,37 +312,17 @@ pub struct DeleteContext<'a> {
 pub enum DeleteOutcome {
     Managed,
     External,
-    /// The caller had no in-process runtime and the legacy API loopback was
-    /// used.  The result is intentionally not decoded here: legacy callers
-    /// historically treated the DELETE response as best-effort.
-    Legacy,
 }
 
 /// Perform the daemon-side portion of DELETE once, preserving the exact API
-/// semantics for managed and external agents.  Runtime callers use the
-/// registries directly; a `None` context keeps the one legacy loopback needed
-/// by TUI/team/test callers that have no in-process API owner.
+/// semantics for managed and external agents. Runtime callers use the live
+/// registries directly; transport fallback belongs to the MCP routing layer.
 pub fn delete_instance(
     home: &Path,
     name: &str,
-    context: Option<&DeleteContext<'_>>,
+    context: &DeleteContext<'_>,
     skip_exit_wait: bool,
 ) -> DeleteOutcome {
-    let Some(context) = context else {
-        let mut params = json!({"name": name});
-        if skip_exit_wait {
-            params["no_wait"] = json!(true);
-        }
-        let _ = crate::api::call(
-            home,
-            &json!({
-                "method": crate::api::method::DELETE,
-                "params": params,
-            }),
-        );
-        return DeleteOutcome::Legacy;
-    };
-
     // Match the API adapter's external-first behavior.  External agents have
     // no managed registry/config entry and therefore need no notifier event.
     if agent::lock_external(context.externals)

--- a/src/api/handlers/instance.rs
+++ b/src/api/handlers/instance.rs
@@ -81,7 +81,7 @@ pub(crate) fn handle_delete(params: &Value, ctx: &HandlerCtx) -> Value {
         externals: ctx.externals,
         notifier: ctx.notifier,
     };
-    crate::agent_ops::delete_instance(ctx.home, name, Some(&delete_context), skip_exit_wait);
+    crate::agent_ops::delete_instance(ctx.home, name, &delete_context, skip_exit_wait);
     json!({"ok": true})
 }
 

--- a/src/api/handlers/instance.rs
+++ b/src/api/handlers/instance.rs
@@ -74,36 +74,14 @@ pub(crate) fn handle_delete(params: &Value, ctx: &HandlerCtx) -> Value {
     if let Err(e) = agent::validate_name(name) {
         return json!({"ok": false, "error": e});
     }
-    // Check external registry first
-    {
-        let mut ext = agent::lock_external(ctx.externals);
-        if ext.remove(name).is_some() {
-            crate::event_log::log(ctx.home, "delete", name, "external agent deleted");
-            return json!({"ok": true});
-        }
-    }
-    // delete_transaction kills the process tree, waits up to CHILD_EXIT_TIMEOUT
-    // for actual exit, then removes registry / drops Telegram binding /
-    // removes configs / removes IPC port / emits event log. Sprint 20 F2 fix:
-    // the previous implementation removed the registry entry before the OS
-    // had reaped the PID, exposing PID re-use + concurrent-spawn collision
-    // races.
     let skip_exit_wait = params["no_wait"].as_bool().unwrap_or(false);
-    crate::daemon::lifecycle::delete_transaction(
-        ctx.home,
-        name,
-        ctx.registry,
-        Some(ctx.configs),
-        skip_exit_wait,
-    );
-    // H3: clean up poll_reminder dedup state for deleted agent
-    crate::daemon::poll_reminder::remove_agent(name);
-    if let Some(n) = ctx.notifier {
-        tracing::info!(agent = name, "DELETE emitting InstanceDeleted");
-        n.notify(ApiEvent::InstanceDeleted {
-            name: name.to_string(),
-        });
-    }
+    let delete_context = crate::agent_ops::DeleteContext {
+        registry: ctx.registry,
+        configs: ctx.configs,
+        externals: ctx.externals,
+        notifier: ctx.notifier,
+    };
+    crate::agent_ops::delete_instance(ctx.home, name, Some(&delete_context), skip_exit_wait);
     json!({"ok": true})
 }
 

--- a/src/api/handlers/mcp_proxy.rs
+++ b/src/api/handlers/mcp_proxy.rs
@@ -146,6 +146,7 @@ pub(crate) fn handle_mcp_tool(params: &Value, ctx: &HandlerCtx) -> Value {
     let timeout = tool_timeout(tool);
     let runtime = crate::mcp::handlers::dispatch::RuntimeContext {
         registry: ctx.registry.clone(),
+        configs: ctx.configs.clone(),
         externals: ctx.externals.clone(),
         capability: ctx.capability,
         app_restart: ctx.app_restart.cloned(),

--- a/src/api/handlers/mcp_proxy.rs
+++ b/src/api/handlers/mcp_proxy.rs
@@ -1119,7 +1119,7 @@ mod tests {
         let id = crate::types::InstanceId::new().full();
         std::fs::write(
             crate::fleet::fleet_yaml_path(&home),
-            format!("instances:\n  victim:\n    id: {id}\n    backend: claude\n"),
+            format!("instances:\n  victim:\n    id: {id}\n    backend: claude\n    created_by: s10-delete-caller-2454\n"),
         )
         .unwrap();
         let previous_home = std::env::var_os("AGEND_HOME");
@@ -1158,7 +1158,7 @@ mod tests {
         let response = handle_mcp_tool(
             &json!({
                 "tool": "delete_instance",
-                "instance": "victim",
+                "instance": "s10-delete-caller-2454",
                 "arguments": {"instance": "victim"}
             }),
             &ctx,

--- a/src/api/handlers/mcp_proxy.rs
+++ b/src/api/handlers/mcp_proxy.rs
@@ -1086,6 +1086,115 @@ mod tests {
         std::fs::remove_dir_all(&home).ok();
     }
 
+    /// #2454 Slice 10 RED: drive the real MCP delete_instance ingress with no
+    /// API listener. A managed fleet/config entry must be removed in-process
+    /// and the supplied notifier must receive InstanceDeleted; the current
+    /// adapter still falls back to the lifecycle helper's DELETE loopback.
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn delete_instance_real_entry_removes_managed_state_and_notifies_2454() {
+        use crate::api::{ApiEvent, ApiNotifier};
+
+        struct RecordingNotifier {
+            events: parking_lot::Mutex<Vec<ApiEvent>>,
+        }
+
+        impl ApiNotifier for RecordingNotifier {
+            fn notify(&self, event: ApiEvent) {
+                self.events.lock().push(event);
+            }
+        }
+
+        let _guard = crate::mcp::handlers::fleet_test_guard();
+        let home = std::env::temp_dir().join(format!(
+            "agend-s10-mcp-delete-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&home).unwrap();
+        let id = crate::types::InstanceId::new().full();
+        std::fs::write(
+            crate::fleet::fleet_yaml_path(&home),
+            format!("instances:\n  victim:\n    id: {id}\n    backend: claude\n"),
+        )
+        .unwrap();
+        let previous_home = std::env::var_os("AGEND_HOME");
+        std::env::set_var("AGEND_HOME", &home);
+
+        let registry: crate::agent::AgentRegistry = Default::default();
+        let configs: crate::api::ConfigRegistry = Default::default();
+        configs.lock().insert(
+            "victim".to_string(),
+            crate::daemon::AgentConfig {
+                name: "victim".to_string(),
+                backend: None,
+                backend_command: crate::default_shell().to_string(),
+                args: Vec::new(),
+                env: None,
+                working_dir: None,
+                submit_key: "\r".to_string(),
+            },
+        );
+        let externals: crate::agent::ExternalRegistry = Default::default();
+        let notifier = std::sync::Arc::new(RecordingNotifier {
+            events: parking_lot::Mutex::new(Vec::new()),
+        });
+        let notifier_trait: std::sync::Arc<dyn ApiNotifier> = notifier.clone();
+        let ctx = HandlerCtx {
+            registry: &registry,
+            configs: &configs,
+            externals: &externals,
+            notifier: Some(&notifier_trait),
+            home: &home,
+            capability: crate::api::RestartCapability::Unsupported,
+            app_restart: None,
+            post_flush: crate::api::app_restart::PostFlushSlot::new(),
+            shutdown: None,
+        };
+        let response = handle_mcp_tool(
+            &json!({
+                "tool": "delete_instance",
+                "instance": "victim",
+                "arguments": {"instance": "victim"}
+            }),
+            &ctx,
+        );
+        let fleet_has_victim =
+            crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&home))
+                .ok()
+                .and_then(|fleet| fleet.instances.get("victim").map(|_| ()))
+                .is_some();
+        let config_present = configs.lock().contains_key("victim");
+        let events = std::mem::take(&mut *notifier.events.lock());
+
+        match previous_home {
+            Some(value) => std::env::set_var("AGEND_HOME", value),
+            None => std::env::remove_var("AGEND_HOME"),
+        }
+        std::fs::remove_dir_all(&home).ok();
+
+        assert_eq!(
+            response["ok"], true,
+            "MCP delete ingress must return a response: {response}"
+        );
+        assert_eq!(
+            response["result"].get("error"),
+            None,
+            "managed delete must complete without residual error: {response}"
+        );
+        assert!(
+            !fleet_has_victim
+                && !config_present
+                && matches!(events.as_slice(), [ApiEvent::InstanceDeleted { name }] if name == "victim"),
+            "managed delete must remove fleet/config state and emit InstanceDeleted; got \
+             fleet_has_victim={fleet_has_victim}, config_present={config_present}, \
+             events={events:?}, response={response}"
+        );
+    }
+
     /// #2454 Slice 9: drive the real MCP restart_daemon ingress with a Daemon
     /// capability and an injected shutdown flag.
     #[test]

--- a/src/mcp/handlers/dispatch.rs
+++ b/src/mcp/handlers/dispatch.rs
@@ -51,6 +51,9 @@ pub(crate) struct HandlerCtx<'a> {
 #[derive(Clone)]
 pub(crate) struct RuntimeContext {
     pub registry: crate::agent::AgentRegistry,
+    /// #2454 Slice 10: live managed-agent configuration registry shared by
+    /// direct API and MCP DELETE paths.
+    pub configs: crate::api::ConfigRegistry,
     pub externals: crate::agent::ExternalRegistry,
     /// #2453 Stage R1: the API-server owner's restart capability, injected at
     /// `crate::api::serve` and carried here from the API `HandlerCtx` so
@@ -250,18 +253,16 @@ pub(crate) fn dispatch_create_instance(ctx: &HandlerCtx<'_>) -> Value {
 pub(crate) fn dispatch_interrupt(ctx: &HandlerCtx<'_>) -> Value {
     instance::handle_interrupt(ctx.home, ctx.args, ctx.runtime)
 }
-adapter!(
-    dispatch_delete_instance,
-    has,
-    instance::handle_delete_instance
-);
+/// #2454 Slice 10: pass the in-process runtime to the full managed teardown.
+pub(crate) fn dispatch_delete_instance(ctx: &HandlerCtx<'_>) -> Value {
+    instance::handle_delete_instance_with_runtime(ctx.home, ctx.args, ctx.sender, ctx.runtime)
+}
 adapter!(dispatch_start_instance, ha, instance::handle_start_instance);
 adapter!(dispatch_bind_topic, ha, instance::handle_bind_topic);
-adapter!(
-    dispatch_restart_instance,
-    ha,
-    instance::handle_restart_instance
-);
+/// #2454 Slice 10: D7 restart DELETE uses the same runtime-owned service.
+pub(crate) fn dispatch_restart_instance(ctx: &HandlerCtx<'_>) -> Value {
+    instance::handle_restart_instance_with_runtime(ctx.home, ctx.args, ctx.runtime)
+}
 adapter!(
     dispatch_set_model,
     has,
@@ -510,6 +511,7 @@ mod tests {
             registry: std::sync::Arc::new(
                 parking_lot::Mutex::new(std::collections::HashMap::new()),
             ),
+            configs: Default::default(),
             externals: std::sync::Arc::new(parking_lot::Mutex::new(
                 std::collections::HashMap::new(),
             )),
@@ -981,6 +983,7 @@ mod tests {
             registry: std::sync::Arc::new(
                 parking_lot::Mutex::new(std::collections::HashMap::new()),
             ),
+            configs: Default::default(),
             externals: std::sync::Arc::new(parking_lot::Mutex::new(
                 std::collections::HashMap::from([(
                     name.to_string(),
@@ -1135,6 +1138,7 @@ mod tests {
             registry: std::sync::Arc::new(
                 parking_lot::Mutex::new(std::collections::HashMap::new()),
             ),
+            configs: Default::default(),
             externals: std::sync::Arc::new(parking_lot::Mutex::new(
                 std::collections::HashMap::new(),
             )),

--- a/src/mcp/handlers/dispatch.rs
+++ b/src/mcp/handlers/dispatch.rs
@@ -1448,12 +1448,12 @@ mod tests {
         std::fs::remove_dir_all(&home).ok();
     }
 
-    /// Baseline count: exactly 11 same-daemon api::call production sites
-    /// remain in src/mcp/handlers/ at this commit (was 12 before Slice 9
-    /// removed the supervised restart SHUTDOWN loopback). Any addition without
-    /// a corresponding removal is a regression.
+    /// Baseline count: exactly 10 same-daemon api::call production sites
+    /// remain in src/mcp/handlers/ at the post-Slice-10 target (was 11 before
+    /// the managed DELETE loopback is removed). This RED expectation must move
+    /// only with the corresponding production deletion.
     #[test]
-    fn production_api_call_baseline_is_11_2454() {
+    fn production_api_call_baseline_is_10_2454() {
         let needle_call = concat!("crate::", "api::", "call");
         let needle_at = concat!("api::", "call_at");
         let test_mod_marker = "#[cfg(test)]\nmod ";
@@ -1482,8 +1482,8 @@ mod tests {
             }
         }
         assert_eq!(
-            count, 11,
-            "production same-daemon api::call baseline must be exactly 11; got {count}"
+            count, 10,
+            "production same-daemon api::call baseline must be exactly 10; got {count}"
         );
     }
 

--- a/src/mcp/handlers/dispatch.rs
+++ b/src/mcp/handlers/dispatch.rs
@@ -1453,19 +1453,14 @@ mod tests {
     }
 
     /// Baseline count: exactly 10 same-daemon api::call production sites
-    /// remain across MCP dispatch plus the shared neutral service at the
-    /// post-Slice-10 target (was 11 before the managed DELETE loopback is
-    /// removed). This RED expectation must move only with the corresponding
-    /// production deletion.
+    /// remain in src/mcp/handlers/ at the post-Slice-10 target (was 11 before
+    /// the managed DELETE loopback is removed). This RED expectation must move
+    /// only with the corresponding production deletion.
     #[test]
     fn production_api_call_baseline_is_10_2454() {
         let needle_call = concat!("crate::", "api::", "call");
         let needle_at = concat!("api::", "call_at");
         let test_mod_marker = "#[cfg(test)]\nmod ";
-        let agent_ops = include_str!("../../agent_ops.rs");
-        let delete_service = &agent_ops[agent_ops
-            .find("// Instance deletion — shared API/MCP runtime service")
-            .expect("shared delete service marker")..];
         let files: &[&str] = &[
             include_str!("comms.rs"),
             include_str!("comms_delegate/mod.rs"),
@@ -1475,7 +1470,6 @@ mod tests {
             include_str!("instance_state/spawn.rs"),
             include_str!("instance_state/lifecycle.rs"),
             include_str!("instance_metadata.rs"),
-            delete_service,
         ];
         let mut count = 0;
         for src in files {

--- a/src/mcp/handlers/dispatch.rs
+++ b/src/mcp/handlers/dispatch.rs
@@ -1453,14 +1453,19 @@ mod tests {
     }
 
     /// Baseline count: exactly 10 same-daemon api::call production sites
-    /// remain in src/mcp/handlers/ at the post-Slice-10 target (was 11 before
-    /// the managed DELETE loopback is removed). This RED expectation must move
-    /// only with the corresponding production deletion.
+    /// remain across MCP dispatch plus the shared neutral service at the
+    /// post-Slice-10 target (was 11 before the managed DELETE loopback is
+    /// removed). This RED expectation must move only with the corresponding
+    /// production deletion.
     #[test]
     fn production_api_call_baseline_is_10_2454() {
         let needle_call = concat!("crate::", "api::", "call");
         let needle_at = concat!("api::", "call_at");
         let test_mod_marker = "#[cfg(test)]\nmod ";
+        let agent_ops = include_str!("../../agent_ops.rs");
+        let delete_service = &agent_ops[agent_ops
+            .find("// Instance deletion — shared API/MCP runtime service")
+            .expect("shared delete service marker")..];
         let files: &[&str] = &[
             include_str!("comms.rs"),
             include_str!("comms_delegate/mod.rs"),
@@ -1470,6 +1475,7 @@ mod tests {
             include_str!("instance_state/spawn.rs"),
             include_str!("instance_state/lifecycle.rs"),
             include_str!("instance_metadata.rs"),
+            delete_service,
         ];
         let mut count = 0;
         for src in files {

--- a/src/mcp/handlers/instance_metadata.rs
+++ b/src/mcp/handlers/instance_metadata.rs
@@ -413,6 +413,7 @@ mod blocked_reason_runtime_2454_tests {
         handle.pty_writer = Arc::new(Mutex::new(Box::new(std::io::sink())));
         let rt = RuntimeContext {
             registry: Arc::new(Mutex::new(HashMap::from([(id, handle)]))),
+            configs: Default::default(),
             externals: Arc::new(Mutex::new(HashMap::new())),
             capability: crate::api::RestartCapability::Unsupported,
             app_restart: None,

--- a/src/mcp/handlers/instance_queries.rs
+++ b/src/mcp/handlers/instance_queries.rs
@@ -178,6 +178,7 @@ mod tests {
         )])));
         let runtime = RuntimeContext {
             registry,
+            configs: Default::default(),
             externals,
             capability: crate::api::RestartCapability::Unsupported,
             app_restart: None,
@@ -202,6 +203,7 @@ mod tests {
     fn runtime_with_external_one() -> RuntimeContext {
         RuntimeContext {
             registry: Arc::new(parking_lot::Mutex::new(HashMap::new())),
+            configs: Default::default(),
             externals: Arc::new(parking_lot::Mutex::new(HashMap::from([(
                 "external-one".to_string(),
                 crate::agent::ExternalAgentHandle {
@@ -317,6 +319,7 @@ mod tests {
         let externals = Arc::new(parking_lot::Mutex::new(HashMap::new()));
         let runtime = RuntimeContext {
             registry,
+            configs: Default::default(),
             externals,
             capability: crate::api::RestartCapability::Unsupported,
             app_restart: None,

--- a/src/mcp/handlers/instance_state/lifecycle.rs
+++ b/src/mcp/handlers/instance_state/lifecycle.rs
@@ -67,6 +67,17 @@ fn remove_empty_dir_tree(dir: &Path) {
 /// is a human-readable string listing the residual stores plus any
 /// per-step error captured during cleanup.
 pub(crate) fn full_delete_instance(home: &Path, name: &str) -> Result<(), String> {
+    full_delete_instance_with_runtime(home, name, None)
+}
+
+/// Runtime-aware form used by the MCP API ingress.  The legacy wrapper above
+/// intentionally remains for TUI/team/test callers that do not own the live
+/// API registries in this slice.
+pub(crate) fn full_delete_instance_with_runtime(
+    home: &Path,
+    name: &str,
+    delete_context: Option<&crate::agent_ops::DeleteContext<'_>>,
+) -> Result<(), String> {
     let lifecycle_permit = crate::mcp::handlers::dispatch_hook::LifecyclePermit::acquire(
         home,
         name,
@@ -112,10 +123,14 @@ pub(crate) fn full_delete_instance(home: &Path, name: &str) -> Result<(), String
     // stores left residual state.
     let mut step_errors: Vec<String> = Vec::new();
 
-    let _ = crate::api::call(
-        home,
-        &json!({"method": crate::api::method::DELETE, "params": {"name": name}}),
-    );
+    if let Some(context) = delete_context {
+        crate::agent_ops::delete_instance(home, name, Some(context), false);
+    } else {
+        let _ = crate::api::call(
+            home,
+            &json!({"method": crate::api::method::DELETE, "params": {"name": name}}),
+        );
+    }
     if let Err(e) = crate::fleet::remove_instance_from_yaml(home, name) {
         step_errors.push(format!("fleet.yaml removal: {e}"));
         tracing::error!(name, error = %e, "full_delete_instance: fleet.yaml removal failed");

--- a/src/mcp/handlers/instance_state/lifecycle.rs
+++ b/src/mcp/handlers/instance_state/lifecycle.rs
@@ -16,6 +16,7 @@
 
 use crate::agent_ops::{cleanup_admission, cleanup_working_dir_admitted};
 use crate::channel::telegram;
+use serde_json::json;
 use std::path::Path;
 
 /// #1907: remove `dir` and any empty subdirectories bottom-up, stopping at any
@@ -32,6 +33,33 @@ fn remove_empty_dir_tree(dir: &Path) {
         }
     }
     let _ = std::fs::remove_dir(dir); // succeeds only if now-empty
+}
+
+/// Route the daemon-side DELETE through the neutral runtime service when the
+/// in-process API context exists.  Callers without that context retain the
+/// single legacy socket fallback for this slice; D4 and D7 both use this
+/// helper so the fallback cannot drift or be duplicated.
+pub(crate) fn delete_with_runtime_or_legacy(
+    home: &Path,
+    name: &str,
+    delete_context: Option<&crate::agent_ops::DeleteContext<'_>>,
+    skip_exit_wait: bool,
+) {
+    if let Some(context) = delete_context {
+        crate::agent_ops::delete_instance(home, name, context, skip_exit_wait);
+    } else {
+        let mut params = json!({"name": name});
+        if skip_exit_wait {
+            params["no_wait"] = json!(true);
+        }
+        let _ = crate::api::call(
+            home,
+            &json!({
+                "method": crate::api::method::DELETE,
+                "params": params,
+            }),
+        );
+    }
 }
 
 /// Sprint 53 Smoke 2 r1: shared full single-instance teardown used by both
@@ -122,7 +150,7 @@ pub(crate) fn full_delete_instance_with_runtime(
     // stores left residual state.
     let mut step_errors: Vec<String> = Vec::new();
 
-    crate::agent_ops::delete_instance(home, name, delete_context, false);
+    delete_with_runtime_or_legacy(home, name, delete_context, false);
     if let Err(e) = crate::fleet::remove_instance_from_yaml(home, name) {
         step_errors.push(format!("fleet.yaml removal: {e}"));
         tracing::error!(name, error = %e, "full_delete_instance: fleet.yaml removal failed");

--- a/src/mcp/handlers/instance_state/lifecycle.rs
+++ b/src/mcp/handlers/instance_state/lifecycle.rs
@@ -16,7 +16,6 @@
 
 use crate::agent_ops::{cleanup_admission, cleanup_working_dir_admitted};
 use crate::channel::telegram;
-use serde_json::json;
 use std::path::Path;
 
 /// #1907: remove `dir` and any empty subdirectories bottom-up, stopping at any
@@ -123,14 +122,7 @@ pub(crate) fn full_delete_instance_with_runtime(
     // stores left residual state.
     let mut step_errors: Vec<String> = Vec::new();
 
-    if let Some(context) = delete_context {
-        crate::agent_ops::delete_instance(home, name, Some(context), false);
-    } else {
-        let _ = crate::api::call(
-            home,
-            &json!({"method": crate::api::method::DELETE, "params": {"name": name}}),
-        );
-    }
+    crate::agent_ops::delete_instance(home, name, delete_context, false);
     if let Err(e) = crate::fleet::remove_instance_from_yaml(home, name) {
         step_errors.push(format!("fleet.yaml removal: {e}"));
         tracing::error!(name, error = %e, "full_delete_instance: fleet.yaml removal failed");

--- a/src/mcp/handlers/instance_state/mod.rs
+++ b/src/mcp/handlers/instance_state/mod.rs
@@ -176,10 +176,20 @@ pub(super) fn handle_create_instance(
     }
 }
 
+#[cfg(test)]
 pub(super) fn handle_delete_instance(
     home: &Path,
     args: &Value,
     sender: &Option<crate::identity::Sender>,
+) -> Value {
+    handle_delete_instance_with_runtime(home, args, sender, None)
+}
+
+pub(super) fn handle_delete_instance_with_runtime(
+    home: &Path,
+    args: &Value,
+    sender: &Option<crate::identity::Sender>,
+    runtime: Option<&super::dispatch::RuntimeContext>,
 ) -> Value {
     let name = match super::require_instance(args) {
         Ok(n) => n,
@@ -300,7 +310,13 @@ pub(super) fn handle_delete_instance(
     }
     // Full multi-store teardown lives in the `lifecycle` submodule of this
     // `instance_state` concept (Sprint 54 P1-B Bug 1).
-    match lifecycle::full_delete_instance(home, name) {
+    let delete_context = runtime.map(|runtime| crate::agent_ops::DeleteContext {
+        registry: &runtime.registry,
+        configs: &runtime.configs,
+        externals: &runtime.externals,
+        notifier: runtime.notifier.as_ref(),
+    });
+    match lifecycle::full_delete_instance_with_runtime(home, name, delete_context.as_ref()) {
         Ok(()) => json!({"name": name}),
         Err(detail) => json!({
             "name": name,
@@ -502,6 +518,14 @@ fn await_unsent_draft_or_grace(home: &Path, name: &str, force: bool) {
 }
 
 pub(super) fn handle_restart_instance(home: &Path, args: &Value) -> Value {
+    handle_restart_instance_with_runtime(home, args, None)
+}
+
+pub(super) fn handle_restart_instance_with_runtime(
+    home: &Path,
+    args: &Value,
+    runtime: Option<&super::dispatch::RuntimeContext>,
+) -> Value {
     let name = match super::require_instance(args) {
         Ok(n) => n,
         Err(e) => return e,
@@ -566,10 +590,13 @@ pub(super) fn handle_restart_instance(home: &Path, args: &Value) -> Value {
         crate::inbox::settle_delivering_for_session_reset(home, name);
     }
 
-    let _ = crate::api::call(
-        home,
-        &json!({"method": crate::api::method::DELETE, "params": {"name": name, "no_wait": true}}),
-    );
+    let delete_context = runtime.map(|runtime| crate::agent_ops::DeleteContext {
+        registry: &runtime.registry,
+        configs: &runtime.configs,
+        externals: &runtime.externals,
+        notifier: runtime.notifier.as_ref(),
+    });
+    crate::agent_ops::delete_instance(home, name, delete_context.as_ref(), true);
 
     let spawn_params = restart_spawn_params(
         name,

--- a/src/mcp/handlers/instance_state/mod.rs
+++ b/src/mcp/handlers/instance_state/mod.rs
@@ -596,7 +596,7 @@ pub(super) fn handle_restart_instance_with_runtime(
         externals: &runtime.externals,
         notifier: runtime.notifier.as_ref(),
     });
-    crate::agent_ops::delete_instance(home, name, delete_context.as_ref(), true);
+    lifecycle::delete_with_runtime_or_legacy(home, name, delete_context.as_ref(), true);
 
     let spawn_params = restart_spawn_params(
         name,

--- a/src/mcp/handlers/usage_limit_takeover_tests.rs
+++ b/src/mcp/handlers/usage_limit_takeover_tests.rs
@@ -160,6 +160,7 @@ fn fixture(tag: &str) -> Fixture {
     ])));
     let runtime = RuntimeContext {
         registry,
+        configs: Default::default(),
         externals: Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new())),
         capability: crate::api::RestartCapability::Unsupported,
         app_restart: None,


### PR DESCRIPTION
## Summary
- implement Slice 10 shared typed runtime DELETE service for managed and external agents
- route D4 full_delete_instance and D7 restart DELETE through the live runtime context
- preserve one legacy runtime-none API fallback and existing residual cleanup

## Contract and provenance
- Issue: #2454 (later slices remain; this PR intentionally has no closing keyword)
- Immutable RED: `e10d2362db5b67ea8ef49d92226bed1cf47f602d`
- GREEN head: `b388bdd8e3c2ea6e0bf2f3d52509864595413d7`

## Verification
- real-entry managed DELETE RED/ GREEN test
- exact source-budget test (10)
- API delete and lifecycle tests
- `cargo fmt -- --check`
- `cargo clippy --bin agend-terminal --no-default-features -- -D warnings`

Agent signature: `archfix-codex-dev` (Codex Luna xhigh)