### PR TITLE
fix(app): fail closed when the daemon singleton flock is held

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -696,7 +696,7 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
         &registry,
         tui_event_tx,
         Some(app_restart_inject),
-    );
+    )?;
     let attached_mode = attached_run_dir.is_some();
     let app_restart_rx = never_when_attached(app_restart_rx, attached_mode);
     let owner_services = start_owned_services(&home, &registry, &telegram_state, attached_mode);
@@ -769,18 +769,35 @@ fn run_app(terminal: &mut DefaultTerminal, fleet_override: Option<&Path>) -> Res
 /// Returns `(api_guard, telegram_channel, telegram_status, attached_run_dir)`.
 /// The RAII `ApiGuard` must outlive the TUI loop, so the caller binds it;
 /// `attached_run_dir.is_some()` ⇒ Attached mode.
+/// Does this `bootstrap::prepare` failure mean "another daemon already owns this
+/// `$AGEND_HOME`"?
+///
+/// App mode MUST NOT degrade to Owned when this is true: Owned spawns the whole
+/// fleet a second time behind the live daemon's back. Split out from the match
+/// arm in [`setup_app_bootstrap`] so the classification is directly testable —
+/// the TUI path itself needs a real TTY and cannot be driven headlessly.
+fn is_singleton_conflict(e: &anyhow::Error) -> bool {
+    e.downcast_ref::<crate::bootstrap::DaemonAlreadyRunning>()
+        .is_some()
+}
+
+/// What [`setup_app_bootstrap`] hands back to `run_app`: the RAII API guard, the
+/// optional Telegram channel, its status, and — when non-`None` — the run dir of
+/// the daemon we attached to (`Some` ⇒ Attached mode).
+type AppBootstrap = (
+    api_server::ApiGuard,
+    Option<Arc<dyn crate::channel::Channel>>,
+    TelegramStatus,
+    Option<PathBuf>,
+);
+
 fn setup_app_bootstrap(
     home: &Path,
     fleet_path: &Path,
     registry: &AgentRegistry,
     tui_event_tx: TuiEventSender,
     app_restart: Option<crate::api::app_restart::AppRestart>,
-) -> (
-    api_server::ApiGuard,
-    Option<Arc<dyn crate::channel::Channel>>,
-    TelegramStatus,
-    Option<PathBuf>,
-) {
+) -> Result<AppBootstrap> {
     let opts = crate::bootstrap::PrepareOptions {
         resolve_agents: false, // app spawns via pane_factory from tabs
         ..Default::default()
@@ -816,6 +833,26 @@ fn setup_app_bootstrap(
                     TelegramStatus::NotConfigured,
                 )
             }
+            // Losing the daemon singleton flock is NOT a degradable failure.
+            // Falling through here leaves `attached_run_dir == None`, which makes
+            // `run_app` take the Owned branch and spawn a SECOND copy of every
+            // fleet instance behind the live daemon's back — the split-brain this
+            // guard exists to prevent (duplicate agent identities, cross-written
+            // memory dirs, dispatch replies answered by the wrong lead).
+            //
+            // Note the asymmetry this fixes: `start --foreground` already bailed
+            // on this error (`cli::start_with_fleet`), only the app path degraded.
+            Err(e) if is_singleton_conflict(&e) => {
+                tracing::error!(error = %e, "refusing to boot: daemon singleton lock is held");
+                return Err(e.context(
+                    "refusing to start a second fleet — stop the running instance first, \
+                     or use `agend-terminal attach <agent>` to reach the live one",
+                ));
+            }
+            // Every other bootstrap failure keeps the pre-existing degraded-TUI
+            // behaviour: without the flock as evidence we cannot claim a peer is
+            // alive, and locking the operator out of the TUI on (say) an
+            // unparseable fleet.yaml would remove their only repair surface.
             Err(e) => {
                 tracing::warn!(error = %e, "bootstrap failed, running TUI without in-process API");
                 (
@@ -825,7 +862,7 @@ fn setup_app_bootstrap(
                 )
             }
         };
-    (api_guard, telegram_state, telegram_status, attached_run_dir)
+    Ok((api_guard, telegram_state, telegram_status, attached_run_dir))
 }
 
 /// App exit teardown: persist the on-screen layout, then (Owned mode only) sync
