### PR TITLE
fix: preserve review branches with open PRs

### DIFF
--- a/src/cleanup_intents.rs
+++ b/src/cleanup_intents.rs
@@ -1199,6 +1199,43 @@ mod tests {
 
     #[test]
     #[cfg(unix)]
+    fn reconcile_terminal_review_intent_preserves_open_pr_branch() {
+        let home = tmp_dir("reconcile-open-pr");
+        let repo = tmp_repo("reconcile-open-pr-repo");
+        let branch = "review/pr-999-open";
+        let tip = make_branch(&repo, branch);
+        git_in(
+            &repo,
+            &[
+                "remote",
+                "add",
+                "origin",
+                "https://github.com/example/repo.git",
+            ],
+        );
+        let provider = crate::scm::MockScmProvider::with_pr_list(
+            crate::scm::MockPrList::Branches(vec![branch.into()]),
+        );
+        let _provider_guard = crate::scm::set_test_scm_provider(provider);
+        let rs = repo.display().to_string();
+        persist_intent(&home, &rs, branch, &tip, "t-reconcile-open-pr", None, None)
+            .expect("persist");
+        seed_terminal_task(&home, "t-reconcile-open-pr");
+
+        let result = reconcile_terminal_review_intents(&home, false);
+
+        assert_eq!(
+            result.preserved, 1,
+            "open PR must preserve terminal intent: {result:?}"
+        );
+        assert!(branch_exists(&repo, branch), "open PR branch must be preserved");
+        assert!(has_intent(&home, &rs, branch), "open PR intent must be preserved");
+        std::fs::remove_dir_all(&home).ok();
+        std::fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    #[cfg(unix)]
     fn reconcile_preserves_non_terminal_task() {
         let home = tmp_dir("reconcile-nt");
         let repo = tmp_repo("reconcile-nt-repo");

--- a/src/cleanup_intents.rs
+++ b/src/cleanup_intents.rs
@@ -600,6 +600,21 @@ pub(crate) fn reconcile_terminal_review_intents(home: &Path, dry_run: bool) -> R
             continue;
         }
 
+        let default = crate::git_helpers::default_branch(repo_path);
+        let open_pr_status =
+            crate::branch_sweep::open_pr_status(repo_path, &default, &intent.branch);
+        if !matches!(open_pr_status, crate::branch_sweep::OpenPrStatus::NotOpen) {
+            result.preserved += 1;
+            result.candidates.push(ReconcileCandidate {
+                candidate_id: cid,
+                branch: intent.branch.clone(),
+                expected_head: intent.expected_head.clone(),
+                task_id: intent.task_id.clone(),
+                outcome: format!("preserved:open_pr_status:{open_pr_status:?}"),
+            });
+            continue;
+        }
+
         // All gates passed under lock. Dry-run stops here.
         if dry_run {
             result.candidates.push(ReconcileCandidate {
@@ -1213,9 +1228,10 @@ mod tests {
                 "https://github.com/example/repo.git",
             ],
         );
-        let provider = crate::scm::MockScmProvider::with_pr_list(
-            crate::scm::MockPrList::Branches(vec![branch.into()]),
-        );
+        let provider =
+            crate::scm::MockScmProvider::with_pr_list(crate::scm::MockPrList::Branches(vec![
+                branch.into(),
+            ]));
         let _provider_guard = crate::scm::set_test_scm_provider(provider);
         let rs = repo.display().to_string();
         persist_intent(&home, &rs, branch, &tip, "t-reconcile-open-pr", None, None)
@@ -1228,8 +1244,14 @@ mod tests {
             result.preserved, 1,
             "open PR must preserve terminal intent: {result:?}"
         );
-        assert!(branch_exists(&repo, branch), "open PR branch must be preserved");
-        assert!(has_intent(&home, &rs, branch), "open PR intent must be preserved");
+        assert!(
+            branch_exists(&repo, branch),
+            "open PR branch must be preserved"
+        );
+        assert!(
+            has_intent(&home, &rs, branch),
+            "open PR intent must be preserved"
+        );
         std::fs::remove_dir_all(&home).ok();
         std::fs::remove_dir_all(&repo).ok();
     }

--- a/src/worktree_cleanup/reconcile_ordering_tests.rs
+++ b/src/worktree_cleanup/reconcile_ordering_tests.rs
@@ -78,10 +78,6 @@ fn reconcile_runs_before_fetch_loop_ordering() {
     std::env::set_var("AGEND_WORKTREE_AUTO_CLEANUP", "1");
     let home = tmp_home("reconcile-order");
     let repo = setup_test_repo("reconcile-order-repo");
-    git_in(
-        &repo,
-        &["remote", "add", "origin", "/nonexistent/order-test-fixture"],
-    );
     git_in(&repo, &["checkout", "-b", "review/pr-order-test"]);
     std::fs::write(repo.join("f.txt"), "work").ok();
     git_in(&repo, &["add", "."]);


### PR DESCRIPTION
## Problem
Terminal review-intent reconciliation can delete a review branch that still backs an open PR because it lacks an open-PR/SCM gate.

## Solution
Use the existing open_pr_status seam after the under-lock occupancy check. Preserve Open and Unknown; only confirmed NotOpen continues to dry-run/recovery/CAS deletion.

## Tests
- cargo test -q --bin agend-terminal reconcile_terminal_review_intent -- --nocapture (2 passed)
- cargo test -q --bin agend-terminal cleanup_intents::tests -- --nocapture (24 passed)
- cargo fmt -- --check
- cargo clippy -q --bin agend-terminal --tests -- -D warnings

Closes #2873

Agent signature: `archfix-codex-dev` (Codex Luna xhigh)