### PR TITLE
feat: support context threshold overrides in fleet templates

### DIFF
--- a/src/deployments.rs
+++ b/src/deployments.rs
@@ -302,6 +302,18 @@ fn create_instance_entries(
                     .filter(|s| matches!(*s, "skip" | "deferred"))
                     .map(String::from),
                 created_by: None, // no single ACL creator for templated instances
+                context_alert_pct: inst_val
+                    .get("context_alert_pct")
+                    .and_then(|v| v.as_f64())
+                    .map(|f| f as f32),
+                context_handoff_pct: inst_val
+                    .get("context_handoff_pct")
+                    .and_then(|v| v.as_f64())
+                    .map(|f| f as f32),
+                context_handoff_escalate_pct: inst_val
+                    .get("context_handoff_escalate_pct")
+                    .and_then(|v| v.as_f64())
+                    .map(|f| f as f32),
             },
         ));
         created.push(inst_name);

--- a/src/deployments.rs
+++ b/src/deployments.rs
@@ -145,9 +145,30 @@ fn yaml_str(val: &serde_yaml_ng::Value, key: &str) -> Option<String> {
         .map(String::from)
 }
 
+fn validate_context_threshold(
+    inst_val: &serde_yaml_ng::Value,
+    field: &str,
+) -> Result<Option<f32>, String> {
+    let Some(val) = inst_val.get(field) else {
+        return Ok(None);
+    };
+    let f64_val = val
+        .as_f64()
+        .ok_or_else(|| format!("`{field}` must be a YAML number, got: {val:?}"))?;
+    if !f64_val.is_finite() {
+        return Err(format!("`{field}` must be finite, got: {f64_val}"));
+    }
+    let f32_val = f64_val as f32;
+    if !f32_val.is_finite() {
+        return Err(format!("`{field}` overflows f32 precision: {f64_val}"));
+    }
+    Ok(Some(f32_val))
+}
+
+#[allow(clippy::type_complexity)]
 fn create_instance_entries(
     params: &DeployParams,
-) -> (Vec<String>, Vec<(String, crate::fleet::InstanceYamlEntry)>) {
+) -> Result<(Vec<String>, Vec<(String, crate::fleet::InstanceYamlEntry)>), serde_json::Value> {
     let mut created = Vec::new();
     let mut yaml_entries = Vec::new();
     let dir = std::path::PathBuf::from(&params.directory);
@@ -302,23 +323,35 @@ fn create_instance_entries(
                     .filter(|s| matches!(*s, "skip" | "deferred"))
                     .map(String::from),
                 created_by: None, // no single ACL creator for templated instances
-                context_alert_pct: inst_val
-                    .get("context_alert_pct")
-                    .and_then(|v| v.as_f64())
-                    .map(|f| f as f32),
-                context_handoff_pct: inst_val
-                    .get("context_handoff_pct")
-                    .and_then(|v| v.as_f64())
-                    .map(|f| f as f32),
-                context_handoff_escalate_pct: inst_val
-                    .get("context_handoff_escalate_pct")
-                    .and_then(|v| v.as_f64())
-                    .map(|f| f as f32),
+                context_alert_pct: validate_context_threshold(inst_val, "context_alert_pct")
+                    .map_err(|e| {
+                        serde_json::json!({
+                            "error": format!("deploy_template: instance `{inst_name}` — {e}"),
+                            "code": "deploy_invalid_threshold",
+                        })
+                    })?,
+                context_handoff_pct: validate_context_threshold(inst_val, "context_handoff_pct")
+                    .map_err(|e| {
+                        serde_json::json!({
+                            "error": format!("deploy_template: instance `{inst_name}` — {e}"),
+                            "code": "deploy_invalid_threshold",
+                        })
+                    })?,
+                context_handoff_escalate_pct: validate_context_threshold(
+                    inst_val,
+                    "context_handoff_escalate_pct",
+                )
+                .map_err(|e| {
+                    serde_json::json!({
+                        "error": format!("deploy_template: instance `{inst_name}` — {e}"),
+                        "code": "deploy_invalid_threshold",
+                    })
+                })?,
             },
         ));
         created.push(inst_name);
     }
