### PR TITLE
ci-fail: uncertain pre-run diagnostic in fetch_failure_summary

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -15,6 +15,9 @@
 # Warn (mark SLOW) at 60s; SIGKILL the test after 2 periods (120s). Normal tests
 # finish in well under a second; a real-git test that takes >120s is wedged.
 slow-timeout = { period = "60s", terminate-after = 2 }
+# Surface the terminated/hung test prominently in the run summary.
+failure-output = "immediate-final"
+final-status-level = "slow"
 
 # build_provenance_version tests run nested `cargo build` (real git init + fixture
 # compilation). On Windows CI runners the nested build is 2-3× slower — give it
@@ -22,10 +25,6 @@ slow-timeout = { period = "60s", terminate-after = 2 }
 [[profile.ci.overrides]]
 filter = 'test(/build_provenance_version::/)'
 slow-timeout = { period = "120s", terminate-after = 3 }
-
-# Surface the terminated/hung test prominently in the run summary.
-failure-output = "immediate-final"
-final-status-level = "slow"
 
 # #1893: serialize the heavy real-git / worktree / subprocess test cluster.
 # These tests spawn real `git` (worktree add / branch / fetch) and share

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -15,6 +15,14 @@
 # Warn (mark SLOW) at 60s; SIGKILL the test after 2 periods (120s). Normal tests
 # finish in well under a second; a real-git test that takes >120s is wedged.
 slow-timeout = { period = "60s", terminate-after = 2 }
+
+# build_provenance_version tests run nested `cargo build` (real git init + fixture
+# compilation). On Windows CI runners the nested build is 2-3× slower — give it
+# 2× the normal headroom so slow-timeout doesn't false-kill it.
+[[profile.ci.overrides]]
+filter = 'test(/build_provenance_version::/)'
+slow-timeout = { period = "120s", terminate-after = 3 }
+
 # Surface the terminated/hung test prominently in the run summary.
 failure-output = "immediate-final"
 final-status-level = "slow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,8 @@ dependencies = [
  "getrandom 0.4.3",
  "hex",
  "hmac",
+ "serde",
+ "serde_json",
  "sha2 0.11.0",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,8 +98,6 @@ dependencies = [
  "getrandom 0.4.3",
  "hex",
  "hmac",
- "serde",
- "serde_json",
  "sha2 0.11.0",
 ]
 

--- a/src/daemon/ci_watch/poller_tests.rs
+++ b/src/daemon/ci_watch/poller_tests.rs
@@ -4237,12 +4237,11 @@ fn github_fetch_failure_summary_finds_failed_step() {
     assert_eq!(summary, "build / Run tests", "summary: {summary}");
 }
 
-/// When GitHub Actions billing quota is exhausted, the job has
-/// `conclusion: "failure"`, zero steps, and `runner_id: 0` (no runner
-/// assigned).  The daemon must detect this and return a descriptive
-/// detail instead of the uninformative `"unknown step"` fallback.
+/// When a job has `conclusion: "failure"`, zero steps, and `runner_id: 0`
+/// (no runner assigned), the daemon detects a pre-run failure symptom and
+/// returns a cause-unconfirmed diagnostic instead of `"unknown step"`.
 #[test]
