### PR TITLE
fix(arch14): absent-binding legacy marker release via verified Git linkage

### DIFF
--- a/src/mcp/handlers/ci/release.rs
+++ b/src/mcp/handlers/ci/release.rs
@@ -146,25 +146,45 @@ fn absent_binding_legacy_release(
             "code": "managed_release_unauthorized",
         });
     }
-    // Path-anchored Git identity: the worktree's own gitlink names the source…
-    let Some(source_repo) = derive_source_from_gitlink(canonical) else {
+    // Canonical Git identity (GREEN-2, d-20260720053617389698-7): git's OWN
+    // common-dir resolution is the source authority — never lexical gitlink
+    // text arithmetic, so a VALID relative gitlink works exactly like the
+    // absolute form. `--path-format=absolute` makes the answer directly
+    // canonicalizable regardless of the gitlink's spelling.
+    let common_dir = match crate::git_helpers::git_cmd(
+        canonical,
+        &["rev-parse", "--path-format=absolute", "--git-common-dir"],
+    ) {
+        Ok(out) => std::path::PathBuf::from(out.trim()),
+        Err(e) => {
+            return json!({
+                "error": format!(
+                    "legacy marker for '{marker_agent}': worktree Git linkage unverifiable: {e} — refusing"
+                ),
+                "code": "managed_release_unverified_linkage",
+            });
+        }
+    };
+    let Some(source_parent) = common_dir.parent() else {
         return json!({
             "error": format!(
-                "legacy marker for '{marker_agent}': worktree Git linkage unverifiable — refusing"
+                "legacy marker for '{marker_agent}': common-dir '{}' has no parent source — refusing",
+                common_dir.display()
             ),
             "code": "managed_release_unverified_linkage",
         });
     };
-    let Ok(source_canonical) = std::fs::canonicalize(&source_repo) else {
+    let Ok(source_canonical) = std::fs::canonicalize(source_parent) else {
         return json!({
             "error": format!(
                 "legacy marker for '{marker_agent}': linked source '{}' cannot be canonicalized — refusing",
-                source_repo.display()
+                source_parent.display()
             ),
             "code": "managed_release_unverified_linkage",
         });
     };
-    // …and the checked-out branch must equal the marker's branch identity.
+    // The checked-out branch must equal the marker's branch identity (pre-gate;
+    // the canonical transaction re-validates marker identity post-seam).
     let head_branch = match crate::git_helpers::git_cmd(
         canonical,
         &["rev-parse", "--abbrev-ref", "HEAD"],
@@ -187,7 +207,26 @@ fn absent_binding_legacy_release(
             "code": "managed_release_branch_mismatch",
         });
     }
-    // Existing lock order (branch → agent → binding) + CAS re-read.
+    // GREEN-2: converge on the CANONICAL absent-target transaction. The caller
+    // holds the lifecycle permit and L(repo,branch); the transaction acquires
+    // A→B, re-reads the binding as truly absent AFTER the
+    // ReleaseTestPhase::AfterBindingSnapshot seam, re-validates the marker's
+    // agent/branch and the target's common-dir identity
+    // (target_source_repo_matches), preserves dirty WIP, and removes via the
+    // exact-metadata-aware path — no second removal implementation.
+    let permit = match crate::mcp::handlers::dispatch_hook::LifecyclePermit::acquire(
+        home,
+        marker_agent,
+        crate::mcp::handlers::dispatch_hook::LifecycleOperation::Release,
+    ) {
+        Ok(permit) => permit,
+        Err(e) => {
+            return json!({
+                "error": format!("release refused: bind/rebase in flight; {e}"),
+                "code": "managed_release_lock_failed",
+            });
+        }
+    };
     let source_repo_str = source_canonical.display().to_string();
     let _branch_lock =
         match crate::binding::acquire_branch_lease_lock(home, &source_repo_str, &mk_branch) {
@@ -199,42 +238,24 @@ fn absent_binding_legacy_release(
                 });
             }
         };