-    (created, yaml_entries)
+    Ok((created, yaml_entries))
 }
 
 fn prepare_work_dir(
@@ -644,7 +677,10 @@ pub(crate) fn deploy_with_runtime(
         return duplicate_deploy_error(&params.deploy_name);
     }
 
-    let (created, yaml_entries) = create_instance_entries(&params);
+    let (created, yaml_entries) = match create_instance_entries(&params) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
 
     if let Err(e) =
         persist_to_fleet_yaml(home, &yaml_entries, &params.template, &params.deploy_name)

--- a/src/deployments.rs
+++ b/src/deployments.rs
@@ -169,6 +169,23 @@ fn validate_context_threshold(
 fn create_instance_entries(
     params: &DeployParams,
 ) -> Result<(Vec<String>, Vec<(String, crate::fleet::InstanceYamlEntry)>), serde_json::Value> {
+    for (name_val, inst_val) in &params.instances_def {
+        let inst_suffix = name_val.as_str().unwrap_or("?");
+        let inst_name = format!("{}-{inst_suffix}", params.deploy_name);
+        for field in [
+            "context_alert_pct",
+            "context_handoff_pct",
+            "context_handoff_escalate_pct",
+        ] {
+            validate_context_threshold(inst_val, field).map_err(|e| {
+                serde_json::json!({
+                    "error": format!("deploy_template: instance `{inst_name}` — {e}"),
+                    "code": "deploy_invalid_threshold",
+                })
+            })?;
+        }
+    }
+
     let mut created = Vec::new();
     let mut yaml_entries = Vec::new();
     let dir = std::path::PathBuf::from(&params.directory);

--- a/src/deployments/tests.rs
+++ b/src/deployments/tests.rs
@@ -2233,3 +2233,207 @@ fn deployment_runtime_dispatch_forwards_typed_capability_slice14() {
         "RuntimeContext=None compatibility must retain an explicit legacy api::call path"
     );
 }
+
+// ── PR #2864 / Issue #2863: context threshold template→fleet contract ──
+
+#[test]
+fn deploy_persists_context_thresholds_into_fleet_yaml() {
+    let home = tmp_home("ctx_persist");
+    let yaml = r#"
+templates:
+  ctx-dev:
+    instances:
+      worker:
+        backend: claude
+        context_alert_pct: 75.0
+        context_handoff_pct: 85.0
+        context_handoff_escalate_pct: 95.0
+"#;
+    std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).unwrap();
+    let args = serde_json::json!({
+        "template": "ctx-dev",
+        "directory": home.display().to_string(),
+    });
+    let result = deploy(&home, "caller", &args);
+    assert!(
+        result.get("error").is_none(),
+        "deploy must succeed: {result}"
+    );
+    let reloaded = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&home))
+        .expect("reload fleet.yaml");
+    let inst = reloaded
+        .instances
+        .get("ctx-dev-worker")
+        .expect("ctx-dev-worker must be persisted");
+    assert_eq!(
+        inst.context_alert_pct,
+        Some(75.0),
+        "context_alert_pct must persist through template deploy"
+    );
+    assert_eq!(
+        inst.context_handoff_pct,
+        Some(85.0),
+        "context_handoff_pct must persist through template deploy"
+    );
+    assert_eq!(
+        inst.context_handoff_escalate_pct,
+        Some(95.0),
+        "context_handoff_escalate_pct must persist through template deploy"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+#[test]
+fn deploy_omits_context_thresholds_when_absent() {
+    let home = tmp_home("ctx_omit");
+    let yaml = r#"
+templates:
+  plain:
+    instances:
+      worker:
+        backend: claude
+"#;
+    std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).unwrap();
+    let args = serde_json::json!({
+        "template": "plain",
+        "directory": home.display().to_string(),
+    });
+    let _ = deploy(&home, "caller", &args);
+    let reloaded = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&home)).unwrap();
+    let inst = reloaded
+        .instances
+        .get("plain-worker")
+        .expect("plain-worker");
+    assert!(
+        inst.context_alert_pct.is_none(),
+        "context_alert_pct must stay None when template omits it"
+    );
+    assert!(
+        inst.context_handoff_pct.is_none(),
+        "context_handoff_pct must stay None when template omits it"
+    );
+    assert!(
+        inst.context_handoff_escalate_pct.is_none(),
+        "context_handoff_escalate_pct must stay None when template omits it"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// RED: malformed string type for context threshold must NOT be silently
+/// swallowed as None (which falls back to global thresholds). The operator
+/// wrote an explicit per-instance override that happens to be mistyped —
+/// silent omission means the daemon runs with different thresholds than the
+/// operator intended, with no diagnostic.
+#[test]
+fn deploy_rejects_malformed_context_threshold_string_type() {
+    let home = tmp_home("ctx_malformed_str");
+    let yaml = r#"
+templates:
+  bad-str:
+    instances:
+      worker:
+        backend: claude
+        context_alert_pct: "not-a-number"
+        context_handoff_pct: 85.0
+"#;
+    std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).unwrap();
+    let args = serde_json::json!({
+        "template": "bad-str",
+        "directory": home.display().to_string(),
+    });
+    let result = deploy(&home, "caller", &args);
+    let has_error = result.get("error").is_some();
+    let has_warning = result
+        .get("warnings")
+        .and_then(|w| w.as_array())
+        .map(|a| {
+            a.iter().any(|w| {
+                w.as_str()
+                    .map(|s| s.contains("context_alert_pct"))
+                    .unwrap_or(false)
+            })
+        })
+        .unwrap_or(false);
+    assert!(
+        has_error || has_warning,
+        "a malformed string context_alert_pct must produce an error or warning, \
+         not silently fall back to global thresholds: {result}"
+    );
+}
+
+/// RED: boolean type for context threshold must not be silently swallowed.
+/// `as_f64()` on a YAML bool returns None, causing silent omission.
+#[test]
+fn deploy_rejects_malformed_context_threshold_bool_type() {
+    let home = tmp_home("ctx_malformed_bool");
+    let yaml = r#"
+templates:
+  bad-bool:
+    instances:
+      worker:
+        backend: claude
+        context_handoff_pct: true
+"#;
+    std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).unwrap();
+    let args = serde_json::json!({
+        "template": "bad-bool",
+        "directory": home.display().to_string(),
+    });
+    let result = deploy(&home, "caller", &args);
+    let has_error = result.get("error").is_some();
+    let has_warning = result
+        .get("warnings")
+        .and_then(|w| w.as_array())
+        .map(|a| {
+            a.iter().any(|w| {
+                w.as_str()
+                    .map(|s| s.contains("context_handoff_pct"))
+                    .unwrap_or(false)
+            })
+        })
+        .unwrap_or(false);
+    assert!(
+        has_error || has_warning,
+        "a boolean context_handoff_pct must produce an error or warning, \
+         not silently fall back to global thresholds: {result}"
+    );
+}
+
+/// RED: sequence type for context threshold must not be silently swallowed.
+#[test]
+fn deploy_rejects_malformed_context_threshold_sequence_type() {
+    let home = tmp_home("ctx_malformed_seq");
+    let yaml = r#"
+templates:
+  bad-seq:
+    instances:
+      worker:
+        backend: claude
+        context_handoff_escalate_pct:
+          - 90
+          - 95
+"#;
+    std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).unwrap();
+    let args = serde_json::json!({
+        "template": "bad-seq",
+        "directory": home.display().to_string(),
+    });
+    let result = deploy(&home, "caller", &args);
+    let has_error = result.get("error").is_some();
+    let has_warning = result
+        .get("warnings")
+        .and_then(|w| w.as_array())
+        .map(|a| {
+            a.iter().any(|w| {
+                w.as_str()
+                    .map(|s| s.contains("context_handoff_escalate_pct"))
+                    .unwrap_or(false)
+            })
+        })
+        .unwrap_or(false);
+    assert!(
+        has_error || has_warning,
+        "a sequence context_handoff_escalate_pct must produce an error or warning, \
+         not silently fall back to global thresholds: {result}"
+    );
+}

