### PR TITLE
fix: remove branch equality gate from disposable review task-terminal check

### DIFF
--- a/src/worktree_pool.rs
+++ b/src/worktree_pool.rs
@@ -695,25 +695,17 @@ fn disposable_review_provisioned_head(
     Ok(Some(head))
 }
 
-fn disposable_review_task_terminal(home: &Path, task_id: &str, branch: &str) -> Option<bool> {
+fn disposable_review_task_terminal(home: &Path, task_id: &str) -> Option<bool> {
     if task_id.is_empty() {
         return None;
     }
     match crate::tasks::load_routed(home, task_id) {
-        Ok(routed) => {
-            // A terminal task is authoritative only for the branch it owns;
-            // a mismatched branch is contradictory evidence and must preserve
-            // the disposable review branch fail-closed.
-            if routed.task.branch.as_deref() != Some(branch) {
-                return None;
-            }
-            Some(matches!(
-                routed.task.status,
-                crate::task_events::TaskStatus::Done
-                    | crate::task_events::TaskStatus::Cancelled
-                    | crate::task_events::TaskStatus::Verified
-            ))
-        }
+        Ok(routed) => Some(matches!(
+            routed.task.status,
+            crate::task_events::TaskStatus::Done
+                | crate::task_events::TaskStatus::Cancelled
+                | crate::task_events::TaskStatus::Verified
+        )),
         Err(crate::tasks::TaskRouteError::NotFound)
         | Err(crate::tasks::TaskRouteError::Unreadable { .. })
         | Err(crate::tasks::TaskRouteError::Ambiguous { .. }) => None,
@@ -786,7 +778,7 @@ fn resolve_branch_cleanup(
         if let Some(expected) = review_head {
             let default = crate::git_helpers::default_branch(Path::new(sr_str));
             let task_active = if disposable_head.is_some() {
-                disposable_review_task_terminal(home, task_id, branch).map(|terminal| !terminal)
+                disposable_review_task_terminal(home, task_id).map(|terminal| !terminal)
             } else {
                 task_active_for_branch(home, task_id, branch)
             };

--- a/src/worktree_pool/tests.rs
+++ b/src/worktree_pool/tests.rs
@@ -5213,28 +5213,6 @@ fn disposable_review_missing_corrupt_or_drifted_state_is_kept() {
     assert!(!missing_out.branch_deleted);
     assert!(branch_exists(&repo, branch));
 
-    let mismatch_task = "T-disposable-branch-mismatch";
-    seed_disposable_task(
-        &home,
-        mismatch_task,
-        "review/another-disposable-branch",
-        true,
-    );
-    let mut mismatch = missing_task.clone();
-    mismatch["task_id"] = serde_json::json!(mismatch_task);
-    let mut mismatch_out = ReleaseOutcome::default();
-    resolve_branch_cleanup(
-        &home,
-        &mismatch,
-        true,
-        false,
-        false,
-        false,
-        &mut mismatch_out,
-    );
-    assert!(!mismatch_out.branch_deleted);
-    assert!(branch_exists(&repo, branch));
-
     let mut corrupt = missing_task.clone();
     corrupt["provenance"] = serde_json::json!("Forged");
     let mut corrupt_out = ReleaseOutcome::default();

--- a/src/worktree_pool/tests.rs
+++ b/src/worktree_pool/tests.rs
@@ -5271,3 +5271,42 @@ fn disposable_review_missing_corrupt_or_drifted_state_is_kept() {
     std::fs::remove_dir_all(&home).ok();
     std::fs::remove_dir_all(&repo).ok();
 }
+
+// RED: In real disposable reviews, task.branch is the subject PR branch (e.g.
+// "feat/foo") while binding.branch is the review workspace branch (e.g.
+// "review/pr-123-abc"). The current disposable_review_task_terminal compares
+// these two and returns None on mismatch, causing the disposition classifier
+// to Keep the branch even after the review task is terminal.
+#[test]
+fn disposable_review_terminal_task_with_subject_branch_deletes_review_branch() {
+    let home = tmp_home("disposable-subject-branch-home");
+    let repo = tmp_repo("disposable-subject-branch");
+    let review_branch = "review/pr-subject-1234";
+    let subject_branch = "feat/subject-pr-branch";
+    let tip = make_review_branch(&repo, review_branch);
+    let task_id = "T-disposable-subject-branch";
+
+    // Task is created with branch = subject PR branch (as the real daemon does)
+    seed_disposable_task(&home, task_id, subject_branch, true);
+
+    // Binding uses the review workspace branch (as the real daemon does)
+    let binding =
+        binding_with_disposable_review(review_branch, &repo.display().to_string(), task_id, &tip);
+
+    let mut out = ReleaseOutcome::default();
+    resolve_branch_cleanup(&home, &binding, true, false, false, false, &mut out);
+
+    assert!(
+        out.branch_deleted,
+        "terminal disposable review task must delete review branch even when \
+         task.branch (subject PR) != binding.branch (review workspace): {:?}",
+        out.branch_cleanup_skipped_reason
+    );
+    assert!(
+        !branch_exists(&repo, review_branch),
+        "review branch must be cleaned up after terminal task"
+    );
+
+    std::fs::remove_dir_all(&home).ok();
+    std::fs::remove_dir_all(&repo).ok();
+}


### PR DESCRIPTION
## Summary
- Remove the `branch` parameter and equality gate from `disposable_review_task_terminal` — in real disposable reviews, `task.branch` (subject PR branch) always differs from `binding.branch` (review workspace branch), so the check always returned `None`, preventing cleanup of terminal review branches
- Route errors and missing tasks still preserve fail-closed (return `None`)
- Remove stale test block asserting branch-mismatch preservation

## Test plan
- [x] RED test `disposable_review_terminal_task_with_subject_branch_deletes_review_branch` now passes
- [x] All 14 focused `disposable_review` tests pass
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)