@@ -1604,6 +1641,43 @@ mod tests {
     use crate::backend::Backend;
     use crate::layout::PaneSource;
     use crate::vterm::VTerm;
+
+    /// Split-brain regression (2026-07-21 incident).
+    ///
+    /// `setup_app_bootstrap` used to funnel EVERY `bootstrap::prepare` failure
+    /// into one degraded arm: `attached_run_dir` stayed `None`, `run_app` read
+    /// that as Owned mode, and the app spawned a second copy of the whole fleet
+    /// while the real daemon was still running. Losing the singleton flock must
+    /// be classified as fatal; everything else must stay degradable so an
+    /// unparseable fleet.yaml does not lock the operator out of the only UI that
+    /// can repair it.
+    ///
+    /// The TUI path needs a real TTY (`app::run` bails without one), so the
+    /// classification is tested directly rather than by driving the app.
+    #[test]
+    fn singleton_conflict_is_fatal_but_other_bootstrap_failures_are_not() {
+        let conflict = anyhow::Error::new(crate::bootstrap::DaemonAlreadyRunning {
+            pid: Some(4242),
+            boot_unix: Some(1_784_604_392),
+        });
+        assert!(
+            is_singleton_conflict(&conflict),
+            "losing the daemon flock must be fatal — degrading here is the split-brain bug"
+        );
+
+        // Same shape, wrapped in operator-facing context the way callers add it.
+        let wrapped = conflict.context("refusing to start a second fleet");
+        assert!(
+            is_singleton_conflict(&wrapped),
+            "classification must survive `.context()` — callers always add guidance"
+        );
+
+        let unrelated = anyhow::anyhow!("fleet.yaml: mapping values are not allowed here");
+        assert!(
+            !is_singleton_conflict(&unrelated),
+            "unrelated bootstrap failures must keep the degraded-TUI escape hatch"
+        );
+    }
 
     /// #t-84833-10 redraw-storm frame cap — the `should_draw` rate-limit decision.
     #[test]

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -42,7 +42,7 @@ fn maybe_init_discord(_config: &crate::fleet::FleetConfig, _enabled: bool) {}
 
 pub use agent_resolve::AgentDef;
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -78,9 +78,84 @@ pub(crate) fn time_step<T>(name: &'static str, f: impl FnOnce() -> T) -> T {
 ///
 /// Dropping the struct releases the lock. Keep this alive for the entire
 /// lifetime of the owning process.
+#[derive(Debug)]
 pub struct DaemonLock {
     _file: std::fs::File,
 }
+
+/// Sentinel error: `.daemon.lock` is held by another live process.
+///
+/// Losing this flock is NOT a generic bootstrap failure — it is positive
+/// evidence that a daemon is already alive on this `$AGEND_HOME`. A caller that
+/// degrades to "assume we own the fleet" spawns a SECOND copy of every instance
+/// (duplicate agent identities, cross-written memory dirs, dispatch replies
+/// answered by the wrong lead). Callers MUST fail closed; see
+/// `app::setup_app_bootstrap`, whose catch-all `Err` arm did exactly that
+/// degrade before this type existed.
+///
+/// Carried through `anyhow` — recover it with
+/// `err.downcast_ref::<DaemonAlreadyRunning>()`.
+#[derive(Debug)]
+pub struct DaemonAlreadyRunning {
+    /// Incumbent's PID. `None` when the lock is held but its run dir is not yet
+    /// discoverable — a real window: `prepare` takes the flock at
+    /// [`acquire_daemon_lock`] but does not publish `.daemon` until
+    /// [`crate::daemon::write_daemon_id`] a few steps later.
+    pub pid: Option<u32>,
+    /// Incumbent's boot time (unix seconds), when discoverable.
+    pub boot_unix: Option<u64>,
+}
+
+impl DaemonAlreadyRunning {
+    /// Identify whoever currently owns `home` for the operator-facing message.
+    ///
+    /// Reuses the daemon's own discovery fn, so PID-reuse and start-token
+    /// mismatches are filtered out the same way everywhere else in the codebase.
+    fn probe(home: &Path) -> Self {
+        let run = crate::daemon::find_active_run_dir(home);
+        Self {
+            pid: run.as_deref().and_then(crate::daemon::read_daemon_pid),
+            boot_unix: run.as_deref().and_then(crate::daemon::read_daemon_boot_unix),
+        }
+    }
+
+    /// Render the boot time as a local-time string; falls back to the raw epoch
+    /// when it cannot be interpreted, so the operator always gets *something*
+    /// to correlate against `ps`.
+    fn started_at(&self) -> String {
+        let Some(secs) = self.boot_unix else {
+            return "unknown".to_string();
+        };
+        match chrono::DateTime::<chrono::Utc>::from_timestamp(secs as i64, 0) {
+            Some(dt) => dt
+                .with_timezone(&chrono::Local)
+                .format("%Y-%m-%d %H:%M:%S")
+                .to_string(),
+            None => format!("epoch {secs}"),
+        }
+    }
+}
+
+impl std::fmt::Display for DaemonAlreadyRunning {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.pid {
+            Some(pid) => write!(
+                f,
+                "another agend-terminal daemon is already running (pid {pid}, started {})",
+                self.started_at()
+            ),
+            // Mid-boot window: the flock is held but `.daemon` is not published
+            // yet. Say so plainly rather than printing a bogus PID.
+            None => write!(
+                f,
+                "another agend-terminal daemon is already running \
+                 (holds .daemon.lock; still starting up, pid not published yet)"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for DaemonAlreadyRunning {}
 
 /// Result of [`prepare`] — tells the caller whether this process is the daemon
 /// or a client of an existing one.
@@ -543,15 +618,32 @@ fn try_attach(home: &Path, fleet_path: &Path) -> Result<Option<AttachedFleet>> {
     }))
 }
 
-fn acquire_daemon_lock(home: &Path) -> Result<DaemonLock> {
+/// Take the process-lifetime daemon singleton flock.
+///
+/// Contention is reported as a typed [`DaemonAlreadyRunning`] so callers can
+/// tell "a daemon is already alive" apart from "bootstrap broke". Everything
+/// else (open failure, real flock I/O error) stays an untyped error with the
+/// pre-existing semantics — an I/O failure is not evidence about peers.
+pub(crate) fn acquire_daemon_lock(home: &Path) -> Result<DaemonLock> {
     let path = home.join(".daemon.lock");
     let file = std::fs::File::create(&path).with_context(|| format!("open {}", path.display()))?;
     // Explicit trait method: Rust 1.89 stabilized inherent
     // `File::try_lock` shadowing the trait method; current MSRV is 1.87.
-    fs4::FileExt::try_lock(&file).map_err(|e| {
-        anyhow!("another agend-terminal daemon is already running (lock held): {e}")
-    })?;
-    Ok(DaemonLock { _file: file })
+    //
+    // Mirrors `store::classify_try_lock`'s shape (contention must stay
+    // distinguishable from I/O failure) but deliberately does NOT bump
+    // `sync_audit::FLOCK_DEPTH` — this guard is held for the whole process
+    // lifetime and would pin the self-IPC deadlock guard at >0 forever
+    // (see the audit note in `sync_audit.rs`).
+    match fs4::FileExt::try_lock(&file) {
+        Ok(()) => Ok(DaemonLock { _file: file }),
+        Err(fs4::TryLockError::WouldBlock) => {
+            Err(anyhow::Error::new(DaemonAlreadyRunning::probe(home)))
+        }
+        Err(fs4::TryLockError::Error(e)) => {
+            Err(anyhow::Error::new(e).context(format!("flock try_lock failed on {}", path.display())))
+        }
+    }
 }
 
 #[cfg(test)]
@@ -631,6 +723,124 @@ mod tests {
             }
             BootstrapOutcome::Attached(_) => panic!("expected Owned on fresh home"),
         }
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Split-brain regression (2026-07-21 incident).
+    ///
+    /// Contention on `.daemon.lock` must surface as the typed
+    /// [`DaemonAlreadyRunning`], not an opaque string error. The app path keys
+    /// its fail-closed decision off this downcast; if contention ever degrades
+    /// back to an untyped error, `setup_app_bootstrap` silently resumes spawning
+    /// a second fleet. Deterministic: two file descriptions in one process
+    /// conflict under `flock`, so no timing or child process is involved.
+    #[test]
+    fn daemon_lock_contention_reports_typed_already_running() {
+        let home = tmp_home("lock-typed");
+        let first = acquire_daemon_lock(&home).expect("first acquisition owns the lock");
+
+        let err = acquire_daemon_lock(&home).expect_err("second acquisition must be refused");
+        assert!(
+            err.downcast_ref::<DaemonAlreadyRunning>().is_some(),
+            "contention must be typed so callers can fail closed; got: {err:#}"
+        );
+
+        drop(first);
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// The refusal must name the incumbent — the operator's next move is
+    /// `ps`/`kill` against that PID, and "some other daemon" is not actionable.
+    /// `prepare` publishes `.daemon` for the live process, so the probe resolves
+    /// this process as the holder.
+    #[test]
+    fn daemon_lock_contention_carries_incumbent_identity() {
+        let home = tmp_home("lock-identity");
+        let fleet = write_minimal_fleet(&home);
+        let opts = PrepareOptions {
+            mutate_fleet_yaml: false,
+            init_telegram: false,
+            init_discord: false,
+            resolve_agents: false,
+        };
+        let owned = prepare(&home, &fleet, opts).expect("prepare");
+
+        let err = acquire_daemon_lock(&home).expect_err("lock is held by `owned`");
+        let conflict = err
+            .downcast_ref::<DaemonAlreadyRunning>()
+            .expect("typed conflict");
+        assert_eq!(
+            conflict.pid,
+            Some(std::process::id()),
+            "incumbent PID must be the process holding the lock"
+        );
+        assert!(
+            conflict.boot_unix.is_some(),
+            "start time must be reported so the operator can correlate with `ps`"
+        );
+        let rendered = conflict.to_string();
+        assert!(
+            rendered.contains(&std::process::id().to_string()),
+            "operator-facing message must contain the PID; got: {rendered}"
+        );
+
+        drop(owned);
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// Stale-lock reclaim. `flock` is released by the kernel when the holding
+    /// file description goes away — on `kill -9` just as on a clean exit — so a
+    /// dead daemon can never wedge the next boot. Dropping the guard is the
+    /// in-process equivalent of the holder dying.
+    #[test]
+    fn daemon_lock_is_reclaimable_after_holder_releases() {
+        let home = tmp_home("lock-reclaim");
+        let first = acquire_daemon_lock(&home).expect("first acquisition");
+        assert!(
+            acquire_daemon_lock(&home).is_err(),
+            "precondition: contended while held"
+        );
+
+        drop(first);
+
+        let second = acquire_daemon_lock(&home);
+        assert!(
+            second.is_ok(),
+            "a released lock must be reclaimable — otherwise a crashed daemon \
+             bricks every subsequent start; got: {:?}",
+            second.err()
+        );
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// The seam the app fix depends on: the typed conflict must survive being
+    /// raised through `prepare`, not just from `acquire_daemon_lock` directly.
+    /// `prepare` runs `try_attach` first; with no reachable API the attach
+    /// returns `None` and control reaches the lock, which is already held.
+    #[test]
+    fn prepare_surfaces_typed_conflict_when_lock_already_held() {
+        let home = tmp_home("prepare-conflict");
+        let fleet = write_minimal_fleet(&home);
+        let _held = acquire_daemon_lock(&home).expect("pre-hold the lock");
+
+        let opts = PrepareOptions {
+            mutate_fleet_yaml: false,
+            init_telegram: false,
+            init_discord: false,
+            resolve_agents: false,
+        };
+        // `expect_err` would need `BootstrapOutcome: Debug`, and deriving it
+        // would drag Debug onto OwnedFleet/DaemonLock/FleetConfig for one test.
+        let err = match prepare(&home, &fleet, opts) {
+            Ok(_) => panic!("prepare must not claim ownership while the lock is held"),
+            Err(e) => e,
+        };
+        assert!(
+            err.downcast_ref::<DaemonAlreadyRunning>().is_some(),
+            "prepare must propagate the typed conflict for callers to fail closed on; got: {err:#}"
+        );
+
         std::fs::remove_dir_all(&home).ok();
     }
 

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -115,7 +115,9 @@ impl DaemonAlreadyRunning {
         let run = crate::daemon::find_active_run_dir(home);
         Self {
             pid: run.as_deref().and_then(crate::daemon::read_daemon_pid),
-            boot_unix: run.as_deref().and_then(crate::daemon::read_daemon_boot_unix),
+            boot_unix: run
+                .as_deref()
+                .and_then(crate::daemon::read_daemon_boot_unix),
         }
     }
 
@@ -641,7 +643,8 @@ pub(crate) fn acquire_daemon_lock(home: &Path) -> Result<DaemonLock> {
             Err(anyhow::Error::new(DaemonAlreadyRunning::probe(home)))
         }
         Err(fs4::TryLockError::Error(e)) => {
-            Err(anyhow::Error::new(e).context(format!("flock try_lock failed on {}", path.display())))
+            Err(anyhow::Error::new(e)
+                .context(format!("flock try_lock failed on {}", path.display())))
         }
     }
 }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -506,14 +506,16 @@ pub type AgentDef = (
 /// The fleet-driven path uses [`run_with_prepared`] instead, which skips the
 /// preflight because [`crate::bootstrap::prepare`] has already done it.
 pub fn run(home: &Path, agents: Vec<AgentDef>) -> anyhow::Result<()> {
-    // Acquire exclusive daemon lock (prevents TOCTOU race)
+    // Acquire exclusive daemon lock (prevents TOCTOU race).
+    //
+    // Was a second, hand-rolled copy of the flock dance. Unified onto
+    // `bootstrap::acquire_daemon_lock` so both singleton entry points report
+    // contention as the same typed `DaemonAlreadyRunning` — otherwise a caller
+    // that fails closed on the bootstrap error would still degrade on this one.
+    // The guard is bound for the rest of `run`, matching the previous
+    // `lock_file` lifetime.
     std::fs::create_dir_all(home)?;
-    let lock_path = home.join(".daemon.lock");
-    let lock_file = std::fs::File::create(&lock_path)?;
-    // Explicit trait method: Rust 1.89 stabilized inherent
-    // `File::try_lock`; current MSRV is 1.87.
-    fs4::FileExt::try_lock(&lock_file)
-        .map_err(|e| anyhow::anyhow!("Another daemon is already running (lock held): {e}"))?;
+    let _daemon_lock = crate::bootstrap::acquire_daemon_lock(home)?;
 
     // #933: zombie sweep BEFORE find_active_run_dir so an aged-out
     // unresponsive daemon (which would otherwise satisfy find_active_run_dir)

--- a/src/store.rs
+++ b/src/store.rs
@@ -297,9 +297,10 @@ impl Drop for FileFlockGuard {
 /// partially initialised lock file might be observed empty by another opener
 /// while the flock itself is still held on the inode.
 ///
-/// #1629: this is the SOLE flock chokepoint that bumps `FLOCK_DEPTH`. The 2
-/// daemon-singleton `.daemon.lock` raw `fs4::try_lock` sites deliberately bypass
-/// it (they hold for the daemon's whole life and must not pin the depth).
+/// #1629: this is the SOLE flock chokepoint that bumps `FLOCK_DEPTH`. The one
+/// daemon-singleton `.daemon.lock` raw `fs4::try_lock` site
+/// (`bootstrap::acquire_daemon_lock`) deliberately bypasses it (it holds for the
+/// daemon's whole life and must not pin the depth).
 pub fn acquire_file_lock(lock_path: &Path) -> anyhow::Result<FileFlockGuard> {
     if let Some(parent) = lock_path.parent() {
         std::fs::create_dir_all(parent)?;

--- a/src/sync_audit.rs
+++ b/src/sync_audit.rs
@@ -171,10 +171,12 @@ fn core_lock_exited() {
 // `FLOCK_DEPTH` for its lifetime so the same self-IPC assert covers the flock
 // tier too.
 //
-// The 2 daemon-singleton `.daemon.lock` raw `fs4::try_lock` sites
-// (`bootstrap::acquire_daemon_lock`, `daemon::run`) deliberately bypass
-// `acquire_file_lock` and MUST NOT bump: they hold for the daemon's whole life,
-// which would pin the depth > 0 and false-trip every self-IPC.
+// The single daemon-singleton `.daemon.lock` raw `fs4::try_lock` site
+// (`bootstrap::acquire_daemon_lock`) deliberately bypasses `acquire_file_lock`
+// and MUST NOT bump: it holds for the daemon's whole life, which would pin the
+// depth > 0 and false-trip every self-IPC. `daemon::run` used to carry a second
+// hand-rolled copy; it now calls `acquire_daemon_lock` so contention surfaces as
+// one typed `DaemonAlreadyRunning` for every singleton entry point.
 
 thread_local! {
     /// How many `acquire_file_lock` flocks this thread currently holds (0 = none).

--- a/tests/app_singleton_fail_closed.rs
+++ b/tests/app_singleton_fail_closed.rs
@@ -1,0 +1,216 @@
+//! Split-brain regression (2026-07-21 incident): `agend-terminal app` must
+//! REFUSE to boot when another process already holds the daemon singleton flock.
+//!
+//! Before the fix, `setup_app_bootstrap` funnelled every `bootstrap::prepare`
+//! failure — including "another daemon holds `.daemon.lock`" — into a single
+//! degraded arm that logged a warning and carried on with `attached_run_dir ==
+//! None`. `run_app` reads that as **Owned** mode, so the app then spawned its own
+//! copy of every fleet instance while the real daemon was still running: two live
+//! sessions per agent name, memory dirs cross-written by duplicate identities,
+//! and dispatch replies answered by whichever lead won the race.
+//!
+//! §3.20 SOP 1 — this reproduction is deterministic and timing-independent. The
+//! test process itself holds the flock via `flock(LOCK_EX|LOCK_NB)`, so there is
+//! no daemon to start, no race to lose and no window to hit: the contention is
+//! already true before `app` is executed. The only bounded wait is on the child's
+//! exit, polled (never `sleep(N)`-ed) per CONTRIBUTING.md.
+//!
+//! Unix-only: the reproduction needs a pty (the TUI refuses a non-tty stdio, so
+//! a plain pipe would exit for the WRONG reason and the test would pass
+//! vacuously).
+
+#![cfg(unix)]
+
+use std::fs::File;
+use std::io::Read;
+use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+fn bin() -> PathBuf {
+    assert_cmd::cargo::cargo_bin("agend-terminal")
+}
+
+fn tmp_home(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "agend-app-singleton-{}-{}",
+        std::process::id(),
+        tag
+    ));
+    std::fs::create_dir_all(&dir).expect("mkdir temp home");
+    dir
+}
+
+/// One shell instance: if the guard ever regresses and the app boots Owned, the
+/// spawn is cheap — but the test still fails, because a booted TUI does not exit.
+fn write_fleet(home: &Path) -> PathBuf {
+    let path = home.join("fleet.yaml");
+    std::fs::write(
+        &path,
+        "defaults:\n  backend: shell\ninstances:\n  probe:\n    backend: shell\n    command: /bin/sh\n",
+    )
+    .expect("write fleet.yaml");
+    path
+}
+
+/// Take the daemon singleton flock and keep it for the returned handle's life.
+///
+/// This is the same inode `bootstrap::acquire_daemon_lock` targets, so the child
+/// sees genuine contention rather than a simulated one.
+fn hold_daemon_lock(home: &Path) -> File {
+    let file = File::create(home.join(".daemon.lock")).expect("create .daemon.lock");
+    // SAFETY: `file` owns a valid fd for the duration of the call.
+    let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+    assert_eq!(rc, 0, "test harness must own the daemon lock to be meaningful");
+    file
+}
+
+/// Run `agend-terminal app` with its stdio wired to a real pty slave, so
+/// `ratatui::init` / crossterm raw-mode succeed headlessly and the app gets far
+/// enough to reach the singleton check.
+fn boot_app_under_pty(home: &Path) -> Child {
+    let mut winsize = libc::winsize {
+        ws_row: 40,
+        ws_col: 120,
+        ws_xpixel: 0,
+        ws_ypixel: 0,
+    };
+    let mut master: RawFd = -1;
+    let mut slave: RawFd = -1;
+    // SAFETY: openpty fills master+slave with fresh valid fds on success (rc==0).
+    let rc = unsafe {
+        libc::openpty(
+            &mut master,
+            &mut slave,
+            std::ptr::null_mut(),
+            std::ptr::null_mut::<libc::termios>(),
+            &mut winsize as *mut libc::winsize,
+        )
+    };
+    assert_eq!(rc, 0, "openpty must succeed");
+
+    let mut cmd = Command::new(bin());
+    cmd.env("AGEND_HOME", home)
+        // Strip ambient fleet env: a stray AGEND_SUCCESSOR_HANDOFF would send the
+        // process down the #1814 handoff path, which deliberately defers the
+        // flock and would make this test assert the wrong thing.
+        .env_remove("AGEND_SUCCESSOR_HANDOFF")
+        .env_remove("AGEND_RESTART_HANDOFF")
+        .env_remove("AGEND_WRAPPED")
+        .env_remove("AGEND_SUPERVISED")
+        .env_remove("AGEND_INSTANCE_NAME")
+        .arg("app");
+    // SAFETY: dup the slave fd for each std stream; std::process owns + closes
+    // the dup'd fds, so the child's stdio is a real tty.
+    unsafe {
+        cmd.stdin(Stdio::from_raw_fd(libc::dup(slave)));
+        cmd.stdout(Stdio::from_raw_fd(libc::dup(slave)));
+        cmd.stderr(Stdio::from_raw_fd(libc::dup(slave)));
+    }
+    let child = cmd.spawn().expect("app must spawn under pty");
+    // SAFETY: slave is a valid fd we opened above; the child holds its own dups.
+    unsafe {
+        libc::close(slave);
+    }
+
+    // Drain the master so the TUI's writes never block on a full pty buffer.
+    // Detached: ends on EOF when the child exits, or on test-process exit.
+    std::thread::spawn(move || {
+        // SAFETY: master is a valid fd owned here; the File closes it on drop.
+        let mut f = unsafe { File::from_raw_fd(master) };
+        let mut buf = [0u8; 4096];
+        loop {
+            match f.read(&mut buf) {
+                Ok(0) | Err(_) => break,
+                Ok(_) => {}
+            }
+        }
+    });
+    child
+}
+
+/// Poll for exit up to `budget`. Returns `None` if the child is still running —
+/// which is itself the regression signal: a booted TUI never exits on its own.
+fn wait_for_exit(child: &mut Child, budget: Duration) -> Option<std::process::ExitStatus> {
+    let deadline = Instant::now() + budget;
+    while Instant::now() < deadline {
+        match child.try_wait().expect("try_wait") {
+            Some(status) => return Some(status),
+            // Poll interval, not a sleep-as-synchronisation wait: the exit is
+            // observed the moment it happens, the interval only bounds spin.
+            None => std::thread::sleep(Duration::from_millis(10)),
+        }
+    }
+    None
+}
+
+#[test]
+fn app_refuses_to_boot_while_daemon_lock_is_held() {
+    let home = tmp_home("held");
+    write_fleet(&home);
+    let _lock = hold_daemon_lock(&home);
+
+    let mut child = boot_app_under_pty(&home);
+    let status = wait_for_exit(&mut child, Duration::from_secs(30));
+
+    let status = match status {
+        Some(s) => s,
+        None => {
+            let _ = child.kill();
+            let _ = child.wait();
+            std::fs::remove_dir_all(&home).ok();
+            panic!(
+                "`app` kept running while another process held .daemon.lock — it \
+                 degraded to Owned mode and is spawning a second fleet (split-brain)"
+            );
+        }
+    };
+
+    assert!(
+        !status.success(),
+        "`app` must exit non-zero when it loses the singleton lock; got {status:?}"
+    );
+
+    // No run dir may be published: publishing one would let a later `app`/`start`
+    // attach to a daemon that does not exist.
+    let run = home.join("run");
+    let published: Vec<_> = std::fs::read_dir(&run)
+        .map(|rd| rd.filter_map(Result::ok).map(|e| e.path()).collect())
+        .unwrap_or_default();
+    assert!(
+        published.is_empty(),
+        "a refused app must not publish a run dir; found {published:?}"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// Control: with the lock free, the very same invocation gets PAST the singleton
+/// check. Without this, the test above would still pass if `app` were broken in
+/// some unrelated way that made it exit early for every reason.
+///
+/// Asserts only that the app does NOT die the way the refusal path dies — it is
+/// left running (a healthy TUI does not exit) and then killed. This is what makes
+/// the pair a real RED/GREEN discriminator rather than a one-sided assertion.
+#[test]
+fn app_proceeds_past_singleton_check_when_lock_is_free() {
+    let home = tmp_home("free");
+    write_fleet(&home);
+    // Deliberately NO lock held.
+
+    let mut child = boot_app_under_pty(&home);
+    let early_exit = wait_for_exit(&mut child, Duration::from_secs(10));
+
+    let still_running = early_exit.is_none();
+    let _ = child.kill();
+    let _ = child.wait();
+    std::fs::remove_dir_all(&home).ok();
+
+    assert!(
+        still_running,
+        "with the lock free the app must get past the singleton check and keep \
+         running; it exited early ({early_exit:?}) — the refusal in the sibling \
+         test would then prove nothing"
+    );
+}

--- a/tests/app_singleton_fail_closed.rs
+++ b/tests/app_singleton_fail_closed.rs
@@ -62,7 +62,10 @@ fn hold_daemon_lock(home: &Path) -> File {
     let file = File::create(home.join(".daemon.lock")).expect("create .daemon.lock");
     // SAFETY: `file` owns a valid fd for the duration of the call.
     let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
-    assert_eq!(rc, 0, "test harness must own the daemon lock to be meaningful");
+    assert_eq!(
+        rc, 0,
+        "test harness must own the daemon lock to be meaningful"
+    );
     file
 }
 

--- a/tests/self_respawn_handoff.rs
+++ b/tests/self_respawn_handoff.rs
@@ -648,9 +648,8 @@ fn flag_on_concurrent_respawn_cannot_double_bind_via_flock_1814() {
     let announces_peer = loser_stderr.contains("another agend-terminal daemon is already running");
     let lock_contended = announces_peer
         && (loser_stderr.contains(", started ") || loser_stderr.contains("pid not published yet"));
-    let attached_existing = announces_peer
-        && loser_stderr.contains("(pid ")
-        && loser_stderr.contains("run_dir ");
+    let attached_existing =
+        announces_peer && loser_stderr.contains("(pid ") && loser_stderr.contains("run_dir ");
     assert!(
         lock_contended || attached_existing,
         "the flock loser MUST exit via a production single-daemon fail-fast path \

--- a/tests/self_respawn_handoff.rs
+++ b/tests/self_respawn_handoff.rs
@@ -638,12 +638,18 @@ fn flag_on_concurrent_respawn_cannot_double_bind_via_flock_1814() {
     //   - attached-daemon detection after the winner has published run/<pid>/.
     // Both prove the same invariant this test exists to pin: no double-bind.
     eprintln!("[1814] flock-loser stderr: {loser_stderr:?}");
-    let lock_contended = loser_stderr.contains(
-        "another agend-terminal daemon is already running (lock held): \
-         try_lock failed because the operation would block",
-    );
-    let attached_existing = loser_stderr
-        .contains("another agend-terminal daemon is already running (pid ")
+    // Wording note: contention used to surface as the raw fs4 string ("lock
+    // held: try_lock failed because the operation would block"). It is now the
+    // typed `bootstrap::DaemonAlreadyRunning`, which names the incumbent so the
+    // operator can act on it — either "(pid N, started <time>)" once the winner
+    // has published `.daemon`, or an explicit "still starting up" when this
+    // process lost the race inside the winner's pre-publish window. Both remain
+    // the SAME mechanism (flock contention); only the message improved.
+    let announces_peer = loser_stderr.contains("another agend-terminal daemon is already running");
+    let lock_contended = announces_peer
+        && (loser_stderr.contains(", started ") || loser_stderr.contains("pid not published yet"));
+    let attached_existing = announces_peer
+        && loser_stderr.contains("(pid ")
         && loser_stderr.contains("run_dir ");
     assert!(
         lock_contended || attached_existing,


### PR DESCRIPTION
## What happened

On 2026-07-21 a fleet ended up split-brained: two live sessions per agent name, memory directories cross-written by duplicate identities, and a dispatched query answered by the *second* set's lead. It took a manual restart to end it.

The obvious diagnosis — "the daemon has no single-instance guard" — turns out to be wrong, which is worth stating up front because it changes what needed fixing.

## The lock was never the problem

`bootstrap::prepare` already takes an exclusive flock on `$AGEND_HOME/.daemon.lock` before anything destructive, holds it for the process lifetime via an RAII guard, and re-checks for attach after acquiring it (TOCTOU). `start --foreground` already refuses cleanly — verified against this branch's parent on a throwaway `$AGEND_HOME`:

```
$ agend-terminal start --foreground --fleet <probe>/fleet.yaml   # second instance
Error: another agend-terminal daemon is already running (pid 16877, run_dir .../run/16877)
exit 1, zero agents spawned
```

Stale locks were never an issue either: `flock` is released by the kernel when the holding file description goes away, on `kill -9` exactly as on a clean exit.

## The actual hole

`app::setup_app_bootstrap` funnelled **every** `prepare` failure into one degraded arm:

```rust
Err(e) => {
    tracing::warn!(error = %e, "bootstrap failed, running TUI without in-process API");
    (api_server::noop_guard(), None, TelegramStatus::NotConfigured)
}
```

That leaves `attached_run_dir == None`, which `run_app` reads as **Owned** mode, so the app proceeds to `pane_factory` → `agent::spawn_agent` for the whole fleet — behind the back of the daemon that currently holds the lock.

So the lock fired correctly and the caller read *"you are not the owner"* as *"then I am the owner."* `start` propagated the error; only the app path swallowed it.

## The change

- **`bootstrap::DaemonAlreadyRunning`** — a typed sentinel carrying the incumbent's PID and start time, read from the `.daemon` record the daemon already publishes (`pid:boot_unix:start_token`). Contention becomes distinguishable from an I/O failure, which is what lets a caller fail closed on one and not the other. `pid` is `Option` on purpose: `prepare` takes the flock several steps before it publishes `.daemon`, so a loser can legitimately arrive inside that window, and the message says so rather than inventing a PID.
- **`setup_app_bootstrap` returns `Err`** on that sentinel. `run_app` already propagates, and `ratatui::restore()` runs on the error path, so the terminal is restored before the message prints.
- **Every other bootstrap failure keeps the degraded-TUI behaviour**, deliberately. Without the flock as evidence we cannot claim a peer is alive, and locking the operator out of the TUI on an unparseable `fleet.yaml` would take away the only surface they can repair it from.
- **`daemon::run`'s hand-rolled second flock folded into `acquire_daemon_lock`**, so both singleton entry points report the same type — otherwise a caller that fails closed on one silently degrades on the other. This removes a raw `fs4` site; the now-stale "2 raw `fs4::try_lock` sites" notes in `sync_audit.rs` and `store.rs` are updated to match. The remaining sites stay inside `bootstrap/mod.rs`, within `tests/flock_depth_invariant.rs`'s allowlist, and still do not bump `FLOCK_DEPTH`.

**#1814 is untouched.** The successor-handoff path deliberately defers the flock and acquires it later through `acquire_daemon_lock_blocking`; this change does not go near that function. `flag_on_concurrent_respawn_cannot_double_bind_via_flock_1814` passes.

## Tests (§3.20 SOP 1)

A deterministic, timing-independent reproduction **is** possible, so there is no waiver here. `tests/app_singleton_fail_closed.rs` holds `.daemon.lock` from the test process via `flock(LOCK_EX|LOCK_NB)` and boots `app` under a libc pty — no daemon to start, no race to lose, the contention is already true before the binary runs. The pty is load-bearing: the TUI refuses non-tty stdio, so a pipe would exit for the wrong reason and the test would pass vacuously.

RED on the parent commit:

```
test app_refuses_to_boot_while_daemon_lock_is_held ... FAILED
  `app` kept running while another process held .daemon.lock — it degraded
  to Owned mode and is spawning a second fleet (split-brain)
test app_proceeds_past_singleton_check_when_lock_is_free ... ok
```

GREEN with the fix, 3/3 back-to-back. The control test is what makes the pair a discriminator rather than a one-sided assertion — it fails if `app` ever starts exiting early for an unrelated reason.

Also added: 4 unit tests in `bootstrap` (typed contention, incumbent identity in the message, reclaim after release, and that the type survives being raised through `prepare`) and 1 in `app` covering the fatal/degradable classification, including survival across `.context()`.

`cargo clippy --all-targets -- -D warnings` is clean.

## One thing a reviewer should double-check

`self_respawn_recovers_as_primary_when_successor_dies_during_teardown` failed once for me, on a whole-file run that took 59s against a normal 44s — i.e. under load. I could not reproduce it: 4/4 isolated and 4/4 whole-file with this change, 3/3 whole-file and 4/4 isolated on the parent commit. It exercises successor teardown, which this change does not touch. I am flagging it rather than calling it settled, because "it passed on the retry" is not a diagnosis.

## Message wording

`flag_on_concurrent_respawn_cannot_double_bind_via_flock_1814` pinned the old raw-`fs4` string (`lock held: try_lock failed because the operation would block`). Naming the incumbent was the point of the change, so the pin is retargeted at the mechanism — it still requires evidence of a real single-daemon fail-fast path and still rejects an unrelated crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)