### PR TITLE
fix(arch14): managed-marker producer parity + safe legacy adoption

### DIFF
--- a/src/mcp/handlers/ci/checkout.rs
+++ b/src/mcp/handlers/ci/checkout.rs
@@ -364,9 +364,7 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
             // #1275 + #2755: write `.agend-managed` FAIL-CLOSED — a missing marker
             // breaks release_worktree/GC cleanup, so a write failure rolls back
             // rather than returning a half-managed worktree.
-            // arch14 (d-20260719234211852352-4): canonical four-field identity —
-            // source_repo= included so the deep-validated path-addressed release
-            // accepts checkout-provisioned worktrees.
+            // arch14: canonical four-field identity (source_repo= included).
             let marker_path = worktree_dir.join(crate::worktree_pool::MANAGED_MARKER);
             if std::fs::write(
                 &marker_path,

--- a/src/mcp/handlers/ci/checkout.rs
+++ b/src/mcp/handlers/ci/checkout.rs
@@ -362,9 +362,8 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
             let mut resp =
                 json!({"path": worktree_path_str, "source": source_path, "branch": branch});
             // #1275 + #2755: write `.agend-managed` FAIL-CLOSED — a write failure
-            // rolls back rather than returning a half-managed worktree. arch14:
-            // canonical four-field identity — source_repo persists the CANONICAL
-            // source (bind_full's source_canonical below; symlink-alias safe).
+            // rolls back, never returns a half-managed worktree. arch14: canonical
+            // four-field identity (bind_full's source_canonical; symlink-alias safe).
             let marker_path = worktree_dir.join(crate::worktree_pool::MANAGED_MARKER);
             if std::fs::write(
                 &marker_path,

--- a/src/mcp/handlers/ci/checkout.rs
+++ b/src/mcp/handlers/ci/checkout.rs
@@ -361,15 +361,16 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
             }
             let mut resp =
                 json!({"path": worktree_path_str, "source": source_path, "branch": branch});
-            // #1275 + #2755: write `.agend-managed` FAIL-CLOSED — a missing marker
-            // breaks release_worktree/GC cleanup, so a write failure rolls back
-            // rather than returning a half-managed worktree.
-            // arch14: canonical four-field identity (source_repo= included).
+            // #1275 + #2755: write `.agend-managed` FAIL-CLOSED — a write failure
+            // rolls back rather than returning a half-managed worktree. arch14:
+            // canonical four-field identity — source_repo persists the CANONICAL
+            // source (bind_full's source_canonical below; symlink-alias safe).
             let marker_path = worktree_dir.join(crate::worktree_pool::MANAGED_MARKER);
             if std::fs::write(
                 &marker_path,
                 format!(
-                    "agent={instance_name}\nbranch={branch}\nsource_repo={source_path}\nleased_at={}\n",
+                    "agent={instance_name}\nbranch={branch}\nsource_repo={}\nleased_at={}\n",
+                    source_canonical.display(),
                     chrono::Utc::now().to_rfc3339()
                 ),
             )

--- a/src/mcp/handlers/ci/checkout.rs
+++ b/src/mcp/handlers/ci/checkout.rs
@@ -364,11 +364,14 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
             // #1275 + #2755: write `.agend-managed` FAIL-CLOSED — a missing marker
             // breaks release_worktree/GC cleanup, so a write failure rolls back
             // rather than returning a half-managed worktree.
+            // arch14 (d-20260719234211852352-4): canonical four-field identity —
+            // source_repo= included so the deep-validated path-addressed release
+            // accepts checkout-provisioned worktrees.
             let marker_path = worktree_dir.join(crate::worktree_pool::MANAGED_MARKER);
             if std::fs::write(
                 &marker_path,
                 format!(
-                    "agent={instance_name}\nbranch={branch}\nleased_at={}\n",
+                    "agent={instance_name}\nbranch={branch}\nsource_repo={source_path}\nleased_at={}\n",
                     chrono::Utc::now().to_rfc3339()
                 ),
             )

--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -3579,12 +3579,18 @@ fn arch14_write_legacy_marker(wt: &std::path::Path, agent: &str, branch: &str) {
 
 /// RED 1: the full real chain — `repo checkout bind:true` then path-addressed
 /// `repo release` on the produced worktree — must succeed end-to-end.
+///
+/// Root RED-gate fix: the fixture lives under a release-eligible $HOME path
+/// (release_guard_tmp pattern) — a temp_dir home canonicalizes to
+/// /private/var/… and dies at `validate_release_path`'s system-path check,
+/// which would mask the marker/deep-validation seam this test pins.
 #[test]
 #[cfg(unix)]
 fn arch14_checkout_then_path_release_succeeds() {
-    let home = p778_tmp_home("arch14-chain");
-    let parent = p778_tmp_home("arch14-chain-src");
-    let source = p778_setup_source_repo(&parent, "feat/arch14");
+    let base = release_guard_tmp("arch14-chain");
+    let home = base.join("home");
+    std::fs::create_dir_all(&home).expect("mkdir home");
+    let source = p778_setup_source_repo(&base, "feat/arch14");
     let agent = "arch14-chain-agent";
 
     let resp = super::handle_checkout_repo(
@@ -3605,8 +3611,7 @@ fn arch14_checkout_then_path_release_succeeds() {
         "path-addressed release of a checkout-provisioned worktree must succeed: {r}"
     );
     assert!(!wt.exists(), "released worktree must be removed: {r}");
-    std::fs::remove_dir_all(&home).ok();
-    std::fs::remove_dir_all(&parent).ok();
+    std::fs::remove_dir_all(&base).ok();
 }
 
 /// RED 2: the checkout producer itself writes the canonical four-field
@@ -3887,6 +3892,147 @@ fn arch14_adoption_refused_without_authoritative_binding() {
     assert!(
         r.get("error").is_some() || r.get("code").is_some(),
         "legacy adoption must be refused when the binding is not authoritative: {r}"
+    );
+    assert!(wt.exists(), "worktree must be preserved on refusal");
+    std::fs::remove_dir_all(&base).ok();
+}
+
+// ── Supplemental (root RED-gate 1 additions, m-20260720000244982995-64) ──
+
+/// Parity guard (green today, must stay green): the NORMAL lease and
+/// re-lease paths write the canonical four-field identity with a
+/// source_repo that canonicalizes to the actual source.
+#[test]
+#[cfg(unix)]
+fn arch14_lease_rewrite_marker_source_parity() {
+    let base = release_guard_tmp("arch14-parity");
+    let home = base.join("home");
+    std::fs::create_dir_all(&home).expect("mkdir home");
+    let source = p778_setup_source_repo(&base, "feat/arch14pp");
+    let agent = "arch14-parity-agent";
+
+    let assert_canonical = |path: &std::path::Path, label: &str| {
+        let marker = std::fs::read_to_string(path.join(crate::worktree_pool::MANAGED_MARKER))
+            .unwrap_or_else(|e| panic!("{label}: marker must be readable: {e}"));
+        for field in ["agent=", "branch=", "source_repo=", "leased_at="] {
+            assert!(
+                marker
+                    .lines()
+                    .any(|l| l.strip_prefix(field).is_some_and(|v| !v.trim().is_empty())),
+                "{label}: marker must carry non-empty {field}, got:\n{marker}"
+            );
+        }
+        let src = marker
+            .lines()
+            .find_map(|l| l.strip_prefix("source_repo="))
+            .map(str::trim)
+            .expect("source_repo present");
+        assert_eq!(
+            std::fs::canonicalize(src).expect("marker source resolves"),
+            std::fs::canonicalize(&source).expect("fixture source resolves"),
+            "{label}: marker source_repo must canonicalize to the lease source"
+        );
+    };
+
+    let first = crate::worktree_pool::lease(&home, &source, agent, "feat/arch14pp")
+        .expect("first lease succeeds");
+    assert_canonical(&first.path, "first lease");
+
+    let second = crate::worktree_pool::lease(&home, &source, agent, "feat/arch14pp")
+        .expect("re-lease of an existing worktree succeeds");
+    assert_eq!(first.path, second.path, "re-lease reuses the same worktree");
+    assert_canonical(&second.path, "re-lease rewrite");
+    std::fs::remove_dir_all(&base).ok();
+}
+
+/// Guard G: legacy missing-source marker whose BRANCH drifts from the
+/// binding stays refused — adoption requires agent/branch corroboration,
+/// and today's empty-identity refusal already preserves state.
+#[test]
+#[cfg(unix)]
+fn arch14_adoption_refused_on_branch_drift() {
+    let (base, home, repo, wt) = managed_wt_fixture("arch14-bdrift");
+    arch14_write_legacy_marker(&wt, "arch14-bd-agent", "feat/other-branch");
+    crate::binding::bind_full(&home, "arch14-bd-agent", "", "feat/test", &wt, &repo, false)
+        .expect("bind");
+    let r = dispatch_repo_release(&home, "arch14-bd-agent", wt.to_str().unwrap());
+    assert!(
+        r.get("error").is_some() || r.get("code").is_some(),
+        "legacy marker with branch drift must stay refused: {r}"
+    );
+    assert!(wt.exists(), "worktree must be preserved on refusal");
+    std::fs::remove_dir_all(&base).ok();
+}
+
+/// Guard H: a VALID Git pointer that resolves to a DIFFERENT real repo —
+/// marker and binding fully agree with each other but the worktree actually
+/// belongs elsewhere — stays refused (complements the malformed-pointer
+/// guard: both the fail-safe and the fail-closed arm are pinned).
+#[test]
+#[cfg(unix)]
+fn arch14_release_still_refuses_wrong_repo_git_pointer() {
+    let (base, home, repo, wt) = managed_wt_fixture("arch14-wrongptr");
+    seed_managed_marker(&wt, &repo, &home, "arch14-wp-agent", "feat/test");
+
+    // A second REAL repo with a REAL worktree; graft its valid .git pointer
+    // onto the managed worktree so the pointer resolves — to the wrong repo.
+    let other_repo = base.join("other-source");
+    std::fs::create_dir_all(&other_repo).expect("mkdir other");
+    git_init(&other_repo);
+    let other_wt = base.join("other-wt");
+    std::process::Command::new("git")
+        .args([
+            "worktree",
+            "add",
+            other_wt.to_str().unwrap(),
+            "-b",
+            "feat/other",
+        ])
+        .current_dir(&other_repo)
+        .env("AGEND_GIT_BYPASS", "1")
+        .output()
+        .ok();
+    let grafted = std::fs::read_to_string(other_wt.join(".git")).expect("other .git pointer");
+    std::fs::write(wt.join(".git"), grafted).expect("graft wrong-repo pointer");
+
+    let r = dispatch_repo_release(&home, "arch14-wp-agent", wt.to_str().unwrap());
+    assert!(
+        r.get("error").is_some() || r.get("code").is_some(),
+        "valid-but-wrong-repo git pointer must stay refused: {r}"
+    );
+    assert!(wt.exists(), "worktree must be preserved on refusal");
+    std::fs::remove_dir_all(&base).ok();
+}
+
+/// Guard I: an otherwise fully parseable marker that lacks ONLY the agent=
+/// line stays refused — distinct from the zero-byte case, which pins the
+/// unreadable-identity arm rather than the parseable-but-agentless one.
+#[test]
+#[cfg(unix)]
+fn arch14_release_still_refuses_missing_agent_parseable_marker() {
+    let (base, home, repo, wt) = managed_wt_fixture("arch14-noagentline");
+    std::fs::write(
+        wt.join(".agend-managed"),
+        format!(
+            "branch=feat/test\nsource_repo={}\nleased_at=2026-07-18T00:00:00+00:00\n",
+            repo.display()
+        ),
+    )
+    .expect("agentless parseable marker");
+    crate::binding::bind_full(
+        &home,
+        "arch14-nal-agent",
+        "",
+        "feat/test",
+        &wt,
+        &repo,
+        false,
+    )
+    .expect("bind");
+    let r = dispatch_repo_release(&home, "arch14-nal-agent", wt.to_str().unwrap());
+    assert!(
+        r.get("error").is_some() || r.get("code").is_some(),
+        "parseable marker missing only agent= must stay refused: {r}"
     );
     assert!(wt.exists(), "worktree must be preserved on refusal");
     std::fs::remove_dir_all(&base).ok();

--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -4037,3 +4037,63 @@ fn arch14_release_still_refuses_missing_agent_parseable_marker() {
     assert!(wt.exists(), "worktree must be preserved on refusal");
     std::fs::remove_dir_all(&base).ok();
 }
+
+/// arch14 correction (root-validated review of 6fafa912): producers persist
+/// the CANONICAL source identity, so a lease taken through a symlink ALIAS
+/// stays releasable after the alias is removed — the recorded identity never
+/// depends on the alias's continued existence. Deterministic: symlink
+/// creation/removal is synchronous; no timing.
+#[test]
+#[cfg(unix)]
+fn arch14_symlink_alias_lease_survives_alias_removal() {
+    let base = release_guard_tmp("arch14-symlink");
+    let home = base.join("home");
+    std::fs::create_dir_all(&home).expect("mkdir home");
+    let real = p778_setup_source_repo(&base, "feat/arch14sym");
+    let alias = base.join("alias-source");
+    std::os::unix::fs::symlink(&real, &alias).expect("symlink alias");
+    let agent = "arch14-sym-agent";
+
+    let lease = crate::worktree_pool::lease(&home, &alias, agent, "feat/arch14sym")
+        .expect("lease through the alias succeeds");
+    let marker = std::fs::read_to_string(lease.path.join(crate::worktree_pool::MANAGED_MARKER))
+        .expect("marker");
+    let recorded = marker
+        .lines()
+        .find_map(|l| l.strip_prefix("source_repo="))
+        .map(str::trim)
+        .expect("source_repo present");
+    let real_canonical = std::fs::canonicalize(&real).expect("real source resolves");
+    assert_eq!(
+        std::path::Path::new(recorded),
+        real_canonical.as_path(),
+        "marker must record the CANONICAL source, not the alias: {marker}"
+    );
+
+    // Bind with the same canonical identity (mirrors checkout's bind_full,
+    // which passes source_canonical).
+    crate::binding::bind_full(
+        &home,
+        agent,
+        "",
+        "feat/arch14sym",
+        &lease.path,
+        &real_canonical,
+        false,
+    )
+    .expect("bind");
+
+    // The alias disappears — the recorded canonical identity must keep the
+    // lease releasable.
+    std::fs::remove_file(&alias).expect("remove alias symlink");
+    let r = dispatch_repo_release(&home, agent, lease.path.to_str().unwrap());
+    assert!(
+        r["released"].as_bool() == Some(true) && r.get("error").and_then(|e| e.as_str()).is_none(),
+        "release from the recorded canonical identity must succeed after alias removal: {r}"
+    );
+    assert!(
+        !lease.path.exists(),
+        "released worktree must be removed: {r}"
+    );
+    std::fs::remove_dir_all(&base).ok();
+}

--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -3556,3 +3556,338 @@ fn repo_release_nonexistent_source_refuses() {
     );
     std::fs::remove_dir_all(&base).ok();
 }
+
+// ═══ Arch14 managed-marker source parity + safe legacy adoption ═══════════
+// (t-20260719234255106641-39872-4, decision d-20260719234211852352-4)
+//
+// RED group (red on 1394597d, green after the producer/adoption fix):
+//   the real checkout/create producers write 3-line sourceless markers that
+//   the #2810 deep-validated path-addressed release categorically refuses.
+// GREEN-guard group (green on 1394597d, MUST stay green): the fail-closed
+//   negative matrix — refusals assert `error` presence + state preservation
+//   only, never message text, so the fix cannot be satisfied by rewording.
+
+/// Write a pre-fix LEGACY marker: agent/branch/leased_at, NO source_repo line.
+#[cfg(unix)]
+fn arch14_write_legacy_marker(wt: &std::path::Path, agent: &str, branch: &str) {
+    std::fs::write(
+        wt.join(".agend-managed"),
+        format!("agent={agent}\nbranch={branch}\nleased_at=2026-07-18T00:00:00+00:00\n"),
+    )
+    .expect("write legacy marker");
+}
+
+/// RED 1: the full real chain — `repo checkout bind:true` then path-addressed
+/// `repo release` on the produced worktree — must succeed end-to-end.
+#[test]
+#[cfg(unix)]
+fn arch14_checkout_then_path_release_succeeds() {
+    let home = p778_tmp_home("arch14-chain");
+    let parent = p778_tmp_home("arch14-chain-src");
+    let source = p778_setup_source_repo(&parent, "feat/arch14");
+    let agent = "arch14-chain-agent";
+
+    let resp = super::handle_checkout_repo(
+        &home,
+        &serde_json::json!({
+            "repository_path": source.display().to_string(),
+            "branch": "feat/arch14",
+            "bind": true,
+        }),
+        agent,
+    );
+    assert!(resp.get("error").is_none(), "checkout must succeed: {resp}");
+    let wt = std::path::PathBuf::from(resp["path"].as_str().expect("path"));
+
+    let r = dispatch_repo_release(&home, agent, wt.to_str().unwrap());
+    assert!(
+        r["released"].as_bool() == Some(true) && r.get("error").and_then(|e| e.as_str()).is_none(),
+        "path-addressed release of a checkout-provisioned worktree must succeed: {r}"
+    );
+    assert!(!wt.exists(), "released worktree must be removed: {r}");
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&parent).ok();
+}
+
+/// RED 2: the checkout producer itself writes the canonical four-field
+/// identity — `source_repo=` present and pointing at the canonical source.
+#[test]
+#[cfg(unix)]
+fn arch14_checkout_marker_writes_canonical_source_repo() {
+    let home = p778_tmp_home("arch14-prod");
+    let parent = p778_tmp_home("arch14-prod-src");
+    let source = p778_setup_source_repo(&parent, "feat/arch14p");
+    let agent = "arch14-prod-agent";
+
+    let resp = super::handle_checkout_repo(
+        &home,
+        &serde_json::json!({
+            "repository_path": source.display().to_string(),
+            "branch": "feat/arch14p",
+            "bind": true,
+        }),
+        agent,
+    );
+    assert!(resp.get("error").is_none(), "checkout must succeed: {resp}");
+    let wt = std::path::PathBuf::from(resp["path"].as_str().expect("path"));
+    let marker =
+        std::fs::read_to_string(wt.join(crate::worktree_pool::MANAGED_MARKER)).expect("marker");
+    let src_line = marker
+        .lines()
+        .find_map(|l| l.strip_prefix("source_repo="))
+        .map(str::trim)
+        .unwrap_or("");
+    assert!(
+        !src_line.is_empty(),
+        "checkout-written marker must carry a non-empty source_repo= line, got:\n{marker}"
+    );
+    let canon_marker = std::fs::canonicalize(src_line).expect("marker source must resolve");
+    let canon_source = std::fs::canonicalize(&source).expect("fixture source resolves");
+    assert_eq!(
+        canon_marker, canon_source,
+        "marker source_repo must canonicalize to the checkout source"
+    );
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&parent).ok();
+}
+
+/// RED 3: the earliest producer — `worktree::create`'s orphan-guard first
+/// write — must already carry source_repo, so no crash window can leave a
+/// sourceless marker on disk.
+#[test]
+#[cfg(unix)]
+fn arch14_worktree_create_first_marker_writes_source_repo() {
+    let home = p778_tmp_home("arch14-create");
+    let parent = p778_tmp_home("arch14-create-src");
+    let source = p778_setup_source_repo(&parent, "feat/arch14c");
+
+    let info = crate::worktree::create(&home, &source, "arch14-create-agent", Some("feat/arch14c"))
+        .expect("create must succeed");
+    let marker = std::fs::read_to_string(info.path.join(crate::worktree_pool::MANAGED_MARKER))
+        .expect("marker written by create");
+    assert!(
+        marker.lines().any(|l| l
+            .strip_prefix("source_repo=")
+            .is_some_and(|v| !v.trim().is_empty())),
+        "create's first marker write must include non-empty source_repo=, got:\n{marker}"
+    );
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&parent).ok();
+}
+
+/// RED 4: safe legacy adoption — a known pre-fix three-line marker (missing
+/// source_repo line entirely) with an AUTHORITATIVE disk-fresh binding whose
+/// agent/branch corroborate the marker and whose worktree Git pointer matches
+/// must release successfully.
+#[test]
+#[cfg(unix)]
+fn arch14_legacy_three_line_marker_adopted_on_release() {
+    let (base, home, repo, wt) = managed_wt_fixture("arch14-adopt");
+    arch14_write_legacy_marker(&wt, "arch14-adopt-agent", "feat/test");
+    crate::binding::bind_full(
+        &home,
+        "arch14-adopt-agent",
+        "",
+        "feat/test",
+        &wt,
+        &repo,
+        false,
+    )
+    .expect("bind");
+
+    let r = dispatch_repo_release(&home, "arch14-adopt-agent", wt.to_str().unwrap());
+    assert!(
+        r["released"].as_bool() == Some(true) && r.get("error").and_then(|e| e.as_str()).is_none(),
+        "legacy sourceless marker with corroborating authoritative binding must be adopted and released: {r}"
+    );
+    assert!(!wt.exists(), "adopted worktree must be removed: {r}");
+    std::fs::remove_dir_all(&base).ok();
+}
+
+/// RED 5: a producer write failure must surface — a reused-worktree lease
+/// whose marker path is unwritable (a directory) must either return Err or
+/// leave a valid readable marker; silently succeeding with a broken marker
+/// is the pre-fix swallowed-error behavior.
+#[test]
+#[cfg(unix)]
+fn arch14_lease_marker_write_failure_fails_loud() {
+    let home = p778_tmp_home("arch14-loud");
+    let parent = p778_tmp_home("arch14-loud-src");
+    let source = p778_setup_source_repo(&parent, "feat/arch14l");
+    let agent = "arch14-loud-agent";
+
+    let first = crate::worktree_pool::lease(&home, &source, agent, "feat/arch14l")
+        .expect("first lease succeeds");
+    let marker_path = first.path.join(crate::worktree_pool::MANAGED_MARKER);
+    std::fs::remove_file(&marker_path).expect("remove marker");
+    std::fs::create_dir(&marker_path).expect("block marker path with a directory");
+
+    let second = crate::worktree_pool::lease(&home, &source, agent, "feat/arch14l");
+    match second {
+        Err(_) => {} // fail-loud: acceptable post-fix behavior
+        Ok(lease) => {
+            let content =
+                std::fs::read_to_string(lease.path.join(crate::worktree_pool::MANAGED_MARKER));
+            assert!(
+                content.is_ok_and(|c| c.lines().any(|l| l.starts_with("agent="))),
+                "lease reported success but the managed marker is not a valid readable file — \
+                 producer write errors must not be silently swallowed"
+            );
+        }
+    }
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&parent).ok();
+}
+
+// ── GREEN-guard negative matrix (green today, must stay green) ───────────
+
+/// Guard A: a marker with no agent= identity is refused and state preserved.
+#[test]
+#[cfg(unix)]
+fn arch14_release_still_refuses_agentless_marker() {
+    let (base, home, repo, wt) = managed_wt_fixture("arch14-noagent");
+    std::fs::write(wt.join(".agend-managed"), "").expect("empty marker");
+    crate::binding::bind_full(&home, "arch14-na-agent", "", "feat/test", &wt, &repo, false)
+        .expect("bind");
+    let r = dispatch_repo_release(&home, "arch14-na-agent", wt.to_str().unwrap());
+    assert!(
+        r.get("error").is_some() || r.get("code").is_some(),
+        "agentless marker must be refused: {r}"
+    );
+    assert!(wt.exists(), "worktree must be preserved on refusal");
+    std::fs::remove_dir_all(&base).ok();
+}
+
+/// Guard B: an EXPLICIT blank `source_repo=` line is NOT the legacy-missing
+/// case — it must stay refused (adoption is for a missing line only).
+#[test]
+#[cfg(unix)]
+fn arch14_release_still_refuses_explicit_blank_source() {
+    let (base, home, repo, wt) = managed_wt_fixture("arch14-blank");
+    std::fs::write(
+        wt.join(".agend-managed"),
+        "agent=arch14-blank-agent\nbranch=feat/test\nsource_repo=\nleased_at=2026-07-18T00:00:00+00:00\n",
+    )
+    .expect("marker");
+    crate::binding::bind_full(
+        &home,
+        "arch14-blank-agent",
+        "",
+        "feat/test",
+        &wt,
+        &repo,
+        false,
+    )
+    .expect("bind");
+    let r = dispatch_repo_release(&home, "arch14-blank-agent", wt.to_str().unwrap());
+    assert!(
+        r.get("error").is_some() || r.get("code").is_some(),
+        "explicit blank source_repo= must stay refused: {r}"
+    );
+    assert!(wt.exists(), "worktree must be preserved on refusal");
+    std::fs::remove_dir_all(&base).ok();
+}
+
+/// Guard C: identity drift — the marker claims a different agent than the
+/// binding/caller — stays refused, state preserved.
+#[test]
+#[cfg(unix)]
+fn arch14_release_still_refuses_identity_drift() {
+    let (base, home, repo, wt) = managed_wt_fixture("arch14-drift");
+    arch14_write_legacy_marker(&wt, "someone-else", "feat/test");
+    crate::binding::bind_full(
+        &home,
+        "arch14-drift-agent",
+        "",
+        "feat/test",
+        &wt,
+        &repo,
+        false,
+    )
+    .expect("bind");
+    let r = dispatch_repo_release(&home, "arch14-drift-agent", wt.to_str().unwrap());
+    assert!(
+        r.get("error").is_some() || r.get("code").is_some(),
+        "marker/binding agent drift must stay refused: {r}"
+    );
+    assert!(wt.exists(), "worktree must be preserved on refusal");
+    std::fs::remove_dir_all(&base).ok();
+}
+
+/// Guard D: an explicit marker source_repo that MISMATCHES the binding's
+/// source stays refused, state preserved.
+#[test]
+#[cfg(unix)]
+fn arch14_release_still_refuses_mismatching_source() {
+    let (base, home, repo, wt) = managed_wt_fixture("arch14-mismatch");
+    let other = base.join("other-existing-dir");
+    std::fs::create_dir_all(&other).expect("mkdir other");
+    std::fs::write(
+        wt.join(".agend-managed"),
+        format!(
+            "agent=arch14-mm-agent\nbranch=feat/test\nsource_repo={}\nleased_at=2026-07-18T00:00:00+00:00\n",
+            other.display()
+        ),
+    )
+    .expect("marker");
+    crate::binding::bind_full(&home, "arch14-mm-agent", "", "feat/test", &wt, &repo, false)
+        .expect("bind");
+    let r = dispatch_repo_release(&home, "arch14-mm-agent", wt.to_str().unwrap());
+    assert!(
+        r.get("error").is_some() || r.get("code").is_some(),
+        "marker/binding source mismatch must stay refused: {r}"
+    );
+    assert!(wt.exists(), "worktree must be preserved on refusal");
+    std::fs::remove_dir_all(&base).ok();
+}
+
+/// Guard E: a malformed worktree Git pointer stays refused even when marker
+/// and binding fully agree — no blind-.git authority in either direction.
+#[test]
+#[cfg(unix)]
+fn arch14_release_still_refuses_malformed_git_pointer() {
+    let (base, home, repo, wt) = managed_wt_fixture("arch14-gitptr");
+    seed_managed_marker(&wt, &repo, &home, "arch14-gp-agent", "feat/test");
+    std::fs::write(
+        wt.join(".git"),
+        "gitdir: /nonexistent/definitely/not/a/gitdir\n",
+    )
+    .expect("corrupt git pointer");
+    let r = dispatch_repo_release(&home, "arch14-gp-agent", wt.to_str().unwrap());
+    assert!(
+        r.get("error").is_some() || r.get("code").is_some(),
+        "malformed git pointer must stay refused: {r}"
+    );
+    assert!(wt.exists(), "worktree must be preserved on refusal");
+    std::fs::remove_dir_all(&base).ok();
+}
+
+/// Guard F: legacy adoption never proceeds off a NON-authoritative binding —
+/// a hand-tampered binding.json (invalid signature) plus a legacy marker
+/// stays refused, state preserved.
+#[test]
+#[cfg(unix)]
+fn arch14_adoption_refused_without_authoritative_binding() {
+    let (base, home, repo, wt) = managed_wt_fixture("arch14-noauth");
+    arch14_write_legacy_marker(&wt, "arch14-nb-agent", "feat/test");
+    crate::binding::bind_full(&home, "arch14-nb-agent", "", "feat/test", &wt, &repo, false)
+        .expect("bind");
+    // Tamper: rewrite binding.json bytes directly — the HMAC sidecar no longer
+    // matches, so the binding is NOT authoritative.
+    let bpath = crate::paths::runtime_dir(&home)
+        .join("arch14-nb-agent")
+        .join("binding.json");
+    let mut doc: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&bpath).expect("read binding"))
+            .expect("parse binding");
+    doc["task_id"] = serde_json::json!("tampered");
+    std::fs::write(&bpath, serde_json::to_string_pretty(&doc).expect("ser")).expect("tamper");
+
+    let r = dispatch_repo_release(&home, "arch14-nb-agent", wt.to_str().unwrap());
+    assert!(
+        r.get("error").is_some() || r.get("code").is_some(),
+        "legacy adoption must be refused when the binding is not authoritative: {r}"
+    );
+    assert!(wt.exists(), "worktree must be preserved on refusal");
+    std::fs::remove_dir_all(&base).ok();
+}

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -81,6 +81,24 @@ pub fn create(
     instance_name: &str,
     custom_branch: Option<&str>,
 ) -> Option<WorktreeInfo> {
+    // arch14: snapshot the CANONICAL source identity ONCE, before the reuse
+    // check and any side effect, and use it for everything downstream — the
+    // git worktree add/remove target, the marker, and WorktreeInfo.source_repo.
+    // A symlink-alias caller therefore can never split identities across
+    // stages (repo-A worktree with repo-B identity after an alias retarget),
+    // and a failure rollback never aims at a vanished alias. Fail-closed.
+    let repo_dir_canonical = match std::fs::canonicalize(repo_dir) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!(
+                repo = %repo_dir.display(),
+                error = %e,
+                "source repo cannot be canonicalized — refusing worktree creation (fail-closed)"
+            );
+            return None;
+        }
+    };
+    let repo_dir: &Path = &repo_dir_canonical;
     if !is_git_repo(repo_dir) {
         return None;
     }