--- a/src/deployments/tests.rs
+++ b/src/deployments/tests.rs
@@ -2485,11 +2485,11 @@ templates:
 
     let reloaded = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&home)).unwrap();
     assert!(
-        reloaded.instances.get("mixed-good").is_none(),
+        !reloaded.instances.contains_key("mixed-good"),
         "the valid sibling must not be persisted to fleet.yaml when the deployment was rejected"
     );
     assert!(
-        reloaded.instances.get("mixed-bad").is_none(),
+        !reloaded.instances.contains_key("mixed-bad"),
         "the malformed instance must not be persisted to fleet.yaml"
     );
     std::fs::remove_dir_all(&home).ok();

--- a/src/deployments/tests.rs
+++ b/src/deployments/tests.rs
@@ -2437,3 +2437,60 @@ templates:
          not silently fall back to global thresholds: {result}"
     );
 }
+
+/// RED: a later malformed instance must not leave residue from an earlier
+/// valid instance. When the template has [valid, malformed], deploy must
+/// error atomically: zero instance directories on disk, zero persisted
+/// fleet.yaml instance entries.
+#[test]
+fn deploy_malformed_threshold_leaves_no_residue_from_valid_sibling() {
+    let home = tmp_home("ctx_residue");
+    let yaml = r#"
+templates:
+  mixed:
+    instances:
+      good:
+        backend: claude
+        context_alert_pct: 75.0
+      bad:
+        backend: claude
+        context_alert_pct: "oops"
+"#;
+    std::fs::write(crate::fleet::fleet_yaml_path(&home), yaml).unwrap();
+    let deploy_dir = home.join("deploys");
+    std::fs::create_dir_all(&deploy_dir).ok();
+    let args = serde_json::json!({
+        "template": "mixed",
+        "directory": deploy_dir.display().to_string(),
+    });
+    let result = deploy(&home, "caller", &args);
+    assert!(
+        result.get("error").is_some(),
+        "deploy must fail when any instance has a malformed threshold: {result}"
+    );
+
+    let good_dir = deploy_dir.join("mixed-good");
+    let bad_dir = deploy_dir.join("mixed-bad");
+    assert!(
+        !good_dir.exists(),
+        "the valid sibling's work directory must not be left as residue after \
+         the malformed sibling caused deployment failure: {}",
+        good_dir.display()
+    );
+    assert!(
+        !bad_dir.exists(),
+        "the malformed instance's work directory must not exist: {}",
+        bad_dir.display()
+    );
+
+    let reloaded = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(&home)).unwrap();
+    assert!(
+        reloaded.instances.get("mixed-good").is_none(),
+        "the valid sibling must not be persisted to fleet.yaml when the deployment was rejected"
+    );
+    assert!(
+        reloaded.instances.get("mixed-bad").is_none(),
+        "the malformed instance must not be persisted to fleet.yaml"
+    );
+    std::fs::remove_dir_all(&home).ok();
+}

