### PR TITLE
test(inbox): clear reused tmp_home

### DIFF
--- a/src/inbox/tests.rs
+++ b/src/inbox/tests.rs
@@ -14,6 +14,7 @@ static READONLY_TEST_LOCK: Mutex<()> = Mutex::new(());
 
 fn tmp_home(suffix: &str) -> PathBuf {
     let dir = std::env::temp_dir().join(format!("agend-inbox-{}-{}", suffix, std::process::id()));
+    fs::remove_dir_all(&dir).ok();
     fs::create_dir_all(&dir).ok();
     dir
 }

--- a/src/inbox/tests.rs
+++ b/src/inbox/tests.rs
@@ -18,6 +18,22 @@ fn tmp_home(suffix: &str) -> PathBuf {
     dir
 }
 
+#[test]
+fn tmp_home_starts_clean_when_suffix_is_reused() {
+    let first = tmp_home("freshness");
+    let stale = first.join("stale.marker");
+    fs::write(&stale, "stale").unwrap();
+
+    let second = tmp_home("freshness");
+    let stale_survives = second.join("stale.marker").exists();
+    fs::remove_dir_all(&first).ok();
+
+    assert!(
+        !stale_survives,
+        "tmp_home must remove stale content when reused"
+    );
+}
+
 fn make_msg(from: &str, text: &str) -> InboxMessage {
     msg().sender(from).text(text).build()
 }


### PR DESCRIPTION
Implements decision d-20260722000023815497-3 for the #2883 inbox test isolation failure.

- RED commit ad681245: focused test seeds tmp_home and proves stale content survives suffix reuse before the fix.
- GREEN commit 1ca2c6d: tmp_home removes a pre-existing directory before create_dir_all.
- No production, lock, append, recovery, sequence/UUID, or RAII changes.

Validation:
- cargo test --bin agend-terminal inbox::tests::tmp_home_starts_clean_when_suffix_is_reused: passed
- cargo test --bin agend-terminal inbox::tests:: -- --nocapture: 170 passed
- cargo clippy --all-targets --all-features -- -D warnings: passed
- git diff --check: passed
- Full cargo fmt --all -- --check is blocked by pre-existing formatting drift in vendor files and unrelated existing lines in src/inbox/tests.rs; the changed block is rustfmt-formatted.

Related: #2883