-    let _agent_lock = match crate::binding::acquire_agent_mutation_lock(home, marker_agent) {
-        Ok(lock) => lock,
-        Err(e) => {
-            return json!({
-                "error": format!("agent mutation lock failed: {e} — refusing"),
-                "code": "managed_release_lock_failed",
-            });
-        }
-    };
-    let _binding_lock = match crate::binding::acquire_binding_file_lock(home, marker_agent) {
-        Ok(lock) => lock,
-        Err(e) => {
-            return json!({
-                "error": format!("binding file lock failed: {e} — refusing"),
-                "code": "managed_release_lock_failed",
-            });
-        }
-    };
-    match crate::binding::guarded_binding_disk_fresh(home, marker_agent) {
-        crate::binding::GuardedBinding::Absent => {}
-        _ => {
-            return json!({
-                "error": format!(
-                    "binding for '{marker_agent}' appeared or is undecidable under lock — refusing (an in-flight bind wins)"
-                ),
-                "code": "managed_release_raced",
-            });
-        }
-    }
-    // Verified — reuse the canonical linked-worktree removal under the locks.
-    let mut resp = remove_linked_worktree_canonical(canonical, &canonical.display().to_string());
-    if let Some(obj) = resp.as_object_mut() {
-        obj.insert("released".into(), json!(!canonical.exists()));
-        obj.insert("legacy_absent_binding".into(), json!(true));
-    }
-    resp
+    let sender = (!caller.is_empty()).then_some(caller);
+    let outcome = crate::worktree_pool::release_absent_target_under_branch_lock(
+        home,
+        marker_agent,
+        &mk_branch,
+        canonical,
+        &source_canonical,
+        sender,
+        &permit,
+    );
+    json!({
+        "path": canonical.display().to_string(),
+        "legacy_absent_binding": true,
+        "released": outcome.released,
+        "worktree_removed": outcome.worktree_removed,
+        "git_metadata_pruned": outcome.git_metadata_pruned,
+        "error": outcome.error,
+    })
 }
 
 /// #t-…83936-6 P0 (data-loss incident): is `p` a TRUE linked git worktree — the

--- a/src/mcp/handlers/ci/release.rs
+++ b/src/mcp/handlers/ci/release.rs
@@ -1,20 +1,43 @@
 use serde_json::{json, Value};
 use std::path::Path;
 
