### PR TITLE
fix: auto-arm carries next_after_ci=team orchestrator

### DIFF
--- a/src/daemon/pr_state/auto_arm.rs
+++ b/src/daemon/pr_state/auto_arm.rs
@@ -275,6 +275,55 @@ mod tests {
         std::fs::remove_dir_all(&home).ok();
     }
 
+    fn watch_json(home: &Path, branch: &str) -> serde_json::Value {
+        let path = crate::daemon::ci_watch::ci_watches_dir(home)
+            .join(crate::daemon::ci_watch::watch_filename(REPO, branch));
+        serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap()
+    }
+
+    fn write_fleet(home: &Path) {
+        std::fs::write(
+            crate::fleet::fleet_yaml_path(home),
+            "instances:\n  dev-x:\n    backend: claude\n  lead:\n    backend: claude\n\
+             teams:\n  t:\n    members: [dev-x, lead]\n    orchestrator: lead\n",
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn auto_arm_team_member_carries_next_after_ci_orchestrator() {
+        let home = tmp_home("team-nac");
+        write_fleet(&home);
+        bind(&home, "dev-x", "feat/x");
+        auto_arm_unwatched_open_prs(
+            &home,
+            REPO,
+            &[meta("feat/x", GhPrState::Open, false, false)],
+        );
+        assert!(watch_exists(&home, "feat/x"), "watch must be armed");
+        let watch = watch_json(&home, "feat/x");
+        let next: Vec<String> = crate::daemon::ci_watch::watch_state::normalize_next_after_ci(
+            watch
+                .get("next_after_ci")
+                .unwrap_or(&serde_json::Value::Null),
+        );
+        assert_eq!(
+            next,
+            vec!["lead"],
+            "auto-arm of a non-orchestrator team member must carry \
+             next_after_ci=<team orchestrator>; got {next:?}"
+        );
+        assert!(
+            watch.get("task_id").and_then(|v| v.as_str()).is_none(),
+            "auto-arm must NOT fabricate a task_id"
+        );
+        assert!(
+            watch.get("review_class").and_then(|v| v.as_str()).is_none(),
+            "auto-arm must NOT set review_class (stays Unresolved/fail-closed)"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
     #[test]
     fn open_pr_no_bound_agent_fails_loud_no_arm() {
         let home = tmp_home("failloud");

--- a/src/daemon/pr_state/auto_arm.rs
+++ b/src/daemon/pr_state/auto_arm.rs
@@ -64,11 +64,12 @@ pub fn auto_arm_unwatched_open_prs(home: &Path, repo: &str, prs: &[GhPrMetadata]
             continue;
         };
 
-        // Arm with the bound agent as the sole subscriber; next_after_ci unset →
-        // on CI pass the agent receives the informational `[ci-pass]` (PR-1 #1796
-        // fallback). The actionable `[ci-ready-for-action]` chain still requires
-        // an explicit next_after_ci (review handoff stays explicit, PR-2 #1797).
-        let args = serde_json::json!({ "repository": repo, "branch": branch });
+        let mut args = serde_json::json!({ "repository": repo, "branch": branch });
+        if let Some(orch) = crate::fleet::team_orchestrator_for(home, &agent) {
+            if orch != agent {
+                args["next_after_ci"] = serde_json::json!(orch);
+            }
+        }
         let resp = crate::mcp::handlers::ci::handle_watch_ci(home, &args, &agent);
         if let Some(err) = resp.get("error").and_then(|e| e.as_str()) {
             tracing::warn!(


### PR DESCRIPTION
## Summary
- PR-3 auto-arm now resolves `fleet::team_orchestrator_for` for the bound subscriber
- If a distinct orchestrator exists, populates `next_after_ci` on the watch request
- Closes the handoff gap: auto-armed watches get actionable `[ci-ready-for-action]` chain instead of informational-only `[ci-pass]`
- `task_id` and `review_class` intentionally left absent (Unresolved/fail-closed)

## Test plan
- [x] RED test `auto_arm_team_member_carries_next_after_ci_orchestrator` now passes (was `left: [] right: ["lead"]`)
- [x] All 6 auto_arm tests pass (zero regression)
- [x] `cargo fmt -- --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] Production diff: 1 file, +6/-5 lines (minimal wire-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)