### PR TITLE
fix: publish Restarting only for admitted retries (#2872)

### DIFF
--- a/src/agent/crash_disposition.rs
+++ b/src/agent/crash_disposition.rs
@@ -755,6 +755,60 @@ mod tests {
     }
 
     #[test]
+    fn terminal_debit_keeps_state_crashed_until_no_restart_2872_red() {
+        let ledger = CrashDispositionLedger::new();
+        let id = InstanceId::new();
+        let deleted = Arc::new(AtomicBool::new(false));
+        let obs = observation(id, SpawnGeneration::new(2872), &deleted, None);
+        obs.core.lock().health.total_crashes = 4;
+        ledger.register_generation(id, obs.generation);
+        assert!(ledger.publish_crashed(obs.clone()));
+        let token = ledger.claim(obs.key(), Claimant::Crash).expect("claim");
+        assert!(ledger.mark_ready(token));
+
+        let mut permit = ledger.begin_execute(token).expect("permit");
+        let attempt = permit
+            .debit_attempt(crate::teams::SelfOrchStatus::No)
+            .expect("terminal debit");
+        assert!(!attempt.should_respawn);
+        assert_eq!(
+            obs.core.lock().state.get_state(),
+            crate::state::AgentState::Crashed,
+            "terminal retry exhaustion must never publish Restarting"
+        );
+        assert!(ledger.mark_failed(permit));
+        assert_eq!(ledger.disposition(obs.key()), Some(Disposition::Failed));
+    }
+
+    #[test]
+    fn retryable_debit_admits_restarting_after_budget_check_2872_red() {
+        let ledger = CrashDispositionLedger::new();
+        let id = InstanceId::new();
+        let deleted = Arc::new(AtomicBool::new(false));
+        let obs = observation(id, SpawnGeneration::new(2873), &deleted, None);
+        ledger.register_generation(id, obs.generation);
+        assert!(ledger.publish_crashed(obs.clone()));
+        let token = ledger.claim(obs.key(), Claimant::Crash).expect("claim");
+        assert!(ledger.mark_ready(token));
+
+        let mut permit = ledger.begin_execute(token).expect("permit");
+        let attempt = permit
+            .debit_attempt(crate::teams::SelfOrchStatus::No)
+            .expect("retryable debit");
+        assert!(attempt.should_respawn);
+        assert_eq!(
+            obs.core.lock().state.get_state(),
+            crate::state::AgentState::Crashed,
+            "Restarting must wait until retry budget admits a spawn"
+        );
+        assert!(permit.admit_restarting());
+        assert_eq!(
+            obs.core.lock().state.get_state(),
+            crate::state::AgentState::Restarting
+        );
+    }
+
+    #[test]
     fn admitted_permit_debits_exact_core_once() {
         let ledger = CrashDispositionLedger::new();
         let id = InstanceId::new();

--- a/src/agent/crash_disposition.rs
+++ b/src/agent/crash_disposition.rs
@@ -150,8 +150,8 @@ pub(crate) struct RecoveryExecutionPermit {
 }
 
 /// The health/accounting result committed by one exact-generation permit.
-/// This value is produced only after [`RecoveryExecutionPermit::admit_restarting`]
-/// succeeds and therefore never represents a raw crash observation.
+/// This value is produced only after exact execution admission and therefore
+/// never represents a raw crash observation.
 pub(crate) struct RecoveryAttempt {
     pub(crate) should_respawn: bool,
     pub(crate) delay: std::time::Duration,
@@ -163,7 +163,7 @@ pub(crate) struct RecoveryAttempt {
 
 impl RecoveryExecutionPermit {
     /// Publish Restarting on the exact old core immediately before spawning a
-    /// replacement.  This is idempotent only as a guarded one-shot operation;
+    /// replacement. This is idempotent only as a guarded one-shot operation;
     /// callers cannot use the same permit to publish a second transition.
     pub(crate) fn admit_restarting(&mut self) -> bool {
         if self.restarting_admitted {
@@ -183,13 +183,14 @@ impl RecoveryExecutionPermit {
     }
 
     /// Debit the retry budget exactly once on the exact old core captured by
-    /// this permit.  A reused permit cannot issue another attempt or mutate
-    /// persistence/accounting a second time.
+    /// this permit. A reused permit cannot issue another attempt or mutate
+    /// persistence/accounting a second time; retryability is decided before
+    /// the caller publishes Restarting.
     pub(crate) fn debit_attempt(
         &mut self,
         self_orch: crate::teams::SelfOrchStatus,
     ) -> Option<RecoveryAttempt> {
-        if !self.restarting_admitted || self.attempt_debited {
+        if self.attempt_debited {
             return None;
         }
         self.attempt_debited = true;
@@ -357,7 +358,7 @@ impl CrashDispositionLedger {
     }
 
     pub(crate) fn mark_failed(&self, permit: RecoveryExecutionPermit) -> bool {
-        if !permit.restarting_admitted {
+        if !permit.restarting_admitted && !permit.attempt_debited {
             return false;
         }
         let key = permit.key();

--- a/src/daemon/crash_respawn.rs
+++ b/src/daemon/crash_respawn.rs
@@ -417,19 +417,12 @@ fn respawn_agent_worker(
     }
     let mut permit = match claim {
         Some(token) => {
-            let Some(mut permit) = agent::crash_disposition::owner_ledger().begin_execute(token)
-            else {
+            let Some(permit) = agent::crash_disposition::owner_ledger().begin_execute(token) else {
                 tracing::info!(agent = %config.name, "exact-generation recovery was discarded before execution");
                 #[cfg(test)]
                 signal_test_worker_done(&test_done);
                 return;
             };
-            if !permit.admit_restarting() {
-                tracing::info!(agent = %config.name, "execution permit could not admit Restarting");
-                #[cfg(test)]
-                signal_test_worker_done(&test_done);
-                return;
-            }
             Some(permit)
         }
         None => None,
@@ -481,6 +474,14 @@ fn respawn_agent_worker(
             if let Some(permit) = permit.take() {
                 let _ = agent::crash_disposition::owner_ledger().mark_failed(permit);
             }
+            #[cfg(test)]
+            signal_test_worker_done(&test_done);
+            return;
+        }
+    }
+    if let Some(permit) = permit.as_mut() {
+        if !permit.admit_restarting() {
+            tracing::info!(agent = %config.name, "execution permit could not admit Restarting");
             #[cfg(test)]
             signal_test_worker_done(&test_done);
             return;


### PR DESCRIPTION
Closes #2872

## Summary
- keep the raw agent state Crashed while the exact-generation permit debits the retry budget
- settle terminal exhaustion without ever publishing Restarting
- publish Restarting immediately before the existing spawn only after a retryable debit
- preserve watchdog admission, retry policy, notifications, worker topology, permit identity, and event schema

## RED/GREEN
RED at 996fb0207e8a5507c0d5d1bf4fff93d9876a6bf7: paired terminal/retryable permit tests failed because debit required prior Restarting publication.
GREEN at 132e4129f4a5394277c5084fb8b6f841d7810246: permit debit accepts pre-Restarting budget check; terminal mark_failed accepts the debited permit; crash worker admits Restarting only after retryability is known.

## Verification
- cargo check --bin agend-terminal
- cargo clippy --bin agend-terminal --tests --message-format=short -- -D warnings
- rustfmt --edition 2021 --check changed files
- crash disposition tests: 14 passed
- crash respawn deleted/admission tests: 7 passed
- paired #2872 tests: 2 passed

Exact base: 01a3430caff2353d8f0efef4dc698e46a4292001
Exact head: 132e4129f4a5394277c5084fb8b6f841d7810246
No #2869/#2875/#2880 bundling.