### PR TITLE
fix: preserve declared backend identity in AgentHandle (#2877)

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -73,6 +73,10 @@ pub struct ApiActivity {
 pub struct AgentHandle {
     pub(crate) id: crate::types::InstanceId,
     pub(crate) name: crate::types::AgentName,
+    /// Immutable logical backend declared for this spawn. Unlike
+    /// `backend_command`, this identity never changes when the live process is
+    /// replaced by a shell or another fallback executable.
+    pub(crate) declared_backend: Option<crate::backend::Backend>,
     pub(crate) backend_command: String,
     pub(crate) pty_writer: PtyWriter,
     pub(crate) pty_master: Arc<Mutex<Box<dyn MasterPty + Send>>>,
@@ -1325,6 +1329,7 @@ pub fn spawn_agent(
             AgentHandle {
                 id: instance_id,
                 name: name.to_string().into(),
+                declared_backend: detected_backend.clone(),
                 backend_command: backend_command.to_string(),
                 pty_writer: Arc::clone(&pty_writer),
                 pty_master: Arc::clone(&pty_master),
@@ -2880,6 +2885,7 @@ pub(crate) fn mk_test_handle(name: &str, id: crate::types::InstanceId) -> AgentH
     AgentHandle {
         id,
         name: name.to_string().into(),
+        declared_backend: None,
         backend_command: "true".to_string(),
         pty_writer,
         pty_master,

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -1152,6 +1152,48 @@ fn build_command_wrapper_uses_declared_backend_for_presets_and_flags_2801() {
     std::fs::remove_dir_all(workspace).ok();
 }
 
+/// #2877 RED: an arbitrarily named wrapper must leave the declared backend on
+/// the live handle so exit detection and UsageLimit routing do not infer from
+/// the mutable executable command.
+#[test]
+fn wrapper_spawn_persists_declared_backend_for_consumers_2877() {
+    let registry: AgentRegistry = Arc::new(Mutex::new(HashMap::new()));
+    let declared = Backend::ClaudeCode;
+    let config = SpawnConfig {
+        name: "wrapper-2877",
+        backend: Some(&declared),
+        backend_command: "true",
+        args: &[],
+        spawn_mode: crate::backend::SpawnMode::Fresh,
+        cols: 80,
+        rows: 24,
+        env: None,
+        working_dir: None,
+        submit_key: "\r",
+        home: None,
+        crash_tx: None,
+        shutdown: None,
+    };
+    let id = spawn_agent(&config, &registry).expect("wrapper spawn");
+    let handle = registry
+        .lock()
+        .remove(&id)
+        .expect("spawned handle must be registered");
+
+    assert_eq!(handle.declared_backend, Some(Backend::ClaudeCode));
+    assert!(crate::daemon::per_tick::backend_exit_detection::backend_mismatch_declared(
+        handle.declared_backend.as_ref(),
+        "codex",
+    ));
+    assert_eq!(
+        crate::daemon::supervisor::usage_limit_control::backend_identity_name(
+            handle.declared_backend.as_ref(),
+            "true",
+        ),
+        "claude"
+    );
+}
+
 #[test]
 fn build_command_without_declared_backend_keeps_legacy_inference_2801() {
     let config = SpawnConfig {

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -372,6 +372,7 @@ fn sweep_child_tree_body(pid_file: &std::path::Path) {
     let handle = AgentHandle {
         id: crate::types::InstanceId::default(),
         name: agent_name.clone().into(),
+        declared_backend: None,
         backend_command: "sh".to_string(),
         pty_writer,
         pty_master,
@@ -988,6 +989,7 @@ fn write_to_agent_typed_uses_timeout() {
     let handle = AgentHandle {
         id: crate::types::InstanceId::default(),
         name: "typed-test".into(),
+        declared_backend: None,
         backend_command: "test".to_string(),
         pty_writer: writer,
         pty_master: Arc::new(Mutex::new(pair.master)),
@@ -1181,10 +1183,12 @@ fn wrapper_spawn_persists_declared_backend_for_consumers_2877() {
         .expect("spawned handle must be registered");
 
     assert_eq!(handle.declared_backend, Some(Backend::ClaudeCode));
-    assert!(crate::daemon::per_tick::backend_exit_detection::backend_mismatch_declared(
-        handle.declared_backend.as_ref(),
-        "codex",
-    ));
+    assert!(
+        crate::daemon::per_tick::backend_exit_detection::backend_mismatch_declared(
+            handle.declared_backend.as_ref(),
+            "codex",
+        )
+    );
     assert_eq!(
         crate::daemon::supervisor::usage_limit_control::backend_identity_name(
             handle.declared_backend.as_ref(),
@@ -1944,6 +1948,7 @@ fn pty_read_error_triggers_cleanup() {
         AgentHandle {
             id: instance_id,
             name: agent_name.to_string().into(),
+            declared_backend: None,
             backend_command: "test".to_string(),
             pty_writer: Arc::clone(&pty_writer),
             pty_master: Arc::new(Mutex::new(
@@ -2078,6 +2083,7 @@ fn make_crash_exit_handle(deleted: bool) -> (AgentHandle, crate::types::Instance
     let handle = AgentHandle {
         id,
         name: "rank4-guard".to_string().into(),
+        declared_backend: None,
         backend_command: "test".to_string(),
         pty_writer,
         pty_master: Arc::new(Mutex::new(
@@ -2512,6 +2518,7 @@ fn mk_handle_1441(name: &str, id: crate::types::InstanceId) -> AgentHandle {
     AgentHandle {
         id,
         name: name.to_string().into(),
+        declared_backend: None,
         backend_command: "true".to_string(),
         pty_writer,
         pty_master,

--- a/src/daemon/crash_respawn.rs
+++ b/src/daemon/crash_respawn.rs
@@ -698,6 +698,7 @@ mod deleted_gate_tests_1913 {
         AgentHandle {
             id: InstanceId::parse(VICTIM_UUID).expect("uuid"),
             name: VICTIM.to_string().into(),
+            declared_backend: None,
             backend_command: "true".to_string(),
             pty_writer,
             pty_master,

--- a/src/daemon/lifecycle.rs
+++ b/src/daemon/lifecycle.rs
@@ -415,6 +415,7 @@ mod tests {
         crate::agent::AgentHandle {
             id: crate::types::InstanceId::default(),
             name: name.to_string().into(),
+            declared_backend: None,
             backend_command: "true".to_string(),
             pty_writer,
             pty_master,

--- a/src/daemon/per_tick/backend_exit_detection.rs
+++ b/src/daemon/per_tick/backend_exit_detection.rs
@@ -1,16 +1,18 @@
 //! #2538: backend-exit detection — the daemon already knows (via
-//! `AgentHandle::backend_command`, mutated by `agent::on_clean_exit_shell_fallback`
-//! and any other exit-driven respawn) when an instance's LIVE foreground identity
-//! no longer matches its fleet.yaml-DECLARED backend (e.g. a `codex`-configured
+//! `AgentHandle::declared_backend` plus the live `backend_command` (mutated by
+//! `agent::on_clean_exit_shell_fallback` and any other exit-driven respawn) when
+//! an instance's LIVE foreground identity no longer matches its
+//! fleet.yaml-DECLARED backend (e.g. a `codex`-configured
 //! instance whose backend exited cleanly and the daemon deliberately spawned a
 //! bare shell in its place — the pane looks alive, `health_state` stays
 //! `healthy`, and nothing ever notices). This ground-truth signal was already in
 //! hand and simply never consumed — same family as #2413's API-activity probe /
 //! #1523 state-detection.
 //!
-//! Every tick: snapshot each agent's live `backend_command` (registry lock, no
-//! file IO), resolve the fleet.yaml-declared backend ONCE for the whole tick (no
-//! lock held), then re-lock briefly to apply the `HealthState::Unhealthy`
+//! Every tick: snapshot each agent's immutable declared backend and live
+//! `backend_command` (registry lock, no file IO), resolve the fleet.yaml
+//! configuration ONCE for the whole tick (no lock held), then re-lock briefly to
+//! apply the `HealthState::Unhealthy`
 //! transition (or clear it once the mismatch resolves) and fire a debounced
 //! `backend_exited` notify.
 
@@ -34,25 +36,53 @@ const NOTIFY_COOLDOWN: Duration = Duration::from_secs(60);
 /// with a Shell or unrecognized Raw backend — there is no known preset identity
 /// to compare against, so it is exempt. This is also how a `backend: shell`
 /// instance is naturally exempt (its resolved command never maps to a preset).
+#[cfg(test)]
 pub(crate) fn backend_mismatch(
     configured_backend_command: &str,
     live_backend_command: &str,
 ) -> bool {
-    let Some(expected) = Backend::from_command(configured_backend_command) else {
+    backend_mismatch_declared(
+        Backend::from_command(configured_backend_command).as_ref(),
+        live_backend_command,
+    )
+}
+
+/// Pure: does the LIVE `backend_command` mismatch the immutable declared
+/// backend identity? Shell and raw declarations have no preset executable
+/// identity to compare, so they remain exempt just like legacy command
+/// inference.
+pub(crate) fn backend_mismatch_declared(
+    declared_backend: Option<&Backend>,
+    live_backend_command: &str,
+) -> bool {
+    let Some(expected) = declared_backend else {
         return false;
     };
-    Backend::from_command(live_backend_command) != Some(expected)
+    if matches!(expected, Backend::Shell | Backend::Raw(_)) {
+        return false;
+    }
+    Backend::from_command(live_backend_command).as_ref() != Some(expected)
 }
 
 /// Pure: should this tick fire a backend-exit detection for an agent whose live
 /// backend mismatches its configured one, `elapsed_since_spawn` since its last
 /// (re)spawn?
+#[cfg(test)]
 pub(crate) fn should_fire_backend_exit(
     configured_backend_command: &str,
     live_backend_command: &str,
     elapsed_since_spawn: Duration,
 ) -> bool {
     backend_mismatch(configured_backend_command, live_backend_command)
+        && elapsed_since_spawn >= BACKEND_EXIT_GRACE
+}
+
+fn should_fire_backend_exit_declared(
+    declared_backend: Option<&Backend>,
+    live_backend_command: &str,
+    elapsed_since_spawn: Duration,
+) -> bool {
+    backend_mismatch_declared(declared_backend, live_backend_command)
         && elapsed_since_spawn >= BACKEND_EXIT_GRACE
 }
 
@@ -75,11 +105,18 @@ impl PerTickHandler for BackendExitDetectionHandler {
 
     fn run(&self, ctx: &TickContext<'_>) {
         // Phase 1 (registry lock, NO file IO — DAEMON-LOCK-ORDERING): snapshot
-        // each agent's live backend_command + spawn instant.
-        let snaps: Vec<(String, String, Instant)> = {
+        // each agent's immutable declared backend, live backend_command + spawn instant.
+        let snaps: Vec<(String, Option<Backend>, String, Instant)> = {
             let reg = crate::agent::lock_registry(ctx.registry);
             reg.values()
-                .map(|h| (h.name.to_string(), h.backend_command.clone(), h.spawned_at))
+                .map(|h| {
+                    (
+                        h.name.to_string(),
+                        h.declared_backend.clone(),
+                        h.backend_command.clone(),
+                        h.spawned_at,
+                    )
+                })
                 .collect()
         };
         if snaps.is_empty() {
@@ -97,15 +134,18 @@ impl PerTickHandler for BackendExitDetectionHandler {
         let mut mismatched: std::collections::HashSet<String> = std::collections::HashSet::new();
         let mut to_notify: Vec<(String, String, String)> = Vec::new();
 
-        for (name, live_backend, spawned_at) in &snaps {
+        for (name, declared_backend, live_backend, spawned_at) in &snaps {
             let Some(resolved) = fleet.resolve_instance(name) else {
                 continue;
             };
-            if backend_mismatch(&resolved.backend_command, live_backend) {
+            let expected_backend = declared_backend
+                .clone()
+                .or_else(|| Some(resolved.backend.clone()));
+            if backend_mismatch_declared(expected_backend.as_ref(), live_backend) {
                 mismatched.insert(name.clone());
             }
-            if should_fire_backend_exit(
-                &resolved.backend_command,
+            if should_fire_backend_exit_declared(
+                expected_backend.as_ref(),
                 live_backend,
                 spawned_at.elapsed(),
             ) {
@@ -115,11 +155,11 @@ impl PerTickHandler for BackendExitDetectionHandler {
                     .is_none_or(|t| now.duration_since(*t) >= NOTIFY_COOLDOWN);
                 if should_notify {
                     tracker.insert(name.clone(), now);
-                    to_notify.push((
-                        name.clone(),
-                        resolved.backend_command.clone(),
-                        live_backend.clone(),
-                    ));
+                    let expected = expected_backend
+                        .as_ref()
+                        .map(|backend| backend.as_str().to_string())
+                        .unwrap_or_else(|| resolved.backend.as_str().to_string());
+                    to_notify.push((name.clone(), expected, live_backend.clone()));
                 }
             } else {
                 // Recovered (or never mismatched) — drop any stale debounce entry

--- a/src/daemon/per_tick/mod.rs
+++ b/src/daemon/per_tick/mod.rs
@@ -604,6 +604,7 @@ pub(crate) fn mock_live_agent_no_context(
     let handle = crate::agent::AgentHandle {
         id: crate::types::InstanceId::default(),
         name: name.to_string().into(),
+        declared_backend: None,
         backend_command: "claude".to_string(),
         pty_writer,
         pty_master: Arc::new(parking_lot::Mutex::new(pair.master)),
@@ -676,6 +677,7 @@ pub(crate) fn mock_live_agent_with_context(
     let handle = crate::agent::AgentHandle {
         id: crate::types::InstanceId::default(),
         name: name.to_string().into(),
+        declared_backend: None,
         backend_command: "claude".to_string(),
         pty_writer,
         pty_master: Arc::new(parking_lot::Mutex::new(pair.master)),

--- a/src/daemon/poll_reminder.rs
+++ b/src/daemon/poll_reminder.rs
@@ -313,6 +313,7 @@ mod tests {
         let handle = AgentHandle {
             id: crate::types::InstanceId::default(),
             name: name.to_string().into(),
+            declared_backend: None,
             backend_command: "test".to_string(),
             pty_writer: Arc::new(Mutex::new(writer)),
             pty_master: Arc::new(Mutex::new(pair.master)),

--- a/src/daemon/supervisor.rs
+++ b/src/daemon/supervisor.rs
@@ -667,12 +667,13 @@ fn tick(
     // deadlocks against code paths that take core then registry.
     // #1441: registry is UUID-keyed; carry the id for the re-lock lookup and
     // the display name for the many name-keyed side channels in this loop.
-    // #1530/F2: also capture each agent's backend_command here (under the
-    // registry lock, registry→core order) so the per-agent loop never needs to
-    // RE-acquire the registry while holding that agent's core — the core→registry
-    // inversion that risked an AB-BA deadlock with the registry→core render/
-    // monitor loops. `Backend::from_command` on the captured string is lock-free.
-    let handles: Vec<(String, String, _)> = {
+    // #1530/F2: also capture each agent's immutable declared backend and live
+    // backend_command here (under the registry lock, registry→core order) so
+    // the per-agent loop never needs to RE-acquire the registry while holding
+    // that agent's core — the core→registry inversion that risked an AB-BA
+    // deadlock with the registry→core render/monitor loops. Backend resolution
+    // on the captured values is lock-free.
+    let handles: Vec<(String, Option<crate::backend::Backend>, String, _)> = {
         let reg = agent::lock_registry(registry);
         reg.values()
             // #1915 TIER-B1: skip a handle being deleted (deleted flag set in
@@ -684,6 +685,7 @@ fn tick(
             .map(|h| {
                 (
                     h.name.to_string(),
+                    h.declared_backend.clone(),
                     h.backend_command.clone(),
                     Arc::clone(&h.core),
                 )
@@ -691,7 +693,7 @@ fn tick(
             .collect()
     };
 
-    for (name, backend_command, core) in handles {
+    for (name, declared_backend, backend_command, core) in handles {
         // #1665/#2042 reply-ledger: TTL/settled fallback for a user-message
         // turn that never hit a clear site (no reply, no mirror, no takeover).
         // Lock-free snapshot read; acts only past the grace window AND when the
@@ -854,9 +856,12 @@ fn tick(
             // make it compile-impossible is deferred (#1644) — revisit when a new
             // reaction is added to this loop; both guards above make that safe.
             for decision in reactions_from_transitions(&transitions) {
-                // #1530/F2: backend resolved from the pre-captured command
-                // (no registry re-acquire while holding core).
-                let backend = crate::backend::Backend::from_command(&backend_command);
+                // #1530/F2/#2877: backend resolved from the immutable declared
+                // identity, falling back to the captured live command for legacy
+                // handles (no registry re-acquire while holding core).
+                let backend = declared_backend
+                    .clone()
+                    .or_else(|| crate::backend::Backend::from_command(&backend_command));
                 reaction_intents.push(ReactionIntent {
                     from: decision.from,
                     to: decision.to,
@@ -1027,6 +1032,7 @@ fn tick(
             registry,
             &name,
             usage_limit_raw_state,
+            declared_backend.as_ref(),
             &backend_command,
             &usage_limit_pane_tail,
         ) {

--- a/src/daemon/supervisor/tests.rs
+++ b/src/daemon/supervisor/tests.rs
@@ -1393,6 +1393,7 @@ fn mock_agent_handle_with_size(
     let handle = crate::agent::AgentHandle {
         id: crate::types::InstanceId::default(),
         name: name.to_string().into(),
+        declared_backend: None,
         backend_command: "claude".to_string(),
         pty_writer,
         pty_master: Arc::new(parking_lot::Mutex::new(pair.master)),

--- a/src/daemon/supervisor/usage_limit_control.rs
+++ b/src/daemon/supervisor/usage_limit_control.rs
@@ -553,6 +553,22 @@ fn correlation_from_disk(home: &Path, source: &str) -> Option<(Correlation, crat
     Some((correlation, task))
 }
 
+/// Resolve the logical backend identity used by UsageLimit source/candidate
+/// facts. A declared backend is authoritative even when the live executable is
+/// an arbitrarily named wrapper; legacy handles retain command inference.
+pub(crate) fn backend_identity_name(
+    declared_backend: Option<&crate::backend::Backend>,
+    live_backend_command: &str,
+) -> String {
+    declared_backend
+        .map(|backend| backend.as_str().to_string())
+        .or_else(|| {
+            crate::backend::Backend::from_command(live_backend_command)
+                .map(|backend| backend.as_str().to_string())
+        })
+        .unwrap_or_else(|| live_backend_command.to_string())
+}
+
 pub(crate) fn fleet_facts(
     home: &Path,
     registry: &crate::agent::AgentRegistry,
@@ -583,9 +599,10 @@ pub(crate) fn fleet_facts(
                 (
                     handle.name.to_string(),
                     (
-                        crate::backend::Backend::from_command(&handle.backend_command)
-                            .map(|backend| backend.as_str().to_string())
-                            .unwrap_or_else(|| handle.backend_command.clone()),
+                        backend_identity_name(
+                            handle.declared_backend.as_ref(),
+                            &handle.backend_command,
+                        ),
                         state,
                         !handle.deleted.load(std::sync::atomic::Ordering::Acquire),
                         std::sync::Arc::clone(&handle.core),
@@ -667,6 +684,7 @@ pub(crate) fn observe_supervisor_tick(
     registry: &crate::agent::AgentRegistry,
     source: &str,
     raw_state: AgentState,
+    declared_backend: Option<&crate::backend::Backend>,
     backend_command: &str,
     pane_tail: &str,
 ) -> anyhow::Result<TickOutcome> {
@@ -727,9 +745,7 @@ pub(crate) fn observe_supervisor_tick(
     let unlock_at = super::parse_unlock_at(pane_tail)
         .as_deref()
         .and_then(|hhmm| super::unlock_deadline(hhmm, now));
-    let source_backend = crate::backend::Backend::from_command(backend_command)
-        .map(|backend| backend.as_str().to_string())
-        .unwrap_or_else(|| backend_command.to_string());
+    let source_backend = backend_identity_name(declared_backend, backend_command);
     observe_tick(
         &mut effects,
         TickInput {

--- a/src/daemon/usage_limit.rs
+++ b/src/daemon/usage_limit.rs
@@ -54,7 +54,10 @@ pub fn propagate_usage_limit(
         if handle.name.as_str() == source_agent {
             continue;
         }
-        let their_backend = crate::backend::Backend::from_command(&handle.backend_command);
+        let their_backend = handle
+            .declared_backend
+            .clone()
+            .or_else(|| crate::backend::Backend::from_command(&handle.backend_command));
         if their_backend.as_ref() == Some(source_backend) {
             let mut core = handle.core.lock();
             core.health


### PR DESCRIPTION
Closes #2877

## Summary
- persist the immutable declared backend on AgentHandle while preserving backend_command as the live executable identity
- use declared identity for backend-exit expectations and usage-limit source/candidate propagation
- add a wrapper-backed regression test covering the consumer seams

## Verification
- cargo check --bin agend-terminal
- cargo clippy --bin agend-terminal --tests --message-format=short -- -D warnings
- rustfmt --edition 2021 --check on changed files
- focused backend-exit tests: 8 passed
- focused usage-limit tests: 16 passed
- wrapper regression test: 1 passed

Base: 0451f38e895623ae2c77990d480014bf2d5d5bf7
Head: 86e6bda5 (86e6bda5b8c16f27ac752ebf34cbdeeb85e57493)