### PR TITLE
fix: release exact unbound managed checkout

### DIFF
--- a/src/mcp/handlers/force_release/mod.rs
+++ b/src/mcp/handlers/force_release/mod.rs
@@ -171,6 +171,88 @@ mod tests {
     }
 
     #[test]
+    fn force_release_finds_unbound_checkout_by_exact_managed_marker_2878() {
+        let home = tmp_home("2878-unbound-checkout");
+        let repo = home.join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        assert!(git_bypassed(&repo, &["init", "-b", "main"])
+            .status
+            .success());
+        assert!(git_bypassed(
+            &repo,
+            &[
+                "-c",
+                "user.name=t",
+                "-c",
+                "user.email=t@t",
+                "commit",
+                "--allow-empty",
+                "-m",
+                "init",
+            ],
+        )
+        .status
+        .success());
+
+        let agent = "dev-2878";
+        let branch = "feat/unbound-2878";
+        let target = home.join("worktrees").join("dev-2878-mangled-repo");
+        std::fs::create_dir_all(target.parent().unwrap()).unwrap();
+        let add = git_bypassed(
+            &repo,
+            &["worktree", "add", "-b", branch, target.to_str().unwrap()],
+        );
+        assert!(
+            add.status.success(),
+            "worktree add failed: {}",
+            String::from_utf8_lossy(&add.stderr)
+        );
+        std::fs::write(
+            target.join(crate::worktree_pool::MANAGED_MARKER),
+            format!(
+                "agent={agent}\nbranch={branch}\nsource_repo={}\n",
+                repo.display()
+            ),
+        )
+        .unwrap();
+
+        let outcome = rebase_clean_self(&home, agent, branch, Some(&repo), None)
+            .expect("exact marker must identify the unbound checkout");
+        assert!(outcome.dir_existed, "the discovered checkout exists");
+        assert!(outcome.dir_removed, "the discovered checkout is reclaimed");
+        assert!(!target.exists(), "the physical checkout must be gone");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn force_release_refuses_ambiguous_unbound_marker_matches_2878() {
+        let home = tmp_home("2878-ambiguous");
+        let repo = home.join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        let agent = "dev-2878";
+        let branch = "feat/ambiguous-2878";
+        for suffix in ["one", "two"] {
+            let target = home
+                .join("worktrees")
+                .join(format!("{agent}-mangled-{suffix}"));
+            std::fs::create_dir_all(&target).unwrap();
+            std::fs::write(
+                target.join(crate::worktree_pool::MANAGED_MARKER),
+                format!(
+                    "agent={agent}\nbranch={branch}\nsource_repo={}\n",
+                    repo.display()
+                ),
+            )
+            .unwrap();
+        }
+
+        let error = rebase_clean_self(&home, agent, branch, Some(&repo), None)
+            .expect_err("multiple exact markers must fail closed");
+        assert!(error.contains("ambiguous"), "unexpected error: {error}");
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
     fn rebase_clean_self_rejects_path_outside_worktree_pool() {
         // Defense-in-depth: even if a malicious caller bypassed the
         // outer validators, the helper refuses to clean paths outside

--- a/src/mcp/handlers/force_release/s2.rs
+++ b/src/mcp/handlers/force_release/s2.rs
@@ -137,7 +137,7 @@ pub(crate) fn force_release(
             (Some(identity), Some(fingerprint))
         }
         GuardedBinding::Absent => {
-            let target = crate::worktree::worktree_path(home, agent, branch);
+            let target = unbound(home, agent, branch, explicit_repo)?;
             let target_state = classify_target(&target)?;
             let identity = match target_state {
                 TargetState::Present => {
@@ -316,6 +316,42 @@ fn resolve_identity(
         worktree: worktree.to_path_buf(),
         source_repo,
     })
+}
+
+fn unbound(home: &Path, agent: &str, branch: &str, repo: Option<&Path>) -> Result<PathBuf, String> {
+    let legacy = crate::worktree::worktree_path(home, agent, branch);
+    if matches!(classify_target(&legacy)?, TargetState::Present) {
+        return Ok(legacy);
+    }
+    let Some(repo) = repo else {
+        return Ok(legacy);
+    };
+    let repo = canonical_repo(repo)?;
+    let entries = match std::fs::read_dir(home.join("worktrees")) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(legacy),
+        Err(error) => return Err(format!("force release refused: unreadable pool: {error}")),
+    };
+    let prefix = format!("{agent}-");
+    let mut found = None;
+    for entry in entries {
+        let entry = entry.map_err(|e| format!("force release refused: unreadable entry: {e}"))?;
+        let path = entry.path();
+        if !entry.file_name().to_string_lossy().starts_with(&prefix)
+            || marker_field(&path, "agent").as_deref() != Some(agent)
+            || marker_field(&path, "branch").as_deref() != Some(branch)
+        {
+            continue;
+        }
+        let marker_repo = marker_field(&path, "source_repo").ok_or("target missing source_repo")?;
+        if canonical_repo(Path::new(&marker_repo))? != repo {
+            continue;
+        }
+        if found.replace(path).is_some() {
+            return Err("force release refused: ambiguous exact managed targets".to_string());
+        }
+    }
+    Ok(found.unwrap_or(legacy))
 }
 
 fn canonical_repo(path: &Path) -> Result<PathBuf, String> {


### PR DESCRIPTION
Closes #2878.\n\nWhen release_worktree(force:true) sees no binding and the legacy nested path is absent, inspect only immediate daemon-managed candidates and require an exact agent + branch + canonical explicit repository marker match. Zero matches preserves the existing idempotent absence contract; multiple matches fail closed.\n\nKISS scope: one existing S2 path, 37 production insertions and two targeted tests. No registry, GC change, or repo action=release redesign.\n\nRED: 973718953022c1414b023c42eacf185c822609c0\nGREEN: 4c90377b6a10e69efda23c018094aa23ef15a3a9\n\nVerified: focused #2878 tests 2/2; idempotent control 1/1; fmt-owned check; clippy with warnings denied; S2 remains 749 LOC.