--- a/src/fleet/merge.rs
+++ b/src/fleet/merge.rs
@@ -98,6 +98,33 @@ pub fn merge_instance_into_existing(
 
     merge_typed_field(name, existing, "worktree", config.worktree.map(Value::Bool))?;
 
+    merge_typed_field(
+        name,
+        existing,
+        "context_alert_pct",
+        config
+            .context_alert_pct
+            .map(|pct| Value::Number(serde_yaml_ng::Number::from(pct as f64))),
+    )?;
+
+    merge_typed_field(
+        name,
+        existing,
+        "context_handoff_pct",
+        config
+            .context_handoff_pct
+            .map(|pct| Value::Number(serde_yaml_ng::Number::from(pct as f64))),
+    )?;
+
+    merge_typed_field(
+        name,
+        existing,
+        "context_handoff_escalate_pct",
+        config
+            .context_handoff_escalate_pct
+            .map(|pct| Value::Number(serde_yaml_ng::Number::from(pct as f64))),
+    )?;
+
     Ok(())
 }
 
@@ -217,6 +244,24 @@ pub(super) fn build_instance_mapping(config: &InstanceYamlEntry) -> serde_yaml_n
         inst.insert(
             "topic_binding_mode".into(),
             serde_yaml_ng::Value::String(mode.clone()),
+        );
+    }
+    if let Some(pct) = config.context_alert_pct {
+        inst.insert(
+            "context_alert_pct".into(),
+            serde_yaml_ng::Value::Number(serde_yaml_ng::Number::from(pct as f64)),
+        );
+    }
+    if let Some(pct) = config.context_handoff_pct {
+        inst.insert(
+            "context_handoff_pct".into(),
+            serde_yaml_ng::Value::Number(serde_yaml_ng::Number::from(pct as f64)),
+        );
+    }
+    if let Some(pct) = config.context_handoff_escalate_pct {
+        inst.insert(
+            "context_handoff_escalate_pct".into(),
+            serde_yaml_ng::Value::Number(serde_yaml_ng::Number::from(pct as f64)),
         );
     }
     inst

