### PR TITLE
fix(#2454): route create_instance team through runtime owner

### DIFF
--- a/src/api/handlers/mcp_proxy_2454_tests.rs
+++ b/src/api/handlers/mcp_proxy_2454_tests.rs
@@ -4,7 +4,7 @@ use serde_json::json;
 // ── #2454 Slice 12: SEND runtime contract RED tests ─────────────
 
 /// #2454 Slice 12 RED (1/3): structural budget + reachability guard.
-/// (a) cumulative handler api::call == 5, (b) dispatch_send not adapter!,
+/// (a) cumulative handler api::call == 3, (b) dispatch_send not adapter!,
 /// (c) agent_ops::send_to zero api::call, (d) SEND region bridge == 1.
 #[test]
 fn send_structural_budget_and_reachability_2454() {
@@ -12,7 +12,7 @@ fn send_structural_budget_and_reachability_2454() {
     let needle_at = concat!("api::", "call_at");
     let test_mod_marker = "#[cfg(test)]\nmod ";
 
-    // (a) cumulative budget: 8 → 5
+    // (a) cumulative budget: 8 → 3
     // Three handler-local sites to eliminate: SEND (comms.rs),
     // REPORT (comms.rs), DELEGATE (comms_delegate/mod.rs).
     let files: &[&str] = &[
@@ -40,8 +40,8 @@ fn send_structural_budget_and_reachability_2454() {
         }
     }
     assert_eq!(
-        handler_count, 4,
-        "Slice-13 cumulative api::call budget must be 4; got {handler_count}"
+        handler_count, 3,
+        "Slice-14 cumulative api::call budget must be 3; got {handler_count}"
     );
 
     // (b) dispatch_send must NOT be adapter! — custom fn threads RuntimeContext

--- a/src/mcp/handlers/dispatch.rs
+++ b/src/mcp/handlers/dispatch.rs
@@ -1456,43 +1456,6 @@ mod tests {
         std::fs::remove_dir_all(&home).ok();
     }
 
-    /// Frozen Slice-12 baseline (pre-Slice-13): exactly 5 same-daemon
-    /// api::call production sites remain in src/mcp/handlers/.
-    #[test]
-    fn production_api_call_baseline_is_5_2454() {
-        let needle_call = concat!("crate::", "api::", "call");
-        let needle_at = concat!("api::", "call_at");
-        let test_mod_marker = "#[cfg(test)]\nmod ";
-        let files: &[&str] = &[
-            include_str!("comms.rs"),
-            include_str!("comms_delegate/mod.rs"),
-            include_str!("task.rs"),
-            include_str!("restart.rs"),
-            include_str!("instance_state/mod.rs"),
-            include_str!("instance_state/spawn.rs"),
-            include_str!("instance_state/lifecycle.rs"),
-            include_str!("instance_metadata.rs"),
-        ];
-        let mut count = 0;
-        for src in files {
-            let boundary = src.rfind(test_mod_marker).unwrap_or(src.len());
-            let production = &src[..boundary];
-            for line in production.lines() {
-                let trimmed = line.trim();
-                if trimmed.starts_with("//") || trimmed.starts_with("///") {
-                    continue;
-                }
-                if line.contains(needle_call) && !line.contains(needle_at) {
-                    count += 1;
-                }
-            }
-        }
-        assert_eq!(
-            count, 4,
-            "production same-daemon api::call post-Slice-13 must be exactly 4; got {count}"
-        );
-    }
-
     /// #2454 residual RED: after the create_instance(team=...) migration,
     /// exactly 3 same-daemon api::call production sites should remain.
     #[test]

--- a/src/mcp/handlers/dispatch.rs
+++ b/src/mcp/handlers/dispatch.rs
@@ -1493,10 +1493,10 @@ mod tests {
         );
     }
 
-    /// #2454 Slice 13 RED: after CREATE_TEAM migration, exactly 4
-    /// same-daemon api::call production sites remain (down from 5).
+    /// #2454 residual RED: after the create_instance(team=...) migration,
+    /// exactly 3 same-daemon api::call production sites should remain.
     #[test]
-    fn production_api_call_post_create_team_is_4_2454() {
+    fn production_api_call_post_create_instance_team_is_3_2454() {
         let needle_call = concat!("crate::", "api::", "call");
         let needle_at = concat!("api::", "call_at");
         let test_mod_marker = "#[cfg(test)]\nmod ";
@@ -1525,8 +1525,8 @@ mod tests {
             }
         }
         assert_eq!(
-            count, 4,
-            "production same-daemon api::call post-Slice-13 must be exactly 4; got {count}"
+            count, 3,
+            "production same-daemon api::call after create_instance(team=...) must be exactly 3; got {count}"
         );
     }
 

--- a/src/mcp/handlers/instance_state/mod.rs
+++ b/src/mcp/handlers/instance_state/mod.rs
@@ -118,7 +118,10 @@ pub(super) fn handle_create_instance(
                         .filter(|s| matches!(*s, "skip" | "deferred"))
                         .map(String::from),
                     orchestrator: None,
-                    description: args["description"].as_str().map(String::from),
+                    description: args
+                        .get("description")
+                        .and_then(Value::as_str)
+                        .map(String::from),
                     repository_path: None,
                     project_id: None,
                     accept_from: Vec::new(),

--- a/src/mcp/handlers/instance_state/mod.rs
+++ b/src/mcp/handlers/instance_state/mod.rs
@@ -113,7 +113,10 @@ pub(super) fn handle_create_instance(
                     name: team_name.to_string(),
                     per_member_backends: per_member_backends.clone(),
                     existing_members: Vec::new(),
-                    topic_binding_mode: args["topic_binding"].as_str().map(String::from),
+                    topic_binding_mode: args["topic_binding"]
+                        .as_str()
+                        .filter(|s| matches!(*s, "skip" | "deferred"))
+                        .map(String::from),
                     orchestrator: None,
                     description: args["description"].as_str().map(String::from),
                     repository_path: None,

--- a/src/mcp/handlers/instance_state/mod.rs
+++ b/src/mcp/handlers/instance_state/mod.rs
@@ -106,20 +106,47 @@ pub(super) fn handle_create_instance(
             )});
         }
         let task = args.get("task").and_then(|v| v.as_str()).map(String::from);
-        match crate::api::call(
-            home,
-            &json!({"method": crate::api::method::CREATE_TEAM, "params": {
-                "name": team_name,
-                "backends": per_member_backends,
-                "description": args.get("description"),
-                // #991 PR-B: team-level default (all spawned members share
-                // it) — forwarded to handle_create_team, which persists +
-                // gates topic creation the same way handle_spawn does for
-                // single-instance create_instance.
-                "topic_binding": args.get("topic_binding"),
-            }}),
-        ) {
-            Ok(resp) if resp["ok"].as_bool() == Some(true) => {
+        let resp = if let Some(rt) = runtime {
+            crate::team_ops::create(
+                home,
+                crate::team_ops::CreateTeamRequest {
+                    name: team_name.to_string(),
+                    per_member_backends: per_member_backends.clone(),
+                    existing_members: Vec::new(),
+                    topic_binding_mode: args["topic_binding"].as_str().map(String::from),
+                    orchestrator: None,
+                    description: args["description"].as_str().map(String::from),
+                    repository_path: None,
+                    project_id: None,
+                    accept_from: Vec::new(),
+                },
+                &rt.registry,
+                rt.notifier.as_deref(),
+            )
+        } else {
+            // Standalone bridge calls retain the legacy API transport. Reuse
+            // the existing SPAWN compatibility leaf so this loopback remains
+            // isolated to RuntimeContext=None without adding another socket
+            // call site.
+            match spawn::legacy_spawn(
+                home,
+                &json!({"method": crate::api::method::CREATE_TEAM, "params": {
+                    "name": team_name,
+                    "backends": per_member_backends.clone(),
+                    "description": args.get("description"),
+                    // #991 PR-B: team-level default (all spawned members share
+                    // it) — forwarded to handle_create_team, which persists +
+                    // gates topic creation the same way handle_spawn does for
+                    // single-instance create_instance.
+                    "topic_binding": args.get("topic_binding"),
+                }}),
+            ) {
+                Ok(resp) => resp,
+                Err(e) => return json!({"error": format!("API unavailable: {e}")}),
+            }
+        };
+        match resp {
+            resp if resp["ok"].as_bool() == Some(true) => {
                 let spawned: Vec<String> = resp["spawned"]
                     .as_array()
                     .map(|a| {
@@ -166,10 +193,9 @@ pub(super) fn handle_create_instance(
                 }
                 result
             }
-            Ok(resp) => {
+            resp => {
                 json!({"error": resp["error"].as_str().unwrap_or("team creation failed")})
             }
-            Err(e) => json!({"error": format!("API unavailable: {e}")}),
         }
     } else {
         spawn::spawn_single_instance(home, instance_name, args, runtime)

--- a/src/mcp/handlers/instance_state/tests.rs
+++ b/src/mcp/handlers/instance_state/tests.rs
@@ -54,6 +54,47 @@ fn create_instance_team_runtime_some_reaches_typed_owner_without_api_2454() {
     std::fs::remove_dir_all(&home).ok();
 }
 
+/// #2454 parity RED: the legacy CREATE_TEAM adapter normalizes `auto` and
+/// other unsupported topic-binding values to `None`, preserving the default
+/// topic-creation behavior. The direct RuntimeContext path must keep that
+/// same boundary contract before handing the typed request to team_ops.
+#[test]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+fn create_instance_team_runtime_some_normalizes_topic_binding_like_api_2454() {
+    let _guard = crate::mcp::handlers::fleet_test_guard();
+    let runtime = crate::mcp::handlers::minimal_test_runtime();
+    for mode in ["auto", "invalid"] {
+        let home = tmp_home_for_create_instance_team("topic-binding-parity");
+        let result = handle_create_instance(
+            &home,
+            &serde_json::json!({
+                "team": "parity-team",
+                "backends": ["/definitely-missing-agent-binary-2454"],
+                "topic_binding": mode
+            }),
+            "caller",
+            Some(&runtime),
+        );
+        assert!(
+            result["error"]
+                .as_str()
+                .is_some_and(|error| error.contains("all 1 spawns failed")),
+            "typed owner should still be reached for {mode}: {result}"
+        );
+        let fleet = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&home))
+            .expect("typed owner should persist its planned member");
+        let entry = fleet
+            .instances
+            .get("parity-team-1")
+            .expect("typed owner should persist the generated member");
+        assert_eq!(
+            entry.topic_binding_mode, None,
+            "unsupported topic_binding={mode:?} must retain API auto-default semantics"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+}
+
 /// #2454 residual contract: a standalone bridge has no RuntimeContext and
 /// keeps the isolated legacy API transport. With no listener, it fails closed
 /// and must not create a team as a side effect.

--- a/src/mcp/handlers/instance_state/tests.rs
+++ b/src/mcp/handlers/instance_state/tests.rs
@@ -1,6 +1,117 @@
 use super::*;
 use std::collections::HashMap;
 
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+fn tmp_home_for_create_instance_team(tag: &str) -> std::path::PathBuf {
+    let home = std::env::temp_dir().join(format!(
+        "agend-create-instance-team-{tag}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&home).unwrap();
+    home
+}
+
+/// #2454 residual RED: pure generated-member team mode must route a live MCP
+/// RuntimeContext directly to the merged typed CREATE_TEAM owner. The missing
+/// owner wire-up currently tries the API socket and therefore reports its
+/// transport failure before the deliberately invalid backend can be observed.
+#[test]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+fn create_instance_team_runtime_some_reaches_typed_owner_without_api_2454() {
+    let _guard = crate::mcp::handlers::fleet_test_guard();
+    let home = tmp_home_for_create_instance_team("runtime-some");
+    let runtime = crate::mcp::handlers::minimal_test_runtime();
+    let result = handle_create_instance(
+        &home,
+        &serde_json::json!({
+            "team": "runtime-team",
+            "backends": ["/definitely-missing-agent-binary-2454"],
+            "description": "runtime-owner-red",
+            "topic_binding": "skip"
+        }),
+        "caller",
+        Some(&runtime),
+    );
+    let error = result["error"].as_str().unwrap_or_default();
+    assert!(
+        error.contains("all 1 spawns failed"),
+        "runtime=Some pure team mode must reach team_ops::create without an API listener; got {result}"
+    );
+    assert!(
+        !error.contains("API unavailable"),
+        "runtime=Some must not use the legacy API loopback: {result}"
+    );
+    let fleet = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&home))
+        .expect("typed owner should persist its planned member before spawn");
+    assert!(
+        fleet.instances.contains_key("runtime-team-1"),
+        "typed owner must preserve generated-member planning before the spawn failure: {fleet:?}"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// #2454 residual contract: a standalone bridge has no RuntimeContext and
+/// keeps the isolated legacy API transport. With no listener, it fails closed
+/// and must not create a team as a side effect.
+#[test]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+fn create_instance_team_runtime_none_keeps_legacy_bridge_2454() {
+    let _guard = crate::mcp::handlers::fleet_test_guard();
+    let home = tmp_home_for_create_instance_team("runtime-none");
+    let result = handle_create_instance(
+        &home,
+        &serde_json::json!({
+            "team": "legacy-team",
+            "backends": ["/definitely-missing-agent-binary-2454"]
+        }),
+        "caller",
+        None,
+    );
+    let error = result["error"].as_str().unwrap_or_default();
+    assert!(
+        error.contains("API unavailable") || error.contains("daemon") || error.contains("run dir"),
+        "runtime=None must retain the isolated legacy API transport failure: {result}"
+    );
+    let fleet_content =
+        std::fs::read_to_string(crate::fleet::fleet_yaml_path(&home)).unwrap_or_default();
+    assert!(
+        !fleet_content.contains("legacy-team"),
+        "legacy bridge failure must not create a team as a side effect: {fleet_content}"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// #2454 residual RED seam: the executable RED test above omits `task` so it
+/// never sleeps. This structural pin keeps the existing delayed task capture
+/// intact until GREEN rewires only the CREATE_TEAM leaf.
+#[test]
+fn create_instance_team_delayed_injection_captures_runtime_and_spawned_2454() {
+    let source = include_str!("mod.rs");
+    let marker = source
+        .find("\"team_task_inject\"")
+        .expect("team task injection thread marker");
+    let region_start = marker.saturating_sub(1_000);
+    let region_end = (marker + 1_200).min(source.len());
+    let region = &source[region_start..region_end];
+    for needle in [
+        "let names = spawned.clone()",
+        "runtime.map",
+        "Arc::clone(&rt.registry)",
+        "Arc::clone(&rt.externals)",
+        "inject_with_routing",
+        "Duration::from_secs(3)",
+    ] {
+        assert!(
+            region.contains(needle),
+            "team task injection must preserve `{needle}` capture/routing seam"
+        );
+    }
+}
+
 #[test]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 fn delete_instance_denies_non_owner_non_orchestrator_audit2_002() {

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1230,6 +1230,7 @@ mod tests {
             ("create_instance", "count", "mcp/handlers/instance.rs team-mode count"),
             ("create_instance", "team", "mcp/handlers/instance.rs team-mode prefix"),
             ("create_instance", "backends", "mcp/handlers/instance.rs per-member backends"),
+            ("create_instance", "description", "instance_state/mod.rs team-mode description"),
             ("create_instance", "command", "instance_state/spawn.rs deprecated backend alias"),
             ("create_instance", "role", "instance_state/spawn.rs fleet.yaml role"),
             ("create_instance", "env", "instance_state/spawn.rs per-instance env (#900)"),

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -123,6 +123,7 @@ pub(crate) fn def_create_instance() -> Value {
         "count": {"type": "integer", "description": "Number of instances to spawn (requires team; ignored when `backends` is set)"},
         "team": {"type": "string", "description": "Team name — members become <team>-1, <team>-2, ... grouped in one tab"},
         "backends": {"type": "array", "items": {"type": "string"}, "description": "Per-member backend list for a mixed-backend team (requires team). Length dictates member count."},
+        "description": {"type": "string", "description": "Optional description recorded for a created team (team mode only)."},
         "command": {"type": "string", "description": "Deprecated: use 'backend' instead"},
         "role": {"type": "string", "description": "Agent role label (e.g. `reviewer`) recorded on the spawned instance's fleet.yaml entry."},
         "env": {"type": "object", "description": "#900: environment variables (object of string→string) injected into the spawned backend process and persisted to the fleet.yaml entry so replace/restart flows re-apply them."},


### PR DESCRIPTION
## Summary
- Route pure generated-member create_instance(team=...) calls through the typed team_ops::create owner when RuntimeContext is present.
- Preserve RuntimeContext=None legacy API transport via the existing compatibility leaf.
- Keep validation, response projection, and delayed task injection capture unchanged.

## Scope
Only the pure team-mode branch (team present, explicit name absent). Explicit name+team joins, single spawns, task.rs, deployments, and #2453 are out of scope.

## Validation
- cargo test --bin agend-terminal create_instance_team_ -- --nocapture (6 passed)
- cargo test --bin agend-terminal create_team_ -- --nocapture (19 passed)
- strict clippy with tray/features (passed)
- rustfmt check and git diff --check (passed)

---
*archfix-codex-dev* · codex