### PR TITLE
feat(#2454): migrate team create to typed runtime service

### DIFF
--- a/src/api/handlers/mcp_proxy_2454_tests.rs
+++ b/src/api/handlers/mcp_proxy_2454_tests.rs
@@ -40,8 +40,8 @@ fn send_structural_budget_and_reachability_2454() {
         }
     }
     assert_eq!(
-        handler_count, 5,
-        "Slice-12 cumulative api::call budget must be 5; got {handler_count}"
+        handler_count, 4,
+        "Slice-13 cumulative api::call budget must be 4; got {handler_count}"
     );
 
     // (b) dispatch_send must NOT be adapter! — custom fn threads RuntimeContext

--- a/src/api/handlers/mod.rs
+++ b/src/api/handlers/mod.rs
@@ -35,6 +35,7 @@ use std::sync::Arc;
 /// Must be called *before* the backend process starts: `backend::spawn_flags`
 /// checks the file's presence at flag-build time and silently drops
 /// `--append-system-prompt-file` when the instructions file is missing.
+#[cfg(test)]
 pub(crate) fn prepare_instructions(
     home: &Path,
     name: &str,

--- a/src/api/handlers/mod.rs
+++ b/src/api/handlers/mod.rs
@@ -16,36 +16,6 @@ use crate::api::{ApiNotifier, ConfigRegistry};
 use std::path::Path;
 use std::sync::Arc;
 
-/// Write `agend.md` / `GEMINI.md` and the MCP config into `work_dir` before
-/// the child process is spawned. Centralises the fleet-aware instruction
-/// generation that every API-level spawn should perform.
-///
-/// Role resolution order:
-///   1. `explicit_role` — caller passes it directly (SPAWN/CREATE_TEAM
-///      params). Used when the caller has the role in-hand and doesn't
-///      want to depend on fleet.yaml read order.
-///   2. `fleet.yaml` entry under `name` — used by deploy_template which
-///      persists the entry before calling SPAWN.
-///   3. None — ad-hoc spawn (verify, shell pane). Identity block still
-///      emits name + peers, just no Role line.
-///
-/// Peers always come from `fleet.yaml`, so any combination of spawn
-/// callers produces a coherent peer list.
-///
-/// Must be called *before* the backend process starts: `backend::spawn_flags`
-/// checks the file's presence at flag-build time and silently drops
-/// `--append-system-prompt-file` when the instructions file is missing.
-#[cfg(test)]
-pub(crate) fn prepare_instructions(
-    home: &Path,
-    name: &str,
-    command: &str,
-    work_dir: &Path,
-    explicit_role: Option<&str>,
-) -> Result<(), String> {
-    crate::agent_ops::spawn::prepare_instructions(home, name, command, work_dir, explicit_role)
-}
-
 /// Shared context passed to extracted handler functions.
 ///
 /// Bundles the session-scoped references that `handle_session` holds.

--- a/src/api/handlers/team.rs
+++ b/src/api/handlers/team.rs
@@ -77,6 +77,7 @@ pub(crate) fn handle_create_team(params: &Value, ctx: &HandlerCtx) -> Value {
             orchestrator: params["orchestrator"].as_str().map(String::from),
             description: params["description"].as_str().map(String::from),
             repository_path: params["repository_path"].as_str().map(String::from),
+            project_id: params["project_id"].as_str().map(String::from),
             accept_from,
         },
         ctx.registry,

--- a/src/api/handlers/team.rs
+++ b/src/api/handlers/team.rs
@@ -1,4 +1,8 @@
 //! Team handlers: UPDATE_TEAM (Slice C1), CREATE_TEAM (Slice C2).
+//!
+//! #2454 Slice 13: CREATE_TEAM logic moved to `crate::team_ops` (neutral
+//! typed owner). This file retains the API adapter (param parsing +
+//! delegation) and UPDATE_TEAM (unchanged).
 
 use super::HandlerCtx;
 use crate::api::ApiEvent;
@@ -26,78 +30,13 @@ pub(crate) fn handle_update_team(params: &Value, ctx: &HandlerCtx) -> Value {
     json!({"ok": true, "result": outcome.result})
 }
 
-/// #1964 Bug 1: plan `count` member names for `team` as `<team>-N`. Names
-/// were index-based (`{team}-{i+1}`), restarting at 1 on EVERY call — a second
-/// `create_instance(team=X)` re-picked X-1 and failed "agent already exists"
-/// instead of incrementing. Numbering starts at one past the max existing
-/// `<team>-N` in fleet.yaml (never re-filling gaps, so a freed number is not
-/// resurrected) and skips any candidate still held by fleet.yaml (an entry
-/// that exists but is not running would be silently overwritten by
-/// `add_instances_to_yaml`) or by the live registry (`taken`, #1441
-/// UUID-keyed).
-fn plan_member_names(
-    fleet: &crate::fleet::FleetConfig,
-    team: &str,
-    count: usize,
-    taken: impl Fn(&str) -> bool,
-) -> Vec<String> {
-    let prefix = format!("{team}-");
-    let mut next_n: u64 = fleet
-        .instances
-        .keys()
-        .filter_map(|k| k.strip_prefix(&prefix)?.parse::<u64>().ok())
-        .max()
-        .map_or(1, |m| m + 1);
-    let mut names = Vec::with_capacity(count);
-    while names.len() < count {
-        let candidate = format!("{team}-{next_n}");
-        next_n += 1;
-        if fleet.instances.contains_key(&candidate) || taken(&candidate) {
-            tracing::info!(
-                team,
-                member = %candidate,
-                "CREATE_TEAM: name taken — advancing to the next number (#1964)"
-            );
-            continue;
-        }
-        names.push(candidate);
-    }
-    names
-}
-
-/// #991 PR-B: build each planned member's fleet.yaml entry — extracted from
-/// `handle_create_team`'s Phase 1 so `topic_binding_mode` propagation is
-/// unit-testable without going through Phase 2's real PTY spawn (`spawn_one`
-/// has no direct test coverage anywhere in this codebase — it forks a real
-/// process).
-fn build_member_entries(
-    planned: &[(String, String, std::path::PathBuf)],
-    topic_binding_mode: Option<&str>,
-) -> Vec<(String, crate::fleet::InstanceYamlEntry)> {
-    planned
-        .iter()
-        .map(|(name, be, wd)| {
-            (
-                name.clone(),
-                crate::fleet::InstanceYamlEntry {
-                    backend: Some(be.clone()),
-                    working_directory: Some(wd.display().to_string()),
-                    topic_binding_mode: topic_binding_mode.map(String::from),
-                    ..Default::default()
-                },
-            )
-        })
-        .collect()
-}
-
-#[allow(clippy::too_many_lines)]
+/// #2454 Slice 13: thin API adapter — parses transport-specific params and
+/// delegates to the neutral typed `team_ops::create` owner.
 pub(crate) fn handle_create_team(params: &Value, ctx: &HandlerCtx) -> Value {
-    let team_name = match params["name"].as_str() {
-        Some(n) => n,
+    let name = match params["name"].as_str() {
+        Some(n) => n.to_string(),
         None => return json!({"ok": false, "error": "missing name"}),
     };
-    // `backends: [..]` — per-member backend (heterogeneous team).
-    // Falls back to repeating `backend` `count` times when absent.
     let per_member_backends: Vec<String> = if let Some(arr) = params["backends"].as_array() {
         arr.iter()
             .filter_map(|v| v.as_str().map(String::from))
@@ -107,174 +46,11 @@ pub(crate) fn handle_create_team(params: &Value, ctx: &HandlerCtx) -> Value {
         let backend = params["backend"].as_str().unwrap_or("claude").to_string();
         vec![backend; count]
     };
-    let count = per_member_backends.len();
-    // #991 PR-B: team-level default, shared by every spawned member — same
-    // "skip"/"deferred" filter as the single-instance create_instance path
-    // (mcp/handlers/instance_state/spawn.rs); anything else (including
-    // "auto") stays None (unchanged auto-create default).
     let topic_binding_mode: Option<String> = params["topic_binding"]
         .as_str()
         .filter(|s| matches!(*s, "skip" | "deferred"))
         .map(String::from);
-    tracing::info!(
-        team = team_name,
-        count,
-        backends = ?per_member_backends,
-        topic_binding_mode = ?topic_binding_mode,
-        "CREATE_TEAM begin"
-    );
-
-    // #1964: snapshot fleet.yaml once — Bug-1 numbering scans its instance
-    // names, Bug-2 roster routing checks team existence against it.
-    let fleet_snapshot = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(ctx.home))
-        .unwrap_or_default();
-    let team_already_exists = fleet_snapshot.teams.contains_key(team_name);
-
-    // Phase 1 — plan every member's fleet.yaml entry (name, backend, dir)
-    // before any spawn happens. The full list is written to fleet.yaml
-    // before Phase 2 so prepare_instructions sees the complete peer set
-    // when generating each member's agend.md.
-    //
-    // #1964 Bug 1: member names were index-based (`{team}-{i+1}`), restarting
-    // at 1 on EVERY call — a second `create_instance(team=X)` re-picked X-1
-    // and failed "agent already exists" instead of incrementing. Start from
-    // (max existing `<team>-N` in fleet.yaml) + 1 and skip any name still
-    // held by fleet.yaml (an entry that exists but isn't running would be
-    // silently overwritten by add_instances_to_yaml) or by the live registry
-    // (#1441: UUID-keyed, resolve via fleet.yaml).
-    let names = plan_member_names(&fleet_snapshot, team_name, per_member_backends.len(), |c| {
-        crate::fleet::resolve_uuid(ctx.home, c)
-            .is_some_and(|id| crate::agent::lock_registry(ctx.registry).contains_key(&id))
-    });
-    let mut planned: Vec<(String, String, std::path::PathBuf)> = Vec::new(); // (name, backend, work_dir)
-    let mut failed: Vec<String> = Vec::new();
-    for (inst_name, backend) in names.into_iter().zip(per_member_backends.iter()) {
-        let work_dir = crate::paths::workspace_dir(ctx.home).join(&inst_name);
-        planned.push((inst_name, backend.clone(), work_dir));
-    }
-
-    if !planned.is_empty() {
-        let entries = build_member_entries(&planned, topic_binding_mode.as_deref());
-        let refs: Vec<(&str, &crate::fleet::InstanceYamlEntry)> =
-            entries.iter().map(|(n, e)| (n.as_str(), e)).collect();
-        if let Err(e) = crate::fleet::add_instances_to_yaml(ctx.home, &refs) {
-            tracing::warn!(error = %e, "failed to persist team to fleet.yaml");
-        }
-    }
-
-    // Phase 2 — generate instructions and spawn each planned member. The
-    // helper reads fleet.yaml (now complete) for the peer list, so every
-    // member boots with a full Identity/Peers block in its agend.md.
-    let mut spawned: Vec<(String, String)> = Vec::new();
-    let size = crossterm::terminal::size().unwrap_or((120, 40));
-    for (inst_name, backend, work_dir) in &planned {
-        // #46776 fail-closed: skip (do not spawn) a member whose provisioning is
-        // refused — a workspace-identity conflict or I/O failure — rather than
-        // fork it against foreign or half-written provisioned state.
-        if let Err(e) = super::prepare_instructions(ctx.home, inst_name, backend, work_dir, None) {
-            tracing::error!(agent = %inst_name, error = %e,
-                "team spawn: provisioning refused — skipping member");
-            continue;
-        }
-        // #900: resolve the just-written fleet.yaml entry so any
-        // operator-supplied `env:` (or `defaults.env`) reaches the
-        // spawned process. The entry is in fleet.yaml at this point
-        // (Phase 1 above wrote it), so resolve_instance returns the
-        // merged defaults+instance map. CREATE_TEAM-time team members
-        // currently have env: None at write-time (line 110), but
-        // operator hand-edits and downstream restart flows can populate
-        // env on the entry between the write and this re-read — we
-        // honour whatever the disk says.
-        let resolved = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(ctx.home))
-            .ok()
-            .and_then(|f| f.resolve_instance(inst_name));
-        let resolved_env = resolved.as_ref().map(|r| r.env.clone());
-        // #2038: boot parity for args + model, same rule as handle_spawn's
-        // fleet fallback. CREATE_TEAM-time entries are written with
-        // args/model: None (Phase 1 above), but `defaults.args` /
-        // `defaults.model` and operator hand-edits between the write and
-        // this re-read merge in via resolve_instance.
-        let mut member_args = resolved
-            .as_ref()
-            .map(|r| r.args.clone())
-            .unwrap_or_default();
-        let declared_backend = resolved
-            .as_ref()
-            .map(|r| r.backend.clone())
-            .unwrap_or_else(|| crate::backend::Backend::parse_str(backend));
-        if let Some(model) = resolved.as_ref().and_then(|r| r.model.as_deref()) {
-            // #2744: DECLARED identity — the resolved fleet entry's backend
-            // (Phase 1 wrote it); fallback parses the declared member NAME,
-            // never a command string.
-            crate::backend::Backend::push_model_arg(&mut member_args, &declared_backend, model);
-        }
-        match crate::agent_ops::spawn_one(
-            ctx.home,
-            ctx.registry,
-            inst_name,
-            backend,
-            &member_args,
-            crate::backend::SpawnMode::Fresh,
-            work_dir,
-            size,
-            resolved_env.as_ref(),
-            Some(&declared_backend),
-        ) {
-            Ok(_) => {
-                tracing::info!(team = team_name, member = %inst_name, backend = %backend, "CREATE_TEAM spawn ok");
-                // #966: Every successful spawn gets a channel topic via
-                // the hub `ensure_topic_for`. NoChannel is the happy path
-                // when no channel is configured; Failed is surfaced via
-                // warn (Pushback B: prior `let _ = ch.create_topic()`
-                // swallowed errors, same antipattern as pre-#962 silent
-                // persist).
-                // #991 PR-B: skip/deferred opts the whole team out — mirrors
-                // the single-instance gate in api/handlers/instance.rs
-                // (handle_spawn). Without this, topic_binding_mode was
-                // correctly persisted to fleet.yaml above but a topic got
-                // created anyway (this path calls agent_ops::spawn_one
-                // directly, bypassing handle_spawn's existing gate).
-                if let Some(mode) = topic_binding_mode.as_deref() {
-                    tracing::info!(
-                        team = team_name,
-                        member = %inst_name,
-                        topic_binding_mode = mode,
-                        "CREATE_TEAM: skipping topic creation (opted out)"
-                    );
-                } else {
-                    match crate::channel::ensure_topic_for(inst_name) {
-                        crate::channel::TopicOutcome::Created(_)
-                        | crate::channel::TopicOutcome::NoChannel => {}
-                        crate::channel::TopicOutcome::Failed(err) => {
-                            tracing::warn!(
-                                team = team_name,
-                                member = %inst_name,
-                                error = %err,
-                                "CREATE_TEAM: channel exists but create_topic failed; \
-                                 member spawn proceeds without topic"
-                            );
-                        }
-                    }
-                }
-                spawned.push((inst_name.clone(), backend.clone()));
-            }
-            Err(e) => {
-                tracing::warn!(team = team_name, member = %inst_name, backend = %backend, error = %e, "CREATE_TEAM spawn failed");
-                failed.push(format!("{inst_name}: {e}"));
-            }
-        }
-    }
-    tracing::info!(
-        team = team_name,
-        spawned = spawned.len(),
-        failed = failed.len(),
-        "CREATE_TEAM spawn phase done"
-    );
-    if count > 0 && spawned.is_empty() {
-        return json!({"ok": false, "error": format!("all {} spawns failed: {}", count, failed.join("; "))});
-    }
-
-    let existing: Vec<String> = params["members"]
+    let existing_members: Vec<String> = params["members"]
         .as_array()
         .map(|a| {
             a.iter()
@@ -282,117 +58,30 @@ pub(crate) fn handle_create_team(params: &Value, ctx: &HandlerCtx) -> Value {
                 .collect()
         })
         .unwrap_or_default();
-    let spawned_names: Vec<String> = spawned.iter().map(|(n, _)| n.clone()).collect();
-    let all_members: Vec<String> = existing
-        .into_iter()
-        .chain(spawned_names.iter().cloned())
-        .collect();
+    let accept_from: Vec<String> = params["accept_from"]
+        .as_array()
+        .map(|a| {
+            a.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
 
-    // Preserve orchestrator from the caller. Without this, routing
-    // deploy_template / MCP create_team through CREATE_TEAM would silently
-    // drop the orchestrator designation — teams::create accepts it but
-    // this handler never forwarded the field.
-    let mut team_params = json!({
-        "name": team_name,
-        "members": all_members,
-        "description": params["description"],
-    });
-    if let Some(orch) = params.get("orchestrator").and_then(|v| v.as_str()) {
-        team_params["orchestrator"] = json!(orch);
-    }
-    // #1833: forward `repository_path` (team source_repo) — same allowlist-drop
-    // class as the orchestrator preservation above. #1329 made `deployments.rs`
-    // set `team_args["repository_path"]` and route through CREATE_TEAM, but this
-    // handler re-marshals `params` into a fresh `team_params` and dropped the
-    // field, so every deploy/`api::call(CREATE_TEAM)` produced a team with
-    // `source_repo=null` regardless of the template/caller (`teams::create`
-    // reads `repository_path`, teams.rs).
-    if let Some(repo) = params.get("repository_path").and_then(|v| v.as_str()) {
-        team_params["repository_path"] = json!(repo);
-    }
-    // #1837 (reviewer-2): `accept_from` is the SAME re-marshal allowlist-drop —
-    // a documented CREATE_TEAM param (mcp/tools.rs cross-team allowlist, "empty =
-    // deny all") that `teams::create` reads from `args["accept_from"]` (teams.rs)
-    // but this handler never forwarded. The main path `team(action=create,
-    // accept_from=[...])` → `api::call(CREATE_TEAM)` → here → dropped → the
-    // operator's cross-team allowlist was silently emptied (fail-closed, but a
-    // real functional loss). Forward it to close the root-cause pattern entirely.
-    if let Some(af) = params.get("accept_from") {
-        team_params["accept_from"] = af.clone();
-    }
-    // #1964 Bug 2: when the team ALREADY exists (the create_instance(team=X)
-    // grow-the-team use case), `teams::create` errors "team already exists" —
-    // and that error was swallowed into `result` while the members had ALREADY
-    // spawned: named `X-N` but never written to the roster, so
-    // `find_team_for` read team=None and the send policy cross-team-blocked
-    // same-team traffic. Route the roster write through `teams::update(add)`
-    // instead (same fleet.yaml `teams:` store the send policy reads — one
-    // write path, one read path). New-team creation is unchanged.
-    let result = if team_already_exists {
-        tracing::info!(
-            team = team_name,
-            adding = ?all_members,
-            "CREATE_TEAM: team exists — extending roster (#1964)"
-        );
-        let mut update_params = json!({
-            "name": team_name,
-            "add": all_members,
-        });
-        if let Some(orch) = params.get("orchestrator").and_then(|v| v.as_str()) {
-            update_params["orchestrator"] = json!(orch);
-        }
-        // #2525: same allowlist-drop class as the orchestrator/repository_path/
-        // accept_from forwarding above (#1833/#1837) — this branch re-marshals
-        // into a fresh update_params too, and repository_path was never added
-        // here. teams::update reads args["repository_path"] (set-or-preserve),
-        // so without this a second create_instance(team=X, repository_path=Y)
-        // on an existing team silently drops Y.
-        if let Some(repo) = params.get("repository_path").and_then(|v| v.as_str()) {
-            update_params["repository_path"] = json!(repo);
-        }
-        crate::teams::update(ctx.home, &update_params)
-    } else {
-        crate::teams::create(ctx.home, &team_params)
-    };
-    // Surface a roster-write failure honestly: the members are spawned but
-    // team-less (the exact #1964 silent shape) — ok:false lets the caller see
-    // it instead of a fake success.
-    if let Some(err) = result.get("error").and_then(|e| e.as_str()) {
-        tracing::warn!(team = team_name, error = %err, "CREATE_TEAM roster write failed — spawned members are NOT on the team roster");
-        return json!({
-            "ok": false,
-            "error": format!("members spawned but roster write failed: {err}"),
-            "spawned": &spawned_names,
-        });
-    }
-
-    if let Some(n) = ctx.notifier {
-        if team_already_exists {
-            if !spawned_names.is_empty() {
-                tracing::info!(team = team_name, added = ?spawned_names, "CREATE_TEAM emitting TeamMembersChanged (extend)");
-                n.notify(ApiEvent::TeamMembersChanged {
-                    name: team_name.to_string(),
-                    added: spawned_names.clone(),
-                    removed: Vec::new(),
-                });
-            }
-        } else if !all_members.is_empty() {
-            tracing::info!(team = team_name, members = ?all_members, "CREATE_TEAM emitting TeamCreated");
-            n.notify(ApiEvent::TeamCreated {
-                name: team_name.to_string(),
-                members: all_members.clone(),
-            });
-        }
-    }
-    // Broadcast team context to every member so their running prompts
-    // learn about the team's name / orchestrator / roster without a
-    // respawn. Guard on the same empty-members condition as the TUI
-    // event — an empty team would have no targets anyway.
-    let mut resp = json!({"ok": true, "result": result, "spawned": &spawned_names});
-    if !failed.is_empty() {
-        resp["failed"] = json!(failed);
-    }
-    resp
+    crate::team_ops::create(
+        ctx.home,
+        crate::team_ops::CreateTeamRequest {
+            name,
+            per_member_backends,
+            existing_members,
+            topic_binding_mode,
+            orchestrator: params["orchestrator"].as_str().map(String::from),
+            description: params["description"].as_str().map(String::from),
+            repository_path: params["repository_path"].as_str().map(String::from),
+            accept_from,
+        },
+        ctx.registry,
+        ctx.notifier.map(|n| n.as_ref()),
+    )
 }
 
 #[cfg(test)]
@@ -585,15 +274,15 @@ mod tests_1964 {
         }
         // Consecutive two-member plan: 8, 9 (max=7 → +1; the gap 2-6 is NOT
         // reused; "sqd-lead"/"other-3" don't poison the parse).
-        let names = plan_member_names(&fleet, "sqd", 2, |_| false);
+        let names = crate::team_ops::plan_member_names(&fleet, "sqd", 2, |_| false);
         assert_eq!(names, vec!["sqd-8".to_string(), "sqd-9".to_string()]);
 
         // A registry-held (running but yaml-less) candidate is skipped too.
-        let names = plan_member_names(&fleet, "sqd", 1, |c| c == "sqd-8");
+        let names = crate::team_ops::plan_member_names(&fleet, "sqd", 1, |c| c == "sqd-8");
         assert_eq!(names, vec!["sqd-9".to_string()]);
 
         // Fresh team: starts at 1 and increments WITHIN one call.
-        let names = plan_member_names(&fleet, "fresh", 2, |_| false);
+        let names = crate::team_ops::plan_member_names(&fleet, "fresh", 2, |_| false);
         assert_eq!(names, vec!["fresh-1".to_string(), "fresh-2".to_string()]);
     }
 
@@ -615,13 +304,13 @@ mod tests_1964 {
             ),
         ];
 
-        let skip_entries = build_member_entries(&planned, Some("skip"));
+        let skip_entries = crate::team_ops::build_member_entries(&planned, Some("skip"));
         assert_eq!(skip_entries.len(), 2);
         for (_, e) in &skip_entries {
             assert_eq!(e.topic_binding_mode.as_deref(), Some("skip"));
         }
 
-        let auto_entries = build_member_entries(&planned, None);
+        let auto_entries = crate::team_ops::build_member_entries(&planned, None);
         for (_, e) in &auto_entries {
             assert!(
                 e.topic_binding_mode.is_none(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,6 +91,7 @@ mod store;
 mod sync_audit;
 mod task_events;
 mod tasks;
+mod team_ops;
 mod teams;
 mod thread_census;
 mod token_cost;

--- a/src/mcp/handlers/dispatch.rs
+++ b/src/mcp/handlers/dispatch.rs
@@ -1560,6 +1560,60 @@ mod tests {
         );
     }
 
+    /// #2454 Slice 13 RED: both API and MCP CREATE_TEAM handlers must route
+    /// through one shared neutral typed service. The neutral service must NOT
+    /// take HandlerCtx or raw serde_json::Value as its primary boundary type
+    /// — it must own a typed domain interface.
+    #[test]
+    fn create_team_both_adapters_share_neutral_typed_owner_2454() {
+        let mcp_src = include_str!("task.rs");
+        let mcp_boundary = mcp_src.rfind("#[cfg(test)]\nmod ").unwrap_or(mcp_src.len());
+        let mcp_prod = &mcp_src[..mcp_boundary];
+        let mcp_fn_start = mcp_prod
+            .find("fn handle_create_team(")
+            .expect("MCP handle_create_team");
+        let mcp_fn_end = mcp_prod[mcp_fn_start..]
+            .find("\n}\n")
+            .map(|o| mcp_fn_start + o)
+            .unwrap_or(mcp_prod.len());
+        let mcp_fn = &mcp_prod[mcp_fn_start..mcp_fn_end];
+
+        let api_src = include_str!("../../api/handlers/team.rs");
+        let api_boundary = api_src
+            .rfind("#[cfg(test)]\n#[allow")
+            .unwrap_or(api_src.len());
+        let api_prod = &api_src[..api_boundary];
+        let api_fn_start = api_prod
+            .find("fn handle_create_team(")
+            .expect("API handle_create_team");
+        let api_fn_end = api_prod[api_fn_start..]
+            .find("\n}\n")
+            .map(|o| api_fn_start + o)
+            .unwrap_or(api_prod.len());
+        let api_fn = &api_prod[api_fn_start..api_fn_end];
+
+        // Both adapters must reference the same neutral service identifier
+        // (not teams::create, not api::call, not inline logic).
+        let neutral_marker = "team_ops::create";
+        assert!(
+            mcp_fn.contains(neutral_marker),
+            "#2454: MCP handle_create_team must call neutral typed service \
+             `{neutral_marker}`, not own the logic"
+        );
+        assert!(
+            api_fn.contains(neutral_marker),
+            "#2454: API handle_create_team must call neutral typed service \
+             `{neutral_marker}`, not own the logic"
+        );
+
+        // The neutral service must not take HandlerCtx as a parameter
+        // (its boundary must be typed, not framework-coupled).
+        assert!(
+            !mcp_fn.contains("HandlerCtx"),
+            "#2454: MCP CREATE_TEAM adapter must not pass HandlerCtx to the service"
+        );
+    }
+
     /// Wiring pin: both fire-and-forget thread bodies must call the shared
     /// `inject_with_routing` helper (not inline api::call or inject_input).
     #[test]

--- a/src/mcp/handlers/dispatch.rs
+++ b/src/mcp/handlers/dispatch.rs
@@ -413,12 +413,12 @@ action_adapter!(dispatch_set_metadata, "set_metadata", [
     "description"  => instance::handle_set_description,  hai;
 ]);
 
-/// #2454 Slice 7: team update carries the owned runtime notifier into the
-/// transport-neutral roster service; other team actions retain their legacy
+/// #2454 Slice 7+13: team create and update carry the owned runtime into
+/// the transport-neutral service; other team actions retain their legacy
 /// adapter shapes.
 pub(crate) fn dispatch_team(ctx: &HandlerCtx<'_>) -> Value {
     match ctx.args["action"].as_str().unwrap_or("") {
-        "create" => task::handle_create_team(ctx.home, ctx.args),
+        "create" => task::handle_create_team(ctx.home, ctx.args, ctx.runtime),
         "delete" => task::handle_delete_team(ctx.home, ctx.args),
         "list" => task::handle_list_teams(ctx.home),
         "update" => task::handle_update_team(ctx.home, ctx.args, ctx.runtime),
@@ -1488,8 +1488,8 @@ mod tests {
             }
         }
         assert_eq!(
-            count, 5,
-            "production same-daemon api::call post-Slice-12 must be exactly 5; got {count}"
+            count, 4,
+            "production same-daemon api::call post-Slice-13 must be exactly 4; got {count}"
         );
     }
 

--- a/src/mcp/handlers/dispatch.rs
+++ b/src/mcp/handlers/dispatch.rs
@@ -1563,9 +1563,14 @@ mod tests {
     /// #2454 Slice 13 RED: both API and MCP CREATE_TEAM handlers must route
     /// through one shared neutral typed service. The neutral service must NOT
     /// take HandlerCtx or raw serde_json::Value as its primary boundary type
-    /// — it must own a typed domain interface.
+    /// — it must own a typed domain interface. Wrapping old logic behind a
+    /// same-named raw-Value helper cannot pass this guard.
     #[test]
     fn create_team_both_adapters_share_neutral_typed_owner_2454() {
+        let neutral_marker = "team_ops::create";
+
+        // ── Adapter convergence: both MCP and API must call the same owner ──
+
         let mcp_src = include_str!("task.rs");
         let mcp_boundary = mcp_src.rfind("#[cfg(test)]\nmod ").unwrap_or(mcp_src.len());
         let mcp_prod = &mcp_src[..mcp_boundary];
@@ -1592,9 +1597,6 @@ mod tests {
             .unwrap_or(api_prod.len());
         let api_fn = &api_prod[api_fn_start..api_fn_end];
 
-        // Both adapters must reference the same neutral service identifier
-        // (not teams::create, not api::call, not inline logic).
-        let neutral_marker = "team_ops::create";
         assert!(
             mcp_fn.contains(neutral_marker),
             "#2454: MCP handle_create_team must call neutral typed service \
@@ -1605,12 +1607,61 @@ mod tests {
             "#2454: API handle_create_team must call neutral typed service \
              `{neutral_marker}`, not own the logic"
         );
-
-        // The neutral service must not take HandlerCtx as a parameter
-        // (its boundary must be typed, not framework-coupled).
         assert!(
             !mcp_fn.contains("HandlerCtx"),
             "#2454: MCP CREATE_TEAM adapter must not pass HandlerCtx to the service"
+        );
+
+        // ── Owner boundary: the neutral service's definition must be typed ──
+        // Scan the module that should own the neutral service. Its `pub fn
+        // create` (or `pub(crate) fn create`) signature must NOT accept
+        // `HandlerCtx` or raw `Value`/`&Value` as a parameter — the boundary
+        // must be typed domain types. A same-named helper that just wraps
+        // teams::create with a raw Value interface cannot pass.
+
+        // team_ops module must exist as a file
+        let team_ops_exists =
+            std::path::Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/src/team_ops.rs")).exists()
+                || std::path::Path::new(concat!(
+                    env!("CARGO_MANIFEST_DIR"),
+                    "/src/team_ops/mod.rs"
+                ))
+                .exists();
+        assert!(
+            team_ops_exists,
+            "#2454: neutral typed service module `team_ops` must exist as src/team_ops.rs or src/team_ops/mod.rs"
+        );
+
+        // Read the module and inspect the create function signature
+        let team_ops_path =
+            if std::path::Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/src/team_ops.rs"))
+                .exists()
+            {
+                concat!(env!("CARGO_MANIFEST_DIR"), "/src/team_ops.rs")
+            } else {
+                concat!(env!("CARGO_MANIFEST_DIR"), "/src/team_ops/mod.rs")
+            };
+        let team_ops_src =
+            std::fs::read_to_string(team_ops_path).expect("read team_ops module source");
+        let create_fn_start = team_ops_src
+            .find("fn create(")
+            .or_else(|| team_ops_src.find("fn create_team("))
+            .expect("team_ops must define a create/create_team function");
+        // Extract the signature line (up to the opening brace)
+        let sig_end = team_ops_src[create_fn_start..]
+            .find('{')
+            .map(|o| create_fn_start + o)
+            .unwrap_or(team_ops_src.len());
+        let signature = &team_ops_src[create_fn_start..sig_end];
+        assert!(
+            !signature.contains("HandlerCtx"),
+            "#2454: team_ops::create signature must not accept HandlerCtx \
+             (framework-coupled boundary): {signature}"
+        );
+        assert!(
+            !signature.contains("&Value") && !signature.contains(": Value"),
+            "#2454: team_ops::create signature must not accept raw serde_json::Value \
+             (untyped boundary — wrapping old logic behind a same-named helper): {signature}"
         );
     }
 

--- a/src/mcp/handlers/dispatch.rs
+++ b/src/mcp/handlers/dispatch.rs
@@ -1456,8 +1456,8 @@ mod tests {
         std::fs::remove_dir_all(&home).ok();
     }
 
-    /// Frozen Slice-12 target: exactly 5 same-daemon api::call production sites
-    /// remain in src/mcp/handlers/ after SEND migration to typed runtime service.
+    /// Frozen Slice-12 baseline (pre-Slice-13): exactly 5 same-daemon
+    /// api::call production sites remain in src/mcp/handlers/.
     #[test]
     fn production_api_call_baseline_is_5_2454() {
         let needle_call = concat!("crate::", "api::", "call");
@@ -1490,6 +1490,73 @@ mod tests {
         assert_eq!(
             count, 5,
             "production same-daemon api::call post-Slice-12 must be exactly 5; got {count}"
+        );
+    }
+
+    /// #2454 Slice 13 RED: after CREATE_TEAM migration, exactly 4
+    /// same-daemon api::call production sites remain (down from 5).
+    #[test]
+    fn production_api_call_post_create_team_is_4_2454() {
+        let needle_call = concat!("crate::", "api::", "call");
+        let needle_at = concat!("api::", "call_at");
+        let test_mod_marker = "#[cfg(test)]\nmod ";
+        let files: &[&str] = &[
+            include_str!("comms.rs"),
+            include_str!("comms_delegate/mod.rs"),
+            include_str!("task.rs"),
+            include_str!("restart.rs"),
+            include_str!("instance_state/mod.rs"),
+            include_str!("instance_state/spawn.rs"),
+            include_str!("instance_state/lifecycle.rs"),
+            include_str!("instance_metadata.rs"),
+        ];
+        let mut count = 0;
+        for src in files {
+            let boundary = src.rfind(test_mod_marker).unwrap_or(src.len());
+            let production = &src[..boundary];
+            for line in production.lines() {
+                let trimmed = line.trim();
+                if trimmed.starts_with("//") || trimmed.starts_with("///") {
+                    continue;
+                }
+                if line.contains(needle_call) && !line.contains(needle_at) {
+                    count += 1;
+                }
+            }
+        }
+        assert_eq!(
+            count, 4,
+            "production same-daemon api::call post-Slice-13 must be exactly 4; got {count}"
+        );
+    }
+
+    /// #2454 Slice 13 RED: the neutral typed CREATE_TEAM service must own
+    /// the team-creation logic, and both MCP and API handlers must route
+    /// through thin adapters to it — not call teams::create directly.
+    #[test]
+    fn create_team_neutral_service_owns_logic_2454() {
+        let task_src = include_str!("task.rs");
+        let test_boundary = task_src
+            .rfind("#[cfg(test)]\nmod ")
+            .unwrap_or(task_src.len());
+        let production = &task_src[..test_boundary];
+        let create_fn_start = production
+            .find("fn handle_create_team(")
+            .expect("MCP handle_create_team must exist");
+        let create_fn_end = production[create_fn_start..]
+            .find("\n}\n")
+            .map(|o| create_fn_start + o)
+            .unwrap_or(production.len());
+        let create_fn = &production[create_fn_start..create_fn_end];
+        assert!(
+            !create_fn.contains("api::call"),
+            "#2454: MCP handle_create_team must not contain api::call: \
+             it must route through the neutral typed service"
+        );
+        assert!(
+            !create_fn.contains("teams::create("),
+            "#2454: MCP handle_create_team must not call teams::create directly: \
+             it must route through the neutral typed service"
         );
     }
 

--- a/src/mcp/handlers/r3_46776_red_tests.rs
+++ b/src/mcp/handlers/r3_46776_red_tests.rs
@@ -72,7 +72,7 @@ fn g1_prepare_instructions_contextless_fallback_refuses_foreign_identity() {
 
     seed_agents_owned_by(&ws, "existing-owner");
 
-    let result = crate::api::handlers::prepare_instructions(
+    let result = crate::agent_ops::spawn::prepare_instructions(
         &home,
         "new-agent",
         "codex",
@@ -476,7 +476,7 @@ fn r4_malformed_fleet_refuses_prepare_instructions() {
     let fleet_path = crate::fleet::fleet_yaml_path(&home);
     std::fs::write(&fleet_path, "{{{{invalid yaml nonsense!!!!").unwrap();
 
-    let result = crate::api::handlers::prepare_instructions(&home, "agent", "codex", &ws, None);
+    let result = crate::agent_ops::spawn::prepare_instructions(&home, "agent", "codex", &ws, None);
 
     assert!(
         result.is_err(),
@@ -509,7 +509,7 @@ fn r4_ensure_project_root_failure_propagates() {
     std::fs::write(ws.join(".git"), "invalid content — not a valid gitlink").unwrap();
 
     // No fleet.yaml → NotFound fallback (legitimate), reaches generate_with_context.
-    let result = crate::api::handlers::prepare_instructions(&home, "agent", "codex", &ws, None);
+    let result = crate::agent_ops::spawn::prepare_instructions(&home, "agent", "codex", &ws, None);
 
     assert!(
         result.is_err(),
@@ -536,7 +536,7 @@ fn r4_migrate_claude_old_rules_failure_propagates() {
     std::fs::create_dir_all(&old_rules).unwrap();
 
     // No fleet.yaml → NotFound fallback. Backend = "claude" triggers migrate.
-    let result = crate::api::handlers::prepare_instructions(&home, "agent", "claude", &ws, None);
+    let result = crate::agent_ops::spawn::prepare_instructions(&home, "agent", "claude", &ws, None);
 
     assert!(
         result.is_err(),
@@ -715,7 +715,7 @@ fn r5_absent_workdir_stays_absent_on_malformed_fleet() {
     let fleet_path = crate::fleet::fleet_yaml_path(&home);
     std::fs::write(&fleet_path, "{{invalid yaml!!").unwrap();
 
-    let result = crate::api::handlers::prepare_instructions(&home, "agent", "codex", &ws, None);
+    let result = crate::agent_ops::spawn::prepare_instructions(&home, "agent", "codex", &ws, None);
 
     assert!(result.is_err(), "precondition: malformed fleet must refuse");
     assert!(
@@ -753,7 +753,7 @@ fn r5_claude_migration_opaque_io_propagates() {
     std::fs::set_permissions(&rules_dir, std::fs::Permissions::from_mode(0o600)).unwrap();
 
     // No fleet.yaml → NotFound fallback. Backend = "claude" triggers migrate.
-    let result = crate::api::handlers::prepare_instructions(&home, "agent", "claude", &ws, None);
+    let result = crate::agent_ops::spawn::prepare_instructions(&home, "agent", "claude", &ws, None);
 
     // Restore for cleanup.
     std::fs::set_permissions(&rules_dir, std::fs::Permissions::from_mode(0o755)).ok();

--- a/src/mcp/handlers/task.rs
+++ b/src/mcp/handlers/task.rs
@@ -97,19 +97,6 @@ pub(super) fn handle_create_team(
         Some(n) => n.to_string(),
         None => return json!({"error": "missing 'name'"}),
     };
-    let per_member_backends: Vec<String> = if let Some(arr) = args["backends"].as_array() {
-        arr.iter()
-            .filter_map(|v| v.as_str().map(String::from))
-            .collect()
-    } else {
-        let count = args["count"].as_u64().unwrap_or(0) as usize;
-        let backend = args["backend"].as_str().unwrap_or("claude").to_string();
-        vec![backend; count]
-    };
-    let topic_binding_mode: Option<String> = args["topic_binding"]
-        .as_str()
-        .filter(|s| matches!(*s, "skip" | "deferred"))
-        .map(String::from);
     let existing_members: Vec<String> = args["members"]
         .as_array()
         .map(|a| {
@@ -131,12 +118,13 @@ pub(super) fn handle_create_team(
         home,
         crate::team_ops::CreateTeamRequest {
             name,
-            per_member_backends,
+            per_member_backends: Vec::new(),
             existing_members,
-            topic_binding_mode,
+            topic_binding_mode: None,
             orchestrator: args["orchestrator"].as_str().map(String::from),
             description: args["description"].as_str().map(String::from),
             repository_path: args["repository_path"].as_str().map(String::from),
+            project_id: args["project_id"].as_str().map(String::from),
             accept_from,
         },
         &rt.registry,

--- a/src/mcp/handlers/task.rs
+++ b/src/mcp/handlers/task.rs
@@ -80,19 +80,68 @@ pub(super) fn handle_task(home: &Path, args: &Value, instance_name: &str) -> Val
     crate::tasks::handle(home, instance_name, args)
 }
 
-pub(super) fn handle_create_team(home: &Path, args: &Value) -> Value {
-    match crate::api::call(
+/// #2454 Slice 13: thin MCP adapter — delegates to `team_ops::create`
+/// via the in-process RuntimeContext when available, or returns a
+/// structured transport failure when the runtime is absent.
+pub(super) fn handle_create_team(
+    home: &Path,
+    args: &Value,
+    runtime: Option<&super::dispatch::RuntimeContext>,
+) -> Value {
+    let Some(rt) = runtime else {
+        return json!({
+            "error": "runtime unavailable: team creation requires an in-process runtime"
+        });
+    };
+    let name = match args["name"].as_str() {
+        Some(n) => n.to_string(),
+        None => return json!({"error": "missing 'name'"}),
+    };
+    let per_member_backends: Vec<String> = if let Some(arr) = args["backends"].as_array() {
+        arr.iter()
+            .filter_map(|v| v.as_str().map(String::from))
+            .collect()
+    } else {
+        let count = args["count"].as_u64().unwrap_or(0) as usize;
+        let backend = args["backend"].as_str().unwrap_or("claude").to_string();
+        vec![backend; count]
+    };
+    let topic_binding_mode: Option<String> = args["topic_binding"]
+        .as_str()
+        .filter(|s| matches!(*s, "skip" | "deferred"))
+        .map(String::from);
+    let existing_members: Vec<String> = args["members"]
+        .as_array()
+        .map(|a| {
+            a.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+    let accept_from: Vec<String> = args["accept_from"]
+        .as_array()
+        .map(|a| {
+            a.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    crate::team_ops::create(
         home,
-        &json!({"method": crate::api::method::CREATE_TEAM, "params": args}),
-    ) {
-        Ok(resp) if resp["ok"].as_bool() == Some(true) => {
-            resp.get("result").cloned().unwrap_or_default()
-        }
-        Ok(resp) => {
-            json!({"error": resp["error"].as_str().unwrap_or("create_team failed")})
-        }
-        Err(_) => crate::teams::create(home, args),
-    }
+        crate::team_ops::CreateTeamRequest {
+            name,
+            per_member_backends,
+            existing_members,
+            topic_binding_mode,
+            orchestrator: args["orchestrator"].as_str().map(String::from),
+            description: args["description"].as_str().map(String::from),
+            repository_path: args["repository_path"].as_str().map(String::from),
+            accept_from,
+        },
+        &rt.registry,
+        rt.notifier.as_deref(),
+    )
 }
 
 pub(super) fn handle_delete_team(home: &Path, args: &Value) -> Value {

--- a/src/mcp/handlers/tests.rs
+++ b/src/mcp/handlers/tests.rs
@@ -2825,6 +2825,91 @@ fn create_team_runtime_some_has_spawned_field_2454() {
     std::fs::remove_dir_all(&home).ok();
 }
 
+/// #2454 Slice 13 RED: runtime=Some with a recording notifier must emit
+/// exactly one TeamCreated event with correct name+members, zero
+/// InstanceCreated events, and return API-equivalent ok/result/spawned.
+#[test]
+fn create_team_runtime_some_emits_team_created_event_2454() {
+    let _g = fleet_test_guard();
+    let home = tmp_home("team-rt-event");
+    std::env::set_var("AGEND_HOME", &home);
+    std::fs::write(
+        crate::fleet::fleet_yaml_path(&home),
+        "instances: {}\nteams: {}\n",
+    )
+    .unwrap();
+    struct EventRecorder {
+        events: parking_lot::Mutex<Vec<crate::api::ApiEvent>>,
+    }
+    impl EventRecorder {
+        fn new() -> std::sync::Arc<Self> {
+            std::sync::Arc::new(Self {
+                events: parking_lot::Mutex::new(Vec::new()),
+            })
+        }
+        fn take(&self) -> Vec<crate::api::ApiEvent> {
+            std::mem::take(&mut *self.events.lock())
+        }
+    }
+    impl crate::api::ApiNotifier for EventRecorder {
+        fn notify(&self, event: crate::api::ApiEvent) {
+            self.events.lock().push(event);
+        }
+    }
+    let recorder = EventRecorder::new();
+    let notifier: std::sync::Arc<dyn crate::api::ApiNotifier> = recorder.clone();
+    let runtime = super::dispatch::RuntimeContext {
+        registry: std::sync::Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new())),
+        configs: Default::default(),
+        externals: std::sync::Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new())),
+        capability: crate::api::RestartCapability::Unsupported,
+        app_restart: None,
+        post_flush: None,
+        notifier: Some(notifier),
+        shutdown: None,
+    };
+    let result = super::handle_tool_with_runtime(
+        "team",
+        &json!({"action": "create", "name": "ev-team", "members": ["alice", "bob"]}),
+        "sender",
+        Some(runtime),
+    );
+    assert_eq!(
+        result.get("ok").and_then(|v| v.as_bool()),
+        Some(true),
+        "#2454: runtime=Some+notifier CREATE_TEAM must return ok:true: {result}"
+    );
+    let events = recorder.take();
+    let team_created_count = events
+        .iter()
+        .filter(|e| matches!(e, crate::api::ApiEvent::TeamCreated { .. }))
+        .count();
+    assert_eq!(
+        team_created_count, 1,
+        "#2454: exactly one TeamCreated event expected, got {team_created_count}: {events:?}"
+    );
+    if let Some(crate::api::ApiEvent::TeamCreated { name, members }) = events
+        .iter()
+        .find(|e| matches!(e, crate::api::ApiEvent::TeamCreated { .. }))
+    {
+        assert_eq!(name, "ev-team", "#2454: TeamCreated name mismatch");
+        assert!(
+            members.contains(&"alice".to_string()) && members.contains(&"bob".to_string()),
+            "#2454: TeamCreated members must include alice and bob: {members:?}"
+        );
+    }
+    let instance_created_count = events
+        .iter()
+        .filter(|e| matches!(e, crate::api::ApiEvent::InstanceCreated { .. }))
+        .count();
+    assert_eq!(
+        instance_created_count, 0,
+        "#2454: zero InstanceCreated events expected for team(action=create) with pre-listed members: {events:?}"
+    );
+    std::env::remove_var("AGEND_HOME");
+    std::fs::remove_dir_all(&home).ok();
+}
+
 #[test]
 fn update_team_fallback_to_direct_when_daemon_unreachable() {
     let _g = fleet_test_guard();

--- a/src/mcp/handlers/tests.rs
+++ b/src/mcp/handlers/tests.rs
@@ -2937,6 +2937,55 @@ fn create_team_runtime_some_emits_team_created_event_2454() {
     std::fs::remove_dir_all(&home).ok();
 }
 
+/// #2454 Slice 13 RED: runtime CREATE_TEAM with `project_id` must persist
+/// the exact project_id to the team roster on disk. The neutral typed
+/// service must forward project_id through to teams::create so that
+/// teams::list surfaces it — same as the API handler path.
+#[test]
+fn create_team_runtime_some_persists_project_id_2454() {
+    let _g = fleet_test_guard();
+    let home = tmp_home("team-rt-pid");
+    std::env::set_var("AGEND_HOME", &home);
+    std::fs::write(
+        crate::fleet::fleet_yaml_path(&home),
+        "instances: {}\nteams: {}\n",
+    )
+    .unwrap();
+    let result = handle_tool_rt(
+        "team",
+        &json!({
+            "action": "create",
+            "name": "pid-team",
+            "members": ["dev-1"],
+            "project_id": "custom-board-42"
+        }),
+        "sender",
+    );
+    assert_eq!(
+        result.get("ok").and_then(|v| v.as_bool()),
+        Some(true),
+        "#2454: runtime CREATE_TEAM with project_id must succeed: {result}"
+    );
+
+    // Reload fleet.yaml and verify project_id was persisted
+    let listed = crate::teams::list(&home);
+    let team = listed["teams"]
+        .as_array()
+        .expect("teams array")
+        .iter()
+        .find(|t| t["name"] == "pid-team")
+        .expect("#2454: team 'pid-team' must be present in list");
+    assert_eq!(
+        team["project_id"].as_str(),
+        Some("custom-board-42"),
+        "#2454: runtime CREATE_TEAM must persist exact project_id \
+         through the neutral typed service to disk; got: {}",
+        team["project_id"]
+    );
+    std::env::remove_var("AGEND_HOME");
+    std::fs::remove_dir_all(&home).ok();
+}
+
 #[test]
 fn update_team_fallback_to_direct_when_daemon_unreachable() {
     let _g = fleet_test_guard();

--- a/src/mcp/handlers/tests.rs
+++ b/src/mcp/handlers/tests.rs
@@ -2744,23 +2744,82 @@ fn checkout_repo_agent_name_source_with_agent_not_found() {
     std::fs::remove_dir_all(&home).ok();
 }
 
-// --- task.rs fallback paths ---
+// --- #2454 Slice 13: team(action=create) typed runtime migration ---
 
+/// #2454 Slice 13 RED: runtime=None must return an explicit structured
+/// transport failure — never silently fall back to teams::create.
+/// Retargets the pre-migration create_team_fallback_to_direct_when_daemon_unreachable.
 #[test]
-fn create_team_fallback_to_direct_when_daemon_unreachable() {
+fn create_team_runtime_none_returns_structured_error_2454() {
     let _g = fleet_test_guard();
-    let home = tmp_home("team-fallback");
+    let home = tmp_home("team-rt-none");
     std::env::set_var("AGEND_HOME", &home);
-    // No daemon running → API call fails → falls back to teams::create
     let result = handle_tool(
         "team",
-        &json!({"action": "create", "name": "test-team", "members": ["a", "b"]}),
+        &json!({"action": "create", "name": "no-rt-team", "members": ["a", "b"]}),
         "sender",
     );
-    // Should succeed via direct fallback (or return structured error, not panic)
     assert!(
-        result.get("error").is_none() || result.get("name").is_some(),
-        "create_team fallback must not panic: {result}"
+        result.get("error").is_some(),
+        "#2454: runtime=None CREATE_TEAM must return structured error, not fallback success: {result}"
+    );
+    assert!(
+        result["error"]
+            .as_str()
+            .is_some_and(|e| e.contains("runtime")),
+        "#2454: error must mention runtime unavailability: {result}"
+    );
+    // Zero side effects: no team created in fleet.yaml
+    let fleet_path = home.join("fleet.yaml");
+    let fleet_content = std::fs::read_to_string(&fleet_path).unwrap_or_default();
+    assert!(
+        !fleet_content.contains("no-rt-team"),
+        "#2454: runtime=None must not create team as a side effect: {fleet_content}"
+    );
+    std::env::remove_var("AGEND_HOME");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// #2454 Slice 13 RED: runtime=Some must succeed in-process without
+/// an API listener, through the neutral typed CREATE_TEAM service —
+/// not teams::create fallback.
+#[test]
+fn create_team_runtime_some_succeeds_without_api_2454() {
+    let _g = fleet_test_guard();
+    let home = tmp_home("team-rt-some");
+    std::env::set_var("AGEND_HOME", &home);
+    let result = handle_tool_rt(
+        "team",
+        &json!({"action": "create", "name": "rt-team", "members": ["alice"]}),
+        "sender",
+    );
+    // API-equivalent result shape: must have ok:true (not raw teams::create output)
+    assert_eq!(
+        result.get("ok").and_then(|v| v.as_bool()),
+        Some(true),
+        "#2454: runtime=Some CREATE_TEAM must return API-equivalent ok:true, \
+         not teams::create fallback shape: {result}"
+    );
+    std::env::remove_var("AGEND_HOME");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// #2454 Slice 13 RED: runtime=Some result must carry `spawned` field
+/// with API-equivalent event semantics (members spawned in-process).
+#[test]
+fn create_team_runtime_some_has_spawned_field_2454() {
+    let _g = fleet_test_guard();
+    let home = tmp_home("team-rt-spawned");
+    std::env::set_var("AGEND_HOME", &home);
+    let result = handle_tool_rt(
+        "team",
+        &json!({"action": "create", "name": "sp-team", "members": ["bob"]}),
+        "sender",
+    );
+    assert!(
+        result.get("spawned").is_some(),
+        "#2454: runtime=Some CREATE_TEAM must include spawned field \
+         (API-equivalent semantics): {result}"
     );
     std::env::remove_var("AGEND_HOME");
     std::fs::remove_dir_all(&home).ok();

--- a/src/mcp/handlers/tests.rs
+++ b/src/mcp/handlers/tests.rs
@@ -2874,37 +2874,64 @@ fn create_team_runtime_some_emits_team_created_event_2454() {
         "sender",
         Some(runtime),
     );
+    // API-equivalent response shape: ok + result{status,name} + spawned=[]
     assert_eq!(
         result.get("ok").and_then(|v| v.as_bool()),
         Some(true),
         "#2454: runtime=Some+notifier CREATE_TEAM must return ok:true: {result}"
     );
-    let events = recorder.take();
-    let team_created_count = events
-        .iter()
-        .filter(|e| matches!(e, crate::api::ApiEvent::TeamCreated { .. }))
-        .count();
     assert_eq!(
-        team_created_count, 1,
-        "#2454: exactly one TeamCreated event expected, got {team_created_count}: {events:?}"
+        result["result"]["status"].as_str(),
+        Some("created"),
+        "#2454: result.status must be \"created\": {result}"
     );
-    if let Some(crate::api::ApiEvent::TeamCreated { name, members }) = events
-        .iter()
-        .find(|e| matches!(e, crate::api::ApiEvent::TeamCreated { .. }))
-    {
-        assert_eq!(name, "ev-team", "#2454: TeamCreated name mismatch");
-        assert!(
-            members.contains(&"alice".to_string()) && members.contains(&"bob".to_string()),
-            "#2454: TeamCreated members must include alice and bob: {members:?}"
-        );
-    }
-    let instance_created_count = events
-        .iter()
-        .filter(|e| matches!(e, crate::api::ApiEvent::InstanceCreated { .. }))
-        .count();
     assert_eq!(
-        instance_created_count, 0,
-        "#2454: zero InstanceCreated events expected for team(action=create) with pre-listed members: {events:?}"
+        result["result"]["name"].as_str(),
+        Some("ev-team"),
+        "#2454: result.name must be exact: {result}"
+    );
+    // Pre-listed members (no count/backends) → zero spawns
+    assert_eq!(
+        result.get("spawned").and_then(|v| v.as_array()),
+        Some(&vec![]),
+        "#2454: spawned must be exactly []: {result}"
+    );
+
+    // Roster on disk must contain exactly the declared members
+    let fleet = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&home)).unwrap();
+    let team_cfg = fleet
+        .teams
+        .get("ev-team")
+        .expect("#2454: team must be persisted to fleet.yaml");
+    let mut roster = team_cfg.members.clone();
+    roster.sort();
+    assert_eq!(
+        roster,
+        vec!["alice", "bob"],
+        "#2454: persisted team roster must equal exactly [alice, bob]: {:?}",
+        team_cfg.members
+    );
+
+    // Event assertions: exactly one event total, and it is TeamCreated
+    let events = recorder.take();
+    assert_eq!(
+        events.len(),
+        1,
+        "#2454: exactly one event expected (no InstanceCreated, no other variants): {events:?}"
+    );
+    let crate::api::ApiEvent::TeamCreated { name, members } = &events[0] else {
+        panic!(
+            "#2454: sole event must be TeamCreated, got: {:?}",
+            events[0]
+        );
+    };
+    assert_eq!(name, "ev-team", "#2454: TeamCreated name must be exact");
+    let mut sorted_members = members.clone();
+    sorted_members.sort();
+    assert_eq!(
+        sorted_members,
+        vec!["alice", "bob"],
+        "#2454: TeamCreated members must equal exactly [alice, bob]: {members:?}"
     );
     std::env::remove_var("AGEND_HOME");
     std::fs::remove_dir_all(&home).ok();

--- a/src/team_ops.rs
+++ b/src/team_ops.rs
@@ -1,0 +1,283 @@
+//! #2454 Slice 13: neutral typed CREATE_TEAM service.
+//!
+//! Shared owner for team creation logic — both the API handler
+//! (`api::handlers::team`) and the MCP handler (`mcp::handlers::task`)
+//! route through `create()` via thin adapters. The interface is typed
+//! (no `HandlerCtx`, no raw `serde_json::Value` parameters).
+
+use serde_json::{json, Value};
+use std::path::Path;
+
+/// Typed request for team creation — parsed from raw JSON by each
+/// adapter (API and MCP) before calling `create()`.
+pub(crate) struct CreateTeamRequest {
+    pub name: String,
+    pub per_member_backends: Vec<String>,
+    pub existing_members: Vec<String>,
+    pub topic_binding_mode: Option<String>,
+    pub orchestrator: Option<String>,
+    pub description: Option<String>,
+    pub repository_path: Option<String>,
+    pub accept_from: Vec<String>,
+}
+
+/// #1964 Bug 1: plan `count` member names for `team` as `<team>-N`.
+pub(crate) fn plan_member_names(
+    fleet: &crate::fleet::FleetConfig,
+    team: &str,
+    count: usize,
+    taken: impl Fn(&str) -> bool,
+) -> Vec<String> {
+    let prefix = format!("{team}-");
+    let mut next_n: u64 = fleet
+        .instances
+        .keys()
+        .filter_map(|k| k.strip_prefix(&prefix)?.parse::<u64>().ok())
+        .max()
+        .map_or(1, |m| m + 1);
+    let mut names = Vec::with_capacity(count);
+    while names.len() < count {
+        let candidate = format!("{team}-{next_n}");
+        next_n += 1;
+        if fleet.instances.contains_key(&candidate) || taken(&candidate) {
+            tracing::info!(
+                team,
+                member = %candidate,
+                "CREATE_TEAM: name taken — advancing to the next number (#1964)"
+            );
+            continue;
+        }
+        names.push(candidate);
+    }
+    names
+}
+
+/// #991 PR-B: build each planned member's fleet.yaml entry.
+pub(crate) fn build_member_entries(
+    planned: &[(String, String, std::path::PathBuf)],
+    topic_binding_mode: Option<&str>,
+) -> Vec<(String, crate::fleet::InstanceYamlEntry)> {
+    planned
+        .iter()
+        .map(|(name, be, wd)| {
+            (
+                name.clone(),
+                crate::fleet::InstanceYamlEntry {
+                    backend: Some(be.clone()),
+                    working_directory: Some(wd.display().to_string()),
+                    topic_binding_mode: topic_binding_mode.map(String::from),
+                    ..Default::default()
+                },
+            )
+        })
+        .collect()
+}
+
+/// Neutral typed CREATE_TEAM entry point.
+///
+/// Both API and MCP adapters call this after parsing their transport-specific
+/// input into a [`CreateTeamRequest`]. The `registry` is the live agent
+/// registry (for spawn + UUID resolution); `notifier` emits API lifecycle
+/// events (TeamCreated / TeamMembersChanged).
+#[allow(clippy::too_many_lines)]
+pub(crate) fn create(
+    home: &Path,
+    request: CreateTeamRequest,
+    registry: &crate::agent::AgentRegistry,
+    notifier: Option<&dyn crate::api::ApiNotifier>,
+) -> Value {
+    let team_name = &request.name;
+    let count = request.per_member_backends.len();
+    tracing::info!(
+        team = %team_name,
+        count,
+        backends = ?request.per_member_backends,
+        topic_binding_mode = ?request.topic_binding_mode,
+        "CREATE_TEAM begin"
+    );
+
+    let fleet_snapshot =
+        crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home)).unwrap_or_default();
+    let team_already_exists = fleet_snapshot.teams.contains_key(team_name.as_str());
+
+    // Phase 1 — plan every member's fleet.yaml entry
+    let names = plan_member_names(&fleet_snapshot, team_name, count, |c| {
+        crate::fleet::resolve_uuid(home, c)
+            .is_some_and(|id| crate::agent::lock_registry(registry).contains_key(&id))
+    });
+    let mut planned: Vec<(String, String, std::path::PathBuf)> = Vec::new();
+    let mut failed: Vec<String> = Vec::new();
+    for (inst_name, backend) in names.into_iter().zip(request.per_member_backends.iter()) {
+        let work_dir = crate::paths::workspace_dir(home).join(&inst_name);
+        planned.push((inst_name, backend.clone(), work_dir));
+    }
+
+    if !planned.is_empty() {
+        let entries = build_member_entries(&planned, request.topic_binding_mode.as_deref());
+        let refs: Vec<(&str, &crate::fleet::InstanceYamlEntry)> =
+            entries.iter().map(|(n, e)| (n.as_str(), e)).collect();
+        if let Err(e) = crate::fleet::add_instances_to_yaml(home, &refs) {
+            tracing::warn!(error = %e, "failed to persist team to fleet.yaml");
+        }
+    }
+
+    // Phase 2 — generate instructions and spawn each planned member.
+    let mut spawned: Vec<(String, String)> = Vec::new();
+    let size = crossterm::terminal::size().unwrap_or((120, 40));
+    for (inst_name, backend, work_dir) in &planned {
+        if let Err(e) =
+            crate::agent_ops::spawn::prepare_instructions(home, inst_name, backend, work_dir, None)
+        {
+            tracing::error!(agent = %inst_name, error = %e,
+                "team spawn: provisioning refused — skipping member");
+            continue;
+        }
+        let resolved = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))
+            .ok()
+            .and_then(|f| f.resolve_instance(inst_name));
+        let resolved_env = resolved.as_ref().map(|r| r.env.clone());
+        let mut member_args = resolved
+            .as_ref()
+            .map(|r| r.args.clone())
+            .unwrap_or_default();
+        let declared_backend = resolved
+            .as_ref()
+            .map(|r| r.backend.clone())
+            .unwrap_or_else(|| crate::backend::Backend::parse_str(backend));
+        if let Some(model) = resolved.as_ref().and_then(|r| r.model.as_deref()) {
+            crate::backend::Backend::push_model_arg(&mut member_args, &declared_backend, model);
+        }
+        match crate::agent_ops::spawn_one(
+            home,
+            registry,
+            inst_name,
+            backend,
+            &member_args,
+            crate::backend::SpawnMode::Fresh,
+            work_dir,
+            size,
+            resolved_env.as_ref(),
+            Some(&declared_backend),
+        ) {
+            Ok(_) => {
+                tracing::info!(team = %team_name, member = %inst_name, backend = %backend, "CREATE_TEAM spawn ok");
+                if let Some(mode) = request.topic_binding_mode.as_deref() {
+                    tracing::info!(
+                        team = %team_name,
+                        member = %inst_name,
+                        topic_binding_mode = mode,
+                        "CREATE_TEAM: skipping topic creation (opted out)"
+                    );
+                } else {
+                    match crate::channel::ensure_topic_for(inst_name) {
+                        crate::channel::TopicOutcome::Created(_)
+                        | crate::channel::TopicOutcome::NoChannel => {}
+                        crate::channel::TopicOutcome::Failed(err) => {
+                            tracing::warn!(
+                                team = %team_name,
+                                member = %inst_name,
+                                error = %err,
+                                "CREATE_TEAM: channel exists but create_topic failed; \
+                                 member spawn proceeds without topic"
+                            );
+                        }
+                    }
+                }
+                spawned.push((inst_name.clone(), backend.clone()));
+            }
+            Err(e) => {
+                tracing::warn!(team = %team_name, member = %inst_name, backend = %backend, error = %e, "CREATE_TEAM spawn failed");
+                failed.push(format!("{inst_name}: {e}"));
+            }
+        }
+    }
+    tracing::info!(
+        team = %team_name,
+        spawned = spawned.len(),
+        failed = failed.len(),
+        "CREATE_TEAM spawn phase done"
+    );
+    if count > 0 && spawned.is_empty() {
+        return json!({"ok": false, "error": format!("all {} spawns failed: {}", count, failed.join("; "))});
+    }
+
+    let spawned_names: Vec<String> = spawned.iter().map(|(n, _)| n.clone()).collect();
+    let all_members: Vec<String> = request
+        .existing_members
+        .into_iter()
+        .chain(spawned_names.iter().cloned())
+        .collect();
+
+    // Roster write — teams::create for new team, teams::update for existing
+    let mut team_params = json!({
+        "name": team_name,
+        "members": all_members,
+    });
+    if let Some(desc) = &request.description {
+        team_params["description"] = json!(desc);
+    }
+    if let Some(ref orch) = request.orchestrator {
+        team_params["orchestrator"] = json!(orch);
+    }
+    if let Some(ref repo) = request.repository_path {
+        team_params["repository_path"] = json!(repo);
+    }
+    if !request.accept_from.is_empty() {
+        team_params["accept_from"] = json!(request.accept_from);
+    }
+
+    let result = if team_already_exists {
+        tracing::info!(
+            team = %team_name,
+            adding = ?all_members,
+            "CREATE_TEAM: team exists — extending roster (#1964)"
+        );
+        let mut update_params = json!({
+            "name": team_name,
+            "add": all_members,
+        });
+        if let Some(ref orch) = request.orchestrator {
+            update_params["orchestrator"] = json!(orch);
+        }
+        if let Some(ref repo) = request.repository_path {
+            update_params["repository_path"] = json!(repo);
+        }
+        crate::teams::update(home, &update_params)
+    } else {
+        crate::teams::create(home, &team_params)
+    };
+
+    if let Some(err) = result.get("error").and_then(|e| e.as_str()) {
+        tracing::warn!(team = %team_name, error = %err, "CREATE_TEAM roster write failed — spawned members are NOT on the team roster");
+        return json!({
+            "ok": false,
+            "error": format!("members spawned but roster write failed: {err}"),
+            "spawned": &spawned_names,
+        });
+    }
+
+    if let Some(n) = notifier {
+        if team_already_exists {
+            if !spawned_names.is_empty() {
+                tracing::info!(team = %team_name, added = ?spawned_names, "CREATE_TEAM emitting TeamMembersChanged (extend)");
+                n.notify(crate::api::ApiEvent::TeamMembersChanged {
+                    name: team_name.to_string(),
+                    added: spawned_names.clone(),
+                    removed: Vec::new(),
+                });
+            }
+        } else if !all_members.is_empty() {
+            tracing::info!(team = %team_name, members = ?all_members, "CREATE_TEAM emitting TeamCreated");
+            n.notify(crate::api::ApiEvent::TeamCreated {
+                name: team_name.to_string(),
+                members: all_members.clone(),
+            });
+        }
+    }
+
+    let mut resp = json!({"ok": true, "result": result, "spawned": &spawned_names});
+    if !failed.is_empty() {
+        resp["failed"] = json!(failed);
+    }
+    resp
+}

--- a/src/team_ops.rs
+++ b/src/team_ops.rs
@@ -18,6 +18,7 @@ pub(crate) struct CreateTeamRequest {
     pub orchestrator: Option<String>,
     pub description: Option<String>,
     pub repository_path: Option<String>,
+    pub project_id: Option<String>,
     pub accept_from: Vec<String>,
 }
 
@@ -222,6 +223,9 @@ pub(crate) fn create(
     if let Some(ref repo) = request.repository_path {
         team_params["repository_path"] = json!(repo);
     }
+    if let Some(ref pid) = request.project_id {
+        team_params["project_id"] = json!(pid);
+    }
     if !request.accept_from.is_empty() {
         team_params["accept_from"] = json!(request.accept_from);
     }
@@ -241,6 +245,9 @@ pub(crate) fn create(
         }
         if let Some(ref repo) = request.repository_path {
             update_params["repository_path"] = json!(repo);
+        }
+        if let Some(ref pid) = request.project_id {
+            update_params["project_id"] = json!(pid);
         }
         crate::teams::update(home, &update_params)
     } else {


### PR DESCRIPTION
Closes the team(action=create) Slice 13 portion of #2454.

- moves CREATE_TEAM behavior into one typed neutral owner shared by API and MCP adapters
- removes the MCP same-daemon api::call and direct fallback
- preserves fleet persistence, spawn, topic, roster, notifier, and response semantics
- makes runtime absence an explicit zero-side-effect error
- lowers the direct loopback budget from 5 to 4

Evidence: 61 focused #2454 tests; team-focused tests; cargo fmt --check; cargo clippy --bin agend-terminal.