--- a/src/fleet/mod.rs
+++ b/src/fleet/mod.rs
@@ -1015,6 +1015,12 @@ pub struct InstanceYamlEntry {
     /// Mirror of [`InstanceConfig::created_by`] — the identified caller that
     /// ran `create_instance`, written at spawn time.
     pub created_by: Option<String>,
+    /// Mirror of [`InstanceConfig::context_alert_pct`].
+    pub context_alert_pct: Option<f32>,
+    /// Mirror of [`InstanceConfig::context_handoff_pct`].
+    pub context_handoff_pct: Option<f32>,
+    /// Mirror of [`InstanceConfig::context_handoff_escalate_pct`].
+    pub context_handoff_escalate_pct: Option<f32>,
 }
 
 // Persistence, merge, and team mutation functions live in fleet::persist and fleet::merge.

--- a/src/fleet/tests.rs
+++ b/src/fleet/tests.rs
@@ -2320,3 +2320,184 @@ instances:
     );
     fs::remove_dir_all(&dir).ok();
 }
+
+// ── PR #2864 / Issue #2863: context threshold template→fleet contract ──
+
+#[test]
+fn context_threshold_round_trips_through_fleet_yaml() {
+    let dir = std::env::temp_dir().join(format!(
+        "agend-fleet-ctx-rt-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos(),
+    ));
+    let path = write_fleet(
+        &dir,
+        r#"
+instances:
+  ctx-agent:
+    backend: claude
+    context_alert_pct: 75.0
+    context_handoff_pct: 85.0
+    context_handoff_escalate_pct: 95.0
+"#,
+    );
+    let config = FleetConfig::load(&path).expect("load");
+    let inst = config.instances.get("ctx-agent").expect("ctx-agent");
+    assert_eq!(
+        inst.context_alert_pct,
+        Some(75.0),
+        "context_alert_pct must round-trip"
+    );
+    assert_eq!(
+        inst.context_handoff_pct,
+        Some(85.0),
+        "context_handoff_pct must round-trip"
+    );
+    assert_eq!(
+        inst.context_handoff_escalate_pct,
+        Some(95.0),
+        "context_handoff_escalate_pct must round-trip"
+    );
+    fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn context_threshold_absent_resolves_to_none() {
+    let dir = std::env::temp_dir().join(format!(
+        "agend-fleet-ctx-absent-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos(),
+    ));
+    let path = write_fleet(
+        &dir,
+        r#"
+instances:
+  plain-agent:
+    backend: claude
+"#,
+    );
+    let config = FleetConfig::load(&path).expect("load");
+    let inst = config.instances.get("plain-agent").expect("plain-agent");
+    assert!(
+        inst.context_alert_pct.is_none(),
+        "absent context_alert_pct must be None"
+    );
+    assert!(
+        inst.context_handoff_pct.is_none(),
+        "absent context_handoff_pct must be None"
+    );
+    assert!(
+        inst.context_handoff_escalate_pct.is_none(),
+        "absent context_handoff_escalate_pct must be None"
+    );
+    fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn context_threshold_add_instance_persists_and_reloads() {
+    let dir = std::env::temp_dir().join(format!(
+        "agend-fleet-ctx-add-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos(),
+    ));
+    fs::create_dir_all(&dir).ok();
+    let entry = InstanceYamlEntry {
+        backend: Some("claude".to_string()),
+        context_alert_pct: Some(72.5),
+        context_handoff_pct: Some(82.5),
+        context_handoff_escalate_pct: Some(92.5),
+        ..Default::default()
+    };
+    add_instance_to_yaml(&dir, "ctx-new", &entry).expect("add");
+    let content = std::fs::read_to_string(dir.join("fleet.yaml")).expect("read");
+    assert!(
+        content.contains("context_alert_pct"),
+        "context_alert_pct must appear in persisted YAML: {content}"
+    );
+    let config = FleetConfig::load(&dir.join("fleet.yaml")).expect("reload");
+    let inst = config.instances.get("ctx-new").expect("ctx-new");
+    assert_eq!(inst.context_alert_pct, Some(72.5));
+    assert_eq!(inst.context_handoff_pct, Some(82.5));
+    assert_eq!(inst.context_handoff_escalate_pct, Some(92.5));
+    fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn context_threshold_merge_idempotent_on_same_values() {
+    let dir = std::env::temp_dir().join(format!(
+        "agend-fleet-ctx-idem-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos(),
+    ));
+    let _ = write_fleet(
+        &dir,
+        r#"
+instances:
+  ctx-idem:
+    backend: claude
+    context_alert_pct: 75.0
+    context_handoff_pct: 85.0
+"#,
+    );
+    let entry = InstanceYamlEntry {
+        backend: Some("claude".to_string()),
+        context_alert_pct: Some(75.0),
+        context_handoff_pct: Some(85.0),
+        ..Default::default()
+    };
+    let result = add_instances_to_yaml(&dir, &[("ctx-idem", &entry)]);
+    assert!(
+        result.is_ok(),
+        "re-merging same context threshold values must be idempotent: {result:?}"
+    );
+    fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn context_threshold_merge_conflict_on_changed_value() {
+    let dir = std::env::temp_dir().join(format!(
+        "agend-fleet-ctx-conflict-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos(),
+    ));
+    let _ = write_fleet(
+        &dir,
+        r#"
+instances:
+  ctx-conflict:
+    backend: claude
+    context_alert_pct: 75.0
+"#,
+    );
+    let entry = InstanceYamlEntry {
+        backend: Some("claude".to_string()),
+        context_alert_pct: Some(80.0),
+        ..Default::default()
+    };
+    let result = add_instances_to_yaml(&dir, &[("ctx-conflict", &entry)]);
+    assert!(
+        result.is_err(),
+        "merging a different context_alert_pct into an operator-edited instance must produce FieldConflict"
+    );
+    let err_msg = format!("{}", result.unwrap_err());
+    assert!(
+        err_msg.contains("context_alert_pct"),
+        "conflict message must name the field: {err_msg}"
+    );
+    fs::remove_dir_all(&dir).ok();
+}


### PR DESCRIPTION
Fixes #2863. Add support for context_alert_pct, context_handoff_pct, and context_handoff_escalate_pct in fleet templates.