@@ -259,25 +277,20 @@ pub fn create(
             // #1137: write .agend-managed marker immediately after successful
             // checkout to prevent orphan dirs if process dies before caller writes it.
             // arch14 (d-20260719234211852352-4): the FIRST write already carries the
-            // canonical four-field identity — no crash window may leave a sourceless
-            // marker — and the recorded source is CANONICALIZED here (fail-loud if
-            // that fails), so a symlink-alias caller can never persist an alias
-            // identity that a later alias retarget/removal would strand. A
-            // write/sync failure likewise aborts instead of handing back a worktree
-            // whose identity the deep-validated release would refuse.
+            // canonical four-field identity (`repo_dir` is the entry-snapshotted
+            // canonical source) — no crash window may leave a sourceless marker —
+            // and a write/sync failure aborts (fail-loud) instead of handing back a
+            // worktree whose identity the deep-validated release would refuse.
             let marker_path = wt_dir.join(".agend-managed");
-            let marker_write = std::fs::canonicalize(repo_dir)
-                .and_then(|source_canonical| {
-                    std::fs::write(
-                        &marker_path,
-                        format!(
-                            "agent={instance_name}\nbranch={branch}\nsource_repo={}\nleased_at={}\n",
-                            source_canonical.display(),
-                            chrono::Utc::now().to_rfc3339()
-                        ),
-                    )
-                })
-                .and_then(|()| crate::worktree_pool::sync_marker_contents(&marker_path));
+            let marker_write = std::fs::write(
+                &marker_path,
+                format!(
+                    "agent={instance_name}\nbranch={branch}\nsource_repo={}\nleased_at={}\n",
+                    repo_dir.display(),
+                    chrono::Utc::now().to_rfc3339()
+                ),
+            )
+            .and_then(|()| crate::worktree_pool::sync_marker_contents(&marker_path));
             if let Err(e) = marker_write {
                 tracing::warn!(
                     instance = instance_name,
@@ -333,21 +346,19 @@ pub fn create(
                         "created worktree on existing branch"
                     );
                     // #1137: write marker immediately (same as primary path above).
-                    // arch14: canonical four-field identity (source canonicalized,
-                    // fail-loud) + rollback, mirroring the primary `-b` arm exactly.
+                    // arch14: canonical four-field identity (entry-snapshotted
+                    // canonical `repo_dir`) + fail-loud rollback, mirroring the
+                    // primary `-b` arm exactly.
                     let marker_path = wt_dir.join(".agend-managed");
-                    let marker_write = std::fs::canonicalize(repo_dir)
-                        .and_then(|source_canonical| {
-                            std::fs::write(
-                                &marker_path,
-                                format!(
-                                    "agent={instance_name}\nbranch={branch}\nsource_repo={}\nleased_at={}\n",
-                                    source_canonical.display(),
-                                    chrono::Utc::now().to_rfc3339()
-                                ),
-                            )
-                        })
-                        .and_then(|()| crate::worktree_pool::sync_marker_contents(&marker_path));
+                    let marker_write = std::fs::write(
+                        &marker_path,
+                        format!(
+                            "agent={instance_name}\nbranch={branch}\nsource_repo={}\nleased_at={}\n",
+                            repo_dir.display(),
+                            chrono::Utc::now().to_rfc3339()
+                        ),
+                    )
+                    .and_then(|()| crate::worktree_pool::sync_marker_contents(&marker_path));
                     if let Err(e) = marker_write {
                         tracing::warn!(
                             instance = instance_name,

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -258,13 +258,40 @@ pub fn create(
             );
             // #1137: write .agend-managed marker immediately after successful
             // checkout to prevent orphan dirs if process dies before caller writes it.
-            let _ = std::fs::write(
-                wt_dir.join(".agend-managed"),
+            // arch14 (d-20260719234211852352-4): the FIRST write already carries the
+            // canonical four-field identity — no crash window may leave a sourceless
+            // marker — and a write/sync failure aborts (fail-loud) instead of handing
+            // back a worktree whose identity the deep-validated release would refuse.
+            let marker_path = wt_dir.join(".agend-managed");
+            let marker_write = std::fs::write(
+                &marker_path,
                 format!(
-                    "agent={instance_name}\nbranch={branch}\nleased_at={}\n",
+                    "agent={instance_name}\nbranch={branch}\nsource_repo={}\nleased_at={}\n",
+                    repo_dir.display(),
                     chrono::Utc::now().to_rfc3339()
                 ),
-            );
+            )
+            .and_then(|()| crate::worktree_pool::sync_marker_contents(&marker_path));
+            if let Err(e) = marker_write {
+                tracing::warn!(
+                    instance = instance_name,
+                    path = %wt_dir.display(),
+                    error = %e,
+                    "managed-marker write/sync failed — rolling back fresh worktree (fail-loud)"
+                );
+                // Rollback the worktree THIS attempt just created (never a reused
+                // tree — that path returned earlier), so no half-managed dir leaks.
+                let _ = git_cmd(
+                    repo_dir,
+                    &[
+                        "worktree",
+                        "remove",
+                        "--force",
+                        &wt_dir.display().to_string(),
+                    ],
+                );
+                return None;
+            }
             // Fresh worktree: `git worktree add` copies gitlinks + .gitmodules
             // but does NOT populate submodule content — init recursively here.
             init_submodules_after_create(&wt_dir);
@@ -300,13 +327,36 @@ pub fn create(
                         "created worktree on existing branch"
                     );
                     // #1137: write marker immediately (same as primary path above).
-                    let _ = std::fs::write(
-                        wt_dir.join(".agend-managed"),
+                    // arch14: canonical four-field identity + fail-loud, mirroring
+                    // the primary `-b` arm exactly.
+                    let marker_path = wt_dir.join(".agend-managed");
+                    let marker_write = std::fs::write(
+                        &marker_path,
                         format!(
-                            "agent={instance_name}\nbranch={branch}\nleased_at={}\n",
+                            "agent={instance_name}\nbranch={branch}\nsource_repo={}\nleased_at={}\n",
+                            repo_dir.display(),
                             chrono::Utc::now().to_rfc3339()
                         ),
-                    );
+                    )
+                    .and_then(|()| crate::worktree_pool::sync_marker_contents(&marker_path));
+                    if let Err(e) = marker_write {
+                        tracing::warn!(
+                            instance = instance_name,
+                            path = %wt_dir.display(),
+                            error = %e,
+                            "managed-marker write/sync failed — rolling back fresh worktree (fail-loud)"
+                        );
+                        let _ = git_cmd(
+                            repo_dir,
+                            &[
+                                "worktree",
+                                "remove",
+                                "--force",
+                                &wt_dir.display().to_string(),
+                            ],
+                        );
+                        return None;
+                    }
                     init_submodules_after_create(&wt_dir);
                     Some(WorktreeInfo {
                         path: wt_dir,

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -260,18 +260,24 @@ pub fn create(
             // checkout to prevent orphan dirs if process dies before caller writes it.
             // arch14 (d-20260719234211852352-4): the FIRST write already carries the
             // canonical four-field identity — no crash window may leave a sourceless
-            // marker — and a write/sync failure aborts (fail-loud) instead of handing
-            // back a worktree whose identity the deep-validated release would refuse.
+            // marker — and the recorded source is CANONICALIZED here (fail-loud if
+            // that fails), so a symlink-alias caller can never persist an alias
+            // identity that a later alias retarget/removal would strand. A
+            // write/sync failure likewise aborts instead of handing back a worktree
+            // whose identity the deep-validated release would refuse.
             let marker_path = wt_dir.join(".agend-managed");
-            let marker_write = std::fs::write(
-                &marker_path,
-                format!(
-                    "agent={instance_name}\nbranch={branch}\nsource_repo={}\nleased_at={}\n",
-                    repo_dir.display(),
-                    chrono::Utc::now().to_rfc3339()
-                ),
-            )
-            .and_then(|()| crate::worktree_pool::sync_marker_contents(&marker_path));
+            let marker_write = std::fs::canonicalize(repo_dir)
+                .and_then(|source_canonical| {
+                    std::fs::write(
+                        &marker_path,
+                        format!(
+                            "agent={instance_name}\nbranch={branch}\nsource_repo={}\nleased_at={}\n",
+                            source_canonical.display(),
+                            chrono::Utc::now().to_rfc3339()
+                        ),
+                    )
+                })
+                .and_then(|()| crate::worktree_pool::sync_marker_contents(&marker_path));
             if let Err(e) = marker_write {
                 tracing::warn!(
                     instance = instance_name,
@@ -327,18 +333,21 @@ pub fn create(
                         "created worktree on existing branch"
                     );
                     // #1137: write marker immediately (same as primary path above).
-                    // arch14: canonical four-field identity + fail-loud, mirroring
-                    // the primary `-b` arm exactly.
+                    // arch14: canonical four-field identity (source canonicalized,
+                    // fail-loud) + rollback, mirroring the primary `-b` arm exactly.
                     let marker_path = wt_dir.join(".agend-managed");
-                    let marker_write = std::fs::write(
-                        &marker_path,
-                        format!(
-                            "agent={instance_name}\nbranch={branch}\nsource_repo={}\nleased_at={}\n",
-                            repo_dir.display(),
-                            chrono::Utc::now().to_rfc3339()
-                        ),
-                    )
-                    .and_then(|()| crate::worktree_pool::sync_marker_contents(&marker_path));
+                    let marker_write = std::fs::canonicalize(repo_dir)
+                        .and_then(|source_canonical| {
+                            std::fs::write(
+                                &marker_path,
+                                format!(
+                                    "agent={instance_name}\nbranch={branch}\nsource_repo={}\nleased_at={}\n",
+                                    source_canonical.display(),
+                                    chrono::Utc::now().to_rfc3339()
+                                ),
+                            )
+                        })
+                        .and_then(|()| crate::worktree_pool::sync_marker_contents(&marker_path));
                     if let Err(e) = marker_write {
                         tracing::warn!(
                             instance = instance_name,

--- a/src/worktree/tests.rs
+++ b/src/worktree/tests.rs
@@ -69,7 +69,14 @@ fn test_create_worktree() {
     let info = info.expect("worktree created");
     assert!(info.path.exists());
     assert_eq!(info.branch, "agend/agent1");
-    assert_eq!(info.source_repo, repo);
+    // arch14: create snapshots the CANONICAL source at entry, so
+    // info.source_repo is the canonicalized repo — not the raw fixture path
+    // (macOS: /var -> /private/var; Windows: \\?\-prefixed canonical form).
+    assert_eq!(
+        info.source_repo,
+        std::fs::canonicalize(&repo).expect("fixture repo canonicalizes"),
+        "info.source_repo must be the entry-snapshotted CANONICAL source"
+    );
     // Sprint 57 Wave 4 (#546 Item 4): worktree must live under
     // `<home>/worktrees/<agent>/<branch>/`, NOT `<repo>/.worktrees/`.
     let expected = home.join("worktrees").join("agent1").join("agend/agent1");

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -140,25 +140,31 @@ pub fn lease(
     // #1137: marker is now written inside worktree::create() immediately
     // after checkout. Re-write here is idempotent and ensures the marker
     // is present for reused worktrees (which skip the create path).
-    // arch14 (d-20260719234211852352-4): a write/sync failure is an ABORT —
-    // the lease must not report success over a broken identity the
-    // deep-validated release would refuse. The (possibly reused) worktree is
-    // deliberately NOT deleted: it may hold WIP; abort-only is the safe arm.
+    // arch14 (d-20260719234211852352-4): the recorded source is CANONICALIZED
+    // (a symlink-alias caller must never persist an alias identity that a
+    // later alias retarget/removal would strand), and a canonicalize/write/
+    // sync failure is an ABORT — the lease must not report success over a
+    // broken identity the deep-validated release would refuse. The (possibly
+    // reused) worktree is deliberately NOT deleted: it may hold WIP;
+    // abort-only is the safe arm.
     let marker = info.path.join(MANAGED_MARKER);
-    std::fs::write(
-        &marker,
-        format!(
-            "agent={agent}\nbranch={branch}\nsource_repo={}\nleased_at={}\n",
-            source_repo.display(),
-            chrono::Utc::now().to_rfc3339()
-        ),
-    )
-    .and_then(|()| sync_marker_contents(&marker))
-    .map_err(|e| {
-        LeaseError::CreateFailed(format!(
-            "managed-marker write/sync failed for {agent}@{branch}: {e}"
-        ))
-    })?;
+    std::fs::canonicalize(source_repo)
+        .and_then(|source_canonical| {
+            std::fs::write(
+                &marker,
+                format!(
+                    "agent={agent}\nbranch={branch}\nsource_repo={}\nleased_at={}\n",
+                    source_canonical.display(),
+                    chrono::Utc::now().to_rfc3339()
+                ),
+            )
+        })
+        .and_then(|()| sync_marker_contents(&marker))
+        .map_err(|e| {
+            LeaseError::CreateFailed(format!(
+                "managed-marker canonicalize/write/sync failed for {agent}@{branch}: {e}"
+            ))
+        })?;
 
     Ok(WorktreeLease {
         agent: agent.to_string(),

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -104,6 +104,19 @@ impl std::error::Error for LeaseError {}
 /// AFTER leasing (dispatch's checked `bind_full` + reused-aware rollback —
 /// arch-review finding D+H). `source_repo` is still required to create the
 /// worktree, but is persisted into the binding by the caller, not here.
+/// arch14: make the `.agend-managed` marker's CONTENTS durable — `fs::write`
+/// alone leaves the bytes vulnerable to a crash/power loss even when the
+/// dirent survives. Opened for WRITE (not read-only): Windows `sync_all`
+/// maps to `FlushFileBuffers`, which needs `GENERIC_WRITE`. Shared by the
+/// `worktree::create` first write and the lease re-write; the checkout
+/// transaction keeps its own seam-instrumented copy (checkout_helpers).
+pub(crate) fn sync_marker_contents(path: &Path) -> std::io::Result<()> {
+    std::fs::OpenOptions::new()
+        .write(true)
+        .open(path)?
+        .sync_all()
+}
+
 pub fn lease(
     home: &Path,
     source_repo: &Path,
@@ -127,15 +140,25 @@ pub fn lease(
     // #1137: marker is now written inside worktree::create() immediately
     // after checkout. Re-write here is idempotent and ensures the marker
     // is present for reused worktrees (which skip the create path).
+    // arch14 (d-20260719234211852352-4): a write/sync failure is an ABORT —
+    // the lease must not report success over a broken identity the
+    // deep-validated release would refuse. The (possibly reused) worktree is
+    // deliberately NOT deleted: it may hold WIP; abort-only is the safe arm.
     let marker = info.path.join(MANAGED_MARKER);
-    let _ = std::fs::write(
+    std::fs::write(
         &marker,
         format!(
             "agent={agent}\nbranch={branch}\nsource_repo={}\nleased_at={}\n",
             source_repo.display(),
             chrono::Utc::now().to_rfc3339()
         ),
-    );
+    )
+    .and_then(|()| sync_marker_contents(&marker))
+    .map_err(|e| {
+        LeaseError::CreateFailed(format!(
+            "managed-marker write/sync failed for {agent}@{branch}: {e}"
+        ))
+    })?;
 
     Ok(WorktreeLease {
         agent: agent.to_string(),
@@ -1157,8 +1180,22 @@ fn release_full_guarded(
         };
         let mk_agent = mk_get("agent=");
         let mk_branch = mk_get("branch=");
-        let mk_source = mk_get("source_repo=");
-        if mk_agent.is_empty() || mk_branch.is_empty() || mk_source.is_empty() {
+        // arch14 (d-20260719234211852352-4): distinguish a MISSING source_repo
+        // line (a pre-fix legacy marker — adoption candidate, decided below
+        // after agent/branch corroboration) from an EXPLICIT blank value
+        // (stays refused as empty identity). Both read back "" through the
+        // old defaulting getter, which is exactly the distinction adoption
+        // must not blur.
+        let mk_source_line = marker_content
+            .lines()
+            .find_map(|l| l.strip_prefix("source_repo="))
+            .map(|s| s.trim().to_string());
+        let legacy_missing_source = mk_source_line.is_none();
+        let mk_source = mk_source_line.unwrap_or_default();
+        if mk_agent.is_empty()
+            || mk_branch.is_empty()
+            || (mk_source.is_empty() && !legacy_missing_source)
+        {
             return ReleaseOutcome {
                 error: Some(format!(
                     "managed marker has empty identity under lock (agent={mk_agent:?} \
@@ -1191,6 +1228,34 @@ fn release_full_guarded(
                 ..ReleaseOutcome::default()
             };
         }
+        // arch14 legacy adoption: a marker MISSING the source_repo line adopts
+        // the AUTHORITATIVE binding's source. Authority here is stricter than
+        // the ordinary release path: on top of the disk-fresh fingerprint-
+        // CAS'd read under the binding file lock, adoption also requires the
+        // binding's #1651 HMAC sidecar to verify (`binding::signature_valid`,
+        // fail-closed on a missing/stale/tampered sidecar) — a hand-edited
+        // binding.json must never lend its source to a sourceless marker.
+        // The marker's agent/branch already corroborated the binding above,
+        // and the worktree Git-pointer/common-dir check below still gates the
+        // final decision, so a marker that merely lost its source line
+        // releases while a worktree that actually belongs to another repo
+        // stays refused. The marker file is NOT rewritten (no migration — it
+        // is about to be released under this same lock).
+        let mk_source = if legacy_missing_source {
+            if !crate::binding::signature_valid(home, agent) {
+                return ReleaseOutcome {
+                    error: Some(
+                        "legacy sourceless marker: binding signature not verifiable — \
+                         refusing adoption (fail-closed)"
+                            .into(),
+                    ),
+                    ..ReleaseOutcome::default()
+                };
+            }
+            bound_source_str.to_string()
+        } else {
+            mk_source
+        };
         let Ok(mk_source_canonical) = std::fs::canonicalize(&mk_source) else {
             return ReleaseOutcome {
                 error: Some(format!(

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -140,31 +140,29 @@ pub fn lease(
     // #1137: marker is now written inside worktree::create() immediately
     // after checkout. Re-write here is idempotent and ensures the marker
     // is present for reused worktrees (which skip the create path).
-    // arch14 (d-20260719234211852352-4): the recorded source is CANONICALIZED
-    // (a symlink-alias caller must never persist an alias identity that a
-    // later alias retarget/removal would strand), and a canonicalize/write/
-    // sync failure is an ABORT — the lease must not report success over a
-    // broken identity the deep-validated release would refuse. The (possibly
-    // reused) worktree is deliberately NOT deleted: it may hold WIP;
-    // abort-only is the safe arm.
+    // arch14 (d-20260719234211852352-4): the recorded source is
+    // `info.source_repo` — the canonical identity `worktree::create`
+    // snapshotted at entry — NEVER a re-canonicalization of the caller's
+    // (possibly symlink-alias) argument, so no alias retarget between stages
+    // can split identities. A write/sync failure is an ABORT — the lease must
+    // not report success over a broken identity the deep-validated release
+    // would refuse. The (possibly reused) worktree is deliberately NOT
+    // deleted: it may hold WIP; abort-only is the safe arm.
     let marker = info.path.join(MANAGED_MARKER);
-    std::fs::canonicalize(source_repo)
-        .and_then(|source_canonical| {
-            std::fs::write(
-                &marker,
-                format!(
-                    "agent={agent}\nbranch={branch}\nsource_repo={}\nleased_at={}\n",
-                    source_canonical.display(),
-                    chrono::Utc::now().to_rfc3339()
-                ),
-            )
-        })
-        .and_then(|()| sync_marker_contents(&marker))
-        .map_err(|e| {
-            LeaseError::CreateFailed(format!(
-                "managed-marker canonicalize/write/sync failed for {agent}@{branch}: {e}"
-            ))
-        })?;
+    std::fs::write(
+        &marker,
+        format!(
+            "agent={agent}\nbranch={branch}\nsource_repo={}\nleased_at={}\n",
+            info.source_repo.display(),
+            chrono::Utc::now().to_rfc3339()
+        ),
+    )
+    .and_then(|()| sync_marker_contents(&marker))
+    .map_err(|e| {
+        LeaseError::CreateFailed(format!(
+            "managed-marker write/sync failed for {agent}@{branch}: {e}"
+        ))
+    })?;
 
     Ok(WorktreeLease {
         agent: agent.to_string(),


### PR DESCRIPTION
Implements frozen decision d-20260719234211852352-4 (task t-20260719234255106641-39872-4, parent audit t-…-39872-2/3). Fixes the producer/gate incompatibility where every `repo action=checkout`-provisioned worktree wrote a 3-line sourceless `.agend-managed` marker that the #2810 deep-validated path-addressed release categorically refused ("empty identity").

## Lineage (RED-first, root-gated)
- exact base: `1394597d` (origin/main)
- RED `84907cb0` → supplemental `b79e3bca` (root-VERIFIED gate 2, tests-only, byte-untouched since): 5 RED + 10 green guards
- GREEN `39c0e9bb`: the fix (3 files, +131/−13)
- `6fafa912`: comment-only trim, ci/checkout.rs back to the 750-LOC handler invariant (752 → 750; base 749)

## Changed producers — one canonical four-field identity, no swallowed write/sync error
| producer | change |
|---|---|
| `worktree.rs` create, BOTH arms (`-b` + existing-branch fallback) | first orphan-guard write now carries `source_repo=`; write+sync failure rolls back the just-created worktree (bounded `git worktree remove --force`) and returns None — the reused path returns earlier and is never rolled back |
| `worktree_pool.rs` lease re-write | write+sync failure aborts with `LeaseError::CreateFailed`; the (possibly reused) worktree is deliberately NOT deleted — it may hold WIP; abort-only is the safe arm |
| `ci/checkout.rs` | marker gains `source_repo={source_path}`; the existing #1275/#2755 fail-closed rollback + fsync transaction is unchanged |
| new `worktree_pool::sync_marker_contents` | write-handle `sync_all`, shared by create/lease; the checkout transaction keeps its seam-instrumented `checkout_helpers` copy |

## Safe legacy adoption (deep-validated release only)
`release_full_exact(validate_marker=true)` — sole caller `delegate_managed_release` (#2810) — now distinguishes a MISSING `source_repo` line (pre-fix legacy marker) from an EXPLICIT blank value (stays refused as empty identity). A missing-line marker adopts the binding's source ONLY when ALL hold:
1. binding is disk-fresh + fingerprint-CAS'd under the existing lock order (lifecycle permit → agent mutation lock → binding file lock → branch lock) — unchanged;
2. marker agent/branch corroborate the binding (existing checks, unchanged);
3. the #1651 HMAC sidecar verifies (`binding::signature_valid`, fail-closed) — a hand-edited binding.json never lends its source;
4. the worktree Git-pointer/common-dir check still corroborates the adopted source (existing check, unchanged).

No marker rewrite (no migration — the worktree is released under the same lock). No blind-.git authority: the pointer is corroboration, never the source of truth.

## Failure preservation (10 green guards, unchanged behavior)
agentless / zero-byte / explicit-blank-source / missing-agent-but-parseable markers, marker↔binding agent drift, branch drift, source mismatch, malformed AND valid-but-wrong-repo Git pointers, tampered (non-verifiable) binding → all still refuse and preserve state. Guards assert error presence + preservation only, never message text.

## Evidence
- `cargo nextest run arch14 --no-fail-fast`: **15/15** (5 RED → green; 10 guards stayed green)
- `file_size_invariant::mcp_handler_files_under_max_loc`: pass (750/750)
- `cargo fmt --check` clean; `cargo clippy --all-targets -- -D warnings` clean
- Full suite (6363 tests): all failures are pre-existing local-environment only — the live agentic-git shim intercepts bare-`git` fixtures lacking bypass (`usage_limit_takeover` ×11, `…2830_red` ×1: "FATAL recursion guard tripped"); identical failures reproduce on the clean RED tree via stash. CI runners are unaffected (no shim on PATH).

Dual adversarial exact-head review; branch CI only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)