### PR TITLE
#2454 Slice 14: route deployment runtime through typed owners

### DIFF
--- a/src/deployments.rs
+++ b/src/deployments.rs
@@ -21,6 +21,16 @@ struct DeploymentStore {
     deployments: Vec<Deployment>,
 }
 
+/// Runtime-owned state forwarded by the in-process MCP adapter.  The
+/// deployments owner deliberately knows only these neutral registries and the
+/// lifecycle notifier; MCP transport context stays at the adapter boundary.
+pub(crate) struct DeploymentRuntime<'a> {
+    pub registry: &'a crate::agent::AgentRegistry,
+    pub configs: &'a crate::api::ConfigRegistry,
+    pub externals: &'a crate::agent::ExternalRegistry,
+    pub notifier: Option<&'a std::sync::Arc<dyn crate::api::ApiNotifier>>,
+}
+
 impl crate::store::SchemaVersioned for DeploymentStore {
     const CURRENT: u32 = 1;
     fn version_mut(&mut self) -> &mut u32 {
@@ -396,6 +406,51 @@ fn spawn_instances(
     home: &Path,
     yaml_entries: &[(String, crate::fleet::InstanceYamlEntry)],
     directory: &str,
+    runtime: Option<&DeploymentRuntime<'_>>,
+) {
+    if let Some(runtime) = runtime {
+        for (inst_name, entry) in yaml_entries {
+            let args = entry.args.as_ref().map(|values| values.join(" "));
+            let work_dir = entry.working_directory.as_deref().unwrap_or(directory);
+            let working_directory = std::path::Path::new(work_dir);
+            let backend = entry.command.as_deref().or(entry.backend.as_deref());
+            let params = crate::agent_ops::spawn::SpawnParams {
+                name: inst_name,
+                backend,
+                args: args.as_deref(),
+                model: entry.model.as_deref(),
+                model_tier: entry.model_tier.as_deref(),
+                working_directory: Some(working_directory),
+                env: entry.env.as_ref(),
+                mode: crate::backend::SpawnMode::Fresh,
+                explicit_role: entry.role.as_deref(),
+                self_kick_on_ready: false,
+                topic_binding: entry.topic_binding_mode.as_deref().unwrap_or("auto"),
+                layout: "tab",
+                spawner: None,
+                target_pane: None,
+            };
+            let request = crate::agent_ops::spawn::resolve_spawn_request(home, &params);
+            let context = crate::agent_ops::spawn::SpawnContext {
+                home,
+                registry: runtime.registry,
+                externals: runtime.externals,
+                notifier: runtime.notifier,
+            };
+            if let Err(error) = crate::agent_ops::spawn::spawn_instance(&context, &request) {
+                tracing::error!(instance = %inst_name, error = %error, "deploy: Phase 3 spawn failed");
+            }
+        }
+        return;
+    }
+
+    spawn_instances_legacy(home, yaml_entries, directory);
+}
+
+fn spawn_instances_legacy(
+    home: &Path,
+    yaml_entries: &[(String, crate::fleet::InstanceYamlEntry)],
+    directory: &str,
 ) {
     for (inst_name, entry) in yaml_entries {
         let backend_name = resolve_spawn_backend(home, inst_name, entry);
@@ -450,29 +505,77 @@ fn create_deployment_team(
     template_def: &serde_yaml_ng::Value,
     template_source_repo: &Option<String>,
     created: &[String],
+    runtime: Option<&DeploymentRuntime<'_>>,
 ) -> bool {
     if created.len() <= 1 {
         return false;
     }
+    let description = format!("Template deployment: {template}");
+    let orchestrator = template_def
+        .get("orchestrator")
+        .and_then(|value| value.as_str())
+        .and_then(|suffix| {
+            let full = format!("{deploy_name}-{suffix}");
+            if created.contains(&full) {
+                Some(full)
+            } else {
+                tracing::warn!(
+                    template,
+                    suffix,
+                    "template orchestrator not among spawned instances; team created without one"
+                );
+                None
+            }
+        });
+    if let Some(runtime) = runtime {
+        let request = crate::team_ops::CreateTeamRequest {
+            name: deploy_name.to_string(),
+            per_member_backends: Vec::new(),
+            existing_members: created.to_vec(),
+            topic_binding_mode: None,
+            orchestrator,
+            description: Some(description),
+            repository_path: template_source_repo.clone(),
+            project_id: None,
+            accept_from: Vec::new(),
+        };
+        let result = crate::team_ops::create(
+            home,
+            request,
+            runtime.registry,
+            runtime.notifier.map(|notifier| notifier.as_ref()),
+        );
+        return result.get("ok").and_then(Value::as_bool) == Some(true);
+    }
+
+    create_deployment_team_legacy(
+        home,
+        deploy_name,
+        template_source_repo,
+        created,
+        &description,
+        orchestrator.as_deref(),
+    )
+}
+
+fn create_deployment_team_legacy(
+    home: &Path,
+    deploy_name: &str,
+    template_source_repo: &Option<String>,
+    created: &[String],
+    description: &str,
+    orchestrator: Option<&str>,
+) -> bool {
     let mut team_args = serde_json::json!({
         "name": deploy_name,
-        "members": &created,
-        "description": format!("Template deployment: {template}"),
+        "members": created,
+        "description": description,
     });
     if let Some(ref sr) = template_source_repo {
         team_args["repository_path"] = serde_json::Value::String(sr.clone());
     }
-    if let Some(suffix) = template_def.get("orchestrator").and_then(|v| v.as_str()) {
-        let full = format!("{deploy_name}-{suffix}");
-        if created.contains(&full) {
-            team_args["orchestrator"] = serde_json::Value::String(full);
-        } else {
-            tracing::warn!(
-                template,
-                suffix,
-                "template orchestrator not among spawned instances; team created without one"
-            );
-        }
+    if let Some(orchestrator) = orchestrator {
+        team_args["orchestrator"] = serde_json::Value::String(orchestrator.to_string());
     }
     // H15 (CR-2026-06-14): a daemon REJECTION comes back as `Ok(v)` with
     // `v["ok"] == false`, NOT as `Err` — the old catch-all Ok no-op arm swallowed
@@ -496,7 +599,17 @@ fn create_deployment_team(
     }
 }
 
+#[allow(dead_code)]
 pub fn deploy(home: &Path, instance_name: &str, args: &Value) -> Value {
+    deploy_with_runtime(home, instance_name, args, None)
+}
+
+pub(crate) fn deploy_with_runtime(
+    home: &Path,
+    instance_name: &str,
+    args: &Value,
+    runtime: Option<&DeploymentRuntime<'_>>,
+) -> Value {
     let params = match validate_deploy_args(home, args) {
         Ok(p) => p,
         Err(e) => return e,
@@ -527,7 +640,7 @@ pub fn deploy(home: &Path, instance_name: &str, args: &Value) -> Value {
         return e;
     }
 
-    spawn_instances(home, &yaml_entries, &params.directory);
+    spawn_instances(home, &yaml_entries, &params.directory, runtime);
 
     let team_created = create_deployment_team(
         home,
@@ -536,6 +649,7 @@ pub fn deploy(home: &Path, instance_name: &str, args: &Value) -> Value {
         &params.template_def,
         &params.template_source_repo,
         &created,
+        runtime,
     );
 
     let deployment = Deployment {
@@ -594,7 +708,16 @@ pub fn deploy(home: &Path, instance_name: &str, args: &Value) -> Value {
     serde_json::json!({"status": "deployed", "name": params.deploy_name, "instances": created})
 }
 
+#[allow(dead_code)]
 pub fn teardown(home: &Path, args: &Value) -> Value {
+    teardown_with_runtime(home, args, None)
+}
+
+pub(crate) fn teardown_with_runtime(
+    home: &Path,
+    args: &Value,
+    runtime: Option<&DeploymentRuntime<'_>>,
+) -> Value {
     let name = match args["name"].as_str() {
         Some(n) => n,
         None => return serde_json::json!({"error": "missing 'name'"}),
@@ -610,11 +733,18 @@ pub fn teardown(home: &Path, args: &Value) -> Value {
     };
 
     // Delete all instances (full cleanup via DELETE instead of KILL — #456).
-    for inst in &deployment.instances {
-        let _ = crate::api::call(
-            home,
-            &serde_json::json!({"method": crate::api::method::DELETE, "params": {"name": inst}}),
-        );
+    if let Some(runtime) = runtime {
+        let delete_context = crate::agent_ops::DeleteContext {
+            registry: runtime.registry,
+            configs: runtime.configs,
+            externals: runtime.externals,
+            notifier: runtime.notifier,
+        };
+        for inst in &deployment.instances {
+            let _ = crate::agent_ops::delete_instance(home, inst, &delete_context, false);
+        }
+    } else {
+        delete_instances_legacy(home, &deployment.instances);
     }
 
     // Smoke 2 fix: filesystem cleanup of every spawned subdir, including
@@ -658,6 +788,15 @@ pub fn teardown(home: &Path, args: &Value) -> Value {
     }
 
     serde_json::json!({"status": "torn_down", "name": name, "instances": deployment.instances})
+}
+
+fn delete_instances_legacy(home: &Path, instances: &[String]) {
+    for inst in instances {
+        let _ = crate::api::call(
+            home,
+            &serde_json::json!({"method": crate::api::method::DELETE, "params": {"name": inst}}),
+        );
+    }
 }
 
 pub fn list(home: &Path) -> Value {

--- a/src/deployments/tests.rs
+++ b/src/deployments/tests.rs
@@ -2202,6 +2202,31 @@ fn deployment_runtime_dispatch_forwards_typed_capability_slice14() {
             !body.contains("crate::api::call"),
             "typed runtime owner `{needle}` must not contain the legacy api::call transport"
         );
+        if needle == "spawn_instance(" {
+            assert!(
+                body.contains("resolve_spawn_request("),
+                "typed SPAWN wrapper must resolve the persisted deployment fields before spawn"
+            );
+            for field in [
+                "entry.backend",
+                "entry.args",
+                "entry.model",
+                "entry.env",
+                "entry.topic_binding_mode",
+                "entry.working_directory",
+            ] {
+                assert!(
+                    body.contains(field),
+                    "typed SPAWN wrapper must map InstanceYamlEntry field `{field}` into the request"
+                );
+            }
+        }
+        if needle == "team_ops::create" {
+            assert!(
+                !body.contains("crate::teams::create") && !body.contains("teams::create"),
+                "runtime-present typed CREATE_TEAM wrapper must not retain a direct teams::create fallback"
+            );
+        }
     }
     assert!(
         deployments.contains("crate::api::call"),

--- a/src/deployments/tests.rs
+++ b/src/deployments/tests.rs
@@ -2093,7 +2093,7 @@ fn fn_body<'a>(prod: &'a str, sig: &str) -> &'a str {
 #[test]
 fn deploy_api_calls_not_under_flock() {
     let prod = prod_src();
-    let body = fn_body(prod, "pub fn deploy(home");
+    let body = fn_body(prod, "pub(crate) fn deploy_with_runtime(");
     assert!(
         body.contains("runtime"),
         "deploy must receive the deployments-owned runtime capability so runtime-present MCP calls cannot use the legacy transport"
@@ -2124,7 +2124,7 @@ fn deploy_api_calls_not_under_flock() {
 #[test]
 fn teardown_api_calls_not_under_flock() {
     let prod = prod_src();
-    let body = fn_body(prod, "pub fn teardown(home");
+    let body = fn_body(prod, "pub(crate) fn teardown_with_runtime(");
     assert!(
         body.contains("runtime"),
         "teardown must receive the deployments-owned runtime capability so runtime-present MCP calls cannot use the legacy transport"

--- a/src/deployments/tests.rs
+++ b/src/deployments/tests.rs
@@ -2133,12 +2133,32 @@ fn teardown_api_calls_not_under_flock() {
         .find(&["acquire_file", "_lock"].concat())
         .expect("teardown locks the record removal");
     let delete_at = body
-        .find(&["crate::api::", "call"].concat())
-        .expect("teardown DELETEs instances via api::call");
+        .find("delete_instance(")
+        .expect("teardown invokes the typed DELETE owner");
     assert!(
         delete_at < lock_at,
         "the typed DELETE owner must run BEFORE the record-removal flock (#1617 class)"
     );
+}
+
+fn source_function_containing<'a>(source: &'a str, needle: &str) -> &'a str {
+    let needle_at = source
+        .find(needle)
+        .unwrap_or_else(|| panic!("source is missing typed owner needle `{needle}`"));
+    let before = &source[..needle_at];
+    let start = ["\npub(crate) fn ", "\npub fn ", "\nfn "]
+        .into_iter()
+        .filter_map(|marker| before.rfind(marker))
+        .max()
+        .expect("typed owner needle must be inside a function");
+    let after = &source[needle_at..];
+    let end = ["\npub(crate) fn ", "\npub fn ", "\nfn "]
+        .into_iter()
+        .filter_map(|marker| after.find(marker))
+        .min()
+        .map(|offset| needle_at + offset)
+        .unwrap_or(source.len());
+    &source[start..end]
 }
 
 #[test]
@@ -2171,5 +2191,20 @@ fn deployment_runtime_dispatch_forwards_typed_capability_slice14() {
     assert!(
         deployments.contains("DeploymentRuntime"),
         "deployments owner must define/accept a neutral runtime capability rather than MCP HandlerCtx"
+    );
+    assert!(
+        !deployments.contains("HandlerCtx") && !deployments.contains("RuntimeContext"),
+        "deployments owner must not depend on MCP HandlerCtx/RuntimeContext"
+    );
+    for needle in ["spawn_instance(", "team_ops::create", "delete_instance("] {
+        let body = source_function_containing(deployments, needle);
+        assert!(
+            !body.contains("crate::api::call"),
+            "typed runtime owner `{needle}` must not contain the legacy api::call transport"
+        );
+    }
+    assert!(
+        deployments.contains("crate::api::call"),
+        "RuntimeContext=None compatibility must retain an explicit legacy api::call path"
     );
 }

--- a/src/deployments/tests.rs
+++ b/src/deployments/tests.rs
@@ -2094,6 +2094,10 @@ fn fn_body<'a>(prod: &'a str, sig: &str) -> &'a str {
 fn deploy_api_calls_not_under_flock() {
     let prod = prod_src();
     let body = fn_body(prod, "pub fn deploy(home");
+    assert!(
+        body.contains("runtime"),
+        "deploy must receive the deployments-owned runtime capability so runtime-present MCP calls cannot use the legacy transport"
+    );
     // H14: deploy's duplicate-name guard is a plain `load()` READ (no flock)
     // before spawn — #1629 forbids holding ANY flock across the self-IPC
     // spawn/team. So the ONLY `acquire_file_lock` in deploy is still the store
@@ -2121,6 +2125,10 @@ fn deploy_api_calls_not_under_flock() {
 fn teardown_api_calls_not_under_flock() {
     let prod = prod_src();
     let body = fn_body(prod, "pub fn teardown(home");
+    assert!(
+        body.contains("runtime"),
+        "teardown must receive the deployments-owned runtime capability so runtime-present MCP calls cannot use the legacy transport"
+    );
     let lock_at = body
         .find(&["acquire_file", "_lock"].concat())
         .expect("teardown locks the record removal");
@@ -2129,6 +2137,39 @@ fn teardown_api_calls_not_under_flock() {
         .expect("teardown DELETEs instances via api::call");
     assert!(
         delete_at < lock_at,
-        "the DELETE api::call loop must run BEFORE the record-removal flock (#1617 class)"
+        "the typed DELETE owner must run BEFORE the record-removal flock (#1617 class)"
+    );
+}
+
+#[test]
+fn deployment_runtime_dispatch_forwards_typed_capability_slice14() {
+    let dispatch = include_str!("../mcp/handlers/dispatch.rs");
+    let dispatch_start = dispatch
+        .find("pub(crate) fn dispatch_deployment")
+        .expect("deployment dispatcher must exist");
+    let dispatch_tail = &dispatch[dispatch_start..];
+    let dispatch_body = dispatch_tail
+        .split_once("\n///")
+        .map(|(body, _)| body)
+        .unwrap_or(dispatch_tail);
+    assert!(
+        dispatch_body.contains("ctx.runtime"),
+        "deployment dispatcher must forward RuntimeContext into the deployments-owned adapter"
+    );
+    assert!(
+        !dispatch_body.contains("action_adapter!(dispatch_deployment"),
+        "deployment dispatch must not use the runtime-blind action_adapter"
+    );
+
+    let schedule = include_str!("../mcp/handlers/schedule.rs");
+    assert!(
+        schedule.contains("DeploymentRuntime"),
+        "schedule adapter must carry the neutral deployments-owned runtime capability"
+    );
+
+    let deployments = prod_src();
+    assert!(
+        deployments.contains("DeploymentRuntime"),
+        "deployments owner must define/accept a neutral runtime capability rather than MCP HandlerCtx"
     );
 }

--- a/src/mcp/handlers/dispatch.rs
+++ b/src/mcp/handlers/dispatch.rs
@@ -24,6 +24,7 @@
 //! `unknown tool` branch in that match still handles fully-unknown
 //! names.
 
+use crate::deployments::DeploymentRuntime;
 use crate::identity::Sender;
 use serde_json::{json, Value};
 use std::path::Path;
@@ -367,11 +368,27 @@ action_adapter!(dispatch_decision, "decision", [
     "answer" => task::handle_answer_decision,  hais;
 ]);
 
-action_adapter!(dispatch_deployment, "deployment", [
-    "deploy"   => schedule::handle_deploy_template,      hai;
-    "teardown" => schedule::handle_teardown_deployment,   ha;
-    "list"     => schedule::handle_list_deployments,      h;
-]);
+/// #2454 Slice 14: deployment actions need the in-process daemon registries,
+/// while standalone bridge calls retain the legacy transport/fallback path.
+pub(crate) fn dispatch_deployment(ctx: &HandlerCtx<'_>) -> Value {
+    let runtime = ctx.runtime.map(|runtime| DeploymentRuntime {
+        registry: &runtime.registry,
+        configs: &runtime.configs,
+        externals: &runtime.externals,
+        notifier: runtime.notifier.as_ref(),
+    });
+    match ctx.args["action"].as_str().unwrap_or("") {
+        "deploy" => schedule::handle_deploy_template(
+            ctx.home,
+            ctx.args,
+            ctx.instance_name,
+            runtime.as_ref(),
+        ),
+        "teardown" => schedule::handle_teardown_deployment(ctx.home, ctx.args, runtime.as_ref()),
+        "list" => schedule::handle_list_deployments(ctx.home),
+        other => json!({"error": format!("unknown deployment action: {other}")}),
+    }
+}
 
 /// #2454: custom (not `action_adapter!`) because the health WRITE actions now
 /// call the in-process `agent_ops` blocked-reason service and so need the

--- a/src/mcp/handlers/schedule.rs
+++ b/src/mcp/handlers/schedule.rs
@@ -17,12 +17,21 @@ pub(super) fn handle_delete_schedule(home: &Path, args: &Value) -> Value {
     crate::schedules::delete(home, args)
 }
 
-pub(super) fn handle_deploy_template(home: &Path, args: &Value, instance_name: &str) -> Value {
-    crate::deployments::deploy(home, instance_name, args)
+pub(super) fn handle_deploy_template(
+    home: &Path,
+    args: &Value,
+    instance_name: &str,
+    runtime: Option<&crate::deployments::DeploymentRuntime<'_>>,
+) -> Value {
+    crate::deployments::deploy_with_runtime(home, instance_name, args, runtime)
 }
 
-pub(super) fn handle_teardown_deployment(home: &Path, args: &Value) -> Value {
-    crate::deployments::teardown(home, args)
+pub(super) fn handle_teardown_deployment(
+    home: &Path,
+    args: &Value,
+    runtime: Option<&crate::deployments::DeploymentRuntime<'_>>,
+) -> Value {
+    crate::deployments::teardown_with_runtime(home, args, runtime)
 }
 
 pub(super) fn handle_list_deployments(home: &Path) -> Value {

--- a/src/mcp/handlers/tests.rs
+++ b/src/mcp/handlers/tests.rs
@@ -4262,6 +4262,179 @@ templates:
     std::fs::remove_dir_all(&home).ok();
 }
 
+/// #2454 Slice 14 RED: a real runtime-present deployment must reach the typed
+/// SPAWN owner, while retaining the deployment field projection in fleet.yaml.
+/// The generic shell backend resolves to the platform shell; `topic_binding:
+/// skip` keeps this transport-free and the teardown below removes the registry
+/// entry once the GREEN implementation starts spawning in-process.
+#[test]
+fn deployment_runtime_some_deploy_reaches_typed_spawn_owner_slice14() {
+    let _g = fleet_test_guard();
+    let home = tmp_home("deployment-runtime-spawn-slice14");
+    std::env::set_var("AGEND_HOME", &home);
+    std::fs::write(
+        crate::fleet::fleet_yaml_path(&home),
+        r#"
+templates:
+  spawn-slice14:
+    instances:
+      lead:
+        backend: shell
+        args: ["--fixture", "value"]
+        model: sonnet
+        env:
+          SLICE14_MARKER: present
+        topic_binding: skip
+"#,
+    )
+    .unwrap();
+
+    struct EventRecorder {
+        events: parking_lot::Mutex<Vec<crate::api::ApiEvent>>,
+    }
+    impl EventRecorder {
+        fn new() -> std::sync::Arc<Self> {
+            std::sync::Arc::new(Self {
+                events: parking_lot::Mutex::new(Vec::new()),
+            })
+        }
+    }
+    impl crate::api::ApiNotifier for EventRecorder {
+        fn notify(&self, event: crate::api::ApiEvent) {
+            self.events.lock().push(event);
+        }
+    }
+
+    let recorder = EventRecorder::new();
+    let notifier: std::sync::Arc<dyn crate::api::ApiNotifier> = recorder.clone();
+    let runtime = super::dispatch::RuntimeContext {
+        registry: std::sync::Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new())),
+        configs: Default::default(),
+        externals: std::sync::Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new())),
+        capability: crate::api::RestartCapability::Unsupported,
+        app_restart: None,
+        post_flush: None,
+        notifier: Some(notifier),
+        shutdown: None,
+    };
+
+    let result = super::handle_tool_with_runtime(
+        "deployment",
+        &json!({
+            "action": "deploy",
+            "template": "spawn-slice14",
+            "directory": home.join("workspace").display().to_string(),
+        }),
+        "sender",
+        Some(runtime.clone()),
+    );
+    let fleet = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&home)).unwrap();
+    let instance = fleet
+        .instances
+        .get("spawn-slice14-lead")
+        .expect("deploy must persist the typed SPAWN field projection");
+    let projected_args = instance.args.clone();
+    let projected_model = instance.model.clone();
+    let projected_marker = instance.env.get("SLICE14_MARKER").cloned();
+    let projected_topic_binding = instance.topic_binding_mode.clone();
+    let spawn_event_before_teardown = recorder.events.lock().iter().any(|event| {
+        matches!(
+            event,
+            crate::api::ApiEvent::InstanceCreated { name, .. }
+                if name == "spawn-slice14-lead"
+        )
+    });
+
+    // Keep GREEN runs hygienic once the in-process owner actually creates a
+    // registry entry; the current runtime-blind RED path has nothing to delete.
+    let teardown = super::handle_tool_with_runtime(
+        "deployment",
+        &json!({"action": "teardown", "name": "spawn-slice14"}),
+        "sender",
+        Some(runtime),
+    );
+
+    assert_eq!(
+        result["status"].as_str(),
+        Some("deployed"),
+        "deployment must retain its durable success projection: {result}"
+    );
+    assert_eq!(projected_args, vec!["--fixture", "value"]);
+    assert_eq!(projected_model.as_deref(), Some("sonnet"));
+    assert_eq!(projected_marker.as_deref(), Some("present"));
+    assert_eq!(projected_topic_binding.as_deref(), Some("skip"));
+    assert_eq!(
+        teardown["status"].as_str(),
+        Some("torn_down"),
+        "deployment teardown must clean up the real SPAWN entry: {teardown}"
+    );
+    assert!(
+        spawn_event_before_teardown,
+        "runtime-present deployment must emit the typed InstanceCreated event"
+    );
+
+    std::env::remove_var("AGEND_HOME");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// #2454 Slice 14 characterization: RuntimeContext=None keeps the legacy
+/// api::call/fallback deployment path and its existing team projection.
+#[test]
+fn deployment_runtime_none_preserves_legacy_transport_slice14() {
+    let _g = fleet_test_guard();
+    let home = tmp_home("deployment-runtime-none-slice14");
+    std::env::set_var("AGEND_HOME", &home);
+    std::fs::write(
+        crate::fleet::fleet_yaml_path(&home),
+        r#"
+templates:
+  legacy-slice14:
+    instances:
+      lead:
+        backend: /definitely/not-an-agent-command
+      worker:
+        backend: /definitely/not-an-agent-command
+"#,
+    )
+    .unwrap();
+
+    let result = super::handle_tool(
+        "deployment",
+        &json!({"action": "deploy", "template": "legacy-slice14"}),
+        "sender",
+    );
+    let fleet = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&home)).unwrap();
+    let team = fleet
+        .teams
+        .get("legacy-slice14")
+        .expect("legacy deployment must retain its fallback team projection");
+    let mut members = team.members.clone();
+    members.sort();
+    assert_eq!(
+        members,
+        vec!["legacy-slice14-lead", "legacy-slice14-worker"]
+    );
+
+    let teardown = super::handle_tool(
+        "deployment",
+        &json!({"action": "teardown", "name": "legacy-slice14"}),
+        "sender",
+    );
+    assert_eq!(
+        result["status"].as_str(),
+        Some("deployed"),
+        "RuntimeContext=None must preserve the legacy deployment result: {result}"
+    );
+    assert_eq!(
+        teardown["status"].as_str(),
+        Some("torn_down"),
+        "RuntimeContext=None must preserve legacy teardown: {teardown}"
+    );
+
+    std::env::remove_var("AGEND_HOME");
+    std::fs::remove_dir_all(&home).ok();
+}
+
 /// #2454 Slice 14 RED: teardown through the real MCP entry must invoke the
 /// typed DELETE owner before cleanup, even with no API listener. The current
 /// runtime-blind schedule adapter calls the legacy transport and therefore

--- a/src/mcp/handlers/tests.rs
+++ b/src/mcp/handlers/tests.rs
@@ -4179,3 +4179,174 @@ fn send_zero_selectors_returns_typed_missing_selector() {
         "zero selectors must return typed missing_selector error from the unified gate: {result}"
     );
 }
+
+/// #2454 Slice 14 RED: the real deployment MCP entry must forward a present
+/// RuntimeContext into the typed team owner without an API listener. The
+/// current runtime-blind schedule adapter falls back to teams::create, which
+/// creates the team but emits no in-process TeamCreated event.
+#[test]
+fn deployment_runtime_some_deploy_reaches_typed_team_owner_slice14() {
+    let _g = fleet_test_guard();
+    let home = tmp_home("deployment-runtime-deploy-slice14");
+    std::env::set_var("AGEND_HOME", &home);
+    std::fs::write(
+        crate::fleet::fleet_yaml_path(&home),
+        r#"
+templates:
+  slice14:
+    instances:
+      lead:
+        backend: /definitely/not-an-agent-command
+      worker:
+        backend: /definitely/not-an-agent-command
+"#,
+    )
+    .unwrap();
+
+    struct EventRecorder {
+        events: parking_lot::Mutex<Vec<crate::api::ApiEvent>>,
+    }
+    impl EventRecorder {
+        fn new() -> std::sync::Arc<Self> {
+            std::sync::Arc::new(Self {
+                events: parking_lot::Mutex::new(Vec::new()),
+            })
+        }
+    }
+    impl crate::api::ApiNotifier for EventRecorder {
+        fn notify(&self, event: crate::api::ApiEvent) {
+            self.events.lock().push(event);
+        }
+    }
+
+    let recorder = EventRecorder::new();
+    let notifier: std::sync::Arc<dyn crate::api::ApiNotifier> = recorder.clone();
+    let runtime = super::dispatch::RuntimeContext {
+        registry: std::sync::Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new())),
+        configs: Default::default(),
+        externals: std::sync::Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new())),
+        capability: crate::api::RestartCapability::Unsupported,
+        app_restart: None,
+        post_flush: None,
+        notifier: Some(notifier),
+        shutdown: None,
+    };
+
+    let result = super::handle_tool_with_runtime(
+        "deployment",
+        &json!({
+            "action": "deploy",
+            "template": "slice14",
+            "directory": home.join("workspace").display().to_string(),
+        }),
+        "sender",
+        Some(runtime),
+    );
+    assert_eq!(
+        result["status"].as_str(),
+        Some("deployed"),
+        "deployment must complete its durable record even when member spawn commands fail: {result}"
+    );
+    let events = recorder.events.lock();
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            crate::api::ApiEvent::TeamCreated { name, members }
+                if name == "slice14"
+                    && members == &vec!["slice14-lead".to_string(), "slice14-worker".to_string()]
+        )),
+        "runtime-present deployment must emit the typed TeamCreated event: {events:?}"
+    );
+
+    std::env::remove_var("AGEND_HOME");
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// #2454 Slice 14 RED: teardown through the real MCP entry must invoke the
+/// typed DELETE owner before cleanup, even with no API listener. The current
+/// runtime-blind schedule adapter calls the legacy transport and therefore
+/// emits no InstanceDeleted event.
+#[test]
+fn deployment_runtime_some_teardown_reaches_typed_delete_owner_slice14() {
+    let _g = fleet_test_guard();
+    let home = tmp_home("deployment-runtime-teardown-slice14");
+    std::env::set_var("AGEND_HOME", &home);
+    let working_directory = home.join("workspace").join("slice14-lead");
+    std::fs::create_dir_all(&working_directory).unwrap();
+    std::fs::write(
+        crate::fleet::fleet_yaml_path(&home),
+        format!(
+            "instances:\n  slice14-lead:\n    backend: shell\n    working_directory: {}\nteams:\n  slice14:\n    members: [slice14-lead]\n    created_at: now\n",
+            working_directory.display()
+        ),
+    )
+    .unwrap();
+    std::fs::write(
+        home.join("deployments.json"),
+        serde_json::json!({
+            "schema_version": 1,
+            "deployments": [{
+                "name": "slice14",
+                "template": "slice14",
+                "instances": ["slice14-lead"],
+                "team": "slice14",
+                "directory": home.join("workspace").display().to_string(),
+                "created_at": "now"
+            }]
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    struct EventRecorder {
+        events: parking_lot::Mutex<Vec<crate::api::ApiEvent>>,
+    }
+    impl EventRecorder {
+        fn new() -> std::sync::Arc<Self> {
+            std::sync::Arc::new(Self {
+                events: parking_lot::Mutex::new(Vec::new()),
+            })
+        }
+    }
+    impl crate::api::ApiNotifier for EventRecorder {
+        fn notify(&self, event: crate::api::ApiEvent) {
+            self.events.lock().push(event);
+        }
+    }
+
+    let recorder = EventRecorder::new();
+    let notifier: std::sync::Arc<dyn crate::api::ApiNotifier> = recorder.clone();
+    let runtime = super::dispatch::RuntimeContext {
+        registry: std::sync::Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new())),
+        configs: Default::default(),
+        externals: std::sync::Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new())),
+        capability: crate::api::RestartCapability::Unsupported,
+        app_restart: None,
+        post_flush: None,
+        notifier: Some(notifier),
+        shutdown: None,
+    };
+
+    let result = super::handle_tool_with_runtime(
+        "deployment",
+        &json!({"action": "teardown", "name": "slice14"}),
+        "sender",
+        Some(runtime),
+    );
+    assert_eq!(
+        result["status"].as_str(),
+        Some("torn_down"),
+        "teardown should preserve the existing successful cleanup projection: {result}"
+    );
+    let events = recorder.events.lock();
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            crate::api::ApiEvent::InstanceDeleted { name } if name == "slice14-lead"
+        )),
+        "runtime-present teardown must invoke typed DELETE and emit InstanceDeleted: {events:?}"
+    );
+
+    std::env::remove_var("AGEND_HOME");
+    std::fs::remove_dir_all(&home).ok();
+}


### PR DESCRIPTION
## Scope

Implements the bounded #2454 Slice 14 deployment runtime migration from the immutable RED head 652c49e6.

- Custom deployment dispatch forwards a neutral deployments-owned runtime capability.
- Runtime-present deploy uses typed SPAWN resolution/execution and team_ops::create(existing_members).
- Runtime-present teardown uses typed agent_ops::delete_instance before existing cleanup/flock ordering.
- RuntimeContext=None retains the isolated legacy api::call path and historical CREATE_TEAM fallback.
- No changes to #2453, cross-daemon STATUS, rollback redesign, teardown projection, or polling/sleeps.

## GREEN evidence

Exact implementation head: `7ec1ada74dd9122ed581461c886e7e567a57bba6`

- `cargo test --bin agend-terminal deployments::tests --quiet` — 57 passed.
- `cargo test --bin agend-terminal deployment_runtime_ --quiet -- --nocapture` — 5 passed.
- Dispatch reachability guard — passed.
- Deploy/teardown flock guards — passed.
- `cargo check --bin agend-terminal --quiet` — passed.
- `cargo clippy --bin agend-terminal --all-targets --all-features -- -D warnings` — passed.