### PR TITLE
fix: make merge train admission fail closed

### DIFF
--- a/src/mcp/handlers/comms_delegate/merge_train.rs
+++ b/src/mcp/handlers/comms_delegate/merge_train.rs
@@ -1,5 +1,6 @@
 use crate::mcp::handlers::dispatch_hook;
 use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
 use std::path::Path;
 
 pub(crate) enum Admission {
@@ -25,9 +26,119 @@ pub(crate) fn admit(
         None => return Ok(Admission::NotGoverned),
     };
 
-    let repo_slug = resolve_repo(home, args, target)?;
+    let repo_identity = resolve_repo(home, args, target)?;
 
-    let routed = crate::tasks::load_routed(home, task_id).map_err(|e| {
+    let routed = load_task(home, task_id)?;
+    let initial_domain = conflict_domain(routed.record());
+    let lock_key = lock_key(&repo_identity, &initial_domain);
+    let lock_dir = home.join("merge_train");
+    std::fs::create_dir_all(&lock_dir).map_err(|e| {
+        json!({
+            "ok": false,
+            "error": format!("merge train lock directory: {e}"),
+            "code": "merge_train_lock_error",
+        })
+    })?;
+    let _lock = crate::store::acquire_file_lock(&lock_dir.join(format!("{lock_key}.lock")))
+        .map_err(|e| {
+            json!({
+                "ok": false,
+                "error": format!("merge train lock: {e}"),
+                "code": "merge_train_lock_error",
+            })
+        })?;
+
+    // All authority below is freshly replayed under the repo/domain lock. The
+    // preliminary route above exists only to identify which outer lock to take.
+    let routed = load_task(home, task_id)?;
+    let domain = conflict_domain(routed.record());
+    if domain != initial_domain {
+        return Err(json!({
+            "ok": false,
+            "error": format!("merge train: task '{task_id}' conflict domain changed while acquiring admission lock"),
+            "code": "merge_train_domain_changed",
+        }));
+    }
+
+    match TrainState::read(routed.record()) {
+        TrainState::None => {}
+        TrainState::Partial(n) => {
+            return Err(json!({
+                "ok": false,
+                "error": format!("merge train: task '{task_id}' has partial train metadata ({n}/4 keys)"),
+                "code": "merge_train_partial_metadata",
+            }));
+        }
+        TrainState::Complete {
+            repo,
+            domain: dom,
+            position,
+            seq,
+        } => {
+            if !matches!(position.as_str(), "Front" | "Queued") {
+                return Err(json!({
+                    "ok": false,
+                    "error": format!("merge train: task '{task_id}' has invalid stored position '{position}'"),
+                    "code": "merge_train_invalid_position",
+                }));
+            }
+            if repo != repo_identity || dom != domain {
+                return Err(json!({
+                    "ok": false,
+                    "error": format!("merge train: task '{task_id}' metadata mismatch: existing repo={repo} domain={dom} vs canonical repo={repo_identity} domain={domain}"),
+                    "code": "merge_train_metadata_mismatch",
+                }));
+            }
+            return Ok(if position == "Front" {
+                Admission::Front
+            } else {
+                Admission::Queued(json!({
+                    "ok": true,
+                    "merge_train_position": "Queued",
+                    "merge_train_queue_seq": seq,
+                    "merge_train_repository": repo_identity,
+                    "merge_train_domain": domain,
+                }))
+            });
+        }
+    }
+
+    let (fronts, seq) = crate::tasks::scan_merge_train_state(home, &repo_identity, &domain)
+        .map_err(|e| {
+            json!({
+                "ok": false,
+                "error": format!("merge train durable authority scan: {e}"),
+                "code": "merge_train_board_replay_error",
+            })
+        })?;
+    let position = if fronts.is_empty() { "Front" } else { "Queued" };
+
+    crate::tasks::write_merge_train_metadata(
+        home,
+        task_id,
+        &[
+            ("merge_train_repository", json!(repo_identity)),
+            ("merge_train_domain", json!(domain)),
+            ("merge_train_position", json!(position)),
+            ("merge_train_queue_seq", json!(seq)),
+        ],
+    )?;
+
+    if position == "Queued" {
+        Ok(Admission::Queued(json!({
+            "ok": true,
+            "merge_train_position": "Queued",
+            "merge_train_queue_seq": seq,
+            "merge_train_repository": repo_identity,
+            "merge_train_domain": domain,
+        })))
+    } else {
+        Ok(Admission::Front)
+    }
+}
+
+fn load_task(home: &Path, task_id: &str) -> Result<crate::tasks::RoutedTask, Value> {
+    crate::tasks::load_routed(home, task_id).map_err(|e| {
         use crate::tasks::TaskRouteError;
         match e {
             TaskRouteError::NotFound => json!({
@@ -46,99 +157,7 @@ pub(crate) fn admit(
                 "code": "merge_train_route_error",
             }),
         }
-    })?;
-
-    let domain = routed
-        .record()
-        .metadata
-        .get("conflict_domain")
-        .and_then(|v| v.as_str())
-        .unwrap_or("__repo__")
-        .to_string();
-
-    let existing = TrainState::read(routed.record());
-    match existing {
-        TrainState::None => {}
-        TrainState::Partial(n) => {
-            return Err(json!({
-                "ok": false,
-                "error": format!(
-                    "merge train: task '{task_id}' has partial train metadata ({n}/4 keys)"
-                ),
-                "code": "merge_train_partial_metadata",
-            }));
-        }
-        TrainState::Complete {
-            repo,
-            domain: dom,
-            position,
-            seq,
-        } => {
-            if repo != repo_slug || dom != domain {
-                return Err(json!({
-                    "ok": false,
-                    "error": format!(
-                        "merge train: task '{task_id}' metadata mismatch: \
-                         existing repo={repo} domain={dom} vs canonical repo={repo_slug} domain={domain}"
-                    ),
-                    "code": "merge_train_metadata_mismatch",
-                }));
-            }
-            return Ok(match position.as_str() {
-                "Front" => Admission::Front,
-                _ => Admission::Queued(json!({
-                    "ok": true,
-                    "merge_train_position": position,
-                    "merge_train_queue_seq": seq,
-                    "merge_train_repository": repo_slug,
-                    "merge_train_domain": domain,
-                })),
-            });
-        }
-    }
-
-    let lock_key = format!(
-        "{}__{}",
-        sanitize_lock_component(&repo_slug),
-        sanitize_lock_component(&domain)
-    );
-    let lock_dir = home.join("merge_train");
-    std::fs::create_dir_all(&lock_dir).ok();
-    let _lock = crate::store::acquire_file_lock(&lock_dir.join(format!("{lock_key}.lock")))
-        .map_err(|e| {
-            json!({
-                "ok": false,
-                "error": format!("merge train lock: {e}"),
-                "code": "merge_train_lock_error",
-            })
-        })?;
-
-    let fronts = crate::tasks::scan_merge_train_fronts(home, &repo_slug, &domain);
-    let seq = crate::tasks::next_merge_train_seq(home, &repo_slug, &domain);
-    let position = if fronts.is_empty() { "Front" } else { "Queued" };
-
-    crate::tasks::write_merge_train_metadata(
-        home,
-        task_id,
-        &[
-            ("merge_train_repository", json!(repo_slug)),
-            ("merge_train_domain", json!(domain)),
-            ("merge_train_position", json!(position)),
-            ("merge_train_queue_seq", json!(seq)),
-        ],
-    )?;
-
-    if position == "Queued" {
-        Ok(Admission::Queued(json!({
-            "ok": true,
-            "merge_train_position": "Queued",
-            "merge_train_queue_seq": seq,
-            "merge_train_repository": repo_slug,
-            "merge_train_domain": domain,
-        })))
-    } else {
-        Ok(Admission::Front)
-    }
+    })
 }
 
 fn resolve_repo(home: &Path, args: &Value, target: &str) -> Result<String, Value> {
@@ -151,23 +170,35 @@ fn resolve_repo(home: &Path, args: &Value, target: &str) -> Result<String, Value
         })
     };
     if let Some(repo) = args["repository"].as_str().filter(|s| !s.is_empty()) {
-        return dispatch_hook::canonicalize_repo_slug_any_forge(repo).ok_or_else(unresolved);
+        return dispatch_hook::canonicalize_repo_slug_any_forge(repo)
+            .map(|slug| format!("forge:{slug}"))
+            .ok_or_else(unresolved);
     }
-    let source_repo =
-        dispatch_hook::resolve_team_source_repo(home, target).ok_or_else(unresolved)?;
-    dispatch_hook::canonical_repo_slug_for_source(&source_repo).ok_or_else(unresolved)
+    let source_repo = dispatch_hook::resolve_source_repo_for_target(home, target);
+    let canonical = std::fs::canonicalize(&source_repo).map_err(|_| unresolved())?;
+    Ok(
+        match dispatch_hook::canonical_repo_slug_for_source(&canonical) {
+            Some(slug) => format!("forge:{slug}"),
+            None => format!("path:{}", canonical.display()),
+        },
+    )
 }
 
-fn sanitize_lock_component(s: &str) -> String {
-    s.chars()
-        .map(|c| {
-            if c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.') {
-                c
-            } else {
-                '_'
-            }
-        })
-        .collect()
+fn conflict_domain(record: &crate::task_events::TaskRecord) -> String {
+    record
+        .metadata
+        .get("conflict_domain")
+        .and_then(Value::as_str)
+        .unwrap_or("__repo__")
+        .to_string()
+}
+
+fn lock_key(repo: &str, domain: &str) -> String {
+    let mut digest = Sha256::new();
+    digest.update(repo.as_bytes());
+    digest.update([0]);
+    digest.update(domain.as_bytes());
+    hex::encode(digest.finalize())
 }
 
 enum TrainState {

--- a/src/mcp/handlers/comms_delegate/merge_train.rs
+++ b/src/mcp/handlers/comms_delegate/merge_train.rs
@@ -175,7 +175,11 @@ fn resolve_repo(home: &Path, args: &Value, target: &str) -> Result<String, Value
             .ok_or_else(unresolved);
     }
     let source_repo = dispatch_hook::resolve_source_repo_for_target(home, target);
