### PR TITLE
fix(release): gate markerless worktree removal on binding state (#2875)

### DIFF
--- a/src/mcp/handlers/ci/release.rs
+++ b/src/mcp/handlers/ci/release.rs
@@ -439,6 +439,26 @@ pub(crate) fn handle_release_repo(home: &Path, args: &Value, instance_name: &str
         });
     }
 
+    match crate::binding::worktree_binding_state(home, &canonical) {
+        crate::binding::WorktreeBindingState::Bound => {
+            return json!({
+                "error": "release refused: marker absent but an authoritative binding \
+                          targets this worktree — restore the marker or use the managed \
+                          release path",
+                "code": "markerless_bound_worktree",
+            });
+        }
+        crate::binding::WorktreeBindingState::Uncertain => {
+            return json!({
+                "error": "release refused: marker absent and binding state is uncertain \
+                          (unreadable or unparseable binding present) — cannot safely \
+                          determine ownership; resolve the binding or restore the marker",
+                "code": "markerless_uncertain_binding",
+            });
+        }
+        crate::binding::WorktreeBindingState::Unbound => {}
+    }
+
     remove_linked_worktree_canonical(&canonical, path)
 }
 

--- a/src/mcp/handlers/ci/tests.rs
+++ b/src/mcp/handlers/ci/tests.rs
@@ -3556,6 +3556,38 @@ fn repo_release_marker_rewritten_after_snapshot_refuses() {
     std::fs::remove_dir_all(&base).ok();
 }
 
+/// RED #2875: marker already absent at entry with a live binding must refuse,
+/// not raw-remove the worktree while retaining the stale binding.
+#[test]
+#[cfg(unix)]
+fn repo_release_marker_absent_with_live_binding_refuses_2875() {
+    let (base, home, repo, wt) = managed_wt_fixture("2875");
+    seed_managed_marker(&wt, &repo, &home, "agent-2875", "feat/test");
+
+    // Remove ONLY the marker — binding stays live.
+    std::fs::remove_file(wt.join(".agend-managed")).expect("remove marker");
+    assert!(
+        crate::binding::read(&home, "agent-2875").is_some(),
+        "precondition: binding must exist before release"
+    );
+
+    let r = dispatch_repo_release(&home, "agent-2875", wt.to_str().unwrap());
+
+    assert!(
+        r.get("error").is_some(),
+        "marker-absent release with live binding must refuse: {r}"
+    );
+    assert!(
+        wt.exists(),
+        "worktree must be preserved when marker is absent but binding is live"
+    );
+    assert!(
+        crate::binding::read(&home, "agent-2875").is_some(),
+        "binding must be preserved when marker is absent — not left stale"
+    );
+    std::fs::remove_dir_all(&base).ok();
+}
+
 /// Marker DELETED after pre-read — under-lock re-read must refuse.
 #[test]
 #[cfg(unix)]


### PR DESCRIPTION
## Summary

- **Issue**: When `.agend-managed` marker is absent, the unmanaged release path calls `remove_linked_worktree_canonical` without consulting bindings — silently destroying worktrees that a live binding still references.
- **Fix**: Insert a `worktree_binding_state` check between the marker-absence branch and the raw removal call. Bound/Uncertain → refuse; Unbound → proceed (genuinely unmanaged).
- **Scope**: 1 file changed, +20 lines. Surgical gate only; no new types, no new dependencies.

## Commits

1. `fc684797` — RED test: `repo_release_marker_absent_with_live_binding_refuses_2875` (cherry-picked from `f696fe2f`)
2. `4d1bb33c` — GREEN production fix: `worktree_binding_state` gate

## Test plan

- [x] RED test fails on RED-only commit, passes after production fix
- [x] Existing unbound raw-release regression (`handle_release_repo_still_removes_linked_worktree_83936`) still passes
- [x] All 12 `repo_release` tests pass
- [x] `cargo fmt -- --check` clean
- [x] `cargo clippy --tests -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)