-fn github_fetch_failure_summary_detects_billing_exhaustion() {
+fn github_fetch_failure_summary_detects_pre_run_failure() {
     let body = r#"{
         "jobs": [{
             "name": "build",
@@ -4269,13 +4268,13 @@ fn github_fetch_failure_summary_detects_billing_exhaustion() {
         "path: {path}"
     );
     assert_eq!(
-        summary, "billing quota exhausted (no runner assigned)",
+        summary, "pre-run failure: no runner assigned and no steps (cause unconfirmed)",
         "summary: {summary}"
     );
 }
 
 /// A job with zero steps but a non-zero `runner_id` (runner WAS assigned) is
-/// NOT billing exhaustion — it's a different zero-step failure mode.  The
+/// NOT a pre-run failure — it's a different zero-step failure mode.  The
 /// daemon must fall back to `"unknown step"` (the same fallback a real-but-
 /// unclassifiable failure gets).
 #[test]

--- a/src/daemon/ci_watch/poller_tests.rs
+++ b/src/daemon/ci_watch/poller_tests.rs
@@ -4308,18 +4308,21 @@ fn github_fetch_failure_summary_unknown_step_when_runner_was_assigned() {
     assert_eq!(summary, "unknown step", "summary: {summary}");
 }
 
-// --- billing detection conservative contract (RED + guard) ---
+// --- pre-run failure detection conservative contract (RED + guard) ---
 //
-// The conservative contract requires explicit evidence before claiming
-// billing exhaustion: runner_id must be explicitly 0 (not missing/null),
-// steps must be an explicit empty array, and conclusion must be "failure".
-// Real step failures always take precedence over the billing heuristic.
+// The conservative contract treats zero-step + no-runner as an observable
+// pre-run symptom, NOT proof of any specific cause (billing, quota,
+// infrastructure). The Detail message must reflect this uncertainty.
+// runner_id must be explicitly 0 (not missing/null), steps must be an
+// explicit empty array, conclusion must be "failure", and the output
+// message must not claim a specific diagnosed cause.
+// Real step failures always take precedence over the pre-run heuristic.
 
 /// RED: missing `runner_id` field is ambiguous — a partial API response may
-/// omit it without implying billing exhaustion. Must fall back to "unknown
-/// step", not claim billing.
+/// omit it without implying a pre-run failure. Must fall back to "unknown
+/// step", not claim any diagnosed cause.
 #[test]
-fn github_billing_false_positive_runner_id_missing() {
+fn github_pre_run_false_positive_runner_id_missing() {
     let body = r#"{
         "jobs": [{
             "name": "build",
@@ -4340,14 +4343,14 @@ fn github_billing_false_positive_runner_id_missing() {
     handle.join().expect("mock");
     assert_eq!(
         summary, "unknown step",
-        "missing runner_id must not trigger billing detection; got: {summary}"
+        "missing runner_id must not trigger pre-run detection; got: {summary}"
     );
 }
 
 /// RED: `runner_id: null` is ambiguous — the API may return null without
 /// confirming no runner was assigned. Must fall back to "unknown step".
 #[test]
-fn github_billing_false_positive_runner_id_null() {
+fn github_pre_run_false_positive_runner_id_null() {
     let body = r#"{
         "jobs": [{
             "name": "build",
@@ -4369,14 +4372,46 @@ fn github_billing_false_positive_runner_id_null() {
     handle.join().expect("mock");
     assert_eq!(
         summary, "unknown step",
-        "null runner_id must not trigger billing detection; got: {summary}"
+        "null runner_id must not trigger pre-run detection; got: {summary}"
+    );
+}
+
+/// RED: even explicit runner_id=0 + steps=[] is only an observable pre-run
+/// symptom — zero-step + no-runner does not uniquely prove billing. The
+/// conservative contract requires uncertainty-aware messaging, not a
+/// diagnosed cause claim.
+#[test]
+fn github_pre_run_explicit_zero_uncertain_message() {
+    let body = r#"{
+        "jobs": [{
+            "name": "build",
+            "conclusion": "failure",
+            "steps": [],
+            "runner_id": 0,
+            "runner_name": ""
+        }]
+    }"#;
+    let (port, handle, _captured) = github_mock_server(body);
+    let provider = super::GitHubCiProvider::with_base_url(format!("http://127.0.0.1:{port}"))
+        .expect("provider");
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("rt");
+    let summary = rt.block_on(provider.fetch_failure_summary("foo/bar", 67));
+
+    handle.join().expect("mock");
+    assert_eq!(
+        summary, "pre-run failure: no runner assigned and no steps (cause unconfirmed)",
+        "explicit zero must use uncertain pre-run message, not claim billing; got: {summary}"
     );
 }
 
 /// Guard: `steps: null` with `runner_id: 0` — null is not an empty array.
-/// Must not trigger billing detection.
+/// Must not trigger pre-run detection.
 #[test]
-fn github_billing_guard_steps_null_not_triggered() {
+fn github_pre_run_guard_steps_null_not_triggered() {
     let body = r#"{
         "jobs": [{
             "name": "build",
@@ -4398,14 +4433,14 @@ fn github_billing_guard_steps_null_not_triggered() {
     handle.join().expect("mock");
     assert_eq!(
         summary, "unknown step",
-        "null steps must not trigger billing detection; got: {summary}"
+        "null steps must not trigger pre-run detection; got: {summary}"
     );
 }
 
 /// Guard: steps field entirely omitted with `runner_id: 0` — absent field
-/// is not an empty array. Must not trigger billing detection.
+/// is not an empty array. Must not trigger pre-run detection.
 #[test]
-fn github_billing_guard_steps_omitted_not_triggered() {
+fn github_pre_run_guard_steps_omitted_not_triggered() {
     let body = r#"{
         "jobs": [{
             "name": "build",
@@ -4426,15 +4461,15 @@ fn github_billing_guard_steps_omitted_not_triggered() {
     handle.join().expect("mock");
     assert_eq!(
         summary, "unknown step",
-        "omitted steps field must not trigger billing detection; got: {summary}"
+        "omitted steps field must not trigger pre-run detection; got: {summary}"
     );
 }
 
 /// Guard: `conclusion: "cancelled"` with zero steps and no runner is NOT
-/// billing exhaustion — only `"failure"` conclusions qualify. Covers the
+/// a pre-run failure — only `"failure"` conclusions qualify. Covers the
 /// "other terminal conclusions" contract.
 #[test]
-fn github_billing_guard_cancelled_not_triggered() {
+fn github_pre_run_guard_cancelled_not_triggered() {
     let body = r#"{
         "jobs": [{
             "name": "build",
@@ -4456,15 +4491,15 @@ fn github_billing_guard_cancelled_not_triggered() {
     handle.join().expect("mock");
     assert_eq!(
         summary, "unknown step",
-        "cancelled conclusion must not trigger billing detection; got: {summary}"
+        "cancelled conclusion must not trigger pre-run detection; got: {summary}"
     );
 }
 
-/// Guard: mixed jobs — one billing-exhausted job plus another with a real
+/// Guard: mixed jobs — one pre-run-failed job plus another with a real
 /// failed step. The real step failure must take precedence (find_map
-/// discovers the failed step before detect_billing_exhaustion runs).
+/// discovers the failed step before the pre-run heuristic runs).
 #[test]
-fn github_billing_guard_mixed_real_failure_precedence() {
+fn github_pre_run_guard_mixed_real_failure_precedence() {
     let body = r#"{
         "jobs": [
             {
@@ -4497,15 +4532,15 @@ fn github_billing_guard_mixed_real_failure_precedence() {
     handle.join().expect("mock");
     assert_eq!(
         summary, "real-build / Run tests",
-        "real step failure must take precedence over billing detection; got: {summary}"
+        "real step failure must take precedence over pre-run detection; got: {summary}"
     );
 }
 
 /// Guard: a single job with `runner_id: 0` but actual failed steps is NOT
-/// billing exhaustion — the job DID execute, so the step failure takes
-/// precedence via find_map (detect_billing_exhaustion is never reached).
+/// a pre-run failure — the job DID execute, so the step failure takes
+/// precedence via find_map (pre-run heuristic is never reached).
 #[test]
-fn github_billing_guard_step_failure_precedence() {
+fn github_pre_run_guard_step_failure_precedence() {
     let body = r#"{
         "jobs": [{
             "name": "build",

--- a/src/daemon/ci_watch/poller_tests.rs
+++ b/src/daemon/ci_watch/poller_tests.rs
@@ -4308,6 +4308,232 @@ fn github_fetch_failure_summary_unknown_step_when_runner_was_assigned() {
     assert_eq!(summary, "unknown step", "summary: {summary}");
 }
 
+// --- billing detection conservative contract (RED + guard) ---
+//
+// The conservative contract requires explicit evidence before claiming
+// billing exhaustion: runner_id must be explicitly 0 (not missing/null),
+// steps must be an explicit empty array, and conclusion must be "failure".
+// Real step failures always take precedence over the billing heuristic.
+
+/// RED: missing `runner_id` field is ambiguous — a partial API response may
+/// omit it without implying billing exhaustion. Must fall back to "unknown
+/// step", not claim billing.
+#[test]
+fn github_billing_false_positive_runner_id_missing() {
+    let body = r#"{
+        "jobs": [{
+            "name": "build",
+            "conclusion": "failure",
+            "steps": []
+        }]
+    }"#;
+    let (port, handle, _captured) = github_mock_server(body);
+    let provider = super::GitHubCiProvider::with_base_url(format!("http://127.0.0.1:{port}"))
+        .expect("provider");
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("rt");
+    let summary = rt.block_on(provider.fetch_failure_summary("foo/bar", 60));
+
+    handle.join().expect("mock");
+    assert_eq!(
+        summary, "unknown step",
+        "missing runner_id must not trigger billing detection; got: {summary}"
+    );
+}
+
+/// RED: `runner_id: null` is ambiguous — the API may return null without
+/// confirming no runner was assigned. Must fall back to "unknown step".
+#[test]
+fn github_billing_false_positive_runner_id_null() {
+    let body = r#"{
+        "jobs": [{
+            "name": "build",
+            "conclusion": "failure",
+            "steps": [],
+            "runner_id": null
+        }]
+    }"#;
+    let (port, handle, _captured) = github_mock_server(body);
+    let provider = super::GitHubCiProvider::with_base_url(format!("http://127.0.0.1:{port}"))
+        .expect("provider");
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("rt");
+    let summary = rt.block_on(provider.fetch_failure_summary("foo/bar", 61));
+
+    handle.join().expect("mock");
+    assert_eq!(
+        summary, "unknown step",
+        "null runner_id must not trigger billing detection; got: {summary}"
+    );
+}
+
+/// Guard: `steps: null` with `runner_id: 0` — null is not an empty array.
+/// Must not trigger billing detection.
+#[test]
+fn github_billing_guard_steps_null_not_triggered() {
+    let body = r#"{
+        "jobs": [{
+            "name": "build",
+            "conclusion": "failure",
+            "steps": null,
+            "runner_id": 0
+        }]
+    }"#;
+    let (port, handle, _captured) = github_mock_server(body);
+    let provider = super::GitHubCiProvider::with_base_url(format!("http://127.0.0.1:{port}"))
+        .expect("provider");
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("rt");
+    let summary = rt.block_on(provider.fetch_failure_summary("foo/bar", 62));
+
+    handle.join().expect("mock");
+    assert_eq!(
+        summary, "unknown step",
+        "null steps must not trigger billing detection; got: {summary}"
+    );
+}
+
+/// Guard: steps field entirely omitted with `runner_id: 0` — absent field
+/// is not an empty array. Must not trigger billing detection.
+#[test]
+fn github_billing_guard_steps_omitted_not_triggered() {
+    let body = r#"{
+        "jobs": [{
+            "name": "build",
+            "conclusion": "failure",
+            "runner_id": 0
+        }]
+    }"#;
+    let (port, handle, _captured) = github_mock_server(body);
+    let provider = super::GitHubCiProvider::with_base_url(format!("http://127.0.0.1:{port}"))
+        .expect("provider");
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("rt");
+    let summary = rt.block_on(provider.fetch_failure_summary("foo/bar", 63));
+
+    handle.join().expect("mock");
+    assert_eq!(
+        summary, "unknown step",
+        "omitted steps field must not trigger billing detection; got: {summary}"
+    );
+}
+
+/// Guard: `conclusion: "cancelled"` with zero steps and no runner is NOT
+/// billing exhaustion — only `"failure"` conclusions qualify. Covers the
+/// "other terminal conclusions" contract.
+#[test]
+fn github_billing_guard_cancelled_not_triggered() {
+    let body = r#"{
+        "jobs": [{
+            "name": "build",
+            "conclusion": "cancelled",
+            "steps": [],
+            "runner_id": 0
+        }]
+    }"#;
+    let (port, handle, _captured) = github_mock_server(body);
+    let provider = super::GitHubCiProvider::with_base_url(format!("http://127.0.0.1:{port}"))
+        .expect("provider");
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("rt");
+    let summary = rt.block_on(provider.fetch_failure_summary("foo/bar", 64));
+
+    handle.join().expect("mock");
+    assert_eq!(
+        summary, "unknown step",
+        "cancelled conclusion must not trigger billing detection; got: {summary}"
+    );
+}
+
+/// Guard: mixed jobs — one billing-exhausted job plus another with a real
+/// failed step. The real step failure must take precedence (find_map
+/// discovers the failed step before detect_billing_exhaustion runs).
+#[test]
+fn github_billing_guard_mixed_real_failure_precedence() {
+    let body = r#"{
+        "jobs": [
+            {
+                "name": "blocked-by-quota",
+                "conclusion": "failure",
+                "steps": [],
+                "runner_id": 0
+            },
+            {
+                "name": "real-build",
+                "conclusion": "failure",
+                "steps": [
+                    {"name": "Checkout", "conclusion": "success"},
+                    {"name": "Run tests", "conclusion": "failure"}
+                ],
+                "runner_id": 7
+            }
+        ]
+    }"#;
+    let (port, handle, _captured) = github_mock_server(body);
+    let provider = super::GitHubCiProvider::with_base_url(format!("http://127.0.0.1:{port}"))
+        .expect("provider");
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("rt");
+    let summary = rt.block_on(provider.fetch_failure_summary("foo/bar", 65));
+
+    handle.join().expect("mock");
+    assert_eq!(
+        summary, "real-build / Run tests",
+        "real step failure must take precedence over billing detection; got: {summary}"
+    );
+}
+
+/// Guard: a single job with `runner_id: 0` but actual failed steps is NOT
+/// billing exhaustion — the job DID execute, so the step failure takes
+/// precedence via find_map (detect_billing_exhaustion is never reached).
+#[test]
+fn github_billing_guard_step_failure_precedence() {
+    let body = r#"{
+        "jobs": [{
+            "name": "build",
+            "conclusion": "failure",
+            "steps": [
+                {"name": "Setup", "conclusion": "success"},
+                {"name": "Compile", "conclusion": "failure"}
+            ],
+            "runner_id": 0
+        }]
+    }"#;
+    let (port, handle, _captured) = github_mock_server(body);
+    let provider = super::GitHubCiProvider::with_base_url(format!("http://127.0.0.1:{port}"))
+        .expect("provider");
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("rt");
+    let summary = rt.block_on(provider.fetch_failure_summary("foo/bar", 66));
+
+    handle.join().expect("mock");
+    assert_eq!(
+        summary, "build / Compile",
+        "step failure must take precedence even with runner_id=0; got: {summary}"
+    );
+}
+
 #[test]
 fn github_check_pr_terminal_returns_unknown_on_head_ref_mismatch() {
     // Hotfix F gap gate 2 (defensive): even with the correct URL,

--- a/src/daemon/ci_watch/poller_tests.rs
+++ b/src/daemon/ci_watch/poller_tests.rs
@@ -4237,6 +4237,77 @@ fn github_fetch_failure_summary_finds_failed_step() {
     assert_eq!(summary, "build / Run tests", "summary: {summary}");
 }
 
+/// When GitHub Actions billing quota is exhausted, the job has
+/// `conclusion: "failure"`, zero steps, and `runner_id: 0` (no runner
+/// assigned).  The daemon must detect this and return a descriptive
+/// detail instead of the uninformative `"unknown step"` fallback.
+#[test]
+fn github_fetch_failure_summary_detects_billing_exhaustion() {
+    let body = r#"{
+        "jobs": [{
+            "name": "build",
+            "conclusion": "failure",
+            "steps": [],
+            "runner_id": 0,
+            "runner_name": ""
+        }]
+    }"#;
+    let (port, handle, captured) = github_mock_server(body);
+    let provider = super::GitHubCiProvider::with_base_url(format!("http://127.0.0.1:{port}"))
+        .expect("provider");
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("rt");
+    let summary = rt.block_on(provider.fetch_failure_summary("foo/bar", 49));
+
+    handle.join().expect("mock");
+    let (path, _req) = captured.lock().expect("lock").take().expect("captured");
+    assert!(
+        path.contains("/repos/foo/bar/actions/runs/49/jobs"),
+        "path: {path}"
+    );
+    assert_eq!(
+        summary, "billing quota exhausted (no runner assigned)",
+        "summary: {summary}"
+    );
+}
+
+/// A job with zero steps but a non-zero `runner_id` (runner WAS assigned) is
+/// NOT billing exhaustion — it's a different zero-step failure mode.  The
+/// daemon must fall back to `"unknown step"` (the same fallback a real-but-
+/// unclassifiable failure gets).
+#[test]
+fn github_fetch_failure_summary_unknown_step_when_runner_was_assigned() {
+    let body = r#"{
+        "jobs": [{
+            "name": "build",
+            "conclusion": "failure",
+            "steps": [],
+            "runner_id": 42,
+            "runner_name": "github-actions-runner"
+        }]
+    }"#;
+    let (port, handle, captured) = github_mock_server(body);
+    let provider = super::GitHubCiProvider::with_base_url(format!("http://127.0.0.1:{port}"))
+        .expect("provider");
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("rt");
+    let summary = rt.block_on(provider.fetch_failure_summary("foo/bar", 50));
+
+    handle.join().expect("mock");
+    let (path, _req) = captured.lock().expect("lock").take().expect("captured");
+    assert!(
+        path.contains("/repos/foo/bar/actions/runs/50/jobs"),
+        "path: {path}"
+    );
+    assert_eq!(summary, "unknown step", "summary: {summary}");
+}
+
 #[test]
 fn github_check_pr_terminal_returns_unknown_on_head_ref_mismatch() {
     // Hotfix F gap gate 2 (defensive): even with the correct URL,

--- a/src/daemon/ci_watch/provider.rs
+++ b/src/daemon/ci_watch/provider.rs
@@ -838,7 +838,10 @@ impl CiProvider for GitHubCiProvider {
                     })
                 })
             })
-            .unwrap_or_else(|| "unknown step".to_string())
+            .unwrap_or_else(|| {
+                detect_billing_exhaustion(&jobs_resp)
+                    .unwrap_or_else(|| "unknown step".to_string())
+            })
     }
 
     async fn fetch_run_jobs(&self, repo: &str, run_id: u64) -> Vec<CiJob> {
@@ -1015,6 +1018,32 @@ impl CiProvider for GitHubCiProvider {
 
     fn token_warning(&self) -> Option<&'static str> {
         github_token_warning(std::env::var("GITHUB_TOKEN").ok().as_deref())
+    }
+}
+
+/// When a job has `conclusion: "failure"` but zero steps and no runner
+/// assigned, the failure is not a code error — it's a billing / spending
+/// limit exhaustion (the job was rejected at the GitHub scheduler level).
+/// Returns `Some("billing quota exhausted (no runner assigned)")` in that
+/// case, or `None` if the zero-step failure doesn't match the billing profile.
+fn detect_billing_exhaustion(jobs_resp: &serde_json::Value) -> Option<String> {
+    let jobs = jobs_resp["jobs"].as_array()?;
+    let zero_step_failed = jobs.iter().any(|job| {
+        let failed = job["conclusion"]
+            .as_str()
+            .is_some_and(|c| matches!(super::poller::CiOutcome::from(Some(c)), super::poller::CiOutcome::Failure));
+        let no_steps = job["steps"]
+            .as_array()
+            .is_some_and(|s| s.is_empty());
+        let no_runner = job["runner_id"]
+            .as_u64()
+            .is_none_or(|id| id == 0);
+        failed && no_steps && no_runner
+    });
+    if zero_step_failed {
+        Some("billing quota exhausted (no runner assigned)".to_string())
+    } else {
+        None
     }
 }
 

--- a/src/daemon/ci_watch/provider.rs
+++ b/src/daemon/ci_watch/provider.rs
@@ -839,8 +839,7 @@ impl CiProvider for GitHubCiProvider {
                 })
             })
             .unwrap_or_else(|| {
-                detect_billing_exhaustion(&jobs_resp)
-                    .unwrap_or_else(|| "unknown step".to_string())
+                detect_billing_exhaustion(&jobs_resp).unwrap_or_else(|| "unknown step".to_string())
             })
     }
 
@@ -1029,15 +1028,14 @@ impl CiProvider for GitHubCiProvider {
 fn detect_billing_exhaustion(jobs_resp: &serde_json::Value) -> Option<String> {
     let jobs = jobs_resp["jobs"].as_array()?;
     let zero_step_failed = jobs.iter().any(|job| {
-        let failed = job["conclusion"]
-            .as_str()
-            .is_some_and(|c| matches!(super::poller::CiOutcome::from(Some(c)), super::poller::CiOutcome::Failure));
-        let no_steps = job["steps"]
-            .as_array()
-            .is_some_and(|s| s.is_empty());
-        let no_runner = job["runner_id"]
-            .as_u64()
-            .is_none_or(|id| id == 0);
+        let failed = job["conclusion"].as_str().is_some_and(|c| {
+            matches!(
+                super::poller::CiOutcome::from(Some(c)),
+                super::poller::CiOutcome::Failure
+            )
+        });
+        let no_steps = job["steps"].as_array().is_some_and(|s| s.is_empty());
+        let no_runner = job["runner_id"].as_u64().is_none_or(|id| id == 0);
         failed && no_steps && no_runner
     });
     if zero_step_failed {

--- a/src/daemon/ci_watch/provider.rs
+++ b/src/daemon/ci_watch/provider.rs
@@ -839,7 +839,7 @@ impl CiProvider for GitHubCiProvider {
                 })
             })
             .unwrap_or_else(|| {
-                detect_billing_exhaustion(&jobs_resp).unwrap_or_else(|| "unknown step".to_string())
+                detect_pre_run_failure(&jobs_resp).unwrap_or_else(|| "unknown step".to_string())
             })
     }
 
@@ -1020,14 +1020,15 @@ impl CiProvider for GitHubCiProvider {
     }
 }
 
-/// When a job has `conclusion: "failure"` but zero steps and no runner
-/// assigned, the failure is not a code error — it's a billing / spending
-/// limit exhaustion (the job was rejected at the GitHub scheduler level).
-/// Returns `Some("billing quota exhausted (no runner assigned)")` in that
-/// case, or `None` if the zero-step failure doesn't match the billing profile.
-fn detect_billing_exhaustion(jobs_resp: &serde_json::Value) -> Option<String> {
+/// When a job has `conclusion: "failure"` but zero steps and runner_id
+/// explicitly 0, the job never reached a runner — an observable pre-run
+/// symptom whose root cause (billing quota, infrastructure, transient
+/// scheduler error) cannot be confirmed from the API response alone.
+/// Returns a cause-unconfirmed diagnostic, or `None` if the pattern does
+/// not match.
+fn detect_pre_run_failure(jobs_resp: &serde_json::Value) -> Option<String> {
     let jobs = jobs_resp["jobs"].as_array()?;
-    let zero_step_failed = jobs.iter().any(|job| {
+    let pre_run_failed = jobs.iter().any(|job| {
         let failed = job["conclusion"].as_str().is_some_and(|c| {
             matches!(
                 super::poller::CiOutcome::from(Some(c)),
@@ -1035,11 +1036,11 @@ fn detect_billing_exhaustion(jobs_resp: &serde_json::Value) -> Option<String> {
             )
         });
         let no_steps = job["steps"].as_array().is_some_and(|s| s.is_empty());
-        let no_runner = job["runner_id"].as_u64().is_none_or(|id| id == 0);
+        let no_runner = job["runner_id"].as_u64() == Some(0);
         failed && no_steps && no_runner
     });
-    if zero_step_failed {
-        Some("billing quota exhausted (no runner assigned)".to_string())
+    if pre_run_failed {
+        Some("pre-run failure: no runner assigned and no steps (cause unconfirmed)".to_string())
     } else {
         None
     }


### PR DESCRIPTION
## What

When GitHub Actions jobs have `conclusion: "failure"` but zero steps (`steps: []`) and `runner_id: 0` — the job was rejected at the scheduler level before any step ran. Previously `GitHubCiProvider::fetch_failure_summary` only searched for failed steps within jobs and fell back to `"unknown step"`, so the receiving agent had no way to distinguish this pre-run failure pattern from a real code failure.

## How

Added `detect_pre_run_failure()` — a module-level helper in `provider.rs` that checks for the zero-step + explicit-zero-runner pattern. When detected, returns a cause-unconfirmed diagnostic: `"pre-run failure: no runner assigned and no steps (cause unconfirmed)"` — the root cause (billing quota, infrastructure, transient scheduler error) cannot be confirmed from the API response alone.

The detection requires all three conditions: failed conclusion, explicitly empty steps array, and `runner_id` explicitly `0`. Missing or null `runner_id` falls through to `"unknown step"` (conservative: absence is not evidence). A zero-step failure with a runner assigned (different root cause) also falls through.

## Portability

The zero-step + no-runner tuple proves only a pre-run symptom. The underlying cause varies by runner type and repository visibility:

- **Public repos, standard runners**: free hosted minutes — billing exhaustion is not possible, but scheduler/infrastructure failures still produce this pattern.
- **Private repos, standard runners**: consume the repository owner's included allowance or spending limit — billing/quota exhaustion is a plausible cause, but not the only one.
- **Larger runners (public or private)**: always billed — quota exhaustion is plausible.
- **Self-hosted runners**: outside GitHub's hosted-minute billing entirely — this pattern would indicate infrastructure/registration issues, not billing.
- **Reusable workflows**: billing context follows the caller repository, not the callee.

Any billing-specific diagnosis would require stronger primary evidence (e.g., the Actions billing API or run annotations) beyond what the jobs endpoint provides. The current `cause unconfirmed` production message is intentionally portable across all these contexts.

## Tests

- **Pre-existing**: positive detection + assigned-runner negative (updated names/expectations)
- **RED-first contract (8 tests)**: 3 RED pins (runner_id missing/null false positives, explicit-zero uncertain message) turned GREEN by the production fix + 5 guards (steps null/omitted, cancelled conclusion, mixed real-failure precedence, step-failure precedence)

## Scope

- `src/daemon/ci_watch/provider.rs` — pre-run detection logic (rename + runner_id strictness + uncertain message)
- `src/daemon/ci_watch/poller_tests.rs` — 8 RED-first contract tests + 2 pre-existing test updates
- `.config/nextest.toml` — bounded Windows nextest timeout for `build_provenance_version` tests (remediation for observed branch-CI hang; authored by opencode-9a72c0 in e7e704ff)

No change to the notification pipeline, `CiOutcome` enum, `[ci-fail]` message format, or any outcome/retry/merge-gate behavior — just the `Detail:` field becomes informative with uncertainty-aware messaging.

Closes #2865