-    let canonical = std::fs::canonicalize(&source_repo).map_err(|_| unresolved())?;
+    let canonical = match std::fs::canonicalize(&source_repo) {
+        Ok(path) => path,
+        Err(_) if source_repo.is_absolute() => source_repo,
+        Err(_) => return Err(unresolved()),
+    };
     Ok(
         match dispatch_hook::canonical_repo_slug_for_source(&canonical) {
             Some(slug) => format!("forge:{slug}"),

--- a/src/mcp/handlers/comms_delegate/merge_train.rs
+++ b/src/mcp/handlers/comms_delegate/merge_train.rs
@@ -1,0 +1,222 @@
+use crate::mcp::handlers::dispatch_hook;
+use serde_json::{json, Value};
+use std::path::Path;
+
+pub(crate) enum Admission {
+    NotGoverned,
+    Front,
+    Queued(Value),
+}
+
+pub(crate) fn admit(
+    home: &Path,
+    args: &Value,
+    target: &str,
+    is_review: bool,
+) -> Result<Admission, Value> {
+    if is_review {
+        return Ok(Admission::NotGoverned);
+    }
+    if args["branch"].as_str().filter(|b| !b.is_empty()).is_none() {
+        return Ok(Admission::NotGoverned);
+    }
+    let task_id = match args["task_id"].as_str().filter(|s| !s.is_empty()) {
+        Some(t) => t,
+        None => return Ok(Admission::NotGoverned),
+    };
+
+    let repo_slug = resolve_repo(home, args, target)?;
+
+    let routed = crate::tasks::load_routed(home, task_id).map_err(|e| {
+        use crate::tasks::TaskRouteError;
+        match e {
+            TaskRouteError::NotFound => json!({
+                "ok": false,
+                "error": format!("merge train: task '{task_id}' not found on any board"),
+                "code": "merge_train_task_not_found",
+            }),
+            TaskRouteError::Ambiguous { .. } => json!({
+                "ok": false,
+                "error": format!("merge train: task '{task_id}' ambiguous across boards"),
+                "code": "merge_train_ambiguous_task",
+            }),
+            _ => json!({
+                "ok": false,
+                "error": format!("merge train: task '{task_id}' route error: {e}"),
+                "code": "merge_train_route_error",
+            }),
+        }
+    })?;
+
+    let domain = routed
+        .record()
+        .metadata
+        .get("conflict_domain")
+        .and_then(|v| v.as_str())
+        .unwrap_or("__repo__")
+        .to_string();
+
+    let existing = TrainState::read(routed.record());
+    match existing {
+        TrainState::None => {}
+        TrainState::Partial(n) => {
+            return Err(json!({
+                "ok": false,
+                "error": format!(
+                    "merge train: task '{task_id}' has partial train metadata ({n}/4 keys)"
+                ),
+                "code": "merge_train_partial_metadata",
+            }));
+        }
+        TrainState::Complete {
+            repo,
+            domain: dom,
+            position,
+            seq,
+        } => {
+            if repo != repo_slug || dom != domain {
+                return Err(json!({
+                    "ok": false,
+                    "error": format!(
+                        "merge train: task '{task_id}' metadata mismatch: \
+                         existing repo={repo} domain={dom} vs canonical repo={repo_slug} domain={domain}"
+                    ),
+                    "code": "merge_train_metadata_mismatch",
+                }));
+            }
+            return Ok(match position.as_str() {
+                "Front" => Admission::Front,
+                _ => Admission::Queued(json!({
+                    "ok": true,
+                    "merge_train_position": position,
+                    "merge_train_queue_seq": seq,
+                    "merge_train_repository": repo_slug,
+                    "merge_train_domain": domain,
+                })),
+            });
+        }
+    }
+
+    let lock_key = format!(
+        "{}__{}",
+        sanitize_lock_component(&repo_slug),
+        sanitize_lock_component(&domain)
+    );
+    let lock_dir = home.join("merge_train");
+    std::fs::create_dir_all(&lock_dir).ok();
+    let _lock = crate::store::acquire_file_lock(&lock_dir.join(format!("{lock_key}.lock")))
+        .map_err(|e| {
+            json!({
+                "ok": false,
+                "error": format!("merge train lock: {e}"),
+                "code": "merge_train_lock_error",
+            })
+        })?;
+
+    let fronts = crate::tasks::scan_merge_train_fronts(home, &repo_slug, &domain);
+    let seq = crate::tasks::next_merge_train_seq(home, &repo_slug, &domain);
+    let position = if fronts.is_empty() { "Front" } else { "Queued" };
+
+    crate::tasks::write_merge_train_metadata(
+        home,
+        task_id,
+        &[
+            ("merge_train_repository", json!(repo_slug)),
+            ("merge_train_domain", json!(domain)),
+            ("merge_train_position", json!(position)),
+            ("merge_train_queue_seq", json!(seq)),
+        ],
+    )?;
+
+    if position == "Queued" {
+        Ok(Admission::Queued(json!({
+            "ok": true,
+            "merge_train_position": "Queued",
+            "merge_train_queue_seq": seq,
+            "merge_train_repository": repo_slug,
+            "merge_train_domain": domain,
+        })))
+    } else {
+        Ok(Admission::Front)
+    }
+}
+
+fn resolve_repo(home: &Path, args: &Value, target: &str) -> Result<String, Value> {
+    let unresolved = || {
+        json!({
+            "ok": false,
+            "error": "merge train: could not resolve canonical repo identity — \
+                      set `repository=owner/repo` or a team `source_repo`",
+            "code": "merge_train_repo_unresolved",
+        })
+    };
+    if let Some(repo) = args["repository"].as_str().filter(|s| !s.is_empty()) {
+        return dispatch_hook::canonicalize_repo_slug_any_forge(repo).ok_or_else(unresolved);
+    }
+    let source_repo =
+        dispatch_hook::resolve_team_source_repo(home, target).ok_or_else(unresolved)?;
+    dispatch_hook::canonical_repo_slug_for_source(&source_repo).ok_or_else(unresolved)
+}
+
+fn sanitize_lock_component(s: &str) -> String {
+    s.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.') {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+enum TrainState {
+    None,
+    Partial(usize),
+    Complete {
+        repo: String,
+        domain: String,
+        position: String,
+        seq: u64,
+    },
+}
+
+impl TrainState {
+    fn read(record: &crate::task_events::TaskRecord) -> Self {
+        let repo = record
+            .metadata
+            .get("merge_train_repository")
+            .and_then(|v| v.as_str());
+        let domain = record
+            .metadata
+            .get("merge_train_domain")
+            .and_then(|v| v.as_str());
+        let position = record
+            .metadata
+            .get("merge_train_position")
+            .and_then(|v| v.as_str());
+        let seq = record
+            .metadata
+            .get("merge_train_queue_seq")
+            .and_then(|v| v.as_u64());
+        let count = [
+            repo.is_some(),
+            domain.is_some(),
+            position.is_some(),
+            seq.is_some(),
+        ]
+        .iter()
+        .filter(|&&x| x)
+        .count();
+        match (repo, domain, position, seq) {
+            (None, None, None, None) => Self::None,
+            (Some(r), Some(d), Some(p), Some(s)) => Self::Complete {
+                repo: r.to_string(),
+                domain: d.to_string(),
+                position: p.to_string(),
+                seq: s,
+            },
+            _ => Self::Partial(count),
+        }
+    }
+}

--- a/src/mcp/handlers/comms_delegate/mod.rs
+++ b/src/mcp/handlers/comms_delegate/mod.rs
@@ -536,6 +536,20 @@ pub(crate) fn handle_delegate_task(
 
     let composed = compose_delegate_message(task, args, &checks);
 
+    // #2454 atomicity: runtime=None + non-empty branch → fail closed BEFORE
+    // durable mutations, including merge-train admission metadata.
+    if !checks.review_assignment
+        && runtime.is_none()
+        && args["branch"].as_str().is_some_and(|b| !b.is_empty())
+    {
+        return json!({
+            "ok": false,
+            "error": "branch dispatch requires in-process runtime",
+            "code": "runtime_unavailable_branch_2454",
+            "remediation": "ensure MCP handler receives RuntimeContext from daemon dispatch",
+        });
+    }
+
     // Merge train admission — must precede bind/create/deliver so a Queued
     // dispatch never leases a worktree or creates side-effects.
     match merge_train::admit(home, args, target, checks.review_assignment) {
@@ -565,18 +579,6 @@ pub(crate) fn handle_delegate_task(
         return review_assignment::dispatch_review_assignment_via_store(
             home, sender, target, task, args, &checks, &composed, &repo_slug,
         );
-    }
-
-    // #2454 atomicity: runtime=None + non-empty branch → fail closed BEFORE
-    // durable mutations (task-create/delivery). Placed after the
-    // review_assignment early-return to preserve that path byte-for-byte.
-    if runtime.is_none() && args["branch"].as_str().is_some_and(|b| !b.is_empty()) {
-        return json!({
-            "ok": false,
-            "error": "branch dispatch requires in-process runtime",
-            "code": "runtime_unavailable_branch_2454",
-            "remediation": "ensure MCP handler receives RuntimeContext from daemon dispatch",
-        });
     }
 
     let (effective_task_id, auto_created_task_id) = if runtime.is_some() {

--- a/src/mcp/handlers/comms_delegate/mod.rs
+++ b/src/mcp/handlers/comms_delegate/mod.rs
@@ -28,6 +28,7 @@ use super::super::{err_needs_identity, is_ok_result, require_instance};
 
 // #6: pub(crate) so ci/review_workspace_tests.rs can drive the validation
 // function directly (RED-first test for bind/worktree_binding_required rejection).
+mod merge_train;
 pub(crate) mod review_assignment;
 
 /// Sprint 55 P0-C — true when the caller passed `bind: false`.
@@ -534,6 +535,14 @@ pub(crate) fn handle_delegate_task(
     };
 
     let composed = compose_delegate_message(task, args, &checks);
+
+    // Merge train admission — must precede bind/create/deliver so a Queued
+    // dispatch never leases a worktree or creates side-effects.
+    match merge_train::admit(home, args, target, checks.review_assignment) {
+        Ok(merge_train::Admission::NotGoverned | merge_train::Admission::Front) => {}
+        Ok(merge_train::Admission::Queued(v)) => return v,
+        Err(e) => return e,
+    }
 
     let review_assignment_repo = if checks.review_assignment {
         match review_assignment::validate_review_assignment_marker(

--- a/src/mcp/handlers/comms_delegate/mod.rs
+++ b/src/mcp/handlers/comms_delegate/mod.rs
@@ -247,15 +247,16 @@ pub(crate) fn resolve_existing_task_review_class(
     Ok(resolved)
 }
 
-/// Phase 4 — optional auto-bind lease (rejectable).
-fn maybe_auto_bind_lease(
+/// Read-only merge-authority preflight. Uses the exact auto-bind applicability
+/// predicate, but performs no bind/watch side effect.
+fn preflight_auto_bind_review_class(
     home: &Path,
     args: &Value,
     target: &str,
     second_reviewer: bool,
-) -> Result<(), Value> {
+) -> Result<Option<&'static str>, Value> {
     let Some(branch) = args["branch"].as_str() else {
-        return Ok(());
+        return Ok(None);
     };
     let task_id_val = args["task_id"].as_str().unwrap_or("");
     if dispatch_should_skip_auto_bind(args) {
@@ -263,10 +264,8 @@ fn maybe_auto_bind_lease(
             %target, %branch, task_id = %task_id_val,
             "dispatch_auto_bind_lease skipped (bind: false)"
         );
-        return Ok(());
+        return Ok(None);
     }
-    let next_after_ci =
-        crate::daemon::ci_watch::watch_state::normalize_next_after_ci(&args["next_after_ci"]);
     // #2745 (decision d-…-11 + R3 finding 2): this is the MERGE-AUTHORITY branch — a
     // `branch` was supplied → PR-producing / auto-watched. Resolve the durable
     // review_class authority BEFORE arming, with the authority source keyed on the
@@ -305,9 +304,14 @@ fn maybe_auto_bind_lease(
             // byte-identical to the removed default-only `load_by_id` seam (a task
             // not found there yielded `None`). The existing-task resolver then
             // rejects it as `review_class_unspecified` (unchanged #2745 contract).
-            Err(crate::tasks::TaskRouteError::NotFound) => {
+            Err(crate::tasks::TaskRouteError::NotFound) if !task_id_val.starts_with("t-") => {
                 resolve_existing_task_review_class(None, arg_review_class, second_reviewer)
             }
+            // Canonical task ids are governed by merge-train admission. Preserve
+            // its task-existence/uniqueness refusal codes by deferring unresolved
+            // routes to that gate; no bind can occur because admission returns.
+            Err(crate::tasks::TaskRouteError::NotFound) => return Ok(None),
+            Err(_) if task_id_val.starts_with("t-") => return Ok(None),
             // #2760 NEW fail-closed: the task EXISTS but its authoritative board
             // cannot be uniquely proven (duplicate id across boards / unreadable
             // board) — REJECT the merge-authority dispatch atomically BEFORE any
@@ -333,8 +337,8 @@ fn maybe_auto_bind_lease(
             }
         }
     };
-    let armed_review_class = match resolved_review_class {
-        Ok(class) => class.as_token(),
+    match resolved_review_class {
+        Ok(class) => Ok(Some(class.as_token())),
         Err(refusal) => {
             // #2745 fail-closed (root pre-review finding 2): REJECT the
             // merge-authority dispatch ATOMICALLY — before any bind / task-create /
@@ -357,16 +361,35 @@ fn maybe_auto_bind_lease(
                      then re-dispatch"
                 )
             };
-            return Err(json!({
+            Err(json!({
                 "ok": false,
                 "error": refusal.diagnostic(branch),
                 "code": refusal.code(),
                 "remediation": remediation,
                 "branch": branch,
                 "task_id": task_id_val,
-            }));
+            }))
         }
+    }
+}
+
+/// Phase 4 — optional auto-bind lease (rejectable). The review-class authority
+/// was already resolved by the read-only preflight before merge-train admission.
+fn maybe_auto_bind_lease(
+    home: &Path,
+    args: &Value,
+    target: &str,
+    armed_review_class: Option<&str>,
+) -> Result<(), Value> {
+    let Some(armed_review_class) = armed_review_class else {
+        return Ok(());
     };
+    let branch = args["branch"]
+        .as_str()
+        .expect("review-class preflight requires a branch");
+    let task_id_val = args["task_id"].as_str().unwrap_or("");
+    let next_after_ci =
+        crate::daemon::ci_watch::watch_state::normalize_next_after_ci(&args["next_after_ci"]);
     dispatch_hook::dispatch_auto_bind_lease_with_source_and_chain(
         home,
         target,
@@ -550,6 +573,15 @@ pub(crate) fn handle_delegate_task(
         });
     }
 
+    let armed_review_class = if checks.review_assignment {
+        None
+    } else {
+        match preflight_auto_bind_review_class(home, args, target, composed.second_reviewer) {
+            Ok(class) => class,
+            Err(e) => return e,
+        }
+    };
+
     // Merge train admission — must precede bind/create/deliver so a Queued
     // dispatch never leases a worktree or creates side-effects.
     match merge_train::admit(home, args, target, checks.review_assignment) {
@@ -570,7 +602,7 @@ pub(crate) fn handle_delegate_task(
     };
 
     if !checks.review_assignment && runtime.is_some() {
-        if let Err(e) = maybe_auto_bind_lease(home, args, target, composed.second_reviewer) {
+        if let Err(e) = maybe_auto_bind_lease(home, args, target, armed_review_class) {
             return e;
         }
     }

--- a/src/mcp/handlers/comms_delegate/mod.rs
+++ b/src/mcp/handlers/comms_delegate/mod.rs
@@ -1,19 +1,3 @@
-//! W2.2: `handle_delegate_task` as an ordered phase pipeline.
-//!
-//! Stages (failure order preserved — a reject before lease never leases;
-//! a send failure may still have leased/created a task, same as pre-split):
-//!
-//! 1. **resolve** — identity, instance/team target, self-dispatch reject
-//! 2. **validate** — pre-send gates (`comms_gates::run_dispatch_pre_checks`)
-//! 3. **compose** — message body + force_meta
-//! 4. **lease** — optional `dispatch_auto_bind_lease` when `branch` set
-//! 5. **create** — optional auto board task after all rejectable checks
-//! 6. **send** — `execute_send` via neutral typed service (or API bridge fallback)
-//! 7. **track** — dispatch_tracking + UX + `auto_created_task_id` on success
-//!
-//! Loaded as a child of `comms` so `file_size_invariant` keeps `comms.rs` under
-//! the handler LOC cap while the choreography stays one ordered function.
-
 use crate::channel::sink_registry::registry as ux_sink_registry;
 use crate::channel::ux_event::{FleetEvent, UxEvent};
 use crate::daemon::pr_state::ReviewClass;

--- a/src/mcp/handlers/comms_delegate/tests.rs
+++ b/src/mcp/handlers/comms_delegate/tests.rs
@@ -1435,11 +1435,10 @@ mod merge_train_admission_tests {
         std::fs::create_dir_all(corrupt_board.join("task_events.jsonl")).unwrap();
 
         let events_before = train_event_count(&home, "t-r6-board");
-        let fronts = crate::tasks::scan_merge_train_fronts(&home, "owner/repo", "core");
-        let next_seq = crate::tasks::next_merge_train_seq(&home, "owner/repo", "core");
+        let scan = crate::tasks::scan_merge_train_state(&home, "owner/repo", "core");
         assert!(
-            fronts.iter().any(|id| id == "t-r6-board") && next_seq == 2,
-            "unreadable extra board must not degrade authority to no-Front/seq1: fronts={fronts:?} next_seq={next_seq}"
+            scan.is_err(),
+            "unreadable extra board must fail the authority scan closed: {scan:?}"
         );
         assert_eq!(train_event_count(&home, "t-r6-board"), events_before);
 

--- a/src/mcp/handlers/comms_delegate/tests.rs
+++ b/src/mcp/handlers/comms_delegate/tests.rs
@@ -1412,4 +1412,175 @@ mod merge_train_admission_tests {
 
         std::fs::remove_dir_all(&home).ok();
     }
+
+    // ════════════════════════════════════════════════════════════════
+    // R6 — frozen fail-closed and atomicity boundaries
+    // ════════════════════════════════════════════════════════════════
+
+    #[test]
+    fn r6_unreadable_extra_board_refuses_without_train_writes() {
+        let home = mt_home("r6-board-replay");
+        fixture(&home);
+        create_task(&home, "t-r6-board");
+        set_meta(
+            &home,
+            "t-r6-board",
+            "merge_train_repository",
+            json!("owner/repo"),
+        );
+        set_meta(&home, "t-r6-board", "merge_train_domain", json!("core"));
+        set_meta(&home, "t-r6-board", "merge_train_position", json!("Front"));
+        set_meta(&home, "t-r6-board", "merge_train_queue_seq", json!(1));
+        let corrupt_board = crate::task_events::board_root(&home, "corrupt/project");
+        std::fs::create_dir_all(corrupt_board.join("task_events.jsonl")).unwrap();
+
+        let events_before = train_event_count(&home, "t-r6-board");
+        let fronts = crate::tasks::scan_merge_train_fronts(&home, "owner/repo", "core");
+        let next_seq = crate::tasks::next_merge_train_seq(&home, "owner/repo", "core");
+        assert!(
+            fronts.iter().any(|id| id == "t-r6-board") && next_seq == 2,
+            "unreadable extra board must not degrade authority to no-Front/seq1: fronts={fronts:?} next_seq={next_seq}"
+        );
+        assert_eq!(train_event_count(&home, "t-r6-board"), events_before);
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn r6_concurrent_same_task_emits_one_fresh_four_event_batch() {
+        let home = mt_home("r6-same-task");
+        fixture(&home);
+        create_task(&home, "t-r6-same");
+        set_meta(&home, "t-r6-same", "conflict_domain", json!("same-task"));
+
+        const N: usize = 8;
+        let barrier = Arc::new(std::sync::Barrier::new(N));
+        let mut handles = Vec::new();
+        for _ in 0..N {
+            let home = home.clone();
+            let barrier = Arc::clone(&barrier);
+            handles.push(std::thread::spawn(move || {
+                barrier.wait();
+                dispatch(&home, "dev-a", "t-r6-same", "feat/r6-same")
+            }));
+        }
+        let results: Vec<Value> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+
+        assert_eq!(
+            train_event_count(&home, "t-r6-same"),
+            4,
+            "same-task races must commit exactly one fresh four-event authority batch; results={results:?}"
+        );
+        assert_eq!(
+            read_meta(&home, "t-r6-same", "merge_train_position")
+                .and_then(|v| v.as_str().map(str::to_owned)),
+            Some("Front".into())
+        );
+        assert_eq!(
+            read_meta(&home, "t-r6-same", "merge_train_queue_seq"),
+            Some(json!(1))
+        );
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn r6_repository_identity_is_namespaced_across_full_source_resolver() {
+        let forge_home = mt_home("r6-forge-id");
+        fixture(&forge_home);
+        create_task(&forge_home, "t-r6-forge");
+        dispatch(&forge_home, "dev-a", "t-r6-forge", "feat/r6-forge");
+        let forge_identity = read_meta(&forge_home, "t-r6-forge", "merge_train_repository");
+
+        let path_home = mt_home("r6-path-id");
+        let path_repo = init_repo(&path_home, "path-only", "owner/path-only");
+        let remove_remote = std::process::Command::new("git")
+            .args(["remote", "remove", "origin"])
+            .current_dir(&path_repo)
+            .env("AGEND_GIT_BYPASS", "1")
+            .output()
+            .unwrap();
+        assert!(remove_remote.status.success());
+        let yaml = format!(
+            "instances:\n  lead: {{ backend: claude, id: 11111111-1111-4111-8111-111111111111 }}\n  dev-a:\n    backend: claude\n    id: 22222222-2222-4222-8222-222222222222\n    source_repo: {}\nteams:\n  core:\n    orchestrator: lead\n    members: [lead, dev-a]\n",
+            path_repo.display()
+        );
+        std::fs::write(crate::fleet::fleet_yaml_path(&path_home), yaml).unwrap();
+        create_task(&path_home, "t-r6-path");
+        dispatch(&path_home, "dev-a", "t-r6-path", "feat/r6-path");
+        let path_identity = read_meta(&path_home, "t-r6-path", "merge_train_repository");
+
+        assert_eq!(
+            (forge_identity, path_identity),
+            (
+                Some(json!("forge:owner/repo")),
+                Some(json!(format!("path:{}", path_repo.display())))
+            )
+        );
+
+        std::fs::remove_dir_all(&forge_home).ok();
+        std::fs::remove_dir_all(&path_home).ok();
+    }
+
+    #[test]
+    fn r6_distinct_lossy_collision_pairs_use_distinct_lock_identities() {
+        let home = mt_home("r6-lock-hash");
+        fixture(&home);
+        create_task(&home, "t-r6-lock-a");
+        create_task(&home, "t-r6-lock-b");
+        set_meta(&home, "t-r6-lock-a", "conflict_domain", json!("area/a"));
+        set_meta(&home, "t-r6-lock-b", "conflict_domain", json!("area?a"));
+
+        dispatch(&home, "dev-a", "t-r6-lock-a", "feat/r6-lock-a");
+        dispatch(&home, "dev-b", "t-r6-lock-b", "feat/r6-lock-b");
+
+        let mut locks: Vec<String> = std::fs::read_dir(home.join("merge_train"))
+            .unwrap()
+            .flatten()
+            .filter_map(|e| e.file_name().into_string().ok())
+            .filter(|n| n.ends_with(".lock"))
+            .collect();
+        locks.sort();
+        locks.dedup();
+        assert_eq!(
+            locks.len(),
+            2,
+            "distinct repo/domain pairs must have collision-safe lock identities: {locks:?}"
+        );
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn r6_complete_invalid_position_refuses_without_new_train_writes() {
+        let home = mt_home("r6-invalid-position");
+        fixture(&home);
+        create_task(&home, "t-r6-invalid");
+        set_meta(&home, "t-r6-invalid", "conflict_domain", json!("core"));
+        set_meta(
+            &home,
+            "t-r6-invalid",
+            "merge_train_repository",
+            json!("owner/repo"),
+        );
+        set_meta(&home, "t-r6-invalid", "merge_train_domain", json!("core"));
+        set_meta(
+            &home,
+            "t-r6-invalid",
+            "merge_train_position",
+            json!("Sideways"),
+        );
+        set_meta(&home, "t-r6-invalid", "merge_train_queue_seq", json!(1));
+
+        let events_before = train_event_count(&home, "t-r6-invalid");
+        let result = dispatch(&home, "dev-a", "t-r6-invalid", "feat/r6-invalid");
+        assert_eq!(
+            result.get("code").and_then(Value::as_str),
+            Some("merge_train_invalid_position"),
+            "complete invalid position must fail closed: {result}"
+        );
+        assert_eq!(train_event_count(&home, "t-r6-invalid"), events_before);
+
+        std::fs::remove_dir_all(&home).ok();
+    }
 }

--- a/src/mcp/handlers/comms_delegate/tests.rs
+++ b/src/mcp/handlers/comms_delegate/tests.rs
@@ -739,3 +739,520 @@ mod review_assignment_marker_tests {
         std::fs::remove_dir_all(&home).ok();
     }
 }
+
+// ─────────────────────────────────────────────────────────────────
+// Architecture-14 Item 7 — Merge Train Slice 1: admission RED tests.
+//
+// Frozen contract: d-20260720234700739461-7 (corrected seam).
+// These tests exercise `handle_delegate_task` on branch-producing
+// non-review dispatches and assert merge-train admission behavior
+// that does NOT yet exist in production — they must RED stably.
+// ─────────────────────────────────────────────────────────────────
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod merge_train_admission_tests {
+    use super::super::handle_delegate_task;
+    use crate::identity::Sender;
+    use serde_json::{json, Value};
+    use std::path::{Path, PathBuf};
+    use std::sync::Arc;
+
+    // ── helpers ──────────────────────────────────────────────────
+
+    fn mt_home(label: &str) -> PathBuf {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static CTR: AtomicU32 = AtomicU32::new(0);
+        let id = CTR.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "agend-mt-{}-{label}-{id}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn seed_fleet(home: &Path, teams_yaml: &str) {
+        let yaml = format!(
+            "instances:\n\
+             \x20 lead:\n\
+             \x20   backend: claude\n\
+             \x20   id: 11111111-1111-4111-8111-111111111111\n\
+             \x20 dev:\n\
+             \x20   backend: claude\n\
+             \x20   id: 22222222-2222-4222-8222-222222222222\n\
+             {teams_yaml}"
+        );
+        std::fs::write(crate::fleet::fleet_yaml_path(home), yaml).unwrap();
+    }
+
+    const TEAMS_CORE: &str = "\
+teams:\n\
+\x20 core:\n\
+\x20   orchestrator: lead\n\
+\x20   members:\n\
+\x20     - lead\n\
+\x20     - dev\n";
+
+    fn create_task(home: &Path, task_id: &str) {
+        let event = crate::task_events::TaskEvent::Created {
+            task_id: crate::task_events::TaskId(task_id.into()),
+            title: format!("task {task_id}"),
+            description: String::new(),
+            priority: "normal".into(),
+            owner: Some(crate::task_events::InstanceName("lead".into())),
+            due_at: None,
+            depends_on: Vec::new(),
+            routed_to: None,
+            branch: None,
+            bind: None,
+            eta_secs: None,
+            tags: Vec::new(),
+            parent_id: None,
+        };
+        crate::task_events::append(
+            home,
+            &crate::task_events::InstanceName("lead".into()),
+            event,
+        )
+        .unwrap();
+    }
+
+    fn create_task_on_board(home: &Path, task_id: &str, project: &str) {
+        let board = crate::task_events::board_root(home, project);
+        std::fs::create_dir_all(&board).ok();
+        let event = crate::task_events::TaskEvent::Created {
+            task_id: crate::task_events::TaskId(task_id.into()),
+            title: format!("task {task_id}"),
+            description: String::new(),
+            priority: "normal".into(),
+            owner: Some(crate::task_events::InstanceName("lead".into())),
+            due_at: None,
+            depends_on: Vec::new(),
+            routed_to: None,
+            branch: None,
+            bind: None,
+            eta_secs: None,
+            tags: Vec::new(),
+            parent_id: None,
+        };
+        crate::task_events::append_at(
+            &board,
+            &crate::task_events::InstanceName("lead".into()),
+            event,
+        )
+        .unwrap();
+    }
+
+    fn set_meta(home: &Path, task_id: &str, key: &str, value: Value) {
+        let out = crate::tasks::handle(
+            home,
+            "lead",
+            &json!({
+                "action": "metadata_set",
+                "id": task_id,
+                "metadata_key": key,
+                "metadata_value": value,
+            }),
+        );
+        assert!(out.get("error").is_none(), "set_meta({key}) failed: {out}");
+    }
+
+    fn dispatch(home: &Path, task_id: &str, branch: &str) -> Value {
+        let sender = Some(Sender::new("lead").unwrap());
+        handle_delegate_task(home, &json!({"instance": "dev", "task": "implement", "task_id": task_id, "branch": branch}), &sender, None)
+    }
+
+    fn dispatch_with_repo(home: &Path, task_id: &str, branch: &str, repo: &str) -> Value {
+        let sender = Some(Sender::new("lead").unwrap());
+        handle_delegate_task(home, &json!({"instance": "dev", "task": "implement", "task_id": task_id, "branch": branch, "repository": repo}), &sender, None)
+    }
+
+    fn read_meta(home: &Path, task_id: &str, key: &str) -> Option<Value> {
+        let r = crate::tasks::handle(
+            home,
+            "lead",
+            &json!({"action": "metadata_get", "id": task_id, "metadata_key": key}),
+        );
+        r.get("value").filter(|v| !v.is_null()).cloned()
+    }
+
+    const TRAIN_KEYS: [&str; 4] = [
+        "merge_train_repository",
+        "merge_train_domain",
+        "merge_train_position",
+        "merge_train_queue_seq",
+    ];
+
+    fn train_event_count(home: &Path, task_id: &str) -> usize {
+        let mut count = 0;
+        let default_log = home.join("task_events.jsonl");
+        if let Ok(content) = std::fs::read_to_string(&default_log) {
+            count += content
+                .lines()
+                .filter(|l| l.contains(task_id) && l.contains("merge_train_"))
+                .count();
+        }
+        let boards_dir = home.join("boards");
+        if boards_dir.is_dir() {
+            if let Ok(entries) = std::fs::read_dir(&boards_dir) {
+                for e in entries.flatten() {
+                    let p = e.path().join("task_events.jsonl");
+                    if let Ok(c) = std::fs::read_to_string(&p) {
+                        count += c
+                            .lines()
+                            .filter(|l| l.contains(task_id) && l.contains("merge_train_"))
+                            .count();
+                    }
+                }
+            }
+        }
+        count
+    }
+
+    // ════════════════════════════════════════════════════════════════
+    // Group A — concurrent same-key admission
+    // ════════════════════════════════════════════════════════════════
+
+    #[test]
+    fn a_concurrent_same_key_one_front_one_queued() {
+        let home = mt_home("a-conc");
+        seed_fleet(&home, TEAMS_CORE);
+        create_task(&home, "t-a1");
+        create_task(&home, "t-a2");
+        set_meta(&home, "t-a1", "conflict_domain", json!("core"));
+        set_meta(&home, "t-a2", "conflict_domain", json!("core"));
+
+        let barrier = Arc::new(std::sync::Barrier::new(2));
+        let (home1, home2) = (home.clone(), home.clone());
+        let (b1, b2) = (Arc::clone(&barrier), Arc::clone(&barrier));
+
+        let h1 = std::thread::spawn(move || {
+            b1.wait();
+            dispatch(&home1, "t-a1", "feat/a1")
+        });
+        let h2 = std::thread::spawn(move || {
+            b2.wait();
+            dispatch(&home2, "t-a2", "feat/a2")
+        });
+        let _r1 = h1.join().unwrap();
+        let _r2 = h2.join().unwrap();
+
+        let pos1 = read_meta(&home, "t-a1", "merge_train_position");
+        let pos2 = read_meta(&home, "t-a2", "merge_train_position");
+        let positions: Vec<&str> = [&pos1, &pos2]
+            .iter()
+            .filter_map(|v| v.as_ref().and_then(|v| v.as_str()))
+            .collect();
+        assert!(
+            positions.contains(&"Front") && positions.contains(&"Queued"),
+            "concurrent admission must produce exactly one Front and one Queued, \
+             got t-a1={pos1:?} t-a2={pos2:?}"
+        );
+
+        let seq1 = read_meta(&home, "t-a1", "merge_train_queue_seq");
+        let seq2 = read_meta(&home, "t-a2", "merge_train_queue_seq");
+        let seqs: Vec<u64> = [&seq1, &seq2]
+            .iter()
+            .filter_map(|v| v.as_ref().and_then(|v| v.as_u64()))
+            .collect();
+        assert_eq!(seqs.len(), 2, "both tasks must have queue_seq: {seq1:?}, {seq2:?}");
+        assert!(
+            seqs.contains(&1) && seqs.contains(&2),
+            "Front=seq 1, Queued=seq 2, got {seqs:?}"
+        );
+
+        for tid in ["t-a1", "t-a2"] {
+            for key in &TRAIN_KEYS {
+                assert!(
+                    read_meta(&home, tid, key).is_some(),
+                    "{tid} missing durable metadata {key}"
+                );
+            }
+        }
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn a_readmission_emits_zero_new_train_events() {
+        let home = mt_home("a-readmit");
+        seed_fleet(&home, TEAMS_CORE);
+        create_task(&home, "t-r1");
+        set_meta(&home, "t-r1", "conflict_domain", json!("core"));
+
+        dispatch(&home, "t-r1", "feat/r1");
+        assert!(
+            read_meta(&home, "t-r1", "merge_train_position").is_some(),
+            "first dispatch must write merge_train_position"
+        );
+
+        let events_before = train_event_count(&home, "t-r1");
+        dispatch(&home, "t-r1", "feat/r1");
+        let events_after = train_event_count(&home, "t-r1");
+        assert_eq!(
+            events_before, events_after,
+            "re-admission must emit zero new merge_train_* events"
+        );
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    // ════════════════════════════════════════════════════════════════
+    // Group B — queued suppresses all downstream side effects
+    // ════════════════════════════════════════════════════════════════
+
+    #[test]
+    fn b_queued_zero_side_effects() {
+        let home = mt_home("b-queued");
+        seed_fleet(&home, TEAMS_CORE);
+        create_task(&home, "t-front");
+        create_task(&home, "t-q1");
+        set_meta(&home, "t-front", "conflict_domain", json!("core"));
+        set_meta(&home, "t-q1", "conflict_domain", json!("core"));
+
+        dispatch(&home, "t-front", "feat/front");
+
+        let result = dispatch(&home, "t-q1", "feat/q1");
+        assert_eq!(
+            result.get("merge_train_position").and_then(|v| v.as_str()),
+            Some("Queued"),
+            "second dispatch same repo+domain must be Queued: {result}"
+        );
+
+        // 1. inbox
+        let inbox = crate::inbox::drain(&home, "dev");
+        assert!(inbox.is_empty(), "Queued must not deliver to inbox: {} msgs", inbox.len());
+
+        // 2. binding
+        let binding = home.join("runtime").join("dev").join("binding.json");
+        assert!(!binding.exists(), "Queued must not create binding");
+
+        // 3. worktree
+        let wt = home.join("worktrees").join("dev");
+        assert!(!wt.exists(), "Queued must not create worktree");
+
+        // 4. CI watch
+        let ci = home.join("ci_watch");
+        let has_ci = ci.is_dir() && std::fs::read_dir(&ci).map(|d| d.count() > 0).unwrap_or(false);
+        assert!(!has_ci, "Queued must not arm CI watch");
+
+        // 5. review assignment
+        let ra_dir = home.join("reviewer-assignments");
+        let has_ra = ra_dir.is_dir()
+            && std::fs::read_dir(&ra_dir).map(|d| d.count() > 0).unwrap_or(false);
+        assert!(!has_ra, "Queued must not create review assignment");
+
+        // 6. dispatch tracking
+        let dt = crate::store::store_path(&home, "dispatch_tracking.json");
+        let has_dt = dt.exists()
+            && std::fs::read_to_string(&dt)
+                .map(|s| s.contains("t-q1"))
+                .unwrap_or(false);
+        assert!(!has_dt, "Queued must not write dispatch tracking");
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn b_disjoint_repo_is_front() {
+        let home = mt_home("b-disjoint-repo");
+        // First dispatch with team pointing to repo-A.
+        seed_fleet(
+            &home,
+            "teams:\n\
+             \x20 core:\n\
+             \x20   orchestrator: lead\n\
+             \x20   members:\n\
+             \x20     - lead\n\
+             \x20     - dev\n",
+        );
+        create_task(&home, "t-dr1");
+        create_task(&home, "t-dr2");
+        set_meta(&home, "t-dr1", "conflict_domain", json!("core"));
+        set_meta(&home, "t-dr2", "conflict_domain", json!("core"));
+        // Simulate repo-A identity via dispatch arg (future admission reads this).
+        dispatch_with_repo(&home, "t-dr1", "feat/dr1", "repo-a/proj");
+
+        // Second dispatch with a different repo identity.
+        dispatch_with_repo(&home, "t-dr2", "feat/dr2", "repo-b/proj");
+
+        let pos = read_meta(&home, "t-dr2", "merge_train_position");
+        assert_eq!(
+            pos.as_ref().and_then(|v| v.as_str()),
+            Some("Front"),
+            "disjoint repo must be Front (independent train): {pos:?}"
+        );
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn b_disjoint_domain_is_front() {
+        let home = mt_home("b-disjoint-dom");
+        seed_fleet(&home, TEAMS_CORE);
+        create_task(&home, "t-dd1");
+        create_task(&home, "t-dd2");
+        set_meta(&home, "t-dd1", "conflict_domain", json!("backend"));
+        set_meta(&home, "t-dd2", "conflict_domain", json!("frontend"));
+
+        dispatch(&home, "t-dd1", "feat/dd1");
+        dispatch(&home, "t-dd2", "feat/dd2");
+
+        let pos = read_meta(&home, "t-dd2", "merge_train_position");
+        assert_eq!(
+            pos.as_ref().and_then(|v| v.as_str()),
+            Some("Front"),
+            "disjoint domain same repo must be Front: {pos:?}"
+        );
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn b_absent_domain_falls_back_to_repo() {
+        let home = mt_home("b-absent-dom");
+        seed_fleet(&home, TEAMS_CORE);
+        create_task(&home, "t-no1");
+        create_task(&home, "t-no2");
+        // No conflict_domain set — must fall back to __repo__.
+
+        dispatch(&home, "t-no1", "feat/no1");
+        dispatch(&home, "t-no2", "feat/no2");
+
+        let dom1 = read_meta(&home, "t-no1", "merge_train_domain");
+        let dom2 = read_meta(&home, "t-no2", "merge_train_domain");
+        assert_eq!(
+            dom1.as_ref().and_then(|v| v.as_str()),
+            Some("__repo__"),
+            "absent domain falls back to __repo__: {dom1:?}"
+        );
+        assert_eq!(
+            dom2.as_ref().and_then(|v| v.as_str()),
+            Some("__repo__"),
+            "absent domain falls back to __repo__: {dom2:?}"
+        );
+        let pos = read_meta(&home, "t-no2", "merge_train_position");
+        assert_eq!(
+            pos.as_ref().and_then(|v| v.as_str()),
+            Some("Queued"),
+            "second absent-domain task must be Queued: {pos:?}"
+        );
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn b_named_domain_disjoint_from_repo_fallback() {
+        let home = mt_home("b-named-vs-repo");
+        seed_fleet(&home, TEAMS_CORE);
+        create_task(&home, "t-bare");
+        create_task(&home, "t-named");
+        // t-bare: no domain → __repo__ fallback.
+        // t-named: explicit "backend" domain.
+        set_meta(&home, "t-named", "conflict_domain", json!("backend"));
+
+        dispatch(&home, "t-bare", "feat/bare");
+        dispatch(&home, "t-named", "feat/named");
+
+        let pos = read_meta(&home, "t-named", "merge_train_position");
+        assert_eq!(
+            pos.as_ref().and_then(|v| v.as_str()),
+            Some("Front"),
+            "named domain disjoint from __repo__ fallback: {pos:?}"
+        );
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    // ════════════════════════════════════════════════════════════════
+    // Group C — structured refusal on invalid pre-existing state
+    // ════════════════════════════════════════════════════════════════
+
+    #[test]
+    fn c_partial_train_metadata_refuses() {
+        let home = mt_home("c-partial");
+        seed_fleet(&home, TEAMS_CORE);
+        create_task(&home, "t-part");
+        // Pre-seed only ONE of the four required train keys.
+        set_meta(
+            &home,
+            "t-part",
+            "merge_train_repository",
+            json!("forge:owner/repo"),
+        );
+
+        let result = dispatch(&home, "t-part", "feat/part");
+        let code = result.get("code").and_then(|v| v.as_str()).unwrap_or("");
+        assert!(
+            code.starts_with("merge_train_"),
+            "partial train metadata must produce a merge_train_* refusal, got: {result}"
+        );
+
+        let events = train_event_count(&home, "t-part");
+        assert_eq!(events, 0, "partial-refusal must not append merge_train_* events");
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn c_mismatched_metadata_refuses() {
+        let home = mt_home("c-mismatch");
+        seed_fleet(&home, TEAMS_CORE);
+        create_task(&home, "t-mis");
+        // Pre-seed all four train keys but with a WRONG repository.
+        set_meta(&home, "t-mis", "merge_train_repository", json!("forge:wrong/repo"));
+        set_meta(&home, "t-mis", "merge_train_domain", json!("core"));
+        set_meta(&home, "t-mis", "merge_train_position", json!("Front"));
+        set_meta(&home, "t-mis", "merge_train_queue_seq", json!(1));
+
+        let result = dispatch(&home, "t-mis", "feat/mis");
+        let code = result.get("code").and_then(|v| v.as_str()).unwrap_or("");
+        assert!(
+            code.starts_with("merge_train_"),
+            "mismatched repo identity must produce merge_train_* refusal, got: {result}"
+        );
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn c_ambiguous_cross_board_task_refuses() {
+        let home = mt_home("c-ambig");
+        seed_fleet(&home, TEAMS_CORE);
+        // Create same task_id on default board AND a project board.
+        create_task(&home, "t-dup");
+        create_task_on_board(&home, "t-dup", "other/project");
+
+        let result = dispatch(&home, "t-dup", "feat/dup");
+        let code = result.get("code").and_then(|v| v.as_str()).unwrap_or("");
+        assert!(
+            code.starts_with("merge_train_"),
+            "ambiguous task_id across boards must produce merge_train_* refusal, got: {result}"
+        );
+
+        for key in &TRAIN_KEYS {
+            assert!(
+                read_meta(&home, "t-dup", key).is_none(),
+                "ambiguous refusal must not write {key}"
+            );
+        }
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn c_ghost_task_refuses() {
+        let home = mt_home("c-ghost");
+        seed_fleet(&home, TEAMS_CORE);
+        // Do NOT create any task — dispatch a non-existent task_id.
+
+        let result = dispatch(&home, "t-nonexistent", "feat/ghost");
+        let code = result.get("code").and_then(|v| v.as_str()).unwrap_or("");
+        assert!(
+            code.starts_with("merge_train_"),
+            "ghost task_id must produce merge_train_* refusal, got: {result}"
+        );
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+}

--- a/src/mcp/handlers/comms_delegate/tests.rs
+++ b/src/mcp/handlers/comms_delegate/tests.rs
@@ -1514,7 +1514,10 @@ mod merge_train_admission_tests {
             (forge_identity, path_identity),
             (
                 Some(json!("forge:owner/repo")),
-                Some(json!(format!("path:{}", path_repo.display())))
+                Some(json!(format!(
+                    "path:{}",
+                    std::fs::canonicalize(&path_repo).unwrap().display()
+                )))
             )
         );
 
@@ -1561,7 +1564,7 @@ mod merge_train_admission_tests {
             &home,
             "t-r6-invalid",
             "merge_train_repository",
-            json!("owner/repo"),
+            json!("forge:owner/repo"),
         );
         set_meta(&home, "t-r6-invalid", "merge_train_domain", json!("core"));
         set_meta(

--- a/src/mcp/handlers/comms_delegate/tests.rs
+++ b/src/mcp/handlers/comms_delegate/tests.rs
@@ -763,35 +763,94 @@ mod merge_train_admission_tests {
         use std::sync::atomic::{AtomicU32, Ordering};
         static CTR: AtomicU32 = AtomicU32::new(0);
         let id = CTR.fetch_add(1, Ordering::Relaxed);
-        let dir = std::env::temp_dir().join(format!(
-            "agend-mt-{}-{label}-{id}",
-            std::process::id()
-        ));
+        let dir =
+            std::env::temp_dir().join(format!("agend-mt-{}-{label}-{id}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
         dir
     }
 
-    fn seed_fleet(home: &Path, teams_yaml: &str) {
+    fn init_repo(home: &Path, name: &str, slug: &str) -> PathBuf {
+        let repo = home.join(name);
+        std::fs::create_dir_all(&repo).unwrap();
+        let run = |args: &[&str]| {
+            let out = std::process::Command::new("git")
+                .args(args)
+                .current_dir(&repo)
+                .env("AGEND_GIT_BYPASS", "1")
+                .output()
+                .unwrap();
+            assert!(
+                out.status.success(),
+                "git {args:?}: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        };
+        run(&["init", "-b", "main"]);
+        run(&[
+            "-c",
+            "user.name=test",
+            "-c",
+            "user.email=t@t",
+            "commit",
+            "--allow-empty",
+            "-m",
+            "init",
+        ]);
+        run(&[
+            "remote",
+            "add",
+            "origin",
+            &format!("https://github.com/{slug}.git"),
+        ]);
+        let head = std::process::Command::new("git")
+            .args(["rev-parse", "main"])
+            .current_dir(&repo)
+            .env("AGEND_GIT_BYPASS", "1")
+            .output()
+            .unwrap();
+        let head = String::from_utf8(head.stdout).unwrap();
+        run(&["update-ref", "refs/remotes/origin/main", head.trim()]);
+        repo.canonicalize().unwrap()
+    }
+
+    fn seed_fleet(home: &Path, repo: &Path) {
         let yaml = format!(
             "instances:\n\
              \x20 lead:\n\
              \x20   backend: claude\n\
              \x20   id: 11111111-1111-4111-8111-111111111111\n\
-             \x20 dev:\n\
+             \x20 dev-a:\n\
              \x20   backend: claude\n\
              \x20   id: 22222222-2222-4222-8222-222222222222\n\
-             {teams_yaml}"
+             \x20 dev-b:\n\
+             \x20   backend: claude\n\
+             \x20   id: 33333333-3333-4333-8333-333333333333\n\
+             teams:\n\
+             \x20 core:\n\
+             \x20   orchestrator: lead\n\
+             \x20   members:\n\
+             \x20     - lead\n\
+             \x20     - dev-a\n\
+             \x20     - dev-b\n\
+             \x20   source_repo: {}\n",
+            repo.display()
         );
         std::fs::write(crate::fleet::fleet_yaml_path(home), yaml).unwrap();
     }
 
-    const TEAMS_CORE: &str = "\
-teams:\n\
-\x20 core:\n\
-\x20   orchestrator: lead\n\
-\x20   members:\n\
-\x20     - lead\n\
-\x20     - dev\n";
+    fn fixture(home: &Path) -> PathBuf {
+        let repo = init_repo(home, "canonical", "owner/repo");
+        seed_fleet(home, &repo);
+        repo
+    }
+
+    fn seed_two_repo_fleet(home: &Path, repo_a: &Path, repo_b: &Path) {
+        let yaml = format!(
+            "instances:\n  lead: {{ backend: claude, id: 11111111-1111-4111-8111-111111111111 }}\n  dev-a: {{ backend: claude, id: 22222222-2222-4222-8222-222222222222 }}\n  dev-b: {{ backend: claude, id: 33333333-3333-4333-8333-333333333333 }}\nteams:\n  repo-a:\n    orchestrator: lead\n    members: [lead, dev-a]\n    source_repo: {}\n  repo-b:\n    orchestrator: lead\n    members: [lead, dev-b]\n    source_repo: {}\n",
+            repo_a.display(), repo_b.display()
+        );
+        std::fs::write(crate::fleet::fleet_yaml_path(home), yaml).unwrap();
+    }
 
     fn create_task(home: &Path, task_id: &str) {
         let event = crate::task_events::TaskEvent::Created {
@@ -815,6 +874,7 @@ teams:\n\
             event,
         )
         .unwrap();
+        set_meta(home, task_id, "review_class", json!("single"));
     }
 
     fn create_task_on_board(home: &Path, task_id: &str, project: &str) {
@@ -841,39 +901,69 @@ teams:\n\
             event,
         )
         .unwrap();
+        crate::task_events::append_at(
+            &board,
+            &crate::task_events::InstanceName("lead".into()),
+            crate::task_events::TaskEvent::MetadataSet {
+                task_id: crate::task_events::TaskId(task_id.into()),
+                by: crate::task_events::InstanceName("lead".into()),
+                key: "review_class".into(),
+                value: json!("single"),
+            },
+        )
+        .unwrap();
     }
 
     fn set_meta(home: &Path, task_id: &str, key: &str, value: Value) {
-        let out = crate::tasks::handle(
+        crate::task_events::append(
             home,
-            "lead",
-            &json!({
-                "action": "metadata_set",
-                "id": task_id,
-                "metadata_key": key,
-                "metadata_value": value,
-            }),
-        );
-        assert!(out.get("error").is_none(), "set_meta({key}) failed: {out}");
+            &crate::task_events::InstanceName("lead".into()),
+            crate::task_events::TaskEvent::MetadataSet {
+                task_id: crate::task_events::TaskId(task_id.into()),
+                by: crate::task_events::InstanceName("lead".into()),
+                key: key.into(),
+                value,
+            },
+        )
+        .unwrap();
     }
 
-    fn dispatch(home: &Path, task_id: &str, branch: &str) -> Value {
+    fn dispatch(home: &Path, target: &str, task_id: &str, branch: &str) -> Value {
         let sender = Some(Sender::new("lead").unwrap());
-        handle_delegate_task(home, &json!({"instance": "dev", "task": "implement", "task_id": task_id, "branch": branch}), &sender, None)
+        let runtime = crate::mcp::handlers::minimal_test_runtime();
+        handle_delegate_task(
+            home,
+            &json!({"instance": target, "task": "implement", "task_id": task_id, "branch": branch}),
+            &sender,
+            Some(&runtime),
+        )
     }
 
-    fn dispatch_with_repo(home: &Path, task_id: &str, branch: &str, repo: &str) -> Value {
+    fn dispatch_with_repo(
+        home: &Path,
+        target: &str,
+        task_id: &str,
+        branch: &str,
+        repo: &str,
+    ) -> Value {
         let sender = Some(Sender::new("lead").unwrap());
-        handle_delegate_task(home, &json!({"instance": "dev", "task": "implement", "task_id": task_id, "branch": branch, "repository": repo}), &sender, None)
+        let runtime = crate::mcp::handlers::minimal_test_runtime();
+        handle_delegate_task(
+            home,
+            &json!({"instance": target, "task": "implement", "task_id": task_id, "branch": branch, "repository": repo}),
+            &sender,
+            Some(&runtime),
+        )
     }
 
     fn read_meta(home: &Path, task_id: &str, key: &str) -> Option<Value> {
-        let r = crate::tasks::handle(
-            home,
-            "lead",
-            &json!({"action": "metadata_get", "id": task_id, "metadata_key": key}),
-        );
-        r.get("value").filter(|v| !v.is_null()).cloned()
+        crate::task_events::replay(home)
+            .ok()?
+            .tasks
+            .get(&crate::task_events::TaskId(task_id.into()))?
+            .metadata
+            .get(key)
+            .cloned()
     }
 
     const TRAIN_KEYS: [&str; 4] = [
@@ -916,7 +1006,7 @@ teams:\n\
     #[test]
     fn a_concurrent_same_key_one_front_one_queued() {
         let home = mt_home("a-conc");
-        seed_fleet(&home, TEAMS_CORE);
+        fixture(&home);
         create_task(&home, "t-a1");
         create_task(&home, "t-a2");
         set_meta(&home, "t-a1", "conflict_domain", json!("core"));
@@ -928,11 +1018,11 @@ teams:\n\
 
         let h1 = std::thread::spawn(move || {
             b1.wait();
-            dispatch(&home1, "t-a1", "feat/a1")
+            dispatch(&home1, "dev-a", "t-a1", "feat/a1")
         });
         let h2 = std::thread::spawn(move || {
             b2.wait();
-            dispatch(&home2, "t-a2", "feat/a2")
+            dispatch(&home2, "dev-b", "t-a2", "feat/a2")
         });
         let _r1 = h1.join().unwrap();
         let _r2 = h2.join().unwrap();
@@ -955,7 +1045,11 @@ teams:\n\
             .iter()
             .filter_map(|v| v.as_ref().and_then(|v| v.as_u64()))
             .collect();
-        assert_eq!(seqs.len(), 2, "both tasks must have queue_seq: {seq1:?}, {seq2:?}");
+        assert_eq!(
+            seqs.len(),
+            2,
+            "both tasks must have queue_seq: {seq1:?}, {seq2:?}"
+        );
         assert!(
             seqs.contains(&1) && seqs.contains(&2),
             "Front=seq 1, Queued=seq 2, got {seqs:?}"
@@ -976,18 +1070,18 @@ teams:\n\
     #[test]
     fn a_readmission_emits_zero_new_train_events() {
         let home = mt_home("a-readmit");
-        seed_fleet(&home, TEAMS_CORE);
+        fixture(&home);
         create_task(&home, "t-r1");
         set_meta(&home, "t-r1", "conflict_domain", json!("core"));
 
-        dispatch(&home, "t-r1", "feat/r1");
+        dispatch(&home, "dev-a", "t-r1", "feat/r1");
         assert!(
             read_meta(&home, "t-r1", "merge_train_position").is_some(),
             "first dispatch must write merge_train_position"
         );
 
         let events_before = train_event_count(&home, "t-r1");
-        dispatch(&home, "t-r1", "feat/r1");
+        dispatch(&home, "dev-a", "t-r1", "feat/r1");
         let events_after = train_event_count(&home, "t-r1");
         assert_eq!(
             events_before, events_after,
@@ -1004,15 +1098,24 @@ teams:\n\
     #[test]
     fn b_queued_zero_side_effects() {
         let home = mt_home("b-queued");
-        seed_fleet(&home, TEAMS_CORE);
+        let repo = fixture(&home);
         create_task(&home, "t-front");
         create_task(&home, "t-q1");
         set_meta(&home, "t-front", "conflict_domain", json!("core"));
         set_meta(&home, "t-q1", "conflict_domain", json!("core"));
 
-        dispatch(&home, "t-front", "feat/front");
+        dispatch(&home, "dev-a", "t-front", "feat/front");
+        assert!(
+            crate::binding::read(&home, "dev-a").is_some(),
+            "Front fixture must reach auto-bind"
+        );
+        let inbox_before = crate::inbox::unread_count(&home, "dev-b");
+        let ci_before =
+            crate::binding::agent_has_active_ci_watch_on_branch(&home, "dev-b", "feat/q1");
+        let tracking_before = crate::dispatch_tracking::has_for_instance(&home, "dev-b");
+        let assignment_before = home.join("reviewer-assignments").exists();
 
-        let result = dispatch(&home, "t-q1", "feat/q1");
+        let result = dispatch(&home, "dev-b", "t-q1", "feat/q1");
         assert_eq!(
             result.get("merge_train_position").and_then(|v| v.as_str()),
             Some("Queued"),
@@ -1020,35 +1123,53 @@ teams:\n\
         );
 
         // 1. inbox
-        let inbox = crate::inbox::drain(&home, "dev");
-        assert!(inbox.is_empty(), "Queued must not deliver to inbox: {} msgs", inbox.len());
+        assert_eq!(
+            crate::inbox::unread_count(&home, "dev-b"),
+            inbox_before,
+            "Queued must not deliver to inbox"
+        );
 
         // 2. binding
-        let binding = home.join("runtime").join("dev").join("binding.json");
-        assert!(!binding.exists(), "Queued must not create binding");
+        assert!(
+            crate::binding::read(&home, "dev-b").is_none(),
+            "Queued must not create binding"
+        );
 
         // 3. worktree
-        let wt = home.join("worktrees").join("dev");
+        let wt = crate::worktree::worktree_path(&home, "dev-b", "feat/q1");
         assert!(!wt.exists(), "Queued must not create worktree");
 
         // 4. CI watch
-        let ci = home.join("ci_watch");
-        let has_ci = ci.is_dir() && std::fs::read_dir(&ci).map(|d| d.count() > 0).unwrap_or(false);
-        assert!(!has_ci, "Queued must not arm CI watch");
+        assert_eq!(
+            crate::binding::agent_has_active_ci_watch_on_branch(&home, "dev-b", "feat/q1"),
+            ci_before,
+            "Queued must not arm CI watch"
+        );
 
         // 5. review assignment
-        let ra_dir = home.join("reviewer-assignments");
-        let has_ra = ra_dir.is_dir()
-            && std::fs::read_dir(&ra_dir).map(|d| d.count() > 0).unwrap_or(false);
-        assert!(!has_ra, "Queued must not create review assignment");
+        assert_eq!(
+            home.join("reviewer-assignments").exists(),
+            assignment_before,
+            "Queued must not create review assignment"
+        );
 
         // 6. dispatch tracking
-        let dt = crate::store::store_path(&home, "dispatch_tracking.json");
-        let has_dt = dt.exists()
-            && std::fs::read_to_string(&dt)
-                .map(|s| s.contains("t-q1"))
-                .unwrap_or(false);
-        assert!(!has_dt, "Queued must not write dispatch tracking");
+        assert_eq!(
+            crate::dispatch_tracking::has_for_instance(&home, "dev-b"),
+            tracking_before,
+            "Queued must not write dispatch tracking"
+        );
+
+        let ref_status = std::process::Command::new("git")
+            .args(["rev-parse", "--verify", "refs/heads/feat/q1"])
+            .current_dir(repo)
+            .env("AGEND_GIT_BYPASS", "1")
+            .status()
+            .unwrap();
+        assert!(
+            !ref_status.success(),
+            "Queued must not create its canonical branch ref"
+        );
 
         std::fs::remove_dir_all(&home).ok();
     }
@@ -1056,25 +1177,18 @@ teams:\n\
     #[test]
     fn b_disjoint_repo_is_front() {
         let home = mt_home("b-disjoint-repo");
-        // First dispatch with team pointing to repo-A.
-        seed_fleet(
-            &home,
-            "teams:\n\
-             \x20 core:\n\
-             \x20   orchestrator: lead\n\
-             \x20   members:\n\
-             \x20     - lead\n\
-             \x20     - dev\n",
-        );
+        let repo_a = init_repo(&home, "canonical-a", "owner/repo-a");
+        let repo_b = init_repo(&home, "canonical-b", "owner/repo-b");
+        seed_two_repo_fleet(&home, &repo_a, &repo_b);
         create_task(&home, "t-dr1");
         create_task(&home, "t-dr2");
         set_meta(&home, "t-dr1", "conflict_domain", json!("core"));
         set_meta(&home, "t-dr2", "conflict_domain", json!("core"));
         // Simulate repo-A identity via dispatch arg (future admission reads this).
-        dispatch_with_repo(&home, "t-dr1", "feat/dr1", "repo-a/proj");
+        dispatch_with_repo(&home, "dev-a", "t-dr1", "feat/dr1", "owner/repo-a");
 
         // Second dispatch with a different repo identity.
-        dispatch_with_repo(&home, "t-dr2", "feat/dr2", "repo-b/proj");
+        dispatch_with_repo(&home, "dev-b", "t-dr2", "feat/dr2", "owner/repo-b");
 
         let pos = read_meta(&home, "t-dr2", "merge_train_position");
         assert_eq!(
@@ -1089,14 +1203,14 @@ teams:\n\
     #[test]
     fn b_disjoint_domain_is_front() {
         let home = mt_home("b-disjoint-dom");
-        seed_fleet(&home, TEAMS_CORE);
+        fixture(&home);
         create_task(&home, "t-dd1");
         create_task(&home, "t-dd2");
         set_meta(&home, "t-dd1", "conflict_domain", json!("backend"));
         set_meta(&home, "t-dd2", "conflict_domain", json!("frontend"));
 
-        dispatch(&home, "t-dd1", "feat/dd1");
-        dispatch(&home, "t-dd2", "feat/dd2");
+        dispatch(&home, "dev-a", "t-dd1", "feat/dd1");
+        dispatch(&home, "dev-b", "t-dd2", "feat/dd2");
 
         let pos = read_meta(&home, "t-dd2", "merge_train_position");
         assert_eq!(
@@ -1111,13 +1225,13 @@ teams:\n\
     #[test]
     fn b_absent_domain_falls_back_to_repo() {
         let home = mt_home("b-absent-dom");
-        seed_fleet(&home, TEAMS_CORE);
+        fixture(&home);
         create_task(&home, "t-no1");
         create_task(&home, "t-no2");
         // No conflict_domain set — must fall back to __repo__.
 
-        dispatch(&home, "t-no1", "feat/no1");
-        dispatch(&home, "t-no2", "feat/no2");
+        dispatch(&home, "dev-a", "t-no1", "feat/no1");
+        dispatch(&home, "dev-b", "t-no2", "feat/no2");
 
         let dom1 = read_meta(&home, "t-no1", "merge_train_domain");
         let dom2 = read_meta(&home, "t-no2", "merge_train_domain");
@@ -1144,15 +1258,15 @@ teams:\n\
     #[test]
     fn b_named_domain_disjoint_from_repo_fallback() {
         let home = mt_home("b-named-vs-repo");
-        seed_fleet(&home, TEAMS_CORE);
+        fixture(&home);
         create_task(&home, "t-bare");
         create_task(&home, "t-named");
         // t-bare: no domain → __repo__ fallback.
         // t-named: explicit "backend" domain.
         set_meta(&home, "t-named", "conflict_domain", json!("backend"));
 
-        dispatch(&home, "t-bare", "feat/bare");
-        dispatch(&home, "t-named", "feat/named");
+        dispatch(&home, "dev-a", "t-bare", "feat/bare");
+        dispatch(&home, "dev-b", "t-named", "feat/named");
 
         let pos = read_meta(&home, "t-named", "merge_train_position");
         assert_eq!(
@@ -1171,7 +1285,7 @@ teams:\n\
     #[test]
     fn c_partial_train_metadata_refuses() {
         let home = mt_home("c-partial");
-        seed_fleet(&home, TEAMS_CORE);
+        fixture(&home);
         create_task(&home, "t-part");
         // Pre-seed only ONE of the four required train keys.
         set_meta(
@@ -1181,15 +1295,19 @@ teams:\n\
             json!("forge:owner/repo"),
         );
 
-        let result = dispatch(&home, "t-part", "feat/part");
+        let events_before = train_event_count(&home, "t-part");
+        let result = dispatch(&home, "dev-a", "t-part", "feat/part");
         let code = result.get("code").and_then(|v| v.as_str()).unwrap_or("");
         assert!(
             code.starts_with("merge_train_"),
             "partial train metadata must produce a merge_train_* refusal, got: {result}"
         );
 
-        let events = train_event_count(&home, "t-part");
-        assert_eq!(events, 0, "partial-refusal must not append merge_train_* events");
+        let events_after = train_event_count(&home, "t-part");
+        assert_eq!(
+            events_after, events_before,
+            "partial-refusal must append zero new merge_train_* events"
+        );
 
         std::fs::remove_dir_all(&home).ok();
     }
@@ -1197,19 +1315,30 @@ teams:\n\
     #[test]
     fn c_mismatched_metadata_refuses() {
         let home = mt_home("c-mismatch");
-        seed_fleet(&home, TEAMS_CORE);
+        fixture(&home);
         create_task(&home, "t-mis");
         // Pre-seed all four train keys but with a WRONG repository.
-        set_meta(&home, "t-mis", "merge_train_repository", json!("forge:wrong/repo"));
+        set_meta(
+            &home,
+            "t-mis",
+            "merge_train_repository",
+            json!("forge:wrong/repo"),
+        );
         set_meta(&home, "t-mis", "merge_train_domain", json!("core"));
         set_meta(&home, "t-mis", "merge_train_position", json!("Front"));
         set_meta(&home, "t-mis", "merge_train_queue_seq", json!(1));
 
-        let result = dispatch(&home, "t-mis", "feat/mis");
+        let events_before = train_event_count(&home, "t-mis");
+        let result = dispatch(&home, "dev-a", "t-mis", "feat/mis");
         let code = result.get("code").and_then(|v| v.as_str()).unwrap_or("");
         assert!(
             code.starts_with("merge_train_"),
             "mismatched repo identity must produce merge_train_* refusal, got: {result}"
+        );
+        assert_eq!(
+            train_event_count(&home, "t-mis"),
+            events_before,
+            "mismatch refusal must append zero new merge_train_* events"
         );
 
         std::fs::remove_dir_all(&home).ok();
@@ -1218,12 +1347,13 @@ teams:\n\
     #[test]
     fn c_ambiguous_cross_board_task_refuses() {
         let home = mt_home("c-ambig");
-        seed_fleet(&home, TEAMS_CORE);
+        fixture(&home);
         // Create same task_id on default board AND a project board.
         create_task(&home, "t-dup");
         create_task_on_board(&home, "t-dup", "other/project");
 
-        let result = dispatch(&home, "t-dup", "feat/dup");
+        let events_before = train_event_count(&home, "t-dup");
+        let result = dispatch(&home, "dev-a", "t-dup", "feat/dup");
         let code = result.get("code").and_then(|v| v.as_str()).unwrap_or("");
         assert!(
             code.starts_with("merge_train_"),
@@ -1236,6 +1366,11 @@ teams:\n\
                 "ambiguous refusal must not write {key}"
             );
         }
+        assert_eq!(
+            train_event_count(&home, "t-dup"),
+            events_before,
+            "ambiguous refusal must append zero new merge_train_* events"
+        );
 
         std::fs::remove_dir_all(&home).ok();
     }
@@ -1243,10 +1378,10 @@ teams:\n\
     #[test]
     fn c_ghost_task_refuses() {
         let home = mt_home("c-ghost");
-        seed_fleet(&home, TEAMS_CORE);
+        fixture(&home);
         // Do NOT create any task — dispatch a non-existent task_id.
 
-        let result = dispatch(&home, "t-nonexistent", "feat/ghost");
+        let result = dispatch(&home, "dev-a", "t-nonexistent", "feat/ghost");
         let code = result.get("code").and_then(|v| v.as_str()).unwrap_or("");
         assert!(
             code.starts_with("merge_train_"),

--- a/src/mcp/handlers/comms_delegate/tests.rs
+++ b/src/mcp/handlers/comms_delegate/tests.rs
@@ -999,6 +999,28 @@ mod merge_train_admission_tests {
         count
     }
 
+    fn assignment_snapshot(home: &Path) -> Vec<(PathBuf, Vec<u8>)> {
+        fn collect(root: &Path, dir: &Path, out: &mut Vec<(PathBuf, Vec<u8>)>) {
+            let Ok(entries) = std::fs::read_dir(dir) else {
+                return;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    collect(root, &path, out);
+                } else if let Ok(bytes) = std::fs::read(&path) {
+                    out.push((path.strip_prefix(root).unwrap().to_path_buf(), bytes));
+                }
+            }
+        }
+
+        let root = home.join("reviewer-assignments");
+        let mut records = Vec::new();
+        collect(&root, &root, &mut records);
+        records.sort_by(|a, b| a.0.cmp(&b.0));
+        records
+    }
+
     // ════════════════════════════════════════════════════════════════
     // Group A — concurrent same-key admission
     // ════════════════════════════════════════════════════════════════
@@ -1113,7 +1135,7 @@ mod merge_train_admission_tests {
         let ci_before =
             crate::binding::agent_has_active_ci_watch_on_branch(&home, "dev-b", "feat/q1");
         let tracking_before = crate::dispatch_tracking::has_for_instance(&home, "dev-b");
-        let assignment_before = home.join("reviewer-assignments").exists();
+        let assignment_before = assignment_snapshot(&home);
 
         let result = dispatch(&home, "dev-b", "t-q1", "feat/q1");
         assert_eq!(
@@ -1148,9 +1170,9 @@ mod merge_train_admission_tests {
 
         // 5. review assignment
         assert_eq!(
-            home.join("reviewer-assignments").exists(),
+            assignment_snapshot(&home),
             assignment_before,
-            "Queued must not create review assignment"
+            "Queued must not create or mutate reviewer-assignment records"
         );
 
         // 6. dispatch tracking

--- a/src/mcp/handlers/dispatch_hook/mod.rs
+++ b/src/mcp/handlers/dispatch_hook/mod.rs
@@ -722,6 +722,16 @@ fn resolve_source_repo(
     (stub, SourceRepoTier::Stub)
 }
 
+/// Resolve a target's source repository through the exact dispatch tier order.
+/// Kept narrow so pre-dispatch authority checks can share the resolver without
+/// acquiring a bind guard or starting any worktree lifecycle operation.
+pub(crate) fn resolve_source_repo_for_target(home: &Path, target: &str) -> PathBuf {
+    let resolved = crate::fleet::FleetConfig::load(&crate::fleet::fleet_yaml_path(home))
+        .ok()
+        .and_then(|fleet| fleet.resolve_instance(target));
+    resolve_source_repo(home, target, None, resolved.as_ref()).0
+}
+
 /// CR-2026-06-14 F3: dispatch-time `git fetch` budget. `ensure_branch_exists` is
 /// on the synchronous pre-send path bounded by the 30s `send` proxy
 /// (`DEFAULT_TOOL_TIMEOUT`); the prior 300s `NETWORK_GIT_TIMEOUT` let a fetch run

--- a/src/mcp/handlers/dispatch_hook/mod.rs
+++ b/src/mcp/handlers/dispatch_hook/mod.rs
@@ -20,6 +20,7 @@ pub(crate) use lifecycle_permit::{
     is_active as lifecycle_is_active, BindGuard, LifecycleOperation, LifecyclePermit,
 };
 pub(crate) use provider_neutral_slug::canonical_repo_slug_for_source;
+pub(crate) use provider_neutral_slug::canonicalize_repo_slug_any_forge;
 
 /// #781 Piece 7: structured dispatch outcome. Mirrors the #784 success
 /// response shape for `repo action=checkout bind:true` so callers across

--- a/src/tasks/board_router.rs
+++ b/src/tasks/board_router.rs
@@ -750,6 +750,32 @@ pub(super) fn replay_all_boards(home: &Path) -> anyhow::Result<crate::task_event
     Ok(merged)
 }
 
+/// Strict all-board replay for cross-board authority decisions. Every board is
+/// strict-replayed and duplicate task ids are rejected instead of overwritten.
+pub(super) fn replay_all_boards_strict(
+    home: &Path,
+) -> Result<crate::task_events::TaskBoardState, TaskRouteError> {
+    let mut merged = crate::task_events::TaskBoardState::default();
+    for project in enumerate_projects(home)? {
+        let board = board_root(home, &project);
+        let state = crate::task_events::replay_strict_at(&board).map_err(|e| {
+            TaskRouteError::Unreadable {
+                path: e.path,
+                cause: e.cause,
+            }
+        })?;
+        for (id, record) in state.tasks {
+            if merged.tasks.insert(id.clone(), record).is_some() {
+                return Err(TaskRouteError::Ambiguous {
+                    candidates: vec![id.0],
+                    cause: "duplicate task id across boards during merge-train scan".into(),
+                });
+            }
+        }
+    }
+    Ok(merged)
+}
+
 /// P0 cross-lease: strict cross-board task list for authority decisions
 /// (auto-release). Unlike `list_all_boards` (display-only, degrades to
 /// default on error), this function FAILS CLOSED:

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -945,6 +945,95 @@ pub(crate) fn load_routed(home: &Path, task_id: &str) -> Result<RoutedTask, Task
     })
 }
 
+// ── Merge Train Slice 1 — admission metadata through the board-root seam ──
+
+pub(crate) fn scan_merge_train_fronts(home: &Path, repo: &str, domain: &str) -> Vec<String> {
+    let state = match board_router::replay_all_boards(home) {
+        Ok(s) => s,
+        Err(_) => return Vec::new(),
+    };
+    state
+        .tasks
+        .iter()
+        .filter(|(_, r)| {
+            r.metadata
+                .get("merge_train_repository")
+                .and_then(|v| v.as_str())
+                == Some(repo)
+                && r.metadata
+                    .get("merge_train_domain")
+                    .and_then(|v| v.as_str())
+                    == Some(domain)
+                && r.metadata
+                    .get("merge_train_position")
+                    .and_then(|v| v.as_str())
+                    == Some("Front")
+        })
+        .map(|(id, _)| id.0.clone())
+        .collect()
+}
+
+pub(crate) fn next_merge_train_seq(home: &Path, repo: &str, domain: &str) -> u64 {
+    let state = match board_router::replay_all_boards(home) {
+        Ok(s) => s,
+        Err(_) => return 1,
+    };
+    let max_seq = state
+        .tasks
+        .values()
+        .filter(|r| {
+            r.metadata
+                .get("merge_train_repository")
+                .and_then(|v| v.as_str())
+                == Some(repo)
+                && r.metadata
+                    .get("merge_train_domain")
+                    .and_then(|v| v.as_str())
+                    == Some(domain)
+        })
+        .filter_map(|r| {
+            r.metadata
+                .get("merge_train_queue_seq")
+                .and_then(|v| v.as_u64())
+        })
+        .max()
+        .unwrap_or(0);
+    max_seq + 1
+}
+
+pub(crate) fn write_merge_train_metadata(
+    home: &Path,
+    task_id: &str,
+    entries: &[(&str, serde_json::Value)],
+) -> Result<(), serde_json::Value> {
+    let routed = load_routed(home, task_id).map_err(|e| {
+        serde_json::json!({
+            "ok": false,
+            "error": format!("merge train metadata write: task route for '{task_id}': {e}"),
+            "code": "merge_train_route_error",
+        })
+    })?;
+    let board = routed.board().path().to_path_buf();
+    let emitter = crate::task_events::InstanceName("system:merge_train".into());
+    let events: Vec<crate::task_events::TaskEvent> = entries
+        .iter()
+        .map(|(key, value)| crate::task_events::TaskEvent::MetadataSet {
+            task_id: crate::task_events::TaskId(task_id.into()),
+            by: emitter.clone(),
+            key: (*key).into(),
+            value: value.clone(),
+        })
+        .collect();
+    crate::task_events::append_batch_at(&board, &emitter, events).map_err(|e| {
+        serde_json::json!({
+            "ok": false,
+            "error": format!("merge train metadata write: {e}"),
+            "code": "merge_train_write_error",
+        })
+    })?;
+    Ok(())
+}
+
 /// Return all tasks as typed structs. **PR3 cutover** — sources state
 /// from `task_events::replay()` instead of the legacy `tasks.json`.
 /// Dep-derived blocking is computed in-memory at this call (option (a)

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -947,12 +947,13 @@ pub(crate) fn load_routed(home: &Path, task_id: &str) -> Result<RoutedTask, Task
 
 // ── Merge Train Slice 1 — admission metadata through the board-root seam ──
 
-pub(crate) fn scan_merge_train_fronts(home: &Path, repo: &str, domain: &str) -> Vec<String> {
-    let state = match board_router::replay_all_boards(home) {
-        Ok(s) => s,
-        Err(_) => return Vec::new(),
-    };
-    state
+pub(crate) fn scan_merge_train_state(
+    home: &Path,
+    repo: &str,
+    domain: &str,
+) -> Result<(Vec<String>, u64), TaskRouteError> {
+    let state = board_router::replay_all_boards_strict(home)?;
+    let fronts = state
         .tasks
         .iter()
         .filter(|(_, r)| {
@@ -970,14 +971,7 @@ pub(crate) fn scan_merge_train_fronts(home: &Path, repo: &str, domain: &str) -> 
                     == Some("Front")
         })
         .map(|(id, _)| id.0.clone())
-        .collect()
-}
-
-pub(crate) fn next_merge_train_seq(home: &Path, repo: &str, domain: &str) -> u64 {
-    let state = match board_router::replay_all_boards(home) {
-        Ok(s) => s,
-        Err(_) => return 1,
-    };
+        .collect();
     let max_seq = state
         .tasks
         .values()
@@ -998,7 +992,7 @@ pub(crate) fn next_merge_train_seq(home: &Path, repo: &str, domain: &str) -> u64
         })
         .max()
         .unwrap_or(0);
-    max_seq + 1
+    Ok((fronts, max_seq + 1))
 }
 
 pub(crate) fn write_merge_train_metadata(
@@ -1013,7 +1007,6 @@ pub(crate) fn write_merge_train_metadata(
             "code": "merge_train_route_error",
         })
     })?;
-    let board = routed.board().path().to_path_buf();
     let emitter = crate::task_events::InstanceName("system:merge_train".into());
     let events: Vec<crate::task_events::TaskEvent> = entries
         .iter()
@@ -1024,14 +1017,43 @@ pub(crate) fn write_merge_train_metadata(
             value: value.clone(),
         })
         .collect();
-    crate::task_events::append_batch_at(&board, &emitter, events).map_err(|e| {
-        serde_json::json!({
+    let task = crate::task_events::TaskId(task_id.into());
+    match routed.with_revalidated_computed(home, &emitter, move |fresh| {
+        let record = fresh
+            .tasks
+            .get(&task)
+            .ok_or_else(|| format!("task '{}' disappeared before merge-train write", task.0))?;
+        let train_keys = [
+            "merge_train_repository",
+            "merge_train_domain",
+            "merge_train_position",
+            "merge_train_queue_seq",
+        ];
+        if train_keys
+            .iter()
+            .any(|key| record.metadata.contains_key(*key))
+        {
+            return Err("merge-train metadata changed before atomic append".into());
+        }
+        Ok(events)
+    }) {
+        Ok(Ok(Ok(_))) => Ok(()),
+        Ok(Ok(Err(e))) => Err(serde_json::json!({
+            "ok": false,
+            "error": format!("merge train metadata write revalidation: {e}"),
+            "code": "merge_train_write_conflict",
+        })),
+        Ok(Err(e)) => Err(serde_json::json!({
             "ok": false,
             "error": format!("merge train metadata write: {e}"),
             "code": "merge_train_write_error",
-        })
-    })?;
-    Ok(())
+        })),
+        Err(e) => Err(serde_json::json!({
+            "ok": false,
+            "error": format!("merge train metadata route revalidation: {e}"),
+            "code": "merge_train_route_error",
+        })),
+    }
 }
 
 /// Return all tasks as typed structs. **PR3 cutover** — sources state


### PR DESCRIPTION
## Summary
- canonicalize namespaced merge-train repository identities through the dispatch source resolver
- serialize admission with collision-safe repo/domain locks and strict all-board replay
- revalidate fresh task content before the atomic four-event metadata append
- reject invalid stored positions without writes

## Verification
- cargo test --bin agend-terminal merge_train_admission_tests -- --test-threads=1 (16 passed)
- cargo test --bin agend-terminal comms_delegate -- --test-threads=1 (41 passed)
- cargo fmt -- --check
- cargo clippy --bin agend-terminal --tests -- -D warnings