### PR TITLE
feat: nested-submodule discard release seam (arch14)

### DIFF
--- a/src/mcp/handlers/ci/release.rs
+++ b/src/mcp/handlers/ci/release.rs
@@ -40,7 +40,12 @@ fn derive_source_from_gitlink(canonical: &Path) -> Option<std::path::PathBuf> {
         })
 }
 
-fn delegate_managed_release(home: &Path, canonical: &Path, caller: &str) -> Value {
+fn delegate_managed_release(
+    home: &Path,
+    canonical: &Path,
+    caller: &str,
+    nested_discard: Option<&crate::worktree_pool::NestedDirtDiscard<'_>>,
+) -> Value {
     let Some((marker_agent, _, _)) = parse_managed_marker(canonical) else {
         return json!({
             "error": "managed worktree marker unreadable or missing agent — refusing (fail-closed)",
@@ -67,7 +72,13 @@ fn delegate_managed_release(home: &Path, canonical: &Path, caller: &str) -> Valu
             // otherwise-valid marker whose binding no longer exists may release
             // via the target's OWN verified .git linkage — every other absent-
             // binding shape keeps the fail-closed refusal below.
-            return absent_binding_legacy_release(home, canonical, caller, &marker_agent);
+            return absent_binding_legacy_release(
+                home,
+                canonical,
+                caller,
+                &marker_agent,
+                nested_discard,
+            );
         }
         Ok(crate::binding::GuardedBinding::Opaque(reason)) | Err(reason) => {
             return json!({
@@ -118,6 +129,7 @@ fn absent_binding_legacy_release(
     canonical: &Path,
     caller: &str,
     marker_agent: &str,
+    nested_discard: Option<&crate::worktree_pool::NestedDirtDiscard<'_>>,
 ) -> Value {
     let refuse_no_binding = || {
         json!({
@@ -247,6 +259,7 @@ fn absent_binding_legacy_release(
         &source_canonical,
         sender,
         &permit,
+        nested_discard,
     );
     json!({
         "path": canonical.display().to_string(),
@@ -370,13 +383,35 @@ pub(crate) fn handle_release_repo(home: &Path, args: &Value, instance_name: &str
         None => return json!({"error": "missing 'path'"}),
     };
 
+    let discard_nested = args["discard_nested_dirt"].as_bool().unwrap_or(false);
+    let force = args["force"].as_bool().unwrap_or(false);
+    let expected_digest = args["expected_nested_dirt_digest"].as_str();
+    let audit_reason = args["audit_reason"].as_str().unwrap_or("");
+
+    let nested_discard = if discard_nested {
+        if !force {
+            return json!({"error": "nested dirt discard requires force=true"});
+        }
+        match expected_digest {
+            Some(d) => Some(crate::worktree_pool::NestedDirtDiscard {
+                expected_digest: d,
+                audit_reason,
+            }),
+            None => {
+                return json!({"error": "nested dirt discard requires expected_nested_dirt_digest"});
+            }
+        }
+    } else {
+        None
+    };
+
     let canonical = match validate_release_path(path) {
         Ok(p) => p,
         Err(e) => return json!({"error": e}),
     };
 
     if crate::worktree_pool::is_daemon_managed(&canonical) {
-        return delegate_managed_release(home, &canonical, instance_name);
+        return delegate_managed_release(home, &canonical, instance_name, nested_discard.as_ref());
     }
 
     remove_linked_worktree_canonical(&canonical, path)

--- a/src/mcp/handlers/ci/release.rs
+++ b/src/mcp/handlers/ci/release.rs
@@ -99,6 +99,13 @@ fn delegate_managed_release(
             "code": "managed_release_unauthorized",
         });
     }
+    if nested_discard.is_some() {
+        return json!({
+            "error": "nested dirt discard is not supported for Known-bound managed releases; \
+                      resolve nested dirt in place before releasing",
+            "code": "discard_unsupported_release_path",
+        });
+    }
     let outcome = crate::worktree_pool::release_full_exact(home, &marker_agent, &fingerprint, true);
     json!({
         "path": canonical.display().to_string(),
@@ -261,14 +268,18 @@ fn absent_binding_legacy_release(
         &permit,
         nested_discard,
     );
-    json!({
+    let mut resp = json!({
         "path": canonical.display().to_string(),
         "legacy_absent_binding": true,
         "released": outcome.released,
         "worktree_removed": outcome.worktree_removed,
         "git_metadata_pruned": outcome.git_metadata_pruned,
         "error": outcome.error,
-    })
+    });
+    if let Some(ref digest) = outcome.nested_dirt_digest {
+        resp["nested_dirt_digest"] = json!(digest);
+    }
+    resp
 }
 
 /// #t-…83936-6 P0 (data-loss incident): is `p` a TRUE linked git worktree — the
@@ -393,11 +404,17 @@ pub(crate) fn handle_release_repo(home: &Path, args: &Value, instance_name: &str
             return json!({"error": "nested dirt discard requires force=true"});
         }
         match expected_digest {
-            Some(d) => Some(crate::worktree_pool::NestedDirtDiscard {
-                expected_digest: d,
-                audit_reason,
-            }),
-            None => {
+            Some(d) if !d.trim().is_empty() => {
+                let reason = audit_reason.trim();
+                if reason.is_empty() {
+                    return json!({"error": "nested dirt discard requires non-empty audit_reason"});
+                }
+                Some(crate::worktree_pool::NestedDirtDiscard {
+                    expected_digest: d,
+                    audit_reason: reason,
+                })
+            }
+            _ => {
                 return json!({"error": "nested dirt discard requires expected_nested_dirt_digest"});
             }
         }
@@ -412,6 +429,14 @@ pub(crate) fn handle_release_repo(home: &Path, args: &Value, instance_name: &str
 
     if crate::worktree_pool::is_daemon_managed(&canonical) {
         return delegate_managed_release(home, &canonical, instance_name, nested_discard.as_ref());
+    }
+
+    if nested_discard.is_some() {
+        return json!({
+            "error": "nested dirt discard is not supported for unmanaged worktrees; \
+                      resolve nested dirt in place before releasing",
+            "code": "discard_unsupported_release_path",
+        });
     }
 
     remove_linked_worktree_canonical(&canonical, path)

--- a/src/mcp/handlers/force_release/s2.rs
+++ b/src/mcp/handlers/force_release/s2.rs
@@ -192,6 +192,7 @@ pub(crate) fn force_release(
             &identity.source_repo,
             sender,
             &permit,
+            None,
         ),
     };
     let dir_removed = outcome.worktree_removed
@@ -436,6 +437,7 @@ pub(crate) fn rebase_repair(
                 &identity.source_repo,
                 sender,
                 permit,
+                None,
             );
             if let Some(error) = outcome.error {
                 return Err(RepairBlocked::PathUnsafe(error));

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -388,13 +388,15 @@ pub(crate) fn def_repo() -> Value {
             "min_age_days": {"type": "integer", "description": "#817 cleanup_merged_branches: stale_idle threshold in days (default 90)."},
             "apply": {"type": "boolean", "description": "#817 cleanup_merged_branches: when false (default), returns dry-run plan; when true, deletes confirm_ids subset."},
             "confirm_ids": {"type": "array", "items": {"type": "string"}, "description": "#817 cleanup_merged_branches apply=true: subset of candidate_ids from prior dry-run to actually delete via `git branch -D`."},
-            "audit_reason": {"type": "string", "description": "#817 cleanup_merged_branches apply=true: required audit text recorded in event-log.jsonl per deleted branch with source SHA for restore."},
+            "audit_reason": {"type": "string", "description": "#817 cleanup_merged_branches apply=true: required audit text recorded in event-log.jsonl per deleted branch with source SHA for restore. release with discard_nested_dirt: required non-empty justification recorded in the event-log audit entry."},
             "from_ref": {"type": "string", "description": "checkout bind:true: base ref to auto-create `branch` from when it doesn't exist locally (default `origin/main`)."},
             "expected_head": {"type": "string", "description": "#6: optional exact full-SHA precondition. When provided, the branch HEAD must equal this value; mismatch returns structured error with zero mutation. Omitted preserves current behavior."},
             "checkout_purpose": {"type": "string", "enum": ["disposable_review"], "description": "Architecture-14 item 10: typed daemon-provisioned disposable review checkout. Requires bind=true, task_id, expected_head, and a newly-created branch."},
             "task_id": {"type": "string", "description": "#2533: checkout bind:true — optional task board id this self-claim is attributable to. Recorded in binding.json; a task_id-carrying self-claim is treated as in-dispatch (no `binding_out_of_dispatch` operator warning). Absent → unattributed bind, existing warning behavior unchanged."},
-            "force": {"type": "boolean", "description": "#2539: merge — emergency bypass for the CI fail-closed gate and the base-staleness (BEHIND/DIRTY) refusal. Requires non-empty `force_reason`; the bypass is audit-logged to fleet_events.jsonl. The handler always read this field, but it was never declared here — an MCP client validating against this schema had no way to send it, so force=true silently never reached the daemon (#2539)."},
-            "force_reason": {"type": "string", "description": "#2539: merge — required non-empty justification when `force=true`, recorded in the fleet_events.jsonl audit entry."}
+            "force": {"type": "boolean", "description": "#2539: merge — emergency bypass for the CI fail-closed gate and the base-staleness (BEHIND/DIRTY) refusal. Requires non-empty `force_reason`; the bypass is audit-logged to fleet_events.jsonl. release — required when `discard_nested_dirt=true` (confirms destructive intent)."},
+            "force_reason": {"type": "string", "description": "#2539: merge — required non-empty justification when `force=true`, recorded in the fleet_events.jsonl audit entry."},
+            "discard_nested_dirt": {"type": "boolean", "description": "release: authorize discarding unpreservable nested-submodule working-tree dirt. Requires `force=true` and a matching `expected_nested_dirt_digest` (confirmation round-trip). The digest is returned in the refusal response when nested dirt blocks a release."},
+            "expected_nested_dirt_digest": {"type": "string", "description": "release: exact hex digest of the nested-dirt enumeration, as returned by a prior refusal's `nested_dirt_digest` field. Guards against TOCTOU: the daemon re-enumerates under locks and refuses if the digest changed."}
         }, "required": ["action"]}})
 }
 
@@ -1382,5 +1384,31 @@ mod tests {
                  stale entry."
             );
         }
+    }
+
+    #[test]
+    fn repo_schema_exposes_discard_nested_dirt_params() {
+        let d = def_repo();
+        let props = &d["inputSchema"]["properties"];
+        assert!(
+            props["discard_nested_dirt"].is_object(),
+            "def_repo must declare discard_nested_dirt"
+        );
+        assert!(
+            props["expected_nested_dirt_digest"].is_object(),
+            "def_repo must declare expected_nested_dirt_digest"
+        );
+        assert!(
+            props["force"]["description"]
+                .as_str()
+                .is_some_and(|s| s.contains("discard_nested_dirt")),
+            "force description must reference discard_nested_dirt"
+        );
+        assert!(
+            props["audit_reason"]["description"]
+                .as_str()
+                .is_some_and(|s| s.contains("discard")),
+            "audit_reason description must reference discard use"
+        );
     }
 }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1198,6 +1198,8 @@ mod tests {
             ("repo", "checkout_purpose", "ci/checkout.rs typed disposable_review provenance gate (Architecture-14 item 10)"),
             ("repo", "force", "ci/merge.rs handle_merge_repo — CI/base-staleness fail-closed gate bypass (#2539)"),
             ("repo", "force_reason", "ci/merge.rs handle_merge_repo — required non-empty when force=true, audit-logged (#2539)"),
+            ("repo", "discard_nested_dirt", "ci/release.rs handle_release_repo — authorize nested-submodule dirt discard with digest round-trip"),
+            ("repo", "expected_nested_dirt_digest", "ci/release.rs handle_release_repo — TOCTOU digest gate for nested-dirt discard confirmation"),
             // ── bind_self ──
             ("bind_self", "repository_path", "mcp/handlers/worktree.rs preferred source"),
             ("bind_self", "repository", "mcp/handlers/worktree.rs legacy slug"),

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -1368,6 +1368,35 @@ pub(crate) fn enumerate_nested_dirty(wt_path: &Path) -> String {
     out
 }
 
+/// Extract the registered dirty submodule paths at the root level of `wt_path`.
+/// Returns `Ok(paths)` with the list of top-level submodule relative paths that
+/// have internal dirt (`dirty_submodule()` = true), or `Err(reason)` if the
+/// root-level status contains untracked entries (which `git submodule update`
+/// cannot clean) or the git status call itself fails.
+pub(crate) fn dirty_submodule_paths(wt_path: &Path) -> Result<Vec<String>, String> {
+    let entries = match crate::git_helpers::git_cmd(
+        wt_path,
+        &[
+            "--no-optional-locks",
+            "status",
+            "--porcelain=v2",
+            "-z",
+            "--ignore-submodules=none",
+            "--untracked-files=all",
+        ],
+    ) {
+        Ok(s) => parse_porcelain_v2_z(&s),
+        Err(e) => return Err(format!("git status failed: {e}")),
+    };
+    let mut paths = Vec::new();
+    for e in &entries {
+        if e.dirty_submodule() {
+            paths.push(e.path.clone());
+        }
+    }
+    Ok(paths)
+}
+
 /// One level of [`enumerate_nested_dirty`]. `dir_canon` is the canonical repo dir;
 /// `display_prefix` is its path relative to the super (`""` for the super root).
 fn walk_nested_dirty(
@@ -1501,13 +1530,24 @@ fn walk_nested_dirty(
 }
 
 /// Hex digest of a `Hash`-able value via `DefaultHasher` (bounded, allocation-free
-/// key). Used both for the per-worktree marker filename (path) and the last-seen
-/// nested-status content.
-pub(crate) fn hash_hex<T: std::hash::Hash>(v: &T) -> String {
+/// key). Used for per-worktree marker filenames and internal dedup keys.
+/// NOT for public-facing confirmation tokens — use [`nested_dirt_digest_sha256`].
+fn hash_hex<T: std::hash::Hash>(v: &T) -> String {
     use std::hash::Hasher;
     let mut h = std::collections::hash_map::DefaultHasher::new();
     v.hash(&mut h);
     format!("{:016x}", h.finish())
+}
+
+/// SHA-256 hex digest of the nested-dirt enumeration string. Stable across
+/// process restarts (unlike `DefaultHasher`/SipHash whose seed is randomized
+/// on some platforms). Used as the public confirmation token in the discard
+/// round-trip — callers echo it back to prove they saw the exact state.
+pub(crate) fn nested_dirt_digest_sha256(nested_status: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    h.update(nested_status.as_bytes());
+    hex::encode(h.finalize())
 }
 
 /// The per-worktree refusal-notice directory: `<runtime>/release_refusal_notices`.
@@ -1557,7 +1597,7 @@ fn notify_unpreservable_nested_dirty(
     sender: Option<&str>,
 ) {
     let recipient = wip_notice_recipient(home, agent, sender);
-    let current_hash = hash_hex(&nested_status);
+    let current_hash = nested_dirt_digest_sha256(nested_status);
     let dir = refusal_notice_dir(home);
     let key = hash_hex(&wt_path);
     let marker_path = dir.join(&key);

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -1355,7 +1355,7 @@ const NESTED_ENUM_MAX: usize = 256;
 /// canonical CONTAINMENT (reject `..`/symlink escape) + a visited-set (cycle
 /// guard); exceeding [`NESTED_ENUM_MAX`] or any git error appends an explicit
 /// `[truncated: …]` / `[skipped: …]` line rather than stopping silently.
-fn enumerate_nested_dirty(wt_path: &Path) -> String {
+pub(crate) fn enumerate_nested_dirty(wt_path: &Path) -> String {
     let root = match std::fs::canonicalize(wt_path) {
         Ok(p) => p,
         Err(e) => return format!("[truncated: canonicalize worktree root failed: {e}]\n"),
@@ -1503,7 +1503,7 @@ fn walk_nested_dirty(
 /// Hex digest of a `Hash`-able value via `DefaultHasher` (bounded, allocation-free
 /// key). Used both for the per-worktree marker filename (path) and the last-seen
 /// nested-status content.
-fn hash_hex<T: std::hash::Hash>(v: &T) -> String {
+pub(crate) fn hash_hex<T: std::hash::Hash>(v: &T) -> String {
     use std::hash::Hasher;
     let mut h = std::collections::hash_map::DefaultHasher::new();
     v.hash(&mut h);

--- a/src/worktree.rs
+++ b/src/worktree.rs
@@ -1397,6 +1397,16 @@ pub(crate) fn dirty_submodule_paths(wt_path: &Path) -> Result<Vec<String>, Strin
     Ok(paths)
 }
 
+/// Returns `false` if the path contains characters that would make the SHA-256
+/// digest non-canonical: CR, LF, NUL, or the Unicode replacement character
+/// U+FFFD (lossy OsStr→String conversion marker).
+fn is_canonical_nested_path(path: &str) -> bool {
+    !path.contains('\r')
+        && !path.contains('\n')
+        && !path.contains('\0')
+        && !path.contains('\u{FFFD}')
+}
+
 /// One level of [`enumerate_nested_dirty`]. `dir_canon` is the canonical repo dir;
 /// `display_prefix` is its path relative to the super (`""` for the super root).
 fn walk_nested_dirty(
@@ -1444,6 +1454,10 @@ fn walk_nested_dirty(
         out.push_str(&format!("{display_prefix}:\n"));
         for e in &entries {
             if !e.is_submodule() {
+                if !is_canonical_nested_path(&e.path) {
+                    out.push_str("  [skipped: non-canonical nested path]\n");
+                    continue;
+                }
                 out.push_str(&format!("  {} {}\n", e.token, e.path));
             }
         }
@@ -1451,6 +1465,10 @@ fn walk_nested_dirty(
     // Descend into each submodule with INTERNAL dirt.
     for e in &entries {
         if !e.dirty_submodule() {
+            continue;
+        }
+        if !is_canonical_nested_path(&e.path) {
+            out.push_str("[skipped: non-canonical nested path]\n");
             continue;
         }
         let disp = if display_prefix.is_empty() {
@@ -1495,6 +1513,10 @@ fn walk_nested_dirty(
     for e in &entries {
         if e.token != "??" {
             continue; // only an untracked `?` row can be an unregistered embedded repo
+        }
+        if !is_canonical_nested_path(&e.path) {
+            out.push_str("[skipped: non-canonical nested path]\n");
+            continue;
         }
         let candidate = dir_canon.join(&e.path);
         if !candidate.join(".git").exists() {
@@ -1543,6 +1565,11 @@ fn hash_hex<T: std::hash::Hash>(v: &T) -> String {
 /// process restarts (unlike `DefaultHasher`/SipHash whose seed is randomized
 /// on some platforms). Used as the public confirmation token in the discard
 /// round-trip — callers echo it back to prove they saw the exact state.
+///
+/// Canonical over the accepted path subset: paths containing CR, LF, NUL, or
+/// lossy U+FFFD are rejected upstream by [`is_canonical_nested_path`] and never
+/// enter the hashed string (they appear as `[skipped: non-canonical nested
+/// path]` markers, which the discard gate refuses before mutation).
 pub(crate) fn nested_dirt_digest_sha256(nested_status: &str) -> String {
     use sha2::{Digest, Sha256};
     let mut h = Sha256::new();

--- a/src/worktree/tests.rs
+++ b/src/worktree/tests.rs
@@ -3126,3 +3126,218 @@ fn discard_seam_refusal_digest_is_sha256_round_trippable() {
         std::fs::remove_dir_all(root).ok();
     }
 }
+
+/// Deep-nested dirty submodule (sub-within-sub has edits) must be caught by
+/// preflight before any target is mutated.
+#[cfg(unix)]
+#[test]
+fn discard_seam_deep_nested_preflight_refuses() {
+    let home = release_tmp_home("discard-deep-nested");
+    let super_repo = tmp_super_with_nested_submodules("discard-deep-nested");
+    commit_marker_gitignore(&super_repo);
+    let info = create(&home, &super_repo, "agent1", Some("feat/deep-nested")).expect("worktree");
+    let deep_file = info.path.join("vendor/mid/nested/nested_b.txt");
+    std::fs::write(&deep_file, b"deep-nested-edit\n").unwrap();
+
+    let digest = nested_dirt_digest(&info.path);
+    let dirty_content = std::fs::read(&deep_file).unwrap();
+
+    let result = release_entry(
+        &home,
+        "agent1",
+        &info.path,
+        "feat/deep-nested",
+        true,
+        true,
+        Some(&digest),
+    );
+    let error = result["error"].as_str().unwrap_or("");
+    assert!(
+        error.contains("deep-nested"),
+        "preflight must refuse deep-nested dirty submodules: {result}"
+    );
+    assert!(
+        info.path.exists(),
+        "worktree must be preserved on preflight refusal"
+    );
+    assert_eq!(
+        std::fs::read(&deep_file).unwrap(),
+        dirty_content,
+        "deep-nested file must not be modified by preflight refusal"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+    if let Some(root) = super_repo.parent() {
+        std::fs::remove_dir_all(root).ok();
+    }
+}
+
+/// Two dirty submodules: vendor/alpha (valid) and vendor/beta (deep-nested).
+/// Preflight must reject the deep-nested one WITHOUT mutating the valid one.
+#[cfg(unix)]
+#[test]
+fn discard_seam_later_invalid_target_no_earlier_mutation() {
+    let home = release_tmp_home("discard-multi-preflight");
+    let root = std::env::temp_dir().join(format!(
+        "agend-wt-multi-pre-{}-{}",
+        std::process::id(),
+        COUNTER.fetch_add(1, Ordering::Relaxed)
+    ));
+    std::fs::create_dir_all(&root).unwrap();
+
+    let simple = tmp_repo_with_file("multi-alpha", "alpha.txt", "simple-v1\n");
+    let inner = tmp_repo_with_file("multi-inner", "inner.txt", "inner-v1\n");
+    let beta_dir = root.join("beta-src");
+    std::fs::create_dir_all(&beta_dir).unwrap();
+    git_run_ok(&beta_dir, &["init", "-b", "main"], false);
+    git_run_ok(&beta_dir, &["config", "user.email", "t@t"], false);
+    git_run_ok(&beta_dir, &["config", "user.name", "t"], false);
+    git_run_ok(
+        &beta_dir,
+        &["submodule", "add", &inner.display().to_string(), "inner"],
+        true,
+    );
+    git_run_ok(&beta_dir, &["commit", "-m", "beta with inner"], false);
+
+    let super_dir = root.join("super");
+    std::fs::create_dir_all(&super_dir).unwrap();
+    git_run_ok(&super_dir, &["init", "-b", "main"], false);
+    git_run_ok(&super_dir, &["config", "user.email", "t@t"], false);
+    git_run_ok(&super_dir, &["config", "user.name", "t"], false);
+    commit_marker_gitignore(&super_dir);
+    git_run_ok(
+        &super_dir,
+        &[
+            "submodule",
+            "add",
+            &simple.display().to_string(),
+            "vendor/alpha",
+        ],
+        true,
+    );
+    git_run_ok(
+        &super_dir,
+        &[
+            "submodule",
+            "add",
+            &beta_dir.display().to_string(),
+            "vendor/beta",
+        ],
+        true,
+    );
+    git_run_ok(&super_dir, &["commit", "-m", "two submodules"], false);
+
+    let info = create(&home, &super_dir, "agent1", Some("feat/multi-pre")).expect("worktree");
+
+    let alpha_file = info.path.join("vendor/alpha/alpha.txt");
+    std::fs::write(&alpha_file, b"alpha-dirty\n").unwrap();
+    let beta_deep = info.path.join("vendor/beta/inner/inner.txt");
+    std::fs::write(&beta_deep, b"deep-dirty\n").unwrap();
+
+    let digest = nested_dirt_digest(&info.path);
+    let alpha_dirty = std::fs::read(&alpha_file).unwrap();
+
+    let result = release_entry(
+        &home,
+        "agent1",
+        &info.path,
+        "feat/multi-pre",
+        true,
+        true,
+        Some(&digest),
+    );
+    let error = result["error"].as_str().unwrap_or("");
+    assert!(
+        error.contains("deep-nested"),
+        "preflight must catch deep-nested target: {result}"
+    );
+    assert_eq!(
+        std::fs::read(&alpha_file).unwrap(),
+        alpha_dirty,
+        "earlier valid target must NOT be mutated when later target fails preflight"
+    );
+    assert!(
+        info.path.exists(),
+        "worktree must be preserved on preflight refusal"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&root).ok();
+}
+
+/// When worktree removal fails after successful discard, the event log must
+/// contain `nested_dirt_discard_aborted` (with release_failed), NOT the
+/// success event `nested_dirt_discard_release`.
+#[cfg(unix)]
+#[test]
+fn discard_seam_removal_failure_no_success_audit() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let home = release_tmp_home("discard-rm-fail");
+    let super_repo = tmp_super_one_sub("discard-rm-fail");
+    let gi = super_repo.join(".gitignore");
+    let existing = std::fs::read_to_string(&gi).unwrap_or_default();
+    std::fs::write(&gi, format!("{existing}.trap\n")).unwrap();
+    git_run_ok(&super_repo, &["add", ".gitignore"], false);
+    git_run_ok(
+        &super_repo,
+        &[
+            "-c",
+            "user.name=t",
+            "-c",
+            "user.email=t@t",
+            "commit",
+            "-m",
+            "gitignore trap",
+        ],
+        false,
+    );
+
+    let info = create(&home, &super_repo, "agent1", Some("feat/rm-fail")).expect("worktree");
+    std::fs::write(info.path.join("vendor/dep/vendored.txt"), b"nested-edit\n").unwrap();
+
+    let locked = info.path.join(".trap/locked");
+    std::fs::create_dir_all(&locked).unwrap();
+    std::fs::write(locked.join("content.txt"), b"trapped\n").unwrap();
+    std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+    let digest = nested_dirt_digest(&info.path);
+    let event_log = home.join("event-log.jsonl");
+    let before = std::fs::read_to_string(&event_log).unwrap_or_default();
+
+    let result = release_entry(
+        &home,
+        "agent1",
+        &info.path,
+        "feat/rm-fail",
+        true,
+        true,
+        Some(&digest),
+    );
+    assert!(
+        result["error"].as_str().is_some(),
+        "removal failure must surface an error: {result}"
+    );
+
+    let after = std::fs::read_to_string(&event_log).unwrap_or_default();
+    let new_lines: Vec<&str> = after.lines().skip(before.lines().count()).collect();
+    assert!(
+        !new_lines
+            .iter()
+            .any(|l| l.contains("nested_dirt_discard_release")),
+        "removal failure must NOT emit success audit: {new_lines:?}"
+    );
+    assert!(
+        new_lines
+            .iter()
+            .any(|l| l.contains("nested_dirt_discard_aborted") && l.contains("release_failed")),
+        "removal failure must emit aborted/release_failed audit: {new_lines:?}"
+    );
+
+    std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o755)).ok();
+    std::fs::remove_dir_all(&info.path).ok();
+    std::fs::remove_dir_all(&home).ok();
+    if let Some(root) = super_repo.parent() {
+        std::fs::remove_dir_all(root).ok();
+    }
+}

--- a/src/worktree/tests.rs
+++ b/src/worktree/tests.rs
@@ -2552,7 +2552,7 @@ fn release_entry_with_reason(
 /// Compute the nested-dirt digest a caller must supply to authorize discard.
 #[cfg(unix)]
 fn nested_dirt_digest(wt_path: &Path) -> String {
-    hash_hex(&enumerate_nested_dirty(wt_path))
+    nested_dirt_digest_sha256(&enumerate_nested_dirty(wt_path))
 }
 
 /// (a) Without discard authorization, nested-only dirt still refuses through
@@ -2996,6 +2996,130 @@ fn discard_seam_refusal_returns_digest() {
         "refusal must return daemon-computed digest for round-trip: {result}"
     );
     assert!(info.path.exists(), "refusal must preserve target");
+
+    std::fs::remove_dir_all(&home).ok();
+    if let Some(root) = super_repo.parent() {
+        std::fs::remove_dir_all(root).ok();
+    }
+}
+
+/// SHA-256 digest must be 64 hex chars and stable across calls.
+#[cfg(unix)]
+#[test]
+fn discard_seam_sha256_shape_and_stability() {
+    let home = release_tmp_home("discard-sha256");
+    let super_repo = tmp_super_one_sub("discard-sha256");
+    let info = create(&home, &super_repo, "agent1", Some("feat/sha256")).expect("worktree");
+    std::fs::write(info.path.join("vendor/dep/vendored.txt"), b"sha256-test\n").unwrap();
+
+    let d1 = nested_dirt_digest(&info.path);
+    let d2 = nested_dirt_digest(&info.path);
+    assert_eq!(d1.len(), 64, "SHA-256 hex digest must be 64 chars: {d1}");
+    assert!(
+        d1.chars().all(|c| c.is_ascii_hexdigit()),
+        "digest must be pure hex: {d1}"
+    );
+    assert_eq!(d1, d2, "digest must be deterministic across calls");
+
+    std::fs::remove_dir_all(&home).ok();
+    if let Some(root) = super_repo.parent() {
+        std::fs::remove_dir_all(root).ok();
+    }
+}
+
+/// Successful discard must NOT record audit before parent preservation succeeds.
+/// Verify: on success the event is "nested_dirt_discard_release" (not _aborted).
+#[cfg(unix)]
+#[test]
+fn discard_seam_audit_records_after_parent_preservation() {
+    let home = release_tmp_home("discard-audit-order");
+    let super_repo = tmp_super_one_sub("discard-audit-order");
+    let info = create(&home, &super_repo, "agent1", Some("feat/audit-order")).expect("worktree");
+    std::fs::write(info.path.join("vendor/dep/vendored.txt"), b"nested-edit\n").unwrap();
+    std::fs::write(info.path.join("parent-wip.txt"), b"parent-work\n").unwrap();
+
+    let digest = nested_dirt_digest(&info.path);
+    let event_log = home.join("event-log.jsonl");
+    let before = std::fs::read_to_string(&event_log).unwrap_or_default();
+
+    let result = release_entry(
+        &home,
+        "agent1",
+        &info.path,
+        "feat/audit-order",
+        true,
+        true,
+        Some(&digest),
+    );
+    assert_eq!(
+        result["released"].as_bool(),
+        Some(true),
+        "must succeed: {result}"
+    );
+
+    let after = std::fs::read_to_string(&event_log).expect("event log");
+    let new_lines: Vec<&str> = after.lines().skip(before.lines().count()).collect();
+    assert!(
+        new_lines
+            .iter()
+            .any(|l| l.contains("nested_dirt_discard_release")),
+        "success audit must be nested_dirt_discard_release: {new_lines:?}"
+    );
+    assert!(
+        !new_lines
+            .iter()
+            .any(|l| l.contains("nested_dirt_discard_aborted")),
+        "success must NOT have an aborted audit: {new_lines:?}"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+    if let Some(root) = super_repo.parent() {
+        std::fs::remove_dir_all(root).ok();
+    }
+}
+
+/// The refusal digest from an ordinary (no-discard) refusal must be SHA-256
+/// shaped (64 hex chars) and usable in the confirmation round-trip.
+#[cfg(unix)]
+#[test]
+fn discard_seam_refusal_digest_is_sha256_round_trippable() {
+    let home = release_tmp_home("discard-sha-rt");
+    let super_repo = tmp_super_one_sub("discard-sha-rt");
+    let info = create(&home, &super_repo, "agent1", Some("feat/sha-rt")).expect("worktree");
+    std::fs::write(info.path.join("vendor/dep/vendored.txt"), b"edit\n").unwrap();
+
+    let refusal = release_entry(
+        &home,
+        "agent1",
+        &info.path,
+        "feat/sha-rt",
+        false,
+        false,
+        None,
+    );
+    let returned_digest = refusal["nested_dirt_digest"]
+        .as_str()
+        .expect("refusal must return digest");
+    assert_eq!(
+        returned_digest.len(),
+        64,
+        "refusal digest must be SHA-256 (64 hex): {returned_digest}"
+    );
+
+    let result = release_entry(
+        &home,
+        "agent1",
+        &info.path,
+        "feat/sha-rt",
+        true,
+        true,
+        Some(returned_digest),
+    );
+    assert_eq!(
+        result["released"].as_bool(),
+        Some(true),
+        "round-trip with refusal digest must succeed: {result}"
+    );
 
     std::fs::remove_dir_all(&home).ok();
     if let Some(root) = super_repo.parent() {

--- a/src/worktree/tests.rs
+++ b/src/worktree/tests.rs
@@ -3341,3 +3341,129 @@ fn discard_seam_removal_failure_no_success_audit() {
         std::fs::remove_dir_all(root).ok();
     }
 }
+
+/// `dirty_submodule_paths` must return Err (not silently succeed) on a
+/// non-git directory, proving the fail-closed match arm is reachable.
+/// The production code's `match ... Err(e) => refuse` ensures this error
+/// prevents mutation (defense-in-depth behind TOCTOU).
+#[cfg(unix)]
+#[test]
+fn discard_seam_dirty_submodule_paths_errors_on_non_git() {
+    let dir = std::env::temp_dir().join(format!(
+        "agend-wt-nongit-{}-{}",
+        std::process::id(),
+        COUNTER.fetch_add(1, Ordering::Relaxed)
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    let result = dirty_submodule_paths(&dir);
+    assert!(
+        result.is_err(),
+        "non-git directory must return Err: {result:?}"
+    );
+    let msg = result.unwrap_err();
+    assert!(
+        msg.contains("git status failed"),
+        "error must mention git status failure: {msg}"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// When the index gitlink OID is not a reachable commit inside the
+/// submodule, preflight must refuse before any target is mutated.
+#[cfg(unix)]
+#[test]
+fn discard_seam_missing_index_gitlink_object_no_mutation() {
+    let home = release_tmp_home("discard-missing-oid");
+    let super_repo = tmp_super_one_sub("discard-missing-oid");
+    let info = create(&home, &super_repo, "agent1", Some("feat/missing-oid")).expect("worktree");
+    std::fs::write(info.path.join("vendor/dep/vendored.txt"), b"nested-edit\n").unwrap();
+
+    let bogus_oid = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    git_run_ok(
+        &info.path,
+        &[
+            "update-index",
+            "--cacheinfo",
+            &format!("160000,{bogus_oid},vendor/dep"),
+        ],
+        false,
+    );
+
+    let digest = nested_dirt_digest(&info.path);
+    let dirty_content = std::fs::read(info.path.join("vendor/dep/vendored.txt")).unwrap();
+
+    let result = release_entry(
+        &home,
+        "agent1",
+        &info.path,
+        "feat/missing-oid",
+        true,
+        true,
+        Some(&digest),
+    );
+    let error = result["error"].as_str().unwrap_or("");
+    assert!(
+        error.contains("not a reachable commit") || error.contains("index"),
+        "preflight must refuse missing index gitlink object: {result}"
+    );
+    assert_eq!(
+        std::fs::read(info.path.join("vendor/dep/vendored.txt")).unwrap(),
+        dirty_content,
+        "target must NOT be mutated when index gitlink object is missing"
+    );
+    assert!(info.path.exists(), "worktree must be preserved");
+
+    std::fs::remove_dir_all(&home).ok();
+    if let Some(root) = super_repo.parent() {
+        std::fs::remove_dir_all(root).ok();
+    }
+}
+
+/// Audit target encoding must use JSON arrays, not raw comma-join,
+/// so paths containing commas or special chars are unambiguous.
+#[cfg(unix)]
+#[test]
+fn discard_seam_audit_targets_are_json_encoded() {
+    let home = release_tmp_home("discard-json-targets");
+    let super_repo = tmp_super_one_sub("discard-json-targets");
+    let info = create(&home, &super_repo, "agent1", Some("feat/json-targets")).expect("worktree");
+    std::fs::write(info.path.join("vendor/dep/vendored.txt"), b"nested-edit\n").unwrap();
+
+    let digest = nested_dirt_digest(&info.path);
+    let event_log = home.join("event-log.jsonl");
+    let before = std::fs::read_to_string(&event_log).unwrap_or_default();
+
+    let result = release_entry(
+        &home,
+        "agent1",
+        &info.path,
+        "feat/json-targets",
+        true,
+        true,
+        Some(&digest),
+    );
+    assert_eq!(
+        result["released"].as_bool(),
+        Some(true),
+        "discard must succeed for audit encoding check: {result}"
+    );
+
+    let after = std::fs::read_to_string(&event_log).expect("event log");
+    let new_lines: Vec<&str> = after.lines().skip(before.lines().count()).collect();
+    let release_line = new_lines
+        .iter()
+        .find(|l| l.contains("nested_dirt_discard_release"))
+        .expect("success audit must exist");
+    let parsed: serde_json::Value =
+        serde_json::from_str(release_line).expect("audit line must be valid JSON");
+    let detail = parsed["detail"].as_str().expect("detail field must exist");
+    assert!(
+        detail.contains(r#"targets=["vendor/dep"]"#),
+        "audit targets must be JSON-encoded array in detail, got: {detail}"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+    if let Some(root) = super_repo.parent() {
+        std::fs::remove_dir_all(root).ok();
+    }
+}

--- a/src/worktree/tests.rs
+++ b/src/worktree/tests.rs
@@ -2436,23 +2436,78 @@ fn list_residual_includes_workspace_gitlink_2234() {
 
 // ── Phase 1 RED: nested-submodule discard release seam (#arch14-nested-dirt) ──
 //
-// These 6 tests define the contract for the forthcoming `discard_nested_dirt`
-// capability on the force-release path. The test-only `try_discard_and_preserve`
-// shim stands in for the production entry point that GREEN will introduce.
-// Test (a) is a GREEN control; tests (b)–(f) are EXPECTED RED against current code.
+// These tests define the contract for `discard_nested_dirt` on the real
+// release handler. They deliberately call the MCP entry point with a real
+// managed-marker worktree and legacy absent-binding state; there is no
+// helper-level production shim.
 
-/// Test-only seam: represents the production entry point GREEN will add.
-/// RED stub: ignores `expected_digest`, delegates to existing preserve_dirty_worktree.
+/// Resolve the source repository recorded by a linked worktree's git common
+/// directory so the fixture can provide the same source identity that release
+/// uses in production.
 #[cfg(unix)]
-fn try_discard_and_preserve(
+fn source_repo_for_worktree(wt_path: &Path) -> PathBuf {
+    let common = PathBuf::from(git_out(wt_path, &["rev-parse", "--git-common-dir"]));
+    let common = if common.is_absolute() {
+        common
+    } else {
+        wt_path.join(common)
+    };
+    common
+        .canonicalize()
+        .expect("linked worktree common git dir")
+        .parent()
+        .expect("git common dir parent")
+        .to_path_buf()
+}
+
+#[cfg(unix)]
+fn release_tmp_home(name: &str) -> PathBuf {
+    let root = PathBuf::from(std::env::var("HOME").expect("HOME for release fixture"));
+    let dir = root.join(format!(
+        ".agend-nested-release-{}-{name}-{}",
+        std::process::id(),
+        COUNTER.fetch_add(1, Ordering::Relaxed)
+    ));
+    std::fs::create_dir_all(&dir).expect("release fixture home");
+    dir
+}
+
+/// Invoke the actual path-addressed `repo action=release` route. The fixture
+/// uses the legacy managed-marker shape with an absent binding so this reaches
+/// the production absent-binding release transaction rather than a helper.
+#[cfg(unix)]
+fn release_entry(
     home: &Path,
     agent: &str,
     wt_path: &Path,
     branch: &str,
+    discard_nested_dirt: bool,
+    force: bool,
     expected_digest: Option<&str>,
-) -> WipPreservation {
-    let _ = expected_digest;
-    preserve_dirty_worktree(home, agent, wt_path, branch, None)
+) -> serde_json::Value {
+    std::fs::write(
+        wt_path.join(crate::worktree_pool::MANAGED_MARKER),
+        format!("agent={agent}\nbranch={branch}\n"),
+    )
+    .expect("legacy managed marker");
+    crate::binding::unbind(home, agent);
+    let source_repo = source_repo_for_worktree(wt_path);
+    let mut args = serde_json::json!({
+        "action": "release",
+        "path": wt_path,
+        "repository_path": source_repo,
+        "discard_nested_dirt": discard_nested_dirt,
+        "force": force,
+        "audit_reason": "nested discard release confirmation",
+    });
+    if let Some(digest) = expected_digest {
+        args["expected_nested_dirt_digest"] = serde_json::json!(digest);
+    }
+    let _guard = crate::mcp::handlers::fleet_test_guard();
+    std::env::set_var("AGEND_HOME", home);
+    let result = crate::mcp::handlers::handle_tool("repo", &args, "");
+    std::env::remove_var("AGEND_HOME");
+    result
 }
 
 /// Compute the nested-dirt digest a caller must supply to authorize discard.
@@ -2461,25 +2516,70 @@ fn nested_dirt_digest(wt_path: &Path) -> String {
     hash_hex(&enumerate_nested_dirty(wt_path))
 }
 
-/// (a) GREEN control: without discard authorization, nested-only dirt still refuses.
+/// (a) Without discard authorization, nested-only dirt still refuses through
+/// the real handler and keeps the managed target/binding intact.
 #[cfg(unix)]
 #[test]
 fn discard_seam_no_authorization_still_refuses() {
-    let home = tmp_home("discard-no-auth");
+    let home = release_tmp_home("discard-no-auth");
     let super_repo = tmp_super_one_sub("discard-no-auth");
     let info = create(&home, &super_repo, "agent1", Some("feat/no-auth")).expect("worktree");
     std::fs::write(info.path.join("vendor/dep/vendored.txt"), b"nested-edit\n").unwrap();
+    let digest = nested_dirt_digest(&info.path);
 
-    let outcome =
-        try_discard_and_preserve(&home, "agent1", &info.path, "feat/no-auth", None);
-    assert_eq!(
-        pres_kind(&outcome),
-        "UnpreservableNestedDirty",
-        "(a) without discard authorization, nested dirt must still refuse"
+    let result = release_entry(
+        &home,
+        "agent1",
+        &info.path,
+        "feat/no-auth",
+        true,
+        false,
+        Some(&digest),
     );
+    let error = result["error"].as_str().unwrap_or("");
     assert!(
-        outcome.blocked_reason().is_some(),
-        "(a) refusal must be fail-closed"
+        error.contains("discard") && error.contains("force"),
+        "(a) refusal must identify the missing discard authorization: {result}"
+    );
+    assert!(info.path.exists(), "(a) target must remain on refusal");
+    assert!(
+        crate::binding::read(&home, "agent1").is_none(),
+        "(a) absent binding must remain absent on refusal"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+    if let Some(root) = super_repo.parent() {
+        std::fs::remove_dir_all(root).ok();
+    }
+}
+
+/// Explicit discard without a confirmation digest is not authorization.
+#[cfg(unix)]
+#[test]
+fn discard_seam_force_without_digest_refuses() {
+    let home = release_tmp_home("discard-no-digest");
+    let super_repo = tmp_super_one_sub("discard-no-digest");
+    let info = create(&home, &super_repo, "agent1", Some("feat/no-digest")).expect("worktree");
+    std::fs::write(info.path.join("vendor/dep/vendored.txt"), b"nested-edit\n").unwrap();
+
+    let result = release_entry(
+        &home,
+        "agent1",
+        &info.path,
+        "feat/no-digest",
+        true,
+        true,
+        None,
+    );
+    let error = result["error"].as_str().unwrap_or("");
+    assert!(
+        error.contains("digest"),
+        "missing confirmation digest must refuse authorization: {result}"
+    );
+    assert!(info.path.exists(), "missing digest must preserve target");
+    assert!(
+        crate::binding::read(&home, "agent1").is_none(),
+        "missing digest must preserve the absent binding"
     );
 
     std::fs::remove_dir_all(&home).ok();
@@ -2492,24 +2592,32 @@ fn discard_seam_no_authorization_still_refuses() {
 #[cfg(unix)]
 #[test]
 fn discard_seam_matching_digest_succeeds() {
-    let home = tmp_home("discard-match");
+    let home = release_tmp_home("discard-match");
     let super_repo = tmp_super_one_sub("discard-match");
     let info = create(&home, &super_repo, "agent1", Some("feat/match")).expect("worktree");
-    std::fs::write(
-        info.path.join("vendor/dep/vendored.txt"),
-        b"nested-edit\n",
-    )
-    .unwrap();
+    std::fs::write(info.path.join("vendor/dep/vendored.txt"), b"nested-edit\n").unwrap();
 
     let digest = nested_dirt_digest(&info.path);
     assert!(!digest.is_empty(), "precondition: digest is non-empty");
 
-    let outcome =
-        try_discard_and_preserve(&home, "agent1", &info.path, "feat/match", Some(&digest));
+    let result = release_entry(
+        &home,
+        "agent1",
+        &info.path,
+        "feat/match",
+        true,
+        true,
+        Some(&digest),
+    );
     assert_eq!(
-        pres_kind(&outcome),
-        "Clean",
-        "(b) authorized discard with matching digest must succeed as Clean"
+        result["released"].as_bool(),
+        Some(true),
+        "(b) authorized discard with matching digest must release: {result}"
+    );
+    assert!(!info.path.exists(), "(b) released target must be removed");
+    assert!(
+        crate::binding::read(&home, "agent1").is_none(),
+        "(b) release must leave the already-absent binding absent"
     );
 
     std::fs::remove_dir_all(&home).ok();
@@ -2522,10 +2630,9 @@ fn discard_seam_matching_digest_succeeds() {
 #[cfg(unix)]
 #[test]
 fn discard_seam_wrong_digest_refuses_toctou() {
-    let home = tmp_home("discard-toctou");
+    let home = release_tmp_home("discard-toctou");
     let super_repo = tmp_super_one_sub("discard-toctou");
-    let info =
-        create(&home, &super_repo, "agent1", Some("feat/toctou")).expect("worktree");
+    let info = create(&home, &super_repo, "agent1", Some("feat/toctou")).expect("worktree");
     std::fs::write(
         info.path.join("vendor/dep/vendored.txt"),
         b"nested-edit-v1\n",
@@ -2533,10 +2640,16 @@ fn discard_seam_wrong_digest_refuses_toctou() {
     .unwrap();
     let stale_digest = nested_dirt_digest(&info.path);
 
-    // Mutate further so the real digest no longer matches stale_digest.
+    // Mutate further so the real enumeration digest no longer matches the
+    // stale digest (the digest intentionally covers status/path, not bytes).
     std::fs::write(
         info.path.join("vendor/dep/vendored.txt"),
         b"nested-edit-v2-changed\n",
+    )
+    .unwrap();
+    std::fs::write(
+        info.path.join("vendor/dep/toctou-race.txt"),
+        b"appeared-after-confirmation\n",
     )
     .unwrap();
     let fresh_digest = nested_dirt_digest(&info.path);
@@ -2545,21 +2658,46 @@ fn discard_seam_wrong_digest_refuses_toctou() {
         "precondition: digest changed after mutation"
     );
 
-    let outcome = try_discard_and_preserve(
+    assert!(
+        crate::binding::read(&home, "agent1").is_none(),
+        "legacy TOCTOU fixture starts without a binding"
+    );
+    let nested_before = std::fs::read(info.path.join("vendor/dep/vendored.txt"))
+        .expect("nested bytes before TOCTOU release");
+    let race_before = std::fs::read(info.path.join("vendor/dep/toctou-race.txt"))
+        .expect("TOCTOU race file before release");
+    let result = release_entry(
         &home,
         "agent1",
         &info.path,
         "feat/toctou",
+        true,
+        true,
         Some(&stale_digest),
     );
-    assert_eq!(pres_kind(&outcome), "UnpreservableNestedDirty");
-    let reason = match &outcome {
-        WipPreservation::UnpreservableNestedDirty(r) => r.as_str(),
-        _ => panic!("expected UnpreservableNestedDirty"),
-    };
+    let reason = result["error"].as_str().unwrap_or("");
     assert!(
         reason.contains("digest"),
-        "(c) TOCTOU refusal must mention 'digest' in reason, got: {reason}"
+        "(c) TOCTOU refusal must mention 'digest' in reason, got: {result}"
+    );
+    assert!(info.path.exists(), "(c) stale digest must preserve target");
+    assert_eq!(
+        std::fs::read(info.path.join("vendor/dep/vendored.txt")).unwrap(),
+        nested_before,
+        "(c) stale digest must not reset nested bytes"
+    );
+    assert_eq!(
+        std::fs::read(info.path.join("vendor/dep/toctou-race.txt")).unwrap(),
+        race_before,
+        "(c) stale digest must not remove newly appeared nested dirt"
+    );
+    assert!(
+        crate::binding::read(&home, "agent1").is_none(),
+        "(c) stale digest must not create or mutate a binding"
+    );
+    assert!(
+        recovery_ref_names(&super_repo, "feat/toctou").is_empty(),
+        "(c) stale digest must not mint a recovery ref"
     );
 
     std::fs::remove_dir_all(&home).ok();
@@ -2572,40 +2710,49 @@ fn discard_seam_wrong_digest_refuses_toctou() {
 #[cfg(unix)]
 #[test]
 fn discard_seam_residual_dirt_after_reset_refuses() {
-    let home = tmp_home("discard-residual");
+    let home = release_tmp_home("discard-residual");
     let super_repo = tmp_super_one_sub("discard-residual");
-    let info =
-        create(&home, &super_repo, "agent1", Some("feat/residual")).expect("worktree");
+    let info = create(&home, &super_repo, "agent1", Some("feat/residual")).expect("worktree");
     // Tracked modification (would be reset by `git submodule update --force`)
-    std::fs::write(
-        info.path.join("vendor/dep/vendored.txt"),
-        b"tracked-mod\n",
-    )
-    .unwrap();
+    std::fs::write(info.path.join("vendor/dep/vendored.txt"), b"tracked-mod\n").unwrap();
     // Untracked file (persists after `git submodule update --force`)
-    std::fs::write(
-        info.path.join("vendor/dep/rogue-untracked.txt"),
-        b"rogue\n",
-    )
-    .unwrap();
+    std::fs::write(info.path.join("vendor/dep/rogue-untracked.txt"), b"rogue\n").unwrap();
 
     let digest = nested_dirt_digest(&info.path);
 
-    let outcome = try_discard_and_preserve(
+    assert!(
+        crate::binding::read(&home, "agent1").is_none(),
+        "legacy residual fixture starts without a binding"
+    );
+    let nested_before = std::fs::read(info.path.join("vendor/dep/vendored.txt"))
+        .expect("nested bytes before residual release");
+    let result = release_entry(
         &home,
         "agent1",
         &info.path,
         "feat/residual",
+        true,
+        true,
         Some(&digest),
     );
-    assert_eq!(pres_kind(&outcome), "UnpreservableNestedDirty");
-    let reason = match &outcome {
-        WipPreservation::UnpreservableNestedDirty(r) => r.as_str(),
-        _ => panic!("expected UnpreservableNestedDirty"),
-    };
+    let reason = result["error"].as_str().unwrap_or("");
     assert!(
         reason.contains("residual"),
-        "(d) post-reset residual refusal must mention 'residual', got: {reason}"
+        "(d) post-reset residual refusal must mention 'residual', got: {result}"
+    );
+    assert!(info.path.exists(), "(d) residual dirt must preserve target");
+    assert_eq!(
+        std::fs::read(info.path.join("vendor/dep/vendored.txt")).unwrap(),
+        nested_before,
+        "(d) residual refusal must not reset tracked nested bytes"
+    );
+    assert!(
+        crate::binding::read(&home, "agent1").is_none(),
+        "(d) residual refusal must not create or mutate a binding"
+    );
+    assert!(
+        recovery_ref_names(&super_repo, "feat/residual").is_empty(),
+        "(d) residual refusal must not mint a recovery ref"
     );
 
     std::fs::remove_dir_all(&home).ok();
@@ -2618,37 +2765,44 @@ fn discard_seam_residual_dirt_after_reset_refuses() {
 #[cfg(unix)]
 #[test]
 fn discard_seam_preserves_parent_wip() {
-    let home = tmp_home("discard-parent");
+    let home = release_tmp_home("discard-parent");
     let super_repo = tmp_super_one_sub("discard-parent");
-    let info =
-        create(&home, &super_repo, "agent1", Some("feat/parent")).expect("worktree");
+    let info = create(&home, &super_repo, "agent1", Some("feat/parent")).expect("worktree");
     // Parent-level WIP (must be preserved to recovery ref)
     std::fs::write(info.path.join("parent-wip.txt"), b"parent-work\n").unwrap();
     // Nested submodule dirt (must be discarded)
-    std::fs::write(
-        info.path.join("vendor/dep/vendored.txt"),
-        b"nested-edit\n",
-    )
-    .unwrap();
+    std::fs::write(info.path.join("vendor/dep/vendored.txt"), b"nested-edit\n").unwrap();
 
     let digest = nested_dirt_digest(&info.path);
 
-    let outcome = try_discard_and_preserve(
+    let result = release_entry(
         &home,
         "agent1",
         &info.path,
         "feat/parent",
+        true,
+        true,
         Some(&digest),
     );
     assert_eq!(
-        pres_kind(&outcome),
-        "Preserved",
-        "(e) parent WIP must be Preserved after nested discard"
+        result["released"].as_bool(),
+        Some(true),
+        "(e) parent WIP must be recovered while nested dirt is discarded: {result}"
+    );
+    assert!(!info.path.exists(), "(e) released target must be removed");
+    assert!(
+        crate::binding::read(&home, "agent1").is_none(),
+        "(e) release must leave the already-absent binding absent"
     );
     let refs = recovery_ref_names(&super_repo, "feat/parent");
     assert!(
         !refs.is_empty(),
         "(e) recovery ref must exist for parent WIP"
+    );
+    let tree = git_out(&super_repo, &["ls-tree", "-r", "--name-only", &refs[0]]);
+    assert!(
+        tree.lines().any(|line| line == "parent-wip.txt"),
+        "(e) recovery ref must retain parent WIP, got {tree}"
     );
 
     std::fs::remove_dir_all(&home).ok();
@@ -2657,48 +2811,46 @@ fn discard_seam_preserves_parent_wip() {
     }
 }
 
-/// (f) RED: successful discard must write audit evidence under home.
+/// (f) RED: successful discard must use the existing append-only event log.
 #[cfg(unix)]
 #[test]
 fn discard_seam_records_audit_evidence() {
-    let home = tmp_home("discard-audit");
+    let home = release_tmp_home("discard-audit");
     let super_repo = tmp_super_one_sub("discard-audit");
-    let info =
-        create(&home, &super_repo, "agent1", Some("feat/audit")).expect("worktree");
-    std::fs::write(
-        info.path.join("vendor/dep/vendored.txt"),
-        b"nested-edit\n",
-    )
-    .unwrap();
+    let info = create(&home, &super_repo, "agent1", Some("feat/audit")).expect("worktree");
+    std::fs::write(info.path.join("vendor/dep/vendored.txt"), b"nested-edit\n").unwrap();
 
     let digest = nested_dirt_digest(&info.path);
 
-    let outcome = try_discard_and_preserve(
+    let event_log = home.join("event-log.jsonl");
+    let before = std::fs::read_to_string(&event_log).unwrap_or_default();
+    let result = release_entry(
         &home,
         "agent1",
         &info.path,
         "feat/audit",
+        true,
+        true,
         Some(&digest),
     );
     assert_eq!(
-        pres_kind(&outcome),
-        "Clean",
-        "(f) nested-only discard must succeed before audit check"
+        result["released"].as_bool(),
+        Some(true),
+        "(f) nested-only discard must succeed before audit check: {result}"
     );
-
-    let audit_dir = home.join("audit").join("nested_discard");
+    assert!(!info.path.exists(), "(f) successful discard removes target");
+    let after = std::fs::read_to_string(&event_log).expect("existing event log");
+    let new_lines = after
+        .lines()
+        .skip(before.lines().count())
+        .collect::<Vec<_>>();
     assert!(
-        audit_dir.is_dir(),
-        "(f) audit evidence directory must exist at {}",
-        audit_dir.display()
-    );
-    let entries: Vec<_> = std::fs::read_dir(&audit_dir)
-        .expect("read audit dir")
-        .filter_map(|e| e.ok())
-        .collect();
-    assert!(
-        !entries.is_empty(),
-        "(f) at least one audit evidence file must be written"
+        new_lines.iter().any(|line| {
+            line.contains("agent1")
+                && line.contains("feat/audit")
+                && (line.contains("release") || line.contains("discard"))
+        }),
+        "(f) discard must append agent/branch evidence to event-log.jsonl: {after}"
     );
 
     std::fs::remove_dir_all(&home).ok();

--- a/src/worktree/tests.rs
+++ b/src/worktree/tests.rs
@@ -2494,6 +2494,28 @@ fn release_entry(
     force: bool,
     expected_digest: Option<&str>,
 ) -> serde_json::Value {
+    release_entry_with_reason(
+        home,
+        agent,
+        wt_path,
+        branch,
+        discard_nested_dirt,
+        force,
+        expected_digest,
+        "nested discard release confirmation",
+    )
+}
+
+fn release_entry_with_reason(
+    home: &Path,
+    agent: &str,
+    wt_path: &Path,
+    branch: &str,
+    discard_nested_dirt: bool,
+    force: bool,
+    expected_digest: Option<&str>,
+    audit_reason: &str,
+) -> serde_json::Value {
     std::fs::write(
         wt_path.join(crate::worktree_pool::MANAGED_MARKER),
         format!("agent={agent}\nbranch={branch}\n"),
@@ -2507,22 +2529,17 @@ fn release_entry(
         "repository_path": source_repo,
         "discard_nested_dirt": discard_nested_dirt,
         "force": force,
-        "audit_reason": "nested discard release confirmation",
+        "audit_reason": audit_reason,
     });
     if let Some(digest) = expected_digest {
         args["expected_nested_dirt_digest"] = serde_json::json!(digest);
     }
     let _guard = crate::mcp::handlers::fleet_test_guard();
-    // Pin AGENTIC_GIT_HOME to the real daemon home so the git shim's
-    // self-exclusion from PATH still works after AGEND_HOME is overridden
-    // to a test directory (AGEND_HOME is the legacy compat name for
-    // AGENTIC_GIT_HOME — see #1504).
     if let Some(ref h) = *DAEMON_HOME {
         std::env::set_var("AGENTIC_GIT_HOME", h);
     }
     std::env::set_var("AGEND_HOME", home);
     let result = crate::mcp::handlers::handle_tool("repo", &args, "");
-    // Restore AGEND_HOME (not just remove — other tests need it for shim resolution)
     match &*DAEMON_HOME {
         Some(h) => std::env::set_var("AGEND_HOME", h),
         None => std::env::remove_var("AGEND_HOME"),
@@ -2873,6 +2890,111 @@ fn discard_seam_records_audit_evidence() {
         }),
         "(f) discard must append agent/branch evidence to event-log.jsonl: {after}"
     );
+
+    std::fs::remove_dir_all(&home).ok();
+    if let Some(root) = super_repo.parent() {
+        std::fs::remove_dir_all(root).ok();
+    }
+}
+
+/// Trimmed-empty digest must refuse (not silently pass through).
+#[cfg(unix)]
+#[test]
+fn discard_seam_empty_digest_refuses() {
+    let home = release_tmp_home("discard-empty-digest");
+    let super_repo = tmp_super_one_sub("discard-empty-digest");
+    let info = create(&home, &super_repo, "agent1", Some("feat/empty-digest")).expect("worktree");
+    std::fs::write(info.path.join("vendor/dep/vendored.txt"), b"edit\n").unwrap();
+
+    let result = release_entry(
+        &home,
+        "agent1",
+        &info.path,
+        "feat/empty-digest",
+        true,
+        true,
+        Some("  "),
+    );
+    let error = result["error"].as_str().unwrap_or("");
+    assert!(
+        error.contains("digest"),
+        "trimmed-empty digest must refuse: {result}"
+    );
+    assert!(
+        info.path.exists(),
+        "trimmed-empty digest must preserve target"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+    if let Some(root) = super_repo.parent() {
+        std::fs::remove_dir_all(root).ok();
+    }
+}
+
+/// Trimmed-empty audit_reason must refuse.
+#[cfg(unix)]
+#[test]
+fn discard_seam_empty_audit_reason_refuses() {
+    let home = release_tmp_home("discard-empty-reason");
+    let super_repo = tmp_super_one_sub("discard-empty-reason");
+    let info = create(&home, &super_repo, "agent1", Some("feat/empty-reason")).expect("worktree");
+    std::fs::write(info.path.join("vendor/dep/vendored.txt"), b"edit\n").unwrap();
+    let digest = nested_dirt_digest(&info.path);
+
+    let result = release_entry_with_reason(
+        &home,
+        "agent1",
+        &info.path,
+        "feat/empty-reason",
+        true,
+        true,
+        Some(&digest),
+        "  ",
+    );
+    let error = result["error"].as_str().unwrap_or("");
+    assert!(
+        error.contains("audit_reason"),
+        "trimmed-empty audit_reason must refuse: {result}"
+    );
+    assert!(
+        info.path.exists(),
+        "trimmed-empty audit_reason must preserve target"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+    if let Some(root) = super_repo.parent() {
+        std::fs::remove_dir_all(root).ok();
+    }
+}
+
+/// Ordinary nested-dirt refusal (no discard) must return the daemon-computed
+/// digest for the confirmation round-trip.
+#[cfg(unix)]
+#[test]
+fn discard_seam_refusal_returns_digest() {
+    let home = release_tmp_home("discard-refusal-digest");
+    let super_repo = tmp_super_one_sub("discard-refusal-digest");
+    let info = create(&home, &super_repo, "agent1", Some("feat/refusal-digest")).expect("worktree");
+    std::fs::write(info.path.join("vendor/dep/vendored.txt"), b"edit\n").unwrap();
+    let expected = nested_dirt_digest(&info.path);
+
+    let result = release_entry(
+        &home,
+        "agent1",
+        &info.path,
+        "feat/refusal-digest",
+        false,
+        false,
+        None,
+    );
+    let error = result["error"].as_str().unwrap_or("");
+    assert!(!error.is_empty(), "nested dirt must refuse: {result}");
+    let returned_digest = result["nested_dirt_digest"].as_str().unwrap_or("");
+    assert_eq!(
+        returned_digest, expected,
+        "refusal must return daemon-computed digest for round-trip: {result}"
+    );
+    assert!(info.path.exists(), "refusal must preserve target");
 
     std::fs::remove_dir_all(&home).ok();
     if let Some(root) = super_repo.parent() {

--- a/src/worktree/tests.rs
+++ b/src/worktree/tests.rs
@@ -3,6 +3,15 @@ use std::sync::atomic::{AtomicU32, Ordering};
 
 static COUNTER: AtomicU32 = AtomicU32::new(0);
 
+/// Original AGEND_HOME captured once before any test can modify it.
+/// The git shim uses AGEND_HOME as fallback for AGENTIC_GIT_HOME to locate
+/// its own bin/ directory for self-exclusion from PATH (#1504). Tests that
+/// override AGEND_HOME must pin AGENTIC_GIT_HOME to this value so the shim
+/// can still resolve the real git binary.
+#[cfg(unix)]
+static DAEMON_HOME: std::sync::LazyLock<Option<String>> =
+    std::sync::LazyLock::new(|| std::env::var("AGEND_HOME").ok());
+
 fn tmp_repo(name: &str) -> PathBuf {
     let id = COUNTER.fetch_add(1, Ordering::Relaxed);
     let dir = std::env::temp_dir().join(format!(
@@ -2504,9 +2513,21 @@ fn release_entry(
         args["expected_nested_dirt_digest"] = serde_json::json!(digest);
     }
     let _guard = crate::mcp::handlers::fleet_test_guard();
+    // Pin AGENTIC_GIT_HOME to the real daemon home so the git shim's
+    // self-exclusion from PATH still works after AGEND_HOME is overridden
+    // to a test directory (AGEND_HOME is the legacy compat name for
+    // AGENTIC_GIT_HOME — see #1504).
+    if let Some(ref h) = *DAEMON_HOME {
+        std::env::set_var("AGENTIC_GIT_HOME", h);
+    }
     std::env::set_var("AGEND_HOME", home);
     let result = crate::mcp::handlers::handle_tool("repo", &args, "");
-    std::env::remove_var("AGEND_HOME");
+    // Restore AGEND_HOME (not just remove — other tests need it for shim resolution)
+    match &*DAEMON_HOME {
+        Some(h) => std::env::set_var("AGEND_HOME", h),
+        None => std::env::remove_var("AGEND_HOME"),
+    }
+    std::env::remove_var("AGENTIC_GIT_HOME");
     result
 }
 

--- a/src/worktree/tests.rs
+++ b/src/worktree/tests.rs
@@ -2433,3 +2433,276 @@ fn list_residual_includes_workspace_gitlink_2234() {
     std::fs::remove_dir_all(&home).ok();
     std::fs::remove_dir_all(&repo).ok();
 }
+
+// ── Phase 1 RED: nested-submodule discard release seam (#arch14-nested-dirt) ──
+//
+// These 6 tests define the contract for the forthcoming `discard_nested_dirt`
+// capability on the force-release path. The test-only `try_discard_and_preserve`
+// shim stands in for the production entry point that GREEN will introduce.
+// Test (a) is a GREEN control; tests (b)–(f) are EXPECTED RED against current code.
+
+/// Test-only seam: represents the production entry point GREEN will add.
+/// RED stub: ignores `expected_digest`, delegates to existing preserve_dirty_worktree.
+#[cfg(unix)]
+fn try_discard_and_preserve(
+    home: &Path,
+    agent: &str,
+    wt_path: &Path,
+    branch: &str,
+    expected_digest: Option<&str>,
+) -> WipPreservation {
+    let _ = expected_digest;
+    preserve_dirty_worktree(home, agent, wt_path, branch, None)
+}
+
+/// Compute the nested-dirt digest a caller must supply to authorize discard.
+#[cfg(unix)]
+fn nested_dirt_digest(wt_path: &Path) -> String {
+    hash_hex(&enumerate_nested_dirty(wt_path))
+}
+
+/// (a) GREEN control: without discard authorization, nested-only dirt still refuses.
+#[cfg(unix)]
+#[test]
+fn discard_seam_no_authorization_still_refuses() {
+    let home = tmp_home("discard-no-auth");
+    let super_repo = tmp_super_one_sub("discard-no-auth");
+    let info = create(&home, &super_repo, "agent1", Some("feat/no-auth")).expect("worktree");
+    std::fs::write(info.path.join("vendor/dep/vendored.txt"), b"nested-edit\n").unwrap();
+
+    let outcome =
+        try_discard_and_preserve(&home, "agent1", &info.path, "feat/no-auth", None);
+    assert_eq!(
+        pres_kind(&outcome),
+        "UnpreservableNestedDirty",
+        "(a) without discard authorization, nested dirt must still refuse"
+    );
+    assert!(
+        outcome.blocked_reason().is_some(),
+        "(a) refusal must be fail-closed"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+    if let Some(root) = super_repo.parent() {
+        std::fs::remove_dir_all(root).ok();
+    }
+}
+
+/// (b) RED: authorization with matching digest must succeed for nested-only dirt.
+#[cfg(unix)]
+#[test]
+fn discard_seam_matching_digest_succeeds() {
+    let home = tmp_home("discard-match");
+    let super_repo = tmp_super_one_sub("discard-match");
+    let info = create(&home, &super_repo, "agent1", Some("feat/match")).expect("worktree");
+    std::fs::write(
+        info.path.join("vendor/dep/vendored.txt"),
+        b"nested-edit\n",
+    )
+    .unwrap();
+
+    let digest = nested_dirt_digest(&info.path);
+    assert!(!digest.is_empty(), "precondition: digest is non-empty");
+
+    let outcome =
+        try_discard_and_preserve(&home, "agent1", &info.path, "feat/match", Some(&digest));
+    assert_eq!(
+        pres_kind(&outcome),
+        "Clean",
+        "(b) authorized discard with matching digest must succeed as Clean"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+    if let Some(root) = super_repo.parent() {
+        std::fs::remove_dir_all(root).ok();
+    }
+}
+
+/// (c) RED: stale/wrong digest must refuse with a TOCTOU-specific reason.
+#[cfg(unix)]
+#[test]
+fn discard_seam_wrong_digest_refuses_toctou() {
+    let home = tmp_home("discard-toctou");
+    let super_repo = tmp_super_one_sub("discard-toctou");
+    let info =
+        create(&home, &super_repo, "agent1", Some("feat/toctou")).expect("worktree");
+    std::fs::write(
+        info.path.join("vendor/dep/vendored.txt"),
+        b"nested-edit-v1\n",
+    )
+    .unwrap();
+    let stale_digest = nested_dirt_digest(&info.path);
+
+    // Mutate further so the real digest no longer matches stale_digest.
+    std::fs::write(
+        info.path.join("vendor/dep/vendored.txt"),
+        b"nested-edit-v2-changed\n",
+    )
+    .unwrap();
+    let fresh_digest = nested_dirt_digest(&info.path);
+    assert_ne!(
+        stale_digest, fresh_digest,
+        "precondition: digest changed after mutation"
+    );
+
+    let outcome = try_discard_and_preserve(
+        &home,
+        "agent1",
+        &info.path,
+        "feat/toctou",
+        Some(&stale_digest),
+    );
+    assert_eq!(pres_kind(&outcome), "UnpreservableNestedDirty");
+    let reason = match &outcome {
+        WipPreservation::UnpreservableNestedDirty(r) => r.as_str(),
+        _ => panic!("expected UnpreservableNestedDirty"),
+    };
+    assert!(
+        reason.contains("digest"),
+        "(c) TOCTOU refusal must mention 'digest' in reason, got: {reason}"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+    if let Some(root) = super_repo.parent() {
+        std::fs::remove_dir_all(root).ok();
+    }
+}
+
+/// (d) RED: if targeted reset leaves residual untracked dirt, must still refuse.
+#[cfg(unix)]
+#[test]
+fn discard_seam_residual_dirt_after_reset_refuses() {
+    let home = tmp_home("discard-residual");
+    let super_repo = tmp_super_one_sub("discard-residual");
+    let info =
+        create(&home, &super_repo, "agent1", Some("feat/residual")).expect("worktree");
+    // Tracked modification (would be reset by `git submodule update --force`)
+    std::fs::write(
+        info.path.join("vendor/dep/vendored.txt"),
+        b"tracked-mod\n",
+    )
+    .unwrap();
+    // Untracked file (persists after `git submodule update --force`)
+    std::fs::write(
+        info.path.join("vendor/dep/rogue-untracked.txt"),
+        b"rogue\n",
+    )
+    .unwrap();
+
+    let digest = nested_dirt_digest(&info.path);
+
+    let outcome = try_discard_and_preserve(
+        &home,
+        "agent1",
+        &info.path,
+        "feat/residual",
+        Some(&digest),
+    );
+    assert_eq!(pres_kind(&outcome), "UnpreservableNestedDirty");
+    let reason = match &outcome {
+        WipPreservation::UnpreservableNestedDirty(r) => r.as_str(),
+        _ => panic!("expected UnpreservableNestedDirty"),
+    };
+    assert!(
+        reason.contains("residual"),
+        "(d) post-reset residual refusal must mention 'residual', got: {reason}"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+    if let Some(root) = super_repo.parent() {
+        std::fs::remove_dir_all(root).ok();
+    }
+}
+
+/// (e) RED: parent-level dirt + nested dirt + authorized discard → parent Preserved.
+#[cfg(unix)]
+#[test]
+fn discard_seam_preserves_parent_wip() {
+    let home = tmp_home("discard-parent");
+    let super_repo = tmp_super_one_sub("discard-parent");
+    let info =
+        create(&home, &super_repo, "agent1", Some("feat/parent")).expect("worktree");
+    // Parent-level WIP (must be preserved to recovery ref)
+    std::fs::write(info.path.join("parent-wip.txt"), b"parent-work\n").unwrap();
+    // Nested submodule dirt (must be discarded)
+    std::fs::write(
+        info.path.join("vendor/dep/vendored.txt"),
+        b"nested-edit\n",
+    )
+    .unwrap();
+
+    let digest = nested_dirt_digest(&info.path);
+
+    let outcome = try_discard_and_preserve(
+        &home,
+        "agent1",
+        &info.path,
+        "feat/parent",
+        Some(&digest),
+    );
+    assert_eq!(
+        pres_kind(&outcome),
+        "Preserved",
+        "(e) parent WIP must be Preserved after nested discard"
+    );
+    let refs = recovery_ref_names(&super_repo, "feat/parent");
+    assert!(
+        !refs.is_empty(),
+        "(e) recovery ref must exist for parent WIP"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+    if let Some(root) = super_repo.parent() {
+        std::fs::remove_dir_all(root).ok();
+    }
+}
+
+/// (f) RED: successful discard must write audit evidence under home.
+#[cfg(unix)]
+#[test]
+fn discard_seam_records_audit_evidence() {
+    let home = tmp_home("discard-audit");
+    let super_repo = tmp_super_one_sub("discard-audit");
+    let info =
+        create(&home, &super_repo, "agent1", Some("feat/audit")).expect("worktree");
+    std::fs::write(
+        info.path.join("vendor/dep/vendored.txt"),
+        b"nested-edit\n",
+    )
+    .unwrap();
+
+    let digest = nested_dirt_digest(&info.path);
+
+    let outcome = try_discard_and_preserve(
+        &home,
+        "agent1",
+        &info.path,
+        "feat/audit",
+        Some(&digest),
+    );
+    assert_eq!(
+        pres_kind(&outcome),
+        "Clean",
+        "(f) nested-only discard must succeed before audit check"
+    );
+
+    let audit_dir = home.join("audit").join("nested_discard");
+    assert!(
+        audit_dir.is_dir(),
+        "(f) audit evidence directory must exist at {}",
+        audit_dir.display()
+    );
+    let entries: Vec<_> = std::fs::read_dir(&audit_dir)
+        .expect("read audit dir")
+        .filter_map(|e| e.ok())
+        .collect();
+    assert!(
+        !entries.is_empty(),
+        "(f) at least one audit evidence file must be written"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+    if let Some(root) = super_repo.parent() {
+        std::fs::remove_dir_all(root).ok();
+    }
+}

--- a/src/worktree/tests.rs
+++ b/src/worktree/tests.rs
@@ -2506,6 +2506,7 @@ fn release_entry(
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn release_entry_with_reason(
     home: &Path,
     agent: &str,

--- a/src/worktree/tests.rs
+++ b/src/worktree/tests.rs
@@ -3467,3 +3467,60 @@ fn discard_seam_audit_targets_are_json_encoded() {
         std::fs::remove_dir_all(root).ok();
     }
 }
+
+/// A file whose name contains a literal newline inside a dirty submodule triggers
+/// the non-canonical path gate: release is refused, worktree bytes are unchanged,
+/// and no success audit is emitted.
+#[cfg(unix)]
+#[test]
+fn discard_seam_newline_path_no_mutation() {
+    let home = release_tmp_home("discard-newline-path");
+    let super_repo = tmp_super_one_sub("discard-newline-path");
+    let info = create(&home, &super_repo, "agent1", Some("feat/newline")).expect("worktree");
+
+    let sub_dir = info.path.join("vendor/dep");
+    std::fs::write(sub_dir.join("vendored.txt"), b"modified\n").unwrap();
+    std::fs::write(sub_dir.join("foo\nbar.txt"), b"newline-in-name\n").unwrap();
+
+    let digest = nested_dirt_digest(&info.path);
+    let event_log = home.join("event-log.jsonl");
+    let before = std::fs::read_to_string(&event_log).unwrap_or_default();
+
+    let result = release_entry(
+        &home,
+        "agent1",
+        &info.path,
+        "feat/newline",
+        true,
+        true,
+        Some(&digest),
+    );
+
+    assert!(
+        result["error"]
+            .as_str()
+            .unwrap_or("")
+            .contains("skipped/truncated"),
+        "release must be refused due to non-canonical nested path: {result}"
+    );
+    assert!(info.path.exists(), "worktree must survive (no mutation)");
+    assert_eq!(
+        std::fs::read_to_string(sub_dir.join("vendored.txt")).unwrap(),
+        "modified\n",
+        "submodule file bytes must be unchanged"
+    );
+
+    let after = std::fs::read_to_string(&event_log).unwrap_or_default();
+    let new_lines: Vec<&str> = after.lines().skip(before.lines().count()).collect();
+    assert!(
+        !new_lines
+            .iter()
+            .any(|l| l.contains("nested_dirt_discard_release")),
+        "no success audit must be emitted for refused release"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+    if let Some(root) = super_repo.parent() {
+        std::fs::remove_dir_all(root).ok();
+    }
+}

--- a/src/worktree/tests.rs
+++ b/src/worktree/tests.rs
@@ -2506,6 +2506,7 @@ fn release_entry(
     )
 }
 
+#[cfg(unix)]
 #[allow(clippy::too_many_arguments)]
 fn release_entry_with_reason(
     home: &Path,

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -1900,6 +1900,7 @@ pub(crate) fn release_absent_target_under_branch_lock(
         drop(_agent_lock);
         return out;
     }
+    let mut discard_audit_detail: Option<String> = None;
     if matches!(target_state, crate::mcp::handlers::TargetState::Present) {
         let mk_branch = marker_branch(target);
         let branch_for_preserve = mk_branch.as_deref().unwrap_or("");
@@ -1997,6 +1998,57 @@ pub(crate) fn release_absent_target_under_branch_lock(
                     }
                 };
                 for sub_path in &dirty_sub_paths {
+                    let sub_dir = target.join(sub_path);
+                    let gitlink = sub_dir.join(".git");
+                    if !gitlink.is_file() {
+                        drop(_binding_lock);
+                        drop(_agent_lock);
+                        for notice in notices {
+                            notice.emit(home);
+                        }
+                        return ReleaseOutcome {
+                            error: Some(format!(
+                                "nested dirt discard refused: target '{sub_path}' is not a \
+                                 gitlink-registered submodule; state preserved"
+                            )),
+                            ..ReleaseOutcome::default()
+                        };
+                    }
+                    if crate::git_helpers::git_cmd(target, &["ls-tree", "HEAD", "--", sub_path])
+                        .map_or(true, |out| out.trim().is_empty())
+                    {
+                        drop(_binding_lock);
+                        drop(_agent_lock);
+                        for notice in notices {
+                            notice.emit(home);
+                        }
+                        return ReleaseOutcome {
+                            error: Some(format!(
+                                "nested dirt discard refused: target '{sub_path}' has no \
+                                 committed gitlink object in HEAD; state preserved"
+                            )),
+                            ..ReleaseOutcome::default()
+                        };
+                    }
+                    if let Ok(deep) = crate::worktree::dirty_submodule_paths(&sub_dir) {
+                        if !deep.is_empty() {
+                            drop(_binding_lock);
+                            drop(_agent_lock);
+                            for notice in notices {
+                                notice.emit(home);
+                            }
+                            return ReleaseOutcome {
+                                error: Some(format!(
+                                    "nested dirt discard refused: target '{sub_path}' contains \
+                                     deep-nested dirty submodules; state preserved"
+                                )),
+                                ..ReleaseOutcome::default()
+                            };
+                        }
+                    }
+                }
+                let mut completed_targets: Vec<&str> = Vec::new();
+                for sub_path in &dirty_sub_paths {
                     if let Err(e) = crate::git_helpers::git_cmd(
                         target,
                         &[
@@ -2008,19 +2060,39 @@ pub(crate) fn release_absent_target_under_branch_lock(
                             sub_path,
                         ],
                     ) {
+                        crate::event_log::log(
+                            home,
+                            "nested_dirt_discard_aborted",
+                            agent,
+                            &format!(
+                                "branch={branch_for_preserve} discard_digest={} \
+                                 audit_reason={} failed_target={sub_path} \
+                                 completed_targets={} abort_reason=reset_failed",
+                                discard.expected_digest,
+                                discard.audit_reason,
+                                completed_targets.join(","),
+                            ),
+                        );
                         drop(_binding_lock);
                         drop(_agent_lock);
                         for notice in notices {
                             notice.emit(home);
                         }
+                        let partial = if completed_targets.is_empty() {
+                            String::new()
+                        } else {
+                            format!(" (partially reset: {})", completed_targets.join(", "))
+                        };
                         return ReleaseOutcome {
                             error: Some(format!(
-                                "nested dirt discard refused: submodule reset failed for \
-                                 '{sub_path}': {e}; state preserved"
+                                "nested dirt discard aborted: submodule reset failed for \
+                                 '{sub_path}': {e}{partial}; worktree preserved but may be \
+                                 partially modified"
                             )),
                             ..ReleaseOutcome::default()
                         };
                     }
+                    completed_targets.push(sub_path);
                 }
                 let residual = crate::worktree::enumerate_nested_dirty(target);
                 if !residual.is_empty() {
@@ -2071,19 +2143,14 @@ pub(crate) fn release_absent_target_under_branch_lock(
                         ..ReleaseOutcome::default()
                     };
                 }
-                crate::event_log::log(
-                    home,
-                    "nested_dirt_discard_release",
-                    agent,
-                    &format!(
-                        "branch={branch_for_preserve} discard_digest={} audit_reason={} \
-                         pre_discard_status_lines={pre_discard_line_count} \
-                         targets={}",
-                        discard.expected_digest,
-                        discard.audit_reason,
-                        dirty_sub_paths.join(","),
-                    ),
-                );
+                discard_audit_detail = Some(format!(
+                    "branch={branch_for_preserve} discard_digest={} audit_reason={} \
+                     pre_discard_status_lines={pre_discard_line_count} \
+                     targets={}",
+                    discard.expected_digest,
+                    discard.audit_reason,
+                    dirty_sub_paths.join(","),
+                ));
             } else {
                 let digest = if matches!(
                     &preservation,
@@ -2112,15 +2179,29 @@ pub(crate) fn release_absent_target_under_branch_lock(
     }
     match remove_worktree(agent, target, source_repo) {
         WorktreeRemoval::Removed => {
+            if let Some(detail) = &discard_audit_detail {
+                crate::event_log::log(home, "nested_dirt_discard_release", agent, detail);
+            }
             out.released = true;
             out.already_released = true;
             out.worktree_removed = true;
         }
         WorktreeRemoval::AlreadyAbsent => {
+            if let Some(detail) = &discard_audit_detail {
+                crate::event_log::log(home, "nested_dirt_discard_release", agent, detail);
+            }
             out.released = true;
             out.already_released = true;
         }
         WorktreeRemoval::Unmanaged(error) | WorktreeRemoval::Failed(error) => {
+            if let Some(detail) = &discard_audit_detail {
+                crate::event_log::log(
+                    home,
+                    "nested_dirt_discard_aborted",
+                    agent,
+                    &format!("{detail} abort_reason=release_failed"),
+                );
+            }
             out.error = Some(error)
         }
     }

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -2014,8 +2014,67 @@ pub(crate) fn release_absent_target_under_branch_lock(
                             ..ReleaseOutcome::default()
                         };
                     }
-                    if crate::git_helpers::git_cmd(target, &["ls-tree", "HEAD", "--", sub_path])
-                        .map_or(true, |out| out.trim().is_empty())
+                    let ls_out = match crate::git_helpers::git_cmd(
+                        target,
+                        &["ls-files", "--stage", "-z", "--", sub_path],
+                    ) {
+                        Ok(s) => s,
+                        Err(e) => {
+                            drop(_binding_lock);
+                            drop(_agent_lock);
+                            for notice in notices {
+                                notice.emit(home);
+                            }
+                            return ReleaseOutcome {
+                                error: Some(format!(
+                                    "nested dirt discard refused: index query failed for \
+                                     '{sub_path}': {e}; state preserved"
+                                )),
+                                ..ReleaseOutcome::default()
+                            };
+                        }
+                    };
+                    let records: Vec<&str> = ls_out.split('\0').filter(|s| !s.is_empty()).collect();
+                    if records.len() != 1 {
+                        drop(_binding_lock);
+                        drop(_agent_lock);
+                        for notice in notices {
+                            notice.emit(home);
+                        }
+                        return ReleaseOutcome {
+                            error: Some(format!(
+                                "nested dirt discard refused: target '{sub_path}' has {} \
+                                 index stage entries (expected exactly 1); state preserved",
+                                records.len()
+                            )),
+                            ..ReleaseOutcome::default()
+                        };
+                    }
+                    let fields: Vec<&str> = records[0].splitn(3, [' ', '\t']).collect();
+                    let (mode, oid) = if fields.len() >= 2 {
+                        (fields[0], fields[1])
+                    } else {
+                        ("", "")
+                    };
+                    if mode != "160000" {
+                        drop(_binding_lock);
+                        drop(_agent_lock);
+                        for notice in notices {
+                            notice.emit(home);
+                        }
+                        return ReleaseOutcome {
+                            error: Some(format!(
+                                "nested dirt discard refused: target '{sub_path}' index mode \
+                                 is '{mode}', not 160000 (gitlink); state preserved"
+                            )),
+                            ..ReleaseOutcome::default()
+                        };
+                    }
+                    if crate::git_helpers::git_cmd(
+                        &sub_dir,
+                        &["cat-file", "-e", &format!("{oid}^{{commit}}")],
+                    )
+                    .is_err()
                     {
                         drop(_binding_lock);
                         drop(_agent_lock);
@@ -2024,14 +2083,15 @@ pub(crate) fn release_absent_target_under_branch_lock(
                         }
                         return ReleaseOutcome {
                             error: Some(format!(
-                                "nested dirt discard refused: target '{sub_path}' has no \
-                                 committed gitlink object in HEAD; state preserved"
+                                "nested dirt discard refused: target '{sub_path}' index \
+                                 gitlink object {oid} is not a reachable commit; \
+                                 state preserved"
                             )),
                             ..ReleaseOutcome::default()
                         };
                     }
-                    if let Ok(deep) = crate::worktree::dirty_submodule_paths(&sub_dir) {
-                        if !deep.is_empty() {
+                    match crate::worktree::dirty_submodule_paths(&sub_dir) {
+                        Ok(deep) if !deep.is_empty() => {
                             drop(_binding_lock);
                             drop(_agent_lock);
                             for notice in notices {
@@ -2045,6 +2105,21 @@ pub(crate) fn release_absent_target_under_branch_lock(
                                 ..ReleaseOutcome::default()
                             };
                         }
+                        Err(e) => {
+                            drop(_binding_lock);
+                            drop(_agent_lock);
+                            for notice in notices {
+                                notice.emit(home);
+                            }
+                            return ReleaseOutcome {
+                                error: Some(format!(
+                                    "nested dirt discard refused: nested status check \
+                                     failed for '{sub_path}': {e}; state preserved"
+                                )),
+                                ..ReleaseOutcome::default()
+                            };
+                        }
+                        Ok(_) => {}
                     }
                 }
                 let mut completed_targets: Vec<&str> = Vec::new();
@@ -2060,6 +2135,8 @@ pub(crate) fn release_absent_target_under_branch_lock(
                             sub_path,
                         ],
                     ) {
+                        let completed_json = serde_json::to_string(&completed_targets)
+                            .unwrap_or_else(|_| format!("{completed_targets:?}"));
                         crate::event_log::log(
                             home,
                             "nested_dirt_discard_aborted",
@@ -2067,10 +2144,9 @@ pub(crate) fn release_absent_target_under_branch_lock(
                             &format!(
                                 "branch={branch_for_preserve} discard_digest={} \
                                  audit_reason={} failed_target={sub_path} \
-                                 completed_targets={} abort_reason=reset_failed",
-                                discard.expected_digest,
-                                discard.audit_reason,
-                                completed_targets.join(","),
+                                 completed_targets={completed_json} \
+                                 abort_reason=reset_failed",
+                                discard.expected_digest, discard.audit_reason,
                             ),
                         );
                         drop(_binding_lock);
@@ -2143,13 +2219,13 @@ pub(crate) fn release_absent_target_under_branch_lock(
                         ..ReleaseOutcome::default()
                     };
                 }
+                let targets_json = serde_json::to_string(&dirty_sub_paths)
+                    .unwrap_or_else(|_| format!("{dirty_sub_paths:?}"));
                 discard_audit_detail = Some(format!(
                     "branch={branch_for_preserve} discard_digest={} audit_reason={} \
                      pre_discard_status_lines={pre_discard_line_count} \
-                     targets={}",
-                    discard.expected_digest,
-                    discard.audit_reason,
-                    dirty_sub_paths.join(","),
+                     targets={targets_json}",
+                    discard.expected_digest, discard.audit_reason,
                 ));
             } else {
                 let digest = if matches!(

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -5,6 +5,11 @@
 
 use std::path::{Path, PathBuf};
 
+pub(crate) struct NestedDirtDiscard<'a> {
+    pub expected_digest: &'a str,
+    pub audit_reason: &'a str,
+}
+
 #[cfg(test)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum ReleaseTestPhase {
@@ -1768,6 +1773,7 @@ pub(crate) fn release_bound_target_exact_under_branch_lock_for_force(
 /// Absent-binding arm of the S2 force transaction.  The branch lease is held
 /// by the caller; A/B are acquired here and the binding is re-read as truly
 /// absent before the managed target is removed.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn release_absent_target_under_branch_lock(
     home: &Path,
     agent: &str,
@@ -1776,6 +1782,7 @@ pub(crate) fn release_absent_target_under_branch_lock(
     source_repo: &Path,
     sender: Option<&str>,
     permit: &crate::mcp::handlers::dispatch_hook::LifecyclePermit,
+    nested_discard: Option<&NestedDirtDiscard<'_>>,
 ) -> ReleaseOutcome {
     if !permit.authorizes(home, agent) {
         return ReleaseOutcome {
@@ -1892,26 +1899,132 @@ pub(crate) fn release_absent_target_under_branch_lock(
         return out;
     }
     if matches!(target_state, crate::mcp::handlers::TargetState::Present) {
+        let mk_branch = marker_branch(target);
+        let branch_for_preserve = mk_branch.as_deref().unwrap_or("");
         let (preservation, collected) = crate::worktree::preserve_dirty_worktree_collect(
             home,
             agent,
             target,
-            marker_branch(target).as_deref().unwrap_or(""),
+            branch_for_preserve,
             sender,
         );
         notices = collected;
         if let Some(reason) = preservation.blocked_reason() {
-            drop(_binding_lock);
-            drop(_agent_lock);
-            for notice in notices {
-                notice.emit(home);
+            if let (Some(discard), crate::worktree::WipPreservation::UnpreservableNestedDirty(_)) =
+                (nested_discard, &preservation)
+            {
+                let nested_status = crate::worktree::enumerate_nested_dirty(target);
+                let current_digest = crate::worktree::hash_hex(&nested_status);
+                if current_digest != discard.expected_digest {
+                    drop(_binding_lock);
+                    drop(_agent_lock);
+                    for notice in notices {
+                        notice.emit(home);
+                    }
+                    return ReleaseOutcome {
+                        error: Some(format!(
+                            "nested dirt discard refused: digest mismatch (expected {}, got {current_digest}); \
+                             state preserved",
+                            discard.expected_digest
+                        )),
+                        ..ReleaseOutcome::default()
+                    };
+                }
+                if nested_status.lines().any(|l| l.starts_with("  ?? ")) {
+                    drop(_binding_lock);
+                    drop(_agent_lock);
+                    for notice in notices {
+                        notice.emit(home);
+                    }
+                    return ReleaseOutcome {
+                        error: Some(
+                            "nested dirt discard refused: residual untracked nested content would \
+                             survive targeted reset; state preserved"
+                                .to_string(),
+                        ),
+                        ..ReleaseOutcome::default()
+                    };
+                }
+                if let Err(e) = crate::git_helpers::git_cmd(
+                    target,
+                    &["submodule", "update", "--force", "--checkout"],
+                ) {
+                    drop(_binding_lock);
+                    drop(_agent_lock);
+                    for notice in notices {
+                        notice.emit(home);
+                    }
+                    return ReleaseOutcome {
+                        error: Some(format!(
+                            "nested dirt discard refused: submodule reset failed: {e}; state preserved"
+                        )),
+                        ..ReleaseOutcome::default()
+                    };
+                }
+                let residual = crate::worktree::enumerate_nested_dirty(target);
+                if !residual.is_empty() {
+                    drop(_binding_lock);
+                    drop(_agent_lock);
+                    for notice in notices {
+                        notice.emit(home);
+                    }
+                    return ReleaseOutcome {
+                        error: Some(
+                            "nested dirt discard refused: residual nested dirt remains after targeted \
+                             reset; state preserved"
+                                .to_string(),
+                        ),
+                        ..ReleaseOutcome::default()
+                    };
+                }
+                crate::event_log::log(
+                    home,
+                    "nested_dirt_discard_release",
+                    agent,
+                    &format!(
+                        "branch={branch_for_preserve} discard_digest={} audit_reason={} \
+                         pre_discard_status_lines={}",
+                        discard.expected_digest,
+                        discard.audit_reason,
+                        nested_status.lines().count(),
+                    ),
+                );
+                let (pres2, collected2) = crate::worktree::preserve_dirty_worktree_collect(
+                    home,
+                    agent,
+                    target,
+                    branch_for_preserve,
+                    sender,
+                );
+                notices = collected2;
+                if let Some(r2) = pres2.blocked_reason() {
+                    drop(_binding_lock);
+                    drop(_agent_lock);
+                    for notice in notices {
+                        notice.emit(home);
+                    }
+                    return ReleaseOutcome {
+                        error: Some(format!(
+                            "nested dirt discarded but parent WIP preservation failed ({r2}); \
+                             not removing it"
+                        )),
+                        ..ReleaseOutcome::default()
+                    };
+                }
+            } else {
+                drop(_binding_lock);
+                drop(_agent_lock);
+                for notice in notices {
+                    notice.emit(home);
+                }
+                return ReleaseOutcome {
+                    error: Some(format!(
+                        "force release refused: worktree WIP could not be preserved ({reason}); \
+                         not removing it"
+                    )),
+                    ..ReleaseOutcome::default()
+                };
             }
-            return ReleaseOutcome {
-                error: Some(format!(
-                    "force release refused: worktree WIP could not be preserved ({reason}); not removing it"
-                )),
-                ..ReleaseOutcome::default()
-            };
         }
     }
     match remove_worktree(agent, target, source_repo) {

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -233,6 +233,8 @@ pub struct ReleaseOutcome {
     /// Exact S2 absent-arm metadata cleanup, surfaced only by the force
     /// handler after the transaction; ordinary release responses skip it.
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) nested_dirt_digest: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub intent_persist_error: Option<String>,
     #[serde(skip)]
     pub(crate) git_metadata_pruned: usize,
@@ -1945,10 +1947,57 @@ pub(crate) fn release_absent_target_under_branch_lock(
                         ..ReleaseOutcome::default()
                     };
                 }
-                if let Err(e) = crate::git_helpers::git_cmd(
-                    target,
-                    &["submodule", "update", "--force", "--checkout"],
-                ) {
+                if nested_status
+                    .lines()
+                    .any(|l| l.contains("[skipped:") || l.contains("[truncated:"))
+                {
+                    drop(_binding_lock);
+                    drop(_agent_lock);
+                    for notice in notices {
+                        notice.emit(home);
+                    }
+                    return ReleaseOutcome {
+                        error: Some(
+                            "nested dirt discard refused: opaque or unsupported nested state \
+                             detected (skipped/truncated entries); state preserved"
+                                .to_string(),
+                        ),
+                        ..ReleaseOutcome::default()
+                    };
+                }
+                let dirty_sub_paths: Vec<&str> = nested_status
+                    .lines()
+                    .filter_map(|l| {
+                        let l = l.trim_end();
+                        if !l.starts_with(' ')
+                            && !l.starts_with('[')
+                            && l.ends_with(':')
+                            && l.len() > 1
+                        {
+                            Some(&l[..l.len() - 1])
+                        } else {
+                            None
+                        }
+                    })
+                    .collect();
+                if dirty_sub_paths.is_empty() {
+                    drop(_binding_lock);
+                    drop(_agent_lock);
+                    for notice in notices {
+                        notice.emit(home);
+                    }
+                    return ReleaseOutcome {
+                        error: Some(
+                            "nested dirt discard refused: no eligible registered dirty submodule \
+                             paths found; state preserved"
+                                .to_string(),
+                        ),
+                        ..ReleaseOutcome::default()
+                    };
+                }
+                let mut sub_args = vec!["submodule", "update", "--force", "--checkout", "--"];
+                sub_args.extend(dirty_sub_paths.iter().copied());
+                if let Err(e) = crate::git_helpers::git_cmd(target, &sub_args) {
                     drop(_binding_lock);
                     drop(_agent_lock);
                     for notice in notices {
@@ -2012,6 +2061,15 @@ pub(crate) fn release_absent_target_under_branch_lock(
                     };
                 }
             } else {
+                let digest = if matches!(
+                    &preservation,
+                    crate::worktree::WipPreservation::UnpreservableNestedDirty(_)
+                ) {
+                    let ns = crate::worktree::enumerate_nested_dirty(target);
+                    Some(crate::worktree::hash_hex(&ns))
+                } else {
+                    None
+                };
                 drop(_binding_lock);
                 drop(_agent_lock);
                 for notice in notices {
@@ -2022,6 +2080,7 @@ pub(crate) fn release_absent_target_under_branch_lock(
                         "force release refused: worktree WIP could not be preserved ({reason}); \
                          not removing it"
                     )),
+                    nested_dirt_digest: digest,
                     ..ReleaseOutcome::default()
                 };
             }

--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -1916,7 +1916,7 @@ pub(crate) fn release_absent_target_under_branch_lock(
                 (nested_discard, &preservation)
             {
                 let nested_status = crate::worktree::enumerate_nested_dirty(target);
-                let current_digest = crate::worktree::hash_hex(&nested_status);
+                let current_digest = crate::worktree::nested_dirt_digest_sha256(&nested_status);
                 if current_digest != discard.expected_digest {
                     drop(_binding_lock);
                     drop(_agent_lock);
@@ -1965,50 +1965,62 @@ pub(crate) fn release_absent_target_under_branch_lock(
                         ..ReleaseOutcome::default()
                     };
                 }
-                let dirty_sub_paths: Vec<&str> = nested_status
-                    .lines()
-                    .filter_map(|l| {
-                        let l = l.trim_end();
-                        if !l.starts_with(' ')
-                            && !l.starts_with('[')
-                            && l.ends_with(':')
-                            && l.len() > 1
-                        {
-                            Some(&l[..l.len() - 1])
-                        } else {
-                            None
+                let dirty_sub_paths = match crate::worktree::dirty_submodule_paths(target) {
+                    Ok(p) if p.is_empty() => {
+                        drop(_binding_lock);
+                        drop(_agent_lock);
+                        for notice in notices {
+                            notice.emit(home);
                         }
-                    })
-                    .collect();
-                if dirty_sub_paths.is_empty() {
-                    drop(_binding_lock);
-                    drop(_agent_lock);
-                    for notice in notices {
-                        notice.emit(home);
+                        return ReleaseOutcome {
+                            error: Some(
+                                "nested dirt discard refused: no eligible registered dirty \
+                                 submodule paths found; state preserved"
+                                    .to_string(),
+                            ),
+                            ..ReleaseOutcome::default()
+                        };
                     }
-                    return ReleaseOutcome {
-                        error: Some(
-                            "nested dirt discard refused: no eligible registered dirty submodule \
-                             paths found; state preserved"
-                                .to_string(),
-                        ),
-                        ..ReleaseOutcome::default()
-                    };
-                }
-                let mut sub_args = vec!["submodule", "update", "--force", "--checkout", "--"];
-                sub_args.extend(dirty_sub_paths.iter().copied());
-                if let Err(e) = crate::git_helpers::git_cmd(target, &sub_args) {
-                    drop(_binding_lock);
-                    drop(_agent_lock);
-                    for notice in notices {
-                        notice.emit(home);
+                    Ok(p) => p,
+                    Err(e) => {
+                        drop(_binding_lock);
+                        drop(_agent_lock);
+                        for notice in notices {
+                            notice.emit(home);
+                        }
+                        return ReleaseOutcome {
+                            error: Some(format!(
+                                "nested dirt discard refused: {e}; state preserved"
+                            )),
+                            ..ReleaseOutcome::default()
+                        };
                     }
-                    return ReleaseOutcome {
-                        error: Some(format!(
-                            "nested dirt discard refused: submodule reset failed: {e}; state preserved"
-                        )),
-                        ..ReleaseOutcome::default()
-                    };
+                };
+                for sub_path in &dirty_sub_paths {
+                    if let Err(e) = crate::git_helpers::git_cmd(
+                        target,
+                        &[
+                            "submodule",
+                            "update",
+                            "--force",
+                            "--checkout",
+                            "--",
+                            sub_path,
+                        ],
+                    ) {
+                        drop(_binding_lock);
+                        drop(_agent_lock);
+                        for notice in notices {
+                            notice.emit(home);
+                        }
+                        return ReleaseOutcome {
+                            error: Some(format!(
+                                "nested dirt discard refused: submodule reset failed for \
+                                 '{sub_path}': {e}; state preserved"
+                            )),
+                            ..ReleaseOutcome::default()
+                        };
+                    }
                 }
                 let residual = crate::worktree::enumerate_nested_dirty(target);
                 if !residual.is_empty() {
@@ -2026,18 +2038,7 @@ pub(crate) fn release_absent_target_under_branch_lock(
                         ..ReleaseOutcome::default()
                     };
                 }
-                crate::event_log::log(
-                    home,
-                    "nested_dirt_discard_release",
-                    agent,
-                    &format!(
-                        "branch={branch_for_preserve} discard_digest={} audit_reason={} \
-                         pre_discard_status_lines={}",
-                        discard.expected_digest,
-                        discard.audit_reason,
-                        nested_status.lines().count(),
-                    ),
-                );
+                let pre_discard_line_count = nested_status.lines().count();
                 let (pres2, collected2) = crate::worktree::preserve_dirty_worktree_collect(
                     home,
                     agent,
@@ -2047,6 +2048,16 @@ pub(crate) fn release_absent_target_under_branch_lock(
                 );
                 notices = collected2;
                 if let Some(r2) = pres2.blocked_reason() {
+                    crate::event_log::log(
+                        home,
+                        "nested_dirt_discard_aborted",
+                        agent,
+                        &format!(
+                            "branch={branch_for_preserve} discard_digest={} audit_reason={} \
+                             abort_reason=parent_wip_preservation_failed",
+                            discard.expected_digest, discard.audit_reason,
+                        ),
+                    );
                     drop(_binding_lock);
                     drop(_agent_lock);
                     for notice in notices {
@@ -2060,13 +2071,26 @@ pub(crate) fn release_absent_target_under_branch_lock(
                         ..ReleaseOutcome::default()
                     };
                 }
+                crate::event_log::log(
+                    home,
+                    "nested_dirt_discard_release",
+                    agent,
+                    &format!(
+                        "branch={branch_for_preserve} discard_digest={} audit_reason={} \
+                         pre_discard_status_lines={pre_discard_line_count} \
+                         targets={}",
+                        discard.expected_digest,
+                        discard.audit_reason,
+                        dirty_sub_paths.join(","),
+                    ),
+                );
             } else {
                 let digest = if matches!(
                     &preservation,
                     crate::worktree::WipPreservation::UnpreservableNestedDirty(_)
                 ) {
                     let ns = crate::worktree::enumerate_nested_dirty(target);
-                    Some(crate::worktree::hash_hex(&ns))
+                    Some(crate::worktree::nested_dirt_digest_sha256(&ns))
                 } else {
                     None
                 };


### PR DESCRIPTION
## Summary

Implements the nested-submodule dirty-state discard confirmation seam for the release path (Architecture-14 item, decision `d-20260720174703285079-6`).

**Problem**: `git add -A` captures gitlinks but never submodule-internal edits, making nested dirt "unpreservable" by a parent recovery ref. Previously, worktrees with nested-only dirt were permanently stuck — the release path refused (correctly) but offered no resolution mechanism.

**Solution**: A two-phase confirmation protocol:
1. **Refusal with digest** — when nested dirt blocks release, the daemon now returns a `nested_dirt_digest` field containing the exact hex digest of the enumerated nested state.
2. **Authorized discard** — the caller echoes `discard_nested_dirt=true`, `force=true`, `expected_nested_dirt_digest=<digest>`, and a non-empty `audit_reason`. The daemon re-enumerates under locks, verifies the digest (TOCTOU guard), pre-checks for untracked/opaque content, performs a targeted `git submodule update --force --checkout -- <paths>`, verifies clean, logs an audit event, re-preserves parent-level WIP, then proceeds with normal removal.

### Destructive authorization boundaries

- `discard_nested_dirt` without `force=true` → rejected
- `force=true` without a matching `expected_nested_dirt_digest` → rejected
- Trimmed-empty digest or audit_reason → rejected
- Digest mismatch (TOCTOU race) → rejected, state preserved
- Untracked nested content (`??` entries) → rejected pre-mutation
- Opaque/unsupported entries (`[skipped:]`/`[truncated:]`) → rejected pre-mutation
- No eligible registered dirty submodule paths → rejected
- `discard_nested_dirt` on Known-bound managed or unmanaged release paths → structured rejection (`discard_unsupported_release_path`)

### Commits

- RED tests: `a145f50e`, `d7155519` (7 tests, all failing)
- GREEN production code: `b124f3b1` (all 7 pass)
- Review amendments: `5e7561ed` (5 fixes + 3 new tests + schema test)

### Files changed (6 files, +428/-23)

- `src/worktree_pool.rs` — `NestedDirtDiscard` struct, `nested_dirt_digest` on `ReleaseOutcome`, discard logic in `release_absent_target_under_branch_lock`
- `src/mcp/handlers/ci/release.rs` — handler param parsing, early gates, structured rejection for unsupported paths, digest surfacing
- `src/mcp/tools.rs` — `def_repo` schema exposes `discard_nested_dirt`, `expected_nested_dirt_digest`
- `src/worktree.rs` — `enumerate_nested_dirty` and `hash_hex` visibility → `pub(crate)`
- `src/worktree/tests.rs` — 10 tests covering all boundaries + DAEMON_HOME env fix
- `src/mcp/handlers/force_release/s2.rs` — thread `None` for nested_discard

## Test plan

- [x] All 10 `discard_seam_*` tests pass (serial + parallel)
- [x] Schema test `repo_schema_exposes_discard_nested_dirt_params` passes
- [x] `cargo fmt` + `cargo clippy` clean
- [ ] Main CI not required (arch14 feature branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)