### PR TITLE
fix: roll back auto-created checkout branch on worktree failure

### DIFF
--- a/src/mcp/handlers/ci/checkout.rs
+++ b/src/mcp/handlers/ci/checkout.rs
@@ -697,36 +697,22 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
             }
             // Committed durable ⇒ transaction resolved; drop the journal tombstone.
             super::checkout_txn::Journal::clear(home, &mangled);
-            // #6: echo expected_head/actual_head only when the caller supplied it
-            // (omitted → no new fields, byte-compatible with pre-#6 callers).
-            // Re-read the actual HEAD from the provisioned worktree rather than
-            // echoing the expected value — the worktree is the ground truth.
-            if let Some(expected) = args["expected_head"].as_str() {
-                let actual = crate::git_helpers::git_cmd(
-                    Path::new(&worktree_path_str),
-                    &["rev-parse", "HEAD"],
-                )
-                .unwrap_or_default();
-                let actual = actual.trim();
-                resp["actual_head"] = json!(actual);
-                resp["expected_head"] = json!(expected);
-            }
+            super::checkout_helpers::annotate_actual_head(
+                &mut resp,
+                args["expected_head"].as_str(),
+                Path::new(&worktree_path_str),
+            );
             resp
         }
         Ok(o) => {
-            // Prepared journal but `git worktree add` failed ⇒ no worktree to roll
-            // back. If this transaction created the branch, remove only that ref;
-            // pre-existing branches are never touched.
-            if bind && auto_created_branch {
-                super::checkout_disposable::rollback_auto_created_branch(
-                    Path::new(&source_path),
-                    branch,
-                    args["expected_head"].as_str().unwrap_or(""),
-                );
-            }
+            super::checkout_helpers::rollback_auto_created_branch_if_needed(
+                Path::new(&source_path),
+                branch,
+                args["expected_head"].as_str().unwrap_or(""),
+                bind && auto_created_branch,
+            );
             super::checkout_txn::Journal::clear(home, &mangled);
-            let stderr = String::from_utf8_lossy(&o.stderr).to_string();
-            let redacted = redact_paths(stderr.trim());
+            let redacted = redact_paths(String::from_utf8_lossy(&o.stderr).trim());
             let mut err = json!({
                 "error": format!("git worktree add failed: {redacted}"),
                 "code": "worktree_add_failed",
@@ -740,13 +726,12 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
             err
         }
         Err(e) => {
-            if bind && auto_created_branch {
-                super::checkout_disposable::rollback_auto_created_branch(
-                    Path::new(&source_path),
-                    branch,
-                    args["expected_head"].as_str().unwrap_or(""),
-                );
-            }
+            super::checkout_helpers::rollback_auto_created_branch_if_needed(
+                Path::new(&source_path),
+                branch,
+                args["expected_head"].as_str().unwrap_or(""),
+                bind && auto_created_branch,
+            );
             super::checkout_txn::Journal::clear(home, &mangled);
             let spawn_err = redact_paths(&e.to_string());
             let mut err = json!({

--- a/src/mcp/handlers/ci/checkout.rs
+++ b/src/mcp/handlers/ci/checkout.rs
@@ -715,7 +715,15 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
         }
         Ok(o) => {
             // Prepared journal but `git worktree add` failed ⇒ no worktree to roll
-            // back; drop the journal.
+            // back. If this transaction created the branch, remove only that ref;
+            // pre-existing branches are never touched.
+            if bind && auto_created_branch {
+                super::checkout_disposable::rollback_auto_created_branch(
+                    Path::new(&source_path),
+                    branch,
+                    args["expected_head"].as_str().unwrap_or(""),
+                );
+            }
             super::checkout_txn::Journal::clear(home, &mangled);
             let stderr = String::from_utf8_lossy(&o.stderr).to_string();
             let redacted = redact_paths(stderr.trim());
@@ -732,6 +740,13 @@ fn handle_checkout_repo_inner(home: &Path, args: &Value, instance_name: &str) ->
             err
         }
         Err(e) => {
+            if bind && auto_created_branch {
+                super::checkout_disposable::rollback_auto_created_branch(
+                    Path::new(&source_path),
+                    branch,
+                    args["expected_head"].as_str().unwrap_or(""),
+                );
+            }
             super::checkout_txn::Journal::clear(home, &mangled);
             let spawn_err = redact_paths(&e.to_string());
             let mut err = json!({

--- a/src/mcp/handlers/ci/checkout_helpers.rs
+++ b/src/mcp/handlers/ci/checkout_helpers.rs
@@ -27,6 +27,30 @@ pub(crate) fn checkout_source(args: &Value) -> Option<&str> {
         .filter(|s| !s.is_empty())
 }
 
+/// Echo the actual provisioned HEAD only when the caller supplied an exact-head
+/// expectation; the worktree remains the source of truth for the observed value.
+pub(super) fn annotate_actual_head(resp: &mut Value, expected: Option<&str>, worktree: &Path) {
+    if let Some(expected) = expected {
+        let actual =
+            crate::git_helpers::git_cmd(worktree, &["rev-parse", "HEAD"]).unwrap_or_default();
+        resp["actual_head"] = json!(actual.trim());
+        resp["expected_head"] = json!(expected);
+    }
+}
+
+/// Remove only a branch authored by this checkout transaction after worktree-add
+/// failure; pre-existing refs are never touched.
+pub(super) fn rollback_auto_created_branch_if_needed(
+    source: &Path,
+    branch: &str,
+    expected_head: &str,
+    should_rollback: bool,
+) {
+    if should_rollback {
+        super::checkout_disposable::rollback_auto_created_branch(source, branch, expected_head);
+    }
+}
+
 #[cfg(all(test, unix))]
 use std::cell::RefCell;
 

--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -1875,6 +1875,117 @@ fn p780_setup_source_broken_origin(parent: &Path) -> std::path::PathBuf {
     repo
 }
 
+#[cfg(unix)]
+fn p780_checkout_target(home: &Path, agent: &str, source: &Path) -> std::path::PathBuf {
+    home.join("worktrees").join(format!(
+        "{}-{}",
+        agent,
+        source
+            .display()
+            .to_string()
+            .replace(['/', '\\', ':'], "_")
+            .replace('~', "")
+    ))
+}
+
+#[cfg(unix)]
+fn p780_branch_exists(source: &Path, branch: &str) -> bool {
+    std::process::Command::new("git")
+        .args(["rev-parse", "--verify", &format!("refs/heads/{branch}")])
+        .current_dir(source)
+        .env("AGEND_GIT_BYPASS", "1")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .expect("git rev-parse branch")
+        .success()
+}
+
+/// Arch14 residue: a checkout that auto-created its branch must delete only that
+/// branch when the fixed worktree target is already occupied and `git worktree add`
+/// fails. The occupied target is deliberately preserved as out-of-scope state.
+#[test]
+#[cfg(unix)]
+fn checkout_bind_true_worktree_add_failure_rolls_back_auto_created_branch_arch14() {
+    let home = p778_tmp_home("arch14-branch-rollback-new");
+    let parent = p778_tmp_home("arch14-branch-rollback-new-src");
+    let source = p780_setup_source_broken_origin(&parent);
+    let agent = "arch14-rollback-new-agent";
+    let branch = "feat/arch14-rollback-new";
+    let target = p780_checkout_target(&home, agent, &source);
+    std::fs::create_dir_all(&target).expect("occupied checkout target");
+    let keep = target.join("KEEP.txt");
+    std::fs::write(&keep, "legacy dirty worktree state").expect("preserved target state");
+
+    let resp = super::handle_checkout_repo(
+        &home,
+        &serde_json::json!({
+            "repository_path": source.display().to_string(),
+            "branch": branch,
+            "bind": true,
+        }),
+        agent,
+    );
+
+    assert_eq!(resp["code"].as_str(), Some("worktree_add_failed"), "{resp}");
+    assert_eq!(resp["auto_created_branch"].as_bool(), Some(true), "{resp}");
+    assert!(
+        !p780_branch_exists(&source, branch),
+        "a branch created by this failed checkout must be rolled back: {resp}"
+    );
+    assert!(
+        keep.exists(),
+        "the pre-existing occupied target and its dirty state must be preserved"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&parent).ok();
+}
+
+/// Arch14 guard: the same worktree-add failure must never delete a branch that
+/// existed before this checkout transaction began.
+#[test]
+#[cfg(unix)]
+fn checkout_bind_true_worktree_add_failure_preserves_preexisting_branch_arch14() {
+    let home = p778_tmp_home("arch14-branch-rollback-existing");
+    let parent = p778_tmp_home("arch14-branch-rollback-existing-src");
+    let source = p780_setup_source_broken_origin(&parent);
+    let agent = "arch14-rollback-existing-agent";
+    let branch = "feat/arch14-rollback-existing";
+    let create = std::process::Command::new("git")
+        .args(["branch", branch, "main"])
+        .current_dir(&source)
+        .env("AGEND_GIT_BYPASS", "1")
+        .output()
+        .expect("create pre-existing branch");
+    assert!(create.status.success(), "create branch: {:?}", create);
+    let target = p780_checkout_target(&home, agent, &source);
+    std::fs::create_dir_all(&target).expect("occupied checkout target");
+    let keep = target.join("KEEP.txt");
+    std::fs::write(&keep, "legacy dirty worktree state").expect("preserved target state");
+
+    let resp = super::handle_checkout_repo(
+        &home,
+        &serde_json::json!({
+            "repository_path": source.display().to_string(),
+            "branch": branch,
+            "bind": true,
+        }),
+        agent,
+    );
+
+    assert_eq!(resp["code"].as_str(), Some("worktree_add_failed"), "{resp}");
+    assert_eq!(resp["auto_created_branch"].as_bool(), Some(false), "{resp}");
+    assert!(
+        p780_branch_exists(&source, branch),
+        "a pre-existing branch must survive a failed checkout: {resp}"
+    );
+    assert!(keep.exists(), "the occupied target must be preserved");
+
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&parent).ok();
+}
+
 #[test]
 #[cfg(unix)]
 fn checkout_bind_true_invalid_from_ref_returns_structured_error_with_stage() {


### PR DESCRIPTION
## Summary
- roll back only branches auto-created by `repo checkout bind=true` when `git worktree add` fails
- preserve pre-existing branches and occupied worktree state
- add Arch14 regression coverage for both cases

## Validation
- RED: `a2baf022` failed the new auto-created-branch assertion before the fix
- GREEN: `cargo test --bin agend-terminal 'mcp::handlers::ci::tests::checkout_' -- --nocapture`\n- `cargo fmt -- --check`\n- `cargo clippy --bin agend-terminal --tests --no-deps -- -D warnings`