### PR TITLE
fix(worktree_cleanup): skip unrelated bindings before missing-worktree fail-close (#2874)

### DIFF
--- a/src/worktree_cleanup.rs
+++ b/src/worktree_cleanup.rs
@@ -768,6 +768,11 @@ pub(crate) fn branch_has_other_active_binding(
         let source = binding["source_repo"]
             .as_str()
             .filter(|source| !source.is_empty())?;
+        // #2874: canonicalize once; skip rows proven unrelated before worktree identity.
+        let cs = std::fs::canonicalize(source);
+        if matches!(&cs, Ok(s) if bound_branch != branch || *s != canonical_repo) {
+            continue;
+        }
         if excluded_worktree.is_some() && binding["worktree"].as_str().is_none_or(str::is_empty) {
             return None;
         }
@@ -777,12 +782,7 @@ pub(crate) fn branch_has_other_active_binding(
         {
             continue;
         }
-        let Ok(source) = std::fs::canonicalize(source) else {
-            return None;
-        };
-        if bound_branch == branch && source == canonical_repo {
-            return Some(true);
-        }
+        return if cs.is_ok() { Some(true) } else { None };
     }
     Some(false)
 }

--- a/src/worktree_cleanup/lifecycle_r1_tests.rs
+++ b/src/worktree_cleanup/lifecycle_r1_tests.rs
@@ -144,6 +144,58 @@ fn excluded_worktree_requires_binding_worktree_identity() {
     std::fs::remove_dir_all(&home).ok();
 }
 
+/// #2874 RED: an unrelated binding row (different source+branch) whose
+/// worktree field is missing must NOT poison the scan for the target branch.
+/// Currently returns None because the missing-worktree check fires before
+/// the target-relevance check.
+#[test]
+fn unrelated_missing_worktree_binding_does_not_poison_target_scan_2874() {
+    let repo = setup_repo("unrelated-missing-wt");
+    let home = tmp_home("unrelated-missing-wt");
+    let other_repo = setup_repo("unrelated-missing-wt-other");
+    // Unrelated agent: different source_repo AND different branch, no worktree field.
+    write_binding(
+        &home,
+        "unrelated-agent",
+        serde_json::json!({
+            "branch": "feat/completely-different",
+            "source_repo": other_repo.display().to_string()
+        }),
+    );
+    assert_eq!(
+        branch_has_other_active_binding(&home, &repo, "feat/done", Some("/my-worktree")),
+        Some(false),
+        "#2874: unrelated binding with missing worktree must not block target scan"
+    );
+    std::fs::remove_dir_all(&repo).ok();
+    std::fs::remove_dir_all(&other_repo).ok();
+    std::fs::remove_dir_all(&home).ok();
+}
+
+/// #2874 safety control: a SAME-TARGET binding (same source+branch) with
+/// missing worktree must still fail closed (None). This test must pass
+/// today and remain green after the fix.
+#[test]
+fn same_target_missing_worktree_binding_stays_fail_closed_2874() {
+    let repo = setup_repo("same-target-missing-wt");
+    let home = tmp_home("same-target-missing-wt");
+    write_binding(
+        &home,
+        "same-target-agent",
+        serde_json::json!({
+            "branch": "feat/done",
+            "source_repo": repo.display().to_string()
+        }),
+    );
+    assert_eq!(
+        branch_has_other_active_binding(&home, &repo, "feat/done", Some("/my-worktree")),
+        None,
+        "#2874 safety: same-target binding with missing worktree must fail closed"
+    );
+    std::fs::remove_dir_all(&repo).ok();
+    std::fs::remove_dir_all(&home).ok();
+}
+
 #[test]
 fn prune_batches_open_pr_inventory_once_per_repo_sweep() {
     let repo = setup_repo("open-pr-batch");


### PR DESCRIPTION
## Summary

- **Bug**: `branch_has_other_active_binding` checked for missing worktree identity before establishing target relevance — an unrelated binding (different source_repo + branch) with no worktree field returned `None`, blocking cleanup of the target branch.
- **Fix**: Insert a target-relative canonicalization check before the missing-worktree gate: provably-unrelated rows are skipped; same-target and indeterminate rows still fail closed.
- **Scope**: 6 lines added to `src/worktree_cleanup.rs` only; no schema/type/refactor changes.

## Test plan

- [x] `unrelated_missing_worktree_binding_does_not_poison_target_scan_2874` — RED→GREEN
- [x] `same_target_missing_worktree_binding_stays_fail_closed_2874` — stays GREEN (safety control)
- [x] All 59 `worktree_cleanup` tests pass (1 pre-existing `_2830_red` env failure unrelated)
- [x] `cargo fmt -- --check` clean
- [x] `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)