-fn parse_managed_marker(wt: &Path) -> Option<(String, String, String)> {
+/// arch14 (d-20260720044124067125-6): `source_repo` is `None` when the LINE is
+/// missing (a pre-#2860 legacy marker — the absent-binding arm's only legal
+/// input) vs `Some("")` for an explicit blank value (always refused).
+fn parse_managed_marker(wt: &Path) -> Option<(String, String, Option<String>)> {
     let content = std::fs::read_to_string(wt.join(crate::worktree_pool::MANAGED_MARKER)).ok()?;
     let get = |prefix: &str| {
         content
             .lines()
             .find_map(|l| l.strip_prefix(prefix))
             .map(|s| s.trim().to_string())
-            .unwrap_or_default()
     };
-    let agent = get("agent=");
+    let agent = get("agent=").unwrap_or_default();
     if agent.is_empty() {
         return None;
     }
-    Some((agent, get("branch="), get("source_repo=")))
+    Some((
+        agent,
+        get("branch=").unwrap_or_default(),
+        get("source_repo="),
+    ))
+}
+
+/// Derive the source repo from a linked worktree's `.git` gitlink file
+/// (`gitdir: <src>/.git/worktrees/<name>`). Shared by the non-managed removal
+/// path (post-removal prune) and the arch14 absent-binding arm (branch-lease
+/// lock key). `None` on any unexpected shape — callers stay fail-safe.
+fn derive_source_from_gitlink(canonical: &Path) -> Option<std::path::PathBuf> {
+    canonical
+        .join(".git")
+        .is_file()
+        .then(|| std::fs::read_to_string(canonical.join(".git")).ok())
+        .flatten()
+        .and_then(|content| {
+            let gitdir = content.strip_prefix("gitdir: ")?.trim();
+            let p = std::path::Path::new(gitdir);
+            p.parent()?.parent()?.parent().map(|pp| pp.to_path_buf())
+        })
 }
 
 fn delegate_managed_release(home: &Path, canonical: &Path, caller: &str) -> Value {
@@ -40,13 +63,11 @@ fn delegate_managed_release(home: &Path, canonical: &Path, caller: &str) -> Valu
             fingerprint
         }
         Ok(crate::binding::GuardedBinding::Absent) => {
-            return json!({
-                "error": format!(
-                    "managed marker claims agent '{}' but no binding exists — refusing",
-                    marker_agent
-                ),
-                "code": "managed_release_no_binding",
-            });
+            // arch14 (d-20260720044124067125-6): a legacy sourceless-but-
+            // otherwise-valid marker whose binding no longer exists may release
+            // via the target's OWN verified .git linkage — every other absent-
+            // binding shape keeps the fail-closed refusal below.
+            return absent_binding_legacy_release(home, canonical, caller, &marker_agent);
         }
         Ok(crate::binding::GuardedBinding::Opaque(reason)) | Err(reason) => {
             return json!({
@@ -77,6 +98,143 @@ fn delegate_managed_release(home: &Path, canonical: &Path, caller: &str) -> Valu
         "branch_deleted": outcome.branch_deleted,
         "error": outcome.error,
     })
+}
+
+/// arch14 absent-binding arm (d-20260720044124067125-6): a LEGACY marker —
+/// non-empty agent AND branch, source_repo LINE MISSING (pre-#2860 producer
+/// format) — whose binding no longer exists may release via the target's own
+/// verified Git linkage. Everything else keeps the fail-closed
+/// `managed_release_no_binding` refusal. Caller authority is the SAME set as
+/// the bound path (marker agent / its orchestrator / anonymous operator).
+/// Identity is path-anchored: the gitlink names the source, the checked-out
+/// branch must equal the marker's branch, and under the existing
+/// branch→agent→binding lock order the binding must STILL be absent (a bind
+/// that raced in wins). The removal itself reuses the canonical
+/// linked-worktree removal path while the locks are held — the agent lock
+/// blocks a concurrent re-provision of this exact `worktrees/<agent>/<branch>`
+/// path for the removal's duration.
+fn absent_binding_legacy_release(
+    home: &Path,
+    canonical: &Path,
+    caller: &str,
+    marker_agent: &str,
+) -> Value {
+    let refuse_no_binding = || {
+        json!({
+            "error": format!(
+                "managed marker claims agent '{marker_agent}' but no binding exists — refusing"
+            ),
+            "code": "managed_release_no_binding",
+        })
+    };
+    let Some((_, mk_branch, mk_source)) = parse_managed_marker(canonical) else {
+        return refuse_no_binding();
+    };
+    // Only the missing-LINE legacy shape qualifies; an explicit (even blank)
+    // source_repo value or a branchless marker stays refused.
+    if mk_source.is_some() || mk_branch.is_empty() {
+        return refuse_no_binding();
+    }
+    if !caller.is_empty()
+        && caller != marker_agent
+        && !crate::teams::is_orchestrator_of(home, caller, marker_agent)
+    {
+        return json!({
+            "error": format!(
+                "caller '{caller}' not authorized to release agent '{marker_agent}' worktree"
+            ),
+            "code": "managed_release_unauthorized",
+        });
+    }
+    // Path-anchored Git identity: the worktree's own gitlink names the source…
+    let Some(source_repo) = derive_source_from_gitlink(canonical) else {
+        return json!({
+            "error": format!(
+                "legacy marker for '{marker_agent}': worktree Git linkage unverifiable — refusing"
+            ),
+            "code": "managed_release_unverified_linkage",
+        });
+    };
+    let Ok(source_canonical) = std::fs::canonicalize(&source_repo) else {
+        return json!({
+            "error": format!(
+                "legacy marker for '{marker_agent}': linked source '{}' cannot be canonicalized — refusing",
+                source_repo.display()
+            ),
+            "code": "managed_release_unverified_linkage",
+        });
+    };
+    // …and the checked-out branch must equal the marker's branch identity.
+    let head_branch = match crate::git_helpers::git_cmd(
+        canonical,
+        &["rev-parse", "--abbrev-ref", "HEAD"],
+    ) {
+        Ok(out) => out.trim().to_string(),
+        Err(e) => {
+            return json!({
+                "error": format!(
+                    "legacy marker for '{marker_agent}': cannot resolve worktree HEAD branch: {e} — refusing"
+                ),
+                "code": "managed_release_unverified_linkage",
+            });
+        }
+    };
+    if head_branch != mk_branch {
+        return json!({
+            "error": format!(
+                "legacy marker branch '{mk_branch}' does not match checked-out branch '{head_branch}' — refusing"
+            ),
+            "code": "managed_release_branch_mismatch",
+        });
+    }
+    // Existing lock order (branch → agent → binding) + CAS re-read.
+    let source_repo_str = source_canonical.display().to_string();
+    let _branch_lock =
+        match crate::binding::acquire_branch_lease_lock(home, &source_repo_str, &mk_branch) {
+            Ok(lock) => lock,
+            Err(e) => {
+                return json!({
+                    "error": format!("branch lease lock failed: {e} — refusing"),
+                    "code": "managed_release_lock_failed",
+                });
+            }
+        };
+    let _agent_lock = match crate::binding::acquire_agent_mutation_lock(home, marker_agent) {
+        Ok(lock) => lock,
+        Err(e) => {
+            return json!({
+                "error": format!("agent mutation lock failed: {e} — refusing"),
+                "code": "managed_release_lock_failed",
+            });
+        }
+    };
+    let _binding_lock = match crate::binding::acquire_binding_file_lock(home, marker_agent) {
+        Ok(lock) => lock,
+        Err(e) => {
+            return json!({
+                "error": format!("binding file lock failed: {e} — refusing"),
+                "code": "managed_release_lock_failed",
+            });
+        }
+    };
+    match crate::binding::guarded_binding_disk_fresh(home, marker_agent) {
+        crate::binding::GuardedBinding::Absent => {}
+        _ => {
+            return json!({
+                "error": format!(
+                    "binding for '{marker_agent}' appeared or is undecidable under lock — refusing (an in-flight bind wins)"
+                ),
+                "code": "managed_release_raced",
+            });
+        }
+    }
+    // Verified — reuse the canonical linked-worktree removal under the locks.
+    let mut resp = remove_linked_worktree_canonical(canonical, &canonical.display().to_string());
+    if let Some(obj) = resp.as_object_mut() {
+        obj.insert("released".into(), json!(!canonical.exists()));
+        obj.insert("legacy_absent_binding".into(), json!(true));
+    }
+    resp
 }
 
 /// #t-…83936-6 P0 (data-loss incident): is `p` a TRUE linked git worktree — the
@@ -200,20 +358,20 @@ pub(crate) fn handle_release_repo(home: &Path, args: &Value, instance_name: &str
         return delegate_managed_release(home, &canonical, instance_name);
     }
 
+    remove_linked_worktree_canonical(&canonical, path)
+}
+
+/// The canonical linked-worktree removal: bounded `git worktree remove
+/// --force`, the #t-…83936-6 whitelist-guarded `remove_dir_all` fallback, and
+/// the post-removal source prune. Extracted verbatim from
+/// `handle_release_repo`'s tail so the arch14 absent-binding arm reuses the
+/// EXACT same path (no second removal implementation).
+fn remove_linked_worktree_canonical(canonical: &Path, path: &str) -> Value {
     let path_str = canonical.to_string_lossy();
 
     // Derive source repo from worktree .git link before any removal —
     // needed for post-removal prune if git worktree remove fails.
-    let source_repo = canonical
-        .join(".git")
-        .is_file()
-        .then(|| std::fs::read_to_string(canonical.join(".git")).ok())
-        .flatten()
-        .and_then(|content| {
-            let gitdir = content.strip_prefix("gitdir: ")?.trim();
-            let p = std::path::Path::new(gitdir);
-            p.parent()?.parent()?.parent().map(|pp| pp.to_path_buf())
-        });
+    let source_repo = derive_source_from_gitlink(canonical);
 
     // #1899: bounded via spawn_group_bounded with a BARE Command — this site
     // deliberately does NOT set AGEND_GIT_BYPASS and does NOT set current_dir
@@ -246,14 +404,14 @@ pub(crate) fn handle_release_repo(home: &Path, args: &Value, instance_name: &str
             // #t-…83936-6 depth guard (WHITELIST): only `remove_dir_all` a LINKED
             // worktree, even if `git worktree remove` failed and validate was
             // somehow bypassed — this fallback is what deleted the canonical/bare.
-            if is_linked_worktree(&canonical) {
-                let _ = std::fs::remove_dir_all(&canonical);
+            if is_linked_worktree(canonical) {
+                let _ = std::fs::remove_dir_all(canonical);
             }
             json!({"path": path, "note": String::from_utf8_lossy(&o.stderr).to_string()})
         }
         Err(_) => {
-            if is_linked_worktree(&canonical) {
-                let _ = std::fs::remove_dir_all(&canonical);
+            if is_linked_worktree(canonical) {
+                let _ = std::fs::remove_dir_all(canonical);
             }
             json!({"path": path})
         }

--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -4247,3 +4247,46 @@ fn arch14_absent_binding_seam_marker_rewrite_refused() {
     );
     std::fs::remove_dir_all(&base).ok();
 }
+
+/// Supplemental RED 3 (root gate d-20260720060251593745-8, reviewer finding
+/// on 3fbddf7c): the canonical absent-target transaction re-validates
+/// binding/marker/source after AfterBindingSnapshot but never re-reads the
+/// target's ACTUAL Git HEAD branch — a deterministic post-seam checkout
+/// drift (binding still absent, marker agent/branch/source unchanged) must
+/// be refused with the worktree preserved; today the stale pre-gate branch
+/// identity passes and the removal proceeds.
+#[test]
+#[cfg(unix)]
+fn arch14_absent_binding_seam_head_drift_refused() {
+    let (base, home, _repo, wt) = managed_wt_fixture("arch14-headdrift");
+    arch14_write_legacy_marker(&wt, "arch14-hd-agent", "feat/test");
+    // Deliberately NO binding.
+
+    // Deterministic ACTUAL-HEAD drift at the canonical seam: the worktree's
+    // checked-out branch changes hands while marker/binding stay untouched.
+    let wt_for_hook = wt.clone();
+    let _seam = crate::worktree_pool::release_test_seam::install(move |phase| {
+        if phase == crate::worktree_pool::ReleaseTestPhase::AfterBindingSnapshot {
+            let _ = std::process::Command::new("git")
+                .args(["checkout", "-b", "feat/drifted"])
+                .current_dir(&wt_for_hook)
+                .env("AGEND_GIT_BYPASS", "1")
+                .output();
+        }
+    });
+
+    let r = dispatch_repo_release(&home, "arch14-hd-agent", wt.to_str().unwrap());
+    assert!(
+        r.get("error").is_some() || r.get("code").is_some(),
+        "post-seam ACTUAL-HEAD drift must be refused: {r}"
+    );
+    assert!(
+        r["released"].as_bool() != Some(true),
+        "post-seam ACTUAL-HEAD drift must not report released: {r}"
+    );
+    assert!(
+        wt.exists(),
+        "worktree must be preserved when the HEAD drift is refused"
+    );
+    std::fs::remove_dir_all(&base).ok();
+}

--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -4126,9 +4126,9 @@ fn arch14_absent_binding_legacy_marker_releases_via_git_linkage() {
     std::fs::remove_dir_all(&base).ok();
 }
 
-/// Over-correction guard (green today, must stay green): a marker missing
-/// ONLY the branch= line stays refused and preserved — the absent-binding
-/// arm must never weaken the branch identity requirement.
+/// Over-correction guard (green today, must stay green): ABSENT binding +
+/// a marker missing ONLY the branch= line stays refused and preserved — the
+/// absent-binding arm must never derive identity without a branch to match.
 #[test]
 #[cfg(unix)]
 fn arch14_release_still_refuses_missing_branch_marker() {
@@ -4141,16 +4141,7 @@ fn arch14_release_still_refuses_missing_branch_marker() {
         ),
     )
     .expect("branchless marker");
-    crate::binding::bind_full(
-        &home,
-        "arch14-nbr-agent",
-        "",
-        "feat/test",
-        &wt,
-        &repo,
-        false,
-    )
-    .expect("bind");
+    // Deliberately NO binding — this guard constrains the binding-ABSENT arm.
     let r = dispatch_repo_release(&home, "arch14-nbr-agent", wt.to_str().unwrap());
     assert!(
         r.get("error").is_some() || r.get("code").is_some(),

--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -4168,3 +4168,82 @@ fn arch14_absent_binding_zero_byte_marker_still_refused() {
     assert!(wt.exists(), "worktree must be preserved on refusal");
     std::fs::remove_dir_all(&base).ok();
 }
+
+// ── Supplemental RED 2 (root rejection of 98df/7e81 GREEN,
+// d-20260720053617389698-7): the new absent-binding arm must (a) support a
+// VALID RELATIVE gitlink identity and (b) run its revalidation inside the
+// canonical absent-target transaction so a deterministic marker rewrite at
+// ReleaseTestPhase::AfterBindingSnapshot is refused. Today it does neither:
+// the lexical derive fails on relative gitdirs, and the arm never reaches
+// the canonical seam.
+
+/// RED A (fail today): a linked worktree whose `.git` gitlink is RELATIVE
+/// (a shape git itself fully supports and resolves) must release exactly
+/// like the absolute form — the identity authority is git's common-dir
+/// resolution, not lexical path arithmetic on the gitlink text.
+#[test]
+#[cfg(unix)]
+fn arch14_absent_binding_relative_gitlink_releases() {
+    let (base, home, _repo, wt) = managed_wt_fixture("arch14-relgit");
+    // Rewrite the absolute gitlink to the equivalent RELATIVE form; git
+    // resolves it relative to the worktree, so identity stays valid.
+    std::fs::write(
+        wt.join(".git"),
+        "gitdir: ../source/.git/worktrees/managed-wt\n",
+    )
+    .expect("relative gitlink");
+    let probe = crate::git_helpers::git_cmd(&wt, &["rev-parse", "--git-common-dir"])
+        .expect("git must still resolve the relative gitlink");
+    assert!(
+        probe.contains("source"),
+        "fixture sanity: relative gitlink resolves to the source repo: {probe}"
+    );
+    arch14_write_legacy_marker(&wt, "arch14-rel-agent", "feat/test");
+    // Deliberately NO binding.
+
+    let r = dispatch_repo_release(&home, "arch14-rel-agent", wt.to_str().unwrap());
+    assert!(
+        r["released"].as_bool() == Some(true) && r.get("error").and_then(|e| e.as_str()).is_none(),
+        "valid RELATIVE gitlink identity must release like the absolute form: {r}"
+    );
+    assert!(!wt.exists(), "released worktree must be removed: {r}");
+    std::fs::remove_dir_all(&base).ok();
+}
+
+/// RED B (fail today): a deterministic marker rewrite injected at the
+/// canonical ReleaseTestPhase::AfterBindingSnapshot seam must be REFUSED
+/// with the worktree preserved — the absent-binding arm must revalidate
+/// marker agent/branch/source identity INSIDE the canonical absent-target
+/// transaction, after the seam. Today the arm never reaches that seam (its
+/// checks run before its own ad-hoc locks), so the rewrite goes unnoticed
+/// and the worktree is deleted under a changed identity.
+#[test]
+#[cfg(unix)]
+fn arch14_absent_binding_seam_marker_rewrite_refused() {
+    let (base, home, _repo, wt) = managed_wt_fixture("arch14-seam");
+    arch14_write_legacy_marker(&wt, "arch14-seam-agent", "feat/test");
+    // Deliberately NO binding.
+
+    // Deterministic rewrite: at AfterBindingSnapshot the marker's identity
+    // changes hands — the transaction's post-seam revalidation must refuse.
+    let marker_path = wt.join(".agend-managed");
+    let _seam = crate::worktree_pool::release_test_seam::install(move |phase| {
+        if phase == crate::worktree_pool::ReleaseTestPhase::AfterBindingSnapshot {
+            let _ = std::fs::write(
+                &marker_path,
+                "agent=someone-else\nbranch=feat/test\nleased_at=2026-07-18T00:00:00+00:00\n",
+            );
+        }
+    });
+
+    let r = dispatch_repo_release(&home, "arch14-seam-agent", wt.to_str().unwrap());
+    assert!(
+        r.get("error").is_some() || r.get("code").is_some(),
+        "a marker identity rewrite at the canonical seam must be refused: {r}"
+    );
+    assert!(
+        wt.exists(),
+        "worktree must be preserved when the seam rewrite is refused"
+    );
+    std::fs::remove_dir_all(&base).ok();
+}

--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -4097,3 +4097,83 @@ fn arch14_symlink_alias_lease_survives_alias_removal() {
     );
     std::fs::remove_dir_all(&base).ok();
 }
+
+// ═══ Arch14 legacy marker: absent-binding release (t-…-39872-18) ══════════
+// Superseding contract d-20260720044124067125-6. #2860 landed producer
+// canonical source parity + BINDING-authoritative legacy adoption; the
+// remaining hole: a legacy sourceless-but-otherwise-valid managed worktree
+// whose BINDING no longer exists is refused forever
+// (managed_release_no_binding) — no retry source can ever settle it.
+
+/// RED (fail today): binding ABSENT + valid linked worktree + non-empty
+/// agent/branch three-line legacy marker + authorized caller (the marker
+/// agent itself) must path-release via the target's own verified .git
+/// linkage. Today delegate_managed_release dies at
+/// `managed_release_no_binding` before any identity derivation.
+#[test]
+#[cfg(unix)]
+fn arch14_absent_binding_legacy_marker_releases_via_git_linkage() {
+    let (base, home, _repo, wt) = managed_wt_fixture("arch14-nobind");
+    arch14_write_legacy_marker(&wt, "arch14-nb2-agent", "feat/test");
+    // Deliberately NO binding — the legacy worktree's agent is long gone.
+
+    let r = dispatch_repo_release(&home, "arch14-nb2-agent", wt.to_str().unwrap());
+    assert!(
+        r["released"].as_bool() == Some(true) && r.get("error").and_then(|e| e.as_str()).is_none(),
+        "absent-binding legacy marker with verified .git linkage must release: {r}"
+    );
+    assert!(!wt.exists(), "released worktree must be removed: {r}");
+    std::fs::remove_dir_all(&base).ok();
+}
+
+/// Over-correction guard (green today, must stay green): a marker missing
+/// ONLY the branch= line stays refused and preserved — the absent-binding
+/// arm must never weaken the branch identity requirement.
+#[test]
+#[cfg(unix)]
+fn arch14_release_still_refuses_missing_branch_marker() {
+    let (base, home, repo, wt) = managed_wt_fixture("arch14-nobranch");
+    std::fs::write(
+        wt.join(".agend-managed"),
+        format!(
+            "agent=arch14-nbr-agent\nsource_repo={}\nleased_at=2026-07-18T00:00:00+00:00\n",
+            repo.display()
+        ),
+    )
+    .expect("branchless marker");
+    crate::binding::bind_full(
+        &home,
+        "arch14-nbr-agent",
+        "",
+        "feat/test",
+        &wt,
+        &repo,
+        false,
+    )
+    .expect("bind");
+    let r = dispatch_repo_release(&home, "arch14-nbr-agent", wt.to_str().unwrap());
+    assert!(
+        r.get("error").is_some() || r.get("code").is_some(),
+        "marker missing only branch= must stay refused: {r}"
+    );
+    assert!(wt.exists(), "worktree must be preserved on refusal");
+    std::fs::remove_dir_all(&base).ok();
+}
+
+/// Over-correction guard (green today, must stay green): absent binding +
+/// zero-byte marker stays refused — the absent-binding arm derives identity
+/// only for a marker that still carries non-empty agent AND branch.
+#[test]
+#[cfg(unix)]
+fn arch14_absent_binding_zero_byte_marker_still_refused() {
+    let (base, home, _repo, wt) = managed_wt_fixture("arch14-nb-zero");
+    std::fs::write(wt.join(".agend-managed"), "").expect("empty marker");
+
+    let r = dispatch_repo_release(&home, "arch14-nbz-agent", wt.to_str().unwrap());
+    assert!(
+        r.get("error").is_some() || r.get("code").is_some(),
+        "absent binding + zero-byte marker must stay refused: {r}"
+    );
+    assert!(wt.exists(), "worktree must be preserved on refusal");
+    std::fs::remove_dir_all(&base).ok();
+}

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -1819,6 +1819,48 @@ pub(crate) fn release_absent_target_under_branch_lock(
                 .to_string(),
         );
     }
+    // arch14 (d-20260720060251593745-8 + d-20260720061505902353-9): for a
+    // PRESENT target CARRYING a `.git` entry, the ACTUAL checked-out HEAD
+    // branch must equal the requested branch — resolved HERE, after the
+    // AfterBindingSnapshot seam and under the same A/B locks, so a concurrent
+    // checkout drift between the caller's pre-gate and this transaction can
+    // never remove a tree under a stale branch identity. Classification is
+    // `symlink_metadata(target/.git)`: ONLY NotFound counts as marker-only
+    // stale residue (no checkout identity to drift — the existing
+    // marker/source proof + canonical removal apply, keeping the s2 cleanup
+    // of torn/stale pool directories working); ANY `.git` entry (file, dir,
+    // symlink, other) must resolve, and a Git error, detached HEAD (resolves
+    // to the literal "HEAD", which never equals a branch name), or mismatch
+    // refuses with the target preserved. Any other metadata error also
+    // refuses. Applies to every caller uniformly — no opt-out.
+    if matches!(target_state, crate::mcp::handlers::TargetState::Present) {
+        match std::fs::symlink_metadata(target.join(".git")) {
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
+                return opaque_release(format!(
+                    "target .git entry metadata unreadable: {e} — refusing (state preserved)"
+                ));
+            }
+            Ok(_) => {
+                match crate::git_helpers::git_cmd(target, &["rev-parse", "--abbrev-ref", "HEAD"]) {
+                    Ok(out) => {
+                        let actual = out.trim();
+                        if actual != branch {
+                            return opaque_release(format!(
+                            "target actual HEAD branch '{actual}' does not match requested branch \
+                             '{branch}' — refusing (post-seam identity drift; state preserved)"
+                        ));
+                        }
+                    }
+                    Err(e) => {
+                        return opaque_release(format!(
+                        "cannot resolve target actual HEAD branch: {e} — refusing (state preserved)"
+                    ));
+                    }
+                }
+            }
+        }
+    }
     let mut out = ReleaseOutcome::default();
     let mut notices = Vec::new();
     if matches!(target_state, crate::mcp::handlers::TargetState::Absent) {

--- a/tests/review_mcp_ci_worktree_3.rs
+++ b/tests/review_mcp_ci_worktree_3.rs
@@ -86,10 +86,13 @@ fn release_repo_surfaces_unprunable_metadata_leak_mcp_ci_worktree() {
         .expect("src/mcp/handlers/ci/release.rs must exist");
     let text = std::fs::read_to_string(&ci_release).expect("read ci/release.rs");
 
-    let body = fn_body_after(&text, "fn handle_release_repo");
+    // arch14 (PR #2862): handle_release_repo's cleanup tail moved verbatim into
+    // `remove_linked_worktree_canonical` so the absent-binding arm reuses the
+    // exact same removal path — the guarded body is that extracted fn now.
+    let body = fn_body_after(&text, "fn remove_linked_worktree_canonical");
     assert!(
         !body.is_empty(),
-        "could not locate `handle_release_repo` in ci/release.rs — re-check signature drift"
+        "could not locate `remove_linked_worktree_canonical` in ci/release.rs — re-check signature drift"
     );
 
     // Sanity: confirm we located the RIGHT function — it must contain the


### PR DESCRIPTION
Implements the frozen absent-binding arm of superseding decision d-20260720044124067125-6 (task t-20260720043817240076-39872-18). Completes the Arch14 legacy-marker chain: #2860 landed producer canonical-source parity + BINDING-authoritative adoption; the remaining hole was a legacy sourceless-but-otherwise-valid managed worktree whose **binding no longer exists** — refused forever at `managed_release_no_binding` with nothing able to settle it.

## Lineage (RED-first, root-gated)
- exact base: `0c084092` (origin/main)
- RED `a64a8761` → supplemental `b8f89003` (root-VERIFIED; tests-only, byte-untouched since): 1 RED + 2 over-correction guards
- GREEN `98df72b0`: release.rs only, +183/−25

## The absent-binding arm — ALL must hold, else the fail-closed refusal stands
1. **Legacy shape only**: non-empty `agent=` AND `branch=`, `source_repo` LINE missing (`parse_managed_marker` now returns `Option` for source — an explicit blank value stays refused).
2. **Caller authority unchanged**: marker agent / its orchestrator / anonymous operator — the same set as the bound path.
3. **Path-anchored Git identity**: the worktree's own gitlink names the source (`derive_source_from_gitlink`, shared with the non-managed prune path), the source canonicalizes, and the checked-out branch equals the marker's branch.
4. **Existing lock order + CAS**: branch→agent→binding locks held; the binding must STILL be absent under the locks (an in-flight bind wins, release refuses `managed_release_raced`). The agent lock also blocks a concurrent re-provision of this exact `worktrees/<agent>/<branch>` path across the removal.

## Removal reuse — no second implementation
`remove_linked_worktree_canonical` is `handle_release_repo`'s tail extracted **verbatim** (bounded `git worktree remove --force`, the #t-…83936-6 whitelist-guarded `remove_dir_all` fallback, post-removal source prune). The absent arm calls it under the held locks. No direct `remove_dir_all`, no migration, no janitor/self-release/merge-auto-release changes, no producer or binding-present-adoption changes, no weakened provenance.

## Evidence
- absent-binding suite **3/3**: RED → green (legacy release via verified linkage); missing-branch guard and zero-byte guard stayed refused/preserved — both now genuinely constrain the binding-ABSENT arm (the missing-branch guard's `bind_full` was removed at root's RED gate).
- full arch14 family + `mcp::handlers::ci::tests` module + 750-LOC handler invariant: **111/111**.
- `cargo fmt --check` clean; `cargo clippy --all-targets -- -D warnings` clean.
- RED immutability: `git diff b8f89003 -- ci/tests.rs` empty.

Dual adversarial exact-head review